### PR TITLE
Multisig transition preparation.

### DIFF
--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -85,13 +85,13 @@ concordlogger::Logger replicaLogger = concordlogger::Log::getLogger("simpletest.
 bftEngine::Replica *replica = nullptr;
 ReplicaParams rp;
 
-//void signalHandler(int signum) {
-//  if(replica)
-//    replica->stop();
-//
-//  LOG_INFO(replicaLogger, "replica " << rp.replicaId << " stopped");
-//  exit(0);
-//}
+void signalHandler( int signum ) {
+  if(replica)
+    replica->stop();
+
+  LOG_INFO(replicaLogger, "replica " << rp.replicaId << " stopped");
+  exit(0);
+}
 
 #define test_assert(statement, message) \
 { if (!(statement)) { \

--- a/logging/include/Logging.hpp
+++ b/logging/include/Logging.hpp
@@ -80,8 +80,7 @@ class Logger
     va_start (args, format);
     static constexpr size_t size = 1024;
     std::string output(size, '\0');
-    int res = std::vsnprintf(const_cast<char*>(output.c_str()), size, format, args);
-    assert(res >= 0);
+    std::vsnprintf(const_cast<char*>(output.c_str()), size, format, args);
     va_end(args);
 
     printf("%s %s (%s) %s\n",

--- a/threshsign/CMakeLists.txt
+++ b/threshsign/CMakeLists.txt
@@ -27,9 +27,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CXX_FLAGS_INTEGER_CORRECTNESS
     "-Wconversion -Wsign-conversion")
 
-set(CXX_FLAGS_OPTIMIZATIONS "-O3")
-
-string(APPEND CXX_FLAGS " ${CXX_FLAGS_OPTIMIZATIONS}")
 string(APPEND CXX_FLAGS " ${CXX_FLAGS_INTEGER_CORRECTNESS}")
 # TODO: use target_compile_features instead:
 #   https://cmake.org/cmake/help/v3.1/command/target_compile_features.html#command:target_compile_features

--- a/threshsign/include/threshsign/ThresholdSignaturesTypes.h
+++ b/threshsign/include/threshsign/ThresholdSignaturesTypes.h
@@ -105,6 +105,7 @@ private:
 
   uint16_t numSigners;
   uint16_t threshold;
+  bool     forceMultisig_;   // is true if  signers == threshold
 
   // If only one signer's private key is known and stored in this cryptosystem,
   // this field records that signer's ID; otherwise (if no or all private keys

--- a/threshsign/src/ThresholdSignaturesTypes.cpp
+++ b/threshsign/src/ThresholdSignaturesTypes.cpp
@@ -26,7 +26,7 @@ Cryptosystem::Cryptosystem(const std::string& sysType,
                              subtype(sysSubtype),
                              numSigners(sysNumSigners),
                              threshold(sysThreshold),
-                             forceMultisig_((numSigners == threshold)?true:false),
+                             forceMultisig_(numSigners == threshold),
                              signerID(NID),
                              publicKey("uninitialized")
 {

--- a/threshsign/src/ThresholdSignaturesTypes.cpp
+++ b/threshsign/src/ThresholdSignaturesTypes.cpp
@@ -21,7 +21,15 @@
 Cryptosystem::Cryptosystem(const std::string& sysType,
                            const std::string& sysSubtype,
                            uint16_t sysNumSigners,
-                           uint16_t sysThreshold) {
+                           uint16_t sysThreshold) :
+                             type(sysType),
+                             subtype(sysSubtype),
+                             numSigners(sysNumSigners),
+                             threshold(sysThreshold),
+                             forceMultisig_((numSigners == threshold)?true:false),
+                             signerID(NID),
+                             publicKey("uninitialized")
+{
   if (!isValidCryptosystemSelection(sysType, sysSubtype, sysNumSigners,
         sysThreshold)) {
     throw InvalidCryptosystemException("Invalid cryptosystem selection:"
@@ -29,18 +37,13 @@ Cryptosystem::Cryptosystem(const std::string& sysType,
       + std::to_string(sysNumSigners) + " signers and threshold of "
       + std::to_string(sysThreshold) + ".");
   }
-  type = sysType;
-  subtype = sysSubtype;
-  numSigners = sysNumSigners;
-  threshold = sysThreshold;
-  signerID = NID;
 }
 
 // Helper function to generateNewPseudorandomKeys.
 IThresholdFactory* Cryptosystem::createThresholdFactory() {
-  if (type == MULTISIG_BLS_SCHEME) {
+  if (type == MULTISIG_BLS_SCHEME || forceMultisig_) {
     return new BLS::Relic::BlsThresholdFactory(
-      BLS::Relic::PublicParametersFactory::getByCurveType(subtype.c_str()));
+      BLS::Relic::PublicParametersFactory::getByCurveType(subtype.c_str()), true);
   } else if (type == THRESHOLD_BLS_SCHEME) {
     return new BLS::Relic::BlsThresholdFactory(
       BLS::Relic::PublicParametersFactory::getByCurveType(subtype.c_str()));
@@ -59,8 +62,8 @@ void Cryptosystem::generateNewPseudorandomKeys() {
 
   std::tie(signers, verifier)
     = factory->newRandomSigners(threshold, numSigners);
-
-  publicKey = verifier->getPublicKey().toString();
+  if (forceMultisig_ || type == THRESHOLD_BLS_SCHEME)
+    publicKey = verifier->getPublicKey().toString();
 
   verificationKeys.clear();
   verificationKeys.push_back(""); // Account for 1-indexing of signer IDs.
@@ -85,7 +88,7 @@ void Cryptosystem::generateNewPseudorandomKeys() {
 }
 
 std::string Cryptosystem::getSystemPublicKey() const {
-  if (publicKey.length() < 1) {
+  if ((forceMultisig_ || type == THRESHOLD_BLS_SCHEME) && publicKey.length() < 1) {
     throw UninitializedCryptosystemException("A public key has not been"
       " generated or loaded for this cryptosystem.");
   }
@@ -225,8 +228,11 @@ static const size_t expectedPublicKeyLength = 130;
 static const size_t expectedVerificationKeyLength = 130;
 
 bool Cryptosystem::isValidPublicKey(const std::string& key) const {
-  return (key.length() == expectedPublicKeyLength)
-      && (std::regex_match(key, std::regex("[0-9A-Fa-f]+")));
+  if (forceMultisig_ || type == THRESHOLD_BLS_SCHEME)
+    return (key.length() == expectedPublicKeyLength)
+        && (std::regex_match(key, std::regex("[0-9A-Fa-f]+")));
+  else
+    return true;
 }
 
 bool Cryptosystem::isValidVerificationKey(const std::string& key) const {
@@ -284,13 +290,7 @@ bool Cryptosystem::isValidCryptosystemSelection(const std::string& type,
     return false;
   }
 
-  // Note MULTISIG_BLS scheme is not a true threshold scheme and is only
-  // allowable if the threshold equals the number of signers.
-  if ((type == MULTISIG_BLS_SCHEME) && (threshold != numSigners)) {
-   return false;
-  } else {
    return isValidCryptosystemSelection(type, subtype);
-  }
 }
 
 void Cryptosystem::getAvailableCryptosystemTypes(

--- a/threshsign/src/VectorOfShares.cpp
+++ b/threshsign/src/VectorOfShares.cpp
@@ -161,9 +161,7 @@ void VectorOfShares::toBytes(unsigned char * buf, int capacity) const {
         int byteOffset = id0 / 8;
         int bit = id0 % 8;
         int mask = 1 << bit;
-        //logdbg << "Serializing ID " << id1 << " at byte " << byteOffset
-        //    << " and bit " << bit << " with mask " << mask << endl;
-
+        //LOG_TRACE(GL,  "Serializing ID " << id1 << " at byte " << byteOffset << " and bit " << bit << " with mask " << mask );
         *(buf + byteOffset) = static_cast<unsigned char>(*(buf + byteOffset) | mask);
     }
 }
@@ -183,7 +181,7 @@ void VectorOfShares::fromBytes(const unsigned char * buf, int len) {
         for(int c = 0; c < 8; c++) {
             if(byte & bitMask) {
                 int id1 = b * 8 + (c+1);
-                //LOG_DEBUG(GL, "bitMask = " << bitMask << ", deserialized ID " << id1 << " from byte " << (int)byte);
+                //LOG_TRACE(GL, "bitMask = " << bitMask << ", deserialized ID " << id1 << " from byte " << (int)byte);
                 add(id1);
             }
 

--- a/threshsign/src/bls/relic/BlsMultisigAccumulator.cpp
+++ b/threshsign/src/bls/relic/BlsMultisigAccumulator.cpp
@@ -58,7 +58,6 @@ void BlsMultisigAccumulator::sigToBytes(unsigned char * outThreshSig, int thresh
 }
 
 void BlsMultisigAccumulator::aggregateShares() {
-    assertEqual(validSharesBits.count(), reqSigners);
     threshSig = G1T::Identity();
 
     // multiply all the signature shares to obtain the multisig

--- a/threshsign/src/bls/relic/BlsMultisigVerifier.cpp
+++ b/threshsign/src/bls/relic/BlsMultisigVerifier.cpp
@@ -93,14 +93,13 @@ bool BlsMultisigVerifier::verify(const char *msg, int msgLen,
     int idbufLen = VectorOfShares::getByteCount();
     signers.fromBytes(reinterpret_cast<const unsigned char *>(idbuf), idbufLen);
 
+    if(signers.count() < reqSigners_)
+      return false;
     // for reqSigners != numSigners, need to derive PK from signer IDs
-    if (reqSigners_ != numSigners_) {
-      publicKey_ = G2T::Identity();
-      for (ShareID id = signers.first(); !signers.isEnd(id);
-           id = signers.next(id)) {
-        auto idx = static_cast<size_t>(id);
-        publicKey_.y.Add(publicKeysVector_[idx].getPoint());
-      }
+    publicKey_ = G2T::Identity();
+    for (ShareID id = signers.first(); !signers.isEnd(id); id = signers.next(id)) {
+      auto idx = static_cast<size_t>(id);
+      publicKey_.y.Add(publicKeysVector_[idx].getPoint());
     }
   }
 

--- a/threshsign/src/bls/relic/BlsNumTypes.cpp
+++ b/threshsign/src/bls/relic/BlsNumTypes.cpp
@@ -229,11 +229,11 @@ BNT BNT::invertModPrime(const BNT& p) const {
 void G1T::toBytes(unsigned char * buf, int size) const {
     assertGreaterThanOrEqual(size, getByteCount());
     g1_write_bin(buf, size, n, 1);
-    //LOG_DEBUG(GL, "Wrote G1T of " << size << " bytes");
+    //LOG_TRACE(GL, "Wrote G1T of " << size << " bytes");
 }
 
 void G1T::fromBytes(const unsigned char * buf, int size) {
-    //LOG_DEBUG(GL, "Reading G1T of " << size << " bytes");
+    //LOG_TRACE(GL, "Reading G1T of " << size << " bytes");
     g1_read_bin(n, buf, size);
 }
 

--- a/tools/GenerateConcordKeys.cpp
+++ b/tools/GenerateConcordKeys.cpp
@@ -106,7 +106,8 @@ static bool parseUInt16(uint16_t& output,
  *         parameters, but it will not return an exit code indicating an error.
  */
 int main(int argc, char** argv) {
-
+try
+{
   std::string usageMessage = "Usage:\n"
     "GenerateConcordKeys -n TOTAL_NUMBER_OF_REPLICAS \\\n"
       "  -f NUMBER_OF_FAULTY_REPLICAS_TO_TOLERATE -o OUTPUT_FILE_PREFIX\n"
@@ -155,13 +156,22 @@ int main(int argc, char** argv) {
   bool hasN = false;
   bool hasOutput = false;
 
-  std::string execType = "threshold-bls";
+//  std::string execType = MULTISIG_BLS_SCHEME;
+//  std::string execParam = "BN-P254";
+//  std::string slowType = MULTISIG_BLS_SCHEME;
+//  std::string slowParam = "BN-P254";
+//  std::string commitType = MULTISIG_BLS_SCHEME;
+//  std::string commitParam = "BN-P254";
+//  std::string optType = MULTISIG_BLS_SCHEME;
+//  std::string optParam = "BN-P254";
+
+  std::string execType = THRESHOLD_BLS_SCHEME;
   std::string execParam = "BN-P254";
-  std::string slowType = "threshold-bls";
+  std::string slowType = THRESHOLD_BLS_SCHEME;
   std::string slowParam = "BN-P254";
-  std::string commitType = "threshold-bls";
+  std::string commitType = THRESHOLD_BLS_SCHEME;
   std::string commitParam = "BN-P254";
-  std::string optType = "multisig-bls";
+  std::string optType = MULTISIG_BLS_SCHEME;
   std::string optParam = "BN-P254";
   
   // Read input from the command line.
@@ -358,6 +368,10 @@ int main(int argc, char** argv) {
       return -1;
     }
   }
-
+}catch(std::exception& e)
+{
+  std::cerr << "Exception: " << e.what() << std::endl;
+  return 1;
+}
   return 0;
 }

--- a/tools/TestGeneratedKeys.cpp
+++ b/tools/TestGeneratedKeys.cpp
@@ -571,8 +571,8 @@ static bool testThresholdSignature(const std::string& cryptosystemName,
     char* sigBuf = new char[signatureLength];
     try {
       accumulator->getFullSignedData(sigBuf, signatureLength);
-    } catch (std::exception e) {
-      std::cout << invalidKeyset;
+    } catch (std::exception& e) {
+      std::cout << invalidKeyset << e.what() << std::endl;
       releaseAccumulator(verifier, accumulator);
       delete[] sigBuf;
       return false;
@@ -643,13 +643,13 @@ static bool testThresholdCryptosystem(
   // keys for this cryptosystem.
   for (uint16_t i = 0; i < numSigners; ++i) {
     IThresholdVerifier* verifier = verifiers[i];
-    if (verifier->getPublicKey().toString()
-          != referenceVerifier->getPublicKey().toString()) {
-      std::cout << "TestGeneratedKeys: FAILURE: Replica " << i << "'s key file"
-        " has the wrong public key for the " << name << " threshold"
-        " cryptosystem.\n";
-      return false;
-    }
+//    if (verifier->getPublicKey().toString()
+//          != referenceVerifier->getPublicKey().toString()) {
+//      std::cout << "TestGeneratedKeys: FAILURE: Replica " << i << "'s key file"
+//        " has the wrong public key for the " << name << " threshold"
+//        " cryptosystem.\n";
+//      return false;
+//    }
     for (uint16_t j = 0; j < numSigners; ++j) {
       if (verifier->getShareVerificationKey(j).toString()
             != referenceVerifier->getShareVerificationKey(j).toString()) {

--- a/tools/TestGeneratedKeys.cpp
+++ b/tools/TestGeneratedKeys.cpp
@@ -643,13 +643,13 @@ static bool testThresholdCryptosystem(
   // keys for this cryptosystem.
   for (uint16_t i = 0; i < numSigners; ++i) {
     IThresholdVerifier* verifier = verifiers[i];
-//    if (verifier->getPublicKey().toString()
-//          != referenceVerifier->getPublicKey().toString()) {
-//      std::cout << "TestGeneratedKeys: FAILURE: Replica " << i << "'s key file"
-//        " has the wrong public key for the " << name << " threshold"
-//        " cryptosystem.\n";
-//      return false;
-//    }
+    if (verifier->getPublicKey().toString()
+          != referenceVerifier->getPublicKey().toString()) {
+      std::cout << "TestGeneratedKeys: FAILURE: Replica " << i << "'s key file"
+        " has the wrong public key for the " << name << " threshold"
+        " cryptosystem.\n";
+      return false;
+    }
     for (uint16_t j = 0; j < numSigners; ++j) {
       if (verifier->getShareVerificationKey(j).toString()
             != referenceVerifier->getShareVerificationKey(j).toString()) {


### PR DESCRIPTION
Currently multisig is used as an n-out-of-n optimisation for threshold signatures.
Eventually we want to use multisig as a default signing scheme.
In this commit all n-out-of-n assumptions were cleaned out.
No real usage of multisig is done yet.

Tests:
- testGeneratedKeys.sh
	* with existing configuration
	* with multisig-bls for all cryptosystems
- ./simpleTest.py
	* -bft n=6,r=6,f=1,c=1,cl=2,testViewChange
	* -bft n=6,r=6,f=1,c=1,cl=2
	* -bft n=6,r=5,f=1,c=1,cl=2,testViewChange
	* -bft n=6,r=5,f=1,c=1,cl=2
	* -bft n=6,r=4,f=1,c=1,cl=2