### PR TITLE
Add virtual destructor to ICommandsHandler in favour of kvbc code ded…

### DIFF
--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -135,6 +135,7 @@ class ICommandsHandler : public bftEngine::RequestsHandler {
                       uint32_t maxReplySize,
                       char* outReply,
                       uint32_t& outActualReplySize) = 0;
+  virtual ~ICommandsHandler() = default;
 };
 }  // namespace kvbc
 }  // namespace concord


### PR DESCRIPTION
…up since in concord it's used in conjunction with unique_ptr