### PR TITLE
Introduce conan package manager

### DIFF
--- a/.cmake/pmm.cmake
+++ b/.cmake/pmm.cmake
@@ -1,0 +1,65 @@
+## MIT License
+##
+## Copyright (c) 2018 vector-of-bool
+##
+## Permission is hereby granted, free of charge, to any person obtaining a copy
+## of this software and associated documentation files (the "Software"), to deal
+## in the Software without restriction, including without limitation the rights
+## to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+## copies of the Software, and to permit persons to whom the Software is
+## furnished to do so, subject to the following conditions:
+##
+## The above copyright notice and this permission notice shall be included in all
+## copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+## AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+## OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+## SOFTWARE.
+
+# Bump this version to change what PMM version is downloaded
+set(PMM_VERSION_INIT 1.3.1)
+
+# Helpful macro to set a variable if it isn't already set
+macro(_pmm_set_if_undef varname)
+    if(NOT DEFINED "${varname}")
+        set("${varname}" "${ARGN}")
+    endif()
+endmacro()
+
+## Variables used by this script
+# The version:
+_pmm_set_if_undef(PMM_VERSION ${PMM_VERSION_INIT})
+# The base URL we download PMM from:
+_pmm_set_if_undef(PMM_URL_BASE "https://vector-of-bool.github.io/pmm")
+# The real URL we download from (Based on the version)
+_pmm_set_if_undef(PMM_URL "${PMM_URL_BASE}/${PMM_VERSION}")
+# The directory where we store our downloaded files
+_pmm_set_if_undef(PMM_DIR_BASE "${CMAKE_BINARY_DIR}/_pmm")
+_pmm_set_if_undef(PMM_DIR "${PMM_DIR_BASE}/${PMM_VERSION}")
+
+# The file that we first download
+set(_PMM_ENTRY_FILE "${PMM_DIR}/entry.cmake")
+
+if(NOT EXISTS "${_PMM_ENTRY_FILE}" OR PMM_ALWAYS_DOWNLOAD)
+    file(
+        DOWNLOAD "${PMM_URL}/entry.cmake"
+        "${_PMM_ENTRY_FILE}.tmp"
+        STATUS pair
+        )
+    list(GET pair 0 rc)
+    list(GET pair 1 msg)
+    if(rc)
+        message(FATAL_ERROR "Failed to download PMM entry file")
+    endif()
+    file(RENAME "${_PMM_ENTRY_FILE}.tmp" "${_PMM_ENTRY_FILE}")
+endif()
+
+# ^^^ DO NOT CHANGE THIS LINE vvv
+set(_PMM_BOOTSTRAP_VERSION 1)
+# ^^^ DO NOT CHANGE THIS LINE ^^^
+
+include("${_PMM_ENTRY_FILE}")

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/gtest"]
-	path = deps/gtest
-	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,16 @@ if(SLEEP_FOR_DBG)
     add_definitions(-DSLEEP_DBG)
 endif()
 
+# Package Manager Manager (pmm) which pulls Conan
+# https://github.com/vector-of-bool/pmm
+# CMP0057 is required
+cmake_policy(SET CMP0057 NEW)
+include(.cmake/pmm.cmake)
+pmm(CONAN
+    BUILD missing
+    BINCRAFTERS
+    COMMUNITY)
+
 #
 # Compiler options
 #
@@ -154,8 +164,6 @@ add_subdirectory(tools)
 # Setup testing
 #
 if(BUILD_TESTING)
-    add_submodule("deps/gtest")
-    add_subdirectory(deps/gtest)
     add_subdirectory(bftengine/tests)
     add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -101,18 +101,6 @@ Build and install [RELIC](https://github.com/relic-toolkit/relic)
     make
     sudo make install
 
-Build and install [cryptopp](https://github.com/weidai11/cryptopp)
-
-    cd
-    git clone https://github.com/weidai11/cryptopp.git
-    cd cryptopp/
-    git checkout CRYPTOPP_5_6_5;
-    mkdir build/
-    cd build/
-    cmake ..
-    make
-    sudo make install
-
 Get GNU Parallel
 
     sudo apt-get install parallel

--- a/bftengine/tests/bcstatetransfer/CMakeLists.txt
+++ b/bftengine/tests/bcstatetransfer/CMakeLists.txt
@@ -10,5 +10,5 @@ target_include_directories(bcstatetransfer_tests
     ${bftengine_SOURCE_DIR}/src/bcstatetransfer
     ${bftengine_SOURCE_DIR}/src/bftengine)
 
-target_link_libraries(bcstatetransfer_tests gtest_main)
+target_link_libraries(bcstatetransfer_tests CONAN_PKG::gtest)
 target_link_libraries(bcstatetransfer_tests corebft)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,7 @@
+import conans
+
+class ConcordBft(conans.ConanFile):
+    name = 'concord-bft'
+    version = '0.1.0'
+    generators = 'cmake'
+    requires = ('gtest/1.8.1@bincrafters/stable','cryptopp/5.6.5@bincrafters/stable')

--- a/threshsign/CMakeLists.txt
+++ b/threshsign/CMakeLists.txt
@@ -92,7 +92,7 @@ function(link_with_relic_library targetName)
         PUBLIC
         ${RELIC_STATIC_LIBRARY}
         ${GMP_STATIC_LIBRARY}
-        ${CRYPTOPP_STATIC_LIBRARY})
+        CONAN_PKG::cryptopp)
 endfunction()
 
 function(add_relic_executable appName appSrc appDir)
@@ -147,9 +147,6 @@ endif()
 find_library(RELIC_STATIC_LIBRARY NAMES "librelic_s.a")
 
 find_library(GMP_STATIC_LIBRARY NAMES "libgmp.a")
-
-find_package(cryptopp REQUIRED)
-find_library(CRYPTOPP_STATIC_LIBRARY NAMES "libcryptopp.a")
 
 #
 # Targets

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(metric_tests metric_test.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(metric_tests metric_tests)
-target_link_libraries(metric_tests gtest_main util)
+target_link_libraries(metric_tests CONAN_PKG::gtest util)
 
 add_executable(metric_server MetricServerTestMain.cpp $<TARGET_OBJECTS:logging_dev>)
 target_link_libraries(metric_server util)
@@ -11,4 +11,4 @@ add_test(NAME metric_server_tests COMMAND python3 -m unittest
 
 add_executable(mt_tests multithreading.cpp)
 add_test(util_mt_tests mt_tests)
-target_link_libraries(mt_tests gtest_main util)
+target_link_libraries(mt_tests CONAN_PKG::gtest util)


### PR DESCRIPTION
This PR introduces [Conan](http://conan.io) as a package manager, and uses [Package Manager Manager (pmm)](https://github.com/vector-of-bool/pmm) to transparently install Conan, if necessary, during cmake configuration.

Google test has been removed as a submodule, since it is now pulled by Conan instead.

Conan currently installs Google test and cryptopp as a dependencies. The readme has been updated to reflect that cryptopp no longer needs to be installed on the developer's system (and should also eliminate version conflict issues).

Relic doesn't have a Conan package yet. After this PR is accepted, getting Relic packaged in a way it can be consumed by Conan would be next.