### PR TITLE
Run pyclient_tests in verbose mode for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ env:
     - RELEASE=-DCMAKE_BUILD_TYPE=RELEASE
     - RELEASE=-DCMAKE_BUILD_TYPE=RELEASE USE_ROCKSDB=-DBUILD_ROCKSDB_STORAGE=TRUE
 script:
-  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $DEBUG $RELEASE $USE_ROCKSDB .. && make -j $(getconf _NPROCESSORS_ONLN) && ctest
+  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $DEBUG $RELEASE $USE_ROCKSDB .. && make -j $(getconf _NPROCESSORS_ONLN) && ctest -R pyclient --verbose && ctest
 


### PR DESCRIPTION
I'm having trouble reproducing failure of this test, but it fails
periodically in CI (See #212). Since it only takes about 2 seconds to run, run it
in verbose mode so we can see the stack trace. We may want to turn on
verbose mode for all tests in the future, but we need to ensure that
doesn't slow down runs significantly or exceed the 4MB log limit. We ran
into that problem prior.