### PR TITLE
Centralizing replica subsets & config selection logic

### DIFF
--- a/tests/test_skvbc.py
+++ b/tests/test_skvbc.py
@@ -59,7 +59,9 @@ class SkvbcTest(unittest.TestCase):
             with bft.BftTestNetwork(config) as bft_network:
                 skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-                stale_node = random.choice(list(set(range(config.n)) - {0}))
+                stale_node = random.choice(
+                    bft_network.all_replicas(without={0}))
+
                 await skvbc.prime_for_state_transfer(
                     stale_nodes={stale_node},
                     persistency_enabled=False
@@ -69,7 +71,7 @@ class SkvbcTest(unittest.TestCase):
                 await bft_network.wait_for_state_transfer_to_stop(0, stale_node)
                 await skvbc.assert_successful_put_get(self)
                 random_replica = random.choice(
-                    list(set(range(config.n)) - {0, stale_node}))
+                    bft_network.all_replicas(without={0, stale_node}))
                 bft_network.stop_replica(random_replica)
                 await skvbc.assert_successful_put_get(self)
 

--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -113,7 +113,7 @@ class SkvbcFastPathTest(unittest.TestCase):
 
                 await bft_network.assert_fast_path_prevalent()
 
-                unstable_replicas = list(set(range(0, config.n)) - {0})
+                unstable_replicas = bft_network.all_replicas(without={0})
                 bft_network.stop_replica(
                     replica=random.choice(unstable_replicas))
 
@@ -139,7 +139,7 @@ class SkvbcFastPathTest(unittest.TestCase):
         trio.run(self._test_fast_path_resilience_to_crashes)
 
     async def _test_fast_path_resilience_to_crashes(self):
-        for bft_config in bft.interesting_configs(c_min=1):
+        for bft_config in bft.interesting_configs(lambda n, f, c: c >= 1):
             config = bft.TestConfig(n=bft_config['n'],
                                     f=bft_config['f'],
                                     c=bft_config['c'],
@@ -151,7 +151,7 @@ class SkvbcFastPathTest(unittest.TestCase):
                 bft_network.start_all_replicas()
                 skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-                unstable_replicas = list(set(range(0, config.n)) - {0})
+                unstable_replicas = bft_network.all_replicas(without={0})
                 for _ in range(config.c):
                     replica_to_stop = random.choice(unstable_replicas)
                     bft_network.stop_replica(replica_to_stop)

--- a/tests/test_skvbc_slow_path.py
+++ b/tests/test_skvbc_slow_path.py
@@ -41,18 +41,28 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcSlowPathTest(unittest.TestCase):
 
-    def test_slow_path_read_your_write(self):
+    def setUp(self):
+        # Whenever a replica goes down, all messages initially go via the slow path.
+        # However, when an "evaluation period" elapses (set at 64 sequence numbers),
+        # the system should return to the fast path.
+        self.evaluation_period_seq_num = 64
+
+    def test_persistent_slow_path(self):
         """
-        First we write a batch of known K/V entries.
+        Start a full BFT network with c=0 then bring one replica down.
+
+        Write a batch of known K/V entries.
         
-        Then we check that they have been processed on the slow commit path.
+        Then we check that messages from now on are processed on the slow commit path.
+        (note that this is not the case for c>0 where the BFT network eventually
+        returns to the fast commit path)
         
         Finally we check if a known K/V has been executed and readable.
         """
-        trio.run(self._test_slow_path_read_your_write)
+        trio.run(self._test_persistent_slow_path)
 
-    async def _test_slow_path_read_your_write(self):
-        for bft_config in bft.interesting_configs():
+    async def _test_persistent_slow_path(self):
+        for bft_config in bft.interesting_configs(lambda n, f, c: c == 0):
             config = bft.TestConfig(n=bft_config['n'],
                                     f=bft_config['f'],
                                     c=bft_config['c'],
@@ -64,11 +74,11 @@ class SkvbcSlowPathTest(unittest.TestCase):
                 bft_network.start_all_replicas()
                 skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-                unstable_replicas = list(set(range(0, config.n)) - {0})
+                unstable_replicas = bft_network.all_replicas(without={0})
                 bft_network.stop_replica(
                     replica=random.choice(unstable_replicas))
 
-                for _ in range(10):
+                for _ in range(self.evaluation_period_seq_num*2):
                     key, val = await skvbc.write_known_kv()
 
                 await bft_network.assert_slow_path_prevalent(as_of_seq_num=1)
@@ -107,7 +117,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
                 bft_network.start_all_replicas()
                 skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-                unstable_replicas = list(set(range(0, config.n)) - {0})
+                unstable_replicas = bft_network.all_replicas(without={0})
                 crashed_replica = random.choice(unstable_replicas)
                 bft_network.stop_replica(crashed_replica)
 

--- a/tests/util/bft.py
+++ b/tests/util/bft.py
@@ -40,7 +40,9 @@ TestConfig = namedtuple('TestConfig', [
     'start_replica_cmd'
 ])
 
-def interesting_configs(f_min=1, c_min=0):
+def interesting_configs(
+        selected=lambda *config: True):
+
     bft_configs = [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': 4},
                    {'n': 6, 'f': 1, 'c': 1, 'num_clients': 4},
@@ -50,7 +52,7 @@ def interesting_configs(f_min=1, c_min=0):
 
     selected_bft_configs = \
         [conf for conf in bft_configs
-         if conf['f'] >= f_min and conf['c'] >= c_min]
+         if selected(conf['n'], conf['f'], conf['c'])]
 
     assert len(selected_bft_configs) > 0, "No eligible BFT configs"
 
@@ -184,13 +186,21 @@ class BftTestNetwork:
 
         del self.procs[replica]
 
+    def all_replicas(self, without=None):
+        """
+        Returns a list of all replicas excluding the "without" set
+        """
+        if without is None:
+            without = set()
+
+        return list(set(range(0, self.config.n)) - without)
+
     def force_quorum_including_replica(self, replica_id, primary=0):
         """
         Bring down a sufficient number of replicas (excluding the primary),
         so that the remaining replicas form a quorum that includes replica_id
         """
-        unstable_replicas = list(
-            set(range(0, self.config.n)) - {primary, replica_id})
+        unstable_replicas = self.all_replicas(without={primary, replica_id})
 
         random.shuffle(unstable_replicas)
 

--- a/tests/util/skvbc.py
+++ b/tests/util/skvbc.py
@@ -179,7 +179,7 @@ class SimpleKVBCProtocol:
             checkpoints_num=2,
             persistency_enabled=True):
         await self.bft_network.init()
-        initial_nodes = set(range(self.bft_network.config.n)) - stale_nodes
+        initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
         [self.bft_network.start_replica(i) for i in initial_nodes]
         client = SkvbcClient(self.bft_network.random_client())
         # Write a KV pair with a known value


### PR DESCRIPTION
Centralizing replica subsets & config selection logic

With this PR we bring into bft.py the logic for creating subsets of replicas.
Also, introducing a lambda parameter for more flexible selection of interesting BFT configs.

Thanks to this refactoring, two improvements were identified and made:
- [test relevance] the slow path stability can now be tested specifically for c == 0
- [test stability] in _run_state_transfer_while_crashing_primary_once() we determine state transfer has completed using the current_primary instead of a random node (see test_skvbc_persistence:~560)