### PR TITLE
Refactoring and update linearizability tests

### DIFF
--- a/tests/test_skvbc_linearizability.py
+++ b/tests/test_skvbc_linearizability.py
@@ -21,6 +21,7 @@ from util import bft_network_partitioning as net
 from util import skvbc as kvbc
 from util import skvbc_history_tracker
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+from util.skvbc_history_tracker import SkvbcTracker as with_tracker
 
 # The max number of blocks to check for read intersection during conditional
 # writes
@@ -98,9 +99,7 @@ class SkvbcChaosTest(unittest.TestCase):
         bft_network.start_all_replicas()
         async with trio.open_nursery() as nursery:
             nursery.start_soon(self.tracker.run_concurrent_ops, self, num_ops)
-            #nursery.start_soon(self.run_concurrent_ops, num_ops)
 
-        #await self.verify()
         await self.tracker.verify_linearizability(self)
 
     @with_trio
@@ -127,7 +126,6 @@ class SkvbcChaosTest(unittest.TestCase):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(self.tracker.run_concurrent_ops, self, num_ops)
 
-            # await self.verify()
             await self.tracker.verify_linearizability(self)
 
     @with_trio
@@ -151,119 +149,7 @@ class SkvbcChaosTest(unittest.TestCase):
             nursery.start_soon(self.tracker.run_concurrent_ops, self, num_ops)
             nursery.start_soon(self.tracker.crash_primary, self.bft_network)
 
-        # await self.verify()
         await self.tracker.verify_linearizability(self)
-
-    '''
-    async def verify(self):
-        try:
-            # Use a new client, since other clients may not be responsive due to
-            # past failed responses.
-            client = await self.skvbc.bft_network.new_client()
-            last_block_id = await self.get_last_block_id(client)
-            print(f'Last Block ID = {last_block_id}')
-            missing_block_ids = self.tracker.get_missing_blocks(last_block_id)
-            print(f'Missing Block IDs = {missing_block_ids}')
-            blocks = await self.get_blocks(client, missing_block_ids)
-            self.tracker.fill_missing_blocks(blocks)
-            self.tracker.verify()
-        except Exception as e:
-            print(f'retries = {client.retries}')
-            self.status.end_time = time.monotonic()
-            print("HISTORY...")
-            for i, entry in enumerate(self.tracker.history):
-                print(f'Index = {i}: {entry}\n')
-            print("BLOCKS...")
-            print(f'{self.tracker.blocks}\n')
-            print(str(self.status), flush=True)
-            print("FAILURE...")
-            raise(e)
-    
-    async def get_blocks(self, client, block_ids):
-        blocks = {}
-        for block_id in block_ids:
-            retries = 12 # 60 seconds
-            for i in range(0, retries):
-                try:
-                    msg = kvbc.SimpleKVBCProtocol.get_block_data_req(block_id)
-                    blocks[block_id] = kvbc.SimpleKVBCProtocol.parse_reply(await client.read(msg))
-                    break
-                except trio.TooSlowError:
-                    if i == retries - 1:
-                        raise
-            print(f'Retrieved block {block_id}')
-        return blocks
-    
-
-    async def get_last_block_id(self, client):
-        msg = kvbc.SimpleKVBCProtocol.get_last_block_req()
-        return kvbc.SimpleKVBCProtocol.parse_reply(await client.read(msg))
-    
-    async def crash_primary(self):
-        await trio.sleep(.5)
-        self.bft_network.stop_replica(0)
-    
-    async def run_concurrent_ops(self, num_ops):
-        max_concurrency = len(self.bft_network.clients) // 2
-        write_weight = .70
-        max_size = len(self.skvbc.keys) // 2
-        sent = 0
-        while sent < num_ops:
-            clients = self.bft_network.random_clients(max_concurrency)
-            async with trio.open_nursery() as nursery:
-                for client in clients:
-                    if random.random() < write_weight:
-                        nursery.start_soon(self.send_write, client, max_size)
-                    else:
-                        nursery.start_soon(self.send_read, client, max_size)
-            sent += len(clients)
-
-    async def send_write(self, client, max_set_size):
-        readset = self.readset(0, max_set_size)
-        writeset = self.writeset(max_set_size)
-        read_version = self.read_block_id()
-        msg = self.skvbc.write_req(readset, writeset, read_version)
-        seq_num = client.req_seq_num.next()
-        client_id = client.client_id
-        self.tracker.send_write(
-            client_id, seq_num, readset, dict(writeset), read_version)
-        try:
-            serialized_reply = await client.write(msg, seq_num)
-            self.status.record_client_reply(client_id)
-            reply = self.skvbc.parse_reply(serialized_reply)
-            self.tracker.handle_write_reply(client_id, seq_num, reply)
-        except trio.TooSlowError:
-            self.status.record_client_timeout(client_id)
-            return
-
-    async def send_read(self, client, max_set_size):
-        readset = self.readset(1, max_set_size)
-        msg = self.skvbc.read_req(readset)
-        seq_num = client.req_seq_num.next()
-        client_id = client.client_id
-        self.tracker.send_read(client_id, seq_num, readset)
-        try:
-            serialized_reply = await client.read(msg, seq_num)
-            self.status.record_client_reply(client_id)
-            reply = self.skvbc.parse_reply(serialized_reply)
-            self.tracker.handle_read_reply(client_id, seq_num, reply)
-        except trio.TooSlowError:
-            self.status.record_client_timeout(client_id)
-            return
-
-    def read_block_id(self):
-        start = max(0, self.tracker.last_known_block - MAX_LOOKBACK)
-        return random.randint(start, self.tracker.last_known_block)
-
-    def readset(self, min_size, max_size):
-        return self.skvbc.random_keys(random.randint(min_size, max_size))
-
-    def writeset(self, max_size):
-        writeset_keys = self.skvbc.random_keys(random.randint(0, max_size))
-        writeset_values = self.skvbc.random_values(len(writeset_keys))
-        return list(zip(writeset_keys, writeset_values))
-        
-        '''
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_skvbc_linearizability.py
+++ b/tests/test_skvbc_linearizability.py
@@ -93,14 +93,14 @@ class SkvbcChaosTest(unittest.TestCase):
 
         self.skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         init_state = self.skvbc.initial_state()
