### PR TITLE
Replica configuration: read-only replica aware configuration files

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -21,6 +21,13 @@ class IThresholdVerifier;
 
 namespace bftEngine {
 struct ReplicaConfig {
+
+  // Am I a read-only replica?
+  bool isReadOnly = false;
+
+  // number of read-only replicas in a cluster
+  uint16_t numRoReplicas = 0;
+
   // F value - max number of faulty/malicious replicas. fVal >= 1
   uint16_t fVal = 0;
 

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -21,7 +21,6 @@ class IThresholdVerifier;
 
 namespace bftEngine {
 struct ReplicaConfig {
-
   // Am I a read-only replica?
   bool isReadOnly = false;
 

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -83,7 +83,7 @@ ReplicaLoader::ErrorCode checkReplicaConfig(const LoadedReplicaData &ld) {
   Verify(c.concurrencyLevel <= maxLegalConcurrentAgreementsByPrimary, InconsistentErr);
 
   std::set<uint16_t> repIDs;
-  for (auto & v : c.publicKeysOfReplicas) {
+  for (auto &v : c.publicKeysOfReplicas) {
     VerifyAND(v.first >= 0, v.first < numOfReplicas, InconsistentErr);
     Verify(!v.second.empty(), InconsistentErr);  // TODO(GG): make sure that the key is valid
     repIDs.insert(v.first);

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -83,7 +83,7 @@ ReplicaLoader::ErrorCode checkReplicaConfig(const LoadedReplicaData &ld) {
   Verify(c.concurrencyLevel <= maxLegalConcurrentAgreementsByPrimary, InconsistentErr);
 
   std::set<uint16_t> repIDs;
-  for (std::pair<uint16_t, std::string> v : c.publicKeysOfReplicas) {
+  for (auto & v : c.publicKeysOfReplicas) {
     VerifyAND(v.first >= 0, v.first < numOfReplicas, InconsistentErr);
     Verify(!v.second.empty(), InconsistentErr);  // TODO(GG): make sure that the key is valid
     repIDs.insert(v.first);

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -55,8 +55,7 @@ void TestCommConfig::GetReplicaConfig(uint16_t replica_id,
                                       std::string keyFilePrefix,
                                       bftEngine::ReplicaConfig* out_config) {
   std::string key_file_name = keyFilePrefix + std::to_string(replica_id);
-  if(!inputReplicaKeyfile(key_file_name, *out_config))
-    throw std::runtime_error("Unable to parse replica keyfile.");
+  if (!inputReplicaKeyfile(key_file_name, *out_config)) throw std::runtime_error("Unable to parse replica keyfile.");
 }
 
 std::unordered_map<NodeNum, NodeInfo> TestCommConfig::SetUpConfiguredNodes(bool is_replica,

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -55,13 +55,8 @@ void TestCommConfig::GetReplicaConfig(uint16_t replica_id,
                                       std::string keyFilePrefix,
                                       bftEngine::ReplicaConfig* out_config) {
   std::string key_file_name = keyFilePrefix + std::to_string(replica_id);
-  std::ifstream keyfile(key_file_name);
-  if (!keyfile.is_open()) {
-    throw std::runtime_error("Unable to read replica keyfile.");
-  }
-
-  bool success = inputReplicaKeyfile(keyfile, key_file_name, *out_config);
-  if (!success) throw std::runtime_error("Unable to parse replica keyfile.");
+  if(!inputReplicaKeyfile(key_file_name, *out_config))
+    throw std::runtime_error("Unable to parse replica keyfile.");
 }
 
 std::unordered_map<NodeNum, NodeInfo> TestCommConfig::SetUpConfiguredNodes(bool is_replica,

--- a/tools/GenerateConcordKeys.cpp
+++ b/tools/GenerateConcordKeys.cpp
@@ -289,7 +289,7 @@ int main(int argc, char** argv) {
     }
 
     std::vector<std::pair<std::string, std::string>> rsaKeys;
-    for (uint16_t i = 0; i < n+ro; ++i) {
+    for (uint16_t i = 0; i < n + ro; ++i) {
       rsaKeys.push_back(generateRsaKey());
       config.publicKeysOfReplicas.insert(std::pair<uint16_t, std::string>(i, rsaKeys[i].second));
     }
@@ -304,25 +304,17 @@ int main(int argc, char** argv) {
     commitSys.generateNewPseudorandomKeys();
     optSys.generateNewPseudorandomKeys();
 
-
     // Output the generated keys.
-    for (uint16_t i = 0; i < n; ++i){
+    for (uint16_t i = 0; i < n; ++i) {
       config.replicaId = i;
       config.replicaPrivateKey = rsaKeys[i].first;
-      outputReplicaKeyfile( n,
-                            ro,
-                            config,
-                            outputPrefix + std::to_string(i),
-                            &execSys, &slowSys, &commitSys, &optSys);
+      outputReplicaKeyfile(n, ro, config, outputPrefix + std::to_string(i), &execSys, &slowSys, &commitSys, &optSys);
     }
-    for (uint16_t i = n; i < n+ro; ++i){
+    for (uint16_t i = n; i < n + ro; ++i) {
       config.isReadOnly = true;
       config.replicaId = i;
       config.replicaPrivateKey = rsaKeys[i].first;
-      outputReplicaKeyfile( n,
-                            ro,
-                            config,
-                            outputPrefix + std::to_string(i));
+      outputReplicaKeyfile(n, ro, config, outputPrefix + std::to_string(i));
     }
   } catch (std::exception& e) {
     std::cerr << "Exception: " << e.what() << std::endl;

--- a/tools/KeyfileIOUtils.cpp
+++ b/tools/KeyfileIOUtils.cpp
@@ -52,38 +52,37 @@ void outputReplicaKeyfile(uint16_t numReplicas,
                           Cryptosystem* slowSys,
                           Cryptosystem* commitSys,
                           Cryptosystem* optSys) {
-
-  std::ofstream output (outputFilename);
+  std::ofstream output(outputFilename);
   if ((3 * config.fVal + 2 * config.cVal + 1) != numReplicas)
-     throw std::runtime_error("F, C, and number of replicas do not agree for requested output.");
+    throw std::runtime_error("F, C, and number of replicas do not agree for requested output.");
 
-   output << "# Concord-BFT replica keyfile " << outputFilename << ".\n"
-          << "# For replica " << config.replicaId << " in a " << numReplicas << "-replica + " << numRoReplicas << "-read-only-replica cluster.\n\n"
-          << "num_replicas: " << numReplicas << "\n"
-          << "num_ro_replicas: " << numRoReplicas << "\n"
-          << "f_val: " << config.fVal << "\n"
-          << "c_val: " << config.cVal << "\n"
-          << "replica_id: " << config.replicaId << "\n"
-          << "read-only: " << config.isReadOnly << "\n\n"
-          << "# RSA non-threshold replica public keys\n"
-          << "rsa_public_keys:\n";
+  output << "# Concord-BFT replica keyfile " << outputFilename << ".\n"
+         << "# For replica " << config.replicaId << " in a " << numReplicas << "-replica + " << numRoReplicas
+         << "-read-only-replica cluster.\n\n"
+         << "num_replicas: " << numReplicas << "\n"
+         << "num_ro_replicas: " << numRoReplicas << "\n"
+         << "f_val: " << config.fVal << "\n"
+         << "c_val: " << config.cVal << "\n"
+         << "replica_id: " << config.replicaId << "\n"
+         << "read-only: " << config.isReadOnly << "\n\n"
+         << "# RSA non-threshold replica public keys\n"
+         << "rsa_public_keys:\n";
 
-   for (auto & v : config.publicKeysOfReplicas)
-     output << "  - " << v.second << "\n";
+  for (auto& v : config.publicKeysOfReplicas) output << "  - " << v.second << "\n";
 
-   output << "\n# Private keys for this replica\n"
-          << "rsa_private_key: " << config.replicaPrivateKey << "\n";
+  output << "\n# Private keys for this replica\n"
+         << "rsa_private_key: " << config.replicaPrivateKey << "\n";
 
-   if (execSys && slowSys && commitSys && optSys){
-     serializeCryptosystemPublicConfiguration(output, *execSys, "Execution", "execution");
-     serializeCryptosystemPublicConfiguration(output, *slowSys, "Slow path commit", "slow_commit");
-     serializeCryptosystemPublicConfiguration(output, *commitSys, "Commit", "commit");
-     serializeCryptosystemPublicConfiguration(output, *optSys, "Optimistic fast path commit", "optimistic_commit");
+  if (execSys && slowSys && commitSys && optSys) {
+    serializeCryptosystemPublicConfiguration(output, *execSys, "Execution", "execution");
+    serializeCryptosystemPublicConfiguration(output, *slowSys, "Slow path commit", "slow_commit");
+    serializeCryptosystemPublicConfiguration(output, *commitSys, "Commit", "commit");
+    serializeCryptosystemPublicConfiguration(output, *optSys, "Optimistic fast path commit", "optimistic_commit");
 
-     output << "execution_cryptosystem_private_key: " << execSys->getPrivateKey(config.replicaId + 1) << "\n"
-            << "slow_commit_cryptosystem_private_key: " << slowSys->getPrivateKey(config.replicaId + 1) << "\n"
-            << "commit_cryptosystem_private_key: " << commitSys->getPrivateKey(config.replicaId + 1) << "\n"
-            << "optimistic_commit_cryptosystem_private_key: " << optSys->getPrivateKey(config.replicaId + 1) << "\n";
+    output << "execution_cryptosystem_private_key: " << execSys->getPrivateKey(config.replicaId + 1) << "\n"
+           << "slow_commit_cryptosystem_private_key: " << slowSys->getPrivateKey(config.replicaId + 1) << "\n"
+           << "commit_cryptosystem_private_key: " << commitSys->getPrivateKey(config.replicaId + 1) << "\n"
+           << "optimistic_commit_cryptosystem_private_key: " << optSys->getPrivateKey(config.replicaId + 1) << "\n";
   }
 }
 
@@ -91,30 +90,29 @@ void outputReplicaKeyfile(uint16_t numReplicas,
 // created while parsing the keyfile. This function validates that the desired
 // integer is in the map, is a valid integer and not some other string value,
 // and is within range.
-template<typename T>
+template <typename T>
 T parse(const std::string& identifier,
         std::unordered_map<std::string, std::string>& map,
         const std::string& filename,
         const std::unordered_map<std::string, size_t>& lineNumbers,
         bool optional = false) {
   if (map.count(identifier) < 1) {
-    if(optional)
-      return 0;
+    if (optional) return 0;
     if (lineNumbers.count(identifier) < 1)
-      throw std::runtime_error( filename + std::string( ": Missing assignment for required parameter: ") + identifier);
+      throw std::runtime_error(filename + std::string(": Missing assignment for required parameter: ") + identifier);
     else
-      throw std::runtime_error( filename + std::string(": line ") + std::to_string(lineNumbers.at(identifier)) +
-                                std::string( ": expected integer value for ")  + identifier);
+      throw std::runtime_error(filename + std::string(": line ") + std::to_string(lineNumbers.at(identifier)) +
+                               std::string(": expected integer value for ") + identifier);
   }
 
   std::string strVal = map[identifier];
   map.erase(identifier);
-  try{
+  try {
     return concord::util::to<T>(strVal);
-  }catch(std::exception& e){
+  } catch (std::exception& e) {
     std::ostringstream oss;
     oss << "Exception: " << e.what() << " " << filename + ":" << lineNumbers.at(identifier) << ": invalid value for "
-        << identifier << ": "<< strVal << " expected range [" << std::numeric_limits<T>::min() << ", "
+        << identifier << ": " << strVal << " expected range [" << std::numeric_limits<T>::min() << ", "
         << std::numeric_limits<T>::max();
 
     throw std::runtime_error(oss.str());
@@ -178,7 +176,7 @@ static bool deserializeCryptosystemPublicConfiguration(
   std::string verifKeyVar = prefix + "_cryptosystem_verification_keys";
 
   uint16_t numSigners = parse<std::uint16_t>(numSignersVar, valueAssignments, filename, identifierLines);
-  uint16_t threshold  = parse<std::uint16_t>(threshVar, valueAssignments, filename, identifierLines);
+  uint16_t threshold = parse<std::uint16_t>(threshVar, valueAssignments, filename, identifierLines);
 
   if (numSigners != numReplicas) {
     std::cout << filename << ": line " << identifierLines.at(numSignersVar)
@@ -273,14 +271,12 @@ bool parseReplicaKeyfile(const std::string& filename,
   std::vector<std::string>* currentList = nullptr;
   std::vector<size_t>* currentListLines = nullptr;
   std::ifstream input(filename);
-  if(!input.is_open())
-    throw std::runtime_error(std::string("failed to open ") + filename);
+  if (!input.is_open()) throw std::runtime_error(std::string("failed to open ") + filename);
   size_t lineNumber = 1;
-//  while (input.peek() != EOF) {
-//    std::string line;
-//    std::getline(input, line);
-  for (std::string line; std::getline(input, line); ) {
-
+  //  while (input.peek() != EOF) {
+  //    std::string line;
+  //    std::getline(input, line);
+  for (std::string line; std::getline(input, line);) {
     // Ignore comments.
     size_t commentStart = line.find_first_of("#");
     if (commentStart != std::string::npos) {
@@ -427,7 +423,7 @@ bool parseReplicaKeyfile(const std::string& filename,
   return true;
 }
 
-bool inputReplicaKeyfile( const std::string& filename, bftEngine::ReplicaConfig& config) {
+bool inputReplicaKeyfile(const std::string& filename, bftEngine::ReplicaConfig& config) {
   std::unordered_map<std::string, std::string> valueAssignments;
   std::unordered_map<std::string, std::vector<std::string>> listAssignments;
   std::unordered_map<std::string, size_t> identifierLines;
@@ -437,13 +433,13 @@ bool inputReplicaKeyfile( const std::string& filename, bftEngine::ReplicaConfig&
     return false;
   }
 
-  std::uint16_t numReplicas =  parse<std::uint16_t>("num_replicas", valueAssignments, filename, identifierLines);
+  std::uint16_t numReplicas = parse<std::uint16_t>("num_replicas", valueAssignments, filename, identifierLines);
   config.fVal = parse<std::uint16_t>("f_val", valueAssignments, filename, identifierLines);
   config.cVal = parse<std::uint16_t>("c_val", valueAssignments, filename, identifierLines);
   config.replicaId = parse<std::uint16_t>("replica_id", valueAssignments, filename, identifierLines);
-  //optional for backward compatibility
+  // optional for backward compatibility
   config.isReadOnly = parse<bool>("read-only", valueAssignments, filename, identifierLines, true);
-  config.numRoReplicas =  parse<std::uint16_t>("num_ro_replicas", valueAssignments, filename, identifierLines, true);
+  config.numRoReplicas = parse<std::uint16_t>("num_ro_replicas", valueAssignments, filename, identifierLines, true);
 
   // Note we validate the number of replicas using 32-bit integers in case
   // (3 * f + 2 * c + 1) overflows a 16-bit integer.
@@ -475,7 +471,7 @@ bool inputReplicaKeyfile( const std::string& filename, bftEngine::ReplicaConfig&
   std::vector<std::string> rsaPublicKeys = std::move(listAssignments["rsa_public_keys"]);
   listAssignments.erase("rsa_public_keys");
 
-  if (rsaPublicKeys.size() != numReplicas+ config.numRoReplicas) {
+  if (rsaPublicKeys.size() != numReplicas + config.numRoReplicas) {
     std::cout << filename << ": line " << identifierLines["rsa_public_keys"]
               << ": incorrect number of public RSA keys given; the number of RSA keys"
                  " must match num_replicas.\n";
@@ -489,11 +485,8 @@ bool inputReplicaKeyfile( const std::string& filename, bftEngine::ReplicaConfig&
   }
 
   // Load private keys for this replica.
-  if (!expectEntries({"rsa_private_key"},
-                     valueAssignments,
-                     filename,
-                     identifierLines)) {
-      return false;
+  if (!expectEntries({"rsa_private_key"}, valueAssignments, filename, identifierLines)) {
+    return false;
   }
   std::string rsaPrivateKey = valueAssignments["rsa_private_key"];
   valueAssignments.erase("rsa_private_key");
@@ -508,8 +501,7 @@ bool inputReplicaKeyfile( const std::string& filename, bftEngine::ReplicaConfig&
 
   config.replicaPrivateKey = rsaPrivateKey;
 
-  if(config.isReadOnly)
-    return true;
+  if (config.isReadOnly) return true;
 
   // Load cryptosystem public configurations.
   // Note we reference the Cryptosystems here via unique_ptrs rahter than

--- a/tools/KeyfileIOUtils.cpp
+++ b/tools/KeyfileIOUtils.cpp
@@ -16,7 +16,8 @@
 #include <regex>
 #include <string>
 #include <unordered_map>
-
+#include <string.hpp>
+#include <exception>
 #include "KeyfileIOUtils.hpp"
 
 // Helper function to outputReplicaKeyfile.
@@ -43,115 +44,81 @@ static void serializeCryptosystemPublicConfiguration(std::ostream& output,
   }
 }
 
-bool outputReplicaKeyfile(uint16_t replicaID,
-                          uint16_t numReplicas,
-                          uint16_t f,
-                          uint16_t c,
-                          std::ostream& output,
+void outputReplicaKeyfile(uint16_t numReplicas,
+                          uint16_t numRoReplicas,
+                          bftEngine::ReplicaConfig& config,
                           const std::string& outputFilename,
-                          const std::vector<std::pair<std::string, std::string>>& rsaKeys,
-                          const Cryptosystem& execSys,
-                          const Cryptosystem& slowSys,
-                          const Cryptosystem& commitSys,
-                          const Cryptosystem& optSys) {
-  if ((3 * f + 2 * c + 1) != numReplicas) {
-    std::cout << "F, C, and number of replicas do not agree for requested"
-                 " output.\n";
-    return false;
+                          Cryptosystem* execSys,
+                          Cryptosystem* slowSys,
+                          Cryptosystem* commitSys,
+                          Cryptosystem* optSys) {
+
+  std::ofstream output (outputFilename);
+  if ((3 * config.fVal + 2 * config.cVal + 1) != numReplicas)
+     throw std::runtime_error("F, C, and number of replicas do not agree for requested output.");
+
+   output << "# Concord-BFT replica keyfile " << outputFilename << ".\n"
+          << "# For replica " << config.replicaId << " in a " << numReplicas << "-replica + " << numRoReplicas << "-read-only-replica cluster.\n\n"
+          << "num_replicas: " << numReplicas << "\n"
+          << "num_ro_replicas: " << numRoReplicas << "\n"
+          << "f_val: " << config.fVal << "\n"
+          << "c_val: " << config.cVal << "\n"
+          << "replica_id: " << config.replicaId << "\n"
+          << "read-only: " << config.isReadOnly << "\n\n"
+          << "# RSA non-threshold replica public keys\n"
+          << "rsa_public_keys:\n";
+
+   for (auto & v : config.publicKeysOfReplicas)
+     output << "  - " << v.second << "\n";
+
+   output << "\n# Private keys for this replica\n"
+          << "rsa_private_key: " << config.replicaPrivateKey << "\n";
+
+   if (execSys && slowSys && commitSys && optSys){
+     serializeCryptosystemPublicConfiguration(output, *execSys, "Execution", "execution");
+     serializeCryptosystemPublicConfiguration(output, *slowSys, "Slow path commit", "slow_commit");
+     serializeCryptosystemPublicConfiguration(output, *commitSys, "Commit", "commit");
+     serializeCryptosystemPublicConfiguration(output, *optSys, "Optimistic fast path commit", "optimistic_commit");
+
+     output << "execution_cryptosystem_private_key: " << execSys->getPrivateKey(config.replicaId + 1) << "\n"
+            << "slow_commit_cryptosystem_private_key: " << slowSys->getPrivateKey(config.replicaId + 1) << "\n"
+            << "commit_cryptosystem_private_key: " << commitSys->getPrivateKey(config.replicaId + 1) << "\n"
+            << "optimistic_commit_cryptosystem_private_key: " << optSys->getPrivateKey(config.replicaId + 1) << "\n";
   }
-
-  output << "# Concord-BFT replica keyfile " << outputFilename << ".\n";
-  output << "# For replica " << replicaID << " in a " << numReplicas << "-replica cluster.\n\n";
-  output << "num_replicas: " << numReplicas << "\n";
-  output << "f_val: " << f << "\n";
-  output << "c_val: " << c << "\n";
-  output << "replica_id: " << replicaID << "\n\n";
-
-  output << "# RSA non-threshold replica public keys\n";
-  output << "rsa_public_keys:\n";
-  for (uint16_t i = 0; i < numReplicas; ++i) {
-    output << "  - " << rsaKeys[i].second << "\n";
-  }
-
-  serializeCryptosystemPublicConfiguration(output, execSys, "Execution", "execution");
-  serializeCryptosystemPublicConfiguration(output, slowSys, "Slow path commit", "slow_commit");
-  serializeCryptosystemPublicConfiguration(output, commitSys, "Commit", "commit");
-  serializeCryptosystemPublicConfiguration(output, optSys, "Optimistic fast path commit", "optimistic_commit");
-
-  output << "\n# Private keys for this replica\n";
-
-  output << "rsa_private_key: " << rsaKeys[replicaID].first << "\n";
-  output << "execution_cryptosystem_private_key: " << execSys.getPrivateKey(replicaID + 1) << "\n";
-  output << "slow_commit_cryptosystem_private_key: " << slowSys.getPrivateKey(replicaID + 1) << "\n";
-  output << "commit_cryptosystem_private_key: " << commitSys.getPrivateKey(replicaID + 1) << "\n";
-  output << "optimistic_commit_cryptosystem_private_key: " << optSys.getPrivateKey(replicaID + 1) << "\n";
-
-  return true;
-}
-
-// Helper functions to inputReplicaKeyfile
-
-// Trims any whitespace off of both ends of a string.
-static std::string trim(const std::string& str) {
-  std::string ret = str;
-  size_t trim = ret.find_first_not_of(" \t");
-  if (trim != std::string::npos) {
-    ret = ret.substr(trim, ret.length() - trim);
-  }
-  trim = ret.find_last_not_of(" \t");
-  if (trim != std::string::npos) {
-    ret = ret.substr(0, trim + 1);
-  }
-  return ret;
 }
 
 // Handles inputing unsigned 16-bit integers from the identifier->value map
 // created while parsing the keyfile. This function validates that the desired
 // integer is in the map, is a valid integer and not some other string value,
 // and is within range.
-static bool parseUint16(uint16_t& output,
-                        const std::string& identifier,
-                        std::unordered_map<std::string, std::string>& map,
-                        const std::string& filename,
-                        const std::unordered_map<std::string, size_t>& lineNumbers,
-                        uint16_t min,
-                        uint16_t max) {
+template<typename T>
+T parse(const std::string& identifier,
+        std::unordered_map<std::string, std::string>& map,
+        const std::string& filename,
+        const std::unordered_map<std::string, size_t>& lineNumbers,
+        bool optional = false) {
   if (map.count(identifier) < 1) {
-    if (lineNumbers.count(identifier) < 1) {
-      std::cout << filename << ": Missing assignment for required parameter: " << identifier << ".\n";
-    } else {
-      std::cout << filename << ": line " << lineNumbers.at(identifier) << ": expected integer value for " << identifier
-                << ", found list.\n";
-    }
-    return false;
+    if(optional)
+      return 0;
+    if (lineNumbers.count(identifier) < 1)
+      throw std::runtime_error( filename + std::string( ": Missing assignment for required parameter: ") + identifier);
+    else
+      throw std::runtime_error( filename + std::string(": line ") + std::to_string(lineNumbers.at(identifier)) +
+                                std::string( ": expected integer value for ")  + identifier);
   }
 
   std::string strVal = map[identifier];
-  long long unvalidatedVal;
-
-  std::string errorMessage = filename + ": line " + std::to_string(lineNumbers.at(identifier)) +
-                             ": Invalid value given for " + identifier + ": " + strVal +
-                             " ( expected integer in range [" + std::to_string(min) + ", " + std::to_string(max) +
-                             "], inclusive.\n";
-
-  try {
-    unvalidatedVal = std::stoll(strVal);
-  } catch (std::invalid_argument e) {
-    std::cout << errorMessage;
-    return false;
-  } catch (std::out_of_range e) {
-    std::cout << errorMessage;
-    return false;
-  }
-
-  if ((unvalidatedVal < (long long)min) || (unvalidatedVal > (long long)max)) {
-    std::cout << errorMessage;
-    return false;
-  }
-
   map.erase(identifier);
-  output = (uint16_t)unvalidatedVal;
-  return true;
+  try{
+    return concord::util::to<T>(strVal);
+  }catch(std::exception& e){
+    std::ostringstream oss;
+    oss << "Exception: " << e.what() << " " << filename + ":" << lineNumbers.at(identifier) << ": invalid value for "
+        << identifier << ": "<< strVal << " expected range [" << std::numeric_limits<T>::min() << ", "
+        << std::numeric_limits<T>::max();
+
+    throw std::runtime_error(oss.str());
+  }
 }
 
 // Simple validators for RSA keys to ensure they at least conform to the
@@ -210,14 +177,8 @@ static bool deserializeCryptosystemPublicConfiguration(
   std::string pubKeyVar = prefix + "_cryptosystem_public_key";
   std::string verifKeyVar = prefix + "_cryptosystem_verification_keys";
 
-  uint16_t numSigners, threshold;
-
-  if (!parseUint16(numSigners, numSignersVar, valueAssignments, filename, identifierLines, 1, UINT16_MAX)) {
-    return false;
-  }
-  if (!parseUint16(threshold, threshVar, valueAssignments, filename, identifierLines, 1, UINT16_MAX)) {
-    return false;
-  }
+  uint16_t numSigners = parse<std::uint16_t>(numSignersVar, valueAssignments, filename, identifierLines);
+  uint16_t threshold  = parse<std::uint16_t>(threshVar, valueAssignments, filename, identifierLines);
 
   if (numSigners != numReplicas) {
     std::cout << filename << ": line " << identifierLines.at(numSignersVar)
@@ -304,20 +265,21 @@ static std::string getBadSyntaxMessage(const std::string& filename, size_t lineN
 // representations of maps from identifiers to their values. Also creates some
 // records of what line numbers everything it parses come from for use in
 // giving error messages referencing specific lines.
-bool parseReplicaKeyfile(std::istream& input,
-                         const std::string& filename,
+bool parseReplicaKeyfile(const std::string& filename,
                          std::unordered_map<std::string, std::string>& valueAssignments,
                          std::unordered_map<std::string, std::vector<std::string>>& listAssignments,
                          std::unordered_map<std::string, size_t>& identifierLines,
                          std::unordered_map<std::string, std::vector<size_t>>& listEntryLines) {
   std::vector<std::string>* currentList = nullptr;
   std::vector<size_t>* currentListLines = nullptr;
-
+  std::ifstream input(filename);
+  if(!input.is_open())
+    throw std::runtime_error(std::string("failed to open ") + filename);
   size_t lineNumber = 1;
-
-  while (input.peek() != EOF) {
-    std::string line;
-    std::getline(input, line);
+//  while (input.peek() != EOF) {
+//    std::string line;
+//    std::getline(input, line);
+  for (std::string line; std::getline(input, line); ) {
 
     // Ignore comments.
     size_t commentStart = line.find_first_of("#");
@@ -325,7 +287,7 @@ bool parseReplicaKeyfile(std::istream& input,
       line = line.substr(0, commentStart);
     }
 
-    line = trim(line);
+    concord::util::trim_inplace(line);
 
     // Ignore this line if it contains only whitespace and/or comments.
     if (line.length() < 1) {
@@ -347,7 +309,7 @@ bool parseReplicaKeyfile(std::istream& input,
     // Case of a list entry. Format:
     // - LIST_ENTRY
     if ((line.length() > 2) && (line[0] == '-') && (line[1] == ' ')) {
-      std::string value = trim(line.substr(2, line.length() - 2));
+      std::string value = concord::util::trim(line.substr(2, line.length() - 2));
       if (value.find_first_of(" \t") != std::string::npos) {
         std::cout << filename << ": line " << lineNumber
                   << ": Whitespace is"
@@ -382,7 +344,7 @@ bool parseReplicaKeyfile(std::istream& input,
       // Case of assignment of a list to an identifier. Format:
       // IDENTIFIER:
     } else if ((line.length() > 1) && (line[line.length() - 1] == ':')) {
-      std::string identifier = trim(line.substr(0, line.length() - 1));
+      std::string identifier = concord::util::trim(line.substr(0, line.length() - 1));
       if (identifier.find_first_of(" \t") != std::string::npos) {
         std::cout << filename << ": line " << lineNumber
                   << ": Whitespace is"
@@ -415,8 +377,8 @@ bool parseReplicaKeyfile(std::istream& input,
       // IDENTIFIER: VALUE
     } else if ((line.length() >= 3) && (line.find_first_of(":") != std::string::npos)) {
       size_t colonLoc = line.find_first_of(":");
-      std::string identifier = trim(line.substr(0, colonLoc));
-      std::string value = trim(line.substr(colonLoc + 1, line.length() - (colonLoc + 1)));
+      std::string identifier = concord::util::trim(line.substr(0, colonLoc));
+      std::string value = concord::util::trim(line.substr(colonLoc + 1, line.length() - (colonLoc + 1)));
 
       if ((identifier.find_first_of(" \t") != std::string::npos) || (value.find_first_of(" \t") != std::string::npos)) {
         std::cout << filename << ": line " << lineNumber
@@ -465,43 +427,36 @@ bool parseReplicaKeyfile(std::istream& input,
   return true;
 }
 
-bool inputReplicaKeyfile(std::istream& input, const std::string& filename, bftEngine::ReplicaConfig& config) {
+bool inputReplicaKeyfile( const std::string& filename, bftEngine::ReplicaConfig& config) {
   std::unordered_map<std::string, std::string> valueAssignments;
   std::unordered_map<std::string, std::vector<std::string>> listAssignments;
   std::unordered_map<std::string, size_t> identifierLines;
   std::unordered_map<std::string, std::vector<size_t>> listEntryLines;
 
-  if (!parseReplicaKeyfile(input, filename, valueAssignments, listAssignments, identifierLines, listEntryLines)) {
+  if (!parseReplicaKeyfile(filename, valueAssignments, listAssignments, identifierLines, listEntryLines)) {
     return false;
   }
 
-  uint16_t numReplicas, f, c, replicaID;
-
-  if (!parseUint16(numReplicas, "num_replicas", valueAssignments, filename, identifierLines, 1, UINT16_MAX)) {
-    return false;
-  }
-  if (!parseUint16(f, "f_val", valueAssignments, filename, identifierLines, 1, UINT16_MAX)) {
-    return false;
-  }
-  if (!parseUint16(c, "c_val", valueAssignments, filename, identifierLines, 0, UINT16_MAX)) {
-    return false;
-  }
-  if (!parseUint16(replicaID, "replica_id", valueAssignments, filename, identifierLines, 0, UINT16_MAX)) {
-    return false;
-  }
+  std::uint16_t numReplicas =  parse<std::uint16_t>("num_replicas", valueAssignments, filename, identifierLines);
+  config.fVal = parse<std::uint16_t>("f_val", valueAssignments, filename, identifierLines);
+  config.cVal = parse<std::uint16_t>("c_val", valueAssignments, filename, identifierLines);
+  config.replicaId = parse<std::uint16_t>("replica_id", valueAssignments, filename, identifierLines);
+  //optional for backward compatibility
+  config.isReadOnly = parse<bool>("read-only", valueAssignments, filename, identifierLines, true);
+  config.numRoReplicas =  parse<std::uint16_t>("num_ro_replicas", valueAssignments, filename, identifierLines, true);
 
   // Note we validate the number of replicas using 32-bit integers in case
   // (3 * f + 2 * c + 1) overflows a 16-bit integer.
-  uint32_t predictedNumReplicas = 3 * (uint32_t)f + 2 * (uint32_t)c + 1;
+  uint32_t predictedNumReplicas = 3 * (uint32_t)config.fVal + 2 * (uint32_t)config.cVal + 1;
   if (predictedNumReplicas != (uint32_t)numReplicas) {
     std::cout << filename << ": line " << identifierLines["num_replicas"]
               << ": num_replicas must be equal to (3 * f_val + 2 * c_val + 1).\n";
     return false;
   }
-  if (replicaID >= numReplicas) {
+  if (config.replicaId >= numReplicas + config.numRoReplicas) {
     std::cout << filename << ": line " << identifierLines["replica_id"]
               << ": invalid replica_id; replica IDs must be in the range [0,"
-                 " num_replicas], inclusive.\n";
+                 " num_replicas + num_ro_replicas].\n";
   }
 
   // Load RSA public keys
@@ -520,18 +475,41 @@ bool inputReplicaKeyfile(std::istream& input, const std::string& filename, bftEn
   std::vector<std::string> rsaPublicKeys = std::move(listAssignments["rsa_public_keys"]);
   listAssignments.erase("rsa_public_keys");
 
-  if (rsaPublicKeys.size() != numReplicas) {
+  if (rsaPublicKeys.size() != numReplicas+ config.numRoReplicas) {
     std::cout << filename << ": line " << identifierLines["rsa_public_keys"]
               << ": incorrect number of public RSA keys given; the number of RSA keys"
                  " must match num_replicas.\n";
     return false;
   }
-  for (size_t i = 0; i < numReplicas; ++i) {
+  for (size_t i = 0; i < numReplicas + config.numRoReplicas; ++i) {
     if (!validateRSAPublicKey(rsaPublicKeys[i])) {
       std::cout << filename << ": line " << listEntryLines["rsa_public_keys"][i] << ": Invalid RSA public key.\n";
       return false;
     }
   }
+
+  // Load private keys for this replica.
+  if (!expectEntries({"rsa_private_key"},
+                     valueAssignments,
+                     filename,
+                     identifierLines)) {
+      return false;
+  }
+  std::string rsaPrivateKey = valueAssignments["rsa_private_key"];
+  valueAssignments.erase("rsa_private_key");
+
+  if (!validateRSAPrivateKey(rsaPrivateKey)) {
+    std::cout << filename << ": line " << identifierLines["rsa_private_key"] << ": Invalid RSA private key.\n";
+    return false;
+  }
+  config.publicKeysOfReplicas.clear();
+  for (uint16_t i = 0; i < numReplicas + config.numRoReplicas; ++i)
+    config.publicKeysOfReplicas.insert(std::pair<uint16_t, std::string>(i, rsaPublicKeys[i]));
+
+  config.replicaPrivateKey = rsaPrivateKey;
+
+  if(config.isReadOnly)
+    return true;
 
   // Load cryptosystem public configurations.
   // Note we reference the Cryptosystems here via unique_ptrs rahter than
@@ -589,22 +567,13 @@ bool inputReplicaKeyfile(std::istream& input, const std::string& filename, bftEn
   }
 
   // Load private keys for this replica.
-  if (!expectEntries({"rsa_private_key",
-                      "execution_cryptosystem_private_key",
+  if (!expectEntries({"execution_cryptosystem_private_key",
                       "slow_commit_cryptosystem_private_key",
                       "commit_cryptosystem_private_key",
                       "optimistic_commit_cryptosystem_private_key"},
                      valueAssignments,
                      filename,
                      identifierLines)) {
-    return false;
-  }
-
-  std::string rsaPrivateKey = valueAssignments["rsa_private_key"];
-  valueAssignments.erase("rsa_private_key");
-
-  if (!validateRSAPrivateKey(rsaPrivateKey)) {
-    std::cout << filename << ": line " << identifierLines["rsa_private_key"] << ": Invalid RSA private key.\n";
     return false;
   }
 
@@ -639,10 +608,10 @@ bool inputReplicaKeyfile(std::istream& input, const std::string& filename, bftEn
     return false;
   }
 
-  execSys->loadPrivateKey(replicaID + 1, execPrivateKey);
-  slowSys->loadPrivateKey(replicaID + 1, slowPrivateKey);
-  commitSys->loadPrivateKey(replicaID + 1, commitPrivateKey);
-  optSys->loadPrivateKey(replicaID + 1, optPrivateKey);
+  execSys->loadPrivateKey(config.replicaId + 1, execPrivateKey);
+  slowSys->loadPrivateKey(config.replicaId + 1, slowPrivateKey);
+  commitSys->loadPrivateKey(config.replicaId + 1, commitPrivateKey);
+  optSys->loadPrivateKey(config.replicaId + 1, optPrivateKey);
 
   // Verify that there were not any unexpected parameters specified in the
   // keyfile.
@@ -662,14 +631,6 @@ bool inputReplicaKeyfile(std::istream& input, const std::string& filename, bftEn
   // Note we do not begin copying the information until we know it has been
   // loaded successfully, so the configuration struct will not be left in a
   // partially loaded state.
-  config.fVal = f;
-  config.cVal = c;
-  config.replicaId = replicaID;
-  config.publicKeysOfReplicas.clear();
-  for (uint16_t i = 0; i < numReplicas; ++i) {
-    config.publicKeysOfReplicas.insert(std::pair<uint16_t, std::string>(i, rsaPublicKeys[i]));
-  }
-  config.replicaPrivateKey = rsaPrivateKey;
 
   config.thresholdSignerForExecution = execSys->createThresholdSigner();
   config.thresholdSignerForSlowPathCommit = slowSys->createThresholdSigner();

--- a/tools/KeyfileIOUtils.hpp
+++ b/tools/KeyfileIOUtils.hpp
@@ -10,9 +10,11 @@
 // notices and license terms. Your use of these subcomponents is subject to the
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
-
+#pragma once
 #include <iostream>
-
+#include <string.hpp>
+#include <sstream>
+#include <exception>
 #include "bftengine/ReplicaConfig.hpp"
 #include "threshsign/ThresholdSignaturesTypes.h"
 
@@ -21,53 +23,36 @@
  * can then read the keys back to fill out its bftEngine::ReplicaConfig& using
  * inputReplicaKeyFile below.
  *
- * @param replicaID      The replica ID for the replica to which this keyfile
- *                       will correspond. Note replica IDs should be in the
- *                       range [0, numReplicas - 1].
  * @param numReplicas    The total number of replicas in the deployment this
  *                       replica will be in. Note numReplicas must be equal to
  *                       (3 * f + 2 * c + 1).
- * @param f              The F parameter to SBFT for this deployment (the number
- *                       of byzantine faulty replicas to tolerate before safety
- *                       and/or correctness may be lost).
- * @param c              C parameter to the SBFT algorithm for this deployment
- *                       (the number of slow, crashed, or unresponsive replicas
- *                       that can be tolerated before falling back on the slow
- *                       path for commit consensus).
- * @param output         Output stream to which to write this keyfile.
+ *
+ * @param numRoReplicas  The total number of read-only replicas in the deployment this
+ *                       replica will be in.
+ *
+ * @param config         Replica configuration
  * @param outputFilename Filename to which output corresponds; this may be used
  *                       in giving more descriptive error messages.
- * @param rsaKeys        RSA keys generated for this deployment. It is expected
- *                       that there is one pair of keys per replica, each
- *                       represented as a pair of strings in rsaKeys, ordered by
- *                       replicaID. The private key should be the first string
- *                       in each pair and the public key the second.
  * @param execSys        Cryptosystem for consensus on execution results in this
- *                       deployment, with all keys already generated.
+ *                       deployment, with all keys already generated (regular replica).
  * @param slowSys        Cryptosystem for consensus on transaction commit order
  *                       in the slow path for this deployment, with all keys
- *                       already generated.
+ *                       already generated (regular replica).
  * @param commitSys      Cryptosystem for consensus on transaction commit order
  *                       in the general path for this deployment, with all keys
- *                       already generated.
+ *                       already generated (regular replica).
  * @param optSys         Cryptosystem for consensus on transaction commit order
  *                       in the optimistic fast path for this deployment, with
- *                       all keys already generated.
- *
- * @return True if the keyfile was successfully output, false otherwise. Reasons *         this function could fail to
- * successfully output the keyfile may include I/O issues or disagreement of numReplicas with f and c.
+ *                       all keys already generated (regular replica).
  */
-bool outputReplicaKeyfile(uint16_t replicaID,
-                          uint16_t numReplicas,
-                          uint16_t f,
-                          uint16_t c,
-                          std::ostream& output,
-                          const std::string& outputFilename,
-                          const std::vector<std::pair<std::string, std::string>>& rsaKeys,
-                          const Cryptosystem& execSys,
-                          const Cryptosystem& slowSys,
-                          const Cryptosystem& commitSys,
-                          const Cryptosystem& optSys);
+ void outputReplicaKeyfile(uint16_t numReplicas,
+                           uint16_t numRoReplicas,
+                           bftEngine::ReplicaConfig& config,
+                           const std::string& outputFilename,
+                           Cryptosystem* execSys   = nullptr,
+                           Cryptosystem* slowSys   = nullptr,
+                           Cryptosystem* commitSys = nullptr,
+                           Cryptosystem* optSys    = nullptr);
 
 /**
  * Read in a keyfile for the current replica that was output with
@@ -83,7 +68,6 @@ bool outputReplicaKeyfile(uint16_t replicaID,
  * function will not modify the ReplicaConfig at all if it is unsuccesfull; it
  * will instead print an error message and return false.
  *
- * @param input         Input source for the keyfile to be read from.
  * @param inputFilename The filename to which input corresponds. This may be
  *                      used in giving more specific error messages.
  * @param config        A bftEngine::ReplicaConfig to output the cryptographic
@@ -93,4 +77,19 @@ bool outputReplicaKeyfile(uint16_t replicaID,
  *         output to config, and false otherwise. Reasons for failure may
  *         include I/O issues or invalid formatting or contents of the keyfile.
  */
-bool inputReplicaKeyfile(std::istream& input, const std::string& inputFilename, bftEngine::ReplicaConfig& config);
+bool inputReplicaKeyfile(const std::string& inputFilename, bftEngine::ReplicaConfig& config);
+
+template<typename T>
+T parse(const std::string& str, const std::string& name) {
+  try{
+    return concord::util::to<T>(str);
+  }catch(std::exception& e){
+    std::ostringstream oss;
+    oss << "Exception: " << e.what()
+        << " Invalid value  for " << name << ": " << str
+        << " expected range [" << std::numeric_limits<T>::min() << ", "
+        << std::numeric_limits<T>::max();
+
+    throw std::runtime_error(oss.str());
+  }
+}

--- a/tools/KeyfileIOUtils.hpp
+++ b/tools/KeyfileIOUtils.hpp
@@ -45,14 +45,14 @@
  *                       in the optimistic fast path for this deployment, with
  *                       all keys already generated (regular replica).
  */
- void outputReplicaKeyfile(uint16_t numReplicas,
-                           uint16_t numRoReplicas,
-                           bftEngine::ReplicaConfig& config,
-                           const std::string& outputFilename,
-                           Cryptosystem* execSys   = nullptr,
-                           Cryptosystem* slowSys   = nullptr,
-                           Cryptosystem* commitSys = nullptr,
-                           Cryptosystem* optSys    = nullptr);
+void outputReplicaKeyfile(uint16_t numReplicas,
+                          uint16_t numRoReplicas,
+                          bftEngine::ReplicaConfig& config,
+                          const std::string& outputFilename,
+                          Cryptosystem* execSys = nullptr,
+                          Cryptosystem* slowSys = nullptr,
+                          Cryptosystem* commitSys = nullptr,
+                          Cryptosystem* optSys = nullptr);
 
 /**
  * Read in a keyfile for the current replica that was output with
@@ -79,16 +79,14 @@
  */
 bool inputReplicaKeyfile(const std::string& inputFilename, bftEngine::ReplicaConfig& config);
 
-template<typename T>
+template <typename T>
 T parse(const std::string& str, const std::string& name) {
-  try{
+  try {
     return concord::util::to<T>(str);
-  }catch(std::exception& e){
+  } catch (std::exception& e) {
     std::ostringstream oss;
-    oss << "Exception: " << e.what()
-        << " Invalid value  for " << name << ": " << str
-        << " expected range [" << std::numeric_limits<T>::min() << ", "
-        << std::numeric_limits<T>::max();
+    oss << "Exception: " << e.what() << " Invalid value  for " << name << ": " << str << " expected range ["
+        << std::numeric_limits<T>::min() << ", " << std::numeric_limits<T>::max();
 
     throw std::runtime_error(oss.str());
   }

--- a/tools/TestGeneratedKeys.cpp
+++ b/tools/TestGeneratedKeys.cpp
@@ -86,8 +86,7 @@ static bool validateFundamentalFields(const std::vector<bftEngine::ReplicaConfig
   for (uint16_t i = 0; i < numReplicas; ++i) {
     const bftEngine::ReplicaConfig& config = configs[i];
     if (config.replicaId != i) {
-      std::cout << "FAILURE: Key file " << i
-                << " specifies a replica ID disagreeing with its filename.\n";
+      std::cout << "FAILURE: Key file " << i << " specifies a replica ID disagreeing with its filename.\n";
       return false;
     }
     if (config.fVal < 1) {
@@ -122,13 +121,13 @@ static bool validateConfigStructIntegrity(const std::vector<bftEngine::ReplicaCo
   for (uint16_t i = 0; i < numReplicas; ++i) {
     const bftEngine::ReplicaConfig& config = configs[i];
     if (config.publicKeysOfReplicas.size() != numReplicas) {
-      std::cout << "FAILURE: Size of the set of public keys of replicas in replica "
-                << i << "'s key file does not match the number of replicas" << numReplicas << ".\n";
+      std::cout << "FAILURE: Size of the set of public keys of replicas in replica " << i
+                << "'s key file does not match the number of replicas" << numReplicas << ".\n";
       return false;
     }
 
     std::set<uint16_t> foundIDs;
-    for (auto & entry : config.publicKeysOfReplicas) {
+    for (auto& entry : config.publicKeysOfReplicas) {
       uint16_t id = entry.first;
       if (id >= numReplicas) {
         std::cout << "FAILURE: Entry with invalid replica ID (" << id
@@ -142,8 +141,7 @@ static bool validateConfigStructIntegrity(const std::vector<bftEngine::ReplicaCo
       }
       foundIDs.insert(id);
     }
-    if(config.isReadOnly)
-      continue;
+    if (config.isReadOnly) continue;
 
     if (!config.thresholdSignerForExecution) {
       std::cout << "FAILURE: No threshold signer for execution for replica " << i << ".\n";
@@ -194,7 +192,7 @@ static bool testRSAKeyPair(const std::string& privateKey, const std::string& pub
   std::unique_ptr<bftEngine::impl::RSAVerifier> verifier;
 
   std::string invalidPrivateKey = "FAILURE: Invalid RSA private key for replica " + std::to_string(replicaID) + ".\n";
-  std::string invalidPublicKey  = "FAILURE: Invalid RSA public key for replica " +  std::to_string(replicaID) + ".\n";
+  std::string invalidPublicKey = "FAILURE: Invalid RSA public key for replica " + std::to_string(replicaID) + ".\n";
 
   try {
     signer.reset(new bftEngine::impl::RSASigner(privateKey.c_str()));
@@ -289,8 +287,7 @@ static bool testRSAKeys(const std::vector<bftEngine::ReplicaConfig>& configs) {
           existingKeyholder = publicKeyEntry.first;
         }
       }
-      std::cout << "FAILURE: Replicas " << existingKeyholder << " and " << i
-                << " share the same RSA public key.\n";
+      std::cout << "FAILURE: Replicas " << existingKeyholder << " and " << i << " share the same RSA public key.\n";
       return false;
     }
     expectedPublicKeys[i] = publicKey;
@@ -421,8 +418,8 @@ static bool testThresholdSignature(const std::string& cryptosystemName,
                                    const std::vector<uint16_t>& signersToTest,
                                    uint16_t numSigners,
                                    uint16_t threshold) {
-  std::string invalidPublicConfig = "FAILURE: Invalid public and verification keyset for " +  cryptosystemName +
-                                    " threshold cryptosystem.\n";
+  std::string invalidPublicConfig =
+      "FAILURE: Invalid public and verification keyset for " + cryptosystemName + " threshold cryptosystem.\n";
   std::string invalidKeyset = "FAILURE: Invalid keyset for the " + cryptosystemName + " threshold cryptosystem.\n";
 
   uint16_t participatingSigners = signersToTest.size();
@@ -529,8 +526,8 @@ static bool testThresholdSignature(const std::string& cryptosystemName,
         // threshold, as extra signatures are not actually helpful to it for
         // producing the composite signature it was created to produce.
         if (((accumulatorSize + 1) <= threshold) && (addRes != (accumulatorSize + 1))) {
-          std::cout << "FAILURE: Signature accumulator could not validate replica " << signerID
-                    << "'s signature for " << cryptosystemName << " threshold cryptosystem.\n";
+          std::cout << "FAILURE: Signature accumulator could not validate replica " << signerID << "'s signature for "
+                    << cryptosystemName << " threshold cryptosystem.\n";
           releaseAccumulator(verifier, accumulator);
           return false;
         } else {
@@ -574,10 +571,9 @@ static bool testThresholdSignature(const std::string& cryptosystemName,
     }
 
     if (signatureAccepted != (participatingSigners >= threshold)) {
-      std::cout << "FAILURE: Threshold signer with " << participatingSigners
-                << " signatures unexpectedly " << (signatureAccepted ? "accepted" : "rejected") << " under the "
-                << cryptosystemName << " threshold cryptosystem, which has threshold " << threshold << " out of "
-                << numSigners << ".\n";
+      std::cout << "FAILURE: Threshold signer with " << participatingSigners << " signatures unexpectedly "
+                << (signatureAccepted ? "accepted" : "rejected") << " under the " << cryptosystemName
+                << " threshold cryptosystem, which has threshold " << threshold << " out of " << numSigners << ".\n";
       return false;
     }
   }
@@ -788,7 +784,7 @@ static bool containsHelpOption(int argc, char** argv) {
  *         files fail the tests.
  */
 int main(int argc, char** argv) {
-  try{
+  try {
     std::string usageMessage =
         "Usage:\n"
         "TestGeneratedKeys \n"
@@ -854,7 +850,7 @@ int main(int argc, char** argv) {
               << "-replica Concord"
                  " deployment...\n";
 
-    std::vector<bftEngine::ReplicaConfig> configs(numReplicas+ro);
+    std::vector<bftEngine::ReplicaConfig> configs(numReplicas + ro);
 
     for (uint16_t i = 0; i < numReplicas + ro; ++i) {
       std::string filename = outputPrefix + std::to_string(i);
@@ -894,7 +890,7 @@ int main(int argc, char** argv) {
     freeConfigs(configs);
 
     return 0;
-  }catch (std::exception& e) {
+  } catch (std::exception& e) {
     std::cerr << "Exception: " << e.what() << std::endl;
     return 1;
   }

--- a/util/include/string.hpp
+++ b/util/include/string.hpp
@@ -63,26 +63,24 @@ inline unsigned long long to<>(const std::string& s) {
   return std::stoull(s);
 }
 
-inline std::string& ltrim_inplace(std::string& s){
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch);}));
+inline std::string& ltrim_inplace(std::string& s) {
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
   return s;
 }
-inline std::string& rtrim_inplace(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch);}).base(), s.end());
-    return s;
+inline std::string& rtrim_inplace(std::string& s) {
+  s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+  return s;
 }
-inline std::string& trim_inplace(std::string& str){return ltrim_inplace(rtrim_inplace(str));}
-inline std::string ltrim(const std::string& s)
-{
-  auto it =  std::find_if( s.begin() , s.end() , [](char ch){ return !std::isspace(ch);});
+inline std::string& trim_inplace(std::string& str) { return ltrim_inplace(rtrim_inplace(str)); }
+inline std::string ltrim(const std::string& s) {
+  auto it = std::find_if(s.begin(), s.end(), [](char ch) { return !std::isspace(ch); });
   return std::string(it, s.end());
 }
-inline std::string rtrim(const std::string& s)
-{
-  auto it =  std::find_if( s.rbegin() , s.rend() , [](char ch){ return !std::isspace(ch);});
-  return std::string( s.begin(), it.base());
+inline std::string rtrim(const std::string& s) {
+  auto it = std::find_if(s.rbegin(), s.rend(), [](char ch) { return !std::isspace(ch); });
+  return std::string(s.begin(), it.base());
 }
-inline std::string trim(const std::string& s){return ltrim(rtrim(s));}
+inline std::string trim(const std::string& s) { return ltrim(rtrim(s)); }
 
 }  // namespace util
 }  // namespace concord

--- a/util/include/string.hpp
+++ b/util/include/string.hpp
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <assert.h>
+#include <algorithm>
 
 namespace concord {
 namespace util {
@@ -61,5 +62,27 @@ template <>
 inline unsigned long long to<>(const std::string& s) {
   return std::stoull(s);
 }
+
+inline std::string& ltrim_inplace(std::string& s){
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch);}));
+  return s;
+}
+inline std::string& rtrim_inplace(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch);}).base(), s.end());
+    return s;
+}
+inline std::string& trim_inplace(std::string& str){return ltrim_inplace(rtrim_inplace(str));}
+inline std::string ltrim(const std::string& s)
+{
+  auto it =  std::find_if( s.begin() , s.end() , [](char ch){ return !std::isspace(ch);});
+  return std::string(it, s.end());
+}
+inline std::string rtrim(const std::string& s)
+{
+  auto it =  std::find_if( s.rbegin() , s.rend() , [](char ch){ return !std::isspace(ch);});
+  return std::string( s.begin(), it.base());
+}
+inline std::string trim(const std::string& s){return ltrim(rtrim(s));}
+
 }  // namespace util
 }  // namespace concord


### PR DESCRIPTION
https://jira.eng.vmware.com/browse/VB-2228

Add the following info to the configuration files:
For all types of replicas:
	- amount of read-only replicas
	- whether the replica is read-only
For read-only replicas:
	- don't generate threshold signatures

GenerateConcordKeys now can optionally receive -r N paremeter to indicate the amount of read-only replicas in setup.