### PR TITLE
Fix formatting errors which result in clang warnings

### DIFF
--- a/bftengine/src/bftengine/DebugStatistics.cpp
+++ b/bftengine/src/bftengine/DebugStatistics.cpp
@@ -86,7 +86,7 @@ namespace bftEngine
 			fprintf(stdout, "numberOfReceivedSTMessages = %zd\t", d.numberOfReceivedSTMessages);
 			fprintf(stdout, "numberOfReceivedStatusMessages = %zd\t", d.numberOfReceivedStatusMessages);
 			fprintf(stdout, "numberOfReceivedCommitMessages = %zd\t", d.numberOfReceivedCommitMessages);
-			fprintf(stdout, "lastExecutedSeqNumber = %ld\t", d.lastExecutedSequenceNumber);
+			fprintf(stdout, "lastExecutedSeqNumber = %lld\t", d.lastExecutedSequenceNumber);
 			fprintf(stdout, "\n");
 
 			if (d.completedReadOnlyRequests > 0 || d.completedReadWriteRequests > 0)

--- a/bftengine/src/bftengine/DebugStatistics.cpp
+++ b/bftengine/src/bftengine/DebugStatistics.cpp
@@ -86,7 +86,7 @@ namespace bftEngine
 			fprintf(stdout, "numberOfReceivedSTMessages = %zd\t", d.numberOfReceivedSTMessages);
 			fprintf(stdout, "numberOfReceivedStatusMessages = %zd\t", d.numberOfReceivedStatusMessages);
 			fprintf(stdout, "numberOfReceivedCommitMessages = %zd\t", d.numberOfReceivedCommitMessages);
-			fprintf(stdout, "lastExecutedSeqNumber = %lld\t", d.lastExecutedSequenceNumber);
+			fprintf(stdout, "lastExecutedSeqNumber = %" PRId64 "\t", d.lastExecutedSequenceNumber);
 			fprintf(stdout, "\n");
 
 			if (d.completedReadOnlyRequests > 0 || d.completedReadWriteRequests > 0)

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2015,7 +2015,7 @@ namespace bftEngine
 			}
 
 			LOG_INFO_F(GL, "**************** In onNewView curView=%" PRId64 " (num of PPs=%ld, first safe seq=%" PRId64 ","
-                       " last safe seq=%" PRId64 ", lastStableSeqNum=%lld, lastExecutedSeqNum=%" PRId64 ","
+                       " last safe seq=%" PRId64 ", lastStableSeqNum=%" PRId64 ", lastExecutedSeqNum=%" PRId64 ","
                        "stableLowerBoundWhenEnteredToView= %" PRId64 ")",
 				       curView, prePreparesForNewView.size(), firstPPSeq, lastPPSeq,
 				       lastStableSeqNum, lastExecutedSeqNum, viewsManager->stableLowerBoundWhenEnteredToView());

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -611,7 +611,7 @@ namespace bftEngine
 				if (absDifference(currTime, timeOfPartProof) < controller->timeToStartSlowPathMilli() * 1000)
 					break; // don't try the next seq numbers
 
-				LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%llu timeOfPartProof=%llu",
+				LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%" PRIu64 " timeOfPartProof=%" PRIu64,
 				           i, currTime, timeOfPartProof);
 
 				controller->onStartingSlowCommit(i);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -611,7 +611,7 @@ namespace bftEngine
 				if (absDifference(currTime, timeOfPartProof) < controller->timeToStartSlowPathMilli() * 1000)
 					break; // don't try the next seq numbers
 
-				LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%ld timeOfPartProof=%ld",
+				LOG_INFO_F(GL, "Primary initiates slow path for seqNum=%" PRId64 " (currTime=%llu timeOfPartProof=%llu",
 				           i, currTime, timeOfPartProof);
 
 				controller->onStartingSlowCommit(i);
@@ -2015,7 +2015,7 @@ namespace bftEngine
 			}
 
 			LOG_INFO_F(GL, "**************** In onNewView curView=%" PRId64 " (num of PPs=%ld, first safe seq=%" PRId64 ","
-                       " last safe seq=%" PRId64 ", lastStableSeqNum=%ld, lastExecutedSeqNum=%" PRId64 ","
+                       " last safe seq=%" PRId64 ", lastStableSeqNum=%lld, lastExecutedSeqNum=%" PRId64 ","
                        "stableLowerBoundWhenEnteredToView= %" PRId64 ")",
 				       curView, prePreparesForNewView.size(), firstPPSeq, lastPPSeq,
 				       lastStableSeqNum, lastExecutedSeqNum, viewsManager->stableLowerBoundWhenEnteredToView());


### PR DESCRIPTION
This PR addresses formatting warnings emitted by clang, as documented in #132 which cause the build to break when compiling using clang after #129 enabled -Werror. In particular, the wrong formatting type (long instead of long long) were used in these formatting strings. This patch fixes the formatting strings.

In the future, it might be a good idea to have CI test builds under both clang and gcc.

Fixes #132 