### PR TITLE
Add rocksdb related storage code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ option(BUILD_COMM_TCP_PLAIN "Enable TCP communication" FALSE)
 # Default BUILD_COMM_TCP_TLS to FALSE
 option(BUILD_COMM_TCP_TLS "Enable TCP TLS communication" FALSE)
 
+# This requires the rocksdb dependencies to be installed, so defaults to FALSE
+option(BUILD_ROCKSDB_STORAGE "Enable building of RocksDB storage library" FALSE)
+
 set(COMM_MODULES 0)
 if(BUILD_COMM_TCP_PLAIN)
     math(EXPR COMM_MODULES "${COMM_MODULES}+1")
@@ -151,6 +154,7 @@ add_subdirectory(util)
 add_subdirectory(threshsign)
 add_subdirectory(bftengine)
 add_subdirectory(tools)
+add_subdirectory(storage)
 
 #
 # Setup testing

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,0 +1,7 @@
+if (BUILD_ROCKSDB_STORAGE)
+    add_subdirectory(rocksdb)
+    add_subdirectory(blockchain)
+    if (BUILD_TESTING AND USE_LOG4CPP)
+        add_subdirectory(test)
+    endif()
+endif()

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,0 +1,58 @@
+# Overview
+This directory contains **optional** storage libraries that serve as examples of how
+to use the persistent storage interfaces of concord-bft.
+
+Applications must implement the MetadataStorage API, and so we have provided a
+RocksDB implementation in the `rocksdb` directory. The rocksdb directory also
+contains a `rocksdb_client` that implements the interfaces in
+`database_interface.h`. This can be used by higher level storage code to build
+complete systems on top of RocksDB. Again, this is only one way to use RocksDB
+to build a system, and the rocksdb library is completely optional.
+
+Additionally, users may wish to build a blockchain on top of concord-bft. The
+`blockchain` directory contains an example of how to structure the keyspace and
+use the database interfaces to build a blockchain storage layer. Currently, the
+only provided implementation of the database interfaces is the rocksdb library,
+and it is required for linking. However, users can provide alternate
+implementations of these interfaces and use a different low level storage
+mechanism, making the blockchain code independent of the rocksdb library.
+
+Both libraries rely on the util library in `../util` for types such as `Status`
+and `Sliver`.
+
+# Building and testing
+
+The storage libraries rely on RocksDB.
+
+First install RocksDB dependencies:
+
+```shell
+sudo apt-get install libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
+```
+
+Build and install RocksDB:
+
+```shell
+cd
+wget https://github.com/facebook/rocksdb/archive/v5.7.3.tar.gz
+tar -xzf v5.7.3.tar.gz
+cd rocksdb-5.7.3
+make shared_lib
+sudo make install-shared
+```
+
+Configure CMake to build the storage code and tests based on RocksDB. Some tests
+require LOG4CPP, so that also must be installed and enabled. Installation of
+LOG4CPP is detailed in the [main
+README](https://github.com/vmware/concord-bft/blob/master/README.md).
+
+```shell
+cd
+cd concord-bft/build
+cmake -DBUILD_ROCKSDB_STORAGE=TRUE -DBUILD_TESTING=TRUE -DUSE_LOG4CPP=TRUE ..
+make
+```
+
+If testing is enabled, cmake will add automated test targets for the storage
+library. These can be run individually with with `ctest -R <TEST>` or via `make
+test` to run all tests in concord-bft.

--- a/storage/blockchain/CMakeLists.txt
+++ b/storage/blockchain/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(concordbft_storage_blockchain STATIC
+    blockchain_db_adapter.cpp
+    blockchain_db_helpers.cpp
+    comparators.cpp
+)
+
+target_include_directories(concordbft_storage_blockchain PUBLIC
+    ${bftengine_SOURCE_DIR}/include/bftengine
+    .
+)
+
+target_link_libraries(concordbft_storage_blockchain PUBLIC
+    concordbft_storage_rocksdb
+    util
+)

--- a/storage/blockchain/blockchain_db_adapter.cpp
+++ b/storage/blockchain/blockchain_db_adapter.cpp
@@ -1,0 +1,820 @@
+// Copyright 2018 VMware, all rights reserved
+
+// @file blockchain_db_adapter.cpp
+//
+// @brief Contains helper functions for working with composite database keys and
+// using these keys to perform basic database operations.
+//
+// Data is stored in the form of key value pairs. However, the key used is a
+// composite database key. Its composition is : Key Type | Key | Block Id
+//
+// Block Id is functionally equivalent to the version of the block.
+//
+// For the purposes of iteration, the keys appear in the following order:
+//    Ascending order of Key Type
+//    -> Ascending order of Key
+//       -> Descending order of Block Id
+
+#include "blockchain_db_adapter.h"
+
+#include <log4cplus/loggingmacros.h>
+
+#include <chrono>
+#include <limits>
+#include "hash_defs.h"
+#include "sliver.hpp"
+#include "status.hpp"
+#include "blockchain_db_helpers.h"
+#include "blockchain_db_interfaces.h"
+
+using log4cplus::Logger;
+using concordUtils::Status;
+
+namespace concordStorage {
+namespace blockchain {
+
+BlockchainDBAdapter::BlockchainDBAdapter(IDBClient *db, bool readOnly) {
+  logger =
+      log4cplus::Logger::getInstance("concord.storage.BlockchainDBAdapter");
+  m_isEnd = false;
+  m_db = db;
+  Status status = m_db->init(readOnly);
+  if (!status.isOK()) {
+    LOG4CPLUS_FATAL(logger,
+                    "Failure in Database Initialization, status: " << status);
+    throw std::runtime_error("Failure in Database Initialization");
+  }
+}
+
+/**
+ * @brief Generates a Composite Database Key from a Sliver object.
+ *
+ * Merges the key type, data of the key and the block id to generate a composite
+ * database key.
+ *
+ * Format : Key Type | Key | Block Id
+
+ * @param _type Composite Database key type (Either of First, Key, Block or
+ *              Last).
+ * @param _key Sliver object of the key.
+ * @param _blockId BlockId object.
+ * @return Sliver object of the generated composite database key.
+ */
+Sliver KeyManipulator::genDbKey(EDBKeyType _type, Key _key, BlockId _blockId) {
+  size_t sz = sizeof(EDBKeyType) + sizeof(BlockId) + _key.length();
+  uint8_t *out = new uint8_t[sz];
+  size_t offset = 0;
+  copyToAndAdvance(out, &offset, sz, (uint8_t *)&_type, sizeof(EDBKeyType));
+  copyToAndAdvance(out, &offset, sz, (uint8_t *)_key.data(), _key.length());
+  copyToAndAdvance(out, &offset, sz, (uint8_t *)&_blockId, sizeof(BlockId));
+  return Sliver(out, sz);
+}
+
+/**
+ * @brief Helper function that generates a composite database Key of type Block.
+ *
+ * For such Database keys, the "key" component is an empty sliver.
+ *
+ * @param _blockid BlockId object of the block id that needs to be
+ *                 incorporated into the composite database key.
+ * @return Sliver object of the generated composite database key.
+ */
+Sliver KeyManipulator::genBlockDbKey(BlockId _blockId) {
+  return genDbKey(EDBKeyType::E_DB_KEY_TYPE_BLOCK, Sliver(), _blockId);
+}
+
+/**
+ * @brief Helper function that generates a composite database Key of type Key.
+ *
+ * @param _key Sliver object of the "key" component.
+ * @param _blockid BlockId object of the block id that needs to be incorporated
+ *                 into the composite database Key.
+ * @return Sliver object of the generated composite database key.
+ */
+Sliver KeyManipulator::genDataDbKey(Key _key, BlockId _blockId) {
+  return genDbKey(EDBKeyType::E_DB_KEY_TYPE_KEY, _key, _blockId);
+}
+
+/**
+ * @brief Extracts the type of a composite database key.
+ *
+ * Returns the data part of the Sliver object passed as a parameter.
+ *
+ * @param _key The Sliver object of the composite database key whose type gets
+ *             returned.
+ * @return The type of the composite database key.
+ */
+char KeyManipulator::extractTypeFromKey(Key _key) {
+  static_assert(sizeof(EDBKeyType) == 1, "Let's avoid byte-order problems.");
+  return _key.data()[0];
+}
+
+/**
+ * @brief Extracts the Block Id of a composite database key.
+ *
+ * Returns the block id part of the Sliver object passed as a parameter.
+ *
+ * @param _key The Sliver object of the composite database key whose block id
+ *             gets returned.
+ * @return The block id of the composite database key.
+ */
+BlockId KeyManipulator::extractBlockIdFromKey(const Logger &logger, Key _key) {
+  size_t offset = _key.length() - sizeof(BlockId);
+  BlockId id = *(BlockId *)(_key.data() + offset);
+
+  LOG4CPLUS_DEBUG(logger, "Got block ID " << id << " from key " << _key
+                                          << ", offset " << offset);
+  return id;
+}
+
+/**
+ * @brief Extracts the Metadata Object Id of a composite database key.
+ *
+ * Returns the object id part of the Sliver object passed as a parameter.
+ *
+ * @param _key The Sliver object of the composite database key whose object id
+ *             gets returned.
+ * @return The object id of the composite database key.
+ */
+ObjectId KeyManipulator::extractObjectIdFromKey(const Logger &logger,
+                                                Key _key) {
+  assert(_key.length() >= sizeof(ObjectId));
+  size_t offset = _key.length() - sizeof(ObjectId);
+  ObjectId id = *(ObjectId *)(_key.data() + offset);
+
+  LOG4CPLUS_DEBUG(logger, "Got object ID " << id << " from key " << _key
+                                           << ", offset " << offset);
+  return id;
+}
+
+/**
+ * @brief Extracts the key from a composite database key.
+ *
+ * @param _composedKey Sliver object of the composite database key.
+ * @return Sliver object of the key extracted from the composite database key.
+ */
+Sliver KeyManipulator::extractKeyFromKeyComposedWithBlockId(
+    const Logger &logger, Key _composedKey) {
+  size_t sz = _composedKey.length() - sizeof(BlockId) - sizeof(EDBKeyType);
+  Sliver out = Sliver(_composedKey, sizeof(EDBKeyType), sz);
+  LOG4CPLUS_DEBUG(logger,
+                  "Got key " << out << " from composed key " << _composedKey);
+  return out;
+}
+
+Sliver KeyManipulator::extractKeyFromMetadataKey(const Logger &logger,
+                                                 Key _composedKey) {
+  size_t sz = _composedKey.length() - sizeof(EDBKeyType);
+  Sliver out = Sliver(_composedKey, sizeof(EDBKeyType), sz);
+  LOG4CPLUS_DEBUG(logger, "Got metadata key " << out << " from composed key "
+                                              << _composedKey);
+  return out;
+}
+
+bool KeyManipulator::isKeyContainBlockId(Key _composedKey) {
+  return (_composedKey.length() > sizeof(BlockId) + sizeof(EDBKeyType));
+}
+
+/**
+ * @brief Converts a key value pair consisting using a composite database key
+ * into a key value pair using a "simple" key - one without the key type
+ * included.
+ *
+ * @param _p Key value pair consisting of a composite database key
+ * @return Key value pair consisting of a simple key.
+ */
+KeyValuePair KeyManipulator::composedToSimple(const Logger &logger,
+                                              KeyValuePair _p) {
+  if (_p.first.length() == 0) {
+    return _p;
+  }
+  Key key;
+  if (isKeyContainBlockId(_p.first))
+    key = extractKeyFromKeyComposedWithBlockId(logger, _p.first);
+  else
+    key = extractKeyFromMetadataKey(logger, _p.first);
+
+  return KeyValuePair(key, _p.second);
+}
+
+/**
+ * @brief Generates a Composite Database Key from objectId.
+ *
+ * Merges the key type and the block id to generate a composite
+ * database key for E_DB_KEY_TYPE_METADATA_KEY.
+ *
+ * Format : Key Type | Object Id
+ *
+ * @return Sliver object of the generated composite database key.
+ */
+
+Sliver KeyManipulator::generateMetadataKey(ObjectId objectId) {
+  size_t keySize = sizeof(EDBKeyType) + sizeof(objectId);
+  auto keyBuf = new uint8_t[keySize];
+  size_t offset = 0;
+  EDBKeyType keyType = EDBKeyType::E_DB_KEY_TYPE_BFT_METADATA_KEY;
+  copyToAndAdvance(keyBuf, &offset, keySize, (uint8_t *)&keyType,
+                   sizeof(EDBKeyType));
+  copyToAndAdvance(keyBuf, &offset, keySize, (uint8_t *)&objectId,
+                   sizeof(objectId));
+  return Sliver(keyBuf, keySize);
+}
+
+/**
+ * @brief Adds a block to the database.
+ *
+ * Generates a new composite database key of type Block and adds a block to the
+ * database using it.
+ *
+ * @param _blockId The block id to be used for generating the composite database
+ *                 key.
+ * @param _blockRaw The value that needs to be added to the database along with
+ *                  the composite database key.
+ * @return Status of the put operation.
+ */
+Status BlockchainDBAdapter::addBlock(BlockId _blockId, Sliver _blockRaw) {
+  Sliver dbKey = KeyManipulator::genBlockDbKey(_blockId);
+  Status s = m_db->put(dbKey, _blockRaw);
+  return s;
+}
+
+/**
+ * @brief Puts a key value pair to the database with a composite database key of
+ * type Key.
+ *
+ * Generates a new composite database key of type Key and adds a block to the
+ * database using it.
+ *
+ * @param _key The key used for generating the composite database key.
+ * @param _block The block used for generating the composite database key.
+ * @param _value The value that needs to be added to the database.
+ * @return Status of the put operation.
+ */
+Status BlockchainDBAdapter::updateKey(Key _key, BlockId _block, Value _value) {
+  Sliver composedKey = KeyManipulator::genDataDbKey(_key, _block);
+
+  LOG4CPLUS_DEBUG(logger, "Updating composed key " << composedKey
+                                                   << " with value " << _value
+                                                   << " in block " << _block);
+
+  Status s = m_db->put(composedKey, _value);
+  return s;
+}
+
+Status BlockchainDBAdapter::addBlockAndUpdateMultiKey(
+    const SetOfKeyValuePairs &_kvMap, BlockId _block, Sliver _blockRaw) {
+  SetOfKeyValuePairs updatedKVMap;
+  for (auto &it : _kvMap) {
+    Sliver composedKey = KeyManipulator::genDataDbKey(it.first, _block);
+    LOG4CPLUS_DEBUG(logger, "Updating composed key "
+                                << composedKey << " with value " << it.second
+                                << " in block " << _block);
+    updatedKVMap[composedKey] = it.second;
+  }
+  updatedKVMap[KeyManipulator::genBlockDbKey(_block)] = _blockRaw;
+  return m_db->multiPut(updatedKVMap);
+}
+
+/**
+ * @brief Deletes a key value pair from the database.
+ *
+ * Deletes the key value pair corresponding to the composite database key of
+ * type "Key" generated from the key and block id provided as parameters to this
+ * function.
+ *
+ * @param _key The key whose composite version needs to be deleted.
+ * @param _blockId The block id (version) of the key to delete.
+ * @return Status of the operation.
+ */
+Status BlockchainDBAdapter::delKey(Sliver _key, BlockId _blockId) {
+  Sliver composedKey = KeyManipulator::genDataDbKey(_key, _blockId);
+  LOG4CPLUS_DEBUG(logger, "Deleting key " << _key << " block id " << _blockId);
+  Status s = m_db->del(composedKey);
+  return s;
+}
+
+/**
+ * @brief Deletes a key value pair from the database.
+ *
+ * Deletes the key value pair corresponding to the composite database key of
+ * type "Block" generated from the block id provided as a parameter to this
+ * function.
+ *
+ * @param _blockId The ID of the block to be deleted.
+ * @return Status of the operation.
+ */
+Status BlockchainDBAdapter::delBlock(BlockId _blockId) {
+  Sliver dbKey = KeyManipulator::genBlockDbKey(_blockId);
+  Status s = m_db->del(dbKey);
+  return s;
+}
+
+void BlockchainDBAdapter::deleteBlockAndItsKeys(BlockId blockId) {
+  Sliver blockRaw;
+  bool found = false;
+  Status s = getBlockById(blockId, blockRaw, found);
+  if (!s.isOK()) {
+    LOG4CPLUS_FATAL(logger, "Failed to read block id: " << blockId);
+    exit(1);
+  }
+  KeysVector keysVec;
+  if (found && blockRaw.length() > 0) {
+    uint16_t numOfElements = ((BlockHeader *)blockRaw.data())->numberOfElements;
+    auto *entries = (BlockEntry *)(blockRaw.data() + sizeof(BlockHeader));
+    for (size_t i = 0; i < numOfElements; i++) {
+      keysVec.push_back(
+          Key(blockRaw, entries[i].keyOffset, entries[i].keySize));
+    }
+  }
+  if (found) {
+    keysVec.push_back(KeyManipulator::genBlockDbKey(blockId));
+  }
+  s = m_db->multiDel(keysVec);
+  if (!s.isOK()) {
+    LOG4CPLUS_FATAL(logger, "Failed to delete block id: " << blockId);
+    exit(1);
+  }
+}
+
+/**
+ * @brief Searches for record in the database by the read version.
+ *
+ * Read version is used as the block id for generating a composite database key
+ * which is then used to lookup in the database.
+ *
+ * @param readVersion BlockId object signifying the read version with which a
+ *                    lookup needs to be done.
+ * @param key Sliver object of the key.
+ * @param outValue Sliver object where the value of the lookup result is stored.
+ * @param outBlock BlockId object where the read version of the result is
+ *                         stored.
+ * @return Status OK
+ */
+Status BlockchainDBAdapter::getKeyByReadVersion(BlockId readVersion, Sliver key,
+                                                Sliver &outValue,
+                                                BlockId &outBlock) const {
+  LOG4CPLUS_DEBUG(logger, "Getting value of key " << key << " for read version "
+                                                  << readVersion);
+  IDBClient::IDBClientIterator *iter = m_db->getIterator();
+  Sliver foundKey, foundValue;
+  Sliver searchKey = KeyManipulator::genDataDbKey(key, readVersion);
+  KeyValuePair p = iter->seekAtLeast(searchKey);
+  foundKey = KeyManipulator::composedToSimple(logger, p).first;
+  foundValue = p.second;
+
+  LOG4CPLUS_DEBUG(logger,
+                  "Found key " << foundKey << " and value " << foundValue);
+
+  if (!iter->isEnd()) {
+    BlockId currentReadVersion =
+        KeyManipulator::extractBlockIdFromKey(logger, p.first);
+
+    // TODO(JGC): Ask about reason for version comparison logic
+    if (currentReadVersion <= readVersion && foundKey == key) {
+      outValue = foundValue;
+      outBlock = currentReadVersion;
+    } else {
+      outValue = Sliver();
+      outBlock = 0;
+    }
+  } else {
+    outValue = Sliver();
+    outBlock = 0;
+  }
+
+  m_db->freeIterator(iter);
+
+  // TODO(GG): maybe return status of the operation?
+  return Status::OK();
+}
+
+/**
+ * @brief Looks up data by block id.
+ *
+ * Constructs a composite database key using the block id to fire a get request.
+ *
+ * @param _blockId BlockId object used for looking up data.
+ * @param _blockRaw Sliver object where the result of the lookup is stored.
+ * @param _found true if lookup successful, else false.
+ * @return Status of the operation.
+ */
+Status BlockchainDBAdapter::getBlockById(BlockId _blockId, Sliver &_blockRaw,
+                                         bool &_found) const {
+  Sliver key = KeyManipulator::genBlockDbKey(_blockId);
+  Status s = m_db->get(key, _blockRaw);
+  if (s.isNotFound()) {
+    _found = false;
+    return Status::OK();
+  }
+
+  _found = true;
+  return s;
+}
+
+// TODO(BWF): is this still needed?
+/**
+ * @brief Makes a copy of a Sliver object.
+ *
+ * @param _src Sliver object that needs to be copied.
+ * @param _trg Sliver object that contains the result.
+ */
+inline void CopyKey(Sliver _src, Sliver &_trg) {
+  uint8_t *c = new uint8_t[_src.length()];
+  memcpy(c, _src.data(), _src.length());
+  _trg = Sliver(c, _src.length());
+}
+
+// TODO(SG): Add status checks with getStatus() on iterator.
+// TODO(JGC): unserstand difference between .second and .data()
+/**
+ * @brief Finds the first key with block version lesser than or equal to
+ * readVersion.
+ *
+ * Iterates from the first key to find the key with block version lesser than or
+ * equal to the readVersion.
+ *
+ * @param iter Iterator object.
+ * @param readVersion The read version used for searching.
+ * @param actualVersion The read version of the result.
+ * @param isEnd True if end of the database is reached while iterating, else
+ *              false.
+ * @param _key The result's key.
+ * @param _value The result's value.
+ * @return Status NotFound if database is empty, OK otherwise.
+ */
+Status BlockchainDBAdapter::first(IDBClient::IDBClientIterator *iter,
+                                  BlockId readVersion,
+                                  OUT BlockId &actualVersion, OUT bool &isEnd,
+                                  OUT Sliver &_key, OUT Sliver &_value) {
+  Key firstKey;
+  KeyValuePair p = KeyManipulator::composedToSimple(logger, iter->first());
+  if (iter->isEnd()) {
+    m_isEnd = true;
+    isEnd = true;
+    return Status::NotFound("No keys");
+  } else {
+    CopyKey(p.first, firstKey);
+  }
+
+  bool foundKey = false;
+  Sliver value;
+  BlockId actualBlock;
+  while (!iter->isEnd() && p.first == firstKey) {
+    BlockId currentBlock =
+        KeyManipulator::extractBlockIdFromKey(logger, iter->getCurrent().first);
+    if (currentBlock <= readVersion) {
+      value = p.second;
+      actualBlock = currentBlock;
+      foundKey = true;
+      p = KeyManipulator::composedToSimple(logger, iter->next());
+    } else {
+      if (!foundKey) {
+        // If not found a key with actual block version < readVersion, then we
+        // consider the next key as the first key candidate.
+
+        // Start by exhausting the current key with all the newer blocks
+        // records:
+        while (!iter->isEnd() && p.first == firstKey) {
+          p = KeyManipulator::composedToSimple(logger, iter->next());
+        }
+
+        if (iter->isEnd()) {
+          break;
+        }
+
+        CopyKey(p.first, firstKey);
+      } else {
+        // If we already found a suitable first key, we break when we find
+        // the maximal
+        break;
+      }
+    }
+  }
+
+  // It is possible all keys have actualBlock > readVersion (Actually, this
+  // sounds like data is corrupted in this case - unless we allow empty blocks)
+  if (iter->isEnd() && !foundKey) {
+    m_isEnd = true;
+    isEnd = true;
+    return Status::OK();
+  }
+
+  m_isEnd = false;
+  isEnd = false;
+  actualVersion = actualBlock;
+  _key = firstKey;
+  _value = value;
+  m_current = KeyValuePair(_key, _value);
+  return Status::OK();
+}
+
+/**
+ * @brief Finds the first key greater than or equal to the search key with block
+ * version lesser than or equal to readVersion.
+ *
+ * Iterates from the first key greater than or equal to the search key to find
+ * the key with block version lesser than or equal to the readVersion.
+ *
+ * @param iter Iterator object.
+ * @param _searchKey Sliver object of the search key.
+ * @param _readVersion BlockId of the read version used for searching.
+ * @param _actualVersion BlockId in which the version of the result is stored.
+ * @param _key The result's key.
+ * @param _value The result's value.
+ * @param _isEnd True if end of the database is reached while iterating, else
+ *               false.
+ *  @return Status NotFound if search unsuccessful, OK otherwise.
+ */
+// Only for data fields, i.e. E_DB_KEY_TYPE_KEY. It makes more sense to put data
+// second, and blocks first. Stupid optimization nevertheless
+Status BlockchainDBAdapter::seekAtLeast(IDBClient::IDBClientIterator *iter,
+                                        Sliver _searchKey, BlockId _readVersion,
+                                        OUT BlockId &_actualVersion,
+                                        OUT Sliver &_key, OUT Sliver &_value,
+                                        OUT bool &_isEnd) {
+  Key searchKey = _searchKey;
+  BlockId actualBlock;
+  Value value;
+  bool foundKey = false;
+  Sliver rocksKey = KeyManipulator::genDataDbKey(searchKey, _readVersion);
+  KeyValuePair p =
+      KeyManipulator::composedToSimple(logger, iter->seekAtLeast(rocksKey));
+
+  if (!iter->isEnd()) {
+    // p.first is src, searchKey is target
+    CopyKey(p.first, searchKey);
+  }
+
+  LOG4CPLUS_DEBUG(
+      logger, "Searching " << _searchKey << " and currently iterator returned "
+                           << searchKey << " for rocks key " << rocksKey);
+
+  while (!iter->isEnd() && p.first == searchKey) {
+    BlockId currentBlockId =
+        KeyManipulator::extractBlockIdFromKey(logger, iter->getCurrent().first);
+
+    LOG4CPLUS_DEBUG(logger, "Considering key " << p.first << " with block ID "
+                                               << currentBlockId);
+
+    if (currentBlockId <= _readVersion) {
+      LOG4CPLUS_DEBUG(logger, "Found with Block Id " << currentBlockId
+                                                     << " and value "
+                                                     << p.second);
+      value = p.second;
+      actualBlock = currentBlockId;
+      foundKey = true;
+      break;
+    } else {
+      LOG4CPLUS_DEBUG(
+          logger, "Read version " << currentBlockId << " > " << _readVersion);
+      if (!foundKey) {
+        // If not found a key with actual block version < readVersion, then
+        // we consider the next key as the key candidate.
+        LOG4CPLUS_DEBUG(logger, "Find next key");
+
+        // Start by exhausting the current key with all the newer blocks
+        // records:
+        while (!iter->isEnd() && p.first == searchKey) {
+          p = KeyManipulator::composedToSimple(logger, iter->next());
+        }
+
+        if (iter->isEnd()) {
+          break;
+        }
+
+        CopyKey(p.first, searchKey);
+
+        LOG4CPLUS_DEBUG(logger, "Found new search key " << searchKey);
+      } else {
+        // If we already found a suitable key, we break when we find the
+        // maximal
+        break;
+      }
+    }
+  }
+
+  if (iter->isEnd() && !foundKey) {
+    LOG4CPLUS_DEBUG(logger,
+                    "Reached end of map without finding lower bound "
+                    "key with suitable read version");
+    m_isEnd = true;
+    _isEnd = true;
+    return Status::NotFound("Did not find key with suitable read version");
+  }
+
+  m_isEnd = false;
+  _isEnd = false;
+  _actualVersion = actualBlock;
+  _key = searchKey;
+  _value = value;
+  LOG4CPLUS_DEBUG(logger, "Returnign key "
+                              << _key << " value " << _value
+                              << " in actual block " << _actualVersion
+                              << ", read version " << _readVersion);
+  m_current = KeyValuePair(_key, _value);
+  return Status::OK();
+}
+
+/**
+ * @brief Finds the next key with the most recently updated value.
+ *
+ * Finds the most updated value for the next key (with block version <
+ * readVersion).
+ *
+ * @param iter Iterator.
+ * @param _readVersion BlockId object of the read version used for searching.
+ * @param _key Sliver object of the result's key. Contains only the reference.
+ * @param _value Sliver object of the result's value.
+ * @param _actualVersion BlockId object in which the version of the result is
+ *                       stored.
+ * @param _isEnd True if end of the database is reached while iterating, else
+ *               false.
+ * @return Status OK.
+ */
+Status BlockchainDBAdapter::next(IDBClient::IDBClientIterator *iter,
+                                 BlockId _readVersion, OUT Sliver &_key,
+                                 OUT Sliver &_value,
+                                 OUT BlockId &_actualVersion,
+                                 OUT bool &_isEnd) {
+  KeyValuePair p = KeyManipulator::composedToSimple(logger, iter->getCurrent());
+  Key currentKey = p.first;
+
+  // Exhaust all entries for this key
+  while (!iter->isEnd() && p.first == currentKey) {
+    p = KeyManipulator::composedToSimple(logger, iter->next());
+  }
+
+  if (iter->isEnd()) {
+    m_isEnd = true;
+    _isEnd = true;
+    return Status::OK();
+  }
+
+  // Find most updated value for next key (with block version < readVersion)
+  Value value;
+  BlockId actualBlock;
+  Key nextKey;
+  CopyKey(p.first, nextKey);
+  bool foundKey = false;
+  // Find max version
+  while (!iter->isEnd() && p.first == nextKey) {
+    BlockId currentBlockId =
+        KeyManipulator::extractBlockIdFromKey(logger, iter->getCurrent().first);
+    if (currentBlockId <= _readVersion) {
+      value = p.second;
+      actualBlock = currentBlockId;
+      p = KeyManipulator::composedToSimple(logger, iter->next());
+    } else {
+      if (!foundKey) {
+        // If not found a key with actual block version < readVersion, then
+        // we consider the next key as the key candidate.
+
+        // Start by exhausting the current key with all the newer blocks
+        // records:
+        while (!iter->isEnd() && p.first == nextKey) {
+          p = KeyManipulator::composedToSimple(logger, iter->next());
+        }
+
+        if (iter->isEnd()) {
+          break;
+        }
+
+        CopyKey(p.first, nextKey);
+      } else {
+        // If we already found a suitable key, we break when we find the
+        // maximal
+        break;
+      }
+    }
+  }
+
+  m_isEnd = false;
+  _isEnd = false;
+  _actualVersion = actualBlock;
+  _key = nextKey;
+  _value = value;
+  m_current = KeyValuePair(_key, _value);
+
+  // TODO return appropriate status?
+  return Status::OK();
+}
+
+/**
+ * @brief Finds the key and value at the current position.
+ *
+ * Does not use the iterator for this.
+ *
+ * @param iter Iterator.
+ * @param _key Sliver object where the key of the result is stored.
+ * @param _value Sliver object where the value of the result is stored.
+ * @return Status OK.
+ */
+Status BlockchainDBAdapter::getCurrent(IDBClient::IDBClientIterator *iter,
+                                       OUT Sliver &_key, OUT Sliver &_value) {
+  // Not calling to underlying DB iterator, because it may have next()'d during
+  // seekAtLeast
+  _key = m_current.first;
+  _value = m_current.second;
+
+  return Status::OK();
+}
+
+/**
+ * @brief Used to find if the iterator is at the end of the database.
+ *
+ * @param iter Iterator.
+ * @param _isEnd True if iterator is at the end of the database, else false.
+ * @return Status OK.
+ */
+Status BlockchainDBAdapter::isEnd(IDBClient::IDBClientIterator *iter,
+                                  OUT bool &_isEnd) {
+  // Not calling to underlying DB iterator, because it may have next()'d during
+  // seekAtLeast
+  LOG4CPLUS_DEBUG(logger, "Called is end, returning " << m_isEnd);
+  _isEnd = m_isEnd;
+  return Status::OK();
+}
+
+/**
+ * @brief Used to monitor the database.
+ */
+void BlockchainDBAdapter::monitor() const { m_db->monitor(); }
+
+/**
+ * @brief Used to retrieve the latest block.
+ *
+ * Searches for the key with the largest block id component.
+ *
+ * @return Block ID of the latest block.
+ */
+BlockId BlockchainDBAdapter::getLatestBlock() {
+  // Note: RocksDB stores keys in a sorted fashion as per the logic
+  // provided in a custom comparator (for our case, refer to
+  // Comparators.cpp). In short, keys of type 'block' are stored
+  // first followed by keys of type 'key'. All keys of type 'block'
+  // are sorted in ascending order of block ids.
+
+  // Generate maximal key for type 'block'
+  Sliver maxKey =
+      KeyManipulator::genDbKey(EDBKeyType::E_DB_KEY_TYPE_BLOCK, Sliver(),
+                               std::numeric_limits<uint64_t>::max());
+  IDBClient::IDBClientIterator *iter = m_db->getIterator();
+
+  // Since we use the maximal key, SeekAtLeast will take the iterator
+  // to one position beyond the key corresponding to the largest block id.
+  KeyValuePair x = iter->seekAtLeast(maxKey);
+
+  // Read the previous key
+  x = iter->previous();
+
+  m_db->freeIterator(iter);
+
+  if ((x.first).length() == 0) {  // no blocks
+    return 0;
+  }
+
+  LOG4CPLUS_DEBUG(
+      logger, "Latest block ID "
+                  << KeyManipulator::extractBlockIdFromKey(logger, x.first));
+
+  return KeyManipulator::extractBlockIdFromKey(logger, x.first);
+}
+
+/**
+ * @brief Used to retrieve the last reachable block
+ *
+ * Searches for the last reachable block.
+ * From ST perspective, this is maximal block number N
+ * such that all blocks 1 <= i <= N exist.
+ * In the normal state, it should be equal to last block ID
+ *
+ * @return Block ID of the last reachable block.
+ */
+BlockId BlockchainDBAdapter::getLastReachableBlock() {
+  IDBClient::IDBClientIterator *iter = m_db->getIterator();
+
+  BlockId lastReachableId = 0;
+  Sliver blockKey = KeyManipulator::genBlockDbKey(1);
+  KeyValuePair kvp = iter->seekAtLeast(blockKey);
+  if (kvp.first.length() == 0) {
+    m_db->freeIterator(iter);
+    return 0;
+  }
+
+  while (!iter->isEnd() && (KeyManipulator::extractTypeFromKey(kvp.first) ==
+                            (char)EDBKeyType::E_DB_KEY_TYPE_BLOCK)) {
+    BlockId id = KeyManipulator::extractBlockIdFromKey(logger, kvp.first);
+    if (id == lastReachableId + 1) {
+      lastReachableId++;
+      kvp = iter->next();
+    } else {
+      break;
+    }
+  }
+
+  m_db->freeIterator(iter);
+  return lastReachableId;
+}
+
+}  // namespace blockchain 
+}  // namespace concordStorage

--- a/storage/blockchain/blockchain_db_adapter.h
+++ b/storage/blockchain/blockchain_db_adapter.h
@@ -1,0 +1,92 @@
+// Copyright 2018 VMware, all rights reserved
+//
+// Translation between BlockAppender/ILocalkeyValueStorage* to the underlying
+// database.
+
+#ifndef CONCORD_STORAGE_BLOCKCHAIN_DB_ADAPTER_H_
+#define CONCORD_STORAGE_BLOCKCHAIN_DB_ADAPTER_H_
+
+#include <log4cplus/loggingmacros.h>
+
+#include "sliver.hpp"
+#include "blockchain_db_types.h"
+#include "blockchain_db_interfaces.h"
+#include "../database_interface.h"
+
+namespace concordStorage{
+namespace blockchain {
+
+class BlockchainDBAdapter {
+ public:
+  explicit BlockchainDBAdapter(IDBClient *db, bool readOnly = false);
+
+  IDBClient *getDb() { return m_db; }
+
+  Status addBlock(BlockId _blockId, Sliver _blockRaw);
+  Status updateKey(Key _key, BlockId _block, Value _value);
+  Status addBlockAndUpdateMultiKey(const SetOfKeyValuePairs &_kvMap,
+                                   BlockId _block, Sliver _blockRaw);
+  Status getKeyByReadVersion(BlockId readVersion, Sliver key, Sliver &outValue,
+                             BlockId &outBlock) const;
+  Status getBlockById(BlockId _blockId, Sliver &_blockRaw, bool &_found) const;
+
+  IDBClient::IDBClientIterator *getIterator() { return m_db->getIterator(); }
+
+  Status freeIterator(IDBClient::IDBClientIterator *_iter) {
+    return m_db->freeIterator(_iter);
+  }
+
+  Status first(IDBClient::IDBClientIterator *iter, BlockId readVersion,
+               OUT BlockId &actualVersion, OUT bool &isEnd, OUT Sliver &_key,
+               OUT Sliver &_value);
+  Status seekAtLeast(IDBClient::IDBClientIterator *iter, Sliver _searchKey,
+                     BlockId _readVersion, OUT BlockId &_actualVersion,
+                     OUT Sliver &_key, OUT Sliver &_value, OUT bool &_isEnd);
+  Status next(IDBClient::IDBClientIterator *iter, BlockId _readVersion,
+              OUT Sliver &_key, OUT Sliver &_value, OUT BlockId &_actualVersion,
+              OUT bool &_isEnd);
+
+  Status getCurrent(IDBClient::IDBClientIterator *iter, OUT Sliver &_key,
+                    OUT Sliver &_value);
+  Status isEnd(IDBClient::IDBClientIterator *iter, OUT bool &_isEnd);
+
+  Status delKey(Sliver _key, BlockId _blockID);
+  Status delBlock(BlockId _blockId);
+  void deleteBlockAndItsKeys(BlockId blockId);
+
+  void monitor() const;
+
+  BlockId getLatestBlock();
+  BlockId getLastReachableBlock();
+
+ private:
+  log4cplus::Logger logger;
+  IDBClient *m_db;
+  KeyValuePair m_current;
+  bool m_isEnd;
+};
+
+class KeyManipulator {
+ public:
+  static Sliver genDbKey(EDBKeyType _type, Key _key, BlockId _blockId);
+  static Sliver genBlockDbKey(BlockId _blockId);
+  static Sliver genDataDbKey(Key _key, BlockId _blockId);
+  static char extractTypeFromKey(Key _key);
+  static BlockId extractBlockIdFromKey(const log4cplus::Logger &logger,
+                                       Key _key);
+  static ObjectId extractObjectIdFromKey(const log4cplus::Logger &logger,
+                                         Key _key);
+  static Sliver extractKeyFromKeyComposedWithBlockId(
+      const log4cplus::Logger &logger, Key _composedKey);
+  static Sliver extractKeyFromMetadataKey(const log4cplus::Logger &logger,
+                                          Key _composedKey);
+  static bool isKeyContainBlockId(Key _composedKey);
+  static KeyValuePair composedToSimple(const log4cplus::Logger &logger,
+                                       KeyValuePair _p);
+  static Sliver generateMetadataKey(ObjectId objectId);
+};
+
+}  // namespace blockchain 
+}  // namespace concordStorage
+
+#endif  // CONCORD_STORAGE_BLOCKCHAIN_DB_ADAPTER_H_

--- a/storage/blockchain/blockchain_db_helpers.cpp
+++ b/storage/blockchain/blockchain_db_helpers.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+#include "blockchain_db_helpers.h"
+
+namespace concordStorage {
+namespace blockchain {
+
+bool copyToAndAdvance(uint8_t *_buf, size_t *_offset, size_t _maxOffset,
+                      uint8_t *_src, size_t _srcSize) {
+  if (!_buf) {
+    return false;
+  }
+
+  if (!_offset) {
+    return false;
+  }
+
+  if (!_src) {
+    return false;
+  }
+
+  if (*_offset >= _maxOffset && _srcSize > 0) {
+    return false;
+  }
+
+  memcpy(_buf + *_offset, _src, _srcSize);
+  *_offset += _srcSize;
+
+  return true;
+}
+
+}  // namespace blockchain 
+}  // namespace concordStorage

--- a/storage/blockchain/blockchain_db_helpers.h
+++ b/storage/blockchain/blockchain_db_helpers.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+#ifndef CONCORD_STORAGE_BLOCKCHAIN_DB_HELPERS_H_
+#define CONCORD_STORAGE_BLOCKCHAIN_DB_HELPERS_H_
+
+#include <cstdint>
+#include <cstring>
+
+namespace concordStorage {
+namespace blockchain {
+
+bool copyToAndAdvance(uint8_t *_buf, size_t *_offset, size_t _maxOffset,
+                      uint8_t *_src, size_t _srcSize);
+
+}  // namespace blockchain 
+}  // namespace concordStorage
+
+#endif  // CONCORD_STORAGE_BLOCKCHAIN_DB_HELPERS_H_

--- a/storage/blockchain/blockchain_db_interfaces.h
+++ b/storage/blockchain/blockchain_db_interfaces.h
@@ -1,0 +1,91 @@
+// Copyright 2018-2019 VMware, all rights reserved
+
+#ifndef CONCORD_STORAGE_BLOCKCHAIN_DB_INTERFACES_H_
+#define CONCORD_STORAGE_BLOCKCHAIN_DB_INTERFACES_H_
+
+#include <iterator>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include "sliver.hpp"
+#include "status.hpp"
+#include "../database_interface.h"
+
+using std::pair;
+using std::string;
+using std::unordered_map;
+
+namespace concordStorage {
+namespace blockchain {
+
+using concordUtils::Status;
+using concordUtils::Key;
+using concordUtils::Value;
+using concordUtils::BlockId;
+
+// forward declarations
+class ILocalKeyValueStorageReadOnlyIterator;
+
+class ILocalKeyValueStorageReadOnly {
+ public:
+  // convenience where readVersion==latest, and block is not needed?
+  virtual Status get(Key key, Value& outValue) const = 0;
+  virtual Status get(BlockId readVersion, Sliver key, Sliver& outValue,
+                     BlockId& outBlock) const = 0;
+
+  virtual BlockId getLastBlock() const = 0;
+  virtual Status getBlockData(BlockId blockId,
+                              SetOfKeyValuePairs& outBlockData) const = 0;
+  // TODO(GG): explain motivation
+  virtual Status mayHaveConflictBetween(Sliver key, BlockId fromBlock,
+                                        BlockId toBlock,
+                                        bool& outRes) const = 0;
+
+  virtual ILocalKeyValueStorageReadOnlyIterator* getSnapIterator() const = 0;
+  virtual Status freeSnapIterator(
+      ILocalKeyValueStorageReadOnlyIterator* iter) const = 0;
+
+  virtual void monitor() const = 0;
+};
+
+/*
+ * TODO: Iterator cleanup. The general interface should expose only
+ * getCurrent() and isEnd(), and there should be two interfaces inheriting
+ * from it:
+ * 1. One which is "clean", without awareness to blocks
+ * 2. Second which is aware of blocks and versions.
+ */
+class ILocalKeyValueStorageReadOnlyIterator {
+ public:
+  virtual KeyValuePair first(BlockId readVersion, BlockId& actualVersion,
+                             bool& isEnd) = 0;
+  virtual KeyValuePair first() = 0;
+
+  // Assumes lexicographical ordering of the keys, seek the first element
+  // k >= key
+  virtual KeyValuePair seekAtLeast(BlockId readVersion, Key key,
+                                   BlockId& actualVersion, bool& isEnd) = 0;
+  virtual KeyValuePair seekAtLeast(Key key) = 0;
+
+  // Proceed to next element and return it
+  virtual KeyValuePair next(BlockId readVersion, Key key,
+                            BlockId& actualVersion, bool& isEnd) = 0;
+  virtual KeyValuePair next() = 0;
+
+  // Return current element without moving
+  virtual KeyValuePair getCurrent() = 0;
+
+  // Check if iterator is in the end.
+  virtual bool isEnd() = 0;
+};
+
+class IBlocksAppender {
+ public:
+  virtual Status addBlock(const SetOfKeyValuePairs& updates,
+                          BlockId& outBlockId) = 0;
+};
+
+}  // namespace blockchain 
+}  // namespace concordStorage 
+
+#endif  // CONCORD_STORAGE_BLOCKCHAIN_DB_INTERFACES_H_

--- a/storage/blockchain/blockchain_db_types.h
+++ b/storage/blockchain/blockchain_db_types.h
@@ -1,0 +1,54 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#ifndef CONCORD_STORAGE_BLOCKCHAIN_DB_TYPES_H_
+#define CONCORD_STORAGE_BLOCKCHAIN_DB_TYPES_H_
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+
+namespace concordStorage {
+namespace blockchain {
+
+struct BlockHeader {
+  uint32_t numberOfElements;
+  uint32_t parentDigestLength;
+  int8_t
+      parentDigest[bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE];
+};
+
+// BlockEntry structures are coming immediately after the header.
+struct BlockEntry {
+  uint32_t keyOffset;
+  uint32_t keySize;
+  uint32_t valOffset;
+  uint32_t valSize;
+};
+
+enum class EDBKeyType : std::uint8_t {
+  E_DB_KEY_TYPE_FIRST = 1,
+  E_DB_KEY_TYPE_BLOCK = E_DB_KEY_TYPE_FIRST,
+  E_DB_KEY_TYPE_KEY,
+  E_DB_KEY_TYPE_BFT_METADATA_KEY,
+  E_DB_KEY_TYPE_LAST
+};
+
+typedef uint64_t BlockId;
+typedef uint32_t ObjectId;
+
+}  // namespace blockchain 
+}  // namespace concordStorage 
+
+#endif  // CONCORD_STORAGE_BLOCKCHAIN_DB_TYPES_H_

--- a/storage/blockchain/comparators.cpp
+++ b/storage/blockchain/comparators.cpp
@@ -1,0 +1,124 @@
+// Copyright 2018 VMware, all rights reserved
+//
+// Storage key comparators implementation.
+
+#include "comparators.h"
+
+#include <log4cplus/loggingmacros.h>
+
+#include "hex_tools.h"
+#include "sliver.hpp"
+#include "blockchain_db_adapter.h"
+#include "blockchain_db_types.h"
+#include "blockchain_db_interfaces.h"
+#include "rocksdb_client.h"
+
+#include <chrono>
+
+using concordUtils::Sliver;
+using log4cplus::Logger;
+using concordStorage::rocksdb::copyRocksdbSlice;
+
+namespace concordStorage {
+namespace blockchain {
+
+/*
+ * If key a is earlier than key b, return a negative number; if larger, return a
+ * positive number; if equal, return zero.
+ *
+ * Comparison is done by decomposed parts. Types are compared first, followed by
+ * the application key, and finally the block id. Types and keys are sorted in
+ * ascending order, and block IDs are sorted in descending order.
+ */
+int RocksKeyComparator::ComposedKeyComparison(const Logger& logger,
+                                              const Sliver& _a,
+                                              const Sliver& _b) {
+  // TODO(BWF): see note about multiple bytes in extractTypeFromKey
+  char aType = KeyManipulator::extractTypeFromKey(_a);
+  char bType = KeyManipulator::extractTypeFromKey(_b);
+  if (aType != bType) {
+    int ret = aType - bType;
+    return ret;
+  }
+
+  // In case it is E_DB_KEY_TYPE_METADATA_KEY, compare object IDs.
+  if (aType == (char)EDBKeyType::E_DB_KEY_TYPE_BFT_METADATA_KEY) {
+    BlockId aObjId = KeyManipulator::extractObjectIdFromKey(logger, _a);
+    BlockId bObjId = KeyManipulator::extractObjectIdFromKey(logger, _b);
+
+    if (aObjId < bObjId) return -1;
+    if (bObjId < aObjId) return 1;
+    return 0;
+  }
+
+  // if this is a block, we stop with key comparison - it doesn't have a block
+  // id component (that would be redundant)
+  if (aType == ((char)EDBKeyType::E_DB_KEY_TYPE_BLOCK)) {
+    // Extract the block ids to compare so that endianness of environment
+    // does not matter.
+    BlockId aId = KeyManipulator::extractBlockIdFromKey(logger, _a);
+    BlockId bId = KeyManipulator::extractBlockIdFromKey(logger, _b);
+
+    if (aId < bId) {
+      return -1;
+    } else if (bId < aId) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  Sliver aKey =
+      KeyManipulator::extractKeyFromKeyComposedWithBlockId(logger, _a);
+  Sliver bKey =
+      KeyManipulator::extractKeyFromKeyComposedWithBlockId(logger, _b);
+
+  int keyComp = aKey.compare(bKey);
+
+  if (keyComp == 0) {
+    BlockId aId = KeyManipulator::extractBlockIdFromKey(logger, _a);
+    BlockId bId = KeyManipulator::extractBlockIdFromKey(logger, _b);
+
+    // within a type+key, block ids are sorted in reverse order
+    if (aId < bId) {
+      return 1;
+    } else if (bId < aId) {
+      return -1;
+    } else {
+      return 0;
+    }
+  }
+
+  return keyComp;
+}
+
+/* RocksDB */
+#ifdef USE_ROCKSDB
+int RocksKeyComparator::Compare(const ::rocksdb::Slice& _a,
+                                const ::rocksdb::Slice& _b) const {
+  Sliver a = copyRocksdbSlice(_a);
+  Sliver b = copyRocksdbSlice(_b);
+  int ret = ComposedKeyComparison(logger, a, b);
+
+  LOG4CPLUS_DEBUG(logger,
+                  "Compared " << a << " with " << b << ", returning " << ret);
+
+  return ret;
+}
+#endif
+
+/* In memory */
+bool RocksKeyComparator::InMemKeyComp(const Sliver& _a, const Sliver& _b) {
+  Logger logger(
+      log4cplus::Logger::getInstance("concord.storage.RocksKeyComparator"));
+  int comp = ComposedKeyComparison(logger, _a, _b);
+
+  LOG4CPLUS_DEBUG(logger, "Compared " << _a << " with " << _b
+                                      << ", a < b == " << (comp < 0));
+
+  // Check: comp < 0 ==> _a < _b
+  return comp < 0;
+}
+
+}  // namespace blockchain 
+}  // namespace concordStorage

--- a/storage/blockchain/comparators.h
+++ b/storage/blockchain/comparators.h
@@ -1,0 +1,53 @@
+// Copyright 2018 VMware, all rights reserved
+//
+// Storage key comparators definition.
+
+#ifndef CONCORD_STORAGE_COMPARATORS_H_
+#define CONCORD_STORAGE_COMPARATORS_H_
+
+#include <log4cplus/loggingmacros.h>
+
+#ifdef USE_ROCKSDB
+#include "rocksdb/comparator.h"
+#include "rocksdb/slice.h"
+#endif
+
+#include "sliver.hpp"
+
+namespace concordStorage {
+namespace blockchain {
+
+using concordUtils::Sliver;
+
+// Basic comparator. Decomposes storage key into parts (type, version,
+// application key).
+
+// RocksDB
+#ifdef USE_ROCKSDB
+class RocksKeyComparator : public rocksdb::Comparator {
+ public:
+  RocksKeyComparator()
+      : logger(log4cplus::Logger::getInstance(
+            "concord.storage.RocksKeyComparator")) {}
+  int Compare(const rocksdb::Slice& _a, const rocksdb::Slice& _b) const;
+
+  // GG: Ignore the following methods for now:
+  const char* Name() const { return "RocksKeyComparator"; }
+  void FindShortestSeparator(std::string*, const rocksdb::Slice&) const {}
+  void FindShortSuccessor(std::string*) const {}
+  static bool InMemKeyComp(const Sliver& _a, const Sliver& _b);
+
+ private:
+  static int ComposedKeyComparison(const log4cplus::Logger& logger,
+                                   const Sliver& _a,
+                                   const Sliver& _b);
+
+ private:
+  log4cplus::Logger logger;
+};
+#endif
+
+}  // namespace blockchain
+}  // namespace concordStorage
+
+#endif  // CONCORD_STORAGE_COMPARATORS_H_

--- a/storage/database_interface.h
+++ b/storage/database_interface.h
@@ -1,0 +1,62 @@
+// Copyright 2018 VMware, all rights reserved
+
+#ifndef CONCORD_STORAGE_DATABASE_INTERFACE_H_
+#define CONCORD_STORAGE_DATABASE_INTERFACE_H_
+
+#include "sliver.hpp"
+#include "status.hpp"
+#include "kv_types.hpp"
+
+#define OUT
+
+namespace concordStorage {
+
+using concordUtils::Sliver;
+using concordUtils::Status;
+using concordUtils::KeysVector;
+using concordUtils::ValuesVector;
+using concordUtils::KeyValuePair;
+using concordUtils::SetOfKeyValuePairs;
+
+class IDBClient {
+ public:
+  typedef bool (*KeyComparator)(const Sliver &, const Sliver &);
+
+  virtual ~IDBClient() = default;
+  virtual Status init(bool readOnly = false) = 0;
+  virtual Status get(Sliver _key, OUT Sliver &_outValue) const = 0;
+  virtual Status get(Sliver _key, OUT char *&buf, uint32_t bufSize,
+                     OUT uint32_t &_size) const = 0;
+  virtual Status put(Sliver _key, Sliver _value) = 0;
+  virtual Status del(Sliver _key) = 0;
+  virtual Status multiGet(const KeysVector &_keysVec,
+                          OUT ValuesVector &_valuesVec) = 0;
+  virtual Status multiPut(const SetOfKeyValuePairs &_keyValueMap) = 0;
+  virtual Status multiDel(const KeysVector &_keysVec) = 0;
+  virtual void monitor() const = 0;
+  virtual bool isNew() = 0;
+
+  class IDBClientIterator {
+   public:
+    virtual KeyValuePair first() = 0;
+
+    // Returns next keys if not found for this key
+    virtual KeyValuePair seekAtLeast(Sliver _searchKey) = 0;
+    virtual KeyValuePair previous() = 0;
+    virtual KeyValuePair next() = 0;
+    virtual KeyValuePair getCurrent() = 0;
+    virtual bool isEnd() = 0;
+
+    // Status of last operation
+    virtual Status getStatus() = 0;
+
+    virtual ~IDBClientIterator() {}
+  };
+
+  virtual IDBClientIterator *getIterator() const = 0;
+  virtual Status freeIterator(IDBClientIterator *_iter) const = 0;
+};
+
+}  // namespace concordStorage
+
+#endif  // CONCORD_STORAGE_DATABASE_INTERFACE_H_

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(concordbft_storage_rocksdb STATIC
+    rocksdb_client.cpp
+    rocksdb_metadata_storage.cpp
+)
+target_include_directories(concordbft_storage_rocksdb PUBLIC
+    ${bftengine_SOURCE_DIR}/include)
+
+target_include_directories(concordbft_storage_rocksdb PUBLIC .)
+
+find_library(ROCKSDB rocksdb)
+find_library(LIBBZ2 bz2)
+find_library(LIBLZ4 lz4)
+find_library(LIBZSTD zstd)
+find_library(LIBZ z)
+find_library(LIBSNAPPY snappy)
+target_compile_definitions(concordbft_storage_rocksdb PUBLIC USE_ROCKSDB=1)
+target_link_libraries(concordbft_storage_rocksdb PUBLIC ${ROCKSDB} ${LIBBZ2} ${LIBLZ4} ${LIBZSTD} ${LIBZ} ${LIBSNAPPY})
+
+target_compile_definitions(concordbft_storage_rocksdb PUBLIC __BASE=1 SPARSE_STATE=1 USE_TLS=1)
+if(${BUILD_COMM_TCP_TLS})
+    target_compile_definitions(concordbft_storage_rocksdb PUBLIC USE_COMM_TLS_TCP)
+endif()

--- a/storage/rocksdb/rocksdb_client.cpp
+++ b/storage/rocksdb/rocksdb_client.cpp
@@ -1,0 +1,517 @@
+// Copyright 2018 VMware, all rights reserved
+
+/**
+ * @file RocksDBClient.cc
+ *
+ * @brief Contains helper functions for the RocksDBClient and
+ * RocksDBClientIterator classes.
+ *
+ * Wrappers around RocksDB functions for standard database operations.
+ * Functions are included for creating, using, and destroying iterators to
+ * navigate through the RocksDB Database.
+ */
+
+#ifdef USE_ROCKSDB
+
+#include "rocksdb_client.h"
+
+#include <log4cplus/loggingmacros.h>
+
+#include "hash_defs.h"
+#include "rocksdb/comparator.h"
+
+using concordUtils::Sliver;
+using concordUtils::Status;
+
+namespace concordStorage {
+namespace rocksdb {
+
+// Counter for number of read requests
+static unsigned int g_rocksdb_called_read;
+static bool g_rocksdb_print_measurements;
+
+/**
+ * @brief Converts a Sliver object to a RocksDB Slice object.
+ *
+ * @param _s Sliver object.
+ * @return A RocksDB Slice object.
+ */
+::rocksdb::Slice toRocksdbSlice(Sliver _s) {
+  return ::rocksdb::Slice(reinterpret_cast<char *>(_s.data()), _s.length());
+}
+
+/**
+ * @brief Wraps a RocksDB slice in a Sliver.
+ *
+ * Important: Sliver will release the data when it goes out of scope, so:
+ *
+ *  1. You must own the data inside the slice.
+ *  2. Your use of that data must not happen after the Sliver is deleted.
+ *
+ * @param _s A RocksDB Slice object.
+ * @return A Sliver object.
+ */
+Sliver fromRocksdbSlice(::rocksdb::Slice _s) {
+  char *nonConstData = const_cast<char *>(_s.data());
+  return Sliver(reinterpret_cast<uint8_t *>(nonConstData), _s.size());
+}
+
+/**
+ * @brief Copies a RocksDB slice in a Sliver.
+ *
+ * @param _s A RocksDB Slice object.
+ * @return A Sliver object.
+ */
+Sliver copyRocksdbSlice(::rocksdb::Slice _s) {
+  uint8_t *copyData = new uint8_t[_s.size()];
+  std::copy(_s.data(), _s.data() + _s.size(), copyData);
+  return Sliver(copyData, _s.size());
+}
+
+bool RocksDBClient::isNew() {
+  ::rocksdb::DB *db;
+  ::rocksdb::Options options;
+  options.error_if_exists = true;
+  ::rocksdb::Status s = ::rocksdb::DB::Open(options, m_dbPath, &db);
+  return s.IsNotFound();
+}
+
+/**
+ * @brief Opens a RocksDB database connection.
+ *
+ * Uses the RocksDBClient object variables m_dbPath and m_dbInstance to
+ * establish a connection with RocksDB by creating a RocksDB object.
+ *
+ *  @return GeneralError in case of error in connection, else OK.
+ */
+Status RocksDBClient::init(bool readOnly) {
+  ::rocksdb::DB *db;
+  ::rocksdb::Options options;
+  options.create_if_missing = true;
+  options.comparator = m_comparator;
+
+  ::rocksdb::Status s;
+  if (readOnly) {
+    s = ::rocksdb::DB::OpenForReadOnly(options, m_dbPath, &db);
+  } else {
+    s = ::rocksdb::DB::Open(options, m_dbPath, &db);
+  }
+  m_dbInstance.reset(db);
+
+  if (!s.ok()) {
+    LOG4CPLUS_ERROR(logger, "Failed to open rocksdb database at "
+                                << m_dbPath << " due to " << s.ToString());
+    return Status::GeneralError("Database open error");
+  }
+
+  g_rocksdb_called_read = 0;
+
+  // TODO(Shelly): Update for measurements. Remove when done as well as other
+  // g_rocksdb_* variables.
+  g_rocksdb_print_measurements = false;
+
+  return Status::OK();
+}
+
+Status RocksDBClient::get(Sliver _key, OUT std::string &_value) const {
+  ++g_rocksdb_called_read;
+  if (g_rocksdb_print_measurements) {
+    LOG4CPLUS_DEBUG(logger, "Reading count = " << g_rocksdb_called_read
+                                               << ", key " << _key);
+  }
+  ::rocksdb::Status s =
+      m_dbInstance->Get(::rocksdb::ReadOptions(), toRocksdbSlice(_key), &_value);
+
+  if (s.IsNotFound()) {
+    return Status::NotFound("Not found");
+  }
+
+  if (!s.ok()) {
+    LOG4CPLUS_DEBUG(logger,
+                    "Failed to get key " << _key << " due to " << s.ToString());
+    return Status::GeneralError("Failed to read key");
+  }
+
+  return Status::OK();
+}
+
+/**
+ * @brief Services a read request from the RocksDB database.
+ *
+ * Fires a get request to the RocksDB client and stores the data of the
+ * response in a new Sliver object.
+ *
+ * Note: the reference to the data is not stored, the data itself is.
+ *
+ * @param _key Sliver object of the key that needs to be looked up.
+ * @param _outValue Sliver object in which the data of the Get response is
+ *                  stored, if any.
+ * @return Status NotFound if key is not present, Status GeneralError if error
+ *         in Get, else Status OK.
+ */
+Status RocksDBClient::get(Sliver _key, OUT Sliver &_outValue) const {
+  std::string value;
+  Status ret = get(_key, value);
+  if (!ret.isOK()) return ret;
+
+  size_t valueSize = value.size();
+  // Must copy the string data
+  uint8_t *stringCopy = new uint8_t[valueSize];
+  memcpy(stringCopy, value.data(), valueSize);
+  _outValue = Sliver(stringCopy, valueSize);
+
+  return Status::OK();
+}
+
+// A memory for the output buffer is expected to be allocated by a caller.
+Status RocksDBClient::get(Sliver _key, OUT char *&buf, uint32_t bufSize,
+                          OUT uint32_t &_realSize) const {
+  std::string value;
+  Status ret = get(_key, value);
+  if (!ret.isOK()) return ret;
+
+  _realSize = static_cast<uint32_t>(value.length());
+  if (bufSize < _realSize) {
+    LOG4CPLUS_ERROR(logger,
+                    "Object value is bigger than specified buffer bufSize="
+                        << bufSize << ", _realSize=" << _realSize);
+    return Status::GeneralError("Object value is bigger than specified buffer");
+  }
+  memcpy(buf, value.data(), _realSize);
+  return Status::OK();
+}
+
+/**
+ * @brief Returns a RocksDBClientIterator object.
+ *
+ * @return RocksDBClientIterator object.
+ */
+IDBClient::IDBClientIterator *RocksDBClient::getIterator() const {
+  return new RocksDBClientIterator(this);
+}
+
+/**
+ * @brief Frees the RocksDBClientIterator.
+ *
+ * @param _iter Pointer to object of class RocksDBClientIterator (the iterator)
+ *              that needs to be freed.
+ * @return Status InvalidArgument if iterator is null pointer, else, Status OK.
+ */
+Status RocksDBClient::freeIterator(IDBClientIterator *_iter) const {
+  if (_iter == NULL) {
+    return Status::InvalidArgument("Invalid iterator");
+  }
+
+  delete (RocksDBClientIterator *)_iter;
+
+  return Status::OK();
+}
+
+/**
+ * @brief Returns an iterator.
+ *
+ * Returns a reference to a new object of RocksDbIterator.
+ *
+ * @return A pointer to RocksDbIterator object.
+ */
+::rocksdb::Iterator *RocksDBClient::getNewRocksDbIterator() const {
+  return m_dbInstance->NewIterator(::rocksdb::ReadOptions());
+}
+
+/**
+ * @brief Currently used to check the number of read requests received.
+ */
+void RocksDBClient::monitor() const {
+  // TODO Can be used for additional sanity checks and debugging.
+
+  if (g_rocksdb_print_measurements) {
+    LOG4CPLUS_DEBUG(logger, "No. of times read: " << g_rocksdb_called_read);
+  }
+}
+
+/**
+ * @brief Constructor for the RocksDBClientIterator class.
+ *
+ * Calls the getNewRocksDbIterator function.
+ */
+RocksDBClientIterator::RocksDBClientIterator(const RocksDBClient *_parentClient)
+    : logger(log4cplus::Logger::getInstance("com.vmware.concord.kvb")),
+      m_parentClient(_parentClient),
+      m_status(Status::OK()) {
+  m_iter = m_parentClient->getNewRocksDbIterator();
+}
+
+/**
+ * @brief Services a write request to the RocksDB database.
+ *
+ * Fires a put request to the RocksDB client.
+ *
+ * @param _key The key that needs to be stored.
+ * @param _value The value that needs to be stored against the key.
+ * @return Status GeneralError if error in Put, else Status OK.
+ */
+Status RocksDBClient::put(Sliver _key, Sliver _value) {
+  ::rocksdb::WriteOptions woptions = ::rocksdb::WriteOptions();
+
+  ::rocksdb::Status s =
+      m_dbInstance->Put(woptions, toRocksdbSlice(_key), toRocksdbSlice(_value));
+
+  LOG4CPLUS_DEBUG(logger, "Rocksdb Put " << _key << " : " << _value);
+
+  if (!s.ok()) {
+    LOG4CPLUS_ERROR(logger,
+                    "Failed to put key " << _key << ", value " << _value);
+    return Status::GeneralError("Failed to put key");
+  }
+
+  return Status::OK();
+}
+
+/**
+ * @brief Services a delete request to the RocksDB database.
+ *
+ *  Fires a Delete request to the RocksDB database.
+ *
+ *  @param _key The key corresponding to the key value pair which needs to be
+ *              deleted.
+ *  @return Status GeneralError if error in delete, else Status OK.
+ */
+Status RocksDBClient::del(Sliver _key) {
+  ::rocksdb::WriteOptions woptions = ::rocksdb::WriteOptions();
+  ::rocksdb::Status s = m_dbInstance->Delete(woptions, toRocksdbSlice(_key));
+
+  LOG4CPLUS_DEBUG(logger, "Rocksdb delete " << _key);
+
+  if (!s.ok()) {
+    LOG4CPLUS_ERROR(logger, "Failed to delete key " << _key);
+    return Status::GeneralError("Failed to delete key");
+  }
+
+  return Status::OK();
+}
+
+Status RocksDBClient::multiGet(const KeysVector &_keysVec,
+                               OUT ValuesVector &_valuesVec) {
+  std::vector<std::string> values;
+  std::vector<::rocksdb::Slice> keys;
+  for (auto const &it : _keysVec) keys.push_back(toRocksdbSlice(it));
+
+  std::vector<::rocksdb::Status> statuses =
+      m_dbInstance->MultiGet(::rocksdb::ReadOptions(), keys, &values);
+
+  for (size_t i = 0; i < values.size(); i++) {
+    if (statuses[i].IsNotFound()) return Status::NotFound("Not found");
+
+    if (!statuses[i].ok()) {
+      LOG4CPLUS_WARN(logger, "Failed to get key " << _keysVec[i] << " due to "
+                                                  << statuses[i].ToString());
+      return Status::GeneralError("Failed to read key");
+    }
+    size_t valueSize = values[i].size();
+    auto valueStr = new uint8_t[valueSize];
+    memcpy(valueStr, values[i].data(), valueSize);
+    _valuesVec.push_back(Sliver(valueStr, valueSize));
+  }
+  return Status::OK();
+}
+
+std::ostringstream RocksDBClient::collectKeysForPrint(
+    const KeysVector &_keysVec) {
+  std::ostringstream keys;
+  for (auto const &it : _keysVec) keys << it << ", ";
+  return keys;
+}
+
+Status RocksDBClient::launchBatchJob(::rocksdb::WriteBatch &_batchJob,
+                                     const KeysVector &_keysVec) {
+  ::rocksdb::WriteOptions wOptions = ::rocksdb::WriteOptions();
+  ::rocksdb::Status status = m_dbInstance->Write(wOptions, &_batchJob);
+  if (!status.ok()) {
+    LOG4CPLUS_ERROR(logger, "Execution of batch job failed; keys: "
+                                << collectKeysForPrint(_keysVec).str());
+    return Status::GeneralError("Execution of batch job failed");
+  }
+  LOG4CPLUS_DEBUG(logger, "Successfully executed a batch job for keys: "
+                              << collectKeysForPrint(_keysVec).str());
+  return Status::OK();
+}
+
+Status RocksDBClient::multiPut(const SetOfKeyValuePairs &_keyValueMap) {
+  ::rocksdb::WriteBatch batch;
+  KeysVector keysVec;
+  for (const auto &it : _keyValueMap) {
+    batch.Put(toRocksdbSlice(it.first), toRocksdbSlice(it.second));
+    keysVec.push_back(it.first);
+    LOG4CPLUS_DEBUG(logger, "RocksDB Added entry: key ="
+                                << it.first << ", value= " << it.second
+                                << " to the batch job");
+  }
+  Status status = launchBatchJob(batch, keysVec);
+  if (status.isOK())
+    LOG4CPLUS_DEBUG(logger, "Successfully put all entries to the database");
+  return status;
+}
+
+Status RocksDBClient::multiDel(const KeysVector &_keysVec) {
+  ::rocksdb::WriteBatch batch;
+  std::ostringstream keys;
+  for (auto const &it : _keysVec) {
+    batch.Delete(toRocksdbSlice(it));
+  }
+  Status status = launchBatchJob(batch, _keysVec);
+  if (status.isOK()) LOG4CPLUS_DEBUG(logger, "Successfully deleted entries");
+  return status;
+}
+
+/**
+ * @brief Returns the KeyValuePair object of the first key in the database.
+ *
+ * @return The KeyValuePair object of the first key.
+ */
+KeyValuePair RocksDBClientIterator::first() {
+  ++g_rocksdb_called_read;
+  if (g_rocksdb_print_measurements) {
+    LOG4CPLUS_DEBUG(logger, "Reading count = " << g_rocksdb_called_read);
+  }
+
+  // Position at the first key in the database
+  m_iter->SeekToFirst();
+
+  if (!m_iter->Valid()) {
+    LOG4CPLUS_ERROR(logger, "Did not find a first key");
+    m_status = Status::NotFound("Empty database");
+    return KeyValuePair();
+  }
+
+  Sliver key = copyRocksdbSlice(m_iter->key());
+  Sliver value = copyRocksdbSlice(m_iter->value());
+
+  m_status = Status::OK();
+  return KeyValuePair(key, value);
+}
+
+/**
+ * @brief Returns the key value pair of the key which is greater than or equal
+ * to _searchKey.
+ *
+ * Returns the first key value pair whose key is not considered to go before
+ * _searchKey. Also, moves the iterator to this position.
+ *
+ * @param _searchKey Key to search for.
+ * @return Key value pair of the key which is greater than or equal to
+ *         _searchKey.
+ */
+KeyValuePair RocksDBClientIterator::seekAtLeast(Sliver _searchKey) {
+  ++g_rocksdb_called_read;
+  if (g_rocksdb_print_measurements) {
+    LOG4CPLUS_DEBUG(logger, "Reading count = " << g_rocksdb_called_read
+                                               << ", key " << _searchKey);
+  }
+
+  m_iter->Seek(toRocksdbSlice(_searchKey));
+  if (!m_iter->Valid()) {
+    LOG4CPLUS_WARN(logger, "Did not find search key " << _searchKey);
+    // TODO(SG): Status to exception?
+    return KeyValuePair();
+  }
+
+  // We have to copy the data out of the iterator, so that we own it. The
+  // pointers from the iterator will become invalid if the iterator is moved.
+  Sliver key = copyRocksdbSlice(m_iter->key());
+  Sliver value = copyRocksdbSlice(m_iter->value());
+
+  LOG4CPLUS_DEBUG(logger, "Key " << key << " value " << value);
+  m_status = Status::OK();
+  return KeyValuePair(key, value);
+}
+
+/**
+ * @brief Decrements the iterator.
+ *
+ * Decrements the iterator and returns the previous key value pair.
+ *
+ * @return The previous key value pair.
+ */
+KeyValuePair RocksDBClientIterator::previous() {
+  m_iter->Prev();
+
+  if (!m_iter->Valid()) {
+    LOG4CPLUS_ERROR(logger, "Iterator out of bounds");
+    return KeyValuePair();
+  }
+
+  Sliver key = copyRocksdbSlice(m_iter->key());
+  Sliver value = copyRocksdbSlice(m_iter->value());
+
+  LOG4CPLUS_DEBUG(logger, "Key " << key << " value " << value);
+  m_status = Status::OK();
+
+  return KeyValuePair(key, value);
+}
+
+/**
+ * @brief Increments the iterator.
+ *
+ * Increments the iterator and returns the next key value pair.
+ *
+ * @return The next key value pair.
+ */
+KeyValuePair RocksDBClientIterator::next() {
+  ++g_rocksdb_called_read;
+  if (g_rocksdb_print_measurements) {
+    LOG4CPLUS_DEBUG(logger, "Reading count = " << g_rocksdb_called_read);
+  }
+
+  m_iter->Next();
+  if (!m_iter->Valid()) {
+    LOG4CPLUS_ERROR(logger, "No next key");
+    m_status = Status::GeneralError("No next key");
+    return KeyValuePair();
+  }
+
+  Sliver key = copyRocksdbSlice(m_iter->key());
+  Sliver value = copyRocksdbSlice(m_iter->value());
+
+  LOG4CPLUS_DEBUG(logger, "Key " << key << " value " << value);
+  m_status = Status::OK();
+  return KeyValuePair(key, value);
+}
+
+/**
+ * @brief Returns the key value pair at the current position of the iterator.
+ *
+ * @return Current key value pair.
+ */
+KeyValuePair RocksDBClientIterator::getCurrent() {
+  if (!m_iter->Valid()) {
+    LOG4CPLUS_ERROR(logger, "Iterator is not pointing at an element");
+    m_status = Status::GeneralError("Iterator is not pointing at an element");
+    return KeyValuePair();
+  }
+
+  Sliver key = copyRocksdbSlice(m_iter->key());
+  Sliver value = copyRocksdbSlice(m_iter->value());
+
+  m_status = Status::OK();
+  return KeyValuePair(key, value);
+}
+
+/**
+ * @brief Tells whether iterator has crossed the bounds of the last key value
+ * pair.
+ *
+ * @return True if iterator is beyond the bounds, else False.
+ */
+bool RocksDBClientIterator::isEnd() { return !m_iter->Valid(); }
+
+/**
+ * @brief Returns the Status.
+ *
+ * @return The latest Status logged.
+ */
+Status RocksDBClientIterator::getStatus() { return m_status; }
+
+}  // namespace rocksdb 
+}  // namespace concordStorage
+
+#endif

--- a/storage/rocksdb/rocksdb_client.h
+++ b/storage/rocksdb/rocksdb_client.h
@@ -1,0 +1,121 @@
+// Copyright 2018 VMware, all rights reserved
+
+/**
+ * @file RocksDBClient.h
+ *
+ *  @brief Header file containing the RocksDBClientIterator and RocksDBClient
+ *  class definitions.
+ *
+ *  Objects of RocksDBClientIterator contain an iterator for database along with
+ *  a pointer to the client object.
+ *
+ *  Objects of RocksDBClient signify connections with RocksDB database. They
+ *  contain variables for storing the database directory path, connection object
+ *  and comparator.
+ *
+ */
+
+#ifndef CONCORD_STORAGE_ROCKSDB_CLIENT_H_
+#define CONCORD_STORAGE_ROCKSDB_CLIENT_H_
+
+#ifdef USE_ROCKSDB
+#include <log4cplus/loggingmacros.h>
+#include "rocksdb/db.h"
+#include "kv_types.hpp"
+#include "../database_interface.h"
+
+namespace concordStorage {
+namespace rocksdb {
+
+class RocksDBClient;
+
+class RocksDBClientIterator
+    : public concordStorage::IDBClient::IDBClientIterator {
+  friend class RocksDBClient;
+
+ public:
+  RocksDBClientIterator(const RocksDBClient *_parentClient);
+  ~RocksDBClientIterator() { delete m_iter; }
+
+  // Inherited via IDBClientIterator
+  concordUtils::KeyValuePair first() override;
+  concordUtils::KeyValuePair seekAtLeast(concordUtils::Sliver _searchKey) override;
+  concordUtils::KeyValuePair previous() override;
+  KeyValuePair next() override;
+  KeyValuePair getCurrent() override;
+  bool isEnd() override;
+  concordUtils::Status getStatus() override;
+
+ private:
+  log4cplus::Logger logger;
+
+  ::rocksdb::Iterator *m_iter;
+
+  // Reference to the RocksDBClient
+  const RocksDBClient *m_parentClient;
+
+  concordUtils::Status m_status;
+};
+
+class RocksDBClient : public concordStorage::IDBClient {
+ public:
+  RocksDBClient(std::string _dbPath, ::rocksdb::Comparator *_comparator)
+      : logger(log4cplus::Logger::getInstance("com.concord.vmware.kvb")),
+        m_dbPath(_dbPath),
+        m_comparator(_comparator) {}
+
+  concordUtils::Status init(bool readOnly = false) override;
+  concordUtils::Status get(
+      concordUtils::Sliver _key,
+      OUT concordUtils::Sliver &_outValue) const override;
+  concordUtils::Status get(concordUtils::Sliver _key,
+                                 OUT char *&buf, uint32_t bufSize,
+                                 OUT uint32_t &_realSize) const override;
+  IDBClientIterator *getIterator() const override;
+  concordUtils::Status freeIterator(
+      IDBClientIterator *_iter) const override;
+  concordUtils::Status put(concordUtils::Sliver _key,
+                                 concordUtils::Sliver _value) override;
+  concordUtils::Status del(concordUtils::Sliver _key) override;
+  concordUtils::Status multiGet(
+      const KeysVector &_keysVec,
+      OUT ValuesVector &_valuesVec) override;
+  concordUtils::Status multiPut(
+      const SetOfKeyValuePairs &_keyValueMap) override;
+  concordUtils::Status multiDel(
+      const KeysVector &_keysVec) override;
+  ::rocksdb::Iterator *getNewRocksDbIterator() const;
+  void monitor() const override;
+  bool isNew() override;
+
+ private:
+  concordUtils::Status launchBatchJob(
+      ::rocksdb::WriteBatch &_batchJob,
+      const KeysVector &_keysVec);
+  std::ostringstream collectKeysForPrint(
+      const KeysVector &_keysVec);
+  concordUtils::Status get(concordUtils::Sliver _key,
+                                 OUT std::string &_value) const;
+
+ private:
+  log4cplus::Logger logger;
+
+  // Database path on directory (used for connection).
+  std::string m_dbPath;
+
+  // Database object (created on connection).
+  std::unique_ptr<::rocksdb::DB> m_dbInstance;
+
+  // Comparator object.
+  ::rocksdb::Comparator *m_comparator;
+};
+
+::rocksdb::Slice toRocksdbSlice(concordUtils::Sliver _s);
+concordUtils::Sliver fromRocksdbSlice(::rocksdb::Slice _s);
+concordUtils::Sliver copyRocksdbSlice(::rocksdb::Slice _s);
+
+}  // namespace rocksdb
+}  // namespace concordStorage
+
+#endif  // USE_ROCKSDB
+#endif  // CONCORD_STORAGE_ROCKSDB_CLIENT_H_

--- a/storage/rocksdb/rocksdb_metadata_storage.cpp
+++ b/storage/rocksdb/rocksdb_metadata_storage.cpp
@@ -1,0 +1,144 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "rocksdb_metadata_storage.h"
+
+#include <cstring>
+#include <exception>
+#include "hash_defs.h"
+
+using namespace std;
+
+using concordUtils::Status;
+
+namespace concordStorage {
+namespace rocksdb {
+
+void RocksDBMetadataStorage::verifyOperation(uint32_t dataLen,
+                                             const char *buffer) const {
+  if (!dataLen || !buffer) {
+    LOG4CPLUS_ERROR(logger_, WRONG_PARAMETER);
+    throw runtime_error(WRONG_PARAMETER);
+  }
+}
+
+bool RocksDBMetadataStorage::isNewStorage() {
+  uint32_t outActualObjectSize;
+  read(objectsNumParameterId_, sizeof(objectsNum_), (char *)&objectsNum_,
+       outActualObjectSize);
+  return (outActualObjectSize == 0);
+}
+
+bool RocksDBMetadataStorage::initMaxSizeOfObjects(
+    ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) {
+  // Metadata object with id=0 is used to indicate storage initialization state
+  // (number of specified metadata objects).
+  bool isNew = isNewStorage();
+  if (isNew) {
+    objectsNum_ = metadataObjectsArrayLength;
+    atomicWrite(objectsNumParameterId_, (char *)&objectsNum_,
+                sizeof(objectsNum_));
+  }
+  LOG4CPLUS_DEBUG(logger_, "initMaxSizeOfObjects objectsNum_=" << objectsNum_);
+  return isNew;
+}
+
+void RocksDBMetadataStorage::read(uint32_t objectId, uint32_t bufferSize,
+                                  char *outBufferForObject,
+                                  uint32_t &outActualObjectSize) {
+  verifyOperation(bufferSize, outBufferForObject);
+  lock_guard<mutex> lock(ioMutex_);
+  Status status =
+      dbClient_->get(genMetadataKey_(objectId),
+                     outBufferForObject, bufferSize, outActualObjectSize);
+  if (status.isNotFound()) {
+    memset(outBufferForObject, 0, bufferSize);
+    outActualObjectSize = 0;
+    return;
+  }
+  if (!status.isOK()) {
+    throw runtime_error("RocksDB get operation failed");
+  }
+}
+
+void RocksDBMetadataStorage::atomicWrite(uint32_t objectId, char *data,
+                                         uint32_t dataLength) {
+  verifyOperation(dataLength, data);
+  auto *dataCopy = new uint8_t[dataLength];
+  memcpy(dataCopy, data, dataLength);
+  lock_guard<mutex> lock(ioMutex_);
+  Status status = dbClient_->put(genMetadataKey_(objectId),
+                                 Sliver(dataCopy, dataLength));
+  if (!status.isOK()) {
+    throw runtime_error("RocksDB put operation failed");
+  }
+}
+
+void RocksDBMetadataStorage::beginAtomicWriteOnlyTransaction() {
+  LOG4CPLUS_DEBUG(logger_, "Begin atomic transaction");
+  lock_guard<mutex> lock(ioMutex_);
+  if (transaction_) {
+    LOG4CPLUS_INFO(logger_, "Transaction has been opened before; ignoring");
+    return;
+  }
+  transaction_ = new SetOfKeyValuePairs;
+}
+
+void RocksDBMetadataStorage::writeInTransaction(uint32_t objectId, char *data,
+                                                uint32_t dataLength) {
+  LOG4CPLUS_DEBUG(logger_,
+                  "objectId=" << objectId << ", dataLength=" << dataLength);
+  verifyOperation(dataLength, data);
+  auto *dataCopy = new uint8_t[dataLength];
+  memcpy(dataCopy, data, dataLength);
+  lock_guard<mutex> lock(ioMutex_);
+  if (!transaction_) {
+    LOG4CPLUS_ERROR(logger_, WRONG_FLOW);
+    throw runtime_error(WRONG_FLOW);
+  }
+  transaction_->insert(
+      KeyValuePair(genMetadataKey_(objectId),
+                   Sliver(dataCopy, dataLength)));
+}
+
+void RocksDBMetadataStorage::commitAtomicWriteOnlyTransaction() {
+  LOG4CPLUS_DEBUG(logger_, "Commit atomic transaction");
+  lock_guard<mutex> lock(ioMutex_);
+  if (!transaction_) {
+    LOG4CPLUS_ERROR(logger_, WRONG_FLOW);
+    throw runtime_error(WRONG_FLOW);
+  }
+  Status status = dbClient_->multiPut(*transaction_);
+  if (!status.isOK()) {
+    throw runtime_error("RocksDB multiPut operation failed");
+  }
+  delete transaction_;
+  transaction_ = nullptr;
+}
+
+Status RocksDBMetadataStorage::multiDel(const ObjectIdsVector &objectIds) {
+  size_t objectsNumber = objectIds.size();
+  assert(objectsNum_ >= objectsNumber);
+  LOG4CPLUS_DEBUG(logger_, "Going to perform multiple delete");
+  KeysVector keysVec;
+  for (size_t objectId = 0; objectId < objectsNumber; objectId++) {
+    auto key = genMetadataKey_(objectId);
+    keysVec.push_back(key);
+    LOG4CPLUS_INFO(logger_,
+                   "Deleted object id=" << objectId << ", key=" << key);
+  }
+  return dbClient_->multiDel(keysVec);
+}
+
+}  // namespace rocksdb 
+}  // namespace concordStorage

--- a/storage/rocksdb/rocksdb_metadata_storage.h
+++ b/storage/rocksdb/rocksdb_metadata_storage.h
@@ -1,0 +1,76 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#ifndef CONCORD_STORAGE_ROCKSDB_METADATA_STORAGE_H_
+#define CONCORD_STORAGE_ROCKSDB_METADATA_STORAGE_H_
+
+#ifdef USE_ROCKSDB
+
+#include <mutex>
+#include <functional>
+#include <log4cplus/loggingmacros.h>
+#include "bftengine/MetadataStorage.hpp"
+#include "../database_interface.h"
+#include "sliver.hpp"
+
+namespace concordStorage {
+namespace rocksdb {
+
+typedef std::vector<uint32_t> ObjectIdsVector;
+
+class RocksDBMetadataStorage : public bftEngine::MetadataStorage {
+ public:
+  explicit RocksDBMetadataStorage(IDBClient *dbClient, 
+                                  std::function<concordUtils::Sliver(uint32_t)> genMetadataKey)
+      : logger_(log4cplus::Logger::getInstance(
+            "com.concord.vmware.metadatastorage")),
+        dbClient_(dbClient),
+        genMetadataKey_(std::move(genMetadataKey)){}
+
+  bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray,
+                            uint32_t metadataObjectsArrayLength) override;
+  void read(uint32_t objectId, uint32_t bufferSize, char *outBufferForObject,
+            uint32_t &outActualObjectSize) override;
+  void atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) override;
+  void beginAtomicWriteOnlyTransaction() override;
+  void writeInTransaction(uint32_t objectId, char *data,
+                          uint32_t dataLength) override;
+  void commitAtomicWriteOnlyTransaction() override;
+  concordUtils::Status multiDel(const ObjectIdsVector &objectIds);
+  bool isNewStorage() override;
+
+ private:
+  void verifyOperation(uint32_t dataLen, const char *buffer) const;
+
+ private:
+  const char *WRONG_FLOW =
+      "beginAtomicWriteOnlyTransaction should be launched first";
+  const char *WRONG_PARAMETER = "Wrong parameter value specified";
+
+  const uint8_t objectsNumParameterId_ = 1;
+
+  log4cplus::Logger logger_;
+  IDBClient *dbClient_ = nullptr;
+  SetOfKeyValuePairs *transaction_ = nullptr;
+  std::mutex ioMutex_;
+  uint32_t objectsNum_ = 0;
+
+  // A function that creates a metadata key given an object ID
+  std::function<Sliver(uint32_t)> genMetadataKey_;
+};
+
+}  // namespace rocksdb 
+}  // namespace concordStorage 
+
+#endif  // USE_ROCKSDB
+#endif  // CONCORD_STORAGE_ROCKSDB_METADATA_STORAGE_H_

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_executable(multiIO_test multiIO_test.cpp)
+add_test(multiIO_test multiIO_test)
+target_link_libraries(multiIO_test PUBLIC
+    gtest
+    util
+    concordbft_storage_rocksdb
+    concordbft_storage_blockchain
+    ${LOG4CPLUS_LIBRARIES}
+)
+
+add_executable(metadataStorage_test metadataStorage_test.cpp)
+add_test(metadataStorage_test metadataStorage_test)
+target_link_libraries(metadataStorage_test PUBLIC
+    gtest
+    util
+    concordbft_storage_rocksdb
+    concordbft_storage_blockchain
+    ${LOG4CPLUS_LIBRARIES}
+)

