### PR TITLE
Revert test changes made during persistence debug

### DIFF
--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -185,7 +185,6 @@ void signalHandler( int signum ) {
 
 int main(int argc, char **argv) {
   ReplicaParams rp;
-  rp.viewChangeEnabled = true;
   parse_params(argc, argv, rp);
 
   // allows to attach debugger

--- a/bftengine/tests/simpleTest/simple_test_replica_behavior.hpp
+++ b/bftengine/tests/simpleTest/simple_test_replica_behavior.hpp
@@ -113,7 +113,7 @@ public:
   }
 
   explicit Replica2RestartNoVC(ReplicaParams &rp) : 
-    Replica2RestartNoVC(rp, PersistencyTestInfo{10000, 2000, 1}) {
+    Replica2RestartNoVC(rp, PersistencyTestInfo{3000, 2000, 1}) {
   }
   
   Replica2RestartNoVC() = delete;


### PR DESCRIPTION
Two changes made during testing shouldn't have been merged in. This
reverts them.

rp.viewChangeEnabled should only be set for tests that include view
change. The other was part of debugging and does not solve a real issue.

These changes were made based on feedback from Yulia.