### PR TITLE
Fix issue #182

### DIFF
--- a/bftengine/src/bftengine/DebugStatistics.hpp
+++ b/bftengine/src/bftengine/DebugStatistics.hpp
@@ -1,6 +1,6 @@
 //Concord
 //
-//Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//Copyright (c) 2018, 2019 VMware, Inc. All Rights Reserved.
 //
 //This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License. 
 //
@@ -32,6 +32,8 @@ namespace bftEngine
 
 			static void onRequestCompleted(bool isReadOnly);
 
+			static void onSendPrePrepareMessage(size_t batchRequests, size_t pendingRequests);
+
 			static void initDebugStatisticsData();
 
 			static void freeDebugStatisticsData();
@@ -54,6 +56,10 @@ namespace bftEngine
 				size_t   numberOfReceivedStatusMessages;
 				size_t   numberOfReceivedCommitMessages;
 				int64_t  lastExecutedSequenceNumber;
+
+				size_t   prePrepareMessages;
+				size_t   batchRequests;
+				size_t   pendingRequests;
 
 				DebugStatDesc() : initialized(false) {}
 			};

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -210,12 +210,14 @@ void ReplicaImp::sendRaw(char *m, NodeIdType dest, uint16_t type, MsgSize size) 
 IncomingMsg ReplicaImp::recvMsg() {
   while (true) {
     auto msg = incomingMsgsStorage.pop(timersResolution);
-    if (msg.tag != IncomingMsg::INVALID) {
-      return msg;
-    }
+
     // TODO(GG): make sure that we don't check timers too often
     // (i.e. much faster than timersResolution)
     timersScheduler.evaluate();
+
+    if (msg.tag != IncomingMsg::INVALID) {
+      return msg;
+    }
   }
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1,6 +1,6 @@
 //Concord
 //
-//Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//Copyright (c) 2018, 2019 VMware, Inc. All Rights Reserved.
 //
 //This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License. 
 //
@@ -414,6 +414,9 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
 
   Assert(pp->numberOfRequests() > 0);
 
+  if (debugStatisticsEnabled) {
+    DebugStatistics::onSendPrePrepareMessage(pp->numberOfRequests(), requestsQueueOfPrimary.size());
+  }
   LOG_DEBUG_F(GL, "Sending PrePrepareMsg (seqNumber=%"
       PRId64
       ", requests=%d, size=%d",


### PR DESCRIPTION
This pair of commits fixes https://github.com/vmware/concord-bft/issues/182.

The first commit is not strictly related, but without it, simpleTest never really logs any stats at all because the timers never fire when I run it as "./simpleTest.py -l DEBUG -i 5000 -nc -bft n=6,r=6,f=1,c=1,cl=2".

The second commit really fixes the issue. The most difficult part of it was the indentation, which I still don't understand. DebugStatistics.cpp has a mix of tabs on some lines and spaces on others and I don't see how they actually line up properly with any tab width I tried. I tried to imitate what was there but all the possibilities looked wrong one way or another.

I tested this with simpleTest modified to always log debug statistics, like this:

```
diff --git a/bftengine/tests/simpleTest/simple_test_replica.hpp b/bftengine/tests/simpleTest/simple_test_replica.hpp
index 953968a58dd0..16b2f5c8da56 100644
--- a/bftengine/tests/simpleTest/simple_test_replica.hpp
+++ b/bftengine/tests/simpleTest/simple_test_replica.hpp
@@ -211,6 +211,7 @@ class SimpleTestReplica {
     replicaConfig.concurrencyLevel = 1;
     replicaConfig.debugPersistentStorageEnabled = rp.persistencyMode == PersistencyMode::InMemory ||
         rp.persistencyMode == PersistencyMode::File;
+    replicaConfig.debugStatisticsEnabled = true;
 
     // This is the state machine that the replica will drive.
     SimpleAppState *simpleAppState = new SimpleAppState(rp.numOfClients, rp.numOfReplicas);
```