### PR TITLE
Persistency and crash recovery: interfaces, debug, and basic related functionality

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -42,6 +42,7 @@ set(corebft_source_files
 	src/bftengine/NullStateTransfer.cpp
     src/bftengine/BFTEngine.cpp
     src/bftengine/SimpleClient.cpp
+    src/bftengine/DebugPersistentStorage.cpp
     src/communication/PlainUDPCommunication.cpp
     src/communication/CommFactory.cpp
 	src/bcstatetransfer/BCStateTran.cpp

--- a/bftengine/src/bftengine/Bitmap.hpp
+++ b/bftengine/src/bftengine/Bitmap.hpp
@@ -1,0 +1,146 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "PrimitiveTypes.hpp"
+#include "assertUtils.hpp"
+
+#include <vector>
+#include <cstring>
+
+namespace bftEngine {
+namespace impl {
+class Bitmap {
+ public:
+  Bitmap() : numBits_(0), p_(nullptr) {}
+
+  Bitmap(uint32_t numBits) : numBits_(numBits), p_(nullptr) {
+    if (numBits_ > 0) {
+      p_ = (unsigned char*)std::malloc(realSize());
+      zeroAll();
+    }
+  }
+
+  Bitmap(const Bitmap& other) : numBits_(other.numBits_), p_(nullptr) {
+    if (numBits_ == 0) {
+      p_ = nullptr;
+    } else {
+      p_ = (unsigned char*)std::malloc(realSize());
+      std::memcpy(p_, other.p_, realSize());
+    }
+  }
+
+  ~Bitmap() {
+    if (numBits_ > 0) {
+      Assert(p_ != nullptr);
+      std::free(p_);
+    }
+  }
+
+  Bitmap& operator=(const Bitmap& other) {
+    if (numBits_ > 0) {
+      Assert(p_ != nullptr);
+      std::free(p_);
+    }
+
+    numBits_ = other.numBits_;
+    if (numBits_ == 0) {
+      p_ = nullptr;
+    } else {
+      p_ = (unsigned char*)std::malloc(realSize());
+      std::memcpy(p_, other.p_, realSize());
+    }
+
+    return *this;
+  }
+
+  void zeroAll() {
+    if (p_ == nullptr) return;
+    const uint32_t s = realSize();
+    Assert(s > 0);
+    memset((void*)p_, 0, s);
+  }
+
+  uint32_t numOfBits() const { return numBits_; }
+
+  bool get(uint32_t i) const {
+    Assert(i < numBits_);
+    const uint32_t byteIndex = i / 8;
+    const unsigned char byteMask = (1 << (i % 8));
+    return ((p_[byteIndex] & byteMask) != 0);
+  }
+
+  void set(uint32_t i) {
+    Assert(i < numBits_);
+    const uint32_t byteIndex = i / 8;
+    const unsigned char byteMask = (1 << (i % 8));
+    p_[byteIndex] = p_[byteIndex] | byteMask;
+  }
+
+  void reset(uint32_t i) {
+    Assert(i < numBits_);
+    const uint32_t byteIndex = i / 8;
+    const unsigned char byteMask = ((unsigned char)0xFF) & ~(1 << (i % 8));
+    p_[byteIndex] = p_[byteIndex] & byteMask;
+  }
+
+  void writeToBuffer(char* buffer,
+                     uint32_t bufferLength,
+                     uint32_t* actualSize) const {
+    const uint32_t sizeNeeded = sizeNeededInBuffer();
+    Assert(bufferLength >= sizeNeeded);
+    uint32_t* pNumOfBits = (uint32_t*)buffer;
+    char* pBitmap = buffer + sizeof(uint32_t);
+    *pNumOfBits = numBits_;
+    memcpy(pBitmap, p_, realSize());
+    if (actualSize) *actualSize = sizeNeeded;
+  }
+
+  uint32_t sizeNeededInBuffer() const {
+    return (sizeof(uint32_t) + realSize(numBits_));
+  }
+
+  static Bitmap* createBitmapFromBuffer(char* buffer,
+                                        uint32_t bufferLength,
+                                        uint32_t* actualSize) {
+    if (actualSize) *actualSize = 0;
+    if (bufferLength < sizeof(uint32_t)) return nullptr;
+    uint32_t* pNumOfBits = (uint32_t*)buffer;
+    const uint32_t numOfBitmapBytes = realSize(*pNumOfBits);
+    const uint32_t sizeNeeded = sizeof(uint32_t) + numOfBitmapBytes;
+    if (bufferLength < sizeNeeded) return nullptr;
+    Bitmap* b = new Bitmap();
+    if (*pNumOfBits > 0) {
+      char* pBitmap = buffer + sizeof(uint32_t);
+      b->numBits_ = *pNumOfBits;
+      b->p_ = (unsigned char*)std::malloc(numOfBitmapBytes);
+      std::memcpy(b->p_, pBitmap, numOfBitmapBytes);
+    }
+    if (actualSize) *actualSize = sizeNeeded;
+    return b;
+  }
+
+  static uint32_t maxSizeNeededToStoreInBuffer(uint32_t maxNumOfBits) {
+    return (sizeof(uint32_t) + realSize(maxNumOfBits));
+  }
+
+ protected:
+  uint32_t numBits_;
+  unsigned char* p_;
+
+  uint32_t realSize() const { return realSize(numBits_); }
+  static uint32_t realSize(uint32_t nbits) { return ((nbits + 7) / 8); }
+};
+}  // namespace impl
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/CheckpointMsg.cpp
+++ b/bftengine/src/bftengine/CheckpointMsg.cpp
@@ -64,5 +64,16 @@ namespace bftEngine
 
 			return true;
 		}
+
+		MsgSize CheckpointMsg::maxSizeOfCheckpointMsg()
+		{
+			return sizeof(CheckpointMsgHeader);
+		}
+
+		MsgSize CheckpointMsg::maxSizeOfCheckpointMsgInLocalBuffer()
+		{
+			return maxSizeOfCheckpointMsg() + sizeof(RawHeaderOfObjAndMsg);
+		}
+
 	}
 }

--- a/bftengine/src/bftengine/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/CheckpointMsg.hpp
@@ -21,6 +21,10 @@ namespace bftEngine
 
 		public:
 
