### PR TITLE
Fix Andrew's review comments for https://github.com/vmware/concord-bft/pull/392

### DIFF
--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -60,7 +60,8 @@ void ClientRequestMsg::set(ReqId reqSeqNum, uint32_t requestLength, uint8_t flag
 bool ClientRequestMsg::isReadOnly() const { return (msgBody()->flags & READ_ONLY_REQ) != 0; }
 
 void ClientRequestMsg::validate(const ReplicasInfo& repInfo) const {
-  if (size() < (sizeof(ClientRequestMsgHeader) + msgBody()->requestLength))
+  Assert(senderId() != repInfo.myId());
+  if (size() < sizeof(ClientRequestMsgHeader) || size() < (sizeof(ClientRequestMsgHeader) + msgBody()->requestLength))
     throw std::runtime_error(__PRETTY_FUNCTION__);
 }
 

--- a/bftengine/src/preprocessor/RequestProcessingInfo.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.cpp
@@ -41,8 +41,8 @@ void RequestProcessingInfo::handlePreProcessReplyMsg(PreProcessReplyMsgSharedPtr
   preProcessingResultHashes_[convertToArray(preProcessReplyMsg->resultsHash())]++;  // Count equal hashes
 }
 
-HashArray RequestProcessingInfo::convertToArray(const uint8_t resultsHash[SHA3_256::SIZE_IN_BYTES]) {
-  HashArray hashArray;
+SHA3_256::Digest RequestProcessingInfo::convertToArray(const uint8_t resultsHash[SHA3_256::SIZE_IN_BYTES]) {
+  SHA3_256::Digest hashArray;
   for (uint64_t i = 0; i < SHA3_256::SIZE_IN_BYTES; i++) hashArray[i] = resultsHash[i];
   return hashArray;
 }

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -22,7 +22,6 @@ namespace preprocessor {
 // This class collects and stores data relevant to the processing of one specific client request by all replicas.
 
 typedef enum { CONTINUE, COMPLETE, CANCEL, RETRY_PRIMARY } PreProcessingResult;
-typedef std::array<uint8_t, concord::util::SHA3_256::SIZE_IN_BYTES> HashArray;
 
 class RequestProcessingInfo {
  public:
@@ -40,7 +39,7 @@ class RequestProcessingInfo {
   uint32_t getMyPreProcessedResultLen() const { return myPreProcessResultLen_; }
 
  private:
-  static HashArray convertToArray(const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);
+  static concord::util::SHA3_256::Digest convertToArray(const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);
 
  private:
   static uint16_t numOfRequiredEqualReplies_;
@@ -51,8 +50,8 @@ class RequestProcessingInfo {
   uint16_t numOfReceivedReplies_ = 0;
   const char* myPreProcessResult_ = nullptr;
   uint32_t myPreProcessResultLen_ = 0;
-  HashArray myPreProcessResultHash_;
-  std::map<HashArray, int> preProcessingResultHashes_;  // Maps result hash to the number of equal hashes
+  concord::util::SHA3_256::Digest myPreProcessResultHash_;
+  std::map<concord::util::SHA3_256::Digest, int> preProcessingResultHashes_;  // Maps result hash to the number of equal hashes
 };
 
 typedef std::unique_ptr<RequestProcessingInfo> RequestProcessingInfoUniquePtr;

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -26,14 +26,6 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 
-void ClientPreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {
-  Assert(type() == MsgCode::ClientPreProcessRequest);
-  Assert(senderId() != repInfo.myId());
-
-  if (size() < sizeof(ClientRequestMsgHeader) || size() < (sizeof(ClientRequestMsgHeader) + msgBody()->requestLength))
-    throw std::runtime_error(__PRETTY_FUNCTION__);
-}
-
 unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg() {
   msgBody_->msgType = MsgCode::ClientRequest;
   return unique_ptr<MessageBase>((MessageBase*)this);

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -23,7 +23,6 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
  public:
   ClientPreProcessRequestMsg(NodeIdType sender, uint64_t reqSeqNum, uint32_t requestLength, const char* request);
 
-  void validate(const bftEngine::impl::ReplicasInfo&) const override;
   std::unique_ptr<MessageBase> convertToClientRequestMsg();
 };
 


### PR DESCRIPTION
- Use the same validate function for ClientPreProcessRequestMsg and ClientRequestMsg
- Get rid of duplicated HashArray type