### PR TITLE
Add a python metrics client for testing

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -1,7 +1,5 @@
 project (bftengine LANGUAGES CXX)
 
-get_property(LOGGER_INC_DIR GLOBAL PROPERTY LoggerIncludeDir)
-
 set(corebft_source_files
     src/bftengine/PrimitiveTypes.cpp
     src/bftengine/PrePrepareMsg.cpp
@@ -104,8 +102,8 @@ target_include_directories(corebft PUBLIC include/communication)
 target_include_directories(corebft PUBLIC include/bcstatetransfer)
 target_include_directories(corebft PUBLIC include/simplestatetransfer)
 target_include_directories(corebft PUBLIC include/metadatastorage)
-target_include_directories(corebft PUBLIC ${LOGGER_INC_DIR})
 
 target_link_libraries(corebft PUBLIC threshsign)
 target_link_libraries(corebft PUBLIC Threads::Threads)
 target_link_libraries(corebft PUBLIC util)
+target_link_libraries(corebft PUBLIC logging)

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -1,2 +1,2 @@
-set_property(GLOBAL PROPERTY LoggerIncludeDir
-        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_library(logging INTERFACE)
+target_include_directories(logging INTERFACE include/)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,8 +1,17 @@
-add_library(util STATIC src/Metrics.cpp)
+# pthread dependency
+find_package(Threads REQUIRED)
 
+add_library(util STATIC src/Metrics.cpp src/MetricsServer.cpp)
+
+target_link_libraries(util PUBLIC logging Threads::Threads)
 target_include_directories(util PUBLIC include)
 
 if (BUILD_TESTING)
     add_subdirectory(pyclient)
     add_subdirectory(test)
+endif()
+
+if(${USE_LOG4CPP})
+    TARGET_COMPILE_DEFINITIONS(util PUBLIC USE_LOG4CPP)
+    target_link_libraries(util PUBLIC log4cplus)
 endif()

--- a/util/include/MetricsServer.hpp
+++ b/util/include/MetricsServer.hpp
@@ -1,0 +1,64 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <stdint.h>
+#include <memory>
+#include <thread>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include "Logging.hpp"
+#include "Metrics.hpp"
+
+#ifndef CONCORD_BFT_METRICS_SERVER_HPP
+#define CONCORD_BFT_METRICS_SERVER_HPP
+
+#define MAX_MSG_SIZE 64 * 1024  // 64k
+
+namespace concordMetrics {
+
+// A UDP server that returns aggregated metrics
+class Server {
+ public:
+  Server(uint16_t listenPort)
+      : listenPort_{listenPort},
+        logger_{concordlogger::Logger::getLogger("metrics-server")},
+        running_{false},
+        aggregator_{std::make_shared<Aggregator>()} {}
+
+  void Start();
+  void Stop();
+
+  std::shared_ptr<Aggregator> GetAggregator() { return aggregator_; }
+
+ private:
+  uint16_t listenPort_;
+  concordlogger::Logger logger_;
+  bool running_;
+  std::mutex running_lock_;
+
+  std::shared_ptr<Aggregator> aggregator_;
+  std::thread thread_;
+
+  int sock_;
+  uint8_t buf_[MAX_MSG_SIZE];
+
+  void RecvLoop();
+  void sendReply(std::string data, sockaddr_in* cliaddr, socklen_t addrlen);
+  void sendError(sockaddr_in* cliaddr, socklen_t addrlen);
+};
+
+}  // namespace concordMetrics
+
+#endif  // CONCORD_BFT_METRICS_SERVER_HPP

--- a/util/pyclient/CMakeLists.txt
+++ b/util/pyclient/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_test(NAME pyclient_tests COMMAND python3 -m unittest
     test_client
     test_msgs
+    test_metrics_client
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/util/pyclient/client.py
+++ b/util/pyclient/client.py
@@ -11,15 +11,12 @@
 # file.
 
 # This code requires python 3.5 or later
-from collections import namedtuple
 import struct
 import msgs
 import trio
 import time
 
-Config = namedtuple('Config', ['id', 'f', 'c', 'max_msg_size', 'req_timeout_milli',
-    'retry_timeout_milli'])
-Replica = namedtuple('Replica', ['id', 'ip', 'port'])
+from config import Config, Replica
 
 class ReqSeqNum:
     def __init__(self):

--- a/util/pyclient/config.py
+++ b/util/pyclient/config.py
@@ -1,0 +1,19 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+# This code requires python 3.5 or later
+from collections import namedtuple
+
+Config = namedtuple('Config', ['id', 'f', 'c', 'max_msg_size', 'req_timeout_milli',
+    'retry_timeout_milli'])
+
+Replica = namedtuple('Replica', ['id', 'ip', 'port'])

--- a/util/pyclient/metrics_client.py
+++ b/util/pyclient/metrics_client.py
@@ -1,0 +1,54 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+# This code requires python 3.5 or later
+import trio
+import json
+
+from config import Replica
+
+MAX_MSG_SIZE = 64*1024; # 64k
+
+def req():
+    """Return a get request to the metrics server"""
+    req = bytearray()
+    req.append(0)
+    return req
+
+class MetricsClient:
+    def __enter__(self):
+        """context manager method for 'with' statements"""
+        return self
+
+    def __exit__(self, *args):
+        """context manager method for 'with' statements"""
+        self.sock.close()
+
+    def __init__(self, replicas):
+        self.replicas = {}
+        for r in replicas:
+            self.replicas[r.id] = (r.ip, r.port)
+        self.sock = trio.socket.socket(trio.socket.AF_INET,
+                                       trio.socket.SOCK_DGRAM)
+
+    async def get(self, replica):
+        """
+        Send a get metrics request, retrieve the JSON response, decode it and
+        return a map of metrics.
+
+        There is no explicit timeout here. Users should call `with
+        trio.fail_after as necessary`.
+        """
+        await self.sock.sendto(req(), self.replicas[replica])
+        reply, _ = await self.sock.recvfrom(MAX_MSG_SIZE)
+        assert(1, reply[0])
+        return json.loads(reply[1:])

--- a/util/pyclient/test_client.py
+++ b/util/pyclient/test_client.py
@@ -32,6 +32,7 @@ class SimpleTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.origdir = os.getcwd()
         cls.testdir = tempfile.mkdtemp()
         cls.builddir = os.path.abspath("../../build")
         cls.toolsdir = os.path.join(cls.builddir, "tools")
@@ -48,6 +49,7 @@ class SimpleTest(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         shutil.rmtree(self.testdir)
+        os.chdir(self.origdir)
 
     @classmethod
     def generateKeys(cls):

--- a/util/pyclient/test_metrics_client.py
+++ b/util/pyclient/test_metrics_client.py
@@ -1,0 +1,54 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+# This code requires python 3.5 or later
+
+import unittest
+import subprocess
+import os.path
+import trio
+
+from config import Replica
+from metrics_client import MetricsClient
+
+TIMEOUT_MILLI = 5000;
+CHECK_MILLI = 100;
+
+class MetricsClientTest(unittest.TestCase):
+    """
+    Test that we can send and get a response from the MetricsServer wich
+    contains empty metrics.
+    """
+
+    def setUp(self):
+        self.server_path = os.path.abspath("../../build/util/test/metric_server")
+        self.server = subprocess.Popen([self.server_path], close_fds=True)
+        self.replicas = [Replica(0, "127.0.0.1", 6161)]
+
+    def tearDown(self):
+        self.server.kill()
+        self.server.wait()
+
+    def testGet(self):
+        trio.run(self._testGet)
+
+    async def _testGet(self):
+        with MetricsClient(self.replicas) as client:
+            with trio.fail_after(TIMEOUT_MILLI/1000):
+                # Retry every CHECK_MILLI until the server comes up. Give up
+                # after TIMEOUT_MILLI.
+                with trio.move_on_after(CHECK_MILLI/1000):
+                    metrics = await client.get(self.replicas[0].id)
+                    self.assertEqual([], metrics['Components'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/util/src/MetricsServer.cpp
+++ b/util/src/MetricsServer.cpp
@@ -1,0 +1,144 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <string.h>
+#include <unistd.h>
+#include <iostream>
+
+#include "MetricsServer.hpp"
+
+// The MetricServer only handles a single type of request, that requests a JSON
+// metrics blob. The message format is just a single 8-bit 0 on the wire. We can
+// always change the protocol later if needed.
+const uint8_t kRequest = 0;
+
+// The MetricsServer only returns a single type of response. The response is
+// just an 8-bit 1 on the wire followed by a JSON string containing all metrics
+// for all components. Since we are using UDP, the entire message will always be
+// included, so no need to worry about framing. We can always change the
+// protocol if we decide to enhance the Metric server later on or move to a
+// different transport.
+const uint8_t kReply = 1;
+const uint8_t kError = 2;
+
+namespace concordMetrics {
+
+void Server::Start() {
+  if ((sock_ = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+    LOG_FATAL(logger_, "Error creating UDP socket");
+    exit(1);
+  }
+
+  struct sockaddr_in servaddr;
+  memset(&servaddr, 0, sizeof(servaddr));
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_addr.s_addr = INADDR_ANY;
+  servaddr.sin_port = htons(listenPort_);
+
+  if (bind(sock_, (const struct sockaddr*)&servaddr, sizeof(servaddr)) < 0) {
+    LOG_FATAL(logger_,
+              "Error binding UDP socket: IP=" << servaddr.sin_addr.s_addr
+                                              << ", Port=" << servaddr.sin_port
+                                              << ", errno=" << strerror(errno));
+    exit(1);
+  }
+
+  running_lock_.lock();
+  running_ = true;
+  running_lock_.unlock();
+
+  auto recvThread = std::thread(&Server::RecvLoop, &*this);
+  std::swap(thread_, recvThread);
+}
+
+void Server::Stop() {
+  running_lock_.lock();
+  running_ = false;
+  running_lock_.unlock();
+
+  // This will cause `recvfrom` to error in `RecvLoop` and therefore allow it
+  // to check for running_ = false without requiring a timeout on the socket.
+  close(sock_);
+
+  // Wait for the recvLoop thread to stop
+  thread_.join();
+}
+
+void Server::RecvLoop() {
+  int len = 0;
+  struct sockaddr_in cliaddr;
+  memset(&cliaddr, 0, sizeof(cliaddr));
+
+  while (1) {
+    running_lock_.lock();
+    if (!running_) {
+      running_lock_.unlock();
+      return;
+    }
+    running_lock_.unlock();
+
+    socklen_t addrlen = sizeof(cliaddr);
+    len = recvfrom(sock_, buf_, MAX_MSG_SIZE, 0, (sockaddr*)&cliaddr, &addrlen);
+
+    if (len < 0) {
+      LOG_ERROR(logger_, "Failed to recv msg: " << strerror(errno));
+      continue;
+    }
+
+    if (buf_[0] != kRequest || len != 1) {
+      LOG_WARN(logger_, "Received invalid request");
+      sendError(&cliaddr, addrlen);
+      continue;
+    }
+
+    std::string json = aggregator_->ToJson();
+
+    if (json.size() > MAX_MSG_SIZE - 1) {
+      LOG_FATAL(logger_, "Aggregator data too large to be transmitted!");
+      exit(1);
+    }
+
+    sendReply(json, &cliaddr, addrlen);
+  }
+}
+
+void Server::sendReply(std::string data,
+                       sockaddr_in* cliaddr,
+                       socklen_t addrlen) {
+  buf_[0] = kReply;
+  memcpy(buf_ + 1, data.data(), data.size());
+  auto len = sendto(sock_,
+                    buf_,
+                    data.size() + 1,
+                    0,
+                    (const struct sockaddr*)cliaddr,
+                    addrlen);
+  if (len < 0) {
+    LOG_ERROR(logger_, "Failed to send reply msg: " << strerror(errno));
+  }
+}
+
+void Server::sendError(sockaddr_in* cliaddr, socklen_t addrlen) {
+  const char* msg = "Invalid Request";
+  auto msglen = strlen(msg);
+
+  buf_[0] = kError;
+  memcpy(buf_ + 1, msg, msglen);
+  auto len = sendto(
+      sock_, buf_, msglen + 1, 0, (const struct sockaddr*)cliaddr, addrlen);
+  if (len < 0) {
+    LOG_ERROR(logger_, "Failed to send error msg: " << strerror(errno));
+  }
+}
+
+}  // namespace concordMetrics

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_executable(metric_tests metric_test.cpp)
-
 add_test(metric_tests metric_tests)
-
 target_link_libraries(metric_tests gtest_main util)
+
+add_executable(metric_server MetricServerTestMain.cpp)
+target_link_libraries(metric_server util)
+
+add_test(NAME metric_server_tests COMMAND python3 -m unittest
+    metric_server_test
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/util/test/MetricServerTestMain.cpp
+++ b/util/test/MetricServerTestMain.cpp
@@ -1,0 +1,33 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "MetricsServer.hpp"
+#include "Metrics.hpp"
+
+#include <iostream>
+#include <unistd.h>
+
+using namespace std;
+using namespace concordMetrics;
+
+int main() {
+  cout << "Starting MetricsServer" << endl;
+  concordMetrics::Server server(6161);
+  server.Start();
+
+  // We don't join the thread until server.Stop(), so keep the main thread
+  // running.
+  while (1) {
+    sleep(1);
+  }
+}

--- a/util/test/metric_server_test.py
+++ b/util/test/metric_server_test.py
@@ -1,0 +1,65 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import unittest
+import socket
+import subprocess
+import json
+import os.path
+import time
+
+class MetricsSeverTest(unittest.TestCase):
+    """
+    Test that a metric server with empty metrics responds correclty to UDP
+    requests.
+    """
+
+    def setUp(self):
+        self.server_path = os.path.abspath("../../build/util/test/metric_server")
+        self.server = subprocess.Popen([self.server_path], close_fds=True)
+        self.server_addr = ("127.0.0.1", 6161)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.settimeout(.05)
+
+    def tearDown(self):
+        self.server.kill()
+        self.server.wait()
+        self.sock.close()
+
+    def sendAndReceive(self, request):
+       """
+       Retry until we recv a message. This waits for the server to come up.
+       """
+       count = 0
+       while count < 100: # 5 seconds
+           try:
+               count += 1
+               self.sock.sendto(request, self.server_addr)
+               reply, _ = self.sock.recvfrom(1024)
+               return reply
+           except:
+               pass
+
+    def testSuccess(self):
+       """ Send a valid request and wait for a correct reply """
+       request = bytearray()
+       request.append(0) # requests only consist of single byte 0
+       reply = self.sendAndReceive(request)
+       self.assertEqual(1, reply[0])
+       metrics = json.loads(reply[1:])
+       self.assertEqual([], metrics['Components'])
+
+    def testFailure(self):
+       """ Send an invalid request and wait for an error reply """
+       request = b'hello'
+       reply = self.sendAndReceive(request)
+       self.assertEqual(2, reply[0])


### PR DESCRIPTION
 A simple UDP python client was created for testing. It uses trio so that
we can run concurrent requests during testing and it interroperates with
the bft client.

Additionally, client types were moved into config.py and test_client was
modified to reset its working directory so as not to break tests that
run after it.

## Important: This builds upon #77. Only review the second commit. #77 must be merged first.