### PR TITLE
Collect metrics inside ReplicaImp

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -107,3 +107,4 @@ target_include_directories(corebft PUBLIC ${LOGGER_INC_DIR})
 
 target_link_libraries(corebft PUBLIC threshsign)
 target_link_libraries(corebft PUBLIC Threads::Threads)
+target_link_libraries(corebft PUBLIC util)

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -3,6 +3,7 @@ project (bftengine LANGUAGES CXX)
 get_property(LOGGER_INC_DIR GLOBAL PROPERTY LoggerIncludeDir)
 
 set(corebft_source_files
+    src/bftengine/PrimitiveTypes.cpp
     src/bftengine/PrePrepareMsg.cpp
     src/bftengine/CheckpointMsg.cpp
     src/bftengine/DebugStatistics.cpp

--- a/bftengine/src/bftengine/ControllerBase.hpp
+++ b/bftengine/src/bftengine/ControllerBase.hpp
@@ -38,7 +38,7 @@ namespace bftEngine
 			// events (used to pass information to the controller)
 
 			virtual void onNewView(ViewNum v, SeqNum s) {}
-			virtual void onNewSeqNumberExecution(SeqNum n) {}
+			virtual bool onNewSeqNumberExecution(SeqNum n) { return false; }
 
 			virtual void onSendingPrePrepare(SeqNum n, CommitPath commitPath) {}
 			virtual void onStartingSlowCommit(SeqNum n) {}

--- a/bftengine/src/bftengine/ControllerWithSimpleHistory.cpp
+++ b/bftengine/src/bftengine/ControllerWithSimpleHistory.cpp
@@ -30,18 +30,14 @@ namespace bftEngine
                     uint16_t F,
                     ReplicaId replicaId,
                     ViewNum initialView,
-                    SeqNum initialSeq,
-                    concordMetrics::Component &metrics) :
+                    SeqNum initialSeq) :
                   onlyOptimisticFast(C == 0),
                   c(C), f(F), numOfReplicas(3 * F + 2 * C + 1), myId(replicaId),
                   recentActivity(1, nullptr),
                   currentFirstPath{ControllerWithSimpleHistory_debugInitialFirstPath},
                   currentView{initialView},
                   isPrimary{((currentView % numOfReplicas) == myId)},
-                  currentTimeToStartSlowPathMilli{defaultTimeToStartSlowPathMilli},
-                  metrics_first_path_{metrics.RegisterStatus(
-                      "firstCommitPath",
-                      CommitPathToStr(currentFirstPath))}
+                  currentTimeToStartSlowPathMilli{defaultTimeToStartSlowPathMilli}
                 {
 			if (isPrimary) {
                           onBecomePrimary(initialView, initialSeq);
@@ -99,9 +95,12 @@ namespace bftEngine
 				onBecomePrimary(v, s);
 		}
 
-		void ControllerWithSimpleHistory::onNewSeqNumberExecution(SeqNum n)
+                // Return true if currentFirstPath changed
+		bool ControllerWithSimpleHistory::onNewSeqNumberExecution(SeqNum n)
 		{
-			if (!isPrimary || !recentActivity.insideActiveWindow(n)) return;
+			if (!isPrimary || !recentActivity.insideActiveWindow(n)) {
+                          return false;
+                        }
 
 			SeqNoInfo& s = recentActivity.get(n);
 
@@ -123,10 +122,14 @@ namespace bftEngine
 
 			avgAndStdOfExecTime.add((double)duration);
 
-			if (n == recentActivity.currentActiveWindow().second) onEndOfEvaluationPeriod();
+			if (n == recentActivity.currentActiveWindow().second) {
+                          return onEndOfEvaluationPeriod();
+                        }
+                        return false;
 		}
 
-		void ControllerWithSimpleHistory::onEndOfEvaluationPeriod()
+                // Return true if the currentFirstPath changed
+		bool ControllerWithSimpleHistory::onEndOfEvaluationPeriod()
 		{
 			const SeqNum minSeq = recentActivity.currentActiveWindow().first;
 			const SeqNum maxSeq = recentActivity.currentActiveWindow().second;
@@ -134,6 +137,7 @@ namespace bftEngine
 			const CommitPath lastFirstPathVal = currentFirstPath;
 
 			bool downgraded = false;
+                        bool currentFirstPathChanged = false;
 
 			if (currentFirstPath == CommitPath::SLOW)
 			{
@@ -155,11 +159,11 @@ namespace bftEngine
 
 					if (cyclesWithFullCooperation >= (factorForFastOptimisticPath * EvaluationPeriod)) {
 						currentFirstPath = CommitPath::OPTIMISTIC_FAST;
-                                                metrics_first_path_.Get().Set(CommitPathToStr(currentFirstPath));
+                                                currentFirstPathChanged = true;
                                         }
 					else if (!onlyOptimisticFast && (cyclesWithFullCooperation + cyclesWithPartialCooperation >= (factorForFastPath * EvaluationPeriod))) {
 						currentFirstPath = CommitPath::FAST_WITH_THRESHOLD;
-                                                metrics_first_path_.Get().Set(CommitPathToStr(currentFirstPath));
+                                                currentFirstPathChanged = true;
                                         }
 				}
 			}
@@ -187,7 +191,7 @@ namespace bftEngine
 						currentFirstPath = CommitPath::SLOW;
                                         }
 
