### PR TITLE
Remove unused variables which cause build to fail under GCC

### DIFF
--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -156,13 +156,9 @@ ReplicaLoader::ErrorCode loadViewInfo(PersistentStorage *p, LoadedReplicaData &l
 
   Verify((stat == Succ), stat);
 
-  ViewNum initialViewNum = 0;
-  bool isInView = false;
   ViewsManager *viewsManager = nullptr;
   if (!hasDescLastExitFromView && !hasDescOfLastNewView) {
 
-    initialViewNum = 0;
-    isInView = true;
     viewsManager = ViewsManager::createInsideViewZero(
         ld.repsInfo,
         ld.repConfig.thresholdVerifierForSlowPathCommit);
@@ -175,8 +171,6 @@ ReplicaLoader::ErrorCode loadViewInfo(PersistentStorage *p, LoadedReplicaData &l
 
     Verify((descriptorOfLastExitFromView.view == 0), InconsistentErr);
 
-    initialViewNum = 0;
-    isInView = false;
     viewsManager = ViewsManager::createOutsideView(
         ld.repsInfo,
         ld.repConfig.thresholdVerifierForSlowPathCommit,
@@ -196,8 +190,6 @@ ReplicaLoader::ErrorCode loadViewInfo(PersistentStorage *p, LoadedReplicaData &l
 
     Verify((descriptorOfLastExitFromView.view >= 1), InconsistentErr);
 
-    initialViewNum = descriptorOfLastExitFromView.view;
-    isInView = false;
     viewsManager = ViewsManager::createOutsideView(
         ld.repsInfo,
         ld.repConfig.thresholdVerifierForSlowPathCommit,
@@ -218,8 +210,6 @@ ReplicaLoader::ErrorCode loadViewInfo(PersistentStorage *p, LoadedReplicaData &l
     Verify((descriptorOfLastExitFromView.view >= 0), InconsistentErr);
     Verify((descriptorOfLastNewView.view >= 1), InconsistentErr);
 
-    initialViewNum = descriptorOfLastNewView.view;
-    isInView = true;
     viewsManager = ViewsManager::createInsideView(
         ld.repsInfo,
         ld.repConfig.thresholdVerifierForSlowPathCommit,


### PR DESCRIPTION
This PR removes unused variables in ```ReplicaLoader.cpp``` which were causing the build to fail with GCC using -Werror. It appears that these variables were being used to track intermediate state at some point (perhaps for debug?) and are no longer being used.

This PR fixes #136 and should be merged before accepting #135. 