### PR TITLE
Fix Travis formatting checks

### DIFF
--- a/.travis/preinstall.sh
+++ b/.travis/preinstall.sh
@@ -7,7 +7,7 @@ echo "macos homebrew packages handled in .travis.yml"
 else
 # If on Linux, install necessary packages using apt
 sudo apt-get update
-sudo apt-get install -y ccache cmake clang-format libgmp3-dev \
+sudo apt-get install -y ccache cmake clang-format clang-format-7 libgmp3-dev \
 python3-pip python3-setuptools
 fi
 

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -39,7 +39,8 @@ class RequestProcessingInfo {
   uint32_t getMyPreProcessedResultLen() const { return myPreProcessResultLen_; }
 
  private:
-  static concord::util::SHA3_256::Digest convertToArray(const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);
+  static concord::util::SHA3_256::Digest convertToArray(
+      const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);
 
  private:
   static uint16_t numOfRequiredEqualReplies_;
@@ -51,7 +52,8 @@ class RequestProcessingInfo {
   const char* myPreProcessResult_ = nullptr;
   uint32_t myPreProcessResultLen_ = 0;
   concord::util::SHA3_256::Digest myPreProcessResultHash_;
-  std::map<concord::util::SHA3_256::Digest, int> preProcessingResultHashes_;  // Maps result hash to the number of equal hashes
+  std::map<concord::util::SHA3_256::Digest, int>
+      preProcessingResultHashes_;  // Maps result hash to the number of equal hashes
 };
 
 typedef std::unique_ptr<RequestProcessingInfo> RequestProcessingInfoUniquePtr;


### PR DESCRIPTION
* Add clang-format-7 to Travis, such that the format check will work.
* Formatting code with clang-format-7