### PR TITLE
Enhance Sliver for safety and performance

### DIFF
--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -25,10 +25,7 @@ sudo make install
 cd /tmp
 git clone https://github.com/weidai11/cryptopp.git
 cd cryptopp
-git checkout CRYPTOPP_5_6_5
-mkdir build
-cd build
-cmake ..
+git checkout CRYPTOPP_8_2_0
 make
 sudo make install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(concord-bft VERSION 0.1.0.0 LANGUAGES CXX)
 #   TODO: change to set_target_properties?
 #   https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
 #
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,7 @@ Build and install [cryptopp](https://github.com/weidai11/cryptopp)
     cd
     git clone https://github.com/weidai11/cryptopp.git
     cd cryptopp/
-    git checkout CRYPTOPP_5_6_5;
-    mkdir build/
-    cd build/
-    cmake ..
+    git checkout CRYPTOPP_8_2_0;
     make
     sudo make install
 

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -217,7 +217,7 @@ class DBDataStore : public DataStore {
   T get(const ObjectId& objId) {
     concordUtils::Sliver val;
     if (!get(genKey(objId), val)) return 0;
-    std::string s(reinterpret_cast<char*>(val.data()), val.length());
+    std::string s(val.data(), val.length());
     return concord::util::to<T>(s);
   }
   /** *****************************************************************************************************************

--- a/bftengine/src/bcstatetransfer/STDigest.cpp
+++ b/bftengine/src/bcstatetransfer/STDigest.cpp
@@ -46,7 +46,7 @@ DigestContext::DigestContext() {
 void DigestContext::update(const char* data, size_t len) {
   assert(internalState != NULL);
   CryptoPP::SHA256* p = (CryptoPP::SHA256*)internalState;
-  p->Update(reinterpret_cast<byte*>(const_cast<char*>(data)), len);
+  p->Update(reinterpret_cast<CryptoPP::byte*>(const_cast<char*>(data)), len);
 }
 
 void DigestContext::writeDigest(char* outDigest) {
@@ -54,7 +54,7 @@ void DigestContext::writeDigest(char* outDigest) {
   CryptoPP::SHA256* p = (CryptoPP::SHA256*)internalState;
   CryptoPP::SecByteBlock digest(CryptoPP::SHA256::DIGESTSIZE);
   p->Final(digest);
-  const byte* h = digest;
+  const CryptoPP::byte* h = digest;
   memcpy(outDigest, h, CryptoPP::SHA256::DIGESTSIZE);
 
   delete p;

--- a/bftengine/src/bftengine/Crypto.cpp
+++ b/bftengine/src/bftengine/Crypto.cpp
@@ -148,7 +148,8 @@ class RSASignerInternal {
             size_t& lengthOfReturnedData) {
     const size_t sigLen = priv.SignatureLength();
     if (lengthOfOutBuffer < sigLen) return false;
-    lengthOfReturnedData = priv.SignMessage(rand, (CryptoPP::byte*)inBuffer, lengthOfInBuffer, (CryptoPP::byte*)outBuffer);
+    lengthOfReturnedData =
+        priv.SignMessage(rand, (CryptoPP::byte*)inBuffer, lengthOfInBuffer, (CryptoPP::byte*)outBuffer);
     VERIFY(lengthOfReturnedData == sigLen);
 
     return true;
@@ -165,8 +166,7 @@ class RSAVerifierInternal {
 
   size_t signatureLength() { return pub.SignatureLength(); }
 
-  bool verify(const char* data, size_t lengthOfData, const char* signature, size_t lengthOfOSignature)
-  {
+  bool verify(const char* data, size_t lengthOfData, const char* signature, size_t lengthOfOSignature) {
     bool ok = pub.VerifyMessage((CryptoPP::byte*)data, lengthOfData, (CryptoPP::byte*)signature, lengthOfOSignature);
     return ok;
   }

--- a/bftengine/src/bftengine/Crypto.cpp
+++ b/bftengine/src/bftengine/Crypto.cpp
@@ -57,7 +57,7 @@ static RandomPool sGlobalRandGen;  // not thread-safe !!
 void CryptographyWrapper::init(const char* randomSeed) {
   string s(randomSeed);
   if (s.length() < 16) s.resize(16, ' ');
-  sGlobalRandGen.IncorporateEntropy((byte*)s.c_str(), s.length());
+  sGlobalRandGen.IncorporateEntropy((CryptoPP::byte*)s.c_str(), s.length());
 
   VERIFY(DigestUtil::digestLength() == DIGEST_SIZE);
 
@@ -96,9 +96,9 @@ bool DigestUtil::compute(const char* input,
 
   SecByteBlock digest(size);
 
-  dig.Update((byte*)input, inputLength);
+  dig.Update((CryptoPP::byte*)input, inputLength);
   dig.Final(digest);
-  const byte* h = digest;
+  const CryptoPP::byte* h = digest;
   memcpy(outBufferForDigest, h, size);
 
   return true;
@@ -112,7 +112,7 @@ DigestUtil::Context::Context() {
 void DigestUtil::Context::update(const char* data, size_t len) {
   VERIFY(internalState != NULL);
   DigestType* p = (DigestType*)internalState;
-  p->Update((byte*)data, len);
+  p->Update((CryptoPP::byte*)data, len);
 }
 
 void DigestUtil::Context::writeDigest(char* outDigest) {
@@ -120,7 +120,7 @@ void DigestUtil::Context::writeDigest(char* outDigest) {
   DigestType* p = (DigestType*)internalState;
   SecByteBlock digest(digestLength());
   p->Final(digest);
-  const byte* h = digest;
+  const CryptoPP::byte* h = digest;
   memcpy(outDigest, h, digestLength());
 
   delete p;
@@ -148,7 +148,7 @@ class RSASignerInternal {
             size_t& lengthOfReturnedData) {
     const size_t sigLen = priv.SignatureLength();
     if (lengthOfOutBuffer < sigLen) return false;
-    lengthOfReturnedData = priv.SignMessage(rand, (byte*)inBuffer, lengthOfInBuffer, (byte*)outBuffer);
+    lengthOfReturnedData = priv.SignMessage(rand, (CryptoPP::byte*)inBuffer, lengthOfInBuffer, (CryptoPP::byte*)outBuffer);
     VERIFY(lengthOfReturnedData == sigLen);
 
     return true;
@@ -165,8 +165,9 @@ class RSAVerifierInternal {
 
   size_t signatureLength() { return pub.SignatureLength(); }
 
-  bool verify(const char* data, size_t lengthOfData, const char* signature, size_t lengthOfOSignature) {
-    bool ok = pub.VerifyMessage((byte*)data, lengthOfData, (byte*)signature, lengthOfOSignature);
+  bool verify(const char* data, size_t lengthOfData, const char* signature, size_t lengthOfOSignature)
+  {
+    bool ok = pub.VerifyMessage((CryptoPP::byte*)data, lengthOfData, (CryptoPP::byte*)signature, lengthOfOSignature);
     return ok;
   }
 

--- a/bftengine/tests/simpleKVBC/include/block_metadata.hpp
+++ b/bftengine/tests/simpleKVBC/include/block_metadata.hpp
@@ -13,7 +13,7 @@
 
 namespace SimpleKVBC {
 
-const uint8_t kBlockMetadataKey = 0x21;
+const char kBlockMetadataKey = 0x21;
 
 class BlockMetadata {
  private:
@@ -25,7 +25,7 @@ class BlockMetadata {
   BlockMetadata(const concord::storage::blockchain::ILocalKeyValueStorageReadOnly &storage)
       : logger_(concordlogger::Log::getLogger("skvbc.MetadataStorage")),
         storage_(storage),
-        key_(new uint8_t[1]{kBlockMetadataKey}, 1) {}
+        key_(new char[1]{kBlockMetadataKey}, 1) {}
 
   concordUtils::Sliver Key() const { return key_; }
 

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -444,7 +444,7 @@ Sliver ReplicaImp::createBlockFromUpdates(const SetOfKeyValuePairs &updates,
   const uint32_t blockSize = metadataSize + blockBodySize;
 
   try {
-    uint8_t *blockBuffer = new uint8_t[blockSize];
+    char *blockBuffer = new char[blockSize];
     memset(blockBuffer, 0, blockSize);
     Sliver blockSliver(blockBuffer, blockSize);
 
@@ -488,7 +488,7 @@ Sliver ReplicaImp::createBlockFromUpdates(const SetOfKeyValuePairs &updates,
   } catch (std::bad_alloc &ba) {
     LOG_ERROR(concordlogger::Log::getLogger("skvbc.replicaImp"),
               "Failed to alloc size " << blockSize << ", error: " << ba.what());
-    uint8_t *emptyBlockBuffer = new uint8_t[1];
+    char *emptyBlockBuffer = new char[1];
     memset(emptyBlockBuffer, 0, 1);
     return Sliver(emptyBlockBuffer, 1);
   }
@@ -666,7 +666,7 @@ bool ReplicaImp::BlockchainAppState::getPrevDigestFromBlock(uint64_t blockId, St
     exit(1);
   }
 
-  BlockHeader *bh = reinterpret_cast<BlockHeader *>(result.data());
+  const BlockHeader *bh = reinterpret_cast<const BlockHeader *>(result.data());
   assert(outPrevBlockDigest);
   memcpy(outPrevBlockDigest, bh->parentDigest, bh->parentDigestLength);
   return true;
@@ -677,7 +677,7 @@ bool ReplicaImp::BlockchainAppState::getPrevDigestFromBlock(uint64_t blockId, St
  * It is used only by State Transfer to synchronize state between replicas.
  */
 bool ReplicaImp::BlockchainAppState::putBlock(uint64_t blockId, char *block, uint32_t blockSize) {
-  uint8_t *tmpBlockPtr = new uint8_t[blockSize];
+  char *tmpBlockPtr = new char[blockSize];
   memcpy(tmpBlockPtr, block, blockSize);
   Sliver s(tmpBlockPtr, blockSize);
 

--- a/bftengine/tests/simpleKVBC/src/block_metadata.cpp
+++ b/bftengine/tests/simpleKVBC/src/block_metadata.cpp
@@ -12,7 +12,7 @@ using concordUtils::Status;
 namespace SimpleKVBC {
 
 Sliver BlockMetadata::Serialize(uint64_t bft_sequence_num) {
-  return Sliver::copy((uint8_t*)&bft_sequence_num, sizeof(uint64_t));
+  return Sliver::copy((char*)&bft_sequence_num, sizeof(uint64_t));
 }
 
 uint64_t BlockMetadata::Get(Sliver& key) {

--- a/storage/include/blockchain/db_adapter.h
+++ b/storage/include/blockchain/db_adapter.h
@@ -19,22 +19,22 @@ namespace blockchain {
 class KeyManipulator : public IDBClient::IKeyManipulator {
  public:
   KeyManipulator() = default;
-  virtual int composedKeyComparison(const uint8_t *_a_data,
+  virtual int composedKeyComparison(const char *_a_data,
                                     size_t _a_length,
-                                    const uint8_t *_b_data,
+                                    const char *_b_data,
                                     size_t _b_length) override;
 
   Sliver genDbKey(EDBKeyType _type, const Key &_key, BlockId _blockId);
   Sliver genBlockDbKey(BlockId _blockId);
   Sliver genDataDbKey(const Key &_key, BlockId _blockId);
   EDBKeyType extractTypeFromKey(const Key &_key);
-  EDBKeyType extractTypeFromKey(const uint8_t *_key_data);
+  EDBKeyType extractTypeFromKey(const char *_key_data);
   BlockId extractBlockIdFromKey(const Key &_key);
-  BlockId extractBlockIdFromKey(const uint8_t *_key_data, size_t _key_length);
+  BlockId extractBlockIdFromKey(const char *_key_data, size_t _key_length);
   ObjectId extractObjectIdFromKey(const Key &_key);
-  ObjectId extractObjectIdFromKey(const uint8_t *_key_data, size_t _key_length);
+  ObjectId extractObjectIdFromKey(const char *_key_data, size_t _key_length);
   Sliver extractKeyFromKeyComposedWithBlockId(const Key &_composedKey);
-  int compareKeyPartOfComposedKey(const uint8_t *a_data, size_t a_length, const uint8_t *b_data, size_t b_length);
+  int compareKeyPartOfComposedKey(const char *a_data, size_t a_length, const char *b_data, size_t b_length);
   Sliver extractKeyFromMetadataKey(const Key &_composedKey);
   bool isKeyContainBlockId(const Key &_composedKey);
   KeyValuePair composedToSimple(KeyValuePair _p);
@@ -44,8 +44,8 @@ class KeyManipulator : public IDBClient::IKeyManipulator {
   static Sliver generateSTCheckpointDescriptorKey(uint64_t chkpt);
   static Sliver generateSTReservedPageStaticKey(uint32_t pageid, uint64_t chkpt);
   static Sliver generateSTReservedPageDynamicKey(uint32_t pageid, uint64_t chkpt);
-  uint64_t extractCheckPointFromKey(const uint8_t *_key_data, size_t _key_length);
-  std::pair<uint32_t, uint64_t> extractPageIdAndCheckpointFromKey(const uint8_t *_key_data, size_t _key_length);
+  uint64_t extractCheckPointFromKey(const char *_key_data, size_t _key_length);
+  std::pair<uint32_t, uint64_t> extractPageIdAndCheckpointFromKey(const char *_key_data, size_t _key_length);
 
  protected:
   static Sliver generateReservedPageKey(EDBKeyType, uint32_t pageid, uint64_t chkpt);

--- a/storage/include/blockchain/db_adapter.h
+++ b/storage/include/blockchain/db_adapter.h
@@ -49,8 +49,7 @@ class KeyManipulator : public IDBClient::IKeyManipulator {
 
  protected:
   static Sliver generateReservedPageKey(EDBKeyType, uint32_t pageid, uint64_t chkpt);
-
-  static bool copyToAndAdvance(uint8_t *_buf, size_t *_offset, size_t _maxOffset, uint8_t *_src, size_t _srcSize);
+  static bool copyToAndAdvance(char *_buf, size_t *_offset, size_t _maxOffset, char *_src, size_t _srcSize);
 
   concordlogger::Logger &logger() {
     static concordlogger::Logger logger_ = concordlogger::Log::getLogger("concord.storage.blockchain.KeyManipulator");

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -78,8 +78,6 @@ class Client : public IDBClient {
   TKVStore &getMap() { return map_; }
 
  private:
-  concordlogger::Logger logger;
-
   // Keep a copy of comp_ so that it lives as long as map_
   KeyComparator comp_;
 

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -78,6 +78,8 @@ class Client : public IDBClient {
   TKVStore &getMap() { return map_; }
 
  private:
+  concordlogger::Logger logger;
+
   // Keep a copy of comp_ so that it lives as long as map_
   KeyComparator comp_;
 

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -60,7 +60,10 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
 // single thread.
 class Client : public IDBClient {
  public:
-  Client(KeyComparator comp) : comp_(comp), map_([this](const Sliver &a, const Sliver &b) { return comp_(a, b); }) {}
+  Client(KeyComparator comp)
+      : logger(concordlogger::Log::getLogger("concord.storage.memorydb")),
+        comp_(comp),
+        map_([this](const Sliver &a, const Sliver &b) { return comp_(a, b); }) {}
 
   virtual void init(bool readOnly) override;
   virtual Status get(const Sliver &_key, OUT Sliver &_outValue) const override;
@@ -78,6 +81,8 @@ class Client : public IDBClient {
   TKVStore &getMap() { return map_; }
 
  private:
+  concordlogger::Logger logger;
+
   // Keep a copy of comp_ so that it lives as long as map_
   KeyComparator comp_;
 

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -83,10 +83,7 @@ class IDBClient {
 
   class IKeyManipulator {
    public:
-    virtual int composedKeyComparison(const uint8_t* _a_data,
-                                      size_t _a_length,
-                                      const uint8_t* _b_data,
-                                      size_t _b_length) = 0;
+    virtual int composedKeyComparison(const char* _a_data, size_t _a_length, const char* _b_data, size_t _b_length) = 0;
     virtual ~IKeyManipulator() = default;
   };
 

--- a/storage/src/blockchain_db_adapter.cpp
+++ b/storage/src/blockchain_db_adapter.cpp
@@ -442,8 +442,7 @@ Status DBAdapter::addBlock(BlockId _blockId, Sliver _blockRaw) {
   return s;
 }
 
-bool KeyManipulator::copyToAndAdvance(
-    char *_buf, size_t *_offset, size_t _maxOffset, char *_src, size_t _srcSize) {
+bool KeyManipulator::copyToAndAdvance(char *_buf, size_t *_offset, size_t _maxOffset, char *_src, size_t _srcSize) {
   if (!_buf && !_offset && !_src) assert(false);
 
   if (*_offset >= _maxOffset && _srcSize > 0) assert(false);
@@ -646,9 +645,7 @@ Status DBAdapter::getBlockById(BlockId _blockId, Sliver &_blockRaw, bool &_found
  * @param _src Sliver object that needs to be copied.
  * @param _trg Sliver object that contains the result.
  */
-inline void CopyKey(Sliver _src, Sliver &_trg) {
-  _trg = Sliver::copy(_src.data(), _src.length());
-}
+inline void CopyKey(Sliver _src, Sliver &_trg) { _trg = Sliver::copy(_src.data(), _src.length()); }
 
 // TODO(SG): Add status checks with getStatus() on iterator.
 // TODO(JGC): unserstand difference between .second and .data()

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -42,16 +42,14 @@ Status Client::get(const Sliver &_key, OUT Sliver &_outValue) const {
   return Status::OK();
 }
 
-Status Client::get(const Sliver& _key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const {
+Status Client::get(const Sliver &_key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const {
   Sliver value;
-  auto status =  get(_key, value);
+  auto status = get(_key, value);
   if (!status.isOK()) return status;
 
   _size = static_cast<uint32_t>(value.length());
   if (bufSize < _size) {
-    LOG_ERROR(logger,
-        "Object value is bigger than specified buffer bufSize="
-        << bufSize << ", _realSize=" << _size);
+    LOG_ERROR(logger, "Object value is bigger than specified buffer bufSize=" << bufSize << ", _realSize=" << _size);
     return Status::GeneralError("Object value is bigger than specified buffer");
   }
   memcpy(buf, value.data(), _size);
@@ -92,7 +90,7 @@ Status Client::freeIterator(IDBClientIterator *_iter) const {
  * @param _value Value of the mapping.
  * @return Status OK.
  */
-Status Client::put(const Sliver& _key, const Sliver& _value) {
+Status Client::put(const Sliver &_key, const Sliver &_value) {
   map_.insert_or_assign(_key, _value.clone());
   return Status::OK();
 }
@@ -105,7 +103,7 @@ Status Client::put(const Sliver& _key, const Sliver& _value) {
  * @param _key Reference to the key of the mapping.
  * @return Status OK.
  */
-Status Client::del(const Sliver& _key) {
+Status Client::del(const Sliver &_key) {
   map_.erase(_key);
   return Status::OK();
 }

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -51,9 +51,7 @@ static bool g_rocksdb_print_measurements = false;
  * @param _s A RocksDB Slice object.
  * @return A Sliver object.
  */
-Sliver fromRocksdbSlice(::rocksdb::Slice _s) {
-  return Sliver(_s.data(), _s.size());
-}
+Sliver fromRocksdbSlice(::rocksdb::Slice _s) { return Sliver(_s.data(), _s.size()); }
 
 /**
  * @brief Copies a RocksDB slice in a Sliver.
@@ -62,7 +60,7 @@ Sliver fromRocksdbSlice(::rocksdb::Slice _s) {
  * @return A Sliver object.
  */
 Sliver copyRocksdbSlice(::rocksdb::Slice _s) {
-  char* copyData = new char[_s.size()];
+  char *copyData = new char[_s.size()];
   std::copy(_s.data(), _s.data() + _s.size(), copyData);
   return Sliver(copyData, _s.size());
 }

--- a/storage/src/rocksdb_key_comparator.cpp
+++ b/storage/src/rocksdb_key_comparator.cpp
@@ -22,8 +22,7 @@ namespace storage {
 namespace rocksdb {
 
 int KeyComparator::Compare(const ::rocksdb::Slice& _a, const ::rocksdb::Slice& _b) const {
-  int ret = key_manipulator_->composedKeyComparison(
-      reinterpret_cast<const uint8_t*>(_a.data()), _a.size(), reinterpret_cast<const uint8_t*>(_b.data()), _b.size());
+  int ret = key_manipulator_->composedKeyComparison(_a.data(), _a.size(), _b.data(), _b.size());
 
   LOG_TRACE(logger_, "Compared " << _a.ToString(true) << " with " << _b.ToString(true) << ", returning " << ret);
 

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(multiIO_test multiIO_test.cpp)
+add_executable(multiIO_test multiIO_test.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(multiIO_test multiIO_test)
 target_link_libraries(multiIO_test PUBLIC
     gtest
@@ -6,7 +6,7 @@ target_link_libraries(multiIO_test PUBLIC
     concordbft_storage
 )
 
-add_executable(metadataStorage_test metadataStorage_test.cpp)
+add_executable(metadataStorage_test metadataStorage_test.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(metadataStorage_test metadataStorage_test)
 target_link_libraries(metadataStorage_test PUBLIC
     gtest

--- a/storage/test/multiIO_test.cpp
+++ b/storage/test/multiIO_test.cpp
@@ -126,8 +126,7 @@ TEST_F(multiIO_test, multi_del) {
   ASSERT_TRUE(dbClient->multiDel(keys).isOK());
   verifyMultiDel(keys);
 }
-TEST(multiIO_test, basic_transaction)
-{
+TEST_F(multiIO_test, basic_transaction) {
   Sliver key1("basic_transaction::key1");
   Sliver key2("basic_transaction::key2");
   Sliver inValue1("basic_transaction::val1");
@@ -143,8 +142,8 @@ TEST(multiIO_test, basic_transaction)
     g.txn()->del(key1);
     std::string val1 = g.txn()->get(key1);
     ASSERT_TRUE(val1.empty());
-    g.txn->put(key1, inValue1);
-    val1 = g.txn->get(key1);
+    g.txn()->put(key1, inValue1);
+    val1 = g.txn()->get(key1);
     ASSERT_TRUE(inValue1 == Sliver(std::move(val1)));
   }
   Sliver outValue;
@@ -156,24 +155,24 @@ TEST(multiIO_test, basic_transaction)
   ASSERT_TRUE(inValue2 == outValue);
 }
 
-TEST(multiIO_test, no_commit_during_exception)
-{
+TEST_F(multiIO_test, no_commit_during_exception) {
   Sliver key("no_commit_during_exception::key");
   Sliver inValue("no_commit_during_exception::val");
   key = key_manipulator_->genDataDbKey(key, 0);
   try {
-    { // transaction scope
+    {  // transaction scope
       ITransaction::Guard g(dbClient->beginTransaction());
       g.txn()->put(key, inValue);
       g.txn()->del(key);
       std::string val = g.txn()->get(key);
       ASSERT_TRUE(val.empty());
-      g.txn->put(key, inValue);
-      val = g.txn->get(key);
+      g.txn()->put(key, inValue);
+      val = g.txn()->get(key);
       ASSERT_TRUE(inValue == Sliver(std::move(val)));
       throw std::runtime_error("oops");
     }
-  } catch(std::exception& e){}
+  } catch (std::exception &e) {
+  }
   Sliver outValue;
   Status status = dbClient->get(key, outValue);
   ASSERT_FALSE(status.isOK());

--- a/storage/test/multiIO_test.cpp
+++ b/storage/test/multiIO_test.cpp
@@ -34,11 +34,11 @@ const uint16_t valueLen = 500;
 
 std::unique_ptr<Client> dbClient;
 
-uint8_t *createAndFillBuf(size_t length) {
-  auto *buffer = new uint8_t[length];
+char *createAndFillBuf(size_t length) {
+  auto *buffer = new char[length];
   srand(static_cast<uint>(time(nullptr)));
   for (size_t i = 0; i < length; i++) {
-    buffer[i] = static_cast<uint8_t>(rand() % 256);
+    buffer[i] = static_cast<char>(rand() % 256);
   }
   return buffer;
 }
@@ -126,15 +126,12 @@ TEST_F(multiIO_test, multi_del) {
   ASSERT_TRUE(dbClient->multiDel(keys).isOK());
   verifyMultiDel(keys);
 }
-TEST_F(multiIO_test, basic_transaction) {
-  std::string key1_("basic_transaction::key1");
-  Sliver key1(key1_);
-  std::string key2_("basic_transaction::key2");
-  Sliver key2(key2_);
-  std::string val1_("basic_transaction::val1");
-  Sliver inValue1(val1_);
-  std::string val2_("basic_transaction::val2");
-  Sliver inValue2(val2_);
+TEST(multiIO_test, basic_transaction)
+{
+  Sliver key1("basic_transaction::key1");
+  Sliver key2("basic_transaction::key2");
+  Sliver inValue1("basic_transaction::val1");
+  Sliver inValue2("basic_transaction::val2");
 
   key1 = key_manipulator_->genDataDbKey(key1, 0);
   key2 = key_manipulator_->genDataDbKey(key2, 0);
@@ -146,9 +143,9 @@ TEST_F(multiIO_test, basic_transaction) {
     g.txn()->del(key1);
     std::string val1 = g.txn()->get(key1);
     ASSERT_TRUE(val1.empty());
-    g.txn()->put(key1, inValue1);
-    val1 = g.txn()->get(key1);
-    ASSERT_TRUE(inValue1 == Sliver(val1.data(), val1.size()));
+    g.txn->put(key1, inValue1);
+    val1 = g.txn->get(key1);
+    ASSERT_TRUE(inValue1 == Sliver(std::move(val1)));
   }
   Sliver outValue;
   Status status = dbClient->get(key1, outValue);
@@ -159,26 +156,24 @@ TEST_F(multiIO_test, basic_transaction) {
   ASSERT_TRUE(inValue2 == outValue);
 }
 
-TEST_F(multiIO_test, no_commit_during_exception) {
-  std::string key_("no_commit_during_exception::key");
-  Sliver key(key_);
-  std::string val_("no_commit_during_exception::val");
-  Sliver inValue(val_);
+TEST(multiIO_test, no_commit_during_exception)
+{
+  Sliver key("no_commit_during_exception::key");
+  Sliver inValue("no_commit_during_exception::val");
   key = key_manipulator_->genDataDbKey(key, 0);
   try {
-    {  // transaction scope
+    { // transaction scope
       ITransaction::Guard g(dbClient->beginTransaction());
       g.txn()->put(key, inValue);
       g.txn()->del(key);
       std::string val = g.txn()->get(key);
       ASSERT_TRUE(val.empty());
-      g.txn()->put(key, inValue);
-      val = g.txn()->get(key);
-      ASSERT_TRUE(inValue == Sliver(val.data(), val.size()));
+      g.txn->put(key, inValue);
+      val = g.txn->get(key);
+      ASSERT_TRUE(inValue == Sliver(std::move(val)));
       throw std::runtime_error("oops");
     }
-  } catch (std::exception &e) {
-  }
+  } catch(std::exception& e){}
   Sliver outValue;
   Status status = dbClient->get(key, outValue);
   ASSERT_FALSE(status.isOK());

--- a/threshsign/CMakeLists.txt
+++ b/threshsign/CMakeLists.txt
@@ -145,7 +145,6 @@ find_library(RELIC_STATIC_LIBRARY NAMES "librelic_s.a")
 
 find_library(GMP_STATIC_LIBRARY NAMES "libgmp.a")
 
-find_package(cryptopp REQUIRED)
 find_library(CRYPTOPP_STATIC_LIBRARY NAMES "libcryptopp.a")
 
 #

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(GenerateConcordKeys
                       PROPERTIES
                       RUNTIME_OUTPUT_DIRECTORY
                       .)
-                      
+
 target_compile_options(GenerateConcordKeys PUBLIC "-Wno-extra-semi" "-Wno-undefined-var-template") # TODO tmp cryptopp
 add_executable(TestGeneratedKeys
                TestGeneratedKeys.cpp
@@ -46,7 +46,7 @@ set_target_properties(TestGeneratedKeys
                       .)
 
 if (BUILD_ROCKSDB_STORAGE)
-add_executable(skvb_db_editor DBEditor.cpp)
+add_executable(skvb_db_editor DBEditor.cpp $<TARGET_OBJECTS:logging_dev>)
 target_include_directories(skvb_db_editor PUBLIC
   ${PROJECT_SOURCE_DIR}/src include $<TARGET_PROPERTY:logging,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(skvb_db_editor concordbft_storage)

--- a/tools/DBEditor.cpp
+++ b/tools/DBEditor.cpp
@@ -169,7 +169,7 @@ void verifyInputParams(char **argv) {
 }
 
 void parseAndPrint(const ::rocksdb::Slice &key, const ::rocksdb::Slice &val) {
-  EDBKeyType aType = key_manipulator->extractTypeFromKey(reinterpret_cast<const uint8_t *>(key.data()));
+  EDBKeyType aType = key_manipulator->extractTypeFromKey(key.data());
 
   switch (aType) {
     case EDBKeyType::E_DB_KEY_TYPE_BFT_ST_KEY:
@@ -211,7 +211,7 @@ void parseAndPrint(const ::rocksdb::Slice &key, const ::rocksdb::Slice &val) {
     }
     case EDBKeyType::E_DB_KEY_TYPE_BLOCK: {
       //      // Extract the block ids to compare so that endianness of environment does not matter.
-      BlockId aId = key_manipulator->extractBlockIdFromKey(reinterpret_cast<const uint8_t *>(key.data()), key.size());
+      BlockId aId = key_manipulator->extractBlockIdFromKey(key.data(), key.size());
       std::cout << "Block ID: " << aId << std::endl;
       uint16_t numOfElements = ((BlockHeader *)val.data())->numberOfElements;
       auto *entries = (BlockEntry *)(val.data() + sizeof(BlockHeader));

--- a/tools/GenerateConcordKeys.cpp
+++ b/tools/GenerateConcordKeys.cpp
@@ -41,12 +41,12 @@ static std::pair<std::string, std::string> generateRsaKey() {
 
   CryptoPP::RSAES<CryptoPP::OAEP<CryptoPP::SHA256>>::Decryptor priv(sGlobalRandGen, rsaKeyLength);
   CryptoPP::HexEncoder privEncoder(new CryptoPP::StringSink(keyPair.first));
-  priv.DEREncode(privEncoder);
+  priv.AccessMaterial().Save(privEncoder);
   privEncoder.MessageEnd();
 
   CryptoPP::RSAES<CryptoPP::OAEP<CryptoPP::SHA256>>::Encryptor pub(priv);
   CryptoPP::HexEncoder pubEncoder(new CryptoPP::StringSink(keyPair.second));
-  pub.DEREncode(pubEncoder);
+  pub.AccessMaterial().Save(pubEncoder);
   pubEncoder.MessageEnd();
 
   return keyPair;

--- a/util/include/hash_defs.h
+++ b/util/include/hash_defs.h
@@ -13,7 +13,7 @@ namespace concordUtils {
 
 // TODO(GG): do we want this hash function ? See also
 // http://www.cse.yorku.ca/~oz/hash.html
-inline size_t simpleHash(const uint8_t *data, const size_t len) {
+inline size_t simpleHash(const char *data, const size_t len) {
   size_t hash = 5381;
   size_t t;
 

--- a/util/include/hex_tools.h
+++ b/util/include/hex_tools.h
@@ -8,7 +8,7 @@
 
 namespace concordUtils {
 
-std::ostream &hexPrint(std::ostream &s, const uint8_t *data, size_t size);
+std::ostream &hexPrint(std::ostream &s, const char* data, size_t size);
 
 }  // namespace concordUtils
 

--- a/util/include/hex_tools.h
+++ b/util/include/hex_tools.h
@@ -8,7 +8,7 @@
 
 namespace concordUtils {
 
-std::ostream &hexPrint(std::ostream &s, const char* data, size_t size);
+std::ostream &hexPrint(std::ostream &s, const char *data, size_t size);
 
 }  // namespace concordUtils
 

--- a/util/include/sliver.hpp
+++ b/util/include/sliver.hpp
@@ -9,10 +9,11 @@
  *
  * The memory is managed through a std::shared_ptr. If the `Sliver(char* data,
  * size_t length)` constructor is called, that sliver wraps the data pointer in
- * a shared pointer. Sub-slivers reference this same shared pointer, such that
- * the memory is kept around as long as the base sliver or any sub-sliver needs
- * it, and cleaned up once the base sliver and all sub-slivers have finished
- * using it.
+ * a shared pointer. If the `Sliver(const std::sring&&) constructor is called,
+ * the string is wrapped in a shared pointer. Sub-slivers reference this same
+ * shared pointer, such that the memory is kept around as long as the base
+ * sliver or any sub-sliver needs it, and cleaned up once the base sliver and
+ * all sub-slivers have finished using it.
  *
  * Intentionally copyable (via default copy constructor and assignment
  * operator). Copying the shared_ptr increases its reference count by one, so
@@ -29,7 +30,7 @@
 #include <ios>
 #include <variant>
 #include <memory>
-#include <cassert>
+#include <string_view>
 
 namespace concordUtils {
 
@@ -48,6 +49,7 @@ class Sliver {
 
   size_t length() const;
   const char* data() const;
+  std::string_view string_view() const;
 
   std::ostream& operator<<(std::ostream& s) const;
   bool operator==(const Sliver& other) const;

--- a/util/include/sliver.hpp
+++ b/util/include/sliver.hpp
@@ -3,7 +3,7 @@
 /**
  * Sliver -- Zero-copy management of bytes.
  *
- * Sliver provides a view into an allocated region of memory. Views of
+ * A Sliver provides an immutable view into an allocated region of memory. Views of
  * sub-regions, or "sub-slivers" do not copy data, but instead reference the
  * memory of the "base" sliver.
  *
@@ -27,28 +27,27 @@
 #define CONCORD_BFT_UTIL_SLIVER_HPP_
 
 #include <ios>
+#include <variant>
 #include <memory>
+#include <cassert>
 
 namespace concordUtils {
 
 class Sliver {
  public:
   Sliver();
-  Sliver(uint8_t* data, const size_t length);
-  Sliver(char* data, const size_t length);
-  Sliver(const Sliver& base, const size_t offset, const size_t length);
-  Sliver(const uint8_t* data, const size_t length);
   Sliver(const char* data, const size_t length);
-  Sliver(const std::string& s) : Sliver(s.data(), s.length()) {}
-  static Sliver copy(uint8_t* data, const size_t length);
-  static Sliver copy(char* data, const size_t length);
+  Sliver(const std::string&& s);
+  Sliver(const Sliver& base, const size_t offset, const size_t length);
+  static Sliver copy(const char* data, const size_t length);
 
-  uint8_t operator[](const size_t offset) const;
+  char operator[](const size_t offset) const;
 
   Sliver subsliver(const size_t offset, const size_t length) const;
+  Sliver clone() const;
 
   size_t length() const;
-  uint8_t* data() const;
+  const char* data() const;
 
   std::ostream& operator<<(std::ostream& s) const;
   bool operator==(const Sliver& other) const;
@@ -58,11 +57,18 @@ class Sliver {
   std::string toString() const { return std::string(reinterpret_cast<char*>(data()), length()); }
 
  private:
-  // these are never modified, but need to be non-const to support copy
-  // assignment
-  std::shared_ptr<uint8_t> m_data;
-  size_t m_offset;
-  size_t m_length;
+
+  // A wrapper around a std::string. We need to be able to allocate the wrapper
+  // so that we have a pointer that can be stored in a shared_ptr. We don't want
+  // allocate a copy of a string we already have.
+  struct StringBuf {
+    std::string s;
+  };
+
+  std::variant<std::shared_ptr<StringBuf>, std::shared_ptr<const char[]>> data_;
+
+  size_t offset_;
+  size_t length_;
 
   // Delete new and delete, to force the Sliver to be allocated on the stack, so
   // that it is cleaned up properly via RAII scoping.
@@ -70,11 +76,10 @@ class Sliver {
   static void* operator new[](size_t) = delete;
   static void operator delete(void*) = delete;
   static void operator delete[](void*) = delete;
+
 };
 
 std::ostream& operator<<(std::ostream& s, const Sliver& sliver);
-
-bool copyToAndAdvance(uint8_t* _buf, size_t* _offset, size_t _maxOffset, uint8_t* _src, size_t _srcSize);
 
 }  // namespace concordUtils
 

--- a/util/include/sliver.hpp
+++ b/util/include/sliver.hpp
@@ -56,10 +56,9 @@ class Sliver {
   bool operator!=(const Sliver& other) const;
   int compare(const Sliver& other) const;
 
-  std::string toString() const { return std::string(reinterpret_cast<char*>(data()), length()); }
+  std::string toString() const { return std::string(data(), length()); }
 
  private:
-
   // A wrapper around a std::string. We need to be able to allocate the wrapper
   // so that we have a pointer that can be stored in a shared_ptr. We don't want
   // allocate a copy of a string we already have.
@@ -78,7 +77,6 @@ class Sliver {
   static void* operator new[](size_t) = delete;
   static void operator delete(void*) = delete;
   static void operator delete[](void*) = delete;
-
 };
 
 std::ostream& operator<<(std::ostream& s, const Sliver& sliver);

--- a/util/src/hex_tools.cpp
+++ b/util/src/hex_tools.cpp
@@ -10,7 +10,7 @@
 namespace concordUtils {
 
 // Print <size> bytes from <data> to <s> as their 0x<hex> representation.
-std::ostream &hexPrint(std::ostream &s, const uint8_t *data, size_t size) {
+std::ostream &hexPrint(std::ostream &s, const char* data, size_t size) {
   // Store current state of ostream flags
   std::ios::fmtflags f(s.flags());
   s << "0x";

--- a/util/src/hex_tools.cpp
+++ b/util/src/hex_tools.cpp
@@ -10,7 +10,7 @@
 namespace concordUtils {
 
 // Print <size> bytes from <data> to <s> as their 0x<hex> representation.
-std::ostream &hexPrint(std::ostream &s, const char* data, size_t size) {
+std::ostream &hexPrint(std::ostream &s, const char *data, size_t size) {
   // Store current state of ostream flags
   std::ios::fmtflags f(s.flags());
   s << "0x";

--- a/util/src/sliver.cpp
+++ b/util/src/sliver.cpp
@@ -122,7 +122,11 @@ Sliver Sliver::subsliver(const size_t offset, const size_t length) const {
 
 size_t Sliver::length() const { return length_; }
 
-std::ostream& Sliver::operator<<(std::ostream& s) const { return hexPrint(s, data(), length()); }
+std::string_view Sliver::string_view() const { return std::string_view(data(), length_); }
+
+std::ostream& Sliver::operator<<(std::ostream& s) const {
+  return hexPrint(s, data(), length());
+}
 
 std::ostream& operator<<(std::ostream& s, const Sliver& sliver) { return sliver.operator<<(s); }
 

--- a/util/src/sliver.cpp
+++ b/util/src/sliver.cpp
@@ -35,9 +35,7 @@ Sliver::Sliver() : data_(shared_ptr<const char[]>()), offset_(0), length_(0) {}
  * `malloc`, because the shared pointer will use `delete` and not `free`.
  */
 Sliver::Sliver(const char* data, const size_t length)
-    : data_(std::shared_ptr<const char[]>(data)),
-      offset_(0),
-      length_(length) {
+    : data_(std::shared_ptr<const char[]>(data)), offset_(0), length_(length) {
   // Data must be non-null.
   Assert(data != nullptr);
 }
@@ -59,27 +57,21 @@ Sliver::Sliver(const Sliver& base, const size_t offset, const size_t length)
 /**
  * Create a Sliver by moving a string into it.
  */
-Sliver::Sliver(const string&& s)
-  : data_(std::make_shared<StringBuf>(StringBuf {s})),
-    offset_(0),
-    length_(s.length()) {}
-
+Sliver::Sliver(const string&& s) : data_(std::make_shared<StringBuf>(StringBuf{s})), offset_(0), length_(s.length()) {}
 
 /**
  * Shorthand for the copy constructor.
  * */
-Sliver Sliver::clone() const {
-  return subsliver(0, length_);
-}
+Sliver Sliver::clone() const { return subsliver(0, length_); }
 
 /**
  * Create a sliver from a copy of the memory pointed to by `data`, which is
  * `length` bytes in size.
  */
 Sliver Sliver::copy(const char* data, const size_t length) {
-   auto* copy = new char[length];
-   memcpy(copy, data, length);
-   return Sliver(copy, length);
+  auto* copy = new char[length];
+  memcpy(copy, data, length);
+  return Sliver(copy, length);
 }
 
 /**
@@ -113,20 +105,16 @@ const char* Sliver::data() const {
 }
 
 /**
-* Create a subsliver. Syntactic sugar for cases where a function call is more
-* natural than using the sub-sliver constructor directly.
-*/
-Sliver Sliver::subsliver(const size_t offset, const size_t length) const {
-  return Sliver(*this, offset, length);
-}
+ * Create a subsliver. Syntactic sugar for cases where a function call is more
+ * natural than using the sub-sliver constructor directly.
+ */
+Sliver Sliver::subsliver(const size_t offset, const size_t length) const { return Sliver(*this, offset, length); }
 
 size_t Sliver::length() const { return length_; }
 
 std::string_view Sliver::string_view() const { return std::string_view(data(), length_); }
 
-std::ostream& Sliver::operator<<(std::ostream& s) const {
-  return hexPrint(s, data(), length());
-}
+std::ostream& Sliver::operator<<(std::ostream& s) const { return hexPrint(s, data(), length()); }
 
 std::ostream& operator<<(std::ostream& s, const Sliver& sliver) { return sliver.operator<<(s); }
 

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test(util_mt_tests mt_tests)
 target_link_libraries(mt_tests gtest_main util)
 target_compile_options(mt_tests PUBLIC -Wno-sign-compare)
 
-add_executable(sliver_test sliver_test.cpp)
+add_executable(sliver_test sliver_test.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(sliver_test sliver_test)
 target_link_libraries(sliver_test gtest util)
 target_compile_options(sliver_test PUBLIC -Wno-sign-compare)

--- a/util/test/sliver_test.cpp
+++ b/util/test/sliver_test.cpp
@@ -22,8 +22,8 @@ namespace {
  *
  * Remember: the caller must deallocate this buffer.
  */
-uint8_t* new_test_memory(size_t length) {
-  uint8_t* buffer = new uint8_t[length];
+char* new_test_memory(size_t length) {
+  char* buffer = new char[length];
 
   for (size_t i = 0; i < length; i++) {
     buffer[i] = i % 256;
@@ -32,7 +32,8 @@ uint8_t* new_test_memory(size_t length) {
   return buffer;
 }
 
-bool is_match(const uint8_t* expected, const size_t expected_length, const Sliver& actual) {
+bool is_match(const char* expected, const size_t expected_length,
+              const Sliver& actual) {
   if (expected_length != actual.length()) {
     return false;
   }
@@ -49,7 +50,7 @@ bool is_match(const uint8_t* expected, const size_t expected_length, const Slive
  */
 TEST(sliver_test, simple_wrap) {
   const size_t test_size = 100;
-  uint8_t* expected = new_test_memory(test_size);
+  char* expected = new_test_memory(test_size);
 
   Sliver actual(expected, test_size);
   ASSERT_TRUE(is_match(expected, test_size, actual));
@@ -60,7 +61,7 @@ TEST(sliver_test, simple_wrap) {
  */
 TEST(sliver_test, simple_copy) {
   const size_t test_size = 100;
-  uint8_t* expected = new_test_memory(test_size);
+  char* expected = new_test_memory(test_size);
 
   auto actual = Sliver::copy(expected, test_size);
   ASSERT_TRUE(is_match(expected, test_size, actual));
@@ -72,7 +73,7 @@ TEST(sliver_test, simple_copy) {
  */
 TEST(sliver_test, simple_rewrap) {
   const size_t test_size = 101;
-  uint8_t* expected = new_test_memory(test_size);
+  char* expected = new_test_memory(test_size);
 
   Sliver first = Sliver(expected, test_size);
   Sliver actual1(first, 0, first.length());
@@ -87,7 +88,7 @@ TEST(sliver_test, simple_rewrap) {
  */
 TEST(sliver_test, offsets) {
   const size_t test_size = 102;
-  uint8_t* expected = new_test_memory(test_size);
+  char* expected = new_test_memory(test_size);
 
   Sliver base(expected, test_size);
   for (size_t offset = 1; offset < test_size; offset += 5) {
@@ -101,7 +102,7 @@ TEST(sliver_test, offsets) {
  */
 TEST(sliver_test, lengths) {
   const size_t test_size = 103;
-  uint8_t* expected = new_test_memory(test_size);
+  char* expected = new_test_memory(test_size);
 
   Sliver base(expected, test_size);
   const size_t step = 7;
@@ -116,7 +117,7 @@ TEST(sliver_test, lengths) {
  */
 TEST(sliver_test, nested) {
   const size_t test_size = 104;
-  uint8_t* expected = new_test_memory(test_size);
+  char* expected = new_test_memory(test_size);
 
   Sliver base(expected, test_size);
   const size_t offset_step = 3;
@@ -135,8 +136,9 @@ TEST(sliver_test, nested) {
  * Create a base sliver, and then return a subsliver. Used to test that the
  * shared pointer is handled properly.
  */
-Sliver copied_subsliver(size_t base_size, size_t sub_offset, size_t sub_length) {
-  uint8_t* data = new_test_memory(base_size);
+Sliver copied_subsliver(size_t base_size, size_t sub_offset,
+                        size_t sub_length) {
+  char* data = new_test_memory(base_size);
   Sliver base(data, base_size);
   Sliver sub(base, sub_offset, sub_length);
   return sub;
@@ -150,7 +152,7 @@ Sliver copied_subsliver(size_t base_size, size_t sub_offset, size_t sub_length) 
  */
 TEST(sliver_test, copying) {
   const size_t test_size = 105;
-  uint8_t* expected = new_test_memory(test_size);
+  char* expected = new_test_memory(test_size);
 
   const size_t test_offset1 = 20;
   const size_t test_length1 = 30;

--- a/util/test/sliver_test.cpp
+++ b/util/test/sliver_test.cpp
@@ -10,6 +10,7 @@
 #include "sliver.hpp"
 #include "gtest/gtest.h"
 #include <iostream>
+#include <string.h>
 
 using namespace std;
 using concordUtils::Sliver;
@@ -105,9 +106,11 @@ TEST(sliver_test, lengths) {
   char* expected = new_test_memory(test_size);
 
   Sliver base(expected, test_size);
+  ASSERT_EQ(0, memcmp(expected, base.string_view().data(), test_size));
   const size_t step = 7;
   for (size_t length = test_size - 1; length > step; length -= step) {
     Sliver subsliver(base, 0, length);
+    ASSERT_EQ(0, memcmp(expected, subsliver.string_view().data(), length));
     ASSERT_TRUE(is_match(expected, length, subsliver));
   }
 }

--- a/util/test/sliver_test.cpp
+++ b/util/test/sliver_test.cpp
@@ -33,8 +33,7 @@ char* new_test_memory(size_t length) {
   return buffer;
 }
 
-bool is_match(const char* expected, const size_t expected_length,
-              const Sliver& actual) {
+bool is_match(const char* expected, const size_t expected_length, const Sliver& actual) {
   if (expected_length != actual.length()) {
     return false;
   }
@@ -139,8 +138,7 @@ TEST(sliver_test, nested) {
  * Create a base sliver, and then return a subsliver. Used to test that the
  * shared pointer is handled properly.
  */
-Sliver copied_subsliver(size_t base_size, size_t sub_offset,
-                        size_t sub_length) {
+Sliver copied_subsliver(size_t base_size, size_t sub_offset, size_t sub_length) {
   char* data = new_test_memory(base_size);
   Sliver base(data, base_size);
   Sliver sub(base, sub_offset, sub_length);


### PR DESCRIPTION
This change consists of 4 commits to be reviewed independently.

The first updates CryptoPP to the latest version: 8.2.0. This is required because of a change to the standard library in C++ 17 that includes `std::byte` which conflicts with the global `byte` type in version 5.6.5 of CryptoPP.

The second refactors and enhances Sliver significantly. There is a detailed commit message that should be reviewed.

The third is just some code formatting.

The fourth adds a method for returning a [string_view](https://en.cppreference.com/w/cpp/string/basic_string_view) from Sliver.