### PR TITLE
Fix reversed exit code in bftengine simpleTest client

### DIFF
--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018, 2019 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -28,6 +28,7 @@
 // information about how to run the client.
 
 #include <cassert>
+#include <cstdlib>
 #include <thread>
 #include <iostream>
 #include <limits>
@@ -181,5 +182,5 @@ int main(int argc, char **argv) {
                                                                                 << ", clientPeriodicResetThresh: " << scp.clientPeriodicResetThresh);
 
   SimpleTestClient cl(cp, clientLogger);
-  return cl.run();
+  return cl.run() ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
SimpleTestClient::run() returns true if successful.  (It presumably could
return false if it failed, but it actually aborts the process.)  The caller
in client.cpp used this value as a process exit status, but the convention
for process exit status is reversed, where true (1) means failure and
false (0) means success.  This commit fixes the problem.

Fixes https://github.com/vmware/concord-bft/issues/185.