### PR TITLE
Add an in-memory db client to storage library

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -12,7 +12,7 @@ if (BUILD_ROCKSDB_STORAGE)
   find_library(LIBZSTD   zstd)
   find_library(LIBZ      z)
   find_library(LIBSNAPPY snappy)
-  
+
   #cmake_policy(SET CMP0076 NEW) for cmake 3.14
   target_sources(concordbft_storage PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/rocksdb_client.cpp
                                             ${CMAKE_CURRENT_SOURCE_DIR}/src/rocksdb_key_comparator.cpp)
@@ -22,4 +22,7 @@ if (BUILD_ROCKSDB_STORAGE)
   if (BUILD_TESTING)
     add_subdirectory(test)
   endif()
+
+else() # NOT BUILD_ROCKSDB_STORAGE
+  target_sources(concordbft_storage PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/memorydb_client.cpp)
 endif(BUILD_ROCKSDB_STORAGE)

--- a/storage/README.md
+++ b/storage/README.md
@@ -2,27 +2,24 @@
 This directory contains **optional** storage libraries that serve as examples of how
 to use the persistent storage interfaces of concord-bft.
 
-Applications must implement the MetadataStorage API, and so we have provided a
-RocksDB implementation in the `rocksdb` directory. The rocksdb directory also
-contains a `rocksdb_client` that implements the interfaces in
-`database_interface.h`. This can be used by higher level storage code to build
-complete systems on top of RocksDB. Again, this is only one way to use RocksDB
-to build a system, and the rocksdb library is completely optional.
+The code is structured such that the headers are divided into the individually
+usable subsystems of the storage library. `include/storage` contains common code,
+including generic database interfaces that are implemented by the `memorydb` and
+`rocksdb` components. The `blockchain` code is a layer of code useful for
+building blockchain systems that utilize the database interfaces and is usable with
+either the `memorydb` or `rocksdb` implementations of these interfaces.
 
-Additionally, users may wish to build a blockchain on top of concord-bft. The
-`blockchain` directory contains an example of how to structure the keyspace and
-use the database interfaces to build a blockchain storage layer. Currently, the
-only provided implementation of the database interfaces is the rocksdb library,
-and it is required for linking. However, users can provide alternate
-implementations of these interfaces and use a different low level storage
-mechanism, making the blockchain code independent of the rocksdb library.
+Source code for all subsystems lives in `storage/src`. Applications must
+implement the MetadataStorage API, and so we have provided a an implementation
+in `storage/src/db_metadata_strorage` that also uses the database interfaces.
 
-Both libraries rely on the util library in `../util` for types such as `Status`
+Both libraries rely on the util library in the `util` directory for types such as `Status`
 and `Sliver`.
 
 # Building and testing
 
-The storage libraries rely on RocksDB.
+The storage library may optionally use RocksDB. The tests currently require
+RocksDB.
 
 First install RocksDB dependencies:
 
@@ -41,15 +38,12 @@ make shared_lib
 sudo make install-shared
 ```
 
-Configure CMake to build the storage code and tests based on RocksDB. Some tests
-require LOG4CPP, so that also must be installed and enabled. Installation of
-LOG4CPP is detailed in the [main
-README](https://github.com/vmware/concord-bft/blob/master/README.md).
+Configure CMake to build the storage code and tests based on RocksDB.
 
 ```shell
 cd
 cd concord-bft/build
