### PR TITLE
Reduce copying and Sliver construction/destruction in comparator

### DIFF
--- a/storage/include/blockchain/db_adapter.h
+++ b/storage/include/blockchain/db_adapter.h
@@ -20,15 +20,19 @@ namespace blockchain {
 class KeyManipulator: public IDBClient::IKeyManipulator{
  public:
   KeyManipulator():logger_(concordlogger::Log::getLogger("concord.storage.blockchain.KeyManipulator")){}
-  virtual int   composedKeyComparison(const Sliver&, const Sliver& ) override;
+  virtual int   composedKeyComparison(const uint8_t* _a_data, size_t _a_length, const uint8_t* _b_data, size_t _b_length) override;
 
   Sliver        genDbKey(EDBKeyType _type, const Key& _key, BlockId _blockId);
   Sliver        genBlockDbKey(BlockId _blockId);
   Sliver        genDataDbKey(const Key& _key, BlockId _blockId);
   char          extractTypeFromKey(const Key& _key);
+  char          extractTypeFromKey(const uint8_t* _key_data);
   BlockId       extractBlockIdFromKey(const Key& _key);
+  BlockId       extractBlockIdFromKey(const uint8_t* _key_data, size_t _key_length);
   ObjectId      extractObjectIdFromKey(const Key& _key);
+  ObjectId      extractObjectIdFromKey(const uint8_t* _key_data, size_t _key_length);
   Sliver        extractKeyFromKeyComposedWithBlockId(const Key& _composedKey);
+  int           compareKeyPartOfComposedKey(const uint8_t *a_data, size_t a_length, const uint8_t *b_data, size_t b_length);
   Sliver        extractKeyFromMetadataKey(const Key& _composedKey);
   bool          isKeyContainBlockId(const Key& _composedKey);
   KeyValuePair  composedToSimple(KeyValuePair _p);

--- a/storage/include/memorydb/key_comparator.h
+++ b/storage/include/memorydb/key_comparator.h
@@ -24,7 +24,7 @@ class KeyComparator {
         logger_(concordlogger::Log::getLogger("concord.storage.rocksdb.KeyComparator")) {}
 
   bool operator()(const Sliver &a, const Sliver &b) const {
-    int ret = key_manipulator_->composedKeyComparison(a, b);
+    int ret = key_manipulator_->composedKeyComparison(a.data(), a.length(), b.data(), b.length());
     return ret < 0;
   }
 

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -82,7 +82,8 @@ class IDBClient {
 
   class IKeyManipulator{
     public:
-      virtual int composedKeyComparison(const Sliver&, const Sliver& ) = 0;
+    virtual int composedKeyComparison(const uint8_t* _a_data, size_t _a_length,
+                                      const uint8_t* _b_data, size_t _b_length) = 0;
       virtual ~IKeyManipulator() = default;
   };
 

--- a/storage/src/rocksdb_key_comparator.cpp
+++ b/storage/src/rocksdb_key_comparator.cpp
@@ -24,11 +24,10 @@ namespace rocksdb {
 
 int KeyComparator::Compare(const ::rocksdb::Slice& _a,
                            const ::rocksdb::Slice& _b) const {
-  Sliver a = copyRocksdbSlice(_a);
-  Sliver b = copyRocksdbSlice(_b);
-  int ret = key_manipulator_->composedKeyComparison(a, b);
+  int ret = key_manipulator_->composedKeyComparison(reinterpret_cast<const uint8_t*>(_a.data()), _a.size(),
+                                                    reinterpret_cast<const uint8_t*>(_b.data()), _b.size());
 
-  LOG_TRACE(logger_, "Compared " << a << " with " << b << ", returning " << ret);
+  LOG_TRACE(logger_, "Compared " << _a.ToString(true) << " with " << _b.ToString(true) << ", returning " << ret);
 
   return ret;
 }


### PR DESCRIPTION
Profiling showed that a read/write-heavy workload spent significant
amount of time in the rocksdb key comparator, and that most of that
time was spent copying buffers, and constructing and destructing
Sliver objects. This MR adds versions of the functions required by the
key comparator that operate directly on pointers, instead of expecting
a Sliver wrapping. This removes copying and extraneous Sliver
construction in this path, which showed performance improvements in
read/write-heavy tests.