### PR TITLE
Add an API for metrics collection

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -127,11 +127,6 @@ IStateTransfer *create(const Config &config,
                        IAppState *const stateApi,
                        std::shared_ptr<::concord::storage::IDBClient> dbc);
 
-IStateTransfer *create(const Config &config,
-                       IAppState *const stateApi,
-                       std::shared_ptr<::concord::storage::IDBClient> dbc,
-                       std::shared_ptr<concordMetrics::Aggregator> aggregator);
-
 }  // namespace SimpleBlockchainStateTransfer
 }  // namespace bftEngine
 

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -58,7 +58,6 @@ class Replica {
   virtual void stop() = 0;
 
   // TODO(GG) : move the following methods to an "advanced interface"
-  virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) = 0;
   virtual void restartForDebug(uint32_t delayMillis) = 0;  // for debug only.
 };
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -314,77 +314,9 @@ class BCStateTran : public IStateTransfer {
   ///////////////////////////////////////////////////////////////////////////
   // Metrics
   ///////////////////////////////////////////////////////////////////////////
- public:
-  void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a);
 
  private:
   void loadMetrics();
-  concordMetrics::Component metrics_component_;
-
-  typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;
-  typedef concordMetrics::Component::Handle<concordMetrics::Status> StatusHandle;
-  typedef concordMetrics::Component::Handle<concordMetrics::Counter> CounterHandle;
-
-  struct Metrics {
-    StatusHandle fetching_state_;
-    StatusHandle pedantic_checks_enabled_;
-    StatusHandle preferred_replicas_;
-
-    GaugeHandle current_source_replica_;
-    GaugeHandle checkpoint_being_fetched_;
-    GaugeHandle last_stored_checkpoint_;
-    GaugeHandle number_of_reserved_pages_;
-    GaugeHandle size_of_reserved_page_;
-    GaugeHandle last_msg_seq_num_;
-    GaugeHandle next_required_block_;
-    GaugeHandle num_pending_item_data_msgs_;
-    GaugeHandle total_size_of_pending_item_data_msgs_;
-    GaugeHandle last_block_;
-    GaugeHandle last_reachable_block_;
-
-    CounterHandle sent_ask_for_checkpoint_summaries_msg_;
-    CounterHandle sent_checkpoint_summary_msg_;
-
-    CounterHandle sent_fetch_blocks_msg_;
-    CounterHandle sent_fetch_res_pages_msg_;
-    CounterHandle sent_reject_fetch_msg_;
-    CounterHandle sent_item_data_msg_;
-
-    CounterHandle received_ask_for_checkpoint_summaries_msg_;
-    CounterHandle received_checkpoint_summary_msg_;
-    CounterHandle received_fetch_blocks_msg_;
-    CounterHandle received_fetch_res_pages_msg_;
-    CounterHandle received_reject_fetching_msg_;
-    CounterHandle received_item_data_msg_;
-    CounterHandle received_illegal_msg_;
-
-    CounterHandle invalid_ask_for_checkpoint_summaries_msg_;
-    CounterHandle irrelevant_ask_for_checkpoint_summaries_msg_;
-    CounterHandle invalid_checkpoint_summary_msg_;
-    CounterHandle irrelevant_checkpoint_summary_msg_;
-    CounterHandle invalid_fetch_blocks_msg_;
-    CounterHandle irrelevant_fetch_blocks_msg_;
-    CounterHandle invalid_fetch_res_pages_msg_;
-    CounterHandle irrelevant_fetch_res_pages_msg_;
-    CounterHandle invalid_reject_fetching_msg_;
-    CounterHandle irrelevant_reject_fetching_msg_;
-    CounterHandle invalid_item_data_msg_;
-    CounterHandle irrelevant_item_data_msg_;
-
-    CounterHandle create_checkpoint_;
-    CounterHandle mark_checkpoint_as_stable_;
-    CounterHandle load_reserved_page_;
-    CounterHandle load_reserved_page_from_pending_;
-    CounterHandle load_reserved_page_from_checkpoint_;
-    CounterHandle save_reserved_page_;
-    CounterHandle zero_reserved_page_;
-    CounterHandle start_collecting_state_;
-    CounterHandle on_timer_;
-
-    CounterHandle on_transferring_complete_;
-  };
-
-  mutable Metrics metrics_;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -44,8 +44,6 @@ struct ReplicaInternal : public Replica {
 
   virtual void stop() override;
 
-  virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) override;
-
   virtual void restartForDebug(uint32_t delayMillis) override;
 
   ReplicaImp *rep;
@@ -79,8 +77,6 @@ void ReplicaInternal::stop() {
 
   debugWait.notify_all();
 }
