### PR TITLE
enable -Werror for compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ string(APPEND CXX_FLAGS " -Wbuiltin-macro-redefined")
 if(IS_LEAKCHECK)
     string(APPEND CXX_FLAGS " -fsanitize=leak")
 endif()
-#string(APPEND CXX_FLAGS " -Werror")
+string(APPEND CXX_FLAGS " -Werror")
 #string(APPEND CXX_FLAGS " -Wextra")
 
 # TODO: Figure out right way to deal with -fstrict-overflow / -Wstrict-overflow related errors

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -20,7 +20,7 @@
 #include "ReplicaImp.hpp"
 #include "ViewsManager.hpp"
 #include "FullCommitProofMsg.hpp"
-#include "Logging.hpp"
+#include "Logger.hpp"
 
 # define Verify(expr, errorCode) {                                          \
     Assert(expr);                                                    \
@@ -68,7 +68,7 @@ ReplicaLoader::ErrorCode checkReplicaConfig(const LoadedReplicaData &ld) {
   Verify(!c.replicaPrivateKey.empty(), InconsistentErr); // TODO(GG): make sure that the key is valid
 
 //	Verify(c.thresholdSignerForExecution == nullptr, InconsistentErr);
-//	Verify(c.thresholdVerifierForExecution == nullptr, InconsistentErr); 
+//	Verify(c.thresholdVerifierForExecution == nullptr, InconsistentErr);
 
   Verify(c.thresholdSignerForSlowPathCommit != nullptr, InconsistentErr);
   Verify(c.thresholdVerifierForSlowPathCommit != nullptr, InconsistentErr);

--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -10,7 +10,7 @@
 // terms and conditions of the subcomponent's license, as noted in the
 // LICENSE file.
 
-#include "Logging.hpp"
+#include "Logger.hpp"
 #include "CommDefs.hpp"
 
 #include <iostream>

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -20,7 +20,7 @@
 
 #include "SimpleStateTransfer.hpp"
 #include "SimpleBCStateTransfer.hpp"
-#include "Logging.hpp"
+#include "Logger.hpp"
 
 #define Assert(expr) {                                             \
     if((expr) != true) {                                                    \
@@ -681,4 +681,3 @@ uint64_t SimpleStateTran::DummyBDState::getLastBlockNum() {
 }  // namespace impl
 }  // namespace SimpleInMemoryStateTransfer
 }  // namespace bftEngine
-

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -42,7 +42,11 @@
 #include "test_parameters.hpp"
 #include "histogram.hpp"
 #include "misc.hpp"
-#include "Logging.hpp"
+#include "Logger.hpp"
+
+#ifdef USE_LOG4CPP
+#include <log4cplus/configurator.h>
+#endif
 
 using bftEngine::ICommunication;
 using bftEngine::PlainUDPCommunication;

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -61,7 +61,11 @@
 #include "SimpleStateTransfer.hpp"
 #include "test_comm_config.hpp"
 #include "test_parameters.hpp"
-#include "Logging.hpp"
+#include "Logger.hpp"
+
+#ifdef USE_LOG4CPP
+#include <log4cplus/configurator.h>
+#endif
 
 // simpleTest includes
 #include "commonDefs.h"

--- a/threshsign/test/TestThresholdSerialization.cpp
+++ b/threshsign/test/TestThresholdSerialization.cpp
@@ -75,9 +75,7 @@ const char verificationKeyValue4[] =
 
 const int numOfSigners = 3;
 
-BlsPublicParameters params(PublicParametersFactory::getWhatever());
-
-bool testBlsThresholdSigner() {
+bool testBlsThresholdSigner(const BlsPublicParameters &params) {
   ShareID id = 0x208419;
   BNT secretKey(secretKeyValue);
   SharedPtrToClass origSigner(new BlsThresholdSigner(params, id, secretKey));
@@ -115,7 +113,7 @@ void printRawBuf(const UniquePtrToChar &buf, int64_t bufSize) {
   }
 }
 
-bool testBlsThresholdVerifier(const vector<BlsPublicKey> &verificationKeys) {
+bool testBlsThresholdVerifier(const BlsPublicParameters &params, const vector<BlsPublicKey> &verificationKeys) {
   G2T publicKey(publicKeyValue);
 
   SharedPtrToClass origVerifier(new BlsThresholdVerifier(params, publicKey, numOfSigners,
@@ -132,7 +130,7 @@ bool testBlsThresholdVerifier(const vector<BlsPublicKey> &verificationKeys) {
   return (resultVerifier && (*inVerifier == *outVerifier));
 }
 
-bool testBlsMultisigVerifier(const vector<BlsPublicKey> &verificationKeys) {
+bool testBlsMultisigVerifier(const BlsPublicParameters &params, const vector<BlsPublicKey> &verificationKeys) {
   SharedPtrToClass origVerifier(new BlsMultisigVerifier(params, numOfSigners, numOfSigners, verificationKeys));
 
   UniquePtrToChar buf;
@@ -150,10 +148,12 @@ int RelicAppMain(const Library &lib, const vector<string> &args) {
   (void) args;
   (void) lib;
 
-  assertTrue(testBlsThresholdSigner());
+  BlsPublicParameters params(PublicParametersFactory::getWhatever());
+
+  assertTrue(testBlsThresholdSigner(params));
   vector<BlsPublicKey> verificationKeys = prepareVerificationKeysVector();
-  assertTrue(testBlsThresholdVerifier(verificationKeys));
-  assertTrue(testBlsMultisigVerifier(verificationKeys));
+  assertTrue(testBlsThresholdVerifier(params, verificationKeys));
+  assertTrue(testBlsMultisigVerifier(params, verificationKeys));
 
   return 0;
 }


### PR DESCRIPTION
While the build is clean, let's turn on warnings-as-errors, to help
keep it that way.