### PR TITLE
Linearizability of many concurrent operations after view change

### DIFF
--- a/tests/test_skvbc_view_change.py
+++ b/tests/test_skvbc_view_change.py
@@ -78,6 +78,9 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         await tracker.tracked_read_your_writes()
 
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(tracker.run_concurrent_ops, 100)
+
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability
@@ -116,6 +119,9 @@ class SkvbcViewChangeTest(unittest.TestCase):
             )
 
             await tracker.tracked_read_your_writes()
+
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(tracker.run_concurrent_ops, 100)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -163,6 +169,9 @@ class SkvbcViewChangeTest(unittest.TestCase):
         )
 
         await tracker.tracked_read_your_writes()
+
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(tracker.run_concurrent_ops, 100)
 
     @unittest.skip("unstable scenario")
     @with_trio


### PR DESCRIPTION
In addition of a simple "read-your-write" check after view change has completed in various scenarios, we also want to make sure linearizability is preserved.
We check this with a load of 100 concurrent operations (random reads/writes) which are then checked by the @verify_linearizability decorator.