### PR TITLE
Fixing intermittent failure of skvbc-persistence-tests

### DIFF
--- a/tests/test_skvbc_persistence.py
+++ b/tests/test_skvbc_persistence.py
@@ -379,7 +379,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
             print("State transfer completed before we had a chance "
                   "to stop the source replica.")
 
-    def test_st_when_primary_crashes(self):
+    def test_st_while_primary_crashes(self):
         """
         Start N-1 nodes out of a N node cluster. Write a specific key, then
         enough data to the cluster to trigger a checkpoint.
@@ -534,13 +534,13 @@ class SkvbcPersistenceTest(unittest.TestCase):
             print(f'Stopping current primary replica {current_primary} '
                   f'to trigger view change')
             bft_network.stop_replica(current_primary)
+            await self._trigger_view_change(bft_network)
 
             print(f'Repeatedly restarting stale replica {stale} '
                   f'to with view change running in the background.')
-
             for k in range(3):
                 bft_network.start_replica(stale)
-                await self._trigger_view_change(bft_network)
+
                 await trio.sleep(seconds=random.uniform(0, 1))
                 if k == 0:
                     # ensure that we have interrupted state transfer at least once

--- a/tests/util/bft.py
+++ b/tests/util/bft.py
@@ -359,11 +359,14 @@ class BftTestNetwork:
                            return
 
     async def is_state_transfer_complete(self, up_to_date_node, stale_node):
-            # Get the lastExecutedSeqNumber from a reference node
-            key = ['replica', 'Gauges', 'lastExecutedSeqNum']
-            last_exec_seq_num = await self.metrics.get(up_to_date_node, *key)
-            n = await self.metrics.get(stale_node, *key)
-            return n == last_exec_seq_num
+            try:
+                key = ['replica', 'Gauges', 'lastExecutedSeqNum']
+                last_exec_seq_num = await self.metrics.get(up_to_date_node, *key)
+                n = await self.metrics.get(stale_node, *key)
+            except KeyError:
+                return False
+            else:
+                return n == last_exec_seq_num
 
     async def wait_for_replicas_to_checkpoint(self, replica_ids, checkpoint_num):
         """


### PR DESCRIPTION
This PR improves the stability of the BFT system tests when persistence is enabled.

The failures were mostly observed when restarting the stale replica and right afterwards, trying to check whether state transfer has completed. To do so, we need a number of metrics from the stale replica, as well as from an up-to-date node.

With this PR we introduce retry logic in the MetricsClient.This is needed in case we send a UDP get request to the Metrics server while it isn't listening yet. In this case we might end up waiting for a reply whereas the server hasn't received our request in the first place.

We also improve slightly the test logic, in order to make it more robust.

Testing done: ran the failing test 20 consecutive times without failure (previously it would fail every 5-10 runs)