### PR TITLE
Develop a generic metrics collection mechanism

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -127,11 +127,6 @@ IStateTransfer *create(const Config &config,
                        IAppState *const stateApi,
                        std::shared_ptr<::concord::storage::IDBClient> dbc);
 
-IStateTransfer *create(const Config &config,
-                       IAppState *const stateApi,
-                       std::shared_ptr<::concord::storage::IDBClient> dbc,
-                       std::shared_ptr<concordMetrics::Aggregator> aggregator);
-
 }  // namespace SimpleBlockchainStateTransfer
 }  // namespace bftEngine
 

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -62,7 +62,6 @@ class Replica {
   virtual void stop() = 0;
 
   // TODO(GG) : move the following methods to an "advanced interface"
-  virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) = 0;
   virtual void restartForDebug(uint32_t delayMillis) = 0;  // for debug only.
 };
 

--- a/bftengine/include/simplestatetransfer/SimpleStateTransfer.hpp
+++ b/bftengine/include/simplestatetransfer/SimpleStateTransfer.hpp
@@ -17,7 +17,7 @@
 #include <set>
 
 #include "IStateTransfer.hpp"
-
+#include "MetricsCollector.hpp"
 namespace bftEngine {
 
 namespace SimpleInMemoryStateTransfer {

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -314,77 +314,9 @@ class BCStateTran : public IStateTransfer {
   ///////////////////////////////////////////////////////////////////////////
   // Metrics
   ///////////////////////////////////////////////////////////////////////////
- public:
-  void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a);
-
  private:
   void loadMetrics();
-  concordMetrics::Component metrics_component_;
-
-  typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;
-  typedef concordMetrics::Component::Handle<concordMetrics::Status> StatusHandle;
-  typedef concordMetrics::Component::Handle<concordMetrics::Counter> CounterHandle;
-
-  struct Metrics {
-    StatusHandle fetching_state_;
-    StatusHandle pedantic_checks_enabled_;
-    StatusHandle preferred_replicas_;
-
-    GaugeHandle current_source_replica_;
-    GaugeHandle checkpoint_being_fetched_;
-    GaugeHandle last_stored_checkpoint_;
-    GaugeHandle number_of_reserved_pages_;
-    GaugeHandle size_of_reserved_page_;
-    GaugeHandle last_msg_seq_num_;
-    GaugeHandle next_required_block_;
-    GaugeHandle num_pending_item_data_msgs_;
-    GaugeHandle total_size_of_pending_item_data_msgs_;
-    GaugeHandle last_block_;
-    GaugeHandle last_reachable_block_;
-
-    CounterHandle sent_ask_for_checkpoint_summaries_msg_;
-    CounterHandle sent_checkpoint_summary_msg_;
-
-    CounterHandle sent_fetch_blocks_msg_;
-    CounterHandle sent_fetch_res_pages_msg_;
-    CounterHandle sent_reject_fetch_msg_;
-    CounterHandle sent_item_data_msg_;
-
-    CounterHandle received_ask_for_checkpoint_summaries_msg_;
-    CounterHandle received_checkpoint_summary_msg_;
-    CounterHandle received_fetch_blocks_msg_;
-    CounterHandle received_fetch_res_pages_msg_;
-    CounterHandle received_reject_fetching_msg_;
-    CounterHandle received_item_data_msg_;
-    CounterHandle received_illegal_msg_;
-
-    CounterHandle invalid_ask_for_checkpoint_summaries_msg_;
-    CounterHandle irrelevant_ask_for_checkpoint_summaries_msg_;
-    CounterHandle invalid_checkpoint_summary_msg_;
-    CounterHandle irrelevant_checkpoint_summary_msg_;
-    CounterHandle invalid_fetch_blocks_msg_;
-    CounterHandle irrelevant_fetch_blocks_msg_;
-    CounterHandle invalid_fetch_res_pages_msg_;
-    CounterHandle irrelevant_fetch_res_pages_msg_;
-    CounterHandle invalid_reject_fetching_msg_;
-    CounterHandle irrelevant_reject_fetching_msg_;
-    CounterHandle invalid_item_data_msg_;
-    CounterHandle irrelevant_item_data_msg_;
-
-    CounterHandle create_checkpoint_;
-    CounterHandle mark_checkpoint_as_stable_;
-    CounterHandle load_reserved_page_;
-    CounterHandle load_reserved_page_from_pending_;
-    CounterHandle load_reserved_page_from_checkpoint_;
-    CounterHandle save_reserved_page_;
-    CounterHandle zero_reserved_page_;
-    CounterHandle start_collecting_state_;
-    CounterHandle on_timer_;
-
-    CounterHandle on_transferring_complete_;
-  };
-
-  mutable Metrics metrics_;
+  concordMetrics::ComponentCollector& metricsCollector_;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -44,8 +44,6 @@ struct ReplicaInternal : public Replica {
 
   virtual void stop() override;
 
-  virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) override;
-
   virtual void restartForDebug(uint32_t delayMillis) override;
 
   ReplicaImp *rep;
@@ -79,8 +77,6 @@ void ReplicaInternal::stop() {
 
   debugWait.notify_all();
 }
-
-void ReplicaInternal::SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) { return rep->SetAggregator(a); }
 
 void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
   {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -37,7 +37,7 @@ using concordUtil::Timers;
 using namespace std;
 using namespace std::chrono;
 using namespace std::placeholders;
-
+using namespace concordMetrics;
 namespace bftEngine {
 namespace impl {
 
@@ -166,7 +166,7 @@ void ReplicaImp::sendRaw(char *m, NodeIdType dest, uint16_t type, MsgSize size) 
 }
 
 void ReplicaImp::onMessage(ClientRequestMsg *m) {
-  metric_received_client_requests_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_CLIENT_REQUEST_MSGS);
   const NodeIdType senderId = m->senderId();
   const NodeIdType clientId = m->clientProxyId();
   const bool readOnly = m->isReadOnly();
@@ -371,7 +371,7 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
 
   if (firstPath == CommitPath::SLOW) {
     seqNumInfo.startSlowPath();
-    metric_slow_path_count_.Get().Inc();
+    metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_SLOW_PATH_COUNT);
     sendPreparePartial(seqNumInfo);
   } else {
     sendPartialProof(seqNumInfo);
@@ -405,7 +405,7 @@ bool ReplicaImp::relevantMsgForActiveView(const T *msg) {
 }
 
 void ReplicaImp::onMessage(PrePrepareMsg *msg) {
-  metric_received_pre_prepares_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_PREPREPARE_MSGS);
   const SeqNum msgSeqNum = msg->seqNumber();
 
   LOG_DEBUG_F(GL,
@@ -459,7 +459,7 @@ void ReplicaImp::onMessage(PrePrepareMsg *msg) {
         sendPartialProof(seqNumInfo);
       } else {
         seqNumInfo.startSlowPath();
-        metric_slow_path_count_.Get().Inc();
+        metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_SLOW_PATH_COUNT);
         sendPreparePartial(seqNumInfo);
         ;
       }
@@ -514,7 +514,7 @@ void ReplicaImp::tryToStartSlowPaths() {
     controller->onStartingSlowCommit(i);
 
     seqNumInfo.startSlowPath();
-    metric_slow_path_count_.Get().Inc();
+    metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_SLOW_PATH_COUNT);
 
     if (ps_) {
       ps_->beginWriteTran();
@@ -595,7 +595,8 @@ void ReplicaImp::tryToAskForMissingInfo() {
 }
 
 void ReplicaImp::onMessage(StartSlowCommitMsg *msg) {
-  metric_received_start_slow_commits_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_START_SLOW_COMMIT_MSGS);
+
   const SeqNum msgSeqNum = msg->seqNumber();
 
   LOG_INFO_F(GL, "Node %d received StartSlowCommitMsg for seqNumber %" PRId64 "", config_.replicaId, msgSeqNum);
@@ -609,7 +610,7 @@ void ReplicaImp::onMessage(StartSlowCommitMsg *msg) {
       LOG_INFO_F(GL, "Node %d starts slow path for seqNumber %" PRId64 "", config_.replicaId, msgSeqNum);
 
       seqNumInfo.startSlowPath();
-      metric_slow_path_count_.Get().Inc();
+      metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_SLOW_PATH_COUNT);
 
       if (ps_) {
         ps_->beginWriteTran();
@@ -723,7 +724,7 @@ void ReplicaImp::sendCommitPartial(const SeqNum s) {
 }
 
 void ReplicaImp::onMessage(PartialCommitProofMsg *msg) {
-  metric_received_partial_commit_proofs_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_PARTIAL_COMMIT_PROOF_MSGS);
   const SeqNum msgSeqNum = msg->seqNumber();
   const SeqNum msgView = msg->viewNumber();
   const NodeIdType msgSender = msg->senderId();
@@ -765,7 +766,7 @@ void ReplicaImp::onInternalMsg(FullCommitProofMsg *msg) {
 }
 
 void ReplicaImp::onMessage(FullCommitProofMsg *msg) {
-  metric_received_full_commit_proofs_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_FULL_COMMIT_PROOF_MSGS);
   LOG_DEBUG_F(GL,
               "Node %d received FullCommitProofMsg message for seqNumber %d",
               (int)config_.replicaId,
@@ -806,7 +807,7 @@ void ReplicaImp::onMessage(FullCommitProofMsg *msg) {
 }
 
 void ReplicaImp::onMessage(PreparePartialMsg *msg) {
-  metric_received_prepare_partials_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_PREPARER_PARTIAL_MSGS);
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -855,7 +856,7 @@ void ReplicaImp::onMessage(PreparePartialMsg *msg) {
 }
 
 void ReplicaImp::onMessage(CommitPartialMsg *msg) {
-  metric_received_commit_partials_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_COMMIT_PARTIAL_MSGS);
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -898,7 +899,7 @@ void ReplicaImp::onMessage(CommitPartialMsg *msg) {
 }
 
 void ReplicaImp::onMessage(PrepareFullMsg *msg) {
-  metric_received_prepare_fulls_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_PREPARE_FULL_MSGS);
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -939,7 +940,7 @@ void ReplicaImp::onMessage(PrepareFullMsg *msg) {
 }
 
 void ReplicaImp::onMessage(CommitFullMsg *msg) {
-  metric_received_commit_fulls_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_COMMIT_FULL_MSGS);
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -1200,7 +1201,7 @@ void ReplicaImp::onCommitVerifyCombinedSigResult(SeqNum seqNumber, ViewNum v, bo
 }
 
 void ReplicaImp::onMessage(CheckpointMsg *msg) {
-  metric_received_checkpoints_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_CHECKPOINT_MSGS);
   const ReplicaId msgSenderId = msg->senderId();
   const SeqNum msgSeqNum = msg->seqNumber();
   const Digest msgDigest = msg->digestOfState();
@@ -1467,7 +1468,7 @@ void ReplicaImp::onRetransmissionsProcessingResults(
 }
 
 void ReplicaImp::onMessage(ReplicaStatusMsg *msg) {
-  metric_received_replica_statuses_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_STATUS_MSGS);
   // TODO(GG): we need filter for msgs (to avoid denial of service attack) + avoid sending messages at a high rate.
   // TODO(GG): for some communication modules/protocols, we can also utilize information about connection/disconnection.
 
@@ -1692,7 +1693,7 @@ void ReplicaImp::onMessage(ViewChangeMsg *msg) {
     delete msg;
     return;
   }
-  metric_received_view_changes_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_VIEW_CHANGE_MSGS);
 
   const ReplicaId generatedReplicaId =
       msg->idOfGeneratedReplica();  // Notice that generatedReplicaId may be != msg->senderId()
@@ -1744,7 +1745,7 @@ void ReplicaImp::onMessage(ViewChangeMsg *msg) {
 
   if (lastAgreedView < curView) {
     lastAgreedView = curView;
-    metric_last_agreed_view_.Get().Set(lastAgreedView);
+    metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_AGREED_VIEW, lastAgreedView);
     timeOfLastAgreedView = getMonotonicTime();
   }
 
@@ -1756,8 +1757,7 @@ void ReplicaImp::onMessage(NewViewMsg *msg) {
     delete msg;
     return;
   }
-  metric_received_new_views_.Get().Inc();
-
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_NEW_VIEW_MSGS);
   const ReplicaId senderId = msg->senderId();
 
   Assert(senderId != config_.replicaId);  // should be verified in ViewChangeMsg
@@ -1839,7 +1839,7 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
   }
 
   curView = nextView;
-  metric_view_.Get().Set(nextView);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_VIEW, nextView);
 
   LOG_INFO_F(GL,
              "Sending view change message: new view=%" PRId64
@@ -1990,7 +1990,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
       seqNumInfo.addMsg(pp);
 
     seqNumInfo.startSlowPath();
-    metric_slow_path_count_.Get().Inc();
+    metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_SLOW_PATH_COUNT);
   }
 
   if (ps_) ps_->endWriteTran();
@@ -2122,7 +2122,8 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
     ps_->setCheckpointMsgInCheckWindow(newStateCheckpoint, checkpointMsg);
     ps_->endWriteTran();
   }
