### PR TITLE
Fix wrong assert, remove unneeded assert and fix serialization test

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -615,7 +615,6 @@ PersistentStorageImp::getAndAllocateDescriptorOfLastExitFromView() {
 
 DescriptorOfLastNewView
 PersistentStorageImp::getAndAllocateDescriptorOfLastNewView() {
-  Assert(getIsAllowed());
   DescriptorOfLastNewView dbDesc;
   const size_t simpleParamsSize = DescriptorOfLastNewView::simpleParamsSize();
   uint32_t actualSize = 0;
@@ -871,14 +870,9 @@ bool PersistentStorageImp::getSlowStartedInSeqNumWindow(SeqNum seqNum) {
 void PersistentStorageImp::verifySetDescriptorOfLastExitFromView(const DescriptorOfLastExitFromView &desc) {
   Assert(setIsAllowed());
   Assert(desc.view >= 0);
-  // Here we assume that the first view is always 0 (even if we load the initial state from the disk).
-  // TODO: The following line is incorrect (see
-  // https://github.com/vmware/concord-bft/pull/195). However, changing it as in
-  // that PR broke other things. This is a temporary revert until we get the
-  // real fix. While we could comment this line out, I think it's better to
-  // leave it for now so that we don't appear to have a fix when the root
-  // problem isn't solved.
-  Assert(hasDescriptorOfLastExecution() || desc.view == 0);
+  // Here we assume that the first view is always 0
+  // (even if we load the initial state from disk)
+  Assert(hasDescriptorOfLastNewView() || desc.view == 0);
   Assert(desc.elements.size() <= kWorkWindowSize);
 }
 

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -363,8 +363,7 @@ void testSetDescriptors(bool toSet) {
                                                     viewChangeMsg, lastExitStableLowerBound);
 
   ViewChangeMsgsVector msgs;
-  ViewNum newViewNum = 1
-  ;
+  ViewNum newViewNum = 1;
   for (auto i = 1; i <= msgsNum; i++)
     msgs.push_back(new ViewChangeMsg(i, newViewNum, lastExitStableNum));
   SeqNum maxSeqNum = 200;

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -344,7 +344,7 @@ void testSetDescriptors(bool toSet) {
   Bitmap requests(100);
   DescriptorOfLastExecution lastExecutionDesc(lastExecutionSeqNum, requests);
 
-  ViewNum viewNum = 2;
+  ViewNum viewNum = 0;
   SeqNum lastExitExecNum = 65;
   PrevViewInfoElements elements;
   ViewsManager::PrevViewInfo element;
@@ -358,12 +358,13 @@ void testSetDescriptors(bool toSet) {
   SeqNum lastExitStableNum = 60;
   SeqNum lastExitStableLowerBound = 50;
   SeqNum lastStable = 48;
-  auto *viewChangeMsg = new ViewChangeMsg(senderId, viewNum, lastStable);
+  auto *viewChangeMsg = new ViewChangeMsg(senderId, viewNum + 1, lastStable);
   DescriptorOfLastExitFromView lastExitFromViewDesc(viewNum, lastExitStableNum, lastExitExecNum, elements,
                                                     viewChangeMsg, lastExitStableLowerBound);
 
   ViewChangeMsgsVector msgs;
-  ViewNum newViewNum = 6;
+  ViewNum newViewNum = 1
+  ;
   for (auto i = 1; i <= msgsNum; i++)
     msgs.push_back(new ViewChangeMsg(i, newViewNum, lastExitStableNum));
   SeqNum maxSeqNum = 200;


### PR DESCRIPTION
This PR fixes the incorrect assert when verifying descriptor of last exit from the view.
Moreover, the unneeded assert is removed.

All tests passed, including skvbc_persistence

Fixes #194