### PR TITLE
Fix incorrect connectivity status update

### DIFF
--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -210,6 +210,7 @@ class AsyncTlsConnection : public
     _connectTimer.expires_at(boost::posix_time::pos_infin);
     _writeTimer.expires_at(boost::posix_time::pos_infin);
     _readTimer.expires_at(boost::posix_time::pos_infin);
+    _isReplica = check_replica(selfId);
   }
 
   void init() {


### PR DESCRIPTION
When the node is not being identified as replica node and not the client node, the optional status info callback is not called.