### PR TITLE
Fix tcp logger name and Release build warnings

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -224,6 +224,7 @@ void BCStateTran::init(uint64_t maxNumOfRequiredStoredCheckpoints,
 
     bool consistent = checkConsistency(pedanticChecks_);
     assert(consistent);
+    (void)consistent;
 
     FetchingState fs = getFetchingState();
 
@@ -465,6 +466,7 @@ void BCStateTran::markCheckpointAsStable(uint64_t checkpointNumber) {
         lastStoredCheckpoint - maxNumOfStoredCheckpoints_ + 1));
 
   assert(checkpointNumber <= psd_->getLastStoredCheckpoint());
+  (void)lastStoredCheckpoint;
 
   // assert(psd_->hasCheckpointDesc(checkpointNumber));
 
@@ -725,6 +727,7 @@ static ElementOfVirtualBlock* getVirtualElement(uint32_t index,
   HeaderOfVirtualBlock* h =
     reinterpret_cast<HeaderOfVirtualBlock*>(virtualBlock);
   assert(index < h->numberOfUpdatedPages);
+  (void)h;
 
   const uint32_t elementSize = sizeof(ElementOfVirtualBlock) + pageSize - 1;
 
@@ -1072,7 +1075,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg* m,
 
   FetchingState fs = getFetchingState();
   assert(fs == FetchingState::GettingCheckpointSummaries);
-
+  (void)fs;
 
   // if msg is invalid
   if (msgLen < sizeof(CheckpointSummaryMsg) ||
@@ -1239,6 +1242,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg* m,
   uint32_t sizeOfNextBlock = 0;
   bool tmp = as_->getBlock(nextBlock, buffer_, &sizeOfNextBlock);
   assert(tmp && sizeOfNextBlock > 0);
+  (void)tmp;
 
   uint32_t sizeOfLastChunk = maxChunkSize_;
   uint32_t numOfChunksInNextBlock = sizeOfNextBlock / maxChunkSize_;
@@ -1311,6 +1315,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg* m,
       sizeOfNextBlock = 0;
       bool tmp2 = as_->getBlock(nextBlock, buffer_, &sizeOfNextBlock);
       assert(tmp2 && sizeOfNextBlock > 0);
+      (void)tmp2;
 
       sizeOfLastChunk = maxChunkSize_;
       numOfChunksInNextBlock = sizeOfNextBlock / maxChunkSize_;
@@ -1654,6 +1659,7 @@ char* BCStateTran::getVBlockFromCache(
 
   assert(desc.lastCheckpointKnownToRequester ==
          header->lastCheckpointKnownToRequester);
+  (void)header;
 
   return vBlock;
 }
@@ -1663,6 +1669,7 @@ void BCStateTran::setVBlockInCache(const DescOfVBlockForResPages& desc,
   auto p = cacheOfVirtualBlockForResPages.find(desc);
 
   assert(p == cacheOfVirtualBlockForResPages.end());
+  (void)p;
 
   if (cacheOfVirtualBlockForResPages.size() > kMaxVBlocksInCache) {
     auto minItem = cacheOfVirtualBlockForResPages.begin();
@@ -2229,6 +2236,7 @@ void BCStateTran::processData() {
 
       bool b = as_->putBlock(nextRequiredBlock, buffer_, actualBlockSize);
       assert(b);
+      (void)b;
       memset(buffer_, 0, actualBlockSize);
 
       const uint64_t firstRequiredBlock = psd_->getFirstRequiredBlock();
@@ -2334,6 +2342,7 @@ void BCStateTran::processData() {
 
       bool tmp = checkConsistency(pedanticChecks_);
       assert(tmp);
+      (void)tmp;
 
       // Completion
 

--- a/bftengine/src/communication/PlainTcpCommunication.cpp
+++ b/bftengine/src/communication/PlainTcpCommunication.cpp
@@ -98,7 +98,7 @@ class AsyncTcpConnection :
   deadline_timer _connectTimer;
   ConnType _connType;
   bool _closed;
-  bftlogger::Logger _logger;
+  concordlogger::Logger _logger;
   uint16_t _minTimeout = 256;
   uint16_t _maxTimeout = 8192;
   uint16_t _currentTimeout = _minTimeout;
@@ -117,7 +117,7 @@ class AsyncTcpConnection :
                      NodeNum destId,
                      NodeNum selfId,
                      ConnType type,
-                     bftlogger::Logger logger) :
+                     concordlogger::Logger logger) :
       _service(service),
       _bufferLength(bufferLength),
       _fOnError(onError),
@@ -564,7 +564,7 @@ class AsyncTcpConnection :
                                NodeNum destId,
                                NodeNum selfId,
                                ConnType type,
-                               bftlogger::Logger logger) {
+                               concordlogger::Logger logger) {
     auto res = ASYNC_CONN_PTR(
         new AsyncTcpConnection(service,
                                onError,
@@ -601,7 +601,7 @@ class AsyncTcpConnection :
 class PlainTCPCommunication::PlainTcpImpl {
  private:
   unordered_map<NodeNum, ASYNC_CONN_PTR> _connections;
-  bftlogger::Logger _logger = bftlogger::Logger::getLogger("plain-tcp");
+  concordlogger::Logger _logger = concordlogger::Logger::getLogger("plain-tcp");
 
   unique_ptr<tcp::acceptor> _pAcceptor;
   std::thread *_pIoThread = nullptr;


### PR DESCRIPTION
This PR fixes typo bug in PlainTCP module and temporarily solves warning messages for unused variables when building in Release mode