### PR TITLE
Test BFT engine fast path

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_test(NAME skvbc_linearizability_tests COMMAND sh -c
         "python3 -m unittest test_skvbc_history_tracker test_skvbc_linearizability 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_test(NAME skvbc_fast_path_tests COMMAND sh -c
+        "python3 -m unittest test_skvbc_fast_path 2>&1 > /dev/null"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests COMMAND sh -c
             "python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"

--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -1,0 +1,169 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os.path
+import random
+
+import trio
+
+import unittest
+
+from util import bft, skvbc
+
+KEY_FILE_PREFIX = "replica_keys_"
+
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli]
+
+
+class SkvbcFastPathTest(unittest.TestCase):
+
+    def setUp(self):
+        self.protocol = skvbc.SimpleKVBCProtocol()
+        # Whenever a replica goes down, all messages initially go via the slow path.
+        # However, when an "evaluation period" elapses (set at 64 sequence numbers),
+        # the system should return to the fast path.
+        self.evaluation_period_seq_num = 64
+
+    def test_fast_path_read_your_write(self):
+        """
+        This test aims to check that the fast commit path is prevalent
+        in the normal, synchronous case (no failed replicas, no network partitioning).
+
+        First we write a series of known K/V entries.
+        Then we check that, in the process, we have stayed on the fast path.
+
+        Finally we check if a known K/V has been executed.
+        """
+        trio.run(self._test_fast_path_read_your_write)
+
+    async def _test_fast_path_read_your_write(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                for _ in range(10):
+                    key, val = await bft_network.write_known_kv(self.protocol)
+
+                await bft_network.assert_fast_path_prevalent()
+
+                await bft_network.assert_kv_write_executed(self.protocol, key, val)
+
+    def test_fast_to_slow_path_transition(self):
+        """
+        This test aims to check the correct transition from fast to slow commit path.
+
+        First we write a series of known K/V entries, making sure
+        we stay on the fast path.
+
+        Once the first series of K/V writes have been processed, we bring down
+        one of the replicas, which should trigger a transition to the slow path.
+
+        We send a new series of K/V writes and make sure they
+        have been processed using the slow commit path.
+
+        Finally we check if a known K/V has been executed.
+        """
+        trio.run(self._test_fast_to_slow_path_transition)
+
+    async def _test_fast_to_slow_path_transition(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                for _ in range(10):
+                    await bft_network.write_known_kv(self.protocol)
+
+                await bft_network.assert_fast_path_prevalent()
+
+                unstable_replicas = list(set(range(0, config.n)) - {0})
+                bft_network.stop_replica(
+                    replica=random.choice(unstable_replicas))
+
+                for _ in range(10):
+                    key, val = await bft_network.write_known_kv(self.protocol)
+
+                await bft_network.assert_slow_path_prevalent(as_of_seq_num=10)
+
+                await bft_network.assert_kv_write_executed(self.protocol, key, val)
+
+    def test_fast_path_resilience_to_crashes(self):
+        """
+        In this test we check the fast path's resilience when up to "c" nodes fail.
+
+        As a first step, we bring down no more than c replicas,
+        triggering initially the slow path.
+
+        Then we write a series of known K/V entries, making sure
+        the fast path is eventually restored and becomes prevalent.
+
+        Finally we check if a known K/V write has been executed.
+        """
+        trio.run(self._test_fast_path_resilience_to_crashes)
+
+    async def _test_fast_path_resilience_to_crashes(self):
+        for bft_config in bft.interesting_configs(c_min=1):
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                unstable_replicas = list(set(range(0, config.n)) - {0})
+                for _ in range(config.c):
+                    replica_to_stop = random.choice(unstable_replicas)
+                    bft_network.stop_replica(replica_to_stop)
+
+                # make sure we first downgrade to the slow path...
+                for _ in range(self.evaluation_period_seq_num):
+                    await bft_network.write_known_kv(self.protocol)
+                await bft_network.assert_slow_path_prevalent()
+
+                # ...but eventually (after the evaluation period), the fast path is restored!
+                for _ in range(self.evaluation_period_seq_num+1,
+                               self.evaluation_period_seq_num*2):
+                    key, val = await bft_network.write_known_kv(self.protocol)
+                await bft_network.assert_fast_path_prevalent(
+                    as_of_seq_num=self.evaluation_period_seq_num+1,
+                    nb_slow_paths_so_far=self.evaluation_period_seq_num)
+
+                await bft_network.assert_kv_write_executed(self.protocol, key, val)

--- a/tests/util/bft.py
+++ b/tests/util/bft.py
@@ -44,7 +44,7 @@ TestConfig = namedtuple('TestConfig', [
 def interesting_configs(f_min=1, c_min=0):
     bft_configs = [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': 4},
-                   # {'n': 6, 'f': 1, 'c': 1, 'num_clients': 4},
+                   {'n': 6, 'f': 1, 'c': 1, 'num_clients': 4},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 4},
                    # {'n': 12, 'f': 3, 'c': 1, 'num_clients': 4}
                    ]
@@ -392,6 +392,61 @@ class BftTestNetwork:
                 for r in up_replicas:
                     nursery.start_soon(self._assert_state_transfer_not_started,
                                        r)
+
+    async def assert_fast_path_prevalent(
+            self, as_of_seq_num=1, nb_slow_paths_so_far=0):
+        """
+        Asserts there is at most 1 sequence processed on the slow path after "as_of_seq_num",
+        given the "nb_slow_paths_so_far".
+        """
+        metric_key = ['replica', 'Gauges', 'lastExecutedSeqNum']
+        total_nb_executed_sequences = await self.metrics.get(0, *metric_key)
+
+        metric_key = ['replica', 'Counters', 'slowPathCount']
+        total_nb_slow_paths = await self.metrics.get(0, *metric_key)
+        assert total_nb_slow_paths >= nb_slow_paths_so_far
+
+        assert (total_nb_slow_paths - nb_slow_paths_so_far) - (total_nb_executed_sequences - as_of_seq_num) <= 1, \
+            f'Fast path is not prevalent for n={self.config.n}, f={self.config.f}, c={self.config.c}.'
+
+    async def assert_slow_path_prevalent(
+            self, as_of_seq_num=1, nb_slow_paths_so_far=0):
+        """
+        Asserts all executed sequences after "as_of_seq_num" have been processed on the slow path,
+        given the "nb_slow_paths_so_far".
+        """
+        metric_key = ['replica', 'Gauges', 'lastExecutedSeqNum']
+        total_nb_executed_sequences = await self.metrics.get(0, *metric_key)
+
+        metric_key = ['replica', 'Counters', 'slowPathCount']
+        total_nb_slow_paths = await self.metrics.get(0, *metric_key)
+        assert total_nb_slow_paths >= nb_slow_paths_so_far
+
+        assert total_nb_slow_paths - nb_slow_paths_so_far >= total_nb_executed_sequences - as_of_seq_num, \
+            f'Slow path is not prevalent for n={self.config.n}, f={self.config.f}, c={self.config.c}.'
+
+    async def write_known_kv(self, protocol):
+        client = self.random_client()
+
+        key = self.random_key()
+        val = self.random_value()
+        reply = await client.write(
+            protocol.write_req([], [(key, val)], 0))
+        reply = protocol.parse_reply(reply)
+        assert reply.success
+
+        return key, val
+
+    async def assert_kv_write_executed(self, protocol, key, val):
+        config = self.config
+
+        client = self.random_client()
+        reply = await client.read(
+            protocol.read_req([key])
+        )
+        kv_reply = protocol.parse_reply(reply)
+        assert {key: val} == kv_reply, \
+            f'Could not read original key-value in the case of n={config.n}, f={config.f}, c={config.c}.'
 
     async def _assert_state_transfer_not_started(self, replica):
         key = ['replica', 'Counters', 'receivedStateTransferMsgs']


### PR DESCRIPTION
With this PR we introduce the first explicit test suite for the BFT engine's fast commit path.

We first test the normal behavior (without failures), making sure all messages are processed by the fast path. Then we simulate a failure and check the transition to the slow commit path.

Finally, we add a test (disabled for now) which checks the fast path's resilience to up to c failing nodes (as suggested by the SBFT paper). The test can be re-enabled once this functionality becomes available.