### PR TITLE
fix #14 - incorrect UDP Stop process implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Community
 
 [Concord-BFT Slack](https://concordbft.slack.com/).
 
-Get Slack invitation via this [link](https://join.slack.com/t/concordbft/shared_invite/enQtNDI4NjYzMTk5ODMxLWI3ZTc0MTQzNzFhZTNmNDRkM2I0YTZkMWZkMDAwYzg4YTA0YzViNjIyZTIzMjk2YjI5NGZkYzdkMTIyODJhZjI) or send request to <concordbft@gmail.com>. 
+Get Slack invitation via this [link](https://join.slack.com/t/concordbft/shared_invite/enQtNDI4NjYzMTk5ODMxLWI3ZTc0MTQzNzFhZTNmNDRkM2I0YTZkMWZkMDAwYzg4YTA0YzViNjIyZTIzMjk2YjI5NGZkYzdkMTIyODJhZjI) or send request to <concordbft@gmail.com>.
 
 
 
@@ -93,7 +93,7 @@ Build and install [RELIC](https://github.com/relic-toolkit/relic)
     cd relic/
     mkdir build/
     cd build/
-    cmake -DALLOC=AUTO -DWORD=64 -DRAND=UDEV -DSHLIB=ON -DSTLIB=ON -DSTBIN=OFF -DTIMER=HREAL -DCHECK=on -DVERBS=on -DARITH=x64-asm-254 -DFP_PRIME=254 -DFP_METHD="INTEG;INTEG;INTEG;MONTY;LOWER;SLIDE" -DCOMP="-O3 -funroll-loops -fomit-frame-pointer -finline-small-functions -march=native -mtune=native" -DFP_PMERS=off -DFP_QNRES=on -DFPX_METHD="INTEG;INTEG;LAZYR" -DPP_METHD="LAZYR;OATEP" ..
+    cmake -DALLOC=AUTO -DWSIZE=64 -DRAND=UDEV -DSHLIB=ON -DSTLIB=ON -DSTBIN=OFF -DTIMER=HREAL -DCHECK=on -DVERBS=on -DARITH=x64-asm-254 -DFP_PRIME=254 -DFP_METHD="INTEG;INTEG;INTEG;MONTY;LOWER;SLIDE" -DCOMP="-O3 -funroll-loops -fomit-frame-pointer -finline-small-functions -march=native -mtune=native" -DFP_PMERS=off -DFP_QNRES=on -DFPX_METHD="INTEG;INTEG;LAZYR" -DPP_METHD="LAZYR;OATEP" ..
     make
     sudo make install
 
@@ -108,7 +108,7 @@ Build and install [cryptopp](https://github.com/weidai11/cryptopp)
     cmake ..
     make
     sudo make install
-	
+
 Get GNU Parallel
 
     sudo apt-get install parallel

--- a/bftengine/src/bftengine/DynamicUpperLimitWithSimpleFilter2.hpp
+++ b/bftengine/src/bftengine/DynamicUpperLimitWithSimpleFilter2.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cmath> // sqrt
 #include "RollingAvgAndVar.hpp"
 
 namespace bftEngine

--- a/bftengine/src/bftengine/RetransmissionsManager.cpp
+++ b/bftengine/src/bftengine/RetransmissionsManager.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <queue>
+#include <cmath> // sqrt
 
 #include "MessageBase.hpp"
 #include "RetransmissionsManager.hpp"

--- a/bftengine/src/bftengine/StartSlowCommitMsg.cpp
+++ b/bftengine/src/bftengine/StartSlowCommitMsg.cpp
@@ -24,7 +24,7 @@ namespace bftEngine
 
 		bool StartSlowCommitMsg::ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, StartSlowCommitMsg*& outMsg) {
 			Assert(inMsg->type() == MsgCode::StartSlowCommit);
-			if (inMsg->size() < sizeof(StartSlowCommitMsg)) return false;
+			if (inMsg->size() < sizeof(StartSlowCommitMsgHeader)) return false;
 
 			StartSlowCommitMsg* t = (StartSlowCommitMsg*)inMsg;
 

--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -196,6 +196,7 @@ class PlainUDPCommunication::PlainUdpImpl {
     }
 #endif
 
+    running = true;
     startRecvThread();
 
     mutexUnlock(&runningLock);
@@ -347,7 +348,6 @@ class PlainUDPCommunication::PlainUdpImpl {
 
   void
   recvThreadRoutine() {
-    running = true;
     Assert(udpSockFd != 0,
            "Unable to start receiving: socket not define!");
     Assert(receiverRef != 0,


### PR DESCRIPTION
This PR fixes bug #14 - when Stop is called for the UDP module, the "continue" that is called if there is socket error skips sRunning assessment in the recvThreadRoutine method - and this method will not return thus preventing UDP receive thread to join.

The fix removes local sRunning variable and evaluates the "running" member directly. This member implemented as atomic<boolean> for better thread safety. 

Along with this fix, the shutdown call is fixed for windows.