-cmake -DBUILD_ROCKSDB_STORAGE=TRUE -DBUILD_TESTING=TRUE -DUSE_LOG4CPP=TRUE ..
+cmake -DBUILD_ROCKSDB_STORAGE=TRUE -DBUILD_TESTING=TRUE ..
 make
 ```
 

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -1,0 +1,91 @@
+// Copyright 2018-2019 VMware, all rights reserved
+
+// Objects of ClientIterator contain an iterator for the in memory
+// object store (implemented as a map) along with a pointer to the map.
+//
+// Objects of Client are implementations of an in memory database
+// (implemented as a map).
+//
+// The map contains key value pairs of the type KeyValuePair. Keys and values
+// are of type Sliver.
+
+#pragma once
+
+#include "Logger.hpp"
+#include <map>
+#include "sliver.hpp"
+#include "key_comparator.h"
+#include "storage/db_interface.h"
+#include <functional>
+
+
+namespace concord {
+namespace storage {
+namespace memorydb {
+
+class Client;
+
+typedef std::function<bool(const Sliver&, const Sliver&)> Compare;
+typedef std::map<Sliver, Sliver, Compare> TKVStore;
+
+class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
+  friend class Client;
+
+ public:
+  ClientIterator(Client *_parentClient)
+      : logger(concordlogger::Log::getLogger("concord.storage.memorydb")), m_parentClient(_parentClient) {}
+  virtual ~ClientIterator() {}
+
+  // Inherited via IDBClientIterator
+  virtual KeyValuePair first() override;
+  virtual KeyValuePair seekAtLeast(Sliver _searchKey) override;
+  virtual KeyValuePair previous() override;
+  virtual KeyValuePair next() override;
+  virtual KeyValuePair getCurrent() override;
+  virtual bool isEnd() override;
+  virtual concordUtils::Status getStatus() override;
+
+ private:
+  concordlogger::Logger logger;
+
+  // Pointer to the Client.
+  Client *m_parentClient;
+
+  // Current iterator inside the map.
+  TKVStore::const_iterator m_current;
+};
+
+// In-memory IO operations below are not thread-safe.
+// get/put/del/multiGet/multiPut/multiDel operations are not synchronized and
+// not guarded by locks. The caller is expected to use those APIs via a
+// single thread.
+class Client : public IDBClient {
+ public:
+  Client(KeyComparator comp) : comp_(comp), map_([this](const Sliver&a , const Sliver& b){ return comp_(a, b); }) {}
+
+  virtual Status init(bool readOnly) override;
+  virtual Status get(Sliver _key, OUT Sliver &_outValue) const override;
+  Status get(Sliver _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const override;
+  virtual IDBClientIterator *getIterator() const override;
+  virtual concordUtils::Status freeIterator(IDBClientIterator *_iter) const override;
+  virtual concordUtils::Status put(Sliver _key, Sliver _value) override;
+  virtual concordUtils::Status del(Sliver _key) override;
+  concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) override;
+  concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap) override;
+  concordUtils::Status multiDel(const KeysVector &_keysVec) override;
+  virtual void monitor() const override{};
+  bool isNew() override { return true; }
+
+  TKVStore &getMap() { return map_; }
+
+ private:
+  // Keep a copy of comp_ so that it lives as long as map_
+  KeyComparator comp_;
+
+  // map that stores the in memory database.
+  TKVStore map_;
+};
+
+}  // namespace memorydb
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/memorydb/key_comparator.h
+++ b/storage/include/memorydb/key_comparator.h
@@ -1,0 +1,38 @@
+// Copyright 2018 VMware, all rights reserved
+//
+// Storage key comparators definition.
+
+#pragma once
+
+#include "Logger.hpp"
+#include "sliver.hpp"
+#include "storage/db_interface.h"
+
+namespace concord {
+namespace storage {
+namespace memorydb {
+
+using concordUtils::Sliver;
+
+// Basic comparator. Decomposes storage key into parts (type, version,
+// application key).
+
+class KeyComparator {
+ public:
+  KeyComparator(IDBClient::IKeyManipulator* key_manipulator)
+      : key_manipulator_(key_manipulator),
+        logger_(concordlogger::Log::getLogger("concord.storage.rocksdb.KeyComparator")) {}
+
+  bool operator()(const Sliver &a, const Sliver &b) const {
+    int ret = key_manipulator_->composedKeyComparison(a, b);
+    return ret < 0;
+  }
+
+ private:
+  std::shared_ptr<IDBClient::IKeyManipulator> key_manipulator_;
+  concordlogger::Logger logger_;
+};
+
+}  // namespace memorydb
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/rocksdb/key_comparator.h
+++ b/storage/include/rocksdb/key_comparator.h
@@ -22,7 +22,7 @@ using concordUtils::Sliver;
 
 class KeyComparator: public ::rocksdb::Comparator {
  public:
-  KeyComparator(IDBClient::IKeyManipulator* key_manipulator): key_manipilator_(key_manipulator),
+  KeyComparator(IDBClient::IKeyManipulator* key_manipulator): key_manipulator_(key_manipulator),
                                                               logger_(concordlogger::Log::getLogger("concord.storage.rocksdb.KeyComparator")) {}
   virtual int         Compare(const ::rocksdb::Slice& _a, const ::rocksdb::Slice& _b) const override;
   virtual const char* Name() const override { return "RocksKeyComparator"; }
@@ -30,7 +30,7 @@ class KeyComparator: public ::rocksdb::Comparator {
   virtual void        FindShortSuccessor(std::string*) const override {}
 
  private:
-  std::shared_ptr<IDBClient::IKeyManipulator> key_manipilator_;
+  std::shared_ptr<IDBClient::IKeyManipulator> key_manipulator_;
   concordlogger::Logger logger_;
 };
 

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -1,0 +1,268 @@
+// Copyright 2018 VMware, all rights reserved
+
+#include "memorydb/client.h"
+
+#include <chrono>
+#include <cstring>
+
+#include "hash_defs.h"
+#include "sliver.hpp"
+
+using concordUtils::Sliver;
+using concordUtils::Status;
+
+namespace concord {
+namespace storage {
+namespace memorydb {
+
+/**
+ * @brief Does nothing.
+ *
+ * Does nothing.
+ * @return Status OK.
+ */
+Status Client::init(bool readOnly) {
+  // TODO Can be used for constructor calls, etc.
+  return Status::OK();
+}
+
+/**
+ * @brief Services a read request from the In Memory Database.
+ *
+ * Tries to get the value associated with a key.
+ * @param _key Reference to the key being looked up.
+ * @param _outValue Reference to where the value gets stored if the lookup is
+ *                  successful.
+ * @return Status NotFound if no mapping is found, else, Status OK.
+ */
+Status Client::get(Sliver _key, OUT Sliver &_outValue) const {
+  try {
+    _outValue = map_.at(_key);
+  } catch (const std::out_of_range &oor) {
+    return Status::NotFound(oor.what());
+  }
+
+  return Status::OK();
+}
+
+Status Client::get(Sliver _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const {
+  Sliver outValue(buf, bufSize);
+  _size = static_cast<uint32_t>(outValue.length());
+  return get(_key, outValue);
+}
+
+/**
+ * @brief Returns reference to a new object of IDBClientIterator.
+ *
+ * @return A pointer to IDBClientIterator object.
+ */
+IDBClient::IDBClientIterator *Client::getIterator() const {
+  return new ClientIterator((Client *)this);
+}
+
+/**
+ * @brief Frees the IDBClientIterator.
+ *
+ * @param _iter Pointer to object of class IDBClientIterator that needs to be
+ *              freed.
+ * @return Status InvalidArgument if iterator is null pointer, else, Status OK.
+ */
+Status Client::freeIterator(IDBClientIterator *_iter) const {
+  if (_iter == NULL) {
+    return Status::InvalidArgument("Invalid iterator");
+  }
+
+  delete (ClientIterator *)_iter;
+  return Status::OK();
+}
+
+/**
+ * @brief Services a write request to the In Memory database by adding a key
+ * value pair to the map.
+ *
+ * If the map already contains the key, it replaces the value with the data
+ * referred to by _value.
+ *
+ * @param _key Key of the mapping.
+ * @param _value Value of the mapping.
+ * @return Status OK.
+ */
+Status Client::put(Sliver _key, Sliver _value) {
+  // Copy the key and the value
+  bool keyExists = false;
+  if (map_.find(_key) != map_.end()) {
+    keyExists = true;
+  }
+
+  Sliver key;
+  if (!keyExists) {
+    uint8_t *keyBytes = new uint8_t[_key.length()];
+    memcpy(keyBytes, _key.data(), _key.length());
+    key = Sliver(keyBytes, _key.length());
+  } else {
+    key = _key;
+  }
+
+  Sliver value;
+  uint8_t *valueBytes = new uint8_t[_value.length()];
+  memcpy(valueBytes, _value.data(), _value.length());
+  value = Sliver(valueBytes, _value.length());
+
+  map_[key] = value;
+
+  return Status::OK();
+}
+
+/**
+ * @brief Deletes mapping from map.
+ *
+ * If map contains _key, this function will delete the key value pair from it.
+ *
+ * @param _key Reference to the key of the mapping.
+ * @return Status OK.
+ */
+Status Client::del(Sliver _key) {
+  bool keyExists = false;
+  if (map_.find(_key) != map_.end()) {
+    keyExists = true;
+  }
+
+  if (keyExists) {
+    Sliver value = map_[_key];
+    map_.erase(_key);
+  }
+  // Else: Error to delete non-existing key?
+
+  return Status::OK();
+}
+
+Status Client::multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) {
+  Status status = Status::OK();
+  Sliver sliver;
+  for (auto const &it : _keysVec) {
+    status = get(it, sliver);
+    if (!status.isOK()) return status;
+    _valuesVec.push_back(sliver);
+  }
+  return status;
+}
+
+Status Client::multiPut(const SetOfKeyValuePairs &_keyValueMap) {
+  Status status = Status::OK();
+  for (const auto &it : _keyValueMap) {
+    status = put(it.first, it.second);
+    if (!status.isOK()) return status;
+  }
+  return status;
+}
+
+Status Client::multiDel(const KeysVector &_keysVec) {
+  Status status = Status::OK();
+  for (auto const &it : _keysVec) {
+    status = del(it);
+    if (!status.isOK()) return status;
+  }
+  return status;
+}
+
+/**
+ * @brief Moves the iterator to the start of the map.
+ *
+ * @return Moves the iterator to the start of the map and returns the first key
+ * value pair of the map.
+ */
+KeyValuePair ClientIterator::first() {
+  m_current = m_parentClient->getMap().begin();
+  if (m_current == m_parentClient->getMap().end()) {
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Returns the key value pair of the key which is greater than or equal
+ * to _searchKey.
+ *
+ *  Returns the first key value pair whose key is not considered to go before
+ *  _searchKey. Also, moves the iterator to this position.
+ *
+ *  @param _searchKey Key to search for.
+ *  @return Key value pair of the key which is greater than or equal to
+ *  _searchKey.
+ */
+KeyValuePair ClientIterator::seekAtLeast(Sliver _searchKey) {
+  m_current = m_parentClient->getMap().lower_bound(_searchKey);
+  if (m_current == m_parentClient->getMap().end()) {
+    LOG_WARN(logger, "Key " << _searchKey << " not found");
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Decrements the iterator.
+ *
+ * Decrements the iterator and returns the previous key value pair.
+ *
+ * @return The previous key value pair.
+ */
+KeyValuePair ClientIterator::previous() {
+  if (m_current == m_parentClient->getMap().begin()) {
+    LOG_WARN(logger, "Iterator already at first key");
+    return KeyValuePair();
+  }
+  --m_current;
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Increments the iterator.
+ *
+ * Increments the iterator and returns the next key value pair.
+ *
+ * @return The next key value pair.
+ */
+KeyValuePair ClientIterator::next() {
+  ++m_current;
+  if (m_current == m_parentClient->getMap().end()) {
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Returns the key value pair at the current position of the iterator.
+ *
+ * @return Current key value pair.
+ */
+KeyValuePair ClientIterator::getCurrent() {
+  if (m_current == m_parentClient->getMap().end()) {
+    return KeyValuePair();
+  }
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
+ * @brief Tells whether iterator is at the end of the map.
+ *
+ * @return True if iterator is at the end of the map, else False.
+ */
+bool ClientIterator::isEnd() { return m_current == m_parentClient->getMap().end(); }
+
+/**
+ * @brief Does nothing.
+ *
+ * @return Status OK.
+ */
+Status ClientIterator::getStatus() {
+  // TODO Should be used for sanity checks.
+  return Status::OK();
+}
+
+}  // namespace memorydb
+}  // namespace storage
+}  // namespace concord

--- a/storage/src/rocksdb_key_comparator.cpp
+++ b/storage/src/rocksdb_key_comparator.cpp
@@ -26,7 +26,7 @@ int KeyComparator::Compare(const ::rocksdb::Slice& _a,
                            const ::rocksdb::Slice& _b) const {
   Sliver a = copyRocksdbSlice(_a);
   Sliver b = copyRocksdbSlice(_b);
-  int ret = key_manipilator_->composedKeyComparison(a, b);
+  int ret = key_manipulator_->composedKeyComparison(a, b);
 
   LOG_DEBUG(logger_, "Compared " << a << " with " << b << ", returning " << ret);
 


### PR DESCRIPTION
An in-memory client was added as a new low level storage library. It
implements the db client interfaces as an alternative to the rocksdb
implementation. This allows the blockchain code and db_metdata_storageto
be built on top of the in-memory implementation if rocksdb is not being
used.

The README was also updated to reflect these changes.