### PR TITLE
Add basic support for correlation-id in concord-bft

### DIFF
--- a/.conan/rocksdb_pkg/conanfile.py
+++ b/.conan/rocksdb_pkg/conanfile.py
@@ -35,10 +35,11 @@ class RocksdbConan(ConanFile):
         self.options["zstd"].shared = True
 
     def source(self):
-        download("https://github.com/facebook/rocksdb/archive/v5.7.3.tar.gz", "v5.7.3.tar.gz")
-        self.run("tar -xzf v5.7.3.tar.gz")
-        shutil.move("rocksdb-5.7.3", self.name)
-        os.unlink("v5.7.3.tar.gz")
+        tools.replace_in_file("CMakeLists.txt", 'project(rocksdb)',
+          '''project(rocksdb)
+          include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+          conan_basic_setup()
+            ''')
 
     def build(self):
         autotools = AutoToolsBuildEnvironment(self)

--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -25,6 +25,7 @@ struct ClientRequestMsgHeader {
   uint8_t flags;  // bit 0 == isReadOnly, bit 1 = preProcess, bits 2-7 are reserved
   uint64_t reqSeqNum;
   uint32_t requestLength;
+  uint32_t cid_length = 0;
   // followed by the request (security information, such as signatures, should be part of the request)
 
   // TODO(GG): idOfClientProxy is not needed here

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -52,7 +52,8 @@ class SimpleClient {
                           uint64_t timeoutMilli,
                           uint32_t lengthOfReplyBuffer,
                           char* replyBuffer,
-                          uint32_t& actualReplyLength) = 0;
+                          uint32_t& actualReplyLength,
+                          std::string cid = "") = 0;
 
   virtual int sendRequestToResetSeqNum() = 0;
   virtual int sendRequestToReadLatestSeqNum(uint64_t timeoutMilli, uint64_t& outLatestReqSeqNum) = 0;

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -217,7 +217,7 @@ int SimpleClientImp::sendRequest(uint8_t flags,
   if (isPreProcessRequired)
     reqMsg = new preprocessor::ClientPreProcessRequestMsg(clientId_, reqSeqNum, lengthOfRequest, request, msgCid);
   else
-    reqMsg = new ClientRequestMsg(clientId_, isReadOnly, reqSeqNum, lengthOfRequest, request, msgCid);
+    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lengthOfRequest, request, msgCid);
   pendingRequest_ = reqMsg;
 
   sendPendingRequest();

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -44,7 +44,8 @@ class SimpleClientImp : public SimpleClient, public IReceiver {
                   uint64_t timeoutMilli,
                   uint32_t lengthOfReplyBuffer,
                   char* replyBuffer,
-                  uint32_t& actualReplyLength) override;
+                  uint32_t& actualReplyLength,
+                  std::string cid = "") override;
 
   int sendRequestToResetSeqNum() override;
   int sendRequestToReadLatestSeqNum(uint64_t timeoutMilli, uint64_t& outLatestReqSeqNum) override;
