### PR TITLE
[Trivial] Enable output on failure for ctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ env:
     - RELEASE=-DCMAKE_BUILD_TYPE=RELEASE
     - RELEASE=-DCMAKE_BUILD_TYPE=RELEASE USE_ROCKSDB=-DBUILD_ROCKSDB_STORAGE=TRUE
 script:
-  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $DEBUG $RELEASE $USE_ROCKSDB .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest
+  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $DEBUG $RELEASE $USE_ROCKSDB .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest --output-on-failure
 


### PR DESCRIPTION
Currently when a test fails in CI, we do not see any logs from the
failing test case run. Adding the --output-on-failure helps us achieve
exactly this, without outputting all the logs from all tests.