### PR TITLE
Support for object store

### DIFF
--- a/.conan/libs3_pkg/conanfile.py
+++ b/.conan/libs3_pkg/conanfile.py
@@ -1,0 +1,15 @@
+from conans import ConanFile, CMake, tools
+from conans.tools import os_info, SystemPackageTool
+
+
+class LibS3Conan(ConanFile):
+    name = "libs3-dev"
+    version = "2.0-3"
+    def system_requirements(self):
+        pack_name = None
+        if os_info.linux_distro == "ubuntu":
+            pack_name = "libs3-dev"
+ 
+        if pack_name:
+            installer = SystemPackageTool()
+            installer.install(pack_name)

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ compile_commands.json
 
 # clangd directory
 .clangd/
+
+b.sh

--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -7,7 +7,7 @@ echo "macos homebrew packages handled in .travis.yml"
 else
 # If on Linux, install necessary packages using apt
 sudo apt-get update
-sudo apt-get install -y ccache cmake clang-format libgmp3-dev \
+sudo apt-get install -y ccache cmake clang-format libgmp3-dev s3-dev \
 python3-pip python3-setuptools
 fi
 

--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -7,7 +7,7 @@ echo "macos homebrew packages handled in .travis.yml"
 else
 # If on Linux, install necessary packages using apt
 sudo apt-get update
-sudo apt-get install -y ccache cmake clang-format clang-format-7 libgmp3-dev libs3-dev
+sudo apt-get install -y ccache cmake clang-format clang-format-7 libgmp3-dev libs3-dev \
 python3-pip python3-setuptools
 fi
 

--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -7,7 +7,7 @@ echo "macos homebrew packages handled in .travis.yml"
 else
 # If on Linux, install necessary packages using apt
 sudo apt-get update
-sudo apt-get install -y ccache cmake clang-format libgmp3-dev s3-dev \
+sudo apt-get install -y ccache cmake clang-format libgmp3-dev libs3-dev \
 python3-pip python3-setuptools
 fi
 

--- a/b.sh
+++ b/b.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-cd build
-export CC=/usr/bin/clang-7
-export CXX=/usr/bin/clang++-7
-conan install -s compiler="clang" -s compiler.version="7.0" -s compiler.libcxx=libstdc++11 --build missing ..
-cmake -DBUILD_OBJECTSTORE_TEST=1 -DBUILD_TESTING=1 \
--DBUILD_ROCKSDB_STORAGE=1 -USE_OBJECTSTORE_FOR_ROR_TEST=1 $@ ..
-make -j8
-

--- a/b.sh
+++ b/b.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd build
+export CC=/usr/bin/clang-7
+export CXX=/usr/bin/clang++-7
+conan install -s compiler="clang" -s compiler.version="7.0" -s compiler.libcxx=libstdc++11 --build missing ..
+cmake -DBUILD_OBJECTSTORE_TEST=1 -DBUILD_TESTING=1 \
+-DBUILD_ROCKSDB_STORAGE=1 -USE_OBJECTSTORE_FOR_ROR_TEST=1 $@ ..
+make -j8
+

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -12,6 +12,7 @@ snappy/1.1.7@bincrafters/stable
 zstd/1.4.0@bincrafters/stable
 rocksdb/5.7.3
 hdr_histogram/0.9.12
+libs3-dev/2.0-3
 
 [generators]
 cmake

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -2,12 +2,16 @@ cmake_minimum_required (VERSION 3.2)
 project(libkvbc VERSION 0.1.0.0 LANGUAGES CXX)
 
 find_package(Boost ${MIN_BOOST_VERSION})
-add_library(kvbc  src/ClientImp.cpp
-                  src/ReplicaImp.cpp
-                  src/replica_state_sync_imp.cpp
-                  src/block_metadata.cpp
-)
-target_link_libraries(kvbc PUBLIC corebft threshsign util concordbft_storage)
+
+add_library(
+    kvbc
+    src/ClientImp.cpp
+    src/ReplicaImp.cpp
+    src/replica_state_sync_imp.cpp
+    src/block_metadata.cpp
+    src/ror_app_state.cpp)
+
+target_link_libraries(kvbc PUBLIC corebft threshsign util concordbft_storage object_store_lib)
 
 target_include_directories(kvbc PUBLIC include)
 

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -19,6 +19,7 @@
 #include "Metrics.hpp"
 #include "storage/db_interface.h"
 #include "blockchain/db_interfaces.h"
+#include "SimpleBCStateTransfer.hpp"
 #include "Replica.hpp"
 #include "kv_types.hpp"
 
@@ -116,6 +117,8 @@ class IReplica {
   /// need to split interfaces implementations to differrent modules
   /// instead of being all implemented bt ReplicaImpl
   virtual void set_command_handler(ICommandsHandler* handler) = 0;
+
+  virtual void set_app_state(std::shared_ptr<bftEngine::SimpleBlockchainStateTransfer::IAppState> appState) = 0;
 };
 
 /////////////////////////////////////////////////////////////////////////////

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -92,10 +92,10 @@ class ReplicaImp : public IReplica,
              std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
   ReplicaImp(bftEngine::ICommunication *comm,
-  bftEngine::ReplicaConfig &config,
-  concord::storage::blockchain::DBAdapter *dbAdapter,
-  std::shared_ptr<concordMetrics::Aggregator> aggregator,
-  std::shared_ptr<bftEngine::SimpleBlockchainStateTransfer::IAppState> appState);
+             bftEngine::ReplicaConfig &config,
+             concord::storage::blockchain::DBAdapter *dbAdapter,
+             std::shared_ptr<concordMetrics::Aggregator> aggregator,
+             std::shared_ptr<bftEngine::SimpleBlockchainStateTransfer::IAppState> appState);
 
   void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 

--- a/kvbc/include/ror_app_state.hpp
+++ b/kvbc/include/ror_app_state.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "blockchain/block.h"
+#include "blockchain/db_adapter.h"
+#include "kv_types.hpp"
+#include "sliver.hpp"
+#include "status.hpp"
+#include "storage/db_interface.h"
+#include "object_store/object_store_client.hpp"
+
+const std::string kLastBlockIdKey = "1";
+const std::string kLastReachableBlockIdKey = "2";
+
+namespace concord {
+namespace consensus {
+
+class RoRAppState
+    : public bftEngine::SimpleBlockchainStateTransfer::IAppState {
+ public:
+  virtual ~RoRAppState();
+
+  RoRAppState(
+      std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
+          keyManipulator,
+      std::shared_ptr<concord::storage::IDBClient> localClient,
+      std::shared_ptr<concord::storage::IDBClient> objectStoreClient);
+
+  // returns true IFF block blockId exists
+  // (i.e. the block is stored in the application/storage layer).
+  virtual bool hasBlock(uint64_t blockId) override;
+
+  // If block blockId exists, then its content is returned via the arguments
+  // outBlock and outBlockSize. Returns true IFF block blockId exists.
+  virtual bool getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override;
+
+  // If block blockId exists, then the digest of block blockId-1 is returned via
+  // the argument outPrevBlockDigest. Returns true IFF block blockId exists.
+  virtual bool getPrevDigestFromBlock(
+    uint64_t blockId, bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest *outPrevBlockDigest) override;
+    
+  // adds block
+  // blockId   - the block number
+  // block     - pointer to a buffer that contains the new block
+  // blockSize - the size of the new block
+  virtual bool putBlock(uint64_t blockId, char *block, uint32_t blockSize) override;
+  
+  // returns the maximal block number n such that all blocks 1 <= i <= n exist.
+  // if block 1 does not exist, returns 0.
+  virtual uint64_t getLastReachableBlockNum() override;
+  
+  // returns the maximum block number that is currently stored in
+  // the application/storage layer.
+  virtual uint64_t getLastBlockNum() override;
+
+  virtual void wait() override;
+
+  // When the state is updated by the application, getLastReachableBlockNum()
+  // and getLastBlockNum() should always return the same block number.
+  // When that state transfer module is updating the state, then these methods
+  // may return different block numbers.State
+
+ private:
+  std::shared_ptr<bftEngine::SimpleBlockchainStateTransfer::IAppState> pImpl_ =
+      nullptr;
+};
+}  // namespace consensus
+}  // namespace concord

--- a/kvbc/include/ror_app_state.hpp
+++ b/kvbc/include/ror_app_state.hpp
@@ -17,16 +17,13 @@ const std::string kLastReachableBlockIdKey = "2";
 namespace concord {
 namespace consensus {
 
-class RoRAppState
-    : public bftEngine::SimpleBlockchainStateTransfer::IAppState {
+class RoRAppState : public bftEngine::SimpleBlockchainStateTransfer::IAppState {
  public:
   virtual ~RoRAppState();
 
-  RoRAppState(
-      std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
-          keyManipulator,
-      std::shared_ptr<concord::storage::IDBClient> localClient,
-      std::shared_ptr<concord::storage::IDBClient> objectStoreClient);
+  RoRAppState(std::shared_ptr<concord::storage::blockchain::DBKeyManipulator> keyManipulator,
+              std::shared_ptr<concord::storage::IDBClient> localClient,
+              std::shared_ptr<concord::storage::IDBClient> objectStoreClient);
 
   // returns true IFF block blockId exists
   // (i.e. the block is stored in the application/storage layer).
@@ -39,18 +36,18 @@ class RoRAppState
   // If block blockId exists, then the digest of block blockId-1 is returned via
   // the argument outPrevBlockDigest. Returns true IFF block blockId exists.
   virtual bool getPrevDigestFromBlock(
-    uint64_t blockId, bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest *outPrevBlockDigest) override;
-    
+      uint64_t blockId, bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest *outPrevBlockDigest) override;
+
   // adds block
   // blockId   - the block number
   // block     - pointer to a buffer that contains the new block
   // blockSize - the size of the new block
   virtual bool putBlock(uint64_t blockId, char *block, uint32_t blockSize) override;
-  
+
   // returns the maximal block number n such that all blocks 1 <= i <= n exist.
   // if block 1 does not exist, returns 0.
   virtual uint64_t getLastReachableBlockNum() override;
-  
+
   // returns the maximum block number that is currently stored in
   // the application/storage layer.
   virtual uint64_t getLastBlockNum() override;
@@ -63,8 +60,7 @@ class RoRAppState
   // may return different block numbers.State
 
  private:
-  std::shared_ptr<bftEngine::SimpleBlockchainStateTransfer::IAppState> pImpl_ =
-      nullptr;
+  std::shared_ptr<bftEngine::SimpleBlockchainStateTransfer::IAppState> pImpl_ = nullptr;
 };
 }  // namespace consensus
 }  // namespace concord

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -88,10 +88,10 @@ void ReplicaImp::createReplicaAndSyncState() {
     auto t = std::dynamic_pointer_cast<BlockchainAppState>(m_appState);
     assert(t);
     t->m_lastReachableBlock -= removedBlocksNum;
-    LOG_INFO(logger,
-             "createReplicaAndSyncState: removedBlocksNum = "
-                 << removedBlocksNum << ", new m_lastBlock = " << m_lastBlock
-                 << ", new m_lastReachableBlock = " << t->m_lastReachableBlock);
+    LOG_INFO(
+        logger,
+        "createReplicaAndSyncState: removedBlocksNum = " << removedBlocksNum << ", new m_lastBlock = " << m_lastBlock
+                                                         << ", new m_lastReachableBlock = " << t->m_lastReachableBlock);
   }
 }
 
