### PR TITLE
Only initialize submodules if they are empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,12 @@ endif()
 # Initialize submodules and update a specific one
 # This allows us to only pull in dependencies when needed.
 function(add_submodule path)
+    file(GLOB RESULT ${path})
+    list(LENGTH RESULT RES_LEN)
+    if(NOT RES_LEN EQUAL 0)
+        message(STATUS "Submodule ${path} already initialized. Skipping.")
+        return()
+    endif()
     message(STATUS "Submodule update ${path}")
     execute_process(
         COMMAND git submodule update --init --recursive ${path}


### PR DESCRIPTION
This is required for some higher level builds in the blockchain project
that include concord-bft as a submodule and build inside docker.