### PR TITLE
Add a container-like read-only blockchain view

### DIFF
--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -30,6 +30,15 @@ git checkout CRYPTOPP_8_2_0
 make
 sudo make install
 
+# build and install boost
+cd /tmp
+wget --https-only https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz
+tar -xf boost_1_64_0.tar.gz
+cd boost_1_64_0
+./bootstrap.sh --with-libraries=system,filesystem
+./b2
+sudo ./b2 install
+
 # build and install RocksDB and its dependencies
 if [ -n "$USE_ROCKSDB" ]; then
     # Install RocksDB dependencies
@@ -37,7 +46,7 @@ if [ -n "$USE_ROCKSDB" ]; then
 
     # Install RocksDB
     cd /tmp
-    wget https://github.com/facebook/rocksdb/archive/v5.7.3.tar.gz
+    wget --https-only https://github.com/facebook/rocksdb/archive/v5.7.3.tar.gz
     tar -xzf v5.7.3.tar.gz
     cd rocksdb-5.7.3
     make shared_lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(IS_LEAKCHECK FALSE)
 set(SLEEP_FOR_DBG FALSE)
 
+set(MIN_BOOST_VERSION 1.64)
+
 # Default to debug builds
 # Release builds can be enabled by running cmake with -DCMAKE_BUILD_TYPE=Release
 if(NOT CMAKE_BUILD_TYPE)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ version 1.1.1. This is the latest update to Ubuntu 18.04.
 
     sudo apt-get install openssl libssl-dev
 
-
 #### (Optional) Use log4cplus
 
 We have simple console logger but if you wish to use log4cplus - we have an
@@ -178,9 +177,12 @@ It should be
 
     Python 3.x.x
 
-#### (Optional) Only if using TLS or plain TCP as communication module
-We use Boost both for plain TCP and TLS communication. Please follow these
-instructions to install this library
+#### (Optional) Boost
+We use Boost both for:
+ * optional plain TCP or TLS communication
+ * optional concord::kvbc::BlockchainView code residing in kvbc
+
+Please follow these instructions to install this library
 
 Download Boost version 1.64
 

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -95,7 +95,7 @@ if(${BUILD_COMM_TCP_PLAIN} OR ${BUILD_COMM_TCP_TLS})
     set(Boost_USE_STATIC_LIBS ON) # only find static libs
     set(Boost_USE_MULTITHREADED ON)
     set(Boost_USE_STATIC_RUNTIME OFF)
-    find_package(Boost 1.64.0 COMPONENTS system filesystem)
+    find_package(Boost ${MIN_BOOST_VERSION} COMPONENTS system filesystem)
     if(Boost_FOUND)
         include_directories(${Boost_INCLUDE_DIRS})
         target_link_libraries(corebft PUBLIC ${Boost_LIBRARIES})

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.2)
 project(libkvbc VERSION 0.1.0.0 LANGUAGES CXX)
 
