### PR TITLE
Fix skvbc tests

### DIFF
--- a/bftengine/tests/simpleKVBC/src/CMakeLists.txt
+++ b/bftengine/tests/simpleKVBC/src/CMakeLists.txt
@@ -12,8 +12,11 @@ set(simpleKVBC_sources
 )
 
 add_library(simpleKVBC ${simpleKVBC_sources})
-target_link_libraries(simpleKVBC PUBLIC corebft threshsign util)
+target_link_libraries(simpleKVBC PUBLIC corebft threshsign util
+    simple_file_storage_lib)
 
 target_include_directories(simpleKVBC PUBLIC .)
 target_include_directories(simpleKVBC PUBLIC ../../../../tools)
 target_include_directories(simpleKVBC PUBLIC ../include)
+target_include_directories(simpleKVBC PUBLIC ${bftengine_SOURCE_DIR}/tests/simpleStorage)
+

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <inttypes.h>
 #include <chrono>
 
@@ -33,6 +34,8 @@
 #include "SimpleBCStateTransfer.hpp"
 #include "InMemoryDBClient.h"
 #include "KeyfileIOUtils.hpp"
+#include "FileStorage.hpp"
+#include "Logger.hpp"
 
 using namespace bftEngine;
 using namespace bftEngine::SimpleBlockchainStateTransfer;
@@ -774,11 +777,20 @@ IReplica* createReplica(const ReplicaConfig& c,
 		RequestsHandlerImp* reqHandler = new RequestsHandlerImp();
 		reqHandler->m_Executor = r;
 
+                // Use a file for persistence
+                std::ostringstream dbFile;
+                dbFile << "SimpleKVBCTest" << replicaConfig.replicaId << ".txt";
+                remove(dbFile.str().c_str());
+                concordlogger::Logger replicaLogger = 
+                  concordlogger::Log::getLogger("simpletest.replica");
+
+                MetadataStorage *fileStorage = new FileStorage(replicaLogger, dbFile.str());
+
 		Replica* replica = Replica::createNewReplica(&replicaConfig,
 			reqHandler,
 			stateTransfer,
 			comm,
-			nullptr);
+			fileStorage);
                 replica->SetAggregator(aggregator);
 
 		r->m_replica = replica;


### PR DESCRIPTION
Runnng `make test` was causing the skvbc_tests to fail. Running in
verbose mode, an assert was being triggered because persistence wasn't
setup properly.

```
15: skvbc_replica: /home/andrewstone/concord-bft/bftengine/src/bftengine/BFTEngine.cpp:123: static bftEngine::Replica *bftEngine::Replica::createNewReplica(bftEngine::ReplicaConfig *, bftEngine::RequestsHandler *, bftEngine::IStateTransfer *, bftEngine::ICommunication *, bftEngine::MetadataStorage *): Assertion `false' failed.
```

PR #130 was merged in without running the automated tests which caused
this failure. The fix was to use the FileStorage class as backing for
MetadataStorage when calling the SimpleKVBC::ReplicaImp constructor. We
also could have turned on debugPersistence and avoided the assertion,
but it's better to be running our tests with actual persistence. This
way we can start testing the persistence itself from the testing
framework.