### PR TITLE
kvbc code dedup.

### DIFF
--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -88,7 +88,7 @@ class ReplicaImp : public IReplica,
              concord::storage::blockchain::DBAdapter *dbAdapter,
              std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
-  void setReplicaStateSync(ReplicaStateSync* rss) {replicaStateSync_.reset(rss);}
+  void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 
   ~ReplicaImp() override;
 
@@ -269,7 +269,7 @@ class ReplicaImp : public IReplica,
   bftEngine::IStateTransfer *m_stateTransfer = nullptr;
   std::unique_ptr<BlockchainAppState> m_appState;
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
-  std::unique_ptr<ReplicaStateSync>   replicaStateSync_;
+  std::unique_ptr<ReplicaStateSync> replicaStateSync_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 
   // static methods

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -88,6 +88,8 @@ class ReplicaImp : public IReplica,
              concord::storage::blockchain::DBAdapter *dbAdapter,
              std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
+  void setReplicaStateSync(ReplicaStateSync* rss) {replicaStateSync_.reset(rss);}
+
   ~ReplicaImp() override;
 
  protected:
@@ -267,7 +269,7 @@ class ReplicaImp : public IReplica,
   bftEngine::IStateTransfer *m_stateTransfer = nullptr;
   std::unique_ptr<BlockchainAppState> m_appState;
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
-  ReplicaStateSyncImp m_replicaStateSync;
+  std::unique_ptr<ReplicaStateSync>   replicaStateSync_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 
   // static methods

