### PR TITLE
Add linearizabilty checks into persistence tests

### DIFF
--- a/tests/test_skvbc_persistence.py
+++ b/tests/test_skvbc_persistence.py
@@ -163,7 +163,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
         # Perform a put/get transaction pair to ensure we can read newly
         # written data after state transfer.
 
-        await tracker.tracked_read_your_writes(self)
+        await tracker.tracked_read_your_writes()
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -212,7 +212,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
         # Perform a put/get transaction pair to ensure we can read newly
         # written data after state transfer.
 
-        await tracker.tracked_read_your_writes(self)
+        await tracker.tracked_read_your_writes()
 
     async def _fetch_or_finish_state_transfer_while_crashing(self,
                                                              bft_network,

--- a/tests/test_skvbc_persistence.py
+++ b/tests/test_skvbc_persistence.py
@@ -17,7 +17,8 @@ import random
 
 from util import bft
 from util import skvbc as kvbc
-
+from util.skvbc import SimpleKVBCProtocol
+from util.skvbc_history_tracker import verify_linearizability
 from math import inf
 
 from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network
@@ -45,12 +46,14 @@ def start_replica_cmd(builddir, replica_id):
             "-p"
             ]
 
+
 class SkvbcPersistenceTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: f >= 2)
-    async def test_view_change_transitions_safely_without_quorum(self, bft_network):
+    @verify_linearizability
+    async def test_view_change_transitions_safely_without_quorum(self, bft_network, tracker):
         """
         Start up only N-2 out of N replicas and send client commands. This should
         trigger a succesful view change attempt and trigger the assert in issue
@@ -59,12 +62,11 @@ class SkvbcPersistenceTest(unittest.TestCase):
         This is a regression test for
         https://github.com/vmware/concord-bft/issues/194.
         """
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         [bft_network.start_replica(i) for i in range(1, bft_network.config.n - 1)]
         with trio.fail_after(60):  # seconds
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(
-                    skvbc.send_indefinite_write_requests)
+                    tracker.send_indefinite_tracked_ops)
                 # See if replica 1 has become the new primary
                 await bft_network.wait_for_view(
                     replica_id=1,
@@ -100,39 +102,31 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd)
-    async def test_read_written_data_after_restart_of_all_nodes(self, bft_network):
+    @verify_linearizability
+    async def test_read_written_data_after_restart_of_all_nodes(self, bft_network, tracker):
         """
         This test aims to validate the blockchain is persistent
         (i.e. the data is still available after restarting all nodes)
-        1) Write a key-value entry to the blockchain
+        1) Write and track a key-value entry to the blockchain
         2) Restart all replicas (stop all, followed by start all)
         3) Verify the same key-value can be read from the blockchain
         """
         bft_network.start_all_replicas()
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-
-        key = skvbc.random_key()
-        value = skvbc.random_value()
-
-        kv = (key, value)
-        write_kv_msg = skvbc.write_req([], [kv], 0)
-
-        client = bft_network.random_client()
-        await client.write(write_kv_msg)
+        key = tracker.skvbc.random_key()
+        val = tracker.skvbc.random_value()
+        await tracker.write_and_track_known_kv([(key, val)], bft_network.random_client())
 
         bft_network.stop_all_replicas()
         bft_network.start_all_replicas()
 
-        read_key_msg = skvbc.read_req([key])
-        reply = await client.read(read_key_msg)
+        kv_reply = await tracker.read_and_track_known_kv(key, bft_network.random_client())
 
-        kv_reply = skvbc.parse_reply(reply)
-
-        self.assertEqual({key: value}, kv_reply)
+        self.assertEqual({key: val}, kv_reply)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
-    async def test_checkpoints_saved_and_transferred(self, bft_network):
+    @verify_linearizability
+    async def test_checkpoints_saved_and_transferred(self, bft_network, tracker):
         """
         Start a 3 nodes out of a 4 node cluster. Write a specific key, then
         enough data to the cluster to trigger a checkpoint and log garbage
@@ -145,14 +139,14 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         After that ensure that a newly put value can be retrieved.
         """
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         stale_node = random.choice(bft_network.all_replicas(without={0}))
 
-        client, known_key, known_kv = \
-            await skvbc.prime_for_state_transfer(stale_nodes={stale_node})
+        client, known_key, known_val, known_kv = \
+            await tracker.tracked_prime_for_state_transfer(stale_nodes={stale_node})
 
         # Start the replica without any data, and wait for state transfer to
         # complete.
