### PR TITLE
Fixing intermittent failure of skvbc-persistence-tests

### DIFF
--- a/tests/util/bft.py
+++ b/tests/util/bft.py
@@ -358,13 +358,6 @@ class BftTestNetwork:
                         if n >= expected_seq_num:
                            return
 
-    async def is_state_transfer_complete(self, up_to_date_node, stale_node):
-            # Get the lastExecutedSeqNumber from a reference node
-            key = ['replica', 'Gauges', 'lastExecutedSeqNum']
-            last_exec_seq_num = await self.metrics.get(up_to_date_node, *key)
-            n = await self.metrics.get(stale_node, *key)
-            return n == last_exec_seq_num
-
     async def wait_for_replicas_to_checkpoint(self, replica_ids, checkpoint_num):
         """
         Wait for every replica in `replicas` to take a checkpoint.


### PR DESCRIPTION
This PR improves the stability of the BFT system tests when persistence is enabled.

With this PR we significantly simplify the logic for determining when state transfer has completed.
Most notably:
- the is_state_transfer_complete() is dropped as following several refactorings, it became redundant with wait_for_state_transfer_to_stop() - both implement essentially the same logic
- we slightly generalize _fetch_or_finish_state_transfer_while_crashing() and reuse it for test_st_while_primary_crashes()

Testing done: ran test_st_while_primary_crashes() 20 consecutive times without failure (previously it would fail every 5-10 runs)