### PR TITLE
Fix unexpected pre-processing order

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -222,6 +222,7 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
 
   auto &clientEntry = ongoingRequests_[clientId];
   PreProcessingResult result = CANCEL;
+  string cid;
   LOG_DEBUG(GL, "reqSeqNum=" << preProcessReplyMsg->reqSeqNum() << " received from replica=" << senderId);
   {
     lock_guard<mutex> lock(clientEntry->mutex);
@@ -233,8 +234,16 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
     }
     clientEntry->clientReqInfoPtr->handlePreProcessReplyMsg(preProcessReplyMsg);
     result = clientEntry->clientReqInfoPtr->getPreProcessingConsensusResult();
+    cid = clientEntry->clientReqInfoPtr->getPreProcessRequest()->getCid();
   }
-  MDC_CID_PUT(GL, clientEntry->clientReqInfoPtr->getPreProcessRequest()->getCid());
+  handleReqPreProcessedByOneReplica(cid, result, clientId, reqSeqNum);
+}
+
+void PreProcessor::handleReqPreProcessedByOneReplica(const string &cid,
+                                                     PreProcessingResult result,
+                                                     NodeIdType clientId,
+                                                     SeqNum reqSeqNum) {
+  MDC_CID_PUT(GL, cid);
   switch (result) {
     case CONTINUE:  // Not enough equal hashes collected
       return;
@@ -248,6 +257,7 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
       LOG_INFO(GL, "Retry primary replica pre-processing for clientId=" << clientId << " reqSeqNum=" << reqSeqNum);
       PreProcessRequestMsgSharedPtr preProcessRequestMsg;
       {
+        auto &clientEntry = ongoingRequests_[clientId];
         lock_guard<mutex> lock(clientEntry->mutex);
         preProcessRequestMsg = clientEntry->clientReqInfoPtr->getPreProcessRequest();
       }
@@ -373,14 +383,14 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId, ReqId reqSeqNum
   return resultLen;
 }
 
+PreProcessingResult PreProcessor::getPreProcessingConsensusResult(uint16_t clientId) {
+  auto &clientEntry = ongoingRequests_[clientId];
+  lock_guard<mutex> lock(clientEntry->mutex);
+  return clientEntry->clientReqInfoPtr->getPreProcessingConsensusResult();
+}
+
 void PreProcessor::handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum) {
-  PreProcessingResult preProcessingResult = CANCEL;
-  {
-    auto &clientEntry = ongoingRequests_[clientId];
-    lock_guard<mutex> lock(clientEntry->mutex);
-    preProcessingResult = clientEntry->clientReqInfoPtr->getPreProcessingConsensusResult();
-  }
-  if (preProcessingResult == COMPLETE)
+  if (getPreProcessingConsensusResult(clientId) == COMPLETE)
     finalizePreProcessing(clientId, reqSeqNum);
   else
     cancelPreProcessing(clientId, reqSeqNum);
@@ -390,9 +400,17 @@ void PreProcessor::handlePreProcessedReqByPrimary(PreProcessRequestMsgSharedPtr 
                                                   uint16_t clientId,
                                                   uint32_t resultBufLen) {
   auto &clientEntry = ongoingRequests_[clientId];
-  lock_guard<mutex> lock(clientEntry->mutex);
-  if (clientEntry->clientReqInfoPtr)
-    clientEntry->clientReqInfoPtr->handlePrimaryPreProcessed(getPreProcessResultBuffer(clientId), resultBufLen);
+  string cid;
+  PreProcessingResult result = CANCEL;
+  {
+    lock_guard<mutex> lock(clientEntry->mutex);
+    if (clientEntry->clientReqInfoPtr) {
+      clientEntry->clientReqInfoPtr->handlePrimaryPreProcessed(getPreProcessResultBuffer(clientId), resultBufLen);
+      result = clientEntry->clientReqInfoPtr->getPreProcessingConsensusResult();
+      cid = clientEntry->clientReqInfoPtr->getPreProcessRequest()->getCid();
+    }
+  }
+  handleReqPreProcessedByOneReplica(cid, result, clientId, preProcessReqMsg->reqSeqNum());
 }
 
 void PreProcessor::handlePreProcessedReqByNonPrimary(uint16_t clientId, ReqId reqSeqNum, uint32_t resBufLen) {

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -89,6 +89,11 @@ class PreProcessor {
   void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum);
   void finalizePreProcessing(NodeIdType clientId, SeqNum reqSeqNum);
   void cancelPreProcessing(NodeIdType clientId, SeqNum reqSeqNum);
+  PreProcessingResult getPreProcessingConsensusResult(uint16_t clientId);
+  void handleReqPreProcessedByOneReplica(const std::string &cid,
+                                         PreProcessingResult result,
+                                         NodeIdType clientId,
+                                         SeqNum reqSeqNum);
 
  private:
   static std::vector<std::shared_ptr<PreProcessor>> preProcessors_;  // The place holder for PreProcessor objects

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -68,7 +68,8 @@ class PreProcessor {
   template <typename T>
   void onMessage(T *msg);
 
-  void registerClientPreProcessRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg);
+  void registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+                       PreProcessRequestMsgSharedPtr preProcessRequestMsg);
   void releaseClientPreProcessRequest(uint16_t clientId, ReqId requestSeqNum);
   bool validateMessage(MessageBase *msg) const;
   void registerMsgHandlers();

--- a/bftengine/src/preprocessor/RequestProcessingInfo.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.cpp
@@ -33,11 +33,9 @@ RequestProcessingInfo::RequestProcessingInfo(uint16_t numOfReplicas,
 }
 
 void RequestProcessingInfo::handlePrimaryPreProcessed(const char *preProcessResult, uint32_t preProcessResultLen) {
-  numOfReceivedReplies_++;
   myPreProcessResult_ = preProcessResult;
   myPreProcessResultLen_ = preProcessResultLen;
   myPreProcessResultHash_ = convertToArray(SHA3_256().digest(myPreProcessResult_, myPreProcessResultLen_).data());
-  preProcessingResultHashes_[myPreProcessResultHash_]++;
 }
 
 void RequestProcessingInfo::handlePreProcessReplyMsg(PreProcessReplyMsgSharedPtr preProcessReplyMsg) {
@@ -56,6 +54,7 @@ PreProcessingResult RequestProcessingInfo::getPreProcessingConsensusResult() con
 
   uint16_t maxNumOfEqualHashes = 0;
   auto itOfChosenHash = preProcessingResultHashes_.begin();
+  // Calculate a maximum number of the same hashes calculated by non-primary replicas
   for (auto it = preProcessingResultHashes_.begin(); it != preProcessingResultHashes_.end(); it++) {
     if (it->second > maxNumOfEqualHashes) {
       maxNumOfEqualHashes = it->second;
@@ -66,20 +65,26 @@ PreProcessingResult RequestProcessingInfo::getPreProcessingConsensusResult() con
   if (maxNumOfEqualHashes >= numOfRequiredEqualReplies_) {
     if (itOfChosenHash->first == myPreProcessResultHash_)
       return COMPLETE;  // Pre-execution consensus reached
-    else {
-      // Primary replica calculated hash is different from hash that passed consensus => we don't have correct
-      // pre-processed results. The request could be cancelled, retried or executed without pre-processing.
+    else if (myPreProcessResultLen_ != 0) {
+      // Primary replica calculated hash is different from a hash that passed pre-execution consensus => we don't have
+      // correct pre-processed results. Let's launch a pre-processing retry.
       LOG_WARN(GL,
                "Primary replica pre-processing result hash is different from one passed the consensus for reqSeqNum="
                    << reqSeqNum_ << "; retry pre-processing on primary replica");
       return RETRY_PRIMARY;
+    } else {
+      LOG_DEBUG(GL, "Primary replica did not complete pre-processing yet for reqSeqNum=" << reqSeqNum_ << "; continue");
+      return CONTINUE;
     }
   }
 
-  if (numOfReceivedReplies_ == numOfReplicas_ - 1)
-    // Replies from all replicas received, but not enough equal hashes collected => cancel request
+  if (numOfReceivedReplies_ == numOfReplicas_ - 1) {
+    // Replies from all replicas received, but not enough equal hashes collected => pre-execution consensus not
+    // reached => cancel request.
     LOG_WARN(GL, "Not enough equal hashes collected for reqSeqNum=" << reqSeqNum_ << ", cancel request");
-  return CANCEL;
+    return CANCEL;
+  }
+  return CONTINUE;
 }
 
 unique_ptr<MessageBase> RequestProcessingInfo::convertClientPreProcessToClientMsg(bool resetPreProcessFlag) {

--- a/bftengine/src/preprocessor/RequestProcessingInfo.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.cpp
@@ -22,17 +22,18 @@ uint16_t RequestProcessingInfo::numOfRequiredEqualReplies_ = 0;
 RequestProcessingInfo::RequestProcessingInfo(uint16_t numOfReplicas,
                                              uint16_t numOfRequiredReplies,
                                              ReqId reqSeqNum,
-                                             ClientPreProcessReqMsgUniquePtr clientReqMsg)
-    : numOfReplicas_(numOfReplicas), reqSeqNum_(reqSeqNum), clientPreProcessReqMsg_(move(clientReqMsg)) {
+                                             ClientPreProcessReqMsgUniquePtr clientReqMsg,
+                                             PreProcessRequestMsgSharedPtr preProcessRequestMsg)
+    : numOfReplicas_(numOfReplicas),
+      reqSeqNum_(reqSeqNum),
+      clientPreProcessReqMsg_(move(clientReqMsg)),
+      preProcessRequestMsg_(preProcessRequestMsg) {
   numOfRequiredEqualReplies_ = numOfRequiredReplies;
   LOG_DEBUG(GL, "Created RequestProcessingInfo with reqSeqNum=" << reqSeqNum_ << ", numOfReplicas= " << numOfReplicas_);
 }
 
-void RequestProcessingInfo::handlePrimaryPreProcessed(PreProcessRequestMsgSharedPtr msg,
-                                                      const char *preProcessResult,
-                                                      uint32_t preProcessResultLen) {
+void RequestProcessingInfo::handlePrimaryPreProcessed(const char *preProcessResult, uint32_t preProcessResultLen) {
   numOfReceivedReplies_++;
-  preProcessRequestMsg_ = msg;
   myPreProcessResult_ = preProcessResult;
   myPreProcessResultLen_ = preProcessResultLen;
   myPreProcessResultHash_ = convertToArray(SHA3_256().digest(myPreProcessResult_, myPreProcessResultLen_).data());

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -29,12 +29,11 @@ class RequestProcessingInfo {
   RequestProcessingInfo(uint16_t numOfReplicas,
                         uint16_t numOfRequiredReplies,
                         ReqId reqSeqNum,
-                        ClientPreProcessReqMsgUniquePtr clientReqMsg);
+                        ClientPreProcessReqMsgUniquePtr clientReqMsg,
+                        PreProcessRequestMsgSharedPtr preProcessRequestMsg);
   ~RequestProcessingInfo() = default;
 
-  void handlePrimaryPreProcessed(PreProcessRequestMsgSharedPtr msg,
-                                 const char* preProcessResult,
-                                 uint32_t preProcessResultLen);
+  void handlePrimaryPreProcessed(const char* preProcessResult, uint32_t preProcessResultLen);
   void handlePreProcessReplyMsg(PreProcessReplyMsgSharedPtr preProcessReplyMsg);
   std::unique_ptr<MessageBase> convertClientPreProcessToClientMsg(bool resetPreProcessFlag);
   PreProcessRequestMsgSharedPtr getPreProcessRequest() const { return preProcessRequestMsg_; }

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -24,7 +24,8 @@ namespace {
 ReplicaConfig replicaConfig;
 const uint16_t numOfReplicas = 4;
 const uint16_t numOfClients = 4;
-uint16_t numOfRequiredReplies = 3;
+const uint16_t fval = 1;
+const uint16_t numOfRequiredReplies = fval + 1;
 const uint32_t bufLen = 1024;
 char buf[bufLen];
 ReqId reqSeqNum = 123456789;
@@ -191,15 +192,15 @@ TEST(requestPreprocessingInfo_test, notEnoughRepliesReceived) {
                                 ClientPreProcessReqMsgUniquePtr(),
                                 PreProcessRequestMsgSharedPtr());
   ReplicasInfo repInfo(replicaConfig, true, true);
-  reqInfo.handlePrimaryPreProcessed(buf, bufLen);
-  for (auto i = 1; i < numOfRequiredReplies - 1; i++) {
+  for (auto i = 1; i < numOfRequiredReplies; i++) {
     reqInfo.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
     Assert(reqInfo.getPreProcessingConsensusResult() == CONTINUE);
   }
+  reqInfo.handlePrimaryPreProcessed(buf, bufLen);
   Assert(reqInfo.getPreProcessingConsensusResult() == CONTINUE);
 }
 
-TEST(requestPreprocessingInfo_test, notEnoughSameRepliesReceived) {
+TEST(requestPreprocessingInfo_test, allRepliesReceivedButNotEnoughSameHashesCollected) {
   RequestProcessingInfo reqInfo(numOfReplicas,
                                 numOfRequiredReplies,
                                 reqSeqNum,
@@ -208,12 +209,9 @@ TEST(requestPreprocessingInfo_test, notEnoughSameRepliesReceived) {
   ReplicasInfo repInfo(replicaConfig, true, true);
   memset(buf, '5', bufLen);
   reqInfo.handlePrimaryPreProcessed(buf, bufLen);
-  for (auto i = 1; i <= numOfRequiredReplies; i++) {
+  for (auto i = 1; i < numOfReplicas; i++) {
     if (i != numOfReplicas - 1) Assert(reqInfo.getPreProcessingConsensusResult() == CONTINUE);
-    if (i == 1)
-      memset(buf, '6', bufLen);
-    else
-      memset(buf, '4', bufLen);
+    memset(buf, i, bufLen);
     reqInfo.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
   Assert(reqInfo.getPreProcessingConsensusResult() == CANCEL);
@@ -227,15 +225,15 @@ TEST(requestPreprocessingInfo_test, enoughSameRepliesReceived) {
                                 PreProcessRequestMsgSharedPtr());
   ReplicasInfo repInfo(replicaConfig, true, true);
   memset(buf, '5', bufLen);
-  reqInfo.handlePrimaryPreProcessed(buf, bufLen);
-  for (auto i = 1; i <= numOfRequiredReplies - 1; i++) {
+  for (auto i = 1; i <= numOfRequiredReplies; i++) {
     if (i != numOfRequiredReplies - 1) Assert(reqInfo.getPreProcessingConsensusResult() == CONTINUE);
     reqInfo.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
+  reqInfo.handlePrimaryPreProcessed(buf, bufLen);
   Assert(reqInfo.getPreProcessingConsensusResult() == COMPLETE);
 }
 
-TEST(requestPreprocessingInfo_test, primaryReplicaPreProcessingRetry) {
+TEST(requestPreprocessingInfo_test, primaryReplicaPreProcessingRetrySucceeds) {
   RequestProcessingInfo reqInfo(numOfReplicas,
                                 numOfRequiredReplies,
                                 reqSeqNum,
@@ -250,6 +248,25 @@ TEST(requestPreprocessingInfo_test, primaryReplicaPreProcessingRetry) {
     reqInfo.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
   Assert(reqInfo.getPreProcessingConsensusResult() == RETRY_PRIMARY);
+  memset(buf, '4', bufLen);
+  reqInfo.handlePrimaryPreProcessed(buf, bufLen);
+  Assert(reqInfo.getPreProcessingConsensusResult() == COMPLETE);
+}
+
+TEST(requestPreprocessingInfo_test, primaryReplicaDidNotCompletePreProcessingWhileNonPrimariesDid) {
+  RequestProcessingInfo reqInfo(numOfReplicas,
+                                numOfRequiredReplies,
+                                reqSeqNum,
+                                ClientPreProcessReqMsgUniquePtr(),
+                                PreProcessRequestMsgSharedPtr());
+  ReplicasInfo repInfo(replicaConfig, true, true);
+  memset(buf, '5', bufLen);
+  for (auto i = 1; i <= numOfRequiredReplies; i++) {
+    if (i != numOfReplicas - 1) Assert(reqInfo.getPreProcessingConsensusResult() == CONTINUE);
+    memset(buf, '4', bufLen);
+    reqInfo.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
+  }
+  Assert(reqInfo.getPreProcessingConsensusResult() == CONTINUE);
   memset(buf, '4', bufLen);
   reqInfo.handlePrimaryPreProcessed(buf, bufLen);
   Assert(reqInfo.getPreProcessingConsensusResult() == COMPLETE);


### PR DESCRIPTION
Fix the case when non-primary replicas complete pre-processing before the primary:

1. Store PreProcessRequest ing RequestProcessingInfo during RequestProcessingInfo constructing.
2. In case all non-primary replicas returned with the reply, verify that the primary has completed the pre-execution. If not, wait for it.
3. Retry primary pre-execution only after its hash has been calculated.

https://jira.eng.vmware.com/browse/BC-1785
