### PR TITLE
Test for persistence + ST + view change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ env:
     - RELEASE=-DCMAKE_BUILD_TYPE=RELEASE
     - RELEASE=-DCMAKE_BUILD_TYPE=RELEASE USE_ROCKSDB=-DBUILD_ROCKSDB_STORAGE=TRUE
 script:
-  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $DEBUG $RELEASE $USE_ROCKSDB .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest -R skvbc_persistence_tests --verbose && ctest -E skvbc_persistence_tests
+  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $DEBUG $RELEASE $USE_ROCKSDB .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest
 


### PR DESCRIPTION
This PR adds two tests combining persistence, state transfer and view change:

1) Crash primary once (without forcing view change), then trigger state transfer
This test is marked as "skipped" due to an issue it surfaces, tracked under https://github.com/vmware/concord-bft/issues/269

2) Repeatedly trigger view change while interrupting state transfer
In this test, we bring down the primary, trigger view change and repeatedly restart the stale node in the process.

At the end we ensure that state transfer has completed and the value initially written to the incomplete cluster can be
read via a quorum including the stale node.

Both tests run on a 7 node cluster (f=2), thus tolerating both the stale and primary replicas being down simultaneously.

PS: I have also simplified the logic in wait_for_fetching_state() which had become overly complex