### PR TITLE
Include <cmath> so sqrt is not implicitly used

### DIFF
--- a/bftengine/src/bftengine/DynamicUpperLimitWithSimpleFilter2.hpp
+++ b/bftengine/src/bftengine/DynamicUpperLimitWithSimpleFilter2.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cmath> // sqrt
 #include "RollingAvgAndVar.hpp"
 
 namespace bftEngine

--- a/bftengine/src/bftengine/RetransmissionsManager.cpp
+++ b/bftengine/src/bftengine/RetransmissionsManager.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <queue>
+#include <cmath> // sqrt
 
 #include "MessageBase.hpp"
 #include "RetransmissionsManager.hpp"


### PR DESCRIPTION
On some linux distributions cmath is required so `sqrt` can be used. The build will fail otherwise.