### PR TITLE
Disable conan caching in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,3 @@ script:
 cache:
   ccache: true
   pip: true
-  directories:
-    - $HOME/.conan


### PR DESCRIPTION
Reason: conan build of gtest is failing for certain CI configurations (incl. clang)