### PR TITLE
Parameterized Python test suites

### DIFF
--- a/tests/test_skvbc.py
+++ b/tests/test_skvbc.py
@@ -9,7 +9,7 @@
 # notices and license terms. Your use of these subcomponents is subject to the
 # terms and conditions of the subcomponent's license, as noted in the LICENSE
 # file.
-
+import random
 import unittest
 import trio
 import os.path
@@ -51,31 +51,27 @@ class SkvbcTest(unittest.TestCase):
         trio.run(self._test_state_transfer)
 
     async def _test_state_transfer(self):
-        config = bft.TestConfig(n=4,
-                                f=1,
-                                c=0,
-                                num_clients=10,
-                                key_file_prefix=KEY_FILE_PREFIX,
-                                start_replica_cmd=start_replica_cmd)
-        with bft.BftTestNetwork(config) as bft_network:
-            await bft_network.init()
-            [bft_network.start_replica(i) for i in range(3)]
-            # Write enough data to create a need for state transfer
-            # Run num_clients concurrent requests a bunch of times
-            for i in range (100):
-                async with trio.open_nursery() as nursery:
-                    for client in bft_network.clients.values():
-                        msg = self.protocol.write_req([],
-                                [(bft_network.random_key(), bft_network.random_value())],
-                                0)
-                        nursery.start_soon(client.sendSync, msg, False)
-            await bft_network.assert_state_transfer_not_started_all_up_nodes(self)
-            bft_network.start_replica(3)
-            await bft_network.wait_for_state_transfer_to_start()
-            await bft_network.wait_for_state_transfer_to_stop(0, 3)
-            await bft_network.assert_successful_put_get(self, self.protocol)
-            bft_network.stop_replica(2)
-            await bft_network.assert_successful_put_get(self, self.protocol)
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                stale_node = random.choice(list(set(range(config.n)) - {0}))
+                await bft_network.prime_for_state_transfer(
+                    stale_nodes={stale_node},
+                    persistency_enabled=False
+                )
+                bft_network.start_replica(stale_node)
+                await bft_network.wait_for_state_transfer_to_start()
+                await bft_network.wait_for_state_transfer_to_stop(0, stale_node)
+                await bft_network.assert_successful_put_get(self, self.protocol)
+                random_replica = random.choice(
+                    list(set(range(config.n)) - {0, stale_node}))
+                bft_network.stop_replica(random_replica)
+                await bft_network.assert_successful_put_get(self, self.protocol)
 
     def test_get_block_data(self):
         """
@@ -85,49 +81,50 @@ class SkvbcTest(unittest.TestCase):
         trio.run(self._test_get_block_data)
 
     async def _test_get_block_data(self):
-        config = bft.TestConfig(n=4,
-                                f=1,
-                                c=0,
-                                num_clients=10,
-                                key_file_prefix=KEY_FILE_PREFIX,
-                                start_replica_cmd=start_replica_cmd)
-        with bft.BftTestNetwork(config) as bft_network:
-            await bft_network.init()
-            [bft_network.start_replica(i) for i in range(3)]
-            p = self.protocol
-            client = bft_network.random_client()
-            last_block = p.parse_reply(await client.read(p.get_last_block_req()))
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+                p = self.protocol
+                client = bft_network.random_client()
+                last_block = p.parse_reply(await client.read(p.get_last_block_req()))
 
-            # Perform an unconditional KV put.
-            # Ensure keys aren't identical
-            kv = [(bft_network.keys[0], bft_network.random_value()),
-                  (bft_network.keys[1], bft_network.random_value())]
+                # Perform an unconditional KV put.
+                # Ensure keys aren't identical
+                kv = [(bft_network.keys[0], bft_network.random_value()),
+                      (bft_network.keys[1], bft_network.random_value())]
 
-            reply = await client.write(p.write_req([], kv, 0))
-            reply = p.parse_reply(reply)
-            self.assertTrue(reply.success)
-            self.assertEqual(last_block + 1, reply.last_block_id)
+                reply = await client.write(p.write_req([], kv, 0))
+                reply = p.parse_reply(reply)
+                self.assertTrue(reply.success)
+                self.assertEqual(last_block + 1, reply.last_block_id)
 
-            last_block = reply.last_block_id
+                last_block = reply.last_block_id
 
-            # Get the kvpairs in the last written block
-            data = await client.read(p.get_block_data_req(last_block))
-            kv2 = p.parse_reply(data)
-            self.assertDictEqual(kv2, dict(kv))
+                # Get the kvpairs in the last written block
+                data = await client.read(p.get_block_data_req(last_block))
+                kv2 = p.parse_reply(data)
+                self.assertDictEqual(kv2, dict(kv))
 
-            # Write another block with the same keys but (probabilistically)
-            # different data
-            kv3 = [(bft_network.keys[0], bft_network.random_value()),
-                   (bft_network.keys[1], bft_network.random_value())]
-            reply = await client.write(p.write_req([], kv3, 0))
-            reply = p.parse_reply(reply)
-            self.assertTrue(reply.success)
-            self.assertEqual(last_block + 1, reply.last_block_id)
+                # Write another block with the same keys but (probabilistically)
+                # different data
+                kv3 = [(bft_network.keys[0], bft_network.random_value()),
+                       (bft_network.keys[1], bft_network.random_value())]
+                reply = await client.write(p.write_req([], kv3, 0))
+                reply = p.parse_reply(reply)
+                self.assertTrue(reply.success)
+                self.assertEqual(last_block + 1, reply.last_block_id)
 
-            # Get the kvpairs in the previously written block
-            data = await client.read(p.get_block_data_req(last_block))
-            kv2 = p.parse_reply(data)
-            self.assertDictEqual(kv2, dict(kv))
+                # Get the kvpairs in the previously written block
+                data = await client.read(p.get_block_data_req(last_block))
+                kv2 = p.parse_reply(data)
+                self.assertDictEqual(kv2, dict(kv))
 
     def test_conflicting_write(self):
         """