-  metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_EXECUTED_SEQ_NUM, lastExecutedSeqNum);
 
   sendToAllOtherReplicas(checkpointMsg);
 
@@ -2162,7 +2163,8 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
   if (ps_) ps_->beginWriteTran();
 
   lastStableSeqNum = newStableSeqNum;
-  metric_last_stable_seq_num_.Get().Set(lastStableSeqNum);
+
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_STABLE_SEQ_NUM, lastStableSeqNum);
 
   if (ps_) ps_->setLastStableSeqNum(lastStableSeqNum);
 
@@ -2184,7 +2186,9 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     if (lastStableSeqNum > lastExecutedSeqNum) {
       lastExecutedSeqNum = lastStableSeqNum;
       if (ps_) ps_->setLastExecutedSeqNum(lastExecutedSeqNum);
-      metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+
+      metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_EXECUTED_SEQ_NUM,
+                                   lastExecutedSeqNum);
       if (config_.debugStatisticsEnabled) {
         DebugStatistics::onLastExecutedSequenceNumberChanged(lastExecutedSeqNum);
       }
@@ -2320,7 +2324,7 @@ void ReplicaImp::tryToSendReqMissingDataMsg(SeqNum seqNumber, bool slowPathOnly,
 }
 
 void ReplicaImp::onMessage(ReqMissingDataMsg *msg) {
-  metric_received_req_missing_datas_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_REQ_MISSING_DATA_MSGS);
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -2506,10 +2510,8 @@ void ReplicaImp::onDebugStatTimer(Timers::Handle timer) {
   }
 }
 
