### PR TITLE
Change APIs to pass 'flags' instead of isReadOnly parameter

### DIFF
--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -1,8 +1,8 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 //
-// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
 //
 // This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
@@ -11,17 +11,18 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #define REQUEST_MSG_TYPE (700)
 #define REPLY_MSG_TYPE (800)
 
 namespace bftEngine {
+
 #pragma pack(push, 1)
 struct ClientRequestMsgHeader {
   uint16_t msgType;  // always == REQUEST_MSG_TYPE
   uint16_t idOfClientProxy;
-  uint8_t flags;  // bit 0 == isReadOnly ; bits 1-7 are reserved
+  uint8_t flags;  // bit 0 == isReadOnly, bit 1 = preExecute, bits 2-7 are reserved
   uint64_t reqSeqNum;
   uint32_t requestLength;
   // followed by the request (security information, such as signatures, should be part of the request)
@@ -37,4 +38,5 @@ struct ClientReplyMsgHeader {
   uint32_t replyLength;
 };
 #pragma pack(pop)
+
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0 License.
@@ -14,7 +14,7 @@
 
 #include <cstddef>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include "IStateTransfer.hpp"
 #include "ICommunication.hpp"
@@ -23,11 +23,15 @@
 #include "ReplicaConfig.hpp"
 
 namespace bftEngine {
+
+// Possible values for 'flags' parameter
+enum MsgFlag : uint8_t { EMPTY_FLAGS = 0x0, READ_ONLY_FLAG = 0x1, PRE_EXECUTE_FLAG = 0x2, PRE_EXECUTED_FLAG = 0x4 };
+
 class RequestsHandler {
  public:
   virtual int execute(uint16_t clientId,
                       uint64_t sequenceNum,
-                      bool readOnly,
+                      uint8_t flags,
                       uint32_t requestSize,
                       const char *request,
                       uint32_t maxReplySize,

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -1,8 +1,8 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 //
-// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
 //
 // This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
@@ -12,15 +12,13 @@
 #pragma once
 
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <set>
 #include "ICommunication.hpp"
 
-using namespace std;
-
 namespace bftEngine {
-//	 parameters // TODO(GG): move to client configuration
+// Parameters // TODO(GG): move to client configuration
 struct SimpleClientParams {
   uint64_t clientInitialRetryTimeoutMilli = 150;
   uint64_t clientMinRetryTimeoutMilli = 50;
@@ -29,6 +27,9 @@ struct SimpleClientParams {
   uint16_t clientSendsRequestToAllReplicasPeriodThresh = 2;
   uint16_t clientPeriodicResetThresh = 30;
 };
+
+// Possible values for 'flags' parameter
+enum ClientMsgFlag : uint8_t { EMPTY_FLAGS_REQ = 0x0, READ_ONLY_REQ = 0x1, PRE_EXECUTE_REQ = 0x2 };
 
 class SimpleClient {
  public:
@@ -44,7 +45,7 @@ class SimpleClient {
 
   virtual ~SimpleClient();
 
-  virtual int sendRequest(bool isReadOnly,
+  virtual int sendRequest(uint8_t flags,
                           const char* request,
                           uint32_t lengthOfRequest,
                           uint64_t reqSeqNum,
@@ -72,6 +73,7 @@ class SeqNumberGeneratorForClientRequests {
 
   virtual uint64_t generateUniqueSequenceNumberForRequest() = 0;
 
-  virtual ~SeqNumberGeneratorForClientRequests(){};
+  virtual ~SeqNumberGeneratorForClientRequests() = default;
 };
+
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -24,21 +24,30 @@ MsgsCommunicator::MsgsCommunicator(ICommunication* comm,
   msgReceiver_ = msgReceiver;
 }
 
-int MsgsCommunicator::start(uint16_t replicaId) {
+int MsgsCommunicator::startCommunication(uint16_t replicaId) {
   replicaId_ = replicaId;
-  incomingMsgsStorage_->start();
   communication_->setReceiver(replicaId_, msgReceiver_.get());
   int commStatus = communication_->Start();
   Assert(commStatus == 0);
-  LOG_INFO(GL, "MsgsCommunicator for replica " << replicaId_ << " started");
+  LOG_INFO(GL, "Communication for replica " << replicaId_ << " started");
   return commStatus;
 }
 
-int MsgsCommunicator::stop() {
-  incomingMsgsStorage_->stop();
+int MsgsCommunicator::stopCommunication() {
   int res = communication_->Stop();
-  LOG_INFO(GL, "MsgsCommunicator for replica " << replicaId_ << " stopped");
+  LOG_INFO(GL, "Communication for replica " << replicaId_ << " stopped");
   return res;
+}
+
+void MsgsCommunicator::startMsgsProcessing(uint16_t replicaId) {
+  replicaId_ = replicaId;
+  incomingMsgsStorage_->start();
+  LOG_INFO(GL, "Messages processing for replica " << replicaId_ << " started");
+}
+
+void MsgsCommunicator::stopMsgsProcessing() {
+  incomingMsgsStorage_->stop();
+  LOG_INFO(GL, "Messages processing for replica " << replicaId_ << " stopped");
 }
 
 int MsgsCommunicator::sendAsyncMessage(NodeNum destNode, char* message, size_t messageLength) {

--- a/bftengine/src/bftengine/MsgsCommunicator.hpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.hpp
@@ -25,8 +25,10 @@ class MsgsCommunicator {
                             std::shared_ptr<IReceiver>& msgReceiver);
   virtual ~MsgsCommunicator() = default;
 
-  int start(uint16_t replicaId);
-  int stop();
+  int startCommunication(uint16_t replicaId);
+  int stopCommunication();
+  void startMsgsProcessing(uint16_t replicaId);
+  void stopMsgsProcessing();
 
   [[nodiscard]] bool isMsgsProcessingRunning() const { return incomingMsgsStorage_->isRunning(); }
   int sendAsyncMessage(NodeNum destNode, char* message, size_t messageLength);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3027,17 +3027,16 @@ void ReplicaImp::addTimers() {
 
 void ReplicaImp::start() {
   stateTransfer->startRunning(this);
+  addTimers();
   LOG_INFO_F(GL, "Running");
   if (recoveringFromExecutionOfRequests) {
     const SeqNumInfo &seqNumInfo = mainLog->get(lastExecutedSeqNum + 1);
     PrePrepareMsg *pp = seqNumInfo.getPrePrepareMsg();
     Assert(pp != nullptr);
     executeRequestsInPrePrepareMsg(pp, true);
-
     recoveringFromExecutionOfRequests = false;
     mapOfRequestsThatAreBeingRecovered = Bitmap();
   }
-  addTimers();
 }
 
 void ReplicaImp::executeReadOnlyRequest(ClientRequestMsg *request) {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3059,7 +3059,7 @@ void ReplicaImp::executeReadOnlyRequest(ClientRequestMsg *request) {
   if (!supportDirectProofs) {
     error = userRequestsHandler->execute(clientId,
                                          lastExecutedSeqNum,
-                                         true,
+                                         READ_ONLY_FLAG,
                                          request->requestLength(),
                                          request->requestBuf(),
                                          reply.maxReplyLength(),
@@ -3158,7 +3158,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
       userRequestsHandler->execute(
           clientId,
           lastExecutedSeqNum + 1,
-          req.isReadOnly(),
+          req.isReadOnly() ? READ_ONLY_FLAG : EMPTY_FLAGS,
           req.requestLength(),
           req.requestBuf(),
           ReplicaConfigSingleton::GetInstance().GetMaxReplyMessageSize() - sizeof(ClientReplyMsgHeader),

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3026,14 +3026,8 @@ void ReplicaImp::addTimers() {
 }
 
 void ReplicaImp::start() {
-  addTimers();
-  processMessages();
-}
-
-void ReplicaImp::processMessages() {
   stateTransfer->startRunning(this);
   LOG_INFO_F(GL, "Running");
-
   if (recoveringFromExecutionOfRequests) {
     const SeqNumInfo &seqNumInfo = mainLog->get(lastExecutedSeqNum + 1);
     PrePrepareMsg *pp = seqNumInfo.getPrePrepareMsg();
@@ -3043,6 +3037,7 @@ void ReplicaImp::processMessages() {
     recoveringFromExecutionOfRequests = false;
     mapOfRequestsThatAreBeingRecovered = Bitmap();
   }
+  addTimers();
 }
 
 void ReplicaImp::executeReadOnlyRequest(ClientRequestMsg *request) {

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -243,8 +243,6 @@ class ReplicaImp : public InternalReplicaApi, public IReplicaForStateTransfer {
   std::shared_ptr<MsgsCommunicator>& getMsgsCommunicator() { return msgsCommunicator_; }
   std::shared_ptr<MsgHandlersRegistrator>& getMsgHandlersRegistrator() { return msgHandlers_; }
 
-  void processMessages();
-
   // IReplicaForStateTransfer
   virtual void freeStateTransferMsg(char* m) override;
   virtual void sendStateTransferMessage(char* m, uint32_t size, uint16_t replicaId) override;

--- a/bftengine/src/bftengine/messages/MsgCode.hpp
+++ b/bftengine/src/bftengine/messages/MsgCode.hpp
@@ -38,6 +38,10 @@ class MsgCode {
     ReqMissingData,
     StateTransfer,
 
+    ClientPreExecutionRequest,
+    PreExecutionRequest,
+    PreExecutionReply,
+
     ClientRequest = 700,
     ClientReply = 800,
 

--- a/kvbc/include/ClientImp.h
+++ b/kvbc/include/ClientImp.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -16,10 +16,7 @@
 #include "KVBCInterfaces.h"
 #include "SimpleClient.hpp"
 
-using namespace bftEngine;
-
-namespace concord {
-namespace kvbc {
+namespace concord::kvbc {
 
 class ClientImp : public IClient {
  public:
@@ -31,23 +28,23 @@ class ClientImp : public IClient {
 
   virtual Status invokeCommandSynch(const char* request,
                                     uint32_t requestSize,
-                                    bool isReadOnly,
+                                    uint8_t flags,
                                     std::chrono::milliseconds timeout,
                                     uint32_t replySize,
                                     char* outReply,
                                     uint32_t* outActualReplySize) override;
 
  protected:
-  ClientImp(){};
-  ~ClientImp(){};
+  ClientImp() = default;
+  ~ClientImp() override = default;
 
   ClientConfig config_;
-  SeqNumberGeneratorForClientRequests* seqGen_ = nullptr;
-  ICommunication* comm_ = nullptr;
+  bftEngine::SeqNumberGeneratorForClientRequests* seqGen_ = nullptr;
+  bftEngine::ICommunication* comm_ = nullptr;
 
-  SimpleClient* bftClient_ = nullptr;
+  bftEngine::SimpleClient* bftClient_ = nullptr;
 
-  friend IClient* createClient(const ClientConfig& conf, ICommunication* comm);
+  friend IClient* createClient(const ClientConfig& conf, bftEngine::ICommunication* comm);
 };
-}  // namespace kvbc
-}  // namespace concord
+
+}  // namespace concord::kvbc

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -61,7 +61,7 @@ class IClient {
 
   virtual Status invokeCommandSynch(const char* request,
                                     uint32_t requestSize,
-                                    bool isReadOnly,
+                                    uint8_t flags,
                                     std::chrono::milliseconds timeout,
                                     uint32_t replySize,
                                     char* outReply,
@@ -126,7 +126,7 @@ class ICommandsHandler : public bftEngine::RequestsHandler {
  public:
   virtual int execute(uint16_t clientId,
                       uint64_t sequenceNum,
-                      bool readOnly,
+                      uint8_t flags,
                       uint32_t requestSize,
                       const char* request,
                       uint32_t maxReplySize,

--- a/kvbc/src/ClientImp.cpp
+++ b/kvbc/src/ClientImp.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -12,9 +12,9 @@
 // file.
 
 #include "ClientImp.h"
-#include <cstring>
-#include <assert.h>
+#include "assertUtils.hpp"
 
+using namespace bftEngine;
 using bftEngine::ICommunication;
 
 namespace concord {
@@ -53,7 +53,7 @@ bool ClientImp::isRunning() { return (bftClient_ != nullptr); }
 
 Status ClientImp::invokeCommandSynch(const char* request,
                                      uint32_t requestSize,
-                                     bool isReadOnly,
+                                     uint8_t flags,
                                      std::chrono::milliseconds timeout,
                                      uint32_t replySize,
                                      char* outReply,
@@ -62,7 +62,7 @@ Status ClientImp::invokeCommandSynch(const char* request,
 
   uint64_t timeoutMs = timeout <= std::chrono::milliseconds::zero() ? SimpleClient::INFINITE_TIMEOUT : timeout.count();
 
-  auto res = bftClient_->sendRequest(isReadOnly,
+  auto res = bftClient_->sendRequest(flags,
                                      request,
                                      requestSize,
                                      seqGen_->generateUniqueSequenceNumberForRequest(),
@@ -70,7 +70,6 @@ Status ClientImp::invokeCommandSynch(const char* request,
                                      replySize,
                                      outReply,
                                      *outActualReplySize);
-
   assert(res >= -2 && res < 1);
 
   if (res == 0)

--- a/tests/config/commonDefs.h
+++ b/tests/config/commonDefs.h
@@ -13,12 +13,8 @@
 
 // This file contains definition used by both the client and replicas.
 
-#ifndef TESTS_SIMPLETEST_COMMONDEFS_H_
-#define TESTS_SIMPLETEST_COMMONDEFS_H_
 #pragma once
 
 // Request types for replica commands.
 #define READ_VAL_REQ ((uint64_t)100)
 #define SET_VAL_REQ ((uint64_t)200)
-
-#endif  // TESTS_SIMPLETEST_COMMONDEFS_H_

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -12,13 +12,12 @@
 // file.
 
 #include "internalCommandsHandler.hpp"
-#include <assert.h>
-#include <algorithm>
+#include "assertUtils.hpp"
 #include "hash_defs.h"
-#include "blockchain/db_types.h"
 #include "sliver.hpp"
 #include "kv_types.hpp"
 #include "block_metadata.hpp"
+#include <algorithm>
 
 using namespace BasicRandomTests;
 
@@ -30,7 +29,7 @@ using concord::storage::SetOfKeyValuePairs;
 
 int InternalCommandsHandler::execute(uint16_t clientId,
                                      uint64_t sequenceNum,
-                                     bool readOnly,
+                                     uint8_t flags,
                                      uint32_t requestSize,
                                      const char *request,
                                      uint32_t maxReplySize,
@@ -43,6 +42,7 @@ int InternalCommandsHandler::execute(uint16_t clientId,
         "The message is too small: requestSize is " << requestSize << ", required size is " << sizeof(SimpleRequest));
     return -1;
   }
+  bool readOnly = flags & bftEngine::MsgFlag::READ_ONLY_FLAG;
   if (readOnly) {
     res = executeReadOnlyCommand(requestSize, request, maxReplySize, outReply, outActualReplySize);
   } else {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -29,7 +29,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
 
   virtual int execute(uint16_t clientId,
                       uint64_t sequenceNum,
-                      bool readOnly,
+                      uint8_t flags,
                       uint32_t requestSize,
                       const char *request,
                       uint32_t maxReplySize,

--- a/tests/simpleTest/CMakeLists.txt
+++ b/tests/simpleTest/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(simpleTest_server
 target_include_directories(simpleTest_server
                            PRIVATE
                            ../config
+                           ../simpleTest
                            ${bftengine_SOURCE_DIR}/tests/simpleStorage
                            ${concord_bft_tools_SOURCE_DIR}
                            ${bftengine_SOURCE_DIR}/src/bftengine

--- a/tests/simpleTest/client.cpp
+++ b/tests/simpleTest/client.cpp
@@ -27,13 +27,10 @@
 // The program expects no arguments. See the `scripts/` directory for
 // information about how to run the client.
 
-#include <cassert>
 #include <cstdlib>
-#include <thread>
 #include <iostream>
 #include <limits>
 
-#include "test_comm_config.hpp"
 #include "test_parameters.hpp"
 #include "simple_test_client.hpp"
 #include "Logger.hpp"

--- a/tests/simpleTest/replica.cpp
+++ b/tests/simpleTest/replica.cpp
@@ -42,22 +42,21 @@
 // Endianness is not specified. All replicas are assumed to use the same
 // native endianness.
 //
-// The read request must be specified as readOnly. (See
-// bftEngine::SimpleClient::sendRequest.)
+// The read request must be specified as readOnly - see bftEngine::SimpleClient::sendRequest.
 //
 // Values for request types (the `100` and `200` mentioned above) are defined in
 // commonDefs.h
 //
 // See the `scripts/` directory for information about how to run the replicas.
 
-#include <cassert>
 #include <thread>
 #include <csignal>
 
-#include "../../../tests/config/test_comm_config.hpp"
-#include "../../../tests/config/test_parameters.hpp"
-#include "../../../tests/simpleTest/simple_test_replica.hpp"
-#include "../../../tests/simpleTest/simple_test_replica_behavior.hpp"
+#include "test_comm_config.hpp"
+#include "test_parameters.hpp"
+#include "simple_test_replica.hpp"
+#include "simple_test_replica_behavior.hpp"
+
 // bftEngine includes
 #include "Logger.hpp"
 

--- a/tests/simpleTest/simple_test_client.hpp
+++ b/tests/simpleTest/simple_test_client.hpp
@@ -118,8 +118,6 @@ class SimpleTestClient {
         // Read the latest value every readMod-th operation.
 
         // Prepare request parameters.
-        const bool readOnly = true;
-
         const uint32_t kRequestLength = 1;
         const uint64_t requestBuffer[kRequestLength] = {READ_VAL_REQ};
         const char* rawRequestBuffer = reinterpret_cast<const char*>(requestBuffer);
@@ -133,7 +131,7 @@ class SimpleTestClient {
         char replyBuffer[kReplyBufferLength];
         uint32_t actualReplyLength = 0;
 
-        client->sendRequest(readOnly,
+        client->sendRequest(READ_ONLY_REQ,
                             rawRequestBuffer,
                             rawRequestLength,
                             requestSequenceNumber,
@@ -156,8 +154,6 @@ class SimpleTestClient {
         expectedLastValue = (i + 1) * (i + 7) * (i + 18);
 
         // Prepare request parameters.
-        const bool readOnly = false;
-
         const uint32_t kRequestLength = 2;
         const uint64_t requestBuffer[kRequestLength] = {SET_VAL_REQ, expectedLastValue};
         const char* rawRequestBuffer = reinterpret_cast<const char*>(requestBuffer);
@@ -171,7 +167,7 @@ class SimpleTestClient {
         char replyBuffer[kReplyBufferLength];
         uint32_t actualReplyLength = 0;
 
-        client->sendRequest(readOnly,
+        client->sendRequest(EMPTY_FLAGS_REQ,
                             rawRequestBuffer,
                             rawRequestLength,
                             requestSequenceNumber,

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -68,12 +68,13 @@ class SimpleAppState : public RequestsHandler {
   // Handler for the upcall from Concord-BFT.
   int execute(uint16_t clientId,
               uint64_t sequenceNum,
-              bool readOnly,
+              uint8_t flags,
               uint32_t requestSize,
               const char *request,
               uint32_t maxReplySize,
               char *outReply,
               uint32_t &outActualReplySize) override {
+    bool readOnly = flags & READ_ONLY_FLAG;
     if (readOnly) {
       // Our read-only request includes only a type, no argument.
       test_assert_replica(requestSize == sizeof(uint64_t), "requestSize =! " << sizeof(uint64_t));


### PR DESCRIPTION
Pre-execution feature requires to pass additional flags besides READ_ONLY between components.