### PR TITLE
Only preserve stderr output for BFT engine system tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,17 +2,16 @@ add_subdirectory(config)
 add_subdirectory(simpleKVBC)
 add_subdirectory(simpleTest)
 
-add_test(NAME skvbc_basic_tests COMMAND python3 -m unittest
-        test_skvbc
+add_test(NAME skvbc_basic_tests COMMAND sh -c
+        "python3 -m unittest test_skvbc 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_linearizability_tests COMMAND python3 -m unittest
-        test_skvbc_history_tracker
-        test_skvbc_linearizability
+add_test(NAME skvbc_linearizability_tests COMMAND sh -c
+        "python3 -m unittest test_skvbc_history_tracker test_skvbc_linearizability 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 if (BUILD_ROCKSDB_STORAGE)
-    add_test(NAME skvbc_persistence_tests COMMAND python3 -m unittest
-            test_skvbc_persistence
+    add_test(NAME skvbc_persistence_tests COMMAND sh -c
+            "python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()


### PR DESCRIPTION
System tests flush large amounts of data to stdout. Our current CI limits output to 4MB, so most of the time we don't even see the actual error.
Given this limitation, I suggest to ignore stdout in CI and focus solely on stderr which should be small enough.

This way, in case of failures we will see both Concord BFT errors and test failure stacktraces, making CI failures easier to debug.