### PR TITLE
Fix Sliver's constructor that moves a std::string

### DIFF
--- a/util/include/sliver.hpp
+++ b/util/include/sliver.hpp
@@ -31,6 +31,7 @@
 #include <variant>
 #include <memory>
 #include <string_view>
+#include <utility>
 
 namespace concordUtils {
 
@@ -38,7 +39,7 @@ class Sliver {
  public:
   Sliver();
   Sliver(const char* data, const size_t length);
-  Sliver(const std::string&& s);
+  Sliver(std::string&& s);
   Sliver(const Sliver& base, const size_t offset, const size_t length);
   static Sliver copy(const char* data, const size_t length);
 
@@ -64,6 +65,7 @@ class Sliver {
   // so that we have a pointer that can be stored in a shared_ptr. We don't want
   // allocate a copy of a string we already have.
   struct StringBuf {
+    StringBuf(std::string&& p) : s{std::move(p)} {}
     std::string s;
   };
 

--- a/util/src/sliver.cpp
+++ b/util/src/sliver.cpp
@@ -57,7 +57,7 @@ Sliver::Sliver(const Sliver& base, const size_t offset, const size_t length)
 /**
  * Create a Sliver by moving a string into it.
  */
-Sliver::Sliver(const string&& s) : data_(std::make_shared<StringBuf>(StringBuf{s})), offset_(0), length_(s.length()) {}
+Sliver::Sliver(string&& s) : offset_(0), length_(s.length()) { data_ = std::make_shared<StringBuf>(std::move(s)); }
 
 /**
  * Shorthand for the copy constructor.

--- a/util/test/sliver_test.cpp
+++ b/util/test/sliver_test.cpp
@@ -9,7 +9,10 @@
 
 #include "sliver.hpp"
 #include "gtest/gtest.h"
+
 #include <iostream>
+#include <string>
+
 #include <string.h>
 
 using namespace std;
@@ -66,6 +69,8 @@ TEST(sliver_test, simple_copy) {
   auto actual = Sliver::copy(expected, test_size);
   ASSERT_TRUE(is_match(expected, test_size, actual));
   ASSERT_NE(expected, actual.data());
+
+  delete[] expected;
 }
 
 /**
@@ -168,6 +173,30 @@ TEST(sliver_test, copying) {
 
   // we didn't wrap the expected buffer this time, so we need to free it
   // ourselves, instead of letting the Sliver do it
+  delete[] expected;
+}
+
+/**
+ * Test that moving a string into a sliver works.
+ */
+TEST(sliver_test, string_move) {
+  const auto test_size = 105;
+  auto expected = new_test_memory(test_size);
+
+  const auto sliver1 = Sliver::copy(expected, test_size);
+
+  auto str = std::string{expected, test_size};
+  const auto str_data_ptr = str.c_str();
+  const auto sliver2 = Sliver{std::move(str)};
+
+  // Make sure that both slivers contain the same data.
+  ASSERT_TRUE(is_match(expected, test_size, sliver1));
+  ASSERT_TRUE(is_match(expected, test_size, sliver2));
+  ASSERT_TRUE(sliver1 == sliver2);
+
+  // Make sure that the string has actually been moved without copying.
+  ASSERT_EQ(str_data_ptr, sliver2.data());
+
   delete[] expected;
 }
 


### PR DESCRIPTION
Sliver's constructor that is supposed to move a std::string into the
sliver has the following signature: Sliver(const std::string&&). This
PR fixes the mentioned constructor by taking a non-const std::string&&,
i.e. Sliver(std::string&&). This change enables proper move semantics.

Moreover, add a move constructor to StringBuf so that an unnecessary
move operation is avoided when using aggregate initialization.

Add a simple test to show that the move constructor works as expected.

Fix a memory leak in the simple_copy test in sliver_test.cpp to make
valgrind happy.