### PR TITLE
Add linearizability checks to slow path tests

### DIFF
--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -49,10 +49,10 @@ class SkvbcFastPathTest(unittest.TestCase):
         This test aims to check that the fast commit path is prevalent
         in the normal, synchronous case (no failed replicas, no network partitioning).
 
-        First we write a series of known K/V entries.
+        First we write a series of K/V entries and tracked them using the tracker from the decorator.
         Then we check that, in the process, we have stayed on the fast path.
 
-        Finally we check if a known K/V has been executed.
+        Finally the decorator verifies the KV execution.
         """
         bft_network.start_all_replicas()
         max_size = 1
@@ -69,7 +69,7 @@ class SkvbcFastPathTest(unittest.TestCase):
         """
         This test aims to check the correct transition from fast to slow commit path.
 
-        First we write a series of known K/V entries, making sure
+        First we write a series of K/V entries and tracked them using the tracker from the decorator, making sure
         we stay on the fast path.
 
         Once the first series of K/V writes have been processed, we bring down
@@ -78,7 +78,7 @@ class SkvbcFastPathTest(unittest.TestCase):
         We send a new series of K/V writes and make sure they
         have been processed using the slow commit path.
 
-        Finally we check if a known K/V has been executed.
+        Finally the decorator verifies the KV execution.
         """
         bft_network.start_all_replicas()
         max_size = 1
@@ -109,10 +109,10 @@ class SkvbcFastPathTest(unittest.TestCase):
         As a first step, we bring down no more than c replicas,
         triggering initially the slow path.
 
-        Then we write a series of known K/V entries, making sure
+        Then we write a series of K/V entries and tracked them using the tracker from the decorator, making sure
         the fast path is eventually restored and becomes prevalent.
 
-        Finally we check if a known K/V write has been executed.
+        Finally the decorator verifies the KV execution.
         """
         bft_network.start_all_replicas()
         max_size = 1

--- a/tests/test_skvbc_fast_path.py
+++ b/tests/test_skvbc_fast_path.py
@@ -13,7 +13,7 @@
 import os.path
 import random
 import unittest
-
+from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 

--- a/tests/test_skvbc_linearizability.py
+++ b/tests/test_skvbc_linearizability.py
@@ -61,7 +61,7 @@ class SkvbcChaosTest(unittest.TestCase):
         self.bft_network = bft_network
         self.bft_network.start_all_replicas()
         async with trio.open_nursery() as nursery:
-            nursery.start_soon(self.run_concurrent_ops, num_ops, tracker)
+            nursery.start_soon(tracker.run_concurrent_ops, num_ops)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -83,7 +83,7 @@ class SkvbcChaosTest(unittest.TestCase):
             adversary.interfere()
 
             async with trio.open_nursery() as nursery:
-                nursery.start_soon(self.run_concurrent_ops, num_ops, tracker)
+                nursery.start_soon(tracker.run_concurrent_ops, num_ops)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -101,23 +101,8 @@ class SkvbcChaosTest(unittest.TestCase):
         self.bft_network = bft_network
         self.bft_network.start_all_replicas()
         async with trio.open_nursery() as nursery:
-            nursery.start_soon(self.run_concurrent_ops, num_ops, tracker)
+            nursery.start_soon(tracker.run_concurrent_ops, num_ops)
             nursery.start_soon(self.crash_primary)
-
-    async def run_concurrent_ops(self, num_ops, tracker):
-        max_concurrency = len(self.bft_network.clients) // 2
-        write_weight = .70
-        max_size = len(self.skvbc.keys) // 2
-        sent = 0
-        while sent < num_ops:
-            clients = self.bft_network.random_clients(max_concurrency)
-            async with trio.open_nursery() as nursery:
-                for client in clients:
-                    if random.random() < write_weight:
-                        nursery.start_soon(tracker.send_tracked_write, client, max_size)
-                    else:
-                        nursery.start_soon(tracker.send_tracked_read, client, max_size)
-            sent += len(clients)
 
     async def crash_primary(self):
         await trio.sleep(.5)

