### PR TITLE
Remove Roadmap from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,6 @@ when a backwards incompatible change is made.
 
  [v0.5](https://github.com/vmware/concord-bft/releases/tag/v0.5)
 
-Roadmap
-----
-We plan to release updates in a quarterly schedule. The next releases will include: optimized State transfer modules with rocksdb integration, configuration and key generation tools, generic key-value interface, and execution engine for EVM smart contracts. We also plan to support Windows, OS X, and additional Linux distributions.
-
-
 Contributing
 ----
 


### PR DESCRIPTION
The roadmap section is currently inaccurate. We need a more concrete and
formal document that has been vetted by engineering and our
stakeholders.

Once this is merged in we can bump the version to 0.6.