### PR TITLE
SparseMerkle: Add BatchedInternalNode

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -26,5 +26,8 @@ if (BUILD_ROCKSDB_STORAGE)
   endif()
 endif(BUILD_ROCKSDB_STORAGE)
 
-target_sources(concordbft_storage PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/memorydb_client.cpp)
+target_sources(concordbft_storage PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/memorydb_client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/internal_node.cpp
+)
 

--- a/storage/include/sparse_merkle/internal_node.h
+++ b/storage/include/sparse_merkle/internal_node.h
@@ -1,0 +1,287 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <optional>
+#include <variant>
+#include <algorithm>
+
+#include "sliver.hpp"
+#include "sparse_merkle/keys.h"
+#include "sparse_merkle/base_types.h"
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+/*
+A partially full BatchedInternalNode may look like the following:
+
+```
+Level 4               ---------root-------
+                      |                  |
+                  LeafChild       InternalChild
+                                  /            \
+Level 2                     LeafChild    InternalChild
+                                                  \
+Level 1                                       InternalChild
+                                             /             \
+Level 0                                 LeafChild      InternalChild
+
+Note that a LeafChild *never* has any children below it, but an InternalChild
+always does. An InternalChild at level 0 indicates more children in other
+BatchedInternalNodes further down the tree.
+
+Please refer to this diagram to understand the types of children in a
+BatchedInternalNode and their corresponding header comments.
+*/
+
+// A child that is a leaf of the overall tree. It isn't necessarily at height 0
+// in a BatchedInternalNode, although there will not be any children below it.
+struct LeafChild {
+  bool operator==(const LeafChild& other) const { return hash == other.hash && key == other.key; }
+  // The hash of the value blob stored at `key`
+  Hash hash;
+  LeafKey key;
+};
+
+// A child that represents an internal node of the sparse binary merkle tree. It
+// will refer to another BatchedInternalNode if it resides at height 0.
+struct InternalChild {
+  bool operator==(const InternalChild& other) const { return hash == other.hash && version == other.version; }
+  Hash hash;
+  Version version;
+};
+
+typedef std::variant<LeafChild, InternalChild> Child;
+
+/*
+// A batched internal node. The node is a representation of a 4-level tree, such
+// that there are a total possibility of 16 leaves.
+//
+// Children of this tree are stored in an array. A child may represent an
+// internal node of the overall sparse merkle tree, a leaf, or a placeholder
+// node. If an InternalChild resides at height 0 it will point to another
+// BatchedInternalNode. A leaf will always have a pointer to a key containing
+// the actual stored data. It may or may not reside at height 0.
+//
+// The following is a diagram of a complete 4-level tree, re-used with thanks
+// from
+// https://github.com/libra/libra/blob/master/storage/jellyfish-merkle/src/node_type/mod.rs
+//
+//   4 ->              +------ root hash ------+
+//                     |                       |
+//   3 ->        +---- # ----+           +---- # ----+
+//               |           |           |           |
+//   2 ->        #           #           #           #
+//             /   \       /   \       /   \       /   \
+//   1 ->     #     #     #     #     #     #     #     #
+//           / \   / \   / \   / \   / \   / \   / \   / \
+//   0 ->   0   1 2   3 4   5 6   7 8   9 A   B C   D E   F
+//   ^
+// height
+//
+//
+// We use a similar logical layout to libra for trees that are not full. Further
+// quoting the libra source:
+//
+//       "As illustrated above, at nibble height 0, `0..F` in hex denote 16 chidren hashes. Each `#`
+//       means the hash of its two direct children, which will be used to generate the hash of its
+//       parent with the hash of its sibling. Finally, we can get the hash of this internal node.
+//
+//       However, if an internal node doesn't have all 16 chidren exist at height 0 but just a few of
+//       them, we have a modified hashing rule on top of what is stated above:
+//       1. From top to bottom, a node will be replaced by a leaf child if the subtree rooted at this
+//       node has only one child at height 0 and it is a leaf child.
+//       2. From top to bottom, a node will be replaced by the placeholder node if the subtree rooted at
+//       this node doesn't have any child at height 0. For example, if an internal node has 3 leaf
+//       children at index 0, 3, 8, respectively, and 1 internal node at index C, then the computation
+//       graph will be like:"
+//
+//   4 ->              +------ root hash ------+
+//                     |                       |
+//   3 ->        +---- # ----+           +---- # ----+
+//               |           |           |           |
+//   2 ->        #           @           8           #
+//             /   \                               /   \
+//   1 ->     0     3                             #     @
+//                                               / \
+//   0 ->                                       C   @
+//   ^
+// height
+// Note: @ denotes placeholder hash.
+//
+// To further elaborate: `C`, a BatchedInternalNode in our tree, is only present
+// at height 0 if there are multiple keys with matching prefixes that have more than the
+// number of bits from the root of the sparse merkle to height 0 of this tree.
+// Concretely, if the displayed BatchedInternalNode is at depth 0 (height 256)
+// of the entire sparse merkle tree, then 2 keys with 5 leading bits in common
+// would cause `C` to be created and put at height 0 of this
+// BatchedInternalNode. This scenario is demonstrated in the test
+// `split_until_new_batch_node_needed` in `internal_node_test.cpp`.
+//
+*/
+class BatchedInternalNode {
+ public:
+  static constexpr size_t MAX_CHILDREN = 31;
+
+  // The leaf was inserted into this node successfully.
+  //
+  // It's possible that a leaf with the same key hash as the newly inserted leaf
+  // was overwritten.  In this case we need to tell the caller that this
+  // occurred so they can add it to their stale list for pruning later.
+  struct InsertComplete {
+    std::optional<LeafKey> stale_leaf;
+  };
+
+  // A node split has occurred, forcing the need to create new
+  // BatchedInternalNodes.
+  //
+  // Depending upon how many bits in common the key hashes of these 2 leaves
+  // have, more than one BatchedInternalNode may need to be created.
+  //
+  // Return the original child that forced a node split.
+  struct CreateNewBatchedInternalNodes {
+    // This LeafChild was previously stored in this BatchedInternalNode, but was replaced
+    // with an InternalChild. It now needs to be inserted in a new node along
+    // with the LeafChild originally trying to be inserted.
+    LeafChild stored_child;
+  };
+
+  // A leaf could not be added at height 0 because there was an existing
+  // InternalChild at the leaf (height 0) of this BatchedInternalNode.
+  //
+  // An attempt should be made to insert the leaf at the next, already existing
+  // BatchedInternalNode with `next_node_version`.
+  struct InsertIntoExistingNode {
+    // The version of the next BatchedInternalNode to try inserting into. The
+    // caller knows how to construct an InternalNodeKey using this version.
+    Version next_node_version;
+  };
+
+  // insert(child, depth) can return one of three results to the sparse merkle
+  // tree manipulating the BatchedInternalNode.
+  typedef std::variant<InsertComplete, CreateNewBatchedInternalNodes, InsertIntoExistingNode> InsertResult;
+
+  // Insert a LeafChild into this internal node. Return a type indicating success or
+  // failure that contains the necessary data for the caller (the sparse merkle
+  // tree implementation) to do the right thing.
+  //
+  // `depth` represents how many nibbles down the sparse merkle tree this BatchedInternalNode is.
+  InsertResult insert(const LeafChild& child, size_t depth);
+
+  // Return the root hash of this node.
+  const Hash& hash() const { return getHash(0); }
+
+  // Return the version of the root node of this BatchedInternalNode
+  Version version() const;
+
+  // Return the number of children that are not std::nullopt.
+  size_t numChildren() const;
+
+  // Return the number of internal children in this BatchedInternalNode
+  size_t numInternalChildren() const;
+
+  // Return the number of leaf children in this BatchedInternalNode
+  size_t numLeafChildren() const;
+
+ private:
+  // A LeafChild collission has occurred. We need to create new InternalChild nodes so
+  // that the stored LeafChild that collided with the new LeafChild attempting
+  // to be added can live below those new internal nodes.
+  //
+  // Return the index of the bottom most InternalNode created.
+  size_t insertInternalChildren(size_t index, Version version, Nibble child_key, size_t prefix_bits_in_common);
+
+  // After the collission and the creation of new InternalChild nodes, there is
+  // still room in this BatchedInternalNode to add the previously stored
+  // LeafChild and the new LeafChild. Go ahead and do that insertion in this
+  // function.
+  //
+  // Always return InsertComplete{}.
+  InsertResult insertTwoLeafChildren(size_t index,
+                                     Version version,
+                                     Nibble child_key,
+                                     size_t prefix_bits_in_common,
+                                     LeafChild child1,
+                                     LeafChild child2);
+
+  // Return true if the index does not contain a child.
+  bool isEmpty(size_t index) const { return !children_.at(index).has_value(); }
+
+  // Return true if the index has a child that contains an internal node.
+  bool isInternal(size_t index) const;
+
+  // Attempt to insert into an empty child.
+  //
+  // Return InsertComplete if the node was empty.
+  // Otherwise return std::nullopt.
+  std::optional<InsertResult> insertIntoEmptyChild(size_t index, const LeafChild& child);
+
+  // Attempt to overwrite a matching key at index.
+  //
+  // Return InsertComplete if the key was overwritten.
+  // Otherwise return std::nullopt.
+  std::optional<InsertResult> overwrite(size_t index, const LeafChild& child);
+
+  // There has been a collision of leaf keys that do not match.
+  //
+  // One or more parents must be created to store them.
+  //
+  // `depth` is the current depth of this BatchedInternalNode in ths sparse merkle
+  // tree.
+  //
+  // Return either CreateNewBatchedInternalNodes or InsertComplete.
+  InsertResult splitNode(size_t index, const LeafChild& child, size_t depth);
+
+  // Return the hash of a given index.
+  const Hash& getHash(size_t index) const;
+
+  // Walk the tree from `index` up to the root of this BatchedInternalNode to
+  // compute the root hash.
+  //
+  // Update the hashes and versions of nodes along the way.
+  void updateHashes(size_t index, Version version);
+
+  // Return the the height of the node at the given index.
+  //
+  // The height depends upon MAX_CHILDREN, which dictates the maximum depth of a
+  // binary tree.
+  size_t height(size_t index) const;
+
+  // Return the index of the parent node, given the index of the child node.
+  //
+  // Return std::nullopt if the index points to the root of this
+  // BatchedInternalNode.
+  std::optional<size_t> parentIndex(size_t index) {
+    if (index == 0) return std::nullopt;
+    return (index - 1) / 2;
+  }
+
+  // Return the index of the left child of a node at a given index.
+  size_t leftChildIndex(size_t index) const { return 2 * index + 1; }
+
+  // Return the index of the right child of a node at a given index.
+  size_t rightChildIndex(size_t index) const { return 2 * index + 2; }
+
+  // Is this node a left child?
+  bool isLeftChild(size_t index) const { return index % 2 != 0; }
+
+  // All internal and leaf nodes are stored in this array, starting from the
+  // root and proceeding level by level from left to right.
+  std::array<std::optional<Child>, MAX_CHILDREN> children_;
+};
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/sparse_merkle/keys.h
+++ b/storage/include/sparse_merkle/keys.h
@@ -1,0 +1,68 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include "sliver.hpp"
+#include "sparse_merkle/base_types.h"
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+// An InternalNodeKey points to a BatchedInternalNode. It's always on a
+// nibble boundary, hence it's keyed by NibblePath. We retrieve children that
+// are part of the batch by pointing to their containing BatchedInternalNode.
+class InternalNodeKey {
+ public:
+  InternalNodeKey(Version version, NibblePath path) : version_(version), path_(path) {}
+
+  // Return the root of a sparse merkle tree at a given version.
+  static InternalNodeKey root(Version version) { return InternalNodeKey(version, NibblePath()); }
+
+  bool operator==(const InternalNodeKey& other) const { return version_ == other.version_ && path_ == other.path_; }
+
+  Version version() const { return version_; }
+
+ private:
+  Version version_;
+  NibblePath path_;
+};
+
+// The key for a leaf node of a sparse merkle tree.
+//
+// We identify this by the full key hash rather than NibblePath so that we can
+// do direct DB lookups rather than having to walk from the root of the sparse
+// merkle tree.
+class LeafKey {
+ public:
+  LeafKey(Hash key, Version version) : key_(key), version_(version) {}
+
+  bool operator==(const LeafKey& other) const { return key_ == other.key_ && version_ == other.version_; }
+
+  Nibble getNibble(const size_t n) const {
+    Assert(n < Hash::MAX_NIBBLES);
+    return key_.getNibble(n);
+  }
+
+  Version version() const { return version_; }
+
+  const Hash& hash() const { return key_; }
+
+ private:
+  Hash key_;
+  Version version_;
+};
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/src/sparse_merkle/internal_node.cpp
+++ b/storage/src/sparse_merkle/internal_node.cpp
@@ -1,0 +1,234 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "sparse_merkle/internal_node.h"
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+void BatchedInternalNode::updateHashes(size_t index, Version version) {
+  Assert(index > 0);
+  auto hasher = Hasher();
+
+  while (true) {
+    Hash parent_hash;
+    if (isLeftChild(index)) {
+      parent_hash = hasher.parent(getHash(index), getHash(index + 1));
+    } else {
+      parent_hash = hasher.parent(getHash(index - 1), getHash(index));
+    }
+    auto parent_idx = parentIndex(index).value();
+    auto& parent = children_.at(parent_idx);
+    if (!parent) {
+      // We are adding the first child below a non-existent parent. Create the
+      // parent first.
+      children_[parent_idx] = InternalChild{Hash(), version};
+      parent = children_.at(parent_idx);
+    }
+    // A parent is *always* an InternalChild
+    auto& internal_child = std::get<InternalChild>(parent.value());
+    internal_child.hash = parent_hash;
+    internal_child.version = version;
+    if (parent_idx == 0) {
+      // We have reached the root of this BatchedInternalNode
+      return;
+    }
+    index = parent_idx;
+  }
+}
+
+BatchedInternalNode::InsertResult BatchedInternalNode::insert(const LeafChild& child, size_t depth) {
+  // The index into the children_ array
+  size_t index = 0;
+  Nibble child_key = child.key.hash().getNibble(depth);
+
+  for (size_t i = Nibble::SIZE_IN_BITS - 1; i >= 0 && i != SIZE_MAX; i--) {
+    if (child_key.getBit(i)) {
+      index = rightChildIndex(index);
+    } else {
+      index = leftChildIndex(index);
+    }
+    if (isInternal(index)) {
+      continue;
+    }
+
+    // First try to insert into an empty child, then try to overwrite the child,
+    // and lastly split the node.
+    if (auto rv = insertIntoEmptyChild(index, child)) {
+      return rv.value();
+    }
+    if (auto rv = overwrite(index, child)) {
+      return rv.value();
+    }
+    return splitNode(index, child, depth);
+  }
+
+  // We have reached the leaf of this BatchedInternalNode and it points to another
+  // BatchedInternalNode. Return the Version so the caller can construct an
+  // InternalNodeKey and retrieve the next batched node in the tree.
+  auto& stored_child = children_[index];
+  return BatchedInternalNode::InsertIntoExistingNode{std::get<InternalChild>(stored_child.value()).version};
+}
+
+std::optional<BatchedInternalNode::InsertResult> BatchedInternalNode::insertIntoEmptyChild(size_t index,
+                                                                                           const LeafChild& child) {
+  if (isEmpty(index)) {
+    auto version = child.key.version();
+    children_[index] = child;
+    updateHashes(index, version);
+    return BatchedInternalNode::InsertComplete{};
+  }
+  return std::nullopt;
+}
+
+std::optional<BatchedInternalNode::InsertResult> BatchedInternalNode::overwrite(size_t index, const LeafChild& child) {
+  auto& stored_child = std::get<LeafChild>(children_.at(index).value());
+  if (stored_child.key.hash() == child.key.hash()) {
+    auto result = BatchedInternalNode::InsertComplete{stored_child.key};
+    stored_child = child;
+    updateHashes(index, child.key.version());
+    return result;
+  }
+  return std::nullopt;
+}
+
+BatchedInternalNode::InsertResult BatchedInternalNode::splitNode(size_t index, const LeafChild& child, size_t depth) {
+  auto version = child.key.version();
+  auto stored_leaf_child = std::get<LeafChild>(children_.at(index).value());
+
+  // Create a new InternalChild at index.
+  children_.at(index).emplace(InternalChild{Hash(), version});
+
+  if (height(index) == 0) {
+    // We've reached the leaf of this node. Tell the caller to create new
+    // BatchedInternalNodes and insert the previously stored leaf as well as the
+    // leaf it was attempting to insert.
+    //
+    // We purposefully don't call `update_hashes`, since we don't know the true
+    // value of the hash of the child until it gets inserted. The caller will fix
+    // this BatchedInternalNode appropriately when the hash is known.
+    return BatchedInternalNode::CreateNewBatchedInternalNodes{stored_leaf_child};
+  }
+
+  // How many prefix bits do the two leaf key hashes have in common?
+  auto prefix_bits_in_common = stored_leaf_child.key.hash().prefix_bits_in_common(child.key.hash(), depth);
+
+  // Fill in this node with any necessary internal children.
+  Nibble child_key = child.key.hash().getNibble(depth);
+  index = insertInternalChildren(index, version, child_key, prefix_bits_in_common);
+
+  // Is there room to insert the 2 children in this BatchedInternalNode?
+  if (prefix_bits_in_common < Nibble::SIZE_IN_BITS) {
+    return insertTwoLeafChildren(index, version, child_key, prefix_bits_in_common, child, stored_leaf_child);
+  }
+
+  // We've reached the leaf of this node. Tell the caller to create new
+  // BatchedInternalNodes and insert the previously stored leaf as well as the
+  // leaf it was attempting to insert.
+  //
+  // We purposefully don't call `update_hashes`, since we don't know the true
+  // value of the hash of the child until it gets inserted. The caller will fix
+  // this BatchedInternalNode appropriately when the hash is known.
+  return BatchedInternalNode::CreateNewBatchedInternalNodes{stored_leaf_child};
+}
+
+size_t BatchedInternalNode::insertInternalChildren(size_t index,
+                                                   Version version,
+                                                   Nibble child_key,
+                                                   size_t prefix_bits_in_common) {
+  size_t add_internal_children_until_height = 0;
+  if (prefix_bits_in_common < Nibble::SIZE_IN_BITS) {
+    add_internal_children_until_height = Nibble::SIZE_IN_BITS - prefix_bits_in_common;
+  }
+  for (size_t i = height(index) - 1; i >= add_internal_children_until_height && i != SIZE_MAX; i--) {
+    if (child_key.getBit(i)) {
+      index = rightChildIndex(index);
+    } else {
+      index = leftChildIndex(index);
+    }
+    children_.at(index).emplace(InternalChild{Hash(), version});
+  }
+  return index;
+}
+
+BatchedInternalNode::InsertResult BatchedInternalNode::insertTwoLeafChildren(
+    size_t index, Version version, Nibble child_key, size_t prefix_bits_in_common, LeafChild child1, LeafChild child2) {
+  size_t child1_index = 0;
+  size_t child2_index = 0;
+  if (child_key.getBit(prefix_bits_in_common)) {
+    child1_index = rightChildIndex(index);
+    child2_index = leftChildIndex(index);
+  } else {
+    child1_index = leftChildIndex(index);
+    child2_index = rightChildIndex(index);
+  }
+  children_[child1_index] = child1;
+  children_[child2_index] = child2;
+  updateHashes(child1_index, version);
+  return BatchedInternalNode::InsertComplete{};
+}
+
+Version BatchedInternalNode::version() const {
+  auto& root = children_[0];
+  if (!root) return 0;
+  return std::get<InternalChild>(root.value()).version;
+}
+
+size_t BatchedInternalNode::numChildren() const {
+  return std::count_if(children_.begin(), children_.end(), [](const std::optional<Child>& c) { return c.has_value(); });
+}
+
+size_t BatchedInternalNode::numInternalChildren() const {
+  return std::count_if(children_.begin(), children_.end(), [](const std::optional<Child>& c) {
+    if (c) {
+      return std::holds_alternative<InternalChild>(c.value());
+    }
+    return false;
+  });
+}
+
+size_t BatchedInternalNode::numLeafChildren() const {
+  return std::count_if(children_.begin(), children_.end(), [](const std::optional<Child>& c) {
+    if (c) {
+      return std::holds_alternative<LeafChild>(c.value());
+    }
+    return false;
+  });
+}
+
+size_t BatchedInternalNode::height(size_t index) const {
+  if (index == 0) return 4;
+  if (index < 3) return 3;
+  if (index < 7) return 2;
+  if (index < 15) return 1;
+  return 0;
+}
+
+const Hash& BatchedInternalNode::getHash(size_t index) const {
+  auto& child = children_.at(index);
+  if (!child) {
+    return PLACEHOLDER_HASH;
+  }
+  return std::visit([](auto&& arg) -> const Hash& { return arg.hash; }, child.value());
+}
+
+bool BatchedInternalNode::isInternal(size_t index) const {
+  if (auto& child = children_.at(index)) {
+    return std::holds_alternative<InternalChild>(child.value());
+  }
+  return false;
+}
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -21,3 +21,13 @@ target_link_libraries(sparse_merkle_base_types_test PUBLIC
     gtest
     concordbft_storage
 )
