### PR TITLE
Add a test for state transfer when fetcher crashes

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2225,7 +2225,7 @@ void BCStateTran::checkConsistency(bool checkAllBlocks) {
   LOG_INFO(STLogger, "lastBlockNum = " << lastBlockNum << ", lastReachableBlockNum = " << lastReachableBlockNum);
   Assert(lastBlockNum >= lastReachableBlockNum);
   if (lastBlockNum > lastReachableBlockNum) {
-    Assert(getFetchingState() == FetchingState::GettingMissingResPages);
+    Assert(getFetchingState() == FetchingState::GettingMissingBlocks);
     uint64_t x = lastBlockNum - 1;
     while (as_->hasBlock(x))
       x--;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -2,7 +2,7 @@
 //
 //Copyright (c) 2018 VMware, Inc. All Rights Reserved.
 //
-//This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License. 
+//This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License.
 //
 //This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 
@@ -88,6 +88,10 @@ namespace bftEngine
 			bool mainThreadStarted;
 			bool mainThreadShouldStop;
 			bool mainThreadShouldStopWhenStateIsNotCollected;
+
+                        // If this replica was restarted and loaded data from
+                        // persistent storage.
+                        bool restarted_;
 
 			// thread pool of this replica
 			util::SimpleThreadPool internalThreadPool; // TODO(GG): !!!! rename

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -80,7 +80,7 @@ void ReplicaImp::createReplicaAndSyncState() {
   LOG_INFO(logger, "createReplicaAndSyncState: isNewStorage= " << isNewStorage);
   m_replicaPtr = bftEngine::Replica::createNewReplica(
       &m_replicaConfig, m_cmdHandler, m_stateTransfer, m_ptrComm, m_metadataStorage);
-  if (!isNewStorage) {
+  if (!isNewStorage && !m_stateTransfer->isCollectingState()) {
     uint64_t removedBlocksNum = m_replicaStateSync.execute(
         logger, *m_bcDbAdapter, *this, m_appState->m_lastReachableBlock, m_replicaPtr->getLastExecutedSequenceNum());
     m_lastBlock -= removedBlocksNum;

--- a/bftengine/tests/simpleKVBC/src/replica_state_sync_imp.cpp
+++ b/bftengine/tests/simpleKVBC/src/replica_state_sync_imp.cpp
@@ -36,7 +36,7 @@ uint64_t ReplicaStateSyncImp::execute(concordlogger::Logger &logger,
   Key key = metadata.Key();
   do {
     blockSeqNum = metadata.Get(key);
-    LOG_INFO(logger, "Block Metadata key = " << key << ", blockId = " << blockId << ", blockSeqNum = " << blockSeqNum);
+    LOG_INFO(logger, "Block Metadata key = " << key << ", blockId = " << blockId << ", blockSeqNum = " << blockSeqNum << ", lastExecutedSeqNum = " << lastExecutedSeqNum );
     if (blockSeqNum <= lastExecutedSeqNum) {
       LOG_INFO(logger, "Replica state is in sync; removedBlocksNum is " << removedBlocksNum);
       return removedBlocksNum;

--- a/test/skvbc.py
+++ b/test/skvbc.py
@@ -98,3 +98,19 @@ class SimpleKVBCProtocol:
 
     def parse_get_last_block_reply(self, data):
         return struct.unpack("<Q", data)[0]
+
+class Client:
+    """A wrapper around bft_client that uses the SimpleKVBCProtocol"""
+    def __init__(self, bft_client):
+        self.client = bft_client
+        self.protocol = SimpleKVBCProtocol()
+
+    async def write(self, readset, writeset, block_id=0):
+        """Create an skvbc write message and send it via the bft client."""
+        req = self.protocol.write_req(readset, writeset, block_id)
+        return self.protocol.parse_reply(await self.client.write(req))
+
+    async def read(self, readset, block_id=READ_LATEST):
+        """Create an skvbc read message and send it via the bft client."""
+        req = self.protocol.read_req(readset, block_id)
+        return self.protocol.parse_reply(await self.client.read(req))


### PR DESCRIPTION
A system test was added that repeatedly crashes the fetching replica during fetch
and ensures that state transfer completes successfully. This test
duplicated some code from a prior state transfer test so it was broken
out into its own method: `_assert_fill_and_checkpoint`.

This fixes a few bugs and completes some code changes indicated by Guy
and Yulia for when state transfer persistence was completed. Among these
changes:

 * Fix an assert in BCStateTran to indicate the proper fetching state
   when blocks are missing
 * Move loading and clearing of reserved pages from
   `bftengine::ReplicaImp` constructor to
   `bftengine::ReplicaImp::processMessages`, since those methods rely on
   state transfer being started, and processMessages is the main loop
   after bftengine::ReplicaImp::start is called.
 * Only load or clear reserved pages if state transfer is not fetching
 * Only sync metadata state and application state if state transfer is
   not fetching