### PR TITLE
SparseMerkle: Complete key removal functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ compile_commands.json
 
 # clangd directory
 .clangd/
+
+# Apollo test output
+*/apollo/Testing/*

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -32,10 +32,12 @@ endif(BUILD_ROCKSDB_STORAGE)
 
 find_package(OpenSSL REQUIRED)
 target_sources(concordbft_storage PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/memorydb_client.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/internal_node.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/tree.cpp
-    )
-target_include_directories(corebft PUBLIC ${OPENSSL_INCLUDE_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/memorydb_client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/base_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/internal_node.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/tree.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/update_cache.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sparse_merkle/walker.cpp
+)
 target_link_libraries(concordbft_storage PRIVATE ${OPENSSL_LIBRARIES})
 

--- a/storage/include/blockchain/merkle_tree_serialization.h
+++ b/storage/include/blockchain/merkle_tree_serialization.h
@@ -269,7 +269,7 @@ inline sparse_merkle::BatchedInternalNode deserialize<sparse_merkle::BatchedInte
   }
 
   Assert(buf.length() >= sizeof(BatchedInternalMaskType));
-  sparse_merkle::BatchedInternalNode::ChildrenContainer children;
+  sparse_merkle::BatchedInternalNode::Children children;
   const auto mask = concordUtils::fromBigEndianBuffer<BatchedInternalMaskType>(buf.data());
   auto childrenBuf =
       concordUtils::Sliver{buf, sizeof(BatchedInternalMaskType), buf.length() - sizeof(BatchedInternalMaskType)};

--- a/storage/include/sparse_merkle/keys.h
+++ b/storage/include/sparse_merkle/keys.h
@@ -39,7 +39,12 @@ class InternalNodeKey {
     return version_ < other.version_;
   }
 
-  std::string toString() const { return path_.toString() + "-" + version_.toString(); }
+  std::string toString() const {
+    if (path_.empty()) {
+      return std::string("<ROOT>") + "-" + version_.toString();
+    }
+    return path_.toString() + "-" + version_.toString();
+  }
 
   Version version() const { return version_; }
 
@@ -63,6 +68,7 @@ class LeafKey {
   LeafKey(Hash key, Version version) : key_(key), version_(version) {}
 
   bool operator==(const LeafKey& other) const { return key_ == other.key_ && version_ == other.version_; }
+  bool operator!=(const LeafKey& other) const { return !(*this == other); }
 
   // Compare by key_ then version_
   bool operator<(const LeafKey& other) const {

--- a/storage/include/sparse_merkle/tree.h
+++ b/storage/include/sparse_merkle/tree.h
@@ -23,6 +23,7 @@
 #include "sparse_merkle/base_types.h"
 #include "sparse_merkle/db_reader.h"
 #include "sparse_merkle/internal_node.h"
+#include "sparse_merkle/update_batch.h"
 
 namespace concord {
 namespace storage {
@@ -37,33 +38,7 @@ namespace sparse_merkle {
 // can be written to the DB atomically.
 class Tree {
  public:
-  // A set of old tree nodes that are no longer reachable from the new root of
-  // the tree.
-  struct StaleNodeIndexes {
-    // All the following keys became stale at this version.
-    Version stale_since_version;
-    std::vector<InternalNodeKey> internal_keys;
-    std::vector<LeafKey> leaf_keys;
-  };
-
-  // Every mutation of the tree returns a BatchUpdate containing nodes to be written
-  // to the database.
-  struct UpdateBatch {
-    StaleNodeIndexes stale;
-    std::vector<std::pair<InternalNodeKey, BatchedInternalNode>> internal_nodes;
-    std::vector<std::pair<LeafKey, LeafNode>> leaf_nodes;
-  };
-
-  typedef std::stack<BatchedInternalNode, std::vector<BatchedInternalNode>> NodeStack;
-
-  explicit Tree(std::shared_ptr<IDBReader> db_reader) : db_reader_(db_reader) {
-    // Perform a single allocation of the maximum depth of the tree for the
-    // node_stack_.
-    auto vec = std::vector<BatchedInternalNode>();
-    vec.reserve(Hash::MAX_NIBBLES);
-    node_stack_ = NodeStack(std::move(vec));
-    reset();
-  }
+  explicit Tree(std::shared_ptr<IDBReader> db_reader) : db_reader_(db_reader) { reset(); }
 
   const Hash& get_root_hash() const { return root_.hash(); }
   Version get_version() const { return root_.version(); }
@@ -78,70 +53,11 @@ class Tree {
     return update(updates, no_deletes);
   }
 
-  // All data that is loaded from the DB, manipulated, and/or returned from a
-  // call to `update`.
-  //
-  // A new instance of this structure is created during every update call.
-  class UpdateCache {
-   public:
-    UpdateCache(const BatchedInternalNode& root, const std::shared_ptr<IDBReader>& db_reader)
-        : version_(root.version() + 1), db_reader_(db_reader) {
-      internal_nodes_[NibblePath()] = root;
-    }
-
-    const BatchedInternalNode& getRoot() { return internal_nodes_[NibblePath()]; }
-    const Tree::StaleNodeIndexes& stale() const { return stale_; }
-    const auto& internalNodes() const { return internal_nodes_; }
-    Version version() const { return version_; }
-
-    // Get a node if it's in the cache, otherwise get it from the DB.
-    BatchedInternalNode getInternalNode(const InternalNodeKey& key);
-
-    void putStale(const std::optional<LeafKey>& key);
-    void putStale(const InternalNodeKey& key);
-    void put(const NibblePath& path, const BatchedInternalNode& node);
-    void remove(const NibblePath& path);
-
-   private:
-    // The version of the tree after this update is complete.
-    Version version_;
-    std::shared_ptr<IDBReader> db_reader_;
-    Tree::StaleNodeIndexes stale_;
-
-    // All the internal nodes related to the current batch update.
-    //
-    // These nodes are mutable and are all being updated to a single version.
-    // Therefore we key them by their NibblePath alone, without a version.
-    std::map<NibblePath, BatchedInternalNode> internal_nodes_;
-  };
-
-  // A class for ascending and descending the tree. This is used for updates.
-  class Walker {
-   public:
-    Walker(NodeStack& stack, UpdateCache& cache) : stack_(stack), cache_(cache), current_node_(cache.getRoot()) {
-      // Mark the root node stale
-      markCurrentNodeStale();
-    }
-
-    size_t depth() const { return nibble_path_.length(); }
-    BatchedInternalNode& currentNode() { return current_node_; }
-    Version version() { return cache_.version(); }
-    bool atRoot() { return nibble_path_.empty(); }
-    void cacheCurrentNode();
-    void putStale(const std::optional<LeafKey>& key) { cache_.putStale(key); }
-    void appendEmptyNodes(const Hash& key, int nodes_to_create);
-    void descend(const Hash& key, Version next_version);
-    void ascend();
-    void removeCurrentNode();
-
-   private:
-    void markCurrentNodeStale();
-
-    NodeStack& stack_;
-    UpdateCache& cache_;
-    BatchedInternalNode current_node_;
-    NibblePath nibble_path_;
-  };
+  // Perform an update with only delete operations
+  UpdateBatch remove(const concordUtils::KeysVector& deletes) {
+    concordUtils::SetOfKeyValuePairs no_updates;
+    return update(no_updates, deletes);
+  }
 
  private:
   // Reset the tree to the latest version.
@@ -152,10 +68,6 @@ class Tree {
 
   std::shared_ptr<IDBReader> db_reader_;
   BatchedInternalNode root_;
-
-  // Store internal nodes needed when updating a tree. This is a member variable
-  // so that we can allocate only once.
-  NodeStack node_stack_;
 };
 
 }  // namespace sparse_merkle

--- a/storage/include/sparse_merkle/update_batch.h
+++ b/storage/include/sparse_merkle/update_batch.h
@@ -1,0 +1,45 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <set>
+
+#include "sparse_merkle/base_types.h"
+#include "sparse_merkle/keys.h"
+#include "sparse_merkle/internal_node.h"
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+// A set of old tree nodes that are no longer reachable from the new root of
+// the tree.
+struct StaleNodeIndexes {
+  // All the following keys became stale at this version.
+  Version stale_since_version;
+  std::set<InternalNodeKey> internal_keys;
+  std::set<LeafKey> leaf_keys;
+};
+
+// Every mutation of the tree returns a BatchUpdate containing nodes to be written
+// to the database.
+struct UpdateBatch {
+  StaleNodeIndexes stale;
+  std::vector<std::pair<InternalNodeKey, BatchedInternalNode>> internal_nodes;
+  std::vector<std::pair<LeafKey, LeafNode>> leaf_nodes;
+};
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/sparse_merkle/update_cache.h
+++ b/storage/include/sparse_merkle/update_cache.h
@@ -1,0 +1,80 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <map>
+
+#include "sparse_merkle/keys.h"
+#include "sparse_merkle/base_types.h"
+#include "sparse_merkle/db_reader.h"
+#include "sparse_merkle/internal_node.h"
+#include "sparse_merkle/update_batch.h"
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+// This is an implementation detail of the Tree::update mechanism.
+namespace detail {
+
+// All data that is loaded from the DB, manipulated, and/or returned from a
+// call to `update`.
+//
+// A new instance of this structure is created during every update call.
+class UpdateCache {
+ public:
+  UpdateCache(const BatchedInternalNode& root, const std::shared_ptr<IDBReader>& db_reader)
+      : version_(root.version() + 1), db_reader_(db_reader), original_root_(root) {}
+
+  const StaleNodeIndexes& stale() const { return stale_; }
+  const auto& internalNodes() const { return internal_nodes_; }
+  Version version() const { return version_; }
+
+  // Return the root if it's been updated and stored in the cache. Otherwise
+  // return the root at the time of cache creation.
+  const BatchedInternalNode& getRoot();
+
+  // Get a node if it's in the cache, otherwise get it from the DB.
+  // This method assumes the node exists. It is a logic error in the caller if
+  // it does not exist.
+  BatchedInternalNode getInternalNode(const InternalNodeKey& key);
+
+  void putStale(const std::optional<LeafKey>& key);
+  void putStale(const InternalNodeKey& key);
+  void put(const NibblePath& path, const BatchedInternalNode& node);
+  void remove(const NibblePath& path);
+
+ private:
+  // The version of the tree after this update is complete.
+  Version version_;
+  std::shared_ptr<IDBReader> db_reader_;
+  StaleNodeIndexes stale_;
+
+  // The root at the time the cache was created. We don't want to add this to
+  // the cache, because the cache only contains "updated" nodes that are
+  // supposed to be written to disk.
+  BatchedInternalNode original_root_;
+
+  // All the internal nodes related to the current batch update.
+  //
+  // These nodes are mutable and are all being updated to a single version.
+  // Therefore we key them by their NibblePath alone, without a version.
+  std::map<NibblePath, BatchedInternalNode> internal_nodes_;
+};
+
+}  // namespace detail
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/include/sparse_merkle/walker.h
+++ b/storage/include/sparse_merkle/walker.h
@@ -1,0 +1,81 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <stack>
+#include "sparse_merkle/internal_node.h"
+#include "sparse_merkle/update_cache.h"
+
+namespace concord {
+namespace storage {
+namespace sparse_merkle {
+
+// This is an implementation detail of the Tree::update call
+namespace detail {
+
+typedef std::stack<BatchedInternalNode, std::vector<BatchedInternalNode>> NodeStack;
+
+// A class for ascending and descending the tree. This is used for updates.
+class Walker {
+ public:
+  Walker(UpdateCache& cache) : cache_(cache), current_node_(cache.getRoot()) {
+    // Save the version of the root node, in case we only update the root node.
+    stale_version_ = current_node_.version();
+  }
+
+  size_t depth() const { return nibble_path_.length(); }
+  BatchedInternalNode& currentNode() { return current_node_; }
+  Version version() { return cache_.version(); }
+  bool atRoot() { return nibble_path_.empty(); }
+  void appendEmptyNodes(const Hash& key, int nodes_to_create);
+  void descend(const Hash& key, Version next_version);
+
+  // Walk the stack of internal nodes upwards toward the root, updating the
+  // hashes as we go along, and caching the updated nodes.
+  void ascendToRoot(const std::optional<LeafKey>& key);
+  void ascendToRoot();
+
+  // When a key is removed from a BatchedInternalNode, the node will find it,
+  // remove it and inform the caller of the version. It is the callers
+  // responsibility to create a leafKey from the key and version and mark it
+  // stale.
+  void markStale(LeafKey stale) { cache_.putStale(stale); }
+
+  // remove current_node_ and ascend up the tree if not at the root.
+  std::optional<Nibble> removeCurrentNode();
+
+ private:
+  void ascend();
+  std::pair<Nibble, Hash> pop();
+  void markCurrentNodeStale();
+  void cacheCurrentNode();
+
+  // The version of the current node after a call to `descend`, but prior to
+  // user modification. We use it to mark the version prior to modification
+  // stale when we ascend back up the tree.
+  //
+  // If we never ascend, because, for example, a node to delete is "not found",
+  // then we never use the stale_version_;
+  Version stale_version_;
+
+  UpdateCache& cache_;
+  NodeStack stack_;
+  BatchedInternalNode current_node_;
+  NibblePath nibble_path_;
+};
+
+}  // namespace detail
+
+}  // namespace sparse_merkle
+}  // namespace storage
+}  // namespace concord

--- a/storage/src/merkle_tree_db_adapter.cpp
+++ b/storage/src/merkle_tree_db_adapter.cpp
@@ -8,6 +8,7 @@
 #include "blockchain/merkle_tree_serialization.h"
 #include "endianness.hpp"
 #include "Logger.hpp"
+#include "sparse_merkle/update_batch.h"
 #include "sparse_merkle/base_types.h"
 #include "sparse_merkle/keys.h"
 #include "sliver.hpp"
@@ -51,7 +52,7 @@ using namespace detail;
 constexpr auto MAX_BLOCK_ID = std::numeric_limits<BlockId>::max();
 
 // Converts the updates as returned by the merkle tree to key/value pairs suitable for the DB.
-SetOfKeyValuePairs batchToDbUpdates(const Tree::UpdateBatch &batch) {
+SetOfKeyValuePairs batchToDbUpdates(const sparse_merkle::UpdateBatch &batch) {
   SetOfKeyValuePairs updates;
   const Sliver emptySliver;
 

--- a/storage/src/sparse_merkle/base_types.cpp
+++ b/storage/src/sparse_merkle/base_types.cpp
@@ -1,0 +1,43 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+// All freestanding functions must be in a source file
+
+#include "sparse_merkle/base_types.h"
+
+namespace concord::storage::sparse_merkle {
+
+std::ostream& operator<<(std::ostream& os, const Version& version) {
+  os << version.value();
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Nibble& nibble) {
+  os << nibble.hexChar();
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Hash& hash) {
+  for (size_t i = 0; i < Hash::MAX_NIBBLES; i++) {
+    os << hash.getNibble(i).hexChar();
+  }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const NibblePath& path) {
+  for (size_t i = 0; i < path.length(); i++) {
+    os << path.get(i).hexChar();
+  }
+  return os;
+}
+
+}  // namespace concord::storage::sparse_merkle

--- a/storage/src/sparse_merkle/tree.cpp
+++ b/storage/src/sparse_merkle/tree.cpp
@@ -11,22 +11,18 @@
 // LICENSE file.
 
 #include "sparse_merkle/tree.h"
-#include "hash_defs.h"
+#include "sparse_merkle/walker.h"
+
+#include <iostream>
+using namespace std;
 
 using namespace concordUtils;
 
 namespace concord::storage::sparse_merkle {
+using namespace detail;
 
-void insertComplete(Tree::Walker& walker, const BatchedInternalNode::InsertComplete& result) {
-  walker.putStale(result.stale_leaf);
-  // Save the bottom most internal node for the given leaf_key.
-  walker.cacheCurrentNode();
-
-  // Walk the stack of internal nodes upwards toward the root, updating the
-  // hashes as we go along, and caching the updated nodes.
-  while (!walker.atRoot()) {
-    walker.ascend();
-  }
+void insertComplete(Walker& walker, const BatchedInternalNode::InsertComplete& result) {
+  walker.ascendToRoot(result.stale_leaf);
 }
 
 // We have a collision and need to create new internal nodes so that we reach
@@ -37,22 +33,22 @@ void insertComplete(Tree::Walker& walker, const BatchedInternalNode::InsertCompl
 // succeed at the attempt, since this is precisely where they belong after
 // walking the prefix bits they have in common. Both successful inserts return
 // BatchedInternalNode::InsertComplete.
-void handleCollision(Tree::Walker& walker, const LeafChild& stored_child, const LeafChild& new_child) {
+void handleCollision(Walker& walker, const LeafChild& stored_child, const LeafChild& new_child) {
   int nodes_to_create = new_child.key.hash().prefix_bits_in_common(stored_child.key.hash(), walker.depth()) / 4;
   walker.appendEmptyNodes(new_child.key.hash(), nodes_to_create);
-  walker.currentNode().insert(stored_child, walker.depth());
-  auto result = walker.currentNode().insert(new_child, walker.depth());
+  walker.currentNode().insert(stored_child, walker.depth(), walker.version());
+  auto result = walker.currentNode().insert(new_child, walker.depth(), walker.version());
   return insertComplete(walker, std::get<BatchedInternalNode::InsertComplete>(result));
 }
 
 // Insert a LeafChild into the proper BatchedInternalNode. Handle all possible
 // responses and walk the tree as appropriate to get to the correct node, where
 // the insert will succeed.
-void insert(Tree::Walker& walker, const LeafChild& child) {
+void insert(Walker& walker, const LeafChild& child) {
   while (true) {
     Assert(walker.depth() < Hash::MAX_NIBBLES);
 
-    auto result = walker.currentNode().insert(child, walker.depth());
+    auto result = walker.currentNode().insert(child, walker.depth(), walker.version());
 
     if (auto rv = std::get_if<BatchedInternalNode::InsertComplete>(&result)) {
       return insertComplete(walker, *rv);
@@ -67,22 +63,78 @@ void insert(Tree::Walker& walker, const LeafChild& child) {
   }
 }
 
-// TODO: Add support for delete. Only insert/update are supported now.
-Tree::UpdateBatch Tree::update(const SetOfKeyValuePairs& updates, const KeysVector& deleted_keys) {
+void removeBatchedInternalNode(Walker& walker, const std::optional<LeafChild>& promoted) {
+  auto promoted_after_unlink = promoted;
+  while (!walker.atRoot() && walker.currentNode().safeToRemove()) {
+    auto child_key = walker.removeCurrentNode().value();
+    promoted_after_unlink = walker.currentNode().unlinkChild(child_key, walker.version(), promoted_after_unlink);
+  }
+
+  // At this point all empty BatchedInternalNodes have been removed and we
+  // have walked back up the tree.
+  if (promoted_after_unlink) {
+    auto insertResult = walker.currentNode().insert(promoted_after_unlink.value(), walker.depth(), walker.version());
+    Assert(std::holds_alternative<BatchedInternalNode::InsertComplete>(insertResult));
+    walker.ascendToRoot();
+  } else {
+    if (walker.atRoot() && walker.currentNode().safeToRemove()) {
+      walker.removeCurrentNode();
+    } else {
+      walker.ascendToRoot();
+    }
+  }
+}
+
+void remove(Walker& walker, const Hash& key_hash) {
+  while (true) {
+    Assert(walker.depth() < Hash::MAX_NIBBLES);
+
+    auto result = walker.currentNode().remove(key_hash, walker.depth(), walker.version());
+
+    if (auto rv = std::get_if<BatchedInternalNode::RemoveComplete>(&result)) {
+      auto stale = LeafKey(key_hash, rv->version);
+      return walker.ascendToRoot(stale);
+    }
+
+    if (std::holds_alternative<BatchedInternalNode::NotFound>(result)) {
+      // TODO: Log this?
+      return;
+    }
+
+    if (auto rv = std::get_if<BatchedInternalNode::RemoveBatchedInternalNode>(&result)) {
+      walker.markStale(LeafKey(key_hash, rv->removed_version));
+      return removeBatchedInternalNode(walker, rv->promoted);
+    }
+
+    auto next_node_version = std::get<BatchedInternalNode::Descend>(result).next_node_version;
+    walker.descend(key_hash, next_node_version);
+  }
+}
+
+UpdateBatch Tree::update(const SetOfKeyValuePairs& updates, const KeysVector& deleted_keys) {
   reset();
 
   UpdateBatch batch;
   UpdateCache cache(root_, db_reader_);
   const auto version = cache.version();
   Hasher hasher;
+
+  // Deletes come before inserts because it makes more semantic sense. A user can delete a key and then write a new
+  // version, but it makes no sense to add a new version and then delete a key.
+  for (auto& key : deleted_keys) {
+    Walker walker(cache);
+    auto key_hash = hasher.hash(key.data(), key.length());
+    sparse_merkle::remove(walker, key_hash);
+  }
+
   for (auto&& [key, val] : updates) {
     auto leaf_hash = hasher.hash(val.data(), val.length());
     LeafNode leaf_node{val};
     LeafKey leaf_key{hasher.hash(key.data(), key.length()), version};
     LeafChild child{leaf_hash, leaf_key};
-    Walker walker(node_stack_, cache);
+    Walker walker(cache);
     insert(walker, child);
-    batch.leaf_nodes.push_back(std::make_pair(leaf_key, leaf_node));
+    batch.leaf_nodes.emplace_back(leaf_key, leaf_node);
   }
 
   // Create and return the UpdateBatch
@@ -96,82 +148,6 @@ Tree::UpdateBatch Tree::update(const SetOfKeyValuePairs& updates, const KeysVect
   root_ = cache.getRoot();
 
   return batch;
-}
-
-BatchedInternalNode Tree::UpdateCache::getInternalNode(const InternalNodeKey& key) {
-  auto it = internal_nodes_.find(key.path());
-  if (it != internal_nodes_.end()) {
-    return it->second;
-  }
-  return db_reader_->get_internal(key);
-}
-
-void Tree::UpdateCache::putStale(const std::optional<LeafKey>& key) {
-  if (key) {
-    stale_.leaf_keys.push_back(key.value());
-  }
-}
-
-void Tree::UpdateCache::put(const NibblePath& path, const BatchedInternalNode& node) { internal_nodes_[path] = node; }
-
-void Tree::UpdateCache::putStale(const InternalNodeKey& key) { stale_.internal_keys.emplace_back(key); }
-
-void Tree::UpdateCache::remove(const NibblePath& path) { internal_nodes_.erase(path); }
-
-void Tree::Walker::appendEmptyNodes(const Hash& key, int nodes_to_create) {
-  stack_.push(current_node_);
-  for (int i = 0; i < nodes_to_create - 1; i++) {
-    Nibble next_nibble = key.getNibble(depth());
-    nibble_path_.append(next_nibble);
-    stack_.emplace(BatchedInternalNode());
-  }
-  Nibble next_nibble = key.getNibble(depth());
-  nibble_path_.append(next_nibble);
-  current_node_ = BatchedInternalNode();
-}
-
-void Tree::Walker::descend(const Hash& key, Version next_version) {
-  stack_.push(current_node_);
-  Nibble next_nibble = key.getNibble(depth());
-  nibble_path_.append(next_nibble);
-  InternalNodeKey next_internal_key{next_version, nibble_path_};
-  current_node_ = cache_.getInternalNode(next_internal_key);
-  markCurrentNodeStale();
-}
-
-void Tree::Walker::cacheCurrentNode() { cache_.put(nibble_path_, current_node_); }
-
-void Tree::Walker::ascend() {
-  Assert(!stack_.empty());
-  // Get the hash of the updated node, and its location in the parent node
-  Hash hash = current_node_.hash();
-  Nibble child_key = nibble_path_.popBack();
-
-  current_node_ = stack_.top();
-  stack_.pop();
-
-  // We want to just update the hash of the leaf child pointing to the next
-  // BatchedInternalNode. This triggers the root hash of the BatchedInternalNode
-  // to be calculated.
-  InternalChild update{hash, version()};
-  current_node_.write_internal_child_at_level_0(child_key, update);
-  cache_.put(nibble_path_, current_node_);
-}
-
-void Tree::Walker::removeCurrentNode() {
-  markCurrentNodeStale();
-  cache_.remove(nibble_path_);
-  if (!stack_.empty()) {
-    // TODO: Ascend and delete if necessary
-  }
-}
-
-void Tree::Walker::markCurrentNodeStale() {
-  // Don't mark the initial root stale, and don't mark an already cached node
-  // stale.
-  if (current_node_.version() != Version(0) && current_node_.version() != version()) {
-    cache_.putStale(InternalNodeKey(current_node_.version(), nibble_path_));
-  }
 }
 
 }  // namespace concord::storage::sparse_merkle

--- a/storage/src/sparse_merkle/update_cache.cpp
+++ b/storage/src/sparse_merkle/update_cache.cpp
@@ -1,0 +1,45 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "sparse_merkle/update_cache.h"
+
+namespace concord::storage::sparse_merkle::detail {
+
+BatchedInternalNode UpdateCache::getInternalNode(const InternalNodeKey& key) {
+  auto it = internal_nodes_.find(key.path());
+  if (it != internal_nodes_.end()) {
+    return it->second;
+  }
+  return db_reader_->get_internal(key);
+}
+
+void UpdateCache::putStale(const std::optional<LeafKey>& key) {
+  if (key) {
+    stale_.leaf_keys.insert(key.value());
+  }
+}
+
+const BatchedInternalNode& UpdateCache::getRoot() {
+  auto it = internal_nodes_.find(NibblePath());
+  if (it != internal_nodes_.end()) {
+    return it->second;
+  }
+  return original_root_;
+}
+
+void UpdateCache::put(const NibblePath& path, const BatchedInternalNode& node) { internal_nodes_[path] = node; }
+
+void UpdateCache::putStale(const InternalNodeKey& key) { stale_.internal_keys.insert(key); }
+
+void UpdateCache::remove(const NibblePath& path) { internal_nodes_.erase(path); }
+
+}  // namespace concord::storage::sparse_merkle::detail

--- a/storage/src/sparse_merkle/walker.cpp
+++ b/storage/src/sparse_merkle/walker.cpp
@@ -1,0 +1,96 @@
+// Concord
+//
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+#include "sparse_merkle/walker.h"
+#include "assertUtils.hpp"
+
+using namespace concordUtils;
+
+namespace concord::storage::sparse_merkle::detail {
+
+void Walker::appendEmptyNodes(const Hash& key, int nodes_to_create) {
+  stack_.push(current_node_);
+  for (int i = 0; i < nodes_to_create - 1; i++) {
+    Nibble next_nibble = key.getNibble(depth());
+    nibble_path_.append(next_nibble);
+    stack_.emplace(BatchedInternalNode());
+  }
+  Nibble next_nibble = key.getNibble(depth());
+  nibble_path_.append(next_nibble);
+  current_node_ = BatchedInternalNode();
+  stale_version_ = current_node_.version();
+}
+
+void Walker::descend(const Hash& key, Version next_version) {
+  stack_.push(current_node_);
+  Nibble next_nibble = key.getNibble(depth());
+  nibble_path_.append(next_nibble);
+  InternalNodeKey next_internal_key{next_version, nibble_path_};
+  current_node_ = cache_.getInternalNode(next_internal_key);
+  stale_version_ = current_node_.version();
+}
+
+void Walker::ascendToRoot() { ascendToRoot(std::nullopt); }
+
+void Walker::ascendToRoot(const std::optional<LeafKey>& key) {
+  cache_.putStale(key);
+  while (!atRoot()) {
+    ascend();
+  }
+  // Manage root node updates
+  markCurrentNodeStale();
+  cacheCurrentNode();
+}
+
+void Walker::ascend() {
+  Assert(!stack_.empty());
+
+  markCurrentNodeStale();
+  cacheCurrentNode();
+
+  auto [child_key, hash] = pop();
+
+  InternalChild update{hash, version()};
+  current_node_.linkChild(child_key, update);
+}
+
+std::optional<Nibble> Walker::removeCurrentNode() {
+  markCurrentNodeStale();
+  cache_.remove(nibble_path_);
+  if (!atRoot()) {
+    return pop().first;
+  }
+  return std::nullopt;
+}
+
+std::pair<Nibble, Hash> Walker::pop() {
+  Hash hash = current_node_.hash();
+  Nibble child_key = nibble_path_.popBack();
+  current_node_ = stack_.top();
+  stack_.pop();
+
+  // Capture the current version of the node before we update it. This will
+  // allow us to mark it stale on the next ascent.
+  stale_version_ = current_node_.version();
+  return std::make_pair(child_key, hash);
+}
+
+void Walker::markCurrentNodeStale() {
+  // Don't mark the initial root stale, and don't mark an already cached node
+  // stale.
+  if (stale_version_ != Version(0) && stale_version_ != version()) {
+    cache_.putStale(InternalNodeKey(stale_version_, nibble_path_));
+  }
+}
+
+void Walker::cacheCurrentNode() { cache_.put(nibble_path_, current_node_); }
+
+}  // namespace concord::storage::sparse_merkle::detail

--- a/storage/test/merkleTreeAdapter_test.cpp
+++ b/storage/test/merkleTreeAdapter_test.cpp
@@ -449,7 +449,7 @@ TEST(batched_internal, serialization) {
 
   // Full container with LeafChild children.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     for (auto &child : children) {
       child = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
     }
@@ -460,7 +460,7 @@ TEST(batched_internal, serialization) {
 
   // Full container with InternalChild children.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     auto count = 0;
     for (auto &child : children) {
       child = InternalChild{getHash("InternalChild"), defaultBlockId + count};
@@ -473,7 +473,7 @@ TEST(batched_internal, serialization) {
 
   // Full container with alternating children.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     auto internal = false;
     auto count = 0;
     for (auto &child : children) {
@@ -492,7 +492,7 @@ TEST(batched_internal, serialization) {
 
   // 1 LeafChild at the beginning.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[0] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
     const auto node = BatchedInternalNode{};
     ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
@@ -500,7 +500,7 @@ TEST(batched_internal, serialization) {
 
   // 1 LeafChild at the end.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[children.size() - 1] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
     const auto node = BatchedInternalNode{};
     ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
@@ -508,7 +508,7 @@ TEST(batched_internal, serialization) {
 
   // 1 InternalChild at the beginning.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[0] = InternalChild{getHash("InternalChild"), defaultBlockId};
     const auto node = BatchedInternalNode{};
     ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
@@ -516,7 +516,7 @@ TEST(batched_internal, serialization) {
 
   // 1 InternalChild at the end.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[children.size() - 1] = InternalChild{getHash("InternalChild"), defaultBlockId};
     const auto node = BatchedInternalNode{};
     ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
@@ -524,7 +524,7 @@ TEST(batched_internal, serialization) {
 
   // 1 LeafChild at the beginning and one InternalChild at the end.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[0] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
     children[children.size() - 1] = InternalChild{getHash("InternalChild"), defaultBlockId};
     const auto node = BatchedInternalNode{};
@@ -533,7 +533,7 @@ TEST(batched_internal, serialization) {
 
   // 1 InternalChild at the beginning and one LeafChild at the end.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[0] = InternalChild{getHash("InternalChild"), defaultBlockId};
     children[children.size() - 1] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
     const auto node = BatchedInternalNode{};
@@ -542,7 +542,7 @@ TEST(batched_internal, serialization) {
 
   // Children in the middle.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[15] = InternalChild{getHash("InternalChild1"), defaultBlockId};
     children[16] = LeafChild{getHash("LeafChild1"), LeafKey{getHash("LeafKey1"), defaultBlockId}};
     children[17] = InternalChild{getHash("InternalChild2"), defaultBlockId};
@@ -553,7 +553,7 @@ TEST(batched_internal, serialization) {
 
   // Children at the beginning and end.
   {
-    auto children = BatchedInternalNode::ChildrenContainer{};
+    auto children = BatchedInternalNode::Children{};
     children[0] = InternalChild{getHash("InternalChild1"), defaultBlockId + 1};
     children[1] = LeafChild{getHash("LeafChild1"), LeafKey{getHash("LeafKey1"), defaultBlockId + 2}};
     children[2] = InternalChild{getHash("InternalChild2"), defaultBlockId + 3};

--- a/storage/test/sparse_merkle/tree_test.cpp
+++ b/storage/test/sparse_merkle/tree_test.cpp
@@ -10,8 +10,10 @@
 // terms and conditions of the sub-component's license, as noted in the
 // LICENSE file.
 
-#include "gtest/gtest.h"
 #include <memory>
+#include <set>
+
+#include "gtest/gtest.h"
 #include "sparse_merkle/tree.h"
 #include "test_db.h"
 #include "hash_defs.h"
@@ -22,7 +24,7 @@ using namespace std;
 using namespace concordUtils;
 using namespace concord::storage::sparse_merkle;
 
-void db_put(const shared_ptr<TestDB>& db, const Tree::UpdateBatch& batch) {
+void db_put(const shared_ptr<TestDB>& db, const UpdateBatch& batch) {
   for (const auto& [key, val] : batch.internal_nodes) {
     db->put(key, val);
   }
@@ -31,19 +33,130 @@ void db_put(const shared_ptr<TestDB>& db, const Tree::UpdateBatch& batch) {
   }
 }
 
-template <class T>
-void assert_version(uint64_t version, const T& keys) {
+template <typename T>
+::testing::AssertionResult keyVersionMatches(uint64_t version, const T& keys) {
   for (auto& key : keys) {
-    ASSERT_EQ(Version(version), key.version());
+    if (Version(version) != key.version()) {
+      return ::testing::AssertionFailure() << version << " != key.version(): " << key.version().toString();
+    }
   }
+  return ::testing::AssertionSuccess();
 }
-template <class T>
-void assert_node_version(uint64_t version, const T& nodes) {
-  for (auto& [key, _] : nodes) {
-    // Prevent unused variable warning. C++ doesn't allow ignoring in
-    // destructuring yet.
-    (void)_;
-    ASSERT_EQ(Version(version), key.version());
+
+template <typename K, typename V>
+std::vector<K> keys(const std::vector<std::pair<K, V>>& kvpairs) {
+  std::vector<K> rv;
+  for (auto& [key, _] : kvpairs) {
+    (void)_;  // unused variable hack
+    rv.push_back(key);
+  }
+  return rv;
+}
+
+::testing::AssertionResult internalNodeVersionMatches(
+    uint64_t version, std::vector<std::pair<InternalNodeKey, BatchedInternalNode>>& nodes) {
+  for (auto& [key, node] : nodes) {
+    if (Version(version) != key.version()) {
+      return ::testing::AssertionFailure() << version << " != key.version(): " << key.version().toString();
+    }
+    if (Version(version) != node.version()) {
+      return ::testing::AssertionFailure() << version << " != node.version(): " << node.version().toString();
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult hashMatches(const char* key, const Hash& expected) {
+  Hasher hasher;
+  auto hash = hasher.hash(key, strlen(key));
+  if (hash != expected) {
+    return ::testing::AssertionFailure() << "key: " << key << " hashed to " << hash.toString()
+                                         << ", expected: " << expected.toString();
+  }
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult internalKeyExists(const char* path, uint64_t version, std::set<InternalNodeKey> keys) {
+  for (const auto& key : keys) {
+    if (key.path().toString() == path && Version(version) == key.version()) {
+      return ::testing::AssertionSuccess();
+    }
+  }
+  return ::testing::AssertionFailure();
+}
+
+::testing::AssertionResult leafKeyMatches(const char* key, uint64_t version, const LeafKey& expected) {
+  Hasher hasher;
+  auto hash = hasher.hash(key, strlen(key));
+  auto leaf_key = LeafKey(hash, Version(version));
+  if (leaf_key != expected) {
+    return ::testing::AssertionFailure() << "Generated leaf key for key: " << key << ", " << leaf_key.toString()
+                                         << " did not match expected: " << expected.toString();
+  }
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult leafKeyExists(const char* key,
+                                         uint64_t version,
+                                         const std::vector<std::pair<LeafKey, LeafNode>>& kvpairs) {
+  for (const auto& [k, _] : kvpairs) {
+    (void)_;  // unused variable hack
+    auto result = leafKeyMatches(key, version, k);
+    if (result == ::testing::AssertionSuccess()) {
+      return result;
+    }
+  }
+  return ::testing::AssertionFailure();
+}
+
+::testing::AssertionResult leafKeyExists(const char* key, uint64_t version, const std::set<LeafKey>& keys) {
+  for (const auto& k : keys) {
+    auto result = leafKeyMatches(key, version, k);
+    if (result == ::testing::AssertionSuccess()) {
+      return result;
+    }
+  }
+  return ::testing::AssertionFailure();
+}
+
+// Assert that there exists a link from an InternalChild in `linker_node` to `linkee_node`.
+// For the link to be valid, the version and hashes must match.
+::testing::AssertionResult validLinkExists(const InternalNodeKey& linker_key,
+                                           const BatchedInternalNode& linker_node,
+                                           const InternalNodeKey& linkee_key,
+                                           const BatchedInternalNode& linkee_node) {
+  auto depth_of_linker = linker_key.path().length();
+  Nibble key_inside_linker = linkee_key.path().get(depth_of_linker);
+  InternalChild child_inside_linker =
+      std::get<InternalChild>(linker_node.children()[linker_node.nibbleToIndex(key_inside_linker)].value());
+  if (linkee_node.hash() != child_inside_linker.hash || linkee_node.version() != child_inside_linker.version) {
+    return ::testing::AssertionFailure() << "Linkee hash=" << linkee_node.hash().toString()
+                                         << ", version=" << linkee_node.version().toString()
+                                         << " child inside linker hash=" << child_inside_linker.hash.toString()
+                                         << ", version=" << child_inside_linker.version.toString();
+  }
+  return ::testing::AssertionSuccess();
+}
+
+bool leafChildExists(const char* key, uint64_t version, const BatchedInternalNode& node) {
+  auto& children = node.children();
+  return children.end() != std::find_if(children.begin(), children.end(), [&](const std::optional<Child>& c) -> bool {
+           if (c && std::holds_alternative<LeafChild>(c.value())) {
+             return ::testing::AssertionSuccess() == leafKeyMatches(key, version, std::get<LeafChild>(c.value()).key);
+           }
+           return false;
+         });
+}
+
+void debug_print(const UpdateBatch& batch) {
+  cout << "stale keys:" << endl;
+  for (auto& k : batch.stale.internal_keys) {
+    cout << "    " << k.toString() << endl;
+  }
+  cout << "new internal node keys:" << endl;
+  for (auto& [k, _] : batch.internal_nodes) {
+    (void)_;  // unused variable hack
+    cout << "    " << k.toString() << endl;
   }
 }
 
@@ -124,7 +237,7 @@ TEST(tree_tests, insert_multiple_create_single_batched) {
   ASSERT_EQ(2, root.second.numLeafChildren());
 
   // Both leaf nodes should be at version 1
-  assert_node_version(1, batch.leaf_nodes);
+  ASSERT_TRUE(keyVersionMatches(1, keys(batch.leaf_nodes)));
 }
 
 // Insert multiple leaves that create multiple BatchedInternalNode since
@@ -147,20 +260,23 @@ TEST(tree_tests, insert_multiple_create_multiple_batched) {
   ASSERT_EQ(2, batch.internal_nodes.size());
   ASSERT_EQ(2, batch.leaf_nodes.size());
 
-  auto& root = batch.internal_nodes.at(0);
-  ASSERT_EQ(Version(1), root.second.version());
-  ASSERT_NE(PLACEHOLDER_HASH, root.second.hash());
+  auto& [root_key, root_node] = batch.internal_nodes.at(0);
+  ASSERT_EQ(Version(1), root_node.version());
+  ASSERT_NE(PLACEHOLDER_HASH, root_node.hash());
 
   // There should be no leafs in the root
-  ASSERT_EQ(0, root.second.numLeafChildren());
+  ASSERT_EQ(0, root_node.numLeafChildren());
 
   // There should be two leafs in the second node
-  auto& second_node = batch.internal_nodes.at(1);
-  ASSERT_EQ(Version(1), second_node.second.version());
-  ASSERT_EQ(2, second_node.second.numLeafChildren());
+  auto& [second_key, second_node] = batch.internal_nodes.at(1);
+  ASSERT_EQ(Version(1), second_node.version());
+  ASSERT_EQ(2, second_node.numLeafChildren());
+
+  // The root node properly links to the second_node
+  ASSERT_TRUE(validLinkExists(root_key, root_node, second_key, second_node));
 
   // Both leaf nodes should be at version 1
-  assert_node_version(1, batch.leaf_nodes);
+  ASSERT_TRUE(keyVersionMatches(1, keys(batch.leaf_nodes)));
 }
 
 // Perform multiple updates to ensure that we only get back nodes relevant to
@@ -169,6 +285,8 @@ TEST(tree_tests, multiple_updates) {
   std::shared_ptr<TestDB> db(new TestDB);
   Tree tree(db);
   SetOfKeyValuePairs updates;
+
+  // These keys overlap in the first nibble
   updates.emplace(Sliver("key3"), Sliver("val1"));
   updates.emplace(Sliver("key9"), Sliver("val2"));
   auto batch = tree.update(updates);
@@ -185,10 +303,10 @@ TEST(tree_tests, multiple_updates) {
   // There should be 2 internal nodes and 2 leaf nodes
   ASSERT_EQ(2, batch.internal_nodes.size());
   ASSERT_EQ(2, batch.leaf_nodes.size());
-  assert_node_version(1, batch.internal_nodes);
-  assert_node_version(1, batch.leaf_nodes);
+  ASSERT_TRUE(internalNodeVersionMatches(1, batch.internal_nodes));
+  ASSERT_TRUE(keyVersionMatches(1, keys(batch.leaf_nodes)));
 
-  // Insert a new key
+  // Insert a new key that has a different first nibble from the prior 2 keys
   updates.clear();
   updates.emplace(Sliver("key1"), Sliver("val3"));
   batch = tree.update(updates);
@@ -199,11 +317,11 @@ TEST(tree_tests, multiple_updates) {
   ASSERT_EQ(Version(2), batch.stale.stale_since_version);
   ASSERT_EQ(1, batch.stale.internal_keys.size());
   ASSERT_EQ(0, batch.stale.leaf_keys.size());
-  assert_version(1, batch.stale.internal_keys);
+  ASSERT_TRUE(keyVersionMatches(1, batch.stale.internal_keys));
 
   // There should be 1 leaf node at version 2
   ASSERT_EQ(1, batch.leaf_nodes.size());
-  assert_node_version(2, batch.leaf_nodes);
+  ASSERT_TRUE(keyVersionMatches(2, keys(batch.leaf_nodes)));
 
   // Insert an update to a key.
   updates.clear();
@@ -216,25 +334,33 @@ TEST(tree_tests, multiple_updates) {
   ASSERT_EQ(2, batch.stale.internal_keys.size());
   ASSERT_EQ(1, batch.stale.leaf_keys.size());
 
-  // The root node was updated on the second update. But the next
-  // BatchedInternalNode down wasn't, since the udpate inserted into the root
+  // The root node was updated on the insert of key1, but the next
+  // BatchedInternalNode down wasn't, since key1 was inserted into the root
   // node.
-  ASSERT_EQ(Version(2), batch.stale.internal_keys[0].version());
-  ASSERT_EQ(Version(1), batch.stale.internal_keys[1].version());
+  //
+  // Note that since stale nodes are added while ascending the tree, they are
+  // returned in a bottom up order.
+  ASSERT_TRUE(internalKeyExists("b", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("", 2, batch.stale.internal_keys));
 
-  assert_version(1, batch.stale.leaf_keys);
+  ASSERT_TRUE(keyVersionMatches(1, batch.stale.leaf_keys));
 
   // There should two new internal nodes and one new leaf node
   ASSERT_EQ(2, batch.internal_nodes.size());
   ASSERT_EQ(1, batch.leaf_nodes.size());
-  assert_node_version(3, batch.internal_nodes);
-  assert_node_version(3, batch.leaf_nodes);
+  ASSERT_TRUE(internalNodeVersionMatches(3, batch.internal_nodes));
+  ASSERT_TRUE(keyVersionMatches(3, keys(batch.leaf_nodes)));
+
+  // The root node properly links to the second_node
+  auto& [root_key, root_node] = batch.internal_nodes[0];
+  auto& [second_key, second_node] = batch.internal_nodes[1];
+  ASSERT_TRUE(validLinkExists(root_key, root_node, second_key, second_node));
 
   // Inserting a new leaf that matches the first 2 nibbles of an existing key
   // should trigger 3 new internal nodes, a new leaf node, and 2 stale internal
   // nodes.
   // This key was experimentally found by brute force. The first two nibbles
-  // match Hash("key9").
+  // match Hash("key3").
   updates.clear();
   updates.emplace(Sliver("key191"), Sliver("val6"));
   batch = tree.update(updates);
@@ -242,8 +368,8 @@ TEST(tree_tests, multiple_updates) {
 
   ASSERT_EQ(3, batch.internal_nodes.size());
   ASSERT_EQ(1, batch.leaf_nodes.size());
-  assert_node_version(4, batch.internal_nodes);
-  assert_node_version(4, batch.leaf_nodes);
+  ASSERT_TRUE(internalNodeVersionMatches(4, batch.internal_nodes));
+  ASSERT_TRUE(keyVersionMatches(4, keys(batch.leaf_nodes)));
 
   // The leaf node should have the key for 191 only and version 4.
   Hasher hasher;
@@ -253,17 +379,21 @@ TEST(tree_tests, multiple_updates) {
   // The first internal node should have 1 LeafChild ("key1"), the second should have 1
   // LeafChild ("key9"), and the third should have 2 LeafChild(ren) ("key3" and
   // "key191");
-  BatchedInternalNode node1 = batch.internal_nodes[0].second;
-  BatchedInternalNode node2 = batch.internal_nodes[1].second;
-  BatchedInternalNode node3 = batch.internal_nodes[2].second;
+  auto& [key1, node1] = batch.internal_nodes[0];
+  auto& [key2, node2] = batch.internal_nodes[1];
+  auto& [key3, node3] = batch.internal_nodes[2];
   ASSERT_EQ(1, node1.numLeafChildren());
   ASSERT_EQ(1, node2.numLeafChildren());
   ASSERT_EQ(2, node3.numLeafChildren());
 
   // The paths of the node keys in order should be "", "b", "ba"
-  ASSERT_EQ("", batch.internal_nodes[0].first.path().toString());
-  ASSERT_EQ("b", batch.internal_nodes[1].first.path().toString());
-  ASSERT_EQ("ba", batch.internal_nodes[2].first.path().toString());
+  ASSERT_EQ("", key1.path().toString());
+  ASSERT_EQ("b", key2.path().toString());
+  ASSERT_EQ("ba", key3.path().toString());
+
+  // The nodes should linke to each other
+  ASSERT_TRUE(validLinkExists(key1, node1, key2, node2));
+  ASSERT_TRUE(validLinkExists(key2, node2, key3, node3));
 
   // The current version is 4, so stale nodes are stale since 4
   // We aren't overwriting any leaf nodes, so there are no stale leafs. We did
@@ -273,13 +403,664 @@ TEST(tree_tests, multiple_updates) {
   ASSERT_EQ(2, batch.stale.internal_keys.size());
   ASSERT_EQ(0, batch.stale.leaf_keys.size());
 
-  // The paths of the stale node keys should be "" and "b"
-  ASSERT_EQ("", batch.stale.internal_keys[0].path().toString());
-  ASSERT_EQ("b", batch.stale.internal_keys[1].path().toString());
+  // The paths of the stale node keys should be "b" and "" (bottom up order),
+  // and they should exist at version 3.
+  ASSERT_TRUE(internalKeyExists("b", 3, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("", 3, batch.stale.internal_keys));
+}
 
-  // Both the root and node with path "b" should be stale at version 3 since the
-  // last update ovewrote a key at path "b".
-  assert_version(3, batch.stale.internal_keys);
+// Insert 2 keys at the root and remove one of them in a second update. The
+// remove should return a stale root node and an updated root node.
+TEST(tree_tests, remove_complete_at_root_test) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key1"), Sliver("val1"));
+  updates.emplace(Sliver("key2"), Sliver("val2"));
+  auto batch = tree.update(updates);
+  // There should be two leafs in the root
+  ASSERT_EQ(2, batch.internal_nodes[0].second.numLeafChildren());
+  db_put(db, batch);
+
+  // Delete one of the children
+  KeysVector deletes{Sliver("key1")};
+  batch = tree.remove(deletes);
+  db_put(db, batch);
+
+  // The root should only have one leaf child, and should be the only internal
+  // node that needs writing.
+  ASSERT_EQ(1, batch.internal_nodes.size());
+  ASSERT_EQ(0, batch.leaf_nodes.size());
+  auto& [root_key, root_node] = batch.internal_nodes[0];
+  ASSERT_EQ(Version(2), root_key.version());
+  ASSERT_EQ(Version(2), root_node.version());
+  ASSERT_EQ(1, root_node.numLeafChildren());
+
+  // The old root node is the only stale internal node. The deleted LeafKey at
+  // the version 1 should match the hash of "key1".
+  ASSERT_EQ(Version(2), batch.stale.stale_since_version);
+  ASSERT_EQ(1, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 1, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key1", 1, batch.stale.leaf_keys));
+}
+
+// Insert 2 keys that match in the first Nibble, and are inserted at the same
+// InternalNode at depth 1. Deleting one of them should cause the other one to
+// be promoted, and reside in the root. The root is the only new InternalNodeKey
+// to be written.
+TEST(tree_tests, remove_and_promote) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  auto batch = tree.update(updates);
+
+  // There should be 2 internal nodes, with no leaf children in the root node.
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  auto& root_node = batch.internal_nodes[0].second;
+  ASSERT_EQ(0, root_node.numLeafChildren());
+  db_put(db, batch);
+
+  // Delete one of these nodes and cause the other to be promoted.
+  KeysVector deletes{Sliver("key9")};
+  batch = tree.remove(deletes);
+
+  // Only the root node exists in the tree now, and it's at version 2.
+  ASSERT_EQ(1, batch.internal_nodes.size());
+  auto& [root_key, remove_root_node] = batch.internal_nodes[0];
+  ASSERT_EQ("", root_key.path().toString());
+  ASSERT_EQ(Version(2), root_key.version());
+  ASSERT_EQ(Version(2), remove_root_node.version());
+
+  // There are no leaf updates, since key3 was not updated. A pointer
+  // (LeafChild) was just moved to the root node.
+  ASSERT_EQ(0, batch.leaf_nodes.size());
+  ASSERT_EQ(1, remove_root_node.numLeafChildren());
+  ASSERT_TRUE(leafChildExists("key3", 1, remove_root_node));
+
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key9", 1, batch.stale.leaf_keys));
+
+  // Ensure that the bottom most internal node was removed
+  ASSERT_EQ(2, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 1, batch.stale.internal_keys));
+
+  // The hash of the old root should differ from the hash of the new root
+  ASSERT_NE(root_node.hash(), remove_root_node.hash());
+}
+
+// Add 3 nodes such that they all overlap in the first nibble, and two overlap in
+// the second nibble. Thus 1 LeafChild resides at depth 1, and the others reside at depth 2
+// after insert. Removing one of the nodes at depth 2 should cause a promotion
+// to depth 1 such that two LeafChildren live at depth 1.
+TEST(tree_tests, remove_promoted_to_depth_1) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  updates.emplace(Sliver("key191"), Sliver("val3"));
+  auto batch = tree.update(updates);
+
+  // There should be 3 internal nodes, with no leaf children in the root node, 1
+  // leaf child in the second node, and 2 leaf children in the 3rd node.
+  ASSERT_EQ(3, batch.internal_nodes.size());
+  auto& [key1, node1] = batch.internal_nodes[0];
+  auto& [key2, node2] = batch.internal_nodes[1];
+  auto& [key3, node3] = batch.internal_nodes[2];
+
+  ASSERT_EQ(0, node1.numLeafChildren());
+  ASSERT_EQ(1, node2.numLeafChildren());
+  ASSERT_EQ(2, node3.numLeafChildren());
+
+  // The nodes should link to each other
+  ASSERT_TRUE(validLinkExists(key1, node1, key2, node2));
+  ASSERT_TRUE(validLinkExists(key2, node2, key3, node3));
+  db_put(db, batch);
+
+  // Delete one of the nodes at depth 2, in order to trigger promotion.
+  KeysVector deletes{Sliver("key191")};
+  batch = tree.remove(deletes);
+
+  // There is a root node and a node at depth 1 that have been updated.
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  auto& [root_key, root_node] = batch.internal_nodes[0];
+  auto& [depth1_key, depth1_node] = batch.internal_nodes[1];
+  ASSERT_TRUE(internalNodeVersionMatches(2, batch.internal_nodes));
+  ASSERT_EQ("", root_key.path().toString());
+  ASSERT_EQ("b", depth1_key.path().toString());
+
+  ASSERT_TRUE(validLinkExists(root_key, root_node, depth1_key, depth1_node));
+
+  // There are no leaf updates.
+  ASSERT_EQ(0, batch.leaf_nodes.size());
+
+  // The root node still has zero leaf children and the node at depth 1 has 2
+  // children after removal and promotion.
+  //
+  // Note that the version number of these children is still 1, as they were
+  // written in the initial update. The versions of the internal children above
+  // them, including the root of the BatchedInternalnode, have all had their
+  // versions bumped to indicate the update.
+  ASSERT_EQ(0, root_node.numLeafChildren());
+  ASSERT_EQ(2, depth1_node.numLeafChildren());
+  ASSERT_TRUE(leafChildExists("key3", 1, depth1_node));
+  ASSERT_TRUE(leafChildExists("key9", 1, depth1_node));
+
+  // There are 3 old internal keys (root, depth 1, depth 2) and one stale leaf
+  // ("key191").
+  ASSERT_EQ(Version(2), batch.stale.stale_since_version);
+  ASSERT_EQ(3, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("ba", 1, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key191", 1, batch.stale.leaf_keys));
+}
+
+// Add 3 nodes such that they all overlap in the first nibble, and two overlap
+// in the second nibble. Thus 1 LeafChild resides at depth 1, and the others at
+// depth 2 after insert. Removing the LeafChild at depth1 should not cause a
+// promotion to depth 1 for the other 2 nodes because they overlap in 2 nibbles,
+// and therefore share internal nodes at depth 0 and 1 that prohibit promotion.
+TEST(tree_tests, remove_no_promotion_to_depth_1) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  updates.emplace(Sliver("key191"), Sliver("val3"));
+  auto batch = tree.update(updates);
+
+  // There should be 3 internal nodes, with no leaf children in the root node, 1
+  // leaf child in the second node, and 2 leaf children in the 3rd node.
+  ASSERT_EQ(3, batch.internal_nodes.size());
+  ASSERT_EQ(0, batch.internal_nodes[0].second.numLeafChildren());
+  ASSERT_EQ(1, batch.internal_nodes[1].second.numLeafChildren());
+  ASSERT_EQ(2, batch.internal_nodes[2].second.numLeafChildren());
+  db_put(db, batch);
+
+  // Delete the LeafChild in the node at depth1. This should not trigger any promotion.
+  KeysVector deletes{Sliver("key9")};
+  batch = tree.remove(deletes);
+
+  // Only the first two nodes have been updated.
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  ASSERT_TRUE(internalNodeVersionMatches(2, batch.internal_nodes));
+  auto& [root_key, root_node] = batch.internal_nodes[0];
+  auto& [depth1_key, depth1_node] = batch.internal_nodes[1];
+  ASSERT_EQ("", root_key.path().toString());
+  ASSERT_EQ("b", depth1_key.path().toString());
+  ASSERT_TRUE(validLinkExists(root_key, root_node, depth1_key, depth1_node));
+
+  // There are no leaf updates.
+  ASSERT_EQ(0, batch.leaf_nodes.size());
+
+  // The root node still has zero leaf children and the node at depth one has
+  // zero leaf children.
+  //
+  // Note that the version number of these children is still 1, as they were
+  // written in the initial update. The versions of the internal children above
+  // them, including the root of the BatchedInternalnode, have all had their
+  // versions bumped to indicate the update.
+  ASSERT_EQ(0, root_node.numLeafChildren());
+  ASSERT_EQ(0, depth1_node.numLeafChildren());
+
+  // There are 2 old internal keys (root, depth 1) and one stale leaf
+  ASSERT_EQ(Version(2), batch.stale.stale_since_version);
+  ASSERT_EQ(2, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 1, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key9", 1, batch.stale.leaf_keys));
+}
+
+// Add 4 nodes that overlap in the first nibble, with 2 nodes also matching in
+// one second nibble, and 2 nodes matching in the other second nibble. Thus the
+// tree of BatchedInternalNodes will look like the following:
+//
+//                Root
+//                 |
+//                "b"
+//                 |
+//           -------------
+//           |           |
+//         "ba"        "be"
+//
+// Each of "ba" and "be" contain 2 leaf children. Deleting a leaf child from "be"
+// should cause the other leaf child to go to "b", but leave "ba" alone. Thus
+// after the delete, the tree should look like the following:
+//
+//                Root
+//                 |
+//                "b"
+//                 |
+//                "ba"
+//
+TEST(tree_tests, remove_left_node_and_promote_leaving_right_node_alone) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  updates.emplace(Sliver("key191"), Sliver("val3"));
+  updates.emplace(Sliver("key462"), Sliver("val4"));
+  auto batch = tree.update(updates);
+  db_put(db, batch);
+
+  // There should be 4 internal nodes, with no leaf children in the root node (""), no
+  // leaf children in the second node ("b"), and 2 leaf children in the bottom nodes ("ba", "be").
+  ASSERT_EQ(4, batch.internal_nodes.size());
+  auto& [key1, node1] = batch.internal_nodes[0];
+  auto& [key2, node2] = batch.internal_nodes[1];
+  auto& [key3, node3] = batch.internal_nodes[2];
+  auto& [key4, node4] = batch.internal_nodes[3];
+  ASSERT_EQ(0, node1.numLeafChildren());
+  ASSERT_EQ(0, node2.numLeafChildren());
+  ASSERT_EQ(2, node3.numLeafChildren());
+  ASSERT_EQ(2, node4.numLeafChildren());
+  ASSERT_EQ("", key1.path().toString());
+  ASSERT_EQ("b", key2.path().toString());
+  ASSERT_EQ("ba", key3.path().toString());
+  ASSERT_EQ("be", key4.path().toString());
+  ASSERT_TRUE(validLinkExists(key1, node1, key2, node2));
+  ASSERT_TRUE(validLinkExists(key2, node2, key3, node3));
+  ASSERT_TRUE(validLinkExists(key2, node2, key4, node4));
+
+  // Delete a LeafChild at "be". This should should trigger a promotion to "b";
+  KeysVector deletes{Sliver("key9")};
+  batch = tree.remove(deletes);
+
+  // Root and "b" have been updated.
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  ASSERT_TRUE(internalNodeVersionMatches(2, batch.internal_nodes));
+  auto& [root_key, root_node] = batch.internal_nodes[0];
+  auto& [depth1_key, depth1_node] = batch.internal_nodes[1];
+  ASSERT_EQ("", root_key.path().toString());
+  ASSERT_EQ("b", depth1_key.path().toString());
+  ASSERT_TRUE(validLinkExists(root_key, root_node, depth1_key, depth1_node));
+
+  // There are no leaf updates.
+  ASSERT_EQ(0, batch.leaf_nodes.size());
+
+  // The root node still has zero leaf children and the node at depth one ("b"),
+  // has one promoted LeafChild.
+  ASSERT_EQ(0, root_node.numLeafChildren());
+  ASSERT_EQ(1, depth1_node.numLeafChildren());
+  ASSERT_TRUE(leafChildExists("key462", 1, depth1_node));
+
+  // There are 3 old internal keys (root, "b", "be") and one stale leaf
+  ASSERT_EQ(Version(2), batch.stale.stale_since_version);
+  ASSERT_EQ(3, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("be", 1, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key9", 1, batch.stale.leaf_keys));
+}
+
+// This is essentially a combination of the prior 3 tests in succession.
+// We omit the checks after the initial delete since they are done in the prior test.
+TEST(tree_tests, successive_removes) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  updates.emplace(Sliver("key191"), Sliver("val3"));
+  updates.emplace(Sliver("key462"), Sliver("val4"));
+  auto batch = tree.update(updates);
+  db_put(db, batch);
+
+  // Delete a LeafChild at "be". This should should trigger a promotion to "b";
+  KeysVector deletes{Sliver("key9")};
+  batch = tree.remove(deletes);
+  db_put(db, batch);
+
+  // The tree looks like this now:
+  //                Root
+  //                 |
+  //                "b"
+  //                 |
+  //                "ba"
+  //
+  // Deleting the last leaf node from "b" (key462), should not cause this tree
+  // to change, since there is a collision that forces the "ba" node to be
+  // created. In other words there is an InternalLeaf at level 0 of
+  // BatchedInternalNode "b".
+  KeysVector deletes2{Sliver("key462")};
+  batch = tree.remove(deletes2);
+  db_put(db, batch);
+
+  // "" and "b" should be updated.
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  auto& [root_key, root_node] = batch.internal_nodes[0];
+  auto& [b_key, b_node] = batch.internal_nodes[1];
+  ASSERT_EQ("", root_key.path().toString());
+  ASSERT_EQ("b", b_key.path().toString());
+  ASSERT_EQ(0, root_node.numLeafChildren());
+  ASSERT_EQ(0, b_node.numLeafChildren());
+
+  // The root node properly links to the b_node
+  ASSERT_TRUE(validLinkExists(root_key, root_node, b_key, b_node));
+
+  // There are 2 old internal keys (root, "b") and one stale leaf
+  ASSERT_EQ(Version(3), batch.stale.stale_since_version);
+  ASSERT_EQ(2, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 2, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 2, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key462", 1, batch.stale.leaf_keys));
+
+  // The tree looks still like this:
+  //                Root
+  //                 |
+  //                "b"
+  //                 |
+  //                "ba"
+  //
+  // Removing one of the last two remaining keys will cause a promotion of the
+  // other all the way to the root.
+  KeysVector deletes3{Sliver("key3")};
+  batch = tree.remove(deletes3);
+  db_put(db, batch);
+
+  // There is a new version of the root only.
+  ASSERT_EQ(1, batch.internal_nodes.size());
+  auto& [root_key2, root_node2] = batch.internal_nodes[0];
+  ASSERT_EQ("", root_key2.path().toString());
+
+  // There is only one leaf and the root
+  ASSERT_EQ(1, root_node2.numLeafChildren());
+  ASSERT_EQ(1, root_node2.numInternalChildren());
+
+  // There are 3 old internal keys (root, "b", and "ba") and one stale leaf
+  ASSERT_EQ(Version(4), batch.stale.stale_since_version);
+  ASSERT_EQ(3, batch.stale.internal_keys.size());
+  // "ba" was last updated at version 1, "b" and "" at version 3
+  ASSERT_TRUE(internalKeyExists("", 3, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 3, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("ba", 1, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key3", 1, batch.stale.leaf_keys));
+
+  // Removing the last key should remove the root and result in no new nodes.
+  KeysVector deletes4{Sliver("key191")};
+  batch = tree.remove(deletes4);
+  db_put(db, batch);
+
+  ASSERT_EQ(0, batch.internal_nodes.size());
+  ASSERT_EQ(0, batch.leaf_nodes.size());
+
+  ASSERT_EQ(Version(5), batch.stale.stale_since_version);
+  ASSERT_EQ(1, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 4, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key191", 1, batch.stale.leaf_keys));
+}
+
+// Test that removing a key that doesn't exist doesn't modify the tree.
+TEST(tree_tests, test_remove_not_found) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  updates.emplace(Sliver("key462"), Sliver("val4"));
+  auto batch = tree.update(updates);
+  db_put(db, batch);
+
+  // Delete the LeafChild in the node at depth1. This should not trigger any promotion.
+  KeysVector deletes{Sliver("key191")};
+  batch = tree.remove(deletes);
+
+  ASSERT_EQ(0, batch.internal_nodes.size());
+  ASSERT_EQ(0, batch.leaf_nodes.size());
+  ASSERT_EQ(0, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+}
+
+TEST(tree_tests, bulk_add_followed_by_bulk_remove) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key1"), Sliver("val1"));
+  updates.emplace(Sliver("key2"), Sliver("val2"));
+  updates.emplace(Sliver("key3"), Sliver("val3"));
+  auto batch1 = tree.update(updates);
+  db_put(db, batch1);
+
+  // Delete the LeafChild in the node at depth1. This should not trigger any promotion.
+  KeysVector deletes{Sliver("key1"), Sliver("key2"), Sliver("key3")};
+  auto batch2 = tree.remove(deletes);
+
+  // The nodes added in batch 1 should be removed in batch 2.
+  std::set<InternalNodeKey> inserted_internal_keys;
+  std::for_each(batch1.internal_nodes.begin(), batch1.internal_nodes.end(), [&inserted_internal_keys](const auto& p) {
+    inserted_internal_keys.insert(p.first);
+  });
+  std::set<LeafKey> inserted_leaf_keys;
+  std::for_each(batch1.leaf_nodes.begin(), batch1.leaf_nodes.end(), [&inserted_leaf_keys](const auto& p) {
+    inserted_leaf_keys.insert(p.first);
+  });
+  std::set<LeafKey> stale_leaf_keys(batch2.stale.leaf_keys.begin(), batch2.stale.leaf_keys.end());
+
+  ASSERT_EQ(inserted_internal_keys, batch2.stale.internal_keys);
+  ASSERT_EQ(inserted_leaf_keys, stale_leaf_keys);
+}
+
+// Add 4 nodes that overlap in the first nibble, with 2 nodes also matching in
+// one second nibble, and 2 nodes matching in the other second nibble. Thus the
+// tree of BatchedInternalNodes will look like the following:
+//
+//                Root
+//                 |
+//                "b"
+//                 |
+//           -------------
+//           |           |
+//         "ba"        "be"
+//
+// Each of "ba" and "be" contain 2 leaf children. Deleting a leaf child from "be"
+// should cause the other leaf child to go to "b", but leave "ba" alone. Thus
+// after the delete, the tree should look like the following:
+//
+//                Root
+//                 |
+//                "b"
+//                 |
+//                "ba"
+//
+// We then add back in the deleted key and ensure that the tree returns to the
+// original shape. Note that we leave out the assertions for the first addition
+// and removal since we already check the correctness in
+// `remove_left_node_and_promote_leaving_right_node_alone`.
+TEST(tree_tests, add_remove_add) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  updates.emplace(Sliver("key191"), Sliver("val3"));
+  updates.emplace(Sliver("key462"), Sliver("val4"));
+  auto batch1 = tree.update(updates);
+  db_put(db, batch1);
+
+  // Delete a LeafChild at "be". This should should trigger a promotion to "b";
+  KeysVector deletes{Sliver("key9")};
+  auto batch2 = tree.remove(deletes);
+  db_put(db, batch2);
+
+  // Add back in the deleted key. This should recreate "be".
+  SetOfKeyValuePairs updates2;
+  updates2.emplace(Sliver("key9"), Sliver("val4"));
+  auto batch3 = tree.update(updates2);
+
+  // There should be 3 modified internal nodes, with no leaf children in the root node (""), no
+  // leaf children in the second node ("b"), and 2 leaf children in the recreated bottom node ("be").
+  ASSERT_EQ(3, batch3.internal_nodes.size());
+  auto& [key1, node1] = batch3.internal_nodes[0];
+  auto& [key2, node2] = batch3.internal_nodes[1];
+  auto& [key3, node3] = batch3.internal_nodes[2];
+  ASSERT_EQ(0, node1.numLeafChildren());
+  ASSERT_EQ(0, node2.numLeafChildren());
+  ASSERT_EQ(2, node3.numLeafChildren());
+  ASSERT_EQ("", key1.path().toString());
+  ASSERT_EQ("b", key2.path().toString());
+  ASSERT_EQ("be", key3.path().toString());
+  ASSERT_TRUE(validLinkExists(key1, node1, key2, node2));
+  ASSERT_TRUE(validLinkExists(key2, node2, key3, node3));
+  ASSERT_TRUE(leafChildExists("key462", 1, node3));
+  ASSERT_TRUE(leafChildExists("key9", 3, node3));
+
+  // There is one leaf update
+  ASSERT_EQ(1, batch3.leaf_nodes.size());
+  ASSERT_EQ(Version(3), batch3.leaf_nodes[0].first.version());
+  ASSERT_TRUE(hashMatches("key9", batch3.leaf_nodes[0].first.hash()));
+  ASSERT_EQ(Sliver("val4"), batch3.leaf_nodes[0].second.value);
+
+  // There should be 2 stale internal nodes ("" and "b") and no stale leaves
+  ASSERT_EQ(Version(3), batch3.stale.stale_since_version);
+  ASSERT_EQ(2, batch3.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 2, batch3.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 2, batch3.stale.internal_keys));
+  ASSERT_EQ(0, batch3.stale.leaf_keys.size());
+}
+
+TEST(tree_tests, mixed_add_and_remove_in_one_update) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+
+  // Add a few initial keys so we have something to delete. The tree after
+  // addition looks like this, with 2 leaf children in each of the bottom nodes. We
+  // don't bother with assertions since this same structure is used in other
+  // tests.
+  //
+  //                Root
+  //                 |
+  //                "b"
+  //                 |
+  //           -------------
+  //           |           |
+  //         "ba"        "be"
+  SetOfKeyValuePairs updates;
+  updates.emplace(Sliver("key3"), Sliver("val1"));
+  updates.emplace(Sliver("key9"), Sliver("val2"));
+  updates.emplace(Sliver("key191"), Sliver("val3"));
+  updates.emplace(Sliver("key462"), Sliver("val4"));
+  auto batch = tree.update(updates);
+  db_put(db, batch);
+
+  // Add two new keys that differ from all other keys in the first nibble. This
+  // will result in their leaf children living in the root node.
+  SetOfKeyValuePairs updates2;
+  updates2.emplace("key1", Sliver("val10"));
+  updates2.emplace("key2", Sliver("val11"));
+
+  // Delete a LeafChild at "be". This should should trigger a promotion to "b";
+  KeysVector deletes{Sliver("key9")};
+  batch = tree.update(updates2, deletes);
+
+  // Ensure that the tree looks like the following after this update:
+  //                Root
+  //                 |
+  //                "b"
+  //                 |
+  //                "ba"
+  // The two newly inserted keys ("key1" and "key2"), will end up with leaf
+  // children in the root node. Key9 will trigger the removal of
+  // BatchedInternalNode "be", and the promotion of "key462" into "b". "ba" will
+  // retain the same two leaf children ("key3" and "key191")
+  ASSERT_EQ(2, batch.internal_nodes.size());
+  ASSERT_TRUE(internalNodeVersionMatches(2, batch.internal_nodes));
+  auto& [root_key, root_node] = batch.internal_nodes[0];
+  auto& [b_key, b_node] = batch.internal_nodes[1];
+  ASSERT_EQ("", root_key.path().toString());
+  ASSERT_EQ("b", b_key.path().toString());
+  ASSERT_TRUE(validLinkExists(root_key, root_node, b_key, b_node));
+
+  // There are two leaf updates.
+  ASSERT_EQ(2, batch.leaf_nodes.size());
+  ASSERT_TRUE(leafKeyExists("key1", 2, batch.leaf_nodes));
+  ASSERT_TRUE(leafKeyExists("key2", 2, batch.leaf_nodes));
+
+  ASSERT_EQ(2, root_node.numLeafChildren());
+  ASSERT_TRUE(leafChildExists("key1", 2, root_node));
+  ASSERT_TRUE(leafChildExists("key2", 2, root_node));
+
+  // "b" should have one promoted leaf child
+  ASSERT_EQ(1, b_node.numLeafChildren());
+  ASSERT_TRUE(leafChildExists("key462", 1, b_node));
+
+  // There are 3 old internal keys (root, "b", "be") and one stale leaf
+  ASSERT_EQ(Version(2), batch.stale.stale_since_version);
+  ASSERT_EQ(3, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("b", 1, batch.stale.internal_keys));
+  ASSERT_TRUE(internalKeyExists("be", 1, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key9", 1, batch.stale.leaf_keys));
+}
+
+// Adding and removing the same key in a single update should cause the key to be added.
+TEST(tree_tests, add_and_remove_of_same_key_in_single_update_add_wins) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  SetOfKeyValuePairs updates;
+  updates.emplace("key1", Sliver("val1"));
+  KeysVector deletes{Sliver("key1")};
+  auto batch = tree.update(updates, deletes);
+
+  // There's a single InternalNode and a single LeafNode.
+  ASSERT_EQ(1, batch.internal_nodes.size());
+  auto root_node = batch.internal_nodes[0].second;
+  ASSERT_EQ(1, root_node.numLeafChildren());
+  ASSERT_TRUE(leafChildExists("key1", 1, root_node));
+
+  ASSERT_EQ(1, batch.leaf_nodes.size());
+  ASSERT_TRUE(leafKeyExists("key1", 1, batch.leaf_nodes));
+
+  // There were no stale nodes since this is the first insert
+  ASSERT_EQ(Version(1), batch.stale.stale_since_version);
+  ASSERT_EQ(0, batch.stale.internal_keys.size());
+  ASSERT_EQ(0, batch.stale.leaf_keys.size());
+}
+
+// Adding and removing the same key that already exists results in the new version being added.
+TEST(tree_tests, add_and_remove_of_same_existing_key_in_single_update_add_wins) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  // Add an initial version of key1
+  SetOfKeyValuePairs updates;
+  updates.emplace("key1", Sliver("val1"));
+  auto batch = tree.update(updates);
+  db_put(db, batch);
+
+  SetOfKeyValuePairs updates2;
+  updates2.emplace("key1", Sliver("val2"));
+  KeysVector deletes{Sliver("key1")};
+  batch = tree.update(updates2, deletes);
+  db_put(db, batch);
+
+  // There's a single InternalNode and a single LeafNode.
+  ASSERT_EQ(1, batch.internal_nodes.size());
+  auto root_node = batch.internal_nodes[0].second;
+  ASSERT_EQ(1, root_node.numLeafChildren());
+  ASSERT_TRUE(leafChildExists("key1", 2, root_node));
+
+  ASSERT_EQ(1, batch.leaf_nodes.size());
+  ASSERT_TRUE(leafKeyExists("key1", 2, batch.leaf_nodes));
+  ASSERT_EQ(string("val2"), batch.leaf_nodes[0].second.value.toString());
+
+  // There's a single stale node
+  ASSERT_EQ(Version(2), batch.stale.stale_since_version);
+  ASSERT_EQ(1, batch.stale.internal_keys.size());
+  ASSERT_TRUE(internalKeyExists("", 1, batch.stale.internal_keys));
+  ASSERT_EQ(1, batch.stale.leaf_keys.size());
+  ASSERT_TRUE(leafKeyExists("key1", 1, batch.stale.leaf_keys));
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This commit builds upon the previous work that enabled deletion of
individual keys inside BatchedInternalNodes. This enhances the update
functionality, such that keys can be removed as well as added and
overwritten during a `Tree::update` call.

A remove operation is the inverse of an addition, and consequently, must
reverse consequences of addition like splitting nodes. For example,
given a tree with depth 2, that looks like the following, where there
are 2 keys in the bottom BatchedInternalNode, labeled with it's nibble
path, "b":

      Root
       |
      "b"

If the hashes of the two keys are "bax" and "bex", and "bax" is
removed, then the "b" node will also be removed, and "bex" will be
**promoted** to live in the root node. Furthermore, "bex" will move up the
4-level tree inside the root BatchedInternalNode such that it resides at
the highest level in that internal tree where it has a corresponding
peer node. If "bex" is the only child in the root node, then it will
live at depth 1, right under the root of the BatchedInternalNode tree.

Note that if the tree was deeper, it is possible that "bex" would be
promoted all the way to the root still. An example of this is if the two
keys were "bex" and "bey". They would then generate a
BatchedInternalNode at depth 3 named "be", as in the tree below:

     Root
      |
     "b"
      |
     "be"

Removing one of them would cause the other to move upwards until it
reached the root.

The purpose of these examples is to display the primary invariant of a
remove operation on a tree:

    After the removal of a key on a tree, the tree should look the same
    as if the key was never inserted, without regards to versions.

In other words we should maintain the shape of the tree from before a
key is added, after that key is removed.

It's important to realize, that this promotion/compaction, while
computationally more complex, is actually an optimization. Without it,
new versions of BatchedInternalNodes further down the tree would need to
be written to disk.  Additionally, proofs would require more reads from
disks given a deeper tree, but the same number of keys. We always want
to keep the BatchedInternalNodes as densely populated as possible to
reduce disk IOPS.

A key component of the algorithm is the `Walker` class, that manages
loading and caching BatchedInternalNodes as part of the tree traversal.
It also manages the tracking of stale BatchedInternalNodes.
It is used for both insertion and removal of keys. The architectural
separation is such that the Walker is supposed to walk the tree and then
the Tree code itself will mutate the current BatchedInternalNode. This
isn't 100% true, but that's how you can think about it. Additionally,
the walker tries to abstract the cache from the insert and remove
algorithms. This isn't 100% true either, as stale Leafs are still
directly marked from the Tree code.

Many tests were added that construct trees of certain shapes and remove
keys to trigger different code paths. These tests use the following
types of assertions upon the UpdateBatches returned from update
operations to help ensure correctness:
 * The correct nodes and keys are updated
 * The updated nodes are properly linked to form a subtree
 * The correct stale nodes are returned
 * The nodes contain the correct keys
 * The nodes have the proper internal shape

Additionally, other functionality was added as part of this PR:
 * `toString()` methods were added for many types to aid in debugging
 * Types such as `UpdateCache` and `Walker` were moved into their own
 files
 * Base types were enhanced with `<<` operators to obviate the need for
 string allocation in future logging calls.
 * gitignore was enhanced to ignore apollo test files