### PR TITLE
Metrics: Add JSON serialization support

### DIFF
--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -46,6 +46,9 @@ class Aggregator {
   Counter GetCounter(const std::string& component_name,
                      const std::string& val_name);
 
+  // Generate a JSON formatted string
+  std::string ToJson();
+
  private:
   void RegisterComponent(Component& component);
   void UpdateValues(const std::string& name, Values&& values);
@@ -168,6 +171,9 @@ class Component {
     Values copy = values_;
     aggregator_->UpdateValues(name_, std::move(copy));
   }
+
+  // Generate a JSON formatted string
+  std::string ToJson();
 
  private:
   friend class Aggregator;

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -104,4 +104,84 @@ Counter Aggregator::GetCounter(const string& component_name,
                    component.values_.counters_);
 }
 
+// Generate a JSON string of all aggregated components. To save space we don't
+// add any newline characters.
+std::string Aggregator::ToJson() {
+  ostringstream oss;
+  std::lock_guard<std::mutex> lock(lock_);
+
+  // Add the object opening
+  oss << "{\"Components\":[";
+
+  // Add all the components
+  for (auto it = components_.begin(); it != components_.end(); ++it) {
+    // Add a comma between every component
+    if (it != components_.begin()) {
+      oss << ",";
+    }
+    oss << it->second.ToJson();
+  }
+
+  // Add the object end
+  oss << "]}";
+
+  return oss.str();
+}
+
+// Generate a JSON string of the component. To save space we don't add any
+// newline characters.
+std::string Component::ToJson() {
+  ostringstream oss;
+
+  // Add the object opening and component name
+  oss << "{\"Name\":\"" << name_ << "\",";
+
+  // Add any gauges
+  oss << "\"Gauges\":{";
+
+  for (int i = 0; i < names_.gauge_names_.size(); i++) {
+    if (i != 0) {
+      oss << ",";
+    }
+    oss << "\"" << names_.gauge_names_[i] << "\":"
+      << values_.gauges_[i].Get() << "";
+  }
+
+  // End gauges
+  oss << "},";
+
+  // Add any status
+  oss << "\"Statuses\":{";
+
+  for (int i = 0; i < names_.status_names_.size(); i++) {
+    if (i != 0) {
+      oss << ",";
+    }
+    oss << "\"" << names_.status_names_[i] << "\":"
+      << "\"" << values_.statuses_[i].Get() << "\"";
+  }
+
+  // End status
+  oss << "},";
+
+  // Add any counters
+  oss << "\"Counters\":{";
+
+  for (int i = 0; i < names_.counter_names_.size(); i++) {
+    if (i != 0) {
+      oss << ",";
+    }
+    oss << "\"" << names_.counter_names_[i] << "\":"
+      << values_.counters_[i].Get() << "";
+  }
+
+  // End counters
+  oss << "}";
+
+  // End component
+  oss << "}";
+
+  return oss.str();
+}
+
 }  // namespace concordMetrics


### PR DESCRIPTION
Metrics: Add JSON serialization support

A simple hand written JSON serializer was implemented to serialize an
Aggregator and its corresponding components and metrics. There is no
deserializer as deserialization is expected to be done elsewhere as part
of the metric server clients. Since serialization is so simple here, we
decided we didn't need to pull in any dependencies and could hand roll
it.

Tests can be run via:
    ctest -R metric --verbose

The JSON output generated by the test as pretty printed through json_pp
looks like this:

         {
            "Components" : [
               {
                  "Gauges" : {
                     "total_peers" : 4,
                     "connected_peers" : 3
                  },
                  "Statuses" : {
                     "state" : "primary",
                     "commit_path" : "SLOW"
                  },
                  "Counters" : {
                     "messages_received" : 1,
                     "messages_sent" : 0
                  },
                  "Name" : "replica"
               },
               {
                  "Gauges" : {
                     "blocks-remaining" : 4
                  },
                  "Statuses" : {
                     "state" : "sending-blocks"
                  },
                  "Name" : "state-transfer",
                  "Counters" : {}
               }
            ]
         }
