### PR TITLE
BCST Perf Fix: Don't copy the reserved pages map

### DIFF
--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -348,7 +348,7 @@ void DBDataStore::associatePendingResPageWithCheckpointTxn(uint32_t inPageId,
   LOG_DEBUG(logger(),
             "page: " << inPageId << " chkp: " << inCheckpoint << " digest: " << inPageDigest.toString()
                      << " txn: " << txn->getId());
-  auto pendingPages = inmem_->getPendingPagesMap();
+  auto& pendingPages = inmem_->getPendingPagesMap();
   auto page = pendingPages.find(inPageId);
   assert(page != pendingPages.end());
 


### PR DESCRIPTION
A misuse of auto without the & caused a copy of a large map which took
12ms on test run and was causing timeouts. Fix this to just use the
reference directly. This has zero cost.

--cppbug