### PR TITLE
WIP: Add simple log4cpp config file, copy TLS certificates to test folders

### DIFF
--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -46,5 +46,17 @@ if [ -n "$USE_ROCKSDB" ]; then
     sudo make install-shared
 fi
 
+if [-n "$USE_LOG4CPP" ]; then
+  #Install log4cpp
+  sudo apt-get install autoconf automake
+  cd $TRAVIS_BUILD_DIR
+  git clone https://github.com/log4cplus/log4cplus.git
+  cd log4cplus
+  git checkout REL_1_2_1
+  ./configure CXXFLAGS="--std=c++11"
+  make
+  sudo make install
+fi
+
 # trio is need for tests
 python3 -m pip install --upgrade trio

--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -46,17 +46,5 @@ if [ -n "$USE_ROCKSDB" ]; then
     sudo make install-shared
 fi
 
-if [-n "$USE_LOG4CPP" ]; then
-  #Install log4cpp
-  sudo apt-get install autoconf automake
-  cd $TRAVIS_BUILD_DIR
-  git clone https://github.com/log4cplus/log4cplus.git
-  cd log4cplus
-  git checkout REL_1_2_1
-  ./configure CXXFLAGS="--std=c++11"
-  make
-  sudo make install
-fi
-
 # trio is need for tests
 python3 -m pip install --upgrade trio

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -106,3 +106,30 @@ target_include_directories(corebft PUBLIC include/metadatastorage)
 target_link_libraries(corebft PUBLIC threshsign)
 target_link_libraries(corebft PUBLIC Threads::Threads)
 target_link_libraries(corebft PUBLIC util)
+
+# copy certificate creation script to all tests
+add_custom_target(copy_tls_certificates ALL COMMENT "Copying TLS certificates")
+add_custom_command(TARGET copy_tls_certificates
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/test/certs
+        $<TARGET_FILE_DIR:simpleTest_client>/scripts/certs
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/test/certs
+        $<TARGET_FILE_DIR:skvbc_replica>/certs
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/test/certs
+        $<TARGET_FILE_DIR:skvbc_client>/certs)
+
+# copy log4cpp config file for tests to all tests
+add_custom_target(copy_log4cpp_config ALL COMMENT "Copying Log4cpp config
+file")
+add_custom_command(TARGET copy_log4cpp_config
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/test/log4cpp_simple_test.properties
+        $<TARGET_FILE_DIR:simpleTest_client>/scripts
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/test/log4cpp_simple_test.properties
+        $<TARGET_FILE_DIR:skvbc_replica>
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/test/log4cpp_simple_test.properties
+        $<TARGET_FILE_DIR:skvbc_client>)

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -129,7 +129,7 @@ add_custom_command(TARGET copy_log4cpp_config
         $<TARGET_FILE_DIR:simpleTest_client>/scripts
         COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_SOURCE_DIR}/test/log4cpp_simple_test.properties
-        $<TARGET_FILE_DIR:skvbc_replica>
+        $<TARGET_FILE_DIR:skvbc_replica>/../scripts
         COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_SOURCE_DIR}/test/log4cpp_simple_test.properties
-        $<TARGET_FILE_DIR:skvbc_client>)
+        $<TARGET_FILE_DIR:skvbc_client>/../scripts)

--- a/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
+++ b/bftengine/tests/simpleKVBCTests/TesterReplica/main.cpp
@@ -22,7 +22,15 @@
 #include "rocksdb/key_comparator.h"
 #endif
 
