### PR TITLE
Reduce log level of ClientRequestMsg

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -123,13 +123,13 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
   const bool readOnly = m->isReadOnly();
   const ReqId reqSeqNum = m->requestSeqNum();
 
-  LOG_INFO_F(GL,
-             "Node %d received ClientRequestMsg (clientId=%d reqSeqNum=%" PRIu64 ", readOnly=%d) from Node %d",
-             config_.replicaId,
-             clientId,
-             reqSeqNum,
-             readOnly ? 1 : 0,
-             senderId);
+  LOG_DEBUG_F(GL,
+              "Node %d received ClientRequestMsg (clientId=%d reqSeqNum=%" PRIu64 ", readOnly=%d) from Node %d",
+              config_.replicaId,
+              clientId,
+              reqSeqNum,
+              readOnly ? 1 : 0,
+              senderId);
 
   if (isCollectingState()) {
     LOG_INFO(GL,


### PR DESCRIPTION
Similar to ReplicaStatusMsg, this log is printed on every invocation of
onMessage. This is too noisy and hence we reduce the log level to debug. Once
we have fine granual loggers, it should be easy to raise the log level of
ClientRequestMsg only.