### PR TITLE
SparseMerkle: Add initial tree implementation

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(concordbft_storage STATIC src/db_metadata_storage.cpp
                                       src/blockchain_db_adapter.cpp)
 
 target_include_directories(concordbft_storage PUBLIC include)
-target_link_libraries(concordbft_storage corebft)
+target_link_libraries(concordbft_storage PUBLIC corebft)
 
 if (BUILD_ROCKSDB_STORAGE)
   #TODO [TK] find_package
@@ -19,15 +19,18 @@ if (BUILD_ROCKSDB_STORAGE)
                                             ${CMAKE_CURRENT_SOURCE_DIR}/src/rocksdb_key_comparator.cpp)
   target_compile_definitions(concordbft_storage PUBLIC USE_ROCKSDB=1 __BASE=1 SPARSE_STATE=1)
   target_include_directories(concordbft_storage PUBLIC ${ROCKSDB_INCLUDE_DIR})
-  target_link_libraries(concordbft_storage ${ROCKSDB} ${LIBBZ2} ${LIBLZ4} ${LIBZSTD} ${LIBZ} ${LIBSNAPPY})
+  target_link_libraries(concordbft_storage PRIVATE ${ROCKSDB} ${LIBBZ2} ${LIBLZ4} ${LIBZSTD} ${LIBZ} ${LIBSNAPPY})
 
   if (BUILD_TESTING)
     add_subdirectory(test)
   endif()
 endif(BUILD_ROCKSDB_STORAGE)
 
+find_package(OpenSSL REQUIRED)
 target_sources(concordbft_storage PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/memorydb_client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/internal_node.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/tree.cpp
 )
+target_link_libraries(concordbft_storage PRIVATE ${OPENSSL_LIBRARIES})
 

