### PR TITLE
Revert "Fix RocksDB Transaction DB leak"

### DIFF
--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -63,7 +63,7 @@ class Client : public concord::storage::IDBClient {
       : logger(concordlogger::Log::getLogger("rocksdb_client")),
         m_dbPath(_dbPath),
         m_comparator(_comparator) {}
-  ~Client() override;
+
   void init(bool readOnly = false) override;
   concordUtils::Status get(const concordUtils::Sliver& _key, concordUtils::Sliver &_outValue) const override;
   concordUtils::Status get(const concordUtils::Sliver& _key, char *&buf, uint32_t bufSize, uint32_t &_realSize) const override;

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -77,16 +77,13 @@ ITransaction* Client::beginTransaction()
   return new Transaction(txn_db_->BeginTransaction(wo), ++current_transaction_id);
 }
 
+
 bool Client::isNew() {
   ::rocksdb::DB *db;
   ::rocksdb::Options options;
   options.error_if_exists = true;
   ::rocksdb::Status s = ::rocksdb::DB::Open(options, m_dbPath, &db);
   return s.IsNotFound();
-}
-
-Client::~Client() {
-  delete txn_db_;
 }
 
 /**


### PR DESCRIPTION
A memory for txn_db_ is not explicitly allocated in our code. We just ask rocksdb to open TransactionDB and it allocates the memory. No need to clean it here - reverting.