### PR TITLE
Introduce simple Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: bionic
+language: cpp
+
+jobs:
+  include:
+  - os: linux
+    compiler: gcc
+    dist: bionic
+    before_install:
+      - .travis/preinstall.sh
+    script:
+      - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake .. && make -j $(getconf _NPROCESSORS_ONLN) && ctest
+  - os: linux
+    compiler: clang
+    dist: bionic
+    before_install:
+      - .travis/preinstall.sh
+    script:
+      - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake .. && make -j $(getconf _NPROCESSORS_ONLN) && ctest

--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Install needed packages
+if [[ "$OSTYPE" == "darwin"* ]]; then
+# Nothing needed for macos
+echo "macos homebrew packages handled in .travis.yml"
+else
+# If on Linux, install necessary packages using apt
+sudo apt-get update
+sudo apt-get install -y ccache cmake clang-format libgmp3-dev parallel python3-pip python3-setuptools
+fi
+
+# build and install relic
+cd $TRAVIS_BUILD_DIR
+git clone https://github.com/relic-toolkit/relic
+cd relic
+git checkout b984e901ba78c83ea4093ea96addd13628c8c2d0
+mkdir -p build
+cd build
+CC=/usr/bin/gcc CXX=/usr/bin/g++ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DALLOC=AUTO -DWSIZE=64 -DRAND=UDEV -DSHLIB=ON -DSTLIB=ON -DSTBIN=OFF -DTIMER=HREAL -DCHECK=on -DVERBS=on -DARITH=x64-asm-254 -DFP_PRIME=254 -DFP_METHD="INTEG;INTEG;INTEG;MONTY;LOWER;SLIDE" -DCOMP="-O3 -funroll-loops -fomit-frame-pointer -finline-small-functions -march=native -mtune=native" -DFP_PMERS=off -DFP_QNRES=on -DFPX_METHD="INTEG;INTEG;LAZYR" -DPP_METHD="LAZYR;OATEP" ..
+CC=/usr/bin/gcc CXX=/usr/bin/g++ make
+sudo make install
+
+# build and install cryptopp
+cd $TRAVIS_BUILD_DIR
+git clone https://github.com/weidai11/cryptopp.git
+cd cryptopp
+git checkout CRYPTOPP_5_6_5
+mkdir build
+cd build
+cmake ..
+make
+sudo make install
+
+# trio is need for tests
+python3 -m pip install --upgrade trio


### PR DESCRIPTION
This PR introduces a patch that introduces a simple Travis-CI build.

It currently builds on the Ubuntu 18.04 (bionic) infrastructure, using the distribution provided clang and gcc, and also macos with xcode10.1 (Mojave).

In currently does not run tests or clang-format. It should in the future (or I could amend this PR to).

This shouldn't be merged yet, as the build currently fails. 

The GCC build fails with an error about unused variables, documented in #136. This PR shouldn't be merged until the fix, #137, is merged.

The clang build succeeds.

The macos build fails with an error about format specifiers, documented in #132. This PR shouldn't be merged until that issue is fixed. This shows that #132 seems to actually be a cross platform issue. Merging #133 should fix this build.