### PR TITLE
Disable copy operations on RSASigner and RSAVerifier

### DIFF
--- a/bftengine/src/bftengine/Crypto.hpp
+++ b/bftengine/src/bftengine/Crypto.hpp
@@ -16,6 +16,7 @@
 #include <cryptopp/dll.h>
 #include <cryptopp/integer.h>
 
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -35,7 +36,11 @@ class RSASigner {
  public:
   RSASigner(const char* privteKey, const char* randomSeed);
   RSASigner(const char* privateKey);
+  RSASigner(const RSASigner&) = delete;
+  RSASigner(RSASigner&&);
   ~RSASigner();
+  RSASigner& operator=(const RSASigner&) = delete;
+  RSASigner& operator=(RSASigner&&);
   size_t signatureLength() const;
   bool sign(const char* inBuffer,
             size_t lengthOfInBuffer,
@@ -44,19 +49,25 @@ class RSASigner {
             size_t& lengthOfReturnedData) const;
 
  private:
-  void* d;
+  class Impl;
+  std::unique_ptr<Impl> impl;
 };
 
 class RSAVerifier {
  public:
   RSAVerifier(const char* publicKey, const char* randomSeed);
   RSAVerifier(const char* publicKey);
+  RSAVerifier(const RSAVerifier&) = delete;
+  RSAVerifier(RSAVerifier&&);
   ~RSAVerifier();
+  RSAVerifier& operator=(const RSAVerifier&) = delete;
+  RSAVerifier& operator=(RSAVerifier&&);
   size_t signatureLength() const;
   bool verify(const char* data, size_t lengthOfData, const char* signature, size_t lengthOfOSignature) const;
 
  private:
-  void* d;
+  class Impl;
+  std::unique_ptr<Impl> impl;
 };
 
 class DigestUtil {


### PR DESCRIPTION
Current implementations of copy operations on RSASigner and RSAVerifier
will cause core dumps because of double free of the internal
implementation pointer. This PR does the following:
*  Disable copy operations on RSASigner and RSAVerifier
*  Allow move operations on RSASigner and RSAVerifier
*  Implement the pimpl idiom via a std::unique_ptr to avoid casts and
manual memory management

Copy operations might be added in the future if a need arises. That will
need further investigation on the safety of CryptoPP copy operations.