### PR TITLE
Skipping n=4 for Apollo tests

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -51,7 +51,7 @@ def interesting_configs(selected=None):
     if selected is None:
         selected=lambda *config: True
 
-    bft_configs = [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
+    bft_configs = [#{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
                    {'n': 6, 'f': 1, 'c': 1, 'num_clients': 4},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': 4},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 4}


### PR DESCRIPTION
A recent combination of growing build times and increasing number of Apollo tests has led to CI jobs exceeding 50 min of execution. In such cases Travis just interrupts the job and results in CI failure, and blocked PRs/failed master.

Until we find a solution to those Travis limitations, I suggest to only run Apollo for the following BFT configurations:
 * n=6, f=1, c=1
 * n=7, f=2, c=0

Doing so provides sufficient coverage of the BFT parameters, while significantly reducing the overall duration of CI jobs.