### PR TITLE
Improving stability of slow path system test

### DIFF
--- a/tests/test_skvbc_slow_path.py
+++ b/tests/test_skvbc_slow_path.py
@@ -169,11 +169,17 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
                 bft_network.start_replica(0)
 
-                await self._check_slow_path_after_view_change(bft_network, as_of_seq_num=10)
+                await self._wait_for_slow_path_after_view_change(bft_network, as_of_seq_num=10)
 
-    async def _check_slow_path_after_view_change(self, bft_network, as_of_seq_num):
+    async def _wait_for_slow_path_after_view_change(self, bft_network, as_of_seq_num):
         with trio.fail_after(seconds=5):
             while True:
                 with trio.move_on_after(seconds=.5):
-                    await bft_network.assert_slow_path_prevalent(as_of_seq_num)
-                    break
+                    try:
+                        await bft_network.assert_slow_path_prevalent(as_of_seq_num)
+                    except KeyError:
+                        # metrics not yet available, continue looping
+                        continue
+                    else:
+                        # slow path prevalent - done.
+                        break


### PR DESCRIPTION
After triggering view change, the primary is restarted and we immediately check if slow path is prevalent.
However, in some cases some of the required metrics are not available, resulting in a KeyError.

With this PR, we improve the resilience of the slow path + view change test to such circumstances.

Testing done - successfully ran the unstable test 20 consecutive times:
```for i in `seq 20`; do python3 -m unittest test_skvbc_slow_path.SkvbcSlowPathTest.test_slow_path_view_change 1>/dev/null; done```