### PR TITLE
Add a viewChangeTimeout CLI param to Skvbc Replica

### DIFF
--- a/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
@@ -60,6 +60,8 @@ int main(int argc, char **argv) {
   logConfig.configure();
 #endif
 	rp.replicaId = UINT16_MAX;
+        rp.viewChangeEnabled = false;
+        rp.viewChangeTimeout = 45*1000;
 
 	// allows to attach debugger
 	if(rp.debug) {
@@ -70,7 +72,7 @@ int main(int argc, char **argv) {
 	string idStr;
 
 	int o = 0;
-	while ((o = getopt(argc, argv, "r:i:k:n:s:")) != EOF) {
+	while ((o = getopt(argc, argv, "r:i:k:n:s:v:")) != EOF) {
 		switch (o) {
 		case 'i':
 		{
@@ -109,6 +111,18 @@ int main(int argc, char **argv) {
 			if (tempId >= 0 && tempId < UINT16_MAX) 
 				rp.statusReportTimerMillisec = (uint16_t)tempId;
 		}
+                break;
+                case 'v':
+                {
+			strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
+			argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
+			idStr = argTempBuffer;
+			int tempId = std::stoi(idStr);
+			if (tempId >= 0 && (uint32_t)tempId < UINT32_MAX) {
+                          rp.viewChangeTimeout = (uint32_t)tempId;
+                          rp.viewChangeEnabled = true;
+                        }
+                }
                 break;
 
 		default:
@@ -172,8 +186,8 @@ int main(int argc, char **argv) {
         // tests.
 	c.statusReportTimerMillisec = rp.statusReportTimerMillisec;
 	c.concurrencyLevel = 1;
-	c.autoViewChangeEnabled = false;
-	c.viewChangeTimerMillisec = 45 * 1000;
+	c.autoViewChangeEnabled = rp.viewChangeEnabled;
+	c.viewChangeTimerMillisec =  rp.viewChangeTimeout;
 	c.maxBlockSize = 2 * 1024 * 1024;  // 2MB
 
 

--- a/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
+++ b/bftengine/tests/simpleKVBCTests/simpleKVBCTests.cpp
@@ -838,6 +838,7 @@ namespace BasicRandomTests
                                         auto block_id = pGetBlock->block_id;
                                         SetOfKeyValuePairs outBlockData;
                                         if (!roStorage.getBlockData(block_id, outBlockData).ok()) {
+                                          printf("GetBlockData: Failed to retrieve block %" PRId64, block_id);
                                           return false;
                                         }
 


### PR DESCRIPTION
Add a `-v` CLI parameter that allows changing the viewChangeTimeout for
a SimpleKVBCTests TesterReplica. Setting this timeout implicitly enables
view change in the replicas.

Also, add an error message that occurs when a block can't be retrieved
from roStorage.

This is independent of any other change and can be merged directly. Tests pass.