### PR TITLE
Simplify key searches by introducing seekAtMost()

### DIFF
--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -39,6 +39,7 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
   virtual KeyValuePair first() override;
   virtual KeyValuePair last() override;
   virtual KeyValuePair seekAtLeast(const Sliver &_searchKey) override;
+  virtual KeyValuePair seekAtMost(const Sliver &_searchKey) override;
   virtual KeyValuePair previous() override;
   virtual KeyValuePair next() override;
   virtual KeyValuePair getCurrent() override;

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -40,6 +40,7 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
   concordUtils::KeyValuePair first() override;
   concordUtils::KeyValuePair last() override;
   concordUtils::KeyValuePair seekAtLeast(const concordUtils::Sliver& _searchKey) override;
+  concordUtils::KeyValuePair seekAtMost(const concordUtils::Sliver& _searchKey) override;
   concordUtils::KeyValuePair previous() override;
   KeyValuePair next() override;
   KeyValuePair getCurrent() override;

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -73,6 +73,8 @@ class IDBClient {
     virtual KeyValuePair last() = 0;
     // Returns next keys if not found for this key
     virtual KeyValuePair seekAtLeast(const Sliver& _searchKey) = 0;
+    // Returns the key value pair of the last key which is less than or equal to _searchKey
+    virtual KeyValuePair seekAtMost(const Sliver& _searchKey) = 0;
     virtual KeyValuePair previous() = 0;
     virtual KeyValuePair next() = 0;
     virtual KeyValuePair getCurrent() = 0;

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -190,6 +190,41 @@ KeyValuePair ClientIterator::seekAtLeast(const Sliver &_searchKey) {
 }
 
 /**
+ * @brief Returns the key value pair of the last key which is less than or equal
+ * to _searchKey.
+ *
+ *  @param _searchKey Key to search for.
+ *  @return Key value pair of the last key which is less or equal to
+ *  _searchKey.
+ */
+KeyValuePair ClientIterator::seekAtMost(const Sliver &_searchKey) {
+  const auto &map = m_parentClient->getMap();
+  if (map.empty()) {
+    m_current = map.end();
+    LOG_WARN(logger, "Key " << _searchKey << " not found");
+    return KeyValuePair();
+  }
+
+  // Find keys that are greater than or equal to the search key.
+  m_current = map.lower_bound(_searchKey);
+  if (m_current == map.end()) {
+    // If there are no keys that are greater than or equal to the search key, then it means the last one is less than
+    // the search key. Therefore, go back from the end iterator.
+    --m_current;
+  } else if (_searchKey != m_current->first) {
+    // We have found a key that is greater than the search key. If it is not the first element, it means that the
+    // previous one will be less than the search key. If it is the first element, it means there are no keys that are
+    // less than the search key and we return an empty key/value pair.
+    if (m_current != map.begin()) {
+      --m_current;
+    } else {
+      return KeyValuePair();
+    }
+  }
+  return KeyValuePair(m_current->first, m_current->second);
+}
+
+/**
  * @brief Decrements the iterator.
  *
  * Decrements the iterator and returns the previous key value pair.

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -418,6 +418,29 @@ KeyValuePair ClientIterator::seekAtLeast(const Sliver &_searchKey) {
 }
 
 /**
+ * @brief Returns the key value pair of the last key which is less than or equal
+ * to _searchKey.
+ *
+ * @param _searchKey Key to search for.
+ * @return Key value pair of the last key which is less than or equal to
+ *         _searchKey.
+ */
+KeyValuePair ClientIterator::seekAtMost(const Sliver &_searchKey) {
+  ++g_rocksdb_called_read;
+  if (g_rocksdb_print_measurements) {
+    LOG_DEBUG(logger, "Reading count = " << g_rocksdb_called_read << ", key " << _searchKey);
+  }
+
+  m_iter->SeekForPrev(toRocksdbSlice(_searchKey));
+  if (!m_iter->Valid()) {
+    return KeyValuePair();
+  }
+
+  m_status = Status::OK();
+  return KeyValuePair(copyRocksdbSlice(m_iter->key()), copyRocksdbSlice(m_iter->value()));
+}
+
+/**
  * @brief Decrements the iterator.
  *
  * Decrements the iterator and returns the previous key value pair.


### PR DESCRIPTION
A typical operation on merkle tree keys is to search for a key that is
less than or equal to a given key. Current implementation uses
seekAtLeast() and additional logic to implement these kind of searches.
This PR aims to simplify code by introducing the seekAtMost() method
that can be used in the mentioned cases.