@@ -187,10 +188,11 @@ int SimpleClientImp::sendRequest(uint8_t flags,
                                  uint64_t timeoutMilli,
                                  uint32_t lengthOfReplyBuffer,
                                  char* replyBuffer,
-                                 uint32_t& actualReplyLength) {
+                                 uint32_t& actualReplyLength,
+                                 std::string cid) {
   bool isReadOnly = flags & READ_ONLY_REQ;
   bool isPreProcessRequired = flags & PRE_PROCESS_REQ;
-
+  std::string msgCid = cid.empty() ? std::to_string(reqSeqNum) : cid;
   // TODO(GG): check params ...
   LOG_DEBUG(GL,
             "Client " << clientId_ << " - sends request " << reqSeqNum << " (isRO=" << isReadOnly
@@ -213,9 +215,9 @@ int SimpleClientImp::sendRequest(uint8_t flags,
 
   ClientRequestMsg* reqMsg;
   if (isPreProcessRequired)
-    reqMsg = new preprocessor::ClientPreProcessRequestMsg(clientId_, reqSeqNum, lengthOfRequest, request);
+    reqMsg = new preprocessor::ClientPreProcessRequestMsg(clientId_, reqSeqNum, lengthOfRequest, request, msgCid);
   else
-    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lengthOfRequest, request);
+    reqMsg = new ClientRequestMsg(clientId_, isReadOnly, reqSeqNum, lengthOfRequest, request, msgCid);
   pendingRequest_ = reqMsg;
 
   sendPendingRequest();

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -24,12 +24,17 @@ class ClientRequestMsg : public MessageBase {
   static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header), "");
   static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
   static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
-  static_assert(sizeof(ClientRequestMsgHeader) == 17, "ClientRequestMsgHeader is 17B");
+  static_assert(sizeof(ClientRequestMsgHeader) == 21, "ClientRequestMsgHeader size is 21B");
 
   // TODO(GG): more asserts
 
  public:
-  ClientRequestMsg(NodeIdType sender, uint8_t flags, uint64_t reqSeqNum, uint32_t requestLength, const char* request);
+  ClientRequestMsg(NodeIdType sender,
+                   uint8_t flags,
+                   uint64_t reqSeqNum,
+                   uint32_t requestLength,
+                   const char* request,
+                   const std::string& cid = "");
 
   ClientRequestMsg(NodeIdType sender);
 
@@ -48,7 +53,7 @@ class ClientRequestMsg : public MessageBase {
   char* requestBuf() const { return body() + sizeof(ClientRequestMsgHeader); }
 
   void set(ReqId reqSeqNum, uint32_t requestLength, uint8_t flags);
-
+  std::string getCid();
   void validate(const ReplicasInfo&) const override;
 
  protected:

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -18,11 +18,9 @@ namespace preprocessor {
 using namespace std;
 using namespace bftEngine;
 
-ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
-                                                       uint64_t reqSeqNum,
-                                                       uint32_t requestLength,
-                                                       const char* request)
-    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request) {
+ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(
+    NodeIdType sender, uint64_t reqSeqNum, uint32_t requestLength, const char* request, const std::string& cid)
+    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request, cid) {
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -21,7 +21,8 @@ namespace preprocessor {
 
 class ClientPreProcessRequestMsg : public ClientRequestMsg {
  public:
-  ClientPreProcessRequestMsg(NodeIdType sender, uint64_t reqSeqNum, uint32_t requestLength, const char* request);
+  ClientPreProcessRequestMsg(
+      NodeIdType sender, uint64_t reqSeqNum, uint32_t requestLength, const char* request, const std::string& cid);
 
   std::unique_ptr<MessageBase> convertToClientRequestMsg();
 };

--- a/kvbc/include/ClientImp.h
+++ b/kvbc/include/ClientImp.h
@@ -32,7 +32,8 @@ class ClientImp : public IClient {
                                     std::chrono::milliseconds timeout,
                                     uint32_t replySize,
                                     char* outReply,
-                                    uint32_t* outActualReplySize) override;
+                                    uint32_t* outActualReplySize,
+                                    const std::string& = "") override;
 
  protected:
   ClientImp() = default;

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -65,7 +65,8 @@ class IClient {
                                     std::chrono::milliseconds timeout,
                                     uint32_t replySize,
                                     char* outReply,
-                                    uint32_t* outActualReplySize) = 0;
+                                    uint32_t* outActualReplySize,
+                                    const std::string& cid = "") = 0;
 };
 
 // creates a new Client object

