### PR TITLE
ALLOW_0_FAULT_TOLERANCE

### DIFF
--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -46,8 +46,12 @@ ReplicaLoader::ErrorCode checkReplicaConfig(const LoadedReplicaData &ld) {
                                           << ", concurrencyLevel=" << c.concurrencyLevel
                                           << ", autoViewChangeEnabled=" << c.autoViewChangeEnabled
                                           << ", viewChangeTimerMillisec=" << c.viewChangeTimerMillisec);
-
+#ifdef ALLOW_0_FAULT_TOLERANCE
+  Verify(c.fVal >= 0, InconsistentErr);
+#else
   Verify(c.fVal >= 1, InconsistentErr);
+#endif
+
   Verify(c.cVal >= 0, InconsistentErr);
 
   uint16_t numOfReplicas = 3 * c.fVal + 2 * c.cVal + 1;

--- a/bftengine/src/bftengine/SimpleClient.cpp
+++ b/bftengine/src/bftengine/SimpleClient.cpp
@@ -170,7 +170,11 @@ namespace bftEngine
 			clientSendsRequestToAllReplicasPeriodThresh{p.clientSendsRequestToAllReplicasPeriodThresh},
 			clientPeriodicResetThresh{p.clientPeriodicResetThresh}
 		{
-				Assert(_fVal >= 1);
+#ifdef ALLOW_0_FAULT_TOLERANCE
+                Assert(_fVal >= 0);
+#else
+                Assert(_fVal >= 1);
+#endif
 				//Assert(!_communication->isRunning());
 
 				pendingRequest = nullptr;


### PR DESCRIPTION
enable f_val to be set to 0, this is first for testing purposes, but also  a possible feature to continue running with a single node.

`(3 * fVal + 2 * cVal + 1)` equals 1 , when fVal and cVal are both 0. 