### PR TITLE
Give better names for currently used batch functions.

### DIFF
--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -48,11 +48,11 @@ class MetadataStorage {
                            uint32_t dataLength) = 0;
 
   // Atomic write-only transactions
-  virtual void beginAtomicWriteOnlyTransaction() = 0;
-  virtual void writeInTransaction(uint32_t objectId,
-                                  char *data,
-                                  uint32_t dataLength) = 0;
-  virtual void commitAtomicWriteOnlyTransaction() = 0;
+  virtual void beginAtomicWriteOnlyBatch() = 0;
+  virtual void writeInBatch(uint32_t objectId,
+                            char *data,
+                            uint32_t dataLength) = 0;
+  virtual void commitAtomicWriteOnlyBatch() = 0;
 };
 
 }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3501,14 +3501,10 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
                                                                                       currentPrimary(),
                                                                                       replyBuffer,
                                                                                       actualReplyLength);
-
       send(replyMsg, clientId);
-
       delete replyMsg;
-
       clientsManager->removePendingRequestOfClient(clientId);
     }
-
   }
 
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -204,23 +204,23 @@ void FileStorage::atomicWrite(uint32_t objectId, char *data, uint32_t dataLength
   handleObjectWrite(objectId, data, dataLength);
 }
 
-void FileStorage::beginAtomicWriteOnlyTransaction() {
-  LOG_DEBUG(logger_, "FileStorage::beginAtomicWriteOnlyTransaction");
+void FileStorage::beginAtomicWriteOnlyBatch() {
+  LOG_DEBUG(logger_, "FileStorage::beginAtomicWriteOnlyBatch");
   lock_guard<mutex> lock(ioMutex_);
   verifyFileMetadataSetup();
   if (transaction_) {
-    LOG_DEBUG(logger_, "FileStorage::beginAtomicWriteOnlyTransaction Transaction has been opened before; ignoring.");
+    LOG_DEBUG(logger_, "FileStorage::beginAtomicWriteOnlyBatch Transaction has been opened before; ignoring.");
     return;
   }
   transaction_ = new ObjectIdToRequestMap;
 }
 
-void FileStorage::writeInTransaction(uint32_t objectId, char *data, uint32_t dataLength) {
-  LOG_DEBUG(logger_, "FileStorage::writeInTransaction objectId=" << objectId << ", dataLength=" << dataLength);
+void FileStorage::writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) {
+  LOG_DEBUG(logger_, "FileStorage::writeInBatch objectId=" << objectId << ", dataLength=" << dataLength);
   lock_guard<mutex> lock(ioMutex_);
   verifyOperation(objectId, dataLength, data);
   if (!transaction_) {
-    LOG_ERROR(logger_, "FileStorage::writeInTransaction " << WRONG_FLOW);
+    LOG_ERROR(logger_, "FileStorage::writeInBatch " << WRONG_FLOW);
     throw runtime_error(WRONG_FLOW);
   }
 
@@ -230,12 +230,12 @@ void FileStorage::writeInTransaction(uint32_t objectId, char *data, uint32_t dat
   transaction_->insert(pair<uint32_t, RequestInfo>(objectId, RequestInfo(data, dataLength)));
 }
 
-void FileStorage::commitAtomicWriteOnlyTransaction() {
-  LOG_DEBUG(logger_, "FileStorage::commitAtomicWriteOnlyTransaction");
+void FileStorage::commitAtomicWriteOnlyBatch() {
+  LOG_DEBUG(logger_, "FileStorage::commitAtomicWriteOnlyBatch");
   lock_guard<mutex> lock(ioMutex_);
   verifyFileMetadataSetup();
   if (!transaction_) {
-    LOG_ERROR(logger_, "FileStorage::commitAtomicWriteOnlyTransaction " << WRONG_FLOW);
+    LOG_ERROR(logger_, "FileStorage::commitAtomicWriteOnlyBatch " << WRONG_FLOW);
     throw runtime_error(WRONG_FLOW);
   }
   for (const auto &it : *transaction_) {

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -41,12 +41,12 @@ class FileStorage : public MetadataStorage {
 
   void atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) override;
 
-  void beginAtomicWriteOnlyTransaction() override;
+  void beginAtomicWriteOnlyBatch() override;
 
-  void writeInTransaction(uint32_t objectId, char *data,
-                          uint32_t dataLength) override;
+  void writeInBatch(uint32_t objectId, char *data,
+                    uint32_t dataLength) override;
 
-  void commitAtomicWriteOnlyTransaction() override;
+  void commitAtomicWriteOnlyBatch() override;
 
  private:
   void read(void *dataPtr, size_t offset, size_t itemSize,
@@ -83,7 +83,7 @@ class FileStorage : public MetadataStorage {
   const char *WRONG_OBJ_INFO_READ =
       "Failed to read objects info or it is different from expected";
   const char *WRONG_FLOW =
-      "beginAtomicWriteOnlyTransaction should be launched first";
+      "beginAtomicWriteOnlyBatch should be launched first";
 
   const uint8_t initializedObjectId_ = 1;
 

--- a/bftengine/tests/simpleStorage/main.cpp
+++ b/bftengine/tests/simpleStorage/main.cpp
@@ -75,11 +75,11 @@ int main(int argc, char **argv) {
     const uint32_t objId2 = 3;
     const uint32_t objId3 = 4;
     const uint32_t objId4 = 5;
-    fileStorage->beginAtomicWriteOnlyTransaction();
-    fileStorage->writeInTransaction(objId2, objOutBuf, sizeof(objOut));
-    fileStorage->writeInTransaction(objId3, objOutBuf, sizeof(objOut));
-    fileStorage->writeInTransaction(objId4, objOutBuf, sizeof(objOut));
-    fileStorage->commitAtomicWriteOnlyTransaction();
+    fileStorage->beginAtomicWriteOnlyBatch();
+    fileStorage->writeInBatch(objId2, objOutBuf, sizeof(objOut));
+    fileStorage->writeInBatch(objId3, objOutBuf, sizeof(objOut));
+    fileStorage->writeInBatch(objId4, objOutBuf, sizeof(objOut));
+    fileStorage->commitAtomicWriteOnlyBatch();
     for (int i = 0; i < 2; i++) {
       verifyData(*fileStorage, objId2);
       verifyData(*fileStorage, objId3);

--- a/storage/include/storage/db_metadata_storage.h
+++ b/storage/include/storage/db_metadata_storage.h
@@ -39,9 +39,9 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
   void read(uint32_t objectId, uint32_t bufferSize, char *outBufferForObject,
             uint32_t &outActualObjectSize) override;
   void atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) override;
-  void beginAtomicWriteOnlyTransaction() override;
-  void writeInTransaction(uint32_t objectId, char *data, uint32_t dataLength) override;
-  void commitAtomicWriteOnlyTransaction() override;
+  void beginAtomicWriteOnlyBatch() override;
+  void writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) override;
+  void commitAtomicWriteOnlyBatch() override;
   concordUtils::Status multiDel(const ObjectIdsVector &objectIds);
   bool isNewStorage() override;
 
@@ -49,14 +49,14 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
   void verifyOperation(uint32_t objectId, uint32_t dataLen, const char *buffer, bool writeOperation) const;
 
  private:
-  const char *WRONG_FLOW = "beginAtomicWriteOnlyTransaction should be launched first";
+  const char *WRONG_FLOW = "beginAtomicWriteOnlyBatch should be launched first";
   const char *WRONG_PARAMETER = "Wrong parameter value specified";
 
   const uint8_t objectsNumParameterId_ = 1;
 
   concordlogger::Logger logger_;
   IDBClient *dbClient_ = nullptr;
-  SetOfKeyValuePairs *transaction_ = nullptr;
+  SetOfKeyValuePairs *batch_ = nullptr;
   std::mutex ioMutex_;
   ObjectIdToSizeMap objectIdToSizeMap_;
   uint32_t objectsNum_ = 0;

--- a/storage/test/metadataStorage_test.cpp
+++ b/storage/test/metadataStorage_test.cpp
@@ -48,7 +48,7 @@ uint8_t *writeRandomData(const ObjectId &objectId, const uint32_t &dataLen) {
 
 uint8_t *writeInTransaction(const ObjectId &objectId, const uint32_t &dataLen) {
   uint8_t *data = createAndFillBuf(dataLen);
-  metadataStorage->writeInTransaction(objectId, (char *)data, dataLen);
+  metadataStorage->writeInBatch(objectId, (char *)data, dataLen);
   return data;
 }
 
@@ -73,7 +73,7 @@ TEST(metadataStorage_test, single_read) {
 }
 
 TEST(metadataStorage_test, multi_write) {
-  metadataStorage->beginAtomicWriteOnlyTransaction();
+  metadataStorage->beginAtomicWriteOnlyBatch();
   uint8_t *inBuf[objectsNum];
   uint8_t *outBuf[objectsNum];
   uint32_t objectsDataSize[objectsNum];
@@ -82,7 +82,7 @@ TEST(metadataStorage_test, multi_write) {
     inBuf[i] = writeInTransaction(i, objectsDataSize[i]);
     outBuf[i] = new uint8_t[objectsDataSize[i]];
   }
-  metadataStorage->commitAtomicWriteOnlyTransaction();
+  metadataStorage->commitAtomicWriteOnlyBatch();
   uint32_t realSize = 0;
   for (ObjectId i = initialObjectId; i < objectsNum; i++) {
     metadataStorage->read(i, objectsDataSize[i], (char *)outBuf[i], realSize);


### PR DESCRIPTION
As a preparation for a move to RocksDB transactions, rename batch functions to reflect their functionality.