--- a/tests/test_skvbc_slow_path.py
+++ b/tests/test_skvbc_slow_path.py
@@ -18,6 +18,7 @@ import trio
 
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+from util.skvbc_history_tracker import verify_linearizability
 
 
 def start_replica_cmd(builddir, replica_id):
@@ -47,41 +48,43 @@ class SkvbcSlowPathTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: c == 0)
-    async def test_persistent_slow_path(self, bft_network):
+    @verify_linearizability
+    async def test_persistent_slow_path(self, bft_network, tracker):
         """
         Start a full BFT network with c=0 then bring one replica down.
 
-        Write a batch of known K/V entries.
+        Write a batch of K/V entries and track them using the tracker from the decorator.
 
         Then we check that messages from now on are processed on the slow commit path.
         (note that this is not the case for c>0 where the BFT network eventually
         returns to the fast commit path)
 
-        Finally we check if a known K/V has been executed and readable.
+        Finally, we check if a these entries were executed and readable.
         """
+        num_ops = self.evaluation_period_seq_num * 2
+        write_weight = 0.5
+
         bft_network.start_all_replicas()
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
         unstable_replicas = bft_network.all_replicas(without={0})
         bft_network.stop_replica(
             replica=random.choice(unstable_replicas))
 
-        for _ in range(self.evaluation_period_seq_num * 2):
-            key, val = await skvbc.write_known_kv()
-
+        await tracker.run_concurrent_ops(
+            num_ops=num_ops, write_weight=write_weight)
         await bft_network.assert_slow_path_prevalent(as_of_seq_num=1)
-
-        await skvbc.assert_kv_write_executed(key, val)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
-    async def test_slow_to_fast_path_transition(self, bft_network):
+    @verify_linearizability
+    async def test_slow_to_fast_path_transition(self, bft_network, tracker):
         """
         This test aims to check that the system correctly restores
         the fast path once all failed nodes are back online.
 
         First we bring down a non-primary replica, and make sure
-        a batch of K/V entries is processed on the slow path.
+        a batch of K/V entries is processed on the slow path while we track those entries
+        using the tracker from the decorator.
 
         Once the first batch of K/V writes have been processed, we bring the
         failed replica back up, which should restore the system's ability to
@@ -92,50 +95,55 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
         Finally we check if a known K/V has been executed and readable.
         """
+        num_ops = 10
+        write_weight = 0.5
+
         bft_network.start_all_replicas()
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
         unstable_replicas = bft_network.all_replicas(without={0})
         crashed_replica = random.choice(unstable_replicas)
         bft_network.stop_replica(crashed_replica)
 
-        for _ in range(10):
-            await skvbc.write_known_kv()
+        _, slow_path_writes = await tracker.run_concurrent_ops(
+            num_ops=num_ops, write_weight=1)
 
         await bft_network.assert_slow_path_prevalent(as_of_seq_num=1)
 
         bft_network.start_replica(crashed_replica)
 
-        for _ in range(10):
-            key, val = await skvbc.write_known_kv()
+        await tracker.run_concurrent_ops(
+            num_ops=num_ops, write_weight=write_weight)
 
-        await bft_network.assert_fast_path_prevalent(nb_slow_paths_so_far=10)
+        await trio.sleep(5)
+        await bft_network.assert_fast_path_prevalent(nb_slow_paths_so_far=slow_path_writes)
 
-        await skvbc.assert_kv_write_executed(key, val)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
-    async def test_slow_path_view_change(self, bft_network):
+    @verify_linearizability
+    async def test_slow_path_view_change(self, bft_network, tracker):
         """
         This test validates the BFT engine's transition to the slow path
         when the primary goes down. This effectively triggers a view change in the slow path.
 
-        First we write a batch of known K/V entries.
+        First we write a batch of K/V entries and track them using the tracker from the decorator.
 
         We check those entries have been processed via the fast commit path.
 
-        We stop the primary and send a batch of requests, triggering slow path & view change.
+        We stop the primary and send a indefinite batch of tracked read & write requests,
+        triggering slow path & view change.
 
         We bring the primary back up.
 
         We make sure the second batch of requests have been processed via the slow path.
         """
 