+find_package(Boost ${MIN_BOOST_VERSION})
+
 add_library(kvbc  src/ClientImp.cpp
                   src/ReplicaImp.cpp
                   src/replica_state_sync_imp.cpp
@@ -9,3 +11,7 @@ add_library(kvbc  src/ClientImp.cpp
 target_link_libraries(kvbc PUBLIC corebft threshsign util concordbft_storage)
 
 target_include_directories(kvbc PUBLIC include)
+
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()

--- a/kvbc/include/blockchain_view.h
+++ b/kvbc/include/blockchain_view.h
@@ -1,0 +1,280 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iterator>
+#include <limits>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include <boost/iterator/iterator_categories.hpp>
+#include <boost/iterator/iterator_facade.hpp>
+
+#include "kv_types.hpp"
+
+namespace concord {
+namespace kvbc {
+
+namespace detail {
+
+template <typename BlockInfo>
+using BlockInfoCache = std::unordered_map<concordUtils::BlockId, BlockInfo>;
+
+using BlockIdDifferenceType = std::make_signed<concordUtils::BlockId>::type;
+
+}  // namespace detail
+
+// The maximum possible number of blocks this view is able to hold.
+inline constexpr auto MAX_BLOCKCHAIN_VIEW_SIZE = std::numeric_limits<detail::BlockIdDifferenceType>::max();
+
+// A random access blockchain iterator that supports caching block info.
+template <typename BlockInfo, bool loadDataOnAccess>
+class BlockchainIterator : public boost::iterator_facade<BlockchainIterator<BlockInfo, loadDataOnAccess>,
+                                                         const BlockInfo,  // The value type this iterator points to.
+                                                         boost::random_access_traversal_tag,
+                                                         const BlockInfo&,  // Reference to the value type.
+                                                         detail::BlockIdDifferenceType> {
+ private:
+  friend class boost::iterator_core_access;
+  template <typename, bool>
+  friend class BlockchainView;
+
+  using Cache = detail::BlockInfoCache<BlockInfo>;
+
+  BlockchainIterator(concordUtils::BlockId id,
+                     concordUtils::BlockId genesisId,
+                     concordUtils::BlockId endId,
+                     Cache& cache)
+      : blockId_{id}, genesisId_{genesisId}, endId_{endId}, cache_{&cache} {
+    cacheBlock(blockId_);
+  }
+
+  void cacheBlock(concordUtils::BlockId id) const {
+    if (isOutsideRange(id)) {
+      return;
+    }
+
+    // already cached, don't do any work
+    if (auto it = cache_->find(id); it != std::cend(*cache_)) {
+      return;
+    }
+
+    // load data from storage and, if successful, add to cache
+    auto blockInfo = BlockInfo{id};
+    blockInfo.loadIndices();
+    if constexpr (loadDataOnAccess) {
+      blockInfo.loadData();
+    }
+    cache_->emplace(id, std::move(blockInfo));
+  }
+
+  bool isOutsideRange(concordUtils::BlockId id) const noexcept { return id < genesisId_ || id >= endId_; }
+
+  // The following methods are required by boost::iterator_facade as defined by:
+  // https://www.boost.org/doc/libs/1_64_0/libs/iterator/doc/iterator_facade.html#iterator-facade-requirements
+  void increment() {
+    cacheBlock(blockId_ + 1);
+    ++blockId_;
+  }
+
+  void decrement() {
+    cacheBlock(blockId_ - 1);
+    --blockId_;
+  }
+
+  bool equal(const BlockchainIterator& other) const noexcept { return blockId_ == other.blockId_; }
+
+  // Since we always insert into the cache when constructing or incrementing/decrementing BlockchainIterator objects, we
+  // expect find() will not return cend(). Dereferencing BlockchainIterator::cend() is defined as undefined behaviour in
+  // itself. Additionally, we don't expect boost calling dereference() itself.
+  const BlockInfo& dereference() const { return cache_->find(blockId_)->second; }
+
+  void advance(detail::BlockIdDifferenceType n) {
+    cacheBlock(blockId_ + n);
+    blockId_ += n;
+  }
+
+  detail::BlockIdDifferenceType distance_to(const BlockchainIterator& other) const noexcept {
+    return other.blockId_ - blockId_;
+  }
+
+  concordUtils::BlockId blockId_{0};
+  concordUtils::BlockId genesisId_{0};
+  concordUtils::BlockId endId_{0};
+  Cache* cache_{nullptr};
+};
+
+// A block info object that serves as a base class for user-provided block info types.
+// See BlockchainView for requirements on block info types.
+// See TimestampedBlockInfo in blockchain_view_test.cpp for an example.
+class BaseBlockInfo {
+ public:
+  BaseBlockInfo() = default;
+  BaseBlockInfo(concordUtils::BlockId id) : id_{id} {}
+
+  concordUtils::BlockId id() const { return id_; }
+  void loadIndices() {}
+
+ private:
+  template <typename, bool>
+  friend class BlockchainIterator;
+
+  concordUtils::BlockId id_{0};
+};
+
+// Any block info object is equal to another one (from the same blockchain) if their IDs match.
+inline bool operator==(const BaseBlockInfo& lhs, const BaseBlockInfo& rhs) { return lhs.id() == rhs.id(); }
+
+// BlockchainView describes an object that refers to a read-only blockchain. It tries to mimic the interfaces of
+// a const std::vector and of a std::string_view . It assumes block IDs are always increasing and there are no
+// gaps between them.
+//
+// BlockchainView supports a cache of BlockInfo objects that is populated with values only when a block is being
+// loaded from storage. BlockInfo objects store two types of data:
+//  * indices - needed for indexing/ordering of blocks. For example, if the user wants to order blocks on some block
+//   field, he/she can store it in BlockInfo and use it in comparator functions. Indices are always loaded on access.
+//  * data - any data fetched for a block from storage (block key-values, for example). Users can select whether to
+//    automatically load it on access (via the loadDataOnAccess parameter) or they can load it at their own discretion.
+//
+// Users are required to pass a BlockInfo type that represents the block information as fetched from storage.
+// Requirements on BlockInfo are:
+//  * BlockInfo(concordUtils::BlockId) - a constructor that takes the block ID
+//  * [ingored return] loadIndices() - a method that is called when accessing the block through iterators and is
+//  expected to populate any indices needed by the user. Indices will be cached inside the BlockchainView.
+//  * [ignored return] loadData() - an optional method that can be either called by users themselves on demand or by
+//  iterators when loadDataOnAccess = true (mandatory in this case). This method should load block data from storage.
+//  Data will be cached inside the BlockchainView.
+//
+// Incrementing or attempting to access end(), cend(), rend() and crend() results in undefined behavior.
+// Decrementing or attempting to access begin(), cbegin(), rbegin() and crbegin() results in undefined behavior.
+//
+// Non-standard members are named in a camelCase convention. Standard member types and methods are named based on:
+// https://en.cppreference.com/w/cpp/named_req/Container
+template <typename BlockInfo, bool loadDataOnAccess = false>
+class BlockchainView {
+ private:
+  using CacheType = detail::BlockInfoCache<BlockInfo>;
+
+ public:
+  using value_type = BlockInfo;
+  using size_type = concordUtils::BlockId;
+  using difference_type = detail::BlockIdDifferenceType;
+  using const_reference = const BlockInfo&;
+  using reference = const_reference;
+  using const_iterator = BlockchainIterator<BlockInfo, loadDataOnAccess>;
+  using iterator = const_iterator;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+  using reverse_iterator = const_reverse_iterator;
+
+  // Constructs an empty view.
+  BlockchainView() = default;
+
+  // Constructs a view with count elements and the first element pointing to the block at genesisId.
+  // Note: genesisId + count must be <= MAX_BLOCKCHAIN_VIEW_SIZE to properly support end() and cend() iterators.
+  // If count > MAX_BLOCKCHAIN_VIEW_SIZE, an exception is thrown.
+  // If genesisId + count would overflow the concordUtils::BlockId type, behavior is undefined.
+  // If genesisId + count > MAX_BLOCKCHAIN_VIEW_SIZE, an exception is thrown.
+  // Constant complexity.
+  BlockchainView(concordUtils::BlockId genesisId, size_type count)
+      : genesisId_{genesisId}, endId_{genesisId + count}, size_{count} {
+    if (count > MAX_BLOCKCHAIN_VIEW_SIZE) {
+      throw std::length_error{"BlockchainView: exceeded MAX_BLOCKCHAIN_VIEW_SIZE"};
+    } else if (genesisId + count > MAX_BLOCKCHAIN_VIEW_SIZE) {
+      throw std::invalid_argument{"BlockchainView: exceeded allowed range"};
+    }
+  }
+
+  // Return iterators to the first block. If the view is empty, iterators will be equal to end() and cend() .
+  // Attempting to access on an empty view results in undefined behavior.
+  // Decrementing results in undefined behavior.
+  const_iterator begin() const { return const_iterator{genesisId_, genesisId_, endId_, cache_}; }
+  const_iterator cbegin() const { return begin(); }
+
+  // Return iterators to the block following the last block.
+  // Incrementing or attempting to access results in undefined behavior.
+  const_iterator end() const noexcept { return const_iterator{endId_, genesisId_, endId_, cache_}; }
+  const_iterator cend() const noexcept { return end(); }
+
+  // Return reverse iterators to the first block of the reversed view.
+  // If the view is empty, the returned iterator is equal to rend() and crend() .
+  // Attempting to access on an empty view results in undefined behavior.
+  // Decrementing results in undefined behavior.
+  const_reverse_iterator rbegin() const { return std::make_reverse_iterator(end()); }
+  const_reverse_iterator crbegin() const { return rbegin(); }
+
+  // Return reverse iterators to the block following the last block of the reversed view.
+  // Incrementing or attempting to access results in undefined behavior.
+  const_reverse_iterator rend() const { return std::make_reverse_iterator(begin()); }
+  const_reverse_iterator crend() const { return rend(); }
+
+  // Returns a const reference to the first block. Calling on an empty view results in undefined behavior.
+  const_reference front() const { return *begin(); }
+
+  // Returns a const reference to the last block. Calling on an empty view results in undefined behavior.
+  const_reference back() const {
+    auto it = cend();
+    --it;
+    return *it;
+  }
+
+  // Returns the block count in the view.
+  size_type size() const noexcept { return size_; }
+
+  // Returns the maximum possible number of blocks this view is able to hold.
+  // Returned value is MAX_BLOCKCHAIN_VIEW_SIZE .
+  size_type max_size() const noexcept { return MAX_BLOCKCHAIN_VIEW_SIZE; }
+
+  // Checks if the container has no elements.
+  bool empty() const noexcept { return size_ == 0; }
+
+  // Returns a const reference to the block at location pos. Calling with an invalid pos results in undefined behavior.
+  const_reference operator[](size_type pos) const {
+    auto it = const_iterator{genesisId_ + pos, genesisId_, endId_, cache_};
+    return *it;
+  }
+
+  // Returns an iterator to the block with the passed ID. No bounds checking. Calling with an ID that is outside the
+  // range results in undefined behavior. Constant complexity.
+  const_iterator get(concordUtils::BlockId id) const { return const_iterator{id, genesisId_, endId_, cache_}; }
+
+  // Finds a block with the passed ID.
+  // Returns a const iterator to the block with the passed ID. If no such block is found, cend() is returned.
+  // Constant complexity.
+  const_iterator find(concordUtils::BlockId id) const {
+    if (empty() || id < genesisId_ || id > endId_ - 1) {
+      return cend();
+    }
+    return get(id);
+  }
+
+  // Returns the current cache size.
+  size_type cacheSize() const noexcept(noexcept(CacheType{}.size())) { return cache_.size(); }
+
+  // Clears the cache of this view. Invalidates all iterators.
+  void clearCache() noexcept(noexcept(CacheType{}.clear())) { cache_.clear(); }
+
+ private:
+  friend iterator;
+
+  concordUtils::BlockId genesisId_{0};
+  concordUtils::BlockId endId_{0};
+  size_type size_{0};
+  mutable CacheType cache_;
+};
+
+}  // namespace kvbc
+}  // namespace concord

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+if(Boost_FOUND)
+    add_executable(blockchain_view_test blockchain_view_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_test(blockchain_view_test blockchain_view_test)
+    target_include_directories(blockchain_view_test PRIVATE ${Boost_INCLUDE_DIRS})
+    target_link_libraries(blockchain_view_test PUBLIC
+        gtest
+        util
+        kvbc
+    )
+endif()

--- a/kvbc/test/blockchain_view_test.cpp
+++ b/kvbc/test/blockchain_view_test.cpp
@@ -1,0 +1,252 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+
+#include "blockchain_view.h"
+
+namespace {
+
+using namespace concord::kvbc;
+
+using BlockTimestamp = std::uint64_t;
+
+class TimestampedBlockInfo : public BaseBlockInfo {
+ public:
+  static constexpr auto timestampOffset = 100;
+
+  TimestampedBlockInfo(concordUtils::BlockId id) : BaseBlockInfo{id} {}
+  TimestampedBlockInfo(concordUtils::BlockId id, BlockTimestamp ts) : BaseBlockInfo{id}, timestamp_{ts} {}
+
+  BlockTimestamp timestamp() const { return timestamp_; }
+  void loadIndices() { timestamp_ = id() + timestampOffset; }
+  void loadData() {}
+
+ private:
+  BlockTimestamp timestamp_{0};
+};
+
+const auto TimestampCompare = [](const TimestampedBlockInfo& lhs, const TimestampedBlockInfo& rhs) {
+  return lhs.timestamp() < rhs.timestamp();
+};
+
+class LoadException : public std::exception {
+ public:
+  LoadException(const std::string& msg) : msg_{msg} {}
+  const char* what() const noexcept override { return msg_.c_str(); }
+
+ private:
+  std::string msg_;
+};
+
+class SucceedOnceBlockInfo : public BaseBlockInfo {
+ public:
+  SucceedOnceBlockInfo(concordUtils::BlockId id) : BaseBlockInfo{id} {}
+
+  void loadIndices() {
+    if (fail_) {
+      throw LoadException{"Simulate failure"};
+    }
+    fail_ = true;
+  }
+  void loadData() {}
+
+ private:
+  static inline auto fail_ = false;
+};
+
+TEST(blockchain_view_tests, construction) {
+  ASSERT_NO_THROW({
+    auto view1 = BlockchainView<BaseBlockInfo>(0, 1);
+    auto view2 = BlockchainView<BaseBlockInfo>(0, MAX_BLOCKCHAIN_VIEW_SIZE);
+  });
+
+  ASSERT_THROW({ auto view = BlockchainView<BaseBlockInfo>(0, MAX_BLOCKCHAIN_VIEW_SIZE + 1ul); }, std::length_error)
+      << "BlockchainView constructor: count exceeds MAX_BLOCKCHAIN_VIEW_SIZE";
+
+  ASSERT_THROW({ auto view = BlockchainView<BaseBlockInfo>(1, MAX_BLOCKCHAIN_VIEW_SIZE); }, std::invalid_argument)
+      << "BlockchainView constructor: genesis + count > MAX_BLOCKCHAIN_VIEW_SIZE";
+}
+
+TEST(blockchain_view_tests, empty) {
+  const auto empty = BlockchainView<BaseBlockInfo>{42, 0};
+
+  ASSERT_EQ(empty.size(), 0);
+  ASSERT_TRUE(empty.empty());
+  ASSERT_TRUE(std::begin(empty) == std::end(empty));
+  ASSERT_TRUE(std::rbegin(empty) == std::rend(empty));
+}
+
+TEST(blockchain_view_tests, front_back) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 5;
+  const auto view = BlockchainView<BaseBlockInfo>{genesisBlockId, size};
+
+  ASSERT_EQ(view.front().id(), 1);
+  ASSERT_EQ(view.back().id(), 5);
+}
+
+TEST(blockchain_view_tests, iteration) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 5;
+  const auto view = BlockchainView<BaseBlockInfo>{genesisBlockId, size};
+
+  // range-based for
+  {
+    auto id = 1;
+    for (const auto& b : view) {
+      ASSERT_EQ(b.id(), id);
+      ++id;
+    }
+    ASSERT_EQ(id, size + 1);
+  }
+
+  // reverse iteration
+  {
+    auto id = size;
+    std::for_each(std::rbegin(view), std::rend(view), [&id](auto& b) {
+      ASSERT_EQ(b.id(), id);
+      --id;
+    });
+    ASSERT_EQ(id, 0);
+  }
+
+  // raw loop - zero-indexed
+  for (auto i = 0u; i < view.size(); ++i) {
+    ASSERT_EQ(view[i].id(), i + 1);
+  }
+}
+
+TEST(blockchain_view_tests, find) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 5;
+  const auto view = BlockchainView<BaseBlockInfo>{genesisBlockId, size};
+
+  ASSERT_TRUE(view.find(0) == std::cend(view));
+  ASSERT_TRUE(view.find(8) == std::cend(view));
+  ASSERT_TRUE(view.find(6) == std::cend(view));
+  ASSERT_TRUE(view.find(1) == std::cbegin(view));
+  ASSERT_TRUE(view.find(3) == std::cbegin(view) + 2);
+  ASSERT_TRUE(view.find(5) == std::cbegin(view) + 4);
+}
+
+TEST(blockchain_view_tests, linear_search_id) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 10;
+  const auto view = BlockchainView<BaseBlockInfo>{genesisBlockId, size};
+  constexpr auto val = 4;
+
+  auto it = std::find(std::begin(view), std::end(view), BaseBlockInfo{val});
+  ASSERT_TRUE(it != std::end(view));
+  ASSERT_EQ(it->id(), val);
+  ASSERT_EQ(view.cacheSize(), val);
+}
+
+TEST(blockchain_view_tests, binary_search_timestamp) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 10 * 1000ul * 1000 * 1000;
+  const auto log2Size = static_cast<std::uint32_t>(std::log2(size));
+  constexpr auto timeFromLastBlock = 2;
+  const auto view = BlockchainView<TimestampedBlockInfo>{genesisBlockId, size};
+  const auto val = TimestampedBlockInfo{0, view.back().timestamp() - timeFromLastBlock};
+
+  auto it = std::upper_bound(std::begin(view), std::end(view), val, TimestampCompare);
+  ASSERT_TRUE(it != std::end(view));
+  ASSERT_EQ(it->id(), size - 1);
+  ASSERT_EQ(it->timestamp(), size - 1 + TimestampedBlockInfo::timestampOffset);
+  ASSERT_LT(view.cacheSize(), log2Size * 5);  // provide a leeway factor of 5
+}
+
+TEST(blockchain_view_tests, clear_cache) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 5;
+  auto view = BlockchainView<BaseBlockInfo>{genesisBlockId, size};
+
+  // fill the cache and verify its size
+  auto id = 1;
+  for (const auto& b : view) {
+    ASSERT_EQ(b.id(), id);
+    ++id;
+  }
+  ASSERT_EQ(id, size + 1);
+  ASSERT_EQ(view.cacheSize(), size);
+
+  // clear and verify it is cleared
+  view.clearCache();
+  ASSERT_EQ(view.cacheSize(), 0);
+
+  // verify size doesn't change after clearing the cache
+  ASSERT_FALSE(view.empty());
+  ASSERT_EQ(view.size(), size);
+
+  // re-fill the cache and verify
+  id = 1;
+  for (const auto& b : view) {
+    ASSERT_EQ(b.id(), id);
+    ++id;
+  }
+  ASSERT_EQ(id, size + 1);
+  ASSERT_EQ(view.cacheSize(), size);
+}
+
+TEST(blockchain_view_tests, exceptions) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 5;
+  constexpr auto id = 2;
+  auto view = BlockchainView<SucceedOnceBlockInfo>{genesisBlockId, size};
+
+  auto it = view.find(id);
+  ASSERT_TRUE(it != std::cend(view));
+  ASSERT_EQ(it->id(), id);
+  ASSERT_EQ(view.cacheSize(), 1);
+
+  ASSERT_THROW({ ++it; }, LoadException);
+  ASSERT_TRUE(it != std::cend(view));
+  ASSERT_EQ(it->id(), id);
+  ASSERT_EQ(view.cacheSize(), 1);
+
+  ASSERT_THROW({ --it; }, LoadException);
+  ASSERT_TRUE(it != std::cend(view));
+  ASSERT_EQ(it->id(), id);
+  ASSERT_EQ(view.cacheSize(), 1);
+
+  ASSERT_THROW({ it += 2; }, LoadException);
+  ASSERT_TRUE(it != std::cend(view));
+  ASSERT_EQ(it->id(), id);
+  ASSERT_EQ(view.cacheSize(), 1);
+}
+
+TEST(blockchain_view_tests, distance) {
+  constexpr auto genesisBlockId = 1ul;
+  constexpr auto size = 5;
+  constexpr auto id = 3;
+  auto view = BlockchainView<BaseBlockInfo>{genesisBlockId, size};
+
+  ASSERT_EQ(std::distance(std::begin(view), std::end(view)), size);
+  ASSERT_EQ(std::distance(std::begin(view), view.find(id)), size - id);
+
+  ASSERT_EQ(std::distance(std::end(view), std::begin(view)), -size);
+  ASSERT_EQ(std::distance(view.find(id), std::begin(view)), id - size);
+}
+
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Provide a container-like type (BlockchainView) that acts as standard
containers as much as possible. It tries to mimic the interfaces of a
const std::vector and std::string_view. Rationale is that it can be used
in standard algorithms, range-based for loops, looks familiar to C++
developers, etc.

BlockchainView contains block information objects of type provided by
the user. This allows for extensibility and generality. Block
information is divided in two categories - indices and data. Control
over when and how to load it is left up to users. Additionally, block
information is automatically cached inside the BlockchainView on storage
access.

NOTE: Added boost libraries in Travis so that we can run tests for
boost-dependent code.