### PR TITLE
Centralizing replica subsets & config selection logic

### DIFF
--- a/tests/test_skvbc.py
+++ b/tests/test_skvbc.py
@@ -59,7 +59,9 @@ class SkvbcTest(unittest.TestCase):
             with bft.BftTestNetwork(config) as bft_network:
                 skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-                stale_node = random.choice(list(set(range(config.n)) - {0}))
+                stale_node = random.choice(
+                    bft_network.all_replicas(without={0}))
+
                 await skvbc.prime_for_state_transfer(
                     stale_nodes={stale_node},
                     persistency_enabled=False
@@ -69,7 +71,7 @@ class SkvbcTest(unittest.TestCase):
                 await bft_network.wait_for_state_transfer_to_stop(0, stale_node)
                 await skvbc.assert_successful_put_get(self)
                 random_replica = random.choice(
-                    list(set(range(config.n)) - {0, stale_node}))
+                    bft_network.all_replicas(without={0, stale_node}))
                 bft_network.stop_replica(random_replica)
                 await skvbc.assert_successful_put_get(self)
 

--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -113,7 +113,7 @@ class SkvbcFastPathTest(unittest.TestCase):
 
                 await bft_network.assert_fast_path_prevalent()
 
-                unstable_replicas = list(set(range(0, config.n)) - {0})
+                unstable_replicas = bft_network.all_replicas(without={0})
                 bft_network.stop_replica(
                     replica=random.choice(unstable_replicas))
 
@@ -139,7 +139,7 @@ class SkvbcFastPathTest(unittest.TestCase):
         trio.run(self._test_fast_path_resilience_to_crashes)
 
     async def _test_fast_path_resilience_to_crashes(self):
-        for bft_config in bft.interesting_configs(c_min=1):
+        for bft_config in bft.interesting_configs(lambda n, f, c: c >= 1):
             config = bft.TestConfig(n=bft_config['n'],
                                     f=bft_config['f'],
                                     c=bft_config['c'],
@@ -151,7 +151,7 @@ class SkvbcFastPathTest(unittest.TestCase):
                 bft_network.start_all_replicas()
                 skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-                unstable_replicas = list(set(range(0, config.n)) - {0})
+                unstable_replicas = bft_network.all_replicas(without={0})
                 for _ in range(config.c):
                     replica_to_stop = random.choice(unstable_replicas)
                     bft_network.stop_replica(replica_to_stop)

--- a/tests/util/skvbc.py
+++ b/tests/util/skvbc.py
@@ -179,7 +179,7 @@ class SimpleKVBCProtocol:
             checkpoints_num=2,
             persistency_enabled=True):
         await self.bft_network.init()
-        initial_nodes = set(range(self.bft_network.config.n)) - stale_nodes
+        initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
         [self.bft_network.start_replica(i) for i in initial_nodes]
         client = SkvbcClient(self.bft_network.random_client())
         # Write a KV pair with a known value


### PR DESCRIPTION
With this PR we bring into bft.py the logic for selecting interesting BFT configurations, as well as subsets of replicas.
Selecting BFT configs can now be done in a more flexible way, using a lambda.

Thanks to this refactoring, two improvements were identified and made:
- [test relevance] the slow path stability can now be tested specifically for c == 0
- [test stability] in _run_state_transfer_while_crashing_primary_once() we determine state transfer has completed using the current_primary instead of a random node (see test_skvbc_persistence:560)