### PR TITLE
fix type errors logged by gcc 7

### DIFF
--- a/threshsign/src/bls/relic/BlsAccumulatorBase.cpp
+++ b/threshsign/src/bls/relic/BlsAccumulatorBase.cpp
@@ -49,7 +49,7 @@ BlsAccumulatorBase::BlsAccumulatorBase(const std::vector<BlsPublicKey>& verifKey
     : ThresholdAccumulatorBase(verifKeys, reqSigners, totalSigners),
       shareVerificationEnabled(withShareVerification)
 {
-    assertEqual(vks.size(), static_cast<size_t>(totalSigners + 1));
+    assertEqual(vks.size(), static_cast<std::vector<BlsPublicKey>::size_type>(totalSigners + 1));
 
     g2_get_gen(gen2);	// NOTE: requires BLS::Relic::Library::Get() call above to be made
 }

--- a/threshsign/src/bls/relic/BlsMultisigVerifier.cpp
+++ b/threshsign/src/bls/relic/BlsMultisigVerifier.cpp
@@ -29,7 +29,7 @@ BlsMultisigVerifier::BlsMultisigVerifier(const BlsPublicParameters& params,
         NumSharesType reqSigners, NumSharesType numSigners, const std::vector<BlsPublicKey>& verifKeys)
     : BlsThresholdVerifier(params, G2T::Identity(), reqSigners, numSigners, verifKeys)
 {
-    assertEqual(verifKeys.size(), static_cast<size_t>(numSigners + 1));
+    assertEqual(verifKeys.size(), static_cast<std::vector<BlsPublicKey>::size_type>(numSigners + 1));
 
     if(reqSigners == numSigners) {
         // the PK is the aggregate PK of all numSigners and is needed to verify n-out-of-n threshold

--- a/threshsign/src/bls/relic/BlsThresholdVerifier.cpp
+++ b/threshsign/src/bls/relic/BlsThresholdVerifier.cpp
@@ -39,9 +39,9 @@ BlsThresholdVerifier::BlsThresholdVerifier(const BlsPublicParameters& params, co
     : params(params), pk(pk), vks(verifKeys.begin(), verifKeys.end()), gen2(params.getGen2()),
       reqSigners(reqSigners), numSigners(numSigners)
 {
-    assertEqual(verifKeys.size(), static_cast<size_t>(numSigners + 1));
+    assertEqual(verifKeys.size(), static_cast<std::vector<BlsPublicKey>::size_type>(numSigners + 1));
     // verifKeys[0] was copied as well, but it's set to a dummy PK so it does not matter
-    assertEqual(vks.size(), static_cast<size_t>(numSigners + 1));
+    assertEqual(vks.size(), static_cast<std::vector<BlsPublicKey>::size_type>(numSigners + 1));
 
 #ifdef TRACE
     logtrace << "VKs (array has size " << vks.size() << ")" << endl;

--- a/threshsign/src/bls/relic/LagrangeInterpolation.cpp
+++ b/threshsign/src/bls/relic/LagrangeInterpolation.cpp
@@ -57,7 +57,7 @@ LagrangeIncrementalCoeffs::LagrangeIncrementalCoeffs(NumSharesType numSigners, c
 	  numerFull(fieldOrder.getModulus()), numerSign(0),
 	  pi(Library::Get().getPrecomputedInverses())
 {
-	assertEqual(denoms.size(), static_cast<size_t>(numSigners + 1));
+	assertEqual(denoms.size(), static_cast<std::vector<BLS::Relic::AccumulatedBNT>::size_type>(numSigners + 1));
 	assertEqual(denoms.size(), denomSigns.size());
 }
 

--- a/threshsign/test/TestBlsBatchVerifier.cpp
+++ b/threshsign/test/TestBlsBatchVerifier.cpp
@@ -119,8 +119,8 @@ void batchVerifyHelper(BlsBatchVerifier& ver, int numBadShares, const G1T& msgPo
         throw std::logic_error("batchVerify() returned wrong result");
     }
 
-    testAssertEqual(badShares.size(), static_cast<size_t>(numBadShares));
-    testAssertEqual(badShares.size(), static_cast<size_t>(badSubset.count()));
+    testAssertEqual(badShares.size(), static_cast<std::vector<ShareID>::size_type>(numBadShares));
+    testAssertEqual(badShares.size(), static_cast<std::vector<ShareID>::size_type>(badSubset.count()));
     for(ShareID id : badShares) {
         testAssertTrue(badSubset.contains(id));
     }
@@ -131,7 +131,7 @@ void batchVerifyHelper(BlsBatchVerifier& ver, int numBadShares, const G1T& msgPo
         throw std::logic_error("batchVerify() returned wrong result");
     }
 
-    testAssertEqual(goodShares.size(), static_cast<size_t>(goodSubset.count()));
+    testAssertEqual(goodShares.size(), static_cast<std::vector<ShareID>::size_type>(goodSubset.count()));
     for(ShareID id : goodShares) {
         testAssertTrue(goodSubset.contains(id));
     }


### PR DESCRIPTION
When moving from gcc 6 to gcc 7, warnings of this sort were logged for these sites:

```
In file included from /concord/submodules/concord-bft/threshsign/src/bls/relic/BlsMultisigVerifier.cpp:22:0:
concord-bft/threshsign/src/bls/relic/BlsMultisigVerifier.cpp: In constructor 'BLS::Relic::BlsMultisigVerifier::BlsMultisigVerifier(const BLS::Relic::BlsPublicParameters&, NumSharesType, NumSharesType, const std::vector<BLS::Relic::BlsPublicKey>&)':
concord-bft/threshsign/src/bls/relic/BlsMultisigVerifier.cpp:32:35: error: conversion to 'std::vector<BLS::Relic::BlsPublicKey>::size_type {aka long unsigned int}' from 'NumSharesType {aka int}' may change the sign of the result [-Werror=sign-conversion]
     assertEqual(verifKeys.size(), static_cast<size_t>(numSigners + 1));
concord-bft/threshsign/src/bls/relic/../../XAssert.h:95:20: note: in definition of macro 'XASSERT_Equal'
     if((first) != (second)) { \
                    ^~~~~~
concord-bft/threshsign/src/bls/relic/BlsMultisigVerifier.cpp:32:5: note: in expansion of macro 'assertEqual'
     assertEqual(verifKeys.size(), static_cast<size_t>(numSigners + 1));
     ^~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

This change matches the cast type to the comparison type, to clear up the error.