### PR TITLE
Fix the way logger library compiles with outer components, e.g. concord.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Default USE_LOG4CPP to FALSE
-option(USE_LOG4CPP "Enable LOG4CPP" FALSE)
+if (NOT DEFINED USE_LOG4CPP)
+  option(USE_LOG4CPP "Enable LOG4CPP" FALSE)
+endif()
 
 # Default BUILD_COMM_TCP_PLAIN to FALSE
 option(BUILD_COMM_TCP_PLAIN "Enable TCP communication" FALSE)

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -1,21 +1,16 @@
 add_library(logging INTERFACE)
 target_include_directories(logging INTERFACE include/)
 
-#default logger initialization for tests
-add_library(logging_dev OBJECT src/Logger.cpp)
-target_include_directories(logging_dev PUBLIC include/)
-
-
-#############################################################################################
-#  Find log4cplus
+#######################################################################################################################
+#  Find log4cplus TODO [TK] drop when use conan
 #  Once done this will define
 #  LOG4CPLUS_FOUND        - System has log4cplus
 #  LOG4CPLUS_INCLUDE_DIRS - The log4cplus include directories
 #  LOG4CPLUS_LIBRARIES    - The libraries needed to use log4cplus
 #  LOG4CPLUS_DEFINITIONS  - Compiler switches required for using log4cplus
 
-if(${USE_LOG4CPP})
-  set_property(DIRECTORY . APPEND PROPERTY COMPILE_DEFINITIONS USE_LOG4CPP) 
+if(USE_LOG4CPP)
+  message(STATUS "USE_LOG4CPP")
   # First try pkg-config piggybacking
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
@@ -43,23 +38,33 @@ if(${USE_LOG4CPP})
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(LOG4CPLUS DEFAULT_MSG LOG4CPLUS_LIBRARIES LOG4CPLUS_INCLUDE_DIRS)
   endif()
-  
-  #export to upper level 
-  set_property(DIRECTORY .. APPEND PROPERTY LINK_LIBRARIES      ${LOG4CPLUS_LIBRARIES})
-  set_property(DIRECTORY .. APPEND PROPERTY INCLUDE_DIRECTORIES ${LOG4CPLUS_INCLUDE_DIRS})
-  set_property(DIRECTORY .. APPEND PROPERTY COMPILE_DEFINITIONS USE_LOG4CPP) 
-  target_include_directories(logging_dev PUBLIC ${LOG4CPLUS_INCLUDE_DIRS})
-
 endif()
-#############################################################################################
+#######################################################################################################################
 # Default CONCORD_LOGGER_NAME to "concord"
+
 if(NOT CONCORD_LOGGER_NAME)
     set(CONCORD_LOGGER_NAME "concord" CACHE STRING "Set concord logger name" FORCE)
 endif()
-target_compile_definitions(logging INTERFACE DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}")
-target_compile_definitions(logging_dev PUBLIC DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}")
 
-#export to upper level
-set_property(DIRECTORY .. APPEND PROPERTY COMPILE_DEFINITIONS DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}") 
-set_property(DIRECTORY .. APPEND PROPERTY INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:logging,INTERFACE_INCLUDE_DIRECTORIES>")
-set_property(DIRECTORY .. APPEND PROPERTY COMPILE_OPTIONS "-Wformat=2")
+#######################################################################################################################
+#export all the way up to the top level directory
+
+set(current_dir ${CMAKE_CURRENT_SOURCE_DIR})
+while(NOT current_dir STREQUAL "")
+  message(STATUS "setting logger compile definitions for [${current_dir}]")
+  if(USE_LOG4CPP)
+    set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_DEFINITIONS USE_LOG4CPP)
+    set_property(DIRECTORY ${current_dir} APPEND PROPERTY LINK_LIBRARIES      ${LOG4CPLUS_LIBRARIES})
+    set_property(DIRECTORY ${current_dir} APPEND PROPERTY INCLUDE_DIRECTORIES ${LOG4CPLUS_INCLUDE_DIRS})
+  endif()
+  set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_DEFINITIONS DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}")
+  set_property(DIRECTORY ${current_dir} APPEND PROPERTY INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:logging,INTERFACE_INCLUDE_DIRECTORIES>")
+  set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_OPTIONS "-Wformat=2")
+  get_property(current_dir DIRECTORY ${current_dir} PROPERTY PARENT_DIRECTORY)
+endwhile()
+
+#######################################################################################################################
+#default logger initialization for tests
+
+add_library(logging_dev OBJECT src/Logger.cpp)
+target_include_directories(logging_dev PUBLIC include/)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -3,8 +3,6 @@ find_package(Threads REQUIRED)
 
 add_library(util STATIC src/Metrics.cpp src/MetricsServer.cpp src/SimpleThreadPool.cpp src/Serializable.cpp src/histogram.cpp include/misc.hpp)
 
-TARGET_COMPILE_DEFINITIONS(util PUBLIC DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}")
-
 target_link_libraries(util PUBLIC Threads::Threads)
 target_include_directories(util PUBLIC include)
 


### PR DESCRIPTION
1. Recursivelly propagate comilation options and definitions from logging lib to upper directories all the way to the invoking project root direcotry,
   populating their scopes.
2. Concord-bft to use USE_LOG4CPP defined by the invoking project. Default remains FALSE.
3. Removed duplicate definition of DEFAULT_LOGGER_NAME.