+        num_ops = 10
+        write_weight = 0.5
         bft_network.start_all_replicas()
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-        for _ in range(10):
-            await skvbc.write_known_kv()
+        await tracker.run_concurrent_ops(
+            num_ops=num_ops, write_weight=1)
 
         await bft_network.assert_fast_path_prevalent()
 
@@ -143,7 +151,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
         with trio.move_on_after(seconds=5):
             async with trio.open_nursery() as nursery:
-                nursery.start_soon(skvbc.send_indefinite_write_requests)
+                nursery.start_soon(tracker.send_indefinite_tracked_ops, write_weight)
 
         bft_network.start_replica(0)
 

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -872,7 +872,7 @@ class SkvbcTracker:
         return list(zip(writeset_keys, writeset_values))
 
     async def run_concurrent_ops(self, num_ops, write_weight=.70):
-        max_concurrency = min(num_ops, len(self.bft_network.clients) // 2)
+        max_concurrency = len(self.bft_network.clients) // 2
         max_size = len(self.skvbc.keys) // 2
         sent = 0
         while sent < num_ops:

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -875,12 +875,17 @@ class SkvbcTracker:
         max_concurrency = len(self.bft_network.clients) // 2
         max_size = len(self.skvbc.keys) // 2
         sent = 0
+        write_count = 0
+        read_count = 0
         while sent < num_ops:
             clients = self.bft_network.random_clients(max_concurrency)
             async with trio.open_nursery() as nursery:
                 for client in clients:
                     if random.random() < write_weight:
                         nursery.start_soon(self.send_tracked_write, client, max_size)
+                        write_count += 1
                     else:
                         nursery.start_soon(self.send_tracked_read, client, max_size)
+                        read_count += 1
             sent += len(clients)
+        return read_count, write_count

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -889,3 +889,16 @@ class SkvbcTracker:
                         read_count += 1
             sent += len(clients)
         return read_count, write_count
+
+    async def send_indefinite_tracked_ops(self, write_weight=.70):
+        max_size = len(self.skvbc.keys) // 2
+        while True:
+            client = self.bft_network.random_client()
+            try:
+                if random.random() < write_weight:
+                    await self.send_tracked_write(client, max_size)
+                else:
+                    await self.send_tracked_read(client, max_size)
+            except:
+                pass
+            await trio.sleep(.1)

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -872,7 +872,7 @@ class SkvbcTracker:
         return list(zip(writeset_keys, writeset_values))
 
     async def run_concurrent_ops(self, num_ops, write_weight=.70):
-        max_concurrency = len(self.bft_network.clients) // 2
+        max_concurrency = min(num_ops, len(self.bft_network.clients) // 2)
         max_size = len(self.skvbc.keys) // 2
         sent = 0
         while sent < num_ops:

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -870,3 +870,17 @@ class SkvbcTracker:
         writeset_keys = self.skvbc.random_keys(random.randint(0, max_size))
         writeset_values = self.skvbc.random_values(len(writeset_keys))
         return list(zip(writeset_keys, writeset_values))
+
+    async def run_concurrent_ops(self, num_ops, write_weight=.70):
+        max_concurrency = len(self.bft_network.clients) // 2
+        max_size = len(self.skvbc.keys) // 2
+        sent = 0
+        while sent < num_ops:
+            clients = self.bft_network.random_clients(max_concurrency)
+            async with trio.open_nursery() as nursery:
+                for client in clients:
+                    if random.random() < write_weight:
+                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                    else:
+                        nursery.start_soon(self.send_tracked_read, client, max_size)
+            sent += len(clients)


### PR DESCRIPTION
1)add verify_linearizability decorator for each test.
2)replace regular KV writing to tracked KV writing.
3)check KV writing successful execution at the end of the decorator using tracker verify.
4)create "send_indefinite_tracked_ops" that send indefinite operations and track them