### PR TITLE
Add an in-memory db client to storage

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -6,9 +6,11 @@ target_link_libraries(storage corebft)
 
 if (BUILD_ROCKSDB_STORAGE)
   add_subdirectory(rocksdb)
-  add_subdirectory(blockchain)
   if (BUILD_TESTING)
     add_subdirectory(test)
   endif()
+else()
+  add_subdirectory(memory)
 endif()
 
+add_subdirectory(blockchain)

--- a/storage/README.md
+++ b/storage/README.md
@@ -3,21 +3,22 @@ This directory contains **optional** storage libraries that serve as examples of
 to use the persistent storage interfaces of concord-bft.
 
 Applications must implement the MetadataStorage API, and so we have provided a
-RocksDB implementation in the `rocksdb` directory. The rocksdb directory also
-contains a `rocksdb_client` that implements the interfaces in
-`database_interface.h`. This can be used by higher level storage code to build
-complete systems on top of RocksDB. Again, this is only one way to use RocksDB
-to build a system, and the rocksdb library is completely optional.
+an implementation in the `storage/src` directory.
+
+The `storage/rocksdb` directory contains a `rocksdb_client` that implements the interfaces
+in `storage/include/db_interface.h`. This can be used by higher level storage code to
+build complete systems on top of RocksDB. Again, this is only one way to use
+RocksDB to build a system, and the rocksdb library is completely optional.
+
+The `storage/memory` directory contains an `in_memory_db_client` that implements the
+interfaces in `storage/include/db_interface.h` as an alternative to the rocksdb
+implementation that is useful for testing.
 
 Additionally, users may wish to build a blockchain on top of concord-bft. The
-`blockchain` directory contains an example of how to structure the keyspace and
-use the database interfaces to build a blockchain storage layer. Currently, the
-only provided implementation of the database interfaces is the rocksdb library,
-and it is required for linking. However, users can provide alternate
-implementations of these interfaces and use a different low level storage
-mechanism, making the blockchain code independent of the rocksdb library.
+`storage/blockchain` directory contains an example of how to structure the keyspace and
+use the database interfaces to build a blockchain storage layer.
 
-Both libraries rely on the util library in `../util` for types such as `Status`
+Both libraries rely on the util library in the `util` directory for types such as `Status`
 and `Sliver`.
 
 # Building and testing
@@ -41,15 +42,12 @@ make shared_lib
 sudo make install-shared
 ```
 
-Configure CMake to build the storage code and tests based on RocksDB. Some tests
-require LOG4CPP, so that also must be installed and enabled. Installation of
-LOG4CPP is detailed in the [main
-README](https://github.com/vmware/concord-bft/blob/master/README.md).
+Configure CMake to build the storage code and tests based on RocksDB.
 
 ```shell
 cd
 cd concord-bft/build
