### PR TITLE
Fix bug in BCStateTran::cacheOfVirtualBlockForResPages.

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1672,7 +1672,7 @@ void BCStateTran::setVBlockInCache(const DescOfVBlockForResPages& desc,
 
   Assert(p == cacheOfVirtualBlockForResPages.end());
 
-  if (cacheOfVirtualBlockForResPages.size() > kMaxVBlocksInCache) {
+  if (cacheOfVirtualBlockForResPages.size() >= kMaxVBlocksInCache) {
     auto minItem = cacheOfVirtualBlockForResPages.begin();
     std::free(minItem->second);
     cacheOfVirtualBlockForResPages.erase(minItem);


### PR DESCRIPTION
When cacheOfVirtualBlockForResPages is full, an assert in BCStateTran::setVBlockInCache in violated.