### PR TITLE
Add a UDP python client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/*
 *.swp
 tags
 compile_commands.json
+*__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,8 @@ function(add_submodule path)
     endif()
 endfunction()
 
+include(CTest)
+
 #
 # Subdirectories
 #
@@ -159,10 +161,8 @@ add_subdirectory(util)
 #
 # Setup testing
 #
-include(CTest)
 if(BUILD_TESTING)
     add_submodule("deps/gtest")
     add_subdirectory(deps/gtest)
     add_subdirectory(bftengine/tests)
-    add_subdirectory(util/test)
 endif()

--- a/README.md
+++ b/README.md
@@ -179,19 +179,19 @@ We use OpenSSL for TLS communication module. Please install it using
 
     sudo apt-get install openssl libssl-dev
 
-#### (Optional) Only if using TLS or plain TCP as communication module 
-We use Boost both for plain TCP and TLS communication. Please follow these 
+#### (Optional) Only if using TLS or plain TCP as communication module
+We use Boost both for plain TCP and TLS communication. Please follow these
 instructions to install this library
 
 Download Boost version 1.64
 
     wget https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz
-    
+
 Unpack the archive
 
     tar -xf boost_1_64_0.tar.gz
-    
-Build and install Boost (note that these commands will install only modules 
+
+Build and install Boost (note that these commands will install only modules
 that are mandatory for building this project)
 
     cd boost_1_64_0
@@ -237,7 +237,18 @@ useful for building concord-bft:
  * `USE_LOG4CPP`          - TRUE | FALSE (DEFAULT FALSE)
  * `CONCORD_LOGGER_NAME`  - STRING (DEFAULT "concord")
 
- Note: You can't set both BUILD_COMM_TCP_PLAIN and BUILD_COMM_TCP_TLS to TRUE.
+ Note: You can't set both `BUILD_COMM_TCP_PLAIN` and `BUILD_COMM_TCP_TLS` to TRUE.
+
+### (Optional) Python client
+
+The python client is required for running tests. If you do not want to install
+python, you can configure the build of concord-bft by running `cmake
+-DBUILD_TESTING=OFF ..` from the `build` directory.
+
+The python client requires python3(>= 3.5) and trio, which is installed via pip.
+
+    sudo apt install python3 python3-pip
+    python3 -m pip install --upgrade trio
 
 Run examples
 ----

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,3 +1,8 @@
 add_library(util STATIC src/Metrics.cpp)
 
 target_include_directories(util PUBLIC include)
+
+if (BUILD_TESTING)
+    add_subdirectory(pyclient)
+    add_subdirectory(test)
+endif()

--- a/util/pyclient/CMakeLists.txt
+++ b/util/pyclient/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_test(NAME pyclient_tests COMMAND python3 -m unittest
+    test_client
+    test_msgs
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/util/pyclient/README.md
+++ b/util/pyclient/README.md
@@ -1,0 +1,1 @@
+An implementation of a BFT client in Python

--- a/util/pyclient/client.py
+++ b/util/pyclient/client.py
@@ -1,0 +1,166 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+# This code requires python 3.5 or later
+from collections import namedtuple
+import struct
+import msgs
+import trio
+
+Config = namedtuple('Config', ['id', 'f', 'c', 'max_msg_size', 'req_timeout_milli',
+    'retry_timeout_milli'])
+Replica = namedtuple('Replica', ['id', 'ip', 'port'])
+
+
+class UdpClient:
+    def __enter__(self):
+        """context manager method for 'with' statements"""
+        return self
+
+    def __exit__(self, *args):
+        """context manager method for 'with' statements"""
+        self.sock.close()
+
+    def __init__(self, config, replicas):
+        self.config = config
+        self.replicas = replicas
+        self.sock = trio.socket.socket(trio.socket.AF_INET,
+                                       trio.socket.SOCK_DGRAM)
+        self.req_seq_num = 0
+        self.client_id = config.id
+        self.replies = dict()
+        self.primary = None
+        self.reply = None
+        self.retries = 0
+        self.msgs_sent = 0
+        self.reply_quorum = 2*config.f + config.c + 1
+
+    async def sendSync(self, msg, read_only):
+        """
+        Send a client request and wait for a quorum (2F+C+1) of replies.
+
+        Return a single reply message if a quorum of replies matches.
+        Otherwise, raise a trio.TooSlowError indicating the request timed out.
+
+        Retry Strategy:
+            If the request is a write and the primary is known then send only to
+            the primary on the first attempt. Otherwise, if the request is read
+            only or the primary is unknown, then send to all replicas on the
+            first attempt.
+
+            After `config.retry_timeout_milli` without receiving a quorum of
+            identical replies, then clear the replies and send to all replicas.
+            Continue this strategy every `retry_timeout_milli` until
+            `config.req_timeout_milli` elapses. If `config.req_timeout_milli`
+            elapses then a trio.TooSlowError is raised.
+        """
+        self.req_seq_num += 1
+        data = msgs.pack_request(
+                    self.client_id, self.req_seq_num, read_only, msg)
+        # Raise a trio.TooSlowError exception if a quorum of replies
+        with trio.fail_after(self.config.req_timeout_milli/1000):
+            self.reset_on_new_request()
+            self.retries = 0
+            return await self.send_loop(data, read_only)
+
+    def reset_on_retry(self):
+        """Reset any state that must be reset during retries"""
+        self.replies = dict()
+        self.primary = None
+        self.retries += 1
+
+    def reset_on_new_request(self):
+        """Reset any state that must be reset during new requests"""
+        self.replies = dict()
+        self.reply = None
+        self.retries = 0
+
+    async def send_loop(self, data, read_only):
+        """
+        Send and wait for a quorum of replies. Keep retrying if a quorum
+        isn't received. Eventually the max request timeout from the
+        outer scope will fire cancelling all sub-scopes and their coroutines
+        including this one.
+        """
+        while self.reply is None:
+            with trio.move_on_after(self.config.retry_timeout_milli/1000):
+                async with trio.open_nursery() as nursery:
+                    if read_only or self.primary is None:
+                        await self.send_all(data)
+                    else:
+                        await self.send_to_primary(data)
+                    nursery.start_soon(self.recv, nursery.cancel_scope)
+            if self.reply is None:
+                self.reset_on_retry()
+        return self.reply
+
+    async def send_to_primary(self, request):
+        """Send a serialized request to the primary"""
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(self.sendto, request, (self.primary.ip,
+                                                      self.primary.port))
+
+    async def send_all(self, request):
+        """Send a serialized request to all replicas"""
+        async with trio.open_nursery() as nursery:
+            for replica in self.replicas:
+                nursery.start_soon(self.sendto, request, (replica.ip,
+                                                          replica.port))
+    async def sendto(self, request, ip_port):
+        """Send a request over a udp socket"""
+        await self.sock.sendto(request, ip_port)
+        self.msgs_sent += 1
+
+    async def recv(self, cancel_scope):
+        """
+        Receive reply messages until a quorum is achieved or the enclosing
+        cancel_scope times out.
+        """
+        while True:
+            data, sender = await self.sock.recvfrom(self.config.max_msg_size)
+            header, reply = msgs.unpack_reply(data)
+            if self.valid_reply(header):
+                self.replies[sender] = (header, reply)
+            if self.has_quorum():
+                # This cancel will propagate upward and gracefully terminate all
+                # coroutines. self.reply will get set in self.has_quorum()
+                cancel_scope.cancel()
+
+    def valid_reply(self, header):
+        """Return true if the sequence number is correct"""
+        return self.req_seq_num == header.req_seq_num
+
+    def has_quorum(self):
+        """
+        Return true if the client has seen 2F+C+1 matching replies
+
+        Side Effects:
+            Set self.reply to the reply with the quorum
+            Set self.primary to the primary in the quorum of reply headers
+        """
+
+        if len(self.replies) < self.reply_quorum:
+            return False
+
+        # a reply mapped to a count of each specific reply
+        # We must have a quorum of identical replies
+        reply_counts = dict()
+        for reply in self.replies.values():
+            count = reply_counts.get(reply, 0)
+            reply_counts[reply] = count + 1
+
+        for reply, counts in reply_counts.items():
+            if counts >= self.reply_quorum:
+                self.reply = reply[1]
+                self.primary = self.replicas[reply[0].primary_id]
+                return True
+        return False

--- a/util/pyclient/msgs.py
+++ b/util/pyclient/msgs.py
@@ -1,0 +1,114 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+from collections import namedtuple
+import struct
+
+class MsgError(Exception):
+    """ Exception raised when dealing with an invalid Msg"""
+    def __init__(self, message):
+        self.message = message
+
+REQUEST_MSG_TYPE = 700
+REPLY_MSG_TYPE = 800
+
+# A Request type precedes all headers. It can be viewed as part of the headers
+# as in the C++ code, but it's easier to work with headers and messages if we
+# treat it separately during reads/unpack.
+MSG_TYPE_FMT = "<H"
+MSG_TYPE_SIZE = struct.calcsize(MSG_TYPE_FMT)
+
+# The struct definition of the client request msg header
+# Little Endian format with no padding
+# We don't include the msg type here, since we have to read it first to
+# understand what message is incoming.
+REQUEST_HEADER_FMT = "<HBQL"
+REQUEST_HEADER_SIZE = struct.calcsize(REQUEST_HEADER_FMT)
+
+# The struct definition of the client reply msg header
+# Little Endian format with no padding
+# We don't include the msg type here, since we have to read it first to
+# understand what message is incoming.
+REPLY_HEADER_FMT = "<HQL"
+REPLY_HEADER_SIZE = struct.calcsize(REPLY_HEADER_FMT)
+
+RequestHeader = namedtuple('RequestHeader', ['client_id', 'flags',
+    'req_seq_num', 'length'])
+
+ReplyHeader = namedtuple('ReplyHeader', ['primary_id',
+    'req_seq_num', 'length'])
+
+def pack_request(client_id, req_seq_num, read_only, msg):
+    """Create and return a buffer with a header and message"""
+    flags = 0
+    if read_only:
+        flags = 1
+    header = RequestHeader(client_id, flags, req_seq_num, len(msg))
+    data = b''.join([pack_request_header(header), msg])
+    return data
+
+def pack_request_header(header):
+    """Take a RequestHeader and return a buffer"""
+    return b''.join([struct.pack(MSG_TYPE_FMT, REQUEST_MSG_TYPE),
+                     struct.pack(REQUEST_HEADER_FMT, *header)])
+
+def unpack_request(data):
+    """Take a buffer and return a pair of the RequestHeader and app data"""
+    start = MSG_TYPE_SIZE + REQUEST_HEADER_SIZE
+    return (unpack_request_header(data), data[start:])
+
+def unpack_request_header(data):
+    """
+    Take a buffer and return a request header.
+    Throws MsgError if type is not a request or struct.error if structure can't
+    be unpacked.
+    """
+    msg_type = unpack_msg_type(data)
+    if msg_type != REQUEST_MSG_TYPE:
+        raise MsgError("Expected a request message")
+    end = REQUEST_HEADER_SIZE + MSG_TYPE_SIZE
+    return RequestHeader._make(struct.unpack(REQUEST_HEADER_FMT,
+                                             data[MSG_TYPE_SIZE:end]))
+
+def pack_reply(primary_id, req_seq_num, msg):
+    """
+    Take message information and a message and return a construct a buffer
+    containing a serialized reply header and message.
+    """
+    header = ReplyHeader(primary_id, req_seq_num, len(msg))
+    return b''.join([pack_reply_header(header), msg])
+
+def pack_reply_header(header):
+    """Take a ReplyHeader and return a buffer"""
+    return b''.join([struct.pack(MSG_TYPE_FMT, REPLY_MSG_TYPE),
+                     struct.pack(REPLY_HEADER_FMT, *header)])
+
+def unpack_msg_type(data):
+    return struct.unpack(MSG_TYPE_FMT, data[0:MSG_TYPE_SIZE])[0]
+
+def unpack_reply(data):
+    """Take a buffer and return a pair of the ReplyHeader and app data"""
+    start = MSG_TYPE_SIZE + REPLY_HEADER_SIZE
+    return (unpack_reply_header(data), data[start:])
+
+def unpack_reply_header(data):
+    """
+    Take a buffer and return a reply header.
+    Throws MsgError if type is not a reply or struct.error if structure can't be
+    unpacked.
+    """
+    msg_type = unpack_msg_type(data)
+    if msg_type != REPLY_MSG_TYPE:
+        raise MsgError("Expected a reply message")
+    end = REPLY_HEADER_SIZE + MSG_TYPE_SIZE
+    return ReplyHeader._make(struct.unpack(REPLY_HEADER_FMT,
+                                           data[MSG_TYPE_SIZE:end]))

--- a/util/pyclient/test_client.py
+++ b/util/pyclient/test_client.py
@@ -1,0 +1,186 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import unittest
+import struct
+import tempfile
+import shutil
+import os
+import os.path
+import subprocess
+import trio
+
+import msgs
+import client
+
+# This requires python 3.5 for subprocess.run
+class SimpleTest(unittest.TestCase):
+    """
+    Test a UDP client against simpleTest servers
+
+    Use n=4, f=1, c=0
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.testdir = tempfile.mkdtemp()
+        cls.builddir = os.path.abspath("../../build")
+        cls.toolsdir = os.path.join(cls.builddir, "tools")
+        cls.serverbin = os.path.join(cls.builddir,
+                                      "bftengine/tests/simpleTest/server")
+        os.chdir(cls.testdir)
+        cls.generateKeys()
+        cls.config = client.Config(4, 1, 0, 4096, 1000, 50)
+        cls.replicas = [
+                client.Replica(i, "127.0.0.1", 3710 + 2*i) for i in range(0,4)]
+
+        print("Running tests in {}".format(cls.testdir))
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.testdir)
+
+    @classmethod
+    def generateKeys(cls):
+        """Create keys expected by SimpleTest server for 4 nodes"""
+        keygen = os.path.join(cls.toolsdir, "GenerateConcordKeys")
+        args = [keygen, "-n", "4", "-f", "1", "-o", "private_replica_"]
+        subprocess.run(args, check=True)
+
+    def readRequest(self):
+        """Serialize a read request"""
+        return struct.pack("<Q", 100)
+
+    def writeRequest(self, val):
+        """Serialize a write request"""
+        return struct.pack("<QQ", 200, val)
+
+    def read_val(self, val):
+        """Return a deserialized read value"""
+        return struct.unpack("<Q", val)[0]
+
+    def testTimeout(self):
+        """Client requests will timeout since no servers are running"""
+        read = self.readRequest()
+        write = self.writeRequest(1)
+        trio.run(self._testTimeout, read, True)
+        trio.run(self._testTimeout, write, False)
+
+    async def _testTimeout(self, msg, read_only):
+       config = self.config._replace(req_timeout_milli=100)
+       with client.UdpClient(config, self.replicas) as udp_client:
+           # We can't use an ephemeral port because simpleTest servers expect
+           # given client ports.
+           await udp_client.sock.bind(("127.0.0.1", 3718))
+           with self.assertRaises(trio.TooSlowError):
+               await udp_client.sendSync(msg, read_only)
+
+    def startServers(self):
+        """Start all 4 simpleTestServers"""
+        self.procs = [subprocess.Popen([self.serverbin, str(i)], close_fds=True)
+                for i in range(0, 4)]
+
+    def stopServers(self):
+        """Stop all processes in self.procs"""
+        for p in self.procs:
+            p.kill()
+            p.wait()
+
+    def testReadWrittenValue(self):
+        """Write a value and then read it"""
+        self.startServers()
+        try:
+            trio.run(self._testReadWrittenValue)
+        except:
+            raise
+        finally:
+            self.stopServers()
+
+    async def _testReadWrittenValue(self):
+       val = 999
+       with client.UdpClient(self.config, self.replicas) as udp_client:
+           await udp_client.sock.bind(("127.0.0.1", 3718))
+           await udp_client.sendSync(self.writeRequest(val), False)
+           read = await udp_client.sendSync(self.readRequest(), True)
+           self.assertEqual(val, self.read_val(read))
+
+    def testRetry(self):
+        """
+        Start servers after client has already made an attempt to send and
+        ensure request succeeds.
+        """
+        trio.run(self._testRetry)
+
+    async def _testRetry(self):
+        """Start servers after a delay in parallel with a write request"""
+        try:
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(self.startServersWithDelay)
+                nursery.start_soon(self.writeWithRetryAssert)
+        except:
+            raise
+        finally:
+            self.stopServers()
+
+    async def writeWithRetryAssert(self):
+        """Issue a write and ensure that a retry occurs"""
+        config = self.config._replace(req_timeout_milli=5000)
+        val = 1
+        with client.UdpClient(config, self.replicas) as udp_client:
+           self.assertEqual(udp_client.retries, 0)
+           await udp_client.sock.bind(("127.0.0.1", 3718))
+           await udp_client.sendSync(self.writeRequest(val), False)
+           self.assertTrue(udp_client.retries > 0)
+
+    async def startServersWithDelay(self):
+        # Retry timeout is 50ms
+        # This guarantees we wait at least one retry with high probability
+        await trio.sleep(.250)
+        self.startServers()
+
+    def testPrimaryWrite(self):
+        """Test that we learn the primary and using it succeeds."""
+        self.startServers()
+        try:
+            trio.run(self._testPrimaryWrite)
+        except:
+            raise
+        finally:
+            self.stopServers()
+
+    async def _testPrimaryWrite(self):
+       # Try to guarantee we don't retry accidentally
+       config = self.config._replace(retry_timeout_milli=500)
+       with client.UdpClient(self.config, self.replicas) as udp_client:
+           self.assertEqual(None, udp_client.primary)
+           await udp_client.sock.bind(("127.0.0.1", 3718))
+           await udp_client.sendSync(self.writeRequest(1), False)
+           # We know the servers are up once the write completes
+           self.assertNotEqual(None, udp_client.primary)
+           sent = udp_client.msgs_sent
+           read = await udp_client.sendSync(self.readRequest(), True)
+           sent += 4
+           self.assertEqual(sent, udp_client.msgs_sent)
+           self.assertEqual(1, self.read_val(read))
+           self.assertNotEqual(None, udp_client.primary)
+           await udp_client.sendSync(self.writeRequest(2), False)
+           sent += 1 # Only send to the primary
+           self.assertEqual(sent, udp_client.msgs_sent)
+           read = await udp_client.sendSync(self.readRequest(), True)
+           sent += 4
+           self.assertEqual(sent, udp_client.msgs_sent)
+           self.assertEqual(2, self.read_val(read))
+           self.assertNotEqual(None, udp_client.primary)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/util/pyclient/test_msgs.py
+++ b/util/pyclient/test_msgs.py
@@ -1,0 +1,57 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import unittest
+import struct
+
+import msgs
+
+class TestPackUnpack(unittest.TestCase):
+
+    def test_unpack_reply(self):
+        msg = b'hello'
+        primary_id = 0
+        req_seq_num = 1
+        packed = msgs.pack_reply(primary_id, req_seq_num, msg)
+        (header, unpacked_msg) = msgs.unpack_reply(packed)
+        self.assertEqual(primary_id, header.primary_id)
+        self.assertEqual(req_seq_num, header.req_seq_num)
+        self.assertEqual(msg, unpacked_msg)
+
+    def test_unpack_request(self):
+        msg = b'hello'
+        client_id = 4
+        req_seq_num = 1
+        read_only = True
+        packed = msgs.pack_request(client_id, req_seq_num, read_only, msg)
+        (header, unpacked_msg) = msgs.unpack_request(packed)
+        self.assertEqual(client_id, header.client_id)
+        self.assertEqual(1, header.flags) # read_only = True
+        self.assertEqual(req_seq_num, header.req_seq_num)
+        self.assertEqual(msg, unpacked_msg)
+
+    def test_expect_msg_error(self):
+        data = b'someinvalidmsg'
+        self.assertRaises(msgs.MsgError, msgs.unpack_request, data)
+        self.assertRaises(msgs.MsgError, msgs.unpack_reply, data)
+
+    def test_expect_struct_error(self):
+        # Give a valid msg type but invalid data size
+        data = b''.join([struct.pack(msgs.MSG_TYPE_FMT, msgs.REQUEST_MSG_TYPE),
+                         b'invalid'])
+        self.assertRaises(struct.error, msgs.unpack_request, data)
+        data = b''.join([struct.pack(msgs.MSG_TYPE_FMT, msgs.REPLY_MSG_TYPE),
+                         b'invalid'])
+        self.assertRaises(struct.error, msgs.unpack_reply, data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A basic python client was created mainly for system testing.

It uses [trio](https://github.com/python-trio/trio) for networking and
concurrency.

Client requests and replies are implemented in msgs.py and match those
found in ClientMsgs.hpp. Tests for message serialization/deserialization
exist in test_msgs.py. Test can be run with `python3 test_msgs.py`

The client implements a synchronous api similar to simpleTest. The retry
strategy is very naive and retries every configured retry interval. The
code is documented inline describing the strategy.

Tests for the client utilize the simpleTest server. There are 4 main
tests:
 * Ensure a timeout (trio.TooSlowError) occurs when the servers are not
   up.
 * Ensure that a written value can be read when the servers are up
 * Ensure that when servers are brought up after the client request is
   sent a retry will occur and the request will succeed.
 * Ensure that we send to the primary on writes after it is learned

Tests can be run by
    cd concord-bft/build
    cmake ..
    ctest -R pyclient_tests --verbose