### PR TITLE
Use unique_ptrs in InternalMsgsStorage

### DIFF
--- a/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
+++ b/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
@@ -434,14 +434,14 @@ namespace bftEngine
 						verifier->release(accWithVer);
 
 						// send internal message with the results
-						InternalMessage* iMsg = ExternalFunc::createInterCombinedSigFailed(context, expectedSeqNumber, expectedView, replicasWithBadSigs);
-						repMsgsStorage->pushInternalMsg(iMsg);
+                                                std::unique_ptr<InternalMessage> iMsg(ExternalFunc::createInterCombinedSigFailed(context, expectedSeqNumber, expectedView, replicasWithBadSigs));
+						repMsgsStorage->pushInternalMsg(std::move(iMsg));
 					}
 					else
 					{
 						// send internal message with the results
-						InternalMessage* iMsg = ExternalFunc::createInterCombinedSigSucceeded(context, expectedSeqNumber, expectedView, bufferForSigComputations, bufferSize);
-						repMsgsStorage->pushInternalMsg(iMsg);
+                                                std::unique_ptr<InternalMessage> iMsg(ExternalFunc::createInterCombinedSigSucceeded(context, expectedSeqNumber, expectedView, bufferForSigComputations, bufferSize));
+						repMsgsStorage->pushInternalMsg(std::move(iMsg));
 					}
 				}
 			};
@@ -490,8 +490,8 @@ namespace bftEngine
 				{
 					bool succ = verifier->verify((char*)&expectedDigest, sizeof(Digest), combinedSig, combinedSigLen);
 
-					InternalMessage* iMsg = ExternalFunc::createInterVerifyCombinedSigResult(context, expectedSeqNumber, expectedView, succ);
-					repMsgsStorage->pushInternalMsg(iMsg);
+                                        std::unique_ptr<InternalMessage> iMsg(ExternalFunc::createInterVerifyCombinedSigResult(context, expectedSeqNumber, expectedView, succ));
+					repMsgsStorage->pushInternalMsg(std::move(iMsg));
 				}
 			};
 

--- a/bftengine/src/bftengine/IncomingMsgsStorage.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorage.hpp
@@ -15,6 +15,7 @@
 
 #include <queue>
 #include <thread>
+#include <memory>
 #include <mutex>
 #include <condition_variable>
 #include "TimeUtils.hpp"
@@ -27,6 +28,32 @@ class InternalMessage;
 
 using std::queue;
 
