### PR TITLE
Fix build by removing zconf.h include

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -17,7 +17,6 @@
 #include "PersistentStorageImp.hpp"
 
 #include <mutex>
-#include <zconf.h>
 
 namespace bftEngine {
 namespace impl {


### PR DESCRIPTION
It's not needed and we don't have instructions to install zlib in the
README.