### PR TITLE
Long run tests: make replicas persistent

### DIFF
--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -36,7 +36,8 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli]
+            "-v", viewChangeTimeoutMilli,
+            "-p"]
 
 
 class SkvbcLongRunningTest(unittest.TestCase):


### PR DESCRIPTION
Add "-p" variable to the start replicas command.