### PR TITLE
Fix Preprocessor build

### DIFF
--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -20,6 +20,7 @@ set(preprocessor_source_files
 add_library(preprocessor STATIC ${preprocessor_source_files})
 
 target_include_directories(preprocessor PUBLIC ${CRYPTOPP_INCLUDE_DIRS})
+target_include_directories(preprocessor PUBLIC ${OPENSSL_INCLUDE_DIR})
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/include)
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/include/bftengine)
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/src/bftengine)


### PR DESCRIPTION
With a fresh dev environment I noticed that the build was failing due to the
preprocessor couldn't find openssl/evp.h.