### PR TITLE
Fixes for long running tests

### DIFF
--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -52,9 +52,6 @@ class SkvbcLongRunningTest(unittest.TestCase):
                 await SkvbcTest().test_get_block_data\
                     (bft_network=bft_network, already_in_trio=True)
                 await trio.sleep(seconds=10)
-                await SkvbcTest().test_get_block_data_with_blinking_replica\
-                    (bft_network=bft_network, already_in_trio=True)
-                await trio.sleep(seconds=10)
                 await SkvbcTest().test_conflicting_write\
                     (bft_network=bft_network, already_in_trio=True)
                 await trio.sleep(seconds=10)

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -35,6 +35,7 @@ def verify_linearizability(async_fn):
     @wraps(async_fn)
     async def wrapper(*args, **kwargs):
         if 'disable_linearizability_checks' in kwargs:
+            kwargs.pop('disable_linearizability_checks')
             bft_network = kwargs['bft_network']
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             tracker = PassThroughSkvbcTracker(skvbc, bft_network)
@@ -1010,8 +1011,7 @@ class PassThroughSkvbcTracker:
     async def send_tracked_write(self, client, max_set_size):
         readset = self.readset(0, max_set_size)
         writeset = self.writeset(max_set_size)
-        read_version = self.read_block_id()
-        msg = self.skvbc.write_req(readset, writeset, read_version)
+        msg = self.skvbc.write_req(readset, writeset, 0)
         seq_num = client.req_seq_num.next()
         try:
             serialized_reply = await client.write(msg, seq_num)


### PR DESCRIPTION
1) found some bugs on PassThroughSkvbcTracker.
2) Remove "test_get_block_data_with_blinking_replica" from long running tests.

I've tested 2 scenarios - 1. test cases that called with Mock tracker, 2.test cases that called from other tests.

- test cases that called with Mock tracker- run each test case with the PassThroughSkvbcTracker and see that all the methods are supported.

- test cases that called from other tests- Run each est case and verify that he initializes all the decorators as requested.