### PR TITLE
Avoid unaligned memory access in merkle tree code

### DIFF
--- a/storage/src/merkle_tree_db_adapter.cpp
+++ b/storage/src/merkle_tree_db_adapter.cpp
@@ -29,8 +29,8 @@ namespace {
 using BlockNode = block::detail::Node;
 using BlockKeyData = block::detail::KeyData;
 
+using ::concordUtils::fromBigEndianBuffer;
 using ::concordUtils::Key;
-using ::concordUtils::netToHost;
 using ::concordUtils::Sliver;
 using ::concordUtils::Status;
 
@@ -170,7 +170,7 @@ BlockId DBKeyManipulator::extractBlockIdFromKey(const Key &key) {
   Assert(key.length() > sizeof(BlockId));
 
   const auto offset = key.length() - sizeof(BlockId);
-  const auto id = netToHost(*reinterpret_cast<const BlockId *>(key.data() + offset));
+  const auto id = fromBigEndianBuffer<BlockId>(key.data() + offset);
 
   LOG_TRACE(
       logger(),

--- a/util/include/endianness.hpp
+++ b/util/include/endianness.hpp
@@ -5,9 +5,9 @@
 
 #include <arpa/inet.h>
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <iterator>
 #include <string>
 #include <type_traits>
@@ -57,15 +57,16 @@ std::array<std::uint8_t, sizeof(T)> toBigEndianArrayBuffer(T v) {
   v = concordUtils::hostToNet(v);
 
   std::array<std::uint8_t, sizeof(T)> ret;
-  const auto data = reinterpret_cast<const std::uint8_t *>(&v);
-  std::copy(data, data + sizeof(T), std::begin(ret));
+  std::memcpy(ret.data(), &v, sizeof(T));
   return ret;
 }
 
 // Buffer must be at least sizeof(T) bytes long.
 template <typename T>
 T fromBigEndianBuffer(const void *buf) {
-  return netToHost(*reinterpret_cast<const T *>(buf));
+  T v;
+  std::memcpy(&v, buf, sizeof(T));
+  return netToHost(v);
 }
 
 }  // namespace concordUtils


### PR DESCRIPTION
Address sanitizer has found a number of unaligned memory access
instances in the system. This PR resolves the ones in merkle tree DB
adapter code only.