### PR TITLE
Avoid unneeded copy of exception object in BCStateTran::saveReservedP…

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -500,7 +500,7 @@ void BCStateTran::saveReservedPage(uint32_t reservedPageId,
     psd_->setPendingResPage(reservedPageId, inReservedPage, copyLength);
   } catch (std::out_of_range e) {
     LOG_ERROR(STLogger, "BCStateTran::saveReservedPage - got out_of_range exception");
-    throw (e);
+    throw;
   }
 }
 


### PR DESCRIPTION
…age().

Clang 8.0.0 on Fedora 30 issues the following warning without this patch:

bftengine/src/bcstatetransfer/BCStateTran.cpp:503:11: error:
      local variable 'e' will be copied despite being thrown by name
      [-Werror,-Wreturn-std-move]
    throw (e);
          ^~~
bftengine/src/bcstatetransfer/BCStateTran.cpp:503:11: note:
      call 'std::move' explicitly to avoid copying
    throw (e);
          ^~~
          std::move(e)