### PR TITLE
Fixing the "read-your-writes" checks in view change tests

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1872,6 +1872,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
   Assert(lastExecutedSeqNum >= lastStableSeqNum);  // we moved to the new state, only after synchronizing the state
 
   timeOfLastViewEntrance = getMonotonicTime();  // TODO(GG): handle restart/pause
+  metric_current_active_view_.Get().Set(curView);
 
   NewViewMsg *newNewViewMsgToSend = nullptr;
 
@@ -2741,6 +2742,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_last_stable_seq_num_{metrics_.RegisterGauge("lastStableSeqNum", lastStableSeqNum)},
       metric_last_executed_seq_num_{metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)},
       metric_last_agreed_view_{metrics_.RegisterGauge("lastAgreedView", lastAgreedView)},
+      metric_current_active_view_{metrics_.RegisterGauge("currentActiveView", 0)},
       metric_first_commit_path_{metrics_.RegisterStatus(
           "firstCommitPath", CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath))},
       metric_slow_path_count_{metrics_.RegisterCounter("slowPathCount", 0)},

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -156,6 +156,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   GaugeHandle metric_last_stable_seq_num_;
   GaugeHandle metric_last_executed_seq_num_;
   GaugeHandle metric_last_agreed_view_;
+  GaugeHandle metric_current_active_view_;
 
   // The first commit path being attempted for a new request.
   StatusHandle metric_first_commit_path_;

--- a/tests/config/test_comm_config.hpp
+++ b/tests/config/test_comm_config.hpp
@@ -67,7 +67,7 @@ class TestCommConfig : public ITestCommConfig {
   // Network port of the first replica. Other replicas use ports
   // basePort + (2 * index).
   static const uint16_t base_port_ = 3710;
-  static const uint32_t buf_length_ = 64000;
+  static const uint32_t buf_length_ = 128 * 1024;  // 128 kB
   static const std::string default_ip_;
   static const std::string default_listen_ip_;
   static const char* ip_port_delimiter_;

--- a/tests/test_skvbc_auto_view_change.py
+++ b/tests/test_skvbc_auto_view_change.py
@@ -48,6 +48,7 @@ class SkvbcAutoViewChangeTest(unittest.TestCase):
         1) Start a full BFT network
         2) Do nothing (wait for automatic view change to kick-in)
         3) Check that view change has occurred (necessarily, automatic view change)
+        4) Perform a "read-your-writes" check in the new view
         """
         bft_network.start_all_replicas()
 
@@ -63,7 +64,7 @@ class SkvbcAutoViewChangeTest(unittest.TestCase):
             err_msg="Make sure automatic view change has occurred."
         )
 
-        skvbc.read_your_writes(self)
+        await skvbc.read_your_writes(self)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -75,6 +76,7 @@ class SkvbcAutoViewChangeTest(unittest.TestCase):
         2) Stop the initial primary replica
         3) Do nothing (wait for automatic view change to kick-in)
         4) Check that view change has occurred (necessarily, automatic view change)
+        5) Perform a "read-your-writes" check in the new view
         """
         bft_network.start_all_replicas()
 
@@ -91,7 +93,7 @@ class SkvbcAutoViewChangeTest(unittest.TestCase):
             err_msg="Make sure automatic view change has occurred."
         )
 
-        skvbc.read_your_writes(self)
+        await skvbc.read_your_writes(self)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -103,6 +105,7 @@ class SkvbcAutoViewChangeTest(unittest.TestCase):
         2) Send a batch of write commands
         3) Make sure view change occurred at some point while processing the writes
         4) Check that all writes have been processed on the fast commit path
+        5) Perform a "read-your-writes" check in the new view
         """
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
@@ -122,4 +125,4 @@ class SkvbcAutoViewChangeTest(unittest.TestCase):
         await skvbc.assert_kv_write_executed(key, val)
         await bft_network.assert_fast_path_prevalent()
 
-        skvbc.read_your_writes(self)
+        await skvbc.read_your_writes(self)

--- a/tests/test_skvbc_persistence.py
+++ b/tests/test_skvbc_persistence.py
@@ -35,7 +35,7 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "3000"
+    viewChangeTimeoutMilli = "10000"
 
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
@@ -500,9 +500,10 @@ class SkvbcPersistenceTest(unittest.TestCase):
             stale_node=stale
         )
 
-        self.assertGreater(
-            current_primary, 0,
-            "Make sure view change has been triggered during state transfer."
+        await bft_network.wait_for_view(
+            replica_id=random.choice(stable_replicas),
+            expected=lambda v: v > 0,
+            err_msg="Make sure view change has been triggered during state transfer."
         )
 
         print(f'State transfer completed, despite the primary '

--- a/tests/util/skvbc.py
+++ b/tests/util/skvbc.py
@@ -295,14 +295,13 @@ class SimpleKVBCProtocol:
         return keys
 
     async def read_your_writes(self, test_class):
+        print("[READ-YOUR-WRITES] Starting 'read-your-writes' check...")
         client = self.bft_network.random_client()
         # Verify by "Read your write"
         # Perform write with the new primary
-
         last_block = self.parse_reply(
             await client.read(self.get_last_block_req()))
-        # Perform an unconditional KV put.
-        # Ensure keys aren't identical
+        print(f'[READ-YOUR-WRITES] Last block ID: #{last_block}')
         kv = [(self.keys[0], self.random_value()),
               (self.keys[1], self.random_value())]
 
@@ -315,10 +314,12 @@ class SimpleKVBCProtocol:
 
         # Read the last write and check if equal
         # Get the kvpairs in the last written block
+        print(f'[READ-YOUR-WRITES] Checking if the {kv} entry is readable...')
         data = await client.read(self.get_block_data_req(last_block))
         kv2 = self.parse_reply(data)
         test_class.assertDictEqual(kv2, dict(kv))
 
+        print(f'[READ-YOUR-WRITES] OK.')
 
 class SkvbcClient:
     """A wrapper around bft_client that uses the SimpleKVBCProtocol"""


### PR DESCRIPTION
Fixing the "read-your-writes" checks in view change tests

The key takeaway from this effort is that our current view change mechanism is actually quite slow (in the order of 10-s of seconds).
This is why we need to increase the view change timeout, to avoid a second view change kicking-in because the first one did not complete in time.

From our discussions with Guy, it appears the "sanitary minimum" for the view change timeout is around 10 seconds (it should be noted that he was testing with 20 seconds). We may also need to increase this value to make the test more stable. Additionally, to help view change complete in a single iteration, we also bump up the network communication buffer size (a small buffer may result in lost messages for networks bigger than 4 nodes).

The rest of the changes presented here mainly have to do with making the `wait_for_view()` implementation more realistic, waiting for the view change to actually become active, instead of just agreed.

This PR introduces the following changes:
- [SBFT] Introduce a new SBFT metric for tracking the current active view of a given replica
- [SBFT/TesterReplica] Increase the buffer size for network communication when testing
- [Tests] Await the skvbc.read_your_writes() calls
- [Tests] Modify wait_for_view() so that it waits for the new view to become active (in addition to have been "agreed upon")
- [Tests] Make sure the next expected primary is not stopped (otherwise two view changes in a row occur)