+
         bft_network.start_replica(stale_node)
         await bft_network.wait_for_state_transfer_to_start()
         up_to_date_node = 0
@@ -163,16 +157,18 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         # Retrieve the value we put first to ensure state transfer worked
         # when the log went away
-        kvpairs = await client.read([known_key])
+        kvpairs = await tracker.read_and_track_known_kv(known_key, client)
         self.assertDictEqual(dict(known_kv), kvpairs)
 
         # Perform a put/get transaction pair to ensure we can read newly
         # written data after state transfer.
-        await skvbc.assert_successful_put_get(self)
+
+        # await skvbc.read_your_writes(self)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
-    async def test_st_when_fetcher_crashes(self, bft_network):
+    @verify_linearizability
+    async def test_st_when_fetcher_crashes(self, bft_network, tracker):
         """
         Start N-1 nodes out of a N node cluster (hence 1 stale node). Write a specific key,
         then enough data to the cluster to trigger a checkpoint. Then stop all the nodes,
@@ -186,11 +182,10 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         After that ensure that a newly put value can be retrieved.
         """
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         stale_node = random.choice(bft_network.all_replicas(without={0}))
 
-        client, known_key, known_kv = \
-            await skvbc.prime_for_state_transfer(stale_nodes={stale_node})
+        client, known_key, known_val, known_kv = \
+            await tracker.tracked_prime_for_state_transfer(stale_nodes={stale_node})
 
         # Start the empty replica, wait for it to start fetching, then stop
         # it.
@@ -211,42 +206,44 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         # Retrieve the value we put first to ensure state transfer worked
         # when the log went away
-        kvpairs = await client.read([known_key])
+        kvpairs = await tracker.read_and_track_known_kv(known_key, client)
         self.assertDictEqual(dict(known_kv), kvpairs)
 
         # Perform a put/get transaction pair to ensure we can read newly
         # written data after state transfer.
-        await skvbc.assert_successful_put_get(self)
+
+        # await skvbc.assert_successful_put_get(self)
 
     async def _fetch_or_finish_state_transfer_while_crashing(self,
                                                              bft_network,
                                                              up_to_date_node,
                                                              stale_node,
                                                              nb_crashes=20):
-       for _ in range(nb_crashes):
-           print(f'Restarting replica {stale_node}')
-           bft_network.start_replica(stale_node)
-           try:
-               await bft_network.wait_for_fetching_state(stale_node)
-               # Sleep a bit to give some time for the fetch to make progress
-               await trio.sleep(random.uniform(0, 1))
+        for _ in range(nb_crashes):
+            print(f'Restarting replica {stale_node}')
+            bft_network.start_replica(stale_node)
+            try:
+                await bft_network.wait_for_fetching_state(stale_node)
+                # Sleep a bit to give some time for the fetch to make progress
+                await trio.sleep(random.uniform(0, 1))
 
-           except trio.TooSlowError:
-               # We never made it to fetching state. Are we done?
-               try:
-                   await bft_network.wait_for_state_transfer_to_stop(
-                       up_to_date_node, stale_node)
-               except trio.TooSlowError:
-                   self.fail("State transfer did not complete, " +
-                             "but we are not fetching either!")
-           finally:
-               print(f'Stopping replica {stale_node}')
-               bft_network.stop_replica(stale_node)
+            except trio.TooSlowError:
+                # We never made it to fetching state. Are we done?
+                try:
+                    await bft_network.wait_for_state_transfer_to_stop(
+                        up_to_date_node, stale_node)
+                except trio.TooSlowError:
+                    self.fail("State transfer did not complete, " +
+                              "but we are not fetching either!")
+            finally:
+                print(f'Stopping replica {stale_node}')
+                bft_network.stop_replica(stale_node)
 
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: f >= 2)
-    async def test_st_when_fetcher_and_sender_crash(self, bft_network):
+    @verify_linearizability
+    async def test_st_when_fetcher_and_sender_crash(self, bft_network, tracker):
         """
         Start N-1 nodes out of a N node cluster. Write a specific key, then
         enough data to the cluster to trigger a checkpoint.
@@ -264,14 +261,11 @@ class SkvbcPersistenceTest(unittest.TestCase):
         After that ensure that the key-value entry initially written
         can be retrieved.
         """
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         stale_node = random.choice(bft_network.all_replicas(without={0}))
 
