### PR TITLE
Fix use of ferror() return value in simpleStorage FileStorage.

### DIFF
--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -91,7 +91,7 @@ void FileStorage::read(void *dataPtr, size_t offset, size_t itemSize, size_t cou
   size_t read_ = fread(dataPtr, itemSize, count, dataStream_);
   int err = ferror(dataStream_);
   if (err)
-    throw runtime_error("FileStorage::read " +  std::string(strerror(err)));
+    throw runtime_error("FileStorage::read " +  std::string(strerror(errno)));
   if (feof(dataStream_))
     throw runtime_error("FileStorage::read EOF" );
   if (read_ != count)


### PR DESCRIPTION
ferror() just returns zero or nonzero according to whether the stream has
the error indicator set (see
https://pubs.opengroup.org/onlinepubs/9699919799/), so it's necessary to
look at errno to find the actual problem.

(Spotted randomly when I was looking at nearby code, I didn't actually
trigger or test this.)