### PR TITLE
BC ST refactoring and Bug Fixes

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -54,6 +54,7 @@ set(corebft_source_files
     src/bcstatetransfer/InMemoryDataStore.cpp
     src/bcstatetransfer/STDigest.cpp
     src/bcstatetransfer/DBDataStore.cpp
+    src/bcstatetransfer/SourceSelector.cpp
     src/simplestatetransfer/SimpleStateTran.cpp
 )
 #

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2121,6 +2121,7 @@ void BCStateTran::fetch() {
     } else if (!badDataFromCurrentSourceReplica && !isGettingBlocks) {
       if (newBlock) memset(buffer_, 0, actualBlockSize);
       if (newSourceReplica || sourceSelector_.retransmissionTimeoutExpired(currTime)) {
+        sourceSelector_.setSourceSelectionTime(currTime);
         sendFetchResPagesMsg(lastChunkInRequiredBlock);
       }
       break;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -30,6 +30,7 @@
 #include "Messages.hpp"
 #include "STDigest.hpp"
 #include "Metrics.hpp"
+#include "SourceSelector.hpp"
 
 using std::set;
 using std::map;
@@ -119,8 +120,6 @@ class BCStateTran : public IStateTransfer {
   const uint32_t refreshTimerMilli_;
   const uint32_t checkpointSummariesRetransmissionTimeoutMilli_;
   const uint32_t maxAcceptableMsgDelayMilli_;
-  const uint32_t sourceReplicaReplacementTimeoutMilli_;
-  const uint32_t fetchRetransmissionTimeoutMilli_;
 
   const uint32_t maxVBlockSize_;
   const uint32_t maxItemSize_;
@@ -259,13 +258,10 @@ class BCStateTran : public IStateTransfer {
   // or GettingMissingResPages
   ///////////////////////////////////////////////////////////////////////////
 
-  static const uint16_t NO_REPLICA = UINT16_MAX;
+  SourceSelector sourceSelector_;
+
   static const uint64_t ID_OF_VBLOCK_RES_PAGES = UINT64_MAX;
 
-  set<uint16_t> preferredReplicas_;
-  uint16_t currentSourceReplica_ = NO_REPLICA;
-
-  uint64_t timeMilliCurrentSourceReplica_ = 0;
   uint64_t nextRequiredBlock_ = 0;
   STDigest digestOfNextRequiredBlock;
 
@@ -295,15 +291,11 @@ class BCStateTran : public IStateTransfer {
                   const STDigest& expectedDigestOfResPagesDescriptor,
                   char* vblock, uint32_t vblockSize) const;
 
-  uint16_t selectSourceReplica();
-
-  void processData();
+  void fetch();
 
   void EnterGettingCheckpointSummariesState();
+  set<uint16_t> allOtherReplicas();
   void SetAllReplicasAsPreferred();
-  bool ShouldReplaceSourceReplica(
-      bool badDataFromCurrentSourceReplica, uint64_t diffMilli);
-
 
   ///////////////////////////////////////////////////////////////////////////
   // Helper methods
@@ -346,6 +338,7 @@ class BCStateTran : public IStateTransfer {
   void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a);
 
  private:
+  void loadMetrics();
   concordMetrics::Component metrics_component_;
 
   typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;
@@ -358,7 +351,6 @@ class BCStateTran : public IStateTransfer {
     StatusHandle preferred_replicas_;
 
     GaugeHandle current_source_replica_;
-    GaugeHandle current_checkpoint_;
     GaugeHandle checkpoint_being_fetched_;
     GaugeHandle last_stored_checkpoint_;
     GaugeHandle number_of_reserved_pages_;

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -1,0 +1,111 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "SourceSelector.hpp"
+
+namespace bftEngine {
+namespace SimpleBlockchainStateTransfer {
+namespace impl {
+
+bool SourceSelector::hasSource() const {
+  return currentReplica_ != NO_REPLICA && sourceSelectionTimeMilli_ > 0;
+}
+
+void SourceSelector::setSourceSelectionTime(uint64_t currTimeMilli) {
+  sourceSelectionTimeMilli_ = currTimeMilli;
+}
+
+void SourceSelector::removeCurrentReplica() {
+  preferredReplicas_.erase(currentReplica_);
+  currentReplica_ = NO_REPLICA;
+}
+
+void SourceSelector::setAllReplicasAsPreferred() { preferredReplicas_ = allOtherReplicas_; }
+
+void SourceSelector::reset() {
+  preferredReplicas_.clear();
+  currentReplica_ = NO_REPLICA;
+  sourceSelectionTimeMilli_ = 0;
+}
+
+bool SourceSelector::isReset() const {
+  return preferredReplicas_.empty() && currentReplica_ == NO_REPLICA && sourceSelectionTimeMilli_ == 0;
+}
+
+bool SourceSelector::retransmissionTimeoutExpired(uint64_t currTimeMilli) const {
+  // TODO(GG): TBD - compute dynamically
+  return timeSinceSourceSelectedMilli(currTimeMilli) > retransmissionTimeoutMilli_;
+}
+
+uint64_t SourceSelector::timeSinceSourceSelectedMilli(uint64_t currTimeMilli) const {
+  return ((currentReplica_ == NO_REPLICA) || (currTimeMilli < sourceSelectionTimeMilli_))
+             ? 0
+             : (currTimeMilli - sourceSelectionTimeMilli_);
+}
+
+// Replace the source if necessary.
+//
+// Return true if the source was updated, false otherwise.
+bool SourceSelector::updateSource(bool badDataFromCurrentSource, uint64_t currTimeMilli) {
+  if (shouldReplaceSource(currTimeMilli, badDataFromCurrentSource, sourceReplacementTimeoutMilli_)) {
+    if (currentReplica_ != NO_REPLICA) {
+      preferredReplicas_.erase(currentReplica_);
+    }
+    if (preferredReplicas_.size() == 0) {
+      preferredReplicas_ = allOtherReplicas_;
+    }
+    selectSource(currTimeMilli);
+    return true;
+  }
+  return false;
+}
+
+// Create a list of ids of the form "0, 1, 4"
+std::string SourceSelector::preferredReplicasToString() const {
+  std::ostringstream oss;
+  for (auto it = preferredReplicas_.begin(); it != preferredReplicas_.end(); ++it) {
+    if (it == preferredReplicas_.begin()) {
+      oss << *it;
+    } else {
+      oss << ", " << *it;
+    }
+  }
+  return oss.str();
+}
+
+bool SourceSelector::shouldReplaceSource(uint64_t currTimeMilli,
+                                         bool badDataFromCurrentSource,
+                                         uint32_t sourceReplacementTimeoutMilli) const {
+  return currentReplica_ == NO_REPLICA || badDataFromCurrentSource ||
+         timeSinceSourceSelectedMilli(currTimeMilli) > sourceReplacementTimeoutMilli;
+}
+
+void SourceSelector::selectSource(uint64_t currTimeMilli) {
+  const size_t size = preferredReplicas_.size();
+  Assert(size > 0);
+
+  auto i = preferredReplicas_.begin();
+  if (size > 1) {
+    // TODO(GG): can be optimized
+    unsigned int c = randomGen_() % size;
+    while (c > 0) {
+      c--;
+      i++;
+    }
+  }
+  currentReplica_ = *i;
+  sourceSelectionTimeMilli_ = currTimeMilli;
+}
+}  // namespace impl
+}  // namespace SimpleBlockchainStateTransfer
+}  // namespace bftEngine

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -57,7 +57,7 @@ uint64_t SourceSelector::timeSinceSourceSelectedMilli(uint64_t currTimeMilli) co
 //
 // Return true if the source was updated, false otherwise.
 bool SourceSelector::updateSource(bool badDataFromCurrentSource, uint64_t currTimeMilli) {
-  if (shouldReplaceSource(currTimeMilli, badDataFromCurrentSource, sourceReplacementTimeoutMilli_)) {
+  if (shouldReplaceSource(currTimeMilli, badDataFromCurrentSource)) {
     if (currentReplica_ != NO_REPLICA) {
       preferredReplicas_.erase(currentReplica_);
     }
@@ -83,11 +83,9 @@ std::string SourceSelector::preferredReplicasToString() const {
   return oss.str();
 }
 
-bool SourceSelector::shouldReplaceSource(uint64_t currTimeMilli,
-                                         bool badDataFromCurrentSource,
-                                         uint32_t sourceReplacementTimeoutMilli) const {
+bool SourceSelector::shouldReplaceSource(uint64_t currTimeMilli, bool badDataFromCurrentSource) const {
   return currentReplica_ == NO_REPLICA || badDataFromCurrentSource ||
-         timeSinceSourceSelectedMilli(currTimeMilli) > sourceReplacementTimeoutMilli;
+         timeSinceSourceSelectedMilli(currTimeMilli) > sourceReplacementTimeoutMilli_;
 }
 
 void SourceSelector::selectSource(uint64_t currTimeMilli) {

--- a/bftengine/src/bcstatetransfer/SourceSelector.hpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.hpp
@@ -68,11 +68,7 @@ class SourceSelector {
 
  private:
   uint64_t timeSinceSourceSelectedMilli(uint64_t currTimeMilli) const;
-
-  bool shouldReplaceSource(uint64_t currTimeMilli,
-                           bool badDataFromCurrentSource,
-                           uint32_t sourceReplacementTimeoutMilli) const;
-
+  bool shouldReplaceSource(uint64_t currTimeMilli, bool badDataFromCurrentSource) const;
   void selectSource(uint64_t currTimeMilli);
 };
 }  // namespace impl

--- a/bftengine/src/bcstatetransfer/SourceSelector.hpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.hpp
@@ -1,0 +1,80 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+#pragma once
+
+#include <random>
+#include <set>
+#include <stdint.h>
+#include <sstream>
+
+#include "assertUtils.hpp"
+
+namespace bftEngine {
+namespace SimpleBlockchainStateTransfer {
+namespace impl {
+
+static const uint16_t NO_REPLICA = UINT16_MAX;
+
+// Information about which current source is selected and which replicas are
+// preferred, as well as data that helps to select a current source replica.
+class SourceSelector {
+ public:
+  std::set<uint16_t> preferredReplicas_;
+  uint16_t currentReplica_ = NO_REPLICA;
+
+ private:
+  uint64_t sourceSelectionTimeMilli_ = 0;
+  std::set<uint16_t> allOtherReplicas_;
+  std::mt19937 randomGen_;
+  uint32_t retransmissionTimeoutMilli_;
+  uint32_t sourceReplacementTimeoutMilli_;
+
+
+ public:
+  SourceSelector(std::set<uint16_t> allOtherReplicas,
+                 uint32_t retransmissionTimeoutMilli,
+                 uint32_t sourceReplicaReplacementTimeoutMilli)
+      : allOtherReplicas_(allOtherReplicas), randomGen_(std::random_device()()),
+        retransmissionTimeoutMilli_(retransmissionTimeoutMilli),
+        sourceReplacementTimeoutMilli_(sourceReplicaReplacementTimeoutMilli){}
+
+  bool hasSource() const;
+  void removeCurrentReplica();
+  void setAllReplicasAsPreferred();
+  void reset();
+  bool isReset() const;
+  bool retransmissionTimeoutExpired(uint64_t currTimeMilli) const;
+
+  // Replace the source if necessary.
+  //
+  // Return true if the source was updated, false otherwise.
+  bool updateSource(bool badDataFromCurrentSource, uint64_t currTimeMilli);
+
+  // Reset the source selection time without actually changing the source
+  void setSourceSelectionTime(uint64_t currTimeMilli);
+
+  // Create a list of ids of the form "0, 1, 4"
+  std::string preferredReplicasToString() const;
+
+ private:
+  uint64_t timeSinceSourceSelectedMilli(uint64_t currTimeMilli) const;
+
+  bool shouldReplaceSource(uint64_t currTimeMilli,
+                           bool badDataFromCurrentSource,
+                           uint32_t sourceReplacementTimeoutMilli) const;
+
+  void selectSource(uint64_t currTimeMilli);
+};
+}  // namespace impl
+}  // namespace SimpleBlockchainStateTransfer
+}  // namespace bftEngine


### PR DESCRIPTION
This PR contains two commits, each with their own individual commit messages that should be reviewed independently. 

The first commit splits out the source replica selection logic into its own class. This removes several member variables from BCStateTran, and simplifies some of the logic there. It also makes the source selection logic reusable in other state transfer implementations by putting it in its own class. It's not 100% abstracted out, since there is still some initialization of preferredReplicas performed in BCStateTran, but it is mostly complete.

The second change fixes a long standing bug where we would unnecessarily drop valid reserved page data.