### PR TITLE
Configurable message size

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -17,6 +17,7 @@ set(corebft_source_files
     src/bftengine/SeqNumInfo.cpp
     src/bftengine/SignedShareMsgs.cpp
     src/bftengine/ReplicaImp.cpp
+    src/bftengine/ReplicaConfigSingleton.cpp
     src/bftengine/ClientReplyMsg.cpp
     src/bftengine/ReqMissingDataMsg.cpp
     src/bftengine/ClientRequestMsg.cpp

--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -101,6 +101,7 @@ struct Config {
   uint32_t maxPendingDataFromSourceReplica = 32 * 1024 * 1024;
 
   uint32_t maxNumOfReservedPages = 2048;
+  uint32_t sizeOfReservedPage = 4 * 1024;
 
   uint32_t refreshTimerMilli = 300;  // 300ms
   uint32_t checkpointSummariesRetransmissionTimeoutMilli = 2500;  // 2500ms

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -70,6 +70,14 @@ struct ReplicaConfig {
   // signer and verifier of a threshold signature (for threshold N out of N)
   IThresholdSigner *thresholdSignerForOptimisticCommit = nullptr;
   IThresholdVerifier *thresholdVerifierForOptimisticCommit = nullptr;
+
+  // Messages
+  uint32_t maxExternalMessageSize = 1 << 16;
+  uint32_t maxReplyMessageSize = 1 << 13;
+
+  // StateTransfer
+  uint32_t maxNumOfReservedPages = 1 << 11;
+  uint32_t sizeOfReservedPage = 1 << 12;
 };
 
 }

--- a/bftengine/include/bftengine/ReplicaConfigSingleton.hpp
+++ b/bftengine/include/bftengine/ReplicaConfigSingleton.hpp
@@ -1,0 +1,54 @@
+//Concord
+//
+//Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+//This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License. 
+//
+//This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+
+#pragma once
+
+#include <stdint.h>
+#include <set>
+#include <string>
+
+#include "ReplicaConfig.hpp"
+
+class IThresholdSigner;
+class IThresholdVerifier;
+
+namespace bftEngine {
+
+class ReplicaConfigSingleton {
+    public:
+	// Note, for initialization, this function is not thread-safe. The
+	// caller needs to make sure that only one thread at a time calls this
+	// function when a non-nullptr `config` parameter is supplied.
+	static ReplicaConfigSingleton& GetInstance(const ReplicaConfig* config=nullptr);
+
+	uint16_t GetFVal() const;
+	uint16_t GetCVal() const;
+	uint16_t GetReplicaId() const;
+	uint16_t GetNumOfClientProxies() const;
+	uint16_t GetStatusReportTimerMillisec() const;
+	uint16_t GetConcurrencyLevel() const;
+	bool GetAutoViewChangeEnabled() const;
+	uint16_t GetViewChangeTimerMillisec() const;
+	std::set<std::pair<uint16_t, std::string>> GetPublicKeysOfReplicas() const;
+	std::string GetReplicaPrivateKey() const;
+	IThresholdSigner const* GetThresholdSignerForExecution() const;
+	IThresholdVerifier const* GetThresholdVerifierForExecution() const;
+	IThresholdSigner const* GetThresholdSignerForSlowPathCommit() const;
+	IThresholdVerifier const* GetThresholdVerifierForSlowPathCommit() const;
+	IThresholdSigner const* GetThresholdSignerForCommit() const;
+	IThresholdVerifier const* GetThresholdVerifierForCommit() const;
+	IThresholdSigner const* GetThresholdSignerForOptimisticCommit() const;
+	IThresholdVerifier const* GetThresholdVerifierForOptimisticCommit() const;
+
+    private:
+	ReplicaConfigSingleton();
+	ReplicaConfig config_;
+	bool is_initialized_;
+};
+
+}  // namespace bftEngine

--- a/bftengine/include/bftengine/ReplicaConfigSingleton.hpp
+++ b/bftengine/include/bftengine/ReplicaConfigSingleton.hpp
@@ -44,6 +44,10 @@ class ReplicaConfigSingleton {
 	IThresholdVerifier const* GetThresholdVerifierForCommit() const;
 	IThresholdSigner const* GetThresholdSignerForOptimisticCommit() const;
 	IThresholdVerifier const* GetThresholdVerifierForOptimisticCommit() const;
+	uint32_t GetMaxExternalMessageSize() const;
+	uint32_t GetMaxReplyMessageSize() const;
+	uint32_t GetMaxNumOfReservedPages() const;
+	uint32_t GetSizeOfReservedPage() const;
 
     private:
 	ReplicaConfigSingleton();

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -144,7 +144,7 @@ BCStateTran::BCStateTran(
   :
   pedanticChecks_{ config.pedanticChecks },
   as_{ stateApi },
-  psd_{ createDataStore(persistentDataStore, kSizeOfReservedPage) },
+  psd_{ createDataStore(persistentDataStore, config.sizeOfReservedPage) },
   replicas_{ generateSetOfReplicas((3*config.fVal) + (2*config .cVal) + 1) },
   myId_{ config.myReplicaId },
   fVal_{ config.fVal },
@@ -153,6 +153,7 @@ BCStateTran::BCStateTran(
   maxNumberOfChunksInBatch_{ config.maxNumberOfChunksInBatch },
   maxPendingDataFromSourceReplica_{ config.maxPendingDataFromSourceReplica },
   maxNumOfReservedPages_{ config.maxNumOfReservedPages },
+  sizeOfReservedPage_{ config.sizeOfReservedPage },
   refreshTimerMilli_{ config.refreshTimerMilli },
   checkpointSummariesRetransmissionTimeoutMilli_
                     { config.checkpointSummariesRetransmissionTimeoutMilli },
@@ -161,10 +162,10 @@ BCStateTran::BCStateTran(
                              { config.sourceReplicaReplacementTimeoutMilli },
   fetchRetransmissionTimeoutMilli_{ config.fetchRetransmissionTimeoutMilli },
   maxVBlockSize_
-  { calcMaxVBlockSize(config.maxNumOfReservedPages, kSizeOfReservedPage) },
+  { calcMaxVBlockSize(config.maxNumOfReservedPages, sizeOfReservedPage_) },
   maxItemSize_{ calcMaxItemSize(config.maxBlockSize,
                                 config.maxNumOfReservedPages,
-                                 kSizeOfReservedPage) },
+                                config.sizeOfReservedPage) },
   maxNumOfChunksInAppBlock_{ calcMaxNumOfChunksInBlock(maxItemSize_,
                                                        config.maxBlockSize ,
                                                        config.maxChunkSize,
@@ -191,7 +192,7 @@ BCStateTran::BCStateTran(
     LOG_INFO(STLogger, "Creating BCStateTran object:" <<
         " myId_=" << myId_ <<
         " fVal_=" << fVal_ <<
-        " kSizeOfReservedPage=" << kSizeOfReservedPage);
+        " sizeOfReservedPage_=" << sizeOfReservedPage_);
 }
 
 BCStateTran::~BCStateTran() {
@@ -214,7 +215,7 @@ void BCStateTran::init(uint64_t maxNumOfRequiredStoredCheckpoints,
   Assert(!running_);
   Assert(replicaForStateTransfer_ == nullptr);
 
-  Assert(sizeOfReservedPage == kSizeOfReservedPage);
+  Assert(sizeOfReservedPage == sizeOfReservedPage_);
 
   maxNumOfStoredCheckpoints_ = maxNumOfRequiredStoredCheckpoints;
   numberOfReservedPages_ = numberOfRequiredReservedPages;
@@ -224,7 +225,7 @@ void BCStateTran::init(uint64_t maxNumOfRequiredStoredCheckpoints,
     LOG_INFO(STLogger, "Init BCStateTran object:" <<
     " maxNumOfStoredCheckpoints_=" << maxNumOfStoredCheckpoints_ <<
     " numberOfReservedPages_=" << numberOfReservedPages_ <<
-    " kSizeOfReservedPage=" << kSizeOfReservedPage);
+    " sizeOfReservedPage_=" << sizeOfReservedPage_);
 
   if (psd_->initialized()) {
     LOG_INFO(STLogger,
@@ -259,7 +260,7 @@ void BCStateTran::init(uint64_t maxNumOfRequiredStoredCheckpoints,
     psd_->setFirstStoredCheckpoint(0);
 
     for (uint32_t i = 0; i < numberOfReservedPages_; i++)  // reset all pages
-      psd_->setPendingResPage(i, buffer_, kSizeOfReservedPage);
+      psd_->setPendingResPage(i, buffer_, sizeOfReservedPage_);
 
     psd_->setIsFetchingState(false);
     psd_->setFirstRequiredBlock(0);
@@ -391,12 +392,12 @@ STDigest BCStateTran::checkpointReservedPages(uint64_t checkpointNumber) {
 
   for (uint32_t p : pages) {
     STDigest d;
-    psd_->getPendingResPage(p, buffer_, kSizeOfReservedPage);
-    computeDigestOfPage(p, checkpointNumber, buffer_, d);
+    psd_->getPendingResPage(p, buffer_, sizeOfReservedPage_);
+    computeDigestOfPage(p, checkpointNumber, buffer_, sizeOfReservedPage_, d);
     psd_->associatePendingResPageWithCheckpoint(p, checkpointNumber, d);
   }
 
-  memset(buffer_, 0, kSizeOfReservedPage);
+  memset(buffer_, 0, sizeOfReservedPage_);
   Assert(psd_->numOfAllPendingResPage() == 0);
   DataStore::ResPagesDescriptor* allPagesDesc =
                                   psd_->getResPagesDescriptor(checkpointNumber);
@@ -518,7 +519,7 @@ uint32_t BCStateTran::numberOfReservedPages() const {
 
 
 uint32_t BCStateTran::sizeOfReservedPage() const {
-  return kSizeOfReservedPage;
+  return sizeOfReservedPage_;
 }
 
 bool BCStateTran::loadReservedPage(uint32_t reservedPageId,
@@ -530,7 +531,7 @@ bool BCStateTran::loadReservedPage(uint32_t reservedPageId,
   Assert(running_);
   Assert(!isFetching());
   Assert(reservedPageId < numberOfReservedPages_);
-  Assert(copyLength <= kSizeOfReservedPage);
+  Assert(copyLength <= sizeOfReservedPage_);
 
 
   if (psd_->hasPendingResPage(reservedPageId)) {
@@ -558,21 +559,21 @@ void BCStateTran::saveReservedPage(uint32_t reservedPageId,
 
   Assert(!isFetching());
   Assert(reservedPageId < numberOfReservedPages_);
-  Assert(copyLength <= kSizeOfReservedPage);
+  Assert(copyLength <= sizeOfReservedPage_);
 
   psd_->setPendingResPage(reservedPageId, inReservedPage, copyLength);
 }
 
 void BCStateTran::zeroReservedPage(uint32_t reservedPageId) {
-    LOG_INFO(STLogger, "BCStateTran::zeroReservedPage - reservedPageId="
+    LOG_DEBUG(STLogger, "BCStateTran::zeroReservedPage - reservedPageId="
     << reservedPageId);
 
   Assert(!isFetching());
   Assert(reservedPageId < numberOfReservedPages_);
 
-  memset(buffer_, 0, kSizeOfReservedPage);
+  memset(buffer_, 0, sizeOfReservedPage_);
 
-  psd_->setPendingResPage(reservedPageId, buffer_, kSizeOfReservedPage);
+  psd_->setPendingResPage(reservedPageId, buffer_, sizeOfReservedPage_);
 }
 
 void BCStateTran::startCollectingState() {
@@ -692,7 +693,7 @@ struct ElementOfVirtualBlock {
   uint32_t pageId;
   uint64_t checkpointNumber;
   STDigest pageDigest;
-  char page[1];  // the actual size is kSizeOfReservedPage bytes
+  char page[1];  // the actual size is sizeOfReservedPage_ bytes
 };
 #pragma pack(pop)
 
@@ -1375,11 +1376,11 @@ bool BCStateTran::onMessage(const FetchResPagesMsg* m,
   }
 
   uint32_t vblockSize = getSizeOfVirtualBlock(vblock,
-                                              kSizeOfReservedPage);
+                                              sizeOfReservedPage_);
 
   Assert(vblockSize > sizeof(HeaderOfVirtualBlock));
   Assert(checkStructureOfVirtualBlock(vblock, vblockSize,
-                                      kSizeOfReservedPage));
+                                      sizeOfReservedPage_));
 
   // compute information about next chunk
 
@@ -1661,7 +1662,7 @@ char* BCStateTran::createVBlock(const DescOfVBlockForResPages& desc) {
 
   // allocate and fill block
   const uint32_t elementSize =
-    sizeof(ElementOfVirtualBlock) + kSizeOfReservedPage - 1;
+    sizeof(ElementOfVirtualBlock) + sizeOfReservedPage_ - 1;
   const uint32_t size =
     sizeof(HeaderOfVirtualBlock) + numberOfUpdatedPages * elementSize;
 
@@ -1674,7 +1675,7 @@ char* BCStateTran::createVBlock(const DescOfVBlockForResPages& desc) {
 
   if (numberOfUpdatedPages == 0) {
     Assert(checkStructureOfVirtualBlock(rawVBlock, size,
-                                        kSizeOfReservedPage));
+                                        sizeOfReservedPage_));
         LOG_INFO(STLogger, "New vblock contains " << 0
          << " updated pages , its size is " << size);
     return rawVBlock;
@@ -1690,7 +1691,7 @@ char* BCStateTran::createVBlock(const DescOfVBlockForResPages& desc) {
     STDigest pageDigest;
 
     psd_->getResPage(pageId, desc.checkpointNum, &actualPageCheckpoint,
-                     &pageDigest, buffer_, kSizeOfReservedPage);
+                     &pageDigest, buffer_, sizeOfReservedPage_);
     Assert(actualPageCheckpoint <= desc.checkpointNum);
     Assert(actualPageCheckpoint > desc.lastCheckpointKnownToRequester);
     Assert(!pageDigest.isZero());
@@ -1701,8 +1702,8 @@ char* BCStateTran::createVBlock(const DescOfVBlockForResPages& desc) {
     currElement->pageId = pageId;
     currElement->checkpointNumber = actualPageCheckpoint;
     currElement->pageDigest = pageDigest;
-    memcpy(currElement->page, buffer_, kSizeOfReservedPage);
-    memset(buffer_, 0, kSizeOfReservedPage);
+    memcpy(currElement->page, buffer_, sizeOfReservedPage_);
+    memset(buffer_, 0, sizeOfReservedPage_);
 
     idx++;
   }
@@ -1710,7 +1711,7 @@ char* BCStateTran::createVBlock(const DescOfVBlockForResPages& desc) {
   Assert(idx == numberOfUpdatedPages);
 
   Assert(!pedanticChecks_ ||
-         checkStructureOfVirtualBlock(rawVBlock, size, kSizeOfReservedPage));
+         checkStructureOfVirtualBlock(rawVBlock, size, sizeOfReservedPage_));
 
     LOG_INFO(STLogger, "New vblock contains " << numberOfUpdatedPages
     << " updated pages , its size is " << size);
@@ -1912,7 +1913,7 @@ bool BCStateTran::checkVirtualBlockOfResPages(
 
 
   if (!checkStructureOfVirtualBlock(vblock, vblockSize,
-                                    kSizeOfReservedPage)) {
+                                    sizeOfReservedPage_)) {
         LOG_WARN(STLogger, "vblock has illegal structure");
     return false;
   }
@@ -1942,7 +1943,7 @@ bool BCStateTran::checkVirtualBlockOfResPages(
     uint32_t nextUpdateIndex = 0;
 
     ElementOfVirtualBlock* nextUpdate =
-      getVirtualElement(0, kSizeOfReservedPage, vblock);
+      getVirtualElement(0, sizeOfReservedPage_, vblock);
 
     for (uint32_t i = 0; i < numberOfReservedPages_; i++) {
       Assert(pagesDesc->d[i].pageId == i);
@@ -1956,7 +1957,7 @@ bool BCStateTran::checkVirtualBlockOfResPages(
         nextUpdateIndex++;
         if (nextUpdateIndex < numberOfUpdatedPages) {
           nextUpdate =
-            getVirtualElement(nextUpdateIndex, kSizeOfReservedPage, vblock);
+            getVirtualElement(nextUpdateIndex, sizeOfReservedPage_, vblock);
         } else {
           nextUpdate = nullptr;
           break;
@@ -1982,13 +1983,13 @@ bool BCStateTran::checkVirtualBlockOfResPages(
   // check digests of new pages
   for (uint32_t i = 0; i < numberOfUpdatedPages; i++) {
     ElementOfVirtualBlock* e =
-      getVirtualElement(i, kSizeOfReservedPage, vblock);
+      getVirtualElement(i, sizeOfReservedPage_, vblock);
 
     // verified in checkStructureOfVirtualBlock
     Assert(e->checkpointNumber > 0);
 
     STDigest pageDigest;
-    computeDigestOfPage(e->pageId, e->checkpointNumber, e->page, pageDigest);
+    computeDigestOfPage(e->pageId, e->checkpointNumber, e->page, sizeOfReservedPage_, pageDigest);
 
     if (pageDigest != e->pageDigest) {
         LOG_WARN(STLogger, "vblock contains invalid digest for page "
@@ -2245,7 +2246,7 @@ void BCStateTran::processData() {
       uint32_t numOfUpdates = getNumberOfElements(buffer_);
       for (uint32_t i = 0; i < numOfUpdates; i++) {
         ElementOfVirtualBlock* e =
-          getVirtualElement(i, kSizeOfReservedPage, buffer_);
+          getVirtualElement(i, sizeOfReservedPage_, buffer_);
 
         psd_->setResPage(e->pageId, e->checkpointNumber,
                          e->pageDigest, e->page);
@@ -2520,19 +2521,19 @@ bool BCStateTran::checkConsistency(bool checkAllBlocks) {
 
         uint64_t actualCheckpoint = 0;
         psd_->getResPage(j, i, &actualCheckpoint,
-                         buffer_, kSizeOfReservedPage);
+                         buffer_, sizeOfReservedPage_);
 
         CH(allPagesDesc->d[j].relevantCheckpoint == actualCheckpoint);
 
         {
           STDigest d3;
-          computeDigestOfPage(j, actualCheckpoint, buffer_, d3);
+          computeDigestOfPage(j, actualCheckpoint, buffer_, sizeOfReservedPage_, d3);
 
           CH(d3 == allPagesDesc->d[j].pageDigest);
         }
       }
 
-      memset(buffer_, 0, kSizeOfReservedPage);
+      memset(buffer_, 0, sizeOfReservedPage_);
 
       psd_->free(allPagesDesc);
     }
@@ -2563,12 +2564,12 @@ bool BCStateTran::checkConsistency(bool checkAllBlocks) {
 
 void BCStateTran::computeDigestOfPage(
   const uint32_t pageId, const uint64_t checkpointNumber,
-  const char* page, STDigest& outDigest) {
+  const char* page, uint32_t pageSize, STDigest& outDigest) {
   DigestContext c;
   c.update(reinterpret_cast<const char*>(&pageId), sizeof(pageId));
   c.update(reinterpret_cast<const char*>(&checkpointNumber),
            sizeof(checkpointNumber));
-  if (checkpointNumber > 0) c.update(page, kSizeOfReservedPage);
+  if (checkpointNumber > 0) c.update(page, pageSize);
   c.writeDigest(reinterpret_cast<char*>(&outDigest));
 }
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -92,8 +92,6 @@ class BCStateTran : public IStateTransfer {
 
   static const uint64_t kMaxNumOfStoredCheckpoints = 10;
 
-  static const uint32_t kSizeOfReservedPage = 4 * 1024;
-
   static const uint16_t kMaxVBlocksInCache = 28;  // TBD
 
   static const uint32_t kResetCount_AskForCheckpointSummaries = 4;  // TBD
@@ -118,6 +116,7 @@ class BCStateTran : public IStateTransfer {
   const uint32_t maxPendingDataFromSourceReplica_;
 
   const uint32_t maxNumOfReservedPages_;
+  const uint32_t sizeOfReservedPage_;
   const uint32_t refreshTimerMilli_;
   const uint32_t checkpointSummariesRetransmissionTimeoutMilli_;
   const uint32_t maxAcceptableMsgDelayMilli_;
@@ -333,7 +332,7 @@ class BCStateTran : public IStateTransfer {
 
   static void computeDigestOfPage(
              const uint32_t pageId, const uint64_t checkpointNumber,
-             const char* page, STDigest& outDigest);
+             const char* page, uint32_t pageSize, STDigest& outDigest);
 
   static void computeDigestOfPagesDescriptor(
              const DataStore::ResPagesDescriptor* pagesDesc,

--- a/bftengine/src/bftengine/ClientReplyMsg.cpp
+++ b/bftengine/src/bftengine/ClientReplyMsg.cpp
@@ -9,6 +9,7 @@
 #include <string.h>
 #include "ClientReplyMsg.hpp"
 #include "assertUtils.hpp"
+#include "ReplicaConfigSingleton.hpp"
 
 namespace bftEngine
 {
@@ -16,7 +17,7 @@ namespace bftEngine
 	{
 
 		ClientReplyMsg::ClientReplyMsg(ReplicaId primaryId, ReqId reqSeqNum, ReplicaId replicaId)
-			: MessageBase(replicaId, MsgCode::Reply, maxExternalMessageSize) 
+			: MessageBase(replicaId, MsgCode::Reply, ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize())
 		{
 			b()->reqSeqNum = reqSeqNum;
 			b()->currentPrimaryId = primaryId;

--- a/bftengine/src/bftengine/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/ClientRequestMsg.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include "ClientRequestMsg.hpp"
 #include "assertUtils.hpp"
+#include "ReplicaConfigSingleton.hpp"
 
 namespace bftEngine
 {
@@ -54,7 +55,7 @@ namespace bftEngine
 		}
 
 		ClientRequestMsg::ClientRequestMsg(NodeIdType sender)
-			: MessageBase(sender, MsgCode::Request, maxExternalMessageSize)
+			: MessageBase(sender, MsgCode::Request, ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize())
 		{
 			b()->idOfClientProxy = sender;
 			b()->reqSeqNum = 0;

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -13,6 +13,7 @@
 #include "IStateTransfer.hpp"
 #include "assertUtils.hpp"
 #include "Logger.hpp"
+#include "ReplicaConfigSingleton.hpp"
 
 namespace bftEngine
 {
@@ -43,8 +44,8 @@ namespace bftEngine
 				idx++;
 			}
 
-			reservedPagesPerClient_ = maxReplyMessageSize / sizeOfReservedPage;
-			if (maxReplyMessageSize % sizeOfReservedPage != 0) reservedPagesPerClient_++;
+			reservedPagesPerClient_ = ReplicaConfigSingleton::GetInstance().GetMaxReplyMessageSize() / sizeOfReservedPage;
+			if (ReplicaConfigSingleton::GetInstance().GetMaxReplyMessageSize() % sizeOfReservedPage != 0) reservedPagesPerClient_++;
 
 			uint16_t numOfClients = (uint16_t)clientsSet.size();
 
@@ -88,7 +89,7 @@ namespace bftEngine
 				Assert(replyHeader->msgType == 0 || replyHeader->msgType == MsgCode::Reply);
 				Assert(replyHeader->currentPrimaryId == 0);
 				Assert(replyHeader->replyLength >= 0);
-				Assert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader)  <= maxReplyMessageSize);
+				Assert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader)  <= ReplicaConfigSingleton::GetInstance().GetMaxReplyMessageSize());
 
 				ClientInfo& ci = indexToClientInfo_.at(e.second);
 				ci.lastSeqNumberOfReply = replyHeader->reqSeqNum;
@@ -195,7 +196,7 @@ namespace bftEngine
 			Assert(replyHeader->msgType == MsgCode::Reply); 
 			Assert(replyHeader->currentPrimaryId == 0);
 			Assert(replyHeader->replyLength > 0);
-			Assert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplyMessageSize);
+			Assert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= ReplicaConfigSingleton::GetInstance().GetMaxReplyMessageSize());
 
 			uint32_t replyMsgSize = sizeof(ClientReplyMsgHeader) + replyHeader->replyLength;
 

--- a/bftengine/src/bftengine/MessageBase.cpp
+++ b/bftengine/src/bftengine/MessageBase.cpp
@@ -10,6 +10,7 @@
 
 #include "MessageBase.hpp"
 #include "assertUtils.hpp"
+#include "ReplicaConfigSingleton.hpp"
 
 #ifdef DEBUG_MEMORY_MSG
 #include <set>
@@ -169,7 +170,7 @@ MessageBase *MessageBase::createObjAndMsgFromLocalBuffer(char *buffer,
   RawHeaderOfObjAndMsg *pHeader = (RawHeaderOfObjAndMsg *) buffer;
   if (pHeader->magicNum != magicNumOfRawFormat) return nullptr;
   if (pHeader->msgSize == 0) return nullptr;
-  if (pHeader->msgSize > maxExternalMessageSize) return nullptr;
+  if (pHeader->msgSize > ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize()) return nullptr;
   if (pHeader->msgSize + sizeof(RawHeaderOfObjAndMsg) > bufferLength)
     return nullptr;
 

--- a/bftengine/src/bftengine/NewViewMsg.cpp
+++ b/bftengine/src/bftengine/NewViewMsg.cpp
@@ -8,6 +8,7 @@
 
 #include "NewViewMsg.hpp"
 #include "assertUtils.hpp"
+#include "ReplicaConfigSingleton.hpp"
  
 namespace bftEngine
 {
@@ -15,7 +16,7 @@ namespace bftEngine
 	{
 
 		NewViewMsg::NewViewMsg(ReplicaId senderId, ViewNum newView)
-			: MessageBase(senderId, MsgCode::NewView, maxExternalMessageSize)
+			: MessageBase(senderId, MsgCode::NewView, ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize())
 		{
 			b()->newViewNum = newView;
 			b()->elementsCount = 0;
@@ -28,7 +29,7 @@ namespace bftEngine
 			uint16_t requiredSize = sizeof(NewViewMsgHeader) + ((currNumOfElements + 1) * sizeof(NewViewElement));
 
 			// TODO(GG): we should reject configurations that may violate this assert. TODO(GG): we need something similar for the VC message
-			Assert(requiredSize <= maxExternalMessageSize); // not enough space in the message
+			Assert(requiredSize <= ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize()); // not enough space in the message
 
 			NewViewElement* elementsArray = (NewViewElement*)(body() + sizeof(NewViewMsgHeader));
 
@@ -126,7 +127,7 @@ namespace bftEngine
 
 		MsgSize NewViewMsg::maxSizeOfNewViewMsg()
 		{
-			return maxExternalMessageSize;
+			return ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize();
 		}
 
 		MsgSize NewViewMsg::maxSizeOfNewViewMsgInLocalBuffer()

--- a/bftengine/src/bftengine/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/PrePrepareMsg.cpp
@@ -9,6 +9,7 @@
 #include "PrePrepareMsg.hpp"
 #include "SysConsts.hpp"
 #include "Crypto.hpp"
+#include "ReplicaConfigSingleton.hpp"
 
 namespace bftEngine
 {
@@ -26,7 +27,7 @@ namespace bftEngine
 
 		MsgSize PrePrepareMsg::maxSizeOfPrePrepareMsg()
 		{
-			return maxExternalMessageSize;
+			return ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize();
 		}
 
 		MsgSize PrePrepareMsg::maxSizeOfPrePrepareMsgInLocalBuffer()

--- a/bftengine/src/bftengine/ReplicaConfigSingleton.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSingleton.cpp
@@ -118,4 +118,24 @@ IThresholdVerifier const* ReplicaConfigSingleton::GetThresholdVerifierForOptimis
     return config_.thresholdVerifierForOptimisticCommit;
 }
 
+uint32_t ReplicaConfigSingleton::GetMaxExternalMessageSize() const
+{
+    return config_.maxExternalMessageSize;
+}
+
+uint32_t ReplicaConfigSingleton::GetMaxReplyMessageSize() const
+{
+    return config_.maxReplyMessageSize;
+}
+
+uint32_t ReplicaConfigSingleton::GetMaxNumOfReservedPages() const
+{
+    return config_.maxNumOfReservedPages;
+}
+
+uint32_t ReplicaConfigSingleton::GetSizeOfReservedPage() const
+{
+    return config_.sizeOfReservedPage;
+}
+
 } // namespace bftEngine

--- a/bftengine/src/bftengine/ReplicaConfigSingleton.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSingleton.cpp
@@ -1,0 +1,121 @@
+//Concord
+//
+//Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+//This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License.
+//
+//This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+
+#include "ReplicaConfigSingleton.hpp"
+
+#include "ReplicaConfig.hpp"
+
+class IThresholdSigner;
+class IThresholdVerifier;
+
+namespace bftEngine
+{
+
+ReplicaConfigSingleton::ReplicaConfigSingleton() : is_initialized_(false) {}
+
+ReplicaConfigSingleton& ReplicaConfigSingleton::GetInstance(const ReplicaConfig* config)
+{
+    static ReplicaConfigSingleton instance;
+    if (!instance.is_initialized_ && config != nullptr) {
+        instance.config_ = *config;
+        instance.is_initialized_ = true;
+    }
+    return instance;
+}
+
+uint16_t ReplicaConfigSingleton::GetFVal() const
+{
+    return config_.fVal;
+}
+
+uint16_t ReplicaConfigSingleton::GetCVal() const
+{
+    return config_.cVal;
+}
+
+uint16_t ReplicaConfigSingleton::GetReplicaId() const
+{
+    return config_.replicaId;
+}
+
+uint16_t ReplicaConfigSingleton::GetNumOfClientProxies() const
+{
+    return config_.numOfClientProxies;
+}
+
+uint16_t ReplicaConfigSingleton::GetStatusReportTimerMillisec() const
+{
+    return config_.statusReportTimerMillisec;
+}
+
+uint16_t ReplicaConfigSingleton::GetConcurrencyLevel() const
+{
+    return config_.concurrencyLevel;
+}
+
+bool ReplicaConfigSingleton::GetAutoViewChangeEnabled() const
+{
+    return config_.autoViewChangeEnabled;
+}
+
+uint16_t ReplicaConfigSingleton::GetViewChangeTimerMillisec() const
+{
+    return config_.viewChangeTimerMillisec;
+}
+
+std::set<std::pair<uint16_t, std::string>> ReplicaConfigSingleton::GetPublicKeysOfReplicas() const
+{
+    return config_.publicKeysOfReplicas;
+}
+
+std::string ReplicaConfigSingleton::GetReplicaPrivateKey() const
+{
+    return config_.replicaPrivateKey;
+}
+
+IThresholdSigner const* ReplicaConfigSingleton::GetThresholdSignerForExecution() const
+{
+    return config_.thresholdSignerForExecution;
+}
+
+IThresholdVerifier const* ReplicaConfigSingleton::GetThresholdVerifierForExecution() const
+{
+    return config_.thresholdVerifierForExecution;
+}
+
+IThresholdSigner const* ReplicaConfigSingleton::GetThresholdSignerForSlowPathCommit() const
+{
+    return config_.thresholdSignerForSlowPathCommit;
+}
+
+IThresholdVerifier const* ReplicaConfigSingleton::GetThresholdVerifierForSlowPathCommit() const
+{
+    return config_.thresholdVerifierForSlowPathCommit;
+}
+
+IThresholdSigner const* ReplicaConfigSingleton::GetThresholdSignerForCommit() const
+{
+    return config_.thresholdSignerForCommit;
+}
+
+IThresholdVerifier const* ReplicaConfigSingleton::GetThresholdVerifierForCommit() const
+{
+    return config_.thresholdVerifierForCommit;
+}
+
+IThresholdSigner const* ReplicaConfigSingleton::GetThresholdSignerForOptimisticCommit() const
+{
+    return config_.thresholdSignerForOptimisticCommit;
+}
+
+IThresholdVerifier const* ReplicaConfigSingleton::GetThresholdVerifierForOptimisticCommit() const
+{
+    return config_.thresholdVerifierForOptimisticCommit;
+}
+
+} // namespace bftEngine

--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -55,15 +55,6 @@ constexpr uint16_t MaxConcurrentFastPaths = 75;
 static_assert(kWorkWindowSize > MaxConcurrentFastPaths + checkpointWindowSize, "Violation of kWorkWindowSize > MaxConcurrentFastPaths + checkpointWindowSize");
 static_assert(maxLegalConcurrentAgreementsByPrimary < MaxConcurrentFastPaths, "Violation of maxConcurrentAgreementsByPrimary < MaxConcurrentFastPaths");
 
-
-///////////////////////////////////////////////////////////////////////////////
-// Messages
-///////////////////////////////////////////////////////////////////////////////
-
-constexpr uint32_t maxExternalMessageSize = 64 * 1000; // TODO(GG): some message types may need different values  
-
-constexpr uint32_t maxReplyMessageSize = 8 * 1024;
-
 ///////////////////////////////////////////////////////////////////////////////
 // Batching
 ///////////////////////////////////////////////////////////////////////////////
@@ -117,9 +108,6 @@ constexpr bool dynamicCollectorForExecutionProofs = false; // if false, then the
 ///////////////////////////////////////////////////////////////////////////////
 
 constexpr int timeToWaitBeforeStartingStateTransferInMainWindowMilli = 2000; // TODO(GG): move to configuration??
-
-constexpr uint32_t sizeOfReservedPage = 4096;
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Debug and Tuning of ControllerWithSimpleHistory

--- a/bftengine/src/bftengine/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.cpp
@@ -12,13 +12,14 @@
 #include "assertUtils.hpp"
 #include "ViewChangeMsg.hpp"
 #include "Crypto.hpp"
+#include "ReplicaConfigSingleton.hpp"
 
 namespace bftEngine
 {
 	namespace impl
 	{
 
-		ViewChangeMsg::ViewChangeMsg(ReplicaId srcReplicaId, ViewNum newView, SeqNum lastStableSeq) : MessageBase(srcReplicaId, MsgCode::ViewChange, maxExternalMessageSize)
+		ViewChangeMsg::ViewChangeMsg(ReplicaId srcReplicaId, ViewNum newView, SeqNum lastStableSeq) : MessageBase(srcReplicaId, MsgCode::ViewChange, ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize())
 		{
 			b()->genReplicaId = srcReplicaId;
 			b()->newView = newView;
@@ -297,7 +298,7 @@ namespace bftEngine
 
 		MsgSize ViewChangeMsg::maxSizeOfViewChangeMsg()
 		{
-			return maxExternalMessageSize;
+			return ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize();
 		}
 
 		MsgSize ViewChangeMsg::maxSizeOfViewChangeMsgInLocalBuffer()


### PR DESCRIPTION
In order to access the replica configuration values from anywhere inside
concord-bft we can either pass around the ReplicaConfig structure, introduce a
global variable or create a singleton. The former isn't easy to do because it
would touch a lot of function signatures and hence would cause a lot of merge
conflicts for other developers. A singleton is pretty much a global variable
but with the guarantee of a consistent view. At the moment, the properties are
read-only but this is no blocker for future setters.
The main motivation is to make concord-bft properties configurable at start-up
time. Re-compiling every time we want to change a constant is simply not
practical. With the proposed approach, you can add a new config value to the
ReplicaConfig structure, add a getter in the singleton and use it wherever its
needed without passing around the ReplicaConfig structure.

- - -

**Review hint**

1st commit: Introduction of the singleton w/o changing existing logic
2nd commit: Replace constants with configurable values