-void ReplicaImp::onMetricsTimer(Timers::Handle timer) { metrics_.UpdateAggregator(); }
-
 void ReplicaImp::onMessage(SimpleAckMsg *msg) {
-  metric_received_simple_acks_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_SIMPLE_ACK_MAGS);
   if (retransmissionsLogicEnabled) {
     uint16_t relatedMsgType = (uint16_t)msg->ackData();  // TODO(GG): does this make sense ?
 
@@ -2529,7 +2531,7 @@ void ReplicaImp::onMessage(SimpleAckMsg *msg) {
 }
 
 void ReplicaImp::onMessage(StateTransferMsg *m) {
-  metric_received_state_transfers_.Get().Inc();
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_RECEIVED_STATE_TRANSFER_MSGS);
   size_t h = sizeof(MessageBase::Header);
   stateTransfer->handleStateTransferMessage(m->body() + h, m->size() - h, m->senderId());
 }
@@ -2616,16 +2618,19 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
 
   curView = ld.viewsManager->latestActiveView();
   lastAgreedView = curView;
-  metric_view_.Get().Set(curView);
-  metric_last_agreed_view_.Get().Set(lastAgreedView);
+
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_VIEW, curView);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_AGREED_VIEW, lastAgreedView);
 
   const bool inView = ld.viewsManager->viewIsActive(curView);
 
   primaryLastUsedSeqNum = ld.primaryLastUsedSeqNum;
   lastStableSeqNum = ld.lastStableSeqNum;
-  metric_last_stable_seq_num_.Get().Set(lastStableSeqNum);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_STABLE_SEQ_NUM, lastStableSeqNum);
+
   lastExecutedSeqNum = ld.lastExecutedSeqNum;
-  metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_EXECUTED_SEQ_NUM, lastExecutedSeqNum);
+
   strictLowerBoundOfSeqNums = ld.strictLowerBoundOfSeqNums;
   maxSeqNumTransferredFromPrevViews = ld.maxSeqNumTransferredFromPrevViews;
   lastViewThatTransferredSeqNumbersFullyExecuted = ld.lastViewThatTransferredSeqNumbersFullyExecuted;
@@ -2825,31 +2830,15 @@ ReplicaImp::ReplicaImp(bool firstTime,
       timeOfLastStateSynch{getMonotonicTime()},    // TODO(GG): TBD
       timeOfLastViewEntrance{getMonotonicTime()},  // TODO(GG): TBD
       timeOfLastAgreedView{getMonotonicTime()},    // TODO(GG): TBD
-      metrics_{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())},
-      metric_view_{metrics_.RegisterGauge("view", curView)},
-      metric_last_stable_seq_num_{metrics_.RegisterGauge("lastStableSeqNum", lastStableSeqNum)},
-      metric_last_executed_seq_num_{metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)},
-      metric_last_agreed_view_{metrics_.RegisterGauge("lastAgreedView", lastAgreedView)},
-      metric_first_commit_path_{metrics_.RegisterStatus(
-          "firstCommitPath", CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath))},
-      metric_slow_path_count_{metrics_.RegisterCounter("slowPathCount", 0)},
-      metric_received_internal_msgs_{metrics_.RegisterCounter("receivedInternalMsgs")},
-      metric_received_client_requests_{metrics_.RegisterCounter("receivedClientRequestMsgs")},
-      metric_received_pre_prepares_{metrics_.RegisterCounter("receivedPrePrepareMsgs")},
-      metric_received_start_slow_commits_{metrics_.RegisterCounter("receivedStartSlowCommitMsgs")},
-      metric_received_partial_commit_proofs_{metrics_.RegisterCounter("receivedPartialCommitProofMsgs")},
-      metric_received_full_commit_proofs_{metrics_.RegisterCounter("receivedFullCommitProofMsgs")},
-      metric_received_prepare_partials_{metrics_.RegisterCounter("receivedPreparePartialMsgs")},
-      metric_received_commit_partials_{metrics_.RegisterCounter("receivedCommitPartialMsgs")},
-      metric_received_prepare_fulls_{metrics_.RegisterCounter("receivedPrepareFullMsgs")},
-      metric_received_commit_fulls_{metrics_.RegisterCounter("receivedCommitFullMsgs")},
-      metric_received_checkpoints_{metrics_.RegisterCounter("receivedCheckpointMsgs")},
-      metric_received_replica_statuses_{metrics_.RegisterCounter("receivedReplicaStatusMsgs")},
-      metric_received_view_changes_{metrics_.RegisterCounter("receivedViewChangeMsgs")},
-      metric_received_new_views_{metrics_.RegisterCounter("receivedNewViewMsgs")},
-      metric_received_req_missing_datas_{metrics_.RegisterCounter("receivedReqMissingDataMsgs")},
-      metric_received_simple_acks_{metrics_.RegisterCounter("receivedSimpleAckMsgs")},
-      metric_received_state_transfers_{metrics_.RegisterCounter("receivedStateTransferMsgs")} {
+      metricsCollector_{concordMetrics::MetricsCollector::getInstance(config_.replicaId).getReplicaComp()} {
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_VIEW, curView);
+
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_STABLE_SEQ_NUM, lastStableSeqNum);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_EXECUTED_SEQ_NUM, lastExecutedSeqNum);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_AGREED_VIEW, lastAgreedView);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_FIRST_COMMIT_PATH,
+                               CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath));
+
   Assert(config_.replicaId < numOfReplicas);
   // TODO(GG): more asserts on params !!!!!!!!!!!
 
