### PR TITLE
Write State Transfer blocks and their keys atomically

### DIFF
--- a/bftengine/src/bftengine/SimpleClient.cpp
+++ b/bftengine/src/bftengine/SimpleClient.cpp
@@ -400,16 +400,16 @@ namespace bftEngine
 
 			const bool sendToAll = pendingRequest->isReadOnly() || !_primaryReplicaIsKnown || 
 				                   (numberOfTransmissions == clientSendsRequestToAllReplicasFirstThresh) ||
-								   (numberOfTransmissions > clientSendsRequestToAllReplicasFirstThresh && (numberOfTransmissions % clientSendsRequestToAllReplicasPeriodThresh == 0)) ||
+								   (numberOfTransmissions > clientSendsRequestToAllReplicasFirstThresh &&
+								   (numberOfTransmissions % clientSendsRequestToAllReplicasPeriodThresh == 0)) ||
 								   resetReplies;
 
-			LOG_DEBUG_F(GL,"Client %d - sends request %" PRIu64 " "
-														   "(isRO=%d, "
-												   "request "
-                                          "size=%zu, "
-				" retransmissionMilli=%d, numberOfTransmissions=%d, resetReplies=%d, sendToAll=%d)",
-				_clientId, pendingRequest->requestSeqNum(), (int)pendingRequest->isReadOnly(), (size_t)pendingRequest->size(),
-				(int)limitOfExpectedOperationTime.upperLimit(), (int)numberOfTransmissions, (int)resetReplies, (int)sendToAll);
+			if (numberOfTransmissions && !(numberOfTransmissions % 10))
+			  LOG_DEBUG_F(GL,"Client %d - sends request %" PRIu64 " isRO=%d, request size=%zu, "
+				          "retransmissionMilli=%d, numberOfTransmissions=%d, resetReplies=%d, sendToAll=%d",
+				          _clientId, pendingRequest->requestSeqNum(), (int)pendingRequest->isReadOnly(),
+				          (size_t)pendingRequest->size(), (int)limitOfExpectedOperationTime.upperLimit(),
+				          (int)numberOfTransmissions, (int)resetReplies, (int)sendToAll);
 
 
 			if (resetReplies)

--- a/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
+++ b/bftengine/tests/simpleKVBC/src/ReplicaImp.cpp
@@ -316,36 +316,21 @@ void ReplicaImp::insertBlockInternal(BlockId blockId, Sliver block) {
       return;
     }
   } else {
+    SetOfKeyValuePairs keys;
     if (block.length() > 0) {
       uint16_t numOfElements = ((BlockHeader *)block.data())->numberOfElements;
       auto *entries = (BlockEntry *)(block.data() + sizeof(BlockHeader));
       for (size_t i = 0; i < numOfElements; i++) {
         const Sliver keySliver(block, entries[i].keyOffset, entries[i].keySize);
         const Sliver valSliver(block, entries[i].valOffset, entries[i].valSize);
-
-        const KeyIDPair pk(keySliver, blockId);
-
-        s = m_bcDbAdapter->updateKey(pk.key, pk.blockId, valSliver);
-        if (!s.isOK()) {
-          // TODO(SG): What to do?
-          LOG_FATAL(logger, "Failed to update key");
-          exit(1);
-        }
+        keys.insert(KeyValuePair(keySliver, valSliver));
       }
-
-      s = m_bcDbAdapter->addBlock(blockId, block);
-      if (!s.isOK()) {
-        // TODO(SG): What to do?
-        printf("Failed to add block");
-        exit(1);
-      }
-    } else {
-      s = m_bcDbAdapter->addBlock(blockId, block);
-      if (!s.isOK()) {
-        // TODO(SG): What to do?
-        printf("Failed to add block");
-        exit(1);
-      }
+    }
+    s = m_bcDbAdapter->addBlockAndUpdateMultiKey(keys, blockId, block);
+    if (!s.isOK()) {
+      // TODO(SG): What to do?
+      printf("Failed to add block");
+      exit(1);
     }
   }
 }
@@ -689,6 +674,7 @@ bool ReplicaImp::BlockchainAppState::getPrevDigestFromBlock(uint64_t blockId, St
 
 /*
  * This method cant return false by current insertBlockInternal impl.
+ * It is used only by State Transfer to synchronize state between replicas.
  */
 bool ReplicaImp::BlockchainAppState::putBlock(uint64_t blockId, char *block, uint32_t blockSize) {
   uint8_t *tmpBlockPtr = new uint8_t[blockSize];


### PR DESCRIPTION
State Transfer blocks should be written together with their keys using one RocksDB transaction like it is done for regular blocks.

Closes VB-1831