### PR TITLE
Avoid bogus "receiver is NULL" log messages when using UDP.

### DIFF
--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -368,6 +368,12 @@ class PlainUDPCommunication::PlainUdpImpl {
       if (mLen < 0) {
         LOG_DEBUG(_logger, "Node " << selfId << ": Error in recvfrom(): " << mLen);
         continue;
+      } else if (!mLen) {
+        // Probably, Stop() set 'running' to false and shut down the
+        // socket.  (Or, maybe, we received an actual zero-length UDP
+        // datagram, but we never send those.)
+        LOG_DEBUG(_logger, "Node " << selfId << ": Received empty message (shutting down?)");
+        continue;
       }
 
       auto resolveNode = addrToNodeId(fromAdress);
@@ -377,7 +383,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       }
 
       auto sendingNode = resolveNode.nodeId;
-      if (mLen > 0 && (receiverRef != NULL)) {
+      if (receiverRef != NULL) {
         LOG_DEBUG(_logger, "Node " << selfId << ": Calling onNewMessage, msg from: " << sendingNode);
         receiverRef->onNewMessage(sendingNode,
                                   bufferForIncomingMessages,


### PR DESCRIPTION
Every simpleTest run was printing "Node #: receiver is NULL" at the end of
the test logs.  This didn't really make sense because the code sets
receiver nonnull and then never sets it back to null afterward.  However,
a received message length of 0 could also cause the message to be printed,
and that was the issue.  Normally UDP would only return a 0-length message
if the sender was sending 0-length messages, but it also turns out that
(at least with Linux) using shutdown() to half-close a socket for receive
also causes recvfrom() to return 0-length messages.  The Stop() member
function does exactly that, as a way to wake up the receive thread when
it's time for it to exit.  Thus, this is a perfectly normal thing in this
case and doesn't warrant logging a (wrong) error message.  This commit
changes the code to instead log an accurate message at debug level.