### PR TITLE
Restore default C++ compiler to clang++ when compiling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.2)
 
 # Default to building with clang on Linux,OSX,BSD etc...
 # This must come before the project definition or it won't be picked up.
+if(NOT ENV{CXX} AND UNIX)
+    set(ENV{CXX} clang++)
+endif()
+
 project(concord-bft VERSION 0.1.0.0 LANGUAGES CXX)
 
 #


### PR DESCRIPTION
Commit 53c6b149360f ("Enhance build via direct use of cmake (#56)") made
clang++ the default C++ compiler on Unix-like systems, but commit
b8bb68ac500c ("1. removed 3rd-party cmake FindLog4cplus for possible...")
reverted the setting.  I think that the latter was a mistake or an
oversight, because the commit message didn't mention the change and left
the comment that said that clang++ was the default.