### PR TITLE
Split source selection from BC ST into own class

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -54,6 +54,7 @@ set(corebft_source_files
     src/bcstatetransfer/InMemoryDataStore.cpp
     src/bcstatetransfer/STDigest.cpp
     src/bcstatetransfer/DBDataStore.cpp
+    src/bcstatetransfer/SourceSelector.cpp
     src/simplestatetransfer/SimpleStateTran.cpp
 )
 #

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -30,6 +30,7 @@
 #include "Messages.hpp"
 #include "STDigest.hpp"
 #include "Metrics.hpp"
+#include "SourceSelector.hpp"
 
 using std::set;
 using std::map;
@@ -119,8 +120,6 @@ class BCStateTran : public IStateTransfer {
   const uint32_t refreshTimerMilli_;
   const uint32_t checkpointSummariesRetransmissionTimeoutMilli_;
   const uint32_t maxAcceptableMsgDelayMilli_;
-  const uint32_t sourceReplicaReplacementTimeoutMilli_;
-  const uint32_t fetchRetransmissionTimeoutMilli_;
 
   const uint32_t maxVBlockSize_;
   const uint32_t maxItemSize_;
@@ -259,13 +258,10 @@ class BCStateTran : public IStateTransfer {
   // or GettingMissingResPages
   ///////////////////////////////////////////////////////////////////////////
 
-  static const uint16_t NO_REPLICA = UINT16_MAX;
+  SourceSelector sourceSelector_;
+
   static const uint64_t ID_OF_VBLOCK_RES_PAGES = UINT64_MAX;
 
-  set<uint16_t> preferredReplicas_;
-  uint16_t currentSourceReplica_ = NO_REPLICA;
-
-  uint64_t timeMilliCurrentSourceReplica_ = 0;
   uint64_t nextRequiredBlock_ = 0;
   STDigest digestOfNextRequiredBlock;
 
@@ -295,15 +291,11 @@ class BCStateTran : public IStateTransfer {
                   const STDigest& expectedDigestOfResPagesDescriptor,
                   char* vblock, uint32_t vblockSize) const;
 
-  uint16_t selectSourceReplica();
-
   void processData();
 
   void EnterGettingCheckpointSummariesState();
+  set<uint16_t> allOtherReplicas();
   void SetAllReplicasAsPreferred();
-  bool ShouldReplaceSourceReplica(
-      bool badDataFromCurrentSourceReplica, uint64_t diffMilli);
-
 
   ///////////////////////////////////////////////////////////////////////////
   // Helper methods

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -1,0 +1,115 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "SourceSelector.hpp"
+
+namespace bftEngine {
+namespace SimpleBlockchainStateTransfer {
+namespace impl {
+
+bool SourceSelector::hasSource() const {
+  return currentReplica_ != NO_REPLICA && sourceSelectionTimeMilli_ > 0;
+}
+
+void SourceSelector::setSourceSelectionTime(uint64_t currTimeMilli) {
+  sourceSelectionTimeMilli_ = currTimeMilli;
+}
+
+void SourceSelector::setSendTime(uint64_t currTimeMilli) {
+  sendTimeMilli_ = currTimeMilli;
+}
+
+void SourceSelector::removeCurrentReplica() {
+  preferredReplicas_.erase(currentReplica_);
+  currentReplica_ = NO_REPLICA;
+}
+
+void SourceSelector::setAllReplicasAsPreferred() { preferredReplicas_ = allOtherReplicas_; }
+
+void SourceSelector::reset() {
+  preferredReplicas_.clear();
+  currentReplica_ = NO_REPLICA;
+  sourceSelectionTimeMilli_ = 0;
+  sendTimeMilli_ = 0;
+}
+
+bool SourceSelector::isReset() const {
+  return preferredReplicas_.empty() && currentReplica_ == NO_REPLICA &&
+    sourceSelectionTimeMilli_ == 0 && sendTimeMilli_ == 0;
+}
+
+bool SourceSelector::retransmissionTimeoutExpired(uint64_t currTimeMilli) const {
+  // TODO(GG): TBD - compute dynamically
+  return timeSinceSendMilli(currTimeMilli) > retransmissionTimeoutMilli_;
+}
+
+uint64_t SourceSelector::timeSinceSendMilli(uint64_t currTimeMilli) const {
+  return ((currentReplica_ == NO_REPLICA) || (currTimeMilli < sendTimeMilli_))
+             ? 0
+             : (currTimeMilli - sendTimeMilli_);
+}
+
+uint64_t SourceSelector::timeSinceSourceSelectedMilli(uint64_t currTimeMilli) const {
+  return ((currentReplica_ == NO_REPLICA) || (currTimeMilli < sourceSelectionTimeMilli_))
+             ? 0
+             : (currTimeMilli - sourceSelectionTimeMilli_);
+}
+
+// Replace the source.
+void SourceSelector::updateSource(uint64_t currTimeMilli) {
+  if (currentReplica_ != NO_REPLICA) {
+    preferredReplicas_.erase(currentReplica_);
+  }
+  if (preferredReplicas_.empty()) {
+    preferredReplicas_ = allOtherReplicas_;
+  }
+  selectSource(currTimeMilli);
+}
+
+// Create a list of ids of the form "0, 1, 4"
+std::string SourceSelector::preferredReplicasToString() const {
+  std::ostringstream oss;
+  for (auto it = preferredReplicas_.begin(); it != preferredReplicas_.end(); ++it) {
+    if (it == preferredReplicas_.begin()) {
+      oss << *it;
+    } else {
+      oss << ", " << *it;
+    }
+  }
+  return oss.str();
+}
+
+bool SourceSelector::shouldReplaceSource(uint64_t currTimeMilli, bool badDataFromCurrentSource) const {
+  return currentReplica_ == NO_REPLICA || badDataFromCurrentSource ||
+         timeSinceSourceSelectedMilli(currTimeMilli) > sourceReplacementTimeoutMilli_;
+}
+
+void SourceSelector::selectSource(uint64_t currTimeMilli) {
+  const size_t size = preferredReplicas_.size();
+  Assert(size > 0);
+
+  auto i = preferredReplicas_.begin();
+  if (size > 1) {
+    // TODO(GG): can be optimized
+    unsigned int c = randomGen_() % size;
+    while (c > 0) {
+      c--;
+      i++;
+    }
+  }
+  currentReplica_ = *i;
+  sourceSelectionTimeMilli_ = currTimeMilli;
+}
+}  // namespace impl
+}  // namespace SimpleBlockchainStateTransfer
+}  // namespace bftEngine

--- a/bftengine/src/bcstatetransfer/SourceSelector.hpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.hpp
@@ -1,0 +1,107 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+#pragma once
+
+#include <random>
+#include <set>
+#include <stdint.h>
+#include <sstream>
+
+#include "assertUtils.hpp"
+
+namespace bftEngine {
+namespace SimpleBlockchainStateTransfer {
+namespace impl {
+
+static const uint16_t NO_REPLICA = UINT16_MAX;
+
+// Information about which current source is selected and which replicas are
+// preferred, as well as data that helps to select a current source replica.
+class SourceSelector {
+
+ public:
+  SourceSelector(std::set<uint16_t> allOtherReplicas,
+                 uint32_t retransmissionTimeoutMilli,
+                 uint32_t sourceReplicaReplacementTimeoutMilli)
+      : allOtherReplicas_(allOtherReplicas), randomGen_(std::random_device()()),
+        retransmissionTimeoutMilli_(retransmissionTimeoutMilli),
+        sourceReplacementTimeoutMilli_(sourceReplicaReplacementTimeoutMilli){}
+
+  bool hasSource() const;
+  void removeCurrentReplica();
+  void setAllReplicasAsPreferred();
+  void reset();
+  bool isReset() const;
+  bool retransmissionTimeoutExpired(uint64_t currTimeMilli) const;
+
+
+  // Return true if the source should be replaced, false otherwise.
+  bool shouldReplaceSource(uint64_t currTimeMilli, bool badDataFromCurrentSource) const;
+
+  // Replace the source.
+  void updateSource(uint64_t currTimeMilli);
+
+  // Reset the source selection time without actually changing the source
+  void setSourceSelectionTime(uint64_t currTimeMilli);
+
+  // Reset the time since last transmission
+  void setSendTime(uint64_t currTimeMilli);
+
+  // Create a list of ids of the form "0, 1, 4"
+  std::string preferredReplicasToString() const;
+
+  bool hasPreferredReplicas() const {
+    return !preferredReplicas_.empty();
+  }
+
+  bool noPreferredReplicas() const {
+    return preferredReplicas_.empty();
+  }
+
+  void addPreferredReplica(uint16_t replicaId) {
+    preferredReplicas_.insert(replicaId);
+  }
+
+  uint16_t numberOfPreferredReplicas() const {
+    return static_cast<uint16_t>(preferredReplicas_.size());
+  }
+
+  bool isPreferred(uint16_t replicaId) const {
+    return preferredReplicas_.count(replicaId) != 0;
+  }
+
+  uint16_t currentReplica() const {
+    return currentReplica_;
+  }
+
+
+
+ private:
+  uint64_t timeSinceSourceSelectedMilli(uint64_t currTimeMilli) const;
+  uint64_t timeSinceSendMilli(uint64_t currTimeMilli) const;
+  void selectSource(uint64_t currTimeMilli);
+
+  std::set<uint16_t> preferredReplicas_;
+  uint16_t currentReplica_ = NO_REPLICA;
+  uint64_t sourceSelectionTimeMilli_ = 0;
+  uint64_t sendTimeMilli_ = 0;
+  std::set<uint16_t> allOtherReplicas_;
+  std::mt19937 randomGen_;
+  uint32_t retransmissionTimeoutMilli_;
+  uint32_t sourceReplacementTimeoutMilli_;
+
+
+};
+}  // namespace impl
+}  // namespace SimpleBlockchainStateTransfer
+}  // namespace bftEngine


### PR DESCRIPTION
This is a reopening of #238 which resolves the review comments and adds some bug fixes.

This commit is part of a refactoring of BCStateTran to make the logic
easier to understand. Ideally we separate out the low level
implementation details from the high level control in the `processData()`
loop.

The goal was not to change behavior.

Also fix an overflow bug similar to the one
[here](https://github.com/vmware/concord-bft/pull/78).

Additionally, Separate the recording of time of last sent fetch message
from the time of source selection (including received item message).
This allows detecting timeouts multiple times for retransmission before
changing a source. This appears to be the intention of the original code
since there are two separate timeouts:
 * config.fetchRetransmissionTimeoutMilli,
 * config.sourceReplicaReplacementTimeoutMilli

A change was introduced in
commit 1db691abe6c166cb5b8d534787a5bba4ce487c34 that mistakenly reset
the source selection time when a retransmission timeout occurred, but
this would mistakenly mean that the source would not ever be replaced
from timeouts alone during fetching. This change instead resets the
send time when a retransmission occurs, so you get multiple attempts at
retransmission for the same source, and then it will be replaced when
the source needs to be replaced because
config.sourceReplicaReplacementTimeoutMilli expired.