### PR TITLE
VB-1489 Support not-specified Signers/Verifiers in ReplicaConfig.

### DIFF
--- a/bftengine/src/bftengine/ReplicaConfigSerializer.hpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.hpp
@@ -47,6 +47,8 @@ class ReplicaConfigSerializer : public concordSerializable::Serializable {
   void serializeKey(const std::string &key, std::ostream &outStream) const;
   std::string deserializeKey(std::istream &inStream) const;
   void createSignersAndVerifiers(std::istream &inStream, ReplicaConfig &newObject);
+  void serializePointer(concordSerializable::Serializable *ptrToClass, std::ostream &outStream) const;
+  static concordSerializable::SharedPtrToClass deserializePointer(std::istream &inStream);
 
   static void registerClass();
 

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -444,7 +444,7 @@ void fillReplicaConfig() {
   config.publicKeysOfReplicas.insert(IdToKeyPair(2, publicKeyValue3));
   config.publicKeysOfReplicas.insert(IdToKeyPair(3, publicKeyValue4));
 
-  config.thresholdSignerForExecution = new IThresholdSignerDummy;
+  config.thresholdSignerForExecution = nullptr;
   config.thresholdVerifierForExecution = new IThresholdVerifierDummy;
   config.thresholdSignerForSlowPathCommit = new IThresholdSignerDummy;
   config.thresholdVerifierForSlowPathCommit = new IThresholdVerifierDummy;


### PR DESCRIPTION
Serialization/deserialization should handle Signers/Verifiers set to a nullptr in ReplicaConfig structure.