### PR TITLE
 Add a concurrent test against a healthy cluster 

### DIFF
--- a/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
+++ b/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
@@ -157,7 +157,7 @@ namespace BasicRandomTests
 		struct SimpleReadHeader
 		{
 			SimpleRequestHeader h;
-			BlockId readVersion; // if 0, then read from the latest version
+			BlockId readVersion;
 			size_t numberOfKeysToRead;
 			SimpleKey keys[1];
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_test(NAME bft_sys_tests COMMAND python3 -m unittest
     test_skvbc
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_linearizability COMMAND python3 -m unittest
+    test_skvbc_linearizability
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,5 @@
-add_test(NAME bft_sys_tests COMMAND python3 -m unittest
+add_test(NAME skvbc_tests COMMAND python3 -m unittest
     test_skvbc
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-add_test(NAME skvbc_linearizability COMMAND python3 -m unittest
+    test_skvbc_chaos
     test_skvbc_linearizability
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/bft_test_exceptions.py
+++ b/test/bft_test_exceptions.py
@@ -14,14 +14,29 @@ class Error(Exception):
     """Base class for exceptions in this module."""
     pass
 
+##
+## Exceptions for bft_tester
+##
 class AlreadyRunningError(Error):
     def __init__(self, replica):
         self.replica = replica
+        j
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  replica={self.replica}\n')
 
 class AlreadyStoppedError(Error):
     def __init__(self, replica):
         self.replica = replica
 
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  replica={self.replica}\n')
+
 class BadReplyError(Error):
     def __init__(self):
         pass
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}\n'
+

--- a/test/bft_tester.py
+++ b/test/bft_tester.py
@@ -120,6 +120,11 @@ class BftTester:
             keys.append(bytes(key))
         return keys
 
+    def initial_state(self):
+        """Return a dict with KV_LEN zero byte values for all keys"""
+        all_zeros = b''.join([b'\x00' for _ in range(0, KV_LEN)])
+        return dict([(k, all_zeros) for k in self.keys])
+
     async def _create_clients(self):
         for client_id in range(self.config.n,
                                self.config.num_clients+self.config.n):
@@ -145,11 +150,21 @@ class BftTester:
     def random_value(self):
         return bytes(random.sample(self.alphanum, KV_LEN))
 
+    def random_values(self, n):
+        return [self.random_value() for _ in range(0, n)]
+
     def random_client(self):
         return random.choice(list(self.clients.values()))
 
+    def random_clients(self, max_clients):
+        return set(random.choices(list(self.clients.values()), k=max_clients))
+
     def random_key(self):
         return random.choice(self.keys)
+
+    def random_keys(self, max_keys):
+        """Return a set of keys that is of size <= max_keys"""
+        return set(random.choices(self.keys, k=max_keys))
 
     def start_all_replicas(self):
         [self.start_replica(i) for i in range(0, self.config.n)]

--- a/test/bft_tester.py
+++ b/test/bft_tester.py
@@ -10,7 +10,7 @@
 # terms and conditions of the subcomponent's license, as noted in the LICENSE
 # file.
 
-# Add the pyclient directory to $PYTHONPATH 
+# Add the pyclient directory to $PYTHONPATH
 
 import sys
 
@@ -30,7 +30,7 @@ import bft_client
 import bft_metrics_client
 import bft_metrics
 
-from bft_tester_exceptions import AlreadyRunningError, AlreadyStoppedError 
+from bft_test_exceptions import AlreadyRunningError, AlreadyStoppedError
 
 TestConfig = namedtuple('TestConfig', [
     'n',
@@ -77,7 +77,7 @@ class BftTester:
         self.builddir = os.path.abspath("../build")
         self.toolsdir = os.path.join(self.builddir, "tools")
         self.procs = {}
-        self.replicas = [bft_config.Replica(i, "127.0.0.1", 3710 + 2*i) 
+        self.replicas = [bft_config.Replica(i, "127.0.0.1", 3710 + 2*i)
                 for i in range(0, self.config.n)]
         self.alpha = [i for i in range(65, 91)]
         self.alphanum = [i for i in range(48, 58)]
@@ -91,7 +91,7 @@ class BftTester:
     def _generate_crypto_keys(self):
         keygen = os.path.join(self.toolsdir, "GenerateConcordKeys")
         args = [keygen, "-n", str(self.config.n), "-f", str(self.config.f), "-o",
-               self.config.key_file_prefix] 
+               self.config.key_file_prefix]
         subprocess.run(args, check=True)
 
     def _create_keys(self):
@@ -124,7 +124,7 @@ class BftTester:
         for client_id in range(self.config.n,
                                self.config.num_clients+self.config.n):
             config = bft_config.Config(client_id, self.config.f, self.config.c,
-                    MAX_MSG_SIZE, REQ_TIMEOUT_MILLI, RETRY_TIMEOUT_MILLI) 
+                    MAX_MSG_SIZE, REQ_TIMEOUT_MILLI, RETRY_TIMEOUT_MILLI)
             self.clients[client_id] = bft_client.UdpClient(config, self.replicas)
 
     async def _init_metrics(self):
@@ -141,7 +141,7 @@ class BftTester:
         """
         await self._create_clients()
         await self._init_metrics()
-                
+
     def random_value(self):
         return bytes(random.sample(self.alphanum, KV_LEN))
 
@@ -182,7 +182,7 @@ class BftTester:
         p.wait()
 
     async def wait_for_state_transfer_to_start(self):
-        """ 
+        """
         Retry checking every .5 seconds until state transfer starts at least one
         node. Stop trying, and fail the test after 30 seconds.
         """
@@ -194,7 +194,7 @@ class BftTester:
                                        nursery.cancel_scope)
 
     async def _wait_to_receive_st_msgs(self, replica, cancel_scope):
-        """ 
+        """
         Check metrics to see if state transfer started. If so cancel the
         concurrent coroutines in the request scope.
         """
@@ -205,8 +205,8 @@ class BftTester:
                 if n > 0:
                     cancel_scope.cancel()
 
-    async def wait_for_state_transfer_to_stop(self, 
-                                              up_to_date_node, 
+    async def wait_for_state_transfer_to_stop(self,
+                                              up_to_date_node,
                                               stale_node):
         with trio.fail_after(30): # seconds
             # Get the lastExecutedSeqNumber from a started node
@@ -216,7 +216,7 @@ class BftTester:
                 with trio.move_on_after(.5): # seconds
                     n = await self.metrics.get(stale_node, *key)
                     if n >= last_exec_seq_num:
-                       return 
+                       return
 
     async def assert_state_transfer_not_started_all_up_nodes(self, testcase):
         with trio.fail_after(METRICS_TIMEOUT_SEC):
@@ -226,7 +226,7 @@ class BftTester:
                     nursery.start_soon(self._assert_state_transfer_not_started,
                                        testcase,
                                        r)
-           
+
     async def _assert_state_transfer_not_started(self, testcase, replica):
         key = ['replica', 'Counters', 'receivedStateTransferMsgs']
         n = await self.metrics.get(replica.id, *key)
@@ -248,6 +248,6 @@ class BftTester:
             while True:
                 with trio.move_on_after(interval):
                     if await predicate():
-                        return 
+                        return
 
 

--- a/test/skvbc.py
+++ b/test/skvbc.py
@@ -18,6 +18,8 @@ from collections import namedtuple
 ## SimpleKVBC requies fixed size keys and values right now
 KV_LEN = 21
 
+READ_LATEST = 0xFFFFFFFFFFFFFFFF
+
 WriteReply = namedtuple('WriteReply', ['success', 'last_block_id'])
 
 class SimpleKVBCProtocol:
@@ -32,7 +34,7 @@ class SimpleKVBCProtocol:
         self.GET_LAST_BLOCK = 3
         self.GET_BLOCK_DATA = 4
 
-    def write_req(self, readset, writeset, block_id=0):
+    def write_req(self, readset, writeset, block_id):
         data = bytearray()
         # A conditional write request type
         data.append(self.WRITE)
@@ -49,7 +51,7 @@ class SimpleKVBCProtocol:
 
         return data
 
-    def read_req(self, readset, block_id=0):
+    def read_req(self, readset, block_id=READ_LATEST):
         data = bytearray()
         data.append(self.READ)
         # SimpleReadHeader

--- a/test/skvbc.py
+++ b/test/skvbc.py
@@ -11,6 +11,7 @@
 # file.
 
 import struct
+import time
 
 from collections import namedtuple
 
@@ -31,8 +32,7 @@ class SimpleKVBCProtocol:
         self.GET_LAST_BLOCK = 3
         self.GET_BLOCK_DATA = 4
 
-    def write_req(self, readset, writeset):
-        block_id = 0
+    def write_req(self, readset, writeset, block_id=0):
         data = bytearray()
         # A conditional write request type
         data.append(self.WRITE)
@@ -94,5 +94,5 @@ class SimpleKVBCProtocol:
                 data = data[2*KV_LEN:]
         return kv_pairs
 
-    def parse_get_last_block_reply(self, data): 
+    def parse_get_last_block_reply(self, data):
         return struct.unpack("<Q", data)[0]

--- a/test/skvbc_exceptions.py
+++ b/test/skvbc_exceptions.py
@@ -1,0 +1,110 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+class Error(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+##
+## Exceptions for skvbc_linearizability
+##
+class ConflictingBlockWriteError(Error):
+    """The same block was already written by a different conditional write"""
+    def __init__(self, block_id, block, new_request):
+        self.block_id = block_id
+        self.block = block
+        self.new_request = new_request
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  block_id={self.block_id}\n'
+           f'  block={self.block}\n'
+           f'  new_request={self.new_request}\n')
+
+class StaleReadError(Error):
+    """
+    A conditional write did not see that a key in its readset was written after
+    the block it was attempting to read from, but before the block the write
+    created. As an example, The readset block version was X, an update was made
+    to a key in the readset in block X+1, and this write successfully wrote
+    block X+2.
+
+    In our example the parameters to the constructor would be set as:
+
+        readset_block_id = X
+        block_with_conflicting_writeset = X + 1
+        block_being_checked = X + 2
+
+    """
+    def __init__(self,
+                 readset_block_id,
+                 block_with_conflicting_writeset,
+                 block_being_checked):
+        self.readset_block_id = readset_block_id
+        self.block_with_conflicting_writeset = block_with_conflicting_writeset
+        self.block_being_checked = block_being_checked
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  readset_block_id={self.readset_block_id}\n'
+           f'  block_with_conflicting_writeset='
+           f'{self.block_with_conflicting_writeset}\n'
+           f'  block_being_checked={self.block_being_checked}\n')
+
+
+class NoConflictError(Error):
+    """
+    A conditional write failed when it should have succeeded.
+
+    There were no concurrent write requests that actually conflicted with the
+    stale request.
+    """
+    def __init__(self, failed_req, causal_state):
+        self.failed_req = failed_req
+        self.causal_state = causal_state
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  failed_req={self.failed_req}\n'
+           f'  causal_state={self.causal_state}\n')
+
+class InvalidReadError(Error):
+    """
+    The values returned by a read did not linearize given the state of the
+    blockchain and concurrent requests.
+    """
+    def __init__(self, read, concurrent_requests):
+        self.read = read
+        self.concurrent_requests = concurrent_requests
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  read={self.read}\n'
+           f'  concurrent_requests={self.concurrent_requests}\n')
+
+class PhantomBlockError(Error):
+    """
+    A block was created with a given set of kvpairs that no write request
+    generated.
+    """
+    def __init__(self, block_id, kvpairs, matched_blocks, unmatched_requests):
+        self.block_id = block_id
+        self.kvpairs = kvpairs
+        self.matched_blocks = matched_blocks
+        self.unmatched_requests = unmatched_requests
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  block_id={self.block_id}\n'
+           f'  kvpairs={self.kvpairs}\n'
+           f'  matched_blocks={self.matched_blocks}\n'
+           f'  unmatched_requests={self.unmatched_requests}\n')

--- a/test/skvbc_linearizability.py
+++ b/test/skvbc_linearizability.py
@@ -1,0 +1,703 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import time
+from enum import Enum
+
+from skvbc_exceptions import(
+    ConflictingBlockWriteError,
+    StaleReadError,
+    NoConflictError,
+    InvalidReadError,
+    PhantomBlockError
+)
+
+class SkvbcWriteRequest:
+    """
+    A write request sent to an Skvbc cluster. A request may or may not complete.
+    """
+    def __init__(self, client_id, seq_num, readset, writeset, read_block_id=0):
+        self.timestamp = time.monotonic()
+        self.client_id = client_id
+        self.seq_num = seq_num
+        self.readset = readset
+        self.writeset = writeset
+        self.read_block_id = read_block_id
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  readset={self.readset}\n'
+           f'  writeset={self.writeset}\n'
+           f'  read_block_id={self.read_block_id}\n')
+
+class SkvbcReadRequest:
+    """
+    A read request sent to an Skvbc cluster. A request may or may not complete.
+    """
+    def __init__(self, client_id, seq_num, readset, read_block_id=0):
+        self.timestamp = time.monotonic()
+        self.client_id = client_id
+        self.seq_num = seq_num
+        self.readset = readset
+        self.read_block_id = read_block_id
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  readset={self.readset}\n'
+           f'  read_block_id={self.read_block_id}\n')
+
+class SkvbcGetLastBlockReq:
+    """
+    A GET_LAST_BLOCK request sent to an skvbc cluster. A request may or may not
+    complete.
+    """
+    def __init__(self, client_id, seq_num):
+        self.timestamp = time.monotonic()
+        self.client_id = client_id
+        self.seq_num = seq_num
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n')
+
+class SkvbcWriteReply:
+    """A reply to an outstanding write request sent to an Skvbc cluster."""
+    def __init__(self, client_id, seq_num, reply):
+        self.timestamp = time.monotonic()
+        self.client_id = client_id
+        self.seq_num = seq_num
+        self.reply = reply
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  reply={self.reply}\n')
+
+class SkvbcReadReply:
+    """A reply to an outstanding read request sent to an Skvbc cluster."""
+    def __init__(self, client_id, seq_num, kvpairs):
+        self.timestamp = time.monotonic()
+        self.client_id = client_id
+        self.seq_num = seq_num
+        self.kvpairs = kvpairs
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  kvpairs={self.kvpairs}\n')
+
+class SkvbcGetLastBlockReply:
+    """
+    A reply to an outstanding get last block request sent to an Skvbc cluster.
+    """
+    def __init__(self, client_id, seq_num, reply):
+        self.timestamp = time.monotonic()
+        self.client_id = client_id
+        self.seq_num = seq_num
+        self.reply = reply
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  reply={self.reply}\n')
+
+class Result(Enum):
+   """
+   Whether an operation succeeded, failed, or the result is unknown
+   """
+   WRITE_SUCCESS = 1
+   WRITE_FAIL = 2
+   UNKNOWN_WRITE = 3
+   UNKNOWN_READ = 4
+   READ_REPLY = 5
+
+class CompletedRead:
+    def __init__(self, causal_state, kvpairs):
+        self.causal_state = causal_state
+        self.kvpairs = kvpairs
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  causal_state={self.causal_state}\n'
+           f'  kvpairs={self.kvpairs}\n')
+
+class CausalState:
+    """Relevant state of the tracker before a request is started"""
+    def __init__(
+            self, req_index, last_known_block, last_consecutive_block, kvpairs):
+        self.req_index = req_index
+        self.last_known_block = last_known_block
+        self.last_consecutive_block = last_consecutive_block
+
+        # KV pairs contain the value up keys up until last_consecutive_block
+        self.kvpairs = kvpairs
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'    last_known_block={self.last_known_block}\n'
+           f'    last_consecutive_block={self.last_consecutive_block}\n'
+           f'    kvpairs={self.kvpairs}\n')
+
+class ConcurrentValue:
+    """Track the state for a request / reply in self.concurrent"""
+    def __init__(self, is_read):
+        if is_read:
+            self.result = Result.UNKNOWN_READ
+        else:
+            self.result = Result.UNKNOWN_WRITE
+
+        # Only used in writes
+        # Set only when writes succeed.
+        self.written_block_id = None
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  result={self.result}\n'
+           f'  written_block_id={self.written_block_id}\n')
+
+class Block:
+    def __init__(self, kvpairs, req_index=None):
+        self.kvpairs = kvpairs
+        self.req_index = req_index
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}:\n'
+           f'  kvpairs={self.kvpairs}\n'
+           f'  req_index={self.req_index}\n')
+
+class SkvbcTracker:
+    """
+    Track requests, expected and actual responses from SimpleKVBC test
+    clusters, and then allow verification of the linearizability of responses.
+
+    The SkvbcTracker is used by a test to record messages sent and replies
+    received to a cluster of SimpleKVBCTests TesterReplica nodes. Every request
+    sent and reply received is recorded in `self.history`, and indexes into this
+    history for requesets are frequently referred to by other parts of this
+    code.
+
+    By tracking outstanding requests in `self.outstanding` it is able to
+    determine which requests are concurrent with which other requests, and track
+    them in `self.concurrent`. The tracker also records a set of known blocks in
+    `self.blocks` that it learns when ConditionalWrite replies are successful.
+
+    Sometimes replies do not arrive for requests, and therefore the requests are never
+    removed from self.outstanding. Such requests are considered concurrent with
+    all future requests.
+
+    Additionally, the tracker records all completed reads and failed writes so
+    that they can be put into a total order with the blocks and checked for
+    correctness (i.e. linearized).
+
+    A test can send many requests to a cluster while it is also crashing nodes,
+    creating partitions, instigating view changes, playing with clocks, and
+    performing generally malicious actions. These failures can trigger missing
+    replies as well as anomalies in the record of blocks themselves. The goal of
+    the test is to try to trigger these anomalies via contentious writes and
+    failures, such that any flaws in the implementation of concord-sbft can
+    revealed when the tracker performs verification. When a failure is found the
+    tracker state can be dumped along with the specific exception thrown to help
+    developers reason about bugs in the code.
+
+    Any complexity in this code stems primarily from the requirements and
+    implementation of the verification procedure. Unlike general, dynamic
+    model based linearizability checkers like
+    [knossos](https://github.com/jepsen-io/knossos) or
+    [porcupine](https://github.com/anishathalye/porcupine), which attempt an
+    NP-Hard search for correct linearizations soley from requests and responses,
+    the SkvbcTracker relies on the total ordering of blocks provided by the
+    TesterReplica implementation, and can perform correctness checks in linear
+    time. However, the tester also records the complete history of requests and
+    replies and can be used to generate a compatible output file that can then
+    be verified using either knossos or porcupine.
+
+    Every time a successful conditional write reply is received it includes the
+    block number that it generated. This allows us to create a definitive total
+    order for all blocks generated from requests that the tracker knows the
+    replies of. However, we don't know the value of all blocks, because some
+    replies may have been dropped. Before a test calls the `verify` method, it
+    must retrieve and inform the tracker about any missing blocks. However, the
+    test doesn't know which blocks are missing. The test will therfore call the
+    `get_missing_blocks` method with the last_block_id of the cluster, that it
+    retrieves after it is done sending read and write requests. The
+    `get_missing_blocks` method will return a set of blocks which the test
+    should retrieve from the replicas and then inform the tracker about with a
+    call to `fill_missing_blocks`. After `fill_missing_blocks` is called the
+    tracker will have a total order of all blocks in the system, thus obviating
+    the need to perform an NP-hard search to find a write order that also
+    satisfies concurrent reads and failed responses.
+
+    An astute reader will note that we are trusting the TesterReplica cluster to
+    tell us about the values of certain blocks, but that cluster is also the
+    system under test that we are attempting to validate. At an absolute
+    minimum, we want to make sure that any filled blocks could have been
+    generated by outstanding requests. Therefore, the first step in verification
+    is to call `_match_filled_blocks`. If any blocks could not have been
+    generated by the outstanding requests, i.e. requests without replies, than a
+    `PhantomBlockError` exception is raised. We could also try to order
+    identical requests and blocks and determine if they could have successfully
+    created those blocks based on their readsets not conflicting with writesets
+    in the block history. However, this is an expensive search, that is probably
+    similar to general linearizability testing in its complexity, and in long
+    histories with many missing blocks may prolong all tests with little benefit. If we
+    determine the need we can add this procedure later. The assumption here is that
+    any incorrectness in the missing blocks will be detected via the inability
+    of reads and failed requests to serialize, or be the result of unmatched
+    requests. In other words, if the missing blocks are incorrect, other parts
+    of the chain are likely incorrect and will be detected from the remaining
+    parts of the verification procedure.
+
+    The remaining parts of the verification procedure are documented in their
+    respective methods, but will briefly be described here.
+
+    `_verify_successful_writes` ensures that the readset in the write request
+    does not intersect with the writesets in other requests that created blocks
+    up until the creation of the block by this successful write. In essence, it
+    is verifying compare and swap behavior, using the block id of the readset as
+    a version.
+
+    `_linearize_reads` ensures that the returned values of the read could have
+    been returned from the *state* of the kvstore before or after any concurrent
+    requests with the read.
+
+    `_linearize_write_failures` works similar to `_linearize_reads`, in that it
+    looks at concurrent write requests to determine if there was an anomaly. The
+    anomaly in this case would be if the failed request had a readset that
+    didn't actually intersect with any writesets in concurrent requests. This
+    would mean that there wasn't actually a conflict, and therefore the write
+    should have succeeded. It's important to note here that we are only checking
+    explicit failures returned from the cluster that are due to conflict errors
+    in the replica's block state. We do not try to show that timeouts should not
+    have failed. Any request that times out is not recorded as having a reply
+    and remains in `self.outstanding`.
+
+    It's important to note that the verification procedure returns the first
+    error it finds in an exception. There may be other errors that were not
+    reported but existed. In the future we may wish to change this code to track
+    all (or most) errors and report a set of exceptions to the caller, to enable better
+    debugging.
+
+    One more check that may be useful is to take the complete chain in
+    `self.blocks` and compare it to all blocks in the cluster at the end of the
+    test run. The values should be identical. This can be an expensive check in
+    clusters with lots of blocks, but we may want to add it as an optional check
+    in the future.
+    """
+    def __init__(self):
+        # Last block_id received in a response
+        self.last_block_id = 0
+
+        # A partial order of all requests (SkvbcWriteRequest | SkvbcReadRequest)
+        # issued against SimpleKVBC.  History tracks requests and responses. A
+        # happens-before relationship exists between responses and requests
+        # launched after those responses.
+        self.history = []
+
+        # All currently outstanding requests:
+        # (client_id, seq_num) -> CausalState
+        self.outstanding = {}
+
+        # All completed reads by index into history -> CompletedRead
+        self.completed_reads = {}
+
+        # All failed writes by index into history -> CausalState
+        self.failed_writes = {}
+
+        # A set of all concurrent requests and their results for each request in
+        # history
+        # index -> dict{index, ConcurrentValue}
+        self.concurrent = {}
+
+        # All blocks and their kv data based on responses
+        # Each known block is mapped from block id to a Block
+        self.blocks = {}
+
+        # The value of all keys at last_consecutive_block
+        self.kvpairs = {}
+        self.last_consecutive_block = 0
+
+        self.last_known_block = 0
+
+        # Blocks that get filled in by the call to fill_missing_blocks
+        # These blocks were created by write requests that never got replies.
+        self.filled_blocks = {}
+
+    def send_write(self, client_id, seq_num, readset, writeset, read_block_id):
+        """Track the send of a write request"""
+        req = SkvbcWriteRequest(
+                client_id, seq_num, readset, writeset, read_block_id)
+        self._send_req(req, is_read=False)
+
+    def send_read(self, client_id, seq_num, readset):
+        """
+        Track the send of a read request.
+
+        Always get the latest value. We are trying to linearize requests, so we
+        want a real-time ordering which requires getting the latest values.
+        """
+        req = SkvbcReadRequest(client_id, seq_num, readset)
+        self._send_req(req, is_read=True)
+
+    def _send_req(self, req, is_read):
+        self.history.append(req)
+        index = len(self.history) - 1
+        self._update_concurrent_requests(index, is_read)
+        cs = CausalState(index,
+                         self.last_known_block,
+                         self.last_consecutive_block,
+                         self.kvpairs.copy())
+        self.outstanding[(req.client_id, req.seq_num)] = cs
+
+    def handle_write_reply(self, client_id, seq_num, reply):
+        """
+        Match a write reply with its outstanding request.
+        Check for consistency violations and raise an exception if found.
+        """
+        rpy = SkvbcWriteReply(client_id, seq_num, reply)
+        self.history.append(rpy)
+        req, req_index = self._get_matching_request(rpy)
+        if reply.success:
+            if reply.last_block_id in self.blocks:
+                # This block_id has already been written!
+                block = self.blocks[reply.last_block_id]
+                raise ConflictingBlockWriteError(reply.last_block_id, block, req)
+            else:
+                self._record_concurrent_write_success(req_index,
+                                                      rpy,
+                                                      reply.last_block_id)
+                self.blocks[reply.last_block_id] = Block(req.writeset, req_index)
+
+                if reply.last_block_id > self.last_known_block:
+                    self.last_known_block = reply.last_block_id
+
+                # Update consecutive kvpairs
+                if reply.last_block_id == self.last_consecutive_block + 1:
+                    self.last_consecutive_block += 1
+                    for k,v in req.writeset.items():
+                        self.kvpairs[k] = v
+        else:
+            self._record_concurrent_write_failure(req_index, rpy)
+
+    def handle_read_reply(self, client_id, seq_num, kvpairs):
+        """
+        Get a read reply and ensure that it linearizes with the current known
+        concurrent replies.
+        """
+        rpy = SkvbcReadReply(client_id, seq_num, kvpairs)
+        req, req_index = self._get_matching_request(rpy)
+        self.history.append(rpy)
+        self._record_read_reply(req_index, rpy)
+
+    def get_missing_blocks(self, last_block_id):
+        """
+        Retrieve the set of missing blocks.
+
+        This is called during synchronization before continuing with a test,
+        so that the tester can retrieve these blocks and call
+        self.fill_in_missing_blocks().
+
+        After missing blocks are filled in, successful reads can be linearized.
+        """
+        missing_blocks = set([i for i in range(self.last_consecutive_block + 1,
+                                               self.last_known_block)])
+        # Include last_block_id if not already known
+        for i in range(self.last_known_block + 1, last_block_id + 1):
+            missing_blocks.add(i)
+        return missing_blocks
+
+    def fill_missing_blocks(self, missing_blocks):
+        """
+        Add all missing blocks to self.blocks
+
+        Note that these blocks will not have a matching req_index since we never
+        received a reply for the request that created it. In some histories it's
+        not possible to identify an unambiguous request, since there may be
+        multiple possible requests that could have correctly generated the
+        block. Rather than trying to match the requests, to the missing blocks,
+        we just assume the missing blocks are correct for now, and use the full
+        block history to verify successful conditional writes and reads.
+        """
+        for block_id, kvpairs in missing_blocks.items():
+            self.blocks[block_id] = Block(kvpairs)
+            if block_id > self.last_known_block:
+                self.last_known_block = block_id
+        self.filled_blocks = missing_blocks
+
+    def verify(self):
+        self._match_filled_blocks()
+        self._verify_successful_writes()
+        self._linearize_reads()
+        self._linearize_write_failures()
+
+    def _match_filled_blocks(self):
+        """
+        For every filled block, identify an outstanding write request with a
+        matching writeset.
+
+        If there isn't an outstanding request that could have generated the
+        block raise a PhantomBlockError.
+        """
+
+        # Req/block_id pairs
+        matched_blocks = []
+        write_requests = self._get_all_outstanding_write_requests()
+
+        for block_id, block_kvpairs in self.filled_blocks.items():
+            unmatched = []
+            success = False
+            for _ in range(0, len(write_requests)):
+                req = write_requests.pop()
+                if req.writeset == block_kvpairs:
+                    matched_blocks.append((req, block_id))
+                    success = True
+                    break
+                else:
+                    unmatched.append(req)
+            if not success:
+                raise PhantomBlockError(block_id,
+                                        block_kvpairs,
+                                        matched_blocks,
+                                        unmatched)
+            write_requests.extend(unmatched)
+
+    def _get_all_outstanding_write_requests(self):
+        writes = []
+        for causal_state in self.outstanding.values():
+            req = self.history[causal_state.req_index]
+            if isinstance(req, SkvbcWriteRequest):
+                writes.append(req)
+        return writes
+
+    def _verify_successful_writes(self):
+        for i in range(1, self.last_known_block+1):
+            req_index = self.blocks[i].req_index
+            if req_index != None:
+                # A reply was received for this request that created the block
+                req = self.history[req_index]
+                self._verify_successful_write(i, req)
+
+    def _linearize_write_failures(self):
+        """
+        Go through all write failures, and determine if they should have failed
+        due to conflict.
+
+        The failure check involves looking for write conflicts based on the
+        causal state at the time the failed request was issued, and any
+        succeeding concurrent writes.
+
+        If no concurrent writes had writesets that intersected with the readset
+        of the failed write, then that write should have succeeded. In this case
+        we raise a NoConflictError.
+
+        Note that we only count failures explicitly returned from skvbc, i.e.
+        those where writes returned success = false due to conflict. Timeouts
+        remain in outstanding requests, since we don't know whether they would
+        have succeeded or failed.
+        """
+        for req_index, causal_state in self.failed_writes.items():
+            num_intermediate_blocks = (causal_state.last_known_block
+                                      - causal_state.last_consecutive_block)
+            num_concurrent = self._max_possible_concurrent_writes(req_index)
+            # Any missing intermediate block is by definition concurrent, so we
+            # need to subtract it as well.
+            blocks_remaining = (self.last_known_block
+                                - causal_state.last_known_block
+                                - num_intermediate_blocks)
+            blocks_to_check = min(num_concurrent, blocks_remaining)
+
+            failed_req = self.history[req_index]
+
+            # Check for writeset intersection at every block from the block
+            # after the readset until the last possible concurrently generated
+            # block.
+            success = False
+            for i in range(failed_req.read_block_id + 1,
+                           causal_state.last_known_block + blocks_to_check + 1):
+                writeset = set(self.blocks[i].kvpairs.keys())
+                if len(failed_req.readset.intersection(writeset)) != 0:
+                       # We found a block that conflicts. We must
+                       # assume that failed_req was failed correctly.
+                       success = True
+                       break
+
+            if not success:
+                # We didn't find any conflicting blocks.
+                # failed_req should have succeeded!
+                raise NoConflictError(failed_req, causal_state)
+
+
+    def _linearize_reads(self):
+        """
+        At this point, we should know the kv pairs of all blocks.
+
+        Attempt to find linearization points for all reads in
+        self.completed_reads.
+
+        If a read cannot be linearized, then raise an exception.
+        """
+        for req_index, completed_read  in self.completed_reads.items():
+            cs = completed_read.causal_state
+            kv = cs.kvpairs
+            num_intermediate_blocks = (cs.last_known_block
+                                      - cs.last_consecutive_block)
+
+            # We must check that the read linearizes after
+            # causal_state.last_known_block, since it must have started after
+            # that. Build up the kv state until last_known_block.
+            for block_id in range(cs.last_consecutive_block + 1,
+                                  cs.last_known_block + 1):
+                kv.update(self.blocks[block_id].kvpairs)
+            num_concurrent = self._max_possible_concurrent_writes(req_index)
+
+            # Any missing intermediate block is by definition concurrent, so we
+            # need to subtract it as well.
+            blocks_remaining = (self.last_known_block
+                                - cs.last_known_block
+                                - num_intermediate_blocks)
+            blocks_to_check = min(num_concurrent, blocks_remaining)
+
+            success = False
+            for i in range(cs.last_known_block,
+                           cs.last_known_block + blocks_to_check + 1):
+                if i != cs.last_known_block:
+                    kv.update(self.blocks[i].kvpairs)
+                if self._read_is_valid(kv, completed_read.kvpairs):
+                    # The read linearizes here
+                    success = True
+                    break
+
+            if not success:
+                raise InvalidReadError(completed_read,
+                                       self.concurrent[req_index])
+
+    def _read_is_valid(self, kv_state, read_kvpairs):
+        """Return if a read of read_kvpairs is possible given kv_state."""
+        for k, v in read_kvpairs.items():
+            if kv_state.get(k) != v:
+                return False
+        return True
+
+    def _max_possible_concurrent_writes(self, req_index):
+        """
+        Return the maximum possible number of concurrrent writes.
+        This includes writes that returned successfully but also writes with no
+        return that could have generated missing blocks.
+        """
+        count = 0
+        for val in self.concurrent[req_index].values():
+            if val.result == Result.WRITE_SUCCESS or \
+               val.result == Result.UNKNOWN_WRITE:
+                   count += 1
+        return count
+
+    def _update_concurrent_requests(self, index, is_read):
+        """
+        Set the concurrent requests for this request to a dictionary of all
+        indexes into history in self.outstanding mapped to a ConcurrentValue.
+
+        Also update all concurrent requests to include this request in their
+        concurrent dicts.
+        """
+        self.concurrent[index] = {}
+        for causal_state in self.outstanding.values():
+            i = causal_state.req_index
+            is_read_outstanding = isinstance(self.history[i], SkvbcReadRequest)
+            # Add the outstanding request to this request's concurrent dicts
+            self.concurrent[index][i] = ConcurrentValue(is_read_outstanding)
+            # Add this request to the concurrent dicts of each outstanding req
+            self.concurrent[i][index] = ConcurrentValue(is_read)
+
+    def _verify_successful_write(self, written_block_id, req):
+        """
+        Ensure that the block at written_block_id should have been written by
+        req.
+
+        Check that for each key in the readset, there have been no writes to
+        those keys for each block after the block version in the conditional
+        write up to, but not including this block. An example of failure is:
+
+          * We read block id = X
+          * We write block id = X + 2
+          * We notice that block id X + 1 has written a key in the readset of
+            this request that created block X + 2.
+
+        Note that we may have unknown blocks due to missing responses.  We just
+        skip these blocks, as we can't tell if there's a conflict or not. We
+        have to assume there isn't a conflict in this case.
+
+        If there is a conflicting block then there is a bug in the consensus
+        algorithm, and we raise a StaleReadError.
+        """
+        for i in range(req.read_block_id + 1, written_block_id):
+            if i not in self.blocks:
+                # Ensure we have learned about this block.
+                # Move on if we have not.
+                continue
+            block = self.blocks[i]
+
+            # If the writeset of the request that created intermediate blocks
+            # intersects the readset of this request, then we have a conflict.
+            if len(req.readset.intersection(set(block.kvpairs.keys()))) != 0:
+                raise StaleReadError(req.read_block_id, i, written_block_id)
+
+    def _record_concurrent_write_success(self, req_index, rpy, block_id):
+        """Inform all concurrent requests that this request succeeded."""
+        # We don't need the causal state for verification on write successes
+        del self.outstanding[(rpy.client_id, rpy.seq_num)]
+
+        val = ConcurrentValue(is_read=False)
+        val.result = Result.WRITE_SUCCESS
+        val.written_block_id = block_id
+        for i in self.concurrent[req_index].keys():
+            self.concurrent[i][req_index] = val
+
+    def _record_concurrent_write_failure(self, req_index, rpy):
+        """Inform all concurrent requests that this request failed."""
+        causal_state = self.outstanding.pop((rpy.client_id, rpy.seq_num))
+        self.failed_writes[req_index] = causal_state
+
+        val = ConcurrentValue(is_read=False)
+        val.result = Result.WRITE_FAIL
+        for i in self.concurrent[req_index].keys():
+            self.concurrent[i][req_index] = val
+
+    def _record_read_reply(self, req_index, rpy):
+        """Inform all concurrent requests about a read reply"""
+        causal_state = self.outstanding.pop((rpy.client_id, rpy.seq_num))
+        self.completed_reads[req_index] = CompletedRead(causal_state,
+                                                        rpy.kvpairs)
+
+        for i in self.concurrent[req_index].keys():
+            self.concurrent[i][req_index].result = Result.READ_REPLY
+
+    def _get_matching_request(self, rpy):
+        """
+        Return the request that matches rpy along with its index into
+        self.history.
+        """
+        causal_state = self.outstanding[(rpy.client_id, rpy.seq_num)]
+        index = causal_state.req_index
+        return (self.history[index], index)

--- a/test/skvbc_linearizability.py
+++ b/test/skvbc_linearizability.py
@@ -157,6 +157,7 @@ class CausalState:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
+           f'    req_index={self.req_index}\n'
            f'    last_known_block={self.last_known_block}\n'
            f'    last_consecutive_block={self.last_consecutive_block}\n'
            f'    kvpairs={self.kvpairs}\n')
@@ -306,10 +307,7 @@ class SkvbcTracker:
     clusters with lots of blocks, but we may want to add it as an optional check
     in the future.
     """
-    def __init__(self):
-        # Last block_id received in a response
-        self.last_block_id = 0
-
+    def __init__(self, initial_kvpairs={}):
         # A partial order of all requests (SkvbcWriteRequest | SkvbcReadRequest)
         # issued against SimpleKVBC.  History tracks requests and responses. A
         # happens-before relationship exists between responses and requests
@@ -336,9 +334,10 @@ class SkvbcTracker:
         self.blocks = {}
 
         # The value of all keys at last_consecutive_block
-        self.kvpairs = {}
+        self.kvpairs = initial_kvpairs
         self.last_consecutive_block = 0
 
+        # The block last received in a write
         self.last_known_block = 0
 
         # Blocks that get filled in by the call to fill_missing_blocks
@@ -560,7 +559,7 @@ class SkvbcTracker:
         """
         for req_index, completed_read  in self.completed_reads.items():
             cs = completed_read.causal_state
-            kv = cs.kvpairs
+            kv = cs.kvpairs.copy()
             num_intermediate_blocks = (cs.last_known_block
                                       - cs.last_consecutive_block)
 

--- a/test/test_skvbc.py
+++ b/test/test_skvbc.py
@@ -68,7 +68,8 @@ class SkvbcTest(unittest.TestCase):
                 async with trio.open_nursery() as nursery:
                     for client in tester.clients.values():
                         msg = self.protocol.write_req([],
-                                [(tester.random_key(), tester.random_value())])
+                                [(tester.random_key(), tester.random_value())],
+                                0)
                         nursery.start_soon(client.sendSync, msg, False)
             await tester.assert_state_transfer_not_started_all_up_nodes(self)
             tester.start_replica(3)
@@ -105,7 +106,7 @@ class SkvbcTest(unittest.TestCase):
             kv = [(tester.keys[0], tester.random_value()),
                   (tester.keys[1], tester.random_value())]
 
-            reply = await client.write(p.write_req([], kv))
+            reply = await client.write(p.write_req([], kv, 0))
             reply = p.parse_reply(reply)
             self.assertTrue(reply.success)
             self.assertEqual(last_block + 1, reply.last_block_id)
@@ -121,7 +122,7 @@ class SkvbcTest(unittest.TestCase):
             # different data
             kv3 = [(tester.keys[0], tester.random_value()),
                    (tester.keys[1], tester.random_value())]
-            reply = await client.write(p.write_req([], kv3))
+            reply = await client.write(p.write_req([], kv3, 0))
             reply = p.parse_reply(reply)
             self.assertTrue(reply.success)
             self.assertEqual(last_block + 1, reply.last_block_id)
@@ -141,7 +142,7 @@ class SkvbcTest(unittest.TestCase):
         key = tester.random_key()
         val = tester.random_value()
 
-        reply = await client.write(p.write_req([], [(key, val)]))
+        reply = await client.write(p.write_req([], [(key, val)], 0))
         reply = p.parse_reply(reply)
         self.assertTrue(reply.success)
         self.assertEqual(last_block + 1, reply.last_block_id)

--- a/test/test_skvbc_chaos.py
+++ b/test/test_skvbc_chaos.py
@@ -1,0 +1,164 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import unittest
+import trio
+import os.path
+import random
+
+import bft_tester
+import skvbc
+import skvbc_linearizability
+
+KEY_FILE_PREFIX = "replica_keys_"
+
+# The max number of blocks to check for read intersection during conditional
+# writes
+MAX_LOOKBACK=10
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    path = os.path.join(builddir, "bftengine",
+            "tests", "simpleKVBCTests", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli]
+
+def interesting_configs():
+    return [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
+            {'n': 6, 'f': 1, 'c': 1, 'num_clients': 4},
+            {'n': 11, 'f': 2, 'c': 2, 'num_clients': 6}
+            ]
+
+class SkvbcChaosTest(unittest.TestCase):
+    def test_healthy(self):
+        """
+        Run a bunch of concurrrent requests in batches and verify
+        linearizability. The system is healthy and stable and no faults are
+        intentionally generated.
+        """
+        trio.run(self._test_healthy)
+
+    async def _test_healthy(self):
+        num_ops = 500
+        for config in interesting_configs():
+            self.config = config
+            config = bft_tester.TestConfig(config['n'],
+                                           config['f'],
+                                           config['c'],
+                                           config['num_clients'],
+                                           key_file_prefix=KEY_FILE_PREFIX,
+                                           start_replica_cmd=start_replica_cmd)
+
+            with bft_tester.BftTester(config) as tester:
+                init_state = tester.initial_state()
+                self.tracker = skvbc_linearizability.SkvbcTracker(init_state)
+                self.tester = tester
+                await tester.init()
+                tester.start_all_replicas()
+                async with trio.open_nursery() as nursery:
+                    nursery.start_soon(self.run_concurrent_ops, num_ops)
+
+                await self.verify()
+
+    async def verify(self):
+        last_block_id = await self.get_last_block_id()
+        missing_block_ids = self.tracker.get_missing_blocks(last_block_id)
+        blocks = await self.get_blocks(missing_block_ids)
+        self.tracker.fill_missing_blocks(blocks)
+        try:
+            self.tracker.verify()
+        except Exception as e:
+            for i, entry in enumerate(self.tracker.history):
+                print(f'Index = {i}: {entry}')
+            print(e)
+            raise(e)
+
+    async def get_blocks(self, block_ids):
+        client = self.tester.random_client()
+        blocks = {}
+        for block_id in block_ids:
+            msg = self.protocol.get_block_data_req(block_id)
+            blocks[block_id] = self.protocol.parse_reply(await client.read(msg))
+        return blocks
+
+    async def get_last_block_id(self):
+        client = self.tester.random_client()
+        msg = self.protocol.get_last_block_req()
+        return self.protocol.parse_reply(await client.read(msg))
+
+    async def run_concurrent_ops(self, num_ops):
+        max_concurrency = len(self.tester.clients)//2
+        write_weight = .70
+        self.protocol = skvbc.SimpleKVBCProtocol()
+        max_size = len(self.tester.keys)//2
+        sent = 0
+        while sent < num_ops:
+            clients = self.tester.random_clients(max_concurrency)
+            async with trio.open_nursery() as nursery:
+                for client in clients:
+                    if random.random() < write_weight:
+                        nursery.start_soon(self.send_write, client, max_size)
+                    else:
+                        nursery.start_soon(self.send_read, client, max_size)
+            sent += len(clients)
+
+    async def send_write(self, client, max_set_size):
+        readset = self.readset(0, max_set_size)
+        writeset = self.writeset(max_set_size)
+        read_version = self.read_block_id()
+        msg = self.protocol.write_req(readset, writeset, read_version)
+        seq_num = client.req_seq_num.next()
+        client_id = client.client_id
+        self.tracker.send_write(
+            client_id, seq_num, readset, dict(writeset), read_version)
+        try:
+            serialized_reply = await client.write(msg, seq_num)
+            reply = self.protocol.parse_reply(serialized_reply)
+            self.tracker.handle_write_reply(client_id, seq_num, reply)
+        except trio.TooSlowError:
+            return
+
+    async def send_read(self, client, max_set_size):
+        readset = self.readset(1, max_set_size)
+        msg = self.protocol.read_req(readset)
+        seq_num = client.req_seq_num.next()
+        client_id = client.client_id
+        self.tracker.send_read(client_id, seq_num, readset)
+        try:
+            serialized_reply = await client.read(msg, seq_num)
+            reply = self.protocol.parse_reply(serialized_reply)
+            self.tracker.handle_read_reply(client_id, seq_num, reply)
+        except trio.TooSlowError:
+            return
+
+    def read_block_id(self):
+        start = max(0, self.tracker.last_known_block - MAX_LOOKBACK)
+        return random.randint(start, self.tracker.last_known_block)
+
+    def readset(self, min_size, max_size):
+        return self.tester.random_keys(random.randint(min_size, max_size))
+
+    def writeset(self, max_size):
+        writeset_keys = self.tester.random_keys(random.randint(0, max_size))
+        writeset_values = self.tester.random_values(len(writeset_keys))
+        return list(zip(writeset_keys, writeset_values))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_skvbc_linearizability.py
+++ b/test/test_skvbc_linearizability.py
@@ -1,0 +1,528 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import unittest
+import skvbc
+import skvbc_linearizability
+
+from skvbc_exceptions import(
+    ConflictingBlockWriteError,
+    StaleReadError,
+    NoConflictError,
+    InvalidReadError,
+    PhantomBlockError
+)
+
+class TestCompleteHistories(unittest.TestCase):
+    """Test histories where no blocks are unknown"""
+
+    def setUp(self):
+        self.tracker = skvbc_linearizability.SkvbcTracker()
+
+    def test_sucessful_write(self):
+        """
+        A single request results in a single successful reply.
+        The checker finds no errors.
+        """
+        client_id = 0
+        seq_num = 0
+        readset = set()
+        read_block_id = 0
+        writeset = {'a': 'a'}
+        self.tracker.send_write(
+                client_id, seq_num, readset, writeset, read_block_id)
+        reply = skvbc.WriteReply(success=True, last_block_id=1)
+        self.tracker.handle_write_reply(client_id, seq_num, reply)
+        self.tracker.verify()
+
+    def test_failed_write(self):
+        """
+        A single request results in a single failed reply.
+        The checker finds a NoConflictError, because there were no concurrent
+        requests that would have caused the request to fail explicitly.
+        """
+        client_id = 0
+        seq_num = 0
+        readset = set()
+        read_block_id = 0
+        writeset = {'a': 'a'}
+        self.tracker.send_write(
+                client_id, seq_num, readset, writeset, read_block_id)
+        reply = skvbc.WriteReply(success=False, last_block_id=1)
+        self.tracker.handle_write_reply(client_id, seq_num, reply)
+
+        with self.assertRaises(NoConflictError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(0, err.exception.causal_state.req_index)
+
+    def test_contentious_writes_one_success_one_fail(self):
+        """
+        Two writes contend for the same key. Only one should succeed.
+        The checker should not see an error.
+        """
+        # First create an initial block so we can contend with it
+        self.test_sucessful_write()
+        # Send 2 concurrent writes with the same readset and writeset
+        readset = set("a")
+        writeset = {'a': 'a'}
+        self.tracker.send_write(0, 1, readset, writeset, 1)
+        self.tracker.send_write(1, 1, readset, writeset, 1)
+        self.tracker.handle_write_reply(0, 1, skvbc.WriteReply(False, 0))
+        self.tracker.handle_write_reply(1, 1, skvbc.WriteReply(True, 2))
+        self.tracker.verify()
+
+    def test_contentious_writes_both_succeed(self):
+        """
+        Two writes contend for the same key. Both succeed.
+        The checker should raise a StaleReadError, since only one should have
+        succeeded.
+        """
+        # First create an initial block so we can contend with it
+        self.test_sucessful_write()
+        # Send 2 concurrent writes with the same readset and writeset
+        readset = set("a")
+        writeset = {'a': 'a'}
+        self.tracker.send_write(0, 1, readset, writeset, 1)
+        self.tracker.send_write(1, 1, readset, writeset, 1)
+        self.tracker.handle_write_reply(1, 1, skvbc.WriteReply(True, 2))
+        self.tracker.handle_write_reply(0, 1, skvbc.WriteReply(True, 3))
+
+        with self.assertRaises(StaleReadError) as err:
+            self.tracker.verify()
+
+        # Check the exception detected the error correctly
+        self.assertEqual(err.exception.readset_block_id, 1)
+        self.assertEqual(err.exception.block_with_conflicting_writeset, 2)
+        self.assertEqual(err.exception.block_being_checked, 3)
+
+    def test_contentious_writes_both_succeed_same_block(self):
+        """
+        Two writes contend for the same key. Both succeed, apparently
+        creating the same block.
+
+        The checker should raise a ConflictingBlockWriteError, since two
+        requests cannot create the same block.
+        """
+        # First create an initial block so we can contend with it
+        self.test_sucessful_write()
+        # Send 2 concurrent writes with the same readset and writeset
+        readset = set("a")
+        writeset = {'a': 'a'}
+        self.tracker.send_write(0, 1, readset, writeset, 1)
+        self.tracker.send_write(1, 1, readset, writeset, 1)
+        self.tracker.handle_write_reply(1, 1, skvbc.WriteReply(True, 2))
+
+        with self.assertRaises(ConflictingBlockWriteError) as err:
+            self.tracker.handle_write_reply(0, 1, skvbc.WriteReply(True, 2))
+
+        # The conflicting block id was block 2
+        self.assertEqual(err.exception.block_id, 2)
+
+    def test_read_between_2_successful_writes(self):
+        """
+        Send 2 concurrent writes that don't conflict, but overwrite the same
+        value, along with a concurrent read. The read sees the first overwrite,
+        and should linearize after the first overwritten value correctly.
+        """
+        # A non-concurrent write
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+        client0 = 0
+        client1 = 1
+        client2 = 2
+
+        # 2 concurrent writes and a concurrent read
+        self.tracker.send_write(client0, 1, set(), writeset_1, read_block_id)
+        self.tracker.send_write(client1, 1, set(), writeset_2, read_block_id)
+        self.tracker.send_read(client2, 1, ["a"])
+
+        # block2/ writeset_2
+        self.tracker.handle_write_reply(client1, 1, skvbc.WriteReply(True, 2))
+        # block3/ writeset_1
+        self.tracker.handle_write_reply(client0, 1, skvbc.WriteReply(True, 3))
+        self.tracker.handle_read_reply(client2, 1, {"a":"b"})
+        self.tracker.verify()
+
+    def test_read_does_not_linearize_no_concurrent_writes(self):
+        """
+        Read a value that doesn't exist.
+        This should raise an exception.
+        """
+        # state = {'a':'a'}
+        self.test_sucessful_write()
+
+        self.tracker.send_read(1, 0, ["a"])
+        self.tracker.handle_read_reply(1, 0, {"a":"b"})
+        with self.assertRaises(InvalidReadError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(0, len(err.exception.concurrent_requests))
+
+    def test_read_does_not_linearize_two_concurrent_writes(self):
+        """
+        Read a value that doesn't exist when concurrent with 2 reads.
+        This should raise an exception.
+        """
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+        client0 = 0
+        client1 = 1
+        client2 = 2
+
+        # 2 concurrent writes and a concurrent read
+        self.tracker.send_write(client0, 1, set(), writeset_1, read_block_id)
+        self.tracker.send_write(client1, 1, set(), writeset_2, read_block_id)
+        self.tracker.send_read(client2, 1, ["a"])
+
+        # block2/ writeset_2
+        self.tracker.handle_write_reply(client1, 1, skvbc.WriteReply(True, 2))
+        # block3/ writeset_1
+        self.tracker.handle_write_reply(client0, 1, skvbc.WriteReply(True, 3))
+
+        # Read a value that was never written
+        self.tracker.handle_read_reply(client2, 1, {"a":"d"})
+
+        with self.assertRaises(InvalidReadError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(2, len(err.exception.concurrent_requests))
+
+    def test_read_is_stale_with_concurrent_writes(self):
+        """
+        Read a value that doesn't exist when concurrent with 2 reads.
+        This should raise an exception.
+        """
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+        client0 = 0
+        client1 = 1
+        client2 = 2
+
+        # Another successful write commits.
+        # All subsequent ops should see at least state {'a':'b'}
+        self.tracker.send_write(client0, 1, set(), writeset_1, read_block_id)
+        self.tracker.handle_write_reply(client0, 1, skvbc.WriteReply(True, 2))
+
+        # A concurrent write and a concurrent read
+        self.tracker.send_write(client1, 1, set(), writeset_2, read_block_id)
+        self.tracker.send_read(client2, 1, ["a"])
+
+        # block3/ writeset_2
+        self.tracker.handle_write_reply(client1, 1, skvbc.WriteReply(True, 3))
+
+        # Read a stale value. Key "a" was updated to "b" before the read was
+        # sent. "a" can only be "b" or "c".
+        self.tracker.handle_read_reply(client2, 1, {"a":"a"})
+
+        with self.assertRaises(InvalidReadError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(1, len(err.exception.concurrent_requests))
+
+    def test_long_correct_history(self):
+        """
+        Launch a batch of unconditional writes along with reads concurrently
+        a few times. The responses should always be correct.
+        """
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+
+        written_block_id = 1;
+        for seq_num in range(0, 5):
+
+            # track requests
+            for client_id in range(0, 20):
+                if client_id % 3 == 0:
+                    self.tracker.send_read(client_id, seq_num, ["a"])
+                else:
+                    w = writeset_1
+                    if client_id % 2 == 0:
+                        w = writeset_2
+                    self.tracker.send_write(
+                        client_id, seq_num, set(), w, read_block_id)
+
+            # track replies
+            for client_id in range(0, 20):
+                if client_id % 3 == 0:
+                    # expected doesn't really matter for correctness
+                    # it just has to be one of the two written values because
+                    # all writes and reads in a batch are concurrent.
+                    expected = writeset_2
+                    if client_id % 2 == 0:
+                        expected = writeset_1
+                    self.tracker.handle_read_reply(client_id, seq_num, expected)
+                else:
+                     written_block_id += 1;
+                     reply = skvbc.WriteReply(True, written_block_id)
+                     self.tracker.handle_write_reply(client_id, seq_num, reply)
+
+        self.tracker.verify()
+
+    def test_long_failed_history(self):
+        """
+        Launch a batch of unconditional writes along with reads concurrently
+        a few times. Insert a single incorrect read reply.
+        """
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+        stale_read = {'a': 'a'}
+
+        written_block_id = 1;
+        for seq_num in range(0, 5):
+
+            # track requests
+            for client_id in range(0, 20):
+                if client_id % 3 == 0:
+                    self.tracker.send_read(client_id, seq_num, ["a"])
+                else:
+                    w = writeset_1
+                    if client_id % 2 == 0:
+                        w = writeset_2
+                    self.tracker.send_write(
+                        client_id, seq_num, set(), w, read_block_id)
+
+            # track replies
+            for client_id in range(0, 20):
+                if client_id % 3 == 0:
+                    # expected doesn't really matter for correctness
+                    # it just has to be one of the two written values because
+                    # all writes and reads in a batch are concurrent.
+                    expected = writeset_2
+                    if client_id % 2 == 0:
+                        expected = writeset_1
+                    if client_id == 6 and seq_num == 3:
+                        self.tracker.handle_read_reply(
+                                client_id, seq_num, stale_read)
+                    else:
+                        self.tracker.handle_read_reply(client_id, seq_num, expected)
+                else:
+                     written_block_id += 1;
+                     reply = skvbc.WriteReply(True, written_block_id)
+                     self.tracker.handle_write_reply(client_id, seq_num, reply)
+
+        with self.assertRaises(InvalidReadError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(19, len(err.exception.concurrent_requests))
+        self.assertEqual(stale_read, err.exception.read.kvpairs)
+
+
+
+class TestPartialHistories(unittest.TestCase):
+    """
+    Test histories where some writes don't return replies.
+
+    In these cases, blocks may be generated from the write, but the tracker
+    doesn't know what the values are until after the test iteration, when the
+    tester informs it of the missing blocks values.
+    """
+    def setUp(self):
+        self.tracker = skvbc_linearizability.SkvbcTracker()
+
+    def test_sucessful_write(self):
+        """
+        A single request results in a single successful reply.
+        The checker finds no errors.
+        """
+        client_id = 0
+        seq_num = 0
+        readset = set()
+        read_block_id = 0
+        writeset = {'a': 'a'}
+        self.tracker.send_write(
+                client_id, seq_num, readset, writeset, read_block_id)
+        reply = skvbc.WriteReply(success=True, last_block_id=1)
+        self.tracker.handle_write_reply(client_id, seq_num, reply)
+        self.tracker.verify()
+
+    def test_2_concurrent_writes_one_missing_success_two_concurrent_reads(self):
+        """
+        Two concurrent writes are sent with two concurrent reads. One write does
+        not respond.
+
+        One read should linearize correctly based on the write that returned,
+        and the other based on the one that didn't return.
+        """
+        # A non-concurrent write
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+        client0 = 0
+        client1 = 1
+        client2 = 2
+        client3 = 3
+
+        # 2 concurrent unconditional writes and a concurrent read
+        self.tracker.send_write(client0, 1, set(), writeset_1, read_block_id)
+        self.tracker.send_write(client1, 1, set(), writeset_2, read_block_id)
+        self.tracker.send_read(client2, 1, ["a"])
+        self.tracker.send_read(client3, 1, ["a"])
+
+        # writeset_2 written at block 3
+        self.tracker.handle_write_reply(client1, 1, skvbc.WriteReply(True, 3))
+        self.tracker.handle_read_reply(client2, 1, writeset_1)
+        self.tracker.handle_read_reply(client3, 1, writeset_2)
+
+        self.assertEqual(3, self.tracker.last_known_block)
+
+        # The test should call these methods when it stops sending
+        # operations.
+        # The test must ask the tracker what blocks are missing
+        missing_block_id = 2
+        last_block = 3
+        missing_blocks = self.tracker.get_missing_blocks(last_block)
+        self.assertSetEqual(set([missing_block_id]), missing_blocks)
+
+        self.assertEqual(3, self.tracker.last_known_block)
+
+        # The test must retrieve the missing blocks from skvbc TesterReplicas
+        # using the clients and them inform the tracker. This is the call that
+        # informs the tracker.
+        self.tracker.fill_missing_blocks({missing_block_id: writeset_1})
+
+        # The tracker now has all the information it needs. Tell it to verify
+        # that it's read responses linearize.
+        self.tracker.verify()
+
+    def test_2_concurrent_writes_one_missing_failure_two_concurrent_reads(self):
+        """
+        Two concurrent writes are sent with two concurrent reads. One write does
+        not respond.
+
+        One read should linearize correctly based on the write that returned,
+        and the other based on the one that didn't return.
+        """
+        # A non-concurrent write
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+        client0 = 0
+        client1 = 1
+        client2 = 2
+        client3 = 3
+
+        # 2 concurrent unconditional writes and a concurrent read
+        self.tracker.send_write(client0, 1, set("a"), writeset_1, read_block_id)
+        self.tracker.send_write(client1, 1, set("a"), writeset_2, read_block_id)
+        self.tracker.send_read(client2, 1, ["a"])
+        self.tracker.send_read(client3, 1, ["a"])
+
+        # writeset_2 written at block 3
+        self.tracker.handle_write_reply(client1, 1, skvbc.WriteReply(True, 2))
+        self.tracker.handle_read_reply(client2, 1, writeset_1)
+        self.tracker.handle_read_reply(client3, 1, writeset_2)
+
+        self.assertEqual(2, self.tracker.last_known_block)
+
+        # the last block is 2 because one of the writes conflicted
+        last_block = 2
+        missing_blocks = self.tracker.get_missing_blocks(last_block)
+        self.assertSetEqual(set(), missing_blocks)
+
+        with self.assertRaises(InvalidReadError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(3, len(err.exception.concurrent_requests))
+        # The read of writeset_1 fails, since that was the failed request that
+        # never returned.
+        self.assertEqual(writeset_1, err.exception.read.kvpairs)
+
+    def test_phantom_block_fill_hole(self):
+        """
+        Create a phantom block that fills in a missing block in the middle of
+        the block chain, and ensure a PhantomBlockError gets raised.
+        """
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        phantom_writeset = {'a': 'd'}
+        read_block_id = 1
+        client0 = 0
+        client1 = 1
+
+        self.tracker.send_write(client0, 1, set("a"), writeset_1, read_block_id)
+        self.tracker.send_write(client1, 1, set("a"), writeset_2, read_block_id)
+        self.tracker.handle_write_reply(client1, 1, skvbc.WriteReply(True, 3))
+
+        # We are missing block 2
+        last_block = 3
+        missing_block_id = 2
+        missing_blocks = self.tracker.get_missing_blocks(last_block)
+        self.assertSetEqual(set([missing_block_id]), missing_blocks)
+
+        # Fill in block 2 with a block that could never have been generated by a
+        # write request
+        self.tracker.fill_missing_blocks({missing_block_id: phantom_writeset})
+
+        with self.assertRaises(PhantomBlockError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(missing_block_id, err.exception.block_id)
+        self.assertEqual(phantom_writeset, err.exception.kvpairs)
+        self.assertEqual(0, len(err.exception.matched_blocks))
+        self.assertEqual(1, len(err.exception.unmatched_requests))
+
+    def test_phantom_block_fill_extra_block(self):
+        """
+        Create a phantom block that fills in a block at the end of the block
+        chain with an already used request, and ensure a PhantomBlockError gets
+        raised. All write_requests matched in this case, but we ran out of them,
+        as there was 1 more block than write request.
+
+        """
+        self.test_sucessful_write()
+        writeset_1 = {'a': 'b'}
+        writeset_2 = {'a': 'c'}
+        read_block_id = 1
+        client0 = 0
+        client1 = 1
+
+        self.tracker.send_write(client0, 1, set("a"), writeset_1, read_block_id)
+        self.tracker.send_write(client1, 1, set("a"), writeset_2, read_block_id)
+        self.tracker.handle_write_reply(client1, 1, skvbc.WriteReply(True, 3))
+
+        # We are missing blocks 2 and 4
+        last_block = 4
+        missing_block_ids = [2, 4]
+        missing_blocks = self.tracker.get_missing_blocks(last_block)
+        self.assertSetEqual(set(missing_block_ids), missing_blocks)
+
+        # Fill in a block correctly matching writeset1, and then an extra block
+        # with no matching writeset, since we already matched the last request
+        # that used writeset_1.
+        blocks = {2: writeset_1, 4: writeset_1}
+        self.tracker.fill_missing_blocks(blocks)
+
+        with self.assertRaises(PhantomBlockError) as err:
+            self.tracker.verify()
+
+        self.assertEqual(4, err.exception.block_id)
+        self.assertEqual(writeset_1, err.exception.kvpairs)
+        self.assertEqual(1, len(err.exception.matched_blocks))
+        self.assertEqual(0, len(err.exception.unmatched_requests))
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -77,15 +77,15 @@ class UdpClient:
         self.reply_quorum = 2*config.f + config.c + 1
         self.sock_bound = False
 
-    async def write(self, msg):
+    async def write(self, msg, seq_num=None):
         """ A wrapper around sendSync for requests that mutate state """
-        return await self.sendSync(msg, False)
+        return await self.sendSync(msg, False, seq_num)
 
-    async def read(self, msg):
+    async def read(self, msg, seq_num=None):
         """ A wrapper around sendSync for requests that do not mutate state """
-        return await self.sendSync(msg, True)
+        return await self.sendSync(msg, True, seq_num)
 
-    async def sendSync(self, msg, read_only):
+    async def sendSync(self, msg, read_only, seq_num=None):
         """
         Send a client request and wait for a quorum (2F+C+1) of replies.
 
@@ -110,9 +110,12 @@ class UdpClient:
         if not self.sock_bound:
             await self.bind()
 
-        seq = self.req_seq_num.next()
+        if seq_num is None:
+            seq_num = self.req_seq_num.next()
+
         data = bft_msgs.pack_request(
-                    self.client_id, seq, read_only, msg)
+                    self.client_id, seq_num, read_only, msg)
+
         # Raise a trio.TooSlowError exception if a quorum of replies
         with trio.fail_after(self.config.req_timeout_milli/1000):
             self.reset_on_new_request()


### PR DESCRIPTION
Run a test with multiple configurations of a cluster and concurrent
clients sending requests. No faults are introduced in this test and it
is a baseline to ensure that without faults or view changes the cluster
returns valid data.

Also, rename the test group in cmake to skvbc_tests, and add this test.

This test builds upon #101. Only the [last commit](https://github.com/vmware/concord-bft/commit/a9c3beabb794101186b70b580a70251c0a22e1da) is relevant here. 