--- a/kvbc/src/ClientImp.cpp
+++ b/kvbc/src/ClientImp.cpp
@@ -57,7 +57,8 @@ Status ClientImp::invokeCommandSynch(const char* request,
                                      std::chrono::milliseconds timeout,
                                      uint32_t replySize,
                                      char* outReply,
-                                     uint32_t* outActualReplySize) {
+                                     uint32_t* outActualReplySize,
+                                     const std::string& cid) {
   if (!isRunning()) return Status::IllegalOperation("todo");
 
   uint64_t timeoutMs = timeout <= std::chrono::milliseconds::zero() ? SimpleClient::INFINITE_TIMEOUT : timeout.count();
@@ -69,7 +70,8 @@ Status ClientImp::invokeCommandSynch(const char* request,
                                      timeoutMs,
                                      replySize,
                                      outReply,
-                                     *outActualReplySize);
+                                     *outActualReplySize,
+                                     cid);
   assert(res >= -2 && res < 1);
 
   if (res == 0)

--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -25,5 +25,28 @@
  * For development purposes anyone can link with $<TARGET_OBJECTS:logging_dev>
  * and get a default initializations for both loggers.
  */
+
 extern concordlogger::Logger GL;
 extern concordlogger::Logger initLogger();
+
+namespace concordlogger {
+class MDC {
+  concordlogger::Logger& logger_;
+  std::string key_;
+
+ public:
+  MDC(concordlogger::Logger& logger, const std::string& key, const std::string& value);
+  ~MDC();
+};
+}  // namespace concordlogger
+
+/*
+ * These macros meant to append a temporary key-value pairs to the log messages.
+ * The duration of this adding is the scope where MDC_PUT was called - when reaching to the end of this scope,
+ * the key-value will be automatically removed.
+ * When using the internal logger of concord-bft, the temporary key-value will be added to the given logger.
+ * When using log4cpp, the key-value pair will be added to the current thread logger.
+ */
+#define MDC_PUT(l, k, v) concordlogger::MDC mdc_((l), (k), (v))
+#define CID_KEY "cid"
+#define MDC_CID_PUT(l, v) MDC_PUT(l, CID_KEY, v)

