### PR TITLE
Fix typos in docs and comments for python tests.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -91,7 +91,7 @@ class, private methods, fields and functions begin with an underscore.
 The built in
 [__repr__](https://docs.python.org/3/reference/datamodel.html#object.__repr__)
 method is used for data and exception classes to return printable information.
-Write now it's human readable and not bound to python types, but we may want to
+Right now it's human readable and not bound to python types, but we may want to
 change that and add `__str__` methods later.
 
 # Writing a test

--- a/test/skvbc_linearizability.py
+++ b/test/skvbc_linearizability.py
@@ -291,7 +291,7 @@ class SkvbcTracker:
     been returned from the *state* of the kvstore before or after any concurrent
     requests with the read.
 
-    `_linearize_write_failures` works similar to `_linearize_reads`, in that it
+    `_linearize_write_failures` works similarly to `_linearize_reads`, in that it
     looks at concurrent write requests to determine if there was an anomaly. The
     anomaly in this case would be if the failed request had a readset that
     didn't actually intersect with any writesets in concurrent requests. This


### PR DESCRIPTION
Fixes based on a review done by @upshaw-alex for #106. Thanks for the review!