### PR TITLE
Cleanup and document sampleTest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,16 @@ Be sure to include any related GitHub issue references in the commit message.  S
 [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) for referencing issues
 and commits.
 
+### Formatting Code
+
+We follow the guidelines outlined by the
+[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
+If you use emacs, consider installing
+[google-c-style.el](https://raw.githubusercontent.com/google/styleguide/gh-pages/google-c-style.el).
+Please run
+[cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
+against your changes, to ensure adherence to the guidelines.
+
 ## Reporting Bugs and Creating Issues
 
 When opening a new issue, try to roughly follow the commit message format conventions above.

--- a/bftengine/tests/simpleTest/README.md
+++ b/bftengine/tests/simpleTest/README.md
@@ -1,0 +1,92 @@
+# Concord Example Code and Basic Test
+
+In this directory, you'll find a simple test that demonstrates how to
+use Concord. The test implements a single-register state machine. The
+state machine understands two events:
+
+  * WRITE(value) sets the value in the register, and returns the
+    number of times that value has been changed (including this write,
+    so the response to the first write will be one).
+  * READ just returns the latest value that was set in the register
+    (zero if no value has ever been set)
+
+The state machine is defined in the `SimpleAppState` class in
+`replica.cpp`. It exposes only an `execute` method, which is called
+every time the replica receives an event. The `main` function simple
+starts a Concord replica parameterized with this state machine.
+
+The test code is defined in `client.cpp`. The client sends a number of
+write requests, followed by a read request, repeatedly. It verifies
+that the responses to each of these events matches expectations,
+namely that the sequence number advances, and that a read returns the
+last written value.
+
+In the `scripts` directory, you'll find:
+
+  * `private_replica_{0,1,2,3}`, which are the private config files
+    for each replica. The example is for four replicas, with supports
+    an F=1 environment. See `config.cpp` for documentation of the
+    format.
+
+  * `public_replicas_data`, which is the public configuration shared
+    among all nodes. This is how public keys are shared among all
+    nodes. See `config.cpp` for documentation of the format.
+
+  * `testReplicasAndClient.sh`, which starts all four replicas, and
+    then runs the client test.
+
+  * `runReplias.sh`, which just starts all four replicas.
+
+  * `runClient.sh`, which just runs the client test.
+
+If you have built Concord, by running `make.sh` from the top-level
+directory, you can run the test using the following commands:
+
+```
+cd ~/builds/concord-bft/debug/bftengine/tests/simpleTest/scripts
+./testReplicasAndClient.sh
+```
+
+You should see output like the following:
+
+```
+2018-09-18 11:00:00 91178 91178  INFO       LogInitializer: 121 | Compiler successfully avoids evaluating expressions in 'logtrace << expr()'
+
+ 18:00:00.429 INFO: Client 4 - sends request 6447876697453756416 (isRO=0, request size=16, retransmissionMilli=150)
+When using programs that use GNU Parallel to process data for publication please cite:
+
+  O. Tange (2011): GNU Parallel - The Command-Line Power Tool,
+  ;login: The USENIX Magazine, February 2011:42-47.
+
+This helps funding further development; and it won't cost you a cent.
+Or you can get GNU Parallel without this requirement by paying 10000 EUR.
+
+To silence this citation notice run 'parallel --bibtex' once or use '--no-notice'.
+
+
+ 18:00:00.429 INFO: Client 4 - sends request 6447876697453756416 (isRO=0, request size=40,  retransmissionMilli=150, numberOfTransmissions=1, resetReplies=0, sendToAll=1)
+ 18:00:00.631 INFO: Client 4 - sends request 6447876697453756416 (isRO=0, request size=40,  retransmissionMilli=150, numberOfTransmissions=2, resetReplies=0, sendToAll=1)
+ 18:00:00.636 INFO: Client 4 received ClientReplyMsg with seqNum=6447876697453756416 sender=1  size=32  primaryId=0 hash=1
+ 18:00:00.636 INFO: Client 4 received ClientReplyMsg with seqNum=6447876697453756416 sender=0  size=32  primaryId=0 hash=1
+ 18:00:00.637 INFO: Client 4 received ClientReplyMsg with seqNum=6447876697453756416 sender=2  size=32  primaryId=0 hash=1
+ 18:00:00.637 INFO: Client 4 - request 6447876697453756416 has committed (isRO=0, request size=16,  retransmissionMilli=150)
+...
+lots of similar send/receive/commit messages
+...
+ 17:37:11.407 INFO: Client 4 - sends request 6447870955359305728 (isRO=1, request size=8, retransmissionMilli=50)
+ 17:37:11.407 INFO: Client 4 - sends request 6447870955359305728 (isRO=1, request size=32,  retransmissionMilli=50, numberOfTransmissions=1, resetReplies=0, sendToAll=1)
+ 17:37:11.407 INFO: Client 4 received ClientReplyMsg with seqNum=6447870955359305728 sender=3  size=32  primaryId=0 hash=657769120
+ 17:37:11.407 INFO: Client 4 received ClientReplyMsg with seqNum=6447870955359305728 sender=0  size=32  primaryId=0 hash=657769120
+ 17:37:11.407 INFO: Client 4 received ClientReplyMsg with seqNum=6447870955359305728 sender=1  size=32  primaryId=0 hash=657769120
+ 17:37:11.407 INFO: Client 4 - request 6447870955359305728 has committed (isRO=1, request size=8,  retransmissionMilli=50)
+Client is done, killing 'parallel' at PID 91009
+
+parallel: SIGTERM received. No new jobs will be started.
+parallel: Waiting for these 4 jobs to finish. Send SIGTERM again to stop now.
+parallel: /home/bfink/builds/concord-bft/debug/bftengine/tests/simpleTest/scripts/../server 3
+parallel: /home/bfink/builds/concord-bft/debug/bftengine/tests/simpleTest/scripts/../server 2
+parallel: /home/bfink/builds/concord-bft/debug/bftengine/tests/simpleTest/scripts/../server 0
+parallel: /home/bfink/builds/concord-bft/debug/bftengine/tests/simpleTest/scripts/../server 1
+
+Killing server processes named '/home/bfink/builds/concord-bft/debug/bftengine/tests/simpleTest/scripts/../server'
+```

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -1,3 +1,16 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
 #include <stdio.h>
 #include <string.h>
 #include <cassert>

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -22,8 +22,11 @@
 #include "commonDefs.h"
 #include "SimpleClient.hpp"
 
-using namespace std;
-using namespace bftEngine;
+using bftEngine::ICommunication;
+using bftEngine::PlainUDPCommunication;
+using bftEngine::PlainUdpConfig;
+using bftEngine::SeqNumberGeneratorForClientRequests;
+using bftEngine::SimpleClient;
 
 PlainUdpConfig getUDPConfig(uint16_t id);
 

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <thread>
 
-#include "CommFactory.hpp" 
+#include "CommFactory.hpp"
 
 #include "commonDefs.h"
 #include "SimpleClient.hpp"
@@ -14,92 +14,88 @@ using namespace bftEngine;
 
 PlainUdpConfig getUDPConfig(uint16_t id);
 
-int main(int argc, char **argv)
-{
-	const int16_t id = 4;
-	const int numOfOperations = 2800;
-	const int readMod = 7;
+int main(int argc, char **argv) {
+  const int16_t id = 4;
+  const int numOfOperations = 2800;
+  const int readMod = 7;
 
-	SeqNumberGeneratorForClientRequests* pSeqGen = SeqNumberGeneratorForClientRequests::createSeqNumberGeneratorForClientRequests();
+  SeqNumberGeneratorForClientRequests* pSeqGen =
+      SeqNumberGeneratorForClientRequests::
+      createSeqNumberGeneratorForClientRequests();
 
-	PlainUdpConfig udpConf = getUDPConfig(id);
+  PlainUdpConfig udpConf = getUDPConfig(id);
 
-	ICommunication* comm = PlainUDPCommunication::create(udpConf);
-	SimpleClient* client = SimpleClient::createSimpleClient(comm, id, 1, 0);
+  ICommunication* comm = PlainUDPCommunication::create(udpConf);
+  SimpleClient* client = SimpleClient::createSimpleClient(comm, id, 1, 0);
 
-	comm->Start();
-	
-	uint64_t expectedStateNum = 0;
-	bool hasExpectedStateNum = false;
-	uint64_t expectedLastValue = 0;
-	bool hasExpectedLastValue = false;
+  comm->Start();
 
-	for (int i = 1; i <= numOfOperations; i++)
-	{
-		if (i % readMod == 0) // if read
-		{
-			char replyBuffer[sizeof(uint64_t)];
+  uint64_t expectedStateNum = 0;
+  bool hasExpectedStateNum = false;
+  uint64_t expectedLastValue = 0;
+  bool hasExpectedLastValue = false;
 
-			uint64_t reqId = READ_VAL_REQ;
-			uint32_t actualReplyLength = 0;
-			client->sendRequest(true, (char*)&reqId, sizeof(uint64_t),
-				pSeqGen->generateUniqueSequenceNumberForRequest(),
-				SimpleClient::INFINITE_TIMEOUT,
-				sizeof(uint64_t),
-				replyBuffer,
-				actualReplyLength);
+  for (int i = 1; i <= numOfOperations; i++) {
+    if (i % readMod == 0) {
+      // if read
+      char replyBuffer[sizeof(uint64_t)];
 
-			assert(actualReplyLength == sizeof(uint64_t));
+      uint64_t reqId = READ_VAL_REQ;
+      uint32_t actualReplyLength = 0;
+      client->sendRequest(true, (char*)&reqId, sizeof(uint64_t),
+                          pSeqGen->generateUniqueSequenceNumberForRequest(),
+                          SimpleClient::INFINITE_TIMEOUT,
+                          sizeof(uint64_t),
+                          replyBuffer,
+                          actualReplyLength);
 
-			uint64_t retVal = *((uint64_t*)replyBuffer);
+      assert(actualReplyLength == sizeof(uint64_t));
 
-			if (hasExpectedLastValue) 
-				assert(retVal == expectedLastValue);
-		}
-		else // if write
-		{
-			char requestBuffer[sizeof(uint64_t) * 2];
-			char replyBuffer[sizeof(uint64_t)];
+      uint64_t retVal = *((uint64_t*)replyBuffer);
 
-			if(hasExpectedStateNum) expectedStateNum++;
+      if (hasExpectedLastValue)
+        assert(retVal == expectedLastValue);
+    } else {
+      // if write
+      char requestBuffer[sizeof(uint64_t) * 2];
+      char replyBuffer[sizeof(uint64_t)];
 
-			if (!hasExpectedLastValue) hasExpectedLastValue = true;
+      if (hasExpectedStateNum) expectedStateNum++;
 
-			expectedLastValue = (i + 1)*(i + 7)*(i + 18);
+      if (!hasExpectedLastValue) hasExpectedLastValue = true;
 
-			uint64_t* pReqId  = (uint64_t*)requestBuffer;
-			uint64_t* pReqVal = (pReqId + 1);
-			*pReqId = SET_VAL_REQ;
-			*pReqVal = expectedLastValue;
-			uint32_t actualReplyLength = 0;
-			client->sendRequest(false, requestBuffer, sizeof(uint64_t)*2,
-				pSeqGen->generateUniqueSequenceNumberForRequest(),
-				SimpleClient::INFINITE_TIMEOUT,
-				sizeof(uint64_t),
-				replyBuffer,
-				actualReplyLength);
+      expectedLastValue = (i + 1)*(i + 7)*(i + 18);
 
-			assert(actualReplyLength == sizeof(uint64_t));
+      uint64_t* pReqId  = (uint64_t*)requestBuffer;
+      uint64_t* pReqVal = (pReqId + 1);
+      *pReqId = SET_VAL_REQ;
+      *pReqVal = expectedLastValue;
+      uint32_t actualReplyLength = 0;
+      client->sendRequest(false, requestBuffer, sizeof(uint64_t)*2,
+                          pSeqGen->generateUniqueSequenceNumberForRequest(),
+                          SimpleClient::INFINITE_TIMEOUT,
+                          sizeof(uint64_t),
+                          replyBuffer,
+                          actualReplyLength);
 
-			uint64_t retVal = *((uint64_t*)replyBuffer);
+      assert(actualReplyLength == sizeof(uint64_t));
 
-			if (hasExpectedStateNum)
-			{
-				assert(retVal == expectedStateNum);
-			}
-			else
-			{
-				hasExpectedStateNum = true;
-				expectedStateNum = retVal;
-			}
-		}
-	}
-	
-	comm->Stop();
-	
-	delete pSeqGen;
-	delete client;
-	delete comm;
+      uint64_t retVal = *((uint64_t*)replyBuffer);
 
-	return 0;
+      if (hasExpectedStateNum) {
+        assert(retVal == expectedStateNum);
+      } else {
+        hasExpectedStateNum = true;
+        expectedStateNum = retVal;
+      }
+    }
+  }
+
+  comm->Stop();
+
+  delete pSeqGen;
+  delete client;
+  delete comm;
+
+  return 0;
 }

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -55,7 +55,9 @@ int main(int argc, char **argv) {
 
       uint64_t reqId = READ_VAL_REQ;
       uint32_t actualReplyLength = 0;
-      client->sendRequest(true, (char*)&reqId, sizeof(uint64_t),
+      client->sendRequest(true,
+                          reinterpret_cast<char*>(&reqId),
+                          sizeof(uint64_t),
                           pSeqGen->generateUniqueSequenceNumberForRequest(),
                           SimpleClient::INFINITE_TIMEOUT,
                           sizeof(uint64_t),
@@ -64,7 +66,7 @@ int main(int argc, char **argv) {
 
       assert(actualReplyLength == sizeof(uint64_t));
 
-      uint64_t retVal = *((uint64_t*)replyBuffer);
+      uint64_t retVal = *reinterpret_cast<uint64_t*>(replyBuffer);
 
       if (hasExpectedLastValue)
         assert(retVal == expectedLastValue);
@@ -79,7 +81,7 @@ int main(int argc, char **argv) {
 
       expectedLastValue = (i + 1)*(i + 7)*(i + 18);
 
-      uint64_t* pReqId  = (uint64_t*)requestBuffer;
+      uint64_t* pReqId  = reinterpret_cast<uint64_t*>(requestBuffer);
       uint64_t* pReqVal = (pReqId + 1);
       *pReqId = SET_VAL_REQ;
       *pReqVal = expectedLastValue;
@@ -93,7 +95,7 @@ int main(int argc, char **argv) {
 
       assert(actualReplyLength == sizeof(uint64_t));
 
-      uint64_t retVal = *((uint64_t*)replyBuffer);
+      uint64_t retVal = *reinterpret_cast<uint64_t*>(replyBuffer);
 
       if (hasExpectedStateNum) {
         assert(retVal == expectedStateNum);

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -11,15 +11,30 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <stdio.h>
-#include <string.h>
+// This program implements a client that sends requests to the simple register
+// state machine defined in replica.cpp. It sends a preset number of operations
+// to the replicas, and occasionally checks that the responses match
+// expectations.
+//
+// Operations alternate:
+//
+//  1. `readMod-1` write operations, each with a unique value
+//    a. Every second write checks that the returned sequence number is as
+//       expected.
+//  2. Every `readMod`-th operation is a read, which checks that the value
+//     returned is the same as the last value written.
+//
+// The program expects no arguments. See the `scripts/` directory for
+// information about how to run the client.
+
 #include <cassert>
-#include <string>
 
+// bftEngine includes
 #include "CommFactory.hpp"
-
-#include "commonDefs.h"
 #include "SimpleClient.hpp"
+
+// simpleTest includes
+#include "commonDefs.h"
 
 using bftEngine::ICommunication;
 using bftEngine::PlainUDPCommunication;
@@ -27,79 +42,127 @@ using bftEngine::PlainUdpConfig;
 using bftEngine::SeqNumberGeneratorForClientRequests;
 using bftEngine::SimpleClient;
 
+// Declarations of functions form config.cpp.
 PlainUdpConfig getUDPConfig(uint16_t id);
 
 int main(int argc, char **argv) {
+  // This client's index number. Must be larger than the largest replica index
+  // number.
   const int16_t id = 4;
+
+  // The number of operations to send during this run.
   const int numOfOperations = 2800;
+
+  // How often to read the latest value of the register (every `readMod` ops).
   const int readMod = 7;
 
+  // Concord clients must tag each request with a unique sequence number. This
+  // generator handles that for us.
   SeqNumberGeneratorForClientRequests* pSeqGen =
       SeqNumberGeneratorForClientRequests::
       createSeqNumberGeneratorForClientRequests();
 
+  // Configure, create, and start the Concord client to use.
   PlainUdpConfig udpConf = getUDPConfig(id);
-
   ICommunication* comm = PlainUDPCommunication::create(udpConf);
   SimpleClient* client = SimpleClient::createSimpleClient(comm, id, 1, 0);
-
   comm->Start();
 
+  // The state number that the latest write operation returned.
   uint64_t expectedStateNum = 0;
+
+  // The expectedStateNum is not valid until we have issued at least one write
+  // operation.
   bool hasExpectedStateNum = false;
+
+  // The value that the latest write operation sent.
   uint64_t expectedLastValue = 0;
+
+  // The expectedLastValue is not valid until we have issued at least one write
+  // operation.
   bool hasExpectedLastValue = false;
 
   for (int i = 1; i <= numOfOperations; i++) {
     if (i % readMod == 0) {
-      // if read
-      char replyBuffer[sizeof(uint64_t)];
+      // Read the latest value every readMod-th operation.
 
-      uint64_t reqId = READ_VAL_REQ;
+      // Prepare request parameters.
+      const bool readOnly = true;
+
+      const uint32_t kRequestLength = 1;
+      const uint64_t requestBuffer[kRequestLength] = {READ_VAL_REQ};
+      const char* rawRequestBuffer =
+          reinterpret_cast<const char*>(requestBuffer);
+      const uint32_t rawRequestLength = sizeof(uint64_t) * kRequestLength;
+
+      const uint64_t requestSequenceNumber =
+          pSeqGen->generateUniqueSequenceNumberForRequest();
+
+      const uint64_t timeout = SimpleClient::INFINITE_TIMEOUT;
+
+      const uint32_t kReplyBufferLength = sizeof(uint64_t);
+      char replyBuffer[kReplyBufferLength];
       uint32_t actualReplyLength = 0;
-      client->sendRequest(true,
-                          reinterpret_cast<char*>(&reqId),
-                          sizeof(uint64_t),
-                          pSeqGen->generateUniqueSequenceNumberForRequest(),
-                          SimpleClient::INFINITE_TIMEOUT,
-                          sizeof(uint64_t),
-                          replyBuffer,
-                          actualReplyLength);
 
+      client->sendRequest(readOnly,
+                          rawRequestBuffer, rawRequestLength,
+                          requestSequenceNumber,
+                          timeout,
+                          kReplyBufferLength, replyBuffer, actualReplyLength);
+
+      // Read should respond with eight bytes of data.
       assert(actualReplyLength == sizeof(uint64_t));
 
       uint64_t retVal = *reinterpret_cast<uint64_t*>(replyBuffer);
 
+      // Only assert the last expected value if we have previous set a value.
       if (hasExpectedLastValue)
         assert(retVal == expectedLastValue);
     } else {
-      // if write
-      char requestBuffer[sizeof(uint64_t) * 2];
-      char replyBuffer[sizeof(uint64_t)];
+      // Send a write, if we're not doing a read.
 
-      if (hasExpectedStateNum) expectedStateNum++;
-
-      if (!hasExpectedLastValue) hasExpectedLastValue = true;
-
+      // Generate a value to store.
       expectedLastValue = (i + 1)*(i + 7)*(i + 18);
 
-      uint64_t* pReqId  = reinterpret_cast<uint64_t*>(requestBuffer);
-      uint64_t* pReqVal = (pReqId + 1);
-      *pReqId = SET_VAL_REQ;
-      *pReqVal = expectedLastValue;
-      uint32_t actualReplyLength = 0;
-      client->sendRequest(false, requestBuffer, sizeof(uint64_t)*2,
-                          pSeqGen->generateUniqueSequenceNumberForRequest(),
-                          SimpleClient::INFINITE_TIMEOUT,
-                          sizeof(uint64_t),
-                          replyBuffer,
-                          actualReplyLength);
+      // Prepare request parameters.
+      const bool readOnly = false;
 
+      const uint32_t kRequestLength = 2;
+      const uint64_t requestBuffer[kRequestLength] =
+          {SET_VAL_REQ, expectedLastValue};
+      const char* rawRequestBuffer =
+          reinterpret_cast<const char*>(requestBuffer);
+      const uint32_t rawRequestLength = sizeof(uint64_t) * kRequestLength;
+
+      const uint64_t requestSequenceNumber =
+          pSeqGen->generateUniqueSequenceNumberForRequest();
+
+      const uint64_t timeout = SimpleClient::INFINITE_TIMEOUT;
+
+      const uint32_t kReplyBufferLength = sizeof(uint64_t);
+      char replyBuffer[kReplyBufferLength];
+      uint32_t actualReplyLength = 0;
+
+      client->sendRequest(readOnly,
+                          rawRequestBuffer, rawRequestLength,
+                          requestSequenceNumber,
+                          timeout,
+                          kReplyBufferLength, replyBuffer, actualReplyLength);
+
+      // We can now check the expected value on the next read.
+      hasExpectedLastValue = true;
+
+      // Write should respond with eight bytes of data.
       assert(actualReplyLength == sizeof(uint64_t));
 
       uint64_t retVal = *reinterpret_cast<uint64_t*>(replyBuffer);
 
+      // We don't know what state number to expect from the first request. The
+      // replicas might still be up from a previous run of this test.
       if (hasExpectedStateNum) {
+        // If we had done a previous write, then this write should return the
+        // state number right after the state number that that write returned.
+        expectedStateNum++;
         assert(retVal == expectedStateNum);
       } else {
         hasExpectedStateNum = true;
@@ -108,6 +171,7 @@ int main(int argc, char **argv) {
     }
   }
 
+  // After all requests have been issued, stop communication and clean up.
   comm->Stop();
 
   delete pSeqGen;

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <cassert>
 #include <string>
-#include <thread>
 
 #include "CommFactory.hpp"
 

--- a/bftengine/tests/simpleTest/commonDefs.h
+++ b/bftengine/tests/simpleTest/commonDefs.h
@@ -11,10 +11,13 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+// This file contains definition used by both the client and replicas.
+
 #ifndef BFTENGINE_TESTS_SIMPLETEST_COMMONDEFS_H_
 #define BFTENGINE_TESTS_SIMPLETEST_COMMONDEFS_H_
 #pragma once
 
+// Request types for replica commands.
 #define READ_VAL_REQ ((uint64_t)100)
 #define SET_VAL_REQ  ((uint64_t)200)
 

--- a/bftengine/tests/simpleTest/commonDefs.h
+++ b/bftengine/tests/simpleTest/commonDefs.h
@@ -1,5 +1,17 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
 #pragma once
 
 #define READ_VAL_REQ ((uint64_t)100)
 #define SET_VAL_REQ  ((uint64_t)200)
-

--- a/bftengine/tests/simpleTest/commonDefs.h
+++ b/bftengine/tests/simpleTest/commonDefs.h
@@ -11,7 +11,11 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#ifndef BFTENGINE_TESTS_SIMPLETEST_COMMONDEFS_H_
+#define BFTENGINE_TESTS_SIMPLETEST_COMMONDEFS_H_
 #pragma once
 
 #define READ_VAL_REQ ((uint64_t)100)
 #define SET_VAL_REQ  ((uint64_t)200)
+
+#endif  // BFTENGINE_TESTS_SIMPLETEST_COMMONDEFS_H_

--- a/bftengine/tests/simpleTest/config.cpp
+++ b/bftengine/tests/simpleTest/config.cpp
@@ -1,7 +1,7 @@
 #include <utility>
 #include <string>
 
-#include "CommFactory.hpp" 
+#include "CommFactory.hpp"
 #include "ReplicaConfig.hpp"
 #include <threshsign/ThresholdSignaturesSchemes.h>
 
@@ -17,7 +17,12 @@ using namespace bftEngine;
 #define MAX_ITEM_LENGTH_STR "4096"
 
 const char* nameOfPublicFile = "public_replicas_data";
-const char* namesOfPrivateFiles[] = { "private_replica_0", "private_replica_1", "private_replica_2", "private_replica_3" };
+const char* namesOfPrivateFiles[] = {
+  "private_replica_0",
+  "private_replica_1",
+  "private_replica_2",
+  "private_replica_3"
+};
 
 const int numOfReplicas = 4;
 const int fVal = 1;
@@ -29,193 +34,210 @@ const uint16_t basePort = 3710;
 
 
 static void readOneLine(FILE *f, int capacity, char * buf) {
-	fgets(buf, capacity - 1, f);
-	buf[strlen(buf) - 1] = 0; // strip newline
+  fgets(buf, capacity - 1, f);
+  buf[strlen(buf) - 1] = 0;  // strip newline
 }
 
 static void ignoreOneLine(FILE *f) {
-	char buf[8192];
-	readOneLine(f, 8191, buf);
+  char buf[8192];
+  readOneLine(f, 8191, buf);
 }
 
 
-static IThresholdSigner * createThresholdSigner(FILE * f, int id, IThresholdFactory* factory) 
-{
-	if (id < 1) {
-		throw std::runtime_error("Expected replica's ID to be strictly greater than zero!");
-	}
+static IThresholdSigner * createThresholdSigner(FILE * f,
+                                                int id,
+                                                IThresholdFactory* factory) {
+  if (id < 1) {
+    throw std::runtime_error(
+        "Expected replica's ID to be strictly greater than zero!");
+  }
 
-	char secretKey[MAX_ITEM_LENGTH];
-	ignoreOneLine(f);
+  char secretKey[MAX_ITEM_LENGTH];
+  ignoreOneLine(f);
 
-	readOneLine(f, MAX_ITEM_LENGTH, secretKey);
-	return factory->newSigner(id, secretKey);
+  readOneLine(f, MAX_ITEM_LENGTH, secretKey);
+  return factory->newSigner(id, secretKey);
 }
 
 
-static IThresholdFactory* createThresholdFactory(FILE* f, int n) 
-{
-	char buf[MAX_ITEM_LENGTH];
-	char * curveType = buf;
-	char cryptosys[MAX_ITEM_LENGTH];
+static IThresholdFactory* createThresholdFactory(FILE* f, int n) {
+  char buf[MAX_ITEM_LENGTH];
+  char * curveType = buf;
+  char cryptosys[MAX_ITEM_LENGTH];
 
-	ignoreOneLine(f);
-	readOneLine(f, MAX_ITEM_LENGTH, cryptosys);
-	readOneLine(f, MAX_ITEM_LENGTH, buf);
+  ignoreOneLine(f);
+  readOneLine(f, MAX_ITEM_LENGTH, cryptosys);
+  readOneLine(f, MAX_ITEM_LENGTH, buf);
 
-	if (strcmp(cryptosys, MULTISIG_BLS_SCHEME) == 0) {
-		return new BlsThresholdFactory(BLS::Relic::PublicParametersFactory::getByCurveType(curveType));
-	}
-	else if (strcmp(cryptosys, THRESHOLD_BLS_SCHEME) == 0) {
-		return new BlsThresholdFactory(BLS::Relic::PublicParametersFactory::getByCurveType(curveType));
-	}
-	else {		
-		printf("ERROR: Unsupported cryptosystem: %s\n", cryptosys);
-		throw std::runtime_error("ERROR: Unsupported cryptosystem");
-	}
+  if (strcmp(cryptosys, MULTISIG_BLS_SCHEME) == 0) {
+    return new BlsThresholdFactory(
+        BLS::Relic::PublicParametersFactory::getByCurveType(curveType));
+  } else if (strcmp(cryptosys, THRESHOLD_BLS_SCHEME) == 0) {
+    return new BlsThresholdFactory(
+        BLS::Relic::PublicParametersFactory::getByCurveType(curveType));
+  } else {
+    printf("ERROR: Unsupported cryptosystem: %s\n", cryptosys);
+    throw std::runtime_error("ERROR: Unsupported cryptosystem");
+  }
 }
 
-static IThresholdVerifier * createThresholdVerifier(FILE * f, int k, int n, IThresholdFactory* factory) {
-	char publicKey[MAX_ITEM_LENGTH];
-	char verifKey[MAX_ITEM_LENGTH];
+static IThresholdVerifier * createThresholdVerifier(
+    FILE * f, int k, int n, IThresholdFactory* factory) {
+  char publicKey[MAX_ITEM_LENGTH];
+  char verifKey[MAX_ITEM_LENGTH];
 
-	readOneLine(f, MAX_ITEM_LENGTH, publicKey);
+  readOneLine(f, MAX_ITEM_LENGTH, publicKey);
 
-	ignoreOneLine(f);
-	std::vector<std::string> verifKeys;
-	verifKeys.push_back("");    // signer 0 does not exist
-	for (int i = 0; i < n; i++)
-	{
-		readOneLine(f, MAX_ITEM_LENGTH, verifKey);
-		verifKeys.push_back(std::string(verifKey));
-	}
+  ignoreOneLine(f);
+  std::vector<std::string> verifKeys;
+  verifKeys.push_back("");  // signer 0 does not exist
+  for (int i = 0; i < n; i++) {
+    readOneLine(f, MAX_ITEM_LENGTH, verifKey);
+    verifKeys.push_back(std::string(verifKey));
+  }
 
-	// Ignore last comment/empty line
-	ignoreOneLine(f);
+  // Ignore last comment/empty line
+  ignoreOneLine(f);
 
-	return factory->newVerifier(k, n, publicKey, verifKeys);
+  return factory->newVerifier(k, n, publicKey, verifKeys);
 }
 
 
 static void ignoreThresholdSigner(FILE * f) {
-	ignoreOneLine(f);
-	ignoreOneLine(f);
+  ignoreOneLine(f);
+  ignoreOneLine(f);
 }
 
 
-static bool parseReplicaConfig(uint16_t replicaId, FILE* publicKeysFile, FILE* privateKeysFile, ReplicaConfig& outConfig)
-{
+static bool parseReplicaConfig(uint16_t replicaId,
+                               FILE* publicKeysFile,
+                               FILE* privateKeysFile,
+                               ReplicaConfig& outConfig) {
+  int tempInt = 0;
+  char tempString[MAX_ITEM_LENGTH];
 
-	int tempInt = 0;
-	char tempString[MAX_ITEM_LENGTH];
+  std::set <pair<uint16_t, string>> publicKeysOfReplicas;
 
-	std::set <pair<uint16_t, string>> publicKeysOfReplicas;
+  // read from publicKeysFile
 
-	// read from publicKeysFile
+  for (int i = 0; i < numOfReplicas; i++) {
+    fscanf(publicKeysFile, "%" MAX_ITEM_LENGTH_STR "s\n", tempString);
 
-	for (int i = 0; i < numOfReplicas; i++)
-	{
-		fscanf(publicKeysFile, "%" MAX_ITEM_LENGTH_STR "s\n", tempString);
+    string name(tempString);
 
-		string name(tempString);
+    string expectedName = string("replica") + std::to_string(i);
 
-		string expectedName = string("replica") + std::to_string(i);
+    if (expectedName != name) return false;
 
-		if (expectedName != name) return false;
+    fscanf(publicKeysFile, "%" MAX_ITEM_LENGTH_STR "s\n", tempString);
 
-		fscanf(publicKeysFile, "%" MAX_ITEM_LENGTH_STR "s\n", tempString);
+    string publicKeyString(tempString);
 
-		string publicKeyString(tempString);
+    publicKeysOfReplicas.insert({i, publicKeyString});
+  }
 
-		publicKeysOfReplicas.insert({i, publicKeyString});
-	}
+  // Read threshold signatures
+  IThresholdFactory* slowCommitFactory = nullptr;
+  IThresholdSigner* thresholdSignerForSlowPathCommit = nullptr;
+  IThresholdVerifier* thresholdVerifierForSlowPathCommit = nullptr;
 
-	// Read threshold signatures
-	IThresholdFactory* slowCommitFactory = nullptr;
-	IThresholdSigner* thresholdSignerForSlowPathCommit = nullptr;
-	IThresholdVerifier* thresholdVerifierForSlowPathCommit = nullptr;
+  IThresholdFactory* optimisticCommitFactory = nullptr;
+  IThresholdSigner* thresholdSignerForOptimisticCommit = nullptr;
+  IThresholdVerifier* thresholdVerifierForOptimisticCommit = nullptr;
 
-	IThresholdFactory* optimisticCommitFactory = nullptr;
-	IThresholdSigner* thresholdSignerForOptimisticCommit = nullptr;
-	IThresholdVerifier* thresholdVerifierForOptimisticCommit = nullptr;
+  slowCommitFactory = createThresholdFactory(publicKeysFile, numOfReplicas);
+  thresholdVerifierForSlowPathCommit =
+      createThresholdVerifier(publicKeysFile,
+                              numOfReplicas - fVal,
+                              numOfReplicas,
+                              slowCommitFactory);
 
-	slowCommitFactory = createThresholdFactory(publicKeysFile, numOfReplicas);
-	thresholdVerifierForSlowPathCommit = createThresholdVerifier(publicKeysFile, numOfReplicas - fVal, numOfReplicas, slowCommitFactory);
+  optimisticCommitFactory = createThresholdFactory(publicKeysFile,
+                                                   numOfReplicas);
+  thresholdVerifierForOptimisticCommit =
+      createThresholdVerifier(publicKeysFile,
+                              numOfReplicas,
+                              numOfReplicas,
+                              optimisticCommitFactory);
 
-	optimisticCommitFactory = createThresholdFactory(publicKeysFile, numOfReplicas);
-	thresholdVerifierForOptimisticCommit = createThresholdVerifier(publicKeysFile, numOfReplicas, numOfReplicas, optimisticCommitFactory);
+  // read from privateKeysFile
 
-	// read from privateKeysFile
+  fscanf(privateKeysFile, "%d\n", &tempInt);
+  if (tempInt != replicaId) return false;
 
-	fscanf(privateKeysFile, "%d\n", &tempInt);
-	if (tempInt != replicaId) return false;
+  fscanf(privateKeysFile, "%" MAX_ITEM_LENGTH_STR "s\n", tempString);
 
-	fscanf(privateKeysFile, "%" MAX_ITEM_LENGTH_STR "s\n", tempString);
+  string sigPrivateKey(tempString);
 
-	string sigPrivateKey(tempString);
+  thresholdSignerForSlowPathCommit =
+      createThresholdSigner(privateKeysFile, replicaId+1, slowCommitFactory);
 
-	thresholdSignerForSlowPathCommit = createThresholdSigner(privateKeysFile, replicaId+1, slowCommitFactory);
-	
-	thresholdSignerForOptimisticCommit = createThresholdSigner(privateKeysFile, replicaId+1, optimisticCommitFactory);
+  thresholdSignerForOptimisticCommit =
+      createThresholdSigner(privateKeysFile,
+                            replicaId+1,
+                            optimisticCommitFactory);
 
-	delete slowCommitFactory;
-	delete optimisticCommitFactory;
+  delete slowCommitFactory;
+  delete optimisticCommitFactory;
 
-	// set configuration
+  // set configuration
 
-	outConfig.replicaId = replicaId;
-	outConfig.fVal = 1;
-	outConfig.cVal = 0;
-	outConfig.numOfClientProxies = 1;
-	outConfig.statusReportTimerMillisec = 2000;
-	outConfig.concurrencyLevel = 1;
-	outConfig.autoViewChangeEnabled = false;
-	outConfig.viewChangeTimerMillisec = 60000;
+  outConfig.replicaId = replicaId;
+  outConfig.fVal = 1;
+  outConfig.cVal = 0;
+  outConfig.numOfClientProxies = 1;
+  outConfig.statusReportTimerMillisec = 2000;
+  outConfig.concurrencyLevel = 1;
+  outConfig.autoViewChangeEnabled = false;
+  outConfig.viewChangeTimerMillisec = 60000;
 
-	outConfig.publicKeysOfReplicas = publicKeysOfReplicas;
-	outConfig.replicaPrivateKey = sigPrivateKey;
+  outConfig.publicKeysOfReplicas = publicKeysOfReplicas;
+  outConfig.replicaPrivateKey = sigPrivateKey;
 
-	outConfig.thresholdSignerForExecution = nullptr;
-	outConfig.thresholdVerifierForExecution = nullptr;
-	
-	outConfig.thresholdSignerForSlowPathCommit = thresholdSignerForSlowPathCommit;
-	outConfig.thresholdVerifierForSlowPathCommit = thresholdVerifierForSlowPathCommit;
-	
-	outConfig.thresholdSignerForCommit = nullptr;
-	outConfig.thresholdVerifierForCommit = nullptr;
-	
-	outConfig.thresholdSignerForOptimisticCommit = thresholdSignerForOptimisticCommit;
-	outConfig.thresholdVerifierForOptimisticCommit = thresholdVerifierForOptimisticCommit;
+  outConfig.thresholdSignerForExecution = nullptr;
+  outConfig.thresholdVerifierForExecution = nullptr;
 
-	return true;
+  outConfig.thresholdSignerForSlowPathCommit =
+      thresholdSignerForSlowPathCommit;
+  outConfig.thresholdVerifierForSlowPathCommit =
+      thresholdVerifierForSlowPathCommit;
+
+  outConfig.thresholdSignerForCommit = nullptr;
+  outConfig.thresholdVerifierForCommit = nullptr;
+
+  outConfig.thresholdSignerForOptimisticCommit =
+      thresholdSignerForOptimisticCommit;
+  outConfig.thresholdVerifierForOptimisticCommit =
+      thresholdVerifierForOptimisticCommit;
+
+  return true;
 }
 
-void getReplicaConfig(uint16_t replicaId, ReplicaConfig& outConfig)
-{
-	FILE* publicKeysFile = fopen(nameOfPublicFile, "r");
-	if (!publicKeysFile) 
-		throw std::runtime_error("Unable to read public keys");
+void getReplicaConfig(uint16_t replicaId, ReplicaConfig& outConfig) {
+  FILE* publicKeysFile = fopen(nameOfPublicFile, "r");
+  if (!publicKeysFile)
+    throw std::runtime_error("Unable to read public keys");
 
-	FILE* privateKeysFile = fopen(namesOfPrivateFiles[replicaId], "r");
-	if (!privateKeysFile) 
-		throw std::runtime_error("Unable to read private keys");
+  FILE* privateKeysFile = fopen(namesOfPrivateFiles[replicaId], "r");
+  if (!privateKeysFile)
+    throw std::runtime_error("Unable to read private keys");
 
-	bool succ = parseReplicaConfig(replicaId, publicKeysFile, privateKeysFile, outConfig);
-	if (!succ)
-		throw std::runtime_error("Unable to parse configuration");
+  bool succ = parseReplicaConfig(
+      replicaId, publicKeysFile, privateKeysFile, outConfig);
+  if (!succ)
+    throw std::runtime_error("Unable to parse configuration");
 }
 
-PlainUdpConfig getUDPConfig(uint16_t id)
-{
-	std::string ip = "127.0.0.1";
-	uint16_t port = basePort + id*2;
-	uint32_t bufLength = 64000;
+PlainUdpConfig getUDPConfig(uint16_t id) {
+  std::string ip = "127.0.0.1";
+  uint16_t port = basePort + id*2;
+  uint32_t bufLength = 64000;
 
-	std::unordered_map <NodeNum, std::tuple<std::string, uint16_t>> nodes;
-	for (int i = 0; i < (numOfReplicas+1); i++)
-		nodes.insert({ i, std::make_tuple(ip, basePort + i*2) });
-	
-	PlainUdpConfig retVal(ip, port, bufLength, nodes);
-	
-	return retVal;
+  std::unordered_map <NodeNum, std::tuple<std::string, uint16_t>> nodes;
+  for (int i = 0; i < (numOfReplicas+1); i++)
+    nodes.insert({ i, std::make_tuple(ip, basePort + i*2) });
+
+  PlainUdpConfig retVal(ip, port, bufLength, nodes);
+
+  return retVal;
 }

--- a/bftengine/tests/simpleTest/config.cpp
+++ b/bftengine/tests/simpleTest/config.cpp
@@ -11,12 +11,16 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <utility>
+#include <set>
 #include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "CommFactory.hpp"
 #include "ReplicaConfig.hpp"
-#include <threshsign/ThresholdSignaturesSchemes.h>
+#include "threshsign/ThresholdSignaturesSchemes.h"
 
 using bftEngine::PlainUdpConfig;
 using bftEngine::ReplicaConfig;

--- a/bftengine/tests/simpleTest/config.cpp
+++ b/bftengine/tests/simpleTest/config.cpp
@@ -1,3 +1,16 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
 #include <utility>
 #include <string>
 

--- a/bftengine/tests/simpleTest/config.cpp
+++ b/bftengine/tests/simpleTest/config.cpp
@@ -18,10 +18,11 @@
 #include "ReplicaConfig.hpp"
 #include <threshsign/ThresholdSignaturesSchemes.h>
 
+using bftEngine::PlainUdpConfig;
+using bftEngine::ReplicaConfig;
 using BLS::Relic::BlsThresholdFactory;
-using namespace std;
-using namespace bftEngine;
-
+using std::pair;
+using std::string;
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/bftengine/tests/simpleTest/config.cpp
+++ b/bftengine/tests/simpleTest/config.cpp
@@ -125,7 +125,7 @@ static void ignoreThresholdSigner(FILE * f) {
 static bool parseReplicaConfig(uint16_t replicaId,
                                FILE* publicKeysFile,
                                FILE* privateKeysFile,
-                               ReplicaConfig& outConfig) {
+                               ReplicaConfig* outConfig) {
   int tempInt = 0;
   char tempString[MAX_ITEM_LENGTH];
 
@@ -195,38 +195,38 @@ static bool parseReplicaConfig(uint16_t replicaId,
 
   // set configuration
 
-  outConfig.replicaId = replicaId;
-  outConfig.fVal = 1;
-  outConfig.cVal = 0;
-  outConfig.numOfClientProxies = 1;
-  outConfig.statusReportTimerMillisec = 2000;
-  outConfig.concurrencyLevel = 1;
-  outConfig.autoViewChangeEnabled = false;
-  outConfig.viewChangeTimerMillisec = 60000;
+  outConfig->replicaId = replicaId;
+  outConfig->fVal = 1;
+  outConfig->cVal = 0;
+  outConfig->numOfClientProxies = 1;
+  outConfig->statusReportTimerMillisec = 2000;
+  outConfig->concurrencyLevel = 1;
+  outConfig->autoViewChangeEnabled = false;
+  outConfig->viewChangeTimerMillisec = 60000;
 
-  outConfig.publicKeysOfReplicas = publicKeysOfReplicas;
-  outConfig.replicaPrivateKey = sigPrivateKey;
+  outConfig->publicKeysOfReplicas = publicKeysOfReplicas;
+  outConfig->replicaPrivateKey = sigPrivateKey;
 
-  outConfig.thresholdSignerForExecution = nullptr;
-  outConfig.thresholdVerifierForExecution = nullptr;
+  outConfig->thresholdSignerForExecution = nullptr;
+  outConfig->thresholdVerifierForExecution = nullptr;
 
-  outConfig.thresholdSignerForSlowPathCommit =
+  outConfig->thresholdSignerForSlowPathCommit =
       thresholdSignerForSlowPathCommit;
-  outConfig.thresholdVerifierForSlowPathCommit =
+  outConfig->thresholdVerifierForSlowPathCommit =
       thresholdVerifierForSlowPathCommit;
 
-  outConfig.thresholdSignerForCommit = nullptr;
-  outConfig.thresholdVerifierForCommit = nullptr;
+  outConfig->thresholdSignerForCommit = nullptr;
+  outConfig->thresholdVerifierForCommit = nullptr;
 
-  outConfig.thresholdSignerForOptimisticCommit =
+  outConfig->thresholdSignerForOptimisticCommit =
       thresholdSignerForOptimisticCommit;
-  outConfig.thresholdVerifierForOptimisticCommit =
+  outConfig->thresholdVerifierForOptimisticCommit =
       thresholdVerifierForOptimisticCommit;
 
   return true;
 }
 
-void getReplicaConfig(uint16_t replicaId, ReplicaConfig& outConfig) {
+void getReplicaConfig(uint16_t replicaId, ReplicaConfig* outConfig) {
   FILE* publicKeysFile = fopen(nameOfPublicFile, "r");
   if (!publicKeysFile)
     throw std::runtime_error("Unable to read public keys");

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -41,16 +41,16 @@ class SimpleAppState : public RequestsHandler {
     if (readOnly) {
       // read-only request
       assert(requestSize == sizeof(uint64_t));
-      const uint64_t reqId = *((uint64_t*)request);
+      const uint64_t reqId = *reinterpret_cast<const uint64_t*>(request);
       assert(reqId == READ_VAL_REQ);
 
       assert(maxReplySize >= sizeof(uint64_t));
-      uint64_t* pRet = (uint64_t*)outReply;
+      uint64_t* pRet = reinterpret_cast<uint64_t*>(outReply);
       *pRet = lastValue;
       outActualReplySize = sizeof(uint64_t);
     } else {
       assert(requestSize == 2 * sizeof(uint64_t));
-      const uint64_t* pReqId = (uint64_t*)request;
+      const uint64_t* pReqId = reinterpret_cast<const uint64_t*>(request);
       assert(*pReqId == SET_VAL_REQ);
       const uint64_t* pReqVal = (pReqId + 1);
 
@@ -58,7 +58,7 @@ class SimpleAppState : public RequestsHandler {
       lastValue = *pReqVal;
 
       assert(maxReplySize >= sizeof(uint64_t));
-      uint64_t* pRet = (uint64_t*)outReply;
+      uint64_t* pRet = reinterpret_cast<uint64_t*>(outReply);
       *pRet = stateNum;
       outActualReplySize = sizeof(uint64_t);
     }

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -1,3 +1,16 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
 #include <stdio.h>
 #include <string.h>
 #include <cassert>

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -31,13 +31,13 @@ PlainUdpConfig getUDPConfig(uint16_t id);
 
 class SimpleAppState : public RequestsHandler {
  public:
-  virtual int execute(uint16_t clientId,
-                      bool readOnly,
-                      uint32_t requestSize,
-                      const char* request,
-                      uint32_t maxReplySize,
-                      char* outReply,
-                      uint32_t& outActualReplySize) override {
+  int execute(uint16_t clientId,
+              bool readOnly,
+              uint32_t requestSize,
+              const char* request,
+              uint32_t maxReplySize,
+              char* outReply,
+              uint32_t& outActualReplySize) override {
     if (readOnly) {
       // read-only request
       assert(requestSize == sizeof(uint64_t));

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -26,7 +26,7 @@
 using namespace std;
 using namespace bftEngine;
 
-void getReplicaConfig(uint16_t replicaId, bftEngine::ReplicaConfig& outConfig);
+void getReplicaConfig(uint16_t replicaId, bftEngine::ReplicaConfig* outConfig);
 PlainUdpConfig getUDPConfig(uint16_t id);
 
 class SimpleAppState : public RequestsHandler {
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
   if (id >= 4) throw std::runtime_error("Illegal replica id");
 
   ReplicaConfig replicaConfig;
-  getReplicaConfig(id, replicaConfig);
+  getReplicaConfig(id, &replicaConfig);
 
   PlainUdpConfig udpConf = getUDPConfig(id);
 

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <thread>
 
-#include "CommFactory.hpp" 
+#include "CommFactory.hpp"
 #include "ReplicaConfig.hpp"
 
 #include "commonDefs.h"
@@ -16,69 +16,73 @@ using namespace bftEngine;
 void getReplicaConfig(uint16_t replicaId, bftEngine::ReplicaConfig& outConfig);
 PlainUdpConfig getUDPConfig(uint16_t id);
 
-class SimpleAppState : public RequestsHandler
-{
-public:
-	virtual int execute(uint16_t clientId, bool readOnly, uint32_t requestSize, const char* request, uint32_t maxReplySize, char* outReply, uint32_t& outActualReplySize) override
-	{
-		if (readOnly) // read-only request
-		{
-			assert(requestSize == sizeof(uint64_t));
-			const uint64_t reqId = *((uint64_t*)request);
-			assert(reqId == READ_VAL_REQ);
+class SimpleAppState : public RequestsHandler {
+ public:
+  virtual int execute(uint16_t clientId,
+                      bool readOnly,
+                      uint32_t requestSize,
+                      const char* request,
+                      uint32_t maxReplySize,
+                      char* outReply,
+                      uint32_t& outActualReplySize) override {
+    if (readOnly) {
+      // read-only request
+      assert(requestSize == sizeof(uint64_t));
+      const uint64_t reqId = *((uint64_t*)request);
+      assert(reqId == READ_VAL_REQ);
 
-			assert(maxReplySize >= sizeof(uint64_t));
-			uint64_t* pRet = (uint64_t*)outReply;
-			*pRet = lastValue;
-			outActualReplySize = sizeof(uint64_t);
-		}
-		else // read-write request
-		{
-			assert(requestSize == 2 * sizeof(uint64_t));
-			const uint64_t* pReqId = (uint64_t*)request;
-			assert(*pReqId == SET_VAL_REQ);
-			const uint64_t* pReqVal = (pReqId + 1);
+      assert(maxReplySize >= sizeof(uint64_t));
+      uint64_t* pRet = (uint64_t*)outReply;
+      *pRet = lastValue;
+      outActualReplySize = sizeof(uint64_t);
+    } else {
+      assert(requestSize == 2 * sizeof(uint64_t));
+      const uint64_t* pReqId = (uint64_t*)request;
+      assert(*pReqId == SET_VAL_REQ);
+      const uint64_t* pReqVal = (pReqId + 1);
 
-			stateNum++;
-			lastValue = *pReqVal;
+      stateNum++;
+      lastValue = *pReqVal;
 
-			assert(maxReplySize >= sizeof(uint64_t));
-			uint64_t* pRet = (uint64_t*)outReply;
-			*pRet = stateNum;
-			outActualReplySize = sizeof(uint64_t);
-		}
+      assert(maxReplySize >= sizeof(uint64_t));
+      uint64_t* pRet = (uint64_t*)outReply;
+      *pRet = stateNum;
+      outActualReplySize = sizeof(uint64_t);
+    }
 
-		return 0;
-	}
+    return 0;
+  }
 
-protected:
-	// state
-	uint64_t stateNum = 0;
-	uint64_t lastValue = 0;
+ protected:
+  // state
+  uint64_t stateNum = 0;
+  uint64_t lastValue = 0;
 };
 
-int main(int argc, char **argv) 
-{
-	if (argc < 2) throw std::runtime_error("Unable to read replica id");
-	uint16_t id = (argv[1][0] - '0');
-	if (id >= 4) throw std::runtime_error("Illegal replica id");
+int main(int argc, char **argv) {
+  if (argc < 2) throw std::runtime_error("Unable to read replica id");
+  uint16_t id = (argv[1][0] - '0');
+  if (id >= 4) throw std::runtime_error("Illegal replica id");
 
-	ReplicaConfig replicaConfig;
-	getReplicaConfig(id, replicaConfig);
+  ReplicaConfig replicaConfig;
+  getReplicaConfig(id, replicaConfig);
 
-	PlainUdpConfig udpConf = getUDPConfig(id);
-	
+  PlainUdpConfig udpConf = getUDPConfig(id);
 
-	ICommunication* comm = PlainUDPCommunication::create(udpConf);
+  ICommunication* comm = PlainUDPCommunication::create(udpConf);
 
-	SimpleAppState simpleAppState;
+  SimpleAppState simpleAppState;
 
-	Replica* replica = Replica::createNewReplica(&replicaConfig, &simpleAppState, nullptr, comm, nullptr);
+  Replica* replica = Replica::createNewReplica(&replicaConfig,
+                                               &simpleAppState,
+                                               nullptr,
+                                               comm,
+                                               nullptr);
 
-	replica->start();
+  replica->start();
 
-	// wait forever...
-	while (true) std::this_thread::sleep_for(std::chrono::seconds(1)); 
-	
-	return 0;
+  // wait forever...
+  while (true) std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  return 0;
 }

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -23,8 +23,12 @@
 #include "commonDefs.h"
 #include "Replica.hpp"
 
-using namespace std;
-using namespace bftEngine;
+using bftEngine::ICommunication;
+using bftEngine::PlainUDPCommunication;
+using bftEngine::PlainUdpConfig;
+using bftEngine::Replica;
+using bftEngine::ReplicaConfig;
+using bftEngine::RequestsHandler;
 
 void getReplicaConfig(uint16_t replicaId, bftEngine::ReplicaConfig* outConfig);
 PlainUdpConfig getUDPConfig(uint16_t id);

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -11,17 +11,55 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <stdio.h>
-#include <string.h>
+// This replica implements a single unsigned 64-bit register. Supported
+// operations are:
+//
+//  1. Read the last value of the register.
+//  2. Set the value of the register.
+//
+// Requests are given as either eight or sixteen byte strings. The first eight
+// bytes of a requests specifies the type of the request, and the optional
+// additional eight bytes specifies the parameters.
+//
+// # Read Operation
+//
+// Request bytes must be equal to `(uint64_t)100`.
+//
+// Response bytes will be equal to `(uint64_t)value`, where `value` is the value
+// that was last written to the register.
+//
+// # Write Operation
+//
+// Request bytes must be equal to `(uint64_t)200` followed by `(uint64_t)value`,
+// where `value` is the value to write to the register.
+//
+// Response bytes will be equal to `(uint64_t)sequence_number`, where
+// `sequence_number` is the count of how many times the register has been
+// written to (including this write, so the first response will be `1`).
+//
+// # Notes
+//
+// Endianness is not specified. All replicas are assumed to use the same
+// native endianness.
+//
+// The read request must be specified as readOnly. (See
+// bftEngine::SimpleClient::sendRequest.)
+//
+// Values for request types (the `100` and `200` mentioned above) are defined in
+// commonDefs.h
+//
+// See the `scripts/` directory for information about how to run the replicas.
+
 #include <cassert>
-#include <string>
 #include <thread>
 
+// bftEngine includes
 #include "CommFactory.hpp"
+#include "Replica.hpp"
 #include "ReplicaConfig.hpp"
 
+// simpleTest includes
 #include "commonDefs.h"
-#include "Replica.hpp"
 
 using bftEngine::ICommunication;
 using bftEngine::PlainUDPCommunication;
@@ -30,11 +68,14 @@ using bftEngine::Replica;
 using bftEngine::ReplicaConfig;
 using bftEngine::RequestsHandler;
 
+// Declarations of functions from config.cpp.
 void getReplicaConfig(uint16_t replicaId, bftEngine::ReplicaConfig* outConfig);
 PlainUdpConfig getUDPConfig(uint16_t id);
 
+// The replica state machine.
 class SimpleAppState : public RequestsHandler {
  public:
+  // Handler for the upcall from Concord-BFT.
   int execute(uint16_t clientId,
               bool readOnly,
               uint32_t requestSize,
@@ -43,24 +84,36 @@ class SimpleAppState : public RequestsHandler {
               char* outReply,
               uint32_t& outActualReplySize) override {
     if (readOnly) {
-      // read-only request
+      // Our read-only request includes only a type, no argument.
       assert(requestSize == sizeof(uint64_t));
+
+      // We only support the READ operation in read-only mode.
       const uint64_t reqId = *reinterpret_cast<const uint64_t*>(request);
       assert(reqId == READ_VAL_REQ);
 
+      // Copy the latest register value to the reply buffer.
       assert(maxReplySize >= sizeof(uint64_t));
       uint64_t* pRet = reinterpret_cast<uint64_t*>(outReply);
       *pRet = lastValue;
       outActualReplySize = sizeof(uint64_t);
     } else {
+      // Our read-write request includes one eight-byte argument, in addition to
+      // the request type.
       assert(requestSize == 2 * sizeof(uint64_t));
+
+      // We only support the WRITE operation in read-write mode.
       const uint64_t* pReqId = reinterpret_cast<const uint64_t*>(request);
       assert(*pReqId == SET_VAL_REQ);
+
+      // The value to write is the second eight bytes of the request.
       const uint64_t* pReqVal = (pReqId + 1);
 
-      stateNum++;
+      // Modify the register state.
       lastValue = *pReqVal;
+      // Count the number of times we've modified it.
+      stateNum++;
 
+      // Reply with the number of times we've modified the register.
       assert(maxReplySize >= sizeof(uint64_t));
       uint64_t* pRet = reinterpret_cast<uint64_t*>(outReply);
       *pRet = stateNum;
@@ -71,12 +124,16 @@ class SimpleAppState : public RequestsHandler {
   }
 
  protected:
-  // state
+  // Number of modifications made.
   uint64_t stateNum = 0;
+  // Register value.
   uint64_t lastValue = 0;
 };
 
 int main(int argc, char **argv) {
+  // This program expects one argument: the index number of the replica being
+  // started. This index is used to choose the correct config files (which
+  // choose the correct keys, ports, etc.).
   if (argc < 2) throw std::runtime_error("Unable to read replica id");
   uint16_t id = (argv[1][0] - '0');
   if (id >= 4) throw std::runtime_error("Illegal replica id");
@@ -88,6 +145,7 @@ int main(int argc, char **argv) {
 
   ICommunication* comm = PlainUDPCommunication::create(udpConf);
 
+  // This is the state machine that the replica will drive.
   SimpleAppState simpleAppState;
 
   Replica* replica = Replica::createNewReplica(&replicaConfig,
@@ -98,7 +156,8 @@ int main(int argc, char **argv) {
 
   replica->start();
 
-  // wait forever...
+  // The replica is now running in its own thread. Block the main thread forever
+  // while that one handles requests in the background.
   while (true) std::this_thread::sleep_for(std::chrono::seconds(1));
 
   return 0;


### PR DESCRIPTION
This PR cleans up and documents the sampleTest example in three parts:

 1. e95fb1e: whitespace and line length changes required by cpplint
 2. [0002819 through 89d4bae](https://github.com/vmware/concord-bft/pull/3/files/e95fb1e38234ea18ef308c2e1c33b6f59b9a38e6..89d4bae776ed08b466c8e4ef72ac17eab7f46ca3): code style changes required by cpplint
 3. [53bf22f through 4679ef2b](https://github.com/vmware/concord-bft/pull/3/files/89d4bae776ed08b466c8e4ef72ac17eab7f46ca3..469ef2b716db10dcadd17ca8c15fc06c6f4cfc41): actual documentation and light refactoring for clarification

Notes:

 * I've also added a section in CONTRIBUTING.md to explain that we're planning to follow cpplint guidelines.
 * This change uncovered an incompatibility we have with cpplint: it forbids use of the standard `thread` include. This is because cpplint is tailored to the Chromium codebase, which has replacements for `thread`. This means we should probably fork cpplint and re-customize it for Concord.