### PR TITLE
Long run tests: add Test cases into infinite loop

### DIFF
--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -33,12 +33,17 @@ def verify_linearizability(async_fn):
     """
     @wraps(async_fn)
     async def wrapper(*args, **kwargs):
-        bft_network = kwargs['bft_network']
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        init_state = skvbc.initial_state()
-        tracker = SkvbcTracker(init_state, skvbc, bft_network)
-        await async_fn(*args, **kwargs, tracker=tracker)
-        await tracker.fill_missing_blocks_and_verify()
+        if 'tracker' in kwargs:
+            tracker = kwargs.pop('tracker')
+            await async_fn(*args, **kwargs, tracker=tracker)
+            await tracker.fill_missing_blocks_and_verify()
+        else:
+            bft_network = kwargs['bft_network']
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+            init_state = skvbc.initial_state()
+            tracker = SkvbcTracker(init_state, skvbc, bft_network)
+            await async_fn(*args, **kwargs, tracker=tracker)
+            await tracker.fill_missing_blocks_and_verify()
     return wrapper
 
 class SkvbcWriteRequest:


### PR DESCRIPTION
1)  **Make verify_linearizability decorator optional**- a tracker can be passed as input to test cases and then the tracking remains update between each test case.
after each test case, we still check that we don't have missing blocks.

2)  **Tests that not supported linearizability**- I've made those tests to support linearizability.

3)  **creates a method that goes through all the replicas and checks if they're running** - after each test case we check this because some tests are stop replicas and no starting them again.

4)  insert several test cases into the long run loop.