### PR TITLE
fix warnings generated by compilation under clang 7

### DIFF
--- a/bftengine/src/bftengine/Crypto.cpp
+++ b/bftengine/src/bftengine/Crypto.cpp
@@ -52,7 +52,6 @@ namespace bftEngine
 {
 namespace impl
 {
-const unsigned int rsaKeyLength = 2048; // Key length in bits
 
 #define RSA_STANDARD OAEP<SHA256>
 //#define RSA_STANDARD PKCS1v15

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -605,7 +605,7 @@ namespace bftEngine
 				if (absDifference(currTime, timeOfPartProof) < controller->timeToStartSlowPathMilli() * 1000)
 					break; // don't try the next seq numbers
 
-				LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%lld timeOfPartProof=%lld", i, currTime, timeOfPartProof);
+				LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%ld timeOfPartProof=%ld", i, currTime, timeOfPartProof);
 
 				controller->onStartingSlowCommit(i);
 
@@ -904,7 +904,7 @@ namespace bftEngine
 
                         metric_received_full_commit_proofs_.Get().Inc();
 			LOG_INFO_F(GL, "Node %d received FullCommitProofMsg message for seqNumber %" PRId64 "",
-				(int)myReplicaId, (int)msg->seqNumber());
+				(int)myReplicaId, msg->seqNumber());
 
 			const SeqNum msgSeqNum = msg->seqNumber();
 
@@ -1990,7 +1990,7 @@ namespace bftEngine
 				lastPPSeq = prePreparesForNewView.back()->seqNumber();
 			}
 
