### PR TITLE
Add a metrics library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_subdirectory(logging)
 add_subdirectory(threshsign)
 add_subdirectory(bftengine)
 add_subdirectory(tools)
+add_subdirectory(util)
 
 #
 # Setup testing
@@ -146,5 +147,6 @@ if(BUILD_TESTING)
     add_submodule("deps/gtest")
     add_subdirectory(deps/gtest)
     add_subdirectory(bftengine/tests)
+    add_subdirectory(util/test)
 endif()
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(util STATIC src/Metrics.cpp)
+
+target_include_directories(util PUBLIC include)

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -1,0 +1,186 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#ifndef CONCORD_BFT_METRICS_HPP
+#define CONCORD_BFT_METRICS_HPP
+
+#include <stdint.h>
+#include <map>
+#include <vector>
+#include <mutex>
+#include <memory>
+
+namespace concordMetrics {
+
+// Forward declarations since Aggregator requires these types.
+class Component;
+class Values;
+class Gauge;
+class Status;
+class Counter;
+
+// An aggregator maintains metrics for multiple components. Components
+// maintain a handle to the aggregator and update it periodically with
+// all their metric values. Therefore, the state of all metrics is eventually
+// consistent.
+//
+// The Aggregator is the type responsible for reporting metrics for the entire
+// system. A process should have a single aggregator, and any service
+// responsible for reporting system metrics should read it from the aggregator.
+class Aggregator {
+ public:
+  Gauge GetGauge(const std::string& component_name,
+                 const std::string& val_name);
+  Status GetStatus(const std::string& component_name,
+                   const std::string& val_name);
+  Counter GetCounter(const std::string& component_name,
+                     const std::string& val_name);
+
+ private:
+  void RegisterComponent(Component& component);
+  void UpdateValues(const std::string& name, Values&& values);
+
+  std::map<std::string, Component> components_;
+  std::mutex lock_;
+
+  friend class Component;
+};
+
+// A Gauge is a an integer value that shows the current value of something. It
+// can only be varied by directly setting and getting it.
+class Gauge {
+ public:
+  explicit Gauge(const uint64_t val) : val_(val) {}
+
+  void Set(const uint64_t val) { val_ = val; }
+  uint64_t Get() { return val_; }
+
+ private:
+  uint64_t val_;
+};
+
+// Status is a text based representation of a value. It's used for things that
+// don't have strictly numeric representations, like the current state of the
+// BFT or the last message received.
+class Status {
+ public:
+  explicit Status(const std::string& val) : val_(val) {}
+
+  void Set(const std::string& val) { val_ = val; }
+  std::string Get() { return val_; }
+
+ private:
+  std::string val_;
+};
+
+class Counter {
+ public:
+  explicit Counter(const uint64_t val) : val_(val) {}
+
+  // Increment the counter and return the value after incrementing.
+  uint64_t Inc() { return ++val_; }
+
+  uint64_t Get() { return val_; }
+
+ private:
+  uint64_t val_;
+};
+
+class Values {
+ private:
+  std::vector<Gauge> gauges_;
+  std::vector<Status> statuses_;
+  std::vector<Counter> counters_;
+
+  friend class Component;
+  friend class Aggregator;
+};
+
+// We keep the names of values in separate vecs since they remain constant for
+// the life of the program. When we update the component in the aggregator we
+// don't have to copy all the names every time. We just have to do it once
+// during initialization.
+class Names {
+ private:
+  std::vector<std::string> gauge_names_;
+  std::vector<std::string> status_names_;
+  std::vector<std::string> counter_names_;
+
+  friend class Component;
+  friend class Aggregator;
+};
+
+// A Component stores Values of different types and is updated on the local
+// thread. Components are sent to an Aggregator periodically. Components are
+// optimized for fast update access.
+class Component {
+ public:
+  // A Handle allows for fast access to the underlying value inside the
+  // component via an index operation.
+  //
+  // Note that the handle cannot live longer than the Component, and should
+  // never be used from a separate thread.
+  //
+  // In concord-bft we expect components to live for the lifetime of the program
+  // and handles to be member variables used to update values on the same
+  // thread.
+  template <typename T>
+  class Handle {
+   public:
+    Handle(std::vector<T>& values, size_t index)
+        : values_(values), index_(index) {}
+    T& Get() { return values_[index_]; }
+
+   private:
+    std::vector<T>& values_;
+    size_t index_;
+  };
+
+  Component(const std::string& name, std::shared_ptr<Aggregator> aggregator)
+      : aggregator_(aggregator), name_(name) {}
+  std::string Name() { return name_; }
+
+  // Create a Gauge, add it to the component and return a reference to the
+  // gauge.
+  Handle<Gauge> RegisterGauge(const std::string& name, const uint64_t val);
+  Handle<Status> RegisterStatus(const std::string& name,
+                                const std::string& val);
+  Handle<Counter> RegisterCounter(const std::string& name, const uint64_t val);
+
+  // Register the component with the aggregator.
+  // This *must* be done after all values are registered in this component.
+  // If registration happens before all registration of the values, then the
+  // names will not properly exist in the aggregator, since only values get
+  // updated at runtime for performance reasons.
+  void Register() { aggregator_->RegisterComponent(*this); }
+
+  void UpdateAggregator() {
+    Values copy = values_;
+    aggregator_->UpdateValues(name_, std::move(copy));
+  }
+
+ private:
+  friend class Aggregator;
+
+  void SetValues(Values&& values) { values_ = values; }
+
+  std::shared_ptr<Aggregator> aggregator_;
+  std::string name_;
+
+  Names names_;
+  Values values_;
+};
+
+}  // namespace concordMetrics
+
+#endif  // CONCORD_BFT_METRICS_HPP

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -1,0 +1,107 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "Metrics.hpp"
+#include <stdexcept>
+#include <sstream>
+
+using namespace std;
+
+namespace concordMetrics {
+
+const char* const kGaugeName = "gauge";
+const char* const kStatusName = "status";
+const char* const kCounterName = "counter";
+
+template <typename T>
+T FindValue(const char* const val_type,
+            const string& val_name,
+            const vector<string>& names,
+            const vector<T>& values) {
+  for (int i = 0; i < names.size(); i++) {
+    if (names[i] == val_name) {
+      return values[i];
+    }
+  }
+  ostringstream oss;
+  oss << "Invalid " << val_type << " name: " << val_name;
+  throw invalid_argument(oss.str());
+}
+
+Component::Handle<Gauge> Component::RegisterGauge(const string& name,
+                                                  const uint64_t val) {
+  names_.gauge_names_.emplace_back(name);
+  values_.gauges_.emplace_back(Gauge(val));
+  return Component::Handle<Gauge>(values_.gauges_, values_.gauges_.size() - 1);
+}
+
+Component::Handle<Status> Component::RegisterStatus(const string& name,
+                                                    const string& val) {
+  names_.status_names_.emplace_back(name);
+  values_.statuses_.emplace_back(Status(val));
+  return Component::Handle<Status>(values_.statuses_,
+                                   values_.statuses_.size() - 1);
+}
+
+Component::Handle<Counter> Component::RegisterCounter(const string& name,
+                                                      const uint64_t val) {
+  names_.counter_names_.emplace_back(name);
+  values_.counters_.emplace_back(Counter(val));
+  return Component::Handle<Counter>(values_.counters_,
+                                    values_.counters_.size() - 1);
+}
+
+void Aggregator::RegisterComponent(Component& component) {
+  std::lock_guard<std::mutex> lock(lock_);
+  components_.insert(make_pair(component.Name(), component));
+}
+
+// Throws if the component doesn't exist.
+// This is only called from the component itself so it will never actually
+// throw.
+void Aggregator::UpdateValues(const string& name, Values&& values) {
+  std::lock_guard<std::mutex> lock(lock_);
+  components_.at(name).SetValues(std::move(values));
+}
+
+Gauge Aggregator::GetGauge(const string& component_name,
+                           const string& val_name) {
+  std::lock_guard<std::mutex> lock(lock_);
+  auto& component = components_.at(component_name);
+  return FindValue(kGaugeName,
+                   val_name,
+                   component.names_.gauge_names_,
+                   component.values_.gauges_);
+}
+
+Status Aggregator::GetStatus(const string& component_name,
+                             const string& val_name) {
+  std::lock_guard<std::mutex> lock(lock_);
+  auto& component = components_.at(component_name);
+  return FindValue(kStatusName,
+                   val_name,
+                   component.names_.status_names_,
+                   component.values_.statuses_);
+}
+
+Counter Aggregator::GetCounter(const string& component_name,
+                               const string& val_name) {
+  std::lock_guard<std::mutex> lock(lock_);
+  auto& component = components_.at(component_name);
+  return FindValue(kCounterName,
+                   val_name,
+                   component.names_.counter_names_,
+                   component.values_.counters_);
+}
+
+}  // namespace concordMetrics

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(metric_tests metric_test.cpp)
+
+add_test(metric_tests metric_tests)
+
+target_link_libraries(metric_tests gtest_main util)

