### PR TITLE
Update state transfer modules

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -36,9 +36,11 @@ namespace SimpleBlockchainStateTransfer {
 constexpr static uint32_t BLOCK_DIGEST_SIZE = 32;
 
 // represnts a digest
+#pragma pack(push,1)
 struct StateTransferDigest {
   char content[BLOCK_DIGEST_SIZE];
 };
+#pragma pack(pop)
 
 // This method should be used to compute block digests
 void computeBlockDigest(const uint64_t blockId, const char* block,

--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -23,6 +23,7 @@ namespace bftEngine {
 namespace SimpleBlockchainStateTransfer {
 namespace impl {
 
+#pragma pack(push,1)
 
 class MsgType {
  public:
@@ -146,6 +147,8 @@ struct ItemDataMsg : public BCStateTranBaseMsg {
     return sizeof(ItemDataMsg) - 1 + dataSize;;
   }
 };
+
+#pragma pack(pop)
 
 }  // namespace impl
 }  // namespace SimpleBlockchainStateTransfer


### PR DESCRIPTION
- using state transfer in simpleTest
- disable padding in state transfer messages
- update asserts in state transfer modules

Signed-off-by: Guy Gueta <ggolangueta@vmware.com>