-
-void ReplicaInternal::SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) { return rep->SetAggregator(a); }
 
 void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
   {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -166,7 +166,8 @@ void ReplicaImp::sendRaw(char *m, NodeIdType dest, uint16_t type, MsgSize size) 
 }
 
 void ReplicaImp::onMessage(ClientRequestMsg *m) {
-  metric_received_client_requests_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedClientRequestMsgs");
   const NodeIdType senderId = m->senderId();
   const NodeIdType clientId = m->clientProxyId();
   const bool readOnly = m->isReadOnly();
@@ -371,7 +372,8 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
 
   if (firstPath == CommitPath::SLOW) {
     seqNumInfo.startSlowPath();
-    metric_slow_path_count_.Get().Inc();
+    concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                     "/replica/slowPathCount");
     sendPreparePartial(seqNumInfo);
   } else {
     sendPartialProof(seqNumInfo);
@@ -405,7 +407,8 @@ bool ReplicaImp::relevantMsgForActiveView(const T *msg) {
 }
 
 void ReplicaImp::onMessage(PrePrepareMsg *msg) {
-  metric_received_pre_prepares_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedPrePrepareMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
 
   LOG_DEBUG_F(GL,
@@ -459,7 +462,8 @@ void ReplicaImp::onMessage(PrePrepareMsg *msg) {
         sendPartialProof(seqNumInfo);
       } else {
         seqNumInfo.startSlowPath();
-        metric_slow_path_count_.Get().Inc();
+        concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                         "/replica/slowPathCount");
         sendPreparePartial(seqNumInfo);
         ;
       }
@@ -514,7 +518,8 @@ void ReplicaImp::tryToStartSlowPaths() {
     controller->onStartingSlowCommit(i);
 
     seqNumInfo.startSlowPath();
-    metric_slow_path_count_.Get().Inc();
+    concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                     "/replica/slowPathCount");
 
     if (ps_) {
       ps_->beginWriteTran();
@@ -595,7 +600,8 @@ void ReplicaImp::tryToAskForMissingInfo() {
 }
 
 void ReplicaImp::onMessage(StartSlowCommitMsg *msg) {
-  metric_received_start_slow_commits_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedStartSlowCommitMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
 
   LOG_INFO_F(GL, "Node %d received StartSlowCommitMsg for seqNumber %" PRId64 "", config_.replicaId, msgSeqNum);
@@ -609,7 +615,8 @@ void ReplicaImp::onMessage(StartSlowCommitMsg *msg) {
       LOG_INFO_F(GL, "Node %d starts slow path for seqNumber %" PRId64 "", config_.replicaId, msgSeqNum);
 
       seqNumInfo.startSlowPath();
-      metric_slow_path_count_.Get().Inc();
+      concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                       "/replica/slowPathCount");
 
       if (ps_) {
         ps_->beginWriteTran();
@@ -723,7 +730,8 @@ void ReplicaImp::sendCommitPartial(const SeqNum s) {
 }
 
 void ReplicaImp::onMessage(PartialCommitProofMsg *msg) {
-  metric_received_partial_commit_proofs_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedPartialCommitProofMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
   const SeqNum msgView = msg->viewNumber();
   const NodeIdType msgSender = msg->senderId();
@@ -765,7 +773,8 @@ void ReplicaImp::onInternalMsg(FullCommitProofMsg *msg) {
 }
 
 void ReplicaImp::onMessage(FullCommitProofMsg *msg) {
-  metric_received_full_commit_proofs_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedFullCommitProofMsgs");
   LOG_DEBUG_F(GL,
               "Node %d received FullCommitProofMsg message for seqNumber %d",
               (int)config_.replicaId,
@@ -806,7 +815,8 @@ void ReplicaImp::onMessage(FullCommitProofMsg *msg) {
 }
 
 void ReplicaImp::onMessage(PreparePartialMsg *msg) {
-  metric_received_prepare_partials_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedPreparePartialMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -855,7 +865,8 @@ void ReplicaImp::onMessage(PreparePartialMsg *msg) {
 }
 
 void ReplicaImp::onMessage(CommitPartialMsg *msg) {
-  metric_received_commit_partials_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedCommitPartialMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -898,7 +909,8 @@ void ReplicaImp::onMessage(CommitPartialMsg *msg) {
 }
 
 void ReplicaImp::onMessage(PrepareFullMsg *msg) {
-  metric_received_prepare_fulls_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedPrepareFullMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -939,7 +951,8 @@ void ReplicaImp::onMessage(PrepareFullMsg *msg) {
 }
 
 void ReplicaImp::onMessage(CommitFullMsg *msg) {
-  metric_received_commit_fulls_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedCommitFullMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -1200,7 +1213,8 @@ void ReplicaImp::onCommitVerifyCombinedSigResult(SeqNum seqNumber, ViewNum v, bo
 }
 
 void ReplicaImp::onMessage(CheckpointMsg *msg) {
-  metric_received_checkpoints_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedCheckpointMsgs");
   const ReplicaId msgSenderId = msg->senderId();
   const SeqNum msgSeqNum = msg->seqNumber();
   const Digest msgDigest = msg->digestOfState();
@@ -1467,7 +1481,8 @@ void ReplicaImp::onRetransmissionsProcessingResults(
 }
 
 void ReplicaImp::onMessage(ReplicaStatusMsg *msg) {
-  metric_received_replica_statuses_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedReplicaStatusMsgs");
   // TODO(GG): we need filter for msgs (to avoid denial of service attack) + avoid sending messages at a high rate.
   // TODO(GG): for some communication modules/protocols, we can also utilize information about connection/disconnection.
 
@@ -1692,7 +1707,8 @@ void ReplicaImp::onMessage(ViewChangeMsg *msg) {
     delete msg;
     return;
   }
-  metric_received_view_changes_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedViewChangeMsgs");
 
   const ReplicaId generatedReplicaId =
       msg->idOfGeneratedReplica();  // Notice that generatedReplicaId may be != msg->senderId()
@@ -1744,7 +1760,8 @@ void ReplicaImp::onMessage(ViewChangeMsg *msg) {
 
   if (lastAgreedView < curView) {
     lastAgreedView = curView;
-    metric_last_agreed_view_.Get().Set(lastAgreedView);
+    concordMetrics::ConcordbftMetricsCollector::instance().set(
+        std::to_string(config_.replicaId) + "/replica/lastAgreedView", lastAgreedView);
     timeOfLastAgreedView = getMonotonicTime();
   }
 
@@ -1756,8 +1773,8 @@ void ReplicaImp::onMessage(NewViewMsg *msg) {
     delete msg;
     return;
   }
-  metric_received_new_views_.Get().Inc();
-
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedNewViewMsgs");
   const ReplicaId senderId = msg->senderId();
 
   Assert(senderId != config_.replicaId);  // should be verified in ViewChangeMsg
@@ -1839,7 +1856,8 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
   }
 
   curView = nextView;
-  metric_view_.Get().Set(nextView);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(std::to_string(config_.replicaId) + "/replica/view",
+                                                             nextView);
 
   LOG_INFO_F(GL,
              "Sending view change message: new view=%" PRId64
@@ -1990,7 +2008,8 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
       seqNumInfo.addMsg(pp);
 
     seqNumInfo.startSlowPath();
-    metric_slow_path_count_.Get().Inc();
+    concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                     "/replica/slowPathCount");
   }
 
   if (ps_) ps_->endWriteTran();
@@ -2122,7 +2141,8 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
     ps_->setCheckpointMsgInCheckWindow(newStateCheckpoint, checkpointMsg);
     ps_->endWriteTran();
   }
-  metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastExecutedSeqNum", lastExecutedSeqNum);
 
   sendToAllOtherReplicas(checkpointMsg);
 
@@ -2162,7 +2182,8 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
   if (ps_) ps_->beginWriteTran();
 
   lastStableSeqNum = newStableSeqNum;
-  metric_last_stable_seq_num_.Get().Set(lastStableSeqNum);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastStableSeqNum", lastStableSeqNum);
 
   if (ps_) ps_->setLastStableSeqNum(lastStableSeqNum);
 
@@ -2184,7 +2205,8 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     if (lastStableSeqNum > lastExecutedSeqNum) {
       lastExecutedSeqNum = lastStableSeqNum;
       if (ps_) ps_->setLastExecutedSeqNum(lastExecutedSeqNum);
-      metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+      concordMetrics::ConcordbftMetricsCollector::instance().set(
+          std::to_string(config_.replicaId) + "/replica/lastExecutedSeqNum", lastExecutedSeqNum);
       if (config_.debugStatisticsEnabled) {
         DebugStatistics::onLastExecutedSequenceNumberChanged(lastExecutedSeqNum);
       }
@@ -2320,7 +2342,8 @@ void ReplicaImp::tryToSendReqMissingDataMsg(SeqNum seqNumber, bool slowPathOnly,
 }
 
 void ReplicaImp::onMessage(ReqMissingDataMsg *msg) {
-  metric_received_req_missing_datas_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedReqMissingDataMsgs");
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -2506,10 +2529,11 @@ void ReplicaImp::onDebugStatTimer(Timers::Handle timer) {
   }
 }
 
-void ReplicaImp::onMetricsTimer(Timers::Handle timer) { metrics_.UpdateAggregator(); }
+// void ReplicaImp::onMetricsTimer(Timers::Handle timer) { metrics_.UpdateAggregator(); }
 
 void ReplicaImp::onMessage(SimpleAckMsg *msg) {
-  metric_received_simple_acks_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedSimpleAckMsgs");
   if (retransmissionsLogicEnabled) {
     uint16_t relatedMsgType = (uint16_t)msg->ackData();  // TODO(GG): does this make sense ?
 
@@ -2529,7 +2553,8 @@ void ReplicaImp::onMessage(SimpleAckMsg *msg) {
 }
 
 void ReplicaImp::onMessage(StateTransferMsg *m) {
-  metric_received_state_transfers_.Get().Inc();
+  concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                   "/replica/receivedStateTransferMsgs");
   size_t h = sizeof(MessageBase::Header);
   stateTransfer->handleStateTransferMessage(m->body() + h, m->size() - h, m->senderId());
 }
@@ -2616,16 +2641,20 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
 
   curView = ld.viewsManager->latestActiveView();
   lastAgreedView = curView;
-  metric_view_.Get().Set(curView);
-  metric_last_agreed_view_.Get().Set(lastAgreedView);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(std::to_string(config_.replicaId) + "/replica/view",
+                                                             curView);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastAgreedView", lastAgreedView);
 
   const bool inView = ld.viewsManager->viewIsActive(curView);
 
   primaryLastUsedSeqNum = ld.primaryLastUsedSeqNum;
   lastStableSeqNum = ld.lastStableSeqNum;
-  metric_last_stable_seq_num_.Get().Set(lastStableSeqNum);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastStableSeqNum", lastStableSeqNum);
   lastExecutedSeqNum = ld.lastExecutedSeqNum;
-  metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastExecutedSeqNum", lastExecutedSeqNum);
   strictLowerBoundOfSeqNums = ld.strictLowerBoundOfSeqNums;
   maxSeqNumTransferredFromPrevViews = ld.maxSeqNumTransferredFromPrevViews;
   lastViewThatTransferredSeqNumbersFullyExecuted = ld.lastViewThatTransferredSeqNumbersFullyExecuted;
@@ -2824,32 +2853,19 @@ ReplicaImp::ReplicaImp(bool firstTime,
       userRequestsHandler{requestsHandler},
       timeOfLastStateSynch{getMonotonicTime()},    // TODO(GG): TBD
       timeOfLastViewEntrance{getMonotonicTime()},  // TODO(GG): TBD
-      timeOfLastAgreedView{getMonotonicTime()},    // TODO(GG): TBD
-      metrics_{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())},
-      metric_view_{metrics_.RegisterGauge("view", curView)},
-      metric_last_stable_seq_num_{metrics_.RegisterGauge("lastStableSeqNum", lastStableSeqNum)},
-      metric_last_executed_seq_num_{metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)},
-      metric_last_agreed_view_{metrics_.RegisterGauge("lastAgreedView", lastAgreedView)},
-      metric_first_commit_path_{metrics_.RegisterStatus(
-          "firstCommitPath", CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath))},
-      metric_slow_path_count_{metrics_.RegisterCounter("slowPathCount", 0)},
-      metric_received_internal_msgs_{metrics_.RegisterCounter("receivedInternalMsgs")},
-      metric_received_client_requests_{metrics_.RegisterCounter("receivedClientRequestMsgs")},
-      metric_received_pre_prepares_{metrics_.RegisterCounter("receivedPrePrepareMsgs")},
-      metric_received_start_slow_commits_{metrics_.RegisterCounter("receivedStartSlowCommitMsgs")},
-      metric_received_partial_commit_proofs_{metrics_.RegisterCounter("receivedPartialCommitProofMsgs")},
-      metric_received_full_commit_proofs_{metrics_.RegisterCounter("receivedFullCommitProofMsgs")},
-      metric_received_prepare_partials_{metrics_.RegisterCounter("receivedPreparePartialMsgs")},
-      metric_received_commit_partials_{metrics_.RegisterCounter("receivedCommitPartialMsgs")},
-      metric_received_prepare_fulls_{metrics_.RegisterCounter("receivedPrepareFullMsgs")},
-      metric_received_commit_fulls_{metrics_.RegisterCounter("receivedCommitFullMsgs")},
-      metric_received_checkpoints_{metrics_.RegisterCounter("receivedCheckpointMsgs")},
-      metric_received_replica_statuses_{metrics_.RegisterCounter("receivedReplicaStatusMsgs")},
-      metric_received_view_changes_{metrics_.RegisterCounter("receivedViewChangeMsgs")},
-      metric_received_new_views_{metrics_.RegisterCounter("receivedNewViewMsgs")},
-      metric_received_req_missing_datas_{metrics_.RegisterCounter("receivedReqMissingDataMsgs")},
-      metric_received_simple_acks_{metrics_.RegisterCounter("receivedSimpleAckMsgs")},
-      metric_received_state_transfers_{metrics_.RegisterCounter("receivedStateTransferMsgs")} {
+      timeOfLastAgreedView{getMonotonicTime()}     // TODO(GG): TBD
+{
+  concordMetrics::ConcordbftMetricsCollector::instance().set(std::to_string(config_.replicaId) + "/replica/view",
+                                                             curView);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastStableSeqNum", lastStableSeqNum);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastExecutedSeqNum", lastExecutedSeqNum);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastAgreedView", lastAgreedView);
+  concordMetrics::ConcordbftMetricsCollector::instance().update(
+      std::to_string(config_.replicaId) + "/replica/firstCommitPath",
+      CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath));
   Assert(config_.replicaId < numOfReplicas);
   // TODO(GG): more asserts on params !!!!!!!!!!!
 
@@ -2865,7 +2881,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   }
 
   // Register metrics component with the default aggregator.
-  metrics_.Register();
+  //  metrics_.Register();
 
   if (firstTime) {
     sigManager = new SigManager(config_.replicaId,
@@ -2978,8 +2994,6 @@ void ReplicaImp::stop() {
   TimersSingleton::getInstance().cancel(statusReportTimer_);
   TimersSingleton::getInstance().cancel(viewChangeTimer_);
   TimersSingleton::getInstance().cancel(debugStatTimer_);
-  TimersSingleton::getInstance().cancel(metricsTimer_);
-
   msgsCommunicator_->stop();
 }
 
@@ -3020,9 +3034,6 @@ void ReplicaImp::addTimers() {
                                                          Timers::Timer::RECURRING,
                                                          [this](Timers::Handle h) { onDebugStatTimer(h); });
   }
-
-  metricsTimer_ = TimersSingleton::getInstance().add(
-      100ms, Timers::Timer::RECURRING, [this](Timers::Handle h) { onMetricsTimer(h); });
 }
 
 void ReplicaImp::start() {
@@ -3194,8 +3205,8 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
   }
 
   lastExecutedSeqNum = lastExecutedSeqNum + 1;
-
-  metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+  concordMetrics::ConcordbftMetricsCollector::instance().set(
+      std::to_string(config_.replicaId) + "/replica/lastExecutedSeqNum", lastExecutedSeqNum);
   if (config_.debugStatisticsEnabled) {
     DebugStatistics::onLastExecutedSequenceNumberChanged(lastExecutedSeqNum);
   }
@@ -3232,7 +3243,9 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
   bool firstCommitPathChanged = controller->onNewSeqNumberExecution(lastExecutedSeqNum);
 
   if (firstCommitPathChanged) {
-    metric_first_commit_path_.Get().Set(CommitPathToStr(controller->getCurrentFirstPath()));
+    concordMetrics::ConcordbftMetricsCollector::instance().update(
+        std::to_string(config_.replicaId) + "/replica/firstCommitPath",
+        CommitPathToStr(controller->getCurrentFirstPath()));
   }
   // TODO(GG): clean the following logic
   if (mainLog->insideActiveWindow(lastExecutedSeqNum)) {  // update dynamicUpperLimitOfRounds
@@ -3280,10 +3293,6 @@ void ReplicaImp::executeNextCommittedRequests(const bool requestMissingInfo) {
   }
 
   if (isCurrentPrimary() && requestsQueueOfPrimary.size() > 0) tryToSendPrePrepareMsg(true);
-}
-
-void ReplicaImp::SetAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
-  metrics_.SetAggregator(aggregator);
 }
 
 // TODO(GG): the timer for state transfer !!!!

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -169,7 +169,6 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   concordUtil::Timers::Handle statusReportTimer_;
   concordUtil::Timers::Handle viewChangeTimer_;
   concordUtil::Timers::Handle debugStatTimer_;
-  concordUtil::Timers::Handle metricsTimer_;
 
   int viewChangeTimerMilli = 0;
   int autoPrimaryRotationTimerMilli = 0;
@@ -179,41 +178,6 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   bool recoveringFromExecutionOfRequests = false;
   Bitmap mapOfRequestsThatAreBeingRecovered;
 
-  //******** METRICS ************************************
-  concordMetrics::Component metrics_;
-
-  typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;
-  typedef concordMetrics::Component::Handle<concordMetrics::Status> StatusHandle;
-  typedef concordMetrics::Component::Handle<concordMetrics::Counter> CounterHandle;
-
-  GaugeHandle metric_view_;
-  GaugeHandle metric_last_stable_seq_num_;
-  GaugeHandle metric_last_executed_seq_num_;
-  GaugeHandle metric_last_agreed_view_;
-
-  // The first commit path being attempted for a new request.
-  StatusHandle metric_first_commit_path_;
-
-  CounterHandle metric_slow_path_count_;
-  CounterHandle metric_received_internal_msgs_;
-  CounterHandle metric_received_client_requests_;
-  CounterHandle metric_received_pre_prepares_;
-  CounterHandle metric_received_start_slow_commits_;
-  CounterHandle metric_received_partial_commit_proofs_;
-  CounterHandle metric_received_full_commit_proofs_;
-  CounterHandle metric_received_prepare_partials_;
-  CounterHandle metric_received_commit_partials_;
-  CounterHandle metric_received_prepare_fulls_;
-  CounterHandle metric_received_commit_fulls_;
-  CounterHandle metric_received_checkpoints_;
-  CounterHandle metric_received_replica_statuses_;
-  CounterHandle metric_received_view_changes_;
-  CounterHandle metric_received_new_views_;
-  CounterHandle metric_received_req_missing_datas_;
-  CounterHandle metric_received_simple_acks_;
-  CounterHandle metric_received_state_transfers_;
-
-  //*****************************************************
  public:
   ReplicaImp(const ReplicaConfig&,
              RequestsHandler* requestsHandler,
@@ -254,10 +218,11 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   // InternalReplicaApi
   virtual void onInternalMsg(FullCommitProofMsg* m) override;
   virtual void onMerkleExecSignature(ViewNum v, SeqNum s, uint16_t signatureLength, const char* signature) override;
-  void updateMetricsForInternalMessage() override { metric_received_internal_msgs_.Get().Inc(); }
+  void updateMetricsForInternalMessage() override {
+    concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) +
+                                                                     "/replica/receivedInternalMsgs");
+  }
   bool isCollectingState() override { return stateTransfer->isCollectingState(); }
-
-  void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a);
 
  protected:
   ReplicaImp(bool firstTime,
@@ -394,7 +359,7 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   void onSlowPathTimer(concordUtil::Timers::Handle);
   void onInfoRequestTimer(concordUtil::Timers::Handle);
   void onDebugStatTimer(concordUtil::Timers::Handle);
-  void onMetricsTimer(concordUtil::Timers::Handle);
+  //  void onMetricsTimer(concordUtil::Timers::Handle);
 
   // handlers for internal messages
 

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -85,8 +85,7 @@ class ReplicaImp : public IReplica,
 
   ReplicaImp(bftEngine::ICommunication *comm,
              bftEngine::ReplicaConfig &config,
-             concord::storage::blockchain::DBAdapter *dbAdapter,
-             std::shared_ptr<concordMetrics::Aggregator> aggregator);
+             concord::storage::blockchain::DBAdapter *dbAdapter);
 
   void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 
@@ -270,7 +269,6 @@ class ReplicaImp : public IReplica,
   std::unique_ptr<BlockchainAppState> m_appState;
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
   std::unique_ptr<ReplicaStateSync> replicaStateSync_;
-  std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 
   // static methods
   static Sliver createBlockFromUpdates(const concord::storage::SetOfKeyValuePairs &updates,

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -49,14 +49,14 @@ int main(int argc, char** argv) {
   }
 
   auto* dbAdapter = new concord::storage::blockchain::DBAdapter(db);
-  auto* replica = new ReplicaImp(
-      setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
+  auto* replica = new ReplicaImp(setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter);
   replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
 
   // Start metrics server after creation of the replica so that we ensure
   // registration of metrics from the replica with the aggregator and don't
   // return empty metrics from the metrics server.
   setup->GetMetricsServer().Start();
+  setup->GetMetricsServer().registerToDefaultCollector(setup->GetReplicaConfig().replicaId);
 
   InternalCommandsHandler cmdHandler(replica, replica, logger);
   replica->set_command_handler(&cmdHandler);

--- a/util/include/ConcordbftMetricsCollector.hpp
+++ b/util/include/ConcordbftMetricsCollector.hpp
@@ -1,0 +1,20 @@
+//
+// Created by ybuchnik on 12/23/19.
+//
+
+#pragma once
+
+#include <string>
+
+namespace concordMetrics {
+
+class IMetricsCollector {
+ public:
+  IMetricsCollector() = default;
+  virtual ~IMetricsCollector(){};
+
+  virtual void increment(const std::string& counterPath) = 0;
+  virtual void set(const std::string& gaugePath, uint64_t val) = 0;
+  virtual void update(const std::string& statusPath, const std::string& val) = 0;
+};
+}  // namespace concordMetrics

--- a/util/include/ConcordbftMetricsCollector.hpp
+++ b/util/include/ConcordbftMetricsCollector.hpp
@@ -1,6 +1,15 @@
+// Concord
 //
-// Created by ybuchnik on 12/23/19.
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 //
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
 
 #pragma once
 

--- a/util/include/MetricsServer.hpp
+++ b/util/include/MetricsServer.hpp
@@ -58,6 +58,11 @@ class Server {
 
   std::shared_ptr<Aggregator> GetAggregator() { return aggregator_; }
 
+  void registerToDefaultCollector(int repID) {
+    aggregator_ = dynamic_cast<ConcordbftMetricsCollector&>(concordMetrics::ConcordbftMetricsCollector::instance())
+                      .getAggregator(repID);
+  }
+
  private:
   uint16_t listenPort_;
   concordlogger::Logger logger_;

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -16,7 +16,6 @@
 #include <sstream>
 
 using namespace std;
-
 namespace concordMetrics {
 
 const char* const kGaugeName = "gauge";
@@ -24,7 +23,7 @@ const char* const kStatusName = "status";
 const char* const kCounterName = "counter";
 
 template <typename T>
-T FindValue(const char* const val_type, const string& val_name, const vector<string>& names, const vector<T>& values) {
+T& FindValue(const char* const val_type, const string& val_name, const vector<string>& names, vector<T>& values) {
   for (size_t i = 0; i < names.size(); i++) {
     if (names[i] == val_name) {
       return values[i];
@@ -66,19 +65,19 @@ void Aggregator::UpdateValues(const string& name, Values&& values) {
   components_.at(name).SetValues(std::move(values));
 }
 
-Gauge Aggregator::GetGauge(const string& component_name, const string& val_name) {
+Gauge& Aggregator::GetGauge(const string& component_name, const string& val_name) {
   std::lock_guard<std::mutex> lock(lock_);
   auto& component = components_.at(component_name);
   return FindValue(kGaugeName, val_name, component.names_.gauge_names_, component.values_.gauges_);
 }
 
-Status Aggregator::GetStatus(const string& component_name, const string& val_name) {
+Status& Aggregator::GetStatus(const string& component_name, const string& val_name) {
   std::lock_guard<std::mutex> lock(lock_);
   auto& component = components_.at(component_name);
   return FindValue(kStatusName, val_name, component.names_.status_names_, component.values_.statuses_);
 }
 
-Counter Aggregator::GetCounter(const string& component_name, const string& val_name) {
+Counter& Aggregator::GetCounter(const string& component_name, const string& val_name) {
   std::lock_guard<std::mutex> lock(lock_);
   auto& component = components_.at(component_name);
   return FindValue(kCounterName, val_name, component.names_.counter_names_, component.values_.counters_);
@@ -161,5 +160,133 @@ std::string Component::ToJson() {
 
   return oss.str();
 }
+
+std::vector<std::string> ConcordbftMetricsCollector::resolveMetricPath(const std::string& metricPath) {
+  std::stringstream path(metricPath);
+  std::string segment;
+  std::vector<std::string> seglist;
+  while (std::getline(path, segment, '/')) {
+    seglist.push_back(segment);
+  }
+  return seglist;
+}
+
+ConcordbftMetricsCollector::ConcordbftMetricsCollector() {}
+
+void ConcordbftMetricsCollector::increment(const std::string& counterPath) {
+  auto paths = resolveMetricPath(counterPath);
+  int repID = std::stoi(paths[pathOrder::REP]);
+  addAggregatorForNewRegisteredReplica(repID);
+  aggregators_.at(repID)->GetCounter(paths[pathOrder::COMP], paths[pathOrder::NAME]).Inc();
+}
+
+void ConcordbftMetricsCollector::set(const std::string& gaugePath, uint64_t val) {
+  auto paths = resolveMetricPath(gaugePath);
+  int repID = std::stoi(paths[pathOrder::REP]);
+  addAggregatorForNewRegisteredReplica(repID);
+  aggregators_.at(repID)->GetGauge(paths[pathOrder::COMP], paths[pathOrder::NAME]).Set(val);
+}
+
+void ConcordbftMetricsCollector::update(const std::string& statusPath, const std::string& val) {
+  auto paths = resolveMetricPath(statusPath);
+  int repID = std::stoi(paths[pathOrder::REP]);
+  addAggregatorForNewRegisteredReplica(repID);
+  aggregators_.at(repID)->GetStatus(paths[pathOrder::COMP], paths[pathOrder::NAME]).Set(val);
+}
+
+void ConcordbftMetricsCollector::addAggregatorForNewRegisteredReplica(int repID) {
+  std::lock_guard<std::mutex> lock(lock_);
+  if (aggregators_.find(repID) != aggregators_.end()) return;
+  aggregators_[repID] = std::make_shared<Aggregator>();
+  Component replicaMetrics_("replica", aggregators_[repID]);
+  replicaMetrics_.RegisterGauge("view", 0);
+  replicaMetrics_.RegisterGauge("lastStableSeqNum", 0);
+  replicaMetrics_.RegisterGauge("lastExecutedSeqNum", 0);
+  replicaMetrics_.RegisterGauge("lastAgreedView", 0);
+  replicaMetrics_.RegisterStatus("firstCommitPath", "");
+  replicaMetrics_.RegisterCounter("slowPathCount");
+  replicaMetrics_.RegisterCounter("receivedInternalMsgs");
+  replicaMetrics_.RegisterCounter("receivedClientRequestMsgs");
+  replicaMetrics_.RegisterCounter("receivedPrePrepareMsgs");
+  replicaMetrics_.RegisterCounter("receivedStartSlowCommitMsgs");
+  replicaMetrics_.RegisterCounter("receivedPartialCommitProofMsgs");
+  replicaMetrics_.RegisterCounter("receivedFullCommitProofMsgs");
+  replicaMetrics_.RegisterCounter("receivedPreparePartialMsgs");
+  replicaMetrics_.RegisterCounter("receivedCommitPartialMsgs");
+  replicaMetrics_.RegisterCounter("receivedPrepareFullMsgs");
+  replicaMetrics_.RegisterCounter("receivedCommitFullMsgs");
+  replicaMetrics_.RegisterCounter("receivedCheckpointMsgs");
+  replicaMetrics_.RegisterCounter("receivedReplicaStatusMsgs");
+  replicaMetrics_.RegisterCounter("receivedViewChangeMsgs");
+  replicaMetrics_.RegisterCounter("receivedNewViewMsgs");
+  replicaMetrics_.RegisterCounter("receivedReqMissingDataMsgs");
+  replicaMetrics_.RegisterCounter("receivedSimpleAckMsgs");
+  replicaMetrics_.RegisterCounter("receivedStateTransferMsgs");
+  replicaMetrics_.Register();
+
+  Component stateTransferMetrics_("bc_state_transfer", aggregators_[repID]);
+  stateTransferMetrics_.RegisterStatus("fetching_state", "");
+  stateTransferMetrics_.RegisterStatus("pedantic_checks_enabled", "");
+  stateTransferMetrics_.RegisterStatus("preferred_replicas", "");
+  stateTransferMetrics_.RegisterGauge("current_source_replica", 0);
+  stateTransferMetrics_.RegisterGauge("checkpoint_being_fetched", 0);
+  stateTransferMetrics_.RegisterGauge("last_stored_checkpoint", 0);
+  stateTransferMetrics_.RegisterGauge("number_of_reserved_pages", 0);
+  stateTransferMetrics_.RegisterGauge("size_of_reserved_page", 0);
+  stateTransferMetrics_.RegisterGauge("last_msg_seq_num", 0);
+  stateTransferMetrics_.RegisterGauge("next_required_block_", 0);
+  stateTransferMetrics_.RegisterGauge("num_pending_item_data_msgs_", 0);
+  stateTransferMetrics_.RegisterGauge("total_size_of_pending_item_data_msgs", 0);
+  stateTransferMetrics_.RegisterGauge("last_block_", 0);
+  stateTransferMetrics_.RegisterGauge("last_reachable_block", 0);
+
+  stateTransferMetrics_.RegisterCounter("sent_ask_for_checkpoint_summaries_msg");
+  stateTransferMetrics_.RegisterCounter("sent_checkpoint_summary_msg");
+  stateTransferMetrics_.RegisterCounter("sent_fetch_blocks_msg");
+  stateTransferMetrics_.RegisterCounter("sent_fetch_res_pages_msg");
+  stateTransferMetrics_.RegisterCounter("sent_reject_fetch_msg");
+  stateTransferMetrics_.RegisterCounter("sent_item_data_msg");
+
+  stateTransferMetrics_.RegisterCounter("received_ask_for_checkpoint_summaries_msg");
+  stateTransferMetrics_.RegisterCounter("received_checkpoint_summary_msg");
+  stateTransferMetrics_.RegisterCounter("received_fetch_blocks_msg");
+  stateTransferMetrics_.RegisterCounter("received_fetch_res_pages_msg");
+  stateTransferMetrics_.RegisterCounter("received_reject_fetching_msg");
+  stateTransferMetrics_.RegisterCounter("received_item_data_msg");
+  stateTransferMetrics_.RegisterCounter("received_illegal_msg_");
+
+  stateTransferMetrics_.RegisterCounter("invalid_ask_for_checkpoint_summaries_msg");
+  stateTransferMetrics_.RegisterCounter("irrelevant_ask_for_checkpoint_summaries_msg");
+  stateTransferMetrics_.RegisterCounter("invalid_checkpoint_summary_msg");
+  stateTransferMetrics_.RegisterCounter("irrelevant_checkpoint_summary_msg");
+  stateTransferMetrics_.RegisterCounter("invalid_fetch_blocks_msg");
+  stateTransferMetrics_.RegisterCounter("irrelevant_fetch_blocks_msg");
+  stateTransferMetrics_.RegisterCounter("invalid_fetch_res_pages_msg");
+  stateTransferMetrics_.RegisterCounter("irrelevant_fetch_res_pages_msg");
+  stateTransferMetrics_.RegisterCounter("invalid_reject_fetching_msg");
+  stateTransferMetrics_.RegisterCounter("irrelevant_reject_fetching_msg");
+  stateTransferMetrics_.RegisterCounter("invalid_item_data_msg");
+  stateTransferMetrics_.RegisterCounter("irrelevant_item_data_msg");
+
+  stateTransferMetrics_.RegisterCounter("create_checkpoint");
+  stateTransferMetrics_.RegisterCounter("mark_checkpoint_as_stable");
+  stateTransferMetrics_.RegisterCounter("load_reserved_page");
+  stateTransferMetrics_.RegisterCounter("load_reserved_page_from_pending");
+  stateTransferMetrics_.RegisterCounter("load_reserved_page_from_checkpoint");
+  stateTransferMetrics_.RegisterCounter("save_reserved_page");
+  stateTransferMetrics_.RegisterCounter("zero_reserved_page");
+  stateTransferMetrics_.RegisterCounter("start_collecting_state");
+  stateTransferMetrics_.RegisterCounter("on_timer");
+  stateTransferMetrics_.RegisterCounter("on_transferring_complete");
+  stateTransferMetrics_.Register();
+}
+
+std::shared_ptr<Aggregator> ConcordbftMetricsCollector::getAggregator(int repID) {
+  std::lock_guard<std::mutex> lock(lock_);
+  if (aggregators_.find(repID) == aggregators_.end()) return std::make_shared<Aggregator>();
+  return aggregators_[repID];
+}
+std::unique_ptr<IMetricsCollector> ConcordbftMetricsCollector::_instance =
+    std::make_unique<ConcordbftMetricsCollector>();
 
 }  // namespace concordMetrics

--- a/util/test/timers_tests.cpp
+++ b/util/test/timers_tests.cpp
@@ -33,9 +33,10 @@ TEST(TimersTest, Basic) {
 
   // Create a oneshot and a recurring timer and add them to the heap. Each one
   // will fire a callback when it expires that increments a counter.
-  timers.add(duration, Timers::Timer::ONESHOT, [&oneshot_counter](Handle h) { ++oneshot_counter; }, now);
-  auto recurring_handle =
-      timers.add(duration, Timers::Timer::RECURRING, [&recurring_counter](Handle h) { ++recurring_counter; }, now);
+  timers.add(
+      duration, Timers::Timer::ONESHOT, [&oneshot_counter](Handle h) { ++oneshot_counter; }, now);
+  auto recurring_handle = timers.add(
+      duration, Timers::Timer::RECURRING, [&recurring_counter](Handle h) { ++recurring_counter; }, now);
 
   // Clock hasn't advanced so no timers should fire
   timers.evaluate(now);
@@ -98,7 +99,8 @@ TEST(TimersTest, Basic) {
   // Add a third timer and ensure it fires.
   // This tests the monotonicity of counter ids as used by handles.
   bool third_timer_fired = false;
-  timers.add(duration, Timers::Timer::ONESHOT, [&third_timer_fired](Handle h) { third_timer_fired = true; }, now);
+  timers.add(
+      duration, Timers::Timer::ONESHOT, [&third_timer_fired](Handle h) { third_timer_fired = true; }, now);
   now += duration;
   timers.evaluate(now);
   ASSERT_TRUE(third_timer_fired);


### PR DESCRIPTION
Add a generic API for metrics collection.
This API exposes 3 methods:
1. increment - to increment a counter
2.  set - to set a gauge
3. update to update a status
each metric is identified by its metricPath.
A metrics path is a path, separated by "/" in the following format:
{replica_id}/{component_name}/{metric_name}.

For example, in order to increment the replica/receivedClientRequestMsgs metrics, the replica need to call to concordMetrics::ConcordbftMetricsCollector::instance().increment(std::to_string(config_.replicaId) + "/replica/receivedClientRequestMsgs");

In addition, we add an implementation for this API that uses the existing metric framework.