### PR TITLE
Logging improvements for debugging

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -140,7 +140,8 @@ IReplica *IReplica::createNewReplica(ReplicaConfig *replicaConfig,
 
   auto *replicaInternal = new ReplicaInternal();
   shared_ptr<MsgHandlersRegistrator> msgHandlersPtr(new MsgHandlersRegistrator());
-  shared_ptr<IncomingMsgsStorage> incomingMsgsStoragePtr(new IncomingMsgsStorageImp(msgHandlersPtr, timersResolution));
+  shared_ptr<IncomingMsgsStorage> incomingMsgsStoragePtr(
+      new IncomingMsgsStorageImp(msgHandlersPtr, timersResolution, replicaConfig->replicaId));
   shared_ptr<IReceiver> msgReceiverPtr(new MsgReceiver(incomingMsgsStoragePtr));
   shared_ptr<MsgsCommunicator> msgsCommunicatorPtr(
       new MsgsCommunicator(communication, incomingMsgsStoragePtr, msgReceiverPtr));

--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
@@ -40,7 +40,8 @@ namespace bftEngine::impl {
 class IncomingMsgsStorageImp : public IncomingMsgsStorage {
  public:
   explicit IncomingMsgsStorageImp(std::shared_ptr<MsgHandlersRegistrator>& msgHandlersPtr,
-                                  std::chrono::milliseconds msgWaitTimeout);
+                                  std::chrono::milliseconds msgWaitTimeout,
+                                  uint16_t replicaId);
   ~IncomingMsgsStorageImp() override;
 
   void start() override;
@@ -62,6 +63,8 @@ class IncomingMsgsStorageImp : public IncomingMsgsStorage {
  private:
   const uint64_t minTimeBetweenOverflowWarningsMilli_ = 5 * 1000;
   const uint16_t maxNumberOfPendingExternalMsgs_ = 20000;
+
+  uint16_t replicaId_;
 
   std::mutex lock_;
   std::condition_variable condVar_;

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -21,7 +21,8 @@ concordlogger::Logger initLogger() { return concordlogger::Log::getLogger(DEFAUL
 
 concordlogger::Logger initLogger() {
   log4cplus::SharedAppenderPtr ca_ptr = log4cplus::SharedAppenderPtr(new log4cplus::ConsoleAppender(false, true));
-  ca_ptr->setLayout(std::auto_ptr<log4cplus::Layout>(new log4cplus::PatternLayout("%-5p|%c|%M|%m|%n")));
+  ca_ptr->setLayout(
+      std::auto_ptr<log4cplus::Layout>(new log4cplus::PatternLayout("[Node %X{rid}] [%t] %-5p|%c|%M|%m|%n")));
   log4cplus::Logger::getRoot().addAppender(ca_ptr);
   log4cplus::Logger::getRoot().setLogLevel(log4cplus::INFO_LOG_LEVEL);
   return log4cplus::Logger::getInstance(LOG4CPLUS_TEXT(DEFAULT_LOGGER_NAME));

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -166,7 +166,7 @@ bool InternalCommandsHandler::executeGetBlockDataCommand(
   const int numMetadataKeys = 1;
   auto numOfElements = outBlockData.size() - numMetadataKeys;
   size_t replySize = SimpleReply_Read::getSize(numOfElements);
-  LOG_ERROR(m_logger, "NUM OF ELEMENTS IN BLOCK = " << numOfElements);
+  LOG_INFO(m_logger, "NUM OF ELEMENTS IN BLOCK = " << numOfElements);
   if (maxReplySize < replySize) {
     LOG_ERROR(m_logger, "replySize is too big: replySize=" << replySize << ", maxReplySize=" << maxReplySize);
     return false;


### PR DESCRIPTION
- adding a timestamp for each log statement
- logging the replica ID when processing incoming messages
- fixed the log level of "NUM OF ELEMENTS IN BLOCK = " (ERROR -> INFO)

Sample log messsage:
```
[Node 2] [139645684168448] INFO |concord|void bftEngine::impl::ReplicaImp::onMessage(bftEngine::impl::ClientRequestMsg *)|Node 2 received ClientRequestMsg (clientId=4 reqSeqNum=6626155588176838656, readOnly=0) from Node 4|
```