### PR TITLE
Reduce log level of ReplicaStatusMsg

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1434,7 +1434,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
   const ViewNum msgViewNum = msg->getViewNumber();
   Assert(msgLastStable % checkpointWindowSize == 0);
 
-  LOG_INFO_F(GL, "Node %d received ReplicaStatusMsg from node %d", (int)config_.replicaId, (int)msgSenderId);
+  LOG_DEBUG_F(GL, "Node %d received ReplicaStatusMsg from node %d", (int)config_.replicaId, (int)msgSenderId);
 
   /////////////////////////////////////////////////////////////////////////
   // Checkpoints


### PR DESCRIPTION
Depending on the number of replicas there will be lots of status messages
without much value in production. Let's reduce the log level to debug and
increase it at runtime if needed.