--- a/kvbc/include/block_metadata.hpp
+++ b/kvbc/include/block_metadata.hpp
@@ -14,25 +14,44 @@
 namespace concord {
 namespace kvbc {
 
-const char kBlockMetadataKey = 0x21;
+using concordUtils::Sliver;
+using concord::storage::blockchain::ILocalKeyValueStorageReadOnly;
 
-class BlockMetadata {
- private:
+class IBlockMetadata {
+ public:
+  IBlockMetadata(const concord::storage::blockchain::ILocalKeyValueStorageReadOnly& storage):
+    logger_(concordlogger::Log::getLogger("default")),
+    storage_(storage),
+    key_(new char[1]{kBlockMetadataKey}, 1) {}
+
+  virtual ~IBlockMetadata() = default;
+
+  Sliver getKey() const { return key_; }
+
+  virtual uint64_t getSequenceNum(const Sliver& key) const = 0;
+
+  virtual Sliver serialize(uint64_t sequence_num) const = 0;
+
+  static const char kBlockMetadataKey = 0x21;
+
+ protected:
+
   concordlogger::Logger logger_;
-  const concord::storage::blockchain::ILocalKeyValueStorageReadOnly &storage_;
+  const concord::storage::blockchain::ILocalKeyValueStorageReadOnly& storage_;
   const concordUtils::Sliver key_;
 
+};
+
+
+class BlockMetadata: public IBlockMetadata {
  public:
-  BlockMetadata(const concord::storage::blockchain::ILocalKeyValueStorageReadOnly &storage)
-      : logger_(concordlogger::Log::getLogger("skvbc.MetadataStorage")),
-        storage_(storage),
-        key_(new char[1]{kBlockMetadataKey}, 1) {}
+  BlockMetadata(const ILocalKeyValueStorageReadOnly &storage)
+      : IBlockMetadata(storage){
+    logger_ = concordlogger::Log::getLogger("skvbc.MetadataStorage");
+  }
+  virtual uint64_t getSequenceNum(const Sliver& key) const override;
+  virtual Sliver serialize(uint64_t sequence_num) const override;
 
-  concordUtils::Sliver Key() const { return key_; }
-
-  uint64_t Get(concordUtils::Sliver &key);
-
-  concordUtils::Sliver Serialize(uint64_t bft_sequence_num);
 };
 
 }  // namespace kvbc

--- a/kvbc/include/block_metadata.hpp
+++ b/kvbc/include/block_metadata.hpp
@@ -16,11 +16,15 @@ namespace kvbc {
 
 using concordUtils::Sliver;
 using concord::storage::blockchain::ILocalKeyValueStorageReadOnly;
-
+/**
+ * Interface defining the way block is serialized
+ */
 class IBlockMetadata {
  public:
   IBlockMetadata(const concord::storage::blockchain::ILocalKeyValueStorageReadOnly& storage)
-      : logger_(concordlogger::Log::getLogger("default")), storage_(storage), key_(new char[1]{kBlockMetadataKey}, 1) {}
+      : logger_(concordlogger::Log::getLogger("block-metadata")),
+        storage_(storage),
+        key_(new char[1]{kBlockMetadataKey}, 1) {}
 
   virtual ~IBlockMetadata() = default;
 
@@ -38,6 +42,9 @@ class IBlockMetadata {
   const concordUtils::Sliver key_;
 };
 
+/**
+ * Default block serialization
+ */
 class BlockMetadata : public IBlockMetadata {
  public:
   BlockMetadata(const ILocalKeyValueStorageReadOnly& storage) : IBlockMetadata(storage) {

--- a/kvbc/include/block_metadata.hpp
+++ b/kvbc/include/block_metadata.hpp
@@ -19,10 +19,8 @@ using concord::storage::blockchain::ILocalKeyValueStorageReadOnly;
 
 class IBlockMetadata {
  public:
-  IBlockMetadata(const concord::storage::blockchain::ILocalKeyValueStorageReadOnly& storage):
-    logger_(concordlogger::Log::getLogger("default")),
-    storage_(storage),
-    key_(new char[1]{kBlockMetadataKey}, 1) {}
+  IBlockMetadata(const concord::storage::blockchain::ILocalKeyValueStorageReadOnly& storage)
+      : logger_(concordlogger::Log::getLogger("default")), storage_(storage), key_(new char[1]{kBlockMetadataKey}, 1) {}
 
   virtual ~IBlockMetadata() = default;
 
@@ -35,23 +33,18 @@ class IBlockMetadata {
   static const char kBlockMetadataKey = 0x21;
 
  protected:
-
   concordlogger::Logger logger_;
   const concord::storage::blockchain::ILocalKeyValueStorageReadOnly& storage_;
   const concordUtils::Sliver key_;
-
 };
 
-
-class BlockMetadata: public IBlockMetadata {
+class BlockMetadata : public IBlockMetadata {
  public:
-  BlockMetadata(const ILocalKeyValueStorageReadOnly &storage)
-      : IBlockMetadata(storage){
+  BlockMetadata(const ILocalKeyValueStorageReadOnly& storage) : IBlockMetadata(storage) {
     logger_ = concordlogger::Log::getLogger("skvbc.MetadataStorage");
   }
   virtual uint64_t getSequenceNum(const Sliver& key) const override;
   virtual Sliver serialize(uint64_t sequence_num) const override;
-
 };
 
 }  // namespace kvbc

--- a/kvbc/include/replica_state_sync.h
+++ b/kvbc/include/replica_state_sync.h
@@ -11,7 +11,7 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 //
-// Interface for replica state synchronisation.
+// Interface for replica state synchronization.
 
 #pragma once
 
@@ -22,14 +22,15 @@
 namespace concord {
 namespace kvbc {
 
+class IBlockMetadata;
+
 class ReplicaStateSync {
  public:
   virtual ~ReplicaStateSync() = default;
 
-  // Synchronises replica state and returns a number of deleted blocks.
-  virtual uint64_t execute(concordlogger::Logger &logger,
-                           concord::storage::blockchain::DBAdapter &bcDBAdapter,
-                           concord::storage::blockchain::ILocalKeyValueStorageReadOnly &kvs,
+  // Synchronizes replica state and returns a number of deleted blocks.
+  virtual uint64_t execute(concordlogger::Logger& logger,
+                           concord::storage::blockchain::DBAdapter& bcDBAdapter,
                            concord::storage::blockchain::BlockId lastReachableBlockId,
                            uint64_t lastExecutedSeqNum) = 0;
 };

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -20,15 +20,19 @@
 
 namespace concord {
 namespace kvbc {
-class ReplicaStateSyncImp : public ReplicaStateSync {
+
+class ReplicaStateSyncImp: public ReplicaStateSync {
  public:
+  ReplicaStateSyncImp(IBlockMetadata* blockMetadata);
   ~ReplicaStateSyncImp() override = default;
 
-  uint64_t execute(concordlogger::Logger &logger,
-                   concord::storage::blockchain::DBAdapter &bcDBAdapter,
-                   concord::storage::blockchain::ILocalKeyValueStorageReadOnly &kvs,
+  uint64_t execute(concordlogger::Logger& logger,
+                   concord::storage::blockchain::DBAdapter& bcDBAdapter,
                    concord::storage::blockchain::BlockId lastReachableBlockId,
                    uint64_t lastExecutedSeqNum) override;
+
+protected:
+  std::unique_ptr<IBlockMetadata> blockMetadata_;
 };
 
 }  // namespace kvbc

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -21,7 +21,7 @@
 namespace concord {
 namespace kvbc {
 
-class ReplicaStateSyncImp: public ReplicaStateSync {
+class ReplicaStateSyncImp : public ReplicaStateSync {
  public:
   ReplicaStateSyncImp(IBlockMetadata* blockMetadata);
   ~ReplicaStateSyncImp() override = default;
@@ -31,7 +31,7 @@ class ReplicaStateSyncImp: public ReplicaStateSync {
                    concord::storage::blockchain::BlockId lastReachableBlockId,
                    uint64_t lastExecutedSeqNum) override;
 
-protected:
+ protected:
   std::unique_ptr<IBlockMetadata> blockMetadata_;
 };
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -75,17 +75,21 @@ Status ReplicaImp::start() {
 void ReplicaImp::createReplicaAndSyncState() {
   bool isNewStorage = m_metadataStorage->isNewStorage();
   LOG_INFO(logger, "createReplicaAndSyncState: isNewStorage= " << isNewStorage);
-  m_replicaPtr = bftEngine::Replica::createNewReplica(
-      &m_replicaConfig, m_cmdHandler, m_stateTransfer, m_ptrComm, m_metadataStorage);
+  m_replicaPtr = bftEngine::Replica::createNewReplica( &m_replicaConfig,
+                                                       m_cmdHandler,
+                                                       m_stateTransfer,
+                                                       m_ptrComm,
+                                                       m_metadataStorage);
   if (!isNewStorage && !m_stateTransfer->isCollectingState()) {
-    uint64_t removedBlocksNum = m_replicaStateSync.execute(
-        logger, *m_bcDbAdapter, *this, m_appState->m_lastReachableBlock, m_replicaPtr->getLastExecutedSequenceNum());
+    uint64_t removedBlocksNum = replicaStateSync_->execute(logger,
+                                                           *m_bcDbAdapter,
+                                                           m_appState->m_lastReachableBlock,
+                                                           m_replicaPtr->getLastExecutedSequenceNum());
     m_lastBlock -= removedBlocksNum;
     m_appState->m_lastReachableBlock -= removedBlocksNum;
-    LOG_INFO(logger,
-             "createReplicaAndSyncState: removedBlocksNum = "
-                 << removedBlocksNum << ", new m_lastBlock = " << m_lastBlock
-                 << ", new m_lastReachableBlock = " << m_appState->m_lastReachableBlock);
+    LOG_INFO(logger, "createReplicaAndSyncState: removedBlocksNum = "
+                     << removedBlocksNum << ", new m_lastBlock = " << m_lastBlock
+                     << ", new m_lastReachableBlock = " << m_appState->m_lastReachableBlock);
   }
 }
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -75,21 +75,17 @@ Status ReplicaImp::start() {
 void ReplicaImp::createReplicaAndSyncState() {
   bool isNewStorage = m_metadataStorage->isNewStorage();
   LOG_INFO(logger, "createReplicaAndSyncState: isNewStorage= " << isNewStorage);
-  m_replicaPtr = bftEngine::Replica::createNewReplica( &m_replicaConfig,
-                                                       m_cmdHandler,
-                                                       m_stateTransfer,
-                                                       m_ptrComm,
-                                                       m_metadataStorage);
+  m_replicaPtr = bftEngine::Replica::createNewReplica(
+      &m_replicaConfig, m_cmdHandler, m_stateTransfer, m_ptrComm, m_metadataStorage);
   if (!isNewStorage && !m_stateTransfer->isCollectingState()) {
-    uint64_t removedBlocksNum = replicaStateSync_->execute(logger,
-                                                           *m_bcDbAdapter,
-                                                           m_appState->m_lastReachableBlock,
-                                                           m_replicaPtr->getLastExecutedSequenceNum());
+    uint64_t removedBlocksNum = replicaStateSync_->execute(
+        logger, *m_bcDbAdapter, m_appState->m_lastReachableBlock, m_replicaPtr->getLastExecutedSequenceNum());
     m_lastBlock -= removedBlocksNum;
     m_appState->m_lastReachableBlock -= removedBlocksNum;
-    LOG_INFO(logger, "createReplicaAndSyncState: removedBlocksNum = "
-                     << removedBlocksNum << ", new m_lastBlock = " << m_lastBlock
-                     << ", new m_lastReachableBlock = " << m_appState->m_lastReachableBlock);
+    LOG_INFO(logger,
+             "createReplicaAndSyncState: removedBlocksNum = "
+                 << removedBlocksNum << ", new m_lastBlock = " << m_lastBlock
+                 << ", new m_lastReachableBlock = " << m_appState->m_lastReachableBlock);
   }
 }
 

--- a/kvbc/src/block_metadata.cpp
+++ b/kvbc/src/block_metadata.cpp
@@ -6,17 +6,16 @@
 #include "block_metadata.hpp"
 #include "blockchain/db_types.h"
 
-using concordUtils::Sliver;
 using concordUtils::Status;
 
 namespace concord {
 namespace kvbc {
 
-Sliver BlockMetadata::Serialize(uint64_t bft_sequence_num) {
+Sliver BlockMetadata::serialize(uint64_t bft_sequence_num) const {
   return Sliver::copy((char*)&bft_sequence_num, sizeof(uint64_t));
 }
 
-uint64_t BlockMetadata::Get(Sliver& key) {
+uint64_t BlockMetadata::getSequenceNum(const Sliver& key) const {
   Sliver outValue;
   Status status = storage_.get(key, outValue);
   uint64_t sequenceNum = 0;

--- a/kvbc/src/replica_state_sync_imp.cpp
+++ b/kvbc/src/replica_state_sync_imp.cpp
@@ -25,21 +25,20 @@ using concordUtils::Key;
 namespace concord {
 namespace kvbc {
 
-uint64_t ReplicaStateSyncImp::execute(concordlogger::Logger &logger,
+ReplicaStateSyncImp::ReplicaStateSyncImp(IBlockMetadata* blockMetadata): blockMetadata_(blockMetadata){}
+
+uint64_t ReplicaStateSyncImp::execute(concordlogger::Logger& logger,
                                       DBAdapter &bcDBAdapter,
-                                      ILocalKeyValueStorageReadOnly &kvs,
                                       BlockId lastReachableBlockId,
                                       uint64_t lastExecutedSeqNum) {
-  BlockMetadata metadata(kvs);
   BlockId blockId = lastReachableBlockId;
   uint64_t blockSeqNum = 0;
   uint64_t removedBlocksNum = 0;
-  Key key = metadata.Key();
+  Key key = blockMetadata_->getKey();
   do {
-    blockSeqNum = metadata.Get(key);
-    LOG_INFO(logger,
-             "Block Metadata key = " << key << ", blockId = " << blockId << ", blockSeqNum = " << blockSeqNum
-                                     << ", lastExecutedSeqNum = " << lastExecutedSeqNum);
+    blockSeqNum = blockMetadata_->getSequenceNum(key);
+    LOG_INFO(logger, "Block Metadata key = " << key << ", blockId = " << blockId << ", blockSeqNum = " << blockSeqNum
+                     << ", lastExecutedSeqNum = " << lastExecutedSeqNum);
     if (blockSeqNum <= lastExecutedSeqNum) {
       LOG_INFO(logger, "Replica state is in sync; removedBlocksNum is " << removedBlocksNum);
       return removedBlocksNum;

--- a/kvbc/src/replica_state_sync_imp.cpp
+++ b/kvbc/src/replica_state_sync_imp.cpp
@@ -25,10 +25,10 @@ using concordUtils::Key;
 namespace concord {
 namespace kvbc {
 
-ReplicaStateSyncImp::ReplicaStateSyncImp(IBlockMetadata* blockMetadata): blockMetadata_(blockMetadata){}
+ReplicaStateSyncImp::ReplicaStateSyncImp(IBlockMetadata* blockMetadata) : blockMetadata_(blockMetadata) {}
 
 uint64_t ReplicaStateSyncImp::execute(concordlogger::Logger& logger,
-                                      DBAdapter &bcDBAdapter,
+                                      DBAdapter& bcDBAdapter,
                                       BlockId lastReachableBlockId,
                                       uint64_t lastExecutedSeqNum) {
   BlockId blockId = lastReachableBlockId;
@@ -37,8 +37,9 @@ uint64_t ReplicaStateSyncImp::execute(concordlogger::Logger& logger,
   Key key = blockMetadata_->getKey();
   do {
     blockSeqNum = blockMetadata_->getSequenceNum(key);
-    LOG_INFO(logger, "Block Metadata key = " << key << ", blockId = " << blockId << ", blockSeqNum = " << blockSeqNum
-                     << ", lastExecutedSeqNum = " << lastExecutedSeqNum);
+    LOG_INFO(logger,
+             "Block Metadata key = " << key << ", blockId = " << blockId << ", blockSeqNum = " << blockSeqNum
+                                     << ", lastExecutedSeqNum = " << lastExecutedSeqNum);
     if (blockSeqNum <= lastExecutedSeqNum) {
       LOG_INFO(logger, "Replica state is in sync; removedBlocksNum is " << removedBlocksNum);
       return removedBlocksNum;

--- a/storage/include/blockchain/db_interfaces.h
+++ b/storage/include/blockchain/db_interfaces.h
@@ -41,6 +41,7 @@ class ILocalKeyValueStorageReadOnly {
   virtual Status freeSnapIterator(ILocalKeyValueStorageReadOnlyIterator* iter) const = 0;
 
   virtual void monitor() const = 0;
+  virtual ~ILocalKeyValueStorageReadOnly() = default;
 };
 
 /*

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -54,8 +54,8 @@ int InternalCommandsHandler::execute(uint16_t clientId,
 
 void InternalCommandsHandler::addMetadataKeyValue(SetOfKeyValuePairs &updates, uint64_t sequenceNum) const {
   concord::kvbc::BlockMetadata metadata(*m_storage);
-  Sliver metadataKey = metadata.Key();
-  Sliver metadataValue = metadata.Serialize(sequenceNum);
+  Sliver metadataKey = metadata.getKey();
+  Sliver metadataValue = metadata.serialize(sequenceNum);
   updates.insert(KeyValuePair(metadataKey, metadataValue));
 }
 
@@ -179,7 +179,7 @@ bool InternalCommandsHandler::executeGetBlockDataCommand(
   pReply->numOfItems = numOfElements;
 
   concord::kvbc::BlockMetadata metadata(*m_storage);
-  const Sliver metadataKey = metadata.Key();
+  const Sliver metadataKey = metadata.getKey();
 
   auto i = 0;
   for (auto kv : outBlockData) {

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -49,10 +49,8 @@ int main(int argc, char** argv) {
   }
 
   auto* dbAdapter = new concord::storage::blockchain::DBAdapter(db);
-  auto* replica = new ReplicaImp(setup->GetCommunication(),
-                                 setup->GetReplicaConfig(),
-                                 dbAdapter,
-                                 setup->GetMetricsServer().GetAggregator());
+  auto* replica = new ReplicaImp(
+      setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
   replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
 
   // Start metrics server after creation of the replica so that we ensure

--- a/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
+++ b/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
@@ -218,7 +218,7 @@ void TestsBuilder::createAndInsertRandomConditionalWrite() {
     size_t key = 0;
     do {
       key = rand() % NUMBER_OF_KEYS;
-    } while (key == concord::kvbc::kBlockMetadataKey);
+    } while (key == concord::kvbc::IBlockMetadata::kBlockMetadataKey);
     memcpy(readKeysArray[i].key, &key, sizeof(key));
   }
 
@@ -227,7 +227,7 @@ void TestsBuilder::createAndInsertRandomConditionalWrite() {
     size_t key = 0;
     do {  // Avoid duplications
       key = rand() % NUMBER_OF_KEYS;
-    } while (usedKeys.count(key) > 0 || key == concord::kvbc::kBlockMetadataKey);
+    } while (usedKeys.count(key) > 0 || key == concord::kvbc::IBlockMetadata::kBlockMetadataKey);
     usedKeys.insert(key);
 
     size_t value = rand();
@@ -268,7 +268,7 @@ void TestsBuilder::createAndInsertRandomRead() {
     size_t key = 0;
     do {
       key = rand() % NUMBER_OF_KEYS;
-    } while (key == concord::kvbc::kBlockMetadataKey);
+    } while (key == concord::kvbc::IBlockMetadata::kBlockMetadataKey);
     memcpy(requestKeys[i].key, &key, sizeof(key));
   }
 


### PR DESCRIPTION
In order to be able to dedup ReplicaStateSyncImp untroduce concord::kvbc::IBlockMetadata to be used in conjunction with ReplicaStateSyncImp and to have implementation specific to the application.
                                 concord::kvbc::IBlockMetadata
                                           /                         \
concord::kvbc::BlockMetadata      concord::storage::ConcordBlockMetadata
(default serialization)                      (protobuf serialization)