+			static MsgSize maxSizeOfCheckpointMsg();
+
+			static MsgSize maxSizeOfCheckpointMsgInLocalBuffer();
+
 			CheckpointMsg(ReplicaId senderId, SeqNum seqNum, const Digest& stateDigest, bool stateIsStable);
 
 			SeqNum seqNumber() const { return b()->seqNum; }

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -1,0 +1,531 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "DebugPersistentStorage.hpp"
+
+#include "PrePrepareMsg.hpp"
+#include "SignedShareMsgs.hpp"
+#include "NewViewMsg.hpp"
+#include "FullCommitProofMsg.hpp"
+#include "CheckpointMsg.hpp"
+
+namespace bftEngine {
+namespace impl {
+
+DebugPersistentStorage::DebugPersistentStorage(uint16_t fVal, uint16_t cVal)
+    : fVal_{fVal},
+      cVal_{cVal},
+      seqNumWindow{1, nullptr},
+      checkWindow{0, nullptr}
+
+{}
+
+uint8_t DebugPersistentStorage::beginWriteTran() {
+  return ++numOfNestedTransactions;
+}
+
+uint8_t DebugPersistentStorage::endWriteTran() {
+  Assert(numOfNestedTransactions != 0);
+  return --numOfNestedTransactions;
+}
+
+bool DebugPersistentStorage::isInWriteTran() const {
+  return (numOfNestedTransactions != 0);
+}
+
+void DebugPersistentStorage::setReplicaConfig(ReplicaConfig config) {
+  Assert(!hasConfig_);
+  Assert(isInWriteTran());
+  hasConfig_ = true;
+  config_ = config;
+}
+
+void DebugPersistentStorage::setFetchingState(const bool f) {
+  Assert(nonExecSetIsAllowed());
+  Assert(!f || !fetchingState_);  // f ==> !fetchingState_
+  fetchingState_ = f;
+}
+
+void DebugPersistentStorage::setLastExecutedSeqNum(const SeqNum s) {
+  Assert(setIsAllowed());
+  Assert(lastExecutedSeqNum_ <= s);
+  lastExecutedSeqNum_ = s;
+}
+
+void DebugPersistentStorage::setPrimaryLastUsedSeqNum(const SeqNum s) {
+  Assert(nonExecSetIsAllowed());
+  primaryLastUsedSeqNum_ = s;
+}
+
+void DebugPersistentStorage::setStrictLowerBoundOfSeqNums(const SeqNum s) {
+  Assert(nonExecSetIsAllowed());
+  strictLowerBoundOfSeqNums_ = s;
+}
+
+void DebugPersistentStorage::setLastViewThatTransferredSeqNumbersFullyExecuted(
+    const ViewNum v) {
+  Assert(nonExecSetIsAllowed());
+  Assert(lastViewThatTransferredSeqNumbersFullyExecuted_ <= v);
+  lastViewThatTransferredSeqNumbersFullyExecuted_ = v;
+}
+
+void DebugPersistentStorage::setDescriptorOfLastExitFromView(
+    const DescriptorOfLastExitFromView& d) {
+  Assert(nonExecSetIsAllowed());
+  Assert(d.view >= 0);
+
+  // Here we assume that the first view is always 0
+  // (even if we load the initial state from disk)
+  // TODO(GG): check this
+  Assert(hasDescriptorOfLastNewView_ || d.view == 0);
+
+  Assert(!hasDescriptorOfLastExitFromView_ ||
+         d.view > descriptorOfLastExitFromView_.view);
+  Assert(!hasDescriptorOfLastNewView_ ||
+         d.view == descriptorOfLastNewView_.view);
+  Assert(d.lastStable >= lastStableSeqNum_);
+  Assert(d.lastExecuted >= lastExecutedSeqNum_);
+  Assert(d.elements.size() <= kWorkWindowSize);
+  Assert(hasDescriptorOfLastExitFromView_ ||
+         descriptorOfLastExitFromView_.elements.size() == 0);
+
+  std::vector<ViewsManager::PrevViewInfo> clonedElements(d.elements.size());
+
+  for (size_t i = 0; i < d.elements.size(); i++) {
+    const ViewsManager::PrevViewInfo& e = d.elements[i];
+    Assert(e.prePrepare != nullptr);
+    Assert(e.prePrepare->seqNumber() >= lastStableSeqNum_ + 1);
+    Assert(e.prePrepare->seqNumber() <= lastStableSeqNum_ + kWorkWindowSize);
+    Assert(e.prePrepare->viewNumber() == d.view);
+    Assert(e.prepareFull == nullptr || e.prepareFull->viewNumber() == d.view);
+    Assert(e.prepareFull == nullptr ||
+           e.prepareFull->seqNumber() == e.prePrepare->seqNumber());
+
+    PrePrepareMsg* clonedPrePrepareMsg =
+        (PrePrepareMsg*)e.prePrepare->cloneObjAndMsg();
+    Assert(clonedPrePrepareMsg->type() == MsgCode::PrePrepare);
+    PrepareFullMsg* clonedPrepareFull = nullptr;
+    if (e.prepareFull != nullptr) {
+      clonedPrepareFull = (PrepareFullMsg*)e.prepareFull->cloneObjAndMsg();
+      Assert(clonedPrepareFull->type() == MsgCode::PrepareFull);
+    }
+
+    clonedElements[i].prePrepare = clonedPrePrepareMsg;
+    clonedElements[i].hasAllRequests = e.hasAllRequests;
+    clonedElements[i].prepareFull = clonedPrepareFull;
+  }
+
+  // delete messages from previous descriptor
+  for (size_t i = 0; i < descriptorOfLastExitFromView_.elements.size(); i++) {
+    const ViewsManager::PrevViewInfo& e =
+        descriptorOfLastExitFromView_.elements[i];
+    Assert(e.prePrepare != nullptr);
+    delete e.prePrepare;
+    if (e.prepareFull != nullptr) delete e.prepareFull;
+  }
+
+  hasDescriptorOfLastExitFromView_ = true;
+  descriptorOfLastExitFromView_ = DescriptorOfLastExitFromView{
+      d.view, d.lastStable, d.lastExecuted, clonedElements};
+}
+
+void DebugPersistentStorage::setDescriptorOfLastNewView(
+    const DescriptorOfLastNewView& d) {
+  Assert(nonExecSetIsAllowed());
+  Assert(d.view >= 1);
+  Assert(hasDescriptorOfLastExitFromView_);
+  Assert(d.view > descriptorOfLastExitFromView_.view);
+
+  Assert(d.newViewMsg != nullptr);
+  Assert(d.newViewMsg->newView() == d.view);
+
+  const size_t numOfVCMsgs = 2 * fVal_ + 2 * cVal_ + 1;
+
+  Assert(d.viewChangeMsgs.size() == numOfVCMsgs);
+
+  std::vector<ViewChangeMsg*> clonedViewChangeMsgs(numOfVCMsgs);
+
+  for (size_t i = 0; i < numOfVCMsgs; i++) {
+    const ViewChangeMsg* vc = d.viewChangeMsgs[i];
+    Assert(vc != nullptr);
+    Assert(vc->newView() == d.view);
+
+    Digest digestOfVCMsg;
+    vc->getMsgDigest(digestOfVCMsg);
+    Assert(d.newViewMsg->includesViewChangeFromReplica(
+        vc->idOfGeneratedReplica(), digestOfVCMsg));
+
+    ViewChangeMsg* clonedVC = (ViewChangeMsg*)vc->cloneObjAndMsg();
+    Assert(clonedVC->type() == MsgCode::ViewChange);
+    clonedViewChangeMsgs[i] = clonedVC;
+  }
+
+  NewViewMsg* clonedNewViewMsg = (NewViewMsg*)d.newViewMsg->cloneObjAndMsg();
+  Assert(clonedNewViewMsg->type() == MsgCode::NewView);
+
+  if (hasDescriptorOfLastNewView_) {
+    // delete messages from previous descriptor
+    delete descriptorOfLastNewView_.newViewMsg;
+
+    Assert(descriptorOfLastNewView_.viewChangeMsgs.size() == numOfVCMsgs);
+
+    for (size_t i = 0; i < numOfVCMsgs; i++) {
+      delete descriptorOfLastNewView_.viewChangeMsgs[i];
+    }
+  }
+
+  hasDescriptorOfLastNewView_ = true;
+  descriptorOfLastNewView_ =
+      DescriptorOfLastNewView{d.view,
+                              clonedNewViewMsg,
+                              clonedViewChangeMsgs,
+                              d.maxSeqNumTransferredFromPrevViews};
+}
+
+void DebugPersistentStorage::setDescriptorOfLastExecution(
+    const DescriptorOfLastExecution& d) {
+  Assert(setIsAllowed());
+  Assert(!hasDescriptorOfLastExecution_ ||
+         descriptorOfLastExecution_.executedSeqNum < d.executedSeqNum);
+  Assert(lastExecutedSeqNum_ + 1 == d.executedSeqNum);
+  Assert(d.validRequests.numOfBits() >= 1);
+  Assert(d.validRequests.numOfBits() <= maxNumOfRequestsInBatch);
+
+  hasDescriptorOfLastExecution_ = true;
+  descriptorOfLastExecution_ =
+      DescriptorOfLastExecution{d.executedSeqNum, d.validRequests};
+}
+
+void DebugPersistentStorage::setLastStableSeqNum(const SeqNum s) {
+  Assert(s >= lastStableSeqNum_);
+  lastStableSeqNum_ = s;
+  seqNumWindow.advanceActiveWindow(lastStableSeqNum_ + 1);
+  checkWindow.advanceActiveWindow(lastStableSeqNum_);
+}
+
+void DebugPersistentStorage::DebugPersistentStorage::clearSeqNumWindow() {
+  SeqNum s = seqNumWindow.currentActiveWindow().first;
+  Assert(s == lastStableSeqNum_ + 1);
+  seqNumWindow.resetAll(s);
+}
+
+void DebugPersistentStorage::setPrePrepareMsgInSeqNumWindow(
+    const SeqNum s, const PrePrepareMsg* const m) {
+  Assert(seqNumWindow.insideActiveWindow(s));
+  SeqNumData& seqNumData = seqNumWindow.get(s);
+  Assert(seqNumData.prePrepareMsg == nullptr);
+  seqNumData.prePrepareMsg = (PrePrepareMsg*)m->cloneObjAndMsg();
+}
+
+void DebugPersistentStorage::setSlowStartedInSeqNumWindow(
+    const SeqNum s, const bool slowStarted) {
+  Assert(seqNumWindow.insideActiveWindow(s));
+  SeqNumData& seqNumData = seqNumWindow.get(s);
+  seqNumData.slowStarted = slowStarted;
+}
+
+void DebugPersistentStorage::setFullCommitProofMsgInSeqNumWindow(
+    const SeqNum s, const FullCommitProofMsg* const m) {
+  Assert(seqNumWindow.insideActiveWindow(s));
+  SeqNumData& seqNumData = seqNumWindow.get(s);
+  Assert(seqNumData.fullCommitProofMsg == nullptr);
+  seqNumData.fullCommitProofMsg = (FullCommitProofMsg*)m->cloneObjAndMsg();
+}
+
+void DebugPersistentStorage::setForceCompletedInSeqNumWindow(
+    const SeqNum s, const bool forceCompleted) {
+  Assert(forceCompleted == true);
+  Assert(seqNumWindow.insideActiveWindow(s));
+  SeqNumData& seqNumData = seqNumWindow.get(s);
+  seqNumData.forceCompleted = forceCompleted;
+}
+
+void DebugPersistentStorage::setPrepareFullMsgInSeqNumWindow(
+    const SeqNum s, const PrepareFullMsg* const m) {
+  Assert(seqNumWindow.insideActiveWindow(s));
+  SeqNumData& seqNumData = seqNumWindow.get(s);
+  Assert(seqNumData.prepareFullMsg == nullptr);
+  seqNumData.prepareFullMsg = (PrepareFullMsg*)m->cloneObjAndMsg();
+}
+
+void DebugPersistentStorage::setCommitFullMsgInSeqNumWindow(
+    const SeqNum s, const CommitFullMsg* const m) {
+  Assert(seqNumWindow.insideActiveWindow(s));
+  SeqNumData& seqNumData = seqNumWindow.get(s);
+  Assert(seqNumData.commitFullMsg == nullptr);
+  seqNumData.commitFullMsg = (CommitFullMsg*)m->cloneObjAndMsg();
+}
+
+void DebugPersistentStorage::setCheckpointMsgInCheckWindow(
+    const SeqNum s, const CheckpointMsg* const m) {
+  Assert(checkWindow.insideActiveWindow(s));
+  CheckData& checkData = checkWindow.get(s);
+  if (checkData.checkpointMsg != nullptr) delete checkData.checkpointMsg;
+  checkData.checkpointMsg = (CheckpointMsg*)m->cloneObjAndMsg();
+}
+
+void DebugPersistentStorage::setCompletedMarkInCheckWindow(const SeqNum s,
+                                                           const bool f) {
+  Assert(f == true);
+  Assert(checkWindow.insideActiveWindow(s));
+  CheckData& checkData = checkWindow.get(s);
+  checkData.completedMark = f;
+}
+
+bool DebugPersistentStorage::hasReplicaConfig() { return hasConfig_; }
+
+ReplicaConfig DebugPersistentStorage::getReplicaConig() {
+  Assert(getIsAllowed());
+  Assert(hasConfig_);
+  return config_;
+}
+
+bool DebugPersistentStorage::getFetchingState() {
+  Assert(getIsAllowed());
+  return fetchingState_;
+}
+
+SeqNum DebugPersistentStorage::getLastExecutedSeqNum() {
+  Assert(getIsAllowed());
+  return lastStableSeqNum_;
+}
+
+SeqNum DebugPersistentStorage::getPrimaryLastUsedSeqNum() {
+  Assert(getIsAllowed());
+  return primaryLastUsedSeqNum_;
+}
+
+SeqNum DebugPersistentStorage::getStrictLowerBoundOfSeqNums() {
+  Assert(getIsAllowed());
+  return strictLowerBoundOfSeqNums_;
+}
+
+ViewNum
+DebugPersistentStorage::getLastViewThatTransferredSeqNumbersFullyExecuted() {
+  Assert(getIsAllowed());
+  return lastViewThatTransferredSeqNumbersFullyExecuted_;
+}
+
+bool DebugPersistentStorage::hasDescriptorOfLastExitFromView() {
+  Assert(getIsAllowed());
+  return hasDescriptorOfLastExitFromView_;
+}
+
+PersistentStorage::DescriptorOfLastExitFromView
+DebugPersistentStorage::getAndAllocateDescriptorOfLastExitFromView() {
+  Assert(getIsAllowed());
+  Assert(hasDescriptorOfLastExitFromView_);
+
+  DescriptorOfLastExitFromView& d = descriptorOfLastExitFromView_;
+
+  std::vector<ViewsManager::PrevViewInfo> elements(d.elements.size());
+
+  for (size_t i = 0; i < elements.size(); i++) {
+    const ViewsManager::PrevViewInfo& e = d.elements[i];
+    elements[i].prePrepare = (PrePrepareMsg*)e.prePrepare->cloneObjAndMsg();
+    elements[i].hasAllRequests = e.hasAllRequests;
+    if (e.prepareFull != nullptr)
+      elements[i].prepareFull =
+          (PrepareFullMsg*)e.prepareFull->cloneObjAndMsg();
+    else
+      elements[i].prepareFull = nullptr;
+  }
+
+  DescriptorOfLastExitFromView retVal{
+      d.view, d.lastStable, d.lastExecuted, elements};
+
+  return retVal;
+}
+
+bool DebugPersistentStorage::hasDescriptorOfLastNewView() {
+  Assert(getIsAllowed());
+  return hasDescriptorOfLastNewView_;
+}
+
+PersistentStorage::DescriptorOfLastNewView
+DebugPersistentStorage::getAndAllocateDescriptorOfLastNewView() {
+  Assert(getIsAllowed());
+  Assert(hasDescriptorOfLastNewView_);
+
+  DescriptorOfLastNewView& d = descriptorOfLastNewView_;
+
+  NewViewMsg* newViewMsg = (NewViewMsg*)d.newViewMsg->cloneObjAndMsg();
+
+  std::vector<ViewChangeMsg*> viewChangeMsgs(d.viewChangeMsgs.size());
+
+  for (size_t i = 0; i < viewChangeMsgs.size(); i++) {
+    viewChangeMsgs[i] = (ViewChangeMsg*)d.viewChangeMsgs[i]->cloneObjAndMsg();
+  }
+
+  DescriptorOfLastNewView retVal{
+      d.view, newViewMsg, viewChangeMsgs, d.maxSeqNumTransferredFromPrevViews};
+
+  return retVal;
+}
+
+bool DebugPersistentStorage::hasDescriptorOfLastExecution() {
+  Assert(getIsAllowed());
+  return hasDescriptorOfLastExecution_;
+}
+
+PersistentStorage::DescriptorOfLastExecution
+DebugPersistentStorage::getDescriptorOfLastExecution() {
+  Assert(getIsAllowed());
+  Assert(hasDescriptorOfLastExecution_);
+
+  DescriptorOfLastExecution& d = descriptorOfLastExecution_;
+
+  return PersistentStorage::DescriptorOfLastExecution{d.executedSeqNum,
+                                                      d.validRequests};
+}
+
+SeqNum DebugPersistentStorage::getLastStableSeqNum() {
+  Assert(getIsAllowed());
+  return lastStableSeqNum_;
+}
+
+PrePrepareMsg*
+DebugPersistentStorage::getAndAllocatePrePrepareMsgInSeqNumWindow(
+    const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ + 1 == seqNumWindow.currentActiveWindow().first);
+  Assert(seqNumWindow.insideActiveWindow(s));
+  PrePrepareMsg* m =
+      (PrePrepareMsg*)seqNumWindow.get(s).prePrepareMsg->cloneObjAndMsg();
+  Assert(m->type() == MsgCode::PrePrepare);
+  return m;
+}
+
+bool DebugPersistentStorage::getSlowStartedInSeqNumWindow(const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ + 1 == seqNumWindow.currentActiveWindow().first);
+  Assert(seqNumWindow.insideActiveWindow(s));
+  bool b = seqNumWindow.get(s).slowStarted;
+  return b;
+}
+
+FullCommitProofMsg*
+DebugPersistentStorage::getAndAllocateFullCommitProofMsgInSeqNumWindow(
+    const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ + 1 == seqNumWindow.currentActiveWindow().first);
+  Assert(seqNumWindow.insideActiveWindow(s));
+  FullCommitProofMsg* m = (FullCommitProofMsg*)seqNumWindow.get(s)
+                              .fullCommitProofMsg->cloneObjAndMsg();
+  Assert(m->type() == MsgCode::FullCommitProof);
+  return m;
+}
+
+bool DebugPersistentStorage::getForceCompletedInSeqNumWindow(const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ + 1 == seqNumWindow.currentActiveWindow().first);
+  Assert(seqNumWindow.insideActiveWindow(s));
+  bool b = seqNumWindow.get(s).forceCompleted;
+  return b;
+}
+
+PrepareFullMsg*
+DebugPersistentStorage::getAndAllocatePrepareFullMsgInSeqNumWindow(
+    const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ + 1 == seqNumWindow.currentActiveWindow().first);
+  Assert(seqNumWindow.insideActiveWindow(s));
+  PrepareFullMsg* m =
+      (PrepareFullMsg*)seqNumWindow.get(s).prepareFullMsg->cloneObjAndMsg();
+  Assert(m->type() == MsgCode::PrepareFull);
+  return m;
+}
+
+CommitFullMsg*
+DebugPersistentStorage::getAndAllocateCommitFullMsgInSeqNumWindow(
+    const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ + 1 == seqNumWindow.currentActiveWindow().first);
+  Assert(seqNumWindow.insideActiveWindow(s));
+  CommitFullMsg* m =
+      (CommitFullMsg*)seqNumWindow.get(s).commitFullMsg->cloneObjAndMsg();
+  Assert(m->type() == MsgCode::CommitFull);
+  return m;
+}
+
+CheckpointMsg* DebugPersistentStorage::getAndAllocateCheckpointMsgInCheckWindow(
+    const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ == checkWindow.currentActiveWindow().first);
+  Assert(checkWindow.insideActiveWindow(s));
+  CheckpointMsg* m =
+      (CheckpointMsg*)checkWindow.get(s).checkpointMsg->cloneObjAndMsg();
+  Assert(m->type() == MsgCode::Checkpoint);
+  return m;
+}
+
+bool DebugPersistentStorage::getCompletedMarkInCheckWindow(const SeqNum s) {
+  Assert(getIsAllowed());
+  Assert(lastStableSeqNum_ == checkWindow.currentActiveWindow().first);
+  Assert(checkWindow.insideActiveWindow(s));
+  bool b = checkWindow.get(s).completedMark;
+  return b;
+}
+
+bool DebugPersistentStorage::setIsAllowed() const {
+  return isInWriteTran() && hasConfig_;
+}
+
+bool DebugPersistentStorage::getIsAllowed() const {
+  return !isInWriteTran() && hasConfig_;
+}
+
+bool DebugPersistentStorage::nonExecSetIsAllowed() const {
+  return setIsAllowed() &&
+         (!hasDescriptorOfLastExecution_ ||
+          descriptorOfLastExecution_.executedSeqNum <= lastExecutedSeqNum_);
+}
+
+void DebugPersistentStorage::WindowFuncs::init(SeqNumData& i, void* d) {
+  i.prePrepareMsg = nullptr;
+  i.slowStarted = false;
+  i.fullCommitProofMsg = nullptr;
+  i.forceCompleted = false;
+  i.prepareFullMsg = nullptr;
+  i.commitFullMsg = nullptr;
+}
+
+void DebugPersistentStorage::WindowFuncs::free(SeqNumData& i) { reset(i); }
+
+void DebugPersistentStorage::WindowFuncs::reset(SeqNumData& i) {
+  if (i.prePrepareMsg != nullptr) delete i.prePrepareMsg;
+  if (i.fullCommitProofMsg != nullptr) delete i.fullCommitProofMsg;
+  if (i.prepareFullMsg != nullptr) delete i.prepareFullMsg;
+  if (i.commitFullMsg != nullptr) delete i.commitFullMsg;
+  i.prePrepareMsg = nullptr;
+  i.slowStarted = false;
+  i.fullCommitProofMsg = nullptr;
+  i.forceCompleted = false;
+  i.prepareFullMsg = nullptr;
+  i.commitFullMsg = nullptr;
+}
+
+void DebugPersistentStorage::WindowFuncs::init(CheckData& i, void* d) {
+  i.checkpointMsg = nullptr;
+  i.completedMark = false;
+}
+void DebugPersistentStorage::WindowFuncs::free(CheckData& i) { reset(i); }
+
+void DebugPersistentStorage::WindowFuncs::reset(CheckData& i) {
+  if (i.checkpointMsg != nullptr) delete i.checkpointMsg;
+  i.checkpointMsg = nullptr;
+  i.completedMark = false;
+}
+
+}  // namespace impl
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -1,0 +1,161 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "PersistentStorage.hpp"
+#include "SequenceWithActiveWindow.hpp"
+
+namespace bftEngine {
+namespace impl {
+
+class DebugPersistentStorage : public PersistentStorage {
+ public:
+  DebugPersistentStorage(uint16_t fVal, uint16_t cVal);
+
+  // Inherited via PersistentStorage
+  virtual uint8_t beginWriteTran() override;
+  virtual uint8_t endWriteTran() override;
+  virtual bool isInWriteTran() const override;
+  virtual void setReplicaConfig(ReplicaConfig config) override;
+  virtual void setFetchingState(const bool f) override;
+  virtual void setLastExecutedSeqNum(const SeqNum s) override;
+  virtual void setPrimaryLastUsedSeqNum(const SeqNum s) override;
+  virtual void setStrictLowerBoundOfSeqNums(const SeqNum s) override;
+  virtual void setLastViewThatTransferredSeqNumbersFullyExecuted(
+      const ViewNum v) override;
+  virtual void setDescriptorOfLastExitFromView(
+      const DescriptorOfLastExitFromView& prevViewDesc) override;
+  virtual void setDescriptorOfLastNewView(
+      const DescriptorOfLastNewView& prevViewDesc) override;
+  virtual void setDescriptorOfLastExecution(
+      const DescriptorOfLastExecution& prevViewDesc) override;
+  virtual void setLastStableSeqNum(const SeqNum s) override;
+  virtual void clearSeqNumWindow() override;
+  virtual void setPrePrepareMsgInSeqNumWindow(
+      const SeqNum s, const PrePrepareMsg* const m) override;
+  virtual void setSlowStartedInSeqNumWindow(const SeqNum s,
+                                            const bool slowStarted) override;
+  virtual void setFullCommitProofMsgInSeqNumWindow(
+      const SeqNum s, const FullCommitProofMsg* const m) override;
+  virtual void setForceCompletedInSeqNumWindow(
+      const SeqNum s, const bool forceCompleted) override;
+  virtual void setPrepareFullMsgInSeqNumWindow(
+      const SeqNum s, const PrepareFullMsg* const m) override;
+  virtual void setCommitFullMsgInSeqNumWindow(
+      const SeqNum s, const CommitFullMsg* const m) override;
+  virtual void setCheckpointMsgInCheckWindow(
+      const SeqNum s, const CheckpointMsg* const m) override;
+  virtual void setCompletedMarkInCheckWindow(const SeqNum s,
+                                             const bool f) override;
+  virtual bool hasReplicaConfig() override;
+  virtual ReplicaConfig getReplicaConig() override;
+  virtual bool getFetchingState() override;
+  virtual SeqNum getLastExecutedSeqNum() override;
+  virtual SeqNum getPrimaryLastUsedSeqNum() override;
+  virtual SeqNum getStrictLowerBoundOfSeqNums() override;
+  virtual ViewNum getLastViewThatTransferredSeqNumbersFullyExecuted() override;
+  virtual bool hasDescriptorOfLastExitFromView() override;
+  virtual DescriptorOfLastExitFromView
+  getAndAllocateDescriptorOfLastExitFromView() override;
+  virtual bool hasDescriptorOfLastNewView() override;
+  virtual DescriptorOfLastNewView getAndAllocateDescriptorOfLastNewView()
+      override;
+  virtual bool hasDescriptorOfLastExecution() override;
+  virtual DescriptorOfLastExecution getDescriptorOfLastExecution() override;
+  virtual SeqNum getLastStableSeqNum() override;
+  virtual PrePrepareMsg* getAndAllocatePrePrepareMsgInSeqNumWindow(
+      const SeqNum s) override;
+  virtual bool getSlowStartedInSeqNumWindow(const SeqNum s) override;
+  virtual FullCommitProofMsg* getAndAllocateFullCommitProofMsgInSeqNumWindow(
+      const SeqNum s) override;
+  virtual bool getForceCompletedInSeqNumWindow(const SeqNum s) override;
+  virtual PrepareFullMsg* getAndAllocatePrepareFullMsgInSeqNumWindow(
+      const SeqNum s) override;
+  virtual CommitFullMsg* getAndAllocateCommitFullMsgInSeqNumWindow(
+      const SeqNum s) override;
+  virtual CheckpointMsg* getAndAllocateCheckpointMsgInCheckWindow(
+      const SeqNum s) override;
+  virtual bool getCompletedMarkInCheckWindow(const SeqNum s) override;
+
+ protected:
+  bool setIsAllowed() const;
+  bool getIsAllowed() const;
+  bool nonExecSetIsAllowed() const;
+
+  const uint16_t fVal_;
+  const uint16_t cVal_;
+
+  uint8_t numOfNestedTransactions = 0;
+
+  bool hasConfig_ = false;
+  ReplicaConfig config_;
+
+  bool fetchingState_ = false;
+  SeqNum lastExecutedSeqNum_ = 0;
+  SeqNum primaryLastUsedSeqNum_ = 0;
+  SeqNum strictLowerBoundOfSeqNums_ = 0;
+  ViewNum lastViewThatTransferredSeqNumbersFullyExecuted_ = 0;
+
+  bool hasDescriptorOfLastExitFromView_ = false;
+  DescriptorOfLastExitFromView descriptorOfLastExitFromView_ =
+      DescriptorOfLastExitFromView{
+          0, 0, 0, std::vector<ViewsManager::PrevViewInfo>(0)};
+  bool hasDescriptorOfLastNewView_ = false;
+  DescriptorOfLastNewView descriptorOfLastNewView_ =
+      DescriptorOfLastNewView{0, nullptr, std::vector<ViewChangeMsg*>(0), 0};
+  bool hasDescriptorOfLastExecution_ = false;
+  DescriptorOfLastExecution descriptorOfLastExecution_ =
+      DescriptorOfLastExecution{0, Bitmap()};
+
+  SeqNum lastStableSeqNum_ = 0;
+
+  struct SeqNumData {
+    PrePrepareMsg* prePrepareMsg;
+    bool slowStarted;
+    FullCommitProofMsg* fullCommitProofMsg;
+    bool forceCompleted;
+    PrepareFullMsg* prepareFullMsg;
+    CommitFullMsg* commitFullMsg;
+  };
+
+  struct CheckData {
+    CheckpointMsg* checkpointMsg;
+    bool completedMark;
+  };
+
+  struct WindowFuncs {
+    static void init(SeqNumData& i, void* d);
+    static void free(SeqNumData& i);
+    static void reset(SeqNumData& i);
+
+    static void init(CheckData& i, void* d);
+    static void free(CheckData& i);
+    static void reset(CheckData& i);
+  };
+
+  // range: lastStableSeqNum+1 <= i <= lastStableSeqNum + kWorkWindowSize
+  SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumData, WindowFuncs>
+      seqNumWindow;
+
+  // range: TODO(GG): !!!!!!!
+  SequenceWithActiveWindow<kWorkWindowSize + checkpointWindowSize,
+                           checkpointWindowSize,
+                           SeqNum,
+                           CheckData,
+                           WindowFuncs>
+      checkWindow;
+};
+
+}  // namespace impl
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/FullCommitProofMsg.cpp
+++ b/bftengine/src/bftengine/FullCommitProofMsg.cpp
@@ -44,5 +44,16 @@ namespace bftEngine
 
 			return true;
 		}
