### PR TITLE
[Apollo] Long-running tests Make some of existing decorators optional

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -75,7 +75,8 @@ def with_trio(async_fn):
     """ Decorator for running a coroutine (async_fn) with trio. """
     @wraps(async_fn)
     def trio_wrapper(*args, **kwargs):
-        if "bft_network" in kwargs:
+        if "already_in_trio" in kwargs:
+            kwargs.pop("already_in_trio")
             return async_fn(*args, **kwargs)
         else:
             return trio.run(async_fn, *args, **kwargs)


### PR DESCRIPTION
Add the option to get bft_network from the calling function on @with_trio and @with_bft_network, then we just send it to the async_fn.

Tests that will run from other tests with already initialized bft_network will pass the creation of new bft_network and just run the test.
The same with with_trio decorator, if we already made a trio.run so we cant make it again so we are checking if it already made and if it is (the times when a test called from another test) we just call the requested test.