@@ -143,51 +140,51 @@ class SkvbcTest(unittest.TestCase):
         trio.run(self._test_conflicting_write)
 
     async def _test_conflicting_write(self):
-        config = bft.TestConfig(n=4,
-                                f=1,
-                                c=0,
-                                num_clients=1,
-                                key_file_prefix=KEY_FILE_PREFIX,
-                                start_replica_cmd=start_replica_cmd)
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
 
-        with bft.BftTestNetwork(config) as bft_network:
-            await bft_network.init()
-            bft_network.start_all_replicas()
+                key = bft_network.random_key()
 
-            key = bft_network.random_key()
+                write_1 = self.protocol.write_req(
+                    readset=[],
+                    writeset=[(key, bft_network.random_value())],
+                    block_id=0)
 
-            write_1 = self.protocol.write_req(
-                readset=[],
-                writeset=[(key, bft_network.random_value())],
-                block_id=0)
+                write_2 = self.protocol.write_req(
+                    readset=[],
+                    writeset=[(key, bft_network.random_value())],
+                    block_id=0)
 
-            write_2 = self.protocol.write_req(
-                readset=[],
-                writeset=[(key, bft_network.random_value())],
-                block_id=0)
+                client = bft_network.random_client()
 
-            client = bft_network.random_client()
+                await client.write(write_1)
+                last_write_reply = \
+                    self.protocol.parse_reply(await client.write(write_2))
 
-            await client.write(write_1)
-            last_write_reply = \
-                self.protocol.parse_reply(await client.write(write_2))
+                last_block_id = last_write_reply.last_block_id
 
-            last_block_id = last_write_reply.last_block_id
+                key_prime = bft_network.random_key()
 
-            key_prime = bft_network.random_key()
+                # this write is conflicting because the writeset (key_prime) is
+                # based on an outdated version of the readset (key)
+                conflicting_write = self.protocol.write_req(
+                    readset=[key],
+                    writeset=[(key_prime, bft_network.random_value())],
+                    block_id=last_block_id-1)
 
-            # this write is conflicting because the writeset (key_prime) is
-            # based on an outdated version of the readset (key)
-            conflicting_write = self.protocol.write_req(
-                readset=[key],
-                writeset=[(key_prime, bft_network.random_value())],
-                block_id=last_block_id-1)
+                write_result = \
+                    self.protocol.parse_reply(await client.write(conflicting_write))
+                successful_write = write_result.success
 
-            write_result = \
-                self.protocol.parse_reply(await client.write(conflicting_write))
-            successful_write = write_result.success
-
-            self.assertTrue(not successful_write)
+                self.assertTrue(not successful_write)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_skvbc_chaos.py
+++ b/tests/test_skvbc_chaos.py
@@ -42,13 +42,6 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli
             ]
 
-def interesting_configs():
-#    return [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
-#            {'n': 6, 'f': 1, 'c': 1, 'num_clients': 4},
-#            {'n': 11, 'f': 2, 'c': 2, 'num_clients': 6}
-#            ]
-    return [{'n': 11, 'f': 2, 'c': 2, 'num_clients': 6}]
-
 class Status:
     """
     Status about the running test.
@@ -93,7 +86,7 @@ class SkvbcChaosTest(unittest.TestCase):
 
     async def _test_healthy(self):
         num_ops = 500
-        for c in interesting_configs():
+        for c in bft.interesting_configs():
             config = bft.TestConfig(c['n'],
                                     c['f'],
                                     c['c'],
@@ -123,7 +116,7 @@ class SkvbcChaosTest(unittest.TestCase):
 
     async def _test_wreak_havoc(self):
         num_ops = 500
-        for c in interesting_configs():
+        for c in bft.interesting_configs():
             print(f"\n\nStarting test with configuration={c}", flush=True)
             config = bft.TestConfig(c['n'],
                                     c['f'],


### PR DESCRIPTION
Currently the system tests run against statically encoded BFT network
configurations. To run the same test suites against BFT networks with
varying parameters (n, c, f), we need to make significant code changes.

This PR addresses the issue by parameterizing all existing system tests,
which consume the eligible BFT configurations from a central factory
called bft.interesting_configs(). This factory allows to produce and
filter BFT configurations according to key criteria, such as minimum
values for f and for c.

Running the existing system tests against a variety of BFT configurations
now becomes very easy - we can simply add entries in bft.interesting_configs().

Later on, we could even consider feeding those values from command line,
allowing us to run quick CI (n=4) and slower CI (n=4, n=7, n=11, ...).