+
+		MsgSize FullCommitProofMsg::maxSizeOfFullCommitProofMsg()
+		{
+			return sizeof(FullCommitProofMsgHeader) + maxSizeOfCombinedsignature;
+		}
+
+		MsgSize FullCommitProofMsg::maxSizeOfFullCommitProofMsgInLocalBuffer()
+		{
+			return maxSizeOfFullCommitProofMsg() + sizeof(RawHeaderOfObjAndMsg);
+		}
+
 	}
 }

--- a/bftengine/src/bftengine/FullCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/FullCommitProofMsg.hpp
@@ -20,6 +20,11 @@ namespace bftEngine
 		{
 
 		public:
+
+			static MsgSize maxSizeOfFullCommitProofMsg();
+
+			static MsgSize maxSizeOfFullCommitProofMsgInLocalBuffer();
+
 			FullCommitProofMsg(ReplicaId senderId, ViewNum v, SeqNum s, const char* commitProofSig, uint16_t commitProofSigLength);
 
 			ViewNum viewNumber() const { return b()->viewNum; }

--- a/bftengine/src/bftengine/MessageBase.cpp
+++ b/bftengine/src/bftengine/MessageBase.cpp
@@ -119,5 +119,76 @@ namespace bftEngine
 			msgSize_ = size;
 		}
 
