### PR TITLE
Default debugPersistentStorageEnabled to true

### DIFF
--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -137,4 +137,4 @@ constexpr uint32_t MaxSizeOfPrivateKey = 1024; // TODO(GG): should be checked
 constexpr uint32_t MaxSizeOfPublicKey = 1024; // TODO(GG): should be checked
 
 
-constexpr bool debugPersistentStorageEnabled = false;
+constexpr bool debugPersistentStorageEnabled = true;

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -34,7 +34,6 @@
 #include "SimpleBCStateTransfer.hpp"
 #include "InMemoryDBClient.h"
 #include "KeyfileIOUtils.hpp"
-#include "FileStorage.hpp"
 #include "Logger.hpp"
 
 using namespace bftEngine;
@@ -777,20 +776,11 @@ IReplica* createReplica(const ReplicaConfig& c,
 		RequestsHandlerImp* reqHandler = new RequestsHandlerImp();
 		reqHandler->m_Executor = r;
 
-                // Use a file for persistence
-                std::ostringstream dbFile;
-                dbFile << "SimpleKVBCTest" << replicaConfig.replicaId << ".txt";
-                remove(dbFile.str().c_str());
-                concordlogger::Logger replicaLogger = 
-                  concordlogger::Log::getLogger("simpletest.replica");
-
-                MetadataStorage *fileStorage = new FileStorage(replicaLogger, dbFile.str());
-
 		Replica* replica = Replica::createNewReplica(&replicaConfig,
 			reqHandler,
 			stateTransfer,
 			comm,
-			fileStorage);
+			nullptr);
                 replica->SetAggregator(aggregator);
 
 		r->m_replica = replica;


### PR DESCRIPTION
Our tests don't all work with persistent storage. As the storage is not
yet configurable, re-enable debugPersistentStorageEnabled = true, so
that tests pass.

Also, remove related FileStorage code from simpleKVBC, as it makes no
sense to have persistent metadata with in memory application state.

Fixes #152