### PR TITLE
Fix #10, implement #1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 .idea
 cmake-build-debug/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,21 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 
 set(IS_LEAKCHECK FALSE)
-set(BUILD_COMM_TCP_PLAIN FALSE)
 set(BUILD_COMM_TCP_TLS FALSE)
 set(SLEEP_FOR_DBG FALSE)
 
-if(BUILD_COMM_TCP_PLAIN)
-    add_definitions(-DUSE_COMM_PLAIN_TCP)
+#if not set to TRUE by the app, set from here
+if(NOT USE_LOG4CPP)
+    set(USE_LOG4CPP FALSE)
 endif()
+if(NOT BUILD_COMM_TCP_PLAIN)
+    set(BUILD_COMM_TCP_PLAIN FALSE)
+endif()
+
+if(NOT CONCORD_LOGGER_NAME)
+    set(CONCORD_LOGGER_NAME "concord")
+endif()
+
 if(SLEEP_FOR_DBG)
     add_definitions(-DSLEEP_DBG)
 endif()
@@ -26,7 +34,6 @@ endif()
 #
 # Compiler options
 #
-
 # 
 
 string(APPEND CXX_FLAGS " -Wall")
@@ -99,5 +106,6 @@ endif()
 #
 # Subdirectories
 #
+add_subdirectory(logging)
 add_subdirectory(threshsign)
 add_subdirectory(bftengine)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,62 @@ Get g++:
 
     sudo apt-get install g++
 
+(Optional) Use log4cplus
+
+    We have simple console logger but if you wish to use log4cplus - we have an
+    infra that supports it.
+
+    Follow below steps for installing this library:
+
+    1. Install prerequisites.
+    ```
+    sudo apt-get install autoconf automake
+    ```
+
+    2. Clone the repository.
+
+    ```
+    git clone https://github.com/log4cplus/log4cplus.git
+    ```
+
+    3. Move to the extracted directory and checkout the appropriate branch.
+
+    ```
+    cd log4cplus
+    git checkout REL_1_2_1
+    ````
+
+    4. Edit `configure` to change "am__api_version" from 1.14 to 1.15, the
+    version that ubuntu 16.04 supports.
+
+    5. Configure/make/install
+
+    ```
+    ./configure CXXFLAGS="--std=c++11"
+    make
+    sudo make install
+    ```
+    configuring with given flags is important. If log4cplus is build without `c++11` then athena will
+    give linker errors while building.
+
+    This will install all library files and header files into
+    '/usr/local'. (You may need to add `/usr/local/lib` to your
+    `LD_LIBRARY_PATH` to run Athena.)
+    You may also need to export CPLUS_INCLUDE_PATH variable set to
+    /usr/local/include for the header files
+
+    After installation, set USE_LOG4CPP flag to TRUE in the main CmakeLists.txt
+    The library doesn't config the log4cpp formats and appenders, it expects
+    that the upper level application will do it and the log4cpp system is
+    already initialized.
+
+### Select comm module
+    We support both UDP and TCP communication (UDP is the default one).
+    In the main Cmake file please set BUILD_COMM_TCP_PLAIN flag to TRUE to
+    build TCP - then the test client we use will run using TCP. If you wish to
+    use TCP in your application, you need to build the TCP module as mentioned
+    above and then create the communication object using CommFactory
+    and passing PlainTcpConfig object to it.
 
 ### Build concord-bft
 

--- a/README.md
+++ b/README.md
@@ -117,62 +117,56 @@ Get g++:
 
     sudo apt-get install g++
 
-(Optional) Use log4cplus
+#### (Optional) Use log4cplus
 
-    We have simple console logger but if you wish to use log4cplus - we have an
-    infra that supports it.
+We have simple console logger but if you wish to use log4cplus - we have an
+infra that supports it.
 
-    Follow below steps for installing this library:
+Follow below steps for installing this library:
+1. Install prerequisites:
 
-    1. Install prerequisites.
-    ```
+```
     sudo apt-get install autoconf automake
-    ```
+```
 
-    2. Clone the repository.
+2. Clone the repository:
 
-    ```
+```
     git clone https://github.com/log4cplus/log4cplus.git
-    ```
+```
 
-    3. Move to the extracted directory and checkout the appropriate branch.
+3. Move to the extracted directory and checkout the appropriate branch:
 
-    ```
+```
     cd log4cplus
     git checkout REL_1_2_1
-    ````
+```
 
-    4. Edit `configure` to change "am__api_version" from 1.14 to 1.15, the
-    version that ubuntu 16.04 supports.
+4. Edit `configure` to change "am__api_version" from 1.14 to 1.15, the
+version that ubuntu 16.04 supports.
 
-    5. Configure/make/install
+5. Configure/make/install
 
-    ```
+```
     ./configure CXXFLAGS="--std=c++11"
     make
     sudo make install
-    ```
-    configuring with given flags is important. If log4cplus is build without `c++11` then athena will
-    give linker errors while building.
+```
 
-    This will install all library files and header files into
-    '/usr/local'. (You may need to add `/usr/local/lib` to your
-    `LD_LIBRARY_PATH` to run Athena.)
-    You may also need to export CPLUS_INCLUDE_PATH variable set to
-    /usr/local/include for the header files
+Configuring with these flags is important. If log4cplus is build without `c++11` then athena will give linker errors while building.
 
-    After installation, set USE_LOG4CPP flag to TRUE in the main CmakeLists.txt
-    The library doesn't config the log4cpp formats and appenders, it expects
-    that the upper level application will do it and the log4cpp system is
-    already initialized.
+At this point all library files and header files should be installed into `/usr/local`. (You may need to add `/usr/local/lib` to your `LD_LIBRARY_PATH`).
+You may also need to export CPLUS_INCLUDE_PATH variable set to /usr/local/include for the header files.
+
+After installation, set USE_LOG4CPP flag to TRUE in the main CmakeLists.txt . The library doesn't initialize the log4cpp subsystem, including formats and appenders, it expects that the upper level application will do it and the log4cpp subsystem is already initialized.
 
 ### Select comm module
