### PR TITLE
Test BFT engine slow path

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ add_test(NAME skvbc_fast_path_tests COMMAND sh -c
         "python3 -m unittest test_skvbc_fast_path 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_test(NAME skvbc_slow_path_tests COMMAND sh -c
+        "python3 -m unittest test_skvbc_slow_path 2>&1 > /dev/null"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests COMMAND sh -c
             "python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"

--- a/tests/test_skvbc_persistence.py
+++ b/tests/test_skvbc_persistence.py
@@ -71,11 +71,8 @@ class SkvbcPersistenceTest(unittest.TestCase):
                 [bft_network.start_replica(i) for i in range(1,config.n-1)]
                 with trio.fail_after(60): # seconds
                     async with trio.open_nursery() as nursery:
-                        msg = self.protocol.write_req([],
-                                [(bft_network.random_key(), bft_network.random_value())],
-                                0)
-                        nursery.start_soon(bft_network.send_indefinite_write_requests,
-                                bft_network.random_client(), msg)
+                        nursery.start_soon(
+                            bft_network.send_indefinite_write_requests, self.protocol)
                         # See if replica 1 has become the new primary
                         # Check every .5 seconds
                         view = await self._get_view_number(
@@ -576,11 +573,8 @@ class SkvbcPersistenceTest(unittest.TestCase):
         print("Sending random transactions to trigger view change...")
         with trio.move_on_after(1):  # seconds
             async with trio.open_nursery() as nursery:
-                msg = self.protocol.write_req([],
-                                              [(bft_network.random_key(), bft_network.random_value())],
-                                              0)
-                nursery.start_soon(bft_network.send_indefinite_write_requests,
-                                   bft_network.random_client(), msg)
+                nursery.start_soon(
+                    bft_network.send_indefinite_write_requests, self.protocol)
 
     async def _get_view_number(self, bft_network, replica_id, expected):
         with trio.move_on_after(10):

--- a/tests/test_skvbc_slow_path.py
+++ b/tests/test_skvbc_slow_path.py
@@ -1,0 +1,179 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os.path
+import random
+
+import trio
+
+import unittest
+
+from util import bft, skvbc
+
+KEY_FILE_PREFIX = "replica_keys_"
+
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "3000"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-v", viewChangeTimeoutMilli]
+
+
+class SkvbcSlowPathTest(unittest.TestCase):
+
+    def setUp(self):
+        self.protocol = skvbc.SimpleKVBCProtocol()
+
+    def test_slow_path_read_your_write(self):
+        """
+        First we write a batch of known K/V entries.
+        
+        Then we check that they have been processed on the slow commit path.
+        
+        Finally we check if a known K/V has been executed and readable.
+        """
+        trio.run(self._test_slow_path_read_your_write)
+
+    async def _test_slow_path_read_your_write(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                unstable_replicas = list(set(range(0, config.n)) - {0})
+                bft_network.stop_replica(
+                    replica=random.choice(unstable_replicas))
+
+                for _ in range(10):
+                    key, val = await bft_network.write_known_kv(self.protocol)
+
+                await bft_network.assert_slow_path_prevalent(as_of_seq_num=1)
+
+                await bft_network.assert_kv_write_executed(self.protocol, key, val)
+
+    def test_slow_to_fast_path_transition(self):
+        """
+        This test aims to check that the system correctly restores
+        the fast path once all failed nodes are back online.
+
+        First we bring down a non-primary replica, and make sure 
+        a batch of K/V entries is processed on the slow path.
+
+        Once the first batch of K/V writes have been processed, we bring the
+        failed replica back up, which should restore the system's ability to
+        process requests via the fast commit path.
+
+        We send a new batch of K/V writes and make sure they
+        have been processed using the fast path.
+
+        Finally we check if a known K/V has been executed and readable.
+        """
+        trio.run(self._test_slow_to_fast_path_transition)
+
+    async def _test_slow_to_fast_path_transition(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                unstable_replicas = list(set(range(0, config.n)) - {0})
+                crashed_replica = random.choice(unstable_replicas)
+                bft_network.stop_replica(crashed_replica)
+
+                for _ in range(10):
+                    await bft_network.write_known_kv(self.protocol)
+
+                await bft_network.assert_slow_path_prevalent(as_of_seq_num=1)
+
+                bft_network.start_replica(crashed_replica)
+
+                for _ in range(10):
+                    key, val = await bft_network.write_known_kv(self.protocol)
+
+                await bft_network.assert_fast_path_prevalent(
+                    as_of_seq_num=10, nb_slow_paths_so_far=10)
+
+                await bft_network.assert_kv_write_executed(self.protocol, key, val)
+
+    def test_slow_path_view_change(self):
+        """
+        This test validates the BFT engine's transition to the slow path
+        when the primary goes down. This effectively triggers a view change in the slow path.
+
+        First we write a batch of known K/V entries.
+
+        We check those entries have been processed via the fast commit path.
+
+        We stop the primary and send a batch of requests, triggering slow path & view change.
+
+        We bring the primary back up.
+
+        We make sure the second batch of requests have been processed via the slow path.
+        """
+        trio.run(self._test_slow_path_view_change)
+
+    async def _test_slow_path_view_change(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                for _ in range(10):
+                    await bft_network.write_known_kv(self.protocol)
+
+                await bft_network.assert_fast_path_prevalent()
+
+                bft_network.stop_replica(0)
+
+                with trio.move_on_after(seconds=5):
+                    async with trio.open_nursery() as nursery:
+                        nursery.start_soon(
+                            bft_network.send_indefinite_write_requests, self.protocol)
+
+                bft_network.start_replica(0)
+
+                await self._check_slow_path_after_view_change(bft_network, as_of_seq_num=10)
+
+    async def _check_slow_path_after_view_change(self, bft_network, as_of_seq_num):
+        with trio.fail_after(seconds=5):
+            while True:
+                with trio.move_on_after(seconds=.5):
+                    await bft_network.assert_slow_path_prevalent(as_of_seq_num)
+                    break

--- a/tests/util/bft.py
+++ b/tests/util/bft.py
@@ -258,8 +258,11 @@ class BftTestNetwork:
 
         assert len(self.procs) == 2 * self.config.f + self.config.c + 1
 
-    async def send_indefinite_write_requests(self, client, msg):
+    async def send_indefinite_write_requests(self, protocol):
+        msg = protocol.write_req(
+            [], [(self.random_key(), self.random_value())], 0)
         while True:
+            client = self.random_client()
             try:
                 await client.write(msg)
             except:


### PR DESCRIPTION
In this test suite we focus on the slow commit path, covering the following workflows:
- processing requests on the slow path solely
- returning to the fast path after a slow path
- slow path & view change

PS: the changes in bft.py are shared with https://github.com/vmware/concord-bft/pull/284 and will need to be merged