### PR TITLE
Preparation for RO replica

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -93,6 +93,9 @@ class IAppState {
   // When that state transfer module is updating the state, then these methods
   // may return different block numbers.
 
+  // This method MAY be called by ST module when putBlock returns false. The call will block until the underlying storage
+  // becomes available (storage non availabilty is the reason for putBlock to fail). Mainly relevant for network storages.
+  // In regular replica which uses local DB this function should not be called.
   virtual void wait() = 0;
 };
 

--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -92,6 +92,8 @@ class IAppState {
   // and getLastBlockNum() should always return the same block number.
   // When that state transfer module is updating the state, then these methods
   // may return different block numbers.
+
+  virtual void wait() = 0;
 };
 
 struct Config {

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -106,6 +106,8 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
     uint64_t getLastReachableBlockNum() override;
 
     uint64_t getLastBlockNum() override;
+
+    void wait() override;
   };
 
   ///////////////////////////////////////////////////////////////////////////
@@ -584,6 +586,8 @@ bool SimpleStateTran::DummyBDState::putBlock(uint64_t blockId, char* block, uint
 uint64_t SimpleStateTran::DummyBDState::getLastReachableBlockNum() { return 0; }
 
 uint64_t SimpleStateTran::DummyBDState::getLastBlockNum() { return 0; }
+
+void SimpleStateTran::DummyBDState::wait() {}
 
 }  // namespace impl
 }  // namespace SimpleInMemoryStateTransfer

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -70,6 +70,8 @@ class TestAppState : public IAppState {
 
   uint64_t getLastBlockNum() override { return last_block_; };
 
+  void wait() override {};
+
  private:
   uint64_t last_block_;
   std::unordered_map<uint64_t, Block> blocks_;

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -241,6 +241,7 @@ class ReplicaImp : public IReplica,
     virtual bool putBlock(uint64_t blockId, char *block, uint32_t blockSize) override;
     virtual uint64_t getLastReachableBlockNum() override;
     virtual uint64_t getLastBlockNum() override;
+    virtual void wait() override;
 
    private:
     ReplicaImp *const m_ptrReplicaImpl = nullptr;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -605,5 +605,7 @@ uint64_t ReplicaImp::BlockchainAppState::getLastReachableBlockNum() {
 
 uint64_t ReplicaImp::BlockchainAppState::getLastBlockNum() { return m_ptrReplicaImpl->m_lastBlock; }
 
+void ReplicaImp::BlockchainAppState::wait() {return;}
+
 }  // namespace kvbc
 }  // namespace concord


### PR DESCRIPTION
To support RO replica we need to add wait() method to the ST interface.