+// This is needed because we can't safely cast unique_ptrs to void pointers
+// We also can't use a union because it would require custom deleters and
+// could possibly result in unsafe destruction.
+//
+// As a result, we have the overhead of an extra pointer here. However, the
+// structure is on the stack and only one is active at a time in the main loop,
+// so the overhead is negligible. One of the unique_ptrs will be moved out for
+// use depending upon the tag.
+//
+// This is probably a good use case for std::variant, but we are on c++11 and
+// variant is only available in c++17.
+
+class IncomingMsg {
+ public:
+  enum { EXTERNAL, INTERNAL, INVALID } tag;
+
+  IncomingMsg() : tag(IncomingMsg::INVALID) {}
+  IncomingMsg(std::unique_ptr<MessageBase> m)
+      : tag(IncomingMsg::EXTERNAL), external(std::move(m)) {}
+  IncomingMsg(std::unique_ptr<InternalMessage> m)
+      : tag(IncomingMsg::INTERNAL), internal(std::move(m)) {}
+
+  std::unique_ptr<MessageBase> external;
+  std::unique_ptr<InternalMessage> internal;
+};
+
 class IncomingMsgsStorage {
  public:
   const uint64_t minTimeBetweenOverflowWarningsMilli = 5 * 1000;  // 5 seconds
@@ -35,19 +62,19 @@ class IncomingMsgsStorage {
   ~IncomingMsgsStorage();
 
   // can be called by any thread
-  void pushExternalMsg(MessageBase* m);
+  void pushExternalMsg(std::unique_ptr<MessageBase> m);
 
   // can be called by any thread
-  void pushInternalMsg(InternalMessage* m);
+  void pushInternalMsg(std::unique_ptr<InternalMessage> m);
 
   // should only be called by the main thread
-  bool pop(void*& item, bool& external, std::chrono::milliseconds timeout);
+  IncomingMsg pop(std::chrono::milliseconds timeout);
 
   // should only be called by the main thread.
   bool empty();
 
  protected:
-  bool popThreadLocal(void*& item, bool& external);
+  IncomingMsg popThreadLocal();
 
   const uint16_t maxNumberOfPendingExternalMsgs;
 
@@ -55,16 +82,17 @@ class IncomingMsgsStorage {
   std::condition_variable condVar;
 
   // new messages are pushed to ptrProtectedQueue.... ; Protected by lock
-  queue<MessageBase*>* ptrProtectedQueueForExternalMessages;
-  queue<InternalMessage*>* ptrProtectedQueueForInternalMessages;
+  queue<std::unique_ptr<MessageBase>>* ptrProtectedQueueForExternalMessages;
+  queue<std::unique_ptr<InternalMessage>>* ptrProtectedQueueForInternalMessages;
 
   // time of last queue overflow  Protected by lock
   Time lastOverflowWarning;
 
   // messages are fetched from ptrThreadLocalQueue... ; should only be accessed
   // by the main thread
-  queue<MessageBase*>* ptrThreadLocalQueueForExternalMessages;
-  queue<InternalMessage*>* ptrThreadLocalQueueForInternalMessages;
+  queue<std::unique_ptr<MessageBase>>* ptrThreadLocalQueueForExternalMessages;
+  queue<std::unique_ptr<InternalMessage>>*
+      ptrThreadLocalQueueForInternalMessages;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/PartialExecProofsSet.cpp
+++ b/bftengine/src/bftengine/PartialExecProofsSet.cpp
@@ -188,8 +188,8 @@ namespace bftEngine
 				}
 				else
 				{
-					MerkleExecSignatureInternalMsg* pInMsg = new MerkleExecSignatureInternalMsg(replicaApi, view, seqNumber, (uint16_t)sigLength, bufferForSigComputations);
-					replicaApi->getIncomingMsgsStorage().pushInternalMsg(pInMsg);
+                                        std::unique_ptr<InternalMessage> pInMsg(new MerkleExecSignatureInternalMsg(replicaApi, view, seqNumber, (uint16_t)sigLength, bufferForSigComputations));
+					replicaApi->getIncomingMsgsStorage().pushInternalMsg(std::move(pInMsg));
 				}
 				LOG_INFO_F(GL, "PartialExecProofsSet::AsynchProofCreationJob::execute - end (for seqNumber %" PRId64 ")", seqNumber);
 			}

--- a/bftengine/src/bftengine/PartialProofsSet.cpp
+++ b/bftengine/src/bftengine/PartialProofsSet.cpp
@@ -292,8 +292,8 @@ namespace bftEngine
 
 					//			me->sendToAllOtherReplicas(fcpMsg);
 
-					PassFullCommitProofAsInternalMsg* p = new PassFullCommitProofAsInternalMsg(me, fcpMsg);
-					me->getIncomingMsgsStorage().pushInternalMsg(p);
+                                        std::unique_ptr<InternalMessage> p(new PassFullCommitProofAsInternalMsg(me, fcpMsg));
+					me->getIncomingMsgsStorage().pushInternalMsg(std::move(p));
 				}
 
 				LOG_INFO_F(GL, "PartialProofsSet::AsynchProofCreationJob::execute - end (for seqNumber %" PRId64 ")", seqNumber);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -306,7 +306,7 @@ namespace bftEngine
 			IStateTransfer* getStateTransfer() const { return stateTransfer; }
 			ICommunication* getCommunication() const { return communication; }
 
-			void recvMsg(void*& item, bool& external);
+                        IncomingMsg recvMsg();
 
 			void processMessages();
 

--- a/bftengine/src/bftengine/RetransmissionsManager.cpp
+++ b/bftengine/src/bftengine/RetransmissionsManager.cpp
@@ -574,11 +574,11 @@ namespace bftEngine
 
 					logic->getSuggestedRetransmissions(currTime, *suggestedRetransmissions);
 
-					RetranProcResultInternalMsg* iMsg = new	RetranProcResultInternalMsg(
-						replica, lastStable, lastView, suggestedRetransmissions, retranManager);
+                                        std::unique_ptr<InternalMessage> iMsg(new RetranProcResultInternalMsg(
+						replica, lastStable, lastView, suggestedRetransmissions, retranManager));
 
 					// send to main thread
-					incomingMsgs->pushInternalMsg(iMsg);
+					incomingMsgs->pushInternalMsg(std::move(iMsg));
 
 				}
 


### PR DESCRIPTION
InternalMsgsStorage is used for transferring internal and external
messages across threads. This makes the queues use unique_ptrs instead
of raw pointers so that we don't have to keep track of ownership and
lifetimes cross thread. All callers and users were changed to reflect
the new types.

Note that this change causes no changes in the safety of the existing
code. It is being used an introduction to using unique_ptrs to indicate
transfer of ownership across function and data structure boundaries.
Future work will remove the need for manual deletes as the use of smart
pointers is continued.

This was stripped out of a much larger change that attempted to convert
all messages to being contained in unique_ptrs. That change was huge and
effectively unreviewable, so a piecemeal attempt is being made instead.