@@ -2863,9 +2852,6 @@ ReplicaImp::ReplicaImp(bool firstTime,
   if (config_.debugStatisticsEnabled) {
     DebugStatistics::initDebugStatisticsData();
   }
-
-  // Register metrics component with the default aggregator.
-  metrics_.Register();
 
   if (firstTime) {
     sigManager = new SigManager(config_.replicaId,
@@ -2978,7 +2964,6 @@ void ReplicaImp::stop() {
   TimersSingleton::getInstance().cancel(statusReportTimer_);
   if (viewChangeProtocolEnabled) TimersSingleton::getInstance().cancel(viewChangeTimer_);
   if (config_.debugStatisticsEnabled) TimersSingleton::getInstance().cancel(debugStatTimer_);
-  TimersSingleton::getInstance().cancel(metricsTimer_);
 
   msgsCommunicator_->stopMsgsProcessing();
   msgsCommunicator_->stopCommunication();
@@ -3021,9 +3006,6 @@ void ReplicaImp::addTimers() {
                                                          Timers::Timer::RECURRING,
                                                          [this](Timers::Handle h) { onDebugStatTimer(h); });
   }
-
-  metricsTimer_ = TimersSingleton::getInstance().add(
-      100ms, Timers::Timer::RECURRING, [this](Timers::Handle h) { onMetricsTimer(h); });
 }
 
 void ReplicaImp::start() {
@@ -3190,8 +3172,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
   }
 
   lastExecutedSeqNum = lastExecutedSeqNum + 1;
-
-  metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+  metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_LAST_EXECUTED_SEQ_NUM, lastExecutedSeqNum);
   if (config_.debugStatisticsEnabled) {
     DebugStatistics::onLastExecutedSequenceNumberChanged(lastExecutedSeqNum);
   }
@@ -3228,7 +3209,8 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
   bool firstCommitPathChanged = controller->onNewSeqNumberExecution(lastExecutedSeqNum);
 
   if (firstCommitPathChanged) {
-    metric_first_commit_path_.Get().Set(CommitPathToStr(controller->getCurrentFirstPath()));
+    metricsCollector_.takeMetric(concordMetrics::ReplicaMetricsCode::REPLICA_FIRST_COMMIT_PATH,
+                                 CommitPathToStr(controller->getCurrentFirstPath()));
   }
   // TODO(GG): clean the following logic
   if (mainLog->insideActiveWindow(lastExecutedSeqNum)) {  // update dynamicUpperLimitOfRounds
@@ -3276,10 +3258,6 @@ void ReplicaImp::executeNextCommittedRequests(const bool requestMissingInfo) {
   }
 
   if (isCurrentPrimary() && requestsQueueOfPrimary.size() > 0) tryToSendPrePrepareMsg(true);
-}
-
-void ReplicaImp::SetAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
-  metrics_.SetAggregator(aggregator);
 }
 
 // TODO(GG): the timer for state transfer !!!!

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <set>
 #include <utility>
+#include <memory>
 
 #include "SimpleStateTransfer.hpp"
 #include "SimpleBCStateTransfer.hpp"

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -85,8 +85,7 @@ class ReplicaImp : public IReplica,
 
   ReplicaImp(bftEngine::ICommunication *comm,
              bftEngine::ReplicaConfig &config,
-             concord::storage::blockchain::DBAdapter *dbAdapter,
-             std::shared_ptr<concordMetrics::Aggregator> aggregator);
+             concord::storage::blockchain::DBAdapter *dbAdapter);
 
   void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 
@@ -270,7 +269,6 @@ class ReplicaImp : public IReplica,
   std::unique_ptr<BlockchainAppState> m_appState;
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
   std::unique_ptr<ReplicaStateSync> replicaStateSync_;
