### PR TITLE
Abstract away blockchain storage details

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -14,6 +14,7 @@
 #ifndef BFTENGINE_SRC_BCSTATETRANSFER_SIMPLEBCSTATETRANSFER_HPP_
 #define BFTENGINE_SRC_BCSTATETRANSFER_SIMPLEBCSTATETRANSFER_HPP_
 
+#include <cstdint>
 #include <set>
 #include <memory>
 
@@ -40,7 +41,7 @@ namespace SimpleBlockchainStateTransfer {
 // The application/storage layer is responsible to store the digests in the
 // blocks.
 // Blocks are numbered. The first block should be block number 1.
-constexpr static uint32_t BLOCK_DIGEST_SIZE = 32;
+inline constexpr std::uint32_t BLOCK_DIGEST_SIZE = 32;
 
 // represnts a digest
 #pragma pack(push, 1)

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -30,9 +30,8 @@ using concord::storage::IDBClient;
 using concord::storage::ITransaction;
 using concordUtils::Status;
 using concordUtils::Sliver;
-using concord::storage::blockchain::EDBKeyType;
 using concord::storage::blockchain::ObjectId;
-using concord::storage::blockchain::KeyManipulator;
+using concord::storage::blockchain::DBKeyManipulator;
 /** *******************************************************************************************************************
  *  This class is used in one of two modes:
  *  1. When ITransaction is not set - works directly through IDBClient instance;
@@ -224,15 +223,15 @@ class DBDataStore : public DataStore {
    * keys generation
    */
   Sliver dynamicResPageKey(uint32_t pageid, uint64_t chkpt) const {
-    return KeyManipulator::generateSTReservedPageDynamicKey(pageid, chkpt);
+    return DBKeyManipulator::generateSTReservedPageDynamicKey(pageid, chkpt);
   }
   Sliver staticResPageKey(uint32_t pageid, uint64_t chkpt) const {
     static uint64_t maxStored = inmem_->getMaxNumOfStoredCheckpoints();
-    return KeyManipulator::generateSTReservedPageStaticKey(pageid, chkpt % maxStored + 1);
+    return DBKeyManipulator::generateSTReservedPageStaticKey(pageid, chkpt % maxStored + 1);
   }
-  Sliver pendingPageKey(uint32_t pageid) const { return KeyManipulator::generateSTPendingPageKey(pageid); }
-  Sliver chkpDescKey(uint64_t chkpt) const { return KeyManipulator::generateSTCheckpointDescriptorKey(chkpt); }
-  Sliver genKey(const ObjectId& objId) const { return KeyManipulator::generateStateTransferKey(objId); }
+  Sliver pendingPageKey(uint32_t pageid) const { return DBKeyManipulator::generateSTPendingPageKey(pageid); }
+  Sliver chkpDescKey(uint64_t chkpt) const { return DBKeyManipulator::generateSTCheckpointDescriptorKey(chkpt); }
+  Sliver genKey(const ObjectId& objId) const { return DBKeyManipulator::generateStateTransferKey(objId); }
   /** ****************************************************************************************************************/
   concordlogger::Logger& logger() {
     static concordlogger::Logger logger_ = concordlogger::Log::getLogger("DBDataStore");

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -277,7 +277,7 @@ SimpleStateTran::SimpleStateTran(
   config.cVal = cVal;
   config.numReplicas = 3 * fVal + 2 * cVal + 1;
   config.pedanticChecks = pedanticChecks;
-  auto comparator = concord::storage::memorydb::KeyComparator(new concord::storage::blockchain::KeyManipulator());
+  auto comparator = concord::storage::memorydb::KeyComparator(new concord::storage::blockchain::DBKeyComparator());
   concord::storage::IDBClient::ptr db(new concord::storage::memorydb::Client(comparator));
   internalST_ = SimpleBlockchainStateTransfer::create(config, &dummyBDState_, db);
 

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -22,7 +22,7 @@
 #include "memorydb/client.h"
 
 using concord::storage::ITransaction;
-using concord::storage::blockchain::KeyManipulator;
+using concord::storage::blockchain::DBKeyComparator;
 
 #ifdef USE_ROCKSDB
 #include "rocksdb/client.h"
@@ -57,14 +57,14 @@ class BcStTest : public ::testing::Test {
     //      log4cplus::Logger::getInstance( LOG4CPLUS_TEXT("rocksdb")).setLogLevel(log4cplus::TRACE_LOG_LEVEL);
 
     config_ = TestConfig();
-    auto* key_manipulator = new concord::storage::blockchain::KeyManipulator();
+    auto* db_key_comparator = new concord::storage::blockchain::DBKeyComparator();
 #ifdef USE_ROCKSDB
     concord::storage::IDBClient::ptr dbc(
-        new concord::storage::rocksdb::Client("./bcst_db", new KeyComparator(key_manipulator)));
+        new concord::storage::rocksdb::Client("./bcst_db", new KeyComparator(db_key_comparator)));
     dbc->init();
     auto* datastore = new DBDataStore(dbc, config_.sizeOfReservedPage);
 #else
-    auto comparator = concord::storage::memorydb::KeyComparator(key_manipulator);
+    auto comparator = concord::storage::memorydb::KeyComparator(db_key_comparator);
     concord::storage::IDBClient::ptr dbc(new concord::storage::memorydb::Client(comparator));
     auto* datastore = new InMemoryDataStore(config_.sizeOfReservedPage);
 #endif

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -13,10 +13,10 @@
 #include "ICommunication.hpp"
 #include "Replica.hpp"
 #include "ReplicaConfig.hpp"
+#include "SimpleBCStateTransfer.hpp"
 #include "StatusInfo.h"
 #include "Logger.hpp"
 #include "KVBCInterfaces.h"
-#include "hash_defs.h"
 #include "replica_state_sync_imp.hpp"
 #include "blockchain/db_adapter.h"
 #include "blockchain/db_interfaces.h"
@@ -254,7 +254,6 @@ class ReplicaImp : public IReplica,
   };
 
   // DATA
-
  private:
   concordlogger::Logger logger;
   RepStatus m_currentRepStatus;
@@ -271,12 +270,6 @@ class ReplicaImp : public IReplica,
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
   std::unique_ptr<ReplicaStateSync> replicaStateSync_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
-
-  // static methods
-  static Sliver createBlockFromUpdates(const concord::storage::SetOfKeyValuePairs &updates,
-                                       concord::storage::SetOfKeyValuePairs &outUpdatesInNewBlock,
-                                       bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest &parentDigest);
-  static concord::storage::SetOfKeyValuePairs fetchBlockData(Sliver block);
 };
 
 }  // namespace kvbc

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(concordbft_storage STATIC src/db_metadata_storage.cpp src/blockchain_db_adapter.cpp)
+add_library(concordbft_storage STATIC src/db_metadata_storage.cpp
+                                      src/blockchain_db_adapter.cpp
+                                      src/block.cpp)
 
 target_include_directories(concordbft_storage PUBLIC include)
 target_link_libraries(concordbft_storage PUBLIC corebft)