--- a/util/test/metric_test.cpp
+++ b/util/test/metric_test.cpp
@@ -1,0 +1,72 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+#include "gtest/gtest.h"
+#include "Metrics.hpp"
+
+using namespace std;
+
+namespace concordMetrics {
+
+TEST(MetricsTest, UseValues) {
+  auto aggregator = std::make_shared<Aggregator>();
+  Component c("replica", aggregator);
+  auto h_gauge = c.RegisterGauge("connected_peers", 3);
+  auto h_status = c.RegisterStatus("state", "primary");
+  auto h_counter = c.RegisterCounter("messages_sent", 0);
+
+  ASSERT_EQ(3, h_gauge.Get().Get());
+  ASSERT_EQ("primary", h_status.Get().Get());
+  ASSERT_EQ(0, h_counter.Get().Get());
+
+  h_gauge.Get().Set(5);
+  ASSERT_EQ(5, h_gauge.Get().Get());
+  h_status.Get().Set("backup");
+  ASSERT_EQ("backup", h_status.Get().Get());
+  ASSERT_EQ(1, h_counter.Get().Inc());
+}
+
+TEST(MetricsTest, Aggregator) {
+  auto aggregator = std::make_shared<Aggregator>();
+  Component c("replica", aggregator);
+  auto h_gauge = c.RegisterGauge("connected_peers", 3);
+  auto h_status = c.RegisterStatus("state", "primary");
+  auto h_counter = c.RegisterCounter("messages_sent", 0);
+
+  c.Register();
+
+  ASSERT_EQ(3, aggregator->GetGauge(c.Name(), "connected_peers").Get());
+  ASSERT_THROW(aggregator->GetGauge(c.Name(), "non-existent-gauge"),
+               invalid_argument);
+  ASSERT_EQ("primary", aggregator->GetStatus(c.Name(), "state").Get());
+  ASSERT_THROW(aggregator->GetStatus(c.Name(), "no-such-status"),
+               invalid_argument);
+  ASSERT_EQ(0, aggregator->GetCounter(c.Name(), "messages_sent").Get());
+  ASSERT_THROW(aggregator->GetCounter(c.Name(), "no-such-counter"),
+               invalid_argument);
+
+  h_gauge.Get().Set(5);
+  h_status.Get().Set("backup");
+  h_counter.Get().Inc();
+  // We haven't updated the aggregator yet, so it still has the old values
+  ASSERT_EQ(3, aggregator->GetGauge(c.Name(), "connected_peers").Get());
+  ASSERT_EQ("primary", aggregator->GetStatus(c.Name(), "state").Get());
+  ASSERT_EQ(0, aggregator->GetCounter(c.Name(), "messages_sent").Get());
+
+  c.UpdateAggregator();
+  ASSERT_EQ(5, aggregator->GetGauge(c.Name(), "connected_peers").Get());
+  ASSERT_EQ("backup", aggregator->GetStatus(c.Name(), "state").Get());
+  ASSERT_EQ(1, aggregator->GetCounter(c.Name(), "messages_sent").Get());
+}
+
+}  // namespace concordMetrics


