### PR TITLE
Disabling padding in all structs inheriting from MessageBase

### DIFF
--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -25,7 +25,6 @@ namespace bftEngine
 		uint32_t requestLength;
 		// followed by the request (security information, such as signatures, should be part of the request)
 
-		// TODO(GG): alignment and pack
 		// TODO(GG): idOfClientProxy is not needed here
 		// TODO(GG): add information about "suggested repliers" 
 	};
@@ -36,8 +35,6 @@ namespace bftEngine
 		uint16_t currentPrimaryId;
 		uint64_t reqSeqNum;
 		uint32_t replyLength;
-
-		// TODO(GG): alignment and pack
 	};
 #pragma pack(pop)
 }

--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -15,6 +15,7 @@
 
 namespace bftEngine
 {
+#pragma pack(push,1)
 	struct ClientRequestMsgHeader
 	{
 		uint16_t msgType; // always == REQUEST_MSG_TYPE
@@ -29,7 +30,6 @@ namespace bftEngine
 		// TODO(GG): add information about "suggested repliers" 
 	};
 
-
 	struct ClientReplyMsgHeader
 	{
 		uint16_t msgType; // always == REPLY_MSG_TYPE
@@ -39,4 +39,5 @@ namespace bftEngine
 
 		// TODO(GG): alignment and pack
 	};
+#pragma pack(pop)
 }

--- a/bftengine/src/bftengine/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/CheckpointMsg.hpp
@@ -18,6 +18,8 @@ namespace bftEngine
 
 		class CheckpointMsg : public MessageBase
 		{
+			static_assert(sizeof(CheckpointMsgHeader) == (2+8+DIGEST_SIZE+1), "CheckpointMsgHeader is 43B")
+
 		public:
 
 			CheckpointMsg(ReplicaId senderId, SeqNum seqNum, const Digest& stateDigest, bool stateIsStable);
@@ -38,7 +40,7 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, CheckpointMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push,1)
 			struct CheckpointMsgHeader
 			{
 				MessageBase::Header header;
@@ -46,6 +48,7 @@ namespace bftEngine
 				Digest stateDigest;
 				uint8_t flags;
 			};
+#pragma pack(pop)
 
 			CheckpointMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/CheckpointMsg.hpp
@@ -18,7 +18,6 @@ namespace bftEngine
 
 		class CheckpointMsg : public MessageBase
 		{
-			static_assert(sizeof(CheckpointMsgHeader) == (2+8+DIGEST_SIZE+1), "CheckpointMsgHeader is 43B")
 
 		public:
 
@@ -40,6 +39,7 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, CheckpointMsg*& outMsg);
 
 		protected:
+
 #pragma pack(push,1)
 			struct CheckpointMsgHeader
 			{
@@ -49,6 +49,7 @@ namespace bftEngine
 				uint8_t flags;
 			};
 #pragma pack(pop)
+			static_assert(sizeof(CheckpointMsgHeader) == (2 + 8 + DIGEST_SIZE + 1), "CheckpointMsgHeader is 43B")
 
 			CheckpointMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/CheckpointMsg.hpp
@@ -49,7 +49,7 @@ namespace bftEngine
 				uint8_t flags;
 			};
 #pragma pack(pop)
-			static_assert(sizeof(CheckpointMsgHeader) == (2 + 8 + DIGEST_SIZE + 1), "CheckpointMsgHeader is 43B")
+			static_assert(sizeof(CheckpointMsgHeader) == (2 + 8 + DIGEST_SIZE + 1), "CheckpointMsgHeader is 43B");
 
 			CheckpointMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/ClientReplyMsg.hpp
+++ b/bftengine/src/bftengine/ClientReplyMsg.hpp
@@ -23,7 +23,7 @@ namespace bftEngine
 			static_assert(sizeof(ClientReplyMsgHeader::msgType) == sizeof(MessageBase::Header), "");
 			static_assert(sizeof(ClientReplyMsgHeader::reqSeqNum) == sizeof(ReqId), "");
 			static_assert(sizeof(ClientReplyMsgHeader::currentPrimaryId) == sizeof(ReplicaId), "");
-			static_assert(sizeof(ClientReplyMsgHeader) == 16, "ClientRequestMsgHeader is 16B")
+			static_assert(sizeof(ClientReplyMsgHeader) == 16, "ClientRequestMsgHeader is 16B");
 			// TODO(GG): more asserts
 
 		public:

--- a/bftengine/src/bftengine/ClientReplyMsg.hpp
+++ b/bftengine/src/bftengine/ClientReplyMsg.hpp
@@ -23,6 +23,7 @@ namespace bftEngine
 			static_assert(sizeof(ClientReplyMsgHeader::msgType) == sizeof(MessageBase::Header), "");
 			static_assert(sizeof(ClientReplyMsgHeader::reqSeqNum) == sizeof(ReqId), "");
 			static_assert(sizeof(ClientReplyMsgHeader::currentPrimaryId) == sizeof(ReplicaId), "");
+			static_assert(sizeof(ClientReplyMsgHeader) == 16, "ClientRequestMsgHeader is 16B")
 			// TODO(GG): more asserts
 
 		public:

