### PR TITLE
Fix verification callback leak

### DIFF
--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -318,6 +318,16 @@ class AsyncTlsConnection : public
    * @param error code
    */
   void on_handshake_complete_outbound(const B_ERROR_CODE &ec) {
+    set_connected(true);
+    // When authenticated, replace custom verification by default one.
+    // This is mandatory to avoid leaking 'this' since the verification
+    // callback was binded using shared_from_this and the SSL context
+    // will retain the callback and thus 'this' will not be destroyed
+    // when needed
+    _sslContext.set_verify_callback([](bool p,
+                                       asio::ssl::verify_context&) {
+      return p;
+    });
     bool err = was_error(ec, "on_handshake_complete_outbound");
     if (err) {
       handle_error();
@@ -338,6 +348,15 @@ class AsyncTlsConnection : public
    */
   void on_handshake_complete_inbound(const B_ERROR_CODE &ec) {
     set_connected(true);
+    // When authenticated, replace custom verification by default one.
+    // This is mandatory to avoid leaking 'this' since the verification
+    // callback was binded using shared_from_this and the SSL context
+    // will retain the callback and thus 'this' will not be destroyed
+    // when needed
+    _sslContext.set_verify_callback([](bool p,
+                                       asio::ssl::verify_context&) {
+      return p;
+    });
     bool err = was_error(ec, "on_handshake_complete_inbound");
     if (err) {
       handle_error();
@@ -556,15 +575,6 @@ class AsyncTlsConnection : public
                  "connection authenticated, node: " << _selfId << ", type: " << _connType << ", expected peer: " << _expectedDestId
                                                     << ", peer: "
                                                     << remotePeerId);
-        // When authenticated, replace custom verification by default one.
-        // This is mandatory to avoid leaking 'this' since the verification
-        // callback was binded using shared_from_this and the SSL context
-        // will retain the callback and thus 'this' will not be destroyed
-        // when needed
-        _sslContext.set_verify_callback([](bool p,
-            asio::ssl::verify_context&) {
-          return p;
-        });
       }
 
       if(_destId == UNKNOWN_NODE_ID) {

--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -556,6 +556,15 @@ class AsyncTlsConnection : public
                  "connection authenticated, node: " << _selfId << ", type: " << _connType << ", expected peer: " << _expectedDestId
                                                     << ", peer: "
                                                     << remotePeerId);
+        // When authenticated, replace custom verification by default one.
+        // This is mandatory to avoid leaking 'this' since the verification
+        // callback was binded using shared_from_this and the SSL context
+        // will retain the callback and thus 'this' will not be destroyed
+        // when needed
+        _sslContext.set_verify_callback([](bool p,
+            asio::ssl::verify_context&) {
+          return p;
+        });
       }
 
       if(_destId == UNKNOWN_NODE_ID) {


### PR DESCRIPTION
This PR fixes AsyncTlsConnecton object leak when the SSL context verify callback is used with shared_from_this.
The SSL context object retains the custom callback even when connection has been authenticated.
The fix is to replace custom verification by default one, when the connection is authenticated. This will allow the object to be deleted, when needed.