--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -41,7 +41,7 @@ class MDC {
 }  // namespace concordlogger
 
 /*
- * These macros meant to append a temporary key-value pairs to the log messages.
+ * These macros are meant to append temporary key-value pairs to the log messages.
  * The duration of this adding is the scope where MDC_PUT was called - when reaching to the end of this scope,
  * the key-value will be automatically removed.
  * When using the internal logger of concord-bft, the temporary key-value will be added to the given logger.

--- a/logging/include/Logging4cplus.hpp
+++ b/logging/include/Logging4cplus.hpp
@@ -41,4 +41,5 @@ class Log {
 
 #define LOG_FATAL(l, s) LOG4CPLUS_FATAL(l, s)
 #define LOG_FATAL_F(l, ...) LOG4CPLUS_FATAL_FMT(l, __VA_ARGS__)
+
 #endif

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -11,22 +11,39 @@
 // as noted in the LICENSE file.
 
 #include "Logger.hpp"
-
 #ifndef USE_LOG4CPP
 concordlogger::Logger initLogger() { return concordlogger::Log::getLogger(DEFAULT_LOGGER_NAME); }
+concordlogger::MDC::MDC(concordlogger::Logger &logger, const std::string &key, const std::string &value)
+    : logger_(logger), key_(key) {
+  logger_.putMdc(key, value);
+}
+concordlogger::MDC::~MDC() { logger_.removeMdc(key_); }
 #else
 #include <log4cplus/logger.h>
 #include <log4cplus/configurator.h>
 #include <log4cplus/consoleappender.h>
+#include <log4cplus/mdc.h>
 
 concordlogger::Logger initLogger() {
   log4cplus::SharedAppenderPtr ca_ptr = log4cplus::SharedAppenderPtr(new log4cplus::ConsoleAppender(false, true));
   ca_ptr->setLayout(
-      std::auto_ptr<log4cplus::Layout>(new log4cplus::PatternLayout("[Node %X{rid}] [%t] %-5p|%c|%M|%m|%n")));
+      std::auto_ptr<log4cplus::Layout>(new log4cplus::PatternLayout("[Node %X{rid}] [%t] %%%X%% %-5p|%c||%M|%m|%n ")));
   log4cplus::Logger::getRoot().addAppender(ca_ptr);
   log4cplus::Logger::getRoot().setLogLevel(log4cplus::INFO_LOG_LEVEL);
   return log4cplus::Logger::getInstance(LOG4CPLUS_TEXT(DEFAULT_LOGGER_NAME));
 }
+
+concordlogger::MDC::MDC(concordlogger::Logger &logger, const std::string &key, const std::string &value)
+    : logger_(logger), key_(key) {
+  (void)logger_;
+  log4cplus::getMDC().put(key_, value);
+}
+concordlogger::MDC::~MDC() {
+  (void)logger_;
+  log4cplus::getMDC().remove(key_);
+  ;
+}
+
 #endif
 
 concordlogger::Logger GL = initLogger();

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -77,15 +77,15 @@ class UdpClient:
         self.reply_quorum = 2*config.f + config.c + 1
         self.sock_bound = False
 
-    async def write(self, msg, seq_num=None):
+    async def write(self, msg, seq_num=None, cid=None):
         """ A wrapper around sendSync for requests that mutate state """
-        return await self.sendSync(msg, False, seq_num)
+        return await self.sendSync(msg, False, seq_num, cid)
 
-    async def read(self, msg, seq_num=None):
+    async def read(self, msg, seq_num=None, cid=None):
         """ A wrapper around sendSync for requests that do not mutate state """
-        return await self.sendSync(msg, True, seq_num)
+        return await self.sendSync(msg, True, seq_num, cid)
 
-    async def sendSync(self, msg, read_only, seq_num=None):
+    async def sendSync(self, msg, read_only, seq_num=None, cid=None):
         """
         Send a client request and wait for a quorum (2F+C+1) of replies.
 
@@ -113,8 +113,10 @@ class UdpClient:
         if seq_num is None:
             seq_num = self.req_seq_num.next()
 
+        if cid is None:
+            cid = str(seq_num)
         data = bft_msgs.pack_request(
-                    self.client_id, seq_num, read_only, msg)
+                    self.client_id, seq_num, read_only, cid, msg)
 
         # Raise a trio.TooSlowError exception if a quorum of replies
         with trio.fail_after(self.config.req_timeout_milli/1000):

--- a/util/pyclient/test_msgs.py
+++ b/util/pyclient/test_msgs.py
@@ -32,8 +32,10 @@ class TestPackUnpack(unittest.TestCase):
         client_id = 4
         req_seq_num = 1
         read_only = True
-        packed = bft_msgs.pack_request(client_id, req_seq_num, read_only, msg)
-        (header, unpacked_msg) = bft_msgs.unpack_request(packed)
+        cid = str(req_seq_num)
+        packed = bft_msgs.pack_request(client_id, req_seq_num, read_only, cid, msg)
+        (header, unpacked_msg , cid_) = bft_msgs.unpack_request(packed, len(cid))
+        self.assertEqual(cid, cid_)
         self.assertEqual(client_id, header.client_id)
         self.assertEqual(1, header.flags) # read_only = True
         self.assertEqual(req_seq_num, header.req_seq_num)


### PR DESCRIPTION
# Description
We add correlation id for the concord-bft client message such that a client is able to pass correlation ID to the bft engine.
## Detailed Description
Most of concord-bft flows handle a batch of size > 0 of requests. 
Thus, adding correlation ID is done only where the flow handle a single client request (i.e., upon receiving messages and upon executing them).

# More changes
* Formatting the code with clang-format-7
* Adding clang-format-7 to travis prebuild script
* Fixing a little mistake in conan recipe for rocksdb
* Removing some ifdef statement (when using log4cplus) 