### PR TITLE
Add missing include

### DIFF
--- a/bftengine/src/bftengine/DebugStatistics.cpp
+++ b/bftengine/src/bftengine/DebugStatistics.cpp
@@ -17,6 +17,7 @@
 #else
 #include <sys/time.h>
 #endif
+#include <inttypes.h>
 #include <stdio.h>
 #include "MsgCode.hpp"
 


### PR DESCRIPTION
This PR addresses issue #138 where the build fails because ```inttypes.h``` is not included from ```DebugStatistics.cpp```, which is required to use the PRId64 identifier, at least on macos.

Fixes #138