### PR TITLE
Replace typo "becuase" with "because"

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1395,7 +1395,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg* m,
 
   uint16_t nextChunk = m->lastKnownChunk + 1;
 
-  // if msg is invalid (becuase lastKnownChunk+1 does not exist)
+  // if msg is invalid (because lastKnownChunk+1 does not exist)
   if (nextChunk > numOfChunksInVBlock) {
         LOG_WARN(STLogger, "msg is invalid (illegal chunk number)");
     return false;

--- a/bftengine/src/bftengine/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/PrePrepareMsg.cpp
@@ -56,7 +56,7 @@ namespace bftEngine
 
 			// sender
 			if (!repInfo.isIdOfReplica(inMsg->senderId())) return false;
-			// NB: the actual expected sender is verified outside this class (becuase in some cases, during view-change protocol,  this message may sent by a non-primary replica to the primary replica).
+			// NB: the actual expected sender is verified outside this class (because in some cases, during view-change protocol,  this message may sent by a non-primary replica to the primary replica).
 
 			PrePrepareMsg* tmp = (PrePrepareMsg*)inMsg;
 

--- a/bftengine/src/bftengine/SeqNumInfo.cpp
+++ b/bftengine/src/bftengine/SeqNumInfo.cpp
@@ -103,7 +103,7 @@ namespace bftEngine
 			Assert(!forcedCompleted);
 			Assert(prePrepareMsg == nullptr);
 
-			//Assert(me->id() == m->senderId()); // GG: incorrect assert - becuase after a view change it may has been sent by another replica
+			//Assert(me->id() == m->senderId()); // GG: incorrect assert - because after a view change it may has been sent by another replica
 
 			prePrepareMsg = m;
 			primary = true;

--- a/bftengine/src/bftengine/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/ViewChangeMsg.cpp
@@ -172,7 +172,7 @@ namespace bftEngine
 
 					if (remainingBytes < s) return false;
 
-					// we don't check the certificate here (becuase in many cases it is not needed to make progress)
+					// we don't check the certificate here (because in many cases it is not needed to make progress)
 
 					remainingBytes -= s;
 					currLoc += s;

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -570,7 +570,7 @@ ViewChangeMsg* ViewsManager::exitFromCurrentView(
                           preparedCertInPrev->certificateSigLength,
                           sig);
     } else if (allRequests && !pp->isNull()) {
-      // we don't add null-operation to a VC message, becuase our default for
+      // we don't add null-operation to a VC message, because our default for
       // non-safe operations is null-operation (notice that, in the above
       // lines, we still may add prepared certificate for null-op)
       myNewVC->addElement(*replicasInfo,
@@ -752,7 +752,7 @@ bool ViewsManager::tryToEnterView(
         outPrePrepareMsgsOfView->push_back(pp);
         prePrepareMsgsOfRestrictions[idx] = nullptr;
 
-        // if needed, remove from collectionOfPrePrepareMsgs (becuase we don't
+        // if needed, remove from collectionOfPrePrepareMsgs (because we don't
         // want to delete messages returned in outPrePrepareMsgsOfView)
         auto pos = collectionOfPrePrepareMsgs.find(i);
         if ((pos != collectionOfPrePrepareMsgs.end()) && (pos->second == pp))

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -117,7 +117,7 @@ class ViewsManager {
       SeqNum currentLastStable,
       SeqNum currentLastExecuted,
       const std::vector<PrevViewInfo> &prevViewInfo);
-  // TODO(GG): prevViewInfo is defined and used in a confusing way (becuase it
+  // TODO(GG): prevViewInfo is defined and used in a confusing way (because it
   // contains both executed and non-executed items) - TODO: improve by using two
   // different arguments
 


### PR DESCRIPTION
Replaces uses of "becuase" (which I am assuming to be a typo) in Concord-BFT with "because".