### PR TITLE
Update logging header in persistency test

### DIFF
--- a/bftengine/tests/simpleTest/persistency_test.cpp
+++ b/bftengine/tests/simpleTest/persistency_test.cpp
@@ -17,11 +17,15 @@
 #include <vector>
 #include "simple_test_client.hpp"
 #include "simple_test_replica.hpp"
-#include "Logging.hpp"
+#include "Logger.hpp"
 #include <thread>
 #include <chrono>
 #include <time.h>
 #include <memory>
+
+#ifdef USE_LOG4CPP
+#include <log4cplus/configurator.h>
+#endif
 
 namespace test
 {


### PR DESCRIPTION
The old "Logging.h" header was being used which breaks builds when the
`USE_LOG4CPP` cmake option was enabled. Fix it by using "Logger.hpp" and
adding the necessary ifdef.