-                                        metrics_first_path_.Get().Set(CommitPathToStr(currentFirstPath));
+                                        currentFirstPathChanged = true;
 				}
 			}
 
@@ -220,6 +224,7 @@ namespace bftEngine
 
 				LOG_INFO_F(GL, "currentTimeToStartSlowPathMilli = %d", (int)currentTimeToStartSlowPathMilli);
 			}
+                        return currentFirstPathChanged;
 		}
 
 		void ControllerWithSimpleHistory::onSendingPrePrepare(SeqNum n, CommitPath commitPath)
@@ -258,17 +263,5 @@ namespace bftEngine
 			s.replicas.insert(id);
 		}
 
-                std::string CommitPathToStr(CommitPath path) {
-                  switch(path) {
-                    case CommitPath::NA:
-                      return "NA";
-                    case CommitPath::OPTIMISTIC_FAST:
-                      return "OPTIMISTIC_FAST";
-                    case CommitPath::FAST_WITH_THRESHOLD:
-                      return "FAST_WITH_THRESHOLD";
-                    case CommitPath::SLOW:
-                      return "SLOW";
-                  }
-                }
 	}
 }

--- a/bftengine/src/bftengine/ControllerWithSimpleHistory.hpp
+++ b/bftengine/src/bftengine/ControllerWithSimpleHistory.hpp
@@ -15,6 +15,7 @@
 #include "SequenceWithActiveWindow.hpp"
 #include "RollingAvgAndVar.hpp"
 #include "TimeUtils.hpp"
+#include "Metrics.hpp"
 
 namespace bftEngine
 {
@@ -27,7 +28,13 @@ namespace bftEngine
 
 			static const size_t EvaluationPeriod = 64;
 
-			ControllerWithSimpleHistory(uint16_t C, uint16_t F, ReplicaId replicaId, ViewNum initialView, SeqNum initialSeq);
+			ControllerWithSimpleHistory(
+                            uint16_t C,
+                            uint16_t F,
+                            ReplicaId replicaId,
+                            ViewNum initialView,
+                            SeqNum initialSeq,
+                            concordMetrics::Component &metrics);
 
 			// getter methods
 
@@ -97,8 +104,16 @@ namespace bftEngine
 
 			void onBecomePrimary(ViewNum v, SeqNum s);
 			void onEndOfEvaluationPeriod();
+
+                        typedef concordMetrics::Component::Handle<
+                          concordMetrics::Status> StatusHandle;
+
+                        // The first commit path being attempted for a new
+                        // request.
+                        StatusHandle metrics_first_path_;
 		};
 
 
+                std::string CommitPathToStr(CommitPath path);
 	}
 }

