### PR TITLE
Let SimpleKVBCTests TesterReplica use RocksDB

### DIFF
--- a/bftengine/tests/config/test_parameters.hpp
+++ b/bftengine/tests/config/test_parameters.hpp
@@ -33,7 +33,8 @@ enum class PersistencyMode {
   Off, // no persistency at all
   InMemory, // use in memory module
   File, // use file as a storage
-  MAX_VALUE = File
+  RocksDB, // use RocksDB for storage
+  MAX_VALUE=RocksDB
 };
 
 enum class ReplicaBehavior {

--- a/bftengine/tests/simpleKVBCTests/TesterReplica/CMakeLists.txt
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/CMakeLists.txt
@@ -4,6 +4,7 @@ project(skvbc_replica VERSION 0.1.0.0 LANGUAGES CXX)
 set(replica_sources
 	main.cpp
         internalCommandsHandler.cpp
+        setup.cpp
         ../simpleKVBTestsBuilder.cpp
 	${CONFIG_FOLDER_PATH_VALUE}/test_comm_config.cpp
 	${CONFIG_FOLDER_PATH_VALUE}/config_file_parser.cpp)

--- a/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
@@ -11,162 +11,46 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <stdio.h>
-#include <string.h>
-#include <sstream>
-#include <signal.h>
-#include <stdlib.h>
-#include <thread>
-#include <sys/param.h>
-
-#include "KVBCInterfaces.h"
-#include "CommFactory.hpp"
-#include "test_comm_config.hpp"
-#include "test_parameters.hpp"
-#include "MetricsServer.hpp"
+#include "setup.hpp"
 #include "ReplicaImp.h"
-#include "commonKVBTests.hpp"
 #include "memorydb/client.h"
+#include "internalCommandsHandler.hpp"
+#include "commonKVBTests.hpp"
+
+#ifdef USE_ROCKSDB
 #include "rocksdb/client.h"
 #include "rocksdb/key_comparator.h"
-#include "internalCommandsHandler.hpp"
-
-using namespace SimpleKVBC;
-using namespace bftEngine;
-
-using std::string;
-using ::TestCommConfig;
-
-ReplicaParams rp;
-concordlogger::Logger logger = concordlogger::Log::getLogger("skvbctest.replica");
-
-int main(int argc, char** argv) {
-  rp.replicaId = UINT16_MAX;
-  rp.viewChangeEnabled = false;
-  rp.viewChangeTimeout = 45 * 1000;
-
-  // allows to attach debugger
-  if (rp.debug) {
-    std::this_thread::sleep_for(std::chrono::seconds(20));
-  }
-
-  char argTempBuffer[PATH_MAX + 10];
-  string idStr;
-
-  int o = 0;
-  while ((o = getopt(argc, argv, "r:i:k:n:s:v:")) != EOF) {
-    switch (o) {
-      case 'i': {
-        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
-        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
-        idStr = argTempBuffer;
-        int tempId = std::stoi(idStr);
-        if (tempId >= 0 && tempId < UINT16_MAX) rp.replicaId = (uint16_t)tempId;
-        // TODO: check repId
-      } break;
-
-      case 'k': {
-        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
-        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
-        rp.keysFilePrefix = argTempBuffer;
-        // TODO: check keysFilePrefix
-      } break;
-
-      case 'n': {
-        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
-        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
-        rp.configFileName = argTempBuffer;
-      } break;
-      case 's': {
-        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
-        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
-        idStr = argTempBuffer;
-        int tempId = std::stoi(idStr);
-        if (tempId >= 0 && tempId < UINT16_MAX) rp.statusReportTimerMillisec = (uint16_t)tempId;
-      } break;
-      case 'v': {
-        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
-        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
-        idStr = argTempBuffer;
-        int tempId = std::stoi(idStr);
-        if (tempId >= 0 && (uint32_t)tempId < UINT32_MAX) {
-          rp.viewChangeTimeout = (uint32_t)tempId;
-          rp.viewChangeEnabled = true;
-        }
-      } break;
-
-      default:
-        // nop
-        break;
-    }
-  }
-
-  if (rp.replicaId == UINT16_MAX || rp.keysFilePrefix.empty()) {
-    fprintf(stderr, "%s -k KEYS_FILE_PREFIX -i ID -n COMM_CONFIG_FILE", argv[0]);
-    exit(-1);
-  }
-
-  // TODO: check arguments
-
-  // used to get info from parsing the key file
-  bftEngine::ReplicaConfig replicaConfig;
-
-  TestCommConfig testCommConfig(logger);
-  testCommConfig.GetReplicaConfig(rp.replicaId, rp.keysFilePrefix, &replicaConfig);
-
-  // This allows more concurrency and only affects known ids in the
-  // communication classes.
-  replicaConfig.numOfClientProxies = 100;
-  replicaConfig.autoViewChangeEnabled = rp.viewChangeEnabled;
-  replicaConfig.viewChangeTimerMillisec = rp.viewChangeTimeout;
-  replicaConfig.statusReportTimerMillisec = rp.statusReportTimerMillisec;
-  replicaConfig.concurrencyLevel = 1;
-  replicaConfig.debugStatisticsEnabled = true;
-
-  uint16_t numOfReplicas = (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1);
-#ifdef USE_COMM_PLAIN_TCP
-  PlainTcpConfig conf = testCommConfig.GetTCPConfig(
-      true, rp.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, rp.configFileName);
-#elif USE_COMM_TLS_TCP
-  TlsTcpConfig conf = testCommConfig.GetTlsTCPConfig(
-      true, rp.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, rp.configFileName);
-#else
-  PlainUdpConfig conf = testCommConfig.GetUDPConfig(
-      true, rp.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, rp.configFileName);
 #endif
 
-  ICommunication* comm = CommFactory::create(conf);
-
-  // UDP MetricsServer only used in tests.
-  uint16_t metricsPort = conf.listenPort + 1000;
-  concordMetrics::Server server(metricsPort);
-  server.Start();
-
+int main(int argc, char** argv) {
+  auto setup = SimpleKVBC::TestSetup::ParseArgs(argc, argv);
+  auto logger = setup->GetLogger();
   auto* key_manipulator = new concord::storage::blockchain::KeyManipulator();
-  auto comparator = concord::storage::memorydb::KeyComparator(key_manipulator);
-  concord::storage::IDBClient* db = new concord::storage::memorydb::Client(comparator);
+  concord::storage::IDBClient* db;
 
-  // TODO(AJS) - We want 2 separate builds for the tester replica:
-  //  1. Using MemoryDb
-  //  2. Using RocksDB
-  //
-  //  The code below is what needs to change to use RocksDB. Remove the 2
-  //  lines of code before this comment and uncomment out the following four
-  //  lines of code. SimpleKVBC python tests pass with both MemoryDB and RocksDB
-  //  backends.
-  //
-  //  auto comparator = concord::storage::rocksdb::KeyComparator(key_manipulator);
-  //  std::stringstream dbPath;
-  //  dbPath << BasicRandomTests::DB_FILE_PREFIX << rp.replicaId;
-  //  auto db = new concord::storage::rocksdb::Client(dbPath.str(), &comparator);
+  if (setup->UsePersistentStorage()) {
+#ifdef USE_ROCKSDB
+    auto comparator = concord::storage::rocksdb::KeyComparator(key_manipulator);
+    std::stringstream dbPath;
+    dbPath << BasicRandomTests::DB_FILE_PREFIX << setup->GetReplicaConfig().replicaId;
+    db = new concord::storage::rocksdb::Client(dbPath.str(), &comparator);
+#else
+    // Abort if we haven't built rocksdb storage
+    LOG_ERROR(logger, "Must build with -DBUILD_ROCKSDB_STORAGE=TRUE cmake option in order to test with persistent storage enabled");
+    exit(-1);
+#endif
+  } else {
+    // Use in-memory storage
+    auto comparator = concord::storage::memorydb::KeyComparator(key_manipulator);
+    db = new concord::storage::memorydb::Client(comparator);
+  }
 
   auto* dbAdapter = new concord::storage::blockchain::DBAdapter(db);
-
-  ReplicaImp* replica = new ReplicaImp(comm, replicaConfig, dbAdapter, server.GetAggregator());
+  auto* replica = new SimpleKVBC::ReplicaImp(
+      setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsAggregator());
 
   InternalCommandsHandler cmdHandler(replica, replica, logger);
   replica->set_command_handler(&cmdHandler);
-
   replica->start();
   while (replica->isRunning()) std::this_thread::sleep_for(std::chrono::seconds(1));
 }

--- a/bftengine/tests/simpleKVBCTests/TesterReplica/setup.cpp
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/setup.cpp
@@ -1,0 +1,134 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <thread>
+#include <sys/param.h>
+#include <string>
+#include <cstring>
+#include <unistd.h>
+
+#include "setup.hpp"
+#include "CommFactory.hpp"
+#include "test_comm_config.hpp"
+#include "test_parameters.hpp"
+
+using namespace std;
+
+namespace SimpleKVBC {
+
+std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
+  ReplicaParams rp;
+  rp.replicaId = UINT16_MAX;
+  rp.viewChangeEnabled = false;
+  rp.viewChangeTimeout = 45 * 1000;
+
+  // allows to attach debugger
+  if (rp.debug) {
+    std::this_thread::sleep_for(std::chrono::seconds(20));
+  }
+
+  char argTempBuffer[PATH_MAX + 10];
+  string idStr;
+
+  int o = 0;
+  while ((o = getopt(argc, argv, "r:i:k:n:s:v:p")) != EOF) {
+    switch (o) {
+      case 'i': {
+        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
+        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
+        idStr = argTempBuffer;
+        int tempId = std::stoi(idStr);
+        if (tempId >= 0 && tempId < UINT16_MAX) rp.replicaId = (uint16_t)tempId;
+      } break;
+
+      case 'k': {
+        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
+        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
+        rp.keysFilePrefix = argTempBuffer;
+      } break;
+
+      case 'n': {
+        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
+        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
+        rp.configFileName = argTempBuffer;
+      } break;
+      case 's': {
+        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
+        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
+        idStr = argTempBuffer;
+        int tempId = std::stoi(idStr);
+        if (tempId >= 0 && tempId < UINT16_MAX) rp.statusReportTimerMillisec = (uint16_t)tempId;
+      } break;
+      case 'v': {
+        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
+        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
+        idStr = argTempBuffer;
+        int tempId = std::stoi(idStr);
+        if (tempId >= 0 && (uint32_t)tempId < UINT32_MAX) {
+          rp.viewChangeTimeout = (uint32_t)tempId;
+          rp.viewChangeEnabled = true;
+        }
+      } break;
+      // We can only toggle persistence on or off. It defaults to InMemory
+      // unless -p flag is provided.
+      case 'p':
+        rp.persistencyMode = PersistencyMode::RocksDB;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  if (rp.replicaId == UINT16_MAX || rp.keysFilePrefix.empty()) {
+    fprintf(stderr, "%s -k KEYS_FILE_PREFIX -i ID -n COMM_CONFIG_FILE", argv[0]);
+    exit(-1);
+  }
+
+  // used to get info from parsing the key file
+  bftEngine::ReplicaConfig replicaConfig;
+  concordlogger::Logger logger = concordlogger::Log::getLogger("skvbctest.replica");
+
+  TestCommConfig testCommConfig(logger);
+  testCommConfig.GetReplicaConfig(rp.replicaId, rp.keysFilePrefix, &replicaConfig);
+
+  // This allows more concurrency and only affects known ids in the
+  // communication classes.
+  replicaConfig.numOfClientProxies = 100;
+  replicaConfig.autoViewChangeEnabled = rp.viewChangeEnabled;
+  replicaConfig.viewChangeTimerMillisec = rp.viewChangeTimeout;
+  replicaConfig.statusReportTimerMillisec = rp.statusReportTimerMillisec;
+  replicaConfig.concurrencyLevel = 1;
+  replicaConfig.debugStatisticsEnabled = true;
+
+  uint16_t numOfReplicas = (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1);
+#ifdef USE_COMM_PLAIN_TCP
+  PlainTcpConfig conf = testCommConfig.GetTCPConfig(
+      true, rp.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, rp.configFileName);
+#elif USE_COMM_TLS_TCP
+  TlsTcpConfig conf = testCommConfig.GetTlsTCPConfig(
+      true, rp.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, rp.configFileName);
+#else
+  bftEngine::PlainUdpConfig conf = testCommConfig.GetUDPConfig(
+      true, rp.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, rp.configFileName);
+#endif
+
+  std::unique_ptr<bftEngine::ICommunication> comm(bftEngine::CommFactory::create(conf));
+
+  uint16_t metrics_port = conf.listenPort + 1000;
+
+  return std::unique_ptr<TestSetup>(new TestSetup{
+      replicaConfig, std::move(comm), logger, metrics_port, rp.persistencyMode == PersistencyMode::RocksDB});
+}
+
+}  // namespace SimpleKVBC

--- a/bftengine/tests/simpleKVBCTests/TesterReplica/setup.hpp
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/setup.hpp
@@ -1,0 +1,53 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <memory>
+
+#include "ReplicaConfig.hpp"
+#include "ICommunication.hpp"
+#include "Logger.hpp"
+#include "MetricsServer.hpp"
+
+namespace SimpleKVBC {
+
+class TestSetup {
+ public:
+  static std::unique_ptr<TestSetup> ParseArgs(int argc, char** argv);
+
+  bftEngine::ReplicaConfig& GetReplicaConfig() { return replica_config_; }
+  bftEngine::ICommunication* GetCommunication() const { return communication_.get(); }
+  std::shared_ptr<concordMetrics::Aggregator> GetMetricsAggregator() { return metrics_server_.GetAggregator(); }
+  concordlogger::Logger GetLogger() { return logger_; }
+  const bool UsePersistentStorage() const { return use_persistent_storage_; }
+
+ private:
+  TestSetup(bftEngine::ReplicaConfig config,
+            std::unique_ptr<bftEngine::ICommunication> comm,
+            concordlogger::Logger logger,
+            uint16_t metrics_port,
+            bool use_persistent_storage)
+      : replica_config_(config), communication_(std::move(comm)), logger_(logger), metrics_server_(metrics_port), use_persistent_storage_(use_persistent_storage) {
+    metrics_server_.Start();
+  }
+  TestSetup() = delete;
+
+  bftEngine::ReplicaConfig replica_config_;
+  std::unique_ptr<bftEngine::ICommunication> communication_;
+  concordlogger::Logger logger_;
+  concordMetrics::Server metrics_server_;
+  bool use_persistent_storage_;
+};
+
+}  // namespace SimpleKVBC


### PR DESCRIPTION
Configuration of the TesterReplica was moved out into a TestSetup class.
A new command line argument `-p` was added that allows the replica to
run with peristent storage backed by RocksDB. If the -p flag is not
given, in-memory storage will be used. Additionally, if the -p flag is
given but the binary was not compiled with RocksDB support it will exit
with an error message.

This change allows new system tests to be written to test our persistent
storage code.