### PR TITLE
Add a utility for calculating SHA3-256 hashes.

### DIFF
--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -7,7 +7,8 @@ echo "macos homebrew packages handled in .travis.yml"
 else
 # If on Linux, install necessary packages using apt
 sudo apt-get update
-sudo apt-get install -y ccache cmake clang-format libgmp3-dev parallel python3-pip python3-setuptools
+sudo apt-get install -y ccache cmake clang-format libgmp3-dev parallel \
+python3-pip python3-setuptools openssl libssl-dev
 fi
 
 # build and install relic

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Get g++:
 
     sudo apt-get install g++
 
+Get OpenSSL:
+We use OpenSSL for TLS communication and SHA3. For SHA3, OpenSSL must be >=
+version 1.1.1. This is the latest update to Ubuntu 18.04.
+
+    sudo apt-get install openssl libssl-dev
+
+
 #### (Optional) Use log4cplus
 
 We have simple console logger but if you wish to use log4cplus - we have an
@@ -170,11 +177,6 @@ After the installation, please verify the version by running:
 It should be
 
     Python 3.x.x
-
-#### (Optional) Only if using TLS as communication module
-We use OpenSSL for TLS communication module. Please install it using
-
-    sudo apt-get install openssl libssl-dev
 
 #### (Optional) Only if using TLS or plain TCP as communication module
 We use Boost both for plain TCP and TLS communication. Please follow these

--- a/util/include/sha3_256.h
+++ b/util/include/sha3_256.h
@@ -1,0 +1,59 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <array>
+
+#include <openssl/evp.h>
+
+#include "assertUtils.hpp"
+
+namespace concord {
+namespace util {
+
+// A simple wrapper class around OpenSSL versions > 1.1.1, that implements
+// SHA3-256.
+class SHA3_256 {
+ public:
+  static constexpr size_t SIZE_IN_BYTES = 32;
+
+  SHA3_256() : ctx_(EVP_MD_CTX_new()) { Assert(ctx_ != nullptr); }
+
+  ~SHA3_256() { EVP_MD_CTX_destroy(ctx_); }
+
+  // Don't allow copying
+  SHA3_256(const SHA3_256&) = delete;
+  SHA3_256& operator=(const SHA3_256&) = delete;
+
+  // Compute a digest for an entire buffer and return an array containing the
+  // digest.
+  std::array<uint8_t, SIZE_IN_BYTES> digest(const void* buf, size_t size) {
+    Assert(EVP_MD_CTX_reset(ctx_) == 1);
+    Assert(EVP_DigestInit_ex(ctx_, EVP_sha3_256(), NULL) == 1);
+
+    if (size != 0) {
+      Assert(EVP_DigestUpdate(ctx_, buf, size) == 1);
+    }
+
+    std::array<uint8_t, SIZE_IN_BYTES> digest;
+    unsigned int _digest_len;
+    Assert(EVP_DigestFinal_ex(ctx_, digest.data(), &_digest_len) == 1);
+    Assert(_digest_len == SIZE_IN_BYTES);
+    return digest;
+  }
+
+ private:
+  EVP_MD_CTX* ctx_;
+};
+
+}  // namespace util
+}  // namespace concord

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -28,3 +28,9 @@ target_compile_options(serializable_test PUBLIC -Wno-sign-compare)
 add_executable(timers_tests timers_tests.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(timers_tests timers_tests)
 target_link_libraries(timers_tests gtest_main util)
+
+find_package(OpenSSL REQUIRED)
+add_executable(sha3_256_tests sha3_256_tests.cpp)
+add_test(sha3_256_tests sha3_256_tests)
+target_link_libraries(sha3_256_tests gtest_main util ${OPENSSL_LIBRARIES}
+    $<TARGET_OBJECTS:logging_dev>)

--- a/util/test/sha3_256_tests.cpp
+++ b/util/test/sha3_256_tests.cpp
@@ -1,0 +1,74 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+#include "sha3_256.h"
+
+using namespace concord::util;
+
+namespace {
+
+// Convert a lowercase string hash to an array
+std::array<uint8_t, SHA3_256::SIZE_IN_BYTES> string_to_array(const char* s) {
+  std::array<uint8_t, SHA3_256::SIZE_IN_BYTES> hash = {0};
+
+  for (size_t i = 0; i < 64; i++) {
+    auto c = s[i];
+    Assert((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+    uint8_t nibble = 0;
+    ;
+    if (c >= '0' && c <= '9') {
+      nibble = c - '0';
+    } else if (c >= 'a' && c <= 'f') {
+      nibble = c - 'a' + 10;
+    }
+
+    if (i % 2 == 0) {
+      // upper nibble
+      hash[i / 2] = nibble << 4;
+    } else {
+      // lower nibble
+      hash.at(i / 2) |= nibble;
+    }
+  }
+
+  return hash;
+}
+
+// All hash strings in this test were computed with https://emn178.github.io/online-tools/sha3_256.html
+TEST(sha3_256_test, basic) {
+  auto sha3 = SHA3_256();
+  auto expected = string_to_array("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a");
+  const char* empty = "";
+  auto hash = sha3.digest(empty, 0);
+  ASSERT_EQ(expected, hash);
+  // Repeat check, to see that we can reuse the ctx in the SHA3_256 object and
+  // get the same result.
+  hash = sha3.digest(empty, 0);
+  ASSERT_EQ(expected, hash);
+
+  expected = string_to_array("2a3697512e6ce65dcf220b5c189c1045db4aaf59855a507b873d51c7505c54a5");
+  hash = sha3.digest("artist", 6);
+  ASSERT_EQ(expected, hash);
+
+  expected = string_to_array("c817e3a5067a8ff4641fe6c7001717302cd07265ced4f7735719bcafbf55315c");
+  hash = sha3.digest("REM", 3);
+  ASSERT_EQ(expected, hash);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is needed for our merkle tree. It relies on openssl 1.1.1.

Relevant to the tests: https://vimeo.com/6973519#t=2m52s