### PR TITLE
Fix incorrect assert

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -872,7 +872,7 @@ void PersistentStorageImp::verifySetDescriptorOfLastExitFromView(const Descripto
   Assert(setIsAllowed());
   Assert(desc.view >= 0);
   // Here we assume that the first view is always 0 (even if we load the initial state from the disk).
-  Assert(hasDescriptorOfLastExecution() || desc.view == 0);
+  Assert(hasDescriptorOfLastExitFromView() || desc.view == 0);
   Assert(desc.elements.size() <= kWorkWindowSize);
 }
 


### PR DESCRIPTION
The prior assert would cause a crash when the view change transitioned
from view > 0 when a request was not yet executed. This scenario can
occur when a client is sending requests but not enough replicas are up
to achieve consensus. In this case they keep moving through the views,
and this assert fires.

Fix to use the correct assert, which instead of checking if there was a
descriptor for a request executing, checks that there is a descriptor
for exiting the last view. This descriptor is always saved before view
transition in ReplicaImp.cpp:1918.

Fixes #194