--- a/storage/include/blockchain/block.h
+++ b/storage/include/blockchain/block.h
@@ -1,0 +1,69 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "db_types.h"
+#include "kv_types.hpp"
+#include "sliver.hpp"
+#include "hash_defs.h"
+
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+
+#include <cstdint>
+#include <utility>
+
+namespace concord {
+namespace storage {
+namespace blockchain {
+namespace block {
+
+inline constexpr auto BLOCK_DIGEST_SIZE = bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
+
+inline namespace v1DirectKeyValue {
+// Creates a block. The passed parentDigest buffer must be of size BLOCK_DIGEST_SIZE bytes.
+concordUtils::Sliver create(const concordUtils::SetOfKeyValuePairs &updates,
+                            concordUtils::SetOfKeyValuePairs &outUpdatesInNewBlock,
+                            const void *parentDigest);
+
+// Returns the block data in the form of a set of key/value pairs.
+concordUtils::SetOfKeyValuePairs getData(const concordUtils::Sliver &block);
+
+// Returns the parent digest of size BLOCK_DIGEST_SIZE bytes.
+const void *getParentDigest(const concordUtils::Sliver &block);
+
+// Block structure is an implementation detail. External users should not rely on it.
+namespace detail {
+
+struct Header {
+  std::uint32_t numberOfElements;
+  std::uint32_t parentDigestLength;
+  std::uint8_t parentDigest[BLOCK_DIGEST_SIZE];
+};
+
+// Entry structures are coming immediately after the header.
+struct Entry {
+  std::uint32_t keyOffset;
+  std::uint32_t keySize;
+  std::uint32_t valOffset;
+  std::uint32_t valSize;
+};
+
+}  // namespace detail
+
+}  // namespace v1DirectKeyValue
+
+}  // namespace block
+}  // namespace blockchain
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/blockchain/db_types.h
+++ b/storage/include/blockchain/db_types.h
@@ -14,27 +14,14 @@
 #pragma once
 
 #include <cstdint>
-#include <unordered_map>
-#include <vector>
-#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
 
 namespace concord {
 namespace storage {
 namespace blockchain {
 
-struct BlockHeader {
-  uint32_t numberOfElements;
-  uint32_t parentDigestLength;
-  int8_t parentDigest[bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE];
-};
-
-// BlockEntry structures are coming immediately after the header.
-struct BlockEntry {
-  uint32_t keyOffset;
-  uint32_t keySize;
-  uint32_t valOffset;
-  uint32_t valSize;
-};
+inline namespace v1DirectKeyValue {
+// DB key types are an implementation detail. External users should not rely on it.
+namespace detail {
 
 enum class EDBKeyType : std::uint8_t {
   E_DB_KEY_TYPE_FIRST = 1,
@@ -49,8 +36,47 @@ enum class EDBKeyType : std::uint8_t {
   E_DB_KEY_TYPE_LAST
 };
 
-typedef uint64_t BlockId;
-typedef uint32_t ObjectId;
+}  // namespace detail
+}  // namespace v1DirectKeyValue
+
+namespace v2MerkleTree {
+
+// DB key types are an implementation detail. External users should not rely on it.
+namespace detail {
+
+// Top-level DB key types used when saving the blockchain in the form of a merkle tree.
+// Key types might have subtypes so that the top-level enum is not quickly exhausted and keys are structured in
+// a clearer way. A note is that there is an overhead of 1 byte in the key length when using subtypes.
+enum class EDBKeyType : std::uint8_t {
+  Block,
+  Key,
+  BFT,
+};
+
+// Key subtypes. Internal and Stale are used internally by the merkle tree implementation. The Leaf type is the one
+// containing actual application data.
+enum class EKeyType : std::uint8_t {
+  Internal,
+  Stale,
+  Leaf,
+};
+
+// BFT subtypes.
+enum class EBFTType : std::uint8_t {
+  Metadata,
+  ST,
+  STPendingPage,
+  STReservedPageStatic,
+  STReserverdPageDynamic,
+  STCheckpointDescriptor,
+};
+
+}  // namespace detail
+
+}  // namespace v2MerkleTree
+
+typedef std::uint64_t BlockId;
+typedef std::uint32_t ObjectId;
 
 }  // namespace blockchain
 }  // namespace storage

--- a/storage/include/memorydb/key_comparator.h
+++ b/storage/include/memorydb/key_comparator.h
@@ -19,17 +19,17 @@ using concordUtils::Sliver;
 
 class KeyComparator {
  public:
-  KeyComparator(IDBClient::IKeyManipulator *key_manipulator)
-      : key_manipulator_(key_manipulator),
+  KeyComparator(IDBClient::IKeyComparator *key_comparator)
+      : key_comparator_(key_comparator),
         logger_(concordlogger::Log::getLogger("concord.storage.rocksdb.KeyComparator")) {}
 
   bool operator()(const Sliver &a, const Sliver &b) const {
-    int ret = key_manipulator_->composedKeyComparison(a.data(), a.length(), b.data(), b.length());
+    int ret = key_comparator_->composedKeyComparison(a.data(), a.length(), b.data(), b.length());
     return ret < 0;
   }
 
  private:
-  std::shared_ptr<IDBClient::IKeyManipulator> key_manipulator_;
+  std::shared_ptr<IDBClient::IKeyComparator> key_comparator_;
   concordlogger::Logger logger_;
 };
 

--- a/storage/include/rocksdb/key_comparator.h
+++ b/storage/include/rocksdb/key_comparator.h
@@ -22,8 +22,8 @@ using concordUtils::Sliver;
 
 class KeyComparator : public ::rocksdb::Comparator {
  public:
-  KeyComparator(IDBClient::IKeyManipulator* key_manipulator)
-      : key_manipulator_(key_manipulator),
+  KeyComparator(IDBClient::IKeyComparator* key_comparator)
+      : key_comparator_(key_comparator),
         logger_(concordlogger::Log::getLogger("concord.storage.rocksdb.KeyComparator")) {}
   virtual int Compare(const ::rocksdb::Slice& _a, const ::rocksdb::Slice& _b) const override;
   virtual const char* Name() const override { return "RocksKeyComparator"; }
@@ -31,7 +31,7 @@ class KeyComparator : public ::rocksdb::Comparator {
   virtual void FindShortSuccessor(std::string*) const override {}
 
  private:
-  std::shared_ptr<IDBClient::IKeyManipulator> key_manipulator_;
+  std::shared_ptr<IDBClient::IKeyComparator> key_comparator_;
   concordlogger::Logger logger_;
 };
 

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -81,10 +81,10 @@ class IDBClient {
     virtual ~IDBClientIterator() = default;
   };
 
-  class IKeyManipulator {
+  class IKeyComparator {
    public:
     virtual int composedKeyComparison(const char* _a_data, size_t _a_length, const char* _b_data, size_t _b_length) = 0;
-    virtual ~IKeyManipulator() = default;
+    virtual ~IKeyComparator() = default;
   };
 
   virtual IDBClientIterator* getIterator() const = 0;

--- a/storage/src/block.cpp
+++ b/storage/src/block.cpp
@@ -1,0 +1,112 @@
+#include "blockchain/block.h"
+
+#include "Logger.hpp"
+
+#include <cassert>
+#include <cstring>
+
+using concordUtils::Sliver;
+using concordUtils::SetOfKeyValuePairs;
+using concordUtils::KeyValuePair;
+
+namespace concord {
+namespace storage {
+namespace blockchain {
+namespace block {
+inline namespace v1DirectKeyValue {
+concordUtils::Sliver create(const concordUtils::SetOfKeyValuePairs &updates,
+                            concordUtils::SetOfKeyValuePairs &outUpdatesInNewBlock,
+                            const void *parentDigest) {
+  // TODO(GG): overflow handling ....
+  // TODO(SG): How? Right now - will put empty block instead
+
+  assert(outUpdatesInNewBlock.size() == 0);
+
+  std::uint32_t blockBodySize = 0;
+  const std::uint16_t numOfElements = updates.size();
+  for (const auto &elem : updates) {
+    // body is all of the keys and values strung together
+    blockBodySize += (elem.first.length() + elem.second.length());
+  }
+
+  const std::uint32_t metadataSize = sizeof(detail::Header) + sizeof(detail::Entry) * numOfElements;
+
+  const std::uint32_t blockSize = metadataSize + blockBodySize;
+
+  try {
+    char *blockBuffer = new char[blockSize];
+    std::memset(blockBuffer, 0, blockSize);
+    const Sliver blockSliver(blockBuffer, blockSize);
+
+    auto header = (detail::Header *)blockBuffer;
+    std::memcpy(header->parentDigest, parentDigest, BLOCK_DIGEST_SIZE);
+    header->parentDigestLength = BLOCK_DIGEST_SIZE;
+
+    std::int16_t idx = 0;
+    header->numberOfElements = numOfElements;
+    std::int32_t currentOffset = metadataSize;
+    auto *entries = (detail::Entry *)(blockBuffer + sizeof(detail::Header));
+    for (const auto &elem : updates) {
+      const KeyValuePair &kvPair = elem;
+
+      // key
+      entries[idx].keyOffset = currentOffset;
+      entries[idx].keySize = kvPair.first.length();
+      std::memcpy(blockBuffer + currentOffset, kvPair.first.data(), kvPair.first.length());
+      const Sliver newKey(blockSliver, currentOffset, kvPair.first.length());
+
+      currentOffset += kvPair.first.length();
+
+      // value
+      entries[idx].valOffset = currentOffset;
+      entries[idx].valSize = kvPair.second.length();
+      std::memcpy(blockBuffer + currentOffset, kvPair.second.data(), kvPair.second.length());
+      const Sliver newVal(blockSliver, currentOffset, kvPair.second.length());
+
+      currentOffset += kvPair.second.length();
+
+      // add to outUpdatesInNewBlock
+      const KeyValuePair newKVPair(newKey, newVal);
+      outUpdatesInNewBlock.insert(newKVPair);
+
+      idx++;
+    }
+    assert(idx == numOfElements);
+    assert((std::uint32_t)currentOffset == blockSize);
+
+    return blockSliver;
+  } catch (const std::bad_alloc &ba) {  // TODO: do we really want to mask this failure?
+    LOG_ERROR(concordlogger::Log::getLogger("skvbc.replicaImp"),
+              "Failed to alloc size " << blockSize << ", error: " << ba.what());
+    char *emptyBlockBuffer = new char[1];
+    std::memset(emptyBlockBuffer, 0, 1);
+    return Sliver(emptyBlockBuffer, 1);
+  }
+}
+
+SetOfKeyValuePairs getData(const Sliver &block) {
+  SetOfKeyValuePairs retVal;
+
+  if (block.length() > 0) {
+    const auto numOfElements = ((detail::Header *)block.data())->numberOfElements;
+    auto *entries = (const detail::Entry *)(block.data() + sizeof(detail::Header));
+    for (size_t i = 0u; i < numOfElements; i++) {
+      const Sliver keySliver(block, entries[i].keyOffset, entries[i].keySize);
+      const Sliver valSliver(block, entries[i].valOffset, entries[i].valSize);
+      retVal.insert(KeyValuePair(keySliver, valSliver));
+    }
+  }
+  return retVal;
+}
+
+const void *getParentDigest(const concordUtils::Sliver &block) {
+  const auto *bh = reinterpret_cast<const detail::Header *>(block.data());
+  assert(BLOCK_DIGEST_SIZE == bh->parentDigestLength);
+  return bh->parentDigest;
+}
+
+}  // namespace v1DirectKeyValue
+}  // namespace block
+}  // namespace blockchain
+}  // namespace storage
+}  // namespace concord

--- a/storage/src/rocksdb_key_comparator.cpp
+++ b/storage/src/rocksdb_key_comparator.cpp
@@ -22,7 +22,7 @@ namespace storage {
 namespace rocksdb {
 
 int KeyComparator::Compare(const ::rocksdb::Slice& _a, const ::rocksdb::Slice& _b) const {
-  int ret = key_manipulator_->composedKeyComparison(_a.data(), _a.size(), _b.data(), _b.size());
+  int ret = key_comparator_->composedKeyComparison(_a.data(), _a.size(), _b.data(), _b.size());
 
   LOG_TRACE(logger_, "Compared " << _a.ToString(true) << " with " << _b.ToString(true) << ", returning " << ret);
 

--- a/storage/test/metadataStorage_test.cpp
+++ b/storage/test/metadataStorage_test.cpp
@@ -18,7 +18,8 @@
 using namespace std;
 
 using concord::storage::blockchain::ObjectId;
-using concord::storage::blockchain::KeyManipulator;
+using concord::storage::blockchain::DBKeyComparator;
+using concord::storage::blockchain::DBKeyManipulator;
 using concord::storage::rocksdb::KeyComparator;
 using concord::storage::rocksdb::Client;
 using concord::storage::DBMetadataStorage;
@@ -97,12 +98,12 @@ TEST(metadataStorage_test, multi_write) {
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  KeyComparator *kk = new KeyComparator(new KeyManipulator);
+  KeyComparator *kk = new KeyComparator(new DBKeyComparator);
   const string dbPath = "./metadataStorage_test_db";
   remove(dbPath.c_str());
   Client *dbClient = new Client(dbPath, kk);
   dbClient->init();
-  metadataStorage = new DBMetadataStorage(dbClient, KeyManipulator::generateMetadataKey);
+  metadataStorage = new DBMetadataStorage(dbClient, DBKeyManipulator::generateMetadataKey);
   bftEngine::MetadataStorage::ObjectDesc objectDesc[objectsNum];
   for (uint32_t id = initialObjectId; id < objectsNum; ++id) {
     objectDesc[id].id = id;

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -26,12 +26,12 @@ using namespace concord::kvbc;
 int main(int argc, char** argv) {
   auto setup = concord::kvbc::TestSetup::ParseArgs(argc, argv);
   auto logger = setup->GetLogger();
-  auto* key_manipulator = new concord::storage::blockchain::KeyManipulator();
+  auto* db_key_comparator = new concord::storage::blockchain::DBKeyComparator();
   concord::storage::IDBClient* db;
 
   if (setup->UsePersistentStorage()) {
 #ifdef USE_ROCKSDB
-    auto* comparator = new concord::storage::rocksdb::KeyComparator(key_manipulator);
+    auto* comparator = new concord::storage::rocksdb::KeyComparator(db_key_comparator);
     std::stringstream dbPath;
     dbPath << BasicRandomTests::DB_FILE_PREFIX << setup->GetReplicaConfig().replicaId;
     db = new concord::storage::rocksdb::Client(dbPath.str(), comparator);
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
 #endif
   } else {
     // Use in-memory storage
-    auto comparator = concord::storage::memorydb::KeyComparator(key_manipulator);
+    auto comparator = concord::storage::memorydb::KeyComparator(db_key_comparator);
     db = new concord::storage::memorydb::Client(comparator);
   }
 


### PR DESCRIPTION
In order to prepare for changing the storage engine to using merkle
trees, abstract away blockchain storage details (block headers, block
entries, block keys and their respective implementations). When we
introduce merkle trees, we can more easily switch to the new
implementation.

Separate KeyManipulator to DBKeyComparator and DBKeyManipulator as
these two notions can be used independently.

Introduce the v1DirectKeyValue namespace to aid in the future switch to
merkle trees. All existing implementations reside in this namespace.

In addition, introduce layered key types and the v2MerkleTree namespace
for the future merkle tree storage implementation.

Lastly, cleanup code in terms of const, includes, using directives and
static/non-static members.