--- a/storage/include/sparse_merkle/base_types.h
+++ b/storage/include/sparse_merkle/base_types.h
@@ -57,7 +57,7 @@ class Nibble {
 
   // Get the bit of the Nibble starting from LSB.
   // Bits 0-3 are available.
-  bool getBit(const size_t bit) const {
+  bool getBit(size_t bit) const {
     Assert(bit < SIZE_IN_BITS);
     return (data_ >> bit) & 1;
   }

--- a/storage/include/sparse_merkle/base_types.h
+++ b/storage/include/sparse_merkle/base_types.h
@@ -26,11 +26,23 @@ constexpr size_t BYTE_SIZE_IN_BITS = 8;
 static_assert(BYTE_SIZE_IN_BITS == CHAR_BIT);
 
 // A type safe version wrapper
-struct Version {
-  Version() : value(0) {}
-  Version(uint64_t val) : value(val) {}
-  bool operator==(const Version& other) const { return value == other.value; }
-  uint64_t value;
+class Version {
+ public:
+  Version() {}
+  Version(uint64_t val) : value_(val) {}
+  bool operator==(const Version& other) const { return value_ == other.value_; }
+  bool operator!=(const Version& other) const { return value_ != other.value_; }
+  bool operator<(const Version& other) const { return value_ < other.value_; }
+  Version operator+(const Version& other) { return Version(value_ + other.value_); }
+  Version operator+(const int other) {
+    Assert(other > 0);
+    return Version(value_ + 1);
+  }
+  uint64_t value() { return value_; }
+  std::string toString() const { return std::to_string(value_); };
+
+ private:
+  uint64_t value_ = 0;
 };
 
 // A nibble is 4 bits, stored in the lower bits of a byte.
@@ -43,15 +55,26 @@ class Nibble {
     data_ = byte;
   }
 
+  // Get the bit of the Nibble starting from LSB.
+  // Bits 0-3 are available.
   bool getBit(const size_t bit) const {
     Assert(bit < SIZE_IN_BITS);
     return (data_ >> bit) & 1;
   }
 
   bool operator==(const Nibble& other) const { return data_ == other.data_; }
+  bool operator<(const Nibble& other) const { return data_ < other.data_; }
 
   // Return the underlying representation
   uint8_t data() const { return data_; }
+
+  // Return the nibble as its lowercase hex character.
+  char hexChar() const {
+    if (data_ >= 0 && data_ <= 9) {
+      return '0' + data_;
+    }
+    return 'a' + (data_ - 10);
+  }
 
  private:
   // Only the lower 4 bits are used
@@ -95,9 +118,20 @@ class Hash {
   Hash(std::array<uint8_t, SIZE_IN_BYTES> buf) : buf_(buf) {}
 
   bool operator==(const Hash& other) const { return buf_ == other.buf_; }
+  bool operator!=(const Hash& other) const { return buf_ != other.buf_; }
+  bool operator<(const Hash& other) const { return buf_ < other.buf_; }
 
   const uint8_t* data() const { return buf_.data(); }
   size_t size() const { return buf_.size(); }
+
+  // Return buf_ as lowercase hex string
+  std::string toString() const {
+    std::string output;
+    for (size_t i = 0; i < MAX_NIBBLES; i++) {
+      output.push_back(getNibble(i).hexChar());
+    }
+    return output;
+  }
 
   Nibble getNibble(const size_t n) const {
     Assert(!buf_.empty());
@@ -176,6 +210,21 @@ class NibblePath {
   NibblePath() : num_nibbles_(0) {}
 
   bool operator==(const NibblePath& other) const { return num_nibbles_ == other.num_nibbles_ && path_ == other.path_; }
+  bool operator<(const NibblePath& other) const {
+    size_t count = std::min(num_nibbles_, other.num_nibbles_);
+    for (size_t i = 0; i < count; i++) {
+      if (get(i) < other.get(i)) {
+        return true;
+      } else if (other.get(i) < get(i)) {
+        return false;
+      }
+    }
+    // Both match up to count nibbles. Is this one shorter ?
+    if (num_nibbles_ < other.num_nibbles_) {
+      return true;
+    }
+    return false;
+  }
 
   // Return the length of the path_ in nibbles
   size_t length() const { return num_nibbles_; }
@@ -203,7 +252,7 @@ class NibblePath {
       // We have a complete byte at the end of path_. Remove the lower nibble.
       data = path_.back() & 0x0F;
       // Clear the lower nibble.
-      path_.back() |= 0xF0;
+      path_.back() &= 0xF0;
     } else {
       // We have an incomplete byte at the end of path_. Remove the upper nibble.
       data = path_.back() >> Nibble::SIZE_IN_BITS;
@@ -218,6 +267,15 @@ class NibblePath {
   Nibble get(size_t n) const {
     Assert(n < num_nibbles_);
     return ::concord::storage::sparse_merkle::getNibble(n, path_);
+  }
+
+  // Return path_ as lowercase hex string
+  std::string toString() const {
+    std::string output;
+    for (size_t i = 0; i < num_nibbles_; i++) {
+      output.push_back(get(i).hexChar());
+    }
+    return output;
   }
 
  private:

--- a/storage/include/sparse_merkle/db_reader.h
+++ b/storage/include/sparse_merkle/db_reader.h
@@ -1,0 +1,46 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+// Forward declarations
+class BatchedInternalNode;
+class InternalNodeKey;
+struct LeafNode;
+class LeafKey;
+
+// This is a class used for accessing nodes from a database.
+class IDBReader {
+ public:
+  virtual ~IDBReader() = default;
+
+  // Return the latest root node in the system
+  virtual BatchedInternalNode get_latest_root() const = 0;
+
+  // Retrieve a BatchedInternalNode given an InternalNodeKey.
+  //
+  // Throws a std::out_of_range exception if the internal node does not exist.
+  virtual BatchedInternalNode get_internal(const InternalNodeKey&) const = 0;
+
+  // Retrieve a LeafNode given a LeafKey.
+  //
+  // Throws a std::out_of_range exception if the leaf does not exist.
+  virtual LeafNode get_leaf(const LeafKey&) const = 0;
+};
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/sparse_merkle/internal_node.h
+++ b/storage/include/sparse_merkle/internal_node.h
@@ -180,6 +180,12 @@ class BatchedInternalNode {
   // `depth` represents how many nibbles down the sparse merkle tree this BatchedInternalNode is.
   InsertResult insert(const LeafChild& child, size_t depth);
 
+  // Write an InternalChild of the BatchedInternalNode at level 0.
+  //
+  // This occurs when this InternalChild poiints to another BatchedInternalNode
+  // down the tree, and that BatchedInternalNode was just updated.
+  void write_internal_child_at_level_0(Nibble child_key, const InternalChild& child);
+
   // Return the root hash of this node.
   const Hash& hash() const { return getHash(0); }
 
@@ -252,6 +258,10 @@ class BatchedInternalNode {
   //
   // Update the hashes and versions of nodes along the way.
   void updateHashes(size_t index, Version version);
+
+  // Take a nibble representing the logical location a child at height 0 in a
+  // BatchedInternalNode and return the index of that child in `children_`.
+  size_t nibble_to_index(Nibble nibble);
 
   // Return the the height of the node at the given index.
   //

--- a/storage/include/sparse_merkle/internal_node.h
+++ b/storage/include/sparse_merkle/internal_node.h
@@ -182,7 +182,7 @@ class BatchedInternalNode {
 
   // Write an InternalChild of the BatchedInternalNode at level 0.
   //
-  // This occurs when this InternalChild poiints to another BatchedInternalNode
+  // This occurs when this InternalChild points to another BatchedInternalNode
   // down the tree, and that BatchedInternalNode was just updated.
   void write_internal_child_at_level_0(Nibble child_key, const InternalChild& child);
 

--- a/storage/include/sparse_merkle/keys.h
+++ b/storage/include/sparse_merkle/keys.h
@@ -31,7 +31,19 @@ class InternalNodeKey {
 
   bool operator==(const InternalNodeKey& other) const { return version_ == other.version_ && path_ == other.path_; }
 
+  // Compare by version then by path
+  bool operator<(const InternalNodeKey& other) const {
+    if (version_ == other.version_) {
+      return path_ < other.path_;
+    }
+    return version_ < other.version_;
+  }
+
+  std::string toString() const { return path_.toString() + "-" + version_.toString(); }
+
   Version version() const { return version_; }
+
+  const NibblePath& path() const { return path_; }
 
  private:
   Version version_;
@@ -49,6 +61,16 @@ class LeafKey {
 
   bool operator==(const LeafKey& other) const { return key_ == other.key_ && version_ == other.version_; }
 
+  // Compare by key_ then version_
+  bool operator<(const LeafKey& other) const {
+    if (key_ < other.key_) {
+      return true;
+    }
+    return key_ == other.key_ && version_ < other.version_;
+  }
+
+  std::string toString() const { return key_.toString() + "-" + version_.toString(); }
+
   Nibble getNibble(const size_t n) const {
     Assert(n < Hash::MAX_NIBBLES);
     return key_.getNibble(n);
@@ -61,6 +83,11 @@ class LeafKey {
  private:
   Hash key_;
   Version version_;
+};
+
+// A binary blob value
+struct LeafNode {
+  concordUtils::Sliver value;
 };
 
 }  // namespace sparse_merkle

--- a/storage/include/sparse_merkle/tree.h
+++ b/storage/include/sparse_merkle/tree.h
@@ -1,0 +1,98 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include <vector>
+#include <cstddef>
+#include <optional>
+#include <array>
+#include <map>
+#include <stack>
+
+#include "assertUtils.hpp"
+#include "kv_types.hpp"
+#include "sliver.hpp"
+#include "sparse_merkle/base_types.h"
+#include "sparse_merkle/db_reader.h"
+#include "sparse_merkle/internal_node.h"
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+// An in-memory representation of a sparse merkle tree.
+//
+// The tree gets constructed by reading the latest root node from storage.
+// Updates are made to the tree by reading in nodes from storage where necessary
+// and making the changes in memory. A batch of DB updates of both internal and
+// leaf nodes, as well as stale nodes are returned to the caller so that they
+// can be written to the DB atomically.
+class Tree {
+ public:
+  // A set of old tree nodes that are no longer reachable from the new root of
+  // the tree.
+  struct StaleNodeIndexes {
+    // All the following keys became stale at this version.
+    Version stale_since_version;
+    std::vector<InternalNodeKey> internal_keys;
+    std::vector<LeafKey> leaf_keys;
+  };
+
+  // Every mutation of the tree returns a BatchUpdate containing nodes to be written
+  // to the database.
+  struct UpdateBatch {
+    StaleNodeIndexes stale;
+    std::vector<std::pair<InternalNodeKey, BatchedInternalNode>> internal_nodes;
+    std::vector<std::pair<LeafKey, LeafNode>> leaf_nodes;
+  };
+
+  typedef std::stack<BatchedInternalNode, std::vector<BatchedInternalNode>> NodeStack;
+
+  explicit Tree(std::shared_ptr<IDBReader> db_reader) : db_reader_(db_reader) {
+    // Perform a single allocation of the maximum depth of the tree for the
+    // insert_stack_.
+    auto vec = std::vector<BatchedInternalNode>();
+    vec.reserve(Hash::MAX_NIBBLES);
+    insert_stack_ = NodeStack(std::move(vec));
+    reset();
+  }
+
+  const Hash& get_root_hash() const { return root_.hash(); }
+  Version get_version() const { return root_.version(); }
+
+  // Add or update key-value pairs given in `updates`, and remove keys in
+  // `deleted_keys`.
+  //
+  // Return an UpdateBatch to be written to the DB.
+  UpdateBatch update(const concordUtils::SetOfKeyValuePairs& updates, const concordUtils::KeysVector& deleted_keys);
+  UpdateBatch update(const concordUtils::SetOfKeyValuePairs& updates) {
+    concordUtils::KeysVector no_deletes;
+    return update(updates, no_deletes);
+  }
+
+ private:
+  // Reset the tree to the latest version.
+  //
+  // This is necessary to do before updates, as we only allow updating the
+  // latest tree.
+  void reset() { root_ = db_reader_->get_latest_root(); }
+
+  std::shared_ptr<IDBReader> db_reader_;
+  BatchedInternalNode root_;
+
+  // Store internal nodes needed when updating a tree. This is a member variable
+  // so that we can allocate only once.
+  NodeStack insert_stack_;
+};
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/src/sparse_merkle/tree.cpp
+++ b/storage/src/sparse_merkle/tree.cpp
@@ -1,0 +1,198 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "sparse_merkle/tree.h"
+#include "hash_defs.h"
+
+using namespace concordUtils;
+
+namespace concord::storage::sparse_merkle {
+
+// All data that is loaded from the DB, manipulated, and/or returned from a
+// call to `update`.
+//
+// A new instance of this structure is created during every update call.
+struct UpdateCache {
+  UpdateCache(const BatchedInternalNode& root, const std::shared_ptr<IDBReader>& db_reader) : db_reader_(db_reader) {
+    internal_nodes_[NibblePath()] = root;
+  }
+
+  // Get a node if it's in the cache, otherwise get it from the DB.
+  BatchedInternalNode getInternalNode(const InternalNodeKey& key) {
+    auto it = internal_nodes_.find(key.path());
+    if (it != internal_nodes_.end()) {
+      return it->second;
+    }
+    return db_reader_->get_internal(key);
+  }
+
+  std::shared_ptr<IDBReader> db_reader_;
+  Tree::StaleNodeIndexes stale_;
+
+  // All the internal nodes related to the current batch update.
+  //
+  // These nodes are mutable and are all being updated to a single version.
+  // Therefore we key them by their NibblePath alone, without a version.
+  std::map<NibblePath, BatchedInternalNode> internal_nodes_;
+};
+
+// The state of the insert loop.
+//
+// The data in here is only relevant to a single insert.
+//
+// This mainly exists to allow easily splitting up the insert code into separate
+// functions based upon the return value of the BatchedInternalNode insert.
+struct InsertState {
+  InsertState(const BatchedInternalNode& current, Version version, Tree::NodeStack& stack)
+      : current_node(current), version(version), stack(stack) {}
+
+  size_t depth = 0;
+  NibblePath nibble_path;
+  BatchedInternalNode current_node;
+  Version version;
+  std::stack<BatchedInternalNode, std::vector<BatchedInternalNode>>& stack;
+};
+
+// Insert to a BatchedInternalNode completed successfully. Finish processing the
+// call to insert.
+void handleInsertComplete(const BatchedInternalNode::InsertComplete* result, UpdateCache& cache, InsertState& state) {
+  // If there is a stale leaf key then save it.
+  if (result->stale_leaf) {
+    cache.stale_.leaf_keys.push_back(result->stale_leaf.value());
+  }
+
+  // This is bottom most internal node for the given leaf_key.
+  cache.internal_nodes_[state.nibble_path] = state.current_node;
+
+  // Walk the stack of internal nodes upwards toward the root, updating the
+  // hashes as we go along.
+  while (!state.stack.empty()) {
+    Hash hash = state.current_node.hash();
+    state.current_node = state.stack.top();
+    state.stack.pop();
+
+    // We want to just update the hash of leaf child pointing to the next
+    // BatchedInternalNode. This triggers the root hash of the
+    // BatchedInternalNode to be calculated.
+    Nibble child_key = state.nibble_path.popBack();
+    InternalChild update{hash, state.version};
+    state.current_node.write_internal_child_at_level_0(child_key, update);
+
+    // Write this node into our into our cache of internal nodes
+    cache.internal_nodes_[state.nibble_path] = state.current_node;
+  }
+}
+
+// Save the current InternalNodeKey as stale when it is a valid version, and
+// hasn't already been cached.
+void cacheStaleInternalNode(UpdateCache& cache, const InsertState& state) {
+  if (state.current_node.version() != Version(0) && state.current_node.version() != state.version) {
+    cache.stale_.internal_keys.emplace_back(InternalNodeKey(state.current_node.version(), state.nibble_path));
+  }
+}
+
+// Modify the insert state to walk further down the tree
+void descend(Nibble next_nibble, Version next_version, UpdateCache& cache, InsertState& state) {
+  state.nibble_path.append(next_nibble);
+  InternalNodeKey next_internal_key{next_version, state.nibble_path};
+  state.current_node = cache.getInternalNode(next_internal_key);
+  cacheStaleInternalNode(cache, state);
+  state.depth += 1;
+}
+
+// A node split has occurred, due to a collision, triggering the need to create more
+// BatchedInternalNodes.
+void create_internal_nodes(const LeafChild& stored_child, const LeafChild& child_to_insert, InsertState& state) {
+  int nodes_to_create = child_to_insert.key.hash().prefix_bits_in_common(stored_child.key.hash(), state.depth) / 4;
+  for (int i = 0; i < nodes_to_create - 1; i++) {
+    // Add a bunch of empty intermediate nodes
+    state.nibble_path.append(child_to_insert.key.getNibble(state.depth));
+    state.stack.emplace(BatchedInternalNode());
+    state.depth += 1;
+  }
+  // Create the bottom most node and make it the current node
+  state.nibble_path.append(child_to_insert.key.getNibble(state.depth));
+  state.current_node = BatchedInternalNode();
+  state.depth += 1;
+}
+
+// A node split occurred due to a key collision.
+//
+// Create a bunch of new internal nodes and then insert the previously stored
+// child that collided with the child that was attempting to be inserted.
+//
+// On the next loop around the `child_to_insert` will be successfully inserted
+// inside `state.current_node`.
+void handleNodeSplit(BatchedInternalNode::CreateNewBatchedInternalNodes result,
+                     const LeafChild& child_to_insert,
+                     InsertState& state) {
+  create_internal_nodes(result.stored_child, child_to_insert, state);
+
+  // Ignore results. We already know this insert will succeed.
+  state.current_node.insert(result.stored_child, state.depth);
+}
+
+// Insert a single leaf. This is called as part of `update`.
+void insert(UpdateCache& cache, const LeafChild& child, const Version version, Tree::NodeStack& stack) {
+  const auto& root = cache.internal_nodes_[NibblePath()];
+  InsertState state(root, version, stack);
+  cacheStaleInternalNode(cache, state);
+
+  while (true) {
+    Assert(state.depth < Hash::MAX_NIBBLES);
+
+    auto result = state.current_node.insert(child, state.depth);
+
+    if (auto rv = std::get_if<BatchedInternalNode::InsertComplete>(&result)) {
+      return handleInsertComplete(rv, cache, state);
+    }
+
+    // Push the current node onto the stack so that we can update the hash and
+    // version when we are done.
+    state.stack.push(state.current_node);
+
+    if (auto rv = std::get_if<BatchedInternalNode::InsertIntoExistingNode>(&result)) {
+      descend(child.key.getNibble(state.depth), rv->next_node_version, cache, state);
+    } else {
+      handleNodeSplit(std::get<BatchedInternalNode::CreateNewBatchedInternalNodes>(result), child, state);
+    }
+  }
+}
+
+// TODO: Add support for delete. Only insert/update are supported now.
+Tree::UpdateBatch Tree::update(const SetOfKeyValuePairs& updates, const KeysVector& deleted_keys) {
+  reset();
+
+  UpdateBatch batch;
+  UpdateCache cache(root_, db_reader_);
+  auto version = get_version() + 1;
+  Hasher hasher;
+  for (auto&& [key, val] : updates) {
+    auto leaf_hash = hasher.hash(val.data(), val.length());
+    LeafNode leaf_node{val};
+    LeafKey leaf_key{hasher.hash(key.data(), key.length()), version};
+    LeafChild child{leaf_hash, leaf_key};
+    insert(cache, child, version, insert_stack_);
+    batch.leaf_nodes.push_back(std::make_pair(leaf_key, leaf_node));
+  }
+
+  // Create and return the UpdateBatch
+  batch.stale = std::move(cache.stale_);
+  batch.stale.stale_since_version = version;
+  for (auto& it : cache.internal_nodes_) {
+    batch.internal_nodes.emplace_back(InternalNodeKey(version, it.first), it.second);
+  }
+
+  return batch;
+}
+
+}  // namespace concord::storage::sparse_merkle

--- a/storage/src/sparse_merkle/tree.cpp
+++ b/storage/src/sparse_merkle/tree.cpp
@@ -106,7 +106,7 @@ void descend(Nibble next_nibble, Version next_version, UpdateCache& cache, Inser
   InternalNodeKey next_internal_key{next_version, state.nibble_path};
   state.current_node = cache.getInternalNode(next_internal_key);
   cacheStaleInternalNode(cache, state);
-  state.depth += 1;
+  state.depth++;
 }
 
 // A node split has occurred, due to a collision, triggering the need to create more
@@ -117,12 +117,12 @@ void create_internal_nodes(const LeafChild& stored_child, const LeafChild& child
     // Add a bunch of empty intermediate nodes
     state.nibble_path.append(child_to_insert.key.getNibble(state.depth));
     state.stack.emplace(BatchedInternalNode());
-    state.depth += 1;
+    state.depth++;
   }
   // Create the bottom most node and make it the current node
   state.nibble_path.append(child_to_insert.key.getNibble(state.depth));
   state.current_node = BatchedInternalNode();
-  state.depth += 1;
+  state.depth++;
 }
 
 // A node split occurred due to a key collision.
@@ -132,7 +132,7 @@ void create_internal_nodes(const LeafChild& stored_child, const LeafChild& child
 //
 // On the next loop around the `child_to_insert` will be successfully inserted
 // inside `state.current_node`.
-void handleNodeSplit(BatchedInternalNode::CreateNewBatchedInternalNodes result,
+void handleNodeSplit(const BatchedInternalNode::CreateNewBatchedInternalNodes& result,
                      const LeafChild& child_to_insert,
                      InsertState& state) {
   create_internal_nodes(result.stored_child, child_to_insert, state);
@@ -142,7 +142,7 @@ void handleNodeSplit(BatchedInternalNode::CreateNewBatchedInternalNodes result,
 }
 
 // Insert a single leaf. This is called as part of `update`.
-void insert(UpdateCache& cache, const LeafChild& child, const Version version, Tree::NodeStack& stack) {
+void insert(UpdateCache& cache, const LeafChild& child, Version version, Tree::NodeStack& stack) {
   const auto& root = cache.internal_nodes_[NibblePath()];
   InsertState state(root, version, stack);
   cacheStaleInternalNode(cache, state);

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -31,3 +31,13 @@ target_link_libraries(sparse_merkle_internal_node_test PUBLIC
     concordbft_storage
     ${OPENSSL_LIBRARIES}
 )
+
+find_package(OpenSSL REQUIRED)
+add_executable(sparse_merkle_tree_test sparse_merkle/tree_test.cpp
+    $<TARGET_OBJECTS:logging_dev>)
+add_test(sparse_merkle_tree_test sparse_merkle_tree_test)
+target_link_libraries(sparse_merkle_tree_test PUBLIC
+    gtest
+    concordbft_storage
+    ${OPENSSL_LIBRARIES}
+)

--- a/storage/test/sparse_merkle/base_types_test.cpp
+++ b/storage/test/sparse_merkle/base_types_test.cpp
@@ -33,14 +33,14 @@ TEST(nibble_DeathTest, bits_outside_range) { ASSERT_DEATH(Nibble bad(16), ""); }
 
 TEST(nibble_path_test, append_and_get_and_popBack) {
   NibblePath path;
-  path.append(15);
+  path.append(7);
   ASSERT_EQ(path.length(), 1);
   path.append(2);
   ASSERT_EQ(path.length(), 2);
   path.append(0);
   ASSERT_EQ(path.length(), 3);
 
-  ASSERT_EQ(Nibble(15), path.get(0));
+  ASSERT_EQ(Nibble(7), path.get(0));
   ASSERT_EQ(Nibble(2), path.get(1));
   ASSERT_EQ(Nibble(0), path.get(2));
   ASSERT_EQ(3, path.length());
@@ -49,7 +49,7 @@ TEST(nibble_path_test, append_and_get_and_popBack) {
   ASSERT_EQ(2, path.length());
   ASSERT_EQ(Nibble(2), path.popBack());
   ASSERT_EQ(1, path.length());
-  ASSERT_EQ(Nibble(15), path.popBack());
+  ASSERT_EQ(Nibble(7), path.popBack());
 
   ASSERT_TRUE(path.empty());
 }

--- a/storage/test/sparse_merkle/test_db.h
+++ b/storage/test/sparse_merkle/test_db.h
@@ -1,0 +1,48 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include <map>
+
+#include "sparse_merkle/keys.h"
+#include "sparse_merkle/db_reader.h"
+#include "sparse_merkle/internal_node.h"
+
+using namespace std;
+using namespace concord::storage::sparse_merkle;
+
+class TestDB : public concord::storage::sparse_merkle::IDBReader {
+ public:
+  void put(const LeafKey& key, const LeafNode& val) { leaf_nodes_[key] = val; }
+  void put(const InternalNodeKey& key, const BatchedInternalNode& val) {
+    internal_nodes_[key] = val;
+    if (latest_version_ < key.version()) {
+      latest_version_ = key.version();
+    }
+  }
+
+  BatchedInternalNode get_latest_root() const override {
+    if (latest_version_ == 0) {
+      return BatchedInternalNode();
+    }
+    auto root_key = InternalNodeKey::root(latest_version_);
+    return internal_nodes_.at(root_key);
+  }
+
+  BatchedInternalNode get_internal(const InternalNodeKey& key) const override { return internal_nodes_.at(key); }
+
+  LeafNode get_leaf(const LeafKey& key) const override { return leaf_nodes_.at(key); }
+
+ private:
+  Version latest_version_ = 0;
+  map<LeafKey, LeafNode> leaf_nodes_;
+  map<InternalNodeKey, BatchedInternalNode> internal_nodes_;
+};

--- a/storage/test/sparse_merkle/tree_test.cpp
+++ b/storage/test/sparse_merkle/tree_test.cpp
@@ -40,6 +40,9 @@ void assert_version(uint64_t version, const T& keys) {
 template <class T>
 void assert_node_version(uint64_t version, const T& nodes) {
   for (auto& [key, _] : nodes) {
+    // Prevent unused variable warning. C++ doesn't allow ignoring in
+    // destructuring yet.
+    (void)_;
     ASSERT_EQ(Version(version), key.version());
   }
 }

--- a/storage/test/sparse_merkle/tree_test.cpp
+++ b/storage/test/sparse_merkle/tree_test.cpp
@@ -1,0 +1,287 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+#include <memory>
+#include "sparse_merkle/tree.h"
+#include "test_db.h"
+#include "hash_defs.h"
+
+#include <iostream>
+using namespace std;
+
+using namespace concordUtils;
+using namespace concord::storage::sparse_merkle;
+
+void db_put(const shared_ptr<TestDB>& db, const Tree::UpdateBatch& batch) {
+  for (const auto& [key, val] : batch.internal_nodes) {
+    db->put(key, val);
+  }
+  for (const auto& [key, val] : batch.leaf_nodes) {
+    db->put(key, val);
+  }
+}
+
+template <class T>
+void assert_version(uint64_t version, const T& keys) {
+  for (auto& key : keys) {
+    ASSERT_EQ(Version(version), key.version());
+  }
+}
+template <class T>
+void assert_node_version(uint64_t version, const T& nodes) {
+  for (auto& [key, _] : nodes) {
+    ASSERT_EQ(Version(version), key.version());
+  }
+}
+
+// Ensure that getting the latest root from an empty db returns an empty
+// BatchedInternalNode;
+TEST(tree_tests, empty_db) {
+  TestDB db;
+  auto root = db.get_latest_root();
+  ASSERT_EQ(Version(0), root.version());
+  ASSERT_EQ(0, root.numChildren());
+  ASSERT_EQ(PLACEHOLDER_HASH, root.hash());
+}
+
+// Ensure that we can insert a single leaf to an empty tree
+TEST(tree_tests, insert_single_leaf_node) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  const char* key = "key1";
+  updates.emplace(Sliver(key), Sliver("val1"));
+  auto batch = tree.update(updates);
+
+  // There were no stale nodes since this is the first insert
+  ASSERT_EQ(Version(1), batch.stale.stale_since_version);
+  ASSERT_EQ(0, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+
+  // There's a single InternalNode and a single LeafNode that needs to be
+  // written to the database at version 1.
+  ASSERT_EQ(1, batch.internal_nodes.size());
+  ASSERT_EQ(1, batch.leaf_nodes.size());
+
+  // Only a single node was created. It's key is made up of an empty nibble
+  // path, since there are no collisions requring going deeper into the tree.
+  auto& root = batch.internal_nodes.at(0);
+  ASSERT_EQ(InternalNodeKey(1, NibblePath()), root.first);
+
+  // There should be a root and a single leaf
+  ASSERT_EQ(2, root.second.numChildren());
+  ASSERT_EQ(1, root.second.numInternalChildren());
+  ASSERT_EQ(1, root.second.numLeafChildren());
+  ASSERT_EQ(Version(1), root.second.version());
+
+  // The leaf key should contain the right hash and version.
+  Hasher hasher;
+  auto expected = LeafKey(hasher.hash(key, strlen(key)), Version(1));
+  ASSERT_EQ(expected, batch.leaf_nodes[0].first);
+
+  // The hash should have been updated.
+  ASSERT_NE(PLACEHOLDER_HASH, root.second.hash());
+}
+
+// Insert multiple leaves that create a single BatchedInternalNode since
+// the first nibbles of their key's hashes are not equal.
+TEST(tree_tests, insert_multiple_create_single_batched) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key1"), Sliver("val1"));
+  updates.emplace(Sliver("key2"), Sliver("val2"));
+  auto batch = tree.update(updates);
+
+  // There were no stale nodes since this is the first insert
+  ASSERT_EQ(Version(1), batch.stale.stale_since_version);
+  ASSERT_EQ(0, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+
+  // There should be a single internal node (the root node) since the first
+  // nibbles differ between key1 and key2.
+  ASSERT_EQ(1, batch.internal_nodes.size());
+  ASSERT_EQ(2, batch.leaf_nodes.size());
+
+  auto& root = batch.internal_nodes.at(0);
+  ASSERT_EQ(Version(1), root.second.version());
+  ASSERT_NE(PLACEHOLDER_HASH, root.second.hash());
+
+  // There should be two leafs in the root
+  ASSERT_EQ(2, root.second.numLeafChildren());
+
+  // Both leaf nodes should be at version 1
+  assert_node_version(1, batch.leaf_nodes);
+}
+
+// Insert multiple leaves that create multiple BatchedInternalNode since
+// the first nibbles of their key's hashes are equal.
+TEST(tree_tests, insert_multiple_create_multiple_batched) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  auto batch = tree.update(updates);
+
+  // There were no stale nodes since this is the first insert
+  ASSERT_EQ(Version(1), batch.stale.stale_since_version);
+  ASSERT_EQ(0, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+
+  // There should be two internal nodes since the first nibbles differ between
+  // key3 and key9, but the second nibbles differ.
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  ASSERT_EQ(2, batch.leaf_nodes.size());
+
+  auto& root = batch.internal_nodes.at(0);
+  ASSERT_EQ(Version(1), root.second.version());
+  ASSERT_NE(PLACEHOLDER_HASH, root.second.hash());
+
+  // There should be no leafs in the root
+  ASSERT_EQ(0, root.second.numLeafChildren());
+
+  // There should be two leafs in the second node
+  auto& second_node = batch.internal_nodes.at(1);
+  ASSERT_EQ(Version(1), second_node.second.version());
+  ASSERT_EQ(2, second_node.second.numLeafChildren());
+
+  // Both leaf nodes should be at version 1
+  assert_node_version(1, batch.leaf_nodes);
+}
+
+// Perform multiple updates to ensure that we only get back nodes relevant to
+// the latest version and that stale indexes are appropriately returned.
+TEST(tree_tests, multiple_updates) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  auto batch = tree.update(updates);
+
+  // We must save the output nodes to the database. This is what users of the tree
+  // must do. We can ignore saving the stale nodes for now.
+  db_put(db, batch);
+
+  // There were no stale nodes since this is the first insert
+  ASSERT_EQ(Version(1), batch.stale.stale_since_version);
+  ASSERT_EQ(0, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+
+  // There should be 2 internal nodes and 2 leaf nodes
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  ASSERT_EQ(2, batch.leaf_nodes.size());
+  assert_node_version(1, batch.internal_nodes);
+  assert_node_version(1, batch.leaf_nodes);
+
+  // Insert a new key
+  updates.clear();
+  updates.emplace(Sliver("key1"), Sliver("val3"));
+  batch = tree.update(updates);
+  db_put(db, batch);
+
+  // The root should be stale, since we added a new key, and it always updates
+  // the root at a minimum.
+  ASSERT_EQ(Version(2), batch.stale.stale_since_version);
+  ASSERT_EQ(1, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+  assert_version(1, batch.stale.internal_keys);
+
+  // There should be 1 leaf node at version 2
+  ASSERT_EQ(1, batch.leaf_nodes.size());
+  assert_node_version(2, batch.leaf_nodes);
+
+  // Insert an update to a key.
+  updates.clear();
+  updates.emplace(Sliver("key3"), Sliver("val5"));
+  batch = tree.update(updates);
+  db_put(db, batch);
+
+  // There should be 2 stale internal nodes and a stale leaf node
+  ASSERT_EQ(Version(3), batch.stale.stale_since_version);
+  ASSERT_EQ(2, batch.stale.internal_keys.size());
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+
+  // The root node was updated on the second update. But the next
+  // BatchedInternalNode down wasn't, since the udpate inserted into the root
+  // node.
+  ASSERT_EQ(Version(2), batch.stale.internal_keys[0].version());
+  ASSERT_EQ(Version(1), batch.stale.internal_keys[1].version());
+
+  assert_version(1, batch.stale.leaf_keys);
+
+  // There should two new internal nodes and one new leaf node
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  ASSERT_EQ(1, batch.leaf_nodes.size());
+  assert_node_version(3, batch.internal_nodes);
+  assert_node_version(3, batch.leaf_nodes);
+
+  // Inserting a new leaf that matches the first 2 nibbles of an existing key
+  // should trigger 3 new internal nodes, a new leaf node, and 2 stale internal
+  // nodes.
+  // This key was experimentally found by brute force. The first two nibbles
+  // match Hash("key9").
+  updates.clear();
+  updates.emplace(Sliver("key191"), Sliver("val6"));
+  batch = tree.update(updates);
+  db_put(db, batch);
+
+  ASSERT_EQ(3, batch.internal_nodes.size());
+  ASSERT_EQ(1, batch.leaf_nodes.size());
+  assert_node_version(4, batch.internal_nodes);
+  assert_node_version(4, batch.leaf_nodes);
+
+  // The leaf node should have the key for 191 only and version 4.
+  Hasher hasher;
+  auto expected = LeafKey(hasher.hash("key191", strlen("key191")), Version(4));
+  ASSERT_EQ(expected, batch.leaf_nodes[0].first);
+
+  // The first internal node should have 1 LeafChild ("key1"), the second should have 1
+  // LeafChild ("key9"), and the third should have 2 LeafChild(ren) ("key3" and
+  // "key191");
+  BatchedInternalNode node1 = batch.internal_nodes[0].second;
+  BatchedInternalNode node2 = batch.internal_nodes[1].second;
+  BatchedInternalNode node3 = batch.internal_nodes[2].second;
+  ASSERT_EQ(1, node1.numLeafChildren());
+  ASSERT_EQ(1, node2.numLeafChildren());
+  ASSERT_EQ(2, node3.numLeafChildren());
+
+  // The paths of the node keys in order should be "", "b", "ba"
+  ASSERT_EQ("", batch.internal_nodes[0].first.path().toString());
+  ASSERT_EQ("b", batch.internal_nodes[1].first.path().toString());
+  ASSERT_EQ("ba", batch.internal_nodes[2].first.path().toString());
+
+  // The current version is 4, so stale nodes are stale since 4
+  // We aren't overwriting any leaf nodes, so there are no stale leafs. We did
+  // however update below node "b", so both node "b" and the root ("") must have
+  // be updated.
+  ASSERT_EQ(Version(4), batch.stale.stale_since_version);
+  ASSERT_EQ(2, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+
+  // The paths of the stale node keys should be "" and "b"
+  ASSERT_EQ("", batch.stale.internal_keys[0].path().toString());
+  ASSERT_EQ("b", batch.stale.internal_keys[1].path().toString());
+
+  // Both the root and node with path "b" should be stale at version 3 since the
+  // last update ovewrote a key at path "b".
+  assert_version(3, batch.stale.internal_keys);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int res = RUN_ALL_TESTS();
+  return res;
+}


### PR DESCRIPTION
The first implementation of the tree was added, such that batches of
key-value pairs can be inserted via a call to `Update`. The call to
update is an iterative wrapper around calls to
`BatchedInternalNode::insert`, with one call for each KV pair in the
update.

A call to `Tree::update` returns an `UpdateBatch` with data that should
be written to the database. Besides internal and leaf nodes of the
latest updates that need writing, the `UpdateBatch` also contains
information about stale nodes such that we can prune those nodes later.
The database is never directly modified.  This allows for easier testing
and the opportunity to batch disperate writes into single transactions.
However, in order for `update` to operate, it must be able to read
existing key-value pairs from the database. This is performed via the
`IDBReader` interface. Furthermore a cache of these nodes is created and
maintained during each update call, since multiple BatchedInternalNodes
may be modified via multiple insert calls and we always want to operate
on the latest updates.

Each insert must find the correct BatchedInternalNode to insert into,
and then walk back up the tree to the root updating the hashes along
the way. This is performed via the use of a stack. Each
BatchedInternalNode is pushed onto the stack as we descend the tree and
then popped off when we reverse course and update toward the root. This
pop loop occurs when a BatchedInternalNode::insert call returns
`InsertComplete`.

Note that all KV pairs in an update call share the same version, and
therefore, each modified BatchedInternalNode or LeafNode that needs to
be written to the database will be keyed by the same version.

There are a bunch of test covering the update behavior, and test
implementation of IDBReader, called `TestDB`.

Additionally, a bunch of the underlying types were enhanced to add new
operators for comparison, etc...

Lastly, during testing two existing bugs were found:

 1. Nibble.popBack was improperly returning the first Nibble of full
 bytes because an `or` was being used instead of an `and`. The test for
 that function hid it, because the test data was an `F`, which just so
 happens to be the data returned by the bug. The existing test was
 change to use a `7` rather than an `F`. This shows the need for
 property based testing where we can test "every possible input" (via
 randomness) and get more input coverage. We should bring in RapidCheck
 for this.

 2. In `BatchedInternalNode::insertTwoLeafChildren`, we were inserting
 at the wrong index in the node because we were calling
 `child_key.getBit` on the number of prefix_bits_in_common, when we
 should have been starting from the next bit after that to find the
 insertion points, since the two children matched up to
 prefix_bits_in_common and differ in the next bit.