+#if USE_LOG4CPP
+#include "log4cplus/configurator.h"
+#endif
+
 int main(int argc, char** argv) {
+#if USE_LOG4CPP
+  log4cplus::initialize();
+  log4cplus::PropertyConfigurator::doConfigure("log4cpp_simple_test.properties");
+#endif
   auto setup = SimpleKVBC::TestSetup::ParseArgs(argc, argv);
   auto logger = setup->GetLogger();
   auto* key_manipulator = new concord::storage::blockchain::KeyManipulator();

--- a/bftengine/tests/simpleTest/CMakeLists.txt
+++ b/bftengine/tests/simpleTest/CMakeLists.txt
@@ -123,9 +123,3 @@ configure_file (
         "${CMAKE_CURRENT_SOURCE_DIR}/scripts/histogram.py.in"
         "${CMAKE_CURRENT_BINARY_DIR}/scripts/histogram.py"
 )
-
-add_custom_target(copy_tls_script ALL COMMENT "Copying TLS script")
-add_custom_command(TARGET copy_tls_script
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${PROJECT_SOURCE_DIR}/scripts/linux/create_tls_certs.sh
-     $<TARGET_FILE_DIR:simpleTest_client>/scripts/create_tls_certs.sh)

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -39,6 +39,12 @@
 #include "simple_test_client.hpp"
 #include "Logger.hpp"
 
+#include "log4cplus/configurator.h"
+
+#if USE_LOG4CPP
+#include "log4cplus/configurator.h"
+#endif
+
 using bftEngine::ICommunication;
 using bftEngine::PlainUDPCommunication;
 using bftEngine::PlainUdpConfig;
@@ -48,8 +54,6 @@ using bftEngine::TlsTCPCommunication;
 using bftEngine::TlsTcpConfig;
 using bftEngine::SeqNumberGeneratorForClientRequests;
 using bftEngine::SimpleClient;
-
-concordlogger::Logger clientLogger = concordlogger::Log::getLogger("simpletest.client");
 
 void parse_params(int argc, char** argv, ClientParams &cp,
                   bftEngine::SimpleClientParams &scp) {
@@ -168,7 +172,12 @@ void parse_params(int argc, char** argv, ClientParams &cp,
 }
 
 int main(int argc, char **argv) {
-// TODO(IG:) configure Log4Cplus's output format, using default for now
+#if USE_LOG4CPP
+  log4cplus::initialize();
+  log4cplus::PropertyConfigurator::doConfigure("log4cpp_simple_test.properties");
+#endif
+
+  concordlogger::Logger clientLogger = concordlogger::Log::getLogger("simpletest.client");
 
   ClientParams cp;
   bftEngine::SimpleClientParams scp;

--- a/bftengine/tests/simpleTest/client.cpp
+++ b/bftengine/tests/simpleTest/client.cpp
@@ -39,8 +39,6 @@
 #include "simple_test_client.hpp"
 #include "Logger.hpp"
 
-#include "log4cplus/configurator.h"
-
 #if USE_LOG4CPP
 #include "log4cplus/configurator.h"
 #endif

--- a/bftengine/tests/simpleTest/replica.cpp
+++ b/bftengine/tests/simpleTest/replica.cpp
@@ -61,6 +61,10 @@
 #include "Logger.hpp"
 #include "simple_test_replica_behavior.hpp"
 
+#if USE_LOG4CPP
+#include "log4cplus/configurator.h"
+#endif
+
 using bftEngine::ICommunication;
 using bftEngine::PlainUDPCommunication;
 using bftEngine::PlainUdpConfig;
@@ -183,6 +187,12 @@ void signalHandler(int signum) {
 }
 
 int main(int argc, char **argv) {
+#if USE_LOG4CPP
+  log4cplus::initialize();
+  log4cplus::PropertyConfigurator::doConfigure("log4cpp_simple_test.properties");
+#endif
+
+
   ReplicaParams rp;
   parse_params(argc, argv, rp);
 

--- a/test/bft_tester.py
+++ b/test/bft_tester.py
@@ -22,6 +22,7 @@ import subprocess
 from collections import namedtuple
 import tempfile
 import trio
+import shutil
 
 sys.path.append(os.path.abspath("../util/pyclient"))
 
@@ -81,6 +82,9 @@ class BftTester:
         self.alphanum = [i for i in range(48, 58)]
         self.alphanum.extend(self.alpha)
         self.keys = self._create_keys()
+        shutil.copyfile(os.path.join(self.origdir,
+                                     "log4cpp_simple_test.properties"),
+                        os.path.join(self.testdir, "log4cpp_simple_test.properties"))
         os.chdir(self.testdir)
         self._generate_crypto_keys()
         self.clients = {}

--- a/test/log4cpp_simple_test.properties
+++ b/test/log4cpp_simple_test.properties
@@ -1,0 +1,17 @@
+log4cplus.rootLogger=DEBUG, STDOUT, R
+log4cplus.logger.plain-udp=OFF
+log4cplus.logger.concord-bft.tls=OFF
+log4cplus.logger.concord.tls=OFF
+
+log4cplus.appender.STDOUT=log4cplus::ConsoleAppender
+log4cplus.appender.STDOUT.ImmediateFlush=true
+log4cplus.appender.STDOUT.layout=log4cplus::PatternLayout
+log4cplus.appender.STDOUT.layout.ConversionPattern=%d{%FT%H:%M:%S.%q} [%t] %-5p %c{2} %%%x%% %m [%l]%n
+
+log4cplus.appender.R=log4cplus::RollingFileAppender
+log4cplus.appender.R.CreateDirs=true
+log4cplus.appender.R.File=concord-bft.log
+log4cplus.appender.R.MaxFileSize=10MB
+log4cplus.appender.R.MaxBackupIndex=10
+log4cplus.appender.R.layout=log4cplus::PatternLayout
+log4cplus.appender.R.layout.ConversionPattern=%d{%FT%H:%M:%S.%q} [%t] %-5p %c{2} %%%x%% %m [%l]%n


### PR DESCRIPTION
This PR adds 2 small improvements for running tests:
 * Simple log4cpp config file to silence "noisy" loggers when working in DEBUG mode. To enable log4cpp, build with ```-DUSE_LOG4CPP``` and the configuration file will be copied to all test folders
 * TLS certificates are copied to all manual test folders, and if compiled with ```BUILD_COMM_TCP_TLS``` - manual tests will work with TLS as well.

** IMPORTANT ** Tests that are written with the python test framework will not work with TLS until the test client will not implement TLS support (see #232)  