-    We support both UDP and TCP communication (UDP is the default one).
-    In the main Cmake file please set BUILD_COMM_TCP_PLAIN flag to TRUE to
-    build TCP - then the test client we use will run using TCP. If you wish to
-    use TCP in your application, you need to build the TCP module as mentioned
-    above and then create the communication object using CommFactory
-    and passing PlainTcpConfig object to it.
+We support both UDP and TCP communication (UDP is the default one).
+In the main Cmake file please set BUILD_COMM_TCP_PLAIN flag to TRUE to
+build TCP - then the test client we use will run using TCP. If you wish to
+use TCP in your application, you need to build the TCP module as mentioned
+above and then create the communication object using CommFactory
+and passing PlainTcpConfig object to it.
 
 ### Build concord-bft
 

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -1,3 +1,6 @@
+get_property(LOGGER_INC_DIR GLOBAL PROPERTY LoggerIncludeDir)
+get_property(LOGGER_SRC_DIR GLOBAL PROPERTY LoggerSrcDir)
+
 set(corebft_source_files
     src/bftengine/PrePrepareMsg.cpp
     src/bftengine/CheckpointMsg.cpp
@@ -41,13 +44,15 @@ set(corebft_source_files
     src/bftengine/SimpleClient.cpp
     src/communication/PlainUDPCommunication.cpp
     src/communication/CommFactory.cpp
+    ${LOGGER_INC_DIR}/Logging.hpp
+    ${LOGGER_SRC_DIR}/Logging.cpp
 )
 #
 # pthread dependency
 find_package(Threads REQUIRED)
 #message("Threads library: ${CMAKE_THREAD_LIBS_INIT}")
 
-if(BUILD_COMM_TCP_PLAIN)
+if(${BUILD_COMM_TCP_PLAIN})
     set(corebft_source_files ${corebft_source_files} src/communication/PlainTcpCommunication.cpp src/communication/CommFactory.cpp)
 endif()
 
@@ -56,7 +61,7 @@ endif()
 #
 add_library(corebft STATIC ${corebft_source_files})
 
-if(BUILD_COMM_TCP_PLAIN)
+if(${BUILD_COMM_TCP_PLAIN})
     set(Boost_USE_STATIC_LIBS        ON) # only find static libs
     set(Boost_USE_MULTITHREADED      ON)
     set(Boost_USE_STATIC_RUNTIME    OFF)
@@ -65,10 +70,19 @@ if(BUILD_COMM_TCP_PLAIN)
         include_directories(${Boost_INCLUDE_DIRS})
         target_link_libraries(corebft PUBLIC ${Boost_LIBRARIES})
     endif()
+    target_compile_definitions(corebft PUBLIC USE_COMM_PLAIN_TCP)
+endif()
+
+TARGET_COMPILE_DEFINITIONS(corebft PUBLIC
+        DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}")
+if(${USE_LOG4CPP})
+    TARGET_COMPILE_DEFINITIONS(corebft PUBLIC USE_LOG4CPP)
+    target_link_libraries(corebft PUBLIC log4cplus)
 endif()
 
 target_include_directories(corebft PUBLIC include/bftengine)
 target_include_directories(corebft PUBLIC include/communication)
+target_include_directories(corebft PUBLIC ${LOGGER_INC_DIR})
 
 target_link_libraries(corebft PUBLIC threshsign)
 target_link_libraries(corebft PUBLIC Threads::Threads)

--- a/bftengine/include/communication/CommFactory.hpp
+++ b/bftengine/include/communication/CommFactory.hpp
@@ -14,12 +14,13 @@
 #ifndef BFTENGINE_INCLUDE_COMMUNICATION_COMMFACTORY_HPP_
 #define BFTENGINE_INCLUDE_COMMUNICATION_COMMFACTORY_HPP_
 
-#include <type_traits>
-
 #include "CommDefs.hpp"
+#include "Logging.hpp"
 
 namespace bftEngine {
-class CommFactory {
+class CommFactory {  
+ private:
+  static bftlogger::Logger _logger;
  public:
   static ICommunication*
   create(const BaseCommConfig &config);

--- a/bftengine/src/bftengine/Logger.cpp
+++ b/bftengine/src/bftengine/Logger.cpp
@@ -1,10 +1,14 @@
-//Concord
+// Concord
 //
-//Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
 //
-//This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License. 
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
 //
-//This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license,
+// as noted in the LICENSE file.
 
 #include "Logger.hpp"
 #include <stdio.h>
@@ -30,127 +34,122 @@ static const bool infoEnabled = true;
 static const bool warnEnabled = true;
 static const bool includeTime = true;
 
-
-static void printLogMsg(const char* prefix, FILE *stream, const char *format, va_list arg)
-{
-	if(includeTime)
-	{
+static void printLogMsg(const char *prefix,
+                        FILE *stream,
+                        const char *format,
+                        va_list arg) {
+  if (includeTime) {
 #if defined(_WIN32)
 
-		SYSTEMTIME  sysTime;
-		GetLocalTime(&sysTime); // TODO(GG): GetSystemTime ???
+    SYSTEMTIME  sysTime;
+    GetLocalTime(&sysTime); // TODO(GG): GetSystemTime ???
 
-		uint32_t hour = sysTime.wHour;
-		uint32_t minute = sysTime.wMinute;
-		uint32_t seconds = sysTime.wSecond;
-		uint32_t milli = sysTime.wMilliseconds;
+    uint32_t hour = sysTime.wHour;
+    uint32_t minute = sysTime.wMinute;
+    uint32_t seconds = sysTime.wSecond;
+    uint32_t milli = sysTime.wMilliseconds;
 #else
-		timeval t;
-		gettimeofday(&t, NULL);
+    timeval t;
+    gettimeofday(&t, NULL);
 
-		uint32_t secondsInDay = t.tv_sec % (3600 * 24);
+    uint32_t secondsInDay = t.tv_sec % (3600 * 24);
 
-		uint32_t hour = secondsInDay / 3600;
-		uint32_t minute = (secondsInDay % 3600) / 60;
-		uint32_t seconds = secondsInDay % 60;
-		uint32_t milli = t.tv_usec / 1000;
+    uint32_t hour = secondsInDay / 3600;
+    uint32_t minute = (secondsInDay % 3600) / 60;
+    uint32_t seconds = secondsInDay % 60;
+    uint32_t milli = t.tv_usec / 1000;
 
 #endif
-		
-   	   fprintf(stdout, "\n %02u:%02u:%02u.%03u %s", hour, minute, seconds, milli, prefix);
-		
-	}
-	else
-	{
-	  fprintf(stdout, "\n%s", prefix);
-	}
-	
-	vfprintf(stdout, format, arg);
+
+    fprintf(stdout,
+            "\n %02u:%02u:%02u.%03u %s",
+            hour,
+            minute,
+            seconds,
+            milli,
+            prefix);
+
+  } else {
+    fprintf(stdout, "\n%s", prefix);
+  }
+
+  vfprintf(stdout, format, arg);
 }
 
-
-void Logger::printInfo(const char *format, ...)
-{
-	if (!infoEnabled) return;
-	va_list arg;
-	va_start(arg, format);
-	printLogMsg("INFO: ", stdout, format, arg);
-	va_end(arg);
+void Logger::printInfo(const char *format, ...) {
+  if (!infoEnabled) return;
+  va_list arg;
+  va_start(arg, format);
+  printLogMsg("INFO: ", stdout, format, arg);
+  va_end(arg);
 }
 
-void Logger::printWarn(const char *format, ...)
-{
-	if (!warnEnabled) return;
-	va_list arg;
-	{
-		va_start(arg, format);
-		printLogMsg("WARNING: ", stdout, format, arg);
-		va_end(arg);
-	}
-	{
-		va_start(arg, format);
-		printLogMsg("WARNING: ", stderr, format, arg);
-		va_end(arg);
-	}
+void Logger::printWarn(const char *format, ...) {
+  if (!warnEnabled) return;
+  va_list arg;
+  {
+    va_start(arg, format);
+    printLogMsg("WARNING: ", stdout, format, arg);
+    va_end(arg);
+  }
+  {
+    va_start(arg, format);
+    printLogMsg("WARNING: ", stderr, format, arg);
+    va_end(arg);
+  }
 }
 
-void Logger::printError(const char *format, ...)
-{
-	va_list arg;
-	{
-		va_start(arg, format);
-		printLogMsg("ERROR: ", stdout, format, arg);
-		va_end(arg);
-	}
-	{
-		va_start(arg, format);
-		printLogMsg("ERROR: ", stderr, format, arg);
-		va_end(arg);
-	}
+void Logger::printError(const char *format, ...) {
+  va_list arg;
+  {
+    va_start(arg, format);
+    printLogMsg("ERROR: ", stdout, format, arg);
+    va_end(arg);
+  }
+  {
+    va_start(arg, format);
+    printLogMsg("ERROR: ", stderr, format, arg);
+    va_end(arg);
+  }
 }
 
-
-
-void Logger::simpleAssert(bool cond, const char* msg) // TODO(GG): improve
+void Logger::simpleAssert(bool cond, const char *msg) // TODO(GG): improve
 {
 #if defined(_WIN32)
-	if (!cond) {
-		Logger::printError(msg);
-		_ASSERT(false);
-	}
+  if (!cond) {
+      Logger::printError(msg);
+      _ASSERT(false);
+  }
 #else
-	if (!cond) {
-		Logger::printLastStackFrames();
-		Logger::printError(msg);
-		exit(1);
-	}
+  if (!cond) {
+    Logger::printLastStackFrames();
+    Logger::printError(msg);
+    exit(1);
+  }
 #endif
-
 }
 
-
-void Logger::printLastStackFrames()
-{
-	// TODO(GG): replace this method
+void Logger::printLastStackFrames() {
+  // TODO(GG): replace this method
 
 #if !defined(_WIN32)
-	int j, nptrs;
-	void *buffer[20];
-	char **strings;
+  int j, nptrs;
+  void *buffer[20];
+  char **strings;
 
-	nptrs = backtrace(buffer, 20);
-	printf("backtrace() returned %d addresses\n", nptrs);
+  nptrs = backtrace(buffer, 20);
+  printf("backtrace() returned %d addresses\n", nptrs);
 
-	strings = backtrace_symbols(buffer, nptrs);
-	if (strings == NULL) {
-		perror("backtrace_symbols");
-		exit(EXIT_FAILURE);
-	}
+  strings = backtrace_symbols(buffer, nptrs);
+  if (strings == NULL) {
+    perror("backtrace_symbols");
+    exit(EXIT_FAILURE);
+  }
 
-	for (j = 0; j < nptrs; j++)
-		printf("%s\n", strings[j]);
+  for (j = 0; j < nptrs; j++)
+    printf("%s\n", strings[j]);
 
-	free(strings);
+  free(strings);
 #endif
-	
+
 }

--- a/bftengine/src/bftengine/Logger.hpp
+++ b/bftengine/src/bftengine/Logger.hpp
@@ -1,23 +1,27 @@
-//Concord
+// Concord
 //
-//Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
 //
-//This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License. 
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
 //
-//This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to
+// the terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
 
 #pragma once
 
 //TODO(GG): use a standard c++ log
 
 class Logger {
-public:
-	static void printInfo(const char *format, ...);
-	static void printWarn(const char *format, ...);
-	static void printError(const char *format, ...);
+ public:
+  static void printInfo(const char *format, ...);
+  static void printWarn(const char *format, ...);
+  static void printError(const char *format, ...);
 
-	static void printLastStackFrames();
+  static void printLastStackFrames();
 
-	static void simpleAssert(bool cond, const char* msg);
+  static void simpleAssert(bool cond, const char *msg);
 };
 

--- a/bftengine/src/bftengine/SimpleClient.cpp
+++ b/bftengine/src/bftengine/SimpleClient.cpp
@@ -21,7 +21,7 @@
 #include "ClientReplyMsg.hpp"
 #include "MsgsCertificate.hpp"
 #include "DynamicUpperLimitWithSimpleFilter2.hpp"
-#include "Logger.hpp"
+#include "Logging.hpp"
 
 namespace bftEngine
 {
@@ -128,7 +128,9 @@ namespace bftEngine
 			Assert(replyMsg != nullptr);
 			Assert(replyMsg->type() == REPLY_MSG_TYPE);
 
-			Logger::printInfo("Client %d received ClientReplyMsg with seqNum=%" PRIu64 " sender=%d  size=%d  primaryId=%d hash=%" PRIu64 "",
+ 			LOG_INFO_F(GL, "Client %d received ClientReplyMsg with seqNum=%"
+			PRIu64
+			" sender=%d  size=%d  primaryId=%d hash=%" PRIu64 "",
 				_clientId, replyMsg->reqSeqNum(), replyMsg->senderId(), replyMsg->size(), (int)replyMsg->currentPrimaryId(), replyMsg->debugHash());
 
 
@@ -197,14 +199,13 @@ namespace bftEngine
 			Assert(numberOfTransmissions == 0);
 		}
 
-
-
 		int SimpleClientImp::sendRequest(bool isReadOnly, const char* request, uint32_t lengthOfRequest, uint64_t reqSeqNum, uint64_t timeoutMilli, uint32_t lengthOfReplyBuffer, char* replyBuffer, uint32_t& actualReplyLength)
 		{			
 			// TODO(GG): check params ...
-
-			Logger::printInfo("Client %d - sends request %" PRIu64 " (isRO=%d, request size=%zu, retransmissionMilli=%d) ",
-				_clientId, reqSeqNum, (int)isReadOnly, (size_t)lengthOfRequest,  (int)limitOfExpectedOperationTime.upperLimit());
+			LOG_INFO_F(GL, "Client %d - sends request %" PRIu64 " (isRO=%d, "
+                            "request "
+                            "size=%zu, retransmissionMilli=%d) ",
+                            _clientId, reqSeqNum, (int)isReadOnly, (size_t)lengthOfRequest,  (int)limitOfExpectedOperationTime.upperLimit());
 
 			if (!_communication->isRunning())
 			{
@@ -281,9 +282,9 @@ namespace bftEngine
 				uint64_t durationMilli = ((uint64_t)absDifference(getMonotonicTime(), beginTime)) / 1000;
 				limitOfExpectedOperationTime.add(durationMilli);
 
-				Logger::printInfo("Client %d - request %" PRIu64 " has committed (isRO=%d, request size=%zu,  retransmissionMilli=%d) ",
+				LOG_INFO_F(GL, "Client %d - request %" PRIu64 " has committed "
+										  "(isRO=%d, request size=%zu,  retransmissionMilli=%d) ",
 					_clientId, reqSeqNum, (int)isReadOnly, (size_t)lengthOfRequest,  (int)limitOfExpectedOperationTime.upperLimit());
-
 
 				ClientReplyMsg* correctReply = replysCertificate.bestCorrectMsg();
 
@@ -351,7 +352,6 @@ namespace bftEngine
 			numberOfTransmissions = 0;
 		}
 
-
 		int SimpleClientImp::sendRequestToReadLatestSeqNum(uint64_t timeoutMilli, uint64_t& outLatestReqSeqNum)
 		{
 			Assert(false); // not implemented yet
@@ -406,8 +406,10 @@ namespace bftEngine
 								   (numberOfTransmissions > clientSendsRequestToAllReplicasFirstThresh && (numberOfTransmissions % clientSendsRequestToAllReplicasPeriodThresh == 0)) ||
 								   resetReplies;
 
-
-			Logger::printInfo("Client %d - sends request %" PRIu64 " (isRO=%d, request size=%zu, "
+			LOG_INFO_F(GL,"Client %d - sends request %" PRIu64 " "
+														   "(isRO=%d, "
+												   "request "
+                                          "size=%zu, "
 				" retransmissionMilli=%d, numberOfTransmissions=%d, resetReplies=%d, sendToAll=%d)",
 				_clientId, pendingRequest->requestSeqNum(), (int)pendingRequest->isReadOnly(), (size_t)pendingRequest->size(),
 				(int)limitOfExpectedOperationTime.upperLimit(), (int)numberOfTransmissions, (int)resetReplies, (int)sendToAll);

--- a/bftengine/src/communication/CommFactory.cpp
+++ b/bftengine/src/communication/CommFactory.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "CommFactory.hpp"
+#include "Logging.hpp"
 
 using bftEngine::CommFactory;
 using bftEngine::CommType;
@@ -23,11 +24,15 @@ using bftEngine::PlainTcpConfig;
 using bftEngine::PlainUdpConfig;
 using bftEngine::TlsTcpConfig;
 
+bftlogger::Logger CommFactory::_logger =
+   bftlogger::Logger::getLogger("comm-factory");
+
 ICommunication*
 CommFactory::create(const BaseCommConfig &config) {
   ICommunication *res = nullptr;
   switch (config.commType) {
   case CommType::PlainUdp:
+    LOG_INFO(_logger, "Using PlainUDP");
     res = PlainUDPCommunication::create(
       dynamic_cast<const PlainUdpConfig&>(config));
     break;
@@ -35,6 +40,7 @@ CommFactory::create(const BaseCommConfig &config) {
     break;
   case CommType::PlainTcp:
 #ifdef USE_COMM_PLAIN_TCP
+    LOG_INFO(_logger, "Using PlainTCP");
     res = PlainTCPCommunication::create(
       dynamic_cast<const PlainTcpConfig&>(config));
 #endif
@@ -43,6 +49,7 @@ CommFactory::create(const BaseCommConfig &config) {
     break;
   case CommType::TlsTcp:
 #ifdef USE_COMM_TLS_TCP
+    LOG_INFO(_logger, "Using TlsTCP");
     res = TlsTCPCommunication::create(
       dynamic_cast<const TlsTcpConfig&>(config));
 #endif

--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -36,7 +36,7 @@
 using namespace std;
 using namespace bftEngine;
 
-struct NodeAdressResolveResult
+struct NodeAddressResolveResult
 {
   NodeNum nodeId;
   bool wasFound;
@@ -300,18 +300,18 @@ class PlainUDPCommunication::PlainUdpImpl {
                  (void *) this);
   }
 
-  NodeAdressResolveResult
+  NodeAddressResolveResult
   addrToNodeId(Addr netAdress) {
     auto key = create_key(netAdress);
     auto res = addr2nodes.find(key);
     if (res == addr2nodes.end()) {
       // IG: if we don't know the sender we just ignore this message and
       // continue.
-      LOG_WARN(_logger, "Unknown sender, adress: " << key);
-      return NodeAdressResolveResult({0, false});
+      LOG_WARN(_logger, "Unknown sender, address: " << key);
+      return NodeAddressResolveResult({0, false});
     }
 
-    return NodeAdressResolveResult({res->second, true});
+    return NodeAddressResolveResult({res->second, true});
   }
 
   void

--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -19,10 +19,9 @@
 #include <unordered_map>
 #include "CommDefs.hpp"
 #include "Threading.h"
+#include "Logging.hpp"
 
 #define Assert(cond, txtMsg) assert(cond && (txtMsg))
-
-#define LOG_DEBUG(txt) ;
 
 #if defined(_WIN32)
 #define CLOSESOCKET(x) closesocket((x));
@@ -36,6 +35,12 @@
 
 using namespace std;
 using namespace bftEngine;
+
+struct NodeAdressResolveResult
+{
+  NodeNum nodeId;
+  bool wasFound;
+};
 
 class PlainUDPCommunication::PlainUdpImpl {
  private:
@@ -73,6 +78,8 @@ class PlainUDPCommunication::PlainUdpImpl {
   UPDATE_CONNECTIVITY_FN statusCallback = nullptr;
 
   NodeNum selfId;
+
+  bftlogger::Logger _logger = bftlogger::Logger::getLogger("plain-udp");
 
   bool check_replica(NodeNum node)
   {
@@ -131,8 +138,8 @@ class PlainUDPCommunication::PlainUdpImpl {
       nodes2adresses.insert({next->first, ad});
     }
 
-    LOG_DEBUG("Starting UDP communication. Port = %" << udpListenPort);
-    LOG_DEBUG("#endpoints = " << nodes2adresses.size());
+    LOG_DEBUG(_logger, "Starting UDP communication. Port = %" << udpListenPort);
+    LOG_DEBUG(_logger, "#endpoints = " << nodes2adresses.size());
 
     bufferForIncomingMessages = (char *) std::malloc(maxMsgSize);
 
@@ -152,14 +159,14 @@ class PlainUDPCommunication::PlainUdpImpl {
     Addr sAddr;
 
     if (!receiverRef) {
-      LOG_DEBUG("Cannot Start(): Receiver not set");
+      LOG_DEBUG(_logger, "Cannot Start(): Receiver not set");
       return -1;
     }
 
     mutexLock(&runningLock);
 
     if (running == true) {
-      LOG_DEBUG("Cannot Start(): already running!");
+      LOG_DEBUG(_logger, "Cannot Start(): already running!");
       mutexUnlock(&runningLock);
       return -1;
     }
@@ -175,7 +182,7 @@ class PlainUDPCommunication::PlainUdpImpl {
     // Bind the socket.
     error = ::bind(udpSockFd, (struct sockaddr *) &sAddr, sizeof(Addr));
     if (error < 0) {
-      LOG_DEBUG("Error while binding: " << strerror(errno));
+      LOG_DEBUG(_logger, "Error while binding: " << strerror(errno));
       Assert(false, "Failure occurred while binding the socket!");
       exit(1); // TODO(GG): not really ..... change this !
     }
@@ -199,7 +206,7 @@ class PlainUDPCommunication::PlainUdpImpl {
   Stop() {
     mutexLock(&runningLock);
     if (running == false) {
-      LOG_DEBUG("Cannot Stop(): not running!");
+      LOG_DEBUG(_logger, "Cannot Stop(): not running!");
       mutexUnlock(&runningLock);
       return -1;
     }
@@ -249,7 +256,7 @@ class PlainUDPCommunication::PlainUdpImpl {
     Assert(messageLength > 0, "The message length must be positive!");
     Assert(message != NULL, "No message provided!");
 
-    LOG_DEBUG(" Sending " << messageLength
+    LOG_DEBUG(_logger, " Sending " << messageLength
                           << " bytes to "
                           << destNode << " (" << inet_ntoa(to->sin_addr) << ":"
                           << ntohs(to->sin_port));
@@ -260,13 +267,13 @@ class PlainUDPCommunication::PlainUdpImpl {
     if (error < 0) {
       /** -1 return value means underlying socket error. */
       string err = strerror(errno);
-      LOG_DEBUG("Error while sending: " << strerror(errno));
+      LOG_DEBUG(_logger, "Error while sending: " << strerror(errno));
       Assert(false, "Failure occurred while sending!");
       /** Fail-fast. */
     } else if (error < (int) messageLength) {
       /** Mesage was partially sent. Unclear why this would happen, perhaps
         * due to oversized messages (?). */
-      LOG_DEBUG("Sent %d out of %d bytes!");
+      LOG_DEBUG(_logger, "Sent %d out of %d bytes!");
       Assert(false, "Send error occurred!");    /** Fail-fast. */
     }
 
@@ -287,20 +294,24 @@ class PlainUDPCommunication::PlainUdpImpl {
 
   void
   startRecvThread() {
-    LOG_DEBUG("Starting the receiving thread..");
+    LOG_DEBUG(_logger, "Starting the receiving thread..");
     createThread(&recvThreadRef,
                  &PlainUdpImpl::recvRoutineWrapper,
                  (void *) this);
   }
 
-  NodeNum
+  NodeAdressResolveResult
   addrToNodeId(Addr netAdress) {
     auto key = create_key(netAdress);
     auto res = addr2nodes.find(key);
-    if (res == addr2nodes.end())
-      return 0;//TBD, (IG): to change to macro of default NodeNum
+    if (res == addr2nodes.end()) {
+      // IG: if we don't know the sender we just ignore this message and
+      // continue.
+      LOG_WARN(_logger, "Unknown sender, adress: " << key);
+      return NodeAdressResolveResult({0, false});
+    }
 
-    return res->second;
+    return NodeAdressResolveResult({res->second, true});
   }
 
   void
@@ -349,13 +360,19 @@ class PlainUDPCommunication::PlainUdpImpl {
                       (sockaddr *) &fromAdress,
                       &fromAdressLength);
 
-      //LOG_DEBUG("recvfrom returned " << mLen << " bytes");
+      LOG_DEBUG(_logger, "recvfrom returned " << mLen << " bytes");
 
-      if (mLen < 0) { LOG_DEBUG("Error in recvfrom(): " << mLen);
+      if (mLen < 0) {
+        LOG_DEBUG(_logger, "Error in recvfrom(): " << mLen);
         continue;
       }
 
-      auto sendingNode = addrToNodeId(fromAdress);
+      auto resolveNode = addrToNodeId(fromAdress);
+      if(!resolveNode.wasFound) {
+        continue;
+      }
+
+      auto sendingNode = resolveNode.nodeId;
       if (mLen > 0 && (receiverRef != NULL)) {
         receiverRef->onNewMessage(sendingNode,
                                   bufferForIncomingMessages,

--- a/bftengine/tests/simpleTest/CMakeLists.txt
+++ b/bftengine/tests/simpleTest/CMakeLists.txt
@@ -16,6 +16,16 @@ add_executable(simpleTest_server
     ${simpleTest_replica_source_files}
 )
 
+if(USE_LOG4CPP)
+    target_compile_definitions(simpleTest_server PUBLIC USE_LOG4CPP=1)    
+    target_compile_definitions(simpleTest_client PUBLIC USE_LOG4CPP=1)    
+endif()
+
+if(${USE_COMM_PLAIN_TCP})
+    target_compile_definitions(simnpleTest_client PUBLIC USE_COMM_PLAIN_TCP=1)
+    target_compile_definitions(simnpleTest_server PUBLIC USE_COMM_PLAIN_TCP=1)
+endif()
+
 set_target_properties(simpleTest_client PROPERTIES OUTPUT_NAME client)
 set_target_properties(simpleTest_server PROPERTIES OUTPUT_NAME server)
 
@@ -26,3 +36,5 @@ add_custom_target(copy_simple_test_scripts ALL COMMENT "Copying scripts of simpl
 add_custom_command(TARGET copy_simple_test_scripts
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:simpleTest_client>/scripts
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/scripts $<TARGET_FILE_DIR:simpleTest_client>/scripts)
+
+    

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -79,10 +79,10 @@ int main(int argc, char **argv) {
       createSeqNumberGeneratorForClientRequests();
 
   // Configure, create, and start the Concord client to use.
-#ifndef USE_COMM_PLAIN_TCP
-  PlainUdpConfig conf = getUDPConfig(id);
-#else
+#ifdef USE_COMM_PLAIN_TCP
   PlainTcpConfig conf = getTCPConfig(id);
+#else
+  PlainUdpConfig conf = getUDPConfig(id);
 #endif
   ICommunication* comm = bftEngine::CommFactory::create(conf);
 

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -28,6 +28,7 @@
 // information about how to run the client.
 
 #include <cassert>
+#include <thread>
 
 // bftEngine includes
 #include "CommFactory.hpp"
@@ -36,16 +37,31 @@
 // simpleTest includes
 #include "commonDefs.h"
 
+#ifdef USE_LOG4CPP
+#include <log4cplus/configurator.h>
+#endif
+
 using bftEngine::ICommunication;
 using bftEngine::PlainUDPCommunication;
 using bftEngine::PlainUdpConfig;
+using bftEngine::PlainTCPCommunication;
+using bftEngine::PlainTcpConfig;
 using bftEngine::SeqNumberGeneratorForClientRequests;
 using bftEngine::SimpleClient;
 
 // Declarations of functions form config.cpp.
 PlainUdpConfig getUDPConfig(uint16_t id);
+extern PlainTcpConfig getTCPConfig(uint16_t id);
 
 int main(int argc, char **argv) {
+// TODO(IG:) configure Log4Cplus's output format, using default for now
+#ifdef USE_LOG4CPP
+  using namespace log4cplus;
+  initialize();
+  BasicConfigurator config;
+  config.configure();
+#endif
+
   // This client's index number. Must be larger than the largest replica index
   // number.
   const int16_t id = 4;
@@ -63,8 +79,13 @@ int main(int argc, char **argv) {
       createSeqNumberGeneratorForClientRequests();
 
   // Configure, create, and start the Concord client to use.
-  PlainUdpConfig udpConf = getUDPConfig(id);
-  ICommunication* comm = PlainUDPCommunication::create(udpConf);
+#ifndef USE_COMM_PLAIN_TCP
+  PlainUdpConfig conf = getUDPConfig(id);
+#else
+  PlainTcpConfig conf = getTCPConfig(id);
+#endif
+  ICommunication* comm = bftEngine::CommFactory::create(conf);
+
   SimpleClient* client = SimpleClient::createSimpleClient(comm, id, 1, 0);
   comm->Start();
 

--- a/bftengine/tests/simpleTest/config.cpp
+++ b/bftengine/tests/simpleTest/config.cpp
@@ -26,6 +26,7 @@
 #include "threshsign/ThresholdSignaturesSchemes.h"
 
 using bftEngine::PlainUdpConfig;
+using bftEngine::PlainTcpConfig;
 using bftEngine::ReplicaConfig;
 using BLS::Relic::BlsThresholdFactory;
 using std::pair;
@@ -318,5 +319,23 @@ PlainUdpConfig getUDPConfig(uint16_t id) {
       NodeInfo{ip, (uint16_t)(basePort + i*2), i < numOfReplicas} });
 
   PlainUdpConfig retVal(ip, port, bufLength, nodes, id);
+  return retVal;
+}
+
+// Create a UDP communication configuration for the node (replica or client)
+// with index `id`.
+PlainTcpConfig getTCPConfig(uint16_t id) {
+  std::string ip = "127.0.0.1";
+  uint16_t port = basePort + id*2;
+  uint32_t bufLength = 64000;
+
+  // Create a map of where the port for each node is.
+  std::unordered_map <NodeNum, NodeInfo> nodes;
+  for (int i = 0; i < (numOfReplicas + numOfClientProxies); i++)
+    nodes.insert({
+                     i,
+                     NodeInfo{ip, (uint16_t)(basePort + i*2), i < numOfReplicas} });
+
+  PlainTcpConfig retVal(ip, port, bufLength, nodes, numOfReplicas -1, id);
   return retVal;
 }

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -154,10 +154,10 @@ int main(int argc, char **argv) {
   ReplicaConfig replicaConfig;
   getReplicaConfig(id, &replicaConfig);
 
-#ifndef USE_COMM_PLAIN_TCP
-  PlainUdpConfig conf = getUDPConfig(id);
-#else
+#ifdef USE_COMM_PLAIN_TCP
   PlainTcpConfig conf = getTCPConfig(id);
+#else
+  PlainUdpConfig conf = getUDPConfig(id);
 #endif
   ICommunication* comm = bftEngine::CommFactory::create(conf);
   

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -1,0 +1,4 @@
+set_property(GLOBAL PROPERTY LoggerIncludeDir
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set_property(GLOBAL PROPERTY LoggerSrcDir
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/logging/include/Logging.hpp
+++ b/logging/include/Logging.hpp
@@ -1,0 +1,287 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#ifndef CONCORD_BFT_LOGGING_HPP
+#define CONCORD_BFT_LOGGING_HPP
+
+#include <string>
+#include <sstream>
+#include <chrono>
+#include <iomanip>
+#include <stdarg.h>
+
+#ifdef USE_LOG4CPP
+#include <log4cplus/loggingmacros.h>
+typedef log4cplus::Logger LoggerImpl;
+#endif
+
+namespace bftlogger {
+
+#ifndef USE_LOG4CPP
+
+// log levels as defined in log4cpp
+enum LogLevel {
+  trace,
+  debug,
+  info,
+  warn,
+  error,
+  fatal,
+  off,
+  all = trace
+};
+
+constexpr LogLevel CURRENT_LEVEL = LogLevel::info;
+#define CHECK_ENABLED(l) \
+if (CURRENT_LEVEL == LogLevel::off || l < CURRENT_LEVEL) return;
+
+class SimpleLoggerImpl {
+  std::string _name;
+  static std::string LEVELS_STRINGS[6];
+
+ public:
+  SimpleLoggerImpl(std::string name) : _name{name} {}
+
+  void print(LogLevel l, std::string text);
+};
+
+typedef SimpleLoggerImpl LoggerImpl;
+#endif // USE_LOG4CPP
+
+class Logger {
+ private:
+  LoggerImpl _impl;
+  Logger(LoggerImpl impl) : _impl(impl) {}
+
+  inline std::string prepare(const char *format, va_list &args) {
+    auto size = std::snprintf(nullptr, 0, format, args);
+    std::string output(size + 1, '\0');
+    std::vsnprintf((char *) output.c_str(), size + 1, format, args);
+    return output;
+  }
+
+ public:
+  inline LoggerImpl getImpl() {
+    return _impl;
+  }
+
+  inline void fatal(std::string msg) {
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_FATAL(_impl, msg);
+#else
+    CHECK_ENABLED(LogLevel::fatal);
+    _impl.print(LogLevel::fatal, msg);
+#endif
+  }
+
+  inline void fatal(const char *format, ...) {
+    va_list args;
+    va_start (args, format);
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_FATAL_FMT(_impl, format, args);
+#else
+    CHECK_ENABLED(LogLevel::fatal);
+    std::string output = prepare(format, args);
+    fatal(output);
+#endif
+    va_end(args);
+  }
+
+  inline void fatal(std::ostringstream &os) {
+    fatal(os.str());
+  }
+
+  inline void error(std::string msg) {
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_ERROR(_impl, msg);
+#else
+    CHECK_ENABLED(LogLevel::error);
+    _impl.print(LogLevel::error, msg);
+#endif
+  }
+
+  inline void error(const char *format, ...) {
+    va_list args;
+    va_start (args, format);
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_ERROR_FMT(_impl, format, args);
+#else
+    CHECK_ENABLED(LogLevel::error);
+    std::string output = prepare(format, args);
+    error(output);
+#endif
+    va_end(args);
+  }
+
+  inline void error(std::ostringstream &os) {
+    error(os.str());
+  }
+
+  inline void warn(std::string msg) {
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_WARN(_impl, msg);
+#else
+    CHECK_ENABLED(LogLevel::warn);
+    _impl.print(LogLevel::warn, msg);
+#endif
+  }
+
+  inline void warn(const char *format, ...) {
+    va_list args;
+    va_start (args, format);
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_WARN_FMT(_impl, format, args);
+#else
+    CHECK_ENABLED(LogLevel::warn);
+    std::string output = prepare(format, args);
+    warn(output);
+#endif
+    va_end(args);
+  }
+
+  inline void warn(std::ostringstream &os) {
+    warn(os.str());
+  }
+
+  inline void info(std::string msg) {
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_INFO(_impl, msg);
+#else
+    CHECK_ENABLED(LogLevel::info);
+    _impl.print(LogLevel::info, msg);
+#endif
+  }
+
+  inline void info(const char *format, ...) {
+    va_list args;
+    va_start (args, format);
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_INFO_FMT(_impl, format, args);
+#else
+    CHECK_ENABLED(LogLevel::info);
+    std::string output = prepare(format, args);
+    info(output);
+#endif
+    va_end(args);
+  }
+
+  inline void info(std::ostringstream &os) {
+    info(os.str());
+  }
+
+  inline void debug(std::string msg) {
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_DEBUG(_impl, msg);
+#else
+    CHECK_ENABLED(LogLevel::debug);
+    _impl.print(LogLevel::debug, msg);
+#endif
+  }
+
+  inline void debug(const char *format, ...) {
+    va_list args;
+    va_start (args, format);
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_DEBUG_FMT(_impl, format, args);
+#else
+    CHECK_ENABLED(LogLevel::debug);
+    std::string output = prepare(format, args);
+    debug(output);
+#endif
+    va_end(args);
+  }
+
+  inline void debug(std::ostringstream &os) {
+    debug(os.str());
+  }
+
+  inline void trace(std::string msg) {
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_FATAL(_impl, msg);
+#else
+    CHECK_ENABLED(LogLevel::trace);
+    _impl.print(LogLevel::trace, msg);
+#endif
+  }
+
+  inline void trace(const char *format, ...) {
+    va_list args;
+    va_start (args, format);
+#ifdef USE_LOG4CPP
+    LOG4CPLUS_FATAL_FMT(_impl, format, args);
+#else
+    CHECK_ENABLED(LogLevel::trace);
+    std::string output = prepare(format, args);
+    trace(output);
+#endif
+    va_end(args);
+  }
+
+  inline void trace(std::ostringstream &os) {
+    trace(os.str());
+  }
+
+  static Logger getLogger(std::string name) {
+#ifdef USE_LOG4CPP
+    auto l = log4cplus::Logger::getInstance(name);
+    return Logger(l);
+#else
+    return Logger(SimpleLoggerImpl(name));
+#endif // USE_LOG4CPP
+  }
+}; // Logger
+
+#ifdef USE_LOG4CPP
+#define LOG_TRACE(l, s) LOG4CPLUS_TRACE(l.getImpl(),s)
+#define LOG_TRACE_F(l, ...) LOG4CPLUS_TRACE_FMT(l.getImpl(), __VA_ARGS__)
+
+#define LOG_DEBUG(l, s)LOG4CPLUS_DEBUG(l.getImpl(),s)
+#define LOG_DEBUG_F(l,...) LOG4CPLUS_DEBUG_FMT(l.getImpl(),__VA_ARGS__)
+
+#define LOG_INFO(l, s) LOG4CPLUS_INFO(l.getImpl(),s)
+#define LOG_INFO_F(l,...) LOG4CPLUS_INFO_FMT(l.getImpl(), __VA_ARGS__)
+
+#define LOG_WARN(l, s) LOG4CPLUS_WARN(l.getImpl(),s)
+#define LOG_WARN_F(logger,...) LOG4CPLUS_WARN_FMT(logger.getImpl(),__VA_ARGS__)
+
+#define LOG_ERROR(l, s) LOG4CPLUS_ERROR(l.getImpl(),s)
+#define LOG_ERROR_F(l,...) LOG4CPLUS_ERROR_FMT(l.getImpl(),__VA_ARGS__)
+
+#define LOG_FATAL(l, s) LOG4CPLUS_FATAL(l.getImpl(),s)
+#define LOG_FATAL_F(l,...) LOG4CPLUS_FATAL_FMT(l.getImpl(),__VA_ARGS__)
+#else
+#define LOG_TRACE(l, s) {std::ostringstream os; os << s; l.trace (os);}
+#define LOG_TRACE_F(l, ...) l.trace(__VA_ARGS__)
+
+#define LOG_DEBUG(l, s) {std::ostringstream os; os << s; l.debug (os);}
+#define LOG_DEBUG_F(l, ...) l.debug(__VA_ARGS__)
+
+#define LOG_INFO(l, s) {std::ostringstream os; os << s; l.info (os);}
+#define LOG_INFO_F(l, ...) l.info(__VA_ARGS__)
+
+#define LOG_WARN(l, s) {std::ostringstream os; os << s; l.warn(os);}
+#define LOG_WARNL_F(l, ...) l.warn(__VA_ARGS__)
+
+#define LOG_ERROR(l, s) {std::ostringstream os; os << s; l.error(os);}
+#define LOG_ERROR_F(l, ...) l.error(__VA_ARGS__)
+
+#define LOG_FATAL(l, s) {std::ostringstream os; os << s; l.fatal(os);}
+#define LOG_FATAL_F(l, ...) l.fatal(__VA_ARGS__)
+#endif
+
+} // namespace
+
+// globals to support easy logging
+extern bftlogger::Logger globalLogger;
+#define GL globalLogger
+
+#endif //CONCORD_BFT_LOGGING_HPP

--- a/logging/src/Logging.cpp
+++ b/logging/src/Logging.cpp
@@ -1,0 +1,41 @@
+#include "Logging.hpp"
+
+bftlogger::Logger globalLogger =
+    bftlogger::Logger::getLogger(DEFAULT_LOGGER_NAME);
+
+#ifndef USE_LOG4CPP
+std::string bftlogger::SimpleLoggerImpl::LEVELS_STRINGS[6] =
+    {"TRACE",
+      "DEBUG",
+      "INFO",
+      "WARN",
+      "ERROR",
+      "FATAL"};
+
+void get_time(std::stringstream &ss) {
+  using namespace std::chrono;
+  auto now = system_clock::now();
+  auto ms = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
+  auto timer = system_clock::to_time_t(now);
+  std::tm bt = *std::localtime(&timer);
+  ss << std::put_time(&bt, "%F %T")
+     << "."
+     << std::setfill('0') << std::setw(3) << ms.count();
+}
+
+void bftlogger::SimpleLoggerImpl::print(
+    bftlogger::LogLevel l,
+    std::string text) {
+
+  std::stringstream time;
+
+  get_time(time);
+
+  printf("%s %s (%s) %s\n",
+         SimpleLoggerImpl::LEVELS_STRINGS[l].c_str(),
+         time.str().c_str(),
+         _name.c_str(),
+         text.c_str());
+
+}
+#endif


### PR DESCRIPTION
This PR contains the following items:

bug fixed:
when using UDP, instead of returning 0 if message is received from unknown sender, we just ignore this message and produce warning to logs

features:
implemented logging wrapper, that is supposed to be an interface and internally implements either 
log4cpp (if set in CMAKE) or naive console logger. The previous logger is not removed yet and the 
transition to the new one should be continuous effort. w

misc:
added bug and feature request templates