### PR TITLE
Run the UDP Metrics Server for SimpleKVBC Replicas

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -97,6 +97,7 @@ if(${USE_LOG4CPP})
     target_link_libraries(corebft PUBLIC log4cplus)
 endif()
 
+target_include_directories(corebft PUBLIC include/)
 target_include_directories(corebft PUBLIC include/bftengine)
 target_include_directories(corebft PUBLIC include/communication)
 target_include_directories(corebft PUBLIC include/bcstatetransfer)

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -1,27 +1,37 @@
-//Concord
+// Concord
 //
-//Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
 //
-//This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License. 
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
 //
-//This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
 
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include "IStateTransfer.hpp"
 #include "ICommunication.hpp"
 #include "MetadataStorage.hpp"
+#include "Metrics.hpp"
 #include "ReplicaConfig.hpp"
 
 namespace bftEngine {
 class RequestsHandler {
  public:
-  virtual int execute(uint16_t clientId, uint64_t sequenceNum, bool readOnly,
-                      uint32_t requestSize, const char *request,
-                      uint32_t maxReplySize, char *outReply,
+  virtual int execute(uint16_t clientId,
+                      uint64_t sequenceNum,
+                      bool readOnly,
+                      uint32_t requestSize,
+                      const char *request,
+                      uint32_t maxReplySize,
+                      char *outReply,
                       uint32_t &outActualReplySize) = 0;
 };
 
@@ -47,6 +57,8 @@ class Replica {
   virtual void start() = 0;
 
   virtual void stop() = 0;
+
+  virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) = 0;
 };
 
-}
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -25,6 +25,8 @@ namespace bftEngine
 
 			virtual void stop() override;
 
+                        virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) override;
+
 			ReplicaImp* rep;
 		};
 
@@ -55,6 +57,12 @@ namespace bftEngine
 		{
 			return rep->stop();
 		}
+
+                void ReplicaInternal::SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a)
+                {
+                        return rep->SetAggregator(a);
+                }
+
 	}
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -303,6 +303,8 @@ namespace bftEngine
 			virtual void onInternalMsg(FullCommitProofMsg* m) override;
 			virtual void onMerkleExecSignature(ViewNum v, SeqNum s, uint16_t signatureLength, const char* signature) override;
 
+                        void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a);
+
 		protected:
 
 			static std::unordered_map<uint16_t, PtrToMetaMsgHandler> createMapOfMetaMsgHandlers();
@@ -487,8 +489,6 @@ namespace bftEngine
 
 			virtual void onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqNum, const ViewNum relatedViewNumber,
 				const std::forward_list<RetSuggestion>* const suggestedRetransmissions) override;  // TODO(GG): use generic iterators 
-
-                        void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
 		};
 
 

--- a/bftengine/tests/simpleKVBC/include/KVBCInterfaces.h
+++ b/bftengine/tests/simpleKVBC/include/KVBCInterfaces.h
@@ -14,11 +14,13 @@
 #pragma once
 
 #include <string>
+#include <memory>
 #include <iterator>
 #include "Status.h"
 #include "ICommunication.hpp"
 #include "PrimitiveTypes.h"
 #include "SetOfKeyValuePairs.h"