-        self.tracker = skvbc_history_tracker.SkvbcTracker(init_state)
         self.bft_network = bft_network
         self.status = Status(bft_network.config)
+        self.tracker = skvbc_history_tracker.SkvbcTracker(init_state, self.skvbc, self.bft_network, self.status)
         bft_network.start_all_replicas()
         async with trio.open_nursery() as nursery:
-            nursery.start_soon(self.tracker.run_concurrent_ops, self, num_ops)
+            nursery.start_soon(self.tracker.run_concurrent_ops, num_ops)
 
-        await self.tracker.verify_linearizability(self)
+        await self.tracker.verify_linearizability()
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -116,17 +116,17 @@ class SkvbcChaosTest(unittest.TestCase):
                 bft_network, drop_rate_percentage=5) as adversary:
             self.skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             init_state = self.skvbc.initial_state()
-            self.tracker = skvbc_history_tracker.SkvbcTracker(init_state)
             self.bft_network = bft_network
             self.status = Status(bft_network.config)
+            self.tracker = skvbc_history_tracker.SkvbcTracker(init_state, self.skvbc, self.bft_network, self.status)
             bft_network.start_all_replicas()
 
             adversary.interfere()
 
             async with trio.open_nursery() as nursery:
-                nursery.start_soon(self.tracker.run_concurrent_ops, self, num_ops)
+                nursery.start_soon(self.tracker.run_concurrent_ops, num_ops)
 
-            await self.tracker.verify_linearizability(self)
+            await self.tracker.verify_linearizability()
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -141,15 +141,15 @@ class SkvbcChaosTest(unittest.TestCase):
 
         self.skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         init_state = self.skvbc.initial_state()
-        self.tracker = skvbc_history_tracker.SkvbcTracker(init_state)
         self.bft_network = bft_network
         self.status = Status(bft_network.config)
+        self.tracker = skvbc_history_tracker.SkvbcTracker(init_state, self.skvbc, self.bft_network, self.status)
         bft_network.start_all_replicas()
         async with trio.open_nursery() as nursery:
-            nursery.start_soon(self.tracker.run_concurrent_ops, self, num_ops)
-            nursery.start_soon(self.tracker.crash_primary, self.bft_network)
+            nursery.start_soon(self.tracker.run_concurrent_ops, num_ops)
+            nursery.start_soon(self.tracker.crash_primary)
 
-        await self.tracker.verify_linearizability(self)
+        await self.tracker.verify_linearizability()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -204,7 +204,7 @@ class Block:
 class Status:
     """
     Status about the order of writes and reads.
-    This is useful for debugging when test is fall.
+    This is useful for debugging linearizability check failures.
     """
     def __init__(self, config):
         self.config = config

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -203,10 +203,8 @@ class Block:
 
 class Status:
     """
-    Status about the running test.
-    This is useful for debugging if the test fails.
-
-    TODO: Should this live in the tracker?
+    Status about the order of writes and reads.
+    This is useful for debugging and checking linearizability.
     """
     def __init__(self, config):
         self.config = config


### PR DESCRIPTION
1) Extract common utility functions from SkvbcChaosTest to SkvbcTracker.
2) Move Class Status from "test_skvbc_linearizability.py" to "skvbc_history_tracker" - status class helps us to track reads and writes so its main usage is from history tracker.