### PR TITLE
Split out individual SKVBC tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,14 @@
-add_test(NAME skvbc_tests COMMAND python3 -m unittest
-    test_skvbc
-    test_skvbc_chaos
-    test_skvbc_linearizability
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME skvbc_basic_tests COMMAND python3 -m unittest
+  test_skvbc
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_chaos_tests COMMAND python3 -m unittest
+  test_skvbc_chaos
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_linearizability_tests COMMAND python3 -m unittest
+  test_skvbc_linearizability
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 if (BUILD_ROCKSDB_STORAGE)
   add_test(NAME skvbc_persistence_tests COMMAND python3 -m unittest


### PR DESCRIPTION
So far, three SKVBC test suites were being run as a single test as part of CI:
    * test_skvbc
    * test_skvbc_chaos
    * test_skvbc_linearizability
Given how the Python tests layout has evolved recently, such grouping does not make sense anymore. Besides it makes it hard to debug the intermittent failures we've been observing in some of those suites.

So, in this PR I simply suggest to grant those three suites "first-class citizenship".