### PR TITLE
Add a msg for getting blocks from SimpleKVBCTests

### DIFF
--- a/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
+++ b/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
@@ -97,7 +97,9 @@ namespace BasicRandomTests
 
 		struct SimpleRequestHeader
 		{
-			char type; // 1 == conditional write , 2 == read, 3 == get last block
+                        // 1 == conditional write , 2 == read, 3 == get last block,
+                        // 4 = get block data
+			char type;
 
 			static void free(SimpleRequestHeader* p)
 			{
@@ -151,7 +153,6 @@ namespace BasicRandomTests
 				return (SimpleKV*)(((char*)this) + sizeof(SimpleConditionalWriteHeader) + numberOfKeysInReadSet * sizeof(SimpleKey));
 			}
 		};
-
 
 		struct SimpleReadHeader
 		{
@@ -217,7 +218,31 @@ namespace BasicRandomTests
 			SimpleRequestHeader h;
 		};
 
+                // A SimpleGetBlockDataHeader returns a read response, except
+                // all keys are for the specific block requested.
+                struct SimpleGetBlockDataHeader {
+			SimpleRequestHeader h;
+			BlockId block_id;
 
+			static SimpleGetBlockDataHeader* alloc()
+			{
+				size_t size = sizeof(SimpleGetBlockDataHeader);
+				char* pBuf = new char[size];
+				memset(pBuf, 0, size);
+				return (SimpleGetBlockDataHeader*)(pBuf);
+			}
+
+			static void free(SimpleGetBlockDataHeader* p)
+			{
+				char* p1 = (char*)p;
+				delete[] p1;
+			}
+
+			static size_t size()
+			{
+				return sizeof(SimpleGetBlockDataHeader);
+			}
+                };
 
 
 		struct SimpleReplyHeader
@@ -807,6 +832,34 @@ namespace BasicRandomTests
 
 					return true;
 				}
+                                else if (p->type == 4) {
+					CHECK(command.size >= sizeof(SimpleGetBlockDataHeader), "small message");
+					SimpleGetBlockDataHeader* pGetBlock = (SimpleGetBlockDataHeader*)command.data;
+                                        auto block_id = pGetBlock->block_id;
+                                        SetOfKeyValuePairs outBlockData;
+                                        if (!roStorage.getBlockData(block_id, outBlockData).ok()) {
+                                          return false;
+                                        }
+
+                                        auto numOfElements = outBlockData.size();
+					size_t replySize = SimpleReplyHeader_Read::size(numOfElements);
+					CHECK(maxReplySize >= replySize, "small message");
+
+					SimpleReplyHeader_Read* pReply = (SimpleReplyHeader_Read*)(outReply);
+					outReplySize = replySize;
+					memset(pReply, 0, replySize);
+					pReply->h.type = 2;
+					pReply->numberOfElements = numOfElements;
+
+                                        auto i = 0;
+                                        for (auto kv: outBlockData) {
+                                          memcpy(pReply->elements[i].key, kv.first.data, KV_LEN);
+                                          memcpy(pReply->elements[i].val, kv.second.data, KV_LEN);
+                                          ++i;
+                                        }
+                                        return true;
+                                }
+
 				else
 				{
 					outReplySize = 0;
@@ -834,6 +887,10 @@ namespace BasicRandomTests
 			else if (req->type == 3)
 			{
 				return SimpleGetLastBlockHeader::size();
+			}
+			else if (req->type == 4)
+			{
+				return SimpleGetBlockDataHeader::size();
 			}
 			assert(0); 
 			return 0;

--- a/test/bft_tester.py
+++ b/test/bft_tester.py
@@ -67,6 +67,7 @@ class BftTester:
         for proc in self.procs.values():
             proc.kill()
             proc.wait()
+        os.chdir(self.origdir)
 
     def __init__(self, config):
         self.origdir = os.getcwd()

--- a/test/skvbc.py
+++ b/test/skvbc.py
@@ -29,6 +29,7 @@ class SimpleKVBCProtocol:
         self.WRITE = 1
         self.READ = 2
         self.GET_LAST_BLOCK = 3
+        self.GET_BLOCK_DATA = 4
 
     def write_req(self, readset, writeset):
         block_id = 0
@@ -61,6 +62,12 @@ class SimpleKVBCProtocol:
     def get_last_block_req(self):
         data = bytearray()
         data.append(self.GET_LAST_BLOCK)
+        return data
+
+    def get_block_data_req(self, block_id):
+        data = bytearray()
+        data.append(self.GET_BLOCK_DATA)
+        data.extend(struct.pack("<Q", block_id))
         return data
 
     def parse_reply(self, data):


### PR DESCRIPTION
In order to simplify concurrency testing, we need a mechanism for
retrieving block data from SimpleKVBCTests TesterReplica clusters. This
is used to fill in information about blocks that were created by
requests that did not receive responses in the test. This strategy
eliminates the need to do an exponential cost search to find possible
linearizable histories of written blocks that satisfy reads and other
writes, by just filling in the missing block directly.

A test was added to show that the command works.

It implements VB-966.

It will be used in conjunction with #101 to write concurrent system
tests that contend for keys.