### PR TITLE
Dump concord-bft metrics periodically

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -125,7 +125,7 @@ struct Config {
   uint32_t maxAcceptableMsgDelayMilli = 60000;                    // 1 minute
   uint32_t sourceReplicaReplacementTimeoutMilli = 5000;           // 5 seconds
   uint32_t fetchRetransmissionTimeoutMilli = 250;                 // ms
-  uint64_t metricsDumpIntervalSeconds = 600;                      // sec
+  std::chrono::seconds metricsDumpIntervalSeconds;                // sec
 };
 
 // creates an instance of the state transfer module.

--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -125,6 +125,7 @@ struct Config {
   uint32_t maxAcceptableMsgDelayMilli = 60000;                    // 1 minute
   uint32_t sourceReplicaReplacementTimeoutMilli = 5000;           // 5 seconds
   uint32_t fetchRetransmissionTimeoutMilli = 250;                 // ms
+  uint64_t metricsDumpIntervalSeconds = 600;                      // sec
 };
 
 // creates an instance of the state transfer module.

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -104,6 +104,8 @@ struct ReplicaConfig {
   // throughput and number of messages sent.
   bool debugStatisticsEnabled = false;
 
+  // Metrics dump interval
+  uint64_t metricsDumpIntervalSeconds = 600;
   /**
    * create a singleton instance from this object
    * call to this function will have effect only for the first time
@@ -162,6 +164,7 @@ class ReplicaConfigSingleton {
   uint32_t GetMaxNumOfReservedPages() const { return config_->maxNumOfReservedPages; }
   uint32_t GetSizeOfReservedPage() const { return config_->sizeOfReservedPage; }
   uint32_t GetNumOfReplicas() const { return 3 * config_->fVal + 2 * config_->cVal + 1; }
+  uint64_t getMetricsDumpInterval() const { return config_->metricsDumpIntervalSeconds; }
 
  private:
   friend struct ReplicaConfig;

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -164,7 +164,7 @@ class ReplicaConfigSingleton {
   uint32_t GetMaxNumOfReservedPages() const { return config_->maxNumOfReservedPages; }
   uint32_t GetSizeOfReservedPage() const { return config_->sizeOfReservedPage; }
   uint32_t GetNumOfReplicas() const { return 3 * config_->fVal + 2 * config_->cVal + 1; }
-  uint64_t getMetricsDumpInterval() const { return config_->metricsDumpIntervalSeconds; }
+  uint64_t GetMetricsDumpInterval() const { return config_->metricsDumpIntervalSeconds; }
 
  private:
   friend struct ReplicaConfig;

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -151,8 +151,8 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
       randomGen_{randomDevice_()},
       sourceSelector_{SourceSelector(
           allOtherReplicas(), config.fetchRetransmissionTimeoutMilli, config.sourceReplicaReplacementTimeoutMilli)},
-      last_dump_time_(0),
-      dump_interval_in_sec_{config.metricsDumpIntervalSeconds},
+      last_metrics_dump_time_(0),
+      metrics_dump_interval_in_sec_{config.metricsDumpIntervalSeconds},
       metrics_component_{
           concordMetrics::Component("bc_state_transfer", std::make_shared<concordMetrics::Aggregator>())},
 
@@ -607,8 +607,8 @@ void BCStateTran::onTimer() {
   // Dump metrics to log
   auto currTimeForDumping =
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch());
-  if (currTimeForDumping - last_dump_time_ >= dump_interval_in_sec_) {
-    last_dump_time_ = currTimeForDumping;
+  if (currTimeForDumping - last_metrics_dump_time_ >= metrics_dump_interval_in_sec_) {
+    last_metrics_dump_time_ = currTimeForDumping;
     LOG_INFO(STLogger, "--BCStateTransfer metrics dump--" + metrics_component_.ToJson());
   }
   auto currTime = getMonotonicTimeMilli();

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -319,8 +319,8 @@ class BCStateTran : public IStateTransfer {
 
  private:
   void loadMetrics();
-  std::chrono::seconds last_dump_time_;
-  std::chrono::seconds dump_interval_in_sec_;
+  std::chrono::seconds last_metrics_dump_time_;
+  std::chrono::seconds metrics_dump_interval_in_sec_;
   concordMetrics::Component metrics_component_;
 
   typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -319,8 +319,8 @@ class BCStateTran : public IStateTransfer {
 
  private:
   void loadMetrics();
-  uint64_t last_dump_time_ = 0;
-  uint64_t dump_interval_in_sec_ = 600;
+  std::chrono::seconds last_dump_time_;
+  std::chrono::seconds dump_interval_in_sec_;
   concordMetrics::Component metrics_component_;
 
   typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -319,6 +319,8 @@ class BCStateTran : public IStateTransfer {
 
  private:
   void loadMetrics();
+  uint64_t last_dump_time_ = 0;
+  uint64_t dump_interval_in_sec_ = 600;
   concordMetrics::Component metrics_component_;
 
   typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;

--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -27,8 +27,8 @@ ReplicaBase::ReplicaBase(const ReplicaConfig& config,
     : config_(config),
       msgsCommunicator_(msgComm),
       msgHandlers_(msgHandlerReg),
-      last_dump_time_(0),
-      dump_interval_in_sec_(config_.metricsDumpIntervalSeconds),
+      last_metrics_dump_time_(0),
+      metrics_dump_interval_in_sec_(config_.metricsDumpIntervalSeconds),
       metrics_{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())} {
   if (config_.debugStatisticsEnabled) DebugStatistics::initDebugStatisticsData();
 }
@@ -43,8 +43,8 @@ void ReplicaBase::start() {
     metrics_.UpdateAggregator();
     auto currTime =
         std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch());
-    if (currTime - last_dump_time_ >= dump_interval_in_sec_) {
-      last_dump_time_ = currTime;
+    if (currTime - last_metrics_dump_time_ >= metrics_dump_interval_in_sec_) {
+      last_metrics_dump_time_ = currTime;
       LOG_INFO(GL, "-- ReplicaBase metrics dump--" + metrics_.ToJson());
     }
   });

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -103,8 +103,8 @@ class ReplicaBase {
 
   //////////////////////////////////////////////////
   // METRICS
-  uint64_t last_dump_time_ = 0;
-  uint64_t dump_interval_in_sec_ = 600;
+  std::chrono::seconds last_dump_time_;
+  std::chrono::seconds dump_interval_in_sec_;
   concordMetrics::Component metrics_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -103,6 +103,8 @@ class ReplicaBase {
 
   //////////////////////////////////////////////////
   // METRICS
+  uint64_t last_dump_time_ = 0;
+  uint64_t dump_interval_in_sec_ = 600;
   concordMetrics::Component metrics_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -103,8 +103,8 @@ class ReplicaBase {
 
   //////////////////////////////////////////////////
   // METRICS
-  std::chrono::seconds last_dump_time_;
-  std::chrono::seconds dump_interval_in_sec_;
+  std::chrono::seconds last_metrics_dump_time_;
+  std::chrono::seconds metrics_dump_interval_in_sec_;
   concordMetrics::Component metrics_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -30,7 +30,7 @@ uint32_t ReplicaConfigSerializer::maxSize(uint32_t numOfReplicas) {
           IThresholdSigner::maxSize() * 3 + IThresholdVerifier::maxSize() * 3 +
           sizeof(config_->maxExternalMessageSize) + sizeof(config_->maxReplyMessageSize) +
           sizeof(config_->maxNumOfReservedPages) + sizeof(config_->sizeOfReservedPage) +
-          sizeof(config_->debugPersistentStorageEnabled));
+          sizeof(config_->debugPersistentStorageEnabled) + sizeof(config_->metricsDumpIntervalSeconds));
 }
 
 ReplicaConfigSerializer::ReplicaConfigSerializer(ReplicaConfig *config) {
@@ -89,6 +89,9 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
   // Serialize autoPrimaryRotationTimerMillisec
   outStream.write((char *)&config_->autoPrimaryRotationTimerMillisec,
                   sizeof(config_->autoPrimaryRotationTimerMillisec));
+
+  // Serialize metricsDumpIntervalSeconds
+  outStream.write((char*) &config_->metricsDumpIntervalSeconds, sizeof(config_->metricsDumpIntervalSeconds));
 
   // Serialize public keys
   auto numOfPublicKeys = (int64_t)config_->publicKeysOfReplicas.size();
@@ -153,7 +156,8 @@ bool ReplicaConfigSerializer::operator==(const ReplicaConfigSerializer &other) c
        (other.config_->maxExternalMessageSize == config_->maxExternalMessageSize) &&
        (other.config_->maxReplyMessageSize == config_->maxReplyMessageSize) &&
        (other.config_->maxNumOfReservedPages == config_->maxNumOfReservedPages) &&
-       (other.config_->sizeOfReservedPage == config_->sizeOfReservedPage));
+       (other.config_->sizeOfReservedPage == config_->sizeOfReservedPage) &&
+      (other.config_->metricsDumpIntervalSeconds == config_->metricsDumpIntervalSeconds));
   return result;
 }
 
@@ -200,6 +204,8 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
   // Deserialize autoPrimaryRotationTimerMillisec
   inStream.read((char *)&config.autoPrimaryRotationTimerMillisec, sizeof(config.autoPrimaryRotationTimerMillisec));
 
+  // Deserialize metricsDumpIntervalSeconds
+  inStream.read((char *)&config.metricsDumpIntervalSeconds, sizeof(config.metricsDumpIntervalSeconds));
   // Deserialize public keys
   int64_t numOfPublicKeys = 0;
   inStream.read((char *)&numOfPublicKeys, sizeof(numOfPublicKeys));

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -91,7 +91,7 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
                   sizeof(config_->autoPrimaryRotationTimerMillisec));
 
   // Serialize metricsDumpIntervalSeconds
-  outStream.write((char*) &config_->metricsDumpIntervalSeconds, sizeof(config_->metricsDumpIntervalSeconds));
+  outStream.write((char *)&config_->metricsDumpIntervalSeconds, sizeof(config_->metricsDumpIntervalSeconds));
 
   // Serialize public keys
   auto numOfPublicKeys = (int64_t)config_->publicKeysOfReplicas.size();
@@ -157,7 +157,7 @@ bool ReplicaConfigSerializer::operator==(const ReplicaConfigSerializer &other) c
        (other.config_->maxReplyMessageSize == config_->maxReplyMessageSize) &&
        (other.config_->maxNumOfReservedPages == config_->maxNumOfReservedPages) &&
        (other.config_->sizeOfReservedPage == config_->sizeOfReservedPage) &&
-      (other.config_->metricsDumpIntervalSeconds == config_->metricsDumpIntervalSeconds));
+       (other.config_->metricsDumpIntervalSeconds == config_->metricsDumpIntervalSeconds));
   return result;
 }
 

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -90,9 +90,6 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
   outStream.write((char *)&config_->autoPrimaryRotationTimerMillisec,
                   sizeof(config_->autoPrimaryRotationTimerMillisec));
 
-  // Serialize metricsDumpIntervalSeconds
-  outStream.write((char *)&config_->metricsDumpIntervalSeconds, sizeof(config_->metricsDumpIntervalSeconds));
-
   // Serialize public keys
   auto numOfPublicKeys = (int64_t)config_->publicKeysOfReplicas.size();
   outStream.write((char *)&numOfPublicKeys, sizeof(numOfPublicKeys));
@@ -123,6 +120,9 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
 
   // Serialize debugPersistentStorageEnabled
   outStream.write((char *)&config_->debugPersistentStorageEnabled, sizeof(config_->debugPersistentStorageEnabled));
+
+  // Serialize metricsDumpIntervalSeconds
+  outStream.write((char *)&config_->metricsDumpIntervalSeconds, sizeof(config_->metricsDumpIntervalSeconds));
 }
 
 void ReplicaConfigSerializer::serializePointer(Serializable *ptrToClass, ostream &outStream) const {
@@ -204,8 +204,6 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
   // Deserialize autoPrimaryRotationTimerMillisec
   inStream.read((char *)&config.autoPrimaryRotationTimerMillisec, sizeof(config.autoPrimaryRotationTimerMillisec));
 
-  // Deserialize metricsDumpIntervalSeconds
-  inStream.read((char *)&config.metricsDumpIntervalSeconds, sizeof(config.metricsDumpIntervalSeconds));
   // Deserialize public keys
   int64_t numOfPublicKeys = 0;
   inStream.read((char *)&numOfPublicKeys, sizeof(numOfPublicKeys));
@@ -227,6 +225,9 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
   inStream.read((char *)&config.sizeOfReservedPage, sizeof(config.sizeOfReservedPage));
 
   inStream.read((char *)&config.debugPersistentStorageEnabled, sizeof(config.debugPersistentStorageEnabled));
+
+  // Deserialize metricsDumpIntervalSeconds
+  inStream.read((char *)&config.metricsDumpIntervalSeconds, sizeof(config.metricsDumpIntervalSeconds));
 }
 
 SerializablePtr ReplicaConfigSerializer::deserializePointer(std::istream &inStream) {

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -78,6 +78,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       numOfReplicas_(myReplica.getReplicaConfig().numReplicas),
       numOfClients_(myReplica.getReplicaConfig().numOfClientProxies),
       metricsComponent_{concordMetrics::Component("preProcessor", std::make_shared<concordMetrics::Aggregator>())},
+      last_dump_time_(0),
       dump_interval_in_sec_{myReplica_.getReplicaConfig().metricsDumpIntervalSeconds},
       preProcessorMetrics_{metricsComponent_.RegisterCounter("preProcReqReceived"),
                            metricsComponent_.RegisterCounter("preProcReqInvalid"),
@@ -137,11 +138,10 @@ bool PreProcessor::checkClientMsgCorrectness(const ClientPreProcessReqMsgUniqueP
 template <>
 void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequestMsg *msg) {
   if (preProcessorMetrics_.requestReceived.Get().Get() % 10 == 0) metricsComponent_.UpdateAggregator();
-  auto timeSinceEpoch = std::chrono::steady_clock::now().time_since_epoch();
-  uint64_t currTime = std::chrono::duration_cast<std::chrono::milliseconds>(timeSinceEpoch).count();
-  if (currTime - last_dump_time_ >= dump_interval_in_sec_ * 1000) {
+  auto currTime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch());
+  if (currTime - last_dump_time_ >= dump_interval_in_sec_) {
     last_dump_time_ = currTime;
-    LOG_INFO(GL, "--preProcessor metrics dump--\n" + metricsComponent_.ToJson());
+    LOG_INFO(GL, "--preProcessor metrics dump--" + metricsComponent_.ToJson());
   }
   preProcessorMetrics_.requestReceived.Get().Inc();
   ClientPreProcessReqMsgUniquePtr clientPreProcessReqMsg(msg);

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -109,8 +109,8 @@ class PreProcessor {
   // clientId -> *RequestProcessingInfo
   std::unordered_map<uint16_t, std::unique_ptr<ClientRequestInfo>> ongoingRequests_;
   concordMetrics::Component metricsComponent_;
-  uint64_t last_dump_time_ = 0;
-  uint64_t dump_interval_in_sec_ = 600;
+  std::chrono::seconds last_dump_time_;
+  std::chrono::seconds dump_interval_in_sec_;
   struct PreProcessingMetrics {
     concordMetrics::CounterHandle requestReceived;
     concordMetrics::CounterHandle requestInvalid;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -109,8 +109,8 @@ class PreProcessor {
   // clientId -> *RequestProcessingInfo
   std::unordered_map<uint16_t, std::unique_ptr<ClientRequestInfo>> ongoingRequests_;
   concordMetrics::Component metricsComponent_;
-  std::chrono::seconds last_dump_time_;
-  std::chrono::seconds dump_interval_in_sec_;
+  std::chrono::seconds metricsLastDumpTime_;
+  std::chrono::seconds metricsDumpIntervalInSec_;
   struct PreProcessingMetrics {
     concordMetrics::CounterHandle requestReceived;
     concordMetrics::CounterHandle requestInvalid;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -109,6 +109,8 @@ class PreProcessor {
   // clientId -> *RequestProcessingInfo
   std::unordered_map<uint16_t, std::unique_ptr<ClientRequestInfo>> ongoingRequests_;
   concordMetrics::Component metricsComponent_;
+  uint64_t last_dump_time_ = 0;
+  uint64_t dump_interval_in_sec_ = 600;
   struct PreProcessingMetrics {
     concordMetrics::CounterHandle requestReceived;
     concordMetrics::CounterHandle requestInvalid;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -206,6 +206,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   state_transfer_config.cVal = m_replicaConfig.cVal;
   state_transfer_config.fVal = m_replicaConfig.fVal;
   state_transfer_config.numReplicas = m_replicaConfig.numReplicas + m_replicaConfig.numRoReplicas;
+  state_transfer_config.metricsDumpIntervalSeconds = m_replicaConfig.metricsDumpIntervalSeconds;
   if (replicaConfig.maxNumOfReservedPages > 0)
     state_transfer_config.maxNumOfReservedPages = replicaConfig.maxNumOfReservedPages;
   if (replicaConfig.sizeOfReservedPage > 0) state_transfer_config.sizeOfReservedPage = replicaConfig.sizeOfReservedPage;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -206,7 +206,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   state_transfer_config.cVal = m_replicaConfig.cVal;
   state_transfer_config.fVal = m_replicaConfig.fVal;
   state_transfer_config.numReplicas = m_replicaConfig.numReplicas + m_replicaConfig.numRoReplicas;
-  state_transfer_config.metricsDumpIntervalSeconds = m_replicaConfig.metricsDumpIntervalSeconds;
+  state_transfer_config.metricsDumpIntervalSeconds = std::chrono::seconds(m_replicaConfig.metricsDumpIntervalSeconds);
   if (replicaConfig.maxNumOfReservedPages > 0)
     state_transfer_config.maxNumOfReservedPages = replicaConfig.maxNumOfReservedPages;
   if (replicaConfig.sizeOfReservedPage > 0) state_transfer_config.sizeOfReservedPage = replicaConfig.sizeOfReservedPage;


### PR DESCRIPTION
# Motivation
To help to debug and monitoring concord-bft we would like to dump all collected metrics in a while.

# Detailed Description
* Dumping time interval - By default, the metrics are being dumped once in 10 minutes (configurable).
* We dump all three existing components: preProcessor, BCStateTransfer and ReplicaBase.

# Example
## BCStateTransfer
```
 [Node 3] [140617056573184] %{rid, 3}% INFO |state-transfer||virtual void bftEngine::SimpleBlockchainStateTransfer::impl::BCStateTran::onTimer()|BCStateTransfer metrics dump {"Name":"bc_state_transfer","Gauges":{"current_source_replica":65535,"checkpoint_being_fetched":0,"last_stored_checkpoint":0,"number_of_reserved_pages":200,"size_of_reserved_page":4096,"last_msg_seq_num":0,"next_required_block_":0,"num_pending_item_data_msgs_":0,"total_size_of_pending_item_data_msgs":0,"last_block_":0,"last_reachable_block":0},"Statuses":{"fetching_state":"NotFetching","pedantic_checks_enabled":"false","preferred_replicas":""},"Counters":{"sent_ask_for_checkpoint_summaries_msg":0,"sent_checkpoint_summary_msg":0,"sent_fetch_blocks_msg":0,"sent_fetch_res_pages_msg":0,"sent_reject_fetch_msg":0,"sent_item_data_msg":0,"received_ask_for_checkpoint_summaries_msg":0,"received_checkpoint_summary_msg":0,"received_fetch_blocks_msg":0,"received_fetch_res_pages_msg":0,"received_reject_fetching_msg":0,"received_item_data_msg":0,"received_illegal_msg_":0,"invalid_ask_for_checkpoint_summaries_msg":0,"irrelevant_ask_for_checkpoint_summaries_msg":0,"invalid_checkpoint_summary_msg":0,"irrelevant_checkpoint_summary_msg":0,"invalid_fetch_blocks_msg":0,"irrelevant_fetch_blocks_msg":0,"invalid_fetch_res_pages_msg":0,"irrelevant_fetch_res_pages_msg":0,"invalid_reject_fetching_msg":0,"irrelevant_reject_fetching_msg":0,"invalid_item_data_msg":0,"irrelevant_item_data_msg":0,"create_checkpoint":0,"mark_checkpoint_as_stable":0,"load_reserved_page":0,"load_reserved_page_from_pending":0,"load_reserved_page_from_checkpoint":0,"save_reserved_page":0,"zero_reserved_page":200,"start_collecting_state":0,"on_timer":1,"on_transferring_complete":0}}|
```
## ReplicaBase
```
 [Node 1] [139760904541952] %{rid, 1}% INFO |concord||bftEngine::impl::ReplicaBase::start()::<lambda(concordUtil::Timers::Handle)>|ReplicaBase metrics dump {"Name":"replica","Gauges":{"view":0,"lastStableSeqNum":0,"lastExecutedSeqNum":0,"lastAgreedView":0,"currentActiveView":0},"Statuses":{"firstCommitPath":"OPTIMISTIC_FAST"},"Counters":{"receivedStateTransferMsgs":0,"slowPathCount":0,"receivedInternalMsgs":0,"receivedClientRequestMsgs":0,"receivedPrePrepareMsgs":0,"receivedStartSlowCommitMsgs":0,"receivedPartialCommitProofMsgs":0,"receivedFullCommitProofMsgs":0,"receivedPreparePartialMsgs":0,"receivedCommitPartialMsgs":0,"receivedPrepareFullMsgs":0,"receivedCommitFullMsgs":0,"receivedCheckpointMsgs":0,"receivedReplicaStatusMsgs":0,"receivedViewChangeMsgs":0,"receivedNewViewMsgs":0,"receivedReqMissingDataMsgs":0,"receivedSimpleAckMsgs":0}}|
```