### PR TITLE
Throw exception in Timers class in case timer not found

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2972,12 +2972,12 @@ ReplicaImp::~ReplicaImp() {
 
 void ReplicaImp::stop() {
   TimersSingleton::getInstance().cancel(stateTranTimer_);
-  TimersSingleton::getInstance().cancel(retranTimer_);
+  if (retransmissionsLogicEnabled) TimersSingleton::getInstance().cancel(retranTimer_);
   TimersSingleton::getInstance().cancel(slowPathTimer_);
   TimersSingleton::getInstance().cancel(infoReqTimer_);
   TimersSingleton::getInstance().cancel(statusReportTimer_);
-  TimersSingleton::getInstance().cancel(viewChangeTimer_);
-  TimersSingleton::getInstance().cancel(debugStatTimer_);
+  if (viewChangeProtocolEnabled) TimersSingleton::getInstance().cancel(viewChangeTimer_);
+  if (config_.debugStatisticsEnabled) TimersSingleton::getInstance().cancel(debugStatTimer_);
   TimersSingleton::getInstance().cancel(metricsTimer_);
 
   msgsCommunicator_->stopMsgsProcessing();

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -318,7 +318,7 @@ ReplicaLoader::ErrorCode loadReplicaData(shared_ptr<PersistentStorage> p, Loaded
       Verify((e.isCheckpointMsgSet()), InconsistentErr);
       Verify((e.getCheckpointMsg()->seqNumber() == seqNum), InconsistentErr);
       Verify((e.getCheckpointMsg()->senderId() == ld.repConfig.replicaId), InconsistentErr);
-      VerifyOR(seqNum >= ld.lastStableSeqNum, e.getCheckpointMsg()->isStableState(), InconsistentErr);
+      VerifyOR(seqNum > ld.lastStableSeqNum, e.getCheckpointMsg()->isStableState(), InconsistentErr);
     } else {
       Verify((!e.isCheckpointMsgSet()), InconsistentErr);
     }

--- a/storage/src/db_metadata_storage.cpp
+++ b/storage/src/db_metadata_storage.cpp
@@ -111,6 +111,9 @@ void DBMetadataStorage::writeInBatch(uint32_t objectId, char *data, uint32_t dat
     LOG_ERROR(logger_, WRONG_FLOW);
     throw runtime_error(WRONG_FLOW);
   }
+  // Delete an older parameter with the same key (if exists) before inserting a new one.
+  auto elem = batch_->find(genMetadataKey_(objectId));
+  if (elem != batch_->end()) batch_->erase(elem);
   batch_->insert(KeyValuePair(genMetadataKey_(objectId), copy));
 }
 

--- a/util/test/timers_tests.cpp
+++ b/util/test/timers_tests.cpp
@@ -98,10 +98,14 @@ TEST(TimersTest, Basic) {
   // Add a third timer and ensure it fires.
   // This tests the monotonicity of counter ids as used by handles.
   bool third_timer_fired = false;
-  timers.add(duration, Timers::Timer::ONESHOT, [&third_timer_fired](Handle h) { third_timer_fired = true; }, now);
+  auto handle =
+      timers.add(duration, Timers::Timer::ONESHOT, [&third_timer_fired](Handle h) { third_timer_fired = true; }, now);
   now += duration;
   timers.evaluate(now);
   ASSERT_TRUE(third_timer_fired);
+
+  // Try to reset a timer that no longer exists. This should throw an exception.
+  ASSERT_THROW(timers.reset(handle, duration * 2, now), std::invalid_argument);
 }
 
 }  // namespace concordUtil


### PR DESCRIPTION
Return the previous behavior - don't ignore non-existing timers.