### PR TITLE
Fixing flawed fast path assertion logic

### DIFF
--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -166,7 +166,6 @@ class SkvbcFastPathTest(unittest.TestCase):
                                self.evaluation_period_seq_num*2):
                     key, val = await skvbc.write_known_kv()
                 await bft_network.assert_fast_path_prevalent(
-                    as_of_seq_num=self.evaluation_period_seq_num+1,
                     nb_slow_paths_so_far=self.evaluation_period_seq_num)
 
                 await skvbc.assert_kv_write_executed(key, val)

--- a/tests/test_skvbc_slow_path.py
+++ b/tests/test_skvbc_slow_path.py
@@ -131,8 +131,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
                 for _ in range(10):
                     key, val = await skvbc.write_known_kv()
 
-                await bft_network.assert_fast_path_prevalent(
-                    as_of_seq_num=10, nb_slow_paths_so_far=10)
+                await bft_network.assert_fast_path_prevalent(nb_slow_paths_so_far=10)
 
                 await skvbc.assert_kv_write_executed(key, val)
 

--- a/tests/util/bft.py
+++ b/tests/util/bft.py
@@ -333,20 +333,16 @@ class BftTestNetwork:
                     nursery.start_soon(self._assert_state_transfer_not_started,
                                        r)
 
-    async def assert_fast_path_prevalent(
-            self, as_of_seq_num=1, nb_slow_paths_so_far=0):
+    async def assert_fast_path_prevalent(self, nb_slow_paths_so_far=0):
         """
-        Asserts there is at most 1 sequence processed on the slow path after "as_of_seq_num",
+        Asserts there is at most 1 sequence processed on the slow path,
         given the "nb_slow_paths_so_far".
         """
-        metric_key = ['replica', 'Gauges', 'lastExecutedSeqNum']
-        total_nb_executed_sequences = await self.metrics.get(0, *metric_key)
-
         metric_key = ['replica', 'Counters', 'slowPathCount']
         total_nb_slow_paths = await self.metrics.get(0, *metric_key)
         assert total_nb_slow_paths >= nb_slow_paths_so_far
 
-        assert (total_nb_slow_paths - nb_slow_paths_so_far) - (total_nb_executed_sequences - as_of_seq_num) <= 1, \
+        assert total_nb_slow_paths - nb_slow_paths_so_far <= 1, \
             f'Fast path is not prevalent for n={self.config.n}, f={self.config.f}, c={self.config.c}.'
 
     async def assert_slow_path_prevalent(


### PR DESCRIPTION
In order to assert fast path is prevalent, we only need two things:
- the total number of sequences processed on the slow path
- the number of slow paths up to a previous known point in time ("so far")

The number of sequences processed on the fast path between this last known point in time and now,
is equal to the difference between those two numbers.

The "as_of_seq_num" parameter was redundant and resulted in flawed logic.

Note: the tests used to pass because, due to this flaw, the fast path assertion logic was too "permissive".