+		MessageBase* MessageBase::cloneObjAndMsg() const
+		{
+			Assert(owner_);
+			Assert(msgSize_ > 0);
+
+			void* msgBody = std::malloc(msgSize_);
+			memcpy(msgBody, msgBody_, msgSize_);
+
+			MessageBase* otherMsg = 
+				new MessageBase(sender_, (MessageBase::Header*)msgBody, msgSize_,true);
+
+			return otherMsg;
+		}
+
+
+		void MessageBase::writeObjAndMsgToLocalBuffer(char* buffer, size_t bufferLength, size_t* actualSize) const
+		{
+			Assert(owner_);
+			Assert(msgSize_ > 0);
+
+			const size_t sizeNeeded = sizeof(RawHeaderOfObjAndMsg) + msgSize_;
+
+			Assert(sizeNeeded <= bufferLength);
+
+			RawHeaderOfObjAndMsg* pHeader = (RawHeaderOfObjAndMsg*)buffer;
+			pHeader->magicNum = magicNumOfRawFormat;
+			pHeader->msgSize = msgSize_;
+			pHeader->sender = sender_;
+
+			char* pRawMsg = buffer + sizeof(RawHeaderOfObjAndMsg);
+			memcpy(pRawMsg, msgBody_, msgSize_);
+
+			if(actualSize) *actualSize = sizeNeeded;
+		}
+
+		size_t MessageBase::sizeNeededForObjAndMsgInLocalBuffer() const
+		{
+			Assert(owner_);
+			Assert(msgSize_ > 0);
+
+			const size_t sizeNeeded = sizeof(RawHeaderOfObjAndMsg) + msgSize_;
+
+			return sizeNeeded;
+		}
+
+		MessageBase* MessageBase::createObjAndMsgFromLocalBuffer(char* buffer, size_t bufferLength, size_t* actualSize)
+		{
+			if(actualSize) *actualSize = 0;
+
+			if (bufferLength <= sizeof(RawHeaderOfObjAndMsg)) return nullptr;
+
+			RawHeaderOfObjAndMsg* pHeader = (RawHeaderOfObjAndMsg*)buffer;
+			if (pHeader->magicNum != magicNumOfRawFormat) return nullptr;
+			if (pHeader->msgSize == 0) return nullptr;
+			if (pHeader->msgSize > maxExternalMessageSize) return nullptr;
+			if (pHeader->msgSize + sizeof(RawHeaderOfObjAndMsg) > bufferLength) return nullptr;
+			
+			char* pBodyInBuffer = buffer + sizeof(RawHeaderOfObjAndMsg);
+
+			void* msgBody = std::malloc(pHeader->msgSize);
+			memcpy(msgBody, pBodyInBuffer, pHeader->msgSize);
+
+			MessageBase* msgObj =
+				new MessageBase(pHeader->sender, (MessageBase::Header*)msgBody, pHeader->msgSize, true);
+
+			if (actualSize) *actualSize = (pHeader->msgSize + sizeof(RawHeaderOfObjAndMsg));
+
+			return msgObj;
+		}
+
+
 	}
 }

