### PR TITLE
Serialize key/values in blocks in a defined order

### DIFF
--- a/storage/src/direct_kv_block.cpp
+++ b/storage/src/direct_kv_block.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstring>
 
+using concordUtils::order;
 using concordUtils::Sliver;
 using concordUtils::SetOfKeyValuePairs;
 using concordUtils::KeyValuePair;
@@ -48,9 +49,9 @@ Sliver create(const SetOfKeyValuePairs &updates,
     header->numberOfElements = numOfElements;
     std::int32_t currentOffset = metadataSize;
     auto *entries = (detail::Entry *)(blockBuffer + sizeof(detail::Header));
-    for (const auto &elem : updates) {
-      const KeyValuePair &kvPair = elem;
-
+    // Serialize key/values in a deterministic order.
+    const auto orderedUpdates = order(updates);
+    for (const auto &kvPair : orderedUpdates) {
       // key
       entries[idx].keyOffset = currentOffset;
       entries[idx].keySize = kvPair.first.length();

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(util STATIC
     src/histogram.cpp
     src/status.cpp
     src/sliver.cpp
-    src/hex_tools.cpp)
+    src/hex_tools.cpp
+    src/kv_types.cpp)
 
 target_link_libraries(util PUBLIC Threads::Threads)
 target_include_directories(util PUBLIC include)

--- a/util/include/kv_types.hpp
+++ b/util/include/kv_types.hpp
@@ -14,6 +14,7 @@
 #define CONCORD_BFT_UTIL_KV_TYPES_H_
 
 #include <unordered_map>
+#include <map>
 #include <vector>
 #include "sliver.hpp"
 
@@ -23,10 +24,12 @@ typedef Sliver Key;
 typedef Sliver Value;
 typedef std::pair<Key, Value> KeyValuePair;
 typedef std::unordered_map<Key, Value> SetOfKeyValuePairs;
+typedef std::map<Key, Value> OrderedSetOfKeyValuePairs;
 typedef std::vector<Key> KeysVector;
 typedef KeysVector ValuesVector;
 typedef uint64_t BlockId;
 
+OrderedSetOfKeyValuePairs order(const SetOfKeyValuePairs &unordered);
 }  // namespace concordUtils
 
 // Provide hashing for slivers without requiring the user to incldue the header

--- a/util/include/sliver.hpp
+++ b/util/include/sliver.hpp
@@ -84,6 +84,8 @@ class Sliver {
 
 std::ostream& operator<<(std::ostream& s, const Sliver& sliver);
 
+inline bool operator<(const Sliver& lhs, const Sliver& rhs) { return (lhs.compare(rhs) < 0); }
+
 }  // namespace concordUtils
 
 #endif  // CONCORD_BFT_UTIL_SLIVER_HPP_

--- a/util/src/kv_types.cpp
+++ b/util/src/kv_types.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+
+#include "assertUtils.hpp"
+#include "kv_types.hpp"
+
+namespace concordUtils {
+
+OrderedSetOfKeyValuePairs order(const SetOfKeyValuePairs &unordered) {
+  auto ordered = OrderedSetOfKeyValuePairs{};
+  for (const auto &kv : unordered) {
+    ordered.insert(kv);
+  }
+  Assert(unordered.size() == ordered.size());
+  return ordered;
+}
+
+}  // namespace concordUtils


### PR DESCRIPTION
When creating raw blocks (serializing them), we iterate over a
SetOfKeyValuePairs that is an std::unordered_map . Problem is that we
rely on the fact that different replicas will serialize the keys in the
same order and that is not guaranteed. It leads to:
 * Inability to provide an alternate implementation of SBFT as the order
   of keys in the block is not defined.
 * Non-determinism in the state machine. Could lead to different states
   in different replicas.

This PR resolves that by ordering the keys lexicographically when
serializing raw blocks.