### PR TITLE
BCStateTran: Evict VBlock from cache correctly

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1500,7 +1500,7 @@ void BCStateTran::setVBlockInCache(const DescOfVBlockForResPages &desc, char *vB
 
   Assert(p == cacheOfVirtualBlockForResPages.end());
 
-  if (cacheOfVirtualBlockForResPages.size() > kMaxVBlocksInCache) {
+  if (cacheOfVirtualBlockForResPages.size() == kMaxVBlocksInCache) {
     auto minItem = cacheOfVirtualBlockForResPages.begin();
     std::free(minItem->second);
     cacheOfVirtualBlockForResPages.erase(minItem);


### PR DESCRIPTION
There's an off by one error that causes virtual blocks to never be
evicted from the cache. This results in the assertion at
BCStateTran:1510 firing during load tests.

This commit fixes the bug and now LRU evicts when the max number of
vblocks exist in the cache.