### PR DESCRIPTION
The metrics library provides common data types with well defined
interfaces to allow us collect information about the running bft node.
There are two container types, and three value types included in the
library.

Components
---

A `Component` represents a specific piece of code that needs its metrics
trackable during runtime, such as the ReplicaImp or BcStateTransfer. A component
contains a fixed set of Values (Gauge, Status, Counter), is updated on a single
thread, and is optimized for fast writes. The goal was to make writes as fast as
possible while still allowing for some semblance of generic behavior, so that
stats from different components can be aggregated and reported on in similar
ways. They are write optimized, because updating can happen very frequently
especially in the case of counters and histograms (coming in a future commit),
and we don't want to limit our collection due to overhead.

We make writes fast by returning Handles to values which wrap indexes
into vecs. Therefore an update is essentially a vec indexing followed by
the actual operation. Handles are expected to be kept as member
variables in the bft type that also holds the component. Therefore, stats
updates occur by updating member variables, as would be done in a more
naive system.

Aggregators
---

There is typically one aggregator per node which provides an eventually
consistent view of the metrics of all components and their contained
values. Aggregators are expected to be used to retrieve the metrics of
the entire system during end to end tests, and to optionally provide
live runtime debugging information for a given node. They should be
accessed much less frequently than components.

Aggregrators are updated periodically with component values in a thread
safe manner via `UpdateValues`. We minimize the amount of data transferred
during update by only transferring values and not including their names. Since
all components have a pre-defined number of values when they start, we can
inform the aggregator about the names when we call `RegisterComponent()`. This
is the reason that value names are separated from the value contents into
separate types (Names and Values) containing vecs for each value type. We could
always further minimize the amount of data transferred by keeping track of which
values were updated and only transferring those, but that would likely make
updating take longer, and adds complexity. We can do this later if measuring
shows performance issues.

Values
----

There are 3 value types (stats types) that define the types of metrics being
collected. A `Gauge` reports a static integer that changes discretely, but not in
an incremental fashion. A `Status` reports any short textual data, such as whether the
replica is currently a primary or backup. A `Counter` is used for incrementing
stats, such as the number of sent messages. Histograms (via HdrHistogram) are
expected to be added in a future commit.

---

The included `metric_test` tests the basic functionality of all the types and
shows how to use them. Tests can be run with `ctest -R metric
--verbose` from the build directory.

Future commits will include serialization, as well as integration of
components and aggregrators into the rest of the codebase. After that we will
need to add a client command to retrieve the serialized metrics so we can use it
for testing and runtime inspection.