--- a/bftengine/src/bftengine/MessageBase.hpp
+++ b/bftengine/src/bftengine/MessageBase.hpp
@@ -47,6 +47,12 @@ namespace bftEngine
 
 			MsgType type() const { return msgBody_->msgType; }
 
+			MessageBase* cloneObjAndMsg() const;
+
+			void writeObjAndMsgToLocalBuffer(char* buffer, size_t bufferLength, size_t* actualSize) const;
+			size_t sizeNeededForObjAndMsgInLocalBuffer() const;
+			static MessageBase* createObjAndMsgFromLocalBuffer(char* buffer, size_t bufferLength, size_t* actualSize);
+
 #ifdef DEBUG_MEMORY_MSG
 			static void printLiveMessages();
 #endif
@@ -65,6 +71,17 @@ namespace bftEngine
 			MsgSize storageSize_ = 0;
 			NodeIdType sender_;
 			bool owner_ = true; // true IFF this instance is not responsible for deallocating the body
+
+#pragma pack(push,1)
+			struct RawHeaderOfObjAndMsg
+			{
+				uint32_t magicNum;
+				MsgSize msgSize;
+				NodeIdType sender;
+				// TODO(GG): consider to add checksum
+			};
+#pragma pack(pop)
+			static const uint32_t magicNumOfRawFormat = 0x5555897BU;
 		};
 
 