-  std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 
   // static methods
   static Sliver createBlockFromUpdates(const concord::storage::SetOfKeyValuePairs &updates,

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstdlib>
+#include <utility>
 #include "CommDefs.hpp"
 #include "kv_types.hpp"
 #include "hex_tools.h"
@@ -62,7 +63,6 @@ Status ReplicaImp::start() {
   m_metadataStorage = new DBMetadataStorage(m_bcDbAdapter->getDb().get(), KeyManipulator::generateMetadataKey);
 
   createReplicaAndSyncState();
-  m_replicaPtr->SetAggregator(aggregator_);
   m_replicaPtr->start();
   m_currentRepStatus = RepStatus::Running;
 
@@ -183,10 +183,7 @@ Status ReplicaImp::addBlock(const SetOfKeyValuePairs &updates, BlockId &outBlock
 
 void ReplicaImp::set_command_handler(ICommandsHandler *handler) { m_cmdHandler = handler; }
 
-ReplicaImp::ReplicaImp(ICommunication *comm,
-                       bftEngine::ReplicaConfig &replicaConfig,
-                       DBAdapter *dbAdapter,
-                       std::shared_ptr<concordMetrics::Aggregator> aggregator)
+ReplicaImp::ReplicaImp(ICommunication *comm, bftEngine::ReplicaConfig &replicaConfig, DBAdapter *dbAdapter)
     : logger(concordlogger::Log::getLogger("skvbc.replicaImp")),
       m_currentRepStatus(RepStatus::Idle),
       m_InternalStorageWrapperForIdleMode(this),
@@ -194,8 +191,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
       m_lastBlock(dbAdapter->getLatestBlock()),
       m_ptrComm(comm),
       m_replicaConfig(replicaConfig),
-      m_appState(new BlockchainAppState(this)),
-      aggregator_(aggregator) {
+      m_appState(new BlockchainAppState(this)) {
   bftEngine::SimpleBlockchainStateTransfer::Config state_transfer_config;
 
   state_transfer_config.myReplicaId = m_replicaConfig.replicaId;
@@ -205,8 +201,8 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
     state_transfer_config.maxNumOfReservedPages = replicaConfig.maxNumOfReservedPages;
   if (replicaConfig.sizeOfReservedPage > 0) state_transfer_config.sizeOfReservedPage = replicaConfig.sizeOfReservedPage;
 
-  m_stateTransfer = bftEngine::SimpleBlockchainStateTransfer::create(
-      state_transfer_config, m_appState.get(), m_bcDbAdapter->getDb(), aggregator);
+  m_stateTransfer =
+      bftEngine::SimpleBlockchainStateTransfer::create(state_transfer_config, m_appState.get(), m_bcDbAdapter->getDb());
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -47,10 +47,9 @@ int main(int argc, char** argv) {
     auto comparator = concord::storage::memorydb::KeyComparator(key_manipulator);
     db = new concord::storage::memorydb::Client(comparator);
   }
-
   auto* dbAdapter = new concord::storage::blockchain::DBAdapter(db);
-  auto* replica = new ReplicaImp(
-      setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
+  setup->GetMetricsServer().registerMetrics(setup->GetReplicaConfig().replicaId);
+  auto* replica = new ReplicaImp(setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter);
   replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
 
   // Start metrics server after creation of the replica so that we ensure

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -42,7 +42,7 @@ class TestSetup {
       : replica_config_(config),
         communication_(std::move(comm)),
         logger_(logger),
-        metrics_server_(metrics_port),
+        metrics_server_(metrics_port, true),
         use_persistent_storage_(use_persistent_storage) {}
   TestSetup() = delete;
 

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -226,7 +226,6 @@ class SimpleTestReplica {
         testCommConfig.GetUDPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName);
 #endif
     auto comm = bftEngine::CommFactory::create(conf);
-
     bftEngine::SimpleInMemoryStateTransfer::ISimpleInMemoryStateTransfer *st =
         bftEngine::SimpleInMemoryStateTransfer::create(simpleAppState->statePtr,
                                                        sizeof(SimpleAppState::State) * rp.numOfClients,

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -19,6 +19,10 @@
 #include <vector>
 #include <mutex>
 #include <memory>
+#include <thread>
+#include <chrono>
+#include "MetricsCollector.hpp"
+#include "Timers.hpp"
 
 namespace concordMetrics {
 
@@ -189,6 +193,40 @@ class Component {
 
   Names names_;
   Values values_;
+};
+
+class ConcordBftMetricsComp {
+  typedef Component::Handle<Counter> cHandler;
+  typedef Component::Handle<Gauge> gHandler;
+  typedef Component::Handle<Status> sHandler;
+  class Counter_ : public CounterHandler {
+    cHandler h_;
+
+   public:
+    Counter_(const cHandler& h) : h_{h} {}
+    void inc() override { h_.Get().Inc(); }
+  };
+
+  class Gauge_ : public GaugeHandler {
+    gHandler h_;
+
+   public:
+    Gauge_(const gHandler& h) : h_{h} {}
+    void set(uint64_t val) override { h_.Get().Set(val); }
+  };
+
+  class Status_ : public StatusHandler {
+    sHandler h_;
+
+   public:
+    Status_(const sHandler& h) : h_{h} {}
+    void set(const std::string& val) override { h_.Get().Set(val); }
+  };
+
+ public:
+  static void createReplicaComponent(Component& component, ComponentCollector& collecto);
+
+  static void createStateTransferComponent(Component& component, ComponentCollector& collector);
 };
 
 }  // namespace concordMetrics

--- a/util/include/MetricsCollector.hpp
+++ b/util/include/MetricsCollector.hpp
@@ -1,0 +1,161 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <functional>
+
+namespace concordMetrics {
+typedef enum : uint32_t {
+  REPLICA_VIEW,
+  REPLICA_LAST_STABLE_SEQ_NUM,
+  REPLICA_LAST_EXECUTED_SEQ_NUM,
+  REPLICA_LAST_AGREED_VIEW,
+  REPLICA_FIRST_COMMIT_PATH,
+  REPLICA_SLOW_PATH_COUNT,
+  REPLICA_RECEIVED_INTERNAL_MSGS,
+  REPLICA_RECEIVED_CLIENT_REQUEST_MSGS,
+  REPLICA_RECEIVED_PREPREPARE_MSGS,
+  REPLICA_RECEIVED_START_SLOW_COMMIT_MSGS,
+  REPLICA_RECEIVED_PARTIAL_COMMIT_PROOF_MSGS,
+  REPLICA_RECEIVED_FULL_COMMIT_PROOF_MSGS,
+  REPLICA_RECEIVED_PREPARER_PARTIAL_MSGS,
+  REPLICA_RECEIVED_COMMIT_PARTIAL_MSGS,
+  REPLICA_RECEIVED_PREPARE_FULL_MSGS,
+  REPLICA_RECEIVED_COMMIT_FULL_MSGS,
+  REPLICA_RECEIVED_CHECKPOINT_MSGS,
+  REPLICA_RECEIVED_STATUS_MSGS,
+  REPLICA_RECEIVED_VIEW_CHANGE_MSGS,
+  REPLICA_RECEIVED_NEW_VIEW_MSGS,
+  REPLICA_RECEIVED_REQ_MISSING_DATA_MSGS,
+  REPLICA_RECEIVED_SIMPLE_ACK_MAGS,
+  REPLICA_RECEIVED_STATE_TRANSFER_MSGS
+} ReplicaMetricsCode;
+typedef enum : uint32_t {
+  BCST_FETCHING_STATE,
+  BCST_PEDANTIC_CHECKS_ENABLED,
+  BCST_PREFERRED_REPLICAS,
+  BCST_CURRENT_SOURCE_REPLICA,
+  BCST_CHECKPOINT_BEING_FETCHED,
+  BCST_LAST_STORED_CHECKPOINT,
+  BCST_NUMBER_OF_RESERVED_PAGES,
+  BCST_SIZE_OF_RESERVED_PAGES,
+  BCST_LAST_MSG_SEQ_NUM,
+  BCST_NEXT_REQUIRED_BLOCK,
+  BCST_NUM_PENDING_ITEM_DATA_MSGS,
+  BCST_TOTAL_SIZE_OF_PENDING_ITEM_DATA_MSGS,
+  BCST_LAST_BLOCK,
+  BCST_LAST_REACHABLE_BLOCK,
+  BCST_SENT_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+  BCST_SENT_CHECKPOINT_SUMMARY_MSG,
+  BCST_SENT_FETCH_BLOCKS_MSG,
+  BCST_SENT_FETCH_RES_PAGES_MSG,
+  BCST_SENT_REJECT_FETCH_MSG,
+  BCST_SENT_ITEM_DATA_MSG,
+  BCST_RECEIVED_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+  BCST_RECEIVED_CHECKPOINT_SUMMARY_MSG,
+  BCST_RECEIVED_FETCH_BLOCKS_MSG,
+  BCST_RECEIVED_FETCH_RES_PAGES_MSG,
+  BCST_RECEIVED_REJECT_FETCHING_MSG,
+  BCST_RECEIVED_ITEM_DATA_MSG,
+  BCST_RECEIVED_ILLEGAL_MSG,
+  BCST_INVALID_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+  BCST_IRRELEVANT_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+  BCST_INVALID_CHECKPOINT_SUMMARY_MSG,
+  BCST_IRRELEVANT_CHECKPOINT_SUMMARY_MSG,
+  BCST_INVALID_FETCH_BLOCKS_MSG,
+  BCST_IRRELEVANT_FETCH_BLOCKS_MSG,
+  BCST_INVALID_FETCH_RES_PAGES_MSG,
+  BCST_IRRELEVANT_FETCH_RES_PAGES_MSG,
+  BCST_INVALID_REJECT_FETCHING_MSG,
+  BCST_IRRELEVANT_REJECT_FETCHING_MSG,
+  BCST_INVALID_ITEM_DATA_MSG,
+  BCST_IRRELEVANT_ITEM_DATA_MSG,
+  BCST_CREATE_CHECKPOINT,
+  BCST_MARK_CHECKPOINT_AS_STABLE,
+  BCST_LOAD_RESERVED_PAGE,
+  BCST_LOAD_RESERVED_PAGE_FROM_PENDING,
+  BCST_LOAD_RESERVED_PAGE_FROM_CHECKPOINT,
+  BCST_SAVE_RESERVED_PAGE,
+  BCST_ZERO_RESERVED_PAGE,
+  BCST_START_COLLECTION_STATE,
+  BCST_ON_TIMER,
+  BCST_ON_TRANSFERRING_COMPLETE,
+} StateTransferMetricCode;
+
+class CounterHandler {
+ public:
+  virtual ~CounterHandler(){};
+  virtual void inc() = 0;
+};
+
+class GaugeHandler {
+ public:
+  virtual ~GaugeHandler(){};
+  virtual void set(uint64_t val) = 0;
+};
+
+class StatusHandler {
+ public:
+  virtual ~StatusHandler(){};
+  virtual void set(const std::string& val) = 0;
+};
+
+class ComponentCollector {
+  std::unordered_map<uint32_t, std::vector<std::shared_ptr<CounterHandler>>> counters;
+  std::unordered_map<uint32_t, std::vector<std::shared_ptr<GaugeHandler>>> gauges;
+  std::unordered_map<uint32_t, std::vector<std::shared_ptr<StatusHandler>>> statuses;
+
+ public:
+  void add(uint32_t t, std::shared_ptr<CounterHandler> h) { counters[t].emplace_back(std::move(h)); }
+
+  void add(uint32_t t, std::shared_ptr<GaugeHandler> h) { gauges[t].emplace_back(h); }
+
+  void add(uint32_t t, std::shared_ptr<StatusHandler> h) { statuses[t].emplace_back(std::move(h)); }
+
+  void takeMetric(uint32_t t) {
+    for (auto& c : counters[t]) {
+      c->inc();
+    }
+  }
+
+  void takeMetric(uint32_t t, uint64_t val) {
+    for (auto& g : gauges[t]) {
+      g->set(val);
+    }
+  }
+
+  void takeMetric(uint32_t t, const std::string& val) {
+    for (auto& s : statuses[t]) {
+      s->set(val);
+    }
+  }
+};
+
+class MetricsCollector {
+  ComponentCollector replica;
+  ComponentCollector stateTransfer;
+
+ public:
+  ComponentCollector& getReplicaComp() { return replica; }
+
+  ComponentCollector& getStateTransferComp() { return stateTransfer; };
+
+  static MetricsCollector& getInstance(uint32_t id) {
+    static std::unordered_map<uint32_t, MetricsCollector> instances;
+    return instances[id];
+  }
+};
+}  // namespace concordMetrics

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -16,7 +16,6 @@
 #include <sstream>
 
 using namespace std;
-
 namespace concordMetrics {
 
 const char* const kGaugeName = "gauge";
@@ -24,7 +23,7 @@ const char* const kStatusName = "status";
 const char* const kCounterName = "counter";
 
 template <typename T>
-T FindValue(const char* const val_type, const string& val_name, const vector<string>& names, const vector<T>& values) {
+T& FindValue(const char* const val_type, const string& val_name, const vector<string>& names, vector<T>& values) {
   for (size_t i = 0; i < names.size(); i++) {
     if (names[i] == val_name) {
       return values[i];
@@ -162,4 +161,164 @@ std::string Component::ToJson() {
   return oss.str();
 }
 
+void ConcordBftMetricsComp::createReplicaComponent(Component& component, ComponentCollector& collector) {
+  collector.add(ReplicaMetricsCode::REPLICA_VIEW, std::make_shared<Gauge_>(component.RegisterGauge("view", 0)));
+
+  collector.add(ReplicaMetricsCode::REPLICA_LAST_STABLE_SEQ_NUM,
+                std::make_shared<Gauge_>(component.RegisterGauge("lastStableSeqNum", 0)));
+  collector.add(ReplicaMetricsCode::REPLICA_LAST_EXECUTED_SEQ_NUM,
+                std::make_shared<Gauge_>(component.RegisterGauge("lastExecutedSeqNum", 0)));
+  collector.add(ReplicaMetricsCode::REPLICA_LAST_AGREED_VIEW,
+                std::make_shared<Gauge_>(component.RegisterGauge("lastAgreedView", 0)));
+
+  collector.add(ReplicaMetricsCode::REPLICA_FIRST_COMMIT_PATH,
+                std::make_shared<Status_>(component.RegisterStatus("firstCommitPath", "")));
+
+  collector.add(ReplicaMetricsCode::REPLICA_SLOW_PATH_COUNT,
+                std::make_shared<Counter_>(component.RegisterCounter("slowPathCount")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_INTERNAL_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedInternalMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_CLIENT_REQUEST_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedClientRequestMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_PREPREPARE_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedPrePrepareMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_START_SLOW_COMMIT_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedStartSlowCommitMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_PARTIAL_COMMIT_PROOF_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedPartialCommitProofMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_FULL_COMMIT_PROOF_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedFullCommitProofMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_PREPARER_PARTIAL_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedPreparePartialMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_COMMIT_PARTIAL_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedCommitPartialMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_PREPARE_FULL_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedPrepareFullMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_COMMIT_FULL_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedCommitFullMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_CHECKPOINT_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedCheckpointMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_STATUS_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedReplicaStatusMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_VIEW_CHANGE_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedViewChangeMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_NEW_VIEW_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedNewViewMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_REQ_MISSING_DATA_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedReqMissingDataMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_SIMPLE_ACK_MAGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedSimpleAckMsgs")));
+  collector.add(ReplicaMetricsCode::REPLICA_RECEIVED_STATE_TRANSFER_MSGS,
+                std::make_shared<Counter_>(component.RegisterCounter("receivedStateTransferMsgs")));
+  component.Register();
+  component.UpdateAggregator();
+}
+
+void ConcordBftMetricsComp::createStateTransferComponent(Component& component, ComponentCollector& collector) {
+  collector.add(StateTransferMetricCode::BCST_FETCHING_STATE,
+                std::make_shared<Status_>(component.RegisterStatus("fetching_state", "")));
+  collector.add(StateTransferMetricCode::BCST_PEDANTIC_CHECKS_ENABLED,
+                std::make_shared<Status_>(component.RegisterStatus("pedantic_checks_enabled", "")));
+  collector.add(StateTransferMetricCode::BCST_PREFERRED_REPLICAS,
+                std::make_shared<Status_>(component.RegisterStatus("preferred_replicas", "")));
+
+  collector.add(StateTransferMetricCode::BCST_CURRENT_SOURCE_REPLICA,
+                std::make_shared<Gauge_>(component.RegisterGauge("current_source_replica", 0)));
+  collector.add(StateTransferMetricCode::BCST_CHECKPOINT_BEING_FETCHED,
+                std::make_shared<Gauge_>(component.RegisterGauge("checkpoint_being_fetched", 0)));
+  collector.add(StateTransferMetricCode::BCST_LAST_STORED_CHECKPOINT,
+                std::make_shared<Gauge_>(component.RegisterGauge("last_stored_checkpoint", 0)));
+  collector.add(StateTransferMetricCode::BCST_NUMBER_OF_RESERVED_PAGES,
+                std::make_shared<Gauge_>(component.RegisterGauge("number_of_reserved_pages", 0)));
+  collector.add(StateTransferMetricCode::BCST_SIZE_OF_RESERVED_PAGES,
+                std::make_shared<Gauge_>(component.RegisterGauge("size_of_reserved_page", 0)));
+  collector.add(StateTransferMetricCode::BCST_LAST_MSG_SEQ_NUM,
+                std::make_shared<Gauge_>(component.RegisterGauge("last_msg_seq_num", 0)));
+  collector.add(StateTransferMetricCode::BCST_NEXT_REQUIRED_BLOCK,
+                std::make_shared<Gauge_>(component.RegisterGauge("next_required_block_", 0)));
+  collector.add(StateTransferMetricCode::BCST_NUM_PENDING_ITEM_DATA_MSGS,
+                std::make_shared<Gauge_>(component.RegisterGauge("num_pending_item_data_msgs_", 0)));
+  collector.add(StateTransferMetricCode::BCST_TOTAL_SIZE_OF_PENDING_ITEM_DATA_MSGS,
+                std::make_shared<Gauge_>(component.RegisterGauge("total_size_of_pending_item_data_msgs", 0)));
+  collector.add(StateTransferMetricCode::BCST_LAST_BLOCK,
+                std::make_shared<Gauge_>(component.RegisterGauge("last_block_", 0)));
+  collector.add(StateTransferMetricCode::BCST_LAST_REACHABLE_BLOCK,
+                std::make_shared<Gauge_>(component.RegisterGauge("last_reachable_block", 0)));
+
+  collector.add(StateTransferMetricCode::BCST_SENT_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("sent_ask_for_checkpoint_summaries_msg")));
+  collector.add(StateTransferMetricCode::BCST_SENT_CHECKPOINT_SUMMARY_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("sent_checkpoint_summary_msg")));
+  collector.add(StateTransferMetricCode::BCST_SENT_FETCH_BLOCKS_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("sent_fetch_blocks_msg")));
+  collector.add(StateTransferMetricCode::BCST_SENT_FETCH_RES_PAGES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("sent_fetch_res_pages_msg")));
+  collector.add(StateTransferMetricCode::BCST_SENT_REJECT_FETCH_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("sent_reject_fetch_msg")));
+  collector.add(StateTransferMetricCode::BCST_SENT_ITEM_DATA_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("sent_item_data_msg")));
+
+  collector.add(StateTransferMetricCode::BCST_RECEIVED_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("received_ask_for_checkpoint_summaries_msg")));
+  collector.add(StateTransferMetricCode::BCST_RECEIVED_CHECKPOINT_SUMMARY_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("received_checkpoint_summary_msg")));
+  collector.add(StateTransferMetricCode::BCST_RECEIVED_FETCH_BLOCKS_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("received_fetch_blocks_msg")));
+  collector.add(StateTransferMetricCode::BCST_RECEIVED_FETCH_RES_PAGES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("received_fetch_res_pages_msg")));
+  collector.add(StateTransferMetricCode::BCST_RECEIVED_REJECT_FETCHING_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("received_reject_fetching_msg")));
+  collector.add(StateTransferMetricCode::BCST_RECEIVED_ITEM_DATA_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("received_item_data_msg")));
+  collector.add(StateTransferMetricCode::BCST_RECEIVED_ILLEGAL_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("received_illegal_msg_")));
+
+  collector.add(StateTransferMetricCode::BCST_INVALID_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("invalid_ask_for_checkpoint_summaries_msg")));
+  collector.add(StateTransferMetricCode::BCST_IRRELEVANT_ASK_FOR_CHECKPOINT_SUMMARIES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("irrelevant_ask_for_checkpoint_summaries_msg")));
+  collector.add(StateTransferMetricCode::BCST_INVALID_CHECKPOINT_SUMMARY_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("invalid_checkpoint_summary_msg")));
+  collector.add(StateTransferMetricCode::BCST_IRRELEVANT_CHECKPOINT_SUMMARY_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("irrelevant_checkpoint_summary_msg")));
+  collector.add(StateTransferMetricCode::BCST_INVALID_FETCH_BLOCKS_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("invalid_fetch_blocks_msg")));
+  collector.add(StateTransferMetricCode::BCST_IRRELEVANT_FETCH_BLOCKS_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("irrelevant_fetch_blocks_msg")));
+  collector.add(StateTransferMetricCode::BCST_INVALID_FETCH_RES_PAGES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("invalid_fetch_res_pages_msg")));
+  collector.add(StateTransferMetricCode::BCST_IRRELEVANT_FETCH_RES_PAGES_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("irrelevant_fetch_res_pages_msg")));
+  collector.add(StateTransferMetricCode::BCST_INVALID_REJECT_FETCHING_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("invalid_reject_fetching_msg")));
+  collector.add(StateTransferMetricCode::BCST_IRRELEVANT_REJECT_FETCHING_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("irrelevant_reject_fetching_msg")));
+  collector.add(StateTransferMetricCode::BCST_INVALID_ITEM_DATA_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("invalid_item_data_msg")));
+  collector.add(StateTransferMetricCode::BCST_IRRELEVANT_ITEM_DATA_MSG,
+                std::make_shared<Counter_>(component.RegisterCounter("irrelevant_item_data_msg")));
+
+  collector.add(StateTransferMetricCode::BCST_CREATE_CHECKPOINT,
+                std::make_shared<Counter_>(component.RegisterCounter("create_checkpoint")));
+  collector.add(StateTransferMetricCode::BCST_MARK_CHECKPOINT_AS_STABLE,
+                std::make_shared<Counter_>(component.RegisterCounter("mark_checkpoint_as_stable")));
+  collector.add(StateTransferMetricCode::BCST_LOAD_RESERVED_PAGE,
+                std::make_shared<Counter_>(component.RegisterCounter("load_reserved_page")));
+  collector.add(StateTransferMetricCode::BCST_LOAD_RESERVED_PAGE_FROM_PENDING,
+                std::make_shared<Counter_>(component.RegisterCounter("load_reserved_page_from_pending")));
+  collector.add(StateTransferMetricCode::BCST_LOAD_RESERVED_PAGE_FROM_CHECKPOINT,
+                std::make_shared<Counter_>(component.RegisterCounter("load_reserved_page_from_checkpoint")));
+  collector.add(StateTransferMetricCode::BCST_SAVE_RESERVED_PAGE,
+                std::make_shared<Counter_>(component.RegisterCounter("save_reserved_page")));
+  collector.add(StateTransferMetricCode::BCST_ZERO_RESERVED_PAGE,
+                std::make_shared<Counter_>(component.RegisterCounter("zero_reserved_page")));
+  collector.add(StateTransferMetricCode::BCST_START_COLLECTION_STATE,
+                std::make_shared<Counter_>(component.RegisterCounter("start_collecting_state")));
+  collector.add(StateTransferMetricCode::BCST_ON_TIMER,
+                std::make_shared<Counter_>(component.RegisterCounter("on_timer")));
+  collector.add(StateTransferMetricCode::BCST_ON_TRANSFERRING_COMPLETE,
+                std::make_shared<Counter_>(component.RegisterCounter("on_transferring_complete")));
+  component.Register();
+  component.UpdateAggregator();
+}
 }  // namespace concordMetrics

