### PR TITLE
Really enable Fortify in debug mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ string(APPEND CXX_FLAGS " -Werror")
 #    " -fno-strict-overflow")
 # Prevents some buffer overflows: https://access.redhat.com/blogs/766093/posts/1976213
 string(APPEND CXX_FLAGS_DEBUG
-        " -D_FORTIFY_SOURCE=2")
+        " -D_FORTIFY_SOURCE=2 -O")
 
 # GCC and clang-specific options
 string(APPEND CMAKE_CXX_FLAGS

--- a/tools/TestGeneratedKeys.cpp
+++ b/tools/TestGeneratedKeys.cpp
@@ -837,11 +837,11 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  uint16_t numReplicas;
+  uint16_t numReplicas = 0;
   std::string outputPrefix;
 
-  bool hasNumReplicas;
-  bool hasOutputPrefix;
+  bool hasNumReplicas = false;
+  bool hasOutputPrefix = false;
 
   // Read input from the command line.
   // Note we ignore argv[0] because it contains the command that was used to run


### PR DESCRIPTION
feature_test_macros(7) says:

     If  _FORTIFY_SOURCE  is  set  to  1, with compiler optimization
     level 1 (gcc -O1) and above, checks that shouldn't  change  the
     behavior  of  conforming  programs  are  performed.  With _FOR‐
     TIFY_SOURCE set to 2, some more checking  is  added,  but  some
     conforming programs might fail.

Without this patch, CMakeLists.txt enables _FORTIFY_SOURCE but not
optimizations in debug mode.  On Fedora, this causes the build to fail
with:

    /usr/include/features.h:382:4: error: _FORTIFY_SOURCE requires
    compiling with optimization (-O) [-Werror,-W#warnings]

This commit fixes the problem on Fedora, and presumably fixes a hidden
problem on other distributions (that Fortify wasn't really enabled).
With GCC, the best optimization option to use would probably be -Og, which
is specifically for optimizing while still making debugging as easy as
possible, but I can't find any documentation for whether Clang supports
-Og.  I guess an alternative to enabling optimization would be to disable
Fortify, which probably doesn't work at the moment.