### PR TITLE
Add support for merkle tree blocks in DBAdapter

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -2,7 +2,8 @@ add_library(concordbft_storage STATIC src/db_metadata_storage.cpp
                                       src/base_db_adapter.cpp
                                       src/direct_kv_db_adapter.cpp
                                       src/merkle_tree_db_adapter.cpp
-                                      src/block.cpp)
+                                      src/direct_kv_block.cpp
+                                      src/merkle_tree_block.cpp)
 
 target_include_directories(concordbft_storage PUBLIC include)
 target_link_libraries(concordbft_storage PUBLIC corebft)

--- a/storage/include/blockchain/base_db_adapter.h
+++ b/storage/include/blockchain/base_db_adapter.h
@@ -42,8 +42,6 @@ class DBAdapterBase {
  protected:
   DBAdapterBase(const std::shared_ptr<IDBClient> &db, bool readOnly);
 
-  concordUtils::Key getLatestBlock(const concordUtils::Sliver &maxKey) const;
-
  public:
   std::shared_ptr<IDBClient> getDb() const { return db_; }
 

--- a/storage/include/blockchain/block.h
+++ b/storage/include/blockchain/block.h
@@ -10,60 +10,10 @@
 // notices and license terms. Your use of these subcomponents is subject to the
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
+//
+// This convenience header combines different block implementations.
 
 #pragma once
 
-#include "db_types.h"
-#include "kv_types.hpp"
-#include "sliver.hpp"
-#include "hash_defs.h"
-
-#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
-
-#include <cstdint>
-#include <utility>
-
-namespace concord {
-namespace storage {
-namespace blockchain {
-namespace block {
-
-inline constexpr auto BLOCK_DIGEST_SIZE = bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
-
-inline namespace v1DirectKeyValue {
-// Creates a block. The passed parentDigest buffer must be of size BLOCK_DIGEST_SIZE bytes.
-concordUtils::Sliver create(const concordUtils::SetOfKeyValuePairs &updates,
-                            concordUtils::SetOfKeyValuePairs &outUpdatesInNewBlock,
-                            const void *parentDigest);
-
-// Returns the block data in the form of a set of key/value pairs.
-concordUtils::SetOfKeyValuePairs getData(const concordUtils::Sliver &block);
-
-// Returns the parent digest of size BLOCK_DIGEST_SIZE bytes.
-const void *getParentDigest(const concordUtils::Sliver &block);
-
-// Block structure is an implementation detail. External users should not rely on it.
-namespace detail {
-
-struct Header {
-  std::uint32_t numberOfElements;
-  std::uint32_t parentDigestLength;
-  std::uint8_t parentDigest[BLOCK_DIGEST_SIZE];
-};
-
-// Entry structures are coming immediately after the header.
-struct Entry {
-  std::uint32_t keyOffset;
-  std::uint32_t keySize;
-  std::uint32_t valOffset;
-  std::uint32_t valSize;
-};
-
-}  // namespace detail
-
-}  // namespace v1DirectKeyValue
-
-}  // namespace block
-}  // namespace blockchain
-}  // namespace storage
-}  // namespace concord
+#include "blockchain/direct_kv_block.h"
+#include "blockchain/merkle_tree_block.h"

--- a/storage/include/blockchain/direct_kv_block.h
+++ b/storage/include/blockchain/direct_kv_block.h
@@ -1,0 +1,75 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "hash_defs.h"
+#include "kv_types.hpp"
+#include "sliver.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace concord {
+namespace storage {
+namespace blockchain {
+inline namespace v1DirectKeyValue {
+namespace block {
+inline constexpr auto BLOCK_DIGEST_SIZE = bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
+
+// Creates a block with the user data appended at the end of the returned Sliver. The passed parentDigest buffer must be
+// of size BLOCK_DIGEST_SIZE bytes.
+concordUtils::Sliver create(const concordUtils::SetOfKeyValuePairs &updates,
+                            concordUtils::SetOfKeyValuePairs &outUpdatesInNewBlock,
+                            const void *parentDigest,
+                            const void *userData,
+                            std::size_t userDataSize);
+
+// Creates a block. The passed parentDigest buffer must be of size BLOCK_DIGEST_SIZE bytes.
+concordUtils::Sliver create(const concordUtils::SetOfKeyValuePairs &updates,
+                            concordUtils::SetOfKeyValuePairs &outUpdatesInNewBlock,
+                            const void *parentDigest);
+
+// Returns the block data in the form of a set of key/value pairs.
+concordUtils::SetOfKeyValuePairs getData(const concordUtils::Sliver &block);
+
+// Returns the parent digest of size BLOCK_DIGEST_SIZE bytes.
+const void *getParentDigest(const concordUtils::Sliver &block);
+
+// Block structure is an implementation detail. External users should not rely on it.
+namespace detail {
+
+struct Header {
+  std::uint32_t numberOfElements;
+  std::uint32_t parentDigestLength;
+  std::uint8_t parentDigest[BLOCK_DIGEST_SIZE];
+};
+
+// Entry structures are coming immediately after the header.
+struct Entry {
+  std::uint32_t keyOffset;
+  std::uint32_t keySize;
+  std::uint32_t valOffset;
+  std::uint32_t valSize;
+};
+
+}  // namespace detail
+
+}  // namespace block
+
+}  // namespace v1DirectKeyValue
+}  // namespace blockchain
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/blockchain/merkle_tree_block.h
+++ b/storage/include/blockchain/merkle_tree_block.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "kv_types.hpp"
+#include "sparse_merkle/base_types.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <iterator>
+#include <unordered_map>
+
+namespace concord {
+namespace storage {
+namespace blockchain {
+namespace v2MerkleTree {
+namespace block {
+
+inline constexpr auto BLOCK_DIGEST_SIZE = bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
+
+// Creates a block that includes a set of key/values. The passed parentDigest buffer must be of size BLOCK_DIGEST_SIZE
+// bytes.
+concordUtils::Sliver create(concordUtils::BlockId blockId,
+                            const concordUtils::SetOfKeyValuePairs &updates,
+                            const void *parentDigest,
+                            const sparse_merkle::Hash &stateHash);
+
+// Returns the block data in the form of a set of key/value pairs.
+concordUtils::SetOfKeyValuePairs getData(const concordUtils::Sliver &block);
+
+// Returns the parent digest of size BLOCK_DIGEST_SIZE bytes.
+const void *getParentDigest(const concordUtils::Sliver &block);
+
+// Returns the state hash of the passed block.
+sparse_merkle::Hash getStateHash(const concordUtils::Sliver &block);
+
+namespace detail {
+
+// Key lengths are serialized as a KeyLengthType in network byte order.
+using KeyLengthType = std::uint32_t;
+
+// KeyData is serialized as a single byte. Therefore, 7 more flags can be added.
+struct KeyData {
+  bool deleted{false};
+};
+
+inline bool operator==(const KeyData &lhs, const KeyData &rhs) { return lhs.deleted == rhs.deleted; }
+
+using Keys = std::unordered_map<concordUtils::Key, const KeyData>;
+
+// Represents a block node. The parentDigest pointer must point to a buffer that is at least BLOCK_DIGEST_SIZE bytes
+// long.
+struct Node {
+  static constexpr auto MIN_SIZE =
+      sizeof(concordUtils::BlockId) + BLOCK_DIGEST_SIZE + sparse_merkle::Hash::SIZE_IN_BYTES;
+
+  static constexpr auto PARENT_DIGEST_SIZE = BLOCK_DIGEST_SIZE;
+
+  static constexpr auto STATE_HASH_SIZE = sparse_merkle::Hash::SIZE_IN_BYTES;
+
+  static constexpr auto MIN_KEY_SIZE = 1 + sizeof(KeyLengthType);  // Add a byte of key data.
+
+  Node() = default;
+
+  Node(concordUtils::BlockId pBlockId,
+       const void *pParentDigest,
+       const sparse_merkle::Hash &pStateHash,
+       Keys pKeys = Keys{})
+      : blockId{pBlockId}, stateHash{pStateHash}, keys{pKeys} {
+    setParentDigest(pParentDigest);
+  }
+
+  void setParentDigest(const void *pParentDigest) {
+    const auto parentDigestPtr = static_cast<const std::uint8_t *>(pParentDigest);
+    std::copy(parentDigestPtr, parentDigestPtr + BLOCK_DIGEST_SIZE, std::begin(parentDigest));
+  }
+
+  concordUtils::BlockId blockId{0};
+  std::array<std::uint8_t, BLOCK_DIGEST_SIZE> parentDigest;
+  sparse_merkle::Hash stateHash;
+  Keys keys;
+};
+
+inline bool operator==(const Node &lhs, const Node &rhs) {
+  return lhs.blockId == rhs.blockId && lhs.parentDigest == rhs.parentDigest && lhs.stateHash == rhs.stateHash &&
+         lhs.keys == rhs.keys;
+}
+
+// Creates a block node that is saved to the DB. It only includes the keys in the block, excluding the values as they
+// are part of the state tree.
+// Precondition: Keys cannot be longer than std::numeric_limits<KeyLengthType>::max() .
+concordUtils::Sliver createNode(const Node &node);
+
+// Parses a block node from a raw buffer.
+Node parseNode(const concordUtils::Sliver &buffer);
+
+}  // namespace detail
+
+}  // namespace block
+}  // namespace v2MerkleTree
+}  // namespace blockchain
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/blockchain/merkle_tree_db_adapter.h
+++ b/storage/include/blockchain/merkle_tree_db_adapter.h
@@ -58,10 +58,21 @@ class DBAdapter : public DBAdapterBase {
                              concordUtils::Sliver &outValue,
                              BlockId &actualVersion) const;
 
-  // Returns the latest block ID, i.e. the key with the biggest version (block ID).
+  // Returns the latest block ID, i.e. the key with the biggest version (block ID). Returns 0 if there are no blocks in
+  // the system.
   BlockId getLatestBlock() const;
 
+  // Gets a block by its ID. The returned block buffer can be inspected with functions from the block::v2MerkleTree
+  // namespace. Returns the status of the operation. If the block is not found, Status::OK() is returned and the found
+  // output variable is set to false.
+  Status getBlockById(BlockId blockId, concordUtils::Sliver &block, bool &found) const;
+
+  // Returns the current state hash from the internal merkle tree implementation.
+  const sparse_merkle::Hash &getStateHash() const { return smTree_.get_root_hash(); }
+
  private:
+  concordUtils::Sliver createBlockNode(const concordUtils::SetOfKeyValuePairs &updates, BlockId blockId) const;
+
   class Reader : public sparse_merkle::IDBReader {
    public:
     Reader(const DBAdapter &adapter) : adapter_{adapter} {}

--- a/storage/include/blockchain/merkle_tree_db_adapter.h
+++ b/storage/include/blockchain/merkle_tree_db_adapter.h
@@ -36,6 +36,9 @@ class DBKeyManipulator : public DBKeyManipulatorBase {
 
   // Extract the block ID from a EDBKeyType::Block key or from a EKeySubtype::Leaf key.
   static BlockId extractBlockIdFromKey(const concordUtils::Key &key);
+
+  // Extract the hash from a leaf key.
+  static sparse_merkle::Hash extractHashFromLeafKey(const concordUtils::Key &key);
 };
 
 class DBAdapter : public DBAdapterBase {

--- a/storage/include/blockchain/merkle_tree_serialization.h
+++ b/storage/include/blockchain/merkle_tree_serialization.h
@@ -1,0 +1,345 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <assertUtils.hpp>
+#include "blockchain/db_types.h"
+#include "blockchain/merkle_tree_block.h"
+#include "endianness.hpp"
+#include "sliver.hpp"
+#include "sparse_merkle/base_types.h"
+#include "sparse_merkle/internal_node.h"
+#include "sparse_merkle/keys.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace concord {
+namespace storage {
+namespace blockchain {
+namespace v2MerkleTree {
+
+template <typename E>
+constexpr auto toChar(E e) {
+  static_assert(std::is_enum_v<E>);
+  static_assert(sizeof(E) <= sizeof(char));
+  return static_cast<char>(e);
+}
+
+namespace detail {
+
+// Specifies the key type. Used when serializing the stale node index.
+enum class StaleKeyType : std::uint8_t {
+  Internal,
+  Leaf,
+};
+
+// Specifies the child type. Used when serializing BatchedInternalNode objects.
+enum class BatchedInternalNodeChildType : std::uint8_t { Internal, Leaf };
+
+inline BatchedInternalNodeChildType getInternalChildType(const concordUtils::Sliver &buf) {
+  Assert(!buf.empty());
+
+  switch (buf[0]) {
+    case toChar(BatchedInternalNodeChildType::Internal):
+      return BatchedInternalNodeChildType::Internal;
+    case toChar(BatchedInternalNodeChildType::Leaf):
+      return BatchedInternalNodeChildType::Leaf;
+  }
+
+  Assert(false);
+  return BatchedInternalNodeChildType::Internal;
+}
+
+using BatchedInternalMaskType = std::uint32_t;
+
+// Serialize integral types in big-endian (network) byte order so that lexicographical comparison works and we can get
+// away without a custom key comparator. toBigEndianStringBuffer() does not allow bools.
+template <typename T>
+std::string serializeImp(T v) {
+  return concordUtils::toBigEndianStringBuffer(v);
+}
+
+inline std::string serializeImp(EDBKeyType type) { return std::string{toChar(type)}; }
+
+inline std::string serializeImp(EKeySubtype type) { return std::string{toChar(EDBKeyType::Key), toChar(type)}; }
+
+inline std::string serializeImp(EBFTSubtype type) { return std::string{toChar(EDBKeyType::BFT), toChar(type)}; }
+
+inline std::string serializeImp(StaleKeyType type) { return std::string{toChar(type)}; }
+
+inline std::string serializeImp(const std::vector<std::uint8_t> &v) {
+  return std::string{std::cbegin(v), std::cend(v)};
+}
+
+inline std::string serializeImp(const sparse_merkle::NibblePath &path) {
+  return serializeImp(static_cast<std::uint8_t>(path.length())) + serializeImp(path.data());
+}
+
+inline std::string serializeImp(const sparse_merkle::Hash &hash) {
+  return std::string{reinterpret_cast<const char *>(hash.data()), hash.size()};
+}
+
+inline std::string serializeImp(const sparse_merkle::InternalNodeKey &key) {
+  return serializeImp(key.version().value()) + serializeImp(key.path());
+}
+
+inline std::string serializeImp(const sparse_merkle::LeafKey &key) {
+  return serializeImp(key.hash()) + serializeImp(key.version().value());
+}
+
+inline std::string serializeImp(const sparse_merkle::LeafChild &child) {
+  return serializeImp(child.hash) + serializeImp(child.key);
+}
+
+inline std::string serializeImp(const sparse_merkle::InternalChild &child) {
+  return serializeImp(child.hash) + serializeImp(child.version.value());
+}
+
+inline std::string serializeImp(const sparse_merkle::BatchedInternalNode &intNode) {
+  static_assert(sparse_merkle::BatchedInternalNode::MAX_CHILDREN < 32);
+
+  struct Visitor {
+    Visitor(std::string &buf) : buf_{buf} {}
+
+    void operator()(const sparse_merkle::LeafChild &leaf) {
+      buf_ += toChar(BatchedInternalNodeChildType::Leaf) + serializeImp(leaf);
+    }
+
+    void operator()(const sparse_merkle::InternalChild &internal) {
+      buf_ += toChar(BatchedInternalNodeChildType::Internal) + serializeImp(internal);
+    }
+
+    std::string &buf_;
+  };
+
+  const auto &children = intNode.children();
+  std::string serializedChildren;
+  auto mask = BatchedInternalMaskType{0};
+  for (auto i = 0u; i < children.size(); ++i) {
+    const auto &child = children[i];
+    if (child) {
+      mask |= (1 << i);
+      std::visit(Visitor{serializedChildren}, *child);
+    }
+  }
+
+  // If the node is empty, serialize it as an empty string.
+  if (!mask) {
+    return std::string{};
+  }
+
+  // Serialize by putting a bitmask (of type BatchedInternalMaskType) specifying which indexes are set in the children
+  // array. Then, put a type before each child and then the child itself.
+  return serializeImp(mask) + serializedChildren;
+}
+
+inline std::string serializeImp(const block::detail::Node &node) {
+  const auto blockIdBuf = concordUtils::toBigEndianStringBuffer(node.blockId);
+
+  auto nodeSize = block::detail::Node::MIN_SIZE;
+  for (const auto &key : node.keys) {
+    Assert(key.first.length() <= std::numeric_limits<block::detail::KeyLengthType>::max());
+    nodeSize += (sizeof(block::detail::KeyLengthType) + key.first.length() + 1);  // Add a byte of key data.
+  }
+
+  std::string buf;
+  buf.reserve(nodeSize);
+
+  // Block ID.
+  buf += blockIdBuf;
+
+  // Parent digest.
+  buf.append(reinterpret_cast<const char *>(node.parentDigest.data()), node.parentDigest.size());
+
+  // State hash.
+  buf.append(reinterpret_cast<const char *>(node.stateHash.data()), node.stateHash.size());
+
+  // Keys in [key data, length, key] encoding.
+  for (const auto &keyData : node.keys) {
+    // At the moment, only the delete flag is supported. Additional data can be packed in this single byte in the
+    // future.
+    buf += keyData.second.deleted ? char{1} : char{0};
+    buf += concordUtils::toBigEndianStringBuffer(static_cast<block::detail::KeyLengthType>(keyData.first.length()));
+    buf.append(keyData.first.data(), keyData.first.length());
+  }
+
+  return buf;
+}
+
+inline std::string serialize() { return std::string{}; }
+
+template <typename T1, typename... T>
+std::string serialize(const T1 &v1, const T &... v) {
+  return serializeImp(v1) + serialize(v...);
+}
+
+template <typename T>
+T deserialize(const concordUtils::Sliver &buf);
+
+template <>
+inline sparse_merkle::Hash deserialize<sparse_merkle::Hash>(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= sparse_merkle::Hash::SIZE_IN_BYTES);
+  return sparse_merkle::Hash{reinterpret_cast<const uint8_t *>(buf.data())};
+}
+
+template <>
+inline sparse_merkle::Version deserialize<sparse_merkle::Version>(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= sparse_merkle::Version::SIZE_IN_BYTES);
+  return concordUtils::fromBigEndianBuffer<sparse_merkle::Version::Type>(buf.data());
+}
+
+template <>
+inline std::vector<std::uint8_t> deserialize<std::vector<std::uint8_t>>(const concordUtils::Sliver &buf) {
+  std::vector<std::uint8_t> vec;
+  for (auto i = 0u; i < buf.length(); ++i) {
+    vec.push_back(buf[i]);
+  }
+  return vec;
+}
+
+template <>
+inline sparse_merkle::NibblePath deserialize<sparse_merkle::NibblePath>(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= sizeof(std::uint8_t));
+  const auto nibbleCount = static_cast<std::size_t>(buf[0]);
+  const auto path = deserialize<std::vector<std::uint8_t>>(
+      concordUtils::Sliver{buf, sizeof(std::uint8_t), buf.length() - sizeof(std::uint8_t)});
+  return sparse_merkle::NibblePath{nibbleCount, path};
+}
+
+template <>
+inline sparse_merkle::LeafKey deserialize<sparse_merkle::LeafKey>(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= sparse_merkle::LeafKey::SIZE_IN_BYTES);
+  return sparse_merkle::LeafKey{deserialize<sparse_merkle::Hash>(buf),
+                                deserialize<sparse_merkle::Version>(concordUtils::Sliver{
+                                    buf, sparse_merkle::Hash::SIZE_IN_BYTES, sparse_merkle::Version::SIZE_IN_BYTES})};
+}
+
+template <>
+inline sparse_merkle::InternalNodeKey deserialize<sparse_merkle::InternalNodeKey>(const concordUtils::Sliver &buf) {
+  return sparse_merkle::InternalNodeKey{
+      deserialize<sparse_merkle::Version>(buf),
+      deserialize<sparse_merkle::NibblePath>(concordUtils::Sliver{
+          buf, sparse_merkle::Version::SIZE_IN_BYTES, buf.length() - sparse_merkle::Version::SIZE_IN_BYTES})};
+}
+
+template <>
+inline sparse_merkle::LeafChild deserialize<sparse_merkle::LeafChild>(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= sparse_merkle::LeafChild::SIZE_IN_BYTES);
+  return sparse_merkle::LeafChild{deserialize<sparse_merkle::Hash>(buf),
+                                  deserialize<sparse_merkle::LeafKey>(concordUtils::Sliver{
+                                      buf, sparse_merkle::Hash::SIZE_IN_BYTES, sparse_merkle::LeafKey::SIZE_IN_BYTES})};
+}
+
+template <>
+inline sparse_merkle::InternalChild deserialize<sparse_merkle::InternalChild>(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= sparse_merkle::InternalChild::SIZE_IN_BYTES);
+  return sparse_merkle::InternalChild{
+      deserialize<sparse_merkle::Hash>(buf),
+      deserialize<sparse_merkle::Version>(
+          concordUtils::Sliver{buf, sparse_merkle::Hash::SIZE_IN_BYTES, sparse_merkle::Version::SIZE_IN_BYTES})};
+}
+
+template <>
+inline sparse_merkle::BatchedInternalNode deserialize<sparse_merkle::BatchedInternalNode>(
+    const concordUtils::Sliver &buf) {
+  if (buf.empty()) {
+    return sparse_merkle::BatchedInternalNode{};
+  }
+
+  Assert(buf.length() >= sizeof(BatchedInternalMaskType));
+  sparse_merkle::BatchedInternalNode::ChildrenContainer children;
+  const auto mask = concordUtils::fromBigEndianBuffer<BatchedInternalMaskType>(buf.data());
+  auto childrenBuf =
+      concordUtils::Sliver{buf, sizeof(BatchedInternalMaskType), buf.length() - sizeof(BatchedInternalMaskType)};
+  for (auto i = 0u; i < sparse_merkle::BatchedInternalNode::MAX_CHILDREN; ++i) {
+    if (mask & (1 << i)) {
+      // First byte is the type as per BatchedInternalNodeChildType .
+      const auto type = getInternalChildType(childrenBuf);
+      childrenBuf = concordUtils::Sliver{childrenBuf, 1, childrenBuf.length() - 1};
+      switch (type) {
+        case BatchedInternalNodeChildType::Leaf:
+          children[i] = deserialize<sparse_merkle::LeafChild>(childrenBuf);
+          childrenBuf = concordUtils::Sliver{childrenBuf,
+                                             sparse_merkle::LeafChild::SIZE_IN_BYTES,
+                                             childrenBuf.length() - sparse_merkle::LeafChild::SIZE_IN_BYTES};
+          break;
+        case BatchedInternalNodeChildType::Internal:
+          children[i] = deserialize<sparse_merkle::InternalChild>(childrenBuf);
+          childrenBuf = concordUtils::Sliver{childrenBuf,
+                                             sparse_merkle::InternalChild::SIZE_IN_BYTES,
+                                             childrenBuf.length() - sparse_merkle::InternalChild::SIZE_IN_BYTES};
+          break;
+      }
+    }
+  }
+  return children;
+}
+
+template <>
+inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= block::detail::Node::MIN_SIZE);
+
+  auto offset = std::size_t{0};
+  auto node = block::detail::Node{};
+
+  // Block ID.
+  node.blockId = concordUtils::fromBigEndianBuffer<concordUtils::BlockId>(buf.data() + offset);
+  offset += sizeof(concordUtils::BlockId);
+
+  // Parent digest.
+  node.setParentDigest(buf.data() + offset);
+  offset += block::detail::Node::PARENT_DIGEST_SIZE;
+
+  // State hash.
+  node.stateHash = sparse_merkle::Hash{reinterpret_cast<const std::uint8_t *>(buf.data()) + offset};
+  offset += block::detail::Node::STATE_HASH_SIZE;
+
+  // Keys follow the static length of Node::MIN_SIZE bytes.
+  auto keyBuffer =
+      concordUtils::Sliver{buf, block::detail::Node::MIN_SIZE, buf.length() - block::detail::Node::MIN_SIZE};
+  while (!keyBuffer.empty()) {
+    Assert(keyBuffer.length() >= block::detail::Node::MIN_KEY_SIZE);
+
+    // Key data.
+    block::detail::KeyData keyData;
+    if (keyBuffer[0]) {
+      keyData.deleted = true;
+    }
+
+    // Key length.
+    const auto keyLen = concordUtils::fromBigEndianBuffer<block::detail::KeyLengthType>(keyBuffer.data() + 1);
+    Assert(keyLen <= (keyBuffer.length() - block::detail::Node::MIN_KEY_SIZE));
+    node.keys.emplace(concordUtils::Sliver{keyBuffer, block::detail::Node::MIN_KEY_SIZE, keyLen}, keyData);
+
+    keyBuffer = concordUtils::Sliver{keyBuffer,
+                                     block::detail::Node::MIN_KEY_SIZE + keyLen,
+                                     keyBuffer.length() - (block::detail::Node::MIN_KEY_SIZE + keyLen)};
+  }
+
+  return node;
+}
+
+}  // namespace detail
+}  // namespace v2MerkleTree
+}  // namespace blockchain
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -37,6 +37,7 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
 
   // Inherited via IDBClientIterator
   virtual KeyValuePair first() override;
