### PR TITLE
Add missing returns in v2MerkleTree::DBAdapter

### DIFF
--- a/storage/src/merkle_tree_db_adapter.cpp
+++ b/storage/src/merkle_tree_db_adapter.cpp
@@ -183,6 +183,7 @@ SetOfKeyValuePairs batchToDBUpdates(const Tree::UpdateBatch &batch) {
   return updates;
 }
 
+// Undefined behavior if an incorrect type is read from the buffer.
 EDBKeyType getDBKeyType(const Sliver &s) {
   Assert(!s.empty());
 
@@ -194,10 +195,13 @@ EDBKeyType getDBKeyType(const Sliver &s) {
     case toChar(EDBKeyType::BFT):
       return EDBKeyType::BFT;
   }
-
   Assert(false);
+
+  // Dummy return to silence the compiler.
+  return EDBKeyType::Block;
 }
 
+// Undefined behavior if an incorrect type is read from the buffer.
 EKeySubtype getKeySubtype(const Sliver &s) {
   Assert(s.length() > 1);
 
@@ -209,8 +213,10 @@ EKeySubtype getKeySubtype(const Sliver &s) {
     case toChar(EKeySubtype::Leaf):
       return EKeySubtype::Leaf;
   }
-
   Assert(false);
+
+  // Dummy return to silence the compiler.
+  return EKeySubtype::Internal;
 }
 
 }  // namespace


### PR DESCRIPTION
Add return statements in the getDBKeyType() and getKeySubtype()
functions so that the compiler is happy (even if we Assert prior to the
return statement).