### PR TITLE
Utilities for BFT network partitioning

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ add_test(NAME skvbc_basic_tests COMMAND sh -c
         "python3 -m unittest test_skvbc 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_linearizability_tests COMMAND sh -c
+add_test(NAME skvbc_linearizability_tests COMMAND sudo sh -c
         "python3 -m unittest test_skvbc_history_tracker test_skvbc_linearizability 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -18,7 +18,7 @@ add_test(NAME skvbc_slow_path_tests COMMAND sh -c
         "python3 -m unittest test_skvbc_slow_path 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_view_change_tests COMMAND sh -c
+add_test(NAME skvbc_view_change_tests COMMAND sudo sh -c
         "python3 -m unittest test_skvbc_view_change 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/tests/util/bft_network_partitioning.py
+++ b/tests/util/bft_network_partitioning.py
@@ -1,0 +1,116 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+import subprocess
+from abc import ABC, abstractmethod
+from itertools import combinations
+
+
+class NetworkPartitioningAdversary(ABC):
+    """Represents an adversary capable of inflicting network partitioning"""
+
+    BFT_NETWORK_PARTITIONING_RULE_CHAIN = "bft-network-partitioning"
+
+    def __init__(self, bft_network):
+        self.bft_network = bft_network
+
+    def __enter__(self):
+        """context manager method for 'with' statements"""
+        self._init_bft_network_rule_chain()
+
+        return self
+
+    def __exit__(self, *args):
+        """context manager method for 'with' statements"""
+        self._remove_bft_network_rule_chain()
+
+    @abstractmethod
+    def interfere(self):
+        """ This is where the actual malicious behavior is defined """
+        pass
+
+    @classmethod
+    def _init_bft_network_rule_chain(cls):
+        subprocess.run(
+            ["iptables", "-N", cls.BFT_NETWORK_PARTITIONING_RULE_CHAIN],
+            check=True)
+        subprocess.run(
+            ["iptables", "-A", "INPUT",
+             "-s", "localhost", "-d", "localhost",
+             "-j", cls.BFT_NETWORK_PARTITIONING_RULE_CHAIN],
+            check=True)
+
+    @classmethod
+    def _remove_bft_network_rule_chain(cls):
+        subprocess.run(
+            ["iptables", "-D", "INPUT",
+             "-s", "localhost", "-d", "localhost",
+             "-j", cls.BFT_NETWORK_PARTITIONING_RULE_CHAIN],
+            check=True)
+        subprocess.run(
+            ["iptables", "-F", cls.BFT_NETWORK_PARTITIONING_RULE_CHAIN], check=True)
+        subprocess.run(
+            ["iptables", "-X", cls.BFT_NETWORK_PARTITIONING_RULE_CHAIN], check=True)
+
+    @classmethod
+    def _drop_packets_between(
+            cls, source_port, dest_port, drop_rate_percentage=100):
+        assert 0 <= drop_rate_percentage <= 100
+        drop_rate = drop_rate_percentage / 100
+        subprocess.run(
+            ["iptables", "-A", cls.BFT_NETWORK_PARTITIONING_RULE_CHAIN,
+             "-p", "udp",
+             "--sport", str(source_port), "--dport", str(dest_port),
+             "-m", "statistic", "--mode", "random",
+             "--probability", str(drop_rate),
+             "-j", "DROP"],
+            check=True
+        )
+
+
+class PassiveAdversary(NetworkPartitioningAdversary):
+    """ Adversary does nothing = synchronous network """
+
+    def interfere(self):
+        pass
+
+
+class PrimaryIsolatingAdversary(NetworkPartitioningAdversary):
+    """ Adversary that intercepts and drops all outgoing packets from the current primary """
+
+    async def interfere(self):
+        primary = await self.bft_network.get_current_primary()
+        primary_port = self.bft_network.replicas[primary].port
+
+        non_primary_replicas = self.bft_network.all_replicas(without={primary})
+
+        for replica in non_primary_replicas:
+            replica_port = self.bft_network.replicas[replica].port
+
+            self._drop_packets_between(primary_port, replica_port)
+
+
+class PacketDroppingAdversary(NetworkPartitioningAdversary):
+    """ Adversary that drops random packets between all replicas """
+
+    def __init__(self, bft_network, drop_rate_percentage=50):
+        self.drop_rate_percentage = drop_rate_percentage
+        super(PacketDroppingAdversary, self).__init__(bft_network)
+
+    def interfere(self):
+        # drop some packets between every two replicas
+        for connection in combinations(self.bft_network.all_replicas(), 2):
+            source_port = self.bft_network.replicas[connection[0]].port
+            dest_port = self.bft_network.replicas[connection[1]].port
+
+            self._drop_packets_between(
+                source_port, dest_port, self.drop_rate_percentage
+            )

--- a/tests/util/dev/pythonSudo.sh
+++ b/tests/util/dev/pythonSudo.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This shell script allows running the Python interpreter as root
+# NB: the user needs sudo NOPASSWD enabled
+sudo PYTHONPATH=$PYTHONPATH python3 "$@"


### PR DESCRIPTION
Utilities for BFT network partitioning

With this PR we introduce the **bft_network_partitioning** module. It offers basic utilities and abstractions for simulating "adversaries" that are capable of interfering with network communication.
The base class for such adversaries is the **NetworkPartitioningAdversary**. It provides several utility methods for dropping packets based on the **iptables** utility, as well as an abstract _interfere()_ method.
Several sample implementations are provided:
- **PassiveAdversary** - basically the "no-op" adversary
- **PrimaryIsolatingAdversary** - identifies and isolates the primary replica's outgoing communication
- **PacketDroppingAdversary** - drops random packets between all replicas

This PR also provides two samples of how the partitioning module can be used:
1) Introduce the PrimaryIsolatingAdversary into view change tests (verify that view change is triggered due to the presence of such an adversary)
2) Introduce the PacketDroppingAdversary into linearizability tests (with 5% of packets dropped). Going above 5% significantly slows down the test, even though it still succeed.

PS: using _iptables_ requires root privileges, hence the "sudo" addition to the commands for starting system tests.
PPS: all BFT-related partitioning rules are defined in a custom _iptables_ rule chain called "bft-network-partitioning". This rule chain is created/cleaned-up as part of the adversary object's lifecycle (via context manager methods)