### PR TITLE
Take const Sliver& where appropriate in storage

### DIFF
--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -115,7 +115,7 @@ Status ReplicaImp::addBlockToIdleReplica(const SetOfKeyValuePairs &updates) {
   return addBlockInternal(updates, d);
 }
 
-Status ReplicaImp::get(Sliver key, Sliver &outValue) const {
+Status ReplicaImp::get(const Sliver& key, Sliver &outValue) const {
   // TODO(GG): check legality of operation (the method should be invoked from
   // the replica's internal thread)
 
@@ -123,7 +123,7 @@ Status ReplicaImp::get(Sliver key, Sliver &outValue) const {
   return getInternal(m_lastBlock, key, outValue, dummy);
 }
 
-Status ReplicaImp::get(BlockId readVersion, Sliver key, Sliver &outValue, BlockId &outBlock) const {
+Status ReplicaImp::get(BlockId readVersion, const Sliver& key, Sliver &outValue, BlockId &outBlock) const {
   // TODO(GG): check legality of operation (the method should be invoked from
   // the replica's internal thread)
 
@@ -147,7 +147,7 @@ Status ReplicaImp::getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockDat
   return Status::OK();
 }
 
-Status ReplicaImp::mayHaveConflictBetween(Sliver key, BlockId fromBlock, BlockId toBlock, bool &outRes) const {
+Status ReplicaImp::mayHaveConflictBetween(const Sliver& key, BlockId fromBlock, BlockId toBlock, bool &outRes) const {
   // TODO(GG): add assert or print warning if fromBlock==0 (all keys have a
   // conflict in block 0)
 
@@ -368,7 +368,7 @@ Sliver ReplicaImp::getBlockInternal(BlockId blockId) const {
 
 ReplicaImp::StorageWrapperForIdleMode::StorageWrapperForIdleMode(const ReplicaImp *r) : rep(r) {}
 
-Status ReplicaImp::StorageWrapperForIdleMode::get(Sliver key, Sliver &outValue) const {
+Status ReplicaImp::StorageWrapperForIdleMode::get(const Sliver& key, Sliver &outValue) const {
   if (rep->getReplicaStatus() != IReplica::RepStatus::Idle) {
     return Status::IllegalOperation("");
   }
@@ -377,7 +377,7 @@ Status ReplicaImp::StorageWrapperForIdleMode::get(Sliver key, Sliver &outValue) 
 }
 
 Status ReplicaImp::StorageWrapperForIdleMode::get(BlockId readVersion,
-                                                  Sliver key,
+                                                  const Sliver& key,
                                                   Sliver &outValue,
                                                   BlockId &outBlock) const {
   if (rep->getReplicaStatus() != IReplica::RepStatus::Idle) {
@@ -405,7 +405,7 @@ Status ReplicaImp::StorageWrapperForIdleMode::getBlockData(BlockId blockId, SetO
   return Status::OK();
 }
 
-Status ReplicaImp::StorageWrapperForIdleMode::mayHaveConflictBetween(Sliver key,
+Status ReplicaImp::StorageWrapperForIdleMode::mayHaveConflictBetween(const Sliver& key,
                                                                      BlockId fromBlock,
                                                                      BlockId toBlock,
                                                                      bool &outRes) const {
@@ -555,7 +555,7 @@ KeyValuePair ReplicaImp::StorageIterator::first(BlockId readVersion, BlockId &ac
 }
 
 KeyValuePair ReplicaImp::StorageIterator::seekAtLeast(BlockId readVersion,
-                                                      Key key,
+                                                      const Key& key,
                                                       BlockId &actualVersion,
                                                       bool &isEnd) {
   Key actualKey;
@@ -586,7 +586,7 @@ KeyValuePair ReplicaImp::StorageIterator::seekAtLeast(BlockId readVersion,
  * perfectly OK.
  */
 // Note: key,readVersion must exist in map already
-KeyValuePair ReplicaImp::StorageIterator::next(BlockId readVersion, Key key, BlockId &actualVersion, bool &isEnd) {
+KeyValuePair ReplicaImp::StorageIterator::next(BlockId readVersion, const Key& key, BlockId &actualVersion, bool &isEnd) {
   Key nextKey;
   Value nextValue;
   Status s = rep->getBcDbAdapter()->next(m_iter, readVersion, nextKey, nextValue, actualVersion, isEnd);

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.h
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.h
@@ -53,10 +53,10 @@ class ReplicaImp : public SimpleKVBC::IReplica,
   virtual void set_command_handler(SimpleKVBC::ICommandsHandler *handler) override;
 
   // concord::storage::ILocalKeyValueStorageReadOnly methods
-  virtual Status get(Sliver key, Sliver &outValue) const override;
+  virtual Status get(const Sliver& key, Sliver &outValue) const override;
 
   virtual Status get(concord::storage::blockchain::BlockId readVersion,
-                     Sliver key,
+                     const Sliver& key,
                      Sliver &outValue,
                      concord::storage::blockchain::BlockId &outBlock) const override;
 
@@ -65,7 +65,7 @@ class ReplicaImp : public SimpleKVBC::IReplica,
   virtual Status getBlockData(concord::storage::blockchain::BlockId blockId,
                               concord::storage::SetOfKeyValuePairs &outBlockData) const override;
 
-  virtual Status mayHaveConflictBetween(Sliver key,
+  virtual Status mayHaveConflictBetween(const Sliver& key,
                                         concord::storage::blockchain::BlockId fromBlock,
                                         concord::storage::blockchain::BlockId toBlock,
                                         bool &outRes) const override;
@@ -141,10 +141,10 @@ class ReplicaImp : public SimpleKVBC::IReplica,
    public:
     StorageWrapperForIdleMode(const ReplicaImp *r);
 
-    virtual Status get(Sliver key, Sliver &outValue) const override;
+    virtual Status get(const Sliver& key, Sliver &outValue) const override;
 
     virtual Status get(concord::storage::blockchain::BlockId readVersion,
-                       Sliver key,
+                       const Sliver& key,
                        Sliver &outValue,
                        concord::storage::blockchain::BlockId &outBlock) const override;
     virtual concord::storage::blockchain::BlockId getLastBlock() const override;
@@ -152,7 +152,7 @@ class ReplicaImp : public SimpleKVBC::IReplica,
     virtual Status getBlockData(concord::storage::blockchain::BlockId blockId,
                                 concord::storage::SetOfKeyValuePairs &outBlockData) const override;
 
-    virtual Status mayHaveConflictBetween(Sliver key,
+    virtual Status mayHaveConflictBetween(const Sliver& key,
                                           concord::storage::blockchain::BlockId fromBlock,
                                           concord::storage::blockchain::BlockId toBlock,
                                           bool &outRes) const override;
@@ -198,12 +198,12 @@ class ReplicaImp : public SimpleKVBC::IReplica,
     // Assumes lexicographical ordering of the keys, seek the first element
     // k >= key
     virtual concord::storage::KeyValuePair seekAtLeast(concord::storage::blockchain::BlockId readVersion,
-                                                       concordUtils::Key key,
+                                                       const concordUtils::Key& key,
                                                        concord::storage::blockchain::BlockId &actualVersion,
                                                        bool &isEnd) override;
 
     // TODO(SG): Not implemented originally!
-    virtual concord::storage::KeyValuePair seekAtLeast(concordUtils::Key key) override {
+    virtual concord::storage::KeyValuePair seekAtLeast(const concordUtils::Key& key) override {
       concord::storage::blockchain::BlockId block = m_currentBlock;
       concord::storage::blockchain::BlockId dummy;
       bool dummy2;
@@ -212,7 +212,7 @@ class ReplicaImp : public SimpleKVBC::IReplica,
 
     // Proceed to next element and return it
     virtual concord::storage::KeyValuePair next(concord::storage::blockchain::BlockId readVersion,
-                                                concordUtils::Key key,
+                                                const concordUtils::Key& key,
                                                 concord::storage::blockchain::BlockId &actualVersion,
                                                 bool &isEnd) override;
 

--- a/storage/include/blockchain/db_adapter.h
+++ b/storage/include/blockchain/db_adapter.h
@@ -22,15 +22,15 @@ class KeyManipulator: public IDBClient::IKeyManipulator{
   KeyManipulator():logger_(concordlogger::Log::getLogger("concord.storage.blockchain.KeyManipulator")){}
   virtual int   composedKeyComparison(const Sliver&, const Sliver& ) override;
 
-  Sliver        genDbKey(EDBKeyType _type, Key _key, BlockId _blockId);
+  Sliver        genDbKey(EDBKeyType _type, const Key& _key, BlockId _blockId);
   Sliver        genBlockDbKey(BlockId _blockId);
-  Sliver        genDataDbKey(Key _key, BlockId _blockId);
-  char          extractTypeFromKey(Key _key);
-  BlockId       extractBlockIdFromKey(Key _key);
-  ObjectId      extractObjectIdFromKey(Key _key);
-  Sliver        extractKeyFromKeyComposedWithBlockId(Key _composedKey);
-  Sliver        extractKeyFromMetadataKey(Key _composedKey);
-  bool          isKeyContainBlockId(Key _composedKey);
+  Sliver        genDataDbKey(const Key& _key, BlockId _blockId);
+  char          extractTypeFromKey(const Key& _key);
+  BlockId       extractBlockIdFromKey(const Key& _key);
+  ObjectId      extractObjectIdFromKey(const Key& _key);
+  Sliver        extractKeyFromKeyComposedWithBlockId(const Key& _composedKey);
+  Sliver        extractKeyFromMetadataKey(const Key& _composedKey);
+  bool          isKeyContainBlockId(const Key& _composedKey);
   KeyValuePair  composedToSimple(KeyValuePair _p);
   static Sliver generateMetadataKey(ObjectId objectId);
  protected:
@@ -48,9 +48,9 @@ class DBAdapter {
   std::shared_ptr<IDBClient> getDb() { return db_; }
 
   Status addBlock(BlockId _blockId, Sliver _blockRaw);
-  Status updateKey(Key _key, BlockId _block, Value _value);
+  Status updateKey(const Key& _key, BlockId _block, Value _value);
   Status addBlockAndUpdateMultiKey(const SetOfKeyValuePairs &_kvMap, BlockId _block, Sliver _blockRaw);
-  Status getKeyByReadVersion(BlockId readVersion, Sliver key, Sliver &outValue, BlockId &outBlock) const;
+  Status getKeyByReadVersion(BlockId readVersion, const Sliver& key, Sliver &outValue, BlockId &outBlock) const;
   Status getBlockById(BlockId _blockId, Sliver &_blockRaw, bool &_found) const;
 
   IDBClient::IDBClientIterator* getIterator() { return db_->getIterator(); }
@@ -59,7 +59,7 @@ class DBAdapter {
 
   Status first(IDBClient::IDBClientIterator *iter, BlockId readVersion, OUT BlockId &actualVersion, OUT bool &isEnd,
                OUT Sliver &_key, OUT Sliver &_value);
-  Status seekAtLeast(IDBClient::IDBClientIterator *iter, Sliver _searchKey, BlockId _readVersion,
+  Status seekAtLeast(IDBClient::IDBClientIterator *iter, const Sliver& _searchKey, BlockId _readVersion,
                      OUT BlockId &_actualVersion, OUT Sliver &_key, OUT Sliver &_value, OUT bool &_isEnd);
   Status next(IDBClient::IDBClientIterator *iter, BlockId _readVersion, OUT Sliver &_key, OUT Sliver &_value,
               OUT BlockId &_actualVersion, OUT bool &_isEnd);
@@ -67,7 +67,7 @@ class DBAdapter {
   Status getCurrent(IDBClient::IDBClientIterator *iter, OUT Sliver &_key, OUT Sliver &_value);
   Status isEnd(IDBClient::IDBClientIterator *iter, OUT bool &_isEnd);
 
-  Status delKey(Sliver _key, BlockId _blockID);
+  Status delKey(const Sliver& _key, BlockId _blockID);
   Status delBlock(BlockId _blockId);
   void   deleteBlockAndItsKeys(BlockId blockId);
   void   monitor() const;

--- a/storage/include/blockchain/db_interfaces.h
+++ b/storage/include/blockchain/db_interfaces.h
@@ -29,15 +29,15 @@ class ILocalKeyValueStorageReadOnlyIterator;
 class ILocalKeyValueStorageReadOnly {
  public:
   // convenience where readVersion==latest, and block is not needed?
-  virtual Status get(Key key, Value& outValue) const = 0;
-  virtual Status get(BlockId readVersion, Sliver key, Sliver& outValue,
+  virtual Status get(const Key& key, Value& outValue) const = 0;
+  virtual Status get(BlockId readVersion, const Sliver& key, Sliver& outValue,
                      BlockId& outBlock) const = 0;
 
   virtual BlockId getLastBlock() const = 0;
   virtual Status getBlockData(BlockId blockId,
                               SetOfKeyValuePairs& outBlockData) const = 0;
   // TODO(GG): explain motivation
-  virtual Status mayHaveConflictBetween(Sliver key, BlockId fromBlock,
+  virtual Status mayHaveConflictBetween(const Sliver& key, BlockId fromBlock,
                                         BlockId toBlock,
                                         bool& outRes) const = 0;
 
@@ -63,12 +63,12 @@ class ILocalKeyValueStorageReadOnlyIterator {
 
   // Assumes lexicographical ordering of the keys, seek the first element
   // k >= key
-  virtual KeyValuePair seekAtLeast(BlockId readVersion, Key key,
+  virtual KeyValuePair seekAtLeast(BlockId readVersion, const Key& key,
                                    BlockId& actualVersion, bool& isEnd) = 0;
-  virtual KeyValuePair seekAtLeast(Key key) = 0;
+  virtual KeyValuePair seekAtLeast(const Key& key) = 0;
 
   // Proceed to next element and return it
-  virtual KeyValuePair next(BlockId readVersion, Key key,
+  virtual KeyValuePair next(BlockId readVersion, const Key& key,
                             BlockId& actualVersion, bool& isEnd) = 0;
   virtual KeyValuePair next() = 0;
 

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -38,7 +38,7 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
 
   // Inherited via IDBClientIterator
   virtual KeyValuePair first() override;
-  virtual KeyValuePair seekAtLeast(Sliver _searchKey) override;
+  virtual KeyValuePair seekAtLeast(const Sliver& _searchKey) override;
   virtual KeyValuePair previous() override;
   virtual KeyValuePair next() override;
   virtual KeyValuePair getCurrent() override;
@@ -64,12 +64,12 @@ class Client : public IDBClient {
   Client(KeyComparator comp) : comp_(comp), map_([this](const Sliver&a , const Sliver& b){ return comp_(a, b); }) {}
 
   virtual void init(bool readOnly) override;
-  virtual Status get(Sliver _key, OUT Sliver &_outValue) const override;
-  Status get(Sliver _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const override;
+  virtual Status get(const Sliver& _key, OUT Sliver &_outValue) const override;
+  Status get(const Sliver& _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const override;
   virtual IDBClientIterator *getIterator() const override;
   virtual concordUtils::Status freeIterator(IDBClientIterator *_iter) const override;
-  virtual concordUtils::Status put(Sliver _key, Sliver _value) override;
-  virtual concordUtils::Status del(Sliver _key) override;
+  virtual concordUtils::Status put(const Sliver& _key, const Sliver& _value) override;
+  virtual concordUtils::Status del(const Sliver& _key) override;
   concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) override;
   concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap) override;
   concordUtils::Status multiDel(const KeysVector &_keysVec) override;

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -39,7 +39,7 @@ class ClientIterator
 
   // Inherited via IDBClientIterator
   concordUtils::KeyValuePair first() override;
-  concordUtils::KeyValuePair seekAtLeast(concordUtils::Sliver _searchKey) override;
+  concordUtils::KeyValuePair seekAtLeast(const concordUtils::Sliver& _searchKey) override;
   concordUtils::KeyValuePair previous() override;
   KeyValuePair next() override;
   KeyValuePair getCurrent() override;
@@ -65,12 +65,12 @@ class Client : public concord::storage::IDBClient {
         m_comparator(_comparator) {}
 
   void init(bool readOnly = false) override;
-  concordUtils::Status get(concordUtils::Sliver _key, concordUtils::Sliver &_outValue) const override;
-  concordUtils::Status get(concordUtils::Sliver _key, char *&buf, uint32_t bufSize, uint32_t &_realSize) const override;
+  concordUtils::Status get(const concordUtils::Sliver& _key, concordUtils::Sliver &_outValue) const override;
+  concordUtils::Status get(const concordUtils::Sliver& _key, char *&buf, uint32_t bufSize, uint32_t &_realSize) const override;
   IDBClientIterator*   getIterator() const override;
   concordUtils::Status freeIterator(IDBClientIterator *_iter) const override;
-  concordUtils::Status put(concordUtils::Sliver _key, concordUtils::Sliver _value) override;
-  concordUtils::Status del(concordUtils::Sliver _key) override;
+  concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override;
+  concordUtils::Status del(const concordUtils::Sliver& _key) override;
   concordUtils::Status multiGet(const KeysVector &_keysVec, ValuesVector &_valuesVec) override;
   concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap) override;
   concordUtils::Status multiDel(const KeysVector &_keysVec) override;
@@ -81,7 +81,7 @@ class Client : public concord::storage::IDBClient {
 
  private:
   concordUtils::Status launchBatchJob(::rocksdb::WriteBatch &_batchJob);
-  concordUtils::Status get(concordUtils::Sliver _key, std::string &_value) const;
+  concordUtils::Status get(const concordUtils::Sliver& _key, std::string &_value) const;
 
  private:
   concordlogger::Logger logger;
@@ -93,7 +93,7 @@ class Client : public concord::storage::IDBClient {
   ::rocksdb::Comparator*         m_comparator = nullptr;
 };
 
-::rocksdb::Slice toRocksdbSlice(concordUtils::Sliver _s);
+::rocksdb::Slice toRocksdbSlice(const concordUtils::Sliver& _s);
 concordUtils::Sliver fromRocksdbSlice(::rocksdb::Slice _s);
 concordUtils::Sliver copyRocksdbSlice(::rocksdb::Slice _s);
 

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -52,10 +52,10 @@ class IDBClient {
  public:
   virtual ~IDBClient() = default;
   virtual void   init(bool readOnly = false) = 0;
-  virtual Status get(Sliver _key, OUT Sliver &_outValue) const = 0;
-  virtual Status get(Sliver _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const = 0;
-  virtual Status put(Sliver _key, Sliver _value) = 0;
-  virtual Status del(Sliver _key) = 0;
+  virtual Status get(const Sliver& _key, OUT Sliver &_outValue) const = 0;
+  virtual Status get(const Sliver& _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const = 0;
+  virtual Status put(const Sliver& _key, const Sliver& _value) = 0;
+  virtual Status del(const Sliver& _key) = 0;
   virtual Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) = 0;
   virtual Status multiPut(const SetOfKeyValuePairs &_keyValueMap) = 0;
   virtual Status multiDel(const KeysVector &_keysVec) = 0;
@@ -70,7 +70,7 @@ class IDBClient {
    public:
     virtual KeyValuePair first() = 0;
     // Returns next keys if not found for this key
-    virtual KeyValuePair seekAtLeast(Sliver _searchKey) = 0;
+    virtual KeyValuePair seekAtLeast(const Sliver& _searchKey) = 0;
     virtual KeyValuePair previous() = 0;
     virtual KeyValuePair next() = 0;
     virtual KeyValuePair getCurrent() = 0;

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -33,7 +33,7 @@ void Client::init(bool readOnly) {
  *                  successful.
  * @return Status NotFound if no mapping is found, else, Status OK.
  */
-Status Client::get(Sliver _key, OUT Sliver &_outValue) const {
+Status Client::get(const Sliver& _key, OUT Sliver &_outValue) const {
   try {
     _outValue = map_.at(_key);
   } catch (const std::out_of_range &oor) {
@@ -43,7 +43,7 @@ Status Client::get(Sliver _key, OUT Sliver &_outValue) const {
   return Status::OK();
 }
 
-Status Client::get(Sliver _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const {
+Status Client::get(const Sliver& _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const {
   auto copy = Sliver::copy(buf, bufSize);
   auto status =  get(_key, copy);
   memcpy(buf, copy.data(), bufSize);
@@ -86,7 +86,7 @@ Status Client::freeIterator(IDBClientIterator *_iter) const {
  * @param _value Value of the mapping.
  * @return Status OK.
  */
-Status Client::put(Sliver _key, Sliver _value) {
+Status Client::put(const Sliver& _key, const Sliver& _value) {
   // Copy the key and the value
   bool keyExists = false;
   if (map_.find(_key) != map_.end()) {
@@ -120,7 +120,7 @@ Status Client::put(Sliver _key, Sliver _value) {
  * @param _key Reference to the key of the mapping.
  * @return Status OK.
  */
-Status Client::del(Sliver _key) {
+Status Client::del(const Sliver& _key) {
   bool keyExists = false;
   if (map_.find(_key) != map_.end()) {
     keyExists = true;
@@ -190,7 +190,7 @@ KeyValuePair ClientIterator::first() {
  *  @return Key value pair of the key which is greater than or equal to
  *  _searchKey.
  */
-KeyValuePair ClientIterator::seekAtLeast(Sliver _searchKey) {
+KeyValuePair ClientIterator::seekAtLeast(const Sliver& _searchKey) {
   m_current = m_parentClient->getMap().lower_bound(_searchKey);
   if (m_current == m_parentClient->getMap().end()) {
     LOG_WARN(logger, "Key " << _searchKey << " not found");

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -36,7 +36,7 @@ static bool g_rocksdb_print_measurements = false;
  * @param _s Sliver object.
  * @return A RocksDB Slice object.
  */
-::rocksdb::Slice toRocksdbSlice(Sliver _s) {
+::rocksdb::Slice toRocksdbSlice(const Sliver& _s) {
   return ::rocksdb::Slice(reinterpret_cast<const char *>(_s.data()), _s.length());
 }
 
@@ -112,7 +112,7 @@ void Client::init(bool readOnly) {
     throw std::runtime_error("Failed to open rocksdb database at " + m_dbPath + std::string(" reason: ") + s.ToString());
 }
 
-Status Client::get(Sliver _key, OUT std::string &_value) const {
+Status Client::get(const Sliver& _key, OUT std::string &_value) const {
   ++g_rocksdb_called_read;
   if (g_rocksdb_print_measurements) {
     LOG_DEBUG(logger, "Reading count = " << g_rocksdb_called_read
@@ -148,7 +148,7 @@ Status Client::get(Sliver _key, OUT std::string &_value) const {
  * @return Status NotFound if key is not present, Status GeneralError if error
  *         in Get, else Status OK.
  */
-Status Client::get(Sliver _key, OUT Sliver &_outValue) const {
+Status Client::get(const Sliver& _key, OUT Sliver &_outValue) const {
   std::string value;
   Status ret = get(_key, value);
   if (!ret.isOK()) return ret;
@@ -163,7 +163,7 @@ Status Client::get(Sliver _key, OUT Sliver &_outValue) const {
 }
 
 // A memory for the output buffer is expected to be allocated by a caller.
-Status Client::get(Sliver _key, OUT char *&buf, uint32_t bufSize,
+Status Client::get(const Sliver& _key, OUT char *&buf, uint32_t bufSize,
                           OUT uint32_t &_realSize) const {
   std::string value;
   Status ret = get(_key, value);
@@ -249,7 +249,7 @@ ClientIterator::ClientIterator(const Client *_parentClient)
  * @param _value The value that needs to be stored against the key.
  * @return Status GeneralError if error in Put, else Status OK.
  */
-Status Client::put(Sliver _key, Sliver _value) {
+Status Client::put(const Sliver& _key, const Sliver& _value) {
   ::rocksdb::WriteOptions woptions = ::rocksdb::WriteOptions();
 
   ::rocksdb::Status s =
@@ -275,7 +275,7 @@ Status Client::put(Sliver _key, Sliver _value) {
  *              deleted.
  *  @return Status GeneralError if error in delete, else Status OK.
  */
-Status Client::del(Sliver _key) {
+Status Client::del(const Sliver& _key) {
   ::rocksdb::WriteOptions woptions = ::rocksdb::WriteOptions();
   ::rocksdb::Status s = m_dbInstance->Delete(woptions, toRocksdbSlice(_key));
 
@@ -392,7 +392,7 @@ KeyValuePair ClientIterator::first() {
  * @return Key value pair of the key which is greater than or equal to
  *         _searchKey.
  */
-KeyValuePair ClientIterator::seekAtLeast(Sliver _searchKey) {
+KeyValuePair ClientIterator::seekAtLeast(const Sliver& _searchKey) {
   ++g_rocksdb_called_read;
   if (g_rocksdb_print_measurements) {
     LOG_DEBUG(logger, "Reading count = " << g_rocksdb_called_read


### PR DESCRIPTION
Slivers contain a std::shared_ptr<uint8_t> that points to the underlying
data buffer. While taking them by value doesn't incur any copies of the
data, it does incur an expensive atomic ref count bump. In most of our
storage methods we bump this refcount only for the parameter copy, and
then go ahead and destruct it, incurring another cost. This change makes
it so that we eliminate those operations by only taking Slivers by const
reference when we can.

Note that this doesn't actually require changing any of the call sites,
just the signatures :)