-        client, known_key, known_kv = \
-            await skvbc.prime_for_state_transfer(
-                checkpoints_num=4,
-                stale_nodes={stale_node}
-            )
+        client, known_key, known_val, known_kv = \
+            await tracker.tracked_prime_for_state_transfer(checkpoints_num=4,
+                                                           stale_nodes={stale_node})
 
         # exclude the primary and the stale node
         unstable_replicas = bft_network.all_replicas(without={0, stale_node})
@@ -286,7 +280,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         # Retrieve the value we put first to ensure state transfer worked
         # when the log went away
-        kvpairs = await client.read([known_key])
+        kvpairs = await tracker.read_and_track_known_kv(known_key, client)
         self.assertDictEqual(dict(known_kv), kvpairs)
 
     async def _run_state_transfer_while_crashing_non_primary(
@@ -334,7 +328,8 @@ class SkvbcPersistenceTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: f >= 2)
-    async def test_st_while_crashing_primary_with_vc(self, bft_network):
+    @verify_linearizability
+    async def test_st_while_crashing_primary_with_vc(self, bft_network, tracker):
         """
         Start N-1 nodes out of a N node cluster. Write a specific key, then
         enough data to the cluster to trigger a checkpoint.
@@ -353,13 +348,15 @@ class SkvbcPersistenceTest(unittest.TestCase):
         await self._test_st_while_crashing_primary(
             bft_network=bft_network,
             trigger_view_change=True,
-            crash_repeatedly=True
+            crash_repeatedly=True,
+            tracker=tracker
         )
 
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: f >= 2)
-    async def test_st_while_crashing_primary_no_vc(self, bft_network):
+    @verify_linearizability
+    async def test_st_while_crashing_primary_no_vc(self, bft_network, tracker):
         """
         Start N-1 nodes out of a N node cluster. Write a specific key, then
         enough data to the cluster to trigger a checkpoint.
@@ -379,25 +376,22 @@ class SkvbcPersistenceTest(unittest.TestCase):
         await self._test_st_while_crashing_primary(
             bft_network,
             trigger_view_change=False,
-            crash_repeatedly=False
+            crash_repeatedly=False,
+            tracker=tracker
         )
 
     async def _test_st_while_crashing_primary(
-            self, bft_network, trigger_view_change, crash_repeatedly):
+            self, bft_network, trigger_view_change, crash_repeatedly, tracker):
         # we need a BFT network with f >= 2, allowing us to have 2
         # crashed replicas at the same time (the primary and the stale node)
 
         n = bft_network.config.n
 
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         stale_replica = n - 1
 
