### PR TITLE
Add Googletest as a dependency in a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ cmake-build-debug/
 .vscode/
 README.html
 venv/
-
+*.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/gtest"]
+	path = deps/gtest
+	url = git@github.com:google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,3 +111,6 @@ add_subdirectory(threshsign)
 add_subdirectory(bftengine)
 add_subdirectory(tools)
 add_subdirectory(bftengine/tests)
+
+# Dependencies as submodules
+add_subdirectory(deps/gtest)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Get GMP (dependency for [RELIC](https://github.com/relic-toolkit/relic)):
 
     sudo apt-get install libgmp3-dev
 
+Initialize submodules
+
+    git submodule init && git submodule update --recursive
+
 Build and install [RELIC](https://github.com/relic-toolkit/relic)
 
     cd

--- a/bftengine/tests/CMakeLists.txt
+++ b/bftengine/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(simpleTest)
 add_subdirectory(simpleKVBC)
 add_subdirectory(simpleKVBCTests)
+add_subdirectory(datastore)

--- a/bftengine/tests/datastore/CMakeLists.txt
+++ b/bftengine/tests/datastore/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(datastore_unit_tests
+    datastore_unit_tests.cpp)
+
+# We are testing implementation details, so must reach into the src hierarchy
+# for includes that aren't public in cmake.
+target_include_directories(datastore_unit_tests
+    PRIVATE
+    ${bftengine_SOURCE_DIR}/src/bcstatetransfer)
+
+target_link_libraries(datastore_unit_tests gtest_main)
+target_link_libraries(datastore_unit_tests corebft)

--- a/bftengine/tests/datastore/datastore_unit_tests.cpp
+++ b/bftengine/tests/datastore/datastore_unit_tests.cpp
@@ -1,0 +1,8 @@
+#include "gtest/gtest.h"
+#include "InMemoryDataStore.hpp"
+
+TEST(in_memory_data_store, initialize) {
+    auto store = bftEngine::SimpleBlockchainStateTransfer::impl::InMemoryDataStore(4096);
+    store.setAsInitialized();
+    ASSERT_TRUE(store.initialized());
+}


### PR DESCRIPTION
I added gtest as a submodule so we can start to write unit tests.
CMakeLists.txt was updated to pull it in to the build. A very basic
example test was added in bftengine/tests/datastore. The README was also
updated to reflect that submodules need to be initialized.

Additionally, vim temporary files are now ignored by adding them .gitignore.