--- a/bftengine/src/bftengine/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/ClientRequestMsg.hpp
@@ -25,6 +25,8 @@ namespace bftEngine
 			static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header), "");
 			static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
 			static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
+			static_assert(sizeof(ClientRequestMsgHeader) == 17, "ClientRequestMsgHeader is 17B")
+
 			// TODO(GG): more asserts
 
 		public:

--- a/bftengine/src/bftengine/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/ClientRequestMsg.hpp
@@ -25,7 +25,7 @@ namespace bftEngine
 			static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header), "");
 			static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
 			static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
-			static_assert(sizeof(ClientRequestMsgHeader) == 17, "ClientRequestMsgHeader is 17B")
+			static_assert(sizeof(ClientRequestMsgHeader) == 17, "ClientRequestMsgHeader is 17B");
 
 			// TODO(GG): more asserts
 

--- a/bftengine/src/bftengine/FullCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/FullCommitProofMsg.hpp
@@ -42,7 +42,7 @@ namespace bftEngine
 				uint16_t thresholSignatureLength;
 			};
 #pragma pack(pop)
-			static_assert(sizeof(FullCommitProofMsgHeader) == (2 + 8 + 8 + 2), "FullCommitProofMsgHeader is 20B")
+			static_assert(sizeof(FullCommitProofMsgHeader) == (2 + 8 + 8 + 2), "FullCommitProofMsgHeader is 20B");
 
 			FullCommitProofMsgHeader* b() const { return (FullCommitProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/FullCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/FullCommitProofMsg.hpp
@@ -18,6 +18,7 @@ namespace bftEngine
 		// TODO(GG): use SignedShareBase
 		class FullCommitProofMsg : public MessageBase
 		{
+			static_assert(sizeof(FullCommitProofMsgHeader) == (2+8+8+2), "FullCommitProofMsgHeader is 20B")
 
 		public:
 			FullCommitProofMsg(ReplicaId senderId, ViewNum v, SeqNum s, const char* commitProofSig, uint16_t commitProofSigLength);
@@ -33,7 +34,7 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, FullCommitProofMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push,1)
 			struct FullCommitProofMsgHeader
 			{
 				MessageBase::Header header;
@@ -41,6 +42,7 @@ namespace bftEngine
 				SeqNum seqNum;
 				uint16_t thresholSignatureLength;
 			};
+#pragma pack(pop)
 
 			FullCommitProofMsgHeader* b() const { return (FullCommitProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/FullCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/FullCommitProofMsg.hpp
@@ -18,7 +18,6 @@ namespace bftEngine
 		// TODO(GG): use SignedShareBase
 		class FullCommitProofMsg : public MessageBase
 		{
-			static_assert(sizeof(FullCommitProofMsgHeader) == (2+8+8+2), "FullCommitProofMsgHeader is 20B")
 
 		public:
 			FullCommitProofMsg(ReplicaId senderId, ViewNum v, SeqNum s, const char* commitProofSig, uint16_t commitProofSigLength);
@@ -43,6 +42,7 @@ namespace bftEngine
 				uint16_t thresholSignatureLength;
 			};
 #pragma pack(pop)
+			static_assert(sizeof(FullCommitProofMsgHeader) == (2 + 8 + 8 + 2), "FullCommitProofMsgHeader is 20B")
 
 			FullCommitProofMsgHeader* b() const { return (FullCommitProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/FullExecProofMsg.hpp
+++ b/bftengine/src/bftengine/FullExecProofMsg.hpp
@@ -68,7 +68,7 @@ namespace bftEngine
 				// 3. signature (signatureLength bytes) 
 			};
 #pragma pack(pop)
-			static_assert(sizeof(FullExecProofMsgHeader) == (2 + 2 + 8 + 2 + 2 + 2 + 2), "FullExecProofMsgHeader is 20B")
+			static_assert(sizeof(FullExecProofMsgHeader) == (2 + 2 + 8 + 2 + 2 + 2 + 2), "FullExecProofMsgHeader is 20B");
 
 			FullExecProofMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/FullExecProofMsg.hpp
+++ b/bftengine/src/bftengine/FullExecProofMsg.hpp
@@ -18,7 +18,6 @@ namespace bftEngine
 		// TODO(GG): change class name (also used for read-only operations)
 		class FullExecProofMsg : public MessageBase
 		{
-			static_assert(sizeof(FullExecProofMsgHeader) == (2 + 2 + 8 + 2 + 2 + 2 + 2), "FullExecProofMsgHeader is 20B")
 
 		public:
 			FullExecProofMsg(ReplicaId senderId, NodeIdType clientId, ReqId requestId,
@@ -69,6 +68,7 @@ namespace bftEngine
 				// 3. signature (signatureLength bytes) 
 			};
 #pragma pack(pop)
+			static_assert(sizeof(FullExecProofMsgHeader) == (2 + 2 + 8 + 2 + 2 + 2 + 2), "FullExecProofMsgHeader is 20B")
 
 			FullExecProofMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/FullExecProofMsg.hpp
+++ b/bftengine/src/bftengine/FullExecProofMsg.hpp
@@ -18,6 +18,8 @@ namespace bftEngine
 		// TODO(GG): change class name (also used for read-only operations)
 		class FullExecProofMsg : public MessageBase
 		{
+			static_assert(sizeof(FullExecProofMsgHeader) == (2 + 2 + 8 + 2 + 2 + 2 + 2), "FullExecProofMsgHeader is 20B")
+
 		public:
 			FullExecProofMsg(ReplicaId senderId, NodeIdType clientId, ReqId requestId,
 				uint16_t sigLength,
@@ -51,7 +53,7 @@ namespace bftEngine
 			static bool ToActualMsgType(NodeIdType myId, MessageBase* inMsg, FullExecProofMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push, 1)
 			struct FullExecProofMsgHeader
 			{
 				MessageBase::Header header;
@@ -66,6 +68,7 @@ namespace bftEngine
 				// 2. the merkle proof (executionProofLength bytes)
 				// 3. signature (signatureLength bytes) 
 			};
+#pragma pack(pop)
 
 			FullExecProofMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/MessageBase.hpp
+++ b/bftengine/src/bftengine/MessageBase.hpp
@@ -23,10 +23,13 @@ namespace bftEngine
 		class MessageBase
 		{
 		public:
+#pragma pack(push,1)
 			struct Header
 			{
 				MsgType msgType;
 			};
+#pragma pack(pop)
+			static_assert(sizeof(Header) == 2, "MessageBase::Header is 2B");
 
 			MessageBase(NodeIdType sender);
 

--- a/bftengine/src/bftengine/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/NewViewMsg.hpp
@@ -18,6 +18,8 @@ namespace bftEngine
 
 		class NewViewMsg : public MessageBase
 		{
+			static_assert(sizeof(NewViewMsgHeader) == (2 + 8 + 2), "NewViewMsgHeader is 12B")
+
 		public:
 			NewViewMsg(ReplicaId senderId, ViewNum newView);
 
@@ -32,6 +34,7 @@ namespace bftEngine
 			bool includesViewChangeFromReplica(ReplicaId replicaId, const Digest& viewChangeReplica) const;
 
 		protected:
+#pragma pack(push,1)
 			struct NewViewMsgHeader
 			{
 				MessageBase::Header header;
@@ -42,6 +45,7 @@ namespace bftEngine
 										// followed by a sequnce of 2f+2c+1 instances of NewViewElement
 
 			};
+#pragma pack(pop)
 
 			struct NewViewElement
 			{

--- a/bftengine/src/bftengine/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/NewViewMsg.hpp
@@ -45,7 +45,7 @@ namespace bftEngine
 
 			};
 #pragma pack(pop)
-			static_assert(sizeof(NewViewMsgHeader) == (2 + 8 + 2), "NewViewMsgHeader is 12B")
+			static_assert(sizeof(NewViewMsgHeader) == (2 + 8 + 2), "NewViewMsgHeader is 12B");
 
 			struct NewViewElement
 			{

--- a/bftengine/src/bftengine/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/NewViewMsg.hpp
@@ -18,7 +18,6 @@ namespace bftEngine
 
 		class NewViewMsg : public MessageBase
 		{
-			static_assert(sizeof(NewViewMsgHeader) == (2 + 8 + 2), "NewViewMsgHeader is 12B")
 
 		public:
 			NewViewMsg(ReplicaId senderId, ViewNum newView);
@@ -46,6 +45,7 @@ namespace bftEngine
 
 			};
 #pragma pack(pop)
+			static_assert(sizeof(NewViewMsgHeader) == (2 + 8 + 2), "NewViewMsgHeader is 12B")
 
 			struct NewViewElement
 			{

--- a/bftengine/src/bftengine/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/NewViewMsg.hpp
@@ -44,14 +44,16 @@ namespace bftEngine
 										// followed by a sequnce of 2f+2c+1 instances of NewViewElement
 
 			};
-#pragma pack(pop)
-			static_assert(sizeof(NewViewMsgHeader) == (2 + 8 + 2), "NewViewMsgHeader is 12B");
 
 			struct NewViewElement
 			{
 				ReplicaId replicaId;
 				Digest  viewChangeDigest;
 			};
+#pragma pack(pop)
+
+			static_assert(sizeof(NewViewMsgHeader) == (2 + 8 + 2), "NewViewMsgHeader is 12B");
+			static_assert(sizeof(NewViewElement) == (2 + DIGEST_SIZE), "NewViewElement is 34B");
 
 			NewViewMsgHeader* b() const { return (NewViewMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/PartialCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/PartialCommitProofMsg.hpp
@@ -50,7 +50,7 @@ namespace bftEngine
 				// followed by a partial signature
 			};
 #pragma pack(pop)
-			static_assert(sizeof(PartialCommitProofMsgHeader) == (2 + 8 + 8 + sizeof(CommitPath) + 2), "PartialCommitProofMsgHeader is 20B+sizeof(CommitPath)")
+			static_assert(sizeof(PartialCommitProofMsgHeader) == (2 + 8 + 8 + sizeof(CommitPath) + 2), "PartialCommitProofMsgHeader is 20B+sizeof(CommitPath)");
 
 			PartialCommitProofMsgHeader* b() const { return (PartialCommitProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/PartialCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/PartialCommitProofMsg.hpp
@@ -22,6 +22,8 @@ namespace bftEngine
 		// TODO(GG): consider to use SignedShareBase
 		class PartialCommitProofMsg : public MessageBase
 		{
+			static_assert(sizeof(PartialCommitProofMsgHeader) == (2 + 8 + 8 + sizeof(CommitPath) + 2), "PartialCommitProofMsgHeader is 20B+sizeof(CommitPath)")
+
 		public:
 			PartialCommitProofMsg(ReplicaId senderId, ViewNum v, SeqNum s, CommitPath commitPath, Digest& digest, IThresholdSigner* thresholdSigner);
 
@@ -38,7 +40,7 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, PartialCommitProofMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push,1)
 			struct PartialCommitProofMsgHeader
 			{
 				MessageBase::Header header;
@@ -48,6 +50,7 @@ namespace bftEngine
 				uint16_t thresholSignatureLength;
 				// followed by a partial signature
 			};
+#pragma pack(pop)
 
 			PartialCommitProofMsgHeader* b() const { return (PartialCommitProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/PartialCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/PartialCommitProofMsg.hpp
@@ -22,7 +22,6 @@ namespace bftEngine
 		// TODO(GG): consider to use SignedShareBase
 		class PartialCommitProofMsg : public MessageBase
 		{
-			static_assert(sizeof(PartialCommitProofMsgHeader) == (2 + 8 + 8 + sizeof(CommitPath) + 2), "PartialCommitProofMsgHeader is 20B+sizeof(CommitPath)")
 
 		public:
 			PartialCommitProofMsg(ReplicaId senderId, ViewNum v, SeqNum s, CommitPath commitPath, Digest& digest, IThresholdSigner* thresholdSigner);
@@ -51,6 +50,7 @@ namespace bftEngine
 				// followed by a partial signature
 			};
 #pragma pack(pop)
+			static_assert(sizeof(PartialCommitProofMsgHeader) == (2 + 8 + 8 + sizeof(CommitPath) + 2), "PartialCommitProofMsgHeader is 20B+sizeof(CommitPath)")
 
 			PartialCommitProofMsgHeader* b() const { return (PartialCommitProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/PartialExecProofMsg.hpp
+++ b/bftengine/src/bftengine/PartialExecProofMsg.hpp
@@ -21,7 +21,6 @@ namespace bftEngine
 		// TODO(GG): use SignedShareBase
 		class PartialExecProofMsg : public MessageBase
 		{
-			static_assert(sizeof(PartialExecProofMsgHeader) == (2 + 8 + 8 + 2), "PartialExecProofMsgHeader is 20B")
 
 		public:
 			PartialExecProofMsg(ReplicaId senderId, ViewNum v, SeqNum s, Digest& digest, IThresholdSigner* thresholdSigner);
@@ -47,6 +46,7 @@ namespace bftEngine
 				// followed by a signature 
 			};
 #pragma pack(pop)
+			static_assert(sizeof(PartialExecProofMsgHeader) == (2 + 8 + 8 + 2), "PartialExecProofMsgHeader is 20B")
 
 			PartialExecProofMsgHeader* b() const { return (PartialExecProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/PartialExecProofMsg.hpp
+++ b/bftengine/src/bftengine/PartialExecProofMsg.hpp
@@ -46,7 +46,7 @@ namespace bftEngine
 				// followed by a signature 
 			};
 #pragma pack(pop)
-			static_assert(sizeof(PartialExecProofMsgHeader) == (2 + 8 + 8 + 2), "PartialExecProofMsgHeader is 20B")
+			static_assert(sizeof(PartialExecProofMsgHeader) == (2 + 8 + 8 + 2), "PartialExecProofMsgHeader is 20B");
 
 			PartialExecProofMsgHeader* b() const { return (PartialExecProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/PartialExecProofMsg.hpp
+++ b/bftengine/src/bftengine/PartialExecProofMsg.hpp
@@ -21,6 +21,7 @@ namespace bftEngine
 		// TODO(GG): use SignedShareBase
 		class PartialExecProofMsg : public MessageBase
 		{
+			static_assert(sizeof(PartialExecProofMsgHeader) == (2 + 8 + 8 + 2), "PartialExecProofMsgHeader is 20B")
 
 		public:
 			PartialExecProofMsg(ReplicaId senderId, ViewNum v, SeqNum s, Digest& digest, IThresholdSigner* thresholdSigner);
@@ -36,7 +37,7 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, PartialExecProofMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push,1)
 			struct PartialExecProofMsgHeader
 			{
 				MessageBase::Header header;
@@ -45,6 +46,7 @@ namespace bftEngine
 				uint16_t thresholSignatureLength;
 				// followed by a signature 
 			};
+#pragma pack(pop)
 
 			PartialExecProofMsgHeader* b() const { return (PartialExecProofMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/PrePrepareMsg.hpp
@@ -25,8 +25,9 @@ namespace bftEngine
 
 		class PrePrepareMsg : public MessageBase
 		{
-		protected:
 
+		protected:
+#pragma pack(push,1)
 			struct PrePrepareMsgHeader
 			{
 				MessageBase::Header header;
@@ -44,6 +45,8 @@ namespace bftEngine
 				// bits 2-3: represent the first commit path that should be tried (00 = OPTIMISTIC_FAST, 01 = FAST_WITH_THRESHOLD, 10 = SLOW)
 				// bits 4-15: zero
 			};
+#pragma pack(pop)
+			static_assert(sizeof(PrePrepareMsgHeader) == (2 + 8 + 8 + 2 + DIGEST_SIZE + 2 + 4), "PrePrepareMsgHeader is 58B")
 
 			static const size_t prePrepareHeaderPrefix = sizeof(PrePrepareMsgHeader) - sizeof(PrePrepareMsgHeader::numberOfRequests) - sizeof(PrePrepareMsgHeader::endLocationOfLastRequest);
 

--- a/bftengine/src/bftengine/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/PrePrepareMsg.hpp
@@ -46,7 +46,7 @@ namespace bftEngine
 				// bits 4-15: zero
 			};
 #pragma pack(pop)
-			static_assert(sizeof(PrePrepareMsgHeader) == (2 + 8 + 8 + 2 + DIGEST_SIZE + 2 + 4), "PrePrepareMsgHeader is 58B")
+			static_assert(sizeof(PrePrepareMsgHeader) == (2 + 8 + 8 + 2 + DIGEST_SIZE + 2 + 4), "PrePrepareMsgHeader is 58B");
 
 			static const size_t prePrepareHeaderPrefix = sizeof(PrePrepareMsgHeader) - sizeof(PrePrepareMsgHeader::numberOfRequests) - sizeof(PrePrepareMsgHeader::endLocationOfLastRequest);
 

--- a/bftengine/src/bftengine/ReplicaStatusMsg.hpp
+++ b/bftengine/src/bftengine/ReplicaStatusMsg.hpp
@@ -73,7 +73,7 @@ namespace bftEngine
 				uint8_t flags; 				
 			};
 #pragma pack(pop)
-			static_assert(sizeof(ReplicaStatusMsgHeader) == (2 + 8 + 8 + 8 + 1), "ReplicaStatusMsgHeader is 27B")
+			static_assert(sizeof(ReplicaStatusMsgHeader) == (2 + 8 + 8 + 8 + 1), "ReplicaStatusMsgHeader is 27B");
 
 			static MsgSize calcSizeOfReplicaStatusMsg(bool listOfPrePrepareMsgsInActiveWindow, bool listOfMissingViewChangeMsgForViewChange, bool listOfMissingPrePrepareMsgForViewChange);
 

--- a/bftengine/src/bftengine/ReplicaStatusMsg.hpp
+++ b/bftengine/src/bftengine/ReplicaStatusMsg.hpp
@@ -15,6 +15,8 @@ namespace bftEngine
 	{
 		class ReplicaStatusMsg : public MessageBase
 		{
+			static_assert(sizeof(ReplicaStatusMsgHeader) == (2 + 8 + 8 + 8 + 1), "ReplicaStatusMsgHeader is 27B")
+
 		public:
 			ReplicaStatusMsg(ReplicaId senderId, ViewNum viewNumber, 
 				             SeqNum lastStableSeqNum, SeqNum lastExecutedSeqNum,
@@ -55,6 +57,7 @@ namespace bftEngine
 
 		protected:
 
+#pragma pack(push,1)
 			struct ReplicaStatusMsgHeader
 			{
 				MessageBase::Header header;
@@ -70,6 +73,7 @@ namespace bftEngine
 				// bit 4 == has list of missing PrePrepareMsg (for view change)
 				uint8_t flags; 				
 			};
+#pragma pack(pop)
 
 			static MsgSize calcSizeOfReplicaStatusMsg(bool listOfPrePrepareMsgsInActiveWindow, bool listOfMissingViewChangeMsgForViewChange, bool listOfMissingPrePrepareMsgForViewChange);
 

--- a/bftengine/src/bftengine/ReplicaStatusMsg.hpp
+++ b/bftengine/src/bftengine/ReplicaStatusMsg.hpp
@@ -15,7 +15,6 @@ namespace bftEngine
 	{
 		class ReplicaStatusMsg : public MessageBase
 		{
-			static_assert(sizeof(ReplicaStatusMsgHeader) == (2 + 8 + 8 + 8 + 1), "ReplicaStatusMsgHeader is 27B")
 
 		public:
 			ReplicaStatusMsg(ReplicaId senderId, ViewNum viewNumber, 
@@ -74,6 +73,7 @@ namespace bftEngine
 				uint8_t flags; 				
 			};
 #pragma pack(pop)
+			static_assert(sizeof(ReplicaStatusMsgHeader) == (2 + 8 + 8 + 8 + 1), "ReplicaStatusMsgHeader is 27B")
 
 			static MsgSize calcSizeOfReplicaStatusMsg(bool listOfPrePrepareMsgsInActiveWindow, bool listOfMissingViewChangeMsgForViewChange, bool listOfMissingPrePrepareMsgForViewChange);
 

--- a/bftengine/src/bftengine/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/ReqMissingDataMsg.hpp
@@ -16,6 +16,8 @@ namespace bftEngine
 	{
 
 		class ReqMissingDataMsg : public MessageBase {
+			static_assert(sizeof(ReqMissingDataMsgHeader) == (2 + 8 + 8 + 2), "ReqMissingDataMsgHeader is 58B")
+
 		public:
 			ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s);
 
@@ -46,7 +48,7 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, ReqMissingDataMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push,1)
 			struct ReqMissingDataMsgHeader : public MessageBase::Header {
 				ViewNum viewNum;
 				SeqNum seqNum;
@@ -61,6 +63,7 @@ namespace bftEngine
 				// bit 6 : fullPrepareIsMissing
 				// bit 7 : fullCommitIsMissing
 			};
+#pragma pack(pop)
 
 			ReqMissingDataMsgHeader* b() const {
 				return (ReqMissingDataMsgHeader*)msgBody_;

--- a/bftengine/src/bftengine/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/ReqMissingDataMsg.hpp
@@ -16,7 +16,6 @@ namespace bftEngine
 	{
 
 		class ReqMissingDataMsg : public MessageBase {
-			static_assert(sizeof(ReqMissingDataMsgHeader) == (2 + 8 + 8 + 2), "ReqMissingDataMsgHeader is 58B")
 
 		public:
 			ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s);
@@ -64,6 +63,7 @@ namespace bftEngine
 				// bit 7 : fullCommitIsMissing
 			};
 #pragma pack(pop)
+			static_assert(sizeof(ReqMissingDataMsgHeader) == (2 + 8 + 8 + 2), "ReqMissingDataMsgHeader is 58B")
 
 			ReqMissingDataMsgHeader* b() const {
 				return (ReqMissingDataMsgHeader*)msgBody_;

--- a/bftengine/src/bftengine/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/ReqMissingDataMsg.hpp
@@ -63,7 +63,7 @@ namespace bftEngine
 				// bit 7 : fullCommitIsMissing
 			};
 #pragma pack(pop)
-			static_assert(sizeof(ReqMissingDataMsgHeader) == (2 + 8 + 8 + 2), "ReqMissingDataMsgHeader is 58B")
+			static_assert(sizeof(ReqMissingDataMsgHeader) == (2 + 8 + 8 + 2), "ReqMissingDataMsgHeader is 58B");
 
 			ReqMissingDataMsgHeader* b() const {
 				return (ReqMissingDataMsgHeader*)msgBody_;

--- a/bftengine/src/bftengine/SignedShareMsgs.hpp
+++ b/bftengine/src/bftengine/SignedShareMsgs.hpp
@@ -23,6 +23,8 @@ namespace bftEngine
 		///////////////////////////////////////////////////////////////////////////////
 
 		class SignedShareBase : public MessageBase {
+			static_assert(sizeof(SignedShareBaseHeader) == (2 + 8 + 8 + 2), "SignedShareBaseHeader is 58B")
+
 		public:
 
 			ViewNum viewNumber() const { return b()->viewNumber; }
@@ -34,7 +36,7 @@ namespace bftEngine
 			char* signatureBody() const { return body() + sizeof(SignedShareBaseHeader); }
 
 		protected:
-
+#pragma pack(push,1)
 			struct SignedShareBaseHeader
 			{
 				MessageBase::Header header;
@@ -43,6 +45,7 @@ namespace bftEngine
 				uint16_t thresSigLength;
 				// Followed by threshold signature of <viewNumber, seqNumber, and the preprepre digest>
 			};
+#pragma pack(pop)
 
 			static SignedShareBase* create(int16_t type, ViewNum v, SeqNum s, ReplicaId senderId, Digest& digest, IThresholdSigner* thresholdSigner);
 			static SignedShareBase* create(int16_t type, ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen);

--- a/bftengine/src/bftengine/SignedShareMsgs.hpp
+++ b/bftengine/src/bftengine/SignedShareMsgs.hpp
@@ -45,7 +45,7 @@ namespace bftEngine
 				// Followed by threshold signature of <viewNumber, seqNumber, and the preprepre digest>
 			};
 #pragma pack(pop)
-			static_assert(sizeof(SignedShareBaseHeader) == (2 + 8 + 8 + 2), "SignedShareBaseHeader is 58B")
+			static_assert(sizeof(SignedShareBaseHeader) == (2 + 8 + 8 + 2), "SignedShareBaseHeader is 58B");
 
 			static SignedShareBase* create(int16_t type, ViewNum v, SeqNum s, ReplicaId senderId, Digest& digest, IThresholdSigner* thresholdSigner);
 			static SignedShareBase* create(int16_t type, ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen);

--- a/bftengine/src/bftengine/SignedShareMsgs.hpp
+++ b/bftengine/src/bftengine/SignedShareMsgs.hpp
@@ -23,7 +23,6 @@ namespace bftEngine
 		///////////////////////////////////////////////////////////////////////////////
 
 		class SignedShareBase : public MessageBase {
-			static_assert(sizeof(SignedShareBaseHeader) == (2 + 8 + 8 + 2), "SignedShareBaseHeader is 58B")
 
 		public:
 
@@ -46,6 +45,7 @@ namespace bftEngine
 				// Followed by threshold signature of <viewNumber, seqNumber, and the preprepre digest>
 			};
 #pragma pack(pop)
+			static_assert(sizeof(SignedShareBaseHeader) == (2 + 8 + 8 + 2), "SignedShareBaseHeader is 58B")
 
 			static SignedShareBase* create(int16_t type, ViewNum v, SeqNum s, ReplicaId senderId, Digest& digest, IThresholdSigner* thresholdSigner);
 			static SignedShareBase* create(int16_t type, ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen);

--- a/bftengine/src/bftengine/SimpleAckMsg.hpp
+++ b/bftengine/src/bftengine/SimpleAckMsg.hpp
@@ -42,7 +42,7 @@ namespace bftEngine
 				uint64_t    ackData;
 			};
 #pragma pack(pop)
-			static_assert(sizeof(SimpleAckMsgHeader) == (2 + 8 + 8 + 2), "SimpleAckMsgHeader is 20B")
+			static_assert(sizeof(SimpleAckMsgHeader) == (2 + 8 + 8 + 2), "SimpleAckMsgHeader is 20B");
 
 			SimpleAckMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/SimpleAckMsg.hpp
+++ b/bftengine/src/bftengine/SimpleAckMsg.hpp
@@ -42,7 +42,7 @@ namespace bftEngine
 				uint64_t    ackData;
 			};
 #pragma pack(pop)
-			static_assert(sizeof(SimpleAckMsgHeader) == (2 + 8 + 8 + 2), "SimpleAckMsgHeader is 20B");
+			static_assert(sizeof(SimpleAckMsgHeader) == (2 + 8 + 8 + 8), "SimpleAckMsgHeader is 26B");
 
 			SimpleAckMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/SimpleAckMsg.hpp
+++ b/bftengine/src/bftengine/SimpleAckMsg.hpp
@@ -20,6 +20,8 @@ namespace bftEngine
 		///////////////////////////////////////////////////////////////////////////////
 
 		class SimpleAckMsg : public MessageBase
+			static_assert(sizeof(SimpleAckMsgHeader) == (2 + 8 + 8 + 2), "SimpleAckMsgHeader is 20B")
+
 		{
 		public:
 			SimpleAckMsg(SeqNum s, ViewNum v, ReplicaId senderId, uint64_t ackData);
@@ -33,7 +35,7 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, SimpleAckMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push,1)
 			struct SimpleAckMsgHeader
 			{
 				MessageBase::Header header;
@@ -41,6 +43,7 @@ namespace bftEngine
 				ViewNum		viewNum;
 				uint64_t    ackData;
 			};
+#pragma pack(pop)
 
 			SimpleAckMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/SimpleAckMsg.hpp
+++ b/bftengine/src/bftengine/SimpleAckMsg.hpp
@@ -20,8 +20,6 @@ namespace bftEngine
 		///////////////////////////////////////////////////////////////////////////////
 
 		class SimpleAckMsg : public MessageBase
-			static_assert(sizeof(SimpleAckMsgHeader) == (2 + 8 + 8 + 2), "SimpleAckMsgHeader is 20B")
-
 		{
 		public:
 			SimpleAckMsg(SeqNum s, ViewNum v, ReplicaId senderId, uint64_t ackData);
@@ -44,6 +42,7 @@ namespace bftEngine
 				uint64_t    ackData;
 			};
 #pragma pack(pop)
+			static_assert(sizeof(SimpleAckMsgHeader) == (2 + 8 + 8 + 2), "SimpleAckMsgHeader is 20B")
 
 			SimpleAckMsgHeader* b() const
 			{

--- a/bftengine/src/bftengine/StartSlowCommitMsg.hpp
+++ b/bftengine/src/bftengine/StartSlowCommitMsg.hpp
@@ -36,7 +36,7 @@ namespace bftEngine
 				SeqNum seqNum;
 			};
 #pragma pack(pop)
-			static_assert(sizeof(StartSlowCommitMsgHeader) == (2 + 8 + 8), "StartSlowCommitMsgHeader is 12B")
+			static_assert(sizeof(StartSlowCommitMsgHeader) == (2 + 8 + 8), "StartSlowCommitMsgHeader is 12B");
 
 			StartSlowCommitMsgHeader* b() const { return (StartSlowCommitMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/StartSlowCommitMsg.hpp
+++ b/bftengine/src/bftengine/StartSlowCommitMsg.hpp
@@ -18,6 +18,8 @@ namespace bftEngine
 
 		class StartSlowCommitMsg : public MessageBase
 		{
+			static_assert(sizeof(StartSlowCommitMsgHeader) == (2 + 8 + 8), "StartSlowCommitMsgHeader is 12B")
+
 		public:
 			StartSlowCommitMsg(ReplicaId senderId, ViewNum v, SeqNum s);
 
@@ -28,13 +30,14 @@ namespace bftEngine
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, StartSlowCommitMsg*& outMsg);
 
 		protected:
-
+#pragma pack(push,1)
 			struct StartSlowCommitMsgHeader
 			{
 				MessageBase::Header header;
 				ViewNum viewNum;
 				SeqNum seqNum;
 			};
+#pragma pack(pop)
 
 			StartSlowCommitMsgHeader* b() const { return (StartSlowCommitMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/StartSlowCommitMsg.hpp
+++ b/bftengine/src/bftengine/StartSlowCommitMsg.hpp
@@ -18,8 +18,6 @@ namespace bftEngine
 
 		class StartSlowCommitMsg : public MessageBase
 		{
-			static_assert(sizeof(StartSlowCommitMsgHeader) == (2 + 8 + 8), "StartSlowCommitMsgHeader is 12B")
-
 		public:
 			StartSlowCommitMsg(ReplicaId senderId, ViewNum v, SeqNum s);
 
@@ -38,6 +36,7 @@ namespace bftEngine
 				SeqNum seqNum;
 			};
 #pragma pack(pop)
+			static_assert(sizeof(StartSlowCommitMsgHeader) == (2 + 8 + 8), "StartSlowCommitMsgHeader is 12B")
 
 			StartSlowCommitMsgHeader* b() const { return (StartSlowCommitMsgHeader*)msgBody_; }
 		};

--- a/bftengine/src/bftengine/StateTransferMsg.hpp
+++ b/bftengine/src/bftengine/StateTransferMsg.hpp
@@ -18,6 +18,8 @@ namespace bftEngine
 	{
 		class StateTransferMsg : public MessageBase
 		{
+			static_assert(sizeof(StateTransferMsg) == 2, "StartSlowCommitMsgHeader is 2B")
+
 		public:
 
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, StateTransferMsg*& outMsg);

--- a/bftengine/src/bftengine/StateTransferMsg.hpp
+++ b/bftengine/src/bftengine/StateTransferMsg.hpp
@@ -18,8 +18,6 @@ namespace bftEngine
 	{
 		class StateTransferMsg : public MessageBase
 		{
-			static_assert(sizeof(StateTransferMsg) == 2, "StartSlowCommitMsgHeader is 2B")
-
 		public:
 
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, StateTransferMsg*& outMsg);

--- a/bftengine/src/bftengine/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.hpp
@@ -97,7 +97,7 @@ namespace bftEngine
 											// followed by a signature (by genReplicaId)
 			};
 #pragma pack(pop)
-			static_assert(sizeof(ViewChangeMsgHeader) == (2 + 2 + 8 + 8 + 2 + 2), "ViewChangeMsgHeader is 24B")
+			static_assert(sizeof(ViewChangeMsgHeader) == (2 + 2 + 8 + 8 + 2 + 2), "ViewChangeMsgHeader is 24B");
 
 			ViewChangeMsgHeader* b() const { return ((ViewChangeMsgHeader*)msgBody_); }
 

--- a/bftengine/src/bftengine/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.hpp
@@ -20,6 +20,8 @@ namespace bftEngine
 
 		class ViewChangeMsg : public MessageBase
 		{
+			static_assert(sizeof(ViewChangeMsgHeader) == (2+2+8+8+2+2), "ViewChangeMsgHeader is 24B")
+
 		public:
 
 			struct Element {
@@ -84,7 +86,7 @@ namespace bftEngine
 			};
 
 		protected:
-
+#pragma pack(push,1)
 			struct ViewChangeMsgHeader
 			{
 				MessageBase::Header header;
@@ -96,7 +98,7 @@ namespace bftEngine
 											// followed by a sequnce of Element
 											// followed by a signature (by genReplicaId)
 			};
-
+#pragma pack(pop)
 			ViewChangeMsgHeader* b() const { return ((ViewChangeMsgHeader*)msgBody_); }
 
 			bool checkElements(uint16_t sigSize) const;

--- a/bftengine/src/bftengine/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.hpp
@@ -22,11 +22,12 @@ namespace bftEngine
 		{
 		public:
 
+#pragma pack(push,1)
 			struct Element {
 				SeqNum  seqNum;
 				Digest  prePrepreDigest;
 				ViewNum originView;
-				bool    hasPreparedCertificate;
+				bool    hasPreparedCertificate; // TODO(SG): I think sizeof(bool) is implementation dependent
 				// if (hasPreparedCertificate) then followed by PreparedCertificate 
 			};
 
@@ -36,6 +37,9 @@ namespace bftEngine
 				uint16_t certificateSigLength;
 				// Followed by signature of <certificateView, seqNum, pre-prepre digest>
 			};
+#pragma pack(pop)
+			static_assert(sizeof(Element) == (8 + DIGEST_SIZE + 8 + 1), "Element (View Change) is 49B");
+			static_assert(sizeof(PreparedCertificate) == (8 + 2), "PreparedCertificate is 10B");
 
 			ViewChangeMsg(ReplicaId srcReplicaId, ViewNum newView, SeqNum lastStableSeq);
 

--- a/bftengine/src/bftengine/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.hpp
@@ -20,8 +20,6 @@ namespace bftEngine
 
 		class ViewChangeMsg : public MessageBase
 		{
-			static_assert(sizeof(ViewChangeMsgHeader) == (2+2+8+8+2+2), "ViewChangeMsgHeader is 24B")
-
 		public:
 
 			struct Element {
@@ -99,6 +97,8 @@ namespace bftEngine
 											// followed by a signature (by genReplicaId)
 			};
 #pragma pack(pop)
+			static_assert(sizeof(ViewChangeMsgHeader) == (2 + 2 + 8 + 8 + 2 + 2), "ViewChangeMsgHeader is 24B")
+
 			ViewChangeMsgHeader* b() const { return ((ViewChangeMsgHeader*)msgBody_); }
 
 			bool checkElements(uint16_t sigSize) const;


### PR DESCRIPTION
- Wrapping each relevant struct definition with #pragma pack(push,1) ... #pragma pack(pop)
- Adding static_assertions for checking the size of each msg struct (I checked the effect without the pragma setting - it did not pass, as expected)