-        client, known_key, known_kv = \
-            await skvbc.prime_for_state_transfer(
-                checkpoints_num=4,
-                stale_nodes={stale_replica}
-            )
-
+        client, known_key, known_val, known_kv = \
+            await tracker.tracked_prime_for_state_transfer(checkpoints_num=4,
+                                                           stale_nodes={stale_replica})
         view = await bft_network.wait_for_view(
             replica_id=0,
             expected=lambda v: v == 0,
@@ -408,7 +402,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         if crash_repeatedly:
             await self._run_state_transfer_while_crashing_primary_repeatedly(
-                skvbc=skvbc,
+                skvbc=tracker.skvbc,
                 bft_network=bft_network,
                 n=n,
                 primary=0,
@@ -416,7 +410,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
             )
         else:
             await self._run_state_transfer_while_crashing_primary_once(
-                skvbc=skvbc,
+                skvbc=tracker.skvbc,
                 bft_network=bft_network,
                 n=n,
                 primary=0,
@@ -426,7 +420,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         bft_network.force_quorum_including_replica(stale_replica)
 
-        kvpairs = await client.read([known_key])
+        kvpairs = await tracker.read_and_track_known_kv(known_key, client)
         self.assertDictEqual(dict(known_kv), kvpairs)
 
     async def _run_state_transfer_while_crashing_primary_once(
@@ -513,7 +507,6 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         print(f'State transfer completed, despite the primary '
               f'replica crashing repeatedly in the process.')
-
 
     async def _trigger_view_change(self, skvbc):
         print("Sending random transactions to trigger view change...")

--- a/tests/util/skvbc.py
+++ b/tests/util/skvbc.py
@@ -22,7 +22,7 @@ WriteReply = namedtuple('WriteReply', ['success', 'last_block_id'])
 
 
 class SimpleKVBCProtocol:
-    KV_LEN = 21  ## SimpleKVBC requies fixed size keys and values right now
+    KV_LEN = 21 ## SimpleKVBC requies fixed size keys and values right now
     READ_LATEST = 0xFFFFFFFFFFFFFFFF
 
     READ = 1
@@ -51,7 +51,7 @@ class SimpleKVBCProtocol:
         data.append(cls.WRITE)
         # SimpleConditionalWriteHeader
         data.extend(
-            struct.pack("<QQQ", block_id, len(readset), len(writeset)))
+                struct.pack("<QQQ", block_id, len(readset), len(writeset)))
         # SimpleKey[numberOfKeysInReadSet]
         for r in readset:
             data.extend(r)
@@ -108,9 +108,9 @@ class SimpleKVBCProtocol:
         data = data[8:]
         kv_pairs = {}
         for i in range(num_kv_pairs):
-            kv_pairs[data[0:cls.KV_LEN]] = data[cls.KV_LEN:2 * cls.KV_LEN]
-            if i + 1 != num_kv_pairs:
-                data = data[2 * cls.KV_LEN:]
+            kv_pairs[data[0:cls.KV_LEN]] = data[cls.KV_LEN:2*cls.KV_LEN]
+            if i+1 != num_kv_pairs:
+                data = data[2*cls.KV_LEN:]
         return kv_pairs
 
     @staticmethod
@@ -212,7 +212,7 @@ class SimpleKVBCProtocol:
         """
         client = SkvbcClient(self.bft_network.random_client())
         # Write enough data to checkpoint and create a need for state transfer
-        for i in range(1 + checkpoint_num * 150):
+        for i in range (1 + checkpoint_num * 150):
             key = self.random_key()
             val = self.random_value()
             reply = await client.write([], [(key, val)])
@@ -238,7 +238,7 @@ class SimpleKVBCProtocol:
             # checkpoint data.
             [self.bft_network.start_replica(i) for i in initial_nodes]
             await self.bft_network.wait_for_replicas_to_checkpoint(initial_nodes,
-                                                                   checkpoint_num)
+                                                              checkpoint_num)
 
     async def assert_successful_put_get(self, testcase):
         """ Assert that we can get a valid put """
@@ -259,7 +259,7 @@ class SimpleKVBCProtocol:
         # Retrieve the last block and ensure that it matches what's expected
         read_reply = await client.read(self.get_last_block_req())
         newest_block = self.parse_reply(read_reply)
-        testcase.assertEqual(last_block + 1, newest_block)
+        testcase.assertEqual(last_block+1, newest_block)
 
         # Get the previous put value, and ensure it's correct
         read_req = self.read_req([key], newest_block)
@@ -283,7 +283,7 @@ class SimpleKVBCProtocol:
         keys = [b"A...................."]
         for i in range(1, 2 * num_clients):
             end = cur[-1]
-            if chr(end) == 'Z':  # extend the key
+            if chr(end) == 'Z': # extend the key
                 cur.append(self.alpha[0])
             else:
                 cur[-1] = end + 1

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -963,7 +963,7 @@ class SkvbcTracker:
 
         return client, known_key, known_val, known_kv
 
-    async def tracked_read_your_writes(self, test_class):
+    async def tracked_read_your_writes(self):
         client = self.bft_network.random_client()
         keys = self.skvbc._create_keys()
         # Verify by "Read your write"
@@ -979,8 +979,8 @@ class SkvbcTracker:
         #reply = await client.write(self.write_req([], kv, 0))
         #reply = self.parse_reply(reply)
         reply = await self.write_and_track_known_kv(kv,client)
-        test_class.assertTrue(reply.success)
-        test_class.assertEqual(last_block + 1, reply.last_block_id)
+        assert reply.success
+        assert last_block + 1 == reply.last_block_id
 
         last_block = reply.last_block_id
 
@@ -988,4 +988,5 @@ class SkvbcTracker:
         # Get the kvpairs in the last written block
         data = await client.read(self.skvbc.get_block_data_req(last_block))
         kv2 = self.skvbc.parse_reply(data)
-        test_class.assertDictEqual(kv2, dict(kv))
+
+        assert kv2 == dict(kv)

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -916,6 +916,7 @@ class SkvbcTracker:
             self.status.record_client_reply(client_id)
             reply = self.skvbc.parse_reply(serialized_reply)
             self.handle_write_reply(client_id, seq_num, reply)
+            return reply
         except trio.TooSlowError:
             self.status.record_client_timeout(client_id)
             return
@@ -962,3 +963,29 @@ class SkvbcTracker:
 
         return client, known_key, known_val, known_kv
 
+    async def tracked_read_your_writes(self, test_class):
+        client = self.bft_network.random_client()
+        keys = self.skvbc._create_keys()
+        # Verify by "Read your write"
+        # Perform write with the new primary
+
+        last_block = self.skvbc.parse_reply(
+            await client.read(self.skvbc.get_last_block_req()))
+        # Perform an unconditional KV put.
+        # Ensure keys aren't identical
+        kv = [(keys[0], self.skvbc.random_value()),
+              (keys[1], self.skvbc.random_value())]
+
+        #reply = await client.write(self.write_req([], kv, 0))
+        #reply = self.parse_reply(reply)
+        reply = await self.write_and_track_known_kv(kv,client)
+        test_class.assertTrue(reply.success)
+        test_class.assertEqual(last_block + 1, reply.last_block_id)
+
+        last_block = reply.last_block_id
+
+        # Read the last write and check if equal
+        # Get the kvpairs in the last written block
+        data = await client.read(self.skvbc.get_block_data_req(last_block))
+        kv2 = self.skvbc.parse_reply(data)
+        test_class.assertDictEqual(kv2, dict(kv))

--- a/tests/util/skvbc_history_tracker.py
+++ b/tests/util/skvbc_history_tracker.py
@@ -902,3 +902,63 @@ class SkvbcTracker:
             except:
                 pass
             await trio.sleep(.1)
+
+    async def write_and_track_known_kv(self, kv, client):
+        read_version = self.read_block_id()
+        readset = self.readset(0, 0)
+        msg = self.skvbc.write_req(readset, kv, read_version)
+        seq_num = client.req_seq_num.next()
+        client_id = client.client_id
+        self.send_write(
+            client_id, seq_num, readset, dict(kv), read_version)
+        try:
+            serialized_reply = await client.write(msg, seq_num)
+            self.status.record_client_reply(client_id)
+            reply = self.skvbc.parse_reply(serialized_reply)
+            self.handle_write_reply(client_id, seq_num, reply)
+        except trio.TooSlowError:
+            self.status.record_client_timeout(client_id)
+            return
+
+    async def read_and_track_known_kv(self, key, client):
+        msg = self.skvbc.read_req([key])
+        seq_num = client.req_seq_num.next()
+        client_id = client.client_id
+        self.send_read(client_id, seq_num, [key])
+        try:
+            serialized_reply = await client.read(msg, seq_num)
+            self.status.record_client_reply(client_id)
+            reply = self.skvbc.parse_reply(serialized_reply)
+            self.handle_read_reply(client_id, seq_num, reply)
+            return reply
+        except trio.TooSlowError:
+            self.status.record_client_timeout(client_id)
+            return
+
+    async def tracked_prime_for_state_transfer(
+            self, stale_nodes,
+            checkpoints_num=2,
+            persistency_enabled=True):
+        initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
+        [self.bft_network.start_replica(i) for i in initial_nodes]
+        client = self.bft_network.random_client()
+        # Write a KV pair with a known value
+        known_key = self.skvbc.max_key()
+        known_val = self.skvbc.random_value()
+        known_kv = [(known_key, known_val)]
+        await self.write_and_track_known_kv(known_kv, client)
+        # Fill up the initial nodes with data, checkpoint them and stop
+        # them. Then bring them back up and ensure the checkpoint data is
+        # there.
+        client1 = self.bft_network.random_client()
+        # Write enough data to checkpoint and create a need for state transfer
+        for i in range(1 + checkpoints_num * 150):
+            key = self.skvbc.random_key()
+            val = self.skvbc.random_value()
+            kv = [(key, val)]
+            await self.write_and_track_known_kv(kv, client1)
+
+        await self.skvbc.network_wait_for_checkpoint(initial_nodes, checkpoints_num, persistency_enabled)
+
+        return client, known_key, known_val, known_kv
+


### PR DESCRIPTION
Add linearizabilty checks into persistence tests, add tracking option using verify_linearizabilty decorator and with this tracker we track every write and read

1)add verify_linearizability decorator for each test.
2)replace regular KV writing to tracked KV writing.
3)check KV writing successful execution at the end of the decorator using tracker verify.
4)create a linearizability tracked known kv writing function.
5)create a linearizability tracked known kv reading function.
4)create a linearizability tracked prime_for_state_transfer function.