### PR TITLE
Add IObjectStoreClient for Read Only Replica usage

### DIFF
--- a/storage/include/storage/iobject_store_client.h
+++ b/storage/include/storage/iobject_store_client.h
@@ -1,0 +1,44 @@
+// Copyright 2020 VMware, all rights reserved
+
+#pragma once
+
+#include "sliver.hpp"
+#include "status.hpp"
+#include "db_interface.h"
+
+#define OUT
+
+namespace concord::storage {
+
+using concordUtils::Sliver;
+using concordUtils::Status;
+
+// The interface for object store clients
+class IObjectStoreClient {
+  virtual Status get(const Sliver& key, OUT Sliver& outValue) = 0;
+  virtual Status put(const Sliver& key, const Sliver& value) = 0;
+  virtual Status del(const Sliver& key) = 0;
+
+  // We don't just return bool, because we need to know if the operation fails
+  // due to object store unavailability.
+  virtual Status objectExists(const Sliver& key) = 0;
+};
+
+// An implementation of IObjectStoreClient for a database backed by an IDBClient
+class DbObjectStoreClient : public IObjectStoreClient {
+ public:
+  DbObjectStoreClient(const std::shared_ptr<IDBClient>& db) : db_(db) {}
+
+  Status get(const Sliver& key, OUT Sliver& outValue) override { return db_->get(key, outValue); }
+  Status put(const Sliver& key, const Sliver& value) override { return db_->put(key, value); }
+  Status del(const Sliver& key) override { return db_->del(key); }
+  Status objectExists(const Sliver& key) override {
+    Sliver unused;
+    return db_->get(key, unused);
+  }
+
+ private:
+  std::shared_ptr<IDBClient> db_;
+};
+
+}  // namespace concord::storage


### PR DESCRIPTION
Currently the code in #394 has a concrete ObjectStoreClient inherit
from the IDBClient pure abstract class. However, the IDBClient interface
is very powerful and object stores cannot implement it in its entirety.
Therefore the implementation of ObjectStoreClient implements most
methods with the following:

      throw std::logic_error("Not implemented for ECS S3 object store");

In addition to this, object stores have different capabilities and as
such the ObjectStoreClient class has methods not inherited from the
IDBClient interface. This leads to downcasting in order to call these
methods.

Both incomplete inheritence and downcasting suggest that an
ObjectStoreClient should not inherit from IDBClient.

The rationale for doing it this way was to be able to test the
ReadOnlyReplica (specifically RorAppState) without an available object
store. We could then instead use the MemoryDBClient or RocksdbClient for
testing via the same interface.

This commit instead introduces an IObjectStoreClient interface that can
be used as the basis for interacting with any object store in a generic
manner. To satisfy the goal of being able to use the MemoryDBClient and
RocksDBCient, we implement the interface in a DbObjectStoreClient that
can be used during testing. This allows a more complete implementation of the
production ObjectStoreClient without the need for unusable methods, and
prevents the need to downcast during testing.

It is suggested that the code in #394 use the IObjectStoreClient
abstraction instead of the IDBClient abstraction to represent
ObjectStores, and to rename the currently implemented ObjectStoreClient
to `S3ObjectStoreClient` since it uses the S3 API. To maintain the
abstraction, and prevent downcasting, the instantiation of the
S3ObjectStoreClient can be done differently, and then the
IObjectStoreClient used everywhere.