### PR TITLE
Add a Timers class to the util library

### DIFF
--- a/util/include/Timers.hpp
+++ b/util/include/Timers.hpp
@@ -1,0 +1,144 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <functional>
+#include <stdint.h>
+#include <chrono>
+#include <vector>
+#include <algorithm>
+
+namespace concordUtil {
+
+// A collection of timers backed by a vector.
+class Timers {
+ public:
+  class Handle {
+    Handle() {}
+    Handle(uint64_t id) : id_(id) {}
+
+   private:
+    uint64_t id_;
+    friend class Timers;
+  };
+
+  class Timer {
+   public:
+    enum Type {
+      ONESHOT,
+      RECURRING,
+    };
+
+   private:
+    Timer(std::chrono::milliseconds d, Type t, std::function<void()> cb) {
+      Timer(d, t, cb, std::chrono::steady_clock::now());
+    }
+
+    Timer(std::chrono::milliseconds d, Type t, std::function<void()> cb, std::chrono::steady_clock::time_point now)
+        : duration_(d), expires_at_(now + d), type_(t), callback_(cb) {}
+
+    bool expired() const { return expired(std::chrono::steady_clock::now()); }
+
+    bool expired(std::chrono::steady_clock::time_point now) const { return now >= expires_at_; }
+
+    bool recurring() const { return type_ == Type::RECURRING; }
+
+    void run_callback() { callback_(); }
+
+    void reset(std::chrono::steady_clock::time_point now) { expires_at_ = now + duration_; }
+
+    void reset(std::chrono::steady_clock::time_point now, std::chrono::milliseconds d) {
+      duration_ = d;
+      expires_at_ = now + duration_;
+    }
+
+    std::chrono::milliseconds duration_;
+    std::chrono::steady_clock::time_point expires_at_;
+    Type type_;
+    uint64_t id_;
+    std::function<void()> callback_;
+
+    friend class Timers;
+  };
+
+ public:
+  Timers() : id_counter_(0) {}
+
+  Handle add(std::chrono::milliseconds d, Timer::Type t, std::function<void()> cb) {
+    return add(d, t, cb, std::chrono::steady_clock::now());
+  }
+
+  Handle add(std::chrono::milliseconds d,
+             Timer::Type t,
+             std::function<void()> cb,
+             std::chrono::steady_clock::time_point now) {
+    timers_.emplace_back(Timer(d, t, cb, now));
+    id_counter_ += 1;
+    Handle h{id_counter_};
+    timers_.back().id_ = h.id_;
+    return h;
+  }
+
+  std::vector<Timer>::iterator find(Handle handle) {
+    auto it = std::find_if(timers_.begin(), timers_.end(), [&handle](Timer t) { return t.id_ == handle.id_; });
+    if (it == timers_.end()) {
+      throw std::invalid_argument("invalid timer handle");
+    }
+    return it;
+  }
+
+  void reset(Handle handle, std::chrono::milliseconds d) { reset(handle, d, std::chrono::steady_clock::now()); }
+
+  void reset(Handle handle, std::chrono::milliseconds d, std::chrono::steady_clock::time_point now) {
+    auto it = find(handle);
+    it->reset(now, d);
+  }
+
+  void cancel(Handle handle) {
+    auto it = find(handle);
+    timers_.erase(it);
+  }
+
+  // Run the callbacks for all expired timers, and reschedule them if they are
+  // recurring.
+  void evaluate() { evaluate(std::chrono::steady_clock::now()); }
+
+  void evaluate(std::chrono::steady_clock::time_point now) {
+    if (timers_.empty()) return;
+
+    // Expired ids must be stored separately since erasing causes iterator
+    // invalidation.
+    std::vector<Handle> to_cancel;
+
+    for (auto& timer : timers_) {
+      if (timer.expired(now)) {
+        timer.run_callback();
+        if (timer.recurring()) {
+          timer.reset(now);
+        } else {
+          to_cancel.push_back(Handle(timer.id_));
+        }
+      }
+    }
+
+    for (auto& handle : to_cancel) {
+      cancel(handle);
+    }
+  }
+
+ private:
+  std::vector<Timer> timers_;
+  uint64_t id_counter_;
+};
+
+}  // namespace concordUtil

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -24,3 +24,7 @@ add_executable(serializable_test serializable_test.cpp $<TARGET_OBJECTS:logging_
 add_test(serializable_test serializable_test)
 target_link_libraries(serializable_test gtest util)
 target_compile_options(serializable_test PUBLIC -Wno-sign-compare)
+
+add_executable(timers_tests timers_tests.cpp $<TARGET_OBJECTS:logging_dev>)
+add_test(timers_tests timers_tests)
+target_link_libraries(timers_tests gtest_main util)

--- a/util/test/timers_tests.cpp
+++ b/util/test/timers_tests.cpp
@@ -1,0 +1,108 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+
+#include <cstdlib>
+#include "gtest/gtest.h"
+#include "Timers.hpp"
+
+using namespace std;
+using namespace std::chrono;
+
+namespace concordUtil {
+
+TEST(TimersTest, Basic) {
+  milliseconds duration(100);
+
+  int oneshot_counter = 0;
+  int recurring_counter = 0;
+  auto timers = Timers();
+  steady_clock::time_point now = steady_clock::now();
+
+  // Create a oneshot and a recurring timer and add them to the heap. Each one
+  // will fire a callback when it expires that increments a counter.
+  timers.add(duration, Timers::Timer::ONESHOT, [&oneshot_counter]() { ++oneshot_counter; }, now);
+  auto recurring_handle =
+      timers.add(duration, Timers::Timer::RECURRING, [&recurring_counter]() { ++recurring_counter; }, now);
+
+  // Clock hasn't advanced so no timers should fire
+  timers.evaluate(now);
+  ASSERT_EQ(0, oneshot_counter);
+  ASSERT_EQ(0, recurring_counter);
+
+  // Fake steady clock advancement
+  now += duration;
+
+  // Both timers should fire as clock has advanced past their expiry time
+  timers.evaluate(now);
+  ASSERT_EQ(1, oneshot_counter);
+  ASSERT_EQ(1, recurring_counter);
+
+  // No timers should fire, as they already fired and the clock hasn't moved
+  timers.evaluate(now);
+  ASSERT_EQ(1, oneshot_counter);
+  ASSERT_EQ(1, recurring_counter);
+
+  // Advance the clock again.
+  now += duration;
+
+  // Only the recurring timer should fire as the oneshot has been removed.
+  timers.evaluate(now);
+  ASSERT_EQ(1, oneshot_counter);
+  ASSERT_EQ(2, recurring_counter);
+
+  // Reset the duration of the recurring timer to be twice as long.
+  timers.reset(recurring_handle, duration * 2, now);
+
+  // Advance the clock by the original duration.
+  now += duration;
+
+  // Neither timer should fire as the recurring timer is the only one left, and
+  // it hasn't expired yet.
+  timers.evaluate(now);
+  ASSERT_EQ(1, oneshot_counter);
+  ASSERT_EQ(2, recurring_counter);
+
+  // Advance the clock by the original duration again.
+  now += duration;
+
+  // The recurring timer which was rescheduled should fire, since the extended
+  // duration has elapsed.
+  timers.evaluate(now);
+  ASSERT_EQ(1, oneshot_counter);
+  ASSERT_EQ(3, recurring_counter);
+
+  // Delete the recurring timer
+  timers.cancel(recurring_handle);
+
+  // Advance the clock again by the extended duration.
+  now += duration * 2;
+
+  // No timers should fire as both have been removed.
+  timers.evaluate(now);
+  ASSERT_EQ(1, oneshot_counter);
+  ASSERT_EQ(3, recurring_counter);
+
+  // Add a third timer and ensure it fires.
+  // This tests the monotonicity of counter ids as used by handles.
+  bool third_timer_fired = false;
+  auto handle = timers.add(duration, Timers::Timer::ONESHOT, [&third_timer_fired]() { third_timer_fired = true; }, now);
+  now += duration;
+  timers.evaluate(now);
+  ASSERT_TRUE(third_timer_fired);
+
+  // Try to reset a timer that no longer exists. This should throw an exception.
+  ASSERT_THROW(timers.reset(handle, duration * 2, now), std::invalid_argument);
+}
+
+}  // namespace concordUtil


### PR DESCRIPTION
`Timers` maintains a vector of timers, where each is associated with a
callback.  The `Timers::evaluate` method finds all expired timers and
runs their corresponding callback.

Timers can be either `ONESHOT` or `RECURRING`. A ONESHOT timer will be
removed from the collection after it fires once. A RECURRING timer will be
rescheduled to expire at the current time + the duration passed to it's
constructor. Durations can be modified by calling the `Timers::reset`
method with the handle returned from calling `Timers::add`.

The Timer and Timers classes use the std::chrono::steady_clock, and
utilize std::chrono types for safety, to reduce the occurrence of issues
like those in #141.

A detailed test showing how to use the API is also part of this commit.

Future commits will use the Timers class instead of the
SimpleTimerScheduler to provide a typesafe interface for callbacks,
and allow the removal of timer methods from the InternalReplicaAPI. We
can also remove the *TimerHandlerFunc methods from ReplicaImp, since
recurring timers will be rescheduled automatically.