### PR TITLE
Fix intermittent persistence + ST test failure

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -115,7 +115,7 @@ struct Config {
   uint32_t refreshTimerMilli = 300;                               // ms
   uint32_t checkpointSummariesRetransmissionTimeoutMilli = 2500;  // ms
   uint32_t maxAcceptableMsgDelayMilli = 60000;                    // 1 minute
-  uint32_t sourceReplicaReplacementTimeoutMilli = 600000;         // 10 minutes
+  uint32_t sourceReplicaReplacementTimeoutMilli = 5000;           // 5 seconds
   uint32_t fetchRetransmissionTimeoutMilli = 250;                 // ms
 };
 

--- a/test/test_skvbc_persistence.py
+++ b/test/test_skvbc_persistence.py
@@ -320,7 +320,6 @@ class SkvbcPersistenceTest(unittest.TestCase):
         await tester.wait_for_replicas_to_checkpoint(initial_nodes,
                 checkpoint_num)
 
-    @unittest.skip("To be re-enabled once the intermittent failures are fixed")
     def test_st_when_fetcher_and_sender_crash(self):
         """
         Start 3 nodes out of a 4 node cluster. Write a specific key, then


### PR DESCRIPTION
Here we fix an intermittent failure of test_st_when_fetcher_and_sender_crash. The failure is due to the fetcher sending UDP messages to the ST sender node without ever knowing whether the sender node might be down. To remediate this, we reduce significantly the sourceReplicaReplacementTimeoutMilli timer (by default set to 10 min).

This way, sender replicas are rotated more frequently and we avoid the situation described above.

To confirm this change actually fixes the bug, I have run 10 consecutive times the SKVBC persistence test suite which would previously fail intermittently (every 3-4 runs):
``for i in `seq 10`; do ctest -R skvbc_persistence_tests; done``