### PR TITLE
Add linearizability checks to fast path tests

### DIFF
--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -49,10 +49,10 @@ class SkvbcFastPathTest(unittest.TestCase):
         This test aims to check that the fast commit path is prevalent
         in the normal, synchronous case (no failed replicas, no network partitioning).
 
-        First we write a series of known K/V entries.
+        First we write a series of K/V entries and tracked them using the tracker from the decorator.
         Then we check that, in the process, we have stayed on the fast path.
 
-        Finally we check if a known K/V has been executed.
+        Finally the decorator verifies the KV execution.
         """
         bft_network.start_all_replicas()
         max_size = 1
@@ -69,7 +69,7 @@ class SkvbcFastPathTest(unittest.TestCase):
         """
         This test aims to check the correct transition from fast to slow commit path.
 
-        First we write a series of known K/V entries, making sure
+        First we write a series of K/V entries and tracked them using the tracker from the decorator, making sure
         we stay on the fast path.
 
         Once the first series of K/V writes have been processed, we bring down
@@ -78,7 +78,7 @@ class SkvbcFastPathTest(unittest.TestCase):
         We send a new series of K/V writes and make sure they
         have been processed using the slow commit path.
 
-        Finally we check if a known K/V has been executed.
+        Finally the decorator verifies the KV execution.
         """
         bft_network.start_all_replicas()
         max_size = 1
@@ -109,10 +109,10 @@ class SkvbcFastPathTest(unittest.TestCase):
         As a first step, we bring down no more than c replicas,
         triggering initially the slow path.
 
-        Then we write a series of known K/V entries, making sure
+        Then we write a series of K/V entries and tracked them using the tracker from the decorator, making sure
         the fast path is eventually restored and becomes prevalent.
 
-        Finally we check if a known K/V write has been executed.
+        Finally the decorator verifies the KV execution.
         """
         bft_network.start_all_replicas()
         max_size = 1

--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -13,7 +13,7 @@
 import os.path
 import random
 import unittest
-
+from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 

--- a/tests/test_skvbc_linearizability.py
+++ b/tests/test_skvbc_linearizability.py
@@ -61,7 +61,7 @@ class SkvbcChaosTest(unittest.TestCase):
         self.bft_network = bft_network
         self.bft_network.start_all_replicas()
         async with trio.open_nursery() as nursery:
-            nursery.start_soon(self.run_concurrent_ops, num_ops, tracker)
+            nursery.start_soon(tracker.run_concurrent_ops, num_ops)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -83,7 +83,7 @@ class SkvbcChaosTest(unittest.TestCase):
             adversary.interfere()
 
             async with trio.open_nursery() as nursery:
-                nursery.start_soon(self.run_concurrent_ops, num_ops, tracker)
+                nursery.start_soon(tracker.run_concurrent_ops, num_ops)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -101,23 +101,8 @@ class SkvbcChaosTest(unittest.TestCase):
         self.bft_network = bft_network
         self.bft_network.start_all_replicas()
         async with trio.open_nursery() as nursery:
-            nursery.start_soon(self.run_concurrent_ops, num_ops, tracker)
+            nursery.start_soon(tracker.run_concurrent_ops, num_ops)
             nursery.start_soon(self.crash_primary)
-
-    async def run_concurrent_ops(self, num_ops, tracker):
-        max_concurrency = len(self.bft_network.clients) // 2
-        write_weight = .70
-        max_size = len(self.skvbc.keys) // 2
-        sent = 0
-        while sent < num_ops:
-            clients = self.bft_network.random_clients(max_concurrency)
-            async with trio.open_nursery() as nursery:
-                for client in clients:
-                    if random.random() < write_weight:
-                        nursery.start_soon(tracker.send_tracked_write, client, max_size)
-                    else:
-                        nursery.start_soon(tracker.send_tracked_read, client, max_size)
-            sent += len(clients)
 
     async def crash_primary(self):
         await trio.sleep(.5)

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -872,7 +872,7 @@ class SkvbcTracker:
         return list(zip(writeset_keys, writeset_values))
 
     async def run_concurrent_ops(self, num_ops, write_weight=.70):
-        max_concurrency = min(num_ops, len(self.bft_network.clients) // 2)
+        max_concurrency = len(self.bft_network.clients) // 2
         max_size = len(self.skvbc.keys) // 2
         sent = 0
         while sent < num_ops:

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -875,12 +875,17 @@ class SkvbcTracker:
         max_concurrency = len(self.bft_network.clients) // 2
         max_size = len(self.skvbc.keys) // 2
         sent = 0
+        write_count = 0
+        read_count = 0
         while sent < num_ops:
             clients = self.bft_network.random_clients(max_concurrency)
             async with trio.open_nursery() as nursery:
                 for client in clients:
                     if random.random() < write_weight:
                         nursery.start_soon(self.send_tracked_write, client, max_size)
+                        write_count += 1
                     else:
                         nursery.start_soon(self.send_tracked_read, client, max_size)
+                        read_count += 1
             sent += len(clients)
+        return read_count, write_count

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -872,7 +872,7 @@ class SkvbcTracker:
         return list(zip(writeset_keys, writeset_values))
 
     async def run_concurrent_ops(self, num_ops, write_weight=.70):
-        max_concurrency = len(self.bft_network.clients) // 2
+        max_concurrency = min(num_ops, len(self.bft_network.clients) // 2)
         max_size = len(self.skvbc.keys) // 2
         sent = 0
         while sent < num_ops:

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -870,3 +870,17 @@ class SkvbcTracker:
         writeset_keys = self.skvbc.random_keys(random.randint(0, max_size))
         writeset_values = self.skvbc.random_values(len(writeset_keys))
         return list(zip(writeset_keys, writeset_values))
+
+    async def run_concurrent_ops(self, num_ops, write_weight=.70):
+        max_concurrency = len(self.bft_network.clients) // 2
+        max_size = len(self.skvbc.keys) // 2
+        sent = 0
+        while sent < num_ops:
+            clients = self.bft_network.random_clients(max_concurrency)
+            async with trio.open_nursery() as nursery:
+                for client in clients:
+                    if random.random() < write_weight:
+                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                    else:
+                        nursery.start_soon(self.send_tracked_read, client, max_size)
+            sent += len(clients)


### PR DESCRIPTION
1)add verify_linearizability decorator for each test.
2)replace regular KV writing to tracked KV writing.
3)check KV writing successful execution at the end of the decorator using tracker verify.