### PR TITLE
Don't remove root BatchedInternalNode with a child

### DIFF
--- a/storage/include/sparse_merkle/base_types.h
+++ b/storage/include/sparse_merkle/base_types.h
@@ -245,7 +245,7 @@ class NibblePath {
   }
 
   // Return the last nibble off the path
-  Nibble back() {
+  Nibble back() const {
     Assert(!empty());
     if (num_nibbles_ % 2 == 0) {
       // We have a complete byte at the end of path_. Remove the lower nibble.

--- a/storage/include/sparse_merkle/internal_node.h
+++ b/storage/include/sparse_merkle/internal_node.h
@@ -205,7 +205,7 @@ class BatchedInternalNode {
   // Instruct the caller to try the next node.
   struct Descend {
     // The version of the next BatchedInternalNode further down the tree.
-    Version version;
+    Version next_node_version;
   };
 
   typedef std::variant<RemoveComplete, NotFound, RemoveBatchedInternalNode, Descend> RemoveResult;
@@ -270,7 +270,7 @@ class BatchedInternalNode {
 
   // Remove the LeafChild at the given index. Updates of children should be set
   // to new_version.
-  RemoveResult removeLeafChild(size_t index, Version new_version, Version stored_version);
+  RemoveResult removeLeafChild(size_t index, Version new_version, Version stored_version, size_t depth);
 
   // Return true if the index does not contain a child.
   bool isEmpty(size_t index) const { return !children_.at(index).has_value(); }

--- a/util/include/kv_types.hpp
+++ b/util/include/kv_types.hpp
@@ -29,4 +29,10 @@ typedef uint64_t BlockId;
 
 }  // namespace concordUtils
 
+// Provide hashing for slivers without requiring the user to incldue the header
+// and get confused from a weird template error.
+//
+// Note that this must come after the typedefs above.
+#include "hash_defs.h"
+
 #endif  // CONCORD_BFT_UTIL_KV_TYPES_H_


### PR DESCRIPTION
The previous behavior of BatchedInternalNodeRemove always returned
`RemoveBatchedInternalNode` when there was one remaining LeafChild, as
it was capable of being promoted to the parent node. However, when the
LeafChild lives in the root BatchedInternalNode, it cannot be moved up
any further. In this case we should return `RemoveComplete`, which this
commit does.

Additionally, do some minor cleanup related to a review of a prior
commit done.