### PR TITLE
Add a sequence number to MetricsServer

### DIFF
--- a/util/include/MetricsServer.hpp
+++ b/util/include/MetricsServer.hpp
@@ -28,6 +28,22 @@
 
 namespace concordMetrics {
 
+const uint8_t kRequest = 0;
+const uint8_t kReply = 1;
+const uint8_t kError = 2;
+
+#pragma pack(push, 1)
+// All requests are solely Headers with msg_type_ set to kRequest. Replies are
+// JSON strings preceded by a Header with msg_type set to kReply or kError.
+// Since we are using UDP, the entire message will always be included, so no
+// need to worry about framing. We can always change the protocol if we decide
+// to enhance the Metric server later on or move to a different transport.
+struct Header {
+  uint8_t msg_type_;
+  uint64_t seq_num_;
+};
+#pragma pack(pop)
+
 // A UDP server that returns aggregated metrics
 class Server {
  public:

--- a/util/pyclient/test_metrics_client.py
+++ b/util/pyclient/test_metrics_client.py
@@ -32,7 +32,7 @@ class MetricsClientTest(unittest.TestCase):
     def setUp(self):
         self.server_path = os.path.abspath("../../build/util/test/metric_server")
         self.server = subprocess.Popen([self.server_path], close_fds=True)
-        self.replicas = [Replica(0, "127.0.0.1", 6161)]
+        self.replica = Replica(0, "127.0.0.1", 6161)
 
     def tearDown(self):
         self.server.kill()
@@ -42,12 +42,12 @@ class MetricsClientTest(unittest.TestCase):
         trio.run(self._testGet)
 
     async def _testGet(self):
-        with MetricsClient(self.replicas) as client:
+        with MetricsClient(self.replica) as client:
             with trio.fail_after(TIMEOUT_MILLI/1000):
                 # Retry every CHECK_MILLI until the server comes up. Give up
                 # after TIMEOUT_MILLI.
                 with trio.move_on_after(CHECK_MILLI/1000):
-                    metrics = await client.get(self.replicas[0].id)
+                    metrics = await client.get()
                     self.assertEqual([], metrics['Components'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
We want to be able to ignore stale replies during tests, so change the
protocol used by the MetricServer to include a sequence number.

Also change the bft_metrics_client to only operate against a single
replica. This allows easier tracking of sequence numbers and ensures we
don't have to buffer replies in any way.

All tests were updated to reflect the new code. Tests pass.

    andrewstone@ubuntu:~/concord-bft/build$ ctest -R '(pyclient|metric)'
    Test project /home/andrewstone/concord-bft/build
        Start  9: pyclient_tests
    1/3 Test  #9: pyclient_tests ...................   Passed    1.46 sec
        Start 10: metric_tests
    2/3 Test #10: metric_tests .....................   Passed    0.01 sec
        Start 11: metric_server_tests
    3/3 Test #11: metric_server_tests ..............   Passed    0.18 sec

    100% tests passed, 0 tests failed out of 3

    Total Test time (real) =   1.66 sec