### PR TITLE
Revert #195

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -872,7 +872,13 @@ void PersistentStorageImp::verifySetDescriptorOfLastExitFromView(const Descripto
   Assert(setIsAllowed());
   Assert(desc.view >= 0);
   // Here we assume that the first view is always 0 (even if we load the initial state from the disk).
-  Assert(hasDescriptorOfLastExitFromView() || desc.view == 0);
+  // TODO: The following line is incorrect (see
+  // https://github.com/vmware/concord-bft/pull/195). However, changing it as in
+  // that PR broke other things. This is a temporary revert until we get the
+  // real fix. While we could comment this line out, I think it's better to
+  // leave it for now so that we don't appear to have a fix when the root
+  // problem isn't solved.
+  Assert(hasDescriptorOfLastExecution() || desc.view == 0);
   Assert(desc.elements.size() <= kWorkWindowSize);
 }
 


### PR DESCRIPTION
The code is still incorrect below here, but it works correctly on 4 node
clusters. The change made in 195 broke several unit tests and also has a
critical problem of attempting to read from storage while a write
transaction is in progress, which violates invariants in asserts. In
fact the change in #195 led to a situation where there were 2 mutually
exclusive asserts in the code path, and thus would always abort on any
view change attempt:

```
bool PersistentStorageImp::setIsAllowed() const {
  LOG_DEBUG_F(GL, "PersistentStorageImp::setIsAllowed() isInWriteTran=%d, hasReplicaConfig=%d",
              isInWriteTran(), hasReplicaConfig());
  return (isInWriteTran() && hasReplicaConfig());
}

bool PersistentStorageImp::getIsAllowed() const {
  LOG_DEBUG_F(GL, "PersistentStorageImp::getIsAllowed() isInWriteTran=%d", isInWriteTran());
  return (!isInWriteTran());
}
```

There needs to be more work done to figure out what the true change is.
The recommended fix in #194 will not work for the reasons mentioned
above. A regression test that illustrates the problem is coming in a
follow up commit. We can use that to validate any real fixes.