### PR TITLE
Persistency - fix product integration issues. 

### DIFF
--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -28,9 +28,13 @@ class MetadataStorage {
   virtual ~MetadataStorage() = default;
 
   // Initialize the storage before the first time used. In case storage is already initialized, do nothing.
-  // Return boolean saying whether been initialized or not (the IDs and their maximal size are known in advance).
+  // Return 'true' in case DB was virgin (not initialized) before a call to this function
+  // (the IDs and their maximal size are known in advance).
   virtual bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray,
                                     uint32_t metadataObjectsArrayLength) = 0;
+
+  // Return 'true' in case DB is virgin (not initialized).
+  virtual bool isNewStorage() = 0;
 
   // Read object from storage (only used to restart/recovery)
   virtual void read(uint32_t objectId,

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -42,6 +42,9 @@ bool PersistentStorageImp::init(unique_ptr<MetadataStorage> metadataStorage) {
     if (!getStoredVersion().empty()) {
       LOG_INFO_F(GL, "PersistentStorageImp::init version=%s", version_.c_str());
       retrieveWindowsMetadata();
+      // Retrieve metadata parameters stored in the memory
+      getReplicaConfig();
+      getDescriptorOfLastExecution();
       return false;
     }
   } catch (const runtime_error &exc) {}
@@ -643,7 +646,7 @@ DescriptorOfLastExecution PersistentStorageImp::getDescriptorOfLastExecution() {
   metadataStorage_->read(LAST_EXEC_DESC, maxSize, buf.get(), actualSize);
   dbDesc.deserialize(buf.get(), maxSize, actualSize);
   Assert(actualSize != 0);
-  if (!dbDesc.equals(DescriptorOfLastExecution{0, Bitmap()})) {
+  if (!dbDesc.equals(emptyDescriptorOfLastExecution_)) {
     descriptorOfLastExecution_ = dbDesc;
     hasDescriptorOfLastExecution_ = true;
   }
@@ -675,8 +678,6 @@ bool PersistentStorageImp::hasDescriptorOfLastNewView() {
 }
 
 bool PersistentStorageImp::hasDescriptorOfLastExecution() {
-  if (descriptorOfLastExecution_.equals(DescriptorOfLastExecution{0, Bitmap()}))
-    getDescriptorOfLastExecution();
   return hasDescriptorOfLastExecution_;
 }
 

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -215,7 +215,8 @@ class PersistentStorageImp : public PersistentStorage {
   bool hasDescriptorOfLastNewView_ = false;
   bool hasDescriptorOfLastExecution_ = false;
 
-  DescriptorOfLastExecution descriptorOfLastExecution_ = DescriptorOfLastExecution{0, Bitmap()};
+  const DescriptorOfLastExecution emptyDescriptorOfLastExecution_ = DescriptorOfLastExecution{0, Bitmap()};
+  DescriptorOfLastExecution descriptorOfLastExecution_ = emptyDescriptorOfLastExecution_;
 
   // Parameters to be saved persistently
   std::string version_;

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -24,8 +24,8 @@ namespace impl {
 const uint16_t reservedParamsNum = 50;
 
 enum ConstMetadataParameterIds : uint32_t {
-  INITIALIZED_FLAG = 0, // A flag saying whether DB is initialized or not; handled by storage class itself.
-  FIRST_METADATA_PARAMETER = 1,
+  INITIALIZED_FLAG = 1, // A flag saying whether DB is initialized or not; handled by storage class itself.
+  FIRST_METADATA_PARAMETER,
   VERSION_PARAMETER = FIRST_METADATA_PARAMETER,
   FETCHING_STATE,
   LAST_EXEC_SEQ_NUM,

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -104,8 +104,12 @@ void FileStorage::write(void *dataPtr, size_t offset, size_t itemSize,
     fflush(dataStream_);
 }
 
+bool FileStorage::isNewStorage() {
+  return (objectsMetadata_ == nullptr);
+}
+
 bool FileStorage::initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) {
-  if (objectsMetadata_) {
+  if (!isNewStorage()) {
     LOG_WARN(logger_, "FileStorage::initMaxSizeOfObjects Storage file already initialized; ignoring");
     return false;
   }

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -33,6 +33,8 @@ class FileStorage : public MetadataStorage {
   bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray,
                             uint32_t metadataObjectsArrayLength) override;
 
+  bool isNewStorage() override;
+
   void read(uint32_t objectId, uint32_t bufferSize,
             char *outBufferForObject,
             uint32_t &outActualObjectSize) override;

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -85,7 +85,7 @@ class FileStorage : public MetadataStorage {
   const char *WRONG_FLOW =
       "beginAtomicWriteOnlyTransaction should be launched first";
 
-  const uint8_t initializedObjectId_ = 0;
+  const uint8_t initializedObjectId_ = 1;
 
   concordlogger::Logger &logger_;
   const std::string fileName_;

--- a/bftengine/tests/simpleStorage/main.cpp
+++ b/bftengine/tests/simpleStorage/main.cpp
@@ -59,22 +59,22 @@ int main(int argc, char **argv) {
     auto *fileStorage = new FileStorage(logger, dbFile);
     const uint32_t objNum = 6;
     FileStorage::ObjectDesc objects[objNum];
-    // Metadata object with id=0 is used to indicate storage initialization state
-    for (uint32_t i = 1; i < objNum; i++) {
+    // Metadata object with id=1 is used to indicate storage initialization state
+    for (uint32_t i = 2; i < objNum; i++) {
       objects[i].id = i;
       objects[i].maxSize = (uint32_t) i * 2 + 30;
     }
     fileStorage->initMaxSizeOfObjects(objects, objNum);
     Object objOut = {ELEM1, ELEM2, ELEM3, ELEM4};
-    const uint32_t objId1 = 1;
+    const uint32_t objId1 = 2;
     char *objOutBuf = new char[sizeof(objOut)];
     memcpy(objOutBuf, &objOut, sizeof(objOut));
     fileStorage->atomicWrite(objId1, objOutBuf, sizeof(objOut));
     verifyData(*fileStorage, objId1);
 
-    const uint32_t objId2 = 2;
-    const uint32_t objId3 = 3;
-    const uint32_t objId4 = 4;
+    const uint32_t objId2 = 3;
+    const uint32_t objId3 = 4;
+    const uint32_t objId4 = 5;
     fileStorage->beginAtomicWriteOnlyTransaction();
     fileStorage->writeInTransaction(objId2, objOutBuf, sizeof(objOut));
     fileStorage->writeInTransaction(objId3, objOutBuf, sizeof(objOut));


### PR DESCRIPTION
Skip value 0 as a metadata object id.
Load metadata parameters stored in the memory in advance in order to be ready for calls of type has..()
Add function isNewStorage required by the product.