### PR TITLE
Use new Timers class in ReplicaImp

### DIFF
--- a/bftengine/src/bftengine/DebugStatistics.hpp
+++ b/bftengine/src/bftengine/DebugStatistics.hpp
@@ -18,7 +18,7 @@
 namespace bftEngine {
 namespace impl {
 
-const double DEBUG_STAT_PERIOD_SECONDS = 7;  // 2;
+const unsigned int DEBUG_STAT_PERIOD_SECONDS = 7;  // 2;
 
 class DebugStatistics {
  public:

--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -71,24 +71,6 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual IThresholdVerifier* getThresholdVerifierForSlowPathCommit() = 0;
   virtual IThresholdVerifier* getThresholdVerifierForCommit() = 0;
   virtual IThresholdVerifier* getThresholdVerifierForOptimisticCommit() = 0;
-
-  virtual Timer& getViewChangeTimer() = 0;
-  virtual Timer& getStateTranTimer() = 0;
-  virtual Timer& getRetransmissionsTimer() = 0;
-  virtual Timer& getStatusTimer() = 0;
-  virtual Timer& getSlowPathTimer() = 0;
-  virtual Timer& getInfoRequestTimer() = 0;
-  virtual Timer& getDebugStatTimer() = 0;
-  virtual Timer& getMetricsTimer() = 0;
-
-  virtual void onViewsChangeTimer(Time currTime, Timer& timer) = 0;
-  virtual void onStateTranTimer(Time currTime, Timer& timer) = 0;
-  virtual void onRetransmissionsTimer(Time cTime, Timer& timer) = 0;
-  virtual void onStatusReportTimer(Time cTime, Timer& timer) = 0;
-  virtual void onSlowPathTimer(Time cTime, Timer& timer) = 0;
-  virtual void onInfoRequestTimer(Time cTime, Timer& timer) = 0;
-  virtual void onDebugStatTimer(Time cTime, Timer& timer) = 0;
-  virtual void onMetricsTimer(Time cTime, Timer& timer) = 0;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -40,6 +40,8 @@
 #include "ReplicaLoader.hpp"
 #include "Metrics.hpp"
 
+#include "Timers.hpp"
+
 #include <thread>
 
 namespace bftEngine {
@@ -98,9 +100,6 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
 
   // retransmissions manager (can be disabled)
   RetransmissionsManager* retransmissionsManager = nullptr;
-
-  // scheduler
-  SimpleOperationsScheduler timersScheduler;
 
   // controller
   ControllerBase* controller;
@@ -198,15 +197,18 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
                               // view >= v
   Time timeOfLastAgreedView;  // last time we changed lastAgreedView
 
+  // Timer manager/container
+  concordUtil::Timers timers_;
+
   // timers
-  Timer* stateTranTimer;
-  Timer* retranTimer;
-  Timer* slowPathTimer;
-  Timer* infoReqTimer;
-  Timer* statusReportTimer;
-  Timer* viewChangeTimer;
-  Timer* debugStatTimer = nullptr;
-  Timer* metricsTimer_;
+  concordUtil::Timers::Handle stateTranTimer_;
+  concordUtil::Timers::Handle retranTimer_;
+  concordUtil::Timers::Handle slowPathTimer_;
+  concordUtil::Timers::Handle infoReqTimer_;
+  concordUtil::Timers::Handle statusReportTimer_;
+  concordUtil::Timers::Handle viewChangeTimer_;
+  concordUtil::Timers::Handle debugStatTimer_;
+  concordUtil::Timers::Handle metricsTimer_;
 
   int viewChangeTimerMilli;
 
@@ -457,30 +459,14 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
 
   virtual const ReplicasInfo& getReplicasInfo() override { return (*repsInfo); }
 
-  virtual Timer& getViewChangeTimer() override { return *viewChangeTimer; }
-
-  virtual Timer& getStateTranTimer() override { return *stateTranTimer; }
-
-  virtual Timer& getRetransmissionsTimer() override { return *retranTimer; }
-
-  virtual Timer& getStatusTimer() override { return *statusReportTimer; }
-
-  virtual Timer& getSlowPathTimer() override { return *slowPathTimer; }
-
-  virtual Timer& getInfoRequestTimer() override { return *infoReqTimer; }
-
-  virtual Timer& getDebugStatTimer() override { return *debugStatTimer; }
-
-  virtual Timer& getMetricsTimer() override { return *metricsTimer_; }
-
-  virtual void onViewsChangeTimer(Time cTime, Timer& timer) override;
-  virtual void onStateTranTimer(Time cTime, Timer& timer) override;
-  virtual void onRetransmissionsTimer(Time cTime, Timer& timer) override;
-  virtual void onStatusReportTimer(Time cTime, Timer& timer) override;
-  virtual void onSlowPathTimer(Time cTime, Timer& timer) override;
-  virtual void onInfoRequestTimer(Time cTime, Timer& timer) override;
-  virtual void onDebugStatTimer(Time cTime, Timer& timer) override;
-  virtual void onMetricsTimer(Time cTime, Timer& timer) override;
+  void onViewsChangeTimer(concordUtil::Timers::Handle);
+  void onStateTranTimer(concordUtil::Timers::Handle);
+  void onRetransmissionsTimer(concordUtil::Timers::Handle);
+  void onStatusReportTimer(concordUtil::Timers::Handle);
+  void onSlowPathTimer(concordUtil::Timers::Handle);
+  void onInfoRequestTimer(concordUtil::Timers::Handle);
+  void onDebugStatTimer(concordUtil::Timers::Handle);
+  void onMetricsTimer(concordUtil::Timers::Handle);
 
   // handlers for internal messages
 

--- a/util/test/timers_tests.cpp
+++ b/util/test/timers_tests.cpp
@@ -21,6 +21,8 @@ using namespace std::chrono;
 
 namespace concordUtil {
 
+typedef Timers::Handle Handle;
+
 TEST(TimersTest, Basic) {
   milliseconds duration(100);
 
@@ -31,9 +33,9 @@ TEST(TimersTest, Basic) {
 
   // Create a oneshot and a recurring timer and add them to the heap. Each one
   // will fire a callback when it expires that increments a counter.
-  timers.add(duration, Timers::Timer::ONESHOT, [&oneshot_counter]() { ++oneshot_counter; }, now);
+  timers.add(duration, Timers::Timer::ONESHOT, [&oneshot_counter](Handle h) { ++oneshot_counter; }, now);
   auto recurring_handle =
-      timers.add(duration, Timers::Timer::RECURRING, [&recurring_counter]() { ++recurring_counter; }, now);
+      timers.add(duration, Timers::Timer::RECURRING, [&recurring_counter](Handle h) { ++recurring_counter; }, now);
 
   // Clock hasn't advanced so no timers should fire
   timers.evaluate(now);
@@ -96,7 +98,8 @@ TEST(TimersTest, Basic) {
   // Add a third timer and ensure it fires.
   // This tests the monotonicity of counter ids as used by handles.
   bool third_timer_fired = false;
-  auto handle = timers.add(duration, Timers::Timer::ONESHOT, [&third_timer_fired]() { third_timer_fired = true; }, now);
+  auto handle =
+      timers.add(duration, Timers::Timer::ONESHOT, [&third_timer_fired](Handle h) { third_timer_fired = true; }, now);
   now += duration;
   timers.evaluate(now);
   ASSERT_TRUE(third_timer_fired);


### PR DESCRIPTION
This class adds type safety and reduces the amount of work required to
add a new timer.

This change replaces the use of the old Timer and SimpleOperationsScheduler with
the new Timers class.

As the new Timers class uses `std::function` for callbacks, we can capture
`this`directly and no longer need to pass it as a void* parameter and
then cast it to InternalReplicaAPI. Timers also can now be scheduled to
recur and thus remove the need to start them on every callback. And
since these timers are only ever created and manipulated in ReplicaImp,
the above 2 changes allow us to remove all the xxxTimerHandlerFunc
wrapper functions in ReplicaImp, and call the handlers directly via a
closure. It also allows us to remove the callback functions from the
InternalReplicaAPI, since they are unused.

Since these timers are never referred to outside ReplicaImp, we also
remove the accessor functions from InternalReplicaAPI. If we need access
to these specific timers from other modules in the future we can create
a more concrete mechanism to wrap the timer manager and handles.

The Timer callback signature itself was also changed to take a Handle
when a timer fires so it can be reset or cancelled from within the
callback.

A future commit will remove the old TimeUtils code from util and replace
integer usages of time with std::chrono types.