### PR TITLE
Allow hostnames/fqdns instead of IP addresses for PlainTCP and TLSTCP

### DIFF
--- a/bftengine/include/communication/CommDefs.hpp
+++ b/bftengine/include/communication/CommDefs.hpp
@@ -18,6 +18,7 @@
 #include <ws2def.h>
 #else
 #include <arpa/inet.h>
+#include <netdb.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -32,7 +33,7 @@
 typedef struct sockaddr_in Addr;
 
 struct NodeInfo {
-  std::string ip;
+  std::string host;
   std::uint16_t port;
   bool isReplica;
 };
@@ -50,7 +51,7 @@ enum CommType {
 
 struct BaseCommConfig {
   CommType commType;
-  std::string listenIp;
+  std::string listenHost;
   uint16_t listenPort;
   uint32_t bufferLength;
   NodeMap nodes;
@@ -58,14 +59,14 @@ struct BaseCommConfig {
   NodeNum selfId;
 
   BaseCommConfig(CommType type,
-                 std::string ip,
+                 std::string host,
                  uint16_t port,
                  uint32_t bufLength,
                  NodeMap _nodes,
                  NodeNum _selfId,
                  UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
       commType{type},
-      listenIp{std::move(ip)},
+      listenHost{std::move(host)},
       listenPort{port},
       bufferLength{bufLength},
       nodes{std::move(_nodes)},
@@ -77,14 +78,14 @@ struct BaseCommConfig {
 };
 
 struct PlainUdpConfig : BaseCommConfig {
-  PlainUdpConfig(std::string ip,
+  PlainUdpConfig(std::string host,
                  uint16_t port,
                  uint32_t bufLength,
                  NodeMap _nodes,
                  NodeNum _selfId,
                  UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
       BaseCommConfig(CommType::PlainUdp,
-                     std::move(ip),
+                     std::move(host),
                      port,
                      bufLength,
                      std::move(_nodes),
@@ -96,7 +97,7 @@ struct PlainUdpConfig : BaseCommConfig {
 struct PlainTcpConfig : BaseCommConfig {
   int32_t maxServerId;
 
-  PlainTcpConfig(std::string ip,
+  PlainTcpConfig(std::string host,
                  uint16_t port,
                  uint32_t bufLength,
                  NodeMap _nodes,
@@ -104,7 +105,7 @@ struct PlainTcpConfig : BaseCommConfig {
                  NodeNum _selfId,
                  UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
       BaseCommConfig(CommType::PlainTcp,
-                     std::move(ip),
+                     std::move(host),
                      port,
                      bufLength,
                      std::move(_nodes),
@@ -121,7 +122,7 @@ struct TlsTcpConfig : PlainTcpConfig {
   // https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
   std::string cipherSuite;
 
-  TlsTcpConfig(std::string ip,
+  TlsTcpConfig(std::string host,
                uint16_t port,
                uint32_t bufLength,
                NodeMap _nodes,
@@ -130,7 +131,7 @@ struct TlsTcpConfig : PlainTcpConfig {
                std::string certRootPath,
                std::string ciphSuite,
                UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
-      PlainTcpConfig(move(ip),
+      PlainTcpConfig(move(host),
                      port,
                      bufLength,
                      std::move(_nodes),

--- a/bftengine/include/communication/CommDefs.hpp
+++ b/bftengine/include/communication/CommDefs.hpp
@@ -41,13 +41,7 @@ struct NodeInfo {
 typedef std::unordered_map<NodeNum, NodeInfo> NodeMap;
 
 namespace bftEngine {
-enum CommType {
-  PlainUdp,
-  SimpleAuthUdp,
-  PlainTcp,
-  SimpleAuthTcp,
-  TlsTcp
-};
+enum CommType { PlainUdp, SimpleAuthUdp, PlainTcp, SimpleAuthTcp, TlsTcp };
 
 struct BaseCommConfig {
   CommType commType;
@@ -64,15 +58,14 @@ struct BaseCommConfig {
                  uint32_t bufLength,
                  NodeMap _nodes,
                  NodeNum _selfId,
-                 UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
-      commType{type},
-      listenHost{std::move(host)},
-      listenPort{port},
-      bufferLength{bufLength},
-      nodes{std::move(_nodes)},
-      statusCallback{_statusCallback},
-      selfId {_selfId} {
-  }
+                 UPDATE_CONNECTIVITY_FN _statusCallback = nullptr)
+      : commType{type},
+        listenHost{std::move(host)},
+        listenPort{port},
+        bufferLength{bufLength},
+        nodes{std::move(_nodes)},
+        statusCallback{_statusCallback},
+        selfId{_selfId} {}
 
   virtual ~BaseCommConfig() {}
 };
@@ -83,15 +76,9 @@ struct PlainUdpConfig : BaseCommConfig {
                  uint32_t bufLength,
                  NodeMap _nodes,
                  NodeNum _selfId,
-                 UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
-      BaseCommConfig(CommType::PlainUdp,
-                     std::move(host),
-                     port,
-                     bufLength,
-                     std::move(_nodes),
-                     _selfId,
-                     _statusCallback) {
-  }
+                 UPDATE_CONNECTIVITY_FN _statusCallback = nullptr)
+      : BaseCommConfig(
+            CommType::PlainUdp, std::move(host), port, bufLength, std::move(_nodes), _selfId, _statusCallback) {}
 };
 
 struct PlainTcpConfig : BaseCommConfig {
@@ -103,16 +90,10 @@ struct PlainTcpConfig : BaseCommConfig {
                  NodeMap _nodes,
                  int32_t _maxServerId,
                  NodeNum _selfId,
-                 UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
-      BaseCommConfig(CommType::PlainTcp,
-                     std::move(host),
-                     port,
-                     bufLength,
-                     std::move(_nodes),
-                     _selfId,
-                     _statusCallback),
-      maxServerId{_maxServerId} {
-  }
+                 UPDATE_CONNECTIVITY_FN _statusCallback = nullptr)
+      : BaseCommConfig(
+            CommType::PlainTcp, std::move(host), port, bufLength, std::move(_nodes), _selfId, _statusCallback),
+        maxServerId{_maxServerId} {}
 };
 
 struct TlsTcpConfig : PlainTcpConfig {
@@ -130,16 +111,10 @@ struct TlsTcpConfig : PlainTcpConfig {
                NodeNum _selfId,
                std::string certRootPath,
                std::string ciphSuite,
-               UPDATE_CONNECTIVITY_FN _statusCallback = nullptr) :
-      PlainTcpConfig(move(host),
-                     port,
-                     bufLength,
-                     std::move(_nodes),
-                     _maxServerId,
-                     _selfId,
-                     _statusCallback),
-      certificatesRootPath{std::move(certRootPath)},
-      cipherSuite{std::move(ciphSuite)} {
+               UPDATE_CONNECTIVITY_FN _statusCallback = nullptr)
+      : PlainTcpConfig(move(host), port, bufLength, std::move(_nodes), _maxServerId, _selfId, _statusCallback),
+        certificatesRootPath{std::move(certRootPath)},
+        cipherSuite{std::move(ciphSuite)} {
     commType = CommType::TlsTcp;
   }
 };
@@ -152,21 +127,18 @@ class PlainUDPCommunication : public ICommunication {
   int Start() override;
   int Stop() override;
   bool isRunning() const override;
-  ConnectionStatus getCurrentConnectionStatus(
-      const NodeNum node) const override;
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const override;
 
-  int sendAsyncMessage(const NodeNum destNode,
-                       const char *const message,
-                       const size_t messageLength) override;
+  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) override;
 
-  void setReceiver(NodeNum receiverNum,
-                   IReceiver *receiver) override;
+  void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
   virtual ~PlainUDPCommunication();
+
  private:
   class PlainUdpImpl;
 
-  //TODO(IG): convert to smart ptr
+  // TODO(IG): convert to smart ptr
   PlainUdpImpl *_ptrImpl = nullptr;
 
   explicit PlainUDPCommunication(const PlainUdpConfig &config);
@@ -180,17 +152,14 @@ class PlainTCPCommunication : public ICommunication {
   int Start() override;
   int Stop() override;
   bool isRunning() const override;
-  ConnectionStatus getCurrentConnectionStatus(
-      const NodeNum node) const override;
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const override;
 
-  int sendAsyncMessage(const NodeNum destNode,
-                       const char *const message,
-                       const size_t messageLength) override;
+  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) override;
 
-  void setReceiver(NodeNum receiverNum,
-                   IReceiver *receiver) override;
+  void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
   virtual ~PlainTCPCommunication();
+
  private:
   class PlainTcpImpl;
   PlainTcpImpl *_ptrImpl = nullptr;
@@ -206,23 +175,20 @@ class TlsTCPCommunication : public ICommunication {
   int Start() override;
   int Stop() override;
   bool isRunning() const override;
-  ConnectionStatus getCurrentConnectionStatus(
-      const NodeNum node) const override;
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const override;
 
-  int sendAsyncMessage(const NodeNum destNode,
-                       const char *const message,
-                       const size_t messageLength) override;
+  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) override;
 
-  void setReceiver(NodeNum receiverNum,
-                   IReceiver *receiver) override;
+  void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
   virtual ~TlsTCPCommunication();
+
  private:
   class TlsTcpImpl;
   std::shared_ptr<TlsTcpImpl> _ptrImpl = nullptr;
 
   explicit TlsTCPCommunication(const TlsTcpConfig &config);
 };
-}
+}  // namespace bftEngine
 
-#endif //BYZ_COMMDEFS_HPP
+#endif  // BYZ_COMMDEFS_HPP

--- a/bftengine/include/communication/CommFactory.hpp
+++ b/bftengine/include/communication/CommFactory.hpp
@@ -18,12 +18,12 @@
 #include "Logger.hpp"
 
 namespace bftEngine {
-class CommFactory {  
+class CommFactory {
  private:
   static concordlogger::Logger _logger;
+
  public:
-  static ICommunication*
-  create(const BaseCommConfig &config);
+  static ICommunication* create(const BaseCommConfig& config);
 };
 }  // namespace bftEngine
 

--- a/bftengine/include/communication/StatusInfo.h
+++ b/bftengine/include/communication/StatusInfo.h
@@ -8,9 +8,7 @@
 #include <functional>
 #include <string>
 
-enum class PeerInfoType {
-  Connectivity
-};
+enum class PeerInfoType { Connectivity };
 
 struct BasePeerStatus {
  public:
@@ -20,12 +18,7 @@ struct BasePeerStatus {
   int64_t statusTime = 0;
 };
 
-enum class StatusType {
-  Started,
-  MessageReceived,
-  MessageSent,
-  Broken
-};
+enum class StatusType { Started, MessageReceived, MessageSent, Broken };
 struct PeerConnectivityStatus : public BasePeerStatus {
  public:
   StatusType statusType;
@@ -34,4 +27,4 @@ struct PeerConnectivityStatus : public BasePeerStatus {
 
 typedef std::function<void(PeerConnectivityStatus)> UPDATE_CONNECTIVITY_FN;
 
-#endif //STATUSINFO_H
+#endif  // STATUSINFO_H

--- a/bftengine/include/communication/StatusInfo.h
+++ b/bftengine/include/communication/StatusInfo.h
@@ -15,7 +15,7 @@ enum class PeerInfoType {
 struct BasePeerStatus {
  public:
   int64_t peerId = 0;
-  std::string peerIp;
+  std::string peerHost;
   int16_t peerPort = 0;
   int64_t statusTime = 0;
 };

--- a/bftengine/src/communication/CommFactory.cpp
+++ b/bftengine/src/communication/CommFactory.cpp
@@ -24,39 +24,37 @@ using bftEngine::PlainTcpConfig;
 using bftEngine::PlainUdpConfig;
 using bftEngine::TlsTcpConfig;
 
-concordlogger::Logger CommFactory::_logger =
-   concordlogger::Log::getLogger("comm-factory");
+concordlogger::Logger CommFactory::_logger = concordlogger::Log::getLogger("comm-factory");
 
-ICommunication*
-CommFactory::create(const BaseCommConfig &config) {
+ICommunication *CommFactory::create(const BaseCommConfig &config) {
   ICommunication *res = nullptr;
   switch (config.commType) {
-  case CommType::PlainUdp:
-    LOG_INFO(_logger, "Using PlainUDP: " << "Host=" << config.listenHost <<
-                      ", Port=" << config.listenPort);
-    res = PlainUDPCommunication::create(
-      dynamic_cast<const PlainUdpConfig&>(config));
-    break;
-  case CommType::SimpleAuthUdp:
-    break;
-  case CommType::PlainTcp:
+    case CommType::PlainUdp:
+      LOG_INFO(_logger,
+               "Using PlainUDP: "
+                   << "Host=" << config.listenHost << ", Port=" << config.listenPort);
+      res = PlainUDPCommunication::create(dynamic_cast<const PlainUdpConfig &>(config));
+      break;
+    case CommType::SimpleAuthUdp:
+      break;
+    case CommType::PlainTcp:
 #ifdef USE_COMM_PLAIN_TCP
-    LOG_INFO(_logger, "Using PlainTCP: " << "Host=" << config.listenHost <<
-                      ", Port=" << config.listenPort);
-    res = PlainTCPCommunication::create(
-      dynamic_cast<const PlainTcpConfig&>(config));
+      LOG_INFO(_logger,
+               "Using PlainTCP: "
+                   << "Host=" << config.listenHost << ", Port=" << config.listenPort);
+      res = PlainTCPCommunication::create(dynamic_cast<const PlainTcpConfig &>(config));
 #endif
-    break;
-  case CommType::SimpleAuthTcp:
-    break;
-  case CommType::TlsTcp:
+      break;
+    case CommType::SimpleAuthTcp:
+      break;
+    case CommType::TlsTcp:
 #ifdef USE_COMM_TLS_TCP
-    LOG_INFO(_logger, "Using TlsTCP: " << "Host=" << config.listenHost <<
-                      ", Port=" << config.listenPort);
-    res = TlsTCPCommunication::create(
-      dynamic_cast<const TlsTcpConfig&>(config));
+      LOG_INFO(_logger,
+               "Using TlsTCP: "
+                   << "Host=" << config.listenHost << ", Port=" << config.listenPort);
+      res = TlsTCPCommunication::create(dynamic_cast<const TlsTcpConfig &>(config));
 #endif
-    break;
+      break;
   }
 
   return res;

--- a/bftengine/src/communication/CommFactory.cpp
+++ b/bftengine/src/communication/CommFactory.cpp
@@ -32,7 +32,7 @@ CommFactory::create(const BaseCommConfig &config) {
   ICommunication *res = nullptr;
   switch (config.commType) {
   case CommType::PlainUdp:
-    LOG_INFO(_logger, "Using PlainUDP: " << "IP=" << config.listenIp <<
+    LOG_INFO(_logger, "Using PlainUDP: " << "Host=" << config.listenHost <<
                       ", Port=" << config.listenPort);
     res = PlainUDPCommunication::create(
       dynamic_cast<const PlainUdpConfig&>(config));
@@ -41,7 +41,7 @@ CommFactory::create(const BaseCommConfig &config) {
     break;
   case CommType::PlainTcp:
 #ifdef USE_COMM_PLAIN_TCP
-    LOG_INFO(_logger, "Using PlainTCP: " << "IP=" << config.listenIp <<
+    LOG_INFO(_logger, "Using PlainTCP: " << "Host=" << config.listenHost <<
                       ", Port=" << config.listenPort);
     res = PlainTCPCommunication::create(
       dynamic_cast<const PlainTcpConfig&>(config));
@@ -51,7 +51,7 @@ CommFactory::create(const BaseCommConfig &config) {
     break;
   case CommType::TlsTcp:
 #ifdef USE_COMM_TLS_TCP
-    LOG_INFO(_logger, "Using TlsTCP: " << "IP=" << config.listenIp <<
+    LOG_INFO(_logger, "Using TlsTCP: " << "Host=" << config.listenHost <<
                       ", Port=" << config.listenPort);
     res = TlsTCPCommunication::create(
       dynamic_cast<const TlsTcpConfig&>(config));

--- a/bftengine/src/communication/PlainTcpCommunication.cpp
+++ b/bftengine/src/communication/PlainTcpCommunication.cpp
@@ -64,24 +64,16 @@ typedef tcp::socket B_TCP_SOCKET;
 static constexpr uint8_t LENGTH_FIELD_SIZE = 4;
 static constexpr uint8_t MSGTYPE_FIELD_SIZE = 2;
 
-enum MessageType : uint16_t {
-  Reserved = 0,
-  Hello,
-  Regular
-};
+enum MessageType : uint16_t { Reserved = 0, Hello, Regular };
 
-enum ConnType : uint8_t {
-  Incoming,
-  Outgoing
-};
+enum ConnType : uint8_t { Incoming, Outgoing };
 
 /** this class will handle single connection using boost::make_shared idiom
  * will receive the IReceiver as a parameter and call it when new message
  * is available
  * TODO(IG): add multithreading
  */
-class AsyncTcpConnection :
-    public boost::enable_shared_from_this<AsyncTcpConnection> {
+class AsyncTcpConnection : public boost::enable_shared_from_this<AsyncTcpConnection> {
  private:
   bool _isReplica = false;
   bool _destIsReplica = false;
@@ -123,22 +115,21 @@ class AsyncTcpConnection :
                      ConnType type,
                      concordlogger::Logger logger,
                      UPDATE_CONNECTIVITY_FN statusCallback,
-                     NodeMap nodes) :
-      _service(service),
-      _bufferLength(bufferLength),
-      _fOnError(onError),
-      _fOnHellOMessage(onHelloMsg),
-      _destId(destId),
-      _selfId(selfId),
-      _connectTimer(*service),
-      _connType(type),
-      _closed(false),
-      _logger(logger),
-      _statusCallback{statusCallback},
-      _nodes{std::move(nodes)},
-      socket(*service),
-      connected(false) {
-
+                     NodeMap nodes)
+      : _service(service),
+        _bufferLength(bufferLength),
+        _fOnError(onError),
+        _fOnHellOMessage(onHelloMsg),
+        _destId(destId),
+        _selfId(selfId),
+        _connectTimer(*service),
+        _connType(type),
+        _closed(false),
+        _logger(logger),
+        _statusCallback{statusCallback},
+        _nodes{std::move(nodes)},
+        socket(*service),
+        connected(false) {
     LOG_TRACE(_logger, "enter, node " << _selfId << ", dest: " << _destId);
 
     _isReplica = check_replica(_selfId);
@@ -159,42 +150,35 @@ class AsyncTcpConnection :
     return it->second.isReplica;
   }
 
-  void parse_message_header(const char *buffer,
-                            uint32_t &msgLength) {
-    msgLength = *(static_cast<const uint32_t *>(
-        static_cast<const void *>(buffer)));
+  void parse_message_header(const char *buffer, uint32_t &msgLength) {
+    msgLength = *(static_cast<const uint32_t *>(static_cast<const void *>(buffer)));
   }
 
   void close_socket() {
-    LOG_TRACE(_logger, "enter, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << ", closed: " << _closed);
+    LOG_TRACE(
+        _logger,
+        "enter, node " << _selfId << ", dest: " << _destId << ", connected: " << connected << ", closed: " << _closed);
 
     try {
       boost::system::error_code ignored_ec;
-      socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both,
-                      ignored_ec);
+      socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
       socket.close();
     } catch (std::exception &e) {
-      LOG_ERROR(_logger, "exception, node " << _selfId
-               << ", dest: " << _destId
-               << ", connected: " << connected
-               << ", ex: " << e.what());
+      LOG_ERROR(_logger,
+                "exception, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                                   << ", ex: " << e.what());
     }
 
-    LOG_TRACE(_logger, "exit, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << ", closed: " << _closed);
+    LOG_TRACE(
+        _logger,
+        "exit, node " << _selfId << ", dest: " << _destId << ", connected: " << connected << ", closed: " << _closed);
   }
 
   void close() {
     _connecting = true;
-    LOG_TRACE(_logger, "enter, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << ", closed: " << _closed);
+    LOG_TRACE(
+        _logger,
+        "enter, node " << _selfId << ", dest: " << _destId << ", connected: " << connected << ", closed: " << _closed);
 
     lock_guard<recursive_mutex> lock(_connectionsGuard);
 
@@ -207,27 +191,23 @@ class AsyncTcpConnection :
       socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
       socket.close();
     } catch (std::exception &e) {
-      LOG_ERROR(_logger, "exception, node " << _selfId
-                << ", dest: " << _destId
-                << ", connected: " << connected
-                << ", ex: " << e.what());
+      LOG_ERROR(_logger,
+                "exception, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                                   << ", ex: " << e.what());
     }
 
-    LOG_TRACE(_logger, "exit, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << ", closed: " << _closed);
+    LOG_TRACE(
+        _logger,
+        "exit, node " << _selfId << ", dest: " << _destId << ", connected: " << connected << ", closed: " << _closed);
 
     _fOnError(_destId);
   }
 
   bool was_error(const B_ERROR_CODE &ec, string where) {
     if (ec)
-      LOG_ERROR(_logger, "where: " << where
-                << ", node " << _selfId
-                << ", dest: " << _destId
-                << ", connected: " << connected
-                << ", ex: " << ec.message());
+      LOG_ERROR(_logger,
+                "where: " << where << ", node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                          << ", ex: " << ec.message());
 
     return (ec != 0);
   }
@@ -235,10 +215,9 @@ class AsyncTcpConnection :
   void reconnect() {
     _connecting = true;
 
-    LOG_TRACE(_logger, "enter, node " << _selfId
-               << ", dest: " << _destId
-               << ", connected: " << connected
-               << "is_open: " << socket.is_open());
+    LOG_TRACE(_logger,
+              "enter, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                             << "is_open: " << socket.is_open());
 
     lock_guard<recursive_mutex> lock(_connectionsGuard);
 
@@ -250,10 +229,9 @@ class AsyncTcpConnection :
     setTimeOut();
     connect(_host, _port, _destIsReplica);
 
-    LOG_TRACE(_logger, "exit, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << "is_open: " << socket.is_open());
+    LOG_TRACE(_logger,
+              "exit, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                            << "is_open: " << socket.is_open());
   }
 
   void handle_error(B_ERROR_CODE ec) {
@@ -263,8 +241,7 @@ class AsyncTcpConnection :
 
     if (ConnType::Incoming == _connType) {
       close();
-    }
-    else {
+    } else {
       reconnect();
       if (_statusCallback) {
         bool isReplica = check_replica(_selfId);
@@ -281,19 +258,15 @@ class AsyncTcpConnection :
     }
   }
 
-  void
-  read_header_async_completed(const B_ERROR_CODE &ec,
-                              const uint32_t bytesRead) {
-    LOG_TRACE(_logger, "enter, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << "is_open: " << socket.is_open());
+  void read_header_async_completed(const B_ERROR_CODE &ec, const uint32_t bytesRead) {
+    LOG_TRACE(_logger,
+              "enter, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                             << "is_open: " << socket.is_open());
 
     lock_guard<recursive_mutex> lock(_connectionsGuard);
 
     if (_wasError || _connecting) {
-      LOG_TRACE(_logger,
-          "was error, node " << _selfId << ", dest: " << _destId);
+      LOG_TRACE(_logger, "was error, node " << _selfId << ", dest: " << _destId);
       return;
     }
 
@@ -312,17 +285,15 @@ class AsyncTcpConnection :
 
     read_msg_async(LENGTH_FIELD_SIZE, msgLength);
 
-    LOG_TRACE(_logger, "exit, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << "is_open: " << socket.is_open());
+    LOG_TRACE(_logger,
+              "exit, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                            << "is_open: " << socket.is_open());
   }
 
   void read_header_async() {
-    LOG_TRACE(_logger, "enter, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << "is_open: " << socket.is_open());
+    LOG_TRACE(_logger,
+              "enter, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                             << "is_open: " << socket.is_open());
 
     memset(_inBuffer, 0, _bufferLength);
     async_read(socket,
@@ -332,44 +303,35 @@ class AsyncTcpConnection :
                            boost::asio::placeholders::error,
                            boost::asio::placeholders::bytes_transferred));
 
-    LOG_TRACE(_logger, "exit, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << "is_open: " << socket.is_open());
+    LOG_TRACE(_logger,
+              "exit, node " << _selfId << ", dest: " << _destId << ", connected: " << connected
+                            << "is_open: " << socket.is_open());
   }
 
   bool is_service_message() {
-    uint16_t msgType =
-        *(static_cast<uint16_t *>(
-            static_cast<void *>(_inBuffer + LENGTH_FIELD_SIZE)));
+    uint16_t msgType = *(static_cast<uint16_t *>(static_cast<void *>(_inBuffer + LENGTH_FIELD_SIZE)));
     switch (msgType) {
       case MessageType::Hello:
-        _destId =
-            *(static_cast<NodeNum *>(
-                static_cast<void *>(
-                    _inBuffer + LENGTH_FIELD_SIZE +
-                        MSGTYPE_FIELD_SIZE)));
+        _destId = *(static_cast<NodeNum *>(static_cast<void *>(_inBuffer + LENGTH_FIELD_SIZE + MSGTYPE_FIELD_SIZE)));
 
         LOG_DEBUG(_logger, "node: " << _selfId << " got hello from:" << _destId);
 
         _fOnHellOMessage(_destId, shared_from_this());
         _destIsReplica = check_replica(_destId);
-        LOG_DEBUG(_logger, "node: " << _selfId
-                  << " dest is replica: " << _destIsReplica);
+        LOG_DEBUG(_logger, "node: " << _selfId << " dest is replica: " << _destIsReplica);
         return true;
-      default:return false;
+      default:
+        return false;
     }
   }
 
-  void read_msg_async_completed(const boost::system::error_code &ec,
-                                size_t bytesRead) {
+  void read_msg_async_completed(const boost::system::error_code &ec, size_t bytesRead) {
     LOG_TRACE(_logger, "enter, node " << _selfId << ", dest: " << _destId);
 
     lock_guard<recursive_mutex> lock(_connectionsGuard);
 
     if (_wasError || _connecting) {
-      LOG_TRACE(_logger,
-          "was error, node " << _selfId << ", dest: " << _destId);
+      LOG_TRACE(_logger, "was error, node " << _selfId << ", dest: " << _destId);
       return;
     }
 
@@ -381,11 +343,8 @@ class AsyncTcpConnection :
 
     if (!is_service_message()) {
       LOG_DEBUG(_logger, "data msg received, msgLen: " << bytesRead);
-      _receiver->
-          onNewMessage(_destId,
-                       _inBuffer + LENGTH_FIELD_SIZE +
-                           MSGTYPE_FIELD_SIZE,
-                       bytesRead - MSGTYPE_FIELD_SIZE);
+      _receiver->onNewMessage(
+          _destId, _inBuffer + LENGTH_FIELD_SIZE + MSGTYPE_FIELD_SIZE, bytesRead - MSGTYPE_FIELD_SIZE);
     }
 
     read_header_async();
@@ -411,8 +370,7 @@ class AsyncTcpConnection :
     // async operation will finish when either expectedBytes are read
     // or error occured
     async_read(socket,
-               boost::asio::buffer(_inBuffer + offset,
-                                   msgLength),
+               boost::asio::buffer(_inBuffer + offset, msgLength),
                boost::bind(&AsyncTcpConnection::read_msg_async_completed,
                            shared_from_this(),
                            boost::asio::placeholders::error,
@@ -421,13 +379,11 @@ class AsyncTcpConnection :
     LOG_TRACE(_logger, "exit, node " << _selfId << ", dest: " << _destId);
   }
 
-  void write_async_completed(const B_ERROR_CODE &err,
-                             size_t bytesTransferred) {
+  void write_async_completed(const B_ERROR_CODE &err, size_t bytesTransferred) {
     LOG_TRACE(_logger, "enter, node " << _selfId << ", dest: " << _destId);
 
     if (_wasError) {
-      LOG_TRACE(_logger,
-          "was error, node " << _selfId << ", dest: " << _destId);
+      LOG_TRACE(_logger, "was error, node " << _selfId << ", dest: " << _destId);
       return;
     }
 
@@ -445,9 +401,7 @@ class AsyncTcpConnection :
     memset(_outBuffer, 0, _bufferLength);
     uint32_t size = sizeof(msgType) + dataLength;
     memcpy(_outBuffer, &size, LENGTH_FIELD_SIZE);
-    memcpy(_outBuffer + LENGTH_FIELD_SIZE,
-           &msgType,
-           MSGTYPE_FIELD_SIZE);
+    memcpy(_outBuffer + LENGTH_FIELD_SIZE, &msgType, MSGTYPE_FIELD_SIZE);
     return LENGTH_FIELD_SIZE + MSGTYPE_FIELD_SIZE;
   }
 
@@ -455,57 +409,35 @@ class AsyncTcpConnection :
     auto offset = prepare_output_buffer(MessageType::Hello, sizeof(_selfId));
     memcpy(_outBuffer + offset, &_selfId, sizeof(_selfId));
 
-    LOG_DEBUG(_logger, "sending hello from:" << _selfId
-              << " to: " << _destId
-              << ", size: " << (offset + sizeof(_selfId)));
+    LOG_DEBUG(_logger,
+              "sending hello from:" << _selfId << " to: " << _destId << ", size: " << (offset + sizeof(_selfId)));
 
-    AsyncTcpConnection::write_async((const char *) _outBuffer,
-                                    offset + sizeof(_selfId));
+    AsyncTcpConnection::write_async((const char *)_outBuffer, offset + sizeof(_selfId));
   }
 
-  void setTimeOut() {
-    _currentTimeout = _currentTimeout == _maxTimeout
-                      ? _minTimeout
-                      : _currentTimeout * 2;
-  }
+  void setTimeOut() { _currentTimeout = _currentTimeout == _maxTimeout ? _minTimeout : _currentTimeout * 2; }
 
   void connect_timer_tick(const B_ERROR_CODE &ec) {
-    LOG_TRACE(_logger, "enter, node " << _selfId <<
-                                      ", dest: " << _destId << ", ec: "
-                                      << ec.message());
+    LOG_TRACE(_logger, "enter, node " << _selfId << ", dest: " << _destId << ", ec: " << ec.message());
 
     if (_closed) {
-      LOG_DEBUG(_logger,
-                "closed, node " << _selfId << ", dest: " << _destId << ", ec: "
-                                << ec.message());
+      LOG_DEBUG(_logger, "closed, node " << _selfId << ", dest: " << _destId << ", ec: " << ec.message());
     } else {
       if (connected) {
-        LOG_DEBUG(_logger, "already connected, node " << _selfId
-                  << ", dest: " << _destId
-                  << ", ec: " << ec);
+        LOG_DEBUG(_logger, "already connected, node " << _selfId << ", dest: " << _destId << ", ec: " << ec);
         _connectTimer.expires_at(boost::posix_time::pos_infin);
-      } else if (_connectTimer.expires_at() <=
-          deadline_timer::traits_type::now()) {
-
-        LOG_DEBUG(_logger, "reconnecting, node " << _selfId
-                  << ", dest: " << _destId
-                  << ", ec: " << ec);
+      } else if (_connectTimer.expires_at() <= deadline_timer::traits_type::now()) {
+        LOG_DEBUG(_logger, "reconnecting, node " << _selfId << ", dest: " << _destId << ", ec: " << ec);
         reconnect();
       } else {
-        LOG_DEBUG(_logger, "else, node " << _selfId
-                  << ", dest: " << _destId
-                  << ", ec: " << ec.message());
+        LOG_DEBUG(_logger, "else, node " << _selfId << ", dest: " << _destId << ", ec: " << ec.message());
       }
 
       _connectTimer.async_wait(
-          boost::bind(&AsyncTcpConnection::connect_timer_tick,
-                      shared_from_this(),
-                      boost::asio::placeholders::error));
+          boost::bind(&AsyncTcpConnection::connect_timer_tick, shared_from_this(), boost::asio::placeholders::error));
     }
 
-    LOG_TRACE(_logger, "exit, node " << _selfId
-              <<", dest: " << _destId
-              << ", ec: " << ec.message());
+    LOG_TRACE(_logger, "exit, node " << _selfId << ", dest: " << _destId << ", ec: " << ec.message());
   }
 
   void connect_completed(const B_ERROR_CODE &err) {
@@ -516,20 +448,17 @@ class AsyncTcpConnection :
 
     if (!socket.is_open()) {
       // async_connect opens socket on start so
-      //nothing to do here since timeout occured and closed the socket
+      // nothing to do here since timeout occured and closed the socket
       if (connected) {
-        LOG_DEBUG(_logger, "node " << _selfId
-                  << " is DISCONNECTED from node " << _destId);
+        LOG_DEBUG(_logger, "node " << _selfId << " is DISCONNECTED from node " << _destId);
       }
       connected = false;
     } else if (res) {
       connected = false;
-      //timeout didnt happen yet but the connection failed
+      // timeout didnt happen yet but the connection failed
       // nothig to do here, left for clarity
     } else {
-      LOG_DEBUG(_logger, "connected, node " << _selfId
-                << ", dest: " << _destId
-                << ", res: " << res);
+      LOG_DEBUG(_logger, "connected, node " << _selfId << ", dest: " << _destId << ", res: " << res);
       connected = true;
       _wasError = false;
       _connecting = false;
@@ -543,8 +472,7 @@ class AsyncTcpConnection :
   }
 
   void write_async(const char *data, uint32_t length) {
-    if (!connected)
-      return;
+    if (!connected) return;
 
     B_ERROR_CODE ec;
     write(socket, buffer(data, length), ec);
@@ -556,9 +484,7 @@ class AsyncTcpConnection :
 
   void init() {
     _connectTimer.async_wait(
-        boost::bind(&AsyncTcpConnection::connect_timer_tick,
-                    shared_from_this(),
-                    boost::asio::placeholders::error));
+        boost::bind(&AsyncTcpConnection::connect_timer_tick, shared_from_this(), boost::asio::placeholders::error));
   }
 
  public:
@@ -567,10 +493,7 @@ class AsyncTcpConnection :
     _port = port;
     _destIsReplica = destIsReplica;
 
-    LOG_TRACE(_logger, "enter, from: " << _selfId
-              << " ,to: " << _destId
-              << ", host: " << host
-              << ", port: " << port);
+    LOG_TRACE(_logger, "enter, from: " << _selfId << " ,to: " << _destId << ", host: " << host << ", port: " << port);
 
     tcp::resolver::query query(tcp::v4(), _host, std::to_string(_port));
     tcp::resolver resolver(*_service);
@@ -579,18 +502,15 @@ class AsyncTcpConnection :
     if (!ec && results != tcp::resolver::iterator()) {
       tcp::endpoint ep = *results;
 
-      LOG_DEBUG(_logger, "connecting from: " << _selfId
-                << " ,to: " << _destId
-                << ", timeout: " << _currentTimeout
-                << ", dest is replica: " << _destIsReplica);
+      LOG_DEBUG(_logger,
+                "connecting from: " << _selfId << " ,to: " << _destId << ", timeout: " << _currentTimeout
+                                    << ", dest is replica: " << _destIsReplica);
 
-      _connectTimer.expires_from_now(
-        boost::posix_time::millisec(_currentTimeout));
+      _connectTimer.expires_from_now(boost::posix_time::millisec(_currentTimeout));
 
-      socket.async_connect(ep,
-                           boost::bind(&AsyncTcpConnection::connect_completed,
-                                       shared_from_this(),
-                                       boost::asio::placeholders::error));
+      socket.async_connect(
+          ep,
+          boost::bind(&AsyncTcpConnection::connect_completed, shared_from_this(), boost::asio::placeholders::error));
     } else {
       LOG_INFO(_logger, "Unable to resolve " << host << ":" << port);
       if (!ec) {
@@ -599,22 +519,16 @@ class AsyncTcpConnection :
       // Use the async completion handler directly to kick off a retry.
       connect_completed(ec);
     }
-    LOG_TRACE(_logger, "exit, from: " << _selfId
-             << " ,to: " << _destId
-             << ", host: " << host
-             << ", port: " << port);
+    LOG_TRACE(_logger, "exit, from: " << _selfId << " ,to: " << _destId << ", host: " << host << ", port: " << port);
   }
 
-  void start() {
-    read_header_async();
-  }
+  void start() { read_header_async(); }
 
   void send(const char *data, uint32_t length) {
     LOG_TRACE(_logger, "enter, node " << _selfId << ", dest: " << _destId);
 
     lock_guard<recursive_mutex> lock(_connectionsGuard);
-    auto offset = prepare_output_buffer(MessageType::Regular,
-                                        length);
+    auto offset = prepare_output_buffer(MessageType::Regular, length);
     memcpy(_outBuffer + offset, data, length);
     write_async(_outBuffer, offset + length);
 
@@ -628,9 +542,9 @@ class AsyncTcpConnection :
       _statusCallback(pcs);
     }
 
-    LOG_DEBUG(_logger, "send exit, from: " << ", to: " << _destId
-              << ", offset: " << offset
-              << ", length: " << length);
+    LOG_DEBUG(_logger,
+              "send exit, from: "
+                  << ", to: " << _destId << ", offset: " << offset << ", length: " << length);
     LOG_TRACE(_logger, "exit, node " << _selfId << ", dest: " << _destId);
   }
 
@@ -644,38 +558,25 @@ class AsyncTcpConnection :
                                concordlogger::Logger logger,
                                UPDATE_CONNECTIVITY_FN statusCallback,
                                NodeMap nodes) {
-    auto res = ASYNC_CONN_PTR(
-        new AsyncTcpConnection(service,
-                               onError,
-                               onHello,
-                               bufferLength,
-                               destId,
-                               selfId,
-                               type,
-                               logger,
-                               statusCallback,
-                               nodes));
+    auto res = ASYNC_CONN_PTR(new AsyncTcpConnection(
+        service, onError, onHello, bufferLength, destId, selfId, type, logger, statusCallback, nodes));
     res->init();
     return res;
   }
 
-  void setReceiver(IReceiver *rec) {
-    _receiver = rec;
-  }
+  void setReceiver(IReceiver *rec) { _receiver = rec; }
 
   virtual ~AsyncTcpConnection() {
-    LOG_TRACE(_logger, "enter, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << ", closed: " << _closed);
+    LOG_TRACE(
+        _logger,
+        "enter, node " << _selfId << ", dest: " << _destId << ", connected: " << connected << ", closed: " << _closed);
 
     delete[] _inBuffer;
     delete[] _outBuffer;
 
-    LOG_TRACE(_logger, "exit, node " << _selfId
-              << ", dest: " << _destId
-              << ", connected: " << connected
-              << ", closed: " << _closed);
+    LOG_TRACE(
+        _logger,
+        "exit, node " << _selfId << ", dest: " << _destId << ", connected: " << connected << ", closed: " << _closed);
   }
 };
 
@@ -684,8 +585,7 @@ class AsyncTcpConnection :
 class PlainTCPCommunication::PlainTcpImpl {
  private:
   unordered_map<NodeNum, ASYNC_CONN_PTR> _connections;
-  concordlogger::Logger _logger = concordlogger::Log::getLogger
-      ("concord-bft.tcp");
+  concordlogger::Logger _logger = concordlogger::Log::getLogger("concord-bft.tcp");
 
   unique_ptr<tcp::acceptor> _pAcceptor;
   std::thread *_pIoThread = nullptr;
@@ -716,9 +616,7 @@ class PlainTCPCommunication::PlainTcpImpl {
     conn->setReceiver(_pReceiver);
   }
 
-  void on_accept(ASYNC_CONN_PTR conn,
-                 const NodeMap &nodes,
-                 const B_ERROR_CODE &ec) {
+  void on_accept(ASYNC_CONN_PTR conn, const NodeMap &nodes, const B_ERROR_CODE &ec) {
     LOG_TRACE(_logger, "enter, node: " << _selfId << ", ec: " << ec.message());
 
     if (!ec) {
@@ -730,41 +628,29 @@ class PlainTCPCommunication::PlainTcpImpl {
     LOG_TRACE(_logger, "exit, node: " << _selfId << "ec: " << ec.message());
   }
 
-  //here need to check how "this" passed to handlers behaves
+  // here need to check how "this" passed to handlers behaves
   // if the object is deleted.
   void start_accept(const NodeMap &nodes) {
     LOG_TRACE(_logger, "enter, node: " << _selfId);
-    auto conn = AsyncTcpConnection::
-    create(&_service,
-           std::bind(
-               &PlainTcpImpl::on_async_connection_error,
-               this,
-               std::placeholders::_1),
-           std::bind(
-               &PlainTcpImpl::on_hello_message,
-               this,
-               std::placeholders::_1,
-               std::placeholders::_2),
-           _bufferLength,
-           0,
-           _selfId,
-           ConnType::Incoming,
-           _logger,
-           _statusCallback,
-           nodes);
-    _pAcceptor->async_accept(conn->socket,
-                             boost::bind(
-                                 &PlainTcpImpl::on_accept,
-                                 this,
-                                 conn,
-                                 nodes,
-                                 boost::asio::placeholders::error));
+    auto conn = AsyncTcpConnection::create(
+        &_service,
+        std::bind(&PlainTcpImpl::on_async_connection_error, this, std::placeholders::_1),
+        std::bind(&PlainTcpImpl::on_hello_message, this, std::placeholders::_1, std::placeholders::_2),
+        _bufferLength,
+        0,
+        _selfId,
+        ConnType::Incoming,
+        _logger,
+        _statusCallback,
+        nodes);
+    _pAcceptor->async_accept(
+        conn->socket, boost::bind(&PlainTcpImpl::on_accept, this, conn, nodes, boost::asio::placeholders::error));
     LOG_TRACE(_logger, "exit, node: " << _selfId);
   }
 
-  PlainTcpImpl(const PlainTcpImpl &) = delete; // non construction-copyable
-  PlainTcpImpl(const PlainTcpImpl &&) = delete; // non movable
-  PlainTcpImpl &operator=(const PlainTcpImpl &) = delete; // non copyable
+  PlainTcpImpl(const PlainTcpImpl &) = delete;             // non construction-copyable
+  PlainTcpImpl(const PlainTcpImpl &&) = delete;            // non movable
+  PlainTcpImpl &operator=(const PlainTcpImpl &) = delete;  // non copyable
   PlainTcpImpl() = delete;
 
   PlainTcpImpl(NodeNum selfNodeId,
@@ -773,13 +659,13 @@ class PlainTCPCommunication::PlainTcpImpl {
                uint16_t listenPort,
                uint32_t maxServerId,
                string listenHost,
-               UPDATE_CONNECTIVITY_FN statusCallback) :
-      _selfId{selfNodeId},
-      _listenPort{listenPort},
-      _listenHost{listenHost},
-      _bufferLength{bufferLength},
-      _maxServerId{maxServerId},
-      _statusCallback{statusCallback} {
+               UPDATE_CONNECTIVITY_FN statusCallback)
+      : _selfId{selfNodeId},
+        _listenPort{listenPort},
+        _listenHost{listenHost},
+        _bufferLength{bufferLength},
+        _maxServerId{maxServerId},
+        _statusCallback{statusCallback} {
     // all replicas are in listen mode
     if (_selfId <= _maxServerId) {
       tcp::resolver::query query(tcp::v4(), _listenHost, std::to_string(_listenPort));
@@ -794,7 +680,7 @@ class PlainTCPCommunication::PlainTcpImpl {
       LOG_INFO(_logger, "Resolved " << _listenHost << ":" << _listenPort << " to " << ep);
       _pAcceptor = boost::make_unique<tcp::acceptor>(_service, ep);
       start_accept(nodes);
-    } else // clients dont need to listen
+    } else  // clients dont need to listen
       LOG_DEBUG(_logger, "skipping listen for node: " << _selfId);
 
     // this node should connect only to nodes with lower ID
@@ -802,25 +688,17 @@ class PlainTCPCommunication::PlainTcpImpl {
     // we dont want that clients will connect to another clients
     for (auto it = nodes.begin(); it != nodes.end(); it++) {
       if (it->first < _selfId && it->first <= maxServerId) {
-        auto conn =
-            AsyncTcpConnection::
-            create(&_service,
-                   std::bind(
-                       &PlainTcpImpl::on_async_connection_error,
-                       this,
-                       std::placeholders::_1),
-                   std::bind(
-                       &PlainTcpImpl::on_hello_message,
-                       this,
-                       std::placeholders::_1,
-                       std::placeholders::_2),
-                   _bufferLength,
-                   it->first,
-                   _selfId,
-                   ConnType::Outgoing,
-                   _logger,
-                   _statusCallback,
-                   nodes);
+        auto conn = AsyncTcpConnection::create(
+            &_service,
+            std::bind(&PlainTcpImpl::on_async_connection_error, this, std::placeholders::_1),
+            std::bind(&PlainTcpImpl::on_hello_message, this, std::placeholders::_1, std::placeholders::_2),
+            _bufferLength,
+            it->first,
+            _selfId,
+            ConnType::Outgoing,
+            _logger,
+            _statusCallback,
+            nodes);
 
         _connections.insert(make_pair(it->first, conn));
         string peerHost = it->second.host;
@@ -842,45 +720,33 @@ class PlainTCPCommunication::PlainTcpImpl {
     }
   }
 
-
  public:
-  static PlainTcpImpl *
-  create(NodeNum selfNodeId,
-      // tuple of host, listen port, bind port
-         NodeMap nodes,
-         uint32_t bufferLength,
-         uint16_t listenPort,
-         uint32_t tempHighestNodeForConnecting,
-         string listenHost,
-         UPDATE_CONNECTIVITY_FN statusCallback) {
-    return new PlainTcpImpl(selfNodeId,
-                            nodes,
-                            bufferLength,
-                            listenPort,
-                            tempHighestNodeForConnecting,
-                            listenHost,
-                            statusCallback);
+  static PlainTcpImpl *create(NodeNum selfNodeId,
+                              // tuple of host, listen port, bind port
+                              NodeMap nodes,
+                              uint32_t bufferLength,
+                              uint16_t listenPort,
+                              uint32_t tempHighestNodeForConnecting,
+                              string listenHost,
+                              UPDATE_CONNECTIVITY_FN statusCallback) {
+    return new PlainTcpImpl(
+        selfNodeId, nodes, bufferLength, listenPort, tempHighestNodeForConnecting, listenHost, statusCallback);
   }
 
   int Start() {
-    if (_pIoThread)
-      return 0; // running
+    if (_pIoThread) return 0;  // running
 
-    _pIoThread =
-        new std::thread(std::bind
-                            (static_cast<size_t(boost::asio::io_service::*)()>(
-                                 &boost::asio::io_service::run),
-                             std::ref(_service)));
+    _pIoThread = new std::thread(std::bind(
+        static_cast<size_t (boost::asio::io_service::*)()>(&boost::asio::io_service::run), std::ref(_service)));
     return 0;
   }
 
   /**
-  * Stops the object (including its internal threads).
-  * On success, returns 0.
-  */
+   * Stops the object (including its internal threads).
+   * On success, returns 0.
+   */
   int Stop() {
-    if (!_pIoThread)
-      return 0; // stopped
+    if (!_pIoThread) return 0;  // stopped
 
     _service.stop();
     _pIoThread->join();
@@ -891,54 +757,41 @@ class PlainTCPCommunication::PlainTcpImpl {
   }
 
   bool isRunning() const {
-    if (!_pIoThread)
-      return false; // stopped
+    if (!_pIoThread) return false;  // stopped
     return true;
   }
 
-  ConnectionStatus
-  getCurrentConnectionStatus(const NodeNum node) const {
-    return isRunning() ?
-           ConnectionStatus::Connected :
-           ConnectionStatus::Disconnected;
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const {
+    return isRunning() ? ConnectionStatus::Connected : ConnectionStatus::Disconnected;
   }
 
   /**
-  * Sends a message on the underlying communication layer to a given
-  * destination node. Asynchronous (non-blocking) method.
-  * Returns 0 on success.
-  */
-  int sendAsyncMessage(const NodeNum destNode,
-                       const char *const message,
-                       const size_t messageLength) {
-    LOG_TRACE(_logger, "enter, from: " << _selfId
-              << ", to: " << to_string(destNode));
+   * Sends a message on the underlying communication layer to a given
+   * destination node. Asynchronous (non-blocking) method.
+   * Returns 0 on success.
+   */
+  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) {
+    LOG_TRACE(_logger, "enter, from: " << _selfId << ", to: " << to_string(destNode));
 
     lock_guard<recursive_mutex> lock(_connectionsGuard);
     auto temp = _connections.find(destNode);
     if (temp != _connections.end()) {
-      LOG_TRACE(_logger, "conncection found, from: " << _selfId
-                << ", to: " << destNode);
+      LOG_TRACE(_logger, "conncection found, from: " << _selfId << ", to: " << destNode);
 
       if (temp->second->connected) {
         temp->second->send(message, messageLength);
       } else {
-        LOG_TRACE(_logger,
-           "conncection found but disconnected, from: " << _selfId
-           << ", to: " << destNode);
+        LOG_TRACE(_logger, "conncection found but disconnected, from: " << _selfId << ", to: " << destNode);
       }
     }
 
-    LOG_TRACE(_logger, "exit, from: " << _selfId
-              << ", to: " << destNode);
+    LOG_TRACE(_logger, "exit, from: " << _selfId << ", to: " << destNode);
 
     return 0;
   }
 
   /// TODO(IG): return real max message size... what is should be for TCP?
-  int getMaxMessageSize() {
-    return -1;
-  }
+  int getMaxMessageSize() { return -1; }
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) {
     _pReceiver = receiver;
@@ -969,44 +822,33 @@ PlainTCPCommunication::PlainTCPCommunication(const PlainTcpConfig &config) {
                                   config.statusCallback);
 }
 
-PlainTCPCommunication *PlainTCPCommunication::create(
-    const PlainTcpConfig &config) {
+PlainTCPCommunication *PlainTCPCommunication::create(const PlainTcpConfig &config) {
   return new PlainTCPCommunication(config);
 }
 
-int PlainTCPCommunication::getMaxMessageSize() {
-  return _ptrImpl->getMaxMessageSize();
-}
+int PlainTCPCommunication::getMaxMessageSize() { return _ptrImpl->getMaxMessageSize(); }
 
-int PlainTCPCommunication::Start() {
-  return _ptrImpl->Start();
-}
+int PlainTCPCommunication::Start() { return _ptrImpl->Start(); }
 
 int PlainTCPCommunication::Stop() {
-  if (!_ptrImpl)
-    return 0;
+  if (!_ptrImpl) return 0;
 
   auto res = _ptrImpl->Stop();
   return res;
 }
 
-bool PlainTCPCommunication::isRunning() const {
-  return _ptrImpl->isRunning();
-}
+bool PlainTCPCommunication::isRunning() const { return _ptrImpl->isRunning(); }
 
-ConnectionStatus
-PlainTCPCommunication::getCurrentConnectionStatus(const NodeNum node) const {
+ConnectionStatus PlainTCPCommunication::getCurrentConnectionStatus(const NodeNum node) const {
   return _ptrImpl->getCurrentConnectionStatus(node);
 }
 
-int
-PlainTCPCommunication::sendAsyncMessage(const NodeNum destNode,
-                                        const char *const message,
-                                        const size_t messageLength) {
+int PlainTCPCommunication::sendAsyncMessage(const NodeNum destNode,
+                                            const char *const message,
+                                            const size_t messageLength) {
   return _ptrImpl->sendAsyncMessage(destNode, message, messageLength);
 }
 
-void
-PlainTCPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
+void PlainTCPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
   _ptrImpl->setReceiver(receiverNum, receiver);
 }

--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -123,13 +123,13 @@ class PlainUDPCommunication::PlainUdpImpl {
     Assert(config.nodes.size() > 0, "No communication endpoints specified!");
 
     LOG_DEBUG(_logger, "Node " << config.selfId <<
-        ", listen IP: " << config.listenIp <<
+        ", listen IP: " << config.listenHost <<
         ", listen port: " << config.listenPort);
 
     for (auto next = config.nodes.begin();
          next != config.nodes.end();
          next++) {
-      auto key = create_key(next->second.ip, next->second.port);
+      auto key = create_key(next->second.host, next->second.port);
       addr2nodes[key] = next->first;
 
       LOG_DEBUG(_logger, "Node " << config.selfId <<
@@ -138,7 +138,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       if (statusCallback && next->second.isReplica) {
         PeerConnectivityStatus pcs{};
         pcs.peerId = next->first;
-        pcs.peerIp = next->second.ip;
+        pcs.peerHost = next->second.host;
         pcs.peerPort = next->second.port;
         pcs.statusType = StatusType::Started;
         statusCallback(pcs);
@@ -147,7 +147,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       Addr ad;
       memset((char *) &ad, 0, sizeof(ad));
       ad.sin_family = AF_INET;
-      ad.sin_addr.s_addr = inet_addr(next->second.ip.c_str());
+      ad.sin_addr.s_addr = inet_addr(next->second.host.c_str());
       ad.sin_port = htons(next->second.port);
       nodes2addresses.insert({next->first, ad});
     }
@@ -396,7 +396,7 @@ class PlainUDPCommunication::PlainUdpImpl {
 
         char str[INET_ADDRSTRLEN];
         inet_ntop(AF_INET, &(fromAddress.sin_addr), str, INET_ADDRSTRLEN);
-        pcs.peerIp = string(str);
+        pcs.peerHost = string(str);
 
         pcs.peerPort = ntohs(fromAddress.sin_port);
         pcs.statusType = StatusType::MessageReceived;

--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -34,14 +34,13 @@
 #endif
 
 #if defined(_WIN32)
-#pragma warning(disable:4996) // TODO(GG+SG): should be removed!! (see also _CRT_SECURE_NO_WARNINGS)
+#pragma warning(disable : 4996)  // TODO(GG+SG): should be removed!! (see also _CRT_SECURE_NO_WARNINGS)
 #endif
 
 using namespace std;
 using namespace bftEngine;
 
-struct NodeAddressResolveResult
-{
+struct NodeAddressResolveResult {
   NodeNum nodeId;
   bool wasFound;
   string key;
@@ -86,8 +85,7 @@ class PlainUDPCommunication::PlainUdpImpl {
 
   concordlogger::Logger _logger = concordlogger::Log::getLogger("plain-udp");
 
-  bool check_replica(NodeNum node)
-  {
+  bool check_replica(NodeNum node) {
     auto it = endpoints.find(node);
     if (it == endpoints.end()) {
       return false;
@@ -96,22 +94,18 @@ class PlainUDPCommunication::PlainUdpImpl {
     return it->second.isReplica;
   }
 
-  string
-  create_key(string ip, uint16_t port) {
+  string create_key(string ip, uint16_t port) {
     auto key = ip + ":" + to_string(port);
     return key;
   }
 
-  string
-  create_key(Addr a) {
-    return create_key(inet_ntoa(a.sin_addr), ntohs(a.sin_port));
-  }
+  string create_key(Addr a) { return create_key(inet_ntoa(a.sin_addr), ntohs(a.sin_port)); }
 
  public:
   /**
-  * Initializes a new UDPCommunication layer that will listen on the given
-  * listenPort.
-  */
+   * Initializes a new UDPCommunication layer that will listen on the given
+   * listenPort.
+   */
   PlainUdpImpl(const PlainUdpConfig &config)
       : maxMsgSize{config.bufferLength},
         udpListenPort{config.listenPort},
@@ -122,18 +116,15 @@ class PlainUDPCommunication::PlainUdpImpl {
     Assert(config.listenPort > 0, "Port should not be negative!");
     Assert(config.nodes.size() > 0, "No communication endpoints specified!");
 
-    LOG_DEBUG(_logger, "Node " << config.selfId <<
-        ", listen IP: " << config.listenHost <<
-        ", listen port: " << config.listenPort);
+    LOG_DEBUG(
+        _logger,
+        "Node " << config.selfId << ", listen IP: " << config.listenHost << ", listen port: " << config.listenPort);
 
-    for (auto next = config.nodes.begin();
-         next != config.nodes.end();
-         next++) {
+    for (auto next = config.nodes.begin(); next != config.nodes.end(); next++) {
       auto key = create_key(next->second.host, next->second.port);
       addr2nodes[key] = next->first;
 
-      LOG_DEBUG(_logger, "Node " << config.selfId <<
-          ", got peer: " << key);
+      LOG_DEBUG(_logger, "Node " << config.selfId << ", got peer: " << key);
 
       if (statusCallback && next->second.isReplica) {
         PeerConnectivityStatus pcs{};
@@ -145,7 +136,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       }
 
       Addr ad;
-      memset((char *) &ad, 0, sizeof(ad));
+      memset((char *)&ad, 0, sizeof(ad));
       ad.sin_family = AF_INET;
       ad.sin_addr.s_addr = inet_addr(next->second.host.c_str());
       ad.sin_port = htons(next->second.port);
@@ -158,13 +149,9 @@ class PlainUDPCommunication::PlainUdpImpl {
     udpSockFd = 0;
   }
 
-  int
-  getMaxMessageSize() {
-    return maxMsgSize;
-  }
+  int getMaxMessageSize() { return maxMsgSize; }
 
-  int
-  Start() {
+  int Start() {
     int error = 0;
     Addr sAddr;
 
@@ -180,7 +167,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       return -1;
     }
 
-    bufferForIncomingMessages = (char *) std::malloc(maxMsgSize);
+    bufferForIncomingMessages = (char *)std::malloc(maxMsgSize);
 
     // Initialize socket.
     udpSockFd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -191,20 +178,20 @@ class PlainUDPCommunication::PlainUdpImpl {
     sAddr.sin_port = htons(udpListenPort);
 
     // Bind the socket.
-    error = ::bind(udpSockFd, (struct sockaddr *) &sAddr, sizeof(Addr));
+    error = ::bind(udpSockFd, (struct sockaddr *)&sAddr, sizeof(Addr));
     if (error < 0) {
-      LOG_FATAL(_logger, "Error while binding: IP=" << sAddr.sin_addr.s_addr <<
-                         ", Port=" << sAddr.sin_port <<
-                         ", errno="<< strerror(errno));
+      LOG_FATAL(_logger,
+                "Error while binding: IP=" << sAddr.sin_addr.s_addr << ", Port=" << sAddr.sin_port
+                                           << ", errno=" << strerror(errno));
       Assert(false, "Failure occurred while binding the socket!");
-      exit(1); // TODO(GG): not really ..... change this !
+      exit(1);  // TODO(GG): not really ..... change this !
     }
 
 #ifdef WIN32
     {
-       BOOL tmpBuf = FALSE;
-       DWORD bytesReturned = 0;
-       WSAIoctl(udpSockFd, _WSAIOW(IOC_VENDOR, 12), &tmpBuf, sizeof(tmpBuf), NULL, 0, &bytesReturned, NULL, NULL);
+      BOOL tmpBuf = FALSE;
+      DWORD bytesReturned = 0;
+      WSAIoctl(udpSockFd, _WSAIOW(IOC_VENDOR, 12), &tmpBuf, sizeof(tmpBuf), NULL, 0, &bytesReturned, NULL, NULL);
     }
 #endif
 
@@ -214,9 +201,8 @@ class PlainUDPCommunication::PlainUdpImpl {
     return 0;
   }
 
-  int
-  Stop() {
-	  std::lock_guard<std::mutex> guard(runningLock);
+  int Stop() {
+    std::lock_guard<std::mutex> guard(runningLock);
     if (running == false) {
       LOG_DEBUG(_logger, "Cannot Stop(): not running!");
       return -1;
@@ -238,7 +224,7 @@ class PlainUDPCommunication::PlainUdpImpl {
     running = false;
 
     /** Stopping the receiving thread happens as the last step because it
-      * relies on the 'running' flag. */
+     * relies on the 'running' flag. */
     stopRecvThread();
 
     std::free(bufferForIncomingMessages);
@@ -247,25 +233,13 @@ class PlainUDPCommunication::PlainUdpImpl {
     return 0;
   }
 
-  bool
-  isRunning() const {
-    return running;
-  }
+  bool isRunning() const { return running; }
 
-  void
-  setReceiver(NodeNum &receiverNum, IReceiver *pRcv) {
-    receiverRef = pRcv;
-  }
+  void setReceiver(NodeNum &receiverNum, IReceiver *pRcv) { receiverRef = pRcv; }
 
-  ConnectionStatus
-  getCurrentConnectionStatus(const NodeNum &node) const {
-    return ConnectionStatus::Unknown;
-  }
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum &node) const { return ConnectionStatus::Unknown; }
 
-  int
-  sendAsyncMessage(const NodeNum &destNode,
-                   const char *const message,
-                   const size_t &messageLength) {
+  int sendAsyncMessage(const NodeNum &destNode, const char *const message, const size_t &messageLength) {
     int error = 0;
 
     Assert(running == true, "The communication layer is not running!");
@@ -276,25 +250,23 @@ class PlainUDPCommunication::PlainUdpImpl {
     Assert(messageLength > 0, "The message length must be positive!");
     Assert(message != NULL, "No message provided!");
 
-    LOG_DEBUG(_logger, " Sending " << messageLength
-                          << " bytes to "
-                          << destNode << " (" << inet_ntoa(to->sin_addr) << ":"
+    LOG_DEBUG(_logger,
+              " Sending " << messageLength << " bytes to " << destNode << " (" << inet_ntoa(to->sin_addr) << ":"
                           << ntohs(to->sin_port));
 
-    error = sendto(udpSockFd, message, messageLength, 0,
-                   (struct sockaddr *) to, sizeof(Addr));
+    error = sendto(udpSockFd, message, messageLength, 0, (struct sockaddr *)to, sizeof(Addr));
 
     if (error < 0) {
       /** -1 return value means underlying socket error. */
       string err = strerror(errno);
       LOG_INFO(_logger, "Error while sending: " << strerror(errno));
-    } else if (error < (int) messageLength) {
+    } else if (error < (int)messageLength) {
       /** Mesage was partially sent. Unclear why this would happen, perhaps
-        * due to oversized messages (?). */
+       * due to oversized messages (?). */
       LOG_INFO(_logger, "Sent %d out of %d bytes!");
     }
 
-    if (error == (ssize_t) messageLength) {
+    if (error == (ssize_t)messageLength) {
       if (statusCallback) {
         PeerConnectivityStatus pcs{};
         pcs.peerId = selfId;
@@ -309,14 +281,12 @@ class PlainUDPCommunication::PlainUdpImpl {
     return 0;
   }
 
-  void
-  startRecvThread() {
+  void startRecvThread() {
     LOG_DEBUG(_logger, "Starting the receiving thread..");
     recvThreadRef.reset(new std::thread(std::bind(&PlainUdpImpl::recvThreadRoutine, this)));
   }
 
-  NodeAddressResolveResult
-  addrToNodeId(Addr netAddress) {
+  NodeAddressResolveResult addrToNodeId(Addr netAddress) {
     auto key = create_key(netAddress);
     auto res = addr2nodes.find(key);
     if (res == addr2nodes.end()) {
@@ -330,19 +300,15 @@ class PlainUDPCommunication::PlainUdpImpl {
     return NodeAddressResolveResult({res->second, true, key});
   }
 
-  void
-  stopRecvThread() {
-//    LOG_ERROR(_logger,"Stopping the receiving thread..");
+  void stopRecvThread() {
+    //    LOG_ERROR(_logger,"Stopping the receiving thread..");
     recvThreadRef->join();
-//    LOG_ERROR(_logger,"Stopping the receiving thread..");
+    //    LOG_ERROR(_logger,"Stopping the receiving thread..");
   }
 
-  void
-  recvThreadRoutine() {
-    Assert(udpSockFd != 0,
-           "Unable to start receiving: socket not define!");
-    Assert(receiverRef != 0,
-           "Unable to start receiving: receiver not defined!");
+  void recvThreadRoutine() {
+    Assert(udpSockFd != 0, "Unable to start receiving: socket not define!");
+    Assert(receiverRef != 0, "Unable to start receiving: receiver not defined!");
 
     /** The main receive loop. */
     Addr fromAddress;
@@ -353,12 +319,8 @@ class PlainUDPCommunication::PlainUdpImpl {
 #endif
     int mLen = 0;
     do {
-      mLen = recvfrom(udpSockFd,
-                      bufferForIncomingMessages,
-                      maxMsgSize,
-                      0,
-                      (sockaddr *) &fromAddress,
-                      &fromAddressLength);
+      mLen =
+          recvfrom(udpSockFd, bufferForIncomingMessages, maxMsgSize, 0, (sockaddr *)&fromAddress, &fromAddressLength);
 
       LOG_DEBUG(_logger, "Node " << selfId << ": recvfrom returned " << mLen << " bytes");
 
@@ -374,7 +336,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       }
 
       auto resolveNode = addrToNodeId(fromAddress);
-      if(!resolveNode.wasFound) {
+      if (!resolveNode.wasFound) {
         LOG_DEBUG(_logger, "Sender not found, address: " << resolveNode.key);
         continue;
       }
@@ -382,9 +344,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       auto sendingNode = resolveNode.nodeId;
       if (receiverRef != NULL) {
         LOG_DEBUG(_logger, "Node " << selfId << ": Calling onNewMessage, msg from: " << sendingNode);
-        receiverRef->onNewMessage(sendingNode,
-                                  bufferForIncomingMessages,
-                                  mLen);
+        receiverRef->onNewMessage(sendingNode, bufferForIncomingMessages, mLen);
       } else {
         LOG_ERROR(_logger, "Node " << selfId << ": receiver is NULL");
       }
@@ -411,51 +371,38 @@ class PlainUDPCommunication::PlainUdpImpl {
 };
 
 PlainUDPCommunication::~PlainUDPCommunication() {
-  if(_ptrImpl)
-    delete _ptrImpl;
+  if (_ptrImpl) delete _ptrImpl;
 }
 
-PlainUDPCommunication::PlainUDPCommunication(const PlainUdpConfig &config) {
-  _ptrImpl = new PlainUdpImpl(config);
-}
+PlainUDPCommunication::PlainUDPCommunication(const PlainUdpConfig &config) { _ptrImpl = new PlainUdpImpl(config); }
 
 PlainUDPCommunication *PlainUDPCommunication::create(const PlainUdpConfig &config) {
   return new PlainUDPCommunication(config);
 }
 
-int PlainUDPCommunication::getMaxMessageSize() {
-  return _ptrImpl->getMaxMessageSize();
-}
+int PlainUDPCommunication::getMaxMessageSize() { return _ptrImpl->getMaxMessageSize(); }
 
-int PlainUDPCommunication::Start() {
-  return _ptrImpl->Start();
-}
+int PlainUDPCommunication::Start() { return _ptrImpl->Start(); }
 
 int PlainUDPCommunication::Stop() {
-  if (!_ptrImpl)
-    return 0;
+  if (!_ptrImpl) return 0;
 
   auto res = _ptrImpl->Stop();
   return res;
 }
 
-bool PlainUDPCommunication::isRunning() const {
-  return _ptrImpl->isRunning();
-}
+bool PlainUDPCommunication::isRunning() const { return _ptrImpl->isRunning(); }
 
-ConnectionStatus
-PlainUDPCommunication::getCurrentConnectionStatus(const NodeNum node) const {
+ConnectionStatus PlainUDPCommunication::getCurrentConnectionStatus(const NodeNum node) const {
   return _ptrImpl->getCurrentConnectionStatus(node);
 }
 
-int
-PlainUDPCommunication::sendAsyncMessage(const NodeNum destNode,
-                                        const char *const message,
-                                        const size_t messageLength) {
+int PlainUDPCommunication::sendAsyncMessage(const NodeNum destNode,
+                                            const char *const message,
+                                            const size_t messageLength) {
   return _ptrImpl->sendAsyncMessage(destNode, message, messageLength);
 }
 
-void
-PlainUDPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
+void PlainUDPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
   _ptrImpl->setReceiver(receiverNum, receiver);
 }

--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -62,11 +62,7 @@ typedef std::shared_ptr<AsyncTlsConnection> ASYNC_CONN_PTR;
 typedef asio::ssl::stream<asio::ip::tcp::socket> SSL_SOCKET;
 typedef unique_ptr<SSL_SOCKET> B_TLS_SOCKET_PTR;
 
-enum ConnType : uint8_t {
-  NotDefined = 0,
-  Incoming,
-  Outgoing
-};
+enum ConnType : uint8_t { NotDefined = 0, Incoming, Outgoing };
 
 /**
  * this class will handle single connection using boost::make_shared idiom
@@ -78,8 +74,7 @@ enum ConnType : uint8_t {
  * The Outgoing connection instance will be disposed and the new one
  * will be created when connection is broken
  */
-class AsyncTlsConnection : public
-                           std::enable_shared_from_this<AsyncTlsConnection> {
+class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnection> {
  public:
   // since 0 is legal node number, we must initialize it to some "not
   // defined" value. This approach is fragile. TODO:(IG) use real "not
@@ -87,20 +82,15 @@ class AsyncTlsConnection : public
   static const NodeNum UNKNOWN_NODE_ID = numeric_limits<NodeNum>::max();
 
  private:
-
   struct OutMessage {
-    char* data = nullptr;
+    char *data = nullptr;
     size_t length = 0;
 
-    OutMessage(char* msg, uint32_t msgLength) :
-        data{msg},
-        length{msgLength}
-    {
-    }
+    OutMessage(char *msg, uint32_t msgLength) : data{msg}, length{msgLength} {}
 
-    OutMessage& operator=(OutMessage&& other) {
+    OutMessage &operator=(OutMessage &&other) {
       if (this != &other) {
-        if(data) {
+        if (data) {
           delete[] data;
         }
         data = other.data;
@@ -111,15 +101,13 @@ class AsyncTlsConnection : public
       return *this;
     }
 
-    OutMessage(OutMessage&& other) : data{nullptr}, length{0} {
-      *this = std::move(other);
-    };
+    OutMessage(OutMessage &&other) : data{nullptr}, length{0} { *this = std::move(other); };
 
-    OutMessage& operator=(const OutMessage&) = delete;
-    OutMessage(const OutMessage& other) = delete;
+    OutMessage &operator=(const OutMessage &) = delete;
+    OutMessage(const OutMessage &other) = delete;
 
     ~OutMessage() {
-      if(data) {
+      if (data) {
         delete[] data;
       }
     }
@@ -168,8 +156,8 @@ class AsyncTlsConnection : public
   bool _disposed = false;
   bool _authenticated = false;
   bool _connected = false;
- public:
 
+ public:
  private:
   AsyncTlsConnection(asio::io_service *service,
                      function<void(NodeNum)> onError,
@@ -181,32 +169,29 @@ class AsyncTlsConnection : public
                      ConnType type,
                      NodeMap nodes,
                      string cipherSuite,
-                     UPDATE_CONNECTIVITY_FN statusCallback = nullptr) :
-      _service(service),
-      _maxMessageLength(bufferLength + MSG_HEADER_SIZE + 1),
-      _fOnError(onError),
-      _fOnTlsReady(onAuthenticated),
-      _expectedDestId(destId),
-      _bufferLength(bufferLength),
-      _selfId(selfId),
-      _connectTimer(*service),
-      _writeTimer(*service),
-      _readTimer(*service),
-      _connType(type),
-      _cipherSuite(cipherSuite),
-      _certificatesRootFolder(certificatesRootFolder),
-      _logger(Log::getLogger("concord-bft.tls")),
-      _statusCallback{statusCallback},
-      _nodes{std::move(nodes)},
-      _sslContext{asio::ssl::context(type == ConnType::Incoming
-                                     ? asio::ssl::context::tlsv12_server
-                                     : asio::ssl::context::tlsv12_client)},
-      _disposed(false),
-      _authenticated{false},
-      _connected{false} {
-    LOG_DEBUG(_logger, "ctor, node " << _selfId
-                                     << ", destId: " << _expectedDestId
-                                     << ", connType: " << _connType);
+                     UPDATE_CONNECTIVITY_FN statusCallback = nullptr)
+      : _service(service),
+        _maxMessageLength(bufferLength + MSG_HEADER_SIZE + 1),
+        _fOnError(onError),
+        _fOnTlsReady(onAuthenticated),
+        _expectedDestId(destId),
+        _bufferLength(bufferLength),
+        _selfId(selfId),
+        _connectTimer(*service),
+        _writeTimer(*service),
+        _readTimer(*service),
+        _connType(type),
+        _cipherSuite(cipherSuite),
+        _certificatesRootFolder(certificatesRootFolder),
+        _logger(Log::getLogger("concord-bft.tls")),
+        _statusCallback{statusCallback},
+        _nodes{std::move(nodes)},
+        _sslContext{asio::ssl::context(type == ConnType::Incoming ? asio::ssl::context::tlsv12_server
+                                                                  : asio::ssl::context::tlsv12_client)},
+        _disposed(false),
+        _authenticated{false},
+        _connected{false} {
+    LOG_DEBUG(_logger, "ctor, node " << _selfId << ", destId: " << _expectedDestId << ", connType: " << _connType);
 
     _inBuffer = new char[_bufferLength];
     _connectTimer.expires_at(boost::posix_time::pos_infin);
@@ -224,17 +209,11 @@ class AsyncTlsConnection : public
     _socket = B_TLS_SOCKET_PTR(new SSL_SOCKET(*_service, _sslContext));
   }
 
-  void set_disposed(bool value) {
-    _disposed = value;
-  }
+  void set_disposed(bool value) { _disposed = value; }
 
-  void set_connected(bool value) {
-    _connected = value;
-  }
+  void set_connected(bool value) { _connected = value; }
 
-  void set_authenticated(bool value) {
-    _authenticated = value;
-  }
+  void set_authenticated(bool value) { _authenticated = value; }
 
   bool check_replica(NodeNum node) {
     auto it = _nodes.find(node);
@@ -257,21 +236,15 @@ class AsyncTlsConnection : public
    * @param buffer Data received from the stream
    * @return Message length, 4 bytes long
    */
-  uint32_t get_message_length(const char *buffer) {
-    return *(reinterpret_cast<const uint32_t*>(buffer));
-  }
+  uint32_t get_message_length(const char *buffer) { return *(reinterpret_cast<const uint32_t *>(buffer)); }
 
   /// ****************** cleanup functions ******************** ///
 
   bool was_error(const B_ERROR_CODE &ec, string where) {
     if (ec) {
       LOG_ERROR(_logger,
-                "was_error, where: " << where
-                                     << ", node " << _selfId
-                                     << ", dest: " << _destId
-                                     << ", expectedDest: " << _expectedDestId
-                                     << ", connected: " << _connected
-                                     << ", ex: " << ec.message());
+                "was_error, where: " << where << ", node " << _selfId << ", dest: " << _destId << ", expectedDest: "
+                                     << _expectedDestId << ", connected: " << _connected << ", ex: " << ec.message());
     }
     return (ec != 0);
   }
@@ -281,17 +254,14 @@ class AsyncTlsConnection : public
    * we rely on boost cleanup and do not shutdown ssl and sockets explicitly
    */
   void dispose_connection(bool remove) {
-    if (_disposed)
-      return;
+    if (_disposed) return;
 
     set_authenticated(false);
     set_connected(false);
     set_disposed(true);
 
     LOG_DEBUG(_logger,
-              "dispose_connection, node " << _selfId
-                                          << ", dest: " << _expectedDestId
-                                          << ", connected: " << _connected
+              "dispose_connection, node " << _selfId << ", dest: " << _expectedDestId << ", connected: " << _connected
                                           << ", closed: " << _disposed);
 
     _connectTimer.cancel();
@@ -300,7 +270,7 @@ class AsyncTlsConnection : public
 
     // We use _expectedDestId here instead of _destId, because _destId may not
     // be set yet, if the connection failed before authentication completes.
-    if(remove) {
+    if (remove) {
       _fOnError(_expectedDestId);
     }
 
@@ -345,10 +315,7 @@ class AsyncTlsConnection : public
     // callback was binded using shared_from_this and the SSL context
     // will retain the callback and thus 'this' will not be destroyed
     // when needed
-    _sslContext.set_verify_callback([](bool p,
-                                       asio::ssl::verify_context&) {
-      return p;
-    });
+    _sslContext.set_verify_callback([](bool p, asio::ssl::verify_context &) { return p; });
     bool err = was_error(ec, "on_handshake_complete_outbound");
     if (err) {
       handle_error();
@@ -374,10 +341,7 @@ class AsyncTlsConnection : public
     // callback was binded using shared_from_this and the SSL context
     // will retain the callback and thus 'this' will not be destroyed
     // when needed
-    _sslContext.set_verify_callback([](bool p,
-                                       asio::ssl::verify_context&) {
-      return p;
-    });
+    _sslContext.set_verify_callback([](bool p, asio::ssl::verify_context &) { return p; });
     bool err = was_error(ec, "on_handshake_complete_inbound");
     if (err) {
       handle_error();
@@ -405,31 +369,18 @@ class AsyncTlsConnection : public
   }
 
   void set_tls_server() {
-    _sslContext.set_verify_mode(asio::ssl::verify_peer |
-        asio::ssl::verify_fail_if_no_peer_cert);
-    _sslContext.set_options(
-        boost::asio::ssl::context::default_workarounds
-            | boost::asio::ssl::context::no_sslv2
-            | boost::asio::ssl::context::no_sslv3
-            | boost::asio::ssl::context::no_tlsv1
-            | boost::asio::ssl::context::no_tlsv1_1
-            | boost::asio::ssl::context::single_dh_use);
+    _sslContext.set_verify_mode(asio::ssl::verify_peer | asio::ssl::verify_fail_if_no_peer_cert);
+    _sslContext.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 |
+                            boost::asio::ssl::context::no_sslv3 | boost::asio::ssl::context::no_tlsv1 |
+                            boost::asio::ssl::context::no_tlsv1_1 | boost::asio::ssl::context::single_dh_use);
 
     _sslContext.set_verify_callback(
-        boost::bind(&AsyncTlsConnection::verify_certificate_server,
-                    shared_from_this(),
-                    _1,
-                    _2));
+        boost::bind(&AsyncTlsConnection::verify_certificate_server, shared_from_this(), _1, _2));
 
     namespace fs = boost::filesystem;
-    auto path = fs::path(_certificatesRootFolder) /
-        fs::path(to_string(_selfId)) /
-        fs::path("server");
-    _sslContext.use_certificate_chain_file(
-        (path / fs::path("server.cert")).string());
-    _sslContext.use_private_key_file(
-        (path / fs::path("pk.pem")).string(),
-        boost::asio::ssl::context::pem);
+    auto path = fs::path(_certificatesRootFolder) / fs::path(to_string(_selfId)) / fs::path("server");
+    _sslContext.use_certificate_chain_file((path / fs::path("server.cert")).string());
+    _sslContext.use_private_key_file((path / fs::path("pk.pem")).string(), boost::asio::ssl::context::pem);
 
     // if we cant create EC DH params, it may mean that SSL version old or
     // any other crypto related errors, we can't continue with TLS
@@ -439,7 +390,7 @@ class AsyncTlsConnection : public
       abort();
     }
 
-    if (1 != SSL_CTX_set_tmp_ecdh (_sslContext.native_handle(), ecdh)) {
+    if (1 != SSL_CTX_set_tmp_ecdh(_sslContext.native_handle(), ecdh)) {
       LOG_ERROR(_logger, "Unable to set temp EC params");
       abort();
     }
@@ -454,26 +405,17 @@ class AsyncTlsConnection : public
     _sslContext.set_verify_mode(asio::ssl::verify_peer);
 
     namespace fs = boost::filesystem;
-    auto path = fs::path(_certificatesRootFolder) /
-        fs::path(to_string(_selfId)) /
-        "client";
-    auto serverPath = fs::path(_certificatesRootFolder) /
-        fs::path(to_string(_expectedDestId)) /
-        "server";
+    auto path = fs::path(_certificatesRootFolder) / fs::path(to_string(_selfId)) / "client";
+    auto serverPath = fs::path(_certificatesRootFolder) / fs::path(to_string(_expectedDestId)) / "server";
 
     _sslContext.set_verify_callback(
-        boost::bind(&AsyncTlsConnection::verify_certificate_client,
-                    shared_from_this(),
-                    _1,
-                    _2));
+        boost::bind(&AsyncTlsConnection::verify_certificate_client, shared_from_this(), _1, _2));
 
     _sslContext.use_certificate_chain_file((path / "client.cert").string());
-    _sslContext.use_private_key_file((path / "pk.pem").string(),
-                                     boost::asio::ssl::context::pem);
+    _sslContext.use_private_key_file((path / "pk.pem").string(), boost::asio::ssl::context::pem);
   }
 
-  bool verify_certificate_server(bool preverified,
-                                 boost::asio::ssl::verify_context &ctx) {
+  bool verify_certificate_server(bool preverified, boost::asio::ssl::verify_context &ctx) {
     char subject[512];
     X509 *cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
     if (!cert) {
@@ -481,19 +423,14 @@ class AsyncTlsConnection : public
       return false;
     } else {
       X509_NAME_oneline(X509_get_subject_name(cert), subject, 512);
-      LOG_DEBUG(_logger,
-                "Verifying client: " << subject << ", " << preverified);
-      bool res = check_certificate(cert, "client", string(subject),
-                                   UNKNOWN_NODE_ID);
-      LOG_DEBUG(_logger,
-                "Manual verifying client: " << subject
-                                            << ", authenticated: " << res);
+      LOG_DEBUG(_logger, "Verifying client: " << subject << ", " << preverified);
+      bool res = check_certificate(cert, "client", string(subject), UNKNOWN_NODE_ID);
+      LOG_DEBUG(_logger, "Manual verifying client: " << subject << ", authenticated: " << res);
       return res;
     }
   }
 
-  bool verify_certificate_client(bool preverified,
-                                 boost::asio::ssl::verify_context &ctx) {
+  bool verify_certificate_client(bool preverified, boost::asio::ssl::verify_context &ctx) {
     char subject[256];
     X509 *cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
     if (!cert) {
@@ -501,14 +438,10 @@ class AsyncTlsConnection : public
       return false;
     } else {
       X509_NAME_oneline(X509_get_subject_name(cert), subject, 256);
-      LOG_DEBUG(_logger,
-                "Verifying server: " << subject << ", " << preverified);
+      LOG_DEBUG(_logger, "Verifying server: " << subject << ", " << preverified);
 
-      bool res = check_certificate(
-          cert, "server", string(subject), _expectedDestId);
-      LOG_DEBUG(_logger,
-                "Manual verifying server: " << subject
-                                            << ", authenticated: " << res);
+      bool res = check_certificate(cert, "server", string(subject), _expectedDestId);
+      LOG_DEBUG(_logger, "Manual verifying server: " << subject << ", authenticated: " << res);
       return res;
     }
   }
@@ -521,10 +454,7 @@ class AsyncTlsConnection : public
    * and there is no check whether the remote peer id is equal to expected
    * peer id
    */
-  bool check_certificate(X509 *receivedCert,
-                         string connectionType,
-                         string subject,
-                         NodeNum expectedPeerId) {
+  bool check_certificate(X509 *receivedCert, string connectionType, string subject, NodeNum expectedPeerId) {
     // first, basic sanity test, just to eliminate disk read if the certificate
     // is unknown.
     // the certificate must have node id, as we put it in OU field on creation.
@@ -539,9 +469,7 @@ class AsyncTlsConnection : public
       return false;
     }
 
-    string remPeer =
-        sm.str().substr(
-            peerIdPrefixLength, sm.str().length() - peerIdPrefixLength);
+    string remPeer = sm.str().substr(peerIdPrefixLength, sm.str().length() - peerIdPrefixLength);
     if (0 == remPeer.length()) {
       LOG_ERROR(_logger, "OU empty " << subject);
       return false;
@@ -561,9 +489,7 @@ class AsyncTlsConnection : public
     // if server has been verified, check peers match
     if (UNKNOWN_NODE_ID != expectedPeerId) {
       if (remotePeerId != expectedPeerId) {
-        LOG_ERROR(_logger, "peers doesnt match, expected: " << expectedPeerId
-                                                            << ", received: "
-                                                            << remPeer);
+        LOG_ERROR(_logger, "peers doesnt match, expected: " << expectedPeerId << ", received: " << remPeer);
         return false;
       }
     }
@@ -571,9 +497,8 @@ class AsyncTlsConnection : public
     // the actual pinning - read the correct certificate from the disk and
     // compare it to the received one
     namespace fs = boost::filesystem;
-    auto path = fs::path(_certificatesRootFolder) / to_string(remotePeerId)
-        / connectionType
-        / string(connectionType + ".cert");
+    auto path =
+        fs::path(_certificatesRootFolder) / to_string(remotePeerId) / connectionType / string(connectionType + ".cert");
 
     FILE *fp = fopen(path.c_str(), "r");
     if (!fp) {
@@ -593,12 +518,11 @@ class AsyncTlsConnection : public
     if (res == 0) {
       if (_destId == AsyncTlsConnection::UNKNOWN_NODE_ID) {
         LOG_INFO(_logger,
-                 "connection authenticated, node: " << _selfId << ", type: " << _connType << ", expected peer: " << _expectedDestId
-                                                    << ", peer: "
-                                                    << remotePeerId);
+                 "connection authenticated, node: " << _selfId << ", type: " << _connType << ", expected peer: "
+                                                    << _expectedDestId << ", peer: " << remotePeerId);
       }
 
-      if(_destId == UNKNOWN_NODE_ID) {
+      if (_destId == UNKNOWN_NODE_ID) {
         _destId = remotePeerId;
       }
       _destIsReplica = check_replica(remotePeerId);
@@ -621,11 +545,7 @@ class AsyncTlsConnection : public
    * not ready and we don't want to try at the same rate introducing overhead
    * for Asio. This logic can be changed in future.
    */
-  void set_timeout() {
-    _currentTimeout = _currentTimeout == _maxTimeout
-                      ? _maxTimeout
-                      : _currentTimeout * 2;
-  }
+  void set_timeout() { _currentTimeout = _currentTimeout == _maxTimeout ? _maxTimeout : _currentTimeout * 2; }
 
   /**
    * This is timer tick handler, if we are here either the timer was
@@ -639,9 +559,8 @@ class AsyncTlsConnection : public
 
     // deadline reached, try to reconnect
     connect(_host, _port);
-    LOG_DEBUG(_logger, "connect_timer_tick, node " << _selfId
-                                                   << ", dest: " << _expectedDestId
-                                                   << ", ec: " << ec.message());
+    LOG_DEBUG(_logger,
+              "connect_timer_tick, node " << _selfId << ", dest: " << _expectedDestId << ", ec: " << ec.message());
   }
 
   /**
@@ -662,25 +581,18 @@ class AsyncTlsConnection : public
       get_socket().close();
       set_connected(false);
       set_timeout();
-      _connectTimer.expires_from_now(
-          boost::posix_time::millisec(_currentTimeout));
+      _connectTimer.expires_from_now(boost::posix_time::millisec(_currentTimeout));
       _connectTimer.async_wait(
-          boost::bind(&AsyncTlsConnection::connect_timer_tick,
-                      shared_from_this(),
-                      boost::asio::placeholders::error));
+          boost::bind(&AsyncTlsConnection::connect_timer_tick, shared_from_this(), boost::asio::placeholders::error));
     } else {
       set_connected(true);
       _connectTimer.cancel();
-      LOG_DEBUG(_logger, "connected, node " << _selfId
-                                            << ", dest: " << _expectedDestId
-                                            << ", res: " << res);
+      LOG_DEBUG(_logger, "connected, node " << _selfId << ", dest: " << _expectedDestId << ", res: " << res);
       set_no_delay();
       _socket->async_handshake(boost::asio::ssl::stream_base::client,
-                               boost::bind(
-                                   &AsyncTlsConnection::on_handshake_complete_outbound,
-                                   shared_from_this(),
-                                   boost::asio::placeholders::error));
-
+                               boost::bind(&AsyncTlsConnection::on_handshake_complete_outbound,
+                                           shared_from_this(),
+                                           boost::asio::placeholders::error));
     }
 
     LOG_TRACE(_logger, "exit, node " << _selfId << ", dest: " << _destId);
@@ -698,28 +610,25 @@ class AsyncTlsConnection : public
   /// 4. if timer ticks - the read hasnt completed, close the connection.
 
   void on_read_timer_expired(const B_ERROR_CODE &ec) {
-    if(_disposed) {
+    if (_disposed) {
       return;
     }
     // check if the handle is not a result of calling expire_at()
-    if(ec != boost::asio::error::operation_aborted) {
+    if (ec != boost::asio::error::operation_aborted) {
       dispose_connection(true);
     }
   }
 
   /**
-  * occurs when some of msg length bytes are read from the stream
-  * @param ec Error code
-  * @param bytesRead actual bytes read
-  */
-  void
-  read_msglength_completed(const B_ERROR_CODE &ec,
-                           const uint32_t bytesRead,
-                           bool first) {
+   * occurs when some of msg length bytes are read from the stream
+   * @param ec Error code
+   * @param bytesRead actual bytes read
+   */
+  void read_msglength_completed(const B_ERROR_CODE &ec, const uint32_t bytesRead, bool first) {
     // if first is true - we came from partial reading, no timer was started
-    if(!first) {
+    if (!first) {
       __attribute__((unused)) auto res = _readTimer.expires_at(boost::posix_time::pos_infin);
-      assert(res < 2); //can cancel at most 1 pending async_wait
+      assert(res < 2);  // can cancel at most 1 pending async_wait
     }
     if (_disposed) {
       return;
@@ -732,59 +641,51 @@ class AsyncTlsConnection : public
     }
 
     // if partial read of msg length bytes, continue
-    if(first && bytesRead < MSG_LENGTH_FIELD_SIZE) {
-      asio::async_read(
-          *_socket,
-          asio::buffer(_inBuffer + bytesRead, MSG_LENGTH_FIELD_SIZE - bytesRead),
-          boost::bind(&AsyncTlsConnection::read_msglength_completed,
-                      shared_from_this(),
-                      boost::asio::placeholders::error,
-                      boost::asio::placeholders::bytes_transferred,
-                      false));
-    } else { // start reading completely the whole message
+    if (first && bytesRead < MSG_LENGTH_FIELD_SIZE) {
+      asio::async_read(*_socket,
+                       asio::buffer(_inBuffer + bytesRead, MSG_LENGTH_FIELD_SIZE - bytesRead),
+                       boost::bind(&AsyncTlsConnection::read_msglength_completed,
+                                   shared_from_this(),
+                                   boost::asio::placeholders::error,
+                                   boost::asio::placeholders::bytes_transferred,
+                                   false));
+    } else {  // start reading completely the whole message
       uint32_t msgLength = get_message_length(_inBuffer);
-      if(msgLength == 0 || msgLength > _maxMessageLength - 1 - MSG_HEADER_SIZE){
+      if (msgLength == 0 || msgLength > _maxMessageLength - 1 - MSG_HEADER_SIZE) {
         handle_error();
         return;
       }
       read_msg_async(msgLength);
     }
 
-    __attribute__((unused)) auto res = _readTimer.expires_from_now(
-        boost::posix_time::milliseconds(READ_TIME_OUT_MILLI));
-    assert(res == 0); //can cancel at most 1 pending async_wait
+    __attribute__((unused)) auto res =
+        _readTimer.expires_from_now(boost::posix_time::milliseconds(READ_TIME_OUT_MILLI));
+    assert(res == 0);  // can cancel at most 1 pending async_wait
 
     _readTimer.async_wait(
-        boost::bind(&AsyncTlsConnection::on_read_timer_expired,
-                    shared_from_this(),
-                    boost::asio::placeholders::error));
+        boost::bind(&AsyncTlsConnection::on_read_timer_expired, shared_from_this(), boost::asio::placeholders::error));
 
-    LOG_DEBUG(_logger, "exit, node " << _selfId
-                                     << ", dest: " << _destId
-                                     << ", connected: " << _connected
-                                     << "is_open: " << get_socket().is_open());
+    LOG_DEBUG(_logger,
+              "exit, node " << _selfId << ", dest: " << _destId << ", connected: " << _connected
+                            << "is_open: " << get_socket().is_open());
   }
 
   /**
    * start reading message length bytes from the stream
    */
   void read_msg_length_async() {
-    if (_disposed)
-      return;
+    if (_disposed) return;
 
     // since we allow partial reading here, we dont need timeout
-    _socket->async_read_some(
-        asio::buffer(_inBuffer, MSG_LENGTH_FIELD_SIZE),
-        boost::bind(&AsyncTlsConnection::read_msglength_completed,
-                    shared_from_this(),
-                    boost::asio::placeholders::error,
-                    boost::asio::placeholders::bytes_transferred,
-                    true));
+    _socket->async_read_some(asio::buffer(_inBuffer, MSG_LENGTH_FIELD_SIZE),
+                             boost::bind(&AsyncTlsConnection::read_msglength_completed,
+                                         shared_from_this(),
+                                         boost::asio::placeholders::error,
+                                         boost::asio::placeholders::bytes_transferred,
+                                         true));
 
     LOG_DEBUG(_logger,
-              "read_msg_length_async, node " << _selfId
-                                             << ", dest: " << _destId
-                                             << ", connected: " << _connected
+              "read_msg_length_async, node " << _selfId << ", dest: " << _destId << ", connected: " << _connected
                                              << "is_open: " << get_socket().is_open());
   }
 
@@ -793,10 +694,9 @@ class AsyncTlsConnection : public
    * @param ec error code
    * @param bytesRead  actual bytes read
    */
-  void read_msg_async_completed(const boost::system::error_code &ec,
-                                size_t bytesRead) {
+  void read_msg_async_completed(const boost::system::error_code &ec, size_t bytesRead) {
     __attribute__((unused)) auto res = _readTimer.expires_at(boost::posix_time::pos_infin);
-    assert(res < 2); //can cancel at most 1 pending async_wait
+    assert(res < 2);  // can cancel at most 1 pending async_wait
     if (_disposed) {
       return;
     }
@@ -844,8 +744,7 @@ class AsyncTlsConnection : public
       return;
     }
 
-    LOG_DEBUG(_logger, "read_msg_async, node " << _selfId << ", dest: " <<
-                                               _destId);
+    LOG_DEBUG(_logger, "read_msg_async, node " << _selfId << ", dest: " << _destId);
 
     // async operation will finish when either expectedBytes are read
     // or error occured, this is what Asio guarantees
@@ -855,7 +754,6 @@ class AsyncTlsConnection : public
                            shared_from_this(),
                            boost::asio::placeholders::error,
                            boost::asio::placeholders::bytes_transferred));
-
   }
 
   /// ************* read functions end ******************* ////
@@ -871,9 +769,7 @@ class AsyncTlsConnection : public
   /// are in the out queue - if true, start another async_write with timer.
   /// 4. if timer ticks - the write hasn't completed, close the connection.
 
-  void put_message_header(char *data, uint32_t dataLength) {
-    memcpy(data, &dataLength, MSG_LENGTH_FIELD_SIZE);
-  }
+  void put_message_header(char *data, uint32_t dataLength) { memcpy(data, &dataLength, MSG_LENGTH_FIELD_SIZE); }
 
   /**
    * If the timer tick occurs - shut down the connection.
@@ -883,35 +779,30 @@ class AsyncTlsConnection : public
    * @param ec Error code
    */
   void on_write_timer_expired(const B_ERROR_CODE &ec) {
-    if(_disposed) {
+    if (_disposed) {
       return;
     }
     // check if we the handle is not a result of calling expire_at()
-    if(ec != boost::asio::error::operation_aborted) {
+    if (ec != boost::asio::error::operation_aborted) {
       dispose_connection(true);
     }
   }
 
   void start_async_write() {
-    asio::async_write(
-        *_socket,
-        asio::buffer(_outQueue.front().data, _outQueue.front().length),
-        boost::bind(
-            &AsyncTlsConnection::async_write_complete,
-            shared_from_this(),
-            boost::asio::placeholders::error,
-            boost::asio::placeholders::bytes_transferred));
+    asio::async_write(*_socket,
+                      asio::buffer(_outQueue.front().data, _outQueue.front().length),
+                      boost::bind(&AsyncTlsConnection::async_write_complete,
+                                  shared_from_this(),
+                                  boost::asio::placeholders::error,
+                                  boost::asio::placeholders::bytes_transferred));
 
     // start the timer to handle the write timeout
-    __attribute__((unused)) auto res = _writeTimer.expires_from_now(
-        boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
-    assert(res == 0); //should not cancel any pending async wait
-    _writeTimer.expires_from_now(
-        boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
+    __attribute__((unused)) auto res =
+        _writeTimer.expires_from_now(boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
+    assert(res == 0);  // should not cancel any pending async wait
+    _writeTimer.expires_from_now(boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
     _writeTimer.async_wait(
-        boost::bind(&AsyncTlsConnection::on_write_timer_expired,
-                    shared_from_this(),
-                    boost::asio::placeholders::error));
+        boost::bind(&AsyncTlsConnection::on_write_timer_expired, shared_from_this(), boost::asio::placeholders::error));
   }
 
   /**
@@ -919,24 +810,24 @@ class AsyncTlsConnection : public
    */
   void async_write_complete(const B_ERROR_CODE &ec, size_t bytesWritten) {
     __attribute__((unused)) auto res = _writeTimer.expires_at(boost::posix_time::pos_infin);
-    assert(res < 2); //can cancel at most 1 pending async_wait
+    assert(res < 2);  // can cancel at most 1 pending async_wait
     _writeTimer.expires_at(boost::posix_time::pos_infin);
-    if(_disposed) {
+    if (_disposed) {
       return;
     }
     bool err = was_error(ec, "async_write_complete");
-    if(err) {
+    if (err) {
       dispose_connection(true);
       return;
     }
 
     lock_guard<mutex> l(_writeLock);
-    //remove the message that has been sent
+    // remove the message that has been sent
     _outQueue.pop_front();
 
     // if there are more messages, continue to send but don' renmove, s.t.
     // the send() method will not trigger concurrent write
-    if(_outQueue.size() > 0) {
+    if (_outQueue.size() > 0) {
       start_async_write();
     }
   }
@@ -953,7 +844,7 @@ class AsyncTlsConnection : public
 
     //
     lock_guard<mutex> l(_writeLock);
-    if(_outQueue.size() > 0) {
+    if (_outQueue.size() > 0) {
       start_async_write();
     }
   }
@@ -961,9 +852,7 @@ class AsyncTlsConnection : public
   /// ************* write functions end ******************* ////
 
  public:
-  SSL_SOCKET::lowest_layer_type &get_socket() {
-    return _socket->lowest_layer();
-  }
+  SSL_SOCKET::lowest_layer_type &get_socket() { return _socket->lowest_layer(); }
 
   /**
    * start connection to the remote peer (Outgoing connection)
@@ -988,11 +877,9 @@ class AsyncTlsConnection : public
 
       LOG_INFO(_logger, "Resolved " << host << ":" << port << " to " << ep);
 
-      get_socket().
-        async_connect(ep,
-                      boost::bind(&AsyncTlsConnection::connect_completed,
-                                  shared_from_this(),
-                                  boost::asio::placeholders::error));
+      get_socket().async_connect(
+          ep,
+          boost::bind(&AsyncTlsConnection::connect_completed, shared_from_this(), boost::asio::placeholders::error));
     } else {
       LOG_INFO(_logger, "Unable to resolve " << host << ":" << port);
       if (!ec) {
@@ -1002,19 +889,17 @@ class AsyncTlsConnection : public
       connect_completed(ec);
     }
 
-    LOG_TRACE(_logger, "exit, from: " << _selfId
-                                      << ", ec: " << ec
-                                      << ", to: " << _expectedDestId
-                                      << ", host: " << host
-                                      << ", port: " << port);
+    LOG_TRACE(_logger,
+              "exit, from: " << _selfId << ", ec: " << ec << ", to: " << _expectedDestId << ", host: " << host
+                             << ", port: " << port);
   }
 
   void start() {
     set_no_delay();
-    _socket->async_handshake(boost::asio::ssl::stream_base::server,
-                             boost::bind(&AsyncTlsConnection::on_handshake_complete_inbound,
-                                         shared_from_this(),
-                                         boost::asio::placeholders::error));
+    _socket->async_handshake(
+        boost::asio::ssl::stream_base::server,
+        boost::bind(
+            &AsyncTlsConnection::on_handshake_complete_inbound, shared_from_this(), boost::asio::placeholders::error));
   }
 
   /**
@@ -1045,14 +930,11 @@ class AsyncTlsConnection : public
     // - we can start one
     // we must post to asio service because async operations should be
     // started from asio threads and not during pending async read
-    if(_outQueue.size() == 1) {
-      _service->post(boost::bind(&AsyncTlsConnection::do_write,
-                                 shared_from_this()));
+    if (_outQueue.size() == 1) {
+      _service->post(boost::bind(&AsyncTlsConnection::do_write, shared_from_this()));
     }
 
-    LOG_DEBUG(_logger, "from: " << _selfId
-                                << ", to: " << _destId
-                                << ", length: " << length);
+    LOG_DEBUG(_logger, "from: " << _selfId << ", to: " << _destId << ", length: " << length);
 
     if (_statusCallback && _isReplica) {
       PeerConnectivityStatus pcs{};
@@ -1065,9 +947,7 @@ class AsyncTlsConnection : public
     }
   }
 
-  void setReceiver(NodeNum nodeId, IReceiver *rec) {
-    _receiver = rec;
-  }
+  void setReceiver(NodeNum nodeId, IReceiver *rec) { _receiver = rec; }
 
   static ASYNC_CONN_PTR create(asio::io_service *service,
                                function<void(NodeNum)> onError,
@@ -1080,34 +960,28 @@ class AsyncTlsConnection : public
                                UPDATE_CONNECTIVITY_FN statusCallback,
                                NodeMap nodes,
                                string cipherSuite) {
-    auto res = ASYNC_CONN_PTR(
-        new AsyncTlsConnection(service,
-                               onError,
-                               onReady,
-                               bufferLength,
-                               destId,
-                               selfId,
-                               certificatesRootFolder,
-                               type,
-                               nodes,
-                               cipherSuite,
-                               statusCallback));
+    auto res = ASYNC_CONN_PTR(new AsyncTlsConnection(service,
+                                                     onError,
+                                                     onReady,
+                                                     bufferLength,
+                                                     destId,
+                                                     selfId,
+                                                     certificatesRootFolder,
+                                                     type,
+                                                     nodes,
+                                                     cipherSuite,
+                                                     statusCallback));
     res->init();
     return res;
   }
 
   virtual ~AsyncTlsConnection() {
-    LOG_DEBUG(_logger, "Dtor called, node: " << _selfId << "peer: " << _destId << ", type: " <<
-                                            _connType);
+    LOG_DEBUG(_logger, "Dtor called, node: " << _selfId << "peer: " << _destId << ", type: " << _connType);
 
     delete[] _inBuffer;
-
-
   }
 
-  void dispose() {
-    dispose_connection(false);
-  }
+  void dispose() { dispose_connection(false); }
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -1120,8 +994,7 @@ class AsyncTlsConnection : public
  *  from the replicas. In this way we assure that clients will not connect to
  *  each other.
  */
-class TlsTCPCommunication::TlsTcpImpl :
-    public std::enable_shared_from_this<TlsTcpImpl> {
+class TlsTCPCommunication::TlsTcpImpl : public std::enable_shared_from_this<TlsTcpImpl> {
  private:
   unordered_map<NodeNum, ASYNC_CONN_PTR> _connections;
 
@@ -1162,11 +1035,9 @@ class TlsTCPCommunication::TlsTcpImpl :
     // here we check in the nodes map for the peer info and connect again, if
     // needed.
     auto iter = _nodes.find(peerId);
-    if(iter != _nodes.end()) {
+    if (iter != _nodes.end()) {
       if (iter->first < _selfId && iter->first <= _maxServerId) {
-        create_outgoing_connection(peerId,
-                                   iter->second.host,
-                                   iter->second.port);
+        create_outgoing_connection(peerId, iter->second.host, iter->second.port);
       }
     } else {
       LOG_ERROR(_logger, "Unknown peer, id: " << peerId);
@@ -1187,8 +1058,10 @@ class TlsTCPCommunication::TlsTcpImpl :
     // probably bad replica?? TODO: think how to handle it in a better way
     // for now, just throw away both existing and a new one
     if (_connections.find(id) != _connections.end()) {
-      LOG_ERROR(_logger, "new incoming connection with peer id that already "
-                         "exists, destroying both, peer: " << id);
+      LOG_ERROR(_logger,
+                "new incoming connection with peer id that already "
+                "exists, destroying both, peer: "
+                    << id);
       _connections.erase(id);
       return;
     }
@@ -1197,10 +1070,8 @@ class TlsTCPCommunication::TlsTcpImpl :
     _connections.insert(make_pair(id, conn));
   }
 
-  void on_accept(ASYNC_CONN_PTR conn,
-                 const B_ERROR_CODE &ec) {
-    LOG_DEBUG(_logger, "on_accept, enter, node: " + to_string(_selfId) +
-        ", ec: " + ec.message());
+  void on_accept(ASYNC_CONN_PTR conn, const B_ERROR_CODE &ec) {
+    LOG_DEBUG(_logger, "on_accept, enter, node: " + to_string(_selfId) + ", ec: " + ec.message());
 
     if (!ec) {
       conn->start();
@@ -1210,7 +1081,7 @@ class TlsTCPCommunication::TlsTcpImpl :
     // io_service dtor runs they will be invoked with operation_aborted error.
     // In this case we dont want to listen again and we rely on the
     // shared_from_this for the cleanup.
-    if(ec != asio::error::operation_aborted) {
+    if (ec != asio::error::operation_aborted) {
       start_accept();
     }
   }
@@ -1219,32 +1090,22 @@ class TlsTCPCommunication::TlsTcpImpl :
   // deleted.
   void start_accept() {
     LOG_DEBUG(_logger, "start_accept, node: " << _selfId);
-    auto conn =
-        AsyncTlsConnection::create(
-            &_service,
-            std::bind(
-                &TlsTcpImpl::on_async_connection_error,
-                shared_from_this(),
-                std::placeholders::_1),
-            std::bind(
-                &TlsTcpImpl::on_connection_authenticated,
-                shared_from_this(),
-                std::placeholders::_1,
-                std::placeholders::_2),
-            _bufferLength,
-            AsyncTlsConnection::UNKNOWN_NODE_ID,
-            _selfId,
-            _certRootFolder,
-            ConnType::Incoming,
-            _statusCallback,
-            _nodes,
-            _cipherSuite);
-    _pAcceptor->async_accept(conn->get_socket().lowest_layer(),
-                             boost::bind(
-                                 &TlsTcpImpl::on_accept,
-                                 shared_from_this(),
-                                 conn,
-                                 boost::asio::placeholders::error));
+    auto conn = AsyncTlsConnection::create(
+        &_service,
+        std::bind(&TlsTcpImpl::on_async_connection_error, shared_from_this(), std::placeholders::_1),
+        std::bind(
+            &TlsTcpImpl::on_connection_authenticated, shared_from_this(), std::placeholders::_1, std::placeholders::_2),
+        _bufferLength,
+        AsyncTlsConnection::UNKNOWN_NODE_ID,
+        _selfId,
+        _certRootFolder,
+        ConnType::Incoming,
+        _statusCallback,
+        _nodes,
+        _cipherSuite);
+    _pAcceptor->async_accept(
+        conn->get_socket().lowest_layer(),
+        boost::bind(&TlsTcpImpl::on_accept, shared_from_this(), conn, boost::asio::placeholders::error));
   }
 
   TlsTcpImpl(const TlsTcpImpl &) = delete;
@@ -1260,43 +1121,37 @@ class TlsTCPCommunication::TlsTcpImpl :
              string listenHost,
              string certRootFolder,
              string cipherSuite,
-             UPDATE_CONNECTIVITY_FN statusCallback = nullptr) :
-      _selfId(selfNodeNum),
-      _listenPort(listenPort),
-      _listenHost(listenHost),
-      _bufferLength(bufferLength),
-      _maxServerId(maxServerId),
-      _certRootFolder(certRootFolder),
-      _logger(Log::getLogger("concord.tls")),
-      _statusCallback{statusCallback},
-      _cipherSuite{cipherSuite} {
+             UPDATE_CONNECTIVITY_FN statusCallback = nullptr)
+      : _selfId(selfNodeNum),
+        _listenPort(listenPort),
+        _listenHost(listenHost),
+        _bufferLength(bufferLength),
+        _maxServerId(maxServerId),
+        _certRootFolder(certRootFolder),
+        _logger(Log::getLogger("concord.tls")),
+        _statusCallback{statusCallback},
+        _cipherSuite{cipherSuite} {
     //_service = new io_service();
     for (auto it = nodes.begin(); it != nodes.end(); it++) {
       _nodes.insert({it->first, it->second});
     }
   }
 
-  void create_outgoing_connection(
-      NodeNum nodeId, string peerHost, uint16_t peerPort) {
-    auto conn =
-        AsyncTlsConnection::create(
-            &_service,
-            std::bind(&TlsTcpImpl::on_async_connection_error,
-                      shared_from_this(),
-                      std::placeholders::_1),
+  void create_outgoing_connection(NodeNum nodeId, string peerHost, uint16_t peerPort) {
+    auto conn = AsyncTlsConnection::create(
+        &_service,
+        std::bind(&TlsTcpImpl::on_async_connection_error, shared_from_this(), std::placeholders::_1),
 
-            std::bind(&TlsTcpImpl::on_connection_authenticated,
-                      shared_from_this(),
-                      std::placeholders::_1,
-                      std::placeholders::_2),
-            _bufferLength,
-            nodeId,
-            _selfId,
-            _certRootFolder,
-            ConnType::Outgoing,
-            _statusCallback,
-            _nodes,
-            _cipherSuite);
+        std::bind(
+            &TlsTcpImpl::on_connection_authenticated, shared_from_this(), std::placeholders::_1, std::placeholders::_2),
+        _bufferLength,
+        nodeId,
+        _selfId,
+        _certRootFolder,
+        ConnType::Outgoing,
+        _statusCallback,
+        _nodes,
+        _cipherSuite);
 
     conn->connect(peerHost, peerPort);
     LOG_INFO(_logger, "connect called for node " << _selfId << ", dest: " << nodeId);
@@ -1304,28 +1159,26 @@ class TlsTCPCommunication::TlsTcpImpl :
 
  public:
   static std::shared_ptr<TlsTcpImpl> create(NodeNum selfNodeId,
-                            NodeMap nodes,
-                            uint32_t bufferLength,
-                            uint16_t listenPort,
-                            uint32_t tempHighestNodeForConnecting,
-                            string listenHost,
-                            string certRootFolder,
-                            string cipherSuite,
-                            UPDATE_CONNECTIVITY_FN statusCallback) {
+                                            NodeMap nodes,
+                                            uint32_t bufferLength,
+                                            uint16_t listenPort,
+                                            uint32_t tempHighestNodeForConnecting,
+                                            string listenHost,
+                                            string certRootFolder,
+                                            string cipherSuite,
+                                            UPDATE_CONNECTIVITY_FN statusCallback) {
     return std::shared_ptr<TlsTcpImpl>(new TlsTcpImpl(selfNodeId,
-                          nodes,
-                          bufferLength,
-                          listenPort,
-                          tempHighestNodeForConnecting,
-                          listenHost,
-                          certRootFolder,
-                          cipherSuite,
-                          statusCallback));
+                                                      nodes,
+                                                      bufferLength,
+                                                      listenPort,
+                                                      tempHighestNodeForConnecting,
+                                                      listenHost,
+                                                      certRootFolder,
+                                                      cipherSuite,
+                                                      statusCallback));
   }
 
-  int getMaxMessageSize() {
-    return _bufferLength;
-  }
+  int getMaxMessageSize() { return _bufferLength; }
 
   /**
    * logics moved from the ctor to this method to allow shared_from_this
@@ -1335,7 +1188,7 @@ class TlsTCPCommunication::TlsTcpImpl :
     lock_guard<mutex> l(_startStopGuard);
 
     if (_pIoThread) {
-      return 0; // running
+      return 0;  // running
     }
 
     // all replicas are in listen mode
@@ -1356,10 +1209,10 @@ class TlsTCPCommunication::TlsTcpImpl :
       } else {
         LOG_WARN(_logger, "Unable to resolve listen host (" << _listenHost << ") for node " << _selfId << ": " << ec);
         // This node is dead in the water if it can't resolve its own listen host/ip.
-        return -1; // failed
+        return -1;  // failed
       }
-    } else // clients don't listen
-    LOG_DEBUG(_logger, "skipping listen for node: " << _selfId);
+    } else  // clients don't listen
+      LOG_DEBUG(_logger, "skipping listen for node: " << _selfId);
 
     // this node should connect only to nodes with lower ID
     // and all nodes with higher ID will connect to this node
@@ -1381,33 +1234,30 @@ class TlsTCPCommunication::TlsTcpImpl :
       }
     }
 
-    _pIoThread =
-        new std::thread(std::bind
-                            (static_cast<size_t(boost::asio::io_service::*)()>
-                             (&boost::asio::io_service::run),
-                             std::ref(_service)));
+    _pIoThread = new std::thread(std::bind(
+        static_cast<size_t (boost::asio::io_service::*)()>(&boost::asio::io_service::run), std::ref(_service)));
 
     return 0;
   }
 
   /**
-  * Stops the object (including its internal threads).
-  * On success, returns 0.
-  */
+   * Stops the object (including its internal threads).
+   * On success, returns 0.
+   */
   int Stop() {
     lock_guard<mutex> l(_startStopGuard);
 
     if (!_pIoThread) {
-      return 0; // stopped
+      return 0;  // stopped
     }
 
     _service.stop();
-    if(_pIoThread->joinable()) {
+    if (_pIoThread->joinable()) {
       _pIoThread->join();
     }
     _pIoThread = nullptr;
 
-    if(_pAcceptor) {
+    if (_pAcceptor) {
       _pAcceptor->close();
     }
 
@@ -1423,16 +1273,14 @@ class TlsTCPCommunication::TlsTcpImpl :
     lock_guard<mutex> l(_startStopGuard);
 
     if (!_pIoThread) {
-      return false; // stopped
+      return false;  // stopped
     }
 
     return true;
   }
 
-  ConnectionStatus
-  getCurrentConnectionStatus(const NodeNum node) const {
-    return isRunning() ? ConnectionStatus::Connected :
-           ConnectionStatus::Disconnected;
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const {
+    return isRunning() ? ConnectionStatus::Connected : ConnectionStatus::Disconnected;
   }
 
   void setReceiver(NodeNum nodeId, IReceiver *rec) {
@@ -1443,21 +1291,17 @@ class TlsTCPCommunication::TlsTcpImpl :
   }
 
   /**
-  * Sends a message on the underlying communication layer to a given
-  * destination node. Asynchronous (non-blocking) method.
-  * Returns 0 on success.
-  */
-  int sendAsyncMessage(const NodeNum destNode,
-                       const char *const message,
-                       const size_t messageLength) {
+   * Sends a message on the underlying communication layer to a given
+   * destination node. Asynchronous (non-blocking) method.
+   * Returns 0 on success.
+   */
+  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) {
     lock_guard<mutex> lock(_connectionsGuard);
     auto temp = _connections.find(destNode);
     if (temp != _connections.end()) {
       temp->second->send(message, messageLength);
     } else {
-      LOG_DEBUG(_logger,
-                "connection NOT found, from: " << _selfId
-                                               << ", to: " << destNode);
+      LOG_DEBUG(_logger, "connection NOT found, from: " << _selfId << ", to: " << destNode);
     }
 
     return 0;
@@ -1469,9 +1313,7 @@ class TlsTCPCommunication::TlsTcpImpl :
   }
 };
 
-TlsTCPCommunication::~TlsTCPCommunication() {
-
-}
+TlsTCPCommunication::~TlsTCPCommunication() {}
 
 TlsTCPCommunication::TlsTCPCommunication(const TlsTcpConfig &config) {
   _ptrImpl = TlsTcpImpl::create(config.selfId,
@@ -1485,44 +1327,32 @@ TlsTCPCommunication::TlsTCPCommunication(const TlsTcpConfig &config) {
                                 config.statusCallback);
 }
 
-TlsTCPCommunication *TlsTCPCommunication::create(const TlsTcpConfig &config) {
-  return new TlsTCPCommunication(config);
-}
+TlsTCPCommunication *TlsTCPCommunication::create(const TlsTcpConfig &config) { return new TlsTCPCommunication(config); }
 
-int TlsTCPCommunication::getMaxMessageSize() {
-  return _ptrImpl->getMaxMessageSize();
-}
+int TlsTCPCommunication::getMaxMessageSize() { return _ptrImpl->getMaxMessageSize(); }
 
-int TlsTCPCommunication::Start() {
-  return _ptrImpl->Start();
-}
+int TlsTCPCommunication::Start() { return _ptrImpl->Start(); }
 
 int TlsTCPCommunication::Stop() {
-  if (!_ptrImpl)
-    return 0;
+  if (!_ptrImpl) return 0;
 
   auto res = _ptrImpl->Stop();
   return res;
 }
 
-bool TlsTCPCommunication::isRunning() const {
-  return _ptrImpl->isRunning();
-}
+bool TlsTCPCommunication::isRunning() const { return _ptrImpl->isRunning(); }
 
-ConnectionStatus
-TlsTCPCommunication::getCurrentConnectionStatus(const NodeNum node) const {
+ConnectionStatus TlsTCPCommunication::getCurrentConnectionStatus(const NodeNum node) const {
   return _ptrImpl->getCurrentConnectionStatus(node);
 }
 
-int
-TlsTCPCommunication::sendAsyncMessage(const NodeNum destNode,
-                                      const char *const message,
-                                      const size_t messageLength) {
+int TlsTCPCommunication::sendAsyncMessage(const NodeNum destNode,
+                                          const char *const message,
+                                          const size_t messageLength) {
   return _ptrImpl->sendAsyncMessage(destNode, message, messageLength);
 }
 
-void
-TlsTCPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
+void TlsTCPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
   _ptrImpl->setReceiver(receiverNum, receiver);
 }
-} // namespace bftEngine
+}  // namespace bftEngine


### PR DESCRIPTION
The main point of this PR is the first commit, bb0343a, which allows a hostname, instead of an IP, to be passed in the communication config for the TCP and TLS modules. This was not added to the UDP module, because it would have required quite a bit more change there. From the commit message:

    If a hostname is used for local principals, that hostname must be
    resolvable at startup time. If it is not, the node will fail to start,
    after throwing an exception while trying to set up its listening
    sockets.
    
    If a hostname for any remote principal is not resolvable at startup
    time, it is treated as any other connection failure and retried later.

The second commit, e85e3d1, is just running clang-format over the communication code.