### PR TITLE
Fix build warning about incorrect format

### DIFF
--- a/bftengine/src/bftengine/DebugStatistics.cpp
+++ b/bftengine/src/bftengine/DebugStatistics.cpp
@@ -86,7 +86,7 @@ namespace bftEngine
 			fprintf(stdout, "numberOfReceivedSTMessages = %zd\t", d.numberOfReceivedSTMessages);
 			fprintf(stdout, "numberOfReceivedStatusMessages = %zd\t", d.numberOfReceivedStatusMessages);
 			fprintf(stdout, "numberOfReceivedCommitMessages = %zd\t", d.numberOfReceivedCommitMessages);
-			fprintf(stdout, "lastExecutedSeqNumber = %lld\t", d.lastExecutedSequenceNumber);
+			fprintf(stdout, "lastExecutedSeqNumber = %ld\t", d.lastExecutedSequenceNumber);
 			fprintf(stdout, "\n");
 
 			if (d.completedReadOnlyRequests > 0 || d.completedReadWriteRequests > 0)


### PR DESCRIPTION
Clang 7 gave the following warning. I made the suggested change to clear it up.

```
concord-bft/bftengine/src/bftengine/DebugStatistics.cpp:89:54: warning: format specifies type 'long long' but the argument has type 'int64_t' (aka 'long') [-Wformat]
                        fprintf(stdout, "lastExecutedSeqNumber = %lld\t", d.lastExecutedSequenceNumber);
                                                                 ~~~~     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                 %ld
1 warning generated.
```