--- a/bftengine/src/bftengine/NewViewMsg.cpp
+++ b/bftengine/src/bftengine/NewViewMsg.cpp
@@ -120,5 +120,16 @@ namespace bftEngine
 			return false;
 		}
 
+		MsgSize NewViewMsg::maxSizeOfNewViewMsg()
+		{
+			return maxExternalMessageSize;
+		}
+
+		MsgSize NewViewMsg::maxSizeOfNewViewMsgInLocalBuffer()
+		{
+			return maxSizeOfNewViewMsg() + sizeof(RawHeaderOfObjAndMsg);
+		}
+
+
 	}
 }

--- a/bftengine/src/bftengine/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/NewViewMsg.hpp
@@ -20,6 +20,10 @@ namespace bftEngine
 		{
 
 		public:
+
+			static MsgSize maxSizeOfNewViewMsg();
+			static MsgSize maxSizeOfNewViewMsgInLocalBuffer();
+
 			NewViewMsg(ReplicaId senderId, ViewNum newView);
 
 			void addElement(ReplicaId replicaId, Digest& viewChangeDigest);

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -1,0 +1,204 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "PrimitiveTypes.hpp"
+#include "Bitmap.hpp"
+#include "ViewsManager.hpp"
+#include "ReplicaConfig.hpp"
+
+#include <vector>
+
+namespace bftEngine {
+namespace impl {
+class PrePrepareMsg;
+class CheckpointMsg;
+class ViewChangeMsg;
+class NewViewMsg;
+class FullCommitProofMsg;
+class PrepareFullMsg;
+class CommitFullMsg;
+
+// The PersistentStorage interface is used to write/read the concord-bft state 
+// to/from a persistent storage. In case the replica’s process is killed, 
+// crashed or restarted, this interface is used to restore the concord-bft 
+// state from the persistent storage. 
+// PersistentStorage is designed to only store data elements that are essential 
+// to reconstruct the internal in-memory data structures of concord-bft.
+// For simplicity and efficiency, some of the internal data elements are not 
+// written to the persistent storage (for example, messages with partial 
+// threshold signatures are not stored in persistent storage; if needed such 
+// messages are re-created and retransmitted by the replicas).
+
+class PersistentStorage {
+ public:
+  //////////////////////////////////////////////////////////////////////////
+  // Types
+  //////////////////////////////////////////////////////////////////////////
+
+  struct DescriptorOfLastExitFromView {
+    // view >= 0
+    ViewNum view;
+
+    // lastStable >= 0
+    SeqNum lastStable;
+
+    // lastExecuted >= lastStable
+    SeqNum lastExecuted;
+
+    // elements.size() <= kWorkWindowSize
+    // The messages in elements[i] may be null
+    std::vector<ViewsManager::PrevViewInfo> elements;
+  };
+
+  struct DescriptorOfLastNewView {
+    // view >= 1
+    ViewNum view;
+
+    // newViewMsg != nullptr
+    NewViewMsg* newViewMsg;
+
+    // viewChangeMsgs.size() == 2*F + 2*C + 1
+    // The messages in viewChangeMsgs will never be null
+    std::vector<ViewChangeMsg*> viewChangeMsgs;
+
+    // maxSeqNumTransferredFromPrevViews >= 0
+    SeqNum maxSeqNumTransferredFromPrevViews;
+  };
+
+  struct DescriptorOfLastExecution {
+    // executedSeqNum >= 1
+    SeqNum executedSeqNum;
+
+    // 1 <= validRequests.numOfBits() <= maxNumOfRequestsInBatch
+    Bitmap validRequests;
+  };
+
+  //////////////////////////////////////////////////////////////////////////
+  // Transactions management
+  //////////////////////////////////////////////////////////////////////////
+
+  // begin reentrant write-only transaction
+  // returns the number of nested transactions
+  virtual uint8_t beginWriteTran() = 0;
+
+  // end reentrant write-only transaction
+  // returns the number of remaining nested transactions
+  virtual uint8_t endWriteTran() = 0;
+
+  // return true IFF write-only transactions are running now
+  virtual bool isInWriteTran() const = 0;
+
+  //////////////////////////////////////////////////////////////////////////
+  // Update methods (should only be used in write-only transactions)
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual void setReplicaConfig(ReplicaConfig config) = 0;
+
+  virtual void setFetchingState(const bool f) = 0;
+  virtual void setLastExecutedSeqNum(const SeqNum s) = 0;
+  virtual void setPrimaryLastUsedSeqNum(const SeqNum s) = 0;
+  virtual void setStrictLowerBoundOfSeqNums(const SeqNum s) = 0;
+  virtual void setLastViewThatTransferredSeqNumbersFullyExecuted(
+      const ViewNum v) = 0;
+
+  // DescriptorOfLastExitFromView contains pointers to messages (the content of
+  // the messages should be copied, the caller is the owner of these messagse).
+  virtual void setDescriptorOfLastExitFromView(
+      const DescriptorOfLastExitFromView& prevViewDesc) = 0;
+
+  // DescriptorOfLastNewView contains pointers to messages (the content of the
+  // messages should be copied, the caller is the owner of these messagse).
+  virtual void setDescriptorOfLastNewView(
+      const DescriptorOfLastNewView& prevViewDesc) = 0;
+
+  virtual void setDescriptorOfLastExecution(
+      const DescriptorOfLastExecution& prevViewDesc) = 0;
+
+	// We have two windows "SeqNumWindow" and "CheckWindow"	
+	// TODO(GG): explain the windows. 
+
+  virtual void setLastStableSeqNum(const SeqNum s) = 0;
+  
+	//
+  // The window of sequence numbers is:
+  // { i | LS + 1 <= i <= LS + kWorkWindowSize }
+  // where LS=lastStableSeqNum
+  //
+  // The window of checkpoints is:
+  // { LS, LS + CWS, LS + 2 * CWS }
+  // where LS=lastStableSeqNum and CWS=checkpointWindowSize
+
+  virtual void clearSeqNumWindow() = 0;
+
+  virtual void setPrePrepareMsgInSeqNumWindow(const SeqNum s,
+                                              const PrePrepareMsg* const m) = 0;
+  virtual void setSlowStartedInSeqNumWindow(const SeqNum s,
+                                            const bool slowStarted) = 0;
+  virtual void setFullCommitProofMsgInSeqNumWindow(
+      const SeqNum s, const FullCommitProofMsg* const m) = 0;
+  virtual void setForceCompletedInSeqNumWindow(const SeqNum s,
+                                               const bool forceCompleted) = 0;
+  virtual void setPrepareFullMsgInSeqNumWindow(
+      const SeqNum s, const PrepareFullMsg* const m) = 0;
+  virtual void setCommitFullMsgInSeqNumWindow(const SeqNum s,
+                                              const CommitFullMsg* const m) = 0;
+
+  virtual void setCheckpointMsgInCheckWindow(const SeqNum s,
+                                             const CheckpointMsg* const m) = 0;
+  virtual void setCompletedMarkInCheckWindow(const SeqNum s, const bool f) = 0;
+
+  //////////////////////////////////////////////////////////////////////////
+  // Read methods (should only be used before using write-only transactions)
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual bool hasReplicaConfig() = 0;
+  virtual ReplicaConfig getReplicaConig() = 0;
+
+  virtual bool getFetchingState() = 0;
+  virtual SeqNum getLastExecutedSeqNum() = 0;
+  virtual SeqNum getPrimaryLastUsedSeqNum() = 0;
+  virtual SeqNum getStrictLowerBoundOfSeqNums() = 0;
+  virtual ViewNum getLastViewThatTransferredSeqNumbersFullyExecuted() = 0;
+
+  virtual bool hasDescriptorOfLastExitFromView() = 0;
+  virtual DescriptorOfLastExitFromView
+  getAndAllocateDescriptorOfLastExitFromView() = 0;
+
+  virtual bool hasDescriptorOfLastNewView() = 0;
+  virtual DescriptorOfLastNewView getAndAllocateDescriptorOfLastNewView() = 0;
+
+  virtual bool hasDescriptorOfLastExecution() = 0;
+  virtual DescriptorOfLastExecution getDescriptorOfLastExecution() = 0;
+
+  virtual SeqNum getLastStableSeqNum() = 0;
+
+  virtual PrePrepareMsg* getAndAllocatePrePrepareMsgInSeqNumWindow(
+      const SeqNum s) = 0;
+  virtual bool getSlowStartedInSeqNumWindow(const SeqNum s) = 0;
+  virtual FullCommitProofMsg* getAndAllocateFullCommitProofMsgInSeqNumWindow(
+      const SeqNum s) = 0;
+  virtual bool getForceCompletedInSeqNumWindow(const SeqNum s) = 0;
+  virtual PrepareFullMsg* getAndAllocatePrepareFullMsgInSeqNumWindow(
+      const SeqNum s) = 0;
+  virtual CommitFullMsg* getAndAllocateCommitFullMsgInSeqNumWindow(
+      const SeqNum s) = 0;
+
+  virtual CheckpointMsg* getAndAllocateCheckpointMsgInCheckWindow(
+      const SeqNum s) = 0;
+  virtual bool getCompletedMarkInCheckWindow(const SeqNum s) = 0;
+};
+
+}  // namespace impl
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/PrePrepareMsg.cpp
@@ -24,6 +24,16 @@ namespace bftEngine
 		// PrePrepareMsg
 		///////////////////////////////////////////////////////////////////////////////
 
+		MsgSize PrePrepareMsg::maxSizeOfPrePrepareMsg()
+		{
+			return maxExternalMessageSize;
+		}
+
+		MsgSize PrePrepareMsg::maxSizeOfPrePrepareMsgInLocalBuffer()
+		{
+			return maxSizeOfPrePrepareMsg() + sizeof(RawHeaderOfObjAndMsg);
+		}
+
 		PrePrepareMsg* PrePrepareMsg::createNullPrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath)
 		{
 			PrePrepareMsg* p = new PrePrepareMsg(sender, v, s, firstPath, true);
@@ -88,7 +98,7 @@ namespace bftEngine
 
 
 		PrePrepareMsg::PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, bool isNull) :
-			MessageBase(sender, MsgCode::PrePrepare, (isNull ? sizeof(PrePrepareMsgHeader) : maxExternalMessageSize))
+			MessageBase(sender, MsgCode::PrePrepare, (isNull ? sizeof(PrePrepareMsgHeader) : maxSizeOfPrePrepareMsg()))
 
 		{
 			b()->viewNum = v;
@@ -237,6 +247,11 @@ namespace bftEngine
 			: msg{ m }, currLoc{ sizeof(PrePrepareMsg::PrePrepareMsgHeader) }
 		{
 			Assert(msg->isReady());
+		}
+
+		void RequestsIterator::restart()
+		{
+			currLoc = sizeof(PrePrepareMsg::PrePrepareMsgHeader);
 		}
 
 		bool RequestsIterator::getCurrent(char*& pRequest) const

--- a/bftengine/src/bftengine/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/PrePrepareMsg.hpp
@@ -54,6 +54,10 @@ namespace bftEngine
 
 			// static
 
+			static MsgSize maxSizeOfPrePrepareMsg();
+
+			static MsgSize maxSizeOfPrePrepareMsgInLocalBuffer();
+
 			static PrePrepareMsg* createNullPrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath = CommitPath::SLOW); // TODO(GG): why static method ?
 
 			static const Digest& digestOfNullPrePrepareMsg();
@@ -108,6 +112,8 @@ namespace bftEngine
 		{
 		public:
 			RequestsIterator(const PrePrepareMsg* const m);
+
+			void restart();
 
 			bool getCurrent(char*& pRequest) const;
 

--- a/bftengine/src/bftengine/SignedShareMsgs.cpp
+++ b/bftengine/src/bftengine/SignedShareMsgs.cpp
@@ -113,6 +113,17 @@ namespace bftEngine
 		// PrepareFullMsg
 		///////////////////////////////////////////////////////////////////////////////
 
+		MsgSize PrepareFullMsg::maxSizeOfPrepareFull()
+		{
+			return sizeof(SignedShareBaseHeader) + maxSizeOfCombinedsignature;
+		}
+
+		MsgSize PrepareFullMsg::maxSizeOfPrepareFullInLocalBuffer()
+		{
+			return maxSizeOfPrepareFull() + sizeof(RawHeaderOfObjAndMsg);
+		}
+
+
 		PrepareFullMsg* PrepareFullMsg::create(ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen)
 		{
 			return (PrepareFullMsg*)SignedShareBase::create(MsgCode::PrepareFull, v, s, senderId, sig, sigLen);
@@ -152,6 +163,16 @@ namespace bftEngine
 		///////////////////////////////////////////////////////////////////////////////
 		// CommitFullMsg
 		///////////////////////////////////////////////////////////////////////////////
+
+		MsgSize CommitFullMsg::maxSizeOfCommitFull()
+		{
+			return sizeof(SignedShareBaseHeader) + maxSizeOfCombinedsignature;
+		}
+
+		MsgSize CommitFullMsg::maxSizeOfCommitFullInLocalBuffer()
+		{
+			return maxSizeOfCommitFull() + sizeof(RawHeaderOfObjAndMsg);
+		}
 
 		CommitFullMsg* CommitFullMsg::create(ViewNum v, SeqNum s, int16_t senderId, const char* sig, uint16_t sigLen)
 		{

--- a/bftengine/src/bftengine/SignedShareMsgs.hpp
+++ b/bftengine/src/bftengine/SignedShareMsgs.hpp
@@ -79,6 +79,8 @@ namespace bftEngine
 
 		class PrepareFullMsg : public SignedShareBase {
 		public:
+			static MsgSize maxSizeOfPrepareFull();
+			static MsgSize maxSizeOfPrepareFullInLocalBuffer();
 			static PrepareFullMsg* create(ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen);
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, PrepareFullMsg*& outMsg);
 		};
@@ -102,6 +104,8 @@ namespace bftEngine
 
 		class CommitFullMsg : public SignedShareBase {
 		public:
+			static MsgSize maxSizeOfCommitFull();
+			static MsgSize maxSizeOfCommitFullInLocalBuffer();
 			static CommitFullMsg* create(ViewNum v, SeqNum s, int16_t senderId, const char* sig, uint16_t sigLen);
 			static bool ToActualMsgType(const ReplicasInfo& repInfo, MessageBase* inMsg, CommitFullMsg*& outMsg);
 		};

--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -64,6 +64,11 @@ constexpr uint32_t maxExternalMessageSize = 64 * 1000; // TODO(GG): some message
 
 constexpr uint32_t maxReplyMessageSize = 8 * 1024;
 
+///////////////////////////////////////////////////////////////////////////////
+// Batching
+///////////////////////////////////////////////////////////////////////////////
+
+constexpr uint32_t maxNumOfRequestsInBatch = 1024;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Requests for missing information 
@@ -91,8 +96,7 @@ constexpr bool forceViewChangeProtocolEnabled = false;
 constexpr bool forceViewChangeProtocolDisabled = false;
 static_assert(!forceViewChangeProtocolEnabled || !forceViewChangeProtocolDisabled, "");
 
-constexpr int viewChangeTimeoutMilli = 0; //  80 * 1000; // 1 * 60 *
-// 1000; // 20 * 1000; // if 0, this value is taken from config
+constexpr int viewChangeTimeoutMilli = 0; //  80 * 1000; // 1 * 60 * 1000; // 20 * 1000; // if 0, this value is taken from config
 
 
 constexpr bool autoIncViewChangeTimer = true;
@@ -135,3 +139,10 @@ constexpr bool ControllerWithSimpleHistory_debugDowngradeEnabled = true;
 
 constexpr bool ControllerWithSimpleHistory_debugUpgradeEnabled = true;
 
+///////////////////////////////////////////////////////////////////////////////
+// Persistency
+///////////////////////////////////////////////////////////////////////////////
+
+constexpr uint32_t maxSizeOfCombinedsignature = 1024; // TODO(GG): should be checked
+
+constexpr bool debugPersistentStorageEnabled = true;

--- a/bftengine/src/bftengine/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.cpp
@@ -294,5 +294,16 @@ namespace bftEngine
 
 			return validElement;
 		}
+
+		MsgSize ViewChangeMsg::maxSizeOfViewChangeMsg()
+		{
+			return maxExternalMessageSize;
+		}
+
+		MsgSize ViewChangeMsg::maxSizeOfViewChangeMsgInLocalBuffer()
+		{
+			return maxSizeOfViewChangeMsg() + sizeof(RawHeaderOfObjAndMsg);
+		}
+
 	}
 }

