### PR TITLE
Changes in concord.config file don't have an effect.

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -166,6 +166,8 @@ class ReplicaConfigSingleton {
   uint32_t GetNumOfReplicas() const { return 3 * config_->fVal + 2 * config_->cVal + 1; }
   uint64_t GetMetricsDumpInterval() const { return config_->metricsDumpIntervalSeconds; }
 
+  bool GetDebugStatisticsEnabled() const { return config_->debugStatisticsEnabled; }
+
  private:
   friend struct ReplicaConfig;
   void init(ReplicaConfig* config) { config_ = new ReplicaConfig(*config); }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2875,11 +2875,20 @@ ReplicaImp::ReplicaImp(bool firstTime,
     retransmissionsManager = nullptr;
 
   LOG_INFO(GL,
-           "numOfClientProxies=" << config_.numOfClientProxies
-                                 << " maxExternalMessageSize=" << config_.maxExternalMessageSize
-                                 << " maxReplyMessageSize=" << config_.maxReplyMessageSize
-                                 << " maxNumOfReservedPages=" << config_.maxNumOfReservedPages << " sizeOfReservedPage="
-                                 << config_.sizeOfReservedPage << " viewChangeTimerMilli=" << viewChangeTimerMilli);
+           "ReplicaConfig parameters isReadOnly="
+               << config_.isReadOnly << ", numReplicas=" << config_.numReplicas
+               << ", numRoReplicas=" << config_.numRoReplicas << ", fVal=" << config_.fVal << ", cVal=" << config_.cVal
+               << ", replicaId=" << config_.replicaId << ", numOfClientProxies=" << config_.numOfClientProxies
+               << ", statusReportTimerMillisec=" << config_.statusReportTimerMillisec << ", concurrencyLevel="
+               << config_.concurrencyLevel << ", viewChangeProtocolEnabled=" << config_.viewChangeProtocolEnabled
+               << ", viewChangeTimerMillisec=" << config_.viewChangeTimerMillisec
+               << ", autoPrimaryRotationEnabled=" << config_.autoPrimaryRotationEnabled
+               << ", autoPrimaryRotationTimerMillisec=" << config_.autoPrimaryRotationTimerMillisec
+               << ", maxExternalMessageSize=" << config_.maxExternalMessageSize << ", maxReplyMessageSize="
+               << config_.maxReplyMessageSize << ", maxNumOfReservedPages=" << config_.maxNumOfReservedPages
+               << ", sizeOfReservedPage=" << config_.sizeOfReservedPage
+               << ", debugStatisticsEnabled=" << config_.debugStatisticsEnabled
+               << ", metricsDumpIntervalSeconds=" << config_.metricsDumpIntervalSeconds);
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -55,20 +55,6 @@ namespace {
 ReplicaLoader::ErrorCode checkReplicaConfig(const LoadedReplicaData &ld) {
   const ReplicaConfig &c = ld.repConfig;
 
-  LOG_INFO(
-      GL,
-      "ReplicaConfig parameters isReadOnly="
-          << c.isReadOnly << ", numReplicas=" << c.numReplicas << ", numRoReplicas=" << c.numRoReplicas
-          << ", fVal=" << c.fVal << ", cVal=" << c.cVal << ", replicaId=" << c.replicaId << ", numOfClientProxies="
-          << c.numOfClientProxies << ", statusReportTimerMillisec=" << c.statusReportTimerMillisec
-          << ", concurrencyLevel=" << c.concurrencyLevel << ", viewChangeProtocolEnabled="
-          << c.viewChangeProtocolEnabled << ", viewChangeTimerMillisec=" << c.viewChangeTimerMillisec
-          << ", autoPrimaryRotationEnabled=" << c.autoPrimaryRotationEnabled << ", autoPrimaryRotationTimerMillisec="
-          << c.autoPrimaryRotationTimerMillisec << ", maxExternalMessageSize=" << c.maxExternalMessageSize
-          << ", maxReplyMessageSize=" << c.maxReplyMessageSize << ", maxNumOfReservedPages=" << c.maxNumOfReservedPages
-          << ", sizeOfReservedPage=" << c.sizeOfReservedPage << ", debugStatisticsEnabled=" << c.debugStatisticsEnabled
-          << ", metricsDumpIntervalSeconds=" << c.metricsDumpIntervalSeconds);
-
   Verify(c.fVal >= 1, InconsistentErr);
   Verify(c.cVal >= 0, InconsistentErr);
 


### PR DESCRIPTION
All parameters defined ReplicaConfig structure are stored persistently in RocksDB. After replica restarts, the parameters are read from the DB and those specified in the create replica API are ignored. This behavior is correct for some of the parameters that are not expected to change (like replica-id), but others (like timers), we should be able to change.