### PR TITLE
Apollo tests for ReadOnlyReplica

### DIFF
--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -29,10 +29,10 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                                  std::shared_ptr<MsgHandlersRegistrator> msgHandlerReg)
     : ReplicaForStateTransfer(config, stateTransfer, msgComm, msgHandlerReg, true),
       ps_(persistentStorage),
-      ro_metrics_{metrics_.RegisterCounter("received_checkpoint_msg"),
-                  metrics_.RegisterCounter("sent_ask_for_checkpoint_msg"),
-                  metrics_.RegisterCounter("received_invalid_msg"),
-                  metrics_.RegisterGauge("last_executed_seq_num", lastExecutedSeqNum)} {
+      ro_metrics_{metrics_.RegisterCounter("receivedCheckpointMsgs"),
+                  metrics_.RegisterCounter("sentAskForCheckpointMsgs"),
+                  metrics_.RegisterCounter("receivedInvalidMsgs"),
+                  metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)} {
   repsInfo = new ReplicasInfo(config, dynamicCollectorForPartialProofs, dynamicCollectorForExecutionProofs);
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint,
                                    bind(&ReadOnlyReplica::messageHandler<CheckpointMsg>, this, std::placeholders::_1));

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -84,11 +84,11 @@ ReplicaLoader::ErrorCode checkReplicaConfig(const LoadedReplicaData &ld) {
 
   std::set<uint16_t> repIDs;
   for (auto &v : c.publicKeysOfReplicas) {
-    VerifyAND(v.first >= 0, v.first < numOfReplicas, InconsistentErr);
+    VerifyAND(v.first >= 0, v.first < (numOfReplicas + c.numRoReplicas), InconsistentErr);
     Verify(!v.second.empty(), InconsistentErr);  // TODO(GG): make sure that the key is valid
     repIDs.insert(v.first);
   }
-  Verify(repIDs.size() == numOfReplicas, InconsistentErr);
+  Verify(repIDs.size() == numOfReplicas + c.numRoReplicas, InconsistentErr);
 
   Verify(!c.replicaPrivateKey.empty(), InconsistentErr);  // TODO(GG): make sure that the key is valid
 

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -26,8 +26,8 @@ if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests COMMAND sh -c
             "python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()       
-
+            
 add_test(NAME skvbc_ro_replica_tests COMMAND sh -c
         "python3 -m unittest test_skvbc_ro_replica 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()   

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -26,4 +26,8 @@ if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests COMMAND sh -c
             "python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
+endif()       
+
+add_test(NAME skvbc_ro_replica_tests COMMAND sh -c
+        "python3 -m unittest test_skvbc_ro_replica 2>&1 > /dev/null"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -58,7 +58,9 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         Start read-only replica.
         Wait for State Transfer in ReadOnlyReplica to complete.
         """
-        [bft_network.start_replica(i) for i in range(0, bft_network.config.n)]
+        bft_network.start_all_replicas()
+        # TODO replace the below function with the library function:
+        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(initial_nodes=bft_network.all_replicas(), checkpoint_num=1)
         with trio.fail_after(60):  # seconds
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(tracker.send_indefinite_tracked_ops)
@@ -67,24 +69,23 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                         key = ['replica', 'Gauges', 'lastStableSeqNum']
                         replica_id = 0
                         lastStableSeqNum = await bft_network.metrics.get(replica_id, *key)
-                        
+
                         if lastStableSeqNum >= 150:
                             #enough requests
                             print("Consensus: lastStableSeqNum:" + str(lastStableSeqNum))  
                             nursery.cancel_scope.cancel()
-        
         # start the read-only replica
         ro_replica_id = bft_network.config.n
         bft_network.start_replica(ro_replica_id)
         with trio.fail_after(60):  # seconds
-                while True:
-                    with trio.move_on_after(.5):  # seconds
-                        key = ['replica', 'Gauges', 'lastExecutedSeqNum']
-                        lastExecutedSeqNum = await bft_network.metrics.get(ro_replica_id, *key)
-                        # success!
-                        if lastExecutedSeqNum >= 150:
-                            print("Replica " + str(ro_replica_id) + ": lastExecutedSeqNum:" + str(lastExecutedSeqNum))
-                            break
+            while True:
+                with trio.move_on_after(.5):  # seconds
+                    key = ['replica', 'Gauges', 'lastExecutedSeqNum']
+                    lastExecutedSeqNum = await bft_network.metrics.get(ro_replica_id, *key)
+                    # success!
+                    if lastExecutedSeqNum >= 150:
+                        print("Replica " + str(ro_replica_id) + ": lastExecutedSeqNum:" + str(lastExecutedSeqNum))
+                        break
 ####################################################################################################################### 
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd, num_ro_replicas=1)
@@ -96,14 +97,14 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         Send client commands.
         Wait for State Transfer in ReadOnlyReplica to complete.
         """
-        [bft_network.start_replica(i) for i in range(0, bft_network.config.n)]
+        bft_network.start_all_replicas()
         # start the read-only replica
         ro_replica_id = bft_network.config.n
         bft_network.start_replica(ro_replica_id)
-             
+        # TODO replace the below function with the library function:
+        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(initial_nodes=bft_network.all_replicas(), checkpoint_num=1)     
         with trio.fail_after(60):  # seconds
             async with trio.open_nursery() as nursery:
-                #nursery.start_soon(self._wait_for_state_transfer_to_complete, bft_network, 150)
                 nursery.start_soon(tracker.send_indefinite_tracked_ops)
                 while True:
                     with trio.move_on_after(.5):  # seconds

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -1,0 +1,119 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import unittest
+import trio
+import os.path
+import random
+
+from util import bft
+from util import skvbc as kvbc
+from util.skvbc import SimpleKVBCProtocol
+from util.skvbc_history_tracker import verify_linearizability
+from math import inf
+
+from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network
+
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    The replica is started with a short view change timeout and with RocksDB
+    persistence enabled (-p).
+
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "10000"
+
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-p"
+            ]
+
+class SkvbcReadOnlyReplicaTest(unittest.TestCase):
+
+####################################################################################################################### 
+    @with_trio
+    @with_bft_network(start_replica_cmd=start_replica_cmd,
+                      explicit_config=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 1, 'num_ro_replicas': 1}])
+    @verify_linearizability
+    async def test_ro_replica_start_with_delay(self, bft_network, tracker):
+        """
+        Start up N of N regular replicas.
+        Send client commands until checkpoint 1 is reached.
+        Start read-only replica.
+        Wait for State Transfer in ReadOnlyReplica to complete.
+        """
+        [bft_network.start_replica(i) for i in range(0, bft_network.config.n)]
+        
+        with trio.fail_after(60):  # seconds
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(tracker.send_indefinite_tracked_ops)
+                while True:
+                    with trio.move_on_after(.5):  # seconds
+                        key = ['replica', 'Gauges', 'lastStableSeqNum']
+                        replica_id = 0
+                        lastStableSeqNum = await bft_network.metrics.get(replica_id, *key)
+                        
+                        if lastStableSeqNum >= 150:
+                            #enough requests
+                            print("Consensus: lastStableSeqNum:" + str(lastStableSeqNum))  
+                            nursery.cancel_scope.cancel()
+        
+        # start the read-only replica
+        bft_network.start_replica(4)
+        with trio.fail_after(60):  # seconds
+                while True:
+                    with trio.move_on_after(.5):  # seconds
+                        key = ['replica', 'Gauges', 'lastExecutedSeqNum']
+                        replica_id = 4
+                        lastExecutedSeqNum = await bft_network.metrics.get(replica_id, *key)
+                        # success!
+                        if lastExecutedSeqNum >= 150:
+                            print("Replica 4: lastExecutedSeqNum:" + str(lastExecutedSeqNum))
+                            break
+####################################################################################################################### 
+    @with_trio
+    @with_bft_network(start_replica_cmd=start_replica_cmd,
+                      explicit_config=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 1, 'num_ro_replicas': 1}])
+    @verify_linearizability
+    async def test_ro_replica_start_simultaneously (self, bft_network, tracker):
+        """
+        Start up N of N regular replicas.
+        Start read-only replica.
+        Send client commands.
+        Wait for State Transfer in ReadOnlyReplica to complete.
+        """
+        [bft_network.start_replica(i) for i in range(0, bft_network.config.n)]
+        # start the read-only replica
+        bft_network.start_replica(4)
+             
+        with trio.fail_after(60):  # seconds
+            async with trio.open_nursery() as nursery:
+                #nursery.start_soon(self._wait_for_state_transfer_to_complete, bft_network, 150)
+                nursery.start_soon(tracker.send_indefinite_tracked_ops)
+                while True:
+                    with trio.move_on_after(.5):  # seconds
+                        key = ['replica', 'Gauges', 'lastExecutedSeqNum']
+                        replica_id = 4
+                        lastExecutedSeqNum = await bft_network.metrics.get(replica_id, *key)
+                        # success!
+                        if lastExecutedSeqNum >= 150:
+                            print("Replica 4: lastExecutedSeqNum:" + str(lastExecutedSeqNum))
+                            nursery.cancel_scope.cancel()          
+                

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -47,9 +47,7 @@ TestConfig = namedtuple('TestConfig', [
 KEY_FILE_PREFIX = "replica_keys_"
 
 
-def interesting_configs(selected=None, explicit_config=None):
-    if explicit_config is not None:
-        return explicit_config
+def interesting_configs(selected=None):
     if selected is None:
         selected=lambda *config: True
 
@@ -82,17 +80,14 @@ def with_trio(async_fn):
     return trio_wrapper
 
 
-def with_bft_network(start_replica_cmd, selected_configs=None, explicit_config=None):
+def with_bft_network(start_replica_cmd, selected_configs=None, num_ro_replicas=0):
     """
     Runs the decorated async function for all selected BFT configs
     """
     def decorator(async_fn):
         @wraps(async_fn)
         async def wrapper(*args, **kwargs):
-            for bft_config in interesting_configs(selected_configs, explicit_config):
-                num_ro_replicas = 0  
-                if 'num_ro_replicas' in bft_config:
-                    num_ro_replicas = bft_config['num_ro_replicas']
+            for bft_config in interesting_configs(selected_configs):
                        
                 config = TestConfig(n=bft_config['n'],
                                     f=bft_config['f'],


### PR DESCRIPTION
Apollo tests for ReadOnlyReplica
Added an option to explicitly provide configuration for bft_network in Apollo.
Piggybacking on this commit to fix ReplicaLoader assertion.