### PR TITLE
Fix timeout comparison in SimpleClient

### DIFF
--- a/bftengine/src/bftengine/SimpleClient.cpp
+++ b/bftengine/src/bftengine/SimpleClient.cpp
@@ -257,7 +257,8 @@ namespace bftEngine
 
 				const Time currTime = getMonotonicTime();
 
-				if (timeoutMilli != INFINITE_TIMEOUT && (uint64_t)absDifference(beginTime, currTime) > timeoutMilli)
+                                // absDifference returns microseconds, so scale up timeoutMilli to match
+				if (timeoutMilli != INFINITE_TIMEOUT && (uint64_t)absDifference(beginTime, currTime) > timeoutMilli * 1000)
 				{
 					requestTimeout = true;
 					break;


### PR DESCRIPTION
SimpleClient::sendRequest compares its timeoutMilli argument against
the return value of bftengine::impl::absDifference (in TimeUtils.hpp),
which returns a value in microseconds. This change scales the
millisecond argument up to microseconds when performing the
comparison.