--- a/bftengine/src/bftengine/ControllerWithSimpleHistory.hpp
+++ b/bftengine/src/bftengine/ControllerWithSimpleHistory.hpp
@@ -15,7 +15,6 @@
 #include "SequenceWithActiveWindow.hpp"
 #include "RollingAvgAndVar.hpp"
 #include "TimeUtils.hpp"
-#include "Metrics.hpp"
 
 namespace bftEngine
 {
@@ -33,8 +32,7 @@ namespace bftEngine
                             uint16_t F,
                             ReplicaId replicaId,
                             ViewNum initialView,
-                            SeqNum initialSeq,
-                            concordMetrics::Component &metrics);
+                            SeqNum initialSeq);
 
 			// getter methods
 
@@ -45,7 +43,7 @@ namespace bftEngine
 			// events 
 
 			virtual void onNewView(ViewNum v, SeqNum s) override;
-			virtual void onNewSeqNumberExecution(SeqNum n) override;
+			virtual bool onNewSeqNumberExecution(SeqNum n) override;
 
 			virtual void onSendingPrePrepare(SeqNum n, CommitPath commitPath) override;
 			virtual void onStartingSlowCommit(SeqNum n) override;
@@ -103,17 +101,9 @@ namespace bftEngine
 			uint32_t currentTimeToStartSlowPathMilli;
 
 			void onBecomePrimary(ViewNum v, SeqNum s);
-			void onEndOfEvaluationPeriod();
-
-                        typedef concordMetrics::Component::Handle<
-                          concordMetrics::Status> StatusHandle;
-
-                        // The first commit path being attempted for a new
-                        // request.
-                        StatusHandle metrics_first_path_;
+			bool onEndOfEvaluationPeriod();
 		};
 
 
-                std::string CommitPathToStr(CommitPath path);
 	}
 }

--- a/bftengine/src/bftengine/PrimitiveTypes.cpp
+++ b/bftengine/src/bftengine/PrimitiveTypes.cpp
@@ -1,0 +1,20 @@
+#include "PrimitiveTypes.hpp"
+
+namespace bftEngine {
+namespace impl {
+
+std::string CommitPathToStr(CommitPath path) {
+  switch(path) {
+    case CommitPath::NA:
+      return "NA";
+    case CommitPath::OPTIMISTIC_FAST:
+      return "OPTIMISTIC_FAST";
+    case CommitPath::FAST_WITH_THRESHOLD:
+      return "FAST_WITH_THRESHOLD";
+    case CommitPath::SLOW:
+      return "SLOW";
+  }
+}
+
+} // namespace impl
+} // namespace bftEngine

--- a/bftengine/src/bftengine/PrimitiveTypes.hpp
+++ b/bftengine/src/bftengine/PrimitiveTypes.hpp
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <inttypes.h>
+#include <string>
 
 #ifdef max // TODO(GG): remove
 #undef max

--- a/bftengine/src/bftengine/PrimitiveTypes.hpp
+++ b/bftengine/src/bftengine/PrimitiveTypes.hpp
@@ -45,6 +45,7 @@ namespace bftEngine
 			SLOW = 2
 		};
 
+                std::string CommitPathToStr(CommitPath path);
 	}
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -28,6 +28,7 @@
 #include "DebugStatistics.hpp"
 #include "ReplicaStatusMsg.hpp"
 #include "NullStateTransfer.hpp"
+#include "SysConsts.hpp"
 
 
 namespace bftEngine
