### PR TITLE
Fix local build when missing deps/gtest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/gtest"]
 	path = deps/gtest
-	url = git@github.com:google/googletest
+	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ endif()
 # Initialize submodules and update a specific one
 # This allows us to only pull in dependencies when needed.
 function(add_submodule path)
-    file(GLOB RESULT ${path})
+    file(GLOB RESULT ${path}/*)
     list(LENGTH RESULT RES_LEN)
     if(NOT RES_LEN EQUAL 0)
         message(STATUS "Submodule ${path} already initialized. Skipping.")


### PR DESCRIPTION
A prior fix was made to only download the deps/gtest submodule if it
wasn't already downloaded to fix a project using concord-bft that
already had initialized submodules. Unfortunately, the glob pattern used
to perform the check for an existing dep was incorrect and only checked
to see if the directory existed and not if there were any contents. This
commit fixes the glob pattern.

Additionally, unprivileged users on github cannot use git paths to pull,
even from opensource repositories. Therefore replace the .gitmodules
path previously starting with `git@` with an `https://` style path.

I tested this locally and inside our other product build to ensure
correctness. I also tested it on a new server without github
credentials.