+
+find_package(OpenSSL REQUIRED)
+add_executable(sparse_merkle_internal_node_test sparse_merkle/internal_node_test.cpp
+    $<TARGET_OBJECTS:logging_dev>)
+add_test(sparse_merkle_internal_node_test sparse_merkle_internal_node_test)
+target_link_libraries(sparse_merkle_internal_node_test PUBLIC
+    gtest
+    concordbft_storage
+    ${OPENSSL_LIBRARIES}
+)

--- a/storage/test/sparse_merkle/base_types_test.cpp
+++ b/storage/test/sparse_merkle/base_types_test.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0 License.
@@ -17,21 +17,21 @@ using namespace concord::storage::sparse_merkle;
 
 TEST(nibble_test, check_bit_operations) {
   Nibble full(15);
-  ASSERT_TRUE(full.get_bit(0));
-  ASSERT_TRUE(full.get_bit(1));
-  ASSERT_TRUE(full.get_bit(2));
-  ASSERT_TRUE(full.get_bit(3));
+  ASSERT_TRUE(full.getBit(0));
+  ASSERT_TRUE(full.getBit(1));
+  ASSERT_TRUE(full.getBit(2));
+  ASSERT_TRUE(full.getBit(3));
 
   Nibble empty(0);
-  ASSERT_FALSE(empty.get_bit(0));
-  ASSERT_FALSE(empty.get_bit(1));
-  ASSERT_FALSE(empty.get_bit(2));
-  ASSERT_FALSE(empty.get_bit(3));
+  ASSERT_FALSE(empty.getBit(0));
+  ASSERT_FALSE(empty.getBit(1));
+  ASSERT_FALSE(empty.getBit(2));
+  ASSERT_FALSE(empty.getBit(3));
 }
 
 TEST(nibble_DeathTest, bits_outside_range) { ASSERT_DEATH(Nibble bad(16), ""); }
 
