### PR TITLE
BFTEngine Init Vars Internal Linkage

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -23,8 +23,10 @@
 namespace bftEngine {
 namespace impl {
 
+namespace {
 bool cryptoInitialized = false;
 std::mutex mutexForCryptoInitialization;
+}
 
 struct ReplicaInternal : public Replica {
   virtual ~ReplicaInternal() override;


### PR DESCRIPTION
Use internal linkage for the `cryptoInitialized` and `mutexForCryptoInitialization` initialization variables as they are only used in `BFTEngine`'s translation unit. Doing so makes the code more
readable and expresses the intention explicitly.