### PR TITLE
initialize PeerConnectivityStatus structs

### DIFF
--- a/bftengine/src/communication/PlainTcpCommunication.cpp
+++ b/bftengine/src/communication/PlainTcpCommunication.cpp
@@ -93,8 +93,8 @@ class AsyncTcpConnection :
   function<void(NodeNum, ASYNC_CONN_PTR)> _fOnHellOMessage = nullptr;
   NodeNum _destId;
   NodeNum _selfId;
-  string _ip;
-  uint16_t _port;
+  string _ip = "";
+  uint16_t _port = 0;
   deadline_timer _connectTimer;
   ConnType _connType;
   bool _closed;

--- a/bftengine/src/communication/PlainTcpCommunication.cpp
+++ b/bftengine/src/communication/PlainTcpCommunication.cpp
@@ -268,7 +268,7 @@ class AsyncTcpConnection :
       if (_statusCallback) {
         bool isReplica = check_replica(_selfId);
         if (isReplica) {
-          PeerConnectivityStatus pcs;
+          PeerConnectivityStatus pcs{};
           pcs.peerId = _selfId;
           pcs.statusType = StatusType::Broken;
 
@@ -390,7 +390,7 @@ class AsyncTcpConnection :
     read_header_async();
 
     if (_statusCallback && _destIsReplica) {
-      PeerConnectivityStatus pcs;
+      PeerConnectivityStatus pcs{};
       pcs.peerId = _destId;
       pcs.peerIp = _ip;
       pcs.peerPort = _port;
@@ -604,7 +604,7 @@ class AsyncTcpConnection :
     write_async(_outBuffer, offset + length);
 
     if (_statusCallback && _isReplica) {
-      PeerConnectivityStatus pcs;
+      PeerConnectivityStatus pcs{};
       pcs.peerId = _selfId;
       pcs.statusType = StatusType::MessageSent;
 
@@ -806,7 +806,7 @@ class PlainTCPCommunication::PlainTcpImpl {
         LOG_TRACE(_logger, "connect called for node " << to_string(it->first));
       }
       if (it->second.isReplica && _statusCallback) {
-        PeerConnectivityStatus pcs;
+        PeerConnectivityStatus pcs{};
         pcs.peerId = it->first;
         pcs.peerIp = it->second.ip;
         pcs.peerPort = it->second.port;

--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -133,7 +133,7 @@ class PlainUDPCommunication::PlainUdpImpl {
           ", got peer: " << key);
 
       if (statusCallback && next->second.isReplica) {
-        PeerConnectivityStatus pcs;
+        PeerConnectivityStatus pcs{};
         pcs.peerId = next->first;
         pcs.peerIp = next->second.ip;
         pcs.peerPort = next->second.port;
@@ -301,7 +301,7 @@ class PlainUDPCommunication::PlainUdpImpl {
 
     if (error == (ssize_t) messageLength) {
       if (statusCallback) {
-        PeerConnectivityStatus pcs;
+        PeerConnectivityStatus pcs{};
         pcs.peerId = selfId;
         pcs.statusType = StatusType::MessageSent;
 
@@ -406,7 +406,7 @@ class PlainUDPCommunication::PlainUdpImpl {
 
       bool isReplica = check_replica(sendingNode);
       if (statusCallback && isReplica) {
-        PeerConnectivityStatus pcs;
+        PeerConnectivityStatus pcs{};
         pcs.peerId = sendingNode;
 
         char str[INET_ADDRSTRLEN];

--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -143,8 +143,8 @@ class AsyncTlsConnection : public
   uint32_t _bufferLength;
   NodeNum _destId = AsyncTlsConnection::UNKNOWN_NODE_ID;
   NodeNum _selfId;
-  string _ip;
-  uint16_t _port;
+  string _ip = "";
+  uint16_t _port = 0;
   asio::deadline_timer _connectTimer;
   asio::deadline_timer _writeTimer;
   asio::deadline_timer _readTimer;

--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -297,7 +297,7 @@ class AsyncTlsConnection : public
     if (_statusCallback) {
       bool isReplica = check_replica(_destId);
       if (isReplica) {
-        PeerConnectivityStatus pcs;
+        PeerConnectivityStatus pcs{};
         pcs.peerId = _destId;
         pcs.statusType = StatusType::Broken;
 
@@ -801,7 +801,7 @@ class AsyncTlsConnection : public
     read_msg_length_async();
 
     if (_statusCallback && _destIsReplica) {
-      PeerConnectivityStatus pcs;
+      PeerConnectivityStatus pcs{};
       pcs.peerId = _destId;
       pcs.peerIp = _ip;
       pcs.peerPort = _port;
@@ -1010,7 +1010,7 @@ class AsyncTlsConnection : public
                                 << ", length: " << length);
 
     if (_statusCallback && _isReplica) {
-      PeerConnectivityStatus pcs;
+      PeerConnectivityStatus pcs{};
       pcs.peerId = _selfId;
       pcs.statusType = StatusType::MessageSent;
 


### PR DESCRIPTION
Running under valgrind, I see warnings about use of uninitialized
variables that point to the peerPort field of a PeerConnectivityStatus
struct. This field was not set in every place the struct was created
in the communication modules. This change forces default
initialization, to make sure this memory is initialized.

@salieri11 I'm actually not sure this is the correct solution, but it makes valgrind happy. Should peerPort and peerIp be set in all of these places instead? (See VB-931)