@@ -190,11 +190,11 @@ Status ReplicaImp::addBlock(const SetOfKeyValuePairs &updates, BlockId &outBlock
 void ReplicaImp::set_command_handler(ICommandsHandler *handler) { m_cmdHandler = handler; }
 
 void ReplicaImp::set_app_state(std::shared_ptr<bftEngine::SimpleBlockchainStateTransfer::IAppState> appState) {
-  if(!appState)
+  if (!appState)
     m_appState = std::make_shared<BlockchainAppState>(shared_from_this());
   else
     m_appState = appState;
-    
+
   m_stateTransfer = bftEngine::SimpleBlockchainStateTransfer::create(
       state_transfer_config_, m_appState.get(), m_bcDbAdapter->getDb(), aggregator_);
 }
@@ -217,7 +217,8 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   state_transfer_config_.numReplicas = m_replicaConfig.numReplicas + m_replicaConfig.numRoReplicas;
   if (replicaConfig.maxNumOfReservedPages > 0)
     state_transfer_config_.maxNumOfReservedPages = replicaConfig.maxNumOfReservedPages;
-  if (replicaConfig.sizeOfReservedPage > 0) state_transfer_config_.sizeOfReservedPage = replicaConfig.sizeOfReservedPage;
+  if (replicaConfig.sizeOfReservedPage > 0)
+    state_transfer_config_.sizeOfReservedPage = replicaConfig.sizeOfReservedPage;
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/kvbc/src/ror_app_state.cpp
+++ b/kvbc/src/ror_app_state.cpp
@@ -8,7 +8,6 @@
 using namespace concordUtils;
 using namespace bftEngine::SimpleBlockchainStateTransfer;
 using namespace concord::storage;
-namespace block = concord::storage::blockchain::block;
 
 class RoRAppStateImpl : public IAppState {
  public:
@@ -76,7 +75,7 @@ class RoRAppStateImpl : public IAppState {
     LOG_DEBUG(logger_, "getPrevDigestFromBlock, blockId: " << blockId);
 
     assert(outPrevBlockDigest);
-    auto parentDigest = block::getParentDigest(blockData);
+    auto parentDigest = concord::storage::blockchain::block::getParentDigest(blockData);
     assert(outPrevBlockDigest);
     memcpy(outPrevBlockDigest, parentDigest, BLOCK_DIGEST_SIZE);
     return true;

--- a/kvbc/src/ror_app_state.cpp
+++ b/kvbc/src/ror_app_state.cpp
@@ -1,0 +1,201 @@
+#include "ror_app_state.hpp"
+#include <cassert>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+#include "hash_defs.h"
+
+using namespace concordUtils;
+using namespace bftEngine::SimpleBlockchainStateTransfer;
+using namespace concord::storage;
+namespace block = concord::storage::blockchain::block;
+
+class RoRAppStateImpl : public IAppState {
+ public:
+  RoRAppStateImpl(
+      std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
+          keyManipulator,
+      std::shared_ptr<concord::storage::IDBClient> localClient,
+      std::shared_ptr<concord::storage::IDBClient> objectStoreClient)
+      : keyManipulator_{keyManipulator},
+        localClient_{localClient},
+        objectStoreClient_{objectStoreClient} {
+    std::vector<Sliver> keys{lastBlockIdKey, lastReachableBlockIdKey};
+    KeysVector outValues;
+    Status s = localClient_->multiGet(keys, outValues);
+    if (s.isOK()) {
+      lastBlockId_ = *reinterpret_cast<const uint64_t *>(outValues[0].data());
+      lastReachableBlockId_ =
+          *reinterpret_cast<const uint64_t *>(outValues[1].data());
+    } else if (s.isNotFound()) {
+      LOG_INFO(logger_, "RoRAppStateImpl, first time start");
+    } else {
+      LOG_ERROR(
+          logger_,
+          "RoRAppStateImpl, can't read local metadata, status: " << s);
+      exit(-1);
+    }
+  }
+
+  virtual bool hasBlock(uint64_t blockId) override {
+    Sliver key = keyManipulator_->genBlockDbKey(blockId);
+    Status res = Status::OK();
+    // for using in mem db for tests, we must first ty to cast to ObjectStoreClient
+    auto ptr = std::dynamic_pointer_cast<concord::storage::ObjectStoreClient>(objectStoreClient_);
+    if(ptr)
+     res = ptr->object_exists(key);
+    else { //and if we are in test, just use the interface
+      Sliver v;
+      res = objectStoreClient_->get(key, v);
+    }
+                     
+    LOG_DEBUG(logger_, "hasBlock, blockId: " << blockId
+                                             << ", result: " << res.toString());
+    return res.isOK();
+  }
+
+  virtual bool getBlock(uint64_t blockId, char *outBlock,
+                        uint32_t *outBlockSize) override {
+    throw std::logic_error(
+        "this method is not implemented in RoRAppStateImpl");
+  }
+
+  virtual bool getPrevDigestFromBlock(
+      uint64_t blockId, StateTransferDigest *outPrevBlockDigest) override {
+    using namespace concord::storage::blockchain;
+    assert(blockId > 0);
+
+    Sliver blockData;
+    Sliver key = keyManipulator_->genBlockDbKey(blockId);
+    auto s = objectStoreClient_->get(key, blockData);
+    if (!s.isOK()) {
+      LOG_ERROR(logger_, "objectStoreClient_->get returned " << s);
+      return false;
+    }
+
+    LOG_DEBUG(logger_, "getPrevDigestFromBlock, blockId: " << blockId);
+
+    assert(outPrevBlockDigest);
+    auto parentDigest = block::getParentDigest(blockData);
+    assert(outPrevBlockDigest);
+    memcpy(outPrevBlockDigest, parentDigest, BLOCK_DIGEST_SIZE);
+    return true;
+  }
+
+  virtual bool putBlock(uint64_t blockId, char *block,
+                        uint32_t blockSize) override {
+    Sliver key = keyManipulator_->genBlockDbKey(blockId);
+    Sliver value = Sliver::copy(block, blockSize);
+    Status s = objectStoreClient_->put(key, value);
+    if (s.isOK()) {
+      if (blockId > lastBlockId_) {
+        lastBlockId_ = blockId;
+      }
+      // when ST runs, blocks arrive in batches in reverse order. we need to
+      // keep track on the "Gap" and to close it. Only when it is closed, the
+      // last reachable block becomes the same as the last block
+      if (blockId == lastReachableBlockId_ + 1) {
+        lastReachableBlockId_ = lastBlockId_;
+      }
+    } else {
+      LOG_ERROR(logger_, "putBlock, blockId: " << blockId << ", status: " << s);
+      return false;
+    }
+
+    // if the local write fails but the Object store write was OK, we dont worry
+    // because next time ST will write the same block again and in the worst
+    // case the block in the Object store will be overwritten.
+    using namespace concord::storage;
+    using namespace concordUtils;
+
+    SetOfKeyValuePairs meta;
+    Sliver v1 = Sliver::copy((const char *)&lastBlockId_, sizeof(lastBlockId_));
+    Sliver v2 = Sliver::copy((const char *)&lastReachableBlockId_,
+                             sizeof(lastReachableBlockId_));
+    meta.insert(std::make_pair(lastBlockIdKey, v1));
+    meta.insert(std::make_pair(lastReachableBlockIdKey, v2));
+
+    s = localClient_->multiPut(meta);
+    if (!s.isOK()) {
+      LOG_FATAL(logger_,
+                "putBlock, couldn't write local metadata, status: " << s);
+      exit(-1);
+    }
+
+    LOG_DEBUG(logger_, "putBlock, blockId: "
+                           << blockId << ", status: " << s << ", lastBlockId: "
+                           << lastBlockId_ << ", lastReachableBlockId: "
+                           << lastReachableBlockId_);
+    return true;
+  }
+
+  virtual uint64_t getLastReachableBlockNum() override {
+    return lastReachableBlockId_;
+  }
+
+  virtual uint64_t getLastBlockNum() override { return lastBlockId_; }
+
+  virtual void wait() override {
+    std::static_pointer_cast<concord::storage::ObjectStoreClient>(
+        objectStoreClient_)
+        ->wait_for_storage();
+  }
+
+ private:
+  uint64_t lastBlockId_ = 0;
+  uint64_t lastReachableBlockId_ = 0;
+
+  Sliver lastBlockIdKey =
+      Sliver::copy(kLastBlockIdKey.c_str(), kLastBlockIdKey.size());
+  Sliver lastReachableBlockIdKey = Sliver::copy(
+      kLastReachableBlockIdKey.c_str(), kLastReachableBlockIdKey.size());
+
+  std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
+      keyManipulator_ = nullptr;
+  std::shared_ptr<concord::storage::IDBClient> localClient_ = nullptr;
+  std::shared_ptr<concord::storage::IDBClient> objectStoreClient_ = nullptr;
+  concordlogger::Logger logger_ =
+      concordlogger::Log::getLogger("RoRAppStateImpl");
+};
+
+concord::consensus::RoRAppState::RoRAppState(
+    std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
+        keyManipulator,
+    std::shared_ptr<concord::storage::IDBClient> localClient,
+    std::shared_ptr<concord::storage::IDBClient> objectStoreClient) {
+  pImpl_ = std::make_shared<RoRAppStateImpl>(
+      keyManipulator, localClient, objectStoreClient);
+}
+
+concord::consensus::RoRAppState::~RoRAppState() {}
+
+bool concord::consensus::RoRAppState::hasBlock(uint64_t blockId) {
+  return pImpl_->hasBlock(blockId);
+}
+
+bool concord::consensus::RoRAppState::getBlock(uint64_t blockId, char *outBlock,
+                      uint32_t *outBlockSize) {
+  return pImpl_->getBlock(blockId, outBlock, outBlockSize);
+}
+
+bool concord::consensus::RoRAppState::getPrevDigestFromBlock(
+    uint64_t blockId,
+    bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest
+        *outPrevBlockDigest) {
+  return pImpl_->getPrevDigestFromBlock(blockId, outPrevBlockDigest);
+}
+
+bool concord::consensus::RoRAppState::putBlock(uint64_t blockId, char *block,
+                      uint32_t blockSize) {
+  return pImpl_->putBlock(blockId, block, blockSize);
+}
+
+uint64_t concord::consensus::RoRAppState::getLastReachableBlockNum() {
+  return pImpl_->getLastReachableBlockNum();
+}
+
+uint64_t concord::consensus::RoRAppState::getLastBlockNum() {
+  return pImpl_->getLastBlockNum();
+}
+
+void concord::consensus::RoRAppState::wait() { return pImpl_->wait(); }

--- a/kvbc/src/ror_app_state.cpp
+++ b/kvbc/src/ror_app_state.cpp
@@ -11,27 +11,20 @@ using namespace concord::storage;
 
 class RoRAppStateImpl : public IAppState {
  public:
-  RoRAppStateImpl(
-      std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
-          keyManipulator,
-      std::shared_ptr<concord::storage::IDBClient> localClient,
-      std::shared_ptr<concord::storage::IDBClient> objectStoreClient)
-      : keyManipulator_{keyManipulator},
-        localClient_{localClient},
-        objectStoreClient_{objectStoreClient} {
+  RoRAppStateImpl(std::shared_ptr<concord::storage::blockchain::DBKeyManipulator> keyManipulator,
+                  std::shared_ptr<concord::storage::IDBClient> localClient,
+                  std::shared_ptr<concord::storage::IDBClient> objectStoreClient)
+      : keyManipulator_{keyManipulator}, localClient_{localClient}, objectStoreClient_{objectStoreClient} {
     std::vector<Sliver> keys{lastBlockIdKey, lastReachableBlockIdKey};
     KeysVector outValues;
     Status s = localClient_->multiGet(keys, outValues);
     if (s.isOK()) {
       lastBlockId_ = *reinterpret_cast<const uint64_t *>(outValues[0].data());
-      lastReachableBlockId_ =
-          *reinterpret_cast<const uint64_t *>(outValues[1].data());
+      lastReachableBlockId_ = *reinterpret_cast<const uint64_t *>(outValues[1].data());
     } else if (s.isNotFound()) {
       LOG_INFO(logger_, "RoRAppStateImpl, first time start");
     } else {
-      LOG_ERROR(
-          logger_,
-          "RoRAppStateImpl, can't read local metadata, status: " << s);
+      LOG_ERROR(logger_, "RoRAppStateImpl, can't read local metadata, status: " << s);
       exit(-1);
     }
   }
@@ -41,26 +34,22 @@ class RoRAppStateImpl : public IAppState {
     Status res = Status::OK();
     // for using in mem db for tests, we must first ty to cast to ObjectStoreClient
     auto ptr = std::dynamic_pointer_cast<concord::storage::ObjectStoreClient>(objectStoreClient_);
-    if(ptr)
-     res = ptr->object_exists(key);
-    else { //and if we are in test, just use the interface
+    if (ptr)
+      res = ptr->object_exists(key);
+    else {  // and if we are in test, just use the interface
       Sliver v;
       res = objectStoreClient_->get(key, v);
     }
-                     
-    LOG_DEBUG(logger_, "hasBlock, blockId: " << blockId
-                                             << ", result: " << res.toString());
+
+    LOG_DEBUG(logger_, "hasBlock, blockId: " << blockId << ", result: " << res.toString());
     return res.isOK();
   }
 
-  virtual bool getBlock(uint64_t blockId, char *outBlock,
-                        uint32_t *outBlockSize) override {
-    throw std::logic_error(
-        "this method is not implemented in RoRAppStateImpl");
+  virtual bool getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override {
+    throw std::logic_error("this method is not implemented in RoRAppStateImpl");
   }
 
-  virtual bool getPrevDigestFromBlock(
-      uint64_t blockId, StateTransferDigest *outPrevBlockDigest) override {
+  virtual bool getPrevDigestFromBlock(uint64_t blockId, StateTransferDigest *outPrevBlockDigest) override {
     using namespace concord::storage::blockchain;
     assert(blockId > 0);
 
@@ -81,8 +70,7 @@ class RoRAppStateImpl : public IAppState {
     return true;
   }
 
-  virtual bool putBlock(uint64_t blockId, char *block,
-                        uint32_t blockSize) override {
+  virtual bool putBlock(uint64_t blockId, char *block, uint32_t blockSize) override {
     Sliver key = keyManipulator_->genBlockDbKey(blockId);
     Sliver value = Sliver::copy(block, blockSize);
     Status s = objectStoreClient_->put(key, value);
@@ -109,92 +97,69 @@ class RoRAppStateImpl : public IAppState {
 
     SetOfKeyValuePairs meta;
     Sliver v1 = Sliver::copy((const char *)&lastBlockId_, sizeof(lastBlockId_));
-    Sliver v2 = Sliver::copy((const char *)&lastReachableBlockId_,
-                             sizeof(lastReachableBlockId_));
+    Sliver v2 = Sliver::copy((const char *)&lastReachableBlockId_, sizeof(lastReachableBlockId_));
     meta.insert(std::make_pair(lastBlockIdKey, v1));
     meta.insert(std::make_pair(lastReachableBlockIdKey, v2));
 
     s = localClient_->multiPut(meta);
     if (!s.isOK()) {
-      LOG_FATAL(logger_,
-                "putBlock, couldn't write local metadata, status: " << s);
+      LOG_FATAL(logger_, "putBlock, couldn't write local metadata, status: " << s);
       exit(-1);
     }
 
-    LOG_DEBUG(logger_, "putBlock, blockId: "
-                           << blockId << ", status: " << s << ", lastBlockId: "
-                           << lastBlockId_ << ", lastReachableBlockId: "
-                           << lastReachableBlockId_);
+    LOG_DEBUG(logger_,
+              "putBlock, blockId: " << blockId << ", status: " << s << ", lastBlockId: " << lastBlockId_
+                                    << ", lastReachableBlockId: " << lastReachableBlockId_);
     return true;
   }
 
-  virtual uint64_t getLastReachableBlockNum() override {
-    return lastReachableBlockId_;
-  }
+  virtual uint64_t getLastReachableBlockNum() override { return lastReachableBlockId_; }
 
   virtual uint64_t getLastBlockNum() override { return lastBlockId_; }
 
   virtual void wait() override {
-    std::static_pointer_cast<concord::storage::ObjectStoreClient>(
-        objectStoreClient_)
-        ->wait_for_storage();
+    std::static_pointer_cast<concord::storage::ObjectStoreClient>(objectStoreClient_)->wait_for_storage();
   }
 
  private:
   uint64_t lastBlockId_ = 0;
   uint64_t lastReachableBlockId_ = 0;
 
-  Sliver lastBlockIdKey =
-      Sliver::copy(kLastBlockIdKey.c_str(), kLastBlockIdKey.size());
-  Sliver lastReachableBlockIdKey = Sliver::copy(
-      kLastReachableBlockIdKey.c_str(), kLastReachableBlockIdKey.size());
+  Sliver lastBlockIdKey = Sliver::copy(kLastBlockIdKey.c_str(), kLastBlockIdKey.size());
+  Sliver lastReachableBlockIdKey = Sliver::copy(kLastReachableBlockIdKey.c_str(), kLastReachableBlockIdKey.size());
 
-  std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
-      keyManipulator_ = nullptr;
+  std::shared_ptr<concord::storage::blockchain::DBKeyManipulator> keyManipulator_ = nullptr;
   std::shared_ptr<concord::storage::IDBClient> localClient_ = nullptr;
   std::shared_ptr<concord::storage::IDBClient> objectStoreClient_ = nullptr;
-  concordlogger::Logger logger_ =
-      concordlogger::Log::getLogger("RoRAppStateImpl");
+  concordlogger::Logger logger_ = concordlogger::Log::getLogger("RoRAppStateImpl");
 };
 
 concord::consensus::RoRAppState::RoRAppState(
-    std::shared_ptr<concord::storage::blockchain::DBKeyManipulator>
-        keyManipulator,
+    std::shared_ptr<concord::storage::blockchain::DBKeyManipulator> keyManipulator,
     std::shared_ptr<concord::storage::IDBClient> localClient,
     std::shared_ptr<concord::storage::IDBClient> objectStoreClient) {
-  pImpl_ = std::make_shared<RoRAppStateImpl>(
-      keyManipulator, localClient, objectStoreClient);
+  pImpl_ = std::make_shared<RoRAppStateImpl>(keyManipulator, localClient, objectStoreClient);
 }
 
 concord::consensus::RoRAppState::~RoRAppState() {}
 
-bool concord::consensus::RoRAppState::hasBlock(uint64_t blockId) {
-  return pImpl_->hasBlock(blockId);
-}
+bool concord::consensus::RoRAppState::hasBlock(uint64_t blockId) { return pImpl_->hasBlock(blockId); }
 
-bool concord::consensus::RoRAppState::getBlock(uint64_t blockId, char *outBlock,
-                      uint32_t *outBlockSize) {
+bool concord::consensus::RoRAppState::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) {
   return pImpl_->getBlock(blockId, outBlock, outBlockSize);
 }
 
 bool concord::consensus::RoRAppState::getPrevDigestFromBlock(
-    uint64_t blockId,
-    bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest
-        *outPrevBlockDigest) {
+    uint64_t blockId, bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest *outPrevBlockDigest) {
   return pImpl_->getPrevDigestFromBlock(blockId, outPrevBlockDigest);
 }
 
-bool concord::consensus::RoRAppState::putBlock(uint64_t blockId, char *block,
-                      uint32_t blockSize) {
+bool concord::consensus::RoRAppState::putBlock(uint64_t blockId, char *block, uint32_t blockSize) {
   return pImpl_->putBlock(blockId, block, blockSize);
 }
 
-uint64_t concord::consensus::RoRAppState::getLastReachableBlockNum() {
-  return pImpl_->getLastReachableBlockNum();
-}
+uint64_t concord::consensus::RoRAppState::getLastReachableBlockNum() { return pImpl_->getLastReachableBlockNum(); }
 
-uint64_t concord::consensus::RoRAppState::getLastBlockNum() {
-  return pImpl_->getLastBlockNum();
-}
+uint64_t concord::consensus::RoRAppState::getLastBlockNum() { return pImpl_->getLastBlockNum(); }
 
 void concord::consensus::RoRAppState::wait() { return pImpl_->wait(); }

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -9,3 +9,17 @@ if(Boost_FOUND)
         kvbc
     )
 endif()
+
+if(BUILD_ROCKSDB_STORAGE OR USE_OBJECTSTORE_FOR_ROR_TEST)
+    add_executable(
+        ror_app_state_test
+        ror_app_state_test.cpp
+        $<TARGET_OBJECTS:logging_dev>)
+    add_test(ror_app_state_test ror_app_state_test)
+    target_link_libraries(
+        ror_app_state_test PUBLIC
+        GTest::Main
+        object_store_lib
+        kvbc
+        util)
+endif()

--- a/kvbc/test/ror_app_state_test.cpp
+++ b/kvbc/test/ror_app_state_test.cpp
@@ -1,0 +1,197 @@
+// Copyright 2019 VMware, all rights reserved
+//
+// Unit tests for ECS S3 object store replication.
+// IMPORTANT: the test assume that the S3 storage is up.
+
+#include "ror_app_state.hpp"
+#include <cstdlib>
+#include <memory>
+#include "SimpleBCStateTransfer.hpp"
+#include "blockchain/block.h"
+#include "blockchain/db_adapter.h"
+#include "blockchain/db_interfaces.h"
+#include "gtest/gtest.h"
+#include "kv_types.hpp"
+#include "rocksdb/comparator.h"
+#include "sliver.hpp"
+#include "status.hpp"
+#include "storage/db_interface.h"
+#include "ror_test_setup.hpp"
+
+using namespace concord::storage;
+using namespace concord::storage::blockchain;
+using namespace concord::consensus;
+using namespace bftEngine::SimpleBlockchainStateTransfer;
+using namespace concord::storage::blockchain::block::detail;
+
+namespace {
+
+class RoRAppStateTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+#ifdef USE_ROCKSDB
+    std::string a = "sudo rm -rf unit_test_db_meta";
+    std::system(a.c_str());
+    a = "sudo rm -rf unit_test_db_object_store";
+    std::system(a.c_str());
+#endif
+
+    for (int i = 0; i < numOfBlocks * 2; i++) {
+      char *block = new char[kBlockSize];
+      Header *bh = (Header *)block;
+      bh->numberOfElements = 1;
+      bh->parentDigestLength =
+          bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
+      if (i == 0)
+        memset(bh->parentDigest, 0,
+               bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE);
+      else
+        bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(
+            i, reinterpret_cast<const char *>(blocks[i - 1] + sizeof(Header)),
+            kBlockSize - sizeof(Header),
+            (StateTransferDigest *)bh->parentDigest);
+
+      memset(block + sizeof(Header), 'a' + i, kBlockSize - sizeof(Header));
+      blocks.push_back(block);
+    }
+  }
+
+  void TearDown() override {
+    for (size_t i = 0; i < blocks.size(); i++) delete[] blocks[i];
+  }
+
+  void SetClient() {
+    objectStoreClient = set_object_store_client();
+    objectStoreClient->init();
+    localClient = set_local_client();
+    localClient->init();
+    appState = std::make_shared<RoRAppState>(
+        std::make_shared<DBKeyManipulator>(), localClient, objectStoreClient);
+
+    for (size_t i = 0; i < blocks.size(); i++) {
+      Sliver key = km.genBlockDbKey(i + 1);
+      Status res = objectStoreClient->del(key);
+    }
+  }
+
+  void check_metadata(uint64_t expectedLastBlockNum,
+                      int64_t expectedLastReachableBlockNum) {
+    Sliver value;
+    Status s = localClient->get(lastBlockIdKey, value);
+    ASSERT_TRUE(s.isOK());
+    auto lastWrittenBlockNum = *(uint64_t *)value.data();
+    s = localClient->get(lastReachableBlockIdKey, value);
+    ASSERT_TRUE(s.isOK());
+    auto lastWrittenReachBlockNum = *(uint64_t *)value.data();
+
+    auto lastInMemBlockNum = appState->getLastBlockNum();
+    ASSERT_EQ(lastInMemBlockNum, expectedLastBlockNum);
+    auto lastInMemReachableBlockNum = appState->getLastReachableBlockNum();
+    ASSERT_EQ(lastInMemReachableBlockNum, expectedLastReachableBlockNum);
+
+    ASSERT_EQ(lastWrittenBlockNum, lastWrittenReachBlockNum);
+    ASSERT_EQ(lastInMemBlockNum, lastInMemReachableBlockNum);
+    ASSERT_EQ(lastWrittenReachBlockNum, lastInMemBlockNum);
+    ASSERT_EQ(expectedLastBlockNum, lastWrittenBlockNum);
+  }
+
+  const int numOfBlocks = 10;
+  const int kBlockSize = 1000;
+  std::vector<char *> blocks;
+  
+  DBKeyManipulator km;
+  std::shared_ptr<IDBClient> objectStoreClient = nullptr;
+  std::shared_ptr<IDBClient> localClient = nullptr;
+  std::shared_ptr<RoRAppState> appState = nullptr;
+  Sliver lastBlockIdKey =
+      Sliver::copy(kLastBlockIdKey.c_str(), kLastBlockIdKey.size());
+  Sliver lastReachableBlockIdKey = Sliver::copy(
+      kLastReachableBlockIdKey.c_str(), kLastReachableBlockIdKey.size());
+};
+}  // namespace
+
+TEST_F(RoRAppStateTest, PutBlocksCleanState) {
+  SetClient();
+
+  ASSERT_EQ(appState->getLastBlockNum(), 0);
+  ASSERT_EQ(appState->getLastReachableBlockNum(), 0);
+
+  for (int i = numOfBlocks - 1; i >= 0; i--) {
+    bool res = appState->putBlock(i + 1, blocks[i], kBlockSize);
+    ASSERT_TRUE(res);
+
+    if (i > 0) {
+      Sliver value;
+      Status s = localClient->get(lastBlockIdKey, value);
+      ASSERT_TRUE(s.isOK());
+      ASSERT_EQ(numOfBlocks, *(uint64_t *)value.data());
+
+      s = localClient->get(lastReachableBlockIdKey, value);
+      ASSERT_TRUE(s.isOK());
+      ASSERT_EQ(0, *(uint64_t *)value.data());
+
+      ASSERT_EQ(appState->getLastBlockNum(), numOfBlocks);
+      ASSERT_EQ(appState->getLastReachableBlockNum(), 0);
+    }
+  }
+
+  check_metadata(numOfBlocks, numOfBlocks);
+
+  // check that the object store has all blocks
+  for (int i = 0; i < numOfBlocks; i++) {
+    bool res = appState->hasBlock(i + 1);
+    ASSERT_TRUE(res);
+  }
+}
+
+TEST_F(RoRAppStateTest, PutBlocksStateExists) {
+  SetClient();
+  for (int i = numOfBlocks - 1; i >= 0; i--) {
+    bool res = appState->putBlock(i + 1, blocks[i], kBlockSize);
+    ASSERT_TRUE(res);
+  }
+
+  check_metadata(numOfBlocks, numOfBlocks);
+
+  // check that the object store has all blocks
+  for (int i = 0; i < numOfBlocks; i++) {
+    bool res = appState->hasBlock(i + 1);
+    ASSERT_TRUE(res);
+  }
+
+  // now send blocks 20 to 11, as the ST does
+  for (int i = numOfBlocks * 2 - 1; i >= 10; i--) {
+    bool res = appState->putBlock(i + 1, blocks[i], kBlockSize);
+    ASSERT_TRUE(res);
+
+    Sliver v1;
+    Sliver v2;
+    Status s = localClient->get(lastBlockIdKey, v1);
+    ASSERT_TRUE(s.isOK());
+    s = localClient->get(lastReachableBlockIdKey, v2);
+    ASSERT_TRUE(s.isOK());
+
+    ASSERT_EQ(numOfBlocks * 2, *(uint64_t *)v1.data());
+    ASSERT_EQ(numOfBlocks * 2, appState->getLastBlockNum());
+    if (i > numOfBlocks) {
+      ASSERT_EQ(numOfBlocks, appState->getLastReachableBlockNum());
+      ASSERT_EQ(numOfBlocks, *(uint64_t *)v2.data());
+    } else {
+      ASSERT_EQ(numOfBlocks * 2, appState->getLastReachableBlockNum());
+      ASSERT_EQ(numOfBlocks * 2, *(uint64_t *)v2.data());
+    }
+  }
+
+  check_metadata(numOfBlocks * 2, numOfBlocks * 2);
+  // check that the object store has all blocks
+  for (size_t i = 0; i < blocks.size(); i++) {
+    bool res = appState->hasBlock(i + 1);
+    ASSERT_TRUE(res);
+  }
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto exitCode = RUN_ALL_TESTS();
+  return exitCode;
+}

--- a/kvbc/test/ror_app_state_test.cpp
+++ b/kvbc/test/ror_app_state_test.cpp
@@ -27,7 +27,7 @@ using namespace concord::storage::blockchain::block::detail;
 namespace {
 
 class RoRAppStateTest : public ::testing::Test {
-protected:
+ protected:
   void SetUp() override {
 #ifdef USE_ROCKSDB
     std::string a = "sudo rm -rf unit_test_db_meta";
@@ -40,14 +40,13 @@ protected:
       char *block = new char[kBlockSize];
       Header *bh = (Header *)block;
       bh->numberOfElements = 1;
-      bh->parentDigestLength =
-          bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
+      bh->parentDigestLength = bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
       if (i == 0)
-        memset(bh->parentDigest, 0,
-               bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE);
+        memset(bh->parentDigest, 0, bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE);
       else
         bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(
-            i, reinterpret_cast<const char *>(blocks[i - 1] + sizeof(Header)),
+            i,
+            reinterpret_cast<const char *>(blocks[i - 1] + sizeof(Header)),
             kBlockSize - sizeof(Header),
             (StateTransferDigest *)bh->parentDigest);
 
@@ -65,8 +64,7 @@ protected:
     objectStoreClient->init();
     localClient = set_local_client();
     localClient->init();
-    appState = std::make_shared<RoRAppState>(
-        std::make_shared<DBKeyManipulator>(), localClient, objectStoreClient);
+    appState = std::make_shared<RoRAppState>(std::make_shared<DBKeyManipulator>(), localClient, objectStoreClient);
 
     for (size_t i = 0; i < blocks.size(); i++) {
       Sliver key = km.genBlockDbKey(i + 1);
@@ -74,8 +72,7 @@ protected:
     }
   }
 
-  void check_metadata(uint64_t expectedLastBlockNum,
-                      int64_t expectedLastReachableBlockNum) {
+  void check_metadata(uint64_t expectedLastBlockNum, int64_t expectedLastReachableBlockNum) {
     Sliver value;
     Status s = localClient->get(lastBlockIdKey, value);
     ASSERT_TRUE(s.isOK());
@@ -98,15 +95,13 @@ protected:
   const int numOfBlocks = 10;
   const int kBlockSize = 1000;
   std::vector<char *> blocks;
-  
+
   DBKeyManipulator km;
   std::shared_ptr<IDBClient> objectStoreClient = nullptr;
   std::shared_ptr<IDBClient> localClient = nullptr;
   std::shared_ptr<RoRAppState> appState = nullptr;
-  Sliver lastBlockIdKey =
-      Sliver::copy(kLastBlockIdKey.c_str(), kLastBlockIdKey.size());
-  Sliver lastReachableBlockIdKey = Sliver::copy(
-      kLastReachableBlockIdKey.c_str(), kLastReachableBlockIdKey.size());
+  Sliver lastBlockIdKey = Sliver::copy(kLastBlockIdKey.c_str(), kLastBlockIdKey.size());
+  Sliver lastReachableBlockIdKey = Sliver::copy(kLastReachableBlockIdKey.c_str(), kLastReachableBlockIdKey.size());
 };
 }  // namespace
 

--- a/kvbc/test/ror_app_state_test.cpp
+++ b/kvbc/test/ror_app_state_test.cpp
@@ -31,9 +31,11 @@ class RoRAppStateTest : public ::testing::Test {
   void SetUp() override {
 #ifdef USE_ROCKSDB
     std::string a = "sudo rm -rf unit_test_db_meta";
-    std::system(a.c_str());
+    int r = std::system(a.c_str());
+    ASSERT_EQ(r, 0);
     a = "sudo rm -rf unit_test_db_object_store";
-    std::system(a.c_str());
+    r = std::system(a.c_str());
+    ASSERT_EQ(r, 0);
 #endif
 
     for (int i = 0; i < numOfBlocks * 2; i++) {

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -7,6 +7,14 @@ add_library(concordbft_storage STATIC src/db_metadata_storage.cpp
 target_include_directories(concordbft_storage PUBLIC include)
 target_link_libraries(concordbft_storage PUBLIC corebft)
 
+add_library(
+  object_store_lib
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/object_store/object_store_client.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/object_store/ecs_s3_client.hpp)
+  target_include_directories(object_store_lib PUBLIC include)
+  target_link_libraries(object_store_lib PRIVATE s3 util)
+
+
 if (BUILD_ROCKSDB_STORAGE)
   #TODO [TK] find_package
   find_library(ROCKSDB rocksdb)

--- a/storage/include/object_store/object_store_client.hpp
+++ b/storage/include/object_store/object_store_client.hpp
@@ -1,0 +1,82 @@
+// Copyright 2018 VMware, all rights reserved
+
+#pragma once
+
+#include <memory>
+#include "storage/db_interface.h"
+#include <chrono>
+
+namespace concord {
+namespace storage {
+
+struct S3_StoreConfig {
+  std::string bucketName;  // assuminh pre configured, no need to create
+  std::string url;         // from the customer
+  std::string protocol;    // currently tested with HTTP
+  std::string secretKey;   // from the customer
+  std::string accessKey;   // from the customer
+  std::uint32_t maxWaitTime; // in milliseconds
+  virtual ~S3_StoreConfig() {}
+};
+
+// For using in tests. This class is used to tell the ObjectStore client impl to simulate network failure for predefined
+// ammount of time. Also it can be used for controlling deletion of objects (useful for tests)
+class ObjectStoreBehavior {
+ private:
+  bool allowDelete_ = false;
+  bool allowNetworkFailure_ = false;
+  std::chrono::time_point<std::chrono::steady_clock> startTimeForNetworkFailure_;
+  bool doNetworkFailure_ = false;
+  uint64_t doNetworkFailureDurMilli_ = 0;
+ 
+ public:
+  ObjectStoreBehavior(bool canDelete, bool canSimulateNetFailure);
+  // set network failure flag and duration
+  void set_do_net_failure(bool value, uint64_t durationMilli);
+  bool get_do_net_failure() const;
+  bool can_delete() const;
+  // used to assert whether its possible to simulate network failure
+  bool can_simulate_net_failure() const;
+  // returns whether the network failure period has been elapsed
+  bool has_finished() const;
+};
+
+/**
+ * @brief This class implements Abstract object store client assuming S3
+ * protocol
+ *
+ */
+class ObjectStoreClient : public IDBClient {
+ public:
+  ObjectStoreClient(ObjectStoreClient&) = delete;
+  ObjectStoreClient() = delete;
+
+  ObjectStoreClient(const S3_StoreConfig& config, const ObjectStoreBehavior& b);
+
+  virtual ~ObjectStoreClient() = default;
+  virtual void init(bool readOnly = false) override;
+  virtual Status get(const Sliver& _key, OUT Sliver& _outValue) const override;
+  virtual Status get(const Sliver& _key, OUT char*& buf, uint32_t bufSize,
+                     OUT uint32_t& _size) const override;
+  virtual Status put(const Sliver& _key, const Sliver& _value) override;
+  virtual Status del(const Sliver& _key) override;
+  virtual Status multiGet(const KeysVector& _keysVec,
+                          OUT ValuesVector& _valuesVec) override;
+  virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override;
+  virtual Status multiDel(const KeysVector& _keysVec) override;
+  virtual void monitor() const override;
+  virtual bool isNew() override;
+  virtual IDBClient::IDBClientIterator* getIterator() const override;
+  virtual Status freeIterator(IDBClientIterator* _iter) const override;
+  virtual ITransaction* beginTransaction() override;
+
+  void wait_for_storage();
+  Status object_exists(const Sliver& key);
+  Status test_bucket();
+
+ private:
+  std::shared_ptr<IDBClient> pImpl_ = nullptr;
+};  // class ObjectStoreClient
+
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/object_store/object_store_client.hpp
+++ b/storage/include/object_store/object_store_client.hpp
@@ -10,12 +10,12 @@ namespace concord {
 namespace storage {
 
 struct S3_StoreConfig {
-  std::string bucketName;  // assuminh pre configured, no need to create
-  std::string url;         // from the customer
-  std::string protocol;    // currently tested with HTTP
-  std::string secretKey;   // from the customer
-  std::string accessKey;   // from the customer
-  std::uint32_t maxWaitTime; // in milliseconds
+  std::string bucketName;     // assuminh pre configured, no need to create
+  std::string url;            // from the customer
+  std::string protocol;       // currently tested with HTTP
+  std::string secretKey;      // from the customer
+  std::string accessKey;      // from the customer
+  std::uint32_t maxWaitTime;  // in milliseconds
   virtual ~S3_StoreConfig() {}
 };
 
@@ -28,7 +28,7 @@ class ObjectStoreBehavior {
   std::chrono::time_point<std::chrono::steady_clock> startTimeForNetworkFailure_;
   bool doNetworkFailure_ = false;
   uint64_t doNetworkFailureDurMilli_ = 0;
- 
+
  public:
   ObjectStoreBehavior(bool canDelete, bool canSimulateNetFailure);
   // set network failure flag and duration
@@ -56,12 +56,10 @@ class ObjectStoreClient : public IDBClient {
   virtual ~ObjectStoreClient() = default;
   virtual void init(bool readOnly = false) override;
   virtual Status get(const Sliver& _key, OUT Sliver& _outValue) const override;
-  virtual Status get(const Sliver& _key, OUT char*& buf, uint32_t bufSize,
-                     OUT uint32_t& _size) const override;
+  virtual Status get(const Sliver& _key, OUT char*& buf, uint32_t bufSize, OUT uint32_t& _size) const override;
   virtual Status put(const Sliver& _key, const Sliver& _value) override;
   virtual Status del(const Sliver& _key) override;
-  virtual Status multiGet(const KeysVector& _keysVec,
-                          OUT ValuesVector& _valuesVec) override;
+  virtual Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) override;
   virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override;
   virtual Status multiDel(const KeysVector& _keysVec) override;
   virtual void monitor() const override;

--- a/storage/src/merkle_tree_db_adapter.cpp
+++ b/storage/src/merkle_tree_db_adapter.cpp
@@ -194,7 +194,7 @@ EDBKeyType getDBKeyType(const Sliver &s) {
     case toChar(EDBKeyType::BFT):
       return EDBKeyType::BFT;
   }
-  
+
   Assert(false);
   return EDBKeyType::Block;
 }

--- a/storage/src/merkle_tree_db_adapter.cpp
+++ b/storage/src/merkle_tree_db_adapter.cpp
@@ -194,8 +194,9 @@ EDBKeyType getDBKeyType(const Sliver &s) {
     case toChar(EDBKeyType::BFT):
       return EDBKeyType::BFT;
   }
-
+  
   Assert(false);
+  return EDBKeyType::Block;
 }
 
 EKeySubtype getKeySubtype(const Sliver &s) {
@@ -211,6 +212,7 @@ EKeySubtype getKeySubtype(const Sliver &s) {
   }
 
   Assert(false);
+  return EKeySubtype::Internal;
 }
 
 }  // namespace

--- a/storage/src/object_store/ecs_s3_client.hpp
+++ b/storage/src/object_store/ecs_s3_client.hpp
@@ -1,0 +1,451 @@
+// Copyright 2019 VMware, all rights reserved.
+
+#pragma once
+#include <libs3.h>
+#include <cassert>
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <functional>
+#include "Logger.hpp"
+#include "object_store/object_store_client.hpp"
+
+using namespace concord::storage;
+using namespace std;
+
+/**
+ * @brief Internal implementation of ECS EMC S3 client based on libs3
+ * Most of the method are irrelevant for the object store and throw exception if
+ * called. We assume that only ObjectStoreAppState class will use this class
+ *
+ */
+class EcsS3ClientImpl : public IDBClient {
+ public:
+  EcsS3ClientImpl(const S3_StoreConfig& config, const ObjectStoreBehavior& b)
+      : config_{config}, bh_{b} {
+    
+    LOG_INFO(logger_, "ECS S3 client created");
+  }
+
+  ~EcsS3ClientImpl() {
+    /* Destroy LibS3 */
+    S3_deinitialize();
+    init_ = false;
+    LOG_INFO(logger_, "libs3 deinit");
+  }
+
+  /**
+   * @brief used only from the test! name should be immutable string literal
+   *
+   * @param name
+   */
+  void set_bucket_name(string name) { config_.bucketName = name; }
+
+  /**
+   * @brief Initializing underlying libs3. The S3_initialize function must be
+   * called exactly once and only from 1 thread
+   *
+   * @param readOnly
+   */
+  virtual void init(bool readOnly) override {
+    std::lock_guard<std::mutex> g(initLock_);
+    assert(!init_);  // we may return here instead of firing assert failure, but
+                     // probably we want to catch bugs?
+    context_.hostName = config_.url.c_str();
+    context_.protocol =
+        (config_.protocol == "HTTP" ? S3ProtocolHTTP : S3ProtocolHTTPS);
+    context_.uriStyle = S3UriStylePath;
+    /* In ECS terms, this is your object user */
+    context_.accessKeyId = config_.accessKey.c_str();
+    context_.secretAccessKey = config_.secretKey.c_str();
+    /* The name of a bucket to use */
+    context_.bucketName = config_.bucketName.c_str();
+
+    S3Status st = S3_initialize(NULL, S3_INIT_ALL, NULL);
+    if (S3Status::S3StatusOK != st) {
+      LOG_ERROR(logger_, "libs3 init failed, status: " + to_string(st));
+      throw std::runtime_error("libs3 init failed, status: " + to_string(st));
+    }
+    LOG_INFO(logger_, "libs3 initialized");
+    init_ = true;
+  }
+
+  /**
+   * @brief GEt object from the store.
+   *
+   * @param _key key to be retrieved
+   * @param _outValue returned object
+   * @return OK if success, otherwise GeneralError with underlying error status
+   */
+  virtual Status get(const Sliver& _key, OUT Sliver& _outValue) const override {
+    using namespace std::placeholders;
+    Status res = Status::OK();
+    std::function<Status(const Sliver&, OUT Sliver&)> f = std::bind(&EcsS3ClientImpl::get_internal, this, _1, _2);
+    do_with_retry(res, f, _key, _outValue);
+    return res;
+  }
+
+  virtual Status get(const Sliver& _key, OUT char*& buf, uint32_t bufSize,
+                     OUT uint32_t& _size) const override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  /**
+   * @brief Put object to the store.
+   *
+   * @param _key object's key
+   * @param _value object
+   * @return OK if success, otherwise GeneralError with underlying error status
+   */
+  virtual Status put(const Sliver& _key, const Sliver& _value) override {
+    using namespace std::placeholders;
+    std::function<Status(const Sliver&, const Sliver&)> f = std::bind(&EcsS3ClientImpl::put_internal, this, _1, _2);
+    Status res = Status::OK();
+    do_with_retry(res, f, _key, _value);
+    return res;
+  }
+
+  Status test_bucket() {
+    using namespace std::placeholders;
+    std::function<Status()> f = std::bind(&EcsS3ClientImpl::test_bucket_internal, this);
+    Status res = Status::OK();
+
+    do_with_retry(res, f);
+    return res;
+  }
+
+  Status object_exists(const Sliver& key) {
+    using namespace std::placeholders;
+    std::function<Status(const Sliver&)> f = std::bind(&EcsS3ClientImpl::object_exists_internal, this, _1);
+    Status res = Status::OK();
+    do_with_retry(res, f, key);
+    return res;
+  }
+
+  void wait_for_storage() {
+    Status res = Status::OK();
+    do {
+      res = test_bucket();
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+    } while (!res.isOK());
+  }
+
+  virtual Status del(const Sliver& key) override {
+    if (!bh_.can_delete())
+      throw std::logic_error("Not implemented for ECS S3 object store");
+    assert(init_);
+    if (should_net_fail())
+      return Status::GeneralError("Network failure simulated");
+
+    ResponseData rData;
+    S3ResponseHandler rHandler;
+    rHandler.completeCallback = responseCompleteCallback;
+    rHandler.propertiesCallback = propertiesCallback;
+    S3_delete_object(&context_, string(key.data()).c_str(), NULL, &rHandler,
+                     &rData);
+    LOG_DEBUG(logger_, "del key: " << string(key.data())
+                                   << ", status: " << rData.status
+                                   << ", msg: " << rData.errorMessage);
+    if (rData.status == S3Status::S3StatusOK)
+      return Status::OK();
+    else {
+      LOG_ERROR(logger_, "del key: " << string(key.data())
+                                     << ", status: " << rData.status
+                                     << ", msg: " << rData.errorMessage);
+      if (rData.status == S3Status::S3StatusHttpErrorNotFound ||
+          rData.status == S3Status::S3StatusErrorNoSuchBucket ||
+          rData.status == S3Status::S3StatusErrorNoSuchKey)
+        return Status::NotFound("Status: " + to_string(rData.status) +
+                                "msg: " + rData.errorMessage);
+
+      return Status::GeneralError("Status: " + to_string(rData.status) +
+                                  "msg: " + rData.errorMessage);
+    }
+  }
+
+  virtual Status multiGet(const KeysVector& _keysVec,
+                          OUT ValuesVector& _valuesVec) override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  virtual Status multiDel(const KeysVector& _keysVec) override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  virtual void monitor() const override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  virtual bool isNew() override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  virtual IDBClient::IDBClientIterator* getIterator() const override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  virtual Status freeIterator(IDBClientIterator* _iter) const override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  virtual ITransaction* beginTransaction() override {
+    throw std::logic_error("Not implemented for ECS S3 object store");
+  }
+
+  ///////////////////////// private /////////////////////////////
+private:
+  template<typename F, typename... Args>
+  void do_with_retry(Status& r, F&& f, Args&&... args) const {
+    uint16_t delay = initialDelay_;
+    auto start = std::chrono::steady_clock::now();
+    auto now = std::chrono::steady_clock::now();
+    do {
+      r = std::forward<F>(f)(std::forward<Args>(args)...);
+      LOG_DEBUG(logger_, "do_with_retry, delay: " << delay);
+      if(!r.isGeneralError())
+        break;
+      if(delay < config_.maxWaitTime)
+        delay *= delayFactor_;
+      std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+      now = std::chrono::steady_clock::now();
+    } while(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() < (int32_t)config_.maxWaitTime);
+  }
+
+  Status get_internal(const Sliver& _key, OUT Sliver& _outValue) const  {
+    assert(init_);
+    if (should_net_fail())
+      return Status::GeneralError("Network failure simulated");
+    GetObjectResponseData cbData(kInitialGetBufferSize_);
+    S3GetObjectHandler getObjectHandler;
+    getObjectHandler.responseHandler = responseHandler;
+
+    // libs3 uses multiple calls to this callaback to append chunks of data from
+    // the stream
+    auto f = [](int buf_len, const char* buf, void* cb) -> S3Status {
+      GetObjectResponseData* cbData = static_cast<GetObjectResponseData*>(cb);
+      assert(cbData->data);
+      cbData->Write(buf, buf_len);
+      return S3Status::S3StatusOK;
+    };
+    getObjectHandler.getObjectDataCallback = f;
+    S3_get_object(&context_, _key.data(), NULL, 0, 0, NULL, &getObjectHandler,
+                  &cbData);
+    if (cbData.status == S3Status::S3StatusOK) {
+      _outValue = Sliver::copy(reinterpret_cast<const char*>(cbData.data),
+                               cbData.readLength);
+      return Status::OK();
+    } else {
+      LOG_ERROR(logger_, "get status: " << cbData.status);
+      if (cbData.status == S3Status::S3StatusHttpErrorNotFound ||
+          cbData.status == S3Status::S3StatusErrorNoSuchBucket ||
+          cbData.status == S3Status::S3StatusErrorNoSuchKey)
+        return Status::NotFound("Status: " + to_string(cbData.status) +
+                                "msg: " + cbData.errorMessage);
+
+      return Status::GeneralError("Status: " + to_string(cbData.status) +
+                                  "msg: " + cbData.errorMessage);
+    }
+  }
+
+  Status put_internal(const Sliver& _key, const Sliver& _value) {
+    assert(init_);
+    if (this->should_net_fail())
+      return Status::GeneralError("Network failure simulated");
+    PutObjectResponseData cbData(_value.data(), _value.length());
+    S3PutObjectHandler putObjectHandler;
+    putObjectHandler.responseHandler = responseHandler;
+
+    // libs3 uses multiple calls to this callaback to append chunks of data to
+    // the stream
+    auto f = [](int buf_len, char* buf, void* cb) {
+      PutObjectResponseData* cbData = static_cast<PutObjectResponseData*>(cb);
+      int toSend = 0;
+      if (cbData->dataLength) {
+        toSend = std::min(cbData->dataLength, (size_t)buf_len);
+        std::memcpy(buf, cbData->data + cbData->putCount, toSend);
+      }
+      cbData->putCount += toSend;
+      cbData->dataLength -= toSend;
+      return toSend;
+    };
+    putObjectHandler.putObjectDataCallback = f;
+    string s = string(_key.data());
+    S3_put_object(&context_, string(_key.data()).c_str(), _value.length(), NULL,
+                  NULL, &putObjectHandler, &cbData);
+    if (cbData.status == S3Status::S3StatusOK)
+      return Status::OK();
+    else {
+      LOG_ERROR(logger_, "put status: " << cbData.status);
+      if (cbData.status == S3Status::S3StatusHttpErrorNotFound ||
+          cbData.status == S3Status::S3StatusErrorNoSuchBucket)
+        return Status::NotFound("Status: " + to_string(cbData.status) +
+                                "msg: " + cbData.errorMessage);
+
+      return Status::GeneralError("Status: " + to_string(cbData.status) +
+                                  "msg: " + cbData.errorMessage);
+    }
+  }
+
+   Status object_exists_internal(const Sliver& key) {
+    assert(init_);
+    if (should_net_fail())
+      return Status::GeneralError("Network failure simulated");
+    ResponseData rData;
+    S3ResponseHandler rHandler;
+    rHandler.completeCallback = responseCompleteCallback;
+    rHandler.propertiesCallback = propertiesCallback;
+
+    S3_head_object(&context_, string(key.data()).c_str(), NULL, &rHandler,
+                   &rData);
+    LOG_DEBUG(logger_, "object_exist key: " << string(key.data())
+                                            << ", status: " << rData.status
+                                            << ", msg: " << rData.errorMessage);
+    if (rData.status == S3Status::S3StatusOK)
+      return Status::OK();
+    else {
+      LOG_ERROR(logger_,
+                "object_exist key: " << string(key.data())
+                                     << ", status: " << rData.status
+                                     << ", msg: " << rData.errorMessage);
+      if (rData.status == S3Status::S3StatusHttpErrorNotFound ||
+          rData.status == S3Status::S3StatusErrorNoSuchBucket ||
+          rData.status == S3Status::S3StatusErrorNoSuchKey)
+        return Status::NotFound("Status: " + to_string(rData.status) +
+                                "msg: " + rData.errorMessage);
+
+      return Status::GeneralError("Status: " + to_string(rData.status) +
+                                  "msg: " + rData.errorMessage);
+    }
+  }
+
+  Status test_bucket_internal() {
+    assert(init_);
+    if (should_net_fail())
+      return Status::GeneralError("Network failure simulated");
+    ResponseData rData;
+    S3ResponseHandler rHandler;
+    rHandler.completeCallback = responseCompleteCallback;
+    rHandler.propertiesCallback = propertiesCallback;
+    char location[100];
+
+    S3_test_bucket(context_.protocol, context_.uriStyle, context_.accessKeyId,
+                   context_.secretAccessKey, context_.hostName,
+                   context_.bucketName, 100, location, NULL, &rHandler, &rData);
+    LOG_DEBUG(logger_, "test_bucket bucket: "
+                           << context_.bucketName << ", status: "
+                           << rData.status << ", msg: " << rData.errorMessage);
+    if (rData.status == S3Status::S3StatusOK)
+      return Status::OK();
+    else {
+      LOG_ERROR(logger_,
+                "test_bucket bucket: " << context_.bucketName
+                                       << ", status: " << rData.status
+                                       << ", msg: " << rData.errorMessage);
+      if (rData.status == S3Status::S3StatusHttpErrorNotFound ||
+          rData.status == S3Status::S3StatusErrorNoSuchBucket)
+        return Status::NotFound("Status: " + to_string(rData.status) +
+                                "msg: " + rData.errorMessage);
+
+      return Status::GeneralError("Status: " + to_string(rData.status) +
+                                  "msg: " + rData.errorMessage);
+    }
+  }
+
+  struct ResponseData {
+    S3Status status = S3Status::S3StatusOK;
+    string errorMessage;
+  };
+
+  /**
+   * @brief Represents intermidiate data for get operation and is passed to
+   * the lambda callback.
+   *
+   */
+  struct GetObjectResponseData : public ResponseData {
+    GetObjectResponseData(size_t linitialLength)
+        : data(new char[linitialLength]), dataLength(linitialLength) {}
+
+    void CheckAndResize(int& nextReadLength) {
+      if (readLength + nextReadLength <= dataLength) return;
+
+      dataLength *= 2;
+      char* newData = new char[dataLength];
+      memcpy(newData, data, readLength);
+      delete[] data;
+      data = newData;
+    }
+
+    void Write(const char* _data, int& dataSize) {
+      CheckAndResize(dataSize);
+      memcpy(data + readLength, _data, dataSize);
+      readLength += dataSize;
+    }
+
+    ~GetObjectResponseData() { delete[] data; }
+
+    char* data = nullptr;
+    size_t dataLength = 0;
+    size_t readLength = 0;
+  };
+
+  /**
+   * @brief Represents intermidiate data for put operation and is passed to
+   * the lambda callback.
+   *
+   */
+  struct PutObjectResponseData : public ResponseData {
+    PutObjectResponseData(const char* _data, size_t&& _dataLength)
+        : data(_data), dataLength(_dataLength) {}
+
+    const char* data;
+    size_t dataLength;
+    size_t putCount = 0;
+  };
+
+  static void responseCompleteCallback(S3Status status,
+                                       const S3ErrorDetails* error,
+                                       void* callbackData) {
+    ResponseData* cb = nullptr;
+    if (callbackData) {
+      cb = static_cast<ResponseData*>(callbackData);
+      cb->status = status;
+    }
+    if (error) {
+      if (error->message) {
+        if (cb) cb->errorMessage = string(error->message);
+      }
+    }
+  }
+
+  static S3Status propertiesCallback(const S3ResponseProperties* properties,
+                                     void* callbackData) {
+    return S3Status::S3StatusOK;
+  }
+
+  bool should_net_fail() const {
+    bool b1 = bh_.can_simulate_net_failure();
+    if(!b1) return false;
+    bool b3 = bh_.get_do_net_failure();
+    if(!b3) return false;
+    bool b2 = bh_.has_finished();
+    if(b2) return false;
+    return true;
+  }
+
+  S3ResponseHandler responseHandler = {NULL, &responseCompleteCallback};
+  S3_StoreConfig config_;
+  S3BucketContext context_;
+  bool init_ = false;
+  const uint32_t kInitialGetBufferSize_ = 25000;
+  std::mutex initLock_;
+  concordlogger::Logger logger_ =
+      concordlogger::Log::getLogger("concord::storage::EcsS3ClientImpl");
+  ObjectStoreBehavior bh_;
+  uint16_t initialDelay_ = 100;
+  const double delayFactor_ = 1.5;
+};

--- a/storage/src/object_store/object_store_client.cpp
+++ b/storage/src/object_store/object_store_client.cpp
@@ -1,0 +1,94 @@
+// Copyright 2019 VMware, all rights reserved
+
+#include "object_store/object_store_client.hpp"
+#include "ecs_s3_client.hpp"
+
+using namespace concord::storage;
+
+ObjectStoreClient::ObjectStoreClient(const S3_StoreConfig& config,
+                                     const ObjectStoreBehavior& bh) {
+  pImpl_ = std::shared_ptr<EcsS3ClientImpl>(new EcsS3ClientImpl(config, bh));
+}
+
+void ObjectStoreClient::init(bool readOnly) { return pImpl_->init(); }
+
+Status ObjectStoreClient::get(const Sliver& _key, OUT Sliver& _outValue) const {
+  return pImpl_->get(_key, _outValue);
+}
+
+Status ObjectStoreClient::get(const Sliver& _key, OUT char*& buf,
+                              uint32_t bufSize, OUT uint32_t& _size) const {
+  return pImpl_->get(_key, buf, bufSize, _size);
+}
+
+Status ObjectStoreClient::put(const Sliver& _key, const Sliver& _value) {
+  return pImpl_->put(_key, _value);
+}
+
+Status ObjectStoreClient::del(const Sliver& _key) { return pImpl_->del(_key); }
+
+Status ObjectStoreClient::multiGet(const KeysVector& _keysVec,
+                                   OUT ValuesVector& _valuesVec) {
+  return pImpl_->multiGet(_keysVec, _valuesVec);
+}
+
+Status ObjectStoreClient::multiPut(const SetOfKeyValuePairs& _keyValueMap) {
+  return pImpl_->multiPut(_keyValueMap);
+}
+
+Status ObjectStoreClient::multiDel(const KeysVector& _keysVec) {
+  return pImpl_->multiDel(_keysVec);
+}
+
+void ObjectStoreClient::monitor() const { return pImpl_->monitor(); }
+
+bool ObjectStoreClient::isNew() { return pImpl_->isNew(); }
+
+IDBClient::IDBClientIterator* ObjectStoreClient::getIterator() const {
+  return pImpl_->getIterator();
+}
+
+Status ObjectStoreClient::freeIterator(IDBClientIterator* _iter) const {
+  return pImpl_->freeIterator(_iter);
+}
+
+ITransaction* ObjectStoreClient::beginTransaction() {
+  return pImpl_->beginTransaction();
+}
+
+void ObjectStoreClient::wait_for_storage() {
+  return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->wait_for_storage();
+}
+
+Status ObjectStoreClient::object_exists(const Sliver& key) {
+  return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->object_exists(key);
+}
+
+Status ObjectStoreClient::test_bucket() {
+  return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->test_bucket();
+}
+
+ObjectStoreBehavior::ObjectStoreBehavior(bool canDelete, bool canSimulateNetFailure)
+    : allowDelete_{canDelete}, allowNetworkFailure_{canSimulateNetFailure} {}
+
+bool ObjectStoreBehavior::can_delete() const { return allowDelete_; }
+
+bool ObjectStoreBehavior::can_simulate_net_failure() const { 
+  return allowNetworkFailure_; }
+
+bool ObjectStoreBehavior::get_do_net_failure() const {
+  return doNetworkFailure_;
+}
+
+void ObjectStoreBehavior::set_do_net_failure(bool value, uint64_t durationMilli) {
+  doNetworkFailure_ = value;
+  doNetworkFailureDurMilli_ = durationMilli;
+  startTimeForNetworkFailure_ = std::chrono::steady_clock::now();
+}
+
+bool ObjectStoreBehavior::has_finished() const {
+  std::chrono::time_point<std::chrono::steady_clock> time = std::chrono::steady_clock::now();
+  auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(time - startTimeForNetworkFailure_).count();
+  return diff > 0 && (uint64_t)diff > doNetworkFailureDurMilli_;
+}
+

--- a/storage/src/object_store/object_store_client.cpp
+++ b/storage/src/object_store/object_store_client.cpp
@@ -5,80 +5,56 @@
 
 using namespace concord::storage;
 
-ObjectStoreClient::ObjectStoreClient(const S3_StoreConfig& config,
-                                     const ObjectStoreBehavior& bh) {
+ObjectStoreClient::ObjectStoreClient(const S3_StoreConfig& config, const ObjectStoreBehavior& bh) {
   pImpl_ = std::shared_ptr<EcsS3ClientImpl>(new EcsS3ClientImpl(config, bh));
 }
 
 void ObjectStoreClient::init(bool readOnly) { return pImpl_->init(); }
 
-Status ObjectStoreClient::get(const Sliver& _key, OUT Sliver& _outValue) const {
-  return pImpl_->get(_key, _outValue);
-}
+Status ObjectStoreClient::get(const Sliver& _key, OUT Sliver& _outValue) const { return pImpl_->get(_key, _outValue); }
 
-Status ObjectStoreClient::get(const Sliver& _key, OUT char*& buf,
-                              uint32_t bufSize, OUT uint32_t& _size) const {
+Status ObjectStoreClient::get(const Sliver& _key, OUT char*& buf, uint32_t bufSize, OUT uint32_t& _size) const {
   return pImpl_->get(_key, buf, bufSize, _size);
 }
 
-Status ObjectStoreClient::put(const Sliver& _key, const Sliver& _value) {
-  return pImpl_->put(_key, _value);
-}
+Status ObjectStoreClient::put(const Sliver& _key, const Sliver& _value) { return pImpl_->put(_key, _value); }
 
 Status ObjectStoreClient::del(const Sliver& _key) { return pImpl_->del(_key); }
 
-Status ObjectStoreClient::multiGet(const KeysVector& _keysVec,
-                                   OUT ValuesVector& _valuesVec) {
+Status ObjectStoreClient::multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) {
   return pImpl_->multiGet(_keysVec, _valuesVec);
 }
 
-Status ObjectStoreClient::multiPut(const SetOfKeyValuePairs& _keyValueMap) {
-  return pImpl_->multiPut(_keyValueMap);
-}
+Status ObjectStoreClient::multiPut(const SetOfKeyValuePairs& _keyValueMap) { return pImpl_->multiPut(_keyValueMap); }
 
-Status ObjectStoreClient::multiDel(const KeysVector& _keysVec) {
-  return pImpl_->multiDel(_keysVec);
-}
+Status ObjectStoreClient::multiDel(const KeysVector& _keysVec) { return pImpl_->multiDel(_keysVec); }
 
 void ObjectStoreClient::monitor() const { return pImpl_->monitor(); }
 
 bool ObjectStoreClient::isNew() { return pImpl_->isNew(); }
 
-IDBClient::IDBClientIterator* ObjectStoreClient::getIterator() const {
-  return pImpl_->getIterator();
-}
+IDBClient::IDBClientIterator* ObjectStoreClient::getIterator() const { return pImpl_->getIterator(); }
 
-Status ObjectStoreClient::freeIterator(IDBClientIterator* _iter) const {
-  return pImpl_->freeIterator(_iter);
-}
+Status ObjectStoreClient::freeIterator(IDBClientIterator* _iter) const { return pImpl_->freeIterator(_iter); }
 
-ITransaction* ObjectStoreClient::beginTransaction() {
-  return pImpl_->beginTransaction();
-}
+ITransaction* ObjectStoreClient::beginTransaction() { return pImpl_->beginTransaction(); }
 
-void ObjectStoreClient::wait_for_storage() {
-  return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->wait_for_storage();
-}
+void ObjectStoreClient::wait_for_storage() { return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->wait_for_storage(); }
 
 Status ObjectStoreClient::object_exists(const Sliver& key) {
   return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->object_exists(key);
 }
 
-Status ObjectStoreClient::test_bucket() {
-  return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->test_bucket();
-}
+Status ObjectStoreClient::test_bucket() { return static_pointer_cast<EcsS3ClientImpl>(pImpl_)->test_bucket(); }
 
 ObjectStoreBehavior::ObjectStoreBehavior(bool canDelete, bool canSimulateNetFailure)
     : allowDelete_{canDelete}, allowNetworkFailure_{canSimulateNetFailure} {}
 
 bool ObjectStoreBehavior::can_delete() const { return allowDelete_; }
 
-bool ObjectStoreBehavior::can_simulate_net_failure() const { 
-  return allowNetworkFailure_; }
+bool ObjectStoreBehavior::can_simulate_net_failure() const { return allowNetworkFailure_; }
 
-bool ObjectStoreBehavior::get_do_net_failure() const {
-  return doNetworkFailure_;
-}
+bool ObjectStoreBehavior::get_do_net_failure() const { return doNetworkFailure_; }
 
 void ObjectStoreBehavior::set_do_net_failure(bool value, uint64_t durationMilli) {
   doNetworkFailure_ = value;
@@ -91,4 +67,3 @@ bool ObjectStoreBehavior::has_finished() const {
   auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(time - startTimeForNetworkFailure_).count();
   return diff > 0 && (uint64_t)diff > doNetworkFailureDurMilli_;
 }
-

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -51,3 +51,14 @@ target_link_libraries(sparse_merkle_tree_test PUBLIC
     concordbft_storage
     ${OPENSSL_LIBRARIES}
 )
+
+if (BUILD_OBJECTSTORE_TEST)
+    add_executable(
+        ecs_s3_test
+        ecs_s3_test.cpp
+        $<TARGET_OBJECTS:logging_dev>)
+    add_test(ecs_s3_test ecs_s3_test)
+    target_link_libraries(ecs_s3_test PUBLIC
+        GTest::Main
+        object_store_lib)
+endif(BUILD_OBJECTSTORE_TEST)

--- a/storage/test/ecs_s3_test.cpp
+++ b/storage/test/ecs_s3_test.cpp
@@ -1,0 +1,283 @@
+// Copyright 2019 VMware, all rights reserved
+//
+// Unit tests for ECS S3 object store replication
+// IMPORTANT: the test assume that the S3 storage is up.
+
+#include <memory>
+#include "gtest/gtest.h"
+#include "object_store/object_store_client.hpp"
+
+using namespace concord::storage;
+
+namespace {
+
+class EcsS3Test : public ::testing::Test {
+ protected:
+  EcsS3Test() {
+    config.bucketName = "blockchain-dev-asx";
+    config.accessKey = "blockchain-dev";
+    config.protocol = "HTTP";
+    config.url = "10.70.30.244:9020";
+    config.secretKey = "Rz0mdbUNGJBxqdzprn5XGSXPr2AfkgcQsYS4y698";
+    config.maxWaitTime = 10000;
+  }
+
+  void SetClient(ObjectStoreBehavior b = ObjectStoreBehavior(false, false)) {
+    client = std::make_shared<ObjectStoreClient>(config, b);
+    client->init();
+  }
+
+  void SetBucketName(std::string name) { config.bucketName = name; }
+
+  S3_StoreConfig config;
+  std::shared_ptr<ObjectStoreClient> client = nullptr;
+};
+
+/**
+ * @brief put and get regular string object
+ *
+ */
+TEST_F(EcsS3Test, PutGetStringObject) {
+  SetClient();
+
+  Sliver key("unit_test_key");
+  Sliver wvalue("unit_test_object");
+  Status s = client->put(key, wvalue);
+
+  ASSERT_EQ(s, Status::OK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(wvalue, rvalue);
+}
+
+/**
+ * @brief put and get regular string object with retry
+ *
+ */
+TEST_F(EcsS3Test, PutGetStringObjectRetryOK) {
+  ObjectStoreBehavior b(false, true);
+  b.set_do_net_failure(true, config.maxWaitTime / 2);
+  SetClient();
+
+  Sliver key("unit_test_key");
+  Sliver wvalue("unit_test_object");
+
+  Status s = client->put(key, wvalue);
+
+  ASSERT_EQ(s, Status::OK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(wvalue, rvalue);
+}
+
+/**
+ * @brief put and get regular string object with retry
+ *
+ */
+TEST_F(EcsS3Test, PutGetStringObjectRetryFail) {
+  ObjectStoreBehavior b{false, true};
+  b.set_do_net_failure(true, config.maxWaitTime * 2);
+  SetClient(b);
+
+  Sliver key("unit_test_key");
+  Sliver wvalue("unit_test_object");
+  Status s = client->put(key, wvalue);
+
+  ASSERT_EQ(s, Status::GeneralError("Network failure simulated"));
+}
+
+/**
+ * @brief try to put object into non existing bucket
+ *
+ */
+TEST_F(EcsS3Test, PutObjectBucketNotExists) {
+  SetBucketName("non_existing_bucket");
+  SetClient();
+
+  Sliver key("unit_test_key");
+  Sliver wvalue("unit_test_object");
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isNotFound());
+}
+
+/**
+ * @brief try to get object from non existing bucket
+ *
+ */
+TEST_F(EcsS3Test, GetObjectBucketNotExists) {
+  SetBucketName("non_existing_bucket");
+  SetClient();
+
+  Sliver key("unit_test_key");
+  Sliver v;
+  Status s = client->get(key, v);
+  ASSERT_TRUE(s.isNotFound());
+  ASSERT_EQ(v.length(), 0);
+}
+
+TEST_F(EcsS3Test, GetObjectNotExists) {
+  SetClient();
+
+  Sliver key("unit_test_key12345");
+  Sliver value;
+  Status s = client->get(key, value);
+  ASSERT_TRUE(s.isNotFound());
+  ASSERT_EQ(value.length(), 0);
+}
+
+/**
+ * @brief put and get binary object
+ *
+ */
+TEST_F(EcsS3Test, PutGetBinaryObject) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[250];
+  for (int i = 0; i < 250; i++) _value[i] = i;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 250);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(wvalue, rvalue);
+}
+
+/**
+ * @brief Put and get large binary object when 25000 is maximum preallocated
+ * memory for sending the data
+ *
+ */
+TEST_F(EcsS3Test, PutGetLargeBinaryObject) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[25000];
+  for (int i = 0; i < 25000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 25000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(wvalue, rvalue);
+}
+
+/**
+ * @brief Put and get large binary object when 25000 is maximum preallocated
+ * memory for sending the data expecting the buffer to grow exactly 4 times
+ *
+ */
+TEST_F(EcsS3Test, PutGetLargeBinaryObjectWithResize) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[100000];
+  for (int i = 0; i < 100000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 100000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_TRUE(wvalue == rvalue);
+}
+
+/**
+ * @brief Check retrieving object headers functionality
+ *
+ */
+TEST_F(EcsS3Test, ObjectExists) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[100000];
+  for (int i = 0; i < 100000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 100000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  s = client->object_exists(key);
+  ASSERT_TRUE(s.isOK());
+}
+
+/**
+ * @brief Check retrieving object headers functionality
+ *
+ */
+TEST_F(EcsS3Test, ObjectNotExists) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[100000];
+  for (int i = 0; i < 100000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 100000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver key2("non_existing_key");
+  s = client->object_exists(key2);
+  ASSERT_TRUE(s.isNotFound());
+}
+
+/**
+ * @brief Check retrieving object headers functionality
+ *
+ */
+TEST_F(EcsS3Test, TestBucketExists) {
+  SetClient();
+  Status s = client->test_bucket();
+  ASSERT_TRUE(s.isOK());
+}
+
+TEST_F(EcsS3Test, TestBucketExistsRetryOK) {
+  ObjectStoreBehavior b{false, true};
+  b.set_do_net_failure(true, config.maxWaitTime / 2);
+  SetClient(b);
+  Status s = client->test_bucket();
+  ASSERT_EQ(s, Status::OK());
+}
+
+TEST_F(EcsS3Test, TestBucketExistsRetryFail) {
+  ObjectStoreBehavior b{false, true};
+  b.set_do_net_failure(true, config.maxWaitTime * 2);
+  SetClient(b);
+  Status s = client->test_bucket();
+  ASSERT_EQ(s, Status::GeneralError("Network failure simulated"));
+}
+
+TEST_F(EcsS3Test, TestBucketNotExists) {
+  SetBucketName("non_existing_bucket");
+  SetClient();
+  Status s = client->test_bucket();
+  ASSERT_TRUE(s.isNotFound());
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto exitCode = RUN_ALL_TESTS();
+  return exitCode;
+}

--- a/tests/config/test_parameters.hpp
+++ b/tests/config/test_parameters.hpp
@@ -27,6 +27,15 @@ struct ClientParams {
   uint16_t get_numOfReplicas() { return (uint16_t)(3 * numOfFaulty + 2 * numOfSlow + 1); }
 };
 
+enum class RoRAppStateMode {
+  None, // used for non RO replica
+  S3,  // use real S3 storage = 1
+  RocksDB,   // use RocksDB for storage = 2
+  Default = None,
+  MAX_VALUE = RocksDB,
+  MIN_VALUE = S3
+};
+
 enum class PersistencyMode {
   Off,       // no persistency at all
   InMemory,  // use in memory module
@@ -58,6 +67,7 @@ struct ReplicaParams {
   std::string keysFilePrefix;
   PersistencyMode persistencyMode = PersistencyMode::Off;
   ReplicaBehavior replicaBehavior = ReplicaBehavior::Default;
+  RoRAppStateMode rorsAppStateMode = RoRAppStateMode::Default;
 };
 
 #endif  // CONCORD_BFT_TEST_PARAMETERS_HPP

--- a/tests/config/test_parameters.hpp
+++ b/tests/config/test_parameters.hpp
@@ -66,7 +66,7 @@ struct ReplicaParams {
   std::string keysFilePrefix;
   PersistencyMode persistencyMode = PersistencyMode::Off;
   ReplicaBehavior replicaBehavior = ReplicaBehavior::Default;
-  RoRAppStateMode rorsAppStateMode = RoRAppStateMode::Default;
+  RoRAppStateMode rorsAppStateMode = RoRAppStateMode::None;
 };
 
 #endif  // CONCORD_BFT_TEST_PARAMETERS_HPP

--- a/tests/config/test_parameters.hpp
+++ b/tests/config/test_parameters.hpp
@@ -28,9 +28,9 @@ struct ClientParams {
 };
 
 enum class RoRAppStateMode {
-  None, // used for non RO replica
-  S3,  // use real S3 storage = 1
-  RocksDB,   // use RocksDB for storage = 2
+  None,     // used for non RO replica
+  S3,       // use real S3 storage = 1
+  RocksDB,  // use RocksDB for storage = 2
   MAX_VALUE = RocksDB,
   MIN_VALUE = S3
 };

--- a/tests/config/test_parameters.hpp
+++ b/tests/config/test_parameters.hpp
@@ -31,7 +31,6 @@ enum class RoRAppStateMode {
   None, // used for non RO replica
   S3,  // use real S3 storage = 1
   RocksDB,   // use RocksDB for storage = 2
-  Default = None,
   MAX_VALUE = RocksDB,
   MIN_VALUE = S3
 };

--- a/tests/simpleKVBC/TesterReplica/CMakeLists.txt
+++ b/tests/simpleKVBC/TesterReplica/CMakeLists.txt
@@ -15,6 +15,10 @@ if(${USE_COMM_TLS_TCP})
 	target_compile_definitions(skvbc_replica PUBLIC USE_COMM_TLS_TCP)
 endif()
 
+if(BUILD_ROCKSDB_STORAGE)
+	target_compile_definitions(skvbc_replica PUBLIC "USE_ROCKSDB=1")
+endif()
+
 target_link_libraries(skvbc_replica PUBLIC kvbc corebft threshsign util test_config_lib $<TARGET_OBJECTS:logging_dev>)
 
 target_include_directories(skvbc_replica PUBLIC ..)

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -19,11 +19,12 @@
 #include "simpleKVBTestsBuilder.hpp"
 #include "blockchain/db_interfaces.h"
 #include "KVBCInterfaces.h"
+#include <memory>
 
 class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
  public:
-  InternalCommandsHandler(concord::storage::blockchain::ILocalKeyValueStorageReadOnly *storage,
-                          concord::storage::blockchain::IBlocksAppender *blocksAppender,
+  InternalCommandsHandler(std::shared_ptr<concord::storage::blockchain::ILocalKeyValueStorageReadOnly> storage,
+                          std::shared_ptr<concord::storage::blockchain::IBlocksAppender> blocksAppender,
                           concordlogger::Logger &logger)
       : m_storage(storage), m_blocksAppender(blocksAppender), m_logger(logger) {}
 
@@ -66,8 +67,8 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
   static concordUtils::Sliver buildSliverFromStaticBuf(char *buf);
 
  private:
-  concord::storage::blockchain::ILocalKeyValueStorageReadOnly *m_storage;
-  concord::storage::blockchain::IBlocksAppender *m_blocksAppender;
+  std::shared_ptr<concord::storage::blockchain::ILocalKeyValueStorageReadOnly> m_storage;
+  std::shared_ptr<concord::storage::blockchain::IBlocksAppender> m_blocksAppender;
   concordlogger::Logger &m_logger;
   size_t m_readsCounter = 0;
   size_t m_writesCounter = 0;

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -58,11 +58,10 @@ int main(int argc, char** argv) {
   auto* dbAdapter = new concord::storage::blockchain::DBAdapter(db);
   std::shared_ptr<ReplicaImp> replica = nullptr;
 
-  // auto rorMode = setup->GetRoRMode();
-  auto rorMode = setup->GetReplicaConfig().replicaId == 4 ? RoRAppStateMode::S3 : RoRAppStateMode::None;
+  auto rorMode = setup->GetRoRMode();
   replica = std::make_shared<ReplicaImp>(
         setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
-  if(rorMode == RoRAppStateMode::Default) {
+  if(rorMode == RoRAppStateMode::None) {
     replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
     replica->set_app_state(nullptr); //set BlockChainAppState by default
   } else {

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -31,7 +31,7 @@ using namespace concord::storage;
 
 int main(int argc, char** argv) {
   auto setup = concord::kvbc::TestSetup::ParseArgs(argc, argv);
-  
+
   auto logger = setup->GetLogger();
   auto* db_key_comparator = new concord::storage::blockchain::DBKeyComparator();
   std::shared_ptr<concord::storage::IDBClient> db;
@@ -60,19 +60,18 @@ int main(int argc, char** argv) {
 
   auto rorMode = setup->GetRoRMode();
   replica = std::make_shared<ReplicaImp>(
-        setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
-  if(rorMode == RoRAppStateMode::None) {
+      setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
+  if (rorMode == RoRAppStateMode::None) {
     replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
-    replica->set_app_state(nullptr); //set BlockChainAppState by default
+    replica->set_app_state(nullptr);  // set BlockChainAppState by default
   } else {
     using namespace bftEngine::SimpleBlockchainStateTransfer;
     std::shared_ptr<IDBClient> local_client = set_local_client();
     local_client->init();
     std::shared_ptr<IDBClient> os_client = set_object_store_client();
     os_client->init();
-    std::shared_ptr<IAppState> appState = 
-    std::make_shared<concord::consensus::RoRAppState>(
-      std::make_shared<concord::storage::blockchain::DBKeyManipulator>(), local_client, os_client);
+    std::shared_ptr<IAppState> appState = std::make_shared<concord::consensus::RoRAppState>(
+        std::make_shared<concord::storage::blockchain::DBKeyManipulator>(), local_client, os_client);
     replica->set_app_state(appState);
   }
 

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -18,6 +18,8 @@
 #include "commonKVBTests.hpp"
 #include "replica_state_sync_imp.hpp"
 #include "block_metadata.hpp"
+#include "SimpleBCStateTransfer.hpp"
+#include "ror_test_setup.hpp"
 #ifdef USE_ROCKSDB
 #include "rocksdb/client.h"
 #include "rocksdb/key_comparator.h"
@@ -25,9 +27,11 @@
 #include <memory>
 
 using namespace concord::kvbc;
+using namespace concord::storage;
 
 int main(int argc, char** argv) {
   auto setup = concord::kvbc::TestSetup::ParseArgs(argc, argv);
+  
   auto logger = setup->GetLogger();
   auto* db_key_comparator = new concord::storage::blockchain::DBKeyComparator();
   std::shared_ptr<concord::storage::IDBClient> db;
@@ -52,9 +56,26 @@ int main(int argc, char** argv) {
   }
 
   auto* dbAdapter = new concord::storage::blockchain::DBAdapter(db);
-  auto* replica = new ReplicaImp(
-      setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
-  replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
+  std::shared_ptr<ReplicaImp> replica = nullptr;
+
+  // auto rorMode = setup->GetRoRMode();
+  auto rorMode = setup->GetReplicaConfig().replicaId == 4 ? RoRAppStateMode::S3 : RoRAppStateMode::None;
+  replica = std::make_shared<ReplicaImp>(
+        setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
+  if(rorMode == RoRAppStateMode::Default) {
+    replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
+    replica->set_app_state(nullptr); //set BlockChainAppState by default
+  } else {
+    using namespace bftEngine::SimpleBlockchainStateTransfer;
+    std::shared_ptr<IDBClient> local_client = set_local_client();
+    local_client->init();
+    std::shared_ptr<IDBClient> os_client = set_object_store_client();
+    os_client->init();
+    std::shared_ptr<IAppState> appState = 
+    std::make_shared<concord::consensus::RoRAppState>(
+      std::make_shared<concord::storage::blockchain::DBKeyManipulator>(), local_client, os_client);
+    replica->set_app_state(appState);
+  }
 
   // Start metrics server after creation of the replica so that we ensure
   // registration of metrics from the replica with the aggregator and don't

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -94,15 +94,18 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
       case 'p':
         rp.persistencyMode = PersistencyMode::RocksDB;
         break;
-      case 'o':{
+      case 'o': {
         int objectStoreMode = std::atoi(optarg);
         if (objectStoreMode < (int)RoRAppStateMode::MIN_VALUE || objectStoreMode > (int)RoRAppStateMode::MAX_VALUE) {
-          fprintf(stderr, "-o option should be in range [%d,%d]", (int)RoRAppStateMode::MIN_VALUE, (int)RoRAppStateMode::MAX_VALUE);
+          fprintf(stderr,
+                  "-o option should be in range [%d,%d]",
+                  (int)RoRAppStateMode::MIN_VALUE,
+                  (int)RoRAppStateMode::MAX_VALUE);
           exit(-1);
         }
         rp.rorsAppStateMode = (RoRAppStateMode)objectStoreMode;
       } break;
-        
+
       default:
         break;
     }
@@ -147,8 +150,12 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
 
   uint16_t metrics_port = conf.listenPort + 1000;
 
-  return std::unique_ptr<TestSetup>(new TestSetup{
-      replicaConfig, std::move(comm), logger, metrics_port, rp.persistencyMode == PersistencyMode::RocksDB, rp.rorsAppStateMode});
+  return std::unique_ptr<TestSetup>(new TestSetup{replicaConfig,
+                                                  std::move(comm),
+                                                  logger,
+                                                  metrics_port,
+                                                  rp.persistencyMode == PersistencyMode::RocksDB,
+                                                  rp.rorsAppStateMode});
 }
 
 }  // namespace kvbc

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -20,7 +20,6 @@
 #include "setup.hpp"
 #include "CommFactory.hpp"
 #include "config/test_comm_config.hpp"
-#include "config/test_parameters.hpp"
 
 using namespace std;
 
@@ -42,7 +41,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
   string idStr;
 
   int o = 0;
-  while ((o = getopt(argc, argv, "r:i:k:n:s:v:a:p")) != EOF) {
+  while ((o = getopt(argc, argv, "r:i:k:n:s:v:a:po:")) != EOF) {
     switch (o) {
       case 'i': {
         strncpy(argTempBuffer, optarg, sizeof(argTempBuffer) - 1);
@@ -95,7 +94,15 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
       case 'p':
         rp.persistencyMode = PersistencyMode::RocksDB;
         break;
-
+      case 'o':{
+        int objectStoreMode = std::atoi(optarg);
+        if (objectStoreMode < (int)RoRAppStateMode::MIN_VALUE || objectStoreMode > (int)RoRAppStateMode::MAX_VALUE) {
+          fprintf(stderr, "-o option should be in range [%d,%d]", (int)RoRAppStateMode::MIN_VALUE, (int)RoRAppStateMode::MAX_VALUE);
+          exit(-1);
+        }
+        rp.rorsAppStateMode = (RoRAppStateMode)objectStoreMode;
+      } break;
+        
       default:
         break;
     }
@@ -141,7 +148,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
   uint16_t metrics_port = conf.listenPort + 1000;
 
   return std::unique_ptr<TestSetup>(new TestSetup{
-      replicaConfig, std::move(comm), logger, metrics_port, rp.persistencyMode == PersistencyMode::RocksDB});
+      replicaConfig, std::move(comm), logger, metrics_port, rp.persistencyMode == PersistencyMode::RocksDB, rp.rorsAppStateMode});
 }
 
 }  // namespace kvbc

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -33,7 +33,7 @@ class TestSetup {
   concordMetrics::Server& GetMetricsServer() { return metrics_server_; }
   concordlogger::Logger GetLogger() { return logger_; }
   const bool UsePersistentStorage() const { return use_persistent_storage_; }
-  const RoRAppStateMode GetRoRMode() const {return rorMode_;}
+  const RoRAppStateMode GetRoRMode() const { return rorMode_; }
 
  private:
   TestSetup(bftEngine::ReplicaConfig config,

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -19,6 +19,7 @@
 #include "ICommunication.hpp"
 #include "Logger.hpp"
 #include "MetricsServer.hpp"
+#include "config/test_parameters.hpp"
 
 namespace concord {
 namespace kvbc {
@@ -32,13 +33,15 @@ class TestSetup {
   concordMetrics::Server& GetMetricsServer() { return metrics_server_; }
   concordlogger::Logger GetLogger() { return logger_; }
   const bool UsePersistentStorage() const { return use_persistent_storage_; }
+  const RoRAppStateMode GetRoRMode() const {return rorMode_;}
 
  private:
   TestSetup(bftEngine::ReplicaConfig config,
             std::unique_ptr<bftEngine::ICommunication> comm,
             concordlogger::Logger logger,
             uint16_t metrics_port,
-            bool use_persistent_storage)
+            bool use_persistent_storage,
+            RoRAppStateMode rorMode)
       : replica_config_(config),
         communication_(std::move(comm)),
         logger_(logger),
@@ -51,6 +54,7 @@ class TestSetup {
   concordlogger::Logger logger_;
   concordMetrics::Server metrics_server_;
   bool use_persistent_storage_;
+  RoRAppStateMode rorMode_;
 };
 
 }  // namespace kvbc

--- a/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
+++ b/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
@@ -16,7 +16,10 @@ cleanup
 ../TesterReplica/skvbc_replica -k ro_config_ -i 1 -p &
 ../TesterReplica/skvbc_replica -k ro_config_ -i 2 -p &
 ../TesterReplica/skvbc_replica -k ro_config_ -i 3 -p &
-#../TesterReplica/skvbc_replica -k ro_config_ -i 4 -p &
+../TesterReplica/skvbc_replica -k ro_config_ -i 4 -p -o 1 &
+
+echo "Sleeping for 5 seconds"
+sleep 5
 
 time ../TesterClient/skvbc_client -f 1 -c 0 -p 1800 -i 5
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -10,6 +10,13 @@ add_library(util STATIC
     src/sliver.cpp
     src/hex_tools.cpp)
 
+if(USE_OBJECTSTORE_FOR_ROR_TEST)
+    target_compile_definitions(util PUBLIC "TEST_ROR_APPSTATE_OBJECTSTORE=1")
+endif()
+if(BUILD_ROCKSDB_STORAGE)
+    target_compile_definitions(util PUBLIC "USE_ROCKSDB=1")
+endif()
+
 target_link_libraries(util PUBLIC Threads::Threads)
 target_include_directories(util PUBLIC include)
 

--- a/util/include/ror_test_setup.hpp
+++ b/util/include/ror_test_setup.hpp
@@ -76,7 +76,8 @@ class SimpleIntegerKeyComparator : public IDBClient::IKeyComparator {
   return std::static_pointer_cast<IDBClient>(std::make_shared< concord::storage::rocksdb::Client>(
         "unit_test_db_object_store", ::rocksdb::BytewiseComparator()));
 #else
-    assert(false); // we dont support RoRAppState test with in memory, its meaningless
+   return std::static_pointer_cast<IDBClient>(
+      std::make_shared<memorydb::Client>(KeyComparator(new SimpleIntegerKeyComparator())));
 #endif
 }
 

--- a/util/include/ror_test_setup.hpp
+++ b/util/include/ror_test_setup.hpp
@@ -1,0 +1,83 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+// This is helper code to be used with tests related to RO replica.
+// To create RoRAppState, we should provide 2 IDBClients: for local and object store access.
+// The USE_ROCKSDB flag controlls the local IDBClient (in memory or rocksdb) and the TEST_ROR_APPSTATE_OSTORE_IN_MEMORY
+// flag controls object store IBDClient (real Object store, in memory or rocksdb).
+// is no value
+
+#pragma once
+
+#include "storage/db_interface.h"
+#include "ror_app_state.hpp"
+
+#ifdef USE_ROCKSDB
+#include "rocksdb/client.h"
+using namespace concord::storage::rocksdb;
+using namespace concord::storage::blockchain::v1DirectKeyValue;
+#else
+#include "memorydb/client.h"
+using namespace concord::storage::memorydb;
+#endif
+
+#ifdef TEST_ROR_APPSTATE_OSTORE_IN_MEMORY
+#include "memorydb/client.h"
+using namespace concord::storage::memorydb;
+using namespace concord::storage::blockchain::v1DirectKeyValue;
+#endif
+
+using namespace concord::storage;
+
+class SimpleIntegerKeyComparator : public IDBClient::IKeyComparator {
+ int composedKeyComparison(const char* _a_data, size_t _a_length, const char* _b_data, size_t _b_length) override {
+   assert(_a_data);
+   assert(_b_data);
+   assert(_a_length == sizeof(char));
+   assert(_b_length == sizeof(char));
+   char keyA = *reinterpret_cast<const char*>(_a_data);
+   char keyB = *reinterpret_cast<const char*>(_b_data);
+   return keyA - keyB;
+ }
+};
+
+ std::shared_ptr<IDBClient> set_local_client() {
+#ifdef USE_ROCKSDB
+    return std::static_pointer_cast<IDBClient>(std::make_shared< concord::storage::rocksdb::Client>(
+        "unit_test_db_meta", ::rocksdb::BytewiseComparator()));
+#else
+    return std::static_pointer_cast<IDBClient>(
+      std::make_shared<memorydb::Client>(KeyComparator(new SimpleIntegerKeyComparator())));
+#endif
+}
+
+  std::shared_ptr<IDBClient> set_object_store_client() {
+#ifdef TEST_ROR_APPSTATE_OBJECTSTORE
+   S3_StoreConfig config;
+    ObjectStoreBehavior b{true, true};
+    config.bucketName = "blockchain-dev-asx";
+    config.accessKey = "blockchain-dev";
+    config.protocol = "HTTP";
+    config.url = "10.70.30.244:9020";
+    config.secretKey = "Rz0mdbUNGJBxqdzprn5XGSXPr2AfkgcQsYS4y698";
+    return std::static_pointer_cast<IDBClient>(
+      std::make_shared<ObjectStoreClient>(config, b));
+#elif USE_ROCKSDB
+  return std::static_pointer_cast<IDBClient>(std::make_shared< concord::storage::rocksdb::Client>(
+        "unit_test_db_object_store", ::rocksdb::BytewiseComparator()));
+#else
+    assert(false); // we dont support RoRAppState test with in memory, its meaningless
+#endif
+}
+
+

--- a/util/include/ror_test_setup.hpp
+++ b/util/include/ror_test_setup.hpp
@@ -40,45 +40,42 @@ using namespace concord::storage::blockchain::v1DirectKeyValue;
 using namespace concord::storage;
 
 class SimpleIntegerKeyComparator : public IDBClient::IKeyComparator {
- int composedKeyComparison(const char* _a_data, size_t _a_length, const char* _b_data, size_t _b_length) override {
-   assert(_a_data);
-   assert(_b_data);
-   assert(_a_length == sizeof(char));
-   assert(_b_length == sizeof(char));
-   char keyA = *reinterpret_cast<const char*>(_a_data);
-   char keyB = *reinterpret_cast<const char*>(_b_data);
-   return keyA - keyB;
- }
+  int composedKeyComparison(const char* _a_data, size_t _a_length, const char* _b_data, size_t _b_length) override {
+    assert(_a_data);
+    assert(_b_data);
+    assert(_a_length == sizeof(char));
+    assert(_b_length == sizeof(char));
+    char keyA = *reinterpret_cast<const char*>(_a_data);
+    char keyB = *reinterpret_cast<const char*>(_b_data);
+    return keyA - keyB;
+  }
 };
 
- std::shared_ptr<IDBClient> set_local_client() {
+std::shared_ptr<IDBClient> set_local_client() {
 #ifdef USE_ROCKSDB
-    return std::static_pointer_cast<IDBClient>(std::make_shared< concord::storage::rocksdb::Client>(
-        "unit_test_db_meta", ::rocksdb::BytewiseComparator()));
+  return std::static_pointer_cast<IDBClient>(
+      std::make_shared<concord::storage::rocksdb::Client>("unit_test_db_meta", ::rocksdb::BytewiseComparator()));
 #else
-    return std::static_pointer_cast<IDBClient>(
+  return std::static_pointer_cast<IDBClient>(
       std::make_shared<memorydb::Client>(KeyComparator(new SimpleIntegerKeyComparator())));
 #endif
 }
 
-  std::shared_ptr<IDBClient> set_object_store_client() {
+std::shared_ptr<IDBClient> set_object_store_client() {
 #ifdef TEST_ROR_APPSTATE_OBJECTSTORE
-   S3_StoreConfig config;
-    ObjectStoreBehavior b{true, true};
-    config.bucketName = "blockchain-dev-asx";
-    config.accessKey = "blockchain-dev";
-    config.protocol = "HTTP";
-    config.url = "10.70.30.244:9020";
-    config.secretKey = "Rz0mdbUNGJBxqdzprn5XGSXPr2AfkgcQsYS4y698";
-    return std::static_pointer_cast<IDBClient>(
-      std::make_shared<ObjectStoreClient>(config, b));
+  S3_StoreConfig config;
+  ObjectStoreBehavior b{true, true};
+  config.bucketName = "blockchain-dev-asx";
+  config.accessKey = "blockchain-dev";
+  config.protocol = "HTTP";
+  config.url = "10.70.30.244:9020";
+  config.secretKey = "Rz0mdbUNGJBxqdzprn5XGSXPr2AfkgcQsYS4y698";
+  return std::static_pointer_cast<IDBClient>(std::make_shared<ObjectStoreClient>(config, b));
 #elif USE_ROCKSDB
-  return std::static_pointer_cast<IDBClient>(std::make_shared< concord::storage::rocksdb::Client>(
-        "unit_test_db_object_store", ::rocksdb::BytewiseComparator()));
+  return std::static_pointer_cast<IDBClient>(std::make_shared<concord::storage::rocksdb::Client>(
+      "unit_test_db_object_store", ::rocksdb::BytewiseComparator()));
 #else
-   return std::static_pointer_cast<IDBClient>(
+  return std::static_pointer_cast<IDBClient>(
       std::make_shared<memorydb::Client>(KeyComparator(new SimpleIntegerKeyComparator())));
 #endif
 }
-
-


### PR DESCRIPTION
This PR introduce 2 major add ons to the library: Application State implementation for Read Only replica and Objecst store support, which can be used to replicate the data from the RO replica.
The Object Store implementation uses S3 protocol.

Details:
The support is implemented using libs3 library. The library provides basic S3 protocol features and uses libcurl to issue HTTP requests. This new client,ObjectStoreClient which implements IDBClient interface and can be easily changed to local RockDB client (e.g. for tests).

The RoRApplicationState class implements IAppState interface, which was extended to support wait() function. This function may be useful when any of the IAppState IO operations return false (e.g. when the remote Object Store is unavailable) and the State Transfer module (e.g. of the RO replica) needs to wait before pushing new blocks. The call will be blocked until the underlying storage (e.g. S3) will become available.

Tests:
There are gtest suites for both modules, which in CI will run using local RocksDB as an object store.

E2E test:
There is a new script for manual run, readOnlyReplicaTest.sh, which start 4 regular and 1 RO replica. Further development will include automatic tests using our Apollo framework.

CMAKE flags:
There are 2 new cmake flags: BUILD_OBJECTSTORE_TEST when set, the real s3 Gtest suite will be build (assumes working S3 instance, the test needs to have parameters changed such as machine IP, access key and secret key)
USE_OBJECTSTORE_FOR_ROR_TEST when set, the ror_app_state Gtest suite will use real object store and the default (unset) mode will use local RocksDB (CI is running in this mode)