### PR TITLE
A small code clean up.

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -74,12 +74,12 @@ struct ReplicaConfig {
   bool debugPersistentStorageEnabled = false;
 
   // Messages
-  uint32_t maxExternalMessageSize = 1 << 16;
-  uint32_t maxReplyMessageSize = 1 << 13;
+  uint32_t maxExternalMessageSize = 65536;
+  uint32_t maxReplyMessageSize = 8192;
 
   // StateTransfer
-  uint32_t maxNumOfReservedPages = 1 << 11;
-  uint32_t sizeOfReservedPage = 1 << 12;
+  uint32_t maxNumOfReservedPages = 2048;
+  uint32_t sizeOfReservedPage = 4096;
 };
 
 }

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -18,6 +18,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include "bftengine/ReplicaConfigSingleton.hpp"
 
 namespace bftEngine {
 namespace impl {
@@ -111,7 +112,6 @@ void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
   Assert(loadErrCode == ReplicaLoader::ErrorCode::Success);
 
   rep = new ReplicaImp(ld, requestsHandler, stateTransfer, comm, persistentStorage);
-
   rep->start();
 }
 }
@@ -123,7 +123,6 @@ Replica *Replica::createNewReplica(ReplicaConfig *replicaConfig,
                                    IStateTransfer *stateTransfer,
                                    ICommunication *communication,
                                    MetadataStorage *metadataStorage) {
-
   {
     std::lock_guard<std::mutex> lock(mutexForCryptoInitialization);
 
@@ -140,6 +139,9 @@ Replica *Replica::createNewReplica(ReplicaConfig *replicaConfig,
   if (replicaConfig->debugPersistentStorageEnabled) {
     Assert(metadataStorage == nullptr);
   }
+
+  // Initialize the configuration singleton here to use correct values during persistent storage initialization.
+  ReplicaConfigSingleton::GetInstance(replicaConfig);
 
   if (replicaConfig->debugPersistentStorageEnabled )
     if (metadataStorage == nullptr)

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -180,7 +180,7 @@ void parse_params(int argc, char** argv, ReplicaParams &rp) {
 
 }
 
-SimpleTestReplica *replica;
+SimpleTestReplica *replica = nullptr;
 void signalHandler( int signum ) {
   if(replica)
     replica->stop();
@@ -223,8 +223,7 @@ int main(int argc, char **argv) {
     remove(dbFile.str().c_str());
     metaDataStorage = new FileStorage(replicaLogger, dbFile.str());
   }
-  SimpleTestReplica *replica
-    = SimpleTestReplica::create_replica(replicaBehavior, rp, metaDataStorage);
+  replica = SimpleTestReplica::create_replica(replicaBehavior, rp, metaDataStorage);
   replica->start();
   // The replica is now running in its own thread. Block the main thread until
   // sigabort, sigkill or sigterm are not raised and then exit gracefully


### PR DESCRIPTION
- Fix duplicated declaration of replica variable.
- Make configuration parameters more readable.
- VB-1492 Initialization of ReplicaConfigSingleton happens too late.