### PR TITLE
Bugfix: Fix overflow of counter in SimpleClient

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -48,14 +48,22 @@ namespace bftEngine
 		virtual int sendRequestToReadLatestSeqNum(uint64_t timeoutMilli, uint64_t& outLatestReqSeqNum) = 0;		
 	};
 
-	class SeqNumberGeneratorForClientRequests // users are allowed to generate their own sequence numbers (they do not have to use this class)
-	{
-	public:
+        // This class is mainly for testing and SimpleClient applications.
+        // Users are allowed to generate their own sequence numbers (they do not
+        // have to use this class). Other examples of ways to do this include:
+        // (1) A simple counter + store the last counter in a persistent storage
+        // (2) An approach that utilizes the functions
+        //     SimpleClient::sendRequestToResetSeqNum() or
+        //     SimpleClient::sendRequestToReadLatestSeqNum(..)
+        //     [These functions are not yet supported, but if necessary, we will
+        //     support them.]
+        class SeqNumberGeneratorForClientRequests {
+          public:
+            static SeqNumberGeneratorForClientRequests*
+              createSeqNumberGeneratorForClientRequests();
 
-		static SeqNumberGeneratorForClientRequests* createSeqNumberGeneratorForClientRequests();
-		
-		virtual uint64_t generateUniqueSequenceNumberForRequest() = 0;
+            virtual uint64_t generateUniqueSequenceNumberForRequest() = 0;
 
-		virtual ~SeqNumberGeneratorForClientRequests() {};
-	};
+            virtual ~SeqNumberGeneratorForClientRequests() {};
+        };
 }

--- a/bftengine/src/bftengine/SimpleClient.cpp
+++ b/bftengine/src/bftengine/SimpleClient.cpp
@@ -458,8 +458,13 @@ namespace bftEngine
 			}
 			else
 			{
-				if (lastCountOfUniqueFetchID == 0x3FFFFF) lastMilliOfUniqueFetchID++;
-				lastCountOfUniqueFetchID++;
+				if (lastCountOfUniqueFetchID == 0x3FFFFF) {
+                                  LOG_WARN(GL, "Client SeqNum Counter reached max value");
+                                  lastMilliOfUniqueFetchID++;
+                                  lastCountOfUniqueFetchID = 0;
+                                } else {
+                                  lastCountOfUniqueFetchID++;
+                                }
 			}
 
 			uint64_t r = (lastMilliOfUniqueFetchID << (64-42));


### PR DESCRIPTION
When the SimpleClient counter in a request sequence number hits its
maximum value of 0x3FFFFF, the time part of the sequence number
increases by 1 millisecond. However, the counter part was not getting
reset to 0, but instead was incremented also. If this scenario occurred the
an assert would fire and exit the program. The code was fixed to match
the invariant in the assert.