### PR TITLE
Remove certain unnecessary log messages

### DIFF
--- a/threshsign/src/Log.cpp
+++ b/threshsign/src/Log.cpp
@@ -112,13 +112,11 @@ private:
 	// If we're in "no logging" mode, make sure we never evaluate 'expr' we logdbg!
 #ifdef NDEBUG
 		logdbg << shouldNotBeCalled();
-		loginfo << "Compiler successfully avoids evaluating expressions in 'logdbg << expr()'" << std::endl;
 #endif
 
 	// If we're in "no trace" mode, make sure we never evaluate 'expr' we logtrace!
 #ifndef TRACE
 		logtrace << shouldNotBeCalled();
-		loginfo << "Compiler successfully avoids evaluating expressions in 'logtrace << expr()'" << std::endl;
 #endif
 	}
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -103,7 +103,7 @@ Parameter | Expected Value | Description
 `<PREFIX>_cryptosystem_num_signers` | positive integer | Number of signers in this cryptosystem; it is expected that this value will be equal to `num_replicas`.
 `<PREFIX>_cryptosystem_threshold` | positive integrer | Threshold for this cryptosystem, that is, the number of unique signers that are required to produce a complete threshold signature under this cryptosystem.
 `<PREFIX>_cryptosystem_public_key` | cryptographic key of type-dependent format | The public key for this threshold cryptosystem.
-`<PREFIX_cryptosystem_verification_keys>` | list of cryptographic key of type-dependent format | A verification key for each signer under this cryptosystem. The verification keys can be used to verify a specific signer's signature share during the collection of signatures for a complete threshold signture. The keys should be ordered by signer ID of the signer to which they correspond.
+`<PREFIX>_cryptosystem_verification_keys` | list of cryptographic key of type-dependent format | A verification key for each signer under this cryptosystem. The verification keys can be used to verify a specific signer's signature share during the collection of signatures for a complete threshold signture. The keys should be ordered by signer ID of the signer to which they correspond.
 
 ##### Replica Private Keys #####
 


### PR DESCRIPTION
This minor pull request removes two log messages from the `LogInitializer` constructor in `threshsign/src/Log.cpp`. I believe these statements are not needed anymore, and I have found they may (at least under certain circumstances) pollute the output of programs linked with Concord-BFT.