### PR TITLE
Fix status callback in TLS comm module

### DIFF
--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -803,8 +803,6 @@ class AsyncTlsConnection : public
     if (_statusCallback && _destIsReplica) {
       PeerConnectivityStatus pcs{};
       pcs.peerId = _destId;
-      pcs.peerIp = _ip;
-      pcs.peerPort = _port;
       pcs.statusType = StatusType::MessageReceived;
 
       // pcs.statusTime = we dont set it since it is set by the aggregator
@@ -1307,6 +1305,15 @@ class TlsTCPCommunication::TlsTcpImpl :
     // and all nodes with higher ID will connect to this node
     // we don't want that clients will connect to other clients
     for (auto it = _nodes.begin(); it != _nodes.end(); it++) {
+      if (_statusCallback && it->second.isReplica) {
+        PeerConnectivityStatus pcs{};
+        pcs.peerId = it->first;
+        pcs.peerIp = it->second.ip;
+        pcs.peerPort = it->second.port;
+        pcs.statusType = StatusType::Started;
+        _statusCallback(pcs);
+      }
+
       // connect only to nodes with ID higher than selfId
       // and all nodes with lower ID will connect to this node
       if (it->first < _selfId && it->first <= _maxServerId) {


### PR DESCRIPTION
This PR fixes inconsistency of viewing peer status info when using TLS comm module.
When the upper level application provides the callback for connectivity status update, sometimes the IP and port are not set yet, e.g. for incoming connections. In this case the view will be different between calls.
The fix is to create the map of nodes at the time when the comm module is initialised and when messages are sent/received or there is an error, to update the status only.