### PR TITLE
Get rid of unused class data member as it gets messed with function parameters with the same name

### DIFF
--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.h
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.h
@@ -168,10 +168,9 @@ class ReplicaImp : public SimpleKVBC::IReplica,
    private:
     concordlogger::Logger logger;
     const ReplicaImp *rep;
-    concord::storage::blockchain::BlockId readVersion;
     concord::storage::KeyValuePair m_current;
     concord::storage::blockchain::BlockId m_currentBlock;
-    bool m_isEnd;
+    bool m_isEnd = false;
     concord::storage::IDBClient::IDBClientIterator *m_iter;
 
    public:
@@ -180,8 +179,6 @@ class ReplicaImp : public SimpleKVBC::IReplica,
       // allocated by calls to rep::...::getIterator
       delete m_iter;
     }
-
-    virtual void setReadVersion(concord::storage::blockchain::BlockId _readVersion) { readVersion = _readVersion; }
 
     virtual concord::storage::KeyValuePair first(concord::storage::blockchain::BlockId readVersion,
                                                  concord::storage::blockchain::BlockId &actualVersion,


### PR DESCRIPTION
readVersion function parameter and readVersion data member of the class StorageIterator get messed. Removing a data member as unused.