@@ -268,6 +269,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(ClientRequestMsg *m)
 		{
+                        metric_received_client_requests_.Get().Inc();
 			const NodeIdType senderId = m->senderId();
 			const NodeIdType clientId = m->clientProxyId();
 			const bool readOnly = m->isReadOnly();
@@ -502,6 +504,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(PrePrepareMsg* msg)
 		{
+                        metric_received_pre_prepares_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 
 			LOG_INFO_F(GL, "Node %d received PrePrepareMsg from node %d for seqNumber %" PRId64 " (size=%d)",
@@ -688,6 +691,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(StartSlowCommitMsg* msg)
 		{
+                        metric_received_start_slow_commits_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 
 			LOG_INFO_F(GL, "Node %d received StartSlowCommitMsg for seqNumber %" PRId64 "", myReplicaId, msgSeqNum);
@@ -830,6 +834,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(PartialCommitProofMsg* msg)
 		{
+                        metric_received_partial_commit_proofs_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 			const SeqNum msgView = msg->viewNumber();
 			const NodeIdType msgSender = msg->senderId();
@@ -889,6 +894,7 @@ namespace bftEngine
 		void ReplicaImp::onMessage(FullCommitProofMsg* msg)
 		{
 
+                        metric_received_full_commit_proofs_.Get().Inc();
 			LOG_INFO_F(GL, "Node %d received FullCommitProofMsg message for seqNumber %" PRId64 "",
 				(int)myReplicaId, (int)msg->seqNumber());
 
@@ -917,6 +923,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(PreparePartialMsg* msg)
 		{
+                        metric_received_prepare_partials_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 			const ReplicaId msgSender = msg->senderId();
 
@@ -968,6 +975,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(CommitPartialMsg* msg)
 		{
+                        metric_received_commit_partials_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 			const ReplicaId msgSender = msg->senderId();
 
@@ -1010,6 +1018,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(PrepareFullMsg* msg)
 		{
+                        metric_received_prepare_fulls_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 			const ReplicaId msgSender = msg->senderId();
 
@@ -1057,6 +1066,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(CommitFullMsg* msg)
 		{
+                        metric_received_commit_fulls_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 			const ReplicaId msgSender = msg->senderId();
 
@@ -1278,6 +1288,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(CheckpointMsg* msg)
 		{
+                        metric_received_checkpoints_.Get().Inc();
 			const ReplicaId msgSenderId = msg->senderId();
 			const SeqNum msgSeqNum = msg->seqNumber();
 			const Digest msgDigest = msg->digestOfState();
@@ -1540,6 +1551,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(ReplicaStatusMsg* msg)
 		{
+                        metric_received_replica_statuses_.Get().Inc();
 			// TODO(GG): we need filter for msgs (to avoid denial of service attack) + avoid sending messages at a high rate.
 			// TODO(GG): for some communication modules/protocols, we can also utilize information about connection/disconnection. 
 
@@ -1790,6 +1802,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(ViewChangeMsg* msg)
 		{
+                        metric_received_view_changes_.Get().Inc();
 			if (!viewChangeProtocolEnabled) { delete msg; return; }
 
 			const ReplicaId generatedReplicaId = msg->idOfGeneratedReplica(); // Notice that generatedReplicaId may be != msg->senderId()
@@ -1845,6 +1858,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(NewViewMsg* msg)
 		{
+                        metric_received_new_views_.Get().Inc();
 			if (!viewChangeProtocolEnabled) { delete msg; return; }
 
 			const ReplicaId senderId = msg->senderId();
@@ -2383,6 +2397,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(ReqMissingDataMsg* msg)
 		{
+                        metric_received_req_missing_datas_.Get().Inc();
 			const SeqNum msgSeqNum = msg->seqNumber();
 			const ReplicaId msgSender = msg->senderId();
 
@@ -2604,6 +2619,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(SimpleAckMsg* msg)
 		{
+                        metric_received_simple_acks_.Get().Inc();
 			if (retransmissionsLogicEnabled)
 			{
 				uint16_t relatedMsgType = (uint16_t)msg->ackData(); // TODO(GG): does this make sense ?
@@ -2622,6 +2638,7 @@ namespace bftEngine
 
 		void ReplicaImp::onMessage(StateTransferMsg* m)
 		{
+                        metric_received_state_transfers_.Get().Inc();
 			size_t h = sizeof(MessageBase::Header);
 			stateTransfer->handleStateTransferMessage(m->body() + h, m->size() - h, m->senderId());
 		}
@@ -2798,24 +2815,58 @@ namespace bftEngine
 			debugStatTimer{ nullptr },
 			viewChangeTimerMilli{ 0 },
 			startSyncEvent{false},
-                        metricsComponent_{concordMetrics::Component("replica",
+                        metrics_{concordMetrics::Component("replica",
                             std::make_shared<concordMetrics::Aggregator>())},
                         metric_view_{
-                          metricsComponent_.RegisterGauge("view", curView)},
+                          metrics_.RegisterGauge("view", curView)},
                         metric_last_stable_seq_num__{
-                          metricsComponent_.RegisterGauge("lastStableSeqNum",
-                                                           lastStableSeqNum)},
+                          metrics_.RegisterGauge("lastStableSeqNum",
+                                                 lastStableSeqNum)},
                         metric_last_executed_seq_num_{
-                          metricsComponent_.RegisterGauge("lastExecutedSeqNum",
-                                                           lastExecutedSeqNum)},
+                          metrics_.RegisterGauge("lastExecutedSeqNum",
+                                                 lastExecutedSeqNum)},
                         metric_last_agreed_view_{
-                          metricsComponent_.RegisterGauge("lastAgreedView",
-                                                           lastAgreedView)},
+                          metrics_.RegisterGauge("lastAgreedView",
+                                                 lastAgreedView)},
+                        metric_first_commit_path_{
+                          metrics_.RegisterStatus("firstCommitPath", CommitPathToStr(
+                            ControllerWithSimpleHistory_debugInitialFirstPath))},
                         metric_slow_path_count_{
-                          metricsComponent_.RegisterCounter("slowPathCount",
-                                                            0)},
-                        metric_received_msgs_{
-                          metricsComponent_.RegisterCounter("receivedMsgs", 0)}
+                          metrics_.RegisterCounter("slowPathCount", 0)},
+                        metric_received_internal_msgs_{
+                          metrics_.RegisterCounter("receivedInternalMsgs")},
+                        metric_received_client_requests_{
+                          metrics_.RegisterCounter("receivedClientRequestMsgs")},
+                        metric_received_pre_prepares_{
+                          metrics_.RegisterCounter("receivedPrePrepareMsgs")},
+                        metric_received_start_slow_commits_{
+                          metrics_.RegisterCounter("receivedStartSlowCommitMsgs")},
+                        metric_received_partial_commit_proofs_{
+                          metrics_.RegisterCounter("receivedPartialCommitProofMsgs")},
+                        metric_received_full_commit_proofs_{
+                          metrics_.RegisterCounter("receivedFullCommitProofMsgs")},
+                        metric_received_prepare_partials_{
+                          metrics_.RegisterCounter("receivedPreparePartialMsgs")},
+                        metric_received_commit_partials_{
+                          metrics_.RegisterCounter("receivedCommitPartialMsgs")},
+                        metric_received_prepare_fulls_{
+                          metrics_.RegisterCounter("receivedPrepareFullMsgs")},
+                        metric_received_commit_fulls_{
+                          metrics_.RegisterCounter("receivedCommitFullMsgs")},
+                        metric_received_checkpoints_{
+                          metrics_.RegisterCounter("receivedCheckpointMsgs")},
+                        metric_received_replica_statuses_{
+                          metrics_.RegisterCounter("receivedReplicaStatusMsgs")},
+                        metric_received_view_changes_{
+                          metrics_.RegisterCounter("receivedViewChangeMsgs")},
+                        metric_received_new_views_{
+                          metrics_.RegisterCounter("receivedNewViewMsgs")},
+                        metric_received_req_missing_datas_{
+                          metrics_.RegisterCounter("receivedReqMissingDataMsgs")},
+                        metric_received_simple_acks_{
+                          metrics_.RegisterCounter("receivedSimpleAckMsgs")},
+                        metric_received_state_transfers_{
+                          metrics_.RegisterCounter("receivedStateTransferMsgs")}
 
 		{
 			Assert(myReplicaId < numOfReplicas);
@@ -2877,7 +2928,7 @@ namespace bftEngine
 			checkpointsLog = new SequenceWithActiveWindow<kWorkWindowSize + checkpointWindowSize, checkpointWindowSize, SeqNum, CheckpointInfo, CheckpointInfo>(0, (InternalReplicaApi*)this);
 
 			// create controller . TODO(GG): do we want to pass the controller as a parameter ?
-                        controller = new ControllerWithSimpleHistory(cVal, fVal, myReplicaId, curView, primaryLastUsedSeqNum, metricsComponent_);
+                        controller = new ControllerWithSimpleHistory(cVal, fVal, myReplicaId, curView, primaryLastUsedSeqNum);
 
 			statusReportTimer = new Timer(timersScheduler, (uint16_t)statusReportTimerMilli, statusTimerHandlerFunc, (InternalReplicaApi*)this);
 
@@ -3024,10 +3075,10 @@ namespace bftEngine
 				bool externalMsg = false;
 
 				recvMsg(absMsg, externalMsg); // wait for a message
-                                metric_received_msgs_.Get().Inc();
 				if (!externalMsg) // if internal message
 				{
 					// TODO(GG): clean
+                                        metric_received_internal_msgs_.Get().Inc();
 					InternalMessage* inMsg = (InternalMessage*)absMsg;
 					inMsg->handle();
 					delete inMsg;
@@ -3161,14 +3212,16 @@ namespace bftEngine
 
 			LOG_INFO_F(GL, "\nReplica - executeRequestsInPrePrepareMsg() - lastExecutedSeqNum==%" PRId64 "", lastExecutedSeqNum);
 
-			controller->onNewSeqNumberExecution(lastExecutedSeqNum);
+			bool firstCommitPathChanged =
+                          controller->onNewSeqNumberExecution(lastExecutedSeqNum);
 
-
+                        if (firstCommitPathChanged) {
+                          metric_first_commit_path_.Get().Set(CommitPathToStr(
+                              controller->getCurrentFirstPath()));
+                        }
 
 
 			// TODO(GG): clean the following logic
-
-
 
 
 			if (lastViewThatTransferredSeqNumbersFullyExecuted < curView && (lastExecutedSeqNum >= maxSeqNumTransferredFromPrevViews))
@@ -3250,7 +3303,7 @@ namespace bftEngine
 
                 void ReplicaImp::SetAggregator(
                     std::shared_ptr<concordMetrics::Aggregator> aggregator) {
-                  metricsComponent_.SetAggregator(aggregator);
+                  metrics_.SetAggregator(aggregator);
                 }
 
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -32,6 +32,7 @@
 #include "ICommunication.hpp"
 #include "Replica.hpp"
 #include "Threading.h"
+#include "Metrics.hpp"
 
 #include <thread>
 
@@ -200,9 +201,6 @@ namespace bftEngine
 
 			int viewChangeTimerMilli;
 
-
-
-
 			class MsgReceiver : public IReceiver
 			{
 			public:
@@ -235,6 +233,27 @@ namespace bftEngine
 			// this event is signalled iff the start() method has completed
 			// and the process_message() method has not start working yet
 			SimpleAutoResetEvent startSyncEvent;
+
+                        //******** METRICS ************************************
+                        concordMetrics::Component metricsComponent_;
+
+                        typedef concordMetrics::Component::Handle<
+                          concordMetrics::Gauge> GaugeHandle;
+                        typedef concordMetrics::Component::Handle<
+                          concordMetrics::Status> StatusHandle;
+                        typedef concordMetrics::Component::Handle<
+                          concordMetrics::Counter> CounterHandle;
+
+                        GaugeHandle metric_view_;
+                        GaugeHandle metric_last_stable_seq_num__;
+                        GaugeHandle metric_last_executed_seq_num_;
+                        GaugeHandle metric_last_agreed_view_;
+
+                        CounterHandle metric_slow_path_count_;
+                        CounterHandle metric_received_msgs_;
+
+                        //*****************************************************
+
 
 		public:
 
@@ -449,8 +468,9 @@ namespace bftEngine
 			virtual void onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqNum, const ViewNum relatedViewNumber,
 				const std::forward_list<RetSuggestion>* const suggestedRetransmissions) override;  // TODO(GG): use generic iterators 
 
-		};
+                        void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
+		};
 
 
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -235,7 +235,7 @@ namespace bftEngine
 			SimpleAutoResetEvent startSyncEvent;
 
                         //******** METRICS ************************************
-                        concordMetrics::Component metricsComponent_;
+                        concordMetrics::Component metrics_;
 
                         typedef concordMetrics::Component::Handle<
                           concordMetrics::Gauge> GaugeHandle;
@@ -249,8 +249,28 @@ namespace bftEngine
                         GaugeHandle metric_last_executed_seq_num_;
                         GaugeHandle metric_last_agreed_view_;
 
+                        // The first commit path being attempted for a new
+                        // request.
+                        StatusHandle metric_first_commit_path_;
+
                         CounterHandle metric_slow_path_count_;
-                        CounterHandle metric_received_msgs_;
+                        CounterHandle metric_received_internal_msgs_;
+                        CounterHandle metric_received_client_requests_;
+                        CounterHandle metric_received_pre_prepares_;
+                        CounterHandle metric_received_start_slow_commits_;
+                        CounterHandle metric_received_partial_commit_proofs_;
+                        CounterHandle metric_received_full_commit_proofs_;
+                        CounterHandle metric_received_prepare_partials_;
+                        CounterHandle metric_received_commit_partials_;
+                        CounterHandle metric_received_prepare_fulls_;
+                        CounterHandle metric_received_commit_fulls_;
+                        CounterHandle metric_received_checkpoints_;
+                        CounterHandle metric_received_replica_statuses_;
+                        CounterHandle metric_received_view_changes_;
+                        CounterHandle metric_received_new_views_;
+                        CounterHandle metric_received_req_missing_datas_;
+                        CounterHandle metric_received_simple_acks_;
+                        CounterHandle metric_received_state_transfers_;
 
                         //*****************************************************
 
@@ -469,7 +489,6 @@ namespace bftEngine
 				const std::forward_list<RetSuggestion>* const suggestedRetransmissions) override;  // TODO(GG): use generic iterators 
 
                         void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
-
 		};
 
 

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -159,6 +159,9 @@ class Component {
   Handle<Status> RegisterStatus(const std::string& name,
                                 const std::string& val);
   Handle<Counter> RegisterCounter(const std::string& name, const uint64_t val);
+  Handle<Counter> RegisterCounter(const std::string& name) {
+    return RegisterCounter(name, 0);
+  }
 
   // Register the component with the aggregator.
   // This *must* be done after all values are registered in this component.

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -167,9 +167,18 @@ class Component {
   // updated at runtime for performance reasons.
   void Register() { aggregator_->RegisterComponent(*this); }
 
+  // Update the values in the aggregator
   void UpdateAggregator() {
     Values copy = values_;
     aggregator_->UpdateValues(name_, std::move(copy));
+  }
+
+  // Change the aggregator used by the component
+  //
+  // Register the component with the new aggregator.
+  void SetAggregator(std::shared_ptr<Aggregator> aggregator) {
+    aggregator_ = aggregator;
+    Register();
   }
 
   // Generate a JSON formatted string


### PR DESCRIPTION
ReplicaImp now contains a metrics Component and registers some metrics.
The metrics get updated in both ReplicImp.cpp and
ControllerWithSimpleHistory.cpp.

Because the Component requires an aggregator, but an aggregator is not
yet instantiated for the bftengine as a whole, we create a dummy
aggregator, but never actually update it. To avoid having to change the
Replica constructor we also create a method that allows setting a
different aggregator and forward that onto the component in the Metrics
code so that it can register the component with the new Aggregator.

Since the metrics themselves are references into the component they must
be class members that are part of initialization. They will therefore
always be updated and part of ReplicaImp. The plan is to make the
feature optional by not always allowing the aggregated data to be
retrieved. In other words the to be built metric server will not always
be enabled. The overhead of tracking these metrics is very low, so this
seems like a reasonable tradeoff. Otherwise, the implementation of the
Metrics library itself may need to be changed.

A future commit will contain an optional UDP metric server which also contains the
centralized instantiated Aggregator. It will also contain code that
calls metricsComponent_.UpdateAggregator() periodically on some timer
tick.