--- a/storage/test/metadataStorage_test.cpp
+++ b/storage/test/metadataStorage_test.cpp
@@ -1,0 +1,113 @@
+// Copyright 2019 VMware, all rights reserved
+/**
+ * Test public functions for RocksDBMetadataStorage class.
+ */
+
+#define USE_ROCKSDB 1
+
+#include <log4cplus/configurator.h>
+#include <log4cplus/hierarchy.h>
+#include <log4cplus/loggingmacros.h>
+#include "hash_defs.h"
+#include "gtest/gtest.h"
+#include "comparators.h"
+#include "rocksdb_client.h"
+#include "rocksdb_metadata_storage.h"
+#include "blockchain_db_types.h"
+#include "blockchain_db_adapter.h"
+
+using namespace std;
+
+using concordStorage::blockchain::ObjectId;
+using concordStorage::blockchain::RocksKeyComparator;
+using concordStorage::blockchain::KeyManipulator;
+using concordStorage::rocksdb::RocksDBClient;
+using concordStorage::rocksdb::RocksDBMetadataStorage;
+
+namespace {
+
+RocksDBMetadataStorage *metadataStorage = nullptr;
+const ObjectId initialObjectId = 1;
+const uint32_t initialObjDataSize = 80;
+const uint16_t objectsNum = 100;
+
+uint8_t *createAndFillBuf(size_t length) {
+  auto *buffer = new uint8_t[length];
+  srand(static_cast<uint>(time(nullptr)));
+  for (size_t i = 0; i < length; i++) {
+    buffer[i] = static_cast<uint8_t>(rand() % 256);
+  }
+  return buffer;
+}
+
+uint8_t *writeRandomData(const ObjectId &objectId, const uint32_t &dataLen) {
+  uint8_t *data = createAndFillBuf(dataLen);
+  metadataStorage->atomicWrite(objectId, (char *)data, dataLen);
+  return data;
+}
+
+uint8_t *writeInTransaction(const ObjectId &objectId, const uint32_t &dataLen) {
+  uint8_t *data = createAndFillBuf(dataLen);
+  metadataStorage->writeInTransaction(objectId, (char *)data, dataLen);
+  return data;
+}
+
+bool is_match(const uint8_t *exp, const uint8_t *actual, const size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    if (exp[i] != actual[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TEST(metadataStorage_test, single_read) {
+  auto *inBuf = writeRandomData(initialObjectId, initialObjDataSize);
+  auto *outBuf = new uint8_t[initialObjDataSize];
+  uint32_t realSize = 0;
+  metadataStorage->read(initialObjectId, initialObjDataSize, (char *)outBuf,
+                        realSize);
+  ASSERT_TRUE(initialObjDataSize == realSize);
+  ASSERT_TRUE(is_match(inBuf, outBuf, realSize));
+  delete[] inBuf;
+  delete[] outBuf;
+}
+
+TEST(metadataStorage_test, multi_write) {
+  metadataStorage->beginAtomicWriteOnlyTransaction();
+  uint8_t *inBuf[objectsNum];
+  uint8_t *outBuf[objectsNum];
+  uint32_t objectsDataSize[objectsNum] = {initialObjDataSize};
+  for (auto i = 0; i < objectsNum; i++) {
+    objectsDataSize[i] += i;
+    inBuf[i] = writeInTransaction(initialObjectId + i, objectsDataSize[i]);
+    outBuf[i] = new uint8_t[objectsDataSize[i]];
+  }
+  metadataStorage->commitAtomicWriteOnlyTransaction();
+  uint32_t realSize = 0;
+  for (ObjectId i = 0; i < objectsNum; i++) {
+    metadataStorage->read(initialObjectId + i, objectsDataSize[i],
+                          (char *)outBuf[i], realSize);
+    ASSERT_TRUE(objectsDataSize[i] == realSize);
+    ASSERT_TRUE(is_match(inBuf[i], outBuf[i], realSize));
+    delete[] inBuf[i];
+    delete[] outBuf[i];
+  }
+}
+
+}  // end namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  log4cplus::initialize();
+  log4cplus::Hierarchy &hierarchy = log4cplus::Logger::getDefaultHierarchy();
+  hierarchy.disableDebug();
+  log4cplus::BasicConfigurator config(hierarchy, false);
+  config.configure();
+  const string dbPath = "./metadataStorage_test_db";
+  RocksDBClient *dbClient = new RocksDBClient(dbPath, new RocksKeyComparator());
+  dbClient->init();
+  metadataStorage = new RocksDBMetadataStorage(dbClient, KeyManipulator::generateMetadataKey);
+  int res = RUN_ALL_TESTS();
+  return res;
+}

--- a/storage/test/multiIO_test.cpp
+++ b/storage/test/multiIO_test.cpp
@@ -1,0 +1,114 @@
+// Copyright 2019 VMware, all rights reserved
+/**
+ * Test multi* functions for RocksDBClient class.
+ */
+
+#define USE_ROCKSDB 1
+
+#include <log4cplus/configurator.h>
+#include <log4cplus/hierarchy.h>
+#include <log4cplus/loggingmacros.h>
+#include "hash_defs.h"
+#include "gtest/gtest.h"
+#include "comparators.h"
+#include "rocksdb_client.h"
+#include "kv_types.hpp"
+
+using namespace std;
+
+using concordUtils::Status;
+using concordUtils::Sliver;
+using concordUtils::KeysVector;
+using concordUtils::KeyValuePair;
+using concordUtils::SetOfKeyValuePairs;
+using concordStorage::rocksdb::RocksDBClient;
+using concordStorage::blockchain::RocksKeyComparator;
+
+namespace {
+
+RocksDBClient *dbClient = nullptr;
+const uint16_t blocksNum = 50;
+const uint16_t keyLen = 120;
+const uint16_t valueLen = 500;
+
+uint8_t *createAndFillBuf(size_t length) {
+  auto *buffer = new uint8_t[length];
+  srand(static_cast<uint>(time(nullptr)));
+  for (size_t i = 0; i < length; i++) {
+    buffer[i] = static_cast<uint8_t>(rand() % 256);
+  }
+  return buffer;
+}
+
+void verifyMultiGet(KeysVector &keys, Sliver inValues[blocksNum],
+                    KeysVector &outValues) {
+  ASSERT_TRUE(dbClient->multiGet(keys, outValues) == Status::OK());
+  ASSERT_TRUE(outValues.size() == blocksNum);
+  for (int i = 0; i < blocksNum; i++) {
+    ASSERT_TRUE(inValues[i] == outValues[i]);
+  }
+}
+
+void verifyMultiDel(KeysVector &keys) {
+  const Status expectedStatus = Status::NotFound("Not Found");
+  for (const auto &it : keys) {
+    Sliver outValue;
+    ASSERT_TRUE(dbClient->get(it, outValue) == expectedStatus);
+  }
+}
+
+void launchMultiPut(KeysVector &keys, Sliver inValues[blocksNum],
+                    SetOfKeyValuePairs &keyValueMap) {
+  for (auto i = 0; i < blocksNum; i++) {
+    keys[i] = Sliver(createAndFillBuf(keyLen), keyLen);
+    inValues[i] = Sliver(createAndFillBuf(valueLen), valueLen);
+    keyValueMap.insert(KeyValuePair(keys[i], inValues[i]));
+  }
+  ASSERT_TRUE(dbClient->multiPut(keyValueMap).isOK());
+}
+
+TEST(multiIO_test, single_put) {
+  Sliver key(createAndFillBuf(keyLen), keyLen);
+  Sliver inValue(createAndFillBuf(valueLen), valueLen);
+  Status status = dbClient->put(key, inValue);
+  ASSERT_TRUE(status.isOK());
+  Sliver outValue;
+  status = dbClient->get(key, outValue);
+  ASSERT_TRUE(status.isOK());
+  ASSERT_TRUE(inValue == outValue);
+}
+
+TEST(multiIO_test, multi_put) {
+  KeysVector keys(blocksNum);
+  Sliver inValues[blocksNum];
+  SetOfKeyValuePairs keyValueMap;
+  KeysVector outValues;
+  launchMultiPut(keys, inValues, keyValueMap);
+  verifyMultiGet(keys, inValues, outValues);
+}
+
+TEST(multiIO_test, multi_del) {
+  KeysVector keys(blocksNum);
+  Sliver inValues[blocksNum];
+  SetOfKeyValuePairs keyValueMap;
+  KeysVector outValues;
+  launchMultiPut(keys, inValues, keyValueMap);
+  ASSERT_TRUE(dbClient->multiDel(keys).isOK());
+  verifyMultiDel(keys);
+}
+
+}  // end namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  log4cplus::initialize();
+  log4cplus::Hierarchy &hierarchy = log4cplus::Logger::getDefaultHierarchy();
+  hierarchy.disableDebug();
+  log4cplus::BasicConfigurator config(hierarchy, false);
+  config.configure();
+  const string dbPath = "./rocksdb_test";
+  dbClient = new RocksDBClient(dbPath, new RocksKeyComparator());
+  dbClient->init();
+  int res = RUN_ALL_TESTS();
+  return res;
+}

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,7 +1,15 @@
 # pthread dependency
 find_package(Threads REQUIRED)
 
-add_library(util STATIC src/Metrics.cpp src/MetricsServer.cpp src/SimpleThreadPool.cpp src/Serializable.cpp src/histogram.cpp include/misc.hpp)
+add_library(util STATIC
+    src/Metrics.cpp
+    src/MetricsServer.cpp
+    src/SimpleThreadPool.cpp
+    src/Serializable.cpp
+    src/histogram.cpp
+    src/status.cpp
+    src/sliver.cpp
+    src/hex_tools.cpp)
 
 target_link_libraries(util PUBLIC Threads::Threads)
 target_include_directories(util PUBLIC include)

--- a/util/include/hash_defs.h
+++ b/util/include/hash_defs.h
@@ -1,0 +1,53 @@
+// Copyright 2018 VMware, all rights reserved
+//
+// Hash functions for our Sliver and KeyValuePair types.
+
+#ifndef CONCORD_BFT_UTIL_HASH_DEFS_H_
+#define CONCORD_BFT_UTIL_HASH_DEFS_H_
+
+#include <stdlib.h>
+#include "sliver.hpp"
+#include "kv_types.hpp"
+
+namespace concordUtils {
+
+// TODO(GG): do we want this hash function ? See also
+// http://www.cse.yorku.ca/~oz/hash.html
+inline size_t simpleHash(const uint8_t *data, const size_t len) {
+  size_t hash = 5381;
+  size_t t;
+
+  for (size_t i = 0; i < len; i++) {
+    t = data[i];
+    hash = ((hash << 5) + hash) + t;
+  }
+
+  return hash;
+}
+
+} // namespace concordUtils
+
+namespace std {
+template <>
+struct hash<concordUtils::Sliver> {
+  typedef concordUtils::Sliver argument_type;
+  typedef std::size_t result_type;
+
+  result_type operator()(const concordUtils::Sliver &t) const {
+    return concordUtils::simpleHash(t.data(), t.length());
+  }
+};
+
+template <>
+struct hash<concordUtils::KeyValuePair> {
+  typedef concordUtils::KeyValuePair argument_type;
+  typedef std::size_t result_type;
+
+  result_type operator()(const concordUtils::KeyValuePair &t) const {
+    size_t keyHash = concordUtils::simpleHash(t.first.data(), t.first.length());
+    return keyHash;
+  }
+};
+}  // namespace std
+
+#endif  // CONCORD_BFT_UTIL_HASH_DEFS_H_

--- a/util/include/hex_tools.h
+++ b/util/include/hex_tools.h
@@ -1,0 +1,15 @@
+// Copyright 2018 VMware, all rights reserved
+
+#ifndef CONCORD_BFT_UTIL_HEX_TOOLS_H_
+#define CONCORD_BFT_UTIL_HEX_TOOLS_H_
+
+#include <stdio.h>
+#include <string>
+
+namespace concordUtils {
+
+std::ostream &hexPrint(std::ostream &s, const uint8_t *data, size_t size);
+
+}  // namespace concordUtils 
+
+#endif  // CONCORD_BFT_UTIL_HEX_TOOLS_H_

--- a/util/include/kv_types.hpp
+++ b/util/include/kv_types.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+
+#ifndef CONCORD_BFT_UTIL_KV_TYPES_H_
+#define CONCORD_BFT_UTIL_KV_TYPES_H_
+
+#include <unordered_map>
+#include <vector>
+#include "sliver.hpp"
+
+namespace concordUtils {
+
+typedef Sliver Key;
+typedef Sliver Value;
+typedef std::pair<Key, Value> KeyValuePair;
+typedef std::unordered_map<Key, Value> SetOfKeyValuePairs;
+typedef std::vector<Key> KeysVector;
+typedef KeysVector ValuesVector;
+typedef uint64_t BlockId;
+
+} // namespace concordUtils
+
+#endif  // CONCORD_BFT_UTIL_KV_TYPES_H_

--- a/util/include/sliver.hpp
+++ b/util/include/sliver.hpp
@@ -1,0 +1,74 @@
+// Copyright 2018 VMware, all rights reserved
+
+/**
+ * Sliver -- Zero-copy management of bytes.
+ *
+ * Sliver provides a view into an allocated region of memory. Views of
+ * sub-regions, or "sub-slivers" do not copy data, but instead reference the
+ * memory of the "base" sliver.
+ *
+ * The memory is managed through a std::shared_ptr. If the `Sliver(char* data,
+ * size_t length)` constructor is called, that sliver wraps the data pointer in
+ * a shared pointer. Sub-slivers reference this same shared pointer, such that
+ * the memory is kept around as long as the base sliver or any sub-sliver needs
+ * it, and cleaned up once the base sliver and all sub-slivers have finished
+ * using it.
+ *
+ * Intentionally copyable (via default copy constructor and assignment
+ * operator). Copying the shared_ptr increases its reference count by one, so
+ * that it is not released until both copies go out of scope.
+ *
+ * Intentionally movable (via default move constructor and assignment
+ * operator). Moving the shared_ptr avoids modifying its reference count, which
+ * requires an atomic operation that might be considered expensive.
+ */
+
+#ifndef CONCORD_BFT_UTIL_SLIVER_HPP_
+#define CONCORD_BFT_UTIL_SLIVER_HPP_
+
+#include <ios>
+#include <memory>
+
+namespace concordUtils {
+
+class Sliver {
+ public:
+  Sliver();
+  Sliver(uint8_t* data, const size_t length);
+  Sliver(char* data, const size_t length);
+  Sliver(const Sliver& base, const size_t offset, const size_t length);
+
+  uint8_t operator[](const size_t offset) const;
+
+  Sliver subsliver(const size_t offset, const size_t length) const;
+
+  size_t length() const;
+  uint8_t* data() const;
+
+  std::ostream& operator<<(std::ostream& s) const;
+  bool operator==(const Sliver& other) const;
+  int compare(const Sliver& other) const;
+
+ private:
+  // these are never modified, but need to be non-const to support copy
+  // assignment
+  std::shared_ptr<uint8_t> m_data;
+  size_t m_offset;
+  size_t m_length;
+
+  // Delete new and delete, to force the Sliver to be allocated on the stack, so
+  // that it is cleaned up properly via RAII scoping.
+  static void* operator new(size_t) = delete;
+  static void* operator new[](size_t) = delete;
+  static void operator delete(void*) = delete;
+  static void operator delete[](void*) = delete;
+};
+
+std::ostream& operator<<(std::ostream& s, const Sliver& sliver);
+
+bool copyToAndAdvance(uint8_t* _buf, size_t* _offset, size_t _maxOffset,
+                      uint8_t* _src, size_t _srcSize);
+
+}  // namespace concordUtils 
+
+#endif  // CONCORD_BFT_UTIL_SLIVER_HPP_

--- a/util/include/status.hpp
+++ b/util/include/status.hpp
@@ -1,0 +1,80 @@
+// Copyright 2018 VMware, all rights reserved
+
+/**
+ * Status stores the result of an operation.
+ */
+
+#ifndef CONCORD_BFT_UTIL_STATUS_HPP_
+#define CONCORD_BFT_UTIL_STATUS_HPP_
+
+#include <string>
+
+namespace concordUtils {
+
+class Status {
+ public:
+  static Status OK() { return Status(ok, ""); }
+  static Status NotFound(std::string msg) { return Status(notFound, msg); }
+  static Status InvalidArgument(std::string msg) {
+    return Status(invalidArgument, msg);
+  }
+  static Status IllegalOperation(std::string msg) {
+    return Status(illegalOperation, msg);
+  }
+  static Status GeneralError(std::string msg) {
+    return Status(generalError, msg);
+  }
+
+  bool isOK() const { return type == ok; }
+  bool isNotFound() const { return type == notFound; }
+  bool isInvalidArgument() const { return type == invalidArgument; }
+  bool isIllegalOperation() const { return type == illegalOperation; }
+  bool isGeneralError() const { return type == generalError; }
+
+  std::ostream& operator<<(std::ostream& s) const {
+    s << messagePrefix();
+    if (!isOK()) {
+      s << message;
+    }
+    return s;
+  };
+
+  bool operator==(const Status& status) const { return type == status.type; };
+
+ private:
+  enum statusType {
+    ok,
+    notFound,
+    invalidArgument,
+    illegalOperation,
+    generalError
+  };
+
+  statusType type;
+  std::string message;
+
+  Status(statusType t, std::string msg) : type(t), message(msg) {}
+
+  std::string messagePrefix() const {
+    switch (type) {
+      case ok:
+        return "OK";
+      case notFound:
+        return "Not Found: ";
+      case invalidArgument:
+        return "Invalid Argument: ";
+      case illegalOperation:
+        return "Illegal Operation: ";
+      case generalError:
+        return "General Error: ";
+      default:
+        return "Unknown Error Type: ";
+    }
+  }
+};
+
+std::ostream& operator<<(std::ostream& s, Status const& status);
+
+}  // namespace concordUtils
+
+#endif  // CONCORD_BFT_UTIL_STATUS_HPP_

--- a/util/src/hex_tools.cpp
+++ b/util/src/hex_tools.cpp
@@ -1,0 +1,25 @@
+// Copyright 2018 VMware, all rights reserved
+
+#include "hex_tools.h"
+
+#include <iomanip>
+#include <ios>
+#include <ostream>
+#include <stdexcept>
+
+namespace concordUtils {
+
+// Print <size> bytes from <data> to <s> as their 0x<hex> representation.
+std::ostream &hexPrint(std::ostream &s, const uint8_t *data, size_t size) {
+  // Store current state of ostream flags
+  std::ios::fmtflags f(s.flags());
+  s << "0x";
+  for (size_t i = 0; i < size; i++) {
+    s << std::hex << std::setw(2) << std::setfill('0') << (uint)data[i];
+  }
+  // restore current state
+  s.flags(f);
+  return s;
+};
+
+}  // namespace concordUtils 

--- a/util/src/sliver.cpp
+++ b/util/src/sliver.cpp
@@ -1,0 +1,130 @@
+// Copyright 2018 VMware, all rights reserved
+
+/**
+ * Sliver -- Zero-copy management of bytes.
+ *
+ * See sliver.hpp for design details.
+ */
+
+#include "sliver.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <ios>
+#include <memory>
+
+#include "hex_tools.h"
+
+namespace concordUtils {
+
+/**
+ * Create an empty sliver.
+ */
+Sliver::Sliver() : m_data(nullptr), m_offset(0), m_length(0) {}
+
+/**
+ * Create a new sliver that will own the memory pointed to by `data`, which is
+ * `length` bytes in size.
+ *
+ * Important: the `data` buffer should have been allocated with `new`, and not
+ * `malloc`, because the shared pointer will use `delete` and not `free`.
+ */
+Sliver::Sliver(uint8_t* data, const size_t length)
+    : m_data(data, std::default_delete<uint8_t[]>()),
+      m_offset(0),
+      m_length(length) {
+  // Data must be non-null.
+  assert(data);
+}
+
+Sliver::Sliver(char* data, const size_t length)
+    : m_data(reinterpret_cast<uint8_t*>(data),
+             std::default_delete<uint8_t[]>()),
+      m_offset(0),
+      m_length(length) {
+  // Data must be non-null.
+  assert(data);
+}
+
+/**
+ * Create a sub-sliver that references a region of a base sliver.
+ */
+Sliver::Sliver(const Sliver& base, const size_t offset, const size_t length)
+    : m_data(base.m_data),
+      // This sliver starts offset bytes from the offset of its base.
+      m_offset(base.m_offset + offset),
+      m_length(length) {
+  // This sliver must start no later than the end of the base sliver.
+  assert(offset <= base.m_length);
+  // This sliver must end no later than the end of the base sliver.
+  assert(length <= base.m_length - offset);
+}
+
+/**
+ * Get the byte at `offset` in this sliver.
+ */
+uint8_t Sliver::operator[](const size_t offset) const {
+  // This offset must be within this sliver.
+  assert(offset < m_length);
+
+  // The data for the requested offset is that many bytes after the offset from
+  // the base sliver.
+  return m_data.get()[m_offset + offset];
+}
+
+/**
+ * Get a direct pointer to the data for this sliver. Remember that the Sliver
+ * (or its base) still owns the data, so ensure that the lifetime of this Sliver
+ * (or its base) is at least as long as the lifetime of the returned pointer.
+ */
+uint8_t* Sliver::data() const { return m_data.get() + m_offset; }
+
+/**
+ * Create a subsliver. Syntactic sugar for cases where a function call is more
+ * natural than using the sub-sliver constructor directly.
+ */
+Sliver Sliver::subsliver(const size_t offset, const size_t length) const {
+  return Sliver(*this, offset, length);
+}
+
+size_t Sliver::length() const { return m_length; }
+
+std::ostream& Sliver::operator<<(std::ostream& s) const {
+  return hexPrint(s, data(), length());
+}
+
+std::ostream& operator<<(std::ostream& s, const Sliver& sliver) {
+  return sliver.operator<<(s);
+}
+
+/**
+ * Slivers are == if their lengths are the same, and each byte of their data is
+ * the same.
+ */
+bool Sliver::operator==(const Sliver& other) const {
+  // This could be just "compare(other) == 0", but the short-circuit of checking
+  // lengths first can save us many cycles in some cases.
+  return length() == other.length() &&
+         memcmp(data(), other.data(), length()) == 0;
+}
+
+/**
+ * a.compare(b) is:
+ *  - 0 if lengths are the same, and bytes are the same
+ *  - -1 if bytes are the same, but a is shorter
+ *  - 1 if bytes are the same, but a is longer
+ */
+int Sliver::compare(const Sliver& other) const {
+  int comp = memcmp(data(), other.data(), std::min(length(), other.length()));
+  if (comp == 0) {
+    if (length() < other.length()) {
+      comp = -1;
+    } else if (length() > other.length()) {
+      comp = 1;
+    }
+  }
+  return comp;
+}
+
+}  // namespace concordUtils 

--- a/util/src/status.cpp
+++ b/util/src/status.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2018 VMware. All rights reserved.
+
+#include "status.hpp"
+
+#include <ostream>
+
+namespace concordUtils {
+
+std::ostream& operator<<(std::ostream& s, Status const& status) {
+  return status.operator<<(s);
+}
+
+} // namespace concordUtils

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -12,3 +12,7 @@ add_test(NAME metric_server_tests COMMAND python3 -m unittest
 add_executable(mt_tests multithreading.cpp)
 add_test(util_mt_tests mt_tests)
 target_link_libraries(mt_tests gtest_main util)
+
+add_executable(sliver_test sliver_test.cpp)
+add_test(sliver_test sliver_test)
+target_link_libraries(sliver_test gtest util)

--- a/util/test/sliver_test.cpp
+++ b/util/test/sliver_test.cpp
@@ -1,0 +1,168 @@
+// Copyright 2018 VMware, all rights reserved
+/**
+ * Test the Sliver class.
+ *
+ * While these tests check that Sliver "works", the most interesting test is to
+ * run this under valgrind, and make sure that it doesn't find any
+ * leaks/double-frees/etc. `valgrind --leak-check=full test/SliverTests`
+ */
+
+#include "sliver.hpp"
+#include "gtest/gtest.h"
+
+using namespace std;
+using concordUtils::Sliver;
+
+namespace {
+
+/**
+ * Allocate a `length`-byte buffer, and fill it with the sequence
+ * 0,1,2,3...255,0,1,2...
+ *
+ * Remember: the caller must deallocate this buffer.
+ */
+uint8_t* new_test_memory(size_t length) {
+  uint8_t* buffer = new uint8_t[length];
+
+  for (size_t i = 0; i < length; i++) {
+    buffer[i] = i % 256;
+  }
+
+  return buffer;
+}
+
+bool is_match(const uint8_t* expected, const size_t expected_length,
+              const Sliver& actual) {
+  if (expected_length != actual.length()) {
+    return false;
+  }
+  for (size_t i = 0; i < expected_length; i++) {
+    if (expected[i] != actual[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Test that a sliver wraps a char pointer exactly.
+ */
+TEST(sliver_test, simple_wrap) {
+  const size_t test_size = 100;
+  uint8_t* expected = new_test_memory(test_size);
+
+  Sliver actual(expected, test_size);
+  ASSERT_TRUE(is_match(expected, test_size, actual));
+}
+
+/**
+ * Test that re-wrapping works.
+ */
+TEST(sliver_test, simple_rewrap) {
+  const size_t test_size = 101;
+  uint8_t* expected = new_test_memory(test_size);
+
+  Sliver first = Sliver(expected, test_size);
+  Sliver actual1(first, 0, first.length());
+  Sliver actual2 = first.subsliver(0, first.length());
+
+  ASSERT_TRUE(is_match(expected, test_size, actual1));
+  ASSERT_TRUE(is_match(expected, test_size, actual2));
+}
+
+/**
+ * Test that base offsetting works.
+ */
+TEST(sliver_test, offsets) {
+  const size_t test_size = 102;
+  uint8_t* expected = new_test_memory(test_size);
+
+  Sliver base(expected, test_size);
+  for (size_t offset = 1; offset < test_size; offset += 5) {
+    Sliver subsliver(base, offset, test_size - offset);
+    ASSERT_TRUE(is_match(expected + offset, test_size - offset, subsliver));
+  }
+}
+
+/**
+ * Test that base length limiting works.
+ */
+TEST(sliver_test, lengths) {
+  const size_t test_size = 103;
+  uint8_t* expected = new_test_memory(test_size);
+
+  Sliver base(expected, test_size);
+  const size_t step = 7;
+  for (size_t length = test_size - 1; length > step; length -= step) {
+    Sliver subsliver(base, 0, length);
+    ASSERT_TRUE(is_match(expected, length, subsliver));
+  }
+}
+
+/**
+ * Test that nested offsetting and lengths works.
+ */
+TEST(sliver_test, nested) {
+  const size_t test_size = 104;
+  uint8_t* expected = new_test_memory(test_size);
+
+  Sliver base(expected, test_size);
+  const size_t offset_step = 3;
+  const size_t length_step = 4;
+  for (size_t offset = offset_step,
+              length = test_size - (offset_step + length_step);
+       length > (offset_step + length_step);
+       offset += offset_step, length -= (length_step + offset_step)) {
+    Sliver subsliver(base, offset_step,
+                     base.length() - (offset_step + length_step));
+    ASSERT_TRUE(is_match(expected + offset, length, subsliver))
+        << " Expected length: " << length << std::endl
+        << "   Actual length: " << subsliver.length();
+    base = subsliver;
+  }
+}
+
+/**
+ * Create a base sliver, and then return a subsliver. Used to test that the
+ * shared pointer is handled properly.
+ */
+Sliver copied_subsliver(size_t base_size, size_t sub_offset,
+                        size_t sub_length) {
+  uint8_t* data = new_test_memory(base_size);
+  Sliver base(data, base_size);
+  Sliver sub(base, sub_offset, sub_length);
+  return sub;
+}
+
+/**
+ * Test that copying out of creation scope works.
+ *
+ * This test may be non-interesting, but this is a thing some of our functions
+ * do, so I want to test it explicitly.
+ */
+TEST(sliver_test, copying) {
+  const size_t test_size = 105;
+  uint8_t* expected = new_test_memory(test_size);
+
+  const size_t test_offset1 = 20;
+  const size_t test_length1 = 30;
+  Sliver actual1 = copied_subsliver(test_size, test_offset1, test_length1);
+
+  const size_t test_offset2 = 50;
+  const size_t test_length2 = 20;
+  Sliver actual2 = copied_subsliver(test_size, test_offset2, test_length2);
+
+  ASSERT_TRUE(is_match(expected + test_offset1, test_length1, actual1));
+  ASSERT_TRUE(is_match(expected + test_offset2, test_length2, actual2));
+
+  // we didn't wrap the expected buffer this time, so we need to free it
+  // ourselves, instead of letting the Sliver do it
+  delete[] expected;
+}
+
+}  // end namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
All rocksdb code serves as an example and is completely optional.

The storage code is spit into two layers in separate directories:

 * `rocksdb` - contains rocksdb client code and MetadataStorage
 implementation
 * `blockchain` contains higher level code that uses the database
 interfaces to organize blocks of data such that they can be stored
 persistently.

The rocksdb layer is the absolute minimum storage code and can be used
independently of the blockchain layer. The blockchain layer is a thin
abstraction on top of the database interfaces that creates a useful API
for accessing persistent blockchain information. This code serves as an
example and is also useful for building a test replica similar to the
simpleKVBCTests TesterReplica that will allow us to create test clusters
full of persistent replicas.

The majority of this code was not written by me. It was ported from a
closed source repository. I only made minor tweaks to remove circular
dependencies, change namespaces, and split the code into multiple
libraries. Credit for most of the code goes to @guyg8 @robem @beerriot
@yuliasherman. Apologies if I forgot anyone.

Some types were extracted into our util library so that they could be
shared by both the blockchain and rocksdb libraries. It's anticipated
they will be useful elsewhere.

This change also includes tests for storage code and sliver that can be
run in the standard manner with `make test` and `ctest -R <TEST>`.

Please see the README in the storage directory for more information.