### PR TITLE
Increased number of clients to speed up tests.

### DIFF
--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -105,6 +105,7 @@ class SkvbcFastPathTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd,
+                      num_clients = 4,
                       selected_configs=lambda n, f, c: c >= 1)
     @verify_linearizability
     async def test_fast_path_resilience_to_crashes(self, bft_network, tracker):

--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -105,7 +105,7 @@ class SkvbcFastPathTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd,
-                      num_clients = 4,
+                      num_clients=4,
                       selected_configs=lambda n, f, c: c >= 1)
     @verify_linearizability
     async def test_fast_path_resilience_to_crashes(self, bft_network, tracker):

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -78,7 +78,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd,
-                      num_clients = 4)
+                      num_clients=4)
     @verify_linearizability
     async def test_slow_to_fast_path_transition(self, bft_network, tracker):
         """

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -77,7 +77,8 @@ class SkvbcSlowPathTest(unittest.TestCase):
         await bft_network.assert_slow_path_prevalent(as_of_seq_num=1)
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd,
+                      num_clients = 4)
     @verify_linearizability
     async def test_slow_to_fast_path_transition(self, bft_network, tracker):
         """

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -53,8 +53,8 @@ def interesting_configs(selected=None):
         selected=lambda *config: True
 
     bft_configs = [#{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
-                   {'n': 6, 'f': 1, 'c': 1, 'num_clients': 4},
-                   {'n': 7, 'f': 2, 'c': 0, 'num_clients': 4},
+                   {'n': 6, 'f': 1, 'c': 1, 'num_clients': 30},
+                   {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 4}
                    # {'n': 12, 'f': 3, 'c': 1, 'num_clients': 4}
                    ]
@@ -85,7 +85,7 @@ def with_trio(async_fn):
     return trio_wrapper
 
 
-def with_bft_network(start_replica_cmd, selected_configs=None, num_ro_replicas=0):
+def with_bft_network(start_replica_cmd, num_clients=None, selected_configs=None, num_ro_replicas=0):
     """
     Runs the decorated async function for all selected BFT configs
     """
@@ -102,7 +102,9 @@ def with_bft_network(start_replica_cmd, selected_configs=None, num_ro_replicas=0
                     config = TestConfig(n=bft_config['n'],
                                         f=bft_config['f'],
                                         c=bft_config['c'],
-                                        num_clients=bft_config['num_clients'],
+                                        num_clients=bft_config['num_clients'] \
+                                            if num_clients is None \
+                                            else num_clients,
                                         key_file_prefix=KEY_FILE_PREFIX,
                                         start_replica_cmd=start_replica_cmd,
                                         stop_replica_cmd=None,

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -52,11 +52,11 @@ def interesting_configs(selected=None):
     if selected is None:
         selected=lambda *config: True
 
-    bft_configs = [#{'n': 4, 'f': 1, 'c': 0, 'num_clients': 4},
+    bft_configs = [#{'n': 4, 'f': 1, 'c': 0, 'num_clients': 30},
                    {'n': 6, 'f': 1, 'c': 1, 'num_clients': 30},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
-                   # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 4}
-                   # {'n': 12, 'f': 3, 'c': 1, 'num_clients': 4}
+                   # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 30}
+                   # {'n': 12, 'f': 3, 'c': 1, 'num_clients': 30}
                    ]
 
     selected_bft_configs = \
@@ -85,7 +85,7 @@ def with_trio(async_fn):
     return trio_wrapper
 
 
-def with_bft_network(start_replica_cmd, num_clients=None, selected_configs=None, num_ro_replicas=0):
+def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None, num_ro_replicas=0):
     """
     Runs the decorated async function for all selected BFT configs
     """


### PR DESCRIPTION
test_slow_to_fast_path_transition.py and
test_fast_path_resilience_to_crashes.py fail
with more clients, so they remain using only 4
at this time.