### PR TITLE
Remove obsolete comment in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
 
-# Default to building with clang on Linux,OSX,BSD etc...
-# This must come before the project definition or it won't be picked up.
 project(concord-bft VERSION 0.1.0.0 LANGUAGES CXX)
 
 #


### PR DESCRIPTION
Previously, clang++ was the default compiler on Unix-like systems.
Commit b8bb68ac500c ("1. removed 3rd-party cmake FindLog4cplus for
possible...") removed this default, instead using whatever the system's
default compiler was, but it did not remove an associated comment.  For
consistency, this commit removes the comment.

See also https://github.com/vmware/concord-bft/pull/221 for discussion.