--- a/bftengine/src/bftengine/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.hpp
@@ -43,6 +43,9 @@ namespace bftEngine
 
 			ViewChangeMsg(ReplicaId srcReplicaId, ViewNum newView, SeqNum lastStableSeq);
 
+			static MsgSize maxSizeOfViewChangeMsg();
+			static MsgSize maxSizeOfViewChangeMsgInLocalBuffer();
+
 			void setNewViewNumber(ViewNum newView);
 
 			uint16_t idOfGeneratedReplica() const { return b()->genReplicaId; } // TODO(GG): !!!! change meaning/add similar method - this msg may be sent by a different replica (otherwise, the view-change may not completed)

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -272,6 +272,42 @@ NewViewMsg* ViewsManager::getMyNewViewMsgForCurrentView() {
   return r;
 }
 
+vector<ViewChangeMsg*> ViewsManager::getViewChangeMsgsForCurrentView()
+{
+	Assert(stat == Stat::IN_VIEW);
+
+	const uint16_t SMAJOR = (2 * F + 2 * C + 1);
+
+	vector<ViewChangeMsg*> retVal(SMAJOR);
+
+	uint16_t j = 0;
+	for (uint16_t i = 0; (i < N) && (j < SMAJOR); i++)
+	{
+		if (viewChangeMsgsOfPendingView[i] == nullptr) continue;
+
+		Assert(viewChangeMsgsOfPendingView[i]->newView() == myLatestActiveView);
+
+		retVal[j] = viewChangeMsgsOfPendingView[i];
+		j++;
+	}
+	Assert(j == SMAJOR);
+
+	return retVal;
+}
+
+NewViewMsg*	ViewsManager::getNewViewMsgForCurrentView()
+{
+	Assert(stat == Stat::IN_VIEW);
+
+	NewViewMsg* r = newViewMsgOfOfPendingView;
+
+	Assert(r != nullptr);
+	Assert(r->newView() == myLatestActiveView);
+
+	return r;
+}
+
+
 SeqNum ViewsManager::stableLowerBoundWhenEnteredToView() const {
   Assert(stat == Stat::IN_VIEW);
   return lowerBoundStableForPendingView;

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -69,6 +69,9 @@ class ViewsManager {
   // should only be called by the primary of the current active view
   NewViewMsg* getMyNewViewMsgForCurrentView();
 
+	vector<ViewChangeMsg*> getViewChangeMsgsForCurrentView();
+	NewViewMsg*	getNewViewMsgForCurrentView();
+
   SeqNum stableLowerBoundWhenEnteredToView() const;
 
   struct PrevViewInfo {


### PR DESCRIPTION

- Add interface (pure abstract class) PersistentStorage – this class should be used to save/load data to/from the persistent storage. Its implementation should access the persistent storage by using the MetadataStorage interface.

- Add methods that save/load messages to/from buffers.

- Add methods that return the maximum size of messages.

- Add class DebugPersistentStorage: this class is an implementation of PersistentStorage. It was designed to help debugging the code that uses PersistentStorage.

- Add a new constant maxNumOfRequestsInBatch  (in SysConsts.hpp) that represents the maximum number of requests in a batch (in a single Pre-Prepare message). It is needed to implement part of the crash recovery in ReplicaImp.

- Add a new constant maxSizeOfCombinedsignature (in SysConsts.hpp) that represents the maximum size of a combined signature. This is needed to determine the maximum size of several messages with signatures.

- In ViewsManager: add methods that return the ViewChange and NewView messages that have been used to enter the current active view.