--- a/util/src/MetricsServer.cpp
+++ b/util/src/MetricsServer.cpp
@@ -93,9 +93,12 @@ void Server::RecvLoop() {
       sendError(&cliaddr, addrlen);
       continue;
     }
-
+    if (registerMetrics_) {
+      replica.UpdateAggregator();
+      stbc.UpdateAggregator();
+    }
     std::string json = aggregator_->ToJson();
-
+    LOG_INFO(logger_, json);
     if (json.size() > MAX_MSG_SIZE - sizeof(Header)) {
       LOG_FATAL(logger_, "Aggregator data too large to be transmitted!");
       exit(1);

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -3,6 +3,11 @@ add_test(metric_tests metric_tests)
 target_link_libraries(metric_tests gtest_main util)
 target_compile_options(metric_tests PUBLIC -Wno-sign-compare)
 
+add_executable(metrics_collector_tests metrics_collector_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_test(metrics_collector_tests metrics_collector_tests)
+target_link_libraries(metrics_collector_tests gtest_main util)
+target_compile_options(metrics_collector_tests PUBLIC -Wno-sign-compare)
+
 add_executable(metric_server MetricServerTestMain.cpp $<TARGET_OBJECTS:logging_dev>)
 target_link_libraries(metric_server util)
 

--- a/util/test/metrics_collector_test.cpp
+++ b/util/test/metrics_collector_test.cpp
@@ -1,0 +1,153 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+
+#include <cstdlib>
+#include <utility>
+#include "gtest/gtest.h"
+#include "Metrics.hpp"
+
+using namespace std;
+
+namespace concordMetrics {
+class Counter_ : public CounterHandler {
+  uint64_t val;
+
+ public:
+  Counter_() : val{0} {}
+  void inc() override { val++; }
+  uint64_t get() { return val; }
+};
+
+class Gauge_ : public GaugeHandler {
+  uint64_t val;
+
+ public:
+  Gauge_(uint64_t v) : val{v} {}
+  void set(uint64_t val_) override { val = val_; }
+  uint64_t get() { return val; }
+};
+
+class Status_ : public StatusHandler {
+  std::string val;
+
+ public:
+  Status_(std::string v) : val{std::move(v)} {}
+  void set(const std::string& val_) override { val = val_; }
+  const std::string& get() { return val; }
+};
+
+TEST(MetricsCollectorTest, SimpleHandlers) {
+  MetricsCollector mc;
+  auto c = std::make_shared<Counter_>();
+  auto g = std::make_shared<Gauge_>(10);
+  auto s = std::make_shared<Status_>("Hello World");
+
+  mc.getReplicaComp().add(0, c);
+  mc.getReplicaComp().add(1, g);
+  mc.getReplicaComp().add(2, s);
+
+  ASSERT_EQ(0, c->get());
+  ASSERT_EQ(10, g->get());
+  ASSERT_EQ("Hello World", s->get());
+
+  mc.getReplicaComp().takeMetric(0);
+  mc.getReplicaComp().takeMetric(1, 12);
+  mc.getReplicaComp().takeMetric(2, "HW");
+
+  ASSERT_EQ(1, c->get());
+  ASSERT_EQ(12, g->get());
+  ASSERT_EQ("HW", s->get());
+}
+
+TEST(MetricsCollectorTest, MultipleForOneMetric) {
+  MetricsCollector mc;
+  auto c1 = std::make_shared<Counter_>();
+  auto c2 = std::make_shared<Counter_>();
+  auto c3 = std::make_shared<Counter_>();
+
+  mc.getReplicaComp().add(0, c1);
+  mc.getReplicaComp().add(0, c2);
+  mc.getReplicaComp().add(0, c3);
+
+  ASSERT_EQ(0, c1->get());
+  ASSERT_EQ(0, c2->get());
+  ASSERT_EQ(0, c3->get());
+
+  mc.getReplicaComp().takeMetric(0);
+
+  ASSERT_EQ(1, c1->get());
+  ASSERT_EQ(1, c2->get());
+  ASSERT_EQ(1, c3->get());
+}
+TEST(MetricsCollectorTest, TestSingleton) {
+  auto c = std::make_shared<Counter_>();
+  auto g = std::make_shared<Gauge_>(10);
+  auto s = std::make_shared<Status_>("Hello World");
+  ComponentCollector& rep = MetricsCollector::getInstance(0).getReplicaComp();
+
+  rep.add(0, c);
+  rep.add(1, g);
+  rep.add(2, s);
+
+  ASSERT_EQ(0, c->get());
+  ASSERT_EQ(10, g->get());
+  ASSERT_EQ("Hello World", s->get());
+
+  rep.takeMetric(0);
+  rep.takeMetric(1, 12);
+  rep.takeMetric(2, "HW");
+
+  ASSERT_EQ(1, c->get());
+  ASSERT_EQ(12, g->get());
+  ASSERT_EQ("HW", s->get());
+}
+TEST(MetricsCollectorTest, TestSingletonWithConcordMetrics) {
+  auto aggregator = std::make_shared<Aggregator>();
+  Component rep("replica", aggregator);
+  Component st("bc_state_transfer", aggregator);
+
+  ConcordBftMetricsComp::createReplicaComponent(rep, MetricsCollector::getInstance(0).getReplicaComp());
+  ConcordBftMetricsComp::createStateTransferComponent(st, MetricsCollector::getInstance(0).getStateTransferComp());
+
+  ComponentCollector& repComp = MetricsCollector::getInstance(0).getReplicaComp();
+  ASSERT_EQ(0, aggregator->GetGauge("replica", "view").Get());
+  ASSERT_EQ(0, aggregator->GetCounter("replica", "receivedInternalMsgs").Get());
+  ASSERT_EQ("", aggregator->GetStatus("replica", "firstCommitPath").Get());
+
+  repComp.takeMetric(ReplicaMetricsCode::REPLICA_VIEW, 100);
+  repComp.takeMetric(ReplicaMetricsCode::REPLICA_RECEIVED_INTERNAL_MSGS);
+  repComp.takeMetric(ReplicaMetricsCode::REPLICA_FIRST_COMMIT_PATH, "Slow");
+  rep.UpdateAggregator();
+
+  ASSERT_EQ(100, aggregator->GetGauge("replica", "view").Get());
+  ASSERT_EQ(1, aggregator->GetCounter("replica", "receivedInternalMsgs").Get());
+  ASSERT_EQ("Slow", aggregator->GetStatus("replica", "firstCommitPath").Get());
+
+  ComponentCollector& stComp = MetricsCollector::getInstance(0).getStateTransferComp();
+
+  ASSERT_EQ(0, aggregator->GetGauge("bc_state_transfer", "num_pending_item_data_msgs_").Get());
+  ASSERT_EQ(0, aggregator->GetCounter("bc_state_transfer", "received_ask_for_checkpoint_summaries_msg").Get());
+  ASSERT_EQ("", aggregator->GetStatus("bc_state_transfer", "pedantic_checks_enabled").Get());
+
+  stComp.takeMetric(StateTransferMetricCode::BCST_RECEIVED_ASK_FOR_CHECKPOINT_SUMMARIES_MSG);
+  stComp.takeMetric(StateTransferMetricCode::BCST_PEDANTIC_CHECKS_ENABLED, "true");
+  stComp.takeMetric(StateTransferMetricCode::BCST_NUM_PENDING_ITEM_DATA_MSGS, 100);
+  st.UpdateAggregator();
+
+  ASSERT_EQ(100, aggregator->GetGauge("bc_state_transfer", "num_pending_item_data_msgs_").Get());
+  ASSERT_EQ(1, aggregator->GetCounter("bc_state_transfer", "received_ask_for_checkpoint_summaries_msg").Get());
+  ASSERT_EQ("true", aggregator->GetStatus("bc_state_transfer", "pedantic_checks_enabled").Get());
+}
+
+}  // namespace concordMetrics


### PR DESCRIPTION
# Motivation
Currently, collecting metrics is done with the metrics library (see [here](https://github.com/vmware/concord-bft/pull/69)).
To collect metrics, a component (i.e, replica) define its metrics as local variables and update them when needed. As this method is highly efficient, it also imposes some limitations:
* The metrics values are only **eventual consistent** as they are being updated using timers.
* Metrics can be collected only using this library (and not, for example, with Prometheus format).
* Only one aggregator can collect metrics in a given run.
* The large number of local variables, makes the code hard to be readen.
Thus, we developed a new generic mechanism that overcomes the above while trying to preserve the former efficiency.

# Implementation
## CompnentCollcetor
A ComponentCollector maintains lists for CounterHandlers, GaugeHandlers, and StatusHandlers. Each of those [Type]Handler is an interface for a metric variable.
In order to register a metric, one has to implement the corresponding [Type]Handler and register it using the `ComponentCollector.add` method.
By invoking the `ComponentCollector.takeMetrics` method, every registered metric variable will be updated.

## MetricsCollector
The MetricsCollector is a singleton that holds all the ComponentCollectors.  

# Differences from the previous version
With this feature, in default, no metrics are being collected.
When running a replica with a MetricsServer, the MetricsServer initiates two components and register their metrics variables (using the existing metrics library). In addition, the MetricsServer updates the components only on a client request, creating a strong consistency promise for the metrics.
