### PR TITLE
Apollo support for an external BFT network

### DIFF
--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -37,6 +37,8 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcTest(unittest.TestCase):
 
+    __test__ = False  # so that PyTest ignores this test scenario
+
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_state_transfer(self, bft_network):

--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -38,6 +38,8 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcFastPathTest(unittest.TestCase):
 
+    __test__ = False  # so that PyTest ignores this test scenario
+
     def setUp(self):
         # Whenever a replica goes down, all messages initially go via the slow path.
         # However, when an "evaluation period" elapses (set at 64 sequence numbers),
@@ -95,7 +97,7 @@ class SkvbcFastPathTest(unittest.TestCase):
 
         unstable_replicas = bft_network.all_replicas(without={0})
         bft_network.stop_replica(
-            replica=random.choice(unstable_replicas))
+            replica_id=random.choice(unstable_replicas))
 
         await tracker.run_concurrent_ops(num_ops=numops, write_weight=write_weight)
 

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -46,6 +46,8 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcChaosTest(unittest.TestCase):
 
+    __test__ = False  # so that PyTest ignores this test scenario
+
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability

--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -49,4 +49,4 @@ class SkvbcLongRunningTest(unittest.TestCase):
         with trio.move_on_after(seconds=ONE_HOUR_IN_SECONDS):
             while True:
                 await SkvbcTest().test_get_block_data(bft_network=bft_network, already_in_trio=True)
-                trio.sleep(seconds=10)
+                await trio.sleep(seconds=10)

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -49,6 +49,8 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcPersistenceTest(unittest.TestCase):
 
+    __test__ = False  # so that PyTest ignores this test scenario
+
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: f >= 2)

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -39,6 +39,8 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcSlowPathTest(unittest.TestCase):
 
+    __test__ = False  # so that PyTest ignores this test scenario
+
     def setUp(self):
         # Whenever a replica goes down, all messages initially go via the slow path.
         # However, when an "evaluation period" elapses (set at 64 sequence numbers),
@@ -68,7 +70,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
         unstable_replicas = bft_network.all_replicas(without={0})
         bft_network.stop_replica(
-            replica=random.choice(unstable_replicas))
+            replica_id=random.choice(unstable_replicas))
 
         await tracker.run_concurrent_ops(
             num_ops=num_ops, write_weight=write_weight)

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -39,6 +39,8 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcViewChangeTest(unittest.TestCase):
 
+    __test__ = False  # so that PyTest ignores this test scenario
+
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_request_block_not_written_primary_down(self, bft_network):


### PR DESCRIPTION
This PR prepares the existing Apollo tests to be run as part of the Concord product CI.

The most important change here is adding support for an externally provided BFT network. Instead of initializing the BftTestNetwork via its initializer method, we introduce two factory class-methods:
* new() - creates a new BFT network locally
* existing() - the BftTestNetwork object acts as a "proxy" for managing the externally provided BFT network.

In the existing() case we also provide the ability to inject externally prepared client instances.

The start_replica() and stop_replica() methods now both support running externally provided commands (useful for managing replicas that run as Docker containers, for example).

Some additional enhancements are required in order to run Apollo as part of product CI (which uses Pytest):
* apollo/util becomes a package by now having an initialization script \_\_init__.py
* added \_\_test__ = False to test scenarios relevant for product CI (so that PyTest does not directly invoke Apollo tests)