-			LOG_INFO_F(GL, "**************** In onNewView curView=%" PRId64 " (num of PPs=%d, first safe seq=%" PRId64 ", last safe seq=%" PRId64 ", lastStableSeqNum=%" PRId64 ", lastExecutedSeqNum=%" PRId64 ", stableLowerBoundWhenEnteredToView= %" PRId64 ")",
+			LOG_INFO_F(GL, "**************** In onNewView curView=%" PRId64 " (num of PPs=%" PRIu64 ", first safe seq=%" PRId64 ", last safe seq=%" PRId64 ", lastStableSeqNum=%" PRId64 ", lastExecutedSeqNum=%" PRId64 ", stableLowerBoundWhenEnteredToView= %" PRId64 ")",
 				curView, prePreparesForNewView.size(), firstPPSeq, lastPPSeq,
 				lastStableSeqNum, lastExecutedSeqNum, viewsManager->stableLowerBoundWhenEnteredToView());
 
@@ -2558,7 +2558,7 @@ namespace bftEngine
 				if ((diffMilli1 > viewChangeTimeout) &&
 					(diffMilli2 > viewChangeTimeout))
 				{
-					LOG_INFO_F(GL, "**************** Node %d asks to jump to view %" PRId64 " (%" PRIu64  " milli seconds after receiving 2f+2c+1 view change msgs for view %" PRId64 ")", myReplicaId, curView, diffMilli2);
+					LOG_INFO_F(GL, "**************** Node %d asks to jump to view %" PRId64 " (%" PRIu64  " milli seconds after receiving 2f+2c+1 view change msgs for view %" PRId64 ")", myReplicaId, curView, diffMilli2, lastAgreedView);
 
 					GotoNextView();
 					return;


### PR DESCRIPTION
removed unused bftEngine::imple::rsaKeyLength

fixed log formats in ReplicaImp ~and SimpleThreadPool~

Clears up these warnings:

```
[ 26%] Building CXX object bftengine/CMakeFiles/corebft.dir/src/bftengine/ReplicaImp.cpp.o
concord-bft/bftengine/src/bftengine/ReplicaImp.cpp:608:113: warning: format specifies type 'long long' but the argument has type 'bftEngine::impl::Time'
      (aka 'unsigned long') [-Wformat]
                                LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%lld timeOfPartProof=%lld", i, currTime, timeOfPartProof);
                                                                                                             ~~~~                           ^~~~~~~~
                                                                                                             %lu
concord-bft/logging/include/Logging.hpp:279:59: note: expanded from macro 'LOG_INFO_F'
#define LOG_INFO_F(l,...) LOG4CPLUS_INFO_FMT(l.getImpl(), __VA_ARGS__)
                                                          ^~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:356:55: note: expanded from macro 'LOG4CPLUS_INFO_FMT'
    LOG4CPLUS_MACRO_FMT_BODY (logger, INFO_LOG_LEVEL, __VA_ARGS__)
                                                      ^~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:249:34: note: expanded from macro 'LOG4CPLUS_MACRO_FMT_BODY'
                = _snpbuf.print (__VA_ARGS__);                          \
                                 ^~~~~~~~~~~
concord-bft/bftengine/src/bftengine/ReplicaImp.cpp:608:123: warning: format specifies type 'long long' but the argument has type 'bftEngine::impl::Time'
      (aka 'unsigned long') [-Wformat]
                                LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%lld timeOfPartProof=%lld", i, currTime, timeOfPartProof);
                                                                                                                                  ~~~~                ^~~~~~~~~~~~~~~
                                                                                                                                  %lu
concord-bft/logging/include/Logging.hpp:279:59: note: expanded from macro 'LOG_INFO_F'
#define LOG_INFO_F(l,...) LOG4CPLUS_INFO_FMT(l.getImpl(), __VA_ARGS__)
                                                          ^~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:356:55: note: expanded from macro 'LOG4CPLUS_INFO_FMT'
    LOG4CPLUS_MACRO_FMT_BODY (logger, INFO_LOG_LEVEL, __VA_ARGS__)
                                                      ^~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:249:34: note: expanded from macro 'LOG4CPLUS_MACRO_FMT_BODY'
                = _snpbuf.print (__VA_ARGS__);                          \
                                 ^~~~~~~~~~~
concord-bft/bftengine/src/bftengine/ReplicaImp.cpp:907:23: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]
                                (int)myReplicaId, (int)msg->seqNumber());
                                ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
concord-bft/logging/include/Logging.hpp:279:59: note: expanded from macro 'LOG_INFO_F'
#define LOG_INFO_F(l,...) LOG4CPLUS_INFO_FMT(l.getImpl(), __VA_ARGS__)
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:356:55: note: expanded from macro 'LOG4CPLUS_INFO_FMT'
    LOG4CPLUS_MACRO_FMT_BODY (logger, INFO_LOG_LEVEL, __VA_ARGS__)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:249:34: note: expanded from macro 'LOG4CPLUS_MACRO_FMT_BODY'
                = _snpbuf.print (__VA_ARGS__);                          \
                                 ^~~~~~~~~~~
concord-bft/bftengine/src/bftengine/ReplicaImp.cpp:1994:14: warning: format specifies type 'int' but the argument has type 'std::vector::size_type'
      (aka 'unsigned long') [-Wformat]
                                curView, prePreparesForNewView.size(), firstPPSeq, lastPPSeq,
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
concord-bft/logging/include/Logging.hpp:279:59: note: expanded from macro 'LOG_INFO_F'
#define LOG_INFO_F(l,...) LOG4CPLUS_INFO_FMT(l.getImpl(), __VA_ARGS__)
                                                          ^~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:356:55: note: expanded from macro 'LOG4CPLUS_INFO_FMT'
    LOG4CPLUS_MACRO_FMT_BODY (logger, INFO_LOG_LEVEL, __VA_ARGS__)
                                                      ^~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:249:34: note: expanded from macro 'LOG4CPLUS_MACRO_FMT_BODY'
                = _snpbuf.print (__VA_ARGS__);                          \
                                 ^~~~~~~~~~~
concord-bft/bftengine/src/bftengine/ReplicaImp.cpp:2561:161: warning: more '%' conversions than data arguments [-Wformat]
  ...LOG_INFO_F(GL, "**************** Node %d asks to jump to view %" PRId64 " (%" PRIu64  " milli seconds after receiving 2f+2c+1 view change msgs for view %" PRId64 ")", myReplicaId, curView, diffMilli2);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/inttypes.h:57:34: note: expanded from macro 'PRId64'
# define PRId64         __PRI64_PREFIX "d"
                                        ^
concord-bft/logging/include/Logging.hpp:279:59: note: expanded from macro 'LOG_INFO_F'
#define LOG_INFO_F(l,...) LOG4CPLUS_INFO_FMT(l.getImpl(), __VA_ARGS__)
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:356:55: note: expanded from macro 'LOG4CPLUS_INFO_FMT'
    LOG4CPLUS_MACRO_FMT_BODY (logger, INFO_LOG_LEVEL, __VA_ARGS__)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/local/include/log4cplus/loggingmacros.h:249:34: note: expanded from macro 'LOG4CPLUS_MACRO_FMT_BODY'
                = _snpbuf.print (__VA_ARGS__);                          \
                                 ^~~~~~~~~~~
[ 32%] Building CXX object bftengine/CMakeFiles/corebft.dir/src/bftengine/Crypto.cpp.o
concord-bft/bftengine/src/bftengine/Crypto.cpp:55:20: warning: unused variable 'rsaKeyLength' [-Wunused-const-variable]
const unsigned int rsaKeyLength = 2048; // Key length in bits
                   ^
```