+  virtual KeyValuePair last() override;
   virtual KeyValuePair seekAtLeast(const Sliver &_searchKey) override;
   virtual KeyValuePair previous() override;
   virtual KeyValuePair next() override;

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -38,6 +38,7 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
 
   // Inherited via IDBClientIterator
   concordUtils::KeyValuePair first() override;
+  concordUtils::KeyValuePair last() override;
   concordUtils::KeyValuePair seekAtLeast(const concordUtils::Sliver& _searchKey) override;
   concordUtils::KeyValuePair previous() override;
   KeyValuePair next() override;

--- a/storage/include/sparse_merkle/internal_node.h
+++ b/storage/include/sparse_merkle/internal_node.h
@@ -49,6 +49,7 @@ BatchedInternalNode and their corresponding header comments.
 // A child that is a leaf of the overall tree. It isn't necessarily at height 0
 // in a BatchedInternalNode, although there will not be any children below it.
 struct LeafChild {
+  static constexpr auto SIZE_IN_BYTES = Hash::SIZE_IN_BYTES + LeafKey::SIZE_IN_BYTES;
   bool operator==(const LeafChild& other) const { return hash == other.hash && key == other.key; }
   // The hash of the value blob stored at `key`
   Hash hash;
@@ -58,6 +59,7 @@ struct LeafChild {
 // A child that represents an internal node of the sparse binary merkle tree. It
 // will refer to another BatchedInternalNode if it resides at height 0.
 struct InternalChild {
+  static constexpr auto SIZE_IN_BYTES = Hash::SIZE_IN_BYTES + Version::SIZE_IN_BYTES;
   bool operator==(const InternalChild& other) const { return hash == other.hash && version == other.version; }
   Hash hash;
   Version version;
@@ -256,6 +258,9 @@ class BatchedInternalNode {
 
   // Return the internal children container.
   const ChildrenContainer& children() const { return children_; }
+
+  // Return true if this node is identical to the other one and false otherwise.
+  bool operator==(const BatchedInternalNode& other) const { return children_ == other.children_; }
 
  private:
   // A LeafChild collission has occurred. We need to create new InternalChild nodes so

--- a/storage/include/sparse_merkle/keys.h
+++ b/storage/include/sparse_merkle/keys.h
@@ -57,6 +57,9 @@ class InternalNodeKey {
 // merkle tree.
 class LeafKey {
  public:
+  static constexpr auto SIZE_IN_BYTES = Hash::SIZE_IN_BYTES + Version::SIZE_IN_BYTES;
+
+ public:
   LeafKey(Hash key, Version version) : key_(key), version_(version) {}
 
   bool operator==(const LeafKey& other) const { return key_ == other.key_ && version_ == other.version_; }

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -70,6 +70,7 @@ class IDBClient {
   class IDBClientIterator {
    public:
     virtual KeyValuePair first() = 0;
+    virtual KeyValuePair last() = 0;
     // Returns next keys if not found for this key
     virtual KeyValuePair seekAtLeast(const Sliver& _searchKey) = 0;
     virtual KeyValuePair previous() = 0;

--- a/storage/src/base_db_adapter.cpp
+++ b/storage/src/base_db_adapter.cpp
@@ -19,27 +19,6 @@ DBAdapterBase::DBAdapterBase(const std::shared_ptr<IDBClient> &db, bool readOnly
   db_->init(readOnly);
 }
 
-Key DBAdapterBase::getLatestBlock(const Sliver &maxKey) const {
-  // Note: RocksDB stores keys in a sorted fashion as per the logic provided in
-  // a custom comparator (for our case, refer to the `composedKeyComparison`
-  // method above). In short, keys of type 'block' are stored first followed by
-  // keys of type 'key'. All keys of type 'block' are sorted in ascending order
-  // of block ids.
-
-  auto iter = db_->getIterator();
-
-  // Since we use the maximal key, SeekAtLeast will take the iterator
-  // to one position beyond the key corresponding to the largest block id.
-  iter->seekAtLeast(maxKey);
-
-  // Read the previous key
-  const auto kv = iter->previous();
-
-  db_->freeIterator(iter);
-
-  return kv.first;
-}
-
 }  // namespace blockchain
 }  // namespace storage
 }  // namespace concord

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -153,6 +153,22 @@ KeyValuePair ClientIterator::first() {
 }
 
 /**
+ * @brief Moves the iterator to the last element of the map.
+ *
+ * @return The last element of the map if it is not empty and an empty pair otherwise.
+ */
+KeyValuePair ClientIterator::last() {
+  if (m_parentClient->getMap().empty()) {
+    m_current = m_parentClient->getMap().end();
+    return KeyValuePair();
+  }
+
+  m_current = --m_parentClient->getMap().end();
+
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
  * @brief Returns the key value pair of the key which is greater than or equal
  * to _searchKey.
  *

--- a/storage/src/merkle_tree_block.cpp
+++ b/storage/src/merkle_tree_block.cpp
@@ -1,0 +1,63 @@
+#include "blockchain/merkle_tree_block.h"
+
+#include "assertUtils.hpp"
+#include "blockchain/direct_kv_block.h"
+#include "blockchain/merkle_tree_serialization.h"
+#include "endianness.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <string>
+
+namespace concord {
+namespace storage {
+namespace blockchain {
+namespace v2MerkleTree {
+
+namespace block {
+
+using sparse_merkle::Hash;
+
+using ::concordUtils::BlockId;
+using ::concordUtils::Sliver;
+using ::concordUtils::SetOfKeyValuePairs;
+using ::concordUtils::toBigEndianArrayBuffer;
+
+// Use the v1DirectKeyValue implementation and just add the the block ID and the state hash at the back. We want that so
+// that they are included in the block digest. We can do that, because users are not expected to interpret the returned
+// buffer themselves.
+Sliver create(BlockId blockId, const SetOfKeyValuePairs &updates, const void *parentDigest, const Hash &stateHash) {
+  std::array<std::uint8_t, sizeof(blockId) + Hash::SIZE_IN_BYTES> userData;
+  const auto blockIdBuf = toBigEndianArrayBuffer(blockId);
+  std::copy(std::cbegin(blockIdBuf), std::cend(blockIdBuf), std::begin(userData));
+  std::copy(stateHash.data(), stateHash.data() + Hash::SIZE_IN_BYTES, std::begin(userData) + blockIdBuf.size());
+
+  SetOfKeyValuePairs out;
+  return v1DirectKeyValue::block::create(updates, out, parentDigest, userData.data(), userData.size());
+}
+
+SetOfKeyValuePairs getData(const Sliver &block) { return v1DirectKeyValue::block::getData(block); }
+
+const void *getParentDigest(const Sliver &block) { return v1DirectKeyValue::block::getParentDigest(block); }
+
+Hash getStateHash(const Sliver &block) {
+  Assert(block.length() >= Hash::SIZE_IN_BYTES);
+  const auto data = reinterpret_cast<const std::uint8_t *>(block.data());
+  return Hash{data + (block.length() - Hash::SIZE_IN_BYTES)};
+}
+
+namespace detail {
+
+Sliver createNode(const Node &node) { return v2MerkleTree::detail::serialize(node); }
+
+Node parseNode(const Sliver &buffer) { return v2MerkleTree::detail::deserialize<Node>(buffer); }
+}  // namespace detail
+
+}  // namespace block
+}  // namespace v2MerkleTree
+}  // namespace blockchain
+}  // namespace storage
+}  // namespace concord

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -361,6 +361,30 @@ KeyValuePair ClientIterator::first() {
 }
 
 /**
+ * @brief Returns the KeyValuePair object of the last key in the database.
+ *
+ * @return The KeyValuePair object of the last key.
+ */
+KeyValuePair ClientIterator::last() {
+  ++g_rocksdb_called_read;
+  if (g_rocksdb_print_measurements) {
+    LOG_DEBUG(logger, "Reading count = " << g_rocksdb_called_read);
+  }
+
+  // Position at the last key in the database
+  m_iter->SeekToLast();
+
+  if (!m_iter->Valid()) {
+    LOG_ERROR(logger, "Did not find a last key");
+    m_status = Status::NotFound("Empty database");
+    return KeyValuePair();
+  }
+
+  m_status = Status::OK();
+  return KeyValuePair(copyRocksdbSlice(m_iter->key()), copyRocksdbSlice(m_iter->value()));
+}
+
+/**
  * @brief Returns the key value pair of the key which is greater than or equal
  * to _searchKey.
  *

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(merkleTreeAdapter_test PUBLIC
     GTest::Main
     util
     concordbft_storage
+    stdc++fs
 )
 
 add_executable(sparse_merkle_base_types_test sparse_merkle/base_types_test.cpp

--- a/storage/test/merkleTreeAdapter_test.cpp
+++ b/storage/test/merkleTreeAdapter_test.cpp
@@ -4,32 +4,61 @@
 
 #include "gtest/gtest.h"
 
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "blockchain/merkle_tree_block.h"
 #include "blockchain/merkle_tree_db_adapter.h"
+#include "blockchain/merkle_tree_serialization.h"
 #include "endianness.hpp"
 #include "memorydb/client.h"
-#include "memorydb/key_comparator.h"
+#include "rocksdb/client.h"
 #include "sparse_merkle/base_types.h"
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
 #include <memory>
+#include <sstream>
 #include <string>
+#include <thread>
 #include <type_traits>
+#include <utility>
 
-using namespace concord::storage::blockchain::v2MerkleTree;
-using namespace concord::storage::blockchain::v2MerkleTree::detail;
-using concord::storage::blockchain::BlockId;
-using concord::storage::blockchain::ObjectId;
-using concord::storage::memorydb::Client;
-using concord::storage::memorydb::KeyComparator;
-using concord::storage::sparse_merkle::Hash;
-using concord::storage::sparse_merkle::Hasher;
-using concord::storage::sparse_merkle::InternalNodeKey;
-using concord::storage::sparse_merkle::LeafKey;
-using concord::storage::sparse_merkle::NibblePath;
-using concord::storage::sparse_merkle::Version;
-using concordUtils::Sliver;
-using concordUtils::Status;
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing filesystem support"
+#endif
 
 namespace {
+
+using ::bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest;
+using ::bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest;
+
+using namespace ::concord::storage::blockchain::v2MerkleTree;
+using namespace ::concord::storage::blockchain::v2MerkleTree::detail;
+
+using ::concord::storage::IDBClient;
+using ::concord::storage::blockchain::BlockId;
+using ::concord::storage::blockchain::ObjectId;
+using ::concord::storage::sparse_merkle::BatchedInternalNode;
+using ::concord::storage::sparse_merkle::Hash;
+using ::concord::storage::sparse_merkle::Hasher;
+using ::concord::storage::sparse_merkle::InternalChild;
+using ::concord::storage::sparse_merkle::InternalNodeKey;
+using ::concord::storage::sparse_merkle::LeafChild;
+using ::concord::storage::sparse_merkle::LeafKey;
+using ::concord::storage::sparse_merkle::NibblePath;
+using ::concord::storage::sparse_merkle::Version;
+
+using ::concordUtils::SetOfKeyValuePairs;
+using ::concordUtils::Sliver;
+using ::concordUtils::Status;
 
 template <typename E>
 std::string serializeEnum(E e) {
@@ -46,22 +75,70 @@ std::string serializeIntegral(T v) {
 
 Sliver toSliver(std::string b) { return Sliver{std::move(b)}; }
 
+Sliver getSliverOfSize(std::size_t size, char content = char{42}) { return std::string(size, content); }
+
+auto getHash(const std::string &str) {
+  auto hasher = Hasher{};
+  return hasher.hash(str.data(), str.size());
+}
+
+auto getBlockDigest(const std::string &data) { return getHash(data).dataArray(); }
+
+StateTransferDigest blockDigest(BlockId blockId, const Sliver &block) {
+  auto digest = StateTransferDigest{};
+  computeBlockDigest(blockId, block.data(), block.length(), &digest);
+  return digest;
+}
+
+bool operator==(const void *lhs, const StateTransferDigest &rhs) {
+  return std::memcmp(lhs, rhs.content, block::BLOCK_DIGEST_SIZE) == 0;
+}
+
+bool operator==(const StateTransferDigest &lhs, const void *rhs) {
+  return std::memcmp(lhs.content, rhs, block::BLOCK_DIGEST_SIZE) == 0;
+}
+
+StateTransferDigest emptyDigest() {
+  StateTransferDigest digest;
+  std::memset(digest.content, 0, block::BLOCK_DIGEST_SIZE);
+  return digest;
+}
+
+SetOfKeyValuePairs getDeterministicBlockUpdates(std::uint32_t count) {
+  auto updates = SetOfKeyValuePairs{};
+  auto size = std::uint8_t{0};
+  for (auto i = 0u; i < count; ++i) {
+    updates[getSliverOfSize(size + 1)] = getSliverOfSize((size + 1) * 3);
+    ++size;
+  }
+  return updates;
+}
+
 const auto defaultData = std::string{"this is a test string"};
 const auto defaultSliver = Sliver::copy(defaultData.c_str(), defaultData.size());
-auto hasher = Hasher{};
-const auto defaultHash = hasher.hash(defaultData.data(), defaultData.size());
+const auto defaultHash = getHash(defaultData);
 const auto defaultHashStrBuf = std::string{reinterpret_cast<const char *>(defaultHash.data()), defaultHash.size()};
 const auto defaultBlockId = BlockId{42};
 const auto defaultVersion = Version{42};
 const auto defaultObjectId = ObjectId{42};
 const auto defaultPageId = uint32_t{42};
 const auto defaultChkpt = uint64_t{42};
+const auto defaultDigest = getBlockDigest(defaultData + defaultData);
+const auto maxNumKeys = 100u;
+const auto rocksDbPathPrefix = std::string{"/tmp/merkleTreeAdapter_test_rocksdb.db"};
 
 static_assert(sizeof(EDBKeyType) == 1);
 static_assert(sizeof(EKeySubtype) == 1);
 static_assert(sizeof(EBFTSubtype) == 1);
 static_assert(sizeof(BlockId) == 8);
 static_assert(sizeof(ObjectId) == 4);
+
+// Support multithreaded runs by appending the thread ID to the RocksDB path.
+std::string rocksDbPath() {
+  std::stringstream ss;
+  ss << std::this_thread::get_id();
+  return rocksDbPathPrefix + ss.str();
+}
 
 // Expected key structure with respective bit sizes:
 // [EDBKeyType::Block: 8, blockId: 64]
@@ -192,36 +269,326 @@ TEST(key_manipulator, st_res_page_dynamic_key) {
   ASSERT_TRUE(key == expected);
 }
 
+TEST(block, key_data_equality) {
+  ASSERT_TRUE(block::detail::KeyData{true} == block::detail::KeyData{true});
+  ASSERT_FALSE(block::detail::KeyData{true} == block::detail::KeyData{false});
+}
+
+TEST(block, block_node_equality) {
+  // Non-key differences.
+  {
+    const auto node1 = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    const auto node2 = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    const auto node3 = block::detail::Node{defaultBlockId + 1, defaultDigest.data(), defaultHash};
+    const auto node4 = block::detail::Node{defaultBlockId, getBlockDigest("random data").data(), defaultHash};
+    const auto node5 = block::detail::Node{defaultBlockId, defaultDigest.data(), getHash("random data2")};
+
+    ASSERT_EQ(node1.blockId, node2.blockId);
+    ASSERT_TRUE(node1.parentDigest == node2.parentDigest);
+    ASSERT_TRUE(node1.stateHash == node2.stateHash);
+    ASSERT_TRUE(node1.keys == node2.keys);
+
+    ASSERT_NE(node1.blockId, node3.blockId);
+    ASSERT_TRUE(node1.parentDigest == node3.parentDigest);
+    ASSERT_TRUE(node1.stateHash == node3.stateHash);
+    ASSERT_TRUE(node1.keys == node3.keys);
+
+    ASSERT_EQ(node1.blockId, node4.blockId);
+    ASSERT_FALSE(node1.parentDigest == node4.parentDigest);
+    ASSERT_TRUE(node1.stateHash == node4.stateHash);
+    ASSERT_TRUE(node1.keys == node4.keys);
+
+    ASSERT_EQ(node1.blockId, node5.blockId);
+    ASSERT_TRUE(node1.parentDigest == node5.parentDigest);
+    ASSERT_FALSE(node1.stateHash == node5.stateHash);
+    ASSERT_TRUE(node1.keys == node5.keys);
+
+    ASSERT_TRUE(node1 == node2);
+    ASSERT_FALSE(node1 == node3);
+    ASSERT_FALSE(node1 == node4);
+    ASSERT_FALSE(node1 == node5);
+  }
+
+  // Differences in keys only.
+  {
+    auto node1 = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    auto node2 = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    node2.keys.emplace(defaultSliver, block::detail::KeyData{false});
+    auto node3 = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    node3.keys.emplace(defaultSliver, block::detail::KeyData{true});
+    auto node4 = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    node3.keys.emplace(getSliverOfSize(42), block::detail::KeyData{true});
+
+    ASSERT_FALSE(node1 == node2);
+    ASSERT_FALSE(node1 == node3);
+    ASSERT_FALSE(node2 == node3);
+    ASSERT_FALSE(node3 == node4);
+    ASSERT_FALSE(node2 == node4);
+  }
+}
+
+TEST(block, block_node_serialization) {
+  // No keys.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // 1 non-deleted key.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    node.keys.emplace(defaultSliver, block::detail::KeyData{false});
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // 1 deleted key.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    node.keys.emplace(defaultSliver, block::detail::KeyData{true});
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // Empty key.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    node.keys.emplace(getSliverOfSize(0), block::detail::KeyData{true});
+    node.keys.emplace(getSliverOfSize(1), block::detail::KeyData{true});
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // Multiple keys with different sizes and deleted flags.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash};
+    auto deleted = false;
+    for (auto i = 1u; i <= maxNumKeys; ++i) {
+      node.keys.emplace(getSliverOfSize(i), block::detail::KeyData{deleted});
+      deleted = !deleted;
+    }
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+}
+
+TEST(block, block_serialization) {
+  SetOfKeyValuePairs updates;
+  for (auto i = 1u; i <= maxNumKeys; ++i) {
+    updates.emplace(getSliverOfSize(i), getSliverOfSize(i * 10));
+  }
+
+  const auto block = block::create(defaultBlockId, updates, defaultDigest.data(), defaultHash);
+  const auto parsedUpdates = block::getData(block);
+  const auto parsedDigest = static_cast<const std::uint8_t *>(block::getParentDigest(block));
+  const auto parsedStateHash = block::getStateHash(block);
+
+  ASSERT_TRUE(updates == parsedUpdates);
+  ASSERT_TRUE(std::equal(std::cbegin(defaultDigest), std::cend(defaultDigest), parsedDigest));
+  ASSERT_TRUE(defaultHash == parsedStateHash);
+}
+
+// The serialization test doesn't take into account if the test nodes are semantically valid. Instead, it is only
+// focused on serialization/deserialization.
+TEST(batched_internal, serialization) {
+  // No children.
+  {
+    const auto node = BatchedInternalNode{};
+    const auto buf = Sliver{serialize(node)};
+    ASSERT_TRUE(buf.empty());
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(buf) == node);
+  }
+
+  // Full container with LeafChild children.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    for (auto &child : children) {
+      child = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    }
+
+    const auto node = BatchedInternalNode{children};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Full container with InternalChild children.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto count = 0;
+    for (auto &child : children) {
+      child = InternalChild{getHash("InternalChild"), defaultBlockId + count};
+      ++count;
+    }
+
+    const auto node = BatchedInternalNode{children};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Full container with alternating children.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto internal = false;
+    auto count = 0;
+    for (auto &child : children) {
+      if (internal) {
+        child = InternalChild{getHash("InternalChild" + std::to_string(count)), defaultBlockId + count};
+      } else {
+        child = LeafChild{getHash("LeafChild" + std::to_string(count)),
+                          LeafKey{getHash("LeafKey" + std::to_string(count)), defaultBlockId + count}};
+      }
+      ++count;
+    }
+
+    const auto node = BatchedInternalNode{children};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 LeafChild at the beginning.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[0] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 LeafChild at the end.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[children.size() - 1] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 InternalChild at the beginning.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[0] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 InternalChild at the end.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[children.size() - 1] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 LeafChild at the beginning and one InternalChild at the end.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[0] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    children[children.size() - 1] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 InternalChild at the beginning and one LeafChild at the end.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[0] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    children[children.size() - 1] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Children in the middle.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[15] = InternalChild{getHash("InternalChild1"), defaultBlockId};
+    children[16] = LeafChild{getHash("LeafChild1"), LeafKey{getHash("LeafKey1"), defaultBlockId}};
+    children[17] = InternalChild{getHash("InternalChild2"), defaultBlockId};
+    children[18] = LeafChild{getHash("LeafChild2"), LeafKey{getHash("LeafKey2"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Children at the beginning and end.
+  {
+    auto children = BatchedInternalNode::ChildrenContainer{};
+    children[0] = InternalChild{getHash("InternalChild1"), defaultBlockId + 1};
+    children[1] = LeafChild{getHash("LeafChild1"), LeafKey{getHash("LeafKey1"), defaultBlockId + 2}};
+    children[2] = InternalChild{getHash("InternalChild2"), defaultBlockId + 3};
+    children[3] = LeafChild{getHash("LeafChild2"), LeafKey{getHash("LeafKey2"), defaultBlockId + 4}};
+
+    children[30] = InternalChild{getHash("InternalChild3"), defaultBlockId + 5};
+    children[29] = LeafChild{getHash("LeafChild3"), LeafKey{getHash("LeafKey3"), defaultBlockId + 6}};
+    children[28] = InternalChild{getHash("InternalChild4"), defaultBlockId + 7};
+    children[27] = LeafChild{getHash("LeafChild4"), LeafKey{getHash("LeafKey4"), defaultBlockId + 8}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+}
+
+struct IDbClientFactory {
+  virtual std::shared_ptr<IDBClient> db() const = 0;
+  virtual std::string type() const = 0;
+  virtual ~IDbClientFactory() noexcept = default;
+};
+
+struct MemoryDbClientFactory : public IDbClientFactory {
+  std::shared_ptr<IDBClient> db() const override { return std::make_shared<::concord::storage::memorydb::Client>(); }
+
+  std::string type() const override { return "memorydb"; }
+};
+
+struct RocksDbClientFactory : public IDbClientFactory {
+  std::shared_ptr<IDBClient> db() const override {
+    fs::remove_all(rocksDbPath());
+    // Create the RocksDB client with the default lexicographical comparator.
+    return std::make_shared<::concord::storage::rocksdb::Client>(rocksDbPath());
+  }
+
+  std::string type() const override { return "RocksDB"; }
+};
+
+class db_adapter : public ::testing::TestWithParam<std::shared_ptr<IDbClientFactory>> {
+  void SetUp() override { fs::remove_all(rocksDbPath()); }
+  void TearDown() override { fs::remove_all(rocksDbPath()); }
+};
+
 // Test the latest block functionality that relies on key ordering.
-TEST(db_adapter, get_latest_block) {
-  auto db = std::make_shared<Client>();
-  db->put(DBKeyManipulator::genBlockDbKey(1), defaultSliver);
-  db->put(DBKeyManipulator::genBlockDbKey(2), defaultSliver);
-  db->put(DBKeyManipulator::genBlockDbKey(3), defaultSliver);
-  // Insert a dummy root root node.
-  db->put(DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(3)), Sliver{});
-  const auto adapter = DBAdapter{db};
+TEST_P(db_adapter, get_latest_block) {
+  auto adapter = DBAdapter{GetParam()->db()};
+  const auto updates = SetOfKeyValuePairs{std::make_pair(defaultSliver, defaultSliver)};
+  ASSERT_TRUE(adapter.addBlock(updates, 1).isOK());
+  ASSERT_TRUE(adapter.addBlock(updates, 2).isOK());
+  ASSERT_TRUE(adapter.addBlock(updates, 3).isOK());
   ASSERT_EQ(adapter.getLatestBlock(), 3);
 }
 
-TEST(db_adapter, get_key_by_ver) {
-  const auto data3 = Sliver{std::string{"data3"}};
-  const auto data4 = Sliver{std::string{"data4"}};
-  const auto data5 = Sliver{std::string{"data5"}};
-
-  auto db = std::make_shared<Client>();
-  db->put(DBKeyManipulator::genDataDbKey(defaultSliver, 3), data3);
-  db->put(DBKeyManipulator::genDataDbKey(defaultSliver, 4), data4);
-  db->put(DBKeyManipulator::genDataDbKey(defaultSliver, 5), data5);
-  // Insert a dummy root root node.
-  db->put(DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(5)), Sliver{});
-  const auto adapter = DBAdapter{db};
+TEST_P(db_adapter, get_key_by_ver) {
+  auto adapter = DBAdapter{GetParam()->db()};
+  const auto data1 = Sliver{"data1"};
+  const auto data2 = Sliver{"data2"};
+  const auto data3 = Sliver{"data3"};
+  const auto updates1 = SetOfKeyValuePairs{std::make_pair(defaultSliver, data1)};
+  const auto updates2 = SetOfKeyValuePairs{std::make_pair(defaultSliver, data2)};
+  const auto updates3 = SetOfKeyValuePairs{std::make_pair(defaultSliver, data3)};
+  ASSERT_TRUE(adapter.addBlock(updates1, 1).isOK());
+  ASSERT_TRUE(adapter.addBlock(updates2, 2).isOK());
+  ASSERT_TRUE(adapter.addBlock(updates3, 3).isOK());
 
   // Get a key before the first one and expect an empty response.
   {
     Sliver out;
     BlockId actualVersion;
-    const auto status = adapter.getKeyByReadVersion(1, defaultSliver, out, actualVersion);
+    const auto status = adapter.getKeyByReadVersion(0, defaultSliver, out, actualVersion);
     ASSERT_TRUE(status == Status::OK());
     ASSERT_TRUE(out.empty());
     ASSERT_EQ(actualVersion, 0);
@@ -231,42 +598,190 @@ TEST(db_adapter, get_key_by_ver) {
   {
     Sliver out;
     BlockId actualVersion;
-    const auto status = adapter.getKeyByReadVersion(3, defaultSliver, out, actualVersion);
-    ASSERT_TRUE(status == Status::OK());
-    ASSERT_TRUE(out == data3);
-    ASSERT_EQ(actualVersion, 3);
+    const auto status = adapter.getKeyByReadVersion(1, defaultSliver, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data1);
+    ASSERT_EQ(actualVersion, 1);
   }
 
   // Get the second one.
   {
     Sliver out;
     BlockId actualVersion;
-    const auto status = adapter.getKeyByReadVersion(4, defaultSliver, out, actualVersion);
-    ASSERT_TRUE(status == Status::OK());
-    ASSERT_TRUE(out == data4);
-    ASSERT_EQ(actualVersion, 4);
+    const auto status = adapter.getKeyByReadVersion(2, defaultSliver, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data2);
+    ASSERT_EQ(actualVersion, 2);
   }
 
   // Get the last one.
   {
     Sliver out;
     BlockId actualVersion;
-    const auto status = adapter.getKeyByReadVersion(5, defaultSliver, out, actualVersion);
-    ASSERT_TRUE(status == Status::OK());
-    ASSERT_TRUE(out == data5);
-    ASSERT_EQ(actualVersion, 5);
+    const auto status = adapter.getKeyByReadVersion(3, defaultSliver, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data3);
+    ASSERT_EQ(actualVersion, 3);
   }
 
-  // Get a key past the last one and expect the last one
+  // Get a key past the last one and expect the last one.
   {
     Sliver out;
     BlockId actualVersion;
     const auto status = adapter.getKeyByReadVersion(42, defaultSliver, out, actualVersion);
-    ASSERT_TRUE(status == Status::OK());
-    ASSERT_TRUE(out == data5);
-    ASSERT_EQ(actualVersion, 5);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data3);
+    ASSERT_EQ(actualVersion, 3);
   }
 }
+
+TEST_P(db_adapter, add_and_get_block) {
+  for (auto numKeys = 1u; numKeys <= maxNumKeys; ++numKeys) {
+    auto adapter = DBAdapter{GetParam()->db()};
+
+    SetOfKeyValuePairs updates1, updates2;
+    for (auto i = 1u; i <= numKeys; ++i) {
+      // Make the keys overlap between block1 and block2.
+      updates1[getSliverOfSize(i)] = getSliverOfSize(i * 10);
+      updates2[getSliverOfSize(i * 2)] = getSliverOfSize(i * 2 * 10);
+    }
+
+    // Add 2 blocks.
+    {
+      const auto status1 = adapter.addBlock(updates1, 1);
+      ASSERT_TRUE(status1.isOK());
+
+      const auto status2 = adapter.addBlock(updates2, 2);
+      ASSERT_TRUE(status2.isOK());
+    }
+
+    // Try to get a non-existent block.
+    {
+      Sliver block;
+      auto found = true;
+      const auto status = adapter.getBlockById(3, block, found);
+      ASSERT_TRUE(status.isOK());
+      ASSERT_FALSE(found);
+    }
+
+    // Get the first block.
+    Sliver block1;
+    {
+      auto found = false;
+      const auto status = adapter.getBlockById(1, block1, found);
+      ASSERT_TRUE(status.isOK());
+      ASSERT_TRUE(found);
+      ASSERT_TRUE(updates1 == block::getData(block1));
+    }
+
+    // Get the second block.
+    {
+      Sliver block2;
+      auto found = false;
+      const auto status = adapter.getBlockById(2, block2, found);
+      ASSERT_TRUE(status.isOK());
+      ASSERT_TRUE(found);
+      ASSERT_TRUE(updates2 == block::getData(block2));
+      ASSERT_TRUE(adapter.getStateHash() == block::getStateHash(block2));
+      ASSERT_TRUE(block::getParentDigest(block2) == blockDigest(1, block1));
+    }
+  }
+}
+
+TEST_P(db_adapter, add_multiple_deterministic_blocks) {
+  auto adapter = DBAdapter{GetParam()->db()};
+
+  const auto numBlocks = 250;
+  auto count = std::uint16_t{0};
+  for (auto i = 1u; i <= numBlocks; ++i) {
+    ASSERT_TRUE(adapter.addBlock(getDeterministicBlockUpdates(count + 1), i).isOK());
+    ASSERT_EQ(adapter.getLatestBlock(), i);
+    ++count;
+  }
+
+  count = 0;
+  for (auto i = 1u; i <= numBlocks; ++i) {
+    auto block = Sliver{};
+    auto found = false;
+    ASSERT_TRUE(adapter.getBlockById(i, block, found).isOK());
+    ASSERT_FALSE(block.empty());
+    ASSERT_TRUE(found);
+
+    // Expect an empty parent digest for block 1.
+    if (i == 1) {
+      ASSERT_TRUE(block::getParentDigest(block) == emptyDigest());
+    } else {
+      auto parentBlock = Sliver{};
+      auto found = false;
+      ASSERT_TRUE(adapter.getBlockById(i - 1, parentBlock, found).isOK());
+      ASSERT_FALSE(parentBlock.empty());
+      ASSERT_TRUE(found);
+      ASSERT_TRUE(blockDigest(i - 1, parentBlock) == block::getParentDigest(block));
+    }
+
+    const auto updates = getDeterministicBlockUpdates(count + 1);
+    ASSERT_TRUE(block::getData(block) == updates);
+
+    ++count;
+  }
+}
+
+TEST_P(db_adapter, add_empty_blocks) {
+  auto adapter = DBAdapter{GetParam()->db()};
+
+  const auto emptyUpdates = SetOfKeyValuePairs{};
+  const auto numBlocks = 5;
+
+  for (auto i = 1u; i <= numBlocks; ++i) {
+    ASSERT_TRUE(adapter.addBlock(emptyUpdates, i).isOK());
+    ASSERT_EQ(adapter.getLatestBlock(), i);
+  }
+
+  for (auto i = 1u; i <= numBlocks; ++i) {
+    auto block = Sliver{};
+    auto found = false;
+    ASSERT_TRUE(adapter.getBlockById(i, block, found).isOK());
+    ASSERT_TRUE(found);
+    ASSERT_TRUE(emptyUpdates == block::getData(block));
+  }
+}
+
+TEST_P(db_adapter, no_blocks) {
+  const auto adapter = DBAdapter{GetParam()->db()};
+
+  ASSERT_EQ(adapter.getLatestBlock(), 0);
+
+  auto block = Sliver{};
+  auto found = true;
+  ASSERT_TRUE(adapter.getBlockById(defaultBlockId, block, found).isOK());
+  ASSERT_FALSE(found);
+  ASSERT_TRUE(block.empty());
+
+  auto value = Sliver{};
+  auto actualVersion = BlockId{};
+  ASSERT_TRUE(
+      adapter
+          .getKeyByReadVersion(
+              defaultBlockId, DBKeyManipulator::genDataDbKey(defaultSliver, defaultBlockId), value, actualVersion)
+          .isOK());
+  ASSERT_EQ(actualVersion, 0);
+  ASSERT_TRUE(value.empty());
+}
+
+// Generate test name suffixes based on the DB client type.
+struct TypePrinter {
+  template <typename T>
+  std::string operator()(const testing::TestParamInfo<T> &info) const {
+    return info.param->type();
+  }
+};
+
+// Test DBAdapter with both memory and RocksDB clients.
+INSTANTIATE_TEST_CASE_P(db_adapter_tests,
+                        db_adapter,
+                        ::testing::Values(std::make_shared<MemoryDbClientFactory>(),
+                                          std::make_shared<RocksDbClientFactory>()),
+                        TypePrinter{});
 
 }  // namespace
 

--- a/util/include/endianness.hpp
+++ b/util/include/endianness.hpp
@@ -5,13 +5,17 @@
 
 #include <arpa/inet.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <iterator>
+#include <string>
 #include <type_traits>
 
 namespace concordUtils {
 
 template <typename T>
-T swapByteOrder(T v) {
+T hostToNet(T v) {
   static_assert(std::is_integral_v<T>);
 
   if constexpr (sizeof(v) == 2) {
@@ -29,12 +33,39 @@ T swapByteOrder(T v) {
 
 template <typename T>
 T netToHost(T v) {
-  return swapByteOrder(v);
+  return hostToNet(v);
 }
 
 template <typename T>
-T hostToNet(T v) {
-  return swapByteOrder(v);
+using isEndianConvertible = std::conjunction<std::is_integral<T>, std::negation<std::is_same<T, bool>>>;
+
+// Convert integral types (except bool) to a std::string buffer in big endian (network) byte order.
+template <typename T>
+std::string toBigEndianStringBuffer(T v) {
+  static_assert(isEndianConvertible<T>::value);
+
+  v = concordUtils::hostToNet(v);
+
+  const auto data = reinterpret_cast<const char *>(&v);
+  return std::string{data, sizeof(v)};
+}
+
+template <typename T>
+std::array<std::uint8_t, sizeof(T)> toBigEndianArrayBuffer(T v) {
+  static_assert(isEndianConvertible<T>::value);
+
+  v = concordUtils::hostToNet(v);
+
+  std::array<std::uint8_t, sizeof(T)> ret;
+  const auto data = reinterpret_cast<const std::uint8_t *>(&v);
+  std::copy(data, data + sizeof(T), std::begin(ret));
+  return ret;
+}
+
+// Buffer must be at least sizeof(T) bytes long.
+template <typename T>
+T fromBigEndianBuffer(const void *buf) {
+  return netToHost(*reinterpret_cast<const T *>(buf));
 }
 
 }  // namespace concordUtils


### PR DESCRIPTION
Implement functionality to add, get and manipulate blocks in the merkle
tree DBAdapter. That includes serialization of raw blocks that are
passed by users (including state transfer) and also of block nodes that
are saved under a block key type in the DB. Block nodes only contain the
set of keys in the block and raw blocks (including values) are created
on demand (e.g. not directly saved in the DB) from the merkle tree.

Functionalities added depend heavily on the key ordering as defined in
db_types.h . Examples are getting the latest block in the system and
getting the latest internal root node in the merkle tree. Notes are
added at relevant places in the code to explain the intention.

Add the last() method in IDBClientIterator to support a well-defined
mechanism of getting the last element as opposed to getting the
previous element from the end - for example, RocksDB iterators don't
provide a notion of a 'past-the-end' iterator as C++ containers do.

Test with both a memory DB client and a RocksDB client.

Note: This commit uses the <experimental/filesystem> header (in
merkleTreeAdapter_test.cpp) from the standard library if is
not available.