### PR TITLE
SparseMerkle: Add BatchedInternalNode::remove

### DIFF
--- a/storage/test/sparse_merkle/internal_node_test.cpp
+++ b/storage/test/sparse_merkle/internal_node_test.cpp
@@ -16,6 +16,19 @@
 
 using namespace concord::storage::sparse_merkle;
 
+// Return a new hash with the given bit flipped for the given hash.
+//
+// Flip the most significant bit. So bit 0 to be flipped would be the first bit,
+// bit 1, the second bit, etc...
+Hash flipMSBit(size_t bit, const Hash& hash) {
+  Assert(bit < 8);
+  // Flip the first bit so that key1_hash becomes a sibling of key2_hash
+  std::array<uint8_t, Hash::SIZE_IN_BYTES> flipped;
+  std::copy(hash.data(), hash.data() + hash.size(), flipped.begin());
+  flipped[0] ^= (1 << (7 - bit));
+  return Hash(flipped);
+}
+
 TEST(internal_node_tests, empty_invariants) {
   BatchedInternalNode node;
 
@@ -38,7 +51,7 @@ TEST(internal_node_tests, empty_invariants) {
 //     |
 //    Leaf
 //
-TEST(internal_node_tests, insert_single_leaf_node) {
+TEST(insert_tests, insert_single_leaf_node) {
   BatchedInternalNode node;
 
   Hasher hasher;
@@ -88,7 +101,7 @@ TEST(internal_node_tests, insert_single_leaf_node) {
 //     |
 //    Leaf
 //
-TEST(internal_node_tests, overwrite_single_leaf_node) {
+TEST(insert_tests, overwrite_single_leaf_node) {
   BatchedInternalNode node;
 
   Hasher hasher;
@@ -148,7 +161,7 @@ TEST(internal_node_tests, overwrite_single_leaf_node) {
 //      Leaf   Leaf
 //
 */
-TEST(internal_node_tests, create_two_leafs_with_one_parent) {
+TEST(insert_tests, create_two_leaves_with_one_parent) {
   BatchedInternalNode node;
 
   Hasher hasher;
@@ -160,11 +173,7 @@ TEST(internal_node_tests, create_two_leafs_with_one_parent) {
   auto key1_hash = hasher.hash(key1, strlen(key1));
 
   // Flip the first bit so that key1_hash becomes a sibling of key2_hash
-  std::array<uint8_t, Hash::SIZE_IN_BYTES> key2_hash_data;
-  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key2_hash_data.begin());
-  key2_hash_data[0] ^= 0x80;
-  auto key2_hash = Hash(key2_hash_data);
-
+  auto key2_hash = flipMSBit(0, key1_hash);
   ASSERT_EQ(0, key1_hash.prefix_bits_in_common(key2_hash));
 
   auto value1_hash = hasher.hash(value1, strlen(value1));
@@ -216,7 +225,7 @@ TEST(internal_node_tests, create_two_leafs_with_one_parent) {
 //        / \
 //    Leaf   Leaf
 */
-TEST(internal_node_tests, split_leaf) {
+TEST(insert_tests, split_leaf) {
   BatchedInternalNode node;
 
   Hasher hasher;
@@ -229,11 +238,7 @@ TEST(internal_node_tests, split_leaf) {
 
   // Flip the second bit so that key1_hash becomes a sibling of key2_hash at
   // height 2.
-  std::array<uint8_t, Hash::SIZE_IN_BYTES> key2_hash_data;
-  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key2_hash_data.begin());
-  key2_hash_data[0] ^= 0x40;
-  auto key2_hash = Hash(key2_hash_data);
-
+  auto key2_hash = flipMSBit(1, key1_hash);
   ASSERT_EQ(1, key1_hash.prefix_bits_in_common(key2_hash));
 
   auto value1_hash = hasher.hash(value1, strlen(value1));
@@ -305,7 +310,7 @@ TEST(internal_node_tests, split_leaf) {
 //
 */
 
-TEST(internal_node_tests, split_until_new_batch_node_needed) {
+TEST(insert_tests, split_until_new_batch_node_needed) {
   BatchedInternalNode node;
 
   Hasher hasher;
@@ -325,11 +330,7 @@ TEST(internal_node_tests, split_until_new_batch_node_needed) {
 
   // Flip the 5th bit so that key1_hash becomes a sibling of key2_hash at
   // height -1 (in a new node).
-  std::array<uint8_t, Hash::SIZE_IN_BYTES> key2_hash_data;
-  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key2_hash_data.begin());
-  key2_hash_data[0] ^= 0x08;
-  auto key2_hash = Hash(key2_hash_data);
-
+  auto key2_hash = flipMSBit(4, key1_hash);
   ASSERT_EQ(4, key1_hash.prefix_bits_in_common(key2_hash));
 
   auto value1_hash = hasher.hash(value1, strlen(value1));
@@ -370,6 +371,526 @@ TEST(internal_node_tests, split_until_new_batch_node_needed) {
   ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::InsertIntoExistingNode>(result));
   auto insert_result = std::get<BatchedInternalNode::InsertIntoExistingNode>(result);
   ASSERT_EQ(insert_result.next_node_version, Version(2));
+}
+
+// Add a single LeafChild to a BatchedInternalNode and then remove it.
+//
+// The logical tree inside the BatchedInternalNode looks like the following
+// before remove is called:
+//
+//    Root
+//     |
+//     |
+//    Leaf
+//
+TEST(remove_tests, remove_a_single_leaf) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* bad_key = "badkey";
+  size_t depth = 0;
+  auto version = Version(1);
+
+  auto bad_key_hash = hasher.hash(bad_key, strlen(bad_key));
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto leaf_key1 = LeafKey(key1_hash, version);
+  auto child = LeafChild{value1_hash, leaf_key1};
+
+  // A node was successfully inserted. Since it didn't overwrite another node
+  // there is not a stale leaf.
+  auto result = node.insert(child, depth);
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::InsertComplete>(result));
+
+  // Attempting to remove a key that doesn't exist should return NotFound
+  auto remove_result = node.remove(bad_key_hash, depth, version);
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::NotFound>(remove_result));
+
+  // Try to remove a key that doesn't exist, but where a LeafNode does exist that
+  // has a matching prefix. We know the node matching the key doesn't exist,
+  // because there would be at least one InternalNode with the matching prefix
+  // Leaf and this node below it if that were the case.
+  //
+  // Flip the 5th bit.
+  auto partially_matching_hash = flipMSBit(4, key1_hash);
+  remove_result = node.remove(partially_matching_hash, depth, version);
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::NotFound>(remove_result));
+
+  // Deleting this key should return RemoveBatchedInternalNode;
+  remove_result = node.remove(key1_hash, depth, version);
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::RemoveBatchedInternalNode>(remove_result));
+  ASSERT_FALSE(std::get<BatchedInternalNode::RemoveBatchedInternalNode>(remove_result).promoted.has_value());
+}
+
+/*
+// Add 2 LeafChildren to a BatchedInternalNode and then remove one of them.
+//
+// The logical tree inside the BatchedInternalNode looks like the following
+// before remove is called:
+//
+//          Root
+//           |
+//         /   \
+//      Leaf   Leaf
+//
+*/
+TEST(remove_tests, remove_a_leaf_with_a_peer) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the first bit so that key1_hash becomes a sibling of key2_hash
+  auto key2_hash = flipMSBit(0, key1_hash);
+
+  ASSERT_EQ(0, key1_hash.prefix_bits_in_common(key2_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+
+  node.insert(child1, depth);
+  node.insert(child2, depth);
+
+  // There should be one root and two leaves
+  ASSERT_EQ(3, node.numChildren());
+  ASSERT_EQ(1, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+
+  // Deleting key1 should return RemoveBatchedInternalNode with a promoted
+  // child2.
+  auto result = node.remove(key1_hash, depth, Version(3));
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::RemoveBatchedInternalNode>(result));
+  auto promoted = std::get<BatchedInternalNode::RemoveBatchedInternalNode>(result).promoted.value();
+  ASSERT_EQ(child2, promoted);
+}
+
+/*
+// Remove a leaf with a peer at depth 2 (Leaf1). This will cause the peer to
+// move up to depth 1, and then stop, since it will have a new peer. In this
+// case, call to `remove` will return `RemoveComplete`.
+//
+// The logical tree inside the BatchedInternalNode looks like the following
+// before the remove:
+//
+//                Root
+//                 |
+//         -----------------
+//         |               |
+//      Internal         Leaf2
+//         |
+//        / \
+//   Leaf3   Leaf1
+*/
+TEST(remove_tests, remove_a_leaf_with_a_leaf_peer_from__batched_internal_node_with_3_leaves) {
+  BatchedInternalNode node;
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  const char* value3 = "Rihanna";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the first bit so that key1_hash becomes a sibling of key2_hash at
+  // depth 1.
+  auto key2_hash = flipMSBit(0, key1_hash);
+
+  // Flip the second bit so that key1_hash becomes a sibling of key3_hash at
+  // height depth 2.
+  auto key3_hash = flipMSBit(1, key1_hash);
+
+  ASSERT_EQ(0, key1_hash.prefix_bits_in_common(key2_hash));
+  ASSERT_EQ(1, key1_hash.prefix_bits_in_common(key3_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto value3_hash = hasher.hash(value3, strlen(value3));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto leaf_key3 = LeafKey(key3_hash, Version(3));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+  auto child3 = LeafChild{value3_hash, leaf_key3};
+
+  node.insert(child1, depth);
+  node.insert(child2, depth);
+  node.insert(child3, depth);
+
+  ASSERT_EQ(5, node.numChildren());
+  ASSERT_EQ(2, node.numInternalChildren());
+  ASSERT_EQ(3, node.numLeafChildren());
+
+  auto result = node.remove(key1_hash, depth, Version(4));
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::RemoveComplete>(result));
+  auto removed_version = std::get<BatchedInternalNode::RemoveComplete>(result).version;
+  ASSERT_EQ(Version(1), removed_version);
+
+  ASSERT_EQ(3, node.numChildren());
+  ASSERT_EQ(1, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+
+  // Ensure the root hash is correct.
+  ASSERT_EQ(node.hash(), hasher.parent(value3_hash, value2_hash));
+  ASSERT_EQ(Version(4), node.version());
+}
+
+/*
+// Remove a leaf (Leaf2) at depth 1 with an inernal node as a peer.
+//
+// This should cause a single remove to occur, but the left side of the tree to
+// stay as is. RemoveComplete will be returned.
+//
+// The logical tree inside the BatchedInternalNode looks like the following
+// before the remove:
+//
+//                Root
+//                 |
+//         -----------------
+//         |               |
+//      Internal         Leaf2
+//         |
+//        / \
+//   Leaf3   Leaf1
+*/
+TEST(remove_tests, remove_a_leaf_with_internal_peer_from_batched_internal_node_with_3_leaves) {
+  BatchedInternalNode node;
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  const char* value3 = "Rihanna";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the first bit so that key1_hash becomes a sibling of key2_hash at
+  // depth 1.
+  auto key2_hash = flipMSBit(0, key1_hash);
+
+  // Flip the second bit so that key1_hash becomes a sibling of key3_hash at
+  // height depth 2.
+  auto key3_hash = flipMSBit(1, key1_hash);
+
+  ASSERT_EQ(0, key1_hash.prefix_bits_in_common(key2_hash));
+  ASSERT_EQ(1, key1_hash.prefix_bits_in_common(key3_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto value3_hash = hasher.hash(value3, strlen(value3));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto leaf_key3 = LeafKey(key3_hash, Version(3));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+  auto child3 = LeafChild{value3_hash, leaf_key3};
+
+  node.insert(child1, depth);
+  node.insert(child2, depth);
+  node.insert(child3, depth);
+
+  ASSERT_EQ(5, node.numChildren());
+  ASSERT_EQ(2, node.numInternalChildren());
+  ASSERT_EQ(3, node.numLeafChildren());
+
+  auto result = node.remove(key2_hash, depth, Version(4));
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::RemoveComplete>(result));
+  auto removed_version = std::get<BatchedInternalNode::RemoveComplete>(result).version;
+  ASSERT_EQ(Version(2), removed_version);
+
+  ASSERT_EQ(4, node.numChildren());
+  ASSERT_EQ(2, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+
+  // Ensure the root hash is correct.
+  auto internal_hash = hasher.parent(value1_hash, value3_hash);
+  ASSERT_EQ(node.hash(), hasher.parent(internal_hash, PLACEHOLDER_HASH));
+  ASSERT_EQ(Version(4), node.version());
+}
+
+/*
+// Remove a leaf (Leaf1) at depth 3 with leaf node as a peer.
+//
+// This should cause a single remove to occur, with the left side of the tree
+// moving up 2 levels. RemoveComplete will be returned.
+//
+// The logical tree inside the BatchedInternalNode looks like the following
+// before the remove:
+//
+//                  Root
+//                   |
+//           -----------------
+//           |               |
+//        Internal         Leaf2
+//           |
+//          / \
+//   Internal  PLACEHOLDER
+//      |
+//     / \
+// Leaf3  Leaf1
+//
+//
+// After Removing Leaf1, the tree will look like the following:
+//
+//          Root
+//           |
+//         /   \
+//     Leaf3   Leaf2
+*/
+TEST(remove_tests, remove_a_leaf_at_depth_3_with_a_leaf_peer_and_another_peer_at_depth_1) {
+  BatchedInternalNode node;
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  const char* value3 = "Rihanna";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the first bit so that key1_hash becomes a sibling of key2_hash at
+  // depth 1.
+  auto key2_hash = flipMSBit(0, key1_hash);
+
+  // Flip the third bit bit so that key1_hash becomes a sibling of key3_hash at
+  // height depth 3.
+  auto key3_hash = flipMSBit(2, key1_hash);
+
+  ASSERT_EQ(0, key1_hash.prefix_bits_in_common(key2_hash));
+  ASSERT_EQ(2, key1_hash.prefix_bits_in_common(key3_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto value3_hash = hasher.hash(value3, strlen(value3));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto leaf_key3 = LeafKey(key3_hash, Version(3));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+  auto child3 = LeafChild{value3_hash, leaf_key3};
+
+  node.insert(child1, depth);
+  node.insert(child2, depth);
+  node.insert(child3, depth);
+
+  ASSERT_EQ(6, node.numChildren());
+  ASSERT_EQ(3, node.numInternalChildren());
+  ASSERT_EQ(3, node.numLeafChildren());
+
+  auto result = node.remove(key1_hash, depth, Version(4));
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::RemoveComplete>(result));
+  auto removed_version = std::get<BatchedInternalNode::RemoveComplete>(result).version;
+  ASSERT_EQ(Version(1), removed_version);
+
+  ASSERT_EQ(3, node.numChildren());
+  ASSERT_EQ(1, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+  // Ensure the root hash is correct.
+  ASSERT_EQ(node.hash(), hasher.parent(value3_hash, value2_hash));
+  ASSERT_EQ(Version(4), node.version());
+}
+
+/*
+// Remove a leaf (Leaf1) at depth 3 with leaf node as a peer.
+//
+// There are no other leaves in the tree, so RemoveBatchedInternalNode with a
+// promoted peer should be returned.
+//
+// The logical tree inside the BatchedInternalNode looks like the following
+// before the remove:
+//
+//                  Root
+//                   |
+//           -----------------
+//           |               |
+//        Internal      PLACEHOLDER
+//           |
+//          / \
+//   Internal  PLACEHOLDER
+//      |
+//     / \
+// Leaf3  Leaf1
+//
+*/
+TEST(remove_tests, remove_a_leaf_at_depth_3_with_a_leaf_peer_and_no_other_leaves) {
+  BatchedInternalNode node;
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value3 = "Rihanna";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the third bit bit so that key1_hash becomes a sibling of key3_hash at
+  // height depth 3.
+  auto key3_hash = flipMSBit(2, key1_hash);
+
+  ASSERT_EQ(2, key1_hash.prefix_bits_in_common(key3_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value3_hash = hasher.hash(value3, strlen(value3));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key3 = LeafKey(key3_hash, Version(3));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child3 = LeafChild{value3_hash, leaf_key3};
+
+  node.insert(child1, depth);
+  node.insert(child3, depth);
+
+  ASSERT_EQ(5, node.numChildren());
+  ASSERT_EQ(3, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+
+  // Deleting key1 should return RemoveBatchedInternalNode with a promoted
+  // child3.
+  auto result = node.remove(key1_hash, depth, Version(4));
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::RemoveBatchedInternalNode>(result));
+  auto promoted = std::get<BatchedInternalNode::RemoveBatchedInternalNode>(result).promoted.value();
+  ASSERT_EQ(child3, promoted);
+}
+
+/*
+// Try to Remove a leaf (Leaf1) at depth 4 with leaf node as a peer, but return
+// NotFound.
+//
+// The key given will match in the first Nibble, but 5th bit will be different,
+// so NotFound should be returned.
+//
+// The logical tree inside the BatchedInternalNode looks like the following
+// before and after the attempted remove:
+//
+//                       Root
+//                        |
+//                -----------------
+//                |               |
+//              Internal      PLACEHOLDER
+//                |
+//               / \
+//        Internal  PLACEHOLDER
+//           |
+//          / \
+//   Internal  PLACEHOLDER
+//      |
+//     / \
+// Leaf3 Leaf1
+//
+*/
+TEST(remove_tests, remove_a_mismatched_leaf_at_depth_4) {
+  BatchedInternalNode node;
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value3 = "Rihanna";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Flip the 4th bit bit so that key1_hash becomes a sibling of key3_hash at
+  // height depth 3.
+  auto key3_hash = flipMSBit(3, key1_hash);
+
+  // Flip the fifth bit of key1_hash so that it will collide in the first
+  // nibble.
+  auto partially_matching_hash = flipMSBit(4, key1_hash);
+
+  ASSERT_EQ(3, key1_hash.prefix_bits_in_common(key3_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value3_hash = hasher.hash(value3, strlen(value3));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key3 = LeafKey(key3_hash, Version(3));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child3 = LeafChild{value3_hash, leaf_key3};
+
+  node.insert(child1, depth);
+  node.insert(child3, depth);
+
+  ASSERT_EQ(6, node.numChildren());
+  ASSERT_EQ(4, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+
+  auto result = node.remove(partially_matching_hash, depth, Version(4));
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::NotFound>(result));
+
+  ASSERT_EQ(6, node.numChildren());
+  ASSERT_EQ(4, node.numInternalChildren());
+  ASSERT_EQ(2, node.numLeafChildren());
+}
+
+/*
+// The logical tree inside the BatchedInternalNode looks like the following
+// before the remove:
+//
+//                               Root
+//                                 |
+//                         -----------------
+//                         |               |
+//                      Internal      Placeholder
+//                         |
+//                 ----------------
+//                 |              |
+//              Internal       Placeholder
+//                 |
+//          ----------------
+//          |              |
+//      Internal       Placeholder
+//          |
+//    ----------------
+//    |              |
+// Internal       Placeholder
+//
+*/
+TEST(remove_tests, descend_because_requested_node_is_internal) {
+  BatchedInternalNode node;
+
+  Hasher hasher;
+  const char* key1 = "artist";
+  const char* value1 = "REM";
+  const char* value2 = "Nas";
+  size_t depth = 0;
+
+  auto key1_hash = hasher.hash(key1, strlen(key1));
+
+  // Copy the actual hash and set the first nibble to zeroes to make all
+  // internal children left ones.
+  std::array<uint8_t, Hash::SIZE_IN_BYTES> key1_hash_data;
+  std::copy(key1_hash.data(), key1_hash.data() + key1_hash.size(), key1_hash_data.begin());
+  key1_hash_data[0] &= 0x0F;
+  key1_hash = Hash{key1_hash_data};
+
+  // Flip the 5th bit so that key1_hash becomes a sibling of key2_hash at
+  // height -1 (in a new node).
+  auto key2_hash = flipMSBit(4, key1_hash);
+  ASSERT_EQ(4, key1_hash.prefix_bits_in_common(key2_hash));
+
+  auto value1_hash = hasher.hash(value1, strlen(value1));
+  auto value2_hash = hasher.hash(value2, strlen(value2));
+  auto leaf_key1 = LeafKey(key1_hash, Version(1));
+  auto leaf_key2 = LeafKey(key2_hash, Version(2));
+  auto child1 = LeafChild{value1_hash, leaf_key1};
+  auto child2 = LeafChild{value2_hash, leaf_key2};
+
+  node.insert(child1, depth);
+  node.insert(child2, depth);
+
+  ASSERT_EQ(5, node.numChildren());
+  ASSERT_EQ(5, node.numInternalChildren());
+  ASSERT_EQ(0, node.numLeafChildren());
+
+  auto result = node.remove(key1_hash, depth, Version(3));
+  ASSERT_TRUE(std::holds_alternative<BatchedInternalNode::Descend>(result));
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Support for removing a key from a `BatchedInternalNode` was added.
Removal returns one of four variants depending upon the structure of the
BatchedInternalNode:

 1. `RemoveComplete` if this leaf was deleted but other children prevent
 the BatchedInternalNode from being removed
 2. `NotFound` if the key does not exist in the BatchedInternalNode and
 there is not an InternalChild implying it lives in another
 BatchedInternalNode further down the tree.
 3. `RemoveBatchedInternalNode` if there were only 0 or 1 LeafChildren
 remaining such that the caller should remove the node and move the
 LeafChild into its parent.
 4. `Descend` if there is an InternalChild at depth 4 in this node where
 the key would have been found. This implies the key lives further down
 the tree and the caller should retrieve the next BatchedInternalNode.

Some helper methods were also added.

A comprehensive set of tests shows how the remove operates on the
BatchedInternalNode.