-TEST(nibble_path_test, append_and_get_and_pop_back) {
+TEST(nibble_path_test, append_and_get_and_popBack) {
   NibblePath path;
   path.append(15);
   ASSERT_EQ(path.length(), 1);
@@ -45,11 +45,11 @@ TEST(nibble_path_test, append_and_get_and_pop_back) {
   ASSERT_EQ(Nibble(0), path.get(2));
   ASSERT_EQ(3, path.length());
 
-  ASSERT_EQ(Nibble(0), path.pop_back());
+  ASSERT_EQ(Nibble(0), path.popBack());
   ASSERT_EQ(2, path.length());
-  ASSERT_EQ(Nibble(2), path.pop_back());
+  ASSERT_EQ(Nibble(2), path.popBack());
   ASSERT_EQ(1, path.length());
-  ASSERT_EQ(Nibble(15), path.pop_back());
+  ASSERT_EQ(Nibble(15), path.popBack());
 
   ASSERT_TRUE(path.empty());
 }
@@ -61,6 +61,26 @@ TEST(nibble_path_DeathTest, range_errors) {
   }
   ASSERT_DEATH(path.append(0), "");
   ASSERT_DEATH(path.get(Hash::MAX_NIBBLES), "");
+}
+
+TEST(hash_test, prefix_bits_in_common) {
+  // A hash compared with itself should have all bits in common.
+  ASSERT_EQ(Hash::SIZE_IN_BITS, PLACEHOLDER_HASH.prefix_bits_in_common(PLACEHOLDER_HASH));
+
+  // Make the hash differ in the last byte
+  std::array<uint8_t, Hash::SIZE_IN_BYTES> array2 = Hash::EMPTY_BUF;
+  array2[Hash::SIZE_IN_BYTES - 1] = 0xF0;
+  Hash hash2 = Hash(array2);
+
+  ASSERT_EQ(Hash::SIZE_IN_BITS - 8, PLACEHOLDER_HASH.prefix_bits_in_common(hash2));
+
+  // Check that we only have 4 bits in common when we only compare from depth of
+  // MAX_NIBBLES - 3;
+  ASSERT_EQ(Nibble::SIZE_IN_BITS, PLACEHOLDER_HASH.prefix_bits_in_common(hash2, Hash::MAX_NIBBLES - 3));
+
+  // Check that when we exclude all bytes up to the last byte we have no bits in
+  // common.
+  ASSERT_EQ(0, PLACEHOLDER_HASH.prefix_bits_in_common(hash2, Hash::MAX_NIBBLES - 2));
 }
 
 int main(int argc, char **argv) {

--- a/storage/test/sparse_merkle/internal_node_test.cpp
+++ b/storage/test/sparse_merkle/internal_node_test.cpp
@@ -1,0 +1,380 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+#include "sparse_merkle/base_types.h"
+#include "sparse_merkle/internal_node.h"
+
+using namespace concord::storage::sparse_merkle;
+
+TEST(internal_node_tests, empty_invariants) {
+  BatchedInternalNode node;
+
+  // An empty node has a placeholder hash
+  ASSERT_EQ(PLACEHOLDER_HASH, node.hash());
+
+  // An empty node has version 0
+  ASSERT_EQ(Version(0), node.version());
+
+  // There are no children of any kind
+  ASSERT_EQ(0, node.numChildren());
+  ASSERT_EQ(0, node.numInternalChildren());
+  ASSERT_EQ(0, node.numLeafChildren());
+}
+
+// The logical tree inside the BatchedInternalNode looks like the following at the end of this test
+//
+//    Root
+//     |
+//     |
+//    Leaf
+//
+TEST(internal_node_tests, insert_single_leaf_node) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto child = LeafChild{value1_hash, leaf_key1};
+
+  // The key of this child in the 4-level BatchedInternalNode tree.
+  Nibble child_key = key1_hash.getNibble(depth);
+
+  // A node was successfully inserted. Since it didn't overwrite another node
+  // there is not a stale leaf.
+  auto result = node.insert(child, depth);
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::InsertComplete>(result));
+  auto successful_insert = std::get<BatchedInternalNode::InsertComplete>(result);
+  ASSERT_FALSE(successful_insert.stale_leaf.has_value());
+
+  // There should be one root and one leaf
+  ASSERT_EQ(2, node.numChildren());
+  ASSERT_EQ(1, node.numInternalChildren());
+  ASSERT_EQ(1, node.numLeafChildren());
+
+  // The version should be 1.
+  ASSERT_EQ(Version(1), node.version());
+
+  Hash parent_hash;
+  if (child_key.getBit(3)) {
+    // The key was inserted at the right child of the BatchedInternalNode root
+    parent_hash = hasher.parent(PLACEHOLDER_HASH, value1_hash);
+  } else {
+    // The key was inserted at the left child of the BatchedInternalNode root
+    parent_hash = hasher.parent(value1_hash, PLACEHOLDER_HASH);
+  }
+
+  ASSERT_EQ(node.hash(), parent_hash);
+}
+
+// The logical tree inside the BatchedInternalNode looks like the following at the end of this test
+//
+//    Root
+//     |
+//     |
+//    Leaf
+//
+TEST(internal_node_tests, overwrite_single_leaf_node) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key1_hash, Version(2));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+
+  // The key of this child in the 4-level BatchedInternalNode tree.
+  Nibble child_key = key1_hash.getNibble(depth);
+
+  auto result = node.insert(child1, depth);
+  result = node.insert(child2, depth);
+
+  // The second child overwrote the first, thus returning the key of the first
+  // in stale_leaf. No new nodes were generated, since there was no partial
+  // match leading to creation of parent nodes overflowing to create new
+  // BatchedInternalNodes.
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::InsertComplete>(result));
+  auto successful_insert = std::get<BatchedInternalNode::InsertComplete>(result);
+  ASSERT_EQ(successful_insert.stale_leaf.value(), leaf_key1);
+
+  // There should be one root and one leaf
+  ASSERT_EQ(2, node.numChildren());
+  ASSERT_EQ(1, node.numInternalChildren());
+  ASSERT_EQ(1, node.numLeafChildren());
+
+  // The version should be 2.
+  ASSERT_EQ(Version(2), node.version());
+
+  Hash parent_hash;
+  if (child_key.getBit(3)) {
+    // The key was inserted at the right child of the BatchedInternalNode root
+    parent_hash = hasher.parent(PLACEHOLDER_HASH, value2_hash);
+  } else {
+    // The key was inserted at the left child of the BatchedInternalNode root
+    parent_hash = hasher.parent(value2_hash, PLACEHOLDER_HASH);
+  }
+
+  ASSERT_EQ(node.hash(), parent_hash);
+}
+
+/*
+// The logical tree inside the BatchedInternalNode looks like the following at the end of this test
+//
+//          Root
+//           |
+//         /   \
+//      Leaf   Leaf
+//
+*/
+TEST(internal_node_tests, create_two_leafs_with_one_parent) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the first bit so that key1_hash becomes a sibling of key2_hash
+  std::array<uint8_t, Hash::SIZE_IN_BYTES> key2_hash_data;
+  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key2_hash_data.begin());
+  key2_hash_data[0] ^= 0x80;
+  auto key2_hash = Hash(key2_hash_data);
+
+  ASSERT_EQ(0, key1_hash.prefix_bits_in_common(key2_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+
+  // The key of the first child in the 4-level BatchedInternalNode tree.
+  Nibble child1_key = key1_hash.getNibble(depth);
+
+  auto result = node.insert(child1, depth);
+  result = node.insert(child2, depth);
+
+  // No nodes were overwritten and no new BatchedInternalNodes created
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::InsertComplete>(result));
+  auto successful_insert = std::get<BatchedInternalNode::InsertComplete>(result);
+  ASSERT_FALSE(successful_insert.stale_leaf.has_value());
+
+  // There should be one root and two leaves
+  ASSERT_EQ(3, node.numChildren());
+  ASSERT_EQ(1, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+
+  // The version should be 2.
+  ASSERT_EQ(Version(2), node.version());
+
+  Hash parent_hash;
+  if (child1_key.getBit(3)) {
+    // The key was inserted at the right child of the BatchedInternalNode root
+    parent_hash = hasher.parent(value2_hash, value1_hash);
+  } else {
+    // The key was inserted at the left child of the BatchedInternalNode root
+    parent_hash = hasher.parent(value1_hash, value2_hash);
+  }
+
+  ASSERT_EQ(node.hash(), parent_hash);
+}
+/*
+// The logical tree inside the BatchedInternalNode looks like the following at the end of this test
+//
+//                Root
+//                 |
+/          -----------------
+//         |               |
+//      Internal      Placeholder
+//         |
+//        / \
+//    Leaf   Leaf
+*/
+TEST(internal_node_tests, split_leaf) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the second bit so that key1_hash becomes a sibling of key2_hash at
+  // height 2.
+  std::array<uint8_t, Hash::SIZE_IN_BYTES> key2_hash_data;
+  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key2_hash_data.begin());
+  key2_hash_data[0] ^= 0x40;
+  auto key2_hash = Hash(key2_hash_data);
+
+  ASSERT_EQ(1, key1_hash.prefix_bits_in_common(key2_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+
+  // The key of the first child in the 4-level BatchedInternalNode tree.
+  Nibble child1_key = key1_hash.getNibble(depth);
+
+  auto result = node.insert(child1, depth);
+  result = node.insert(child2, depth);
+
+  // No nodes were overwritten and no new BatchedInternalNodes created
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::InsertComplete>(result));
+  auto successful_insert = std::get<BatchedInternalNode::InsertComplete>(result);
+  ASSERT_FALSE(successful_insert.stale_leaf.has_value());
+
+  ASSERT_EQ(4, node.numChildren());
+  // The root + one internal node below the root
+  ASSERT_EQ(2, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+
+  // The version should be 2.
+  ASSERT_EQ(Version(2), node.version());
+
+  Hash level_3_parent_hash;
+  if (child1_key.getBit(2)) {
+    // The key was inserted at the right child of the InternalChild at height 3
+    level_3_parent_hash = hasher.parent(value2_hash, value1_hash);
+  } else {
+    // The key was inserted at the left child of the InternalChild at height 3
+    level_3_parent_hash = hasher.parent(value1_hash, value2_hash);
+  }
+
+  Hash root_hash;
+  if (child1_key.getBit(3)) {
+    // The internal node is at the right of the root
+    root_hash = hasher.parent(PLACEHOLDER_HASH, level_3_parent_hash);
+  } else {
+    root_hash = hasher.parent(level_3_parent_hash, PLACEHOLDER_HASH);
+  }
+
+  ASSERT_EQ(node.hash(), root_hash);
+}
+
+/*
+// The logical tree inside the BatchedInternalNode looks like the following at the end of this test
+//
+//                               Root
+//                                 |
+//                         -----------------
+//                         |               |
+//                      Internal      Placeholder
+//                         |
+//                 ----------------
+//                 |              |
+//              Internal       Placeholder
+//                 |
+//          ----------------
+//          |              |
+//      Internal       Placeholder
+//          |
+//    ----------------
+//    |              |
+// Internal       Placeholder
+//
+*/
+
+TEST(internal_node_tests, split_until_new_batch_node_needed) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Copy the actual hash and set the first nibble to zeroes to make all
+  // internal children left ones.
+  std::array<uint8_t, Hash::SIZE_IN_BYTES> key1_hash_data;
+  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key1_hash_data.begin());
+  key1_hash_data[0] &= 0x0F;
+  key1_hash = Hash{key1_hash_data};
+
+  // Flip the 5th bit so that key1_hash becomes a sibling of key2_hash at
+  // height -1 (in a new node).
+  std::array<uint8_t, Hash::SIZE_IN_BYTES> key2_hash_data;
+  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key2_hash_data.begin());
+  key2_hash_data[0] ^= 0x08;
+  auto key2_hash = Hash(key2_hash_data);
+
+  ASSERT_EQ(4, key1_hash.prefix_bits_in_common(key2_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+
+  auto result = node.insert(child1, depth);
+  result = node.insert(child2, depth);
+
+  // A new BatchedInternalNode must be created.
+  // The first 4 bits of the key of child1 and child2 matched, thus creating new
+  // internal children and causing the previously inserted child1, as well as
+  // child2 to need to find a new home in a new BatchedInternalNode further down
+  // the tree.
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::CreateNewBatchedInternalNodes>(result));
+  auto create_result = std::get<BatchedInternalNode::CreateNewBatchedInternalNodes>(result);
+  ASSERT_EQ(create_result.stored_child, child1);
+
+  ASSERT_EQ(5, node.numChildren());
+  ASSERT_EQ(5, node.numInternalChildren());
+  ASSERT_EQ(0, node.numLeafChildren());
+
+  // NOTE: We cannot check the root hash here, because this tree doesn't yet
+  // have the hash of its InternalChild leaf, since the value must be inserted
+  // into a new node by the caller, and then the hash updated in this node.
+
+  // Pretend that this BatchedInternalNode was properly updated by the caller
+  // already. Inserting a new partially matching prefix key should result in
+  // BatchedInternalNode::InsertIntoExistingNode, since there is already an
+  // InternalLeaf at height 0 that shares a prefix. This tests the bottom of the
+  // insert function, when the entire path is made up of InternalLeafs.
+  //
+  // We can test this by just re-inserting the same key.
+  result = node.insert(child2, depth);
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::InsertIntoExistingNode>(result));
+  auto insert_result = std::get<BatchedInternalNode::InsertIntoExistingNode>(result);
+  ASSERT_EQ(insert_result.next_node_version, Version(2));
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int res = RUN_ALL_TESTS();
+  return res;
+}


### PR DESCRIPTION
The BatchedInternalNode is first major piece of the sparse merkle tree
datastructure. A BatchedInternalNode contains up to 4 levels of a merkle
tree, and is identified by an InternalNodeKey, used for database access.

Insertion into a BatchedInternalNode works now, such that keys can be
added to a single node. In some cases, such as matching prefixes of a
certain length, this can cause the node to split. In this case we inform
the caller of this and tell it to create new nodes and insert the old
stored leaf that triggered the split and the new child attempting to be
inserted. In other cases, insert can discover that the leaf attempting
to be inserted doesn't fit in this node and needs to be placed further
down the tree. There is a return value indicating this as well.

The logic to handle the DB access as well as creation of new nodes and
updates of hashes when required by the creation of a new node is
relegated to the sparse merkle tree logic itself which will come in
further commits.

Base types were modified in order to support the BatchedInternalNode.
Tests were also added to cover the variety of insertion scenarios.

This code heavily uses value types to reduce allocations and keep things
on the stack for performance reasons.