### PR TITLE
Introduce MsgHandlerRegistrator class

### DIFF
--- a/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
+++ b/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
@@ -1,0 +1,39 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <unordered_map>
+
+namespace bftEngine::impl {
+
+typedef std::function<void(MessageBase *)> MsgHandlerCallback;
+
+// The class contains message handling callback functions. One instance of this class should be created per instance
+// of the class that registers message callback functions.
+// For each new message corresponding function of type MsgHandlerCallback should be registered via this class
+// otherwise the message could not be handled later.
+
+class MsgHandlersRegistrator {
+ public:
+  void registerMsgHandler(uint16_t msgId, MsgHandlerCallback callbackFunc) { msgHandlers_[msgId] = move(callbackFunc); }
+
+  MsgHandlerCallback getCallback(uint16_t msgId) {
+    auto iterator = msgHandlers_.find(msgId);
+    if (iterator != msgHandlers_.end()) return iterator->second;
+    return nullptr;
+  }
+
+ private:
+  std::unordered_map<uint16_t, MsgHandlerCallback> msgHandlers_;
+};
+
+}  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
+++ b/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
@@ -17,14 +17,14 @@ namespace bftEngine::impl {
 
 typedef std::function<void(MessageBase*)> MsgHandlerCallback;
 
-// The class contains message handling callback functions. One instance of this class should be created per instance
-// of the class that registers message callback functions.
+// MsgHandlersRegistrator class contains message handling callback functions. One instance of this class should be
+// created per instance of the class that registers message callback functions.
 // For each new message corresponding function of type MsgHandlerCallback should be registered via this class
 // otherwise the message could not be handled later.
 
 class MsgHandlersRegistrator {
  public:
-  void registerMsgHandler(uint16_t msgId, MsgHandlerCallback callbackFunc) { msgHandlers_[msgId] = move(callbackFunc); }
+  void registerMsgHandler(uint16_t msgId, MsgHandlerCallback callbackFunc) { msgHandlers_[msgId] = std::move(callbackFunc); }
 
   MsgHandlerCallback getCallback(uint16_t msgId) {
     auto iterator = msgHandlers_.find(msgId);

--- a/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
+++ b/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
@@ -15,7 +15,7 @@
 
 namespace bftEngine::impl {
 
-typedef std::function<void(MessageBase *)> MsgHandlerCallback;
+typedef std::function<void(MessageBase*)> MsgHandlerCallback;
 
 // The class contains message handling callback functions. One instance of this class should be created per instance
 // of the class that registers message callback functions.

--- a/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
+++ b/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
@@ -17,14 +17,18 @@ namespace bftEngine::impl {
 
 typedef std::function<void(MessageBase*)> MsgHandlerCallback;
 
-// MsgHandlersRegistrator class contains message handling callback functions. One instance of this class should be
-// created per instance of the class that registers message callback functions.
+// MsgHandlersRegistrator class contains message handling callback functions.
+// Logically it's a singleton - only one message handler could be registered for every message type,
+// but practically we launch a number of replicas in the same process in the tests and each ReplicaImp instance
+// needs to have its own callbacks being called.
 // For each new message corresponding function of type MsgHandlerCallback should be registered via this class
 // otherwise the message could not be handled later.
 
 class MsgHandlersRegistrator {
  public:
-  void registerMsgHandler(uint16_t msgId, MsgHandlerCallback callbackFunc) { msgHandlers_[msgId] = std::move(callbackFunc); }
+  void registerMsgHandler(uint16_t msgId, const MsgHandlerCallback& callbackFunc) {
+    msgHandlers_[msgId] = callbackFunc;
+  }
 
   MsgHandlerCallback getCallback(uint16_t msgId) {
     auto iterator = msgHandlers_.find(msgId);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -44,57 +44,56 @@ namespace bftEngine {
 namespace impl {
 
 void ReplicaImp::registerMsgHandlers() {
-  msgHandlers_.registerMsgHandler(MsgCode::Checkpoint,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CheckpointMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::Checkpoint,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CheckpointMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::CommitPartial,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CommitPartialMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::CommitPartial,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CommitPartialMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::CommitFull,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CommitFullMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::CommitFull,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CommitFullMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::FullCommitProof,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<FullCommitProofMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::FullCommitProof,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<FullCommitProofMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::NewView,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<NewViewMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::NewView,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<NewViewMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::PrePrepare,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PrePrepareMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::PrePrepare,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PrePrepareMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::PartialCommitProof,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PartialCommitProofMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::PartialCommitProof,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PartialCommitProofMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::PartialExecProof,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PartialExecProofMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::PartialExecProof,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PartialExecProofMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::PreparePartial,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PreparePartialMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::PreparePartial,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PreparePartialMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::PrepareFull,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PrepareFullMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::PrepareFull,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PrepareFullMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::ReqMissingData,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ReqMissingDataMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::ReqMissingData,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ReqMissingDataMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::SimpleAckMsg,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<SimpleAckMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::SimpleAckMsg,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<SimpleAckMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::StartSlowCommit,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<StartSlowCommitMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::StartSlowCommit,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<StartSlowCommitMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::ViewChange,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ViewChangeMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::ViewChange,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ViewChangeMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::Request,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ClientRequestMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::Request,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ClientRequestMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::ReplicaStatus,
-                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ReplicaStatusMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(MsgCode::ReplicaStatus,
+                                   bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ReplicaStatusMsg>, this, _1));
 
-  msgHandlers_.registerMsgHandler(MsgCode::StateTransfer,
-                                  bind(&ReplicaImp::messageHandler<StateTransferMsg>, this, _1));
-  LOG_INFO_F(GL, "Message handlers have been registered");
+  msgHandlers_->registerMsgHandler(MsgCode::StateTransfer,
+                                   bind(&ReplicaImp::messageHandler<StateTransferMsg>, this, _1));
 }
 
 template <typename T>
@@ -779,7 +778,6 @@ void ReplicaImp::onInternalMsg(FullCommitProofMsg *msg) {
     delete msg;
     return;
   }
-
   onMessage(msg);
 }
 
@@ -2660,8 +2658,17 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
                        RequestsHandler *requestsHandler,
                        IStateTransfer *stateTrans,
                        shared_ptr<MsgsCommunicator> &msgsCommunicator,
-                       shared_ptr<PersistentStorage> &persistentStorage)
-    : ReplicaImp(false, ld.repConfig, requestsHandler, stateTrans, ld.sigManager, ld.repsInfo, ld.viewsManager) {
+                       shared_ptr<PersistentStorage> &persistentStorage,
+                       shared_ptr<MsgHandlersRegistrator> &msgHandlers)
+    : ReplicaImp(false,
+                 ld.repConfig,
+                 requestsHandler,
+                 stateTrans,
+                 ld.sigManager,
+                 ld.repsInfo,
+                 ld.viewsManager,
+                 msgsCommunicator,
+                 msgHandlers) {
   Assert(persistentStorage != nullptr);
 
   ps_ = persistentStorage;
@@ -2832,7 +2839,6 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
     mapOfRequestsThatAreBeingRecovered = b;
   }
 
-  msgsCommunicator_ = msgsCommunicator;
   msgsCommunicator_->start(config_.replicaId);
   internalThreadPool.start(8);  // TODO(GG): use configuration
 }
@@ -2841,8 +2847,9 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
                        RequestsHandler *requestsHandler,
                        IStateTransfer *stateTrans,
                        shared_ptr<MsgsCommunicator> &msgsCommunicator,
-                       shared_ptr<PersistentStorage> &persistentStorage)
-    : ReplicaImp(true, config, requestsHandler, stateTrans, nullptr, nullptr, nullptr) {
+                       shared_ptr<PersistentStorage> &persistentStorage,
+                       shared_ptr<MsgHandlersRegistrator> &msgHandlers)
+    : ReplicaImp(true, config, requestsHandler, stateTrans, nullptr, nullptr, nullptr, msgsCommunicator, msgHandlers) {
   if (persistentStorage != nullptr) {
     ps_ = persistentStorage;
 
@@ -2853,7 +2860,6 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
     ps_->endWriteTran();
   }
 
-  msgsCommunicator_ = msgsCommunicator;
   msgsCommunicator_->start(config_.replicaId);
   internalThreadPool.start(8);  // TODO(GG): use configuration
 }
@@ -2864,7 +2870,9 @@ ReplicaImp::ReplicaImp(bool firstTime,
                        IStateTransfer *stateTrans,
                        SigManager *sigMgr,
                        ReplicasInfo *replicasInfo,
-                       ViewsManager *viewsMgr)
+                       ViewsManager *viewsMgr,
+                       shared_ptr<MsgsCommunicator> &msgsCommunicator,
+                       shared_ptr<MsgHandlersRegistrator> &msgHandlers)
     : config_(config),
       numOfReplicas{(uint16_t)(3 * config_.fVal + 2 * config_.cVal + 1)},
       viewChangeProtocolEnabled{config.viewChangeProtocolEnabled},
@@ -2908,6 +2916,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
   // !firstTime ==> ((sigMgr != nullptr) && (replicasInfo != nullptr) && (viewsMgr != nullptr))
   Assert(firstTime || ((sigMgr != nullptr) && (replicasInfo != nullptr) && (viewsMgr != nullptr)));
 
+  msgsCommunicator_ = msgsCommunicator;
+  msgHandlers_ = msgHandlers;
   registerMsgHandlers();
 
   if (config_.debugStatisticsEnabled) {
@@ -3144,7 +3154,7 @@ void ReplicaImp::processMessages() {
       DebugStatistics::onReceivedExMessage(m->type());
     }
 
-    auto msgHandlerCallback = msgHandlers_.getCallback(m->type());
+    auto msgHandlerCallback = msgHandlers_->getCallback(m->type());
     if (msgHandlerCallback != nullptr)
       msgHandlerCallback(m);
     else {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -36,38 +36,69 @@
 #include "ReplicaConfig.hpp"
 
 using concordUtil::Timers;
+using namespace std;
 using namespace std::chrono;
+using namespace std::placeholders;
 
 namespace bftEngine {
 namespace impl {
 
-std::unordered_map<uint16_t, PtrToMetaMsgHandler> ReplicaImp::createMapOfMetaMsgHandlers() {
-  std::unordered_map<uint16_t, PtrToMetaMsgHandler> r;
+void ReplicaImp::registerMsgHandlers() {
+  msgHandlers_.registerMsgHandler(MsgCode::Checkpoint,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CheckpointMsg>, this, _1));
 
-  r[MsgCode::Checkpoint] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<CheckpointMsg>;
-  r[MsgCode::CommitPartial] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<CommitPartialMsg>;
-  r[MsgCode::CommitFull] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<CommitFullMsg>;
-  r[MsgCode::FullCommitProof] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<FullCommitProofMsg>;
-  r[MsgCode::NewView] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<NewViewMsg>;
-  r[MsgCode::PrePrepare] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<PrePrepareMsg>;
-  r[MsgCode::PartialCommitProof] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<PartialCommitProofMsg>;
-  r[MsgCode::PartialExecProof] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<PartialExecProofMsg>;
-  r[MsgCode::PreparePartial] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<PreparePartialMsg>;
-  r[MsgCode::PrepareFull] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<PrepareFullMsg>;
-  r[MsgCode::ReqMissingData] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<ReqMissingDataMsg>;
-  r[MsgCode::SimpleAckMsg] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<SimpleAckMsg>;
-  r[MsgCode::StartSlowCommit] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<StartSlowCommitMsg>;
-  r[MsgCode::ViewChange] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<ViewChangeMsg>;
-  r[MsgCode::Request] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<ClientRequestMsg>;
-  r[MsgCode::ReplicaStatus] = &ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState<ReplicaStatusMsg>;
+  msgHandlers_.registerMsgHandler(MsgCode::CommitPartial,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CommitPartialMsg>, this, _1));
 
-  r[MsgCode::StateTransfer] = &ReplicaImp::metaMessageHandler<StateTransferMsg>;
+  msgHandlers_.registerMsgHandler(MsgCode::CommitFull,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<CommitFullMsg>, this, _1));
 
-  return r;
+  msgHandlers_.registerMsgHandler(MsgCode::FullCommitProof,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<FullCommitProofMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::NewView,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<NewViewMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::PrePrepare,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PrePrepareMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::PartialCommitProof,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PartialCommitProofMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::PartialExecProof,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PartialExecProofMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::PreparePartial,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PreparePartialMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::PrepareFull,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<PrepareFullMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::ReqMissingData,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ReqMissingDataMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::SimpleAckMsg,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<SimpleAckMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::StartSlowCommit,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<StartSlowCommitMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::ViewChange,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ViewChangeMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::Request,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ClientRequestMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::ReplicaStatus,
+                                  bind(&ReplicaImp::messageHandlerWithIgnoreLogic<ReplicaStatusMsg>, this, _1));
+
+  msgHandlers_.registerMsgHandler(MsgCode::StateTransfer,
+                                  bind(&ReplicaImp::messageHandler<StateTransferMsg>, this, _1));
+  LOG_INFO_F(GL, "Message handlers have been registered");
 }
 
 template <typename T>
-void ReplicaImp::metaMessageHandler(MessageBase *msg) {
+void ReplicaImp::messageHandler(MessageBase *msg) {
   T *validMsg = nullptr;
   bool isValid = T::ToActualMsgType(*repsInfo, msg, validMsg);
 
@@ -81,11 +112,11 @@ void ReplicaImp::metaMessageHandler(MessageBase *msg) {
 }
 
 template <typename T>
-void ReplicaImp::metaMessageHandler_IgnoreWhenCollectingState(MessageBase *msg) {
+void ReplicaImp::messageHandlerWithIgnoreLogic(MessageBase *msg) {
   if (stateTransfer->isCollectingState()) {
     delete msg;
   } else {
-    metaMessageHandler<T>(msg);
+    messageHandler<T>(msg);
   }
 }
 
@@ -143,8 +174,7 @@ IncomingMsg ReplicaImp::recvMsg() {
   while (true) {
     auto msg = getIncomingMsgsStorage().popMsgForProcessing(timersResolution);
 
-    // TODO(GG): make sure that we don't check timers too often
-    // (i.e. much faster than timersResolution)
+    // TODO(GG): make sure that we don't check timers too often (i.e. much faster than timersResolution)
     timers_.evaluate();
 
     if (msg.tag != IncomingMsg::INVALID) {
@@ -169,8 +199,10 @@ void ReplicaImp::onMessage(ClientRequestMsg *m) {
              senderId);
 
   if (stateTransfer->isCollectingState()) {
-    LOG_INFO_F(GL,
-               "ClientRequestMsg is ignored because this replica is collecting missing state from the other replicas");
+    LOG_INFO(GL,
+             "ClientRequestMsg reqSeqNum="
+                 << reqSeqNum
+                 << " is ignored because this replica is collecting missing state from the other replicas");
     delete m;
     return;
   }
@@ -179,10 +211,11 @@ void ReplicaImp::onMessage(ClientRequestMsg *m) {
   const bool invalidClient = !clientsManager->isValidClient(clientId);
   const bool sentFromReplicaToNonPrimary = repsInfo->isIdOfReplica(senderId) && !isCurrentPrimary();
 
-  if (invalidClient || sentFromReplicaToNonPrimary)  // TODO(GG): more conditions (make sure that a request of client A
-                                                     // cannot be generated by client B!=A)
-  {
-    LOG_INFO_F(GL, "ClientRequestMsg is invalid");
+  // TODO(GG): more conditions (make sure that a request of client A cannot be generated by client B!=A)
+  if (invalidClient || sentFromReplicaToNonPrimary) {
+    LOG_INFO(GL,
+             "ClientRequestMsg is invalid: invalidClient=" << invalidClient << ", sentFromReplicaToNonPrimary="
+                                                           << sentFromReplicaToNonPrimary);
     onReportAboutInvalidMessage(m);
     delete m;
     return;
@@ -211,28 +244,31 @@ void ReplicaImp::onMessage(ClientRequestMsg *m) {
         tryToSendPrePrepareMsg(true);
         return;
       } else {
-        LOG_INFO_F(GL,
-                   "ClientRequestMsg is ignored because: request is old, OR primary is current working on a request "
-                   "from the same client, OR queue contains too many requests");
+        LOG_INFO(GL,
+                 "ClientRequestMsg reqSeqNum="
+                     << reqSeqNum
+                     << " is ignored because: request is old, OR primary is current working on a request "
+                        "from the same client, OR queue contains too many requests");
       }
-    } else  // not the current primary
-    {
+    } else {  // not the current primary
       if (clientsManager->noPendingAndRequestCanBecomePending(clientId, reqSeqNum)) {
         clientsManager->addPendingRequest(clientId, reqSeqNum);
 
-        send(m,
-             currentPrimary());  // TODO(GG): add a mechanism that retransmits (otherwise we may start unnecessary
-                                 // view-change )
+        // TODO(GG): add a mechanism that retransmits (otherwise we may start unnecessary view-change)
+        send(m, currentPrimary());
 
-        LOG_INFO_F(GL, "Sending ClientRequestMsg to current primary");
+        LOG_INFO(GL, "Sending ClientRequestMsg reqSeqNum=" << reqSeqNum << " to current primary");
       } else {
-        LOG_INFO_F(GL,
-                   "ClientRequestMsg is ignored because request is old or replica has another pending request from the "
-                   "same client");
+        LOG_INFO(GL,
+                 "ClientRequestMsg reqSeqNum="
+                     << reqSeqNum
+                     << " is ignored because request is old or replica has another pending request from the "
+                        "same client");
       }
     }
   } else if (seqNumberOfLastReply == reqSeqNum) {
-    LOG_DEBUG_F(GL, "ClientRequestMsg has already been executed - retransmit reply to client");
+    LOG_DEBUG(GL,
+              "ClientRequestMsg reqSeqNum=" << reqSeqNum << " has already been executed - retransmit reply to client");
 
     ClientReplyMsg *repMsg = clientsManager->allocateMsgWithLatestReply(clientId, currentPrimary());
 
@@ -240,7 +276,7 @@ void ReplicaImp::onMessage(ClientRequestMsg *m) {
 
     delete repMsg;
   } else {
-    LOG_INFO_F(GL, "ClientRequestMsg is ignored because request is old");
+    LOG_INFO(GL, "ClientRequestMsg reqSeqNum=" << reqSeqNum << " is ignored because request is old");
   }
 
   delete m;
@@ -2169,7 +2205,7 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
   if (ps_) ps_->beginWriteTran();
 
   lastStableSeqNum = newStableSeqNum;
-  metric_last_stable_seq_num__.Get().Set(lastStableSeqNum);
+  metric_last_stable_seq_num_.Get().Set(lastStableSeqNum);
 
   if (ps_) ps_->setLastStableSeqNum(lastStableSeqNum);
 
@@ -2639,7 +2675,7 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
 
   primaryLastUsedSeqNum = ld.primaryLastUsedSeqNum;
   lastStableSeqNum = ld.lastStableSeqNum;
-  metric_last_stable_seq_num__.Get().Set(lastStableSeqNum);
+  metric_last_stable_seq_num_.Get().Set(lastStableSeqNum);
   lastExecutedSeqNum = ld.lastExecutedSeqNum;
   metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
   strictLowerBoundOfSeqNums = ld.strictLowerBoundOfSeqNums;
@@ -2759,7 +2795,6 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
     const CheckData &e = ld.checkWinArr[i];
 
     Assert(checkpointsLog->insideActiveWindow(s));
-    // e.checkpointMsg==nullptr ==> (s>ld.lastStableSeqNum || s == 0)
     Assert(e.isCheckpointMsgSet() || (s > ld.lastStableSeqNum || s == 0));
 
     if (!e.isCheckpointMsgSet()) continue;
@@ -2799,7 +2834,6 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
 
   msgsCommunicator_ = msgsCommunicator;
   msgsCommunicator_->start(config_.replicaId);
-
   internalThreadPool.start(8);  // TODO(GG): use configuration
 }
 
@@ -2835,7 +2869,6 @@ ReplicaImp::ReplicaImp(bool firstTime,
       numOfReplicas{(uint16_t)(3 * config_.fVal + 2 * config_.cVal + 1)},
       viewChangeProtocolEnabled{config.viewChangeProtocolEnabled},
       autoPrimaryRotationEnabled{config.autoPrimaryRotationEnabled},
-      metaMsgHandlers{createMapOfMetaMsgHandlers()},
       restarted_{!firstTime},
       replyBuffer{(char *)std::malloc(config_.maxReplyMessageSize - sizeof(ClientReplyMsgHeader))},
       stateTransfer{(stateTrans != nullptr ? stateTrans : new NullStateTransfer())},
@@ -2846,7 +2879,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       startSyncEvent{false},
       metrics_{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())},
       metric_view_{metrics_.RegisterGauge("view", curView)},
-      metric_last_stable_seq_num__{metrics_.RegisterGauge("lastStableSeqNum", lastStableSeqNum)},
+      metric_last_stable_seq_num_{metrics_.RegisterGauge("lastStableSeqNum", lastStableSeqNum)},
       metric_last_executed_seq_num_{metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)},
       metric_last_agreed_view_{metrics_.RegisterGauge("lastAgreedView", lastAgreedView)},
       metric_first_commit_path_{metrics_.RegisterStatus(
@@ -2874,6 +2907,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
 
   // !firstTime ==> ((sigMgr != nullptr) && (replicasInfo != nullptr) && (viewsMgr != nullptr))
   Assert(firstTime || ((sigMgr != nullptr) && (replicasInfo != nullptr) && (viewsMgr != nullptr)));
+
+  registerMsgHandlers();
 
   if (config_.debugStatisticsEnabled) {
     DebugStatistics::initDebugStatisticsData();
@@ -3109,11 +3144,10 @@ void ReplicaImp::processMessages() {
       DebugStatistics::onReceivedExMessage(m->type());
     }
 
-    auto g = metaMsgHandlers.find(m->type());
-    if (g != metaMsgHandlers.end()) {
-      PtrToMetaMsgHandler ptrMetaHandler = g->second;
-      (this->*ptrMetaHandler)(m);
-    } else {
+    auto msgHandlerCallback = msgHandlers_.getCallback(m->type());
+    if (msgHandlerCallback != nullptr)
+      msgHandlerCallback(m);
+    else {
       LOG_WARN_F(GL, "Unknown message");
       delete m;
     }

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -69,7 +69,7 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   const bool autoPrimaryRotationEnabled;
   const bool supportDirectProofs = false;  // TODO(GG): add support
 
-  MsgHandlersRegistrator msgHandlers_;
+  shared_ptr<MsgHandlersRegistrator> msgHandlers_;
   shared_ptr<MsgsCommunicator> msgsCommunicator_;
 
   // main thread of the this replica
@@ -237,13 +237,15 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
              RequestsHandler* requestsHandler,
              IStateTransfer* stateTransfer,
              shared_ptr<MsgsCommunicator>& msgsCommunicator,
-             shared_ptr<PersistentStorage>& persistentStorage);
+             shared_ptr<PersistentStorage>& persistentStorage,
+             shared_ptr<MsgHandlersRegistrator>& msgHandlers);
 
   ReplicaImp(const LoadedReplicaData&,
              RequestsHandler* requestsHandler,
              IStateTransfer* stateTransfer,
              shared_ptr<MsgsCommunicator>& msgsCommunicator,
-             shared_ptr<PersistentStorage>& persistentStorage);
+             shared_ptr<PersistentStorage>& persistentStorage,
+             shared_ptr<MsgHandlersRegistrator>& msgHandlers);
 
   virtual ~ReplicaImp();
 
@@ -258,6 +260,7 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   RequestsHandler* getRequestsHandler() const { return userRequestsHandler; }
   IStateTransfer* getStateTransfer() const { return stateTransfer; }
   std::shared_ptr<MsgsCommunicator>& getMsgsCommunicator() { return msgsCommunicator_; }
+  std::shared_ptr<MsgHandlersRegistrator>& getMsgHandlersRegistrator() { return msgHandlers_; }
 
   IncomingMsg recvMsg();
   void processMessages();
@@ -281,7 +284,9 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
              IStateTransfer* stateTransfer,
              SigManager* sigMgr,
              ReplicasInfo* replicasInfo,
-             ViewsManager* viewsMgr);
+             ViewsManager* viewsMgr,
+             shared_ptr<MsgsCommunicator>& msgsCommunicator,
+             shared_ptr<MsgHandlersRegistrator>& msgHandlers);
 
   void registerMsgHandlers();
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -36,6 +36,7 @@
 #include "ReplicaLoader.hpp"
 #include "Metrics.hpp"
 #include "Timers.hpp"
+#include "MsgHandlersRegistrator.hpp"
 
 #include <thread>
 
@@ -58,7 +59,6 @@ class ReplicaStatusMsg;
 class ReplicaImp;
 
 using bftEngine::ReplicaConfig;
-using PtrToMetaMsgHandler = void (ReplicaImp::*)(MessageBase* msg);
 
 class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
  protected:
@@ -69,9 +69,7 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   const bool autoPrimaryRotationEnabled;
   const bool supportDirectProofs = false;  // TODO(GG): add support
 
-  // pointers to message handlers
-  const std::unordered_map<uint16_t, PtrToMetaMsgHandler> metaMsgHandlers;
-
+  MsgHandlersRegistrator msgHandlers_;
   shared_ptr<MsgsCommunicator> msgsCommunicator_;
 
   // main thread of the this replica
@@ -206,7 +204,7 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   typedef concordMetrics::Component::Handle<concordMetrics::Counter> CounterHandle;
 
   GaugeHandle metric_view_;
-  GaugeHandle metric_last_stable_seq_num__;
+  GaugeHandle metric_last_stable_seq_num_;
   GaugeHandle metric_last_executed_seq_num_;
   GaugeHandle metric_last_agreed_view_;
 
@@ -285,12 +283,13 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
              ReplicasInfo* replicasInfo,
              ViewsManager* viewsMgr);
 
-  static std::unordered_map<uint16_t, PtrToMetaMsgHandler> createMapOfMetaMsgHandlers();
+  void registerMsgHandlers();
 
   template <typename T>
-  void metaMessageHandler(MessageBase* msg);
+  void messageHandler(MessageBase* msg);
+
   template <typename T>
-  void metaMessageHandler_IgnoreWhenCollectingState(MessageBase* msg);  // TODO(GG): rename
+  void messageHandlerWithIgnoreLogic(MessageBase* msg);
 
   ReplicaId currentPrimary() const { return repsInfo->primaryOfView(curView); }
   bool isCurrentPrimary() const { return (currentPrimary() == config_.replicaId); }


### PR DESCRIPTION
Allow registering message handler functions from any class interested in that service.
For now, it is ReplicaImp and PreExecutor - in the future.
Create MsgHandlerRegistrator in BFTEngine createNewReplica function - this allows launching tests that create all replicas in the same process.