+#include "Metrics.hpp"
 
 namespace SimpleKVBC {
 
@@ -151,9 +153,11 @@ namespace SimpleKVBC {
     };
 
     // creates a new Replica object
-    IReplica* createReplica(const ReplicaConfig& conf,
-                              bftEngine::ICommunication* comm,
-                              ICommandsHandler* _cmdHandler);
+    IReplica* createReplica(
+        const ReplicaConfig& conf,
+        bftEngine::ICommunication* comm,
+        ICommandsHandler* _cmdHandler,
+        std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
 // TODO: Implement:
 //  // deletes a Replica object

--- a/bftengine/tests/simpleKVBC/src/CMakeLists.txt
+++ b/bftengine/tests/simpleKVBC/src/CMakeLists.txt
@@ -12,15 +12,8 @@ set(simpleKVBC_sources
 )
 
 add_library(simpleKVBC ${simpleKVBC_sources})
+target_link_libraries(simpleKVBC PUBLIC corebft threshsign util logging)
 
 target_include_directories(simpleKVBC PUBLIC .)
-target_include_directories(simpleKVBC PUBLIC ../../../../bftengine)
-target_include_directories(simpleKVBC PUBLIC ../../../../bftengine/include/metadatastorage)
-target_include_directories(simpleKVBC PUBLIC ../../../../bftengine/include/bcstatetransfer)
-target_include_directories(simpleKVBC PUBLIC ../../../../bftengine/include/communication)
-target_include_directories(simpleKVBC PUBLIC ../../../../bftengine/include/bftengine)
-target_include_directories(simpleKVBC PUBLIC ../../../../bftengine/include)
-target_include_directories(simpleKVBC PUBLIC ../../../../threshsign/include)
-target_include_directories(simpleKVBC PUBLIC ../../../../logging/include)
 target_include_directories(simpleKVBC PUBLIC ../../../../tools)
 target_include_directories(simpleKVBC PUBLIC ../include)

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -721,8 +721,10 @@ int RequestsHandlerImp::execute(uint16_t clientId,
 	return ret?0:1;
 }
 
-IReplica* createReplica(const ReplicaConfig& c, bftEngine::ICommunication* comm, ICommandsHandler* _cmdHandler)
-{
+IReplica* createReplica(const ReplicaConfig& c,
+                        bftEngine::ICommunication* comm,
+                        ICommandsHandler* _cmdHandler,
+                        std::shared_ptr<concordMetrics::Aggregator> aggregator) {
 
 	IDBClient* _db = new InMemoryDBClient();
 
@@ -777,6 +779,7 @@ IReplica* createReplica(const ReplicaConfig& c, bftEngine::ICommunication* comm,
 			stateTransfer,
 			comm,
 			nullptr);
+                replica->SetAggregator(aggregator);
 
 		r->m_replica = replica;
 		r->maxBlockSize = c.maxBlockSize;

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.h
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.h
@@ -14,11 +14,13 @@
 #pragma once
 
 #include <map>
+#include <memory>
 
 #include "KVBCInterfaces.h"
 #include "BlockchainDBAdapter.h"
 #include "SimpleBCStateTransfer.hpp"
 #include "Replica.hpp"
+#include "Metrics.hpp"
 
 using namespace bftEngine::SimpleBlockchainStateTransfer;
 
@@ -168,7 +170,12 @@ namespace SimpleKVBC {
 
 
 		// friends
-		friend IReplica* createReplica(const ReplicaConfig& conf, bftEngine::ICommunication* comm, ICommandsHandler* _cmdHandler);
+		friend IReplica* createReplica(
+                    const ReplicaConfig& conf,
+                    bftEngine::ICommunication* comm,
+                    ICommandsHandler* _cmdHandler,
+                    std::shared_ptr<concordMetrics::Aggregator> aggregator);
+
 		friend RequestsHandlerImp;
 	};
 

--- a/bftengine/tests/simpleKVBCTests/TesterReplica/CMakeLists.txt
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 target_link_libraries(skvbc_replica LINK_PUBLIC simpleKVBC)
 
-target_link_libraries(skvbc_replica PUBLIC corebft)
+target_link_libraries(skvbc_replica PUBLIC corebft util)
 
 target_include_directories(skvbc_replica PUBLIC ../../SimpleKVBC/include)
 target_include_directories(skvbc_replica PUBLIC ..)

--- a/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
@@ -23,6 +23,8 @@
 #include "CommFactory.hpp"
 #include "test_comm_config.hpp"
 #include "test_parameters.hpp"
+#include "MetricsServer.hpp"
+#include "ReplicaImp.h"
 
 #ifndef _WIN32
 #include <sys/param.h>
@@ -169,8 +171,13 @@ int main(int argc, char **argv) {
 	c.viewChangeTimerMillisec = 45 * 1000;
 	c.maxBlockSize = 2 * 1024 * 1024;  // 2MB
 
-	r = createReplica(c, comm, BasicRandomTests::commandsHandler());
 
+        // UDP MetricsServer only used in tests.
+        uint16_t metricsPort = conf.listenPort + 1000;
+        concordMetrics::Server server(metricsPort);
+        server.Start();
+
+	r = createReplica(c, comm, BasicRandomTests::commandsHandler(), server.GetAggregator());
 	r->start();
 	while (r->isRunning())
 		std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
+++ b/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
@@ -33,6 +33,7 @@ using std::set;
 #define MAX_READ_SET_SIZE_IN_REQ (10)
 #define MAX_READS_IN_REQ (7)
 
+using namespace SimpleKVBC;
 
 namespace BasicRandomTests
 {

--- a/bftengine/tests/simpleKVBCTests/simpleKVBCTests.h
+++ b/bftengine/tests/simpleKVBCTests/simpleKVBCTests.h
@@ -15,11 +15,7 @@
 
 #include "KVBCInterfaces.h"
 
-using namespace SimpleKVBC;
-
-namespace BasicRandomTests
-{
-	void run(IClient* client, const size_t numOfOperations);
-
-	ICommandsHandler* commandsHandler();
+namespace BasicRandomTests {
+  void run(SimpleKVBC::IClient* client, const size_t numOfOperations);
+  SimpleKVBC::ICommandsHandler* commandsHandler();
 }


### PR DESCRIPTION
The Replica abstract base class (along with ReplicaInternal and
ReplicaImp) now has an additional method, `SetAggregator` that allows
establishing the metrics aggregator to use for a given replica. This
aggregator is a member of the MetricsServer class which runs in main for
each SimpleKVBC replica. To allow configuring the SimpleKVBC replica,
the aggregator was added as a parameter to the constructor.

As part of this change the CMakeLists.txt for simpleKVBC was cleaned up
so that it no longer has to include a bunch of relative include
directories for bftEngine, threshsign, and logging. It now just uses
`target_link_libraries` and gets them all for free. This is the modern
cmake approach.

Additionally, a `using namespace SimpleKVBC` directive was removed from
simpleKVBCTests.h as using directives should not be in header files.
This using directive was moved to the cpp file instead.