### PR TITLE
Don't assert when sendto fails in UDP communication

### DIFF
--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -287,14 +287,11 @@ class PlainUDPCommunication::PlainUdpImpl {
     if (error < 0) {
       /** -1 return value means underlying socket error. */
       string err = strerror(errno);
-      LOG_DEBUG(_logger, "Error while sending: " << strerror(errno));
-      Assert(false, "Failure occurred while sending!");
-      /** Fail-fast. */
+      LOG_INFO(_logger, "Error while sending: " << strerror(errno));
     } else if (error < (int) messageLength) {
       /** Mesage was partially sent. Unclear why this would happen, perhaps
         * due to oversized messages (?). */
-      LOG_DEBUG(_logger, "Sent %d out of %d bytes!");
-      Assert(false, "Send error occurred!");    /** Fail-fast. */
+      LOG_INFO(_logger, "Sent %d out of %d bytes!");
     }
 
     if (error == (ssize_t) messageLength) {


### PR DESCRIPTION
sendto can fail for various reasons including a message too large and
the send buffer being full. We shouldn't kill the process when this
occurs.

This was seen in a CI test run:
 https://travis-ci.com/vmware/concord-bft/jobs/235340703#L2443

This is part of a fix when debugging #212, although it doesn't appear to
be the direct issue from the log linked above, since the test that
failed came after the test containing the assert.