### PR TITLE
Small enhancements for BFT metadata parameters structure and handling

### DIFF
--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -41,12 +41,6 @@ void DebugPersistentStorage::setReplicaConfig(const ReplicaConfig &config) {
   config_ = config;
 }
 
-void DebugPersistentStorage::setFetchingState(bool state) {
-  Assert(nonExecSetIsAllowed());
-  Assert(!state || !fetchingState_);  // f ==> !fetchingState_
-  fetchingState_ = state;
-}
-
 void DebugPersistentStorage::setLastExecutedSeqNum(SeqNum seqNum) {
   Assert(setIsAllowed());
   Assert(lastExecutedSeqNum_ <= seqNum);
@@ -284,11 +278,6 @@ ReplicaConfig DebugPersistentStorage::getReplicaConfig() {
   Assert(getIsAllowed());
   Assert(hasConfig_);
   return config_;
-}
-
-bool DebugPersistentStorage::getFetchingState() {
-  Assert(getIsAllowed());
-  return fetchingState_;
 }
 
 SeqNum DebugPersistentStorage::getLastExecutedSeqNum() {

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -29,7 +29,6 @@ class DebugPersistentStorage : public PersistentStorage {
   uint8_t endWriteTran() override;
   bool isInWriteTran() const override;
   void setReplicaConfig(const ReplicaConfig& config) override;
-  void setFetchingState(bool state) override;
   void setLastExecutedSeqNum(SeqNum seqNum) override;
   void setPrimaryLastUsedSeqNum(SeqNum seqNum) override;
   void setStrictLowerBoundOfSeqNums(SeqNum seqNum) override;
@@ -49,7 +48,6 @@ class DebugPersistentStorage : public PersistentStorage {
   void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) override;
   bool hasReplicaConfig() const override;
   ReplicaConfig getReplicaConfig() override;
-  bool getFetchingState() override;
   SeqNum getLastExecutedSeqNum() override;
   SeqNum getPrimaryLastUsedSeqNum() override;
   SeqNum getStrictLowerBoundOfSeqNums() override;
@@ -83,7 +81,6 @@ class DebugPersistentStorage : public PersistentStorage {
   bool hasConfig_ = false;
   ReplicaConfig config_;
 
-  bool fetchingState_ = false;
   SeqNum lastExecutedSeqNum_ = 0;
   SeqNum primaryLastUsedSeqNum_ = 0;
   SeqNum strictLowerBoundOfSeqNums_ = 0;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -67,7 +67,6 @@ class PersistentStorage {
 
   virtual void setReplicaConfig(const ReplicaConfig &config) = 0;
 
-  virtual void setFetchingState(bool state) = 0;
   virtual void setLastExecutedSeqNum(SeqNum seqNum) = 0;
   virtual void setPrimaryLastUsedSeqNum(SeqNum seqNum) = 0;
   virtual void setStrictLowerBoundOfSeqNums(SeqNum seqNum) = 0;
@@ -115,7 +114,6 @@ class PersistentStorage {
   virtual bool hasReplicaConfig() const = 0;
   virtual ReplicaConfig getReplicaConfig() = 0;
 
-  virtual bool getFetchingState() = 0;
   virtual SeqNum getLastExecutedSeqNum() = 0;
   virtual SeqNum getPrimaryLastUsedSeqNum() = 0;
   virtual SeqNum getStrictLowerBoundOfSeqNums() = 0;

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -57,13 +57,12 @@ enum ConstMetadataParameterIds : uint32_t {
   INITIALIZED_FLAG = 1,
   FIRST_METADATA_PARAMETER = 2,
   VERSION_PARAMETER = FIRST_METADATA_PARAMETER,
-  FETCHING_STATE = 3,
-  LAST_EXEC_SEQ_NUM = 4,
-  PRIMARY_LAST_USED_SEQ_NUM = 5,
-  LOWER_BOUND_OF_SEQ_NUM = 6,
-  LAST_VIEW_TRANSFERRED_SEQ_NUM = 7,
-  LAST_STABLE_SEQ_NUM = 8,
-  REPLICA_CONFIG = 9,
+  LAST_EXEC_SEQ_NUM = 3,
+  PRIMARY_LAST_USED_SEQ_NUM = 4,
+  LOWER_BOUND_OF_SEQ_NUM = 5,
+  LAST_VIEW_TRANSFERRED_SEQ_NUM = 6,
+  LAST_STABLE_SEQ_NUM = 7,
+  REPLICA_CONFIG = 8,
   CONST_METADATA_PARAMETERS_NUM
 };
 
@@ -108,7 +107,6 @@ class PersistentStorageImp : public PersistentStorage {
 
   // Setters
   void setReplicaConfig(const ReplicaConfig &config) override;
-  void setFetchingState(bool state) override;
   void setLastExecutedSeqNum(SeqNum seqNum) override;
   void setPrimaryLastUsedSeqNum(SeqNum seqNum) override;
   void setStrictLowerBoundOfSeqNums(SeqNum seqNum) override;
@@ -134,7 +132,6 @@ class PersistentStorageImp : public PersistentStorage {
   std::string getStoredVersion();
   std::string getCurrentVersion() const { return version_; }
   ReplicaConfig getReplicaConfig() override;
-  bool getFetchingState() override;
   SeqNum getLastExecutedSeqNum() override;
   SeqNum getPrimaryLastUsedSeqNum() override;
   SeqNum getStrictLowerBoundOfSeqNums() override;
@@ -217,7 +214,6 @@ class PersistentStorageImp : public PersistentStorage {
   uint8_t readCompletedMarkFromDisk(SeqNum index) const;
 
   void writeBeginningOfActiveWindow(uint32_t index, SeqNum beginning) const;
-  void setFetchingStateInternal(uint8_t state);
   void setLastExecutedSeqNumInternal(SeqNum seqNum);
   void setPrimaryLastUsedSeqNumInternal(SeqNum seqNum);
   void setStrictLowerBoundOfSeqNumsInternal(SeqNum seqNum);
@@ -250,7 +246,6 @@ class PersistentStorageImp : public PersistentStorage {
 
   // Parameters to be saved persistently
   std::string version_;
-  bool fetchingState_ = false;
   SeqNum lastExecutedSeqNum_ = 0;
   SeqNum primaryLastUsedSeqNum_ = 0;
   SeqNum strictLowerBoundOfSeqNums_ = 0;

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -20,20 +20,50 @@
 namespace bftEngine {
 namespace impl {
 
+// BFT Metadata parameters storage scheme:
+//
+// [ConstMetadataParameterIds][reservedSimpleParamsNum][WinMetadataParameterIds][reservedWindowParamsNum]
+// [DescMetadataParameterIds][reservedOtherParamsNum]
+//
+// ConstMetadataParameterIds:
+// INITIALIZED_FLAG = 1
+//    A flag saying whether DB is initialized or not; handled by storage class itself.
+// VERSION_PARAMETER to REPLICA_CONFIG
+//    Simple parameters with enumerated number
+//
+// reservedSimpleParamsNum
+//    A range of simple parameters reserved for a future use
+//
+// WinMetadataParameterIds:
+// BEGINNING_OF_SEQ_NUM_WINDOW to WIN_PARAMETERS_NUM
+//    Contains calculated numOfSeqNumWinObjs + numOfCheckWinObjs parameters
+//
+// reservedWindowParamsNum
+//    A range of windows parameters with calculated numbers reserved for a future use
+//
+// DescMetadataParameterIds:
+// LAST_EXIT_FROM_VIEW_DESC to LAST_NEW_VIEW_DESC
+//    Contains kWorkWindowSize + 2 parameters
+//
+// reservedOtherParamsNum:
+// MAX_METADATA_PARAMS_NUM - LAST_NEW_VIEW_DESC
+//    Parameters reserved for a future use
+
 // Make a reservation for future params
-const uint16_t reservedParamsNum = 50;
+const uint16_t reservedSimpleParamsNum = 500;
+const uint16_t reservedWindowParamsNum = 3000;
 
 enum ConstMetadataParameterIds : uint32_t {
-  INITIALIZED_FLAG = 1,  // A flag saying whether DB is initialized or not; handled by storage class itself.
-  FIRST_METADATA_PARAMETER,
+  INITIALIZED_FLAG = 1,
+  FIRST_METADATA_PARAMETER = 2,
   VERSION_PARAMETER = FIRST_METADATA_PARAMETER,
-  FETCHING_STATE,
-  LAST_EXEC_SEQ_NUM,
-  PRIMARY_LAST_USED_SEQ_NUM,
-  LOWER_BOUND_OF_SEQ_NUM,
-  LAST_VIEW_TRANSFERRED_SEQ_NUM,
-  LAST_STABLE_SEQ_NUM,
-  REPLICA_CONFIG,
+  FETCHING_STATE = 3,
+  LAST_EXEC_SEQ_NUM = 4,
+  PRIMARY_LAST_USED_SEQ_NUM = 5,
+  LOWER_BOUND_OF_SEQ_NUM = 6,
+  LAST_VIEW_TRANSFERRED_SEQ_NUM = 7,
+  LAST_STABLE_SEQ_NUM = 8,
+  REPLICA_CONFIG = 9,
   CONST_METADATA_PARAMETERS_NUM
 };
 
@@ -48,7 +78,7 @@ constexpr uint16_t numOfCheckWinParameters = CheckData::getNumOfParams();
 const uint16_t numOfCheckWinObjs = checkWinSize * numOfCheckWinParameters + 1;
 
 enum WinMetadataParameterIds {
-  BEGINNING_OF_SEQ_NUM_WINDOW = CONST_METADATA_PARAMETERS_NUM + reservedParamsNum,
+  BEGINNING_OF_SEQ_NUM_WINDOW = CONST_METADATA_PARAMETERS_NUM + reservedSimpleParamsNum,
   BEGINNING_OF_CHECK_WINDOW = BEGINNING_OF_SEQ_NUM_WINDOW + numOfSeqNumWinObjs,
   WIN_PARAMETERS_NUM = BEGINNING_OF_CHECK_WINDOW + numOfCheckWinObjs
 };
@@ -60,7 +90,7 @@ const uint16_t numOfLastExitFromViewDescObjs = kWorkWindowSize + 1;
 // LAST_NEW_VIEW_DESC contains numOfReplicas_ (2 * f + 2 * c + 1) descriptor
 // objects plus one - for simple descriptor parameters.
 enum DescMetadataParameterIds {
-  LAST_EXIT_FROM_VIEW_DESC = WIN_PARAMETERS_NUM,
+  LAST_EXIT_FROM_VIEW_DESC = WIN_PARAMETERS_NUM + reservedWindowParamsNum,
   LAST_EXEC_DESC = LAST_EXIT_FROM_VIEW_DESC + numOfLastExitFromViewDescObjs,
   LAST_NEW_VIEW_DESC
 };

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -152,7 +152,6 @@ ReplicaConfig config;
 bftEngine::impl::PersistentStorageImp *persistentStorageImp = nullptr;
 unique_ptr<MetadataStorage> metadataStorage;
 
-bool fetchingState = false;
 SeqNum lastExecutedSeqNum = 0;
 SeqNum primaryLastUsedSeqNum = 0;
 SeqNum strictLowerBoundOfSeqNums = 0;
@@ -168,7 +167,6 @@ CheckWindow checkWindow{0};
 
 void testInit() {
   assert(persistentStorageImp->getStoredVersion() == persistentStorageImp->getCurrentVersion());
-  assert(persistentStorageImp->getFetchingState() == fetchingState);
   assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecutedSeqNum);
   assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == primaryLastUsedSeqNum);
   assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == strictLowerBoundOfSeqNums);
@@ -406,7 +404,6 @@ void testSetDescriptors(bool toSet) {
 }
 
 void testSetSimpleParams(bool toSet) {
-  bool state = true;
   SeqNum lastExecSeqNum = 32;
   SeqNum lastUsedSeqNum = 212;
   SeqNum lowBoundSeqNum = 102;
@@ -414,7 +411,6 @@ void testSetSimpleParams(bool toSet) {
 
   if (toSet) {
     persistentStorageImp->beginWriteTran();
-    persistentStorageImp->setFetchingState(state);
     persistentStorageImp->setLastExecutedSeqNum(lastExecSeqNum);
     persistentStorageImp->setPrimaryLastUsedSeqNum(lastUsedSeqNum);
     persistentStorageImp->setStrictLowerBoundOfSeqNums(lowBoundSeqNum);
@@ -422,7 +418,6 @@ void testSetSimpleParams(bool toSet) {
     persistentStorageImp->endWriteTran();
   }
 
-  assert(persistentStorageImp->getFetchingState() == state);
   assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecSeqNum);
   assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == lastUsedSeqNum);
   assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == lowBoundSeqNum);


### PR DESCRIPTION
- For now, there is a reservation for simple metadata parameters to be stored in the DB. Add the same for windows related ones.
- Get rid of duplicated fetchingState handling. Remove it from BFT metadata parameters as it exists in StateTransfer metadata parameters.