### PR TITLE
Remove unneeded double semicolons (;;)

### DIFF
--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -144,7 +144,7 @@ struct ItemDataMsg : public BCStateTranBaseMsg {
   char data[1];
 
   uint32_t size() const {
-    return sizeof(ItemDataMsg) - 1 + dataSize;;
+    return sizeof(ItemDataMsg) - 1 + dataSize;
   }
 };
 

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -314,7 +314,7 @@ bool DebugPersistentStorage::getFetchingState() {
 
 SeqNum DebugPersistentStorage::getLastExecutedSeqNum() {
   Assert(getIsAllowed());
-  return lastExecutedSeqNum_;;
+  return lastExecutedSeqNum_;
 }
 
 SeqNum DebugPersistentStorage::getPrimaryLastUsedSeqNum() {

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -756,9 +756,9 @@ IReplica* createReplica(const ReplicaConfig& c,
 			throw std::runtime_error("Unexpected C value in security keys file");
 
 		replicaConfig.numOfClientProxies = c.numOfClientProxies;
-		replicaConfig.statusReportTimerMillisec = c.statusReportTimerMillisec;;
-		replicaConfig.concurrencyLevel = c.concurrencyLevel;;
-		replicaConfig.autoViewChangeEnabled = c.autoViewChangeEnabled;;
+		replicaConfig.statusReportTimerMillisec = c.statusReportTimerMillisec;
+		replicaConfig.concurrencyLevel = c.concurrencyLevel;
+		replicaConfig.autoViewChangeEnabled = c.autoViewChangeEnabled;
 		replicaConfig.viewChangeTimerMillisec = c.viewChangeTimerMillisec;
 
 


### PR DESCRIPTION
This PR proposes the removal of unnecessary double semicolons (;;) found in the Concord-BFT codebase; it replaces them with single semicolons (;). 