### PR TITLE
Enable clang-format 6 and 7 to read .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -92,10 +92,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: false


### PR DESCRIPTION
Remove the string formatting that is no longer an option in clang-format
version 7.