### PR TITLE
Log a msg when Checkpoint summaries do not match

### DIFF
--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -18,6 +18,7 @@
 
 #include "STDigest.hpp"
 #include "IStateTransfer.hpp"
+#include "Logger.hpp"
 
 namespace bftEngine {
 namespace SimpleBlockchainStateTransfer {
@@ -64,9 +65,26 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
   STDigest digestOfResPagesDescriptor;
   uint64_t requestMsgSeqNum;
 
-  static bool equivalent(const CheckpointSummaryMsg* a,
-                         const CheckpointSummaryMsg* b) {
+  static bool equivalent(const CheckpointSummaryMsg* a, const CheckpointSummaryMsg* b) {
     return (memcmp(a, b, sizeof(CheckpointSummaryMsg)) == 0);
+  }
+
+  static bool equivalent(const CheckpointSummaryMsg* a, uint16_t a_id,
+                         const CheckpointSummaryMsg* b, uint16_t b_id) {
+    if (memcmp(a, b, sizeof(CheckpointSummaryMsg)) != 0) {
+      auto logger = concordlogger::Log::getLogger("state-transfer");
+      LOG_WARN(logger, "Mismatched Checkpoints for checkpointNum=" << a->checkpointNum  << std::endl
+
+          << "    Replica=" << a_id << " lastBlock=" << a->lastBlock << " digestOfLastBlock="
+          << a->digestOfLastBlock.toString() << " digestOfResPagesDescriptor="
+          << a->digestOfResPagesDescriptor.toString() << " requestMsgSeqNum=" << a->requestMsgSeqNum << std::endl
+
+          << "    Replica=" << b_id << " lastBlock=" << b->lastBlock << " digestOfLastBlock="
+          << b->digestOfLastBlock.toString() << " digestOfResPagesDescriptor="
+          << b->digestOfResPagesDescriptor.toString() << " requestMsgSeqNum=" << b->requestMsgSeqNum << std::endl);
+      return false;
+    }
+    return true;
   }
 
   static void free(void* context, const CheckpointSummaryMsg* a) {

--- a/bftengine/src/bcstatetransfer/MsgsCertificate.hpp
+++ b/bftengine/src/bcstatetransfer/MsgsCertificate.hpp
@@ -191,7 +191,7 @@ addPeerMsg(T* msg, uint16_t replicaId) {
     // TODO(GG) Assert(pos is okay)
     T* representativeMsg = pos->second;
 
-    if (!ExternalFunc::equivalent(representativeMsg, msg))
+    if (!ExternalFunc::equivalent(representativeMsg, cls.representativeReplica, msg, replicaId))
       return;  // msg should be ignored
 
     relevantClass = 0;
@@ -205,7 +205,7 @@ addPeerMsg(T* msg, uint16_t replicaId) {
       // TODO(GG) Assert(pos is okay)
       T* representativeMsg = pos->second;
 
-      if (ExternalFunc::equivalent(representativeMsg, msg)) {
+      if (ExternalFunc::equivalent(representativeMsg, cls.representativeReplica, msg, replicaId)) {
         cls.size = cls.size + 1;
         relevantClass = i;
         break;
@@ -264,7 +264,7 @@ addSelfMsg(T* msg) {
     // TODO(GG) Assert(pos is okay)
     T* representativeMsg = pos->second;
 
-    if (ExternalFunc::equivalent(representativeMsg, msg)) {
+    if (ExternalFunc::equivalent(representativeMsg, cls.representativeReplica, msg, selfId)) {
       cls.size = cls.size + 1;
       relevantClass = i;
       break;


### PR DESCRIPTION
This is useful to detect non-deterministic state machines and malicious
nodes. This is the minimum possible change so we can use it immediately.
More robust detection and alerting strategies can be implemented in the
future.