### PR TITLE
State Transfer bugs fixes cont’d:

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -568,6 +568,8 @@ bool BCStateTran::loadReservedPage(uint32_t reservedPageId,
     psd_->getPendingResPage(reservedPageId, outReservedPage, copyLength);
   } else {
     uint64_t lastCheckpoint = psd_->getLastStoredCheckpoint();
+    if (lastCheckpoint == 0) // case when the system is restarted before reaching the first checkpoint
+      return false;
     uint64_t t = UINT64_MAX;
     metrics_.load_reserved_page_from_checkpoint_.Get().Inc();
     psd_->getResPage(reservedPageId, lastCheckpoint,

--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -57,7 +57,10 @@ void DBDataStore::load() {
     deserializeCheckpoint(iss, cpd);
     inmem_->setCheckpointBeingFetched(cpd);
   }
-  loadResPages();
+  
+  if(inmem_->getLastStoredCheckpoint() > 0)
+    loadResPages();
+    
   loadPendingPages();
 
   LOG_DEBUG(logger(), "MyReplicaId: "               << inmem_->getMyReplicaId());

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -82,8 +82,9 @@ namespace bftEngine
 			for (std::pair<NodeIdType, uint16_t> e : clientIdToIndex_)
 			{
 				const uint32_t firstPageId = e.second * reservedPagesPerClient_;
-
-				stateTransfer_->loadReservedPage(firstPageId, sizeOfReservedPage_, scratchPage_);
+				// to deal with a situation when restarting before state transfer first checkpoint reached
+				if (!stateTransfer_->loadReservedPage(firstPageId, sizeOfReservedPage_, scratchPage_))
+				  continue;
 
 				ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_;
 				Assert(replyHeader->msgType == 0 || replyHeader->msgType == MsgCode::Reply);
@@ -134,7 +135,7 @@ namespace bftEngine
 
 			ClientInfo& c = indexToClientInfo_.at(clientIdx);
 
-			Assert(c.lastSeqNumberOfReply < requestSeqNum);
+			Assert(c.lastSeqNumberOfReply <= requestSeqNum);
 
 			c.lastSeqNumberOfReply = requestSeqNum;
 			c.latestReplyTime = getMonotonicTime();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1384,12 +1384,6 @@ void ReplicaImp::onMessage(CheckpointMsg *msg) {
   if (askForStateTransfer) {
     LOG_INFO_F(GL, "call to startCollectingState()");
 
-    if (ps_) {
-      ps_->beginWriteTran();
-      ps_->setFetchingState(true);
-      ps_->endWriteTran();
-    }
-
     stateTransfer->startCollectingState();
   } else if (msgSeqNum > lastStableSeqNum + kWorkWindowSize) {
     onReportAboutAdvancedReplica(msgSenderId, msgSeqNum);
@@ -2202,9 +2196,8 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
 
   if (ps_) {
     ps_->beginWriteTran();
-    ps_->setFetchingState(false);
   }
-
+    
   if (newStateCheckpoint <= lastExecutedSeqNum) {
     LOG_DEBUG_F(GL,
                "Executing onTransferringCompleteImp(newStateCheckpoint) where newStateCheckpoint <= lastExecutedSeqNum");
@@ -2278,12 +2271,6 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
 
   if (askAnotherStateTransfer) {
     LOG_INFO_F(GL, "call to startCollectingState()");
-
-    if (ps_) {
-      ps_->beginWriteTran();
-      ps_->setFetchingState(true);
-      ps_->endWriteTran();
-    }
 
     stateTransfer->startCollectingState();
   }

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -337,7 +337,7 @@ ReplicaLoader::ErrorCode loadReplicaData(shared_ptr<PersistentStorage> p, Loaded
       Verify(d.executedSeqNum > ld.lastStableSeqNum, InconsistentErr);
       Verify(d.executedSeqNum <= ld.lastStableSeqNum + kWorkWindowSize, InconsistentErr);
 
-      uint64_t idx = d.executedSeqNum - ld.lastStableSeqNum;
+      uint64_t idx = d.executedSeqNum - ld.lastStableSeqNum - 1;
       Assert(idx < kWorkWindowSize);
 
       const SeqNumData &e = ld.seqNumWinArr[idx];

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,8 @@ add_test(NAME skvbc_tests COMMAND python3 -m unittest
     test_skvbc_linearizability
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-#if (BUILD_ROCKSDB_STORAGE)
-#  add_test(NAME skvbc_persistence_tests COMMAND python3 -m unittest
-#      test_skvbc_persistence
-#      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-#endif()
+if (BUILD_ROCKSDB_STORAGE)
+  add_test(NAME skvbc_persistence_tests COMMAND python3 -m unittest
+      test_skvbc_persistence
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()


### PR DESCRIPTION
1. Restarting replica during state transfer in process
   - Before first state transfer checkpoint reached - don't load reserved pages
   - loadReplicaData() - fix index in seqNumWinArray

2. ClientsManager::allocateNewReplyMsgAndWriteToStorage()
   - allow equality in assert in favour of crash recovery

3. ReplicaImpl
  -  not to use setFetchingState() as no one eventually reads this value as it’s set in state transfer functionality.

4. Re-enable skvbc_persistence_tests