### PR TITLE
Fix signed-unsigned comparisons.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
             " --no-system-header-prefix relic")
     string(APPEND CMAKE_CXX_FLAGS
             " -Wmacro-redefined")
+    string(APPEND CMAKE_CXX_FLAGS
+            " -Wsign-compare")
     string(APPEND CMAKE_CXX_FLAGS_DEBUG
             " -fstack-protector-all")
 

--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -509,7 +509,7 @@ class AsyncTlsConnection : public
     // the certificate must have node id, as we put it in OU field on creation.
     // since we use pinning we must know who is the remote peer.
     // peerIdPrefixLength stands for the length of 'OU=' substring
-    size_t peerIdPrefixLength = 3;
+    int peerIdPrefixLength = 3;
     std::regex r("OU=\\d*", std::regex_constants::icase);
     std::smatch sm;
     regex_search(subject, sm, r);

--- a/bftengine/tests/simpleKVBCTests/TesterClient/main.cpp
+++ b/bftengine/tests/simpleKVBCTests/TesterClient/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
 			argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
 			string numOfOpsStr = argTempBuffer;
 			int tempfVal = std::stoi(numOfOpsStr);
-			if (tempfVal >= 1 && tempfVal < UINT32_MAX)
+			if (tempfVal >= 1 && (uint32_t)tempfVal < UINT32_MAX)
 				cp.numOfOperations = (uint32_t)tempfVal;
 			// TODO: check numOfOps
 		}

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -70,16 +70,15 @@ void parse_params(int argc, char** argv, ClientParams &cp,
 
   uint16_t min16_t_u = std::numeric_limits<uint16_t>::min();
   uint16_t max16_t_u = std::numeric_limits<uint16_t>::max();
-  uint32_t min32_t = std::numeric_limits<uint32_t>::min();
-  uint32_t max32_t = std::numeric_limits<uint32_t>::max();
+  uint32_t max32_t_u = std::numeric_limits<uint32_t>::max();
 
   try {
     for (int i = 1; i < argc;) {
       string p(argv[i]);
       if (p == "-i") {
         auto numOp = std::stoi(argv[i + 1]);
-        if (numOp < min32_t || numOp > max32_t) {
-          printf("-i value is out of range (%u - %u)\n", min32_t, max32_t);
+        if (numOp < 0 || (uint32_t)numOp > max32_t_u) {
+          printf("-i value is out of range (%u - %u)\n", 0, max32_t_u);
           exit(-1);
         }
         cp.numOfOperations = (uint32_t)numOp;
@@ -260,7 +259,7 @@ int main(int argc, char **argv) {
 
   LOG_INFO(clientLogger, "Starting " << cp.numOfOperations);
 
-  for (int i = 1; i <= cp.numOfOperations; i++) {
+  for (uint32_t i = 1; i <= cp.numOfOperations; i++) {
 
     // the python script that runs the client needs to know how many
     // iterations has been done - that's the reason we use printf and not

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -99,7 +99,6 @@ void parse_params(int argc, char** argv) {
 
   uint16_t min16_t_u = std::numeric_limits<uint16_t>::min();
   uint16_t max16_t_u = std::numeric_limits<uint16_t>::max();
-  uint32_t min32_t_u = std::numeric_limits<uint32_t>::min();
   uint32_t max32_t_u = std::numeric_limits<uint32_t>::max();
 
   rp.keysFilePrefix = "private_replica_";
@@ -153,12 +152,11 @@ void parse_params(int argc, char** argv) {
           i++;
         } else if (p == "-vct") {
           auto vct = std::stoi(argv[i + 1]);
-          if (vct < min32_t_u || vct > max32_t_u) {
-            printf("-vct value is out of range (%u - %u)", min16_t_u,
-                   max16_t_u);
+          if (vct < 0 || (uint32_t)vct > max32_t_u) {
+            printf("-vct value is out of range (%u - %u)", 0, max32_t_u);
             exit(-1);
           }
-          rp.viewChangeTimeout = vct;
+          rp.viewChangeTimeout = (uint32_t)vct;
           i += 2;
         } else if (p == "-cf") {
           rp.configFileName = argv[i + 1];

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -28,7 +28,7 @@ T FindValue(const char* const val_type,
             const string& val_name,
             const vector<string>& names,
             const vector<T>& values) {
-  for (int i = 0; i < names.size(); i++) {
+  for (size_t i = 0; i < names.size(); i++) {
     if (names[i] == val_name) {
       return values[i];
     }
@@ -139,7 +139,7 @@ std::string Component::ToJson() {
   // Add any gauges
   oss << "\"Gauges\":{";
 
-  for (int i = 0; i < names_.gauge_names_.size(); i++) {
+  for (size_t i = 0; i < names_.gauge_names_.size(); i++) {
     if (i != 0) {
       oss << ",";
     }
@@ -153,7 +153,7 @@ std::string Component::ToJson() {
   // Add any status
   oss << "\"Statuses\":{";
 
-  for (int i = 0; i < names_.status_names_.size(); i++) {
+  for (size_t i = 0; i < names_.status_names_.size(); i++) {
     if (i != 0) {
       oss << ",";
     }
@@ -167,7 +167,7 @@ std::string Component::ToJson() {
   // Add any counters
   oss << "\"Counters\":{";
 
-  for (int i = 0; i < names_.counter_names_.size(); i++) {
+  for (size_t i = 0; i < names_.counter_names_.size(); i++) {
     if (i != 0) {
       oss << ",";
     }


### PR DESCRIPTION
When compiling under gcc7, I see warnings about comparison of signed
and unsigned integer types. This change enables the same warnings for
clang, and fixes the current sites.