### PR TITLE
Fix usage of invalid RocksDB iterators

### DIFF
--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -401,10 +401,15 @@ KeyValuePair ClientIterator::seekAtLeast(const Sliver &_searchKey) {
  * @return The previous key value pair.
  */
 KeyValuePair ClientIterator::previous() {
-  m_iter->Prev();
-
   if (!m_iter->Valid()) {
-    LOG_ERROR(logger, "Iterator out of bounds");
+    LOG_ERROR(logger, "Iterator is not valid");
+    m_status = Status::GeneralError("Iterator is not valid");
+    return KeyValuePair();
+  }
+  m_iter->Prev();
+  if (!m_iter->Valid()) {
+    LOG_WARN(logger, "No previous key");
+    m_status = Status::GeneralError("No previous key");
     return KeyValuePair();
   }
 
@@ -429,9 +434,14 @@ KeyValuePair ClientIterator::next() {
     LOG_DEBUG(logger, "Reading count = " << g_rocksdb_called_read);
   }
 
+  if (!m_iter->Valid()) {
+    LOG_ERROR(logger, "Iterator is not valid");
+    m_status = Status::GeneralError("Iterator is not valid");
+    return KeyValuePair();
+  }
   m_iter->Next();
   if (!m_iter->Valid()) {
-    LOG_ERROR(logger, "No next key");
+    LOG_WARN(logger, "No next key");
     m_status = Status::GeneralError("No next key");
     return KeyValuePair();
   }


### PR DESCRIPTION
Remove calls to rocksdb::Iterator::Next()/Prev()/key()/value() when the
iterator is invalid. Documentation in iterator.h specifies that above
methods require a valid iterator. Assumption is that if the iterator is
invalid, behavior would be undefined.