### PR TITLE
Test BFT engine automatic view change

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -45,11 +45,17 @@ struct ReplicaConfig {
   // 1 <= concurrencyLevel <= 30
   uint16_t concurrencyLevel = 0;
 
-  // autoViewChangeEnabled=true , if the automatic view change protocol is enabled
-  bool autoViewChangeEnabled = false;
+  // viewChangeProtocolEnabled=true , if the view change protocol is enabled at all
+  bool viewChangeProtocolEnabled = false;
 
   // a time interval in milliseconds. represents the timeout used by the  view change protocol (TODO: add more details)
   uint16_t viewChangeTimerMillisec = 0;
+
+  // autoPrimaryRotationEnabled=true , if the automatic primary rotation is enabled
+  bool autoPrimaryRotationEnabled = false;
+
+  // a time interval in milliseconds, represents the timeout for automatically replacing the primary
+  uint16_t autoPrimaryRotationTimerMillisec = 0;
 
   // public keys of all replicas. map from replica identifier to a public key
   std::set<std::pair<uint16_t, const std::string>> publicKeysOfReplicas;
@@ -113,8 +119,11 @@ class ReplicaConfigSingleton {
   uint16_t GetNumOfClientProxies() const { return config_->numOfClientProxies; }
   uint16_t GetStatusReportTimerMillisec() const { return config_->statusReportTimerMillisec; }
   uint16_t GetConcurrencyLevel() const { return config_->concurrencyLevel; }
-  bool GetAutoViewChangeEnabled() const { return config_->autoViewChangeEnabled; }
+  bool GetViewChangeProtocolEnabled() const { return config_->viewChangeProtocolEnabled; }
   uint16_t GetViewChangeTimerMillisec() const { return config_->viewChangeTimerMillisec; }
+  bool GetAutoPrimaryRotationEnabled() const { return config_->autoPrimaryRotationEnabled; }
+
+  uint16_t GetAutoPrimaryRotationTimerMillisec() const { return config_->autoPrimaryRotationTimerMillisec; }
   std::set<std::pair<uint16_t, const std::string>> GetPublicKeysOfReplicas() const {
     return config_->publicKeysOfReplicas;
   }

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -24,8 +24,9 @@ namespace impl {
 uint32_t ReplicaConfigSerializer::maxSize(uint32_t numOfReplicas) {
   return (sizeof(config_->fVal) + sizeof(config_->cVal) + sizeof(config_->replicaId) +
           sizeof(config_->numOfClientProxies) + sizeof(config_->statusReportTimerMillisec) +
-          sizeof(config_->concurrencyLevel) + sizeof(config_->autoViewChangeEnabled) +
-          sizeof(config_->viewChangeTimerMillisec) + MaxSizeOfPrivateKey + numOfReplicas * MaxSizeOfPublicKey +
+          sizeof(config_->concurrencyLevel) + sizeof(config_->viewChangeProtocolEnabled) +
+          sizeof(config_->viewChangeTimerMillisec) + sizeof(config_->autoPrimaryRotationEnabled) +
+          sizeof(config_->autoPrimaryRotationTimerMillisec) + MaxSizeOfPrivateKey + numOfReplicas * MaxSizeOfPublicKey +
           IThresholdSigner::maxSize() * 3 + IThresholdVerifier::maxSize() * 3 +
           sizeof(config_->maxExternalMessageSize) + sizeof(config_->maxReplyMessageSize) +
           sizeof(config_->maxNumOfReservedPages) + sizeof(config_->sizeOfReservedPage) +
@@ -67,11 +68,18 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
   // Serialize concurrencyLevel
   outStream.write((char *)&config_->concurrencyLevel, sizeof(config_->concurrencyLevel));
 
-  // Serialize autoViewChangeEnabled
-  outStream.write((char *)&config_->autoViewChangeEnabled, sizeof(config_->autoViewChangeEnabled));
+  // Serialize viewChangeProtocolEnabled
+  outStream.write((char *)&config_->viewChangeProtocolEnabled, sizeof(config_->viewChangeProtocolEnabled));
 
   // Serialize viewChangeTimerMillisec
   outStream.write((char *)&config_->viewChangeTimerMillisec, sizeof(config_->viewChangeTimerMillisec));
+
+  // Serialize autoPrimaryRotationEnabled
+  outStream.write((char *)&config_->autoPrimaryRotationEnabled, sizeof(config_->autoPrimaryRotationEnabled));
+
+  // Serialize autoPrimaryRotationTimerMillisec
+  outStream.write((char *)&config_->autoPrimaryRotationTimerMillisec,
+                  sizeof(config_->autoPrimaryRotationTimerMillisec));
 
   // Serialize public keys
   auto numOfPublicKeys = (int64_t)config_->publicKeysOfReplicas.size();
@@ -124,8 +132,10 @@ bool ReplicaConfigSerializer::operator==(const ReplicaConfigSerializer &other) c
                  (other.config_->numOfClientProxies == config_->numOfClientProxies) &&
                  (other.config_->statusReportTimerMillisec == config_->statusReportTimerMillisec) &&
                  (other.config_->concurrencyLevel == config_->concurrencyLevel) &&
-                 (other.config_->autoViewChangeEnabled == config_->autoViewChangeEnabled) &&
+                 (other.config_->viewChangeProtocolEnabled == config_->viewChangeProtocolEnabled) &&
                  (other.config_->viewChangeTimerMillisec == config_->viewChangeTimerMillisec) &&
+                 (other.config_->autoPrimaryRotationEnabled == config_->autoPrimaryRotationEnabled) &&
+                 (other.config_->autoPrimaryRotationTimerMillisec == config_->autoPrimaryRotationTimerMillisec) &&
                  (other.config_->replicaPrivateKey == config_->replicaPrivateKey) &&
                  (other.config_->publicKeysOfReplicas == config_->publicKeysOfReplicas) &&
                  (other.config_->debugPersistentStorageEnabled == config_->debugPersistentStorageEnabled) &&
@@ -158,11 +168,17 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
   // Deserialize concurrencyLevel
   inStream.read((char *)&config.concurrencyLevel, sizeof(config.concurrencyLevel));
 
-  // Deserialize autoViewChangeEnabled
-  inStream.read((char *)&config.autoViewChangeEnabled, sizeof(config.autoViewChangeEnabled));
+  // Deserialize viewChangeProtocolEnabled
+  inStream.read((char *)&config.viewChangeProtocolEnabled, sizeof(config.viewChangeProtocolEnabled));
 
   // Deserialize viewChangeTimerMillisec
   inStream.read((char *)&config.viewChangeTimerMillisec, sizeof(config.viewChangeTimerMillisec));
+
+  // Deserialize autoPrimaryRotationEnabled
+  inStream.read((char *)&config.autoPrimaryRotationEnabled, sizeof(config.autoPrimaryRotationEnabled));
+
+  // Deserialize autoPrimaryRotationTimerMillisec
+  inStream.read((char *)&config.autoPrimaryRotationTimerMillisec, sizeof(config.autoPrimaryRotationTimerMillisec));
 
   // Deserialize public keys
   int64_t numOfPublicKeys = 0;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -69,6 +69,7 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
 
   const uint16_t numOfReplicas;
   const bool viewChangeProtocolEnabled;
+  const bool autoPrimaryRotationEnabled;
   const bool supportDirectProofs = false;  // TODO(GG): add support
 
   // pointers to message handlers
@@ -190,6 +191,7 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   concordUtil::Timers::Handle metricsTimer_;
 
   int viewChangeTimerMilli = 0;
+  int autoPrimaryRotationTimerMilli = 0;
 
   std::shared_ptr<PersistentStorage> ps_;
 

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -58,8 +58,10 @@ ReplicaLoader::ErrorCode checkReplicaConfig(const LoadedReplicaData &ld) {
   LOG_INFO(GL,
            "checkReplicaConfig cVal=" << c.cVal << ", fVal=" << c.fVal << ", replicaId=" << c.replicaId
                                       << ", concurrencyLevel=" << c.concurrencyLevel
-                                      << ", autoViewChangeEnabled=" << c.autoViewChangeEnabled
-                                      << ", viewChangeTimerMillisec=" << c.viewChangeTimerMillisec);
+                                      << ", viewChangeProtocolEnabled=" << c.viewChangeProtocolEnabled
+                                      << ", viewChangeTimerMillisec=" << c.viewChangeTimerMillisec
+                                      << ", autoPrimaryRotationEnabled=" << c.autoPrimaryRotationEnabled
+                                      << ", autoPrimaryRotationTimerMillisec=" << c.autoPrimaryRotationTimerMillisec);
 
   Verify(c.fVal >= 1, InconsistentErr);
   Verify(c.cVal >= 0, InconsistentErr);

--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -87,17 +87,10 @@ constexpr int retransmissionsTimerMilli = 40;
 // View Change
 ///////////////////////////////////////////////////////////////////////////////
 
-constexpr bool forceViewChangeProtocolEnabled = false;
-constexpr bool forceViewChangeProtocolDisabled = false;
-static_assert(!forceViewChangeProtocolEnabled || !forceViewChangeProtocolDisabled, "");
-
 constexpr int viewChangeTimeoutMilli =
     0;  //  80 * 1000; // 1 * 60 * 1000; // 20 * 1000; // if 0, this value is taken from config
 
 constexpr bool autoIncViewChangeTimer = true;
-
-constexpr bool autoPrimaryUpdateEnabled = false;
-constexpr int autoPrimaryUpdateMilli = 40 * 1000;  // 3 * 60 * 1000;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Collectors

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -431,8 +431,10 @@ void fillReplicaConfig() {
   config.numOfClientProxies = 8;
   config.statusReportTimerMillisec = 15;
   config.concurrencyLevel = 5;
-  config.autoViewChangeEnabled = true;
+  config.viewChangeProtocolEnabled = true;
   config.viewChangeTimerMillisec = 12;
+  config.autoPrimaryRotationEnabled = false;
+  config.autoPrimaryRotationTimerMillisec = 42;
   config.maxExternalMessageSize = 2048;
   config.maxNumOfReservedPages = 256;
   config.maxReplyMessageSize = 1024;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,10 @@ add_test(NAME skvbc_view_change_tests COMMAND sh -c
         "python3 -m unittest test_skvbc_view_change 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_test(NAME skvbc_auto_view_change_tests COMMAND sh -c
+        "python3 -m unittest test_skvbc_auto_view_change 2>&1 > /dev/null"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests COMMAND sh -c
             "python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"

--- a/tests/config/test_parameters.hpp
+++ b/tests/config/test_parameters.hpp
@@ -50,7 +50,9 @@ struct ReplicaParams {
   uint16_t numOfClients = 1;
   bool debug = false;
   bool viewChangeEnabled = false;
-  uint32_t viewChangeTimeout = 60000;              // ms
+  bool autoPrimaryRotationEnabled = false;
+  uint16_t viewChangeTimeout = 60000;              // ms
+  uint16_t autoPrimaryRotationTimeout = 40000;     // ms
   uint16_t statusReportTimerMillisec = 10 * 1000;  // ms
   std::string configFileName;
   std::string keysFilePrefix;

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
   string idStr;
 
   int o = 0;
-  while ((o = getopt(argc, argv, "r:i:k:n:s:v:p")) != EOF) {
+  while ((o = getopt(argc, argv, "r:i:k:n:s:v:a:p")) != EOF) {
     switch (o) {
       case 'i': {
         strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
@@ -75,9 +75,19 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
         idStr = argTempBuffer;
         int tempId = std::stoi(idStr);
-        if (tempId >= 0 && (uint32_t)tempId < UINT32_MAX) {
-          rp.viewChangeTimeout = (uint32_t)tempId;
+        if (tempId >= 0 && (uint16_t)tempId < UINT16_MAX) {
+          rp.viewChangeTimeout = (uint16_t)tempId;
           rp.viewChangeEnabled = true;
+        }
+      } break;
+      case 'a': {
+        strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
+        argTempBuffer[sizeof(argTempBuffer) - 1] = 0;
+        idStr = argTempBuffer;
+        int tempId = std::stoi(idStr);
+        if (tempId >= 0 && (uint16_t)tempId < UINT16_MAX) {
+          rp.autoPrimaryRotationTimeout = (uint16_t)tempId;
+          rp.autoPrimaryRotationEnabled = true;
         }
       } break;
       // We can only toggle persistence on or off. It defaults to InMemory
@@ -106,8 +116,10 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
   // This allows more concurrency and only affects known ids in the
   // communication classes.
   replicaConfig.numOfClientProxies = 100;
-  replicaConfig.autoViewChangeEnabled = rp.viewChangeEnabled;
+  replicaConfig.viewChangeProtocolEnabled = rp.viewChangeEnabled;
   replicaConfig.viewChangeTimerMillisec = rp.viewChangeTimeout;
+  replicaConfig.autoPrimaryRotationEnabled = rp.autoPrimaryRotationEnabled;
+  replicaConfig.autoPrimaryRotationTimerMillisec = rp.autoPrimaryRotationTimeout;
   replicaConfig.statusReportTimerMillisec = rp.statusReportTimerMillisec;
   replicaConfig.concurrencyLevel = 1;
   replicaConfig.debugStatisticsEnabled = true;

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -201,7 +201,7 @@ class SimpleTestReplica {
     ReplicaConfig replicaConfig;
     testCommConfig.GetReplicaConfig(rp.replicaId, rp.keysFilePrefix, &replicaConfig);
     replicaConfig.numOfClientProxies = rp.numOfClients;
-    replicaConfig.autoViewChangeEnabled = rp.viewChangeEnabled;
+    replicaConfig.viewChangeProtocolEnabled = rp.viewChangeEnabled;
     replicaConfig.viewChangeTimerMillisec = rp.viewChangeTimeout;
     replicaConfig.replicaId = rp.replicaId;
     replicaConfig.statusReportTimerMillisec = 10000;

--- a/tests/test_skvbc_auto_view_change.py
+++ b/tests/test_skvbc_auto_view_change.py
@@ -1,0 +1,146 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import unittest
+
+import os.path
+import random
+import trio
+
+from util import bft
+from util import skvbc as kvbc
+
+KEY_FILE_PREFIX = "replica_keys_"
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "1000"
+    autoPrimaryRotationTimeoutMilli = "5000"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-v", viewChangeTimeoutMilli,
+            "-a", autoPrimaryRotationTimeoutMilli]
+
+class SkvbcAutoViewChangeTest(unittest.TestCase):
+
+    def test_auto_vc_all_nodes_up_no_requests(self):
+        """
+        This test aims to validate automatic view change
+        in the absence of any client messages:
+        1) Start a full BFT network
+        2) Do nothing (wait for automatic view change to kick-in)
+        3) Check that view change has occurred (necessarily, automatic view change)
+        """
+        trio.run(self._test_auto_vc_all_nodes_up_no_requests)
+
+    async def _test_auto_vc_all_nodes_up_no_requests(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                initial_primary = 0
+
+                # do nothing - just wait for an automatic view change
+                await bft_network.wait_for_view_change(
+                    replica_id=random.choice(
+                        bft_network.all_replicas(without={initial_primary})),
+                    expected=lambda v: v > initial_primary,
+                    err_msg="Make sure automatic view change has occurred."
+                )
+
+    def test_auto_vc_when_primary_down(self):
+        """
+        This test aims to validate automatic view change
+        when the primary is down
+        1) Start a full BFT network
+        2) Stop the initial primary replica
+        3) Do nothing (wait for automatic view change to kick-in)
+        4) Check that view change has occurred (necessarily, automatic view change)
+        """
+        trio.run(self._test_auto_vc_when_primary_down)
+
+    async def _test_auto_vc_when_primary_down(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+
+                initial_primary = 0
+                bft_network.stop_replica(initial_primary)
+
+                # do nothing - just wait for an automatic view change
+                await bft_network.wait_for_view_change(
+                    replica_id=random.choice(
+                        bft_network.all_replicas(without={initial_primary})),
+                    expected=lambda v: v > initial_primary,
+                    err_msg="Make sure automatic view change has occurred."
+                )
+
+    def test_auto_vc_all_nodes_up_fast_path(self):
+        """
+        This test aims to validate automatic view change
+        while messages are being processed on the fast path
+        1) Start a full BFT network
+        2) Send a batch of write commands
+        3) Make sure view change occurred at some point while processing the writes
+        4) Check that all writes have been processed on the fast commit path
+        """
+        trio.run(self._test_auto_vc_all_nodes_up_fast_path)
+
+    async def _test_auto_vc_all_nodes_up_fast_path(self):
+        for bft_config in bft.interesting_configs():
+            config = bft.TestConfig(n=bft_config['n'],
+                                    f=bft_config['f'],
+                                    c=bft_config['c'],
+                                    num_clients=bft_config['num_clients'],
+                                    key_file_prefix=KEY_FILE_PREFIX,
+                                    start_replica_cmd=start_replica_cmd)
+            with bft.BftTestNetwork(config) as bft_network:
+                await bft_network.init()
+                bft_network.start_all_replicas()
+                skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+
+                initial_primary = 0
+
+                for _ in range(150):
+                    key, val = await skvbc.write_known_kv()
+
+                await bft_network.wait_for_view_change(
+                    replica_id=random.choice(
+                        bft_network.all_replicas(without={initial_primary})),
+                    expected=lambda v: v > initial_primary,
+                    err_msg="Make sure automatic view change has occurred."
+                )
+
+                await skvbc.assert_kv_write_executed(key, val)
+                await bft_network.assert_fast_path_prevalent()

--- a/tests/util/bft.py
+++ b/tests/util/bft.py
@@ -208,11 +208,15 @@ class BftTestNetwork:
         try:
             with trio.fail_after(seconds=30):
                 while True:
-                    with trio.move_on_after(seconds=1):
-                        key = ['replica', 'Gauges', 'lastAgreedView']
-                        view = await self.metrics.get(replica_id, *key)
-                        if expected(view):
-                            return view
+                    try:
+                        with trio.move_on_after(seconds=1):
+                            key = ['replica', 'Gauges', 'lastAgreedView']
+                            view = await self.metrics.get(replica_id, *key)
+                            if expected(view):
+                                return view
+                    except KeyError:
+                        # metrics not yet available, continue looping
+                        continue
         except trio.TooSlowError:
             assert False, err_msg
 


### PR DESCRIPTION
Test BFT engine automatic view change

This PR introduces system tests for automatic primary rotation ("auto view change").
However, so far this functionality was disabled in a non-configurable manner, hence not available for automated testing.
So this PR has two parts:

**[C++]** Expose configuration parameters for enabling view change. The configuration parameters were simplified
- "basic" view change - configurable via viewChangeProtocolEnabled & viewChangeTimerMillisec (-v in the TesterReplica)
-  auto view change - configurable via autoPrimaryRotationEnabled & autoPrimaryRotationTimerMillisec (-a in the TesterReplica)

Note that autoPrimaryRotationEnabled implies viewChangeProtocolEnabled (auto view change being an "add-on" option to basic view change).

Note: I have removed the "constexpr" forceViewChangeProtocolEnabled & forceViewChangeProtocolDisabled, so that the view change protocol is configurable only via properties.

**[Python]** Add a new system test suite for auto view change:
- verify auto view change occurs "at rest" (no crashing replicas, no incoming requests)
- verify auto view change while the primary is down (no incoming requests)
- verify auto view change while processing requests on the fast commit path