### PR TITLE
Enable conan caching in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ script:
 cache:
   ccache: true
   pip: true
+  directories:
+    - $HOME/.conan


### PR DESCRIPTION
Disabling the Conan cache resulted in a significant slow-down of the build process. In this PR we attempt to re-enable it.