### PR TITLE
Add memorydb transactions to storage library

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -21,10 +21,11 @@ if (BUILD_ROCKSDB_STORAGE)
   target_include_directories(concordbft_storage PUBLIC ${ROCKSDB_INCLUDE_DIR})
   target_link_libraries(concordbft_storage ${ROCKSDB} ${LIBBZ2} ${LIBLZ4} ${LIBZSTD} ${LIBZ} ${LIBSNAPPY})
 
-  if (BUILD_TESTING)
-    add_subdirectory(test)
-  endif()
 endif(BUILD_ROCKSDB_STORAGE)
 
 target_sources(concordbft_storage PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/memorydb_client.cpp)
+
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 

--- a/storage/include/memorydb/transaction.h
+++ b/storage/include/memorydb/transaction.h
@@ -1,0 +1,117 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <sstream>
+
+#include "storage/db_interface.h"
+#include "client.h"
+
+namespace concord {
+namespace storage {
+namespace memorydb {
+
+#define MEMORYDB_THROW(action, status)                                                                \
+  std::ostringstream os;                                                                              \
+  os << "memorydb error: action: " << action << ", txn id[" << getIdStr() << "], reason: " << status; \
+  throw std::runtime_error(os.str())
+
+// In-memory transactions are just a thin wrapper around a client.
+// A transaction already holds a lock when it gets created so it has exclusive
+// control over the client for the lifetime of the transaction.
+//
+// All writes are put into a shadow map and are only applied on commit.
+// This allows the transaction to abort in case of an exception. Reads first
+// check the shadow map, then look in the underlying map accessed via the client
+// if the transaction hasn't updated the requested key.
+class Transaction : public ITransaction {
+ private:
+  enum OpType { Put, Remove };
+  struct WriteOp {
+    OpType type_;
+    Sliver key;
+    Sliver value;
+  };
+
+ public:
+  Transaction(Client* client, ID id, std::unique_lock<std::recursive_mutex> client_lock_guard)
+      : ITransaction(id),
+        client_(client),
+        client_lock_guard_(std::move(client_lock_guard)),
+        updates_(client->getMap().key_comp()) {}
+
+  // Apply all write operations to the memorydb via client_ 
+  void commit() override {
+    for (auto&& kv : updates_) {
+      auto op = kv.second;
+      if (op.type_ == Put) {
+        auto status = client_->put(op.key, op.value);
+        if (!status.isOK()) {
+          MEMORYDB_THROW("Put", status);
+        }
+      } else {
+        auto status = client_->del(op.key);
+        if (!status.isOK()) {
+          MEMORYDB_THROW("Remove", status);
+        }
+      }
+    }
+  }
+
+  void rollback() override {
+    // NOOP
+  }
+
+  void put(const Sliver& key, const Sliver& value) override { updates_[key] = WriteOp{Put, key, value}; }
+
+  // Return an empty string if the key is not found
+  std::string get(const Sliver& key) override {
+    try {
+      // Look in the shadow map to see if the key was updated during the
+      // transaction.
+      WriteOp value = updates_.at(key);
+      if (value.type_ == Put) {
+        return std::string((char*)value.value.data(), value.value.length());
+      } else {
+        return std::string();
+      }
+    } catch (std::out_of_range&) {
+      // The value wasn't in the shadow map. Look in the memorydb via the
+      // client.
+      Sliver out;
+      auto status = client_->get(key, out);
+      if (!status.isOK() && !status.isNotFound()) {
+        MEMORYDB_THROW("Get", status);
+      }
+      return std::string((char*)out.data(), out.length());
+    }
+  }
+
+  void remove(const Sliver& key) override { updates_[key] = WriteOp{Remove, key}; }
+
+ private:
+  // A Client is expected to live for the lifetime of the program
+  Client* client_;
+
+  // A lock around the client is held for the duration of the transaction
+  std::unique_lock<std::recursive_mutex> client_lock_guard_;
+
+  // All writes that take place during the transaction occur in this shadow
+  // map. In transaction gets read from the shadow map first, and then read from
+  // the memorydb client if the key has not been touched.
+  std::map<Sliver, WriteOp, Compare> updates_;
+};
+
+}  // namespace memorydb
+}  // namespace storage
+}  // namespace concord

--- a/storage/test/multiIO_test.cpp
+++ b/storage/test/multiIO_test.cpp
@@ -1,15 +1,19 @@
  // Copyright 2019 VMware, all rights reserved
 /**
- * Test multi* functions for RocksDBClient class.
+ * Test multi* functions and transactions for IDBClient implementations.
  */
-
-#define USE_ROCKSDB 1
 
 #include "Logger.hpp"
 #include "hash_defs.h"
 #include "gtest/gtest.h"
+
+#ifdef USE_ROCKSDB
 #include "rocksdb/key_comparator.h"
 #include "rocksdb/client.h"
+#else
+#include "memorydb/client.h"
+#endif
+
 #include "kv_types.hpp"
 #include "blockchain/db_adapter.h"
 
@@ -20,8 +24,15 @@ using concordUtils::Sliver;
 using concordUtils::KeysVector;
 using concordUtils::KeyValuePair;
 using concordUtils::SetOfKeyValuePairs;
+
+#ifdef USE_ROCKSDB
 using concord::storage::rocksdb::Client;
 using concord::storage::rocksdb::KeyComparator;
+#else
+using concord::storage::memorydb::Client;
+using concord::storage::memorydb::KeyComparator;
+#endif
+
 using concord::storage::ITransaction;
 using concord::storage::blockchain::KeyManipulator;
 namespace {
@@ -157,9 +168,16 @@ TEST(multiIO_test, no_commit_during_exception)
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
+
+#ifdef USE_ROCKSDB
   const string dbPath = "./rocksdb_test";
   dbClient = new Client(dbPath, new KeyComparator(new KeyManipulator()));
   dbClient->init();
+#else
+  // Using memorydb client
+  dbClient = new Client(KeyComparator(new KeyManipulator));
+#endif
+
   int res = RUN_ALL_TESTS();
   return res;
 }


### PR DESCRIPTION
Support for strict serializable transactions was added to the in memory
db. The transactions work by taking an exclusive lock over the in-memory
map holding the keys and values when the transaction is created. Writes
(Put and Remove) are put into a shadow map inside the transaction and
only applied on transaction commit. Reads inside the transaction first
look in the shadow map to see if the transaction modified the given
key and return the value in the shadow map if so. Otherwise they go to
the underlying map via the memorydb client.

Because the transactions take an exclusive lock for simplicity,
transactions should be short lived. We don't anticipate much concurrency
or complex transactions in the near future so this should be fine.

The storage tests were also modified to test the memorydb as well as
rocksdb. The multiIO tests verify the transactions work as expected.