-cmake -DBUILD_ROCKSDB_STORAGE=TRUE -DBUILD_TESTING=TRUE -DUSE_LOG4CPP=TRUE ..
+cmake -DBUILD_ROCKSDB_STORAGE=TRUE -DBUILD_TESTING=TRUE ..
 make
 ```
 

--- a/storage/blockchain/CMakeLists.txt
+++ b/storage/blockchain/CMakeLists.txt
@@ -9,7 +9,11 @@ target_include_directories(concordbft_storage_blockchain PUBLIC
     .
 )
 
-target_link_libraries(concordbft_storage_blockchain PUBLIC
-    concordbft_storage_rocksdb
-    util
-)
+target_link_libraries(concordbft_storage_blockchain PUBLIC util)
+
+if (BUILD_ROCKSDB_STORAGE)
+    target_link_libraries(concordbft_storage_blockchain PUBLIC concordbft_storage_rocksdb)
+else()
+    target_link_libraries(concordbft_storage_blockchain PUBLIC concordbft_storage_memory)
+endif()
+

--- a/storage/blockchain/comparators.cpp
+++ b/storage/blockchain/comparators.cpp
@@ -2,6 +2,7 @@
 //
 // Storage key comparators implementation.
 
+#ifdef USE_ROCKSDB
 #include "comparators.h"
 
 #include "Logger.hpp"
@@ -11,6 +12,7 @@
 #include "blockchain_db_adapter.h"
 #include "blockchain_db_types.h"
 #include "blockchain_db_interfaces.h"
+
 #include "rocksdb_client.h"
 
 #include <chrono>
@@ -93,8 +95,6 @@ int RocksKeyComparator::ComposedKeyComparison(const Logger& logger,
   return keyComp;
 }
 
-/* RocksDB */
-#ifdef USE_ROCKSDB
 int RocksKeyComparator::Compare(const ::rocksdb::Slice& _a,
                                 const ::rocksdb::Slice& _b) const {
   Sliver a = copyRocksdbSlice(_a);
@@ -106,12 +106,11 @@ int RocksKeyComparator::Compare(const ::rocksdb::Slice& _a,
 
   return ret;
 }
-#endif
 
 /* In memory */
 bool RocksKeyComparator::InMemKeyComp(const Sliver& _a, const Sliver& _b) {
   Logger logger(
-      concordlogger::Log::getLogger("concord.storage.RocksKeyComparator"));
+      concordlogger::Log::getLogger("concord.storage.blockchain.RocksKeyComparator"));
   int comp = ComposedKeyComparison(logger, _a, _b);
 
   LOG_DEBUG(logger, "Compared " << _a << " with " << _b
@@ -124,3 +123,4 @@ bool RocksKeyComparator::InMemKeyComp(const Sliver& _a, const Sliver& _b) {
 }
 }
 }
+#endif

--- a/storage/memory/CMakeLists.txt
+++ b/storage/memory/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(concordbft_storage_memory STATIC
+    in_memory_db_client.cpp
+)
+target_include_directories(concordbft_storage_memory PUBLIC .)
+target_link_libraries(concordbft_storage_memory PUBLIC storage)

--- a/storage/memory/in_memory_db_client.cpp
+++ b/storage/memory/in_memory_db_client.cpp
@@ -1,0 +1,268 @@
+// Copyright 2018 VMware, all rights reserved
+
+#include "in_memory_db_client.h"
+
+#include <chrono>
+#include <cstring>
+
+#include "hash_defs.h"
+#include "sliver.hpp"
+
+using concordUtils::Sliver;
+using concordUtils::Status;
+
+namespace concord {
+namespace storage {
+namespace memory {
+
+/**
+ * @brief Does nothing.
+ *
+ * Does nothing.
+ * @return Status OK.
+ */
+Status InMemoryDBClient::init(bool readOnly) {
+  // TODO Can be used for constructor calls, etc.
+  return Status::OK();
+}
+
+/**
+ * @brief Services a read request from the In Memory Database.
+ *
+ * Tries to get the value associated with a key.
+ * @param _key Reference to the key being looked up.
+ * @param _outValue Reference to where the value gets stored if the lookup is
+ *                  successful.
+ * @return Status NotFound if no mapping is found, else, Status OK.
+ */
+Status InMemoryDBClient::get(Sliver _key, OUT Sliver &_outValue) const {
+  try {
+    _outValue = map.at(_key);
+  } catch (const std::out_of_range &oor) {
+    return Status::NotFound(oor.what());
+  }
+
+  return Status::OK();
+}
+
+Status InMemoryDBClient::get(Sliver _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const {
+  Sliver outValue(buf, bufSize);
+  _size = static_cast<uint32_t>(outValue.length());
+  return get(_key, outValue);
+}
+
+/**
+ * @brief Returns reference to a new object of IDBClientIterator.
+ *
+ * @return A pointer to IDBClientIterator object.
+ */
+IDBClient::IDBClientIterator *InMemoryDBClient::getIterator() const {
+  return new InMemoryDBClientIterator((InMemoryDBClient *)this);
+}
+
+/**
+ * @brief Frees the IDBClientIterator.
+ *
+ * @param _iter Pointer to object of class IDBClientIterator that needs to be
+ *              freed.
+ * @return Status InvalidArgument if iterator is null pointer, else, Status OK.
+ */
+Status InMemoryDBClient::freeIterator(IDBClientIterator *_iter) const {
+  if (_iter == NULL) {
+    return Status::InvalidArgument("Invalid iterator");
+  }
+
+  delete (InMemoryDBClientIterator *)_iter;
+  return Status::OK();
+}
+
+/**
+ * @brief Services a write request to the In Memory database by adding a key
+ * value pair to the map.
+ *
+ * If the map already contains the key, it replaces the value with the data
+ * referred to by _value.
+ *
+ * @param _key Key of the mapping.
+ * @param _value Value of the mapping.
+ * @return Status OK.
+ */
+Status InMemoryDBClient::put(Sliver _key, Sliver _value) {
+  // Copy the key and the value
+  bool keyExists = false;
+  if (map.find(_key) != map.end()) {
+    keyExists = true;
+  }
+
+  Sliver key;
+  if (!keyExists) {
+    uint8_t *keyBytes = new uint8_t[_key.length()];
+    memcpy(keyBytes, _key.data(), _key.length());
+    key = Sliver(keyBytes, _key.length());
+  } else {
+    key = _key;
+  }
+
+  Sliver value;
+  uint8_t *valueBytes = new uint8_t[_value.length()];
+  memcpy(valueBytes, _value.data(), _value.length());
+  value = Sliver(valueBytes, _value.length());
+
+  map[key] = value;
+
+  return Status::OK();
+}
+
+/**
+ * @brief Deletes mapping from map.
+ *
+ * If map contains _key, this function will delete the key value pair from it.
+ *
+ * @param _key Reference to the key of the mapping.
+ * @return Status OK.
+ */
+Status InMemoryDBClient::del(Sliver _key) {
+  bool keyExists = false;
+  if (map.find(_key) != map.end()) {
+    keyExists = true;
+  }
+
+  if (keyExists) {
+    Sliver value = map[_key];
+    map.erase(_key);
+  }
+  // Else: Error to delete non-existing key?
+
+  return Status::OK();
+}
+
+Status InMemoryDBClient::multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) {
+  Status status = Status::OK();
+  Sliver sliver;
+  for (auto const &it : _keysVec) {
+    status = get(it, sliver);
+    if (!status.isOK()) return status;
+    _valuesVec.push_back(sliver);
+  }
+  return status;
+}
+
+Status InMemoryDBClient::multiPut(const SetOfKeyValuePairs &_keyValueMap) {
+  Status status = Status::OK();
+  for (const auto &it : _keyValueMap) {
+    status = put(it.first, it.second);
+    if (!status.isOK()) return status;
+  }
+  return status;
+}
+
+Status InMemoryDBClient::multiDel(const KeysVector &_keysVec) {
+  Status status = Status::OK();
+  for (auto const &it : _keysVec) {
+    status = del(it);
+    if (!status.isOK()) return status;
+  }
+  return status;
+}
+
+/**
+ * @brief Moves the iterator to the start of the map.
+ *
+ * @return Moves the iterator to the start of the map and returns the first key
+ * value pair of the map.
+ */
+KeyValuePair InMemoryDBClientIterator::first() {
+  m_current = m_parentClient->getMap().begin();
+  if (m_current == m_parentClient->getMap().end()) {
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Returns the key value pair of the key which is greater than or equal
+ * to _searchKey.
+ *
+ *  Returns the first key value pair whose key is not considered to go before
+ *  _searchKey. Also, moves the iterator to this position.
+ *
+ *  @param _searchKey Key to search for.
+ *  @return Key value pair of the key which is greater than or equal to
+ *  _searchKey.
+ */
+KeyValuePair InMemoryDBClientIterator::seekAtLeast(Sliver _searchKey) {
+  m_current = m_parentClient->getMap().lower_bound(_searchKey);
+  if (m_current == m_parentClient->getMap().end()) {
+    LOG_WARN(logger, "Key " << _searchKey << " not found");
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Decrements the iterator.
+ *
+ * Decrements the iterator and returns the previous key value pair.
+ *
+ * @return The previous key value pair.
+ */
+KeyValuePair InMemoryDBClientIterator::previous() {
+  if (m_current == m_parentClient->getMap().begin()) {
+    LOG_WARN(logger, "Iterator already at first key");
+    return KeyValuePair();
+  }
+  --m_current;
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Increments the iterator.
+ *
+ * Increments the iterator and returns the next key value pair.
+ *
+ * @return The next key value pair.
+ */
+KeyValuePair InMemoryDBClientIterator::next() {
+  ++m_current;
+  if (m_current == m_parentClient->getMap().end()) {
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Returns the key value pair at the current position of the iterator.
+ *
+ * @return Current key value pair.
+ */
+KeyValuePair InMemoryDBClientIterator::getCurrent() {
+  if (m_current == m_parentClient->getMap().end()) {
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Tells whether iterator is at the end of the map.
+ *
+ * @return True if iterator is at the end of the map, else False.
+ */
+bool InMemoryDBClientIterator::isEnd() { return m_current == m_parentClient->getMap().end(); }
+
+/**
+ * @brief Does nothing.
+ *
+ * @return Status OK.
+ */
+Status InMemoryDBClientIterator::getStatus() {
+  // TODO Should be used for sanity checks.
+  return Status::OK();
+}
+
+}  // namespace memory
+}  // namespace storage
+}  // namespace concord

--- a/storage/memory/in_memory_db_client.h
+++ b/storage/memory/in_memory_db_client.h
@@ -1,0 +1,84 @@
+// Copyright 2018 VMware, all rights reserved
+
+// Objects of InMemoryDBClientIterator contain an iterator for the in memory
+// object store (implemented as a map) along with a pointer to the map.
+//
+// Objects of InMemoryDBClient are implementations of an in memory database
+// (implemented as a map).
+//
+// The map contains key value pairs of the type KeyValuePair. Keys and values
+// are of type Sliver.
+
+#pragma once
+
+#include "Logger.hpp"
+#include <map>
+#include "storage/db_interface.h"
+
+namespace concord {
+namespace storage {
+namespace memory {
+
+class InMemoryDBClient;
+
+typedef std::map<concordUtils::Sliver, concordUtils::Sliver, IDBClient::KeyComparator> TKVStore;
+
+class InMemoryDBClientIterator : public IDBClient::IDBClientIterator {
+  friend class InMemoryDBClient;
+
+ public:
+  InMemoryDBClientIterator(InMemoryDBClient *_parentClient)
+      : logger(concordlogger::Log::getLogger("concord.storage.memory")), m_parentClient(_parentClient) {}
+  virtual ~InMemoryDBClientIterator() {}
+
+  // Inherited via IDBClientIterator
+  virtual KeyValuePair first() override;
+  virtual KeyValuePair seekAtLeast(Sliver _searchKey) override;
+  virtual KeyValuePair previous() override;
+  virtual KeyValuePair next() override;
+  virtual KeyValuePair getCurrent() override;
+  virtual bool isEnd() override;
+  virtual concordUtils::Status getStatus() override;
+
+ private:
+  concordlogger::Logger logger;
+
+  // Pointer to the InMemoryDBClient.
+  InMemoryDBClient *m_parentClient;
+
+  // Current iterator inside the map.
+  TKVStore::const_iterator m_current;
+};
+
+// In-memory IO operations below are not thread-safe.
+// get/put/del/multiGet/multiPut/multiDel operations are not synchronized and
+// not guarded by locks. The caller is expected to use those APIs via a
+// single thread.
+class InMemoryDBClient : public IDBClient {
+ public:
+  InMemoryDBClient(KeyComparator comp) { setComparator(comp); }
+
+  virtual Status init(bool readOnly) override;
+  virtual Status get(Sliver _key, OUT Sliver &_outValue) const override;
+  Status get(Sliver _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const override;
+  virtual IDBClientIterator *getIterator() const override;
+  virtual concordUtils::Status freeIterator(IDBClientIterator *_iter) const override;
+  virtual concordUtils::Status put(Sliver _key, Sliver _value) override;
+  virtual concordUtils::Status del(Sliver _key) override;
+  concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) override;
+  concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap) override;
+  concordUtils::Status multiDel(const KeysVector &_keysVec) override;
+  virtual void monitor() const override{};
+  bool isNew() override { return true; }
+
+  TKVStore &getMap() { return map; }
+  void setComparator(KeyComparator comp) { map = TKVStore(comp); }
+
+ private:
+  // map that stores the in memory database.
+  TKVStore map;
+};
+
+}  // namespace memory
+}  // namespace storage
+}  // namespace concord

--- a/storage/rocksdb/rocksdb_client.h
+++ b/storage/rocksdb/rocksdb_client.h
@@ -60,7 +60,7 @@ class RocksDBClientIterator
 class RocksDBClient : public concord::storage::IDBClient {
  public:
   RocksDBClient(std::string _dbPath, ::rocksdb::Comparator *_comparator)
-      : logger(concordlogger::Log::getLogger("com.concord.vmware.kvb")),
+      : logger(concordlogger::Log::getLogger("concord.storage.rocksdb")),
         m_dbPath(_dbPath),
         m_comparator(_comparator) {}
 


### PR DESCRIPTION
An in-memory client was added as a new low level storage library. It
implements the db client interfaces as an alternative to the rocksdb
implementation. This allows the blockchain code to be built on top of
the in-memory implementation if rocksdb is not being used.

The cmake files were changed to decouple the rocksdb build from the
blockchain build. The README was also updated to reflect these and the
prior changes.