### PR TITLE
Ro replica object store integration

### DIFF
--- a/.conan/libs3_pkg/conanfile.py
+++ b/.conan/libs3_pkg/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+from conans.tools import os_info, SystemPackageTool
+
+
+class LibS3Conan(ConanFile):
+    name = "libs3-dev"
+    version = "2.0-3"
+    def system_requirements(self):
+        pack_name = None
+        if os_info.linux_distro == "ubuntu":
+            pack_name = "libs3-dev"
+ 
+        if pack_name:
+            installer = SystemPackageTool()
+            installer.install(pack_name)
+

--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -69,7 +69,7 @@ class IAppState {
 
   // returns true IFF block blockId exists
   // (i.e. the block is stored in the application/storage layer).
-  virtual bool hasBlock(uint64_t blockId) = 0;
+  virtual bool hasBlock(uint64_t blockId) const = 0;
 
   // If block blockId exists, then its content is returned via the arguments
   // outBlock and outBlockSize. Returns true IFF block blockId exists.
@@ -83,25 +83,19 @@ class IAppState {
   // blockId   - the block number
   // block     - pointer to a buffer that contains the new block
   // blockSize - the size of the new block
-  virtual bool putBlock(uint64_t blockId, char *block, uint32_t blockSize) = 0;
+  virtual bool putBlock(const uint64_t blockId, const char *block, const uint32_t blockSize) = 0;
 
   // returns the maximal block number n such that all blocks 1 <= i <= n exist.
   // if block 1 does not exist, returns 0.
-  virtual uint64_t getLastReachableBlockNum() = 0;
-
+  virtual uint64_t getLastReachableBlockNum() const = 0;
   // returns the maximum block number that is currently stored in
   // the application/storage layer.
-  virtual uint64_t getLastBlockNum() = 0;
+  virtual uint64_t getLastBlockNum() const = 0;
 
   // When the state is updated by the application, getLastReachableBlockNum()
   // and getLastBlockNum() should always return the same block number.
   // When that state transfer module is updating the state, then these methods
   // may return different block numbers.
-
-  // This method MAY be called by ST module when putBlock returns false. The call will block until the underlying
-  // storage becomes available (storage non availabilty is the reason for putBlock to fail). Mainly relevant for network
-  // storages. In regular replica which uses local DB this function should not be called.
-  virtual void wait() = 0;
 };
 
 struct Config {
@@ -110,6 +104,7 @@ struct Config {
   uint16_t cVal = 0;
   uint16_t numReplicas = 0;
   bool pedanticChecks = false;
+  bool isReadOnly = false;
 
 #if defined USE_COMM_PLAIN_TCP || defined USE_COMM_TLS_TCP
   uint32_t maxChunkSize = 16384;

--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
@@ -146,7 +146,7 @@ void IncomingMsgsStorageImp::dispatchMessages(std::promise<void>& signalStarted)
           if (msgHandlerCallback) {
             msgHandlerCallback(message);
           } else {
-            LOG_WARN(GL, "Unknown message - delete");
+            LOG_WARN(GL, "Delete unknown message type: " << message->type());
             delete message;
           }
           break;

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -47,7 +47,10 @@ void ReadOnlyReplica::start() {
   lastExecutedSeqNum = ps_->getLastExecutedSeqNum();
   askForCheckpointMsgTimer_ = TimersSingleton::getInstance().add(std::chrono::seconds(5),  // TODO [TK] config
                                                                  Timers::Timer::RECURRING,
-                                                                 [this](Timers::Handle) { sendAskForCheckpointMsg(); });
+                                                                 [this](Timers::Handle) {
+                                                                   if (!this->isCollectingState())
+                                                                     sendAskForCheckpointMsg();
+                                                                 });
 }
 
 void ReadOnlyReplica::stop() {

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -49,8 +49,10 @@ void ReplicaForStateTransfer::start() {
 }
 
 void ReplicaForStateTransfer::stop() {
-  TimersSingleton::getInstance().cancel(stateTranTimer_);
+  // stop in reverse order
   ReplicaBase::stop();
+  stateTransfer->stopRunning();
+  TimersSingleton::getInstance().cancel(stateTranTimer_);
 }
 
 template <>

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -28,7 +28,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
                           bool firstTime  // TODO [TK] get rid of this
   );
 
-  IStateTransfer* getStateTransfer() const { return stateTransfer; }
+  IStateTransfer* getStateTransfer() const { return stateTransfer.get(); }
 
   // IReplicaForStateTransfer
   void freeStateTransferMsg(char* m) override;
@@ -56,7 +56,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   void onMessage(T*);
 
  protected:
-  bftEngine::IStateTransfer* stateTransfer = nullptr;
+  std::unique_ptr<bftEngine::IStateTransfer> stateTransfer;
   Timers::Handle stateTranTimer_;
   CounterHandle metric_received_state_transfers_;
 };

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2839,7 +2839,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   clientsManager =
       new ClientsManager(config_.replicaId, clientsSet, ReplicaConfigSingleton::GetInstance().GetSizeOfReservedPage());
 
-  clientsManager->init(stateTransfer);
+  clientsManager->init(stateTransfer.get());
 
   if (!firstTime || config_.debugPersistentStorageEnabled)
     clientsManager->loadInfoFromReservedPages();

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -93,20 +93,17 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
     // IAppState methods
     ////////////////////////////////////////////////////////////////////////
 
-    bool hasBlock(uint64_t blockId) override;
+    bool hasBlock(uint64_t blockId) const override;
 
     bool getBlock(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) override;
 
     bool getPrevDigestFromBlock(uint64_t blockId,
                                 SimpleBlockchainStateTransfer::StateTransferDigest* outPrevBlockDigest) override;
 
-    bool putBlock(uint64_t blockId, char* block, uint32_t blockSize) override;
+    bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) override;
 
-    uint64_t getLastReachableBlockNum() override;
-
-    uint64_t getLastBlockNum() override;
-
-    void wait() override;
+    uint64_t getLastReachableBlockNum() const override;
+    uint64_t getLastBlockNum() const override;
   };
 
   ///////////////////////////////////////////////////////////////////////////
@@ -564,7 +561,7 @@ void SimpleStateTran::onComplete(int64_t checkpointNumberOfNewState) {
   lastKnownCheckpoint = checkpointNumberOfNewState;
 }
 
-bool SimpleStateTran::DummyBDState::hasBlock(uint64_t blockId) { return false; }
+bool SimpleStateTran::DummyBDState::hasBlock(uint64_t blockId) const { return false; }
 
 bool SimpleStateTran::DummyBDState::getBlock(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) {
   Assert(false);
@@ -577,16 +574,14 @@ bool SimpleStateTran::DummyBDState::getPrevDigestFromBlock(
   return false;
 }
 
-bool SimpleStateTran::DummyBDState::putBlock(uint64_t blockId, char* block, uint32_t blockSize) {
+bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) {
   Assert(false);
   return false;
 }
 
-uint64_t SimpleStateTran::DummyBDState::getLastReachableBlockNum() { return 0; }
+uint64_t SimpleStateTran::DummyBDState::getLastReachableBlockNum() const { return 0; }
 
-uint64_t SimpleStateTran::DummyBDState::getLastBlockNum() { return 0; }
-
-void SimpleStateTran::DummyBDState::wait() {}
+uint64_t SimpleStateTran::DummyBDState::getLastBlockNum() const { return 0; }
 
 }  // namespace impl
 }  // namespace SimpleInMemoryStateTransfer

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -34,7 +34,7 @@ struct Block {
 
 class TestAppState : public IAppState {
  public:
-  bool hasBlock(uint64_t blockId) override {
+  bool hasBlock(uint64_t blockId) const override {
     auto it = blocks_.find(blockId);
     return it != blocks_.end();
   }
@@ -55,7 +55,7 @@ class TestAppState : public IAppState {
     return true;
   };
 
-  bool putBlock(uint64_t blockId, char* block, uint32_t blockSize) override {
+  bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) override {
     assert(blockId < last_block_);
     Block bl;
     computeBlockDigest(blockId, block, blockSize, &bl.digest);
@@ -66,11 +66,8 @@ class TestAppState : public IAppState {
   }
 
   // TODO(AJS): How does this differ from getLastBlockNum?
-  uint64_t getLastReachableBlockNum() override { return last_block_; };
-
-  uint64_t getLastBlockNum() override { return last_block_; };
-
-  void wait() override{};
+  uint64_t getLastReachableBlockNum() const override { return last_block_; }
+  uint64_t getLastBlockNum() const override { return last_block_; };
 
  private:
   uint64_t last_block_;

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -13,6 +13,7 @@ zstd/1.4.0@bincrafters/stable
 rocksdb/5.7.3
 hdr_histogram/0.9.12
 rapidcheck/258d907da00a0855f92c963d8f76eef115531716
+libs3-dev/2.0-3
 
 [options]
 OpenSSL:shared=True

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required (VERSION 3.2)
 project(libkvbc VERSION 0.1.0.0 LANGUAGES CXX)
 
 add_library(kvbc  src/ClientImp.cpp
-                  src/ReplicaImp.cpp
-                  src/replica_state_sync_imp.cpp
-                  src/block_metadata.cpp
+    src/ReplicaImp.cpp
+    src/replica_state_sync_imp.cpp
+    src/block_metadata.cpp
                   src/direct_kv_db_adapter.cpp
                   src/merkle_tree_db_adapter.cpp
                   src/direct_kv_block.cpp
@@ -17,10 +17,9 @@ add_library(kvbc  src/ClientImp.cpp
                   src/sparse_merkle/walker.cpp
 )
 
-target_link_libraries(kvbc PUBLIC threshsign util concordbft_storage corebft)
+target_link_libraries(kvbc PUBLIC corebft )
 
 target_include_directories(kvbc PUBLIC include)
-target_include_directories(kvbc PUBLIC ${bftengine_SOURCE_DIR}/include)
 
 find_package(OpenSSL REQUIRED)
 target_link_libraries(kvbc PRIVATE ${OPENSSL_LIBRARIES})

--- a/kvbc/include/db_adapter.h
+++ b/kvbc/include/db_adapter.h
@@ -38,6 +38,9 @@ class IDbAdapter {
   // Delete a block from the database
   virtual void deleteBlock(const BlockId& blockId) = 0;
 
+  // Checks whether block exists
+  virtual bool hasBlock(const BlockId& blockId) const = 0;
+
   // Used to retrieve the latest block.
   virtual BlockId getLatestBlockId() const = 0;
 

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -36,15 +36,4 @@ class IBlocksAppender {
   virtual ~IBlocksAppender() = default;
 };
 
-/** Defines interface for blockchain data keys generation
- *
- */
-class IDataKeyGenerator {
- public:
-  virtual concordUtils::Sliver blockKey(const BlockId&) const = 0;
-  virtual concordUtils::Sliver dataKey(const Key&, const BlockId&) const = 0;
-
-  virtual ~IDataKeyGenerator() = default;
-};
-
 }  // namespace concord::kvbc

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -120,6 +120,9 @@ class DBAdapter : public IDbAdapter {
 
   std::shared_ptr<storage::IDBClient> getDb() const override { return db_; }
 
+  // TODO [TK] implement
+  bool hasBlock(const BlockId &blockId) const override { return false; }
+
   // Returns the current state hash from the internal merkle tree implementation.
   const sparse_merkle::Hash &getStateHash() const { return smTree_.get_root_hash(); }
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -2,13 +2,11 @@
 //
 // KV Blockchain replica implementation.
 
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/param.h>
 #include <unistd.h>
-
 #include "ReplicaImp.h"
 #include <inttypes.h>
 #include <cassert>
@@ -19,7 +17,6 @@
 #include "hex_tools.h"
 #include "replica_state_sync.h"
 #include "sliver.hpp"
-#include "db_interfaces.h"
 #include "block.h"
 #include "bftengine/DbMetadataStorage.hpp"
 
@@ -33,8 +30,7 @@ using concord::storage::DBMetadataStorage;
 using concord::storage::MetadataKeyManipulator;
 namespace block = concord::kvbc::block;
 
-namespace concord {
-namespace kvbc {
+namespace concord::kvbc {
 
 /**
  * Opens the database and creates the replica thread. Replica state moves to
@@ -48,7 +44,6 @@ Status ReplicaImp::start() {
   }
 
   m_currentRepStatus = RepStatus::Starting;
-  m_metadataStorage = new DBMetadataStorage(m_bcDbAdapter->getDb().get(), MetadataKeyManipulator::generateMetadataKey);
 
   if (m_replicaConfig.isReadOnly) {
     LOG_INFO(logger, "ReadOnly mode");
@@ -74,13 +69,11 @@ void ReplicaImp::createReplicaAndSyncState() {
       &m_replicaConfig, m_cmdHandler, m_stateTransfer, m_ptrComm, m_metadataStorage);
   if (!isNewStorage && !m_stateTransfer->isCollectingState()) {
     uint64_t removedBlocksNum = replicaStateSync_->execute(
-        logger, *m_bcDbAdapter, m_appState->m_lastReachableBlock, m_replicaPtr->getLastExecutedSequenceNum());
-    m_lastBlock -= removedBlocksNum;
-    m_appState->m_lastReachableBlock -= removedBlocksNum;
+        logger, *m_bcDbAdapter, getLastReachableBlockNum(), m_replicaPtr->getLastExecutedSequenceNum());
     LOG_INFO(logger,
              "createReplicaAndSyncState: removedBlocksNum = "
-                 << removedBlocksNum << ", new m_lastBlock = " << m_lastBlock
-                 << ", new m_lastReachableBlock = " << m_appState->m_lastReachableBlock);
+                 << removedBlocksNum << ", new m_lastBlock = " << getLastBlockNum()
+                 << ", new m_lastReachableBlock = " << getLastReachableBlockNum());
   }
 }
 
@@ -96,7 +89,7 @@ Status ReplicaImp::stop() {
 
 ReplicaImp::RepStatus ReplicaImp::getReplicaStatus() const { return m_currentRepStatus; }
 
-const ILocalKeyValueStorageReadOnly &ReplicaImp::getReadOnlyStorage() { return m_InternalStorageWrapperForIdleMode; }
+const ILocalKeyValueStorageReadOnly &ReplicaImp::getReadOnlyStorage() { return *this; }
 
 Status ReplicaImp::addBlockToIdleReplica(const SetOfKeyValuePairs &updates) {
   if (getReplicaStatus() != IReplica::RepStatus::Idle) {
@@ -112,7 +105,7 @@ Status ReplicaImp::get(const Sliver &key, Sliver &outValue) const {
   // the replica's internal thread)
 
   BlockId dummy;
-  return getInternal(m_lastBlock, key, outValue, dummy);
+  return getInternal(getLastBlockNum(), key, outValue, dummy);
 }
 
 Status ReplicaImp::get(BlockId readVersion, const Sliver &key, Sliver &outValue, BlockId &outBlock) const {
@@ -121,8 +114,6 @@ Status ReplicaImp::get(BlockId readVersion, const Sliver &key, Sliver &outValue,
 
   return getInternal(readVersion, key, outValue, outBlock);
 }
-
-BlockId ReplicaImp::getLastBlock() const { return m_lastBlock; }
 
 Status ReplicaImp::getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockData) const {
   // TODO(GG): check legality of operation (the method should be invoked from
@@ -169,30 +160,28 @@ void ReplicaImp::set_command_handler(ICommandsHandler *handler) { m_cmdHandler =
 
 ReplicaImp::ReplicaImp(ICommunication *comm,
                        bftEngine::ReplicaConfig &replicaConfig,
-                       DBAdapter *dbAdapter,
+                       std::unique_ptr<IDbAdapter> dbAdapter,
+                       std::shared_ptr<storage::IDBClient> mdt_dbclient,
                        std::shared_ptr<concordMetrics::Aggregator> aggregator)
     : logger(concordlogger::Log::getLogger("skvbc.replicaImp")),
       m_currentRepStatus(RepStatus::Idle),
-      m_InternalStorageWrapperForIdleMode(this),
-      m_bcDbAdapter(dbAdapter),
-      m_lastBlock(dbAdapter->getLatestBlockId()),
+      m_bcDbAdapter(std::move(dbAdapter)),
       m_ptrComm(comm),
       m_replicaConfig(replicaConfig),
-      m_appState(new BlockchainAppState(this)),
       aggregator_(aggregator) {
   bftEngine::SimpleBlockchainStateTransfer::Config state_transfer_config;
-
   state_transfer_config.myReplicaId = m_replicaConfig.replicaId;
   state_transfer_config.cVal = m_replicaConfig.cVal;
   state_transfer_config.fVal = m_replicaConfig.fVal;
   state_transfer_config.numReplicas = m_replicaConfig.numReplicas + m_replicaConfig.numRoReplicas;
   state_transfer_config.metricsDumpIntervalSeconds = std::chrono::seconds(m_replicaConfig.metricsDumpIntervalSeconds);
+  state_transfer_config.isReadOnly = replicaConfig.isReadOnly;
   if (replicaConfig.maxNumOfReservedPages > 0)
     state_transfer_config.maxNumOfReservedPages = replicaConfig.maxNumOfReservedPages;
   if (replicaConfig.sizeOfReservedPage > 0) state_transfer_config.sizeOfReservedPage = replicaConfig.sizeOfReservedPage;
-
-  m_stateTransfer = bftEngine::SimpleBlockchainStateTransfer::create(
-      state_transfer_config, m_appState.get(), m_bcDbAdapter->getDb(), aggregator);
+  m_stateTransfer =
+      bftEngine::SimpleBlockchainStateTransfer::create(state_transfer_config, this, mdt_dbclient, aggregator_);
+  m_metadataStorage = new DBMetadataStorage(mdt_dbclient.get(), MetadataKeyManipulator::generateMetadataKey);
 }
 
 ReplicaImp::~ReplicaImp() {
@@ -202,25 +191,11 @@ ReplicaImp::~ReplicaImp() {
     }
     delete m_replicaPtr;
   }
-
-  if (m_stateTransfer) {
-    if (m_stateTransfer->isRunning()) {
-      m_stateTransfer->stopRunning();
-    }
-    delete m_stateTransfer;
-  }
 }
 
 Status ReplicaImp::addBlockInternal(const SetOfKeyValuePairs &updates, BlockId &outBlockId) {
-  m_lastBlock++;
-  m_appState->m_lastReachableBlock++;
-
-  BlockId block = m_lastBlock;
-  SetOfKeyValuePairs updatesInNewBlock;
-
-  LOG_DEBUG(logger, "block:" << block << " updates: " << updates.size());
-
   outBlockId = m_bcDbAdapter->addBlock(updates);
+
   return Status::OK();
 }
 
@@ -236,22 +211,18 @@ Status ReplicaImp::getInternal(BlockId readVersion, Key key, Sliver &outValue, B
   }
 }
 
-void ReplicaImp::insertBlockInternal(BlockId blockId, Sliver block) {
-  if (blockId > m_lastBlock) {
-    m_lastBlock = blockId;
-  }
-  // when ST runs, blocks arrive in batches in reverse order. we need to keep
-  // track on the "Gap" and to close it. Only when it is closed, the last
-  // reachable block becomes the same as the last block
-  if (blockId == m_appState->m_lastReachableBlock + 1) {
-    m_appState->m_lastReachableBlock = m_lastBlock;
-  }
-  try {
-    RawBlock existingBlock = m_bcDbAdapter->getRawBlock(blockId);
+/*
+ * This method can't return false by current insertBlockInternal impl.
+ * It is used only by State Transfer to synchronize state between replicas.
+ */
+bool ReplicaImp::putBlock(const uint64_t blockId, const char *block_data, const uint32_t blockSize) {
+  Sliver block = Sliver::copy(block_data, blockSize);
+
+  if (m_bcDbAdapter->hasBlock(blockId)) {
     // if we already have a block with the same ID
+    RawBlock existingBlock = m_bcDbAdapter->getRawBlock(blockId);
     if (existingBlock.length() != block.length() || memcmp(existingBlock.data(), block.data(), block.length())) {
       // the replica is corrupted !
-      // TODO(GG): what do we want to do now ?
       LOG_ERROR(logger,
                 "found block " << blockId << ", size in db is " << existingBlock.length() << ", inserted is "
                                << block.length() << ", data in db " << existingBlock << ", data inserted " << block);
@@ -260,148 +231,47 @@ void ReplicaImp::insertBlockInternal(BlockId blockId, Sliver block) {
                                    << (memcmp(existingBlock.data(), block.data(), block.length())));
 
       m_bcDbAdapter->deleteBlock(blockId);
-
-      // TODO(GG): how do we want to handle this - restart replica?
-      // exit(1);
-      return;
+      throw std::runtime_error(__PRETTY_FUNCTION__ + std::string("data corrupted blockId: ") + std::to_string(blockId));
     }
-  } catch (const NotFoundException &e) {
-    m_bcDbAdapter->addRawBlock(block, blockId);  // TODO [TK] will be replaced after integration of hasBlock
   }
+
+  m_bcDbAdapter->addRawBlock(block, blockId);
+
+  return true;
 }
 
 RawBlock ReplicaImp::getBlockInternal(BlockId blockId) const {
-  assert(blockId <= m_lastBlock);
+  assert(blockId <= getLastBlockNum());
   return m_bcDbAdapter->getRawBlock(blockId);
 }
-
-ReplicaImp::StorageWrapperForIdleMode::StorageWrapperForIdleMode(const ReplicaImp *r) : rep(r) {}
-
-Status ReplicaImp::StorageWrapperForIdleMode::get(const Sliver &key, Sliver &outValue) const {
-  if (rep->getReplicaStatus() != IReplica::RepStatus::Idle) {
-    return Status::IllegalOperation("");
-  }
-
-  return rep->get(key, outValue);
-}
-
-Status ReplicaImp::StorageWrapperForIdleMode::get(BlockId readVersion,
-                                                  const Sliver &key,
-                                                  Sliver &outValue,
-                                                  BlockId &outBlock) const {
-  if (rep->getReplicaStatus() != IReplica::RepStatus::Idle) {
-    return Status::IllegalOperation("");
-  }
-
-  return rep->get(readVersion, key, outValue, outBlock);
-}
-
-BlockId ReplicaImp::StorageWrapperForIdleMode::getLastBlock() const { return rep->getLastBlock(); }
-
-Status ReplicaImp::StorageWrapperForIdleMode::getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockData) const {
-  if (rep->getReplicaStatus() != IReplica::RepStatus::Idle) {
-    return Status::IllegalOperation("");
-  }
-
-  try {
-    Sliver block = rep->getBlockInternal(blockId);
-    outBlockData = rep->getBcDbAdapter()->getBlockData(block);
-  } catch (const NotFoundException &e) {
-    return Status::NotFound("todo");
-  }
-
-  return Status::OK();
-}
-
-Status ReplicaImp::StorageWrapperForIdleMode::mayHaveConflictBetween(const Sliver &key,
-                                                                     BlockId fromBlock,
-                                                                     BlockId toBlock,
-                                                                     bool &outRes) const {
-  outRes = true;
-
-  Sliver dummy;
-  BlockId block = 0;
-  Status s = rep->getInternal(toBlock, key, dummy, block);
-
-  if (s.isOK() && block < fromBlock) {
-    outRes = false;
-  }
-
-  return s;
-}
-
-/*
- * These functions are used by the ST module to interact with the KVB
- */
-ReplicaImp::BlockchainAppState::BlockchainAppState(ReplicaImp *const parent)
-    : m_ptrReplicaImpl{parent},
-      m_logger{concordlogger::Log::getLogger("blockchainappstate")},
-      m_lastReachableBlock{parent->getBcDbAdapter()->getLastReachableBlockId()} {}
 
 /*
  * This method assumes that *outBlock is big enough to hold block content
  * The caller is the owner of the memory
  */
-bool ReplicaImp::BlockchainAppState::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) {
-  Sliver res = m_ptrReplicaImpl->getBlockInternal(blockId);
-  if (0 == res.length()) {
-    // in normal state it should not happen. If it happened - the data is
-    // corrupted
-    LOG_FATAL(m_logger, "Block not found, ID: " << blockId);
-    exit(1);
-  }
-
-  *outBlockSize = res.length();
-  memcpy(outBlock, res.data(), res.length());
+bool ReplicaImp::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) {
+  RawBlock block = getBlockInternal(blockId);
+  *outBlockSize = block.length();
+  memcpy(outBlock, block.data(), block.length());
   return true;
 }
 
-bool ReplicaImp::BlockchainAppState::hasBlock(uint64_t blockId) {
-  try {
-    RawBlock block = m_ptrReplicaImpl->getBlockInternal(blockId);
-    return true;
-  } catch (const NotFoundException &e) {
-    return false;  // TODO [TK] use dbadapter::has after implemented
-  }
-}
+bool ReplicaImp::hasBlock(BlockId blockId) const { return m_bcDbAdapter->hasBlock(blockId); }
 
-bool ReplicaImp::BlockchainAppState::getPrevDigestFromBlock(uint64_t blockId, StateTransferDigest *outPrevBlockDigest) {
+bool ReplicaImp::getPrevDigestFromBlock(BlockId blockId, StateTransferDigest *outPrevBlockDigest) {
   assert(blockId > 0);
   try {
-    RawBlock result = m_ptrReplicaImpl->m_bcDbAdapter->getRawBlock(blockId);
-    auto parentDigest = m_ptrReplicaImpl->m_bcDbAdapter->getParentDigest(result);
+    RawBlock result = getBlockInternal(blockId);
+    auto parentDigest = m_bcDbAdapter->getParentDigest(result);
     assert(outPrevBlockDigest);
     static_assert(parentDigest.size() == BLOCK_DIGEST_SIZE);
     static_assert(sizeof(StateTransferDigest) == BLOCK_DIGEST_SIZE);
     memcpy(outPrevBlockDigest, parentDigest.data(), BLOCK_DIGEST_SIZE);
     return true;
   } catch (const NotFoundException &e) {
-    LOG_FATAL(m_logger, "Block not found for parent digest, ID: " << blockId);
+    LOG_FATAL(logger, "Block not found for parent digest, ID: " << blockId);
     throw;
   }
 }
 
-/*
- * This method cant return false by current insertBlockInternal impl.
- * It is used only by State Transfer to synchronize state between replicas.
- */
-bool ReplicaImp::BlockchainAppState::putBlock(uint64_t blockId, char *block, uint32_t blockSize) {
-  char *tmpBlockPtr = new char[blockSize];
-  memcpy(tmpBlockPtr, block, blockSize);
-  Sliver s(tmpBlockPtr, blockSize);
-
-  m_ptrReplicaImpl->insertBlockInternal(blockId, s);
-  return true;
-}
-
-uint64_t ReplicaImp::BlockchainAppState::getLastReachableBlockNum() {
-  LOG_INFO(m_logger, "m_lastReachableBlock=" << m_lastReachableBlock);
-  return m_lastReachableBlock;
-}
-
-uint64_t ReplicaImp::BlockchainAppState::getLastBlockNum() { return m_ptrReplicaImpl->m_lastBlock; }
-
-void ReplicaImp::BlockchainAppState::wait() { return; }
-
-}  // namespace kvbc
-}  // namespace concord
+}  // namespace concord::kvbc

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -14,9 +14,13 @@ endif()
 
 add_executable(order_test order_test.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(order_test order_test)
-target_include_directories(order_test PUBLIC ${libkvbc_SOURCE_DIR}/include)
-target_link_libraries(order_test GTest::Main util)
+target_link_libraries(order_test GTest::Main kvbc util)
 target_compile_options(order_test PUBLIC -Wno-sign-compare)
+
+add_executable(kvbc_dbadapter_test kvbc_dbadapter_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_test(kvbc_dbadapter_test kvbc_dbadapter_test)
+target_link_libraries(kvbc_dbadapter_test GTest::Main kvbc util)
+
 
 add_executable(sparse_merkle_storage_db_adapter_unit_test
     sparse_merkle_storage/db_adapter_unit_test.cpp $<TARGET_OBJECTS:logging_dev>)
@@ -31,32 +35,32 @@ target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
 )
 
 if(RAPIDCHECK_FOUND)
-    add_executable(sparse_merkle_storage_db_adapter_property_test
-        sparse_merkle_storage/db_adapter_property_test.cpp $<TARGET_OBJECTS:logging_dev>)
-    add_test(sparse_merkle_storage_db_adapter_property_test sparse_merkle_storage_db_adapter_property_test)
-    target_include_directories(sparse_merkle_storage_db_adapter_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
-    target_link_libraries(sparse_merkle_storage_db_adapter_property_test PUBLIC
-        GTest::Main
-        GTest::GTest
-        ${RAPIDCHECK_LIBRARIES}
+add_executable(sparse_merkle_storage_db_adapter_property_test
+    sparse_merkle_storage/db_adapter_property_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_test(sparse_merkle_storage_db_adapter_property_test sparse_merkle_storage_db_adapter_property_test)
+target_include_directories(sparse_merkle_storage_db_adapter_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
+target_link_libraries(sparse_merkle_storage_db_adapter_property_test PUBLIC
+    GTest::Main
+    GTest::GTest
+    ${RAPIDCHECK_LIBRARIES}
         util
         corebft
         kvbc
         stdc++fs
     )
 
-    add_executable(sparse_merkle_internal_node_property_test sparse_merkle/internal_node_property_tests.cpp
-    $<TARGET_OBJECTS:logging_dev>)
-    add_test(sparse_merkle_internal_node_property_test sparse_merkle_internal_node_property_test)
-    target_include_directories(sparse_merkle_internal_node_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
-    target_link_libraries(sparse_merkle_internal_node_property_test PUBLIC
-        GTest::Main
-        GTest::GTest
-        ${RAPIDCHECK_LIBRARIES}
-        util
-        kvbc
-        OpenSSL::Crypto
-    )
+add_executable(sparse_merkle_internal_node_property_test sparse_merkle/internal_node_property_tests.cpp
+$<TARGET_OBJECTS:logging_dev>)
+add_test(sparse_merkle_internal_node_property_test sparse_merkle_internal_node_property_test)
+target_include_directories(sparse_merkle_internal_node_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
+target_link_libraries(sparse_merkle_internal_node_property_test PUBLIC
+    GTest::Main
+    GTest::GTest
+    ${RAPIDCHECK_LIBRARIES}
+    util
+    kvbc
+    OpenSSL::Crypto
+)
 endif ()
 
 add_executable(sparse_merkle_base_types_test sparse_merkle/base_types_test.cpp
@@ -94,14 +98,14 @@ target_link_libraries(sparse_merkle_tree_test PUBLIC
 )
 
 if (BUILD_ROCKSDB_STORAGE)
-    add_executable(multiIO_test multiIO_test.cpp $<TARGET_OBJECTS:logging_dev>)
-    add_test(multiIO_test multiIO_test)
+add_executable(multiIO_test multiIO_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_test(multiIO_test multiIO_test)
 
-    target_link_libraries(multiIO_test PUBLIC
-        GTest::Main
-        GTest::GTest
+target_link_libraries(multiIO_test PUBLIC
+    GTest::Main
+    GTest::GTest
         util
-        kvbc
+    kvbc
         corebft
-    )
+)
 endif(BUILD_ROCKSDB_STORAGE)

--- a/kvbc/test/kvbc_dbadapter_test.cpp
+++ b/kvbc/test/kvbc_dbadapter_test.cpp
@@ -1,0 +1,72 @@
+// Copyright 2019 VMware, all rights reserved
+/**
+ * Test multi* functions for RocksDBClient class.
+ */
+
+#include "Logger.hpp"
+#include "gtest/gtest.h"
+#include "kv_types.hpp"
+#include "db_adapter.h"
+
+#ifdef USE_ROCKSDB
+#include "rocksdb/client.h"
+#include "rocksdb/key_comparator.h"
+#endif
+
+using namespace std;
+
+using concordUtils::Status;
+using concordUtils::Sliver;
+using concord::kvbc::KeysVector;
+using concord::kvbc::KeyValuePair;
+using concord::kvbc::SetOfKeyValuePairs;
+using concord::kvbc::BlockId;
+// using concord::storage::rocksdb::Client;
+// using concord::storage::rocksdb::KeyComparator;
+using concord::storage::ITransaction;
+using concord::kvbc::DBKeyManipulator;
+using concord::kvbc::DBKeyComparator;
+
+namespace {
+
+std::unique_ptr<concord::storage::IDBClient> dbClient;
+
+class kvbc_dbadapter_test : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    //    keyGen_.reset(new concord::kvbc::KeyGenerator);
+    //    comparator_ = new KeyComparator(new DBKeyComparator());
+    //    dbClient.reset(new Client(dbPath_, comparator_));
+    //    dbClient->init();
+  }
+
+  void TearDown() override {
+    //    dbClient.reset();
+    //    delete comparator_;
+    //    string cmd = string("rm -rf ") + dbPath_;
+    //    if (system(cmd.c_str())) {
+    //      ASSERT_TRUE(false);
+    //    }
+  }
+
+  std::unique_ptr<concord::kvbc::IDataKeyGenerator> keyGen_;
+  const string dbPath_ = "./rocksdb_test";
+  //  KeyComparator *comparator_;
+};
+
+TEST_F(kvbc_dbadapter_test, basic) {
+  //  auto config = get_dbadapter_configuration();
+  //  IDbAdapter* dbAdapter = new concord::kvbc::DBAdapter(std::shared_ptr<IDBClient>(std::get<0>(config)),
+  //                                                       std::shared_ptr<IDBClient>(std::get<1>(config)),
+  //                                                       std::unique_ptr<IDataKeyGenerator>(std::get<2>(config)));
+  //  dbAdapter->getDb();
+}
+
+}  // end namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int res = RUN_ALL_TESTS();
+  return res;
+}

--- a/kvbc/test/multiIO_test.cpp
+++ b/kvbc/test/multiIO_test.cpp
@@ -64,7 +64,7 @@ void verifyMultiDel(KeysVector &keys) {
 class multiIO_test : public ::testing::Test {
  protected:
   void SetUp() override {
-    keyGen_.reset(new concord::kvbc::KeyGenerator);
+    keyGen_.reset(new concord::kvbc::RocksKeyGenerator);
     comparator_ = new KeyComparator(new DBKeyComparator());
     dbClient.reset(new Client(dbPath_, comparator_));
     dbClient->init();

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -26,8 +26,7 @@ concordlogger::MDC::~MDC() { logger_.removeMdc(key_); }
 
 concordlogger::Logger initLogger() {
   log4cplus::SharedAppenderPtr ca_ptr = log4cplus::SharedAppenderPtr(new log4cplus::ConsoleAppender(false, true));
-  ca_ptr->setLayout(
-      std::auto_ptr<log4cplus::Layout>(new log4cplus::PatternLayout("[Node %X{rid}] [%t] %%%X%% %-5p|%c||%M|%m|%n ")));
+  ca_ptr->setLayout(std::auto_ptr<log4cplus::Layout>(new log4cplus::PatternLayout("Node %X{rid}|%t|%-5p|%c|%M|%m%n")));
   log4cplus::Logger::getRoot().addAppender(ca_ptr);
   log4cplus::Logger::getRoot().setLogLevel(log4cplus::INFO_LOG_LEVEL);
   return log4cplus::Logger::getInstance(LOG4CPLUS_TEXT(DEFAULT_LOGGER_NAME));

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,8 +1,13 @@
 add_library(concordbft_storage STATIC src/memorydb_client.cpp
-                                      src/key_manipulator.cpp
-)
+                                      src/key_manipulator.cpp)
 
 target_include_directories(concordbft_storage PUBLIC include)
+
+if (USE_S3_OBJECT_STORE)
+target_compile_definitions(concordbft_storage PUBLIC USE_S3_OBJECT_STORE=1)
+target_sources(concordbft_storage PRIVATE src/s3/client.cpp)
+target_link_libraries(concordbft_storage PRIVATE s3)
+endif(USE_S3_OBJECT_STORE)
 
 if (BUILD_ROCKSDB_STORAGE)
   #TODO [TK] find_package

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -36,15 +36,15 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
   virtual ~ClientIterator() {}
 
   // Inherited via IDBClientIterator
-  virtual KeyValuePair first() override;
-  virtual KeyValuePair last() override;
-  virtual KeyValuePair seekAtLeast(const Sliver &_searchKey) override;
-  virtual KeyValuePair seekAtMost(const Sliver &_searchKey) override;
-  virtual KeyValuePair previous() override;
-  virtual KeyValuePair next() override;
-  virtual KeyValuePair getCurrent() override;
-  virtual bool isEnd() override;
-  virtual concordUtils::Status getStatus() override;
+  KeyValuePair first() override;
+  KeyValuePair last() override;
+  KeyValuePair seekAtLeast(const Sliver &_searchKey) override;
+  KeyValuePair seekAtMost(const Sliver &_searchKey) override;
+  KeyValuePair previous() override;
+  KeyValuePair next() override;
+  KeyValuePair getCurrent() override;
+  bool isEnd() override;
+  Status getStatus() override;
 
  private:
   concordlogger::Logger logger;
@@ -70,9 +70,10 @@ class Client : public IDBClient {
         comp_(comp),
         map_([this](const Sliver &a, const Sliver &b) { return comp_(a, b); }) {}
 
-  virtual void init(bool readOnly) override;
-  virtual Status get(const Sliver &_key, OUT Sliver &_outValue) const override;
-  Status get(const Sliver &_key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const override;
+  void init(bool readOnly) override;
+  concordUtils::Status get(const Sliver &_key, OUT Sliver &_outValue) const override;
+  concordUtils::Status get(const Sliver &_key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const override;
+  concordUtils::Status has(const Sliver &_key) const override;
   virtual IDBClientIterator *getIterator() const override;
   virtual concordUtils::Status freeIterator(IDBClientIterator *_iter) const override;
   virtual concordUtils::Status put(const Sliver &_key, const Sliver &_value) override;

--- a/storage/include/object_store/object_store_client.hpp
+++ b/storage/include/object_store/object_store_client.hpp
@@ -1,0 +1,59 @@
+// Copyright 2018 VMware, all rights reserved
+
+#pragma once
+
+#include <memory>
+#include "storage/db_interface.h"
+
+namespace concord::storage {
+
+using namespace concordUtils;
+
+/**
+ * @brief This class implements Abstract object store client assuming S3
+ * protocol
+ *
+ */
+class ObjectStoreClient : public IDBClient {
+ public:
+  ObjectStoreClient(ObjectStoreClient&) = delete;
+  ObjectStoreClient() = delete;
+  ~ObjectStoreClient() = default;
+
+  ObjectStoreClient(IDBClient* impl) : pImpl_(impl) {}
+
+  void init(bool readOnly) { return pImpl_->init(readOnly); }
+
+  Status get(const Sliver& _key, OUT Sliver& _outValue) const { return pImpl_->get(_key, _outValue); }
+
+  Status get(const Sliver& _key, OUT char*& buf, uint32_t bufSize, OUT uint32_t& _size) const {
+    return pImpl_->get(_key, buf, bufSize, _size);
+  }
+
+  Status put(const Sliver& _key, const Sliver& _value) { return pImpl_->put(_key, _value); }
+
+  Status del(const Sliver& _key) { return pImpl_->del(_key); }
+
+  Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) {
+    return pImpl_->multiGet(_keysVec, _valuesVec);
+  }
+
+  Status multiPut(const SetOfKeyValuePairs& _keyValueMap) { return pImpl_->multiPut(_keyValueMap); }
+
+  Status multiDel(const KeysVector& _keysVec) { return pImpl_->multiDel(_keysVec); }
+
+  bool isNew() { return pImpl_->isNew(); }
+
+  IDBClient::IDBClientIterator* getIterator() const { return pImpl_->getIterator(); }
+
+  Status freeIterator(IDBClientIterator* _iter) const { return pImpl_->freeIterator(_iter); }
+
+  ITransaction* beginTransaction() { return pImpl_->beginTransaction(); }
+
+  Status has(const Sliver& key) const { return pImpl_->has(key); }
+
+ protected:
+  std::shared_ptr<IDBClient> pImpl_ = nullptr;
+};
+
+}  // namespace concord::storage

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -77,6 +77,7 @@ class Client : public concord::storage::IDBClient {
                            char*& buf,
                            uint32_t bufSize,
                            uint32_t& _realSize) const override;
+  concordUtils::Status has(const Sliver& _key) const override;
   IDBClientIterator* getIterator() const override;
   concordUtils::Status freeIterator(IDBClientIterator* _iter) const override;
   concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override;

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -1,0 +1,291 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+// This convenience header combines different block implementations.
+
+#include <libs3.h>
+#include <cstring>
+#include <thread>
+#include "Logger.hpp"
+#include "assertUtils.hpp"
+#include "storage/db_interface.h"
+
+namespace concord::storage::s3 {
+
+struct StoreConfig {
+  std::string bucketName;     // assuming pre-configured, no need to create
+  std::string url;            // from the customer
+  std::string protocol;       // currently tested with HTTP
+  std::string secretKey;      // from the customer
+  std::string accessKey;      // from the customer
+  std::uint32_t maxWaitTime;  // in milliseconds
+};
+
+/**
+ * @brief Internal implementation of ECS EMC S3 client based on libs3
+ * Most of the method are irrelevant for the object store and throw exception if
+ * called. We assume that only ObjectStoreAppState class will use this class
+ *
+ */
+class Client : public concord::storage::IDBClient {
+ public:
+  /**
+   * Transaction class. Is used also internally to implement multiPut()
+   */
+  class Transaction : public ITransaction {
+   public:
+    Transaction(Client* client) : ITransaction(nextId()), client_{client} {}
+    void commit() override {
+      for (auto&& pair : multiput_)
+        if (concordUtils::Status s = client_->put(pair.first, pair.second); !s.isOK())
+          throw std::runtime_error("S3 client error: commit failed txn id[" + getIdStr() + std::string("], reason: ") +
+                                   s.toString());
+    }
+    void rollback() override { multiput_.clear(); }
+    void put(const concordUtils::Sliver& key, const concordUtils::Sliver& value) override { multiput_[key] = value; }
+    std::string get(const concordUtils::Sliver& key) override { return multiput_[key].toString(); }
+    void del(const concordUtils::Sliver& key) override { multiput_.erase(key); }
+
+   protected:
+    Client* client_;
+    SetOfKeyValuePairs multiput_;
+    ID nextId() {
+      static ID id_ = 0;
+      return ++id_;
+    }
+  };
+
+  Client(const StoreConfig& config) : config_{config} { LOG_INFO(logger_, "S3 client created"); }
+
+  ~Client() {
+    /* Destroy LibS3 */
+    S3_deinitialize();
+    init_ = false;
+    LOG_INFO(logger_, "libs3 deinit");
+  }
+
+  /**
+   * @brief used only from the test! name should be immutable string literal
+   *
+   * @param name
+   */
+  void set_bucket_name(std::string name) { config_.bucketName = name; }
+
+  /**
+   * @brief Initializing underlying libs3. The S3_initialize function must be
+   * called exactly once and only from 1 thread
+   *
+   * @param readOnly
+   */
+  void init(bool readOnly) override;
+  /**
+   * @brief Get object from the store.
+   *
+   * @param _key key to be retrieved
+   * @param _outValue returned object
+   * @return OK if success, otherwise GeneralError with underlying error status
+   */
+  concordUtils::Status get(const concordUtils::Sliver& _key, OUT concordUtils::Sliver& _outValue) const override {
+    LOG_DEBUG(logger_, _key.toString());
+    using namespace std::placeholders;
+    concordUtils::Status res = concordUtils::Status::OK();
+    std::function<Status(const concordUtils::Sliver&, OUT concordUtils::Sliver&)> f =
+        std::bind(&Client::get_internal, this, _1, _2);
+    do_with_retry(res, f, _key, _outValue);
+    return res;
+  }
+
+  concordUtils::Status get(const concordUtils::Sliver& _key,
+                           OUT char*& buf,
+                           uint32_t bufSize,
+                           OUT uint32_t& _size) const override {
+    concordUtils::Sliver res;
+    if (Status s = get(_key, res); !s.isOK()) return s;
+    size_t len = std::min(res.length(), (size_t)bufSize);
+    memcpy(buf, res.data(), len);
+    _size = len;
+    return concordUtils::Status::OK();
+  }
+
+  /**
+   * @brief Put object to the store.
+   *
+   * @param _key object's key
+   * @param _value object
+   * @return OK if success, otherwise GeneralError with underlying error status
+   */
+  concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override {
+    using namespace std::placeholders;
+    std::function<Status(const concordUtils::Sliver&, const concordUtils::Sliver&)> f =
+        std::bind(&Client::put_internal, this, _1, _2);
+    concordUtils::Status res = concordUtils::Status::OK();
+    do_with_retry(res, f, _key, _value);
+    return res;
+  }
+
+  concordUtils::Status test_bucket() {
+    using namespace std::placeholders;
+    std::function<Status()> f = std::bind(&Client::test_bucket_internal, this);
+    concordUtils::Status res = concordUtils::Status::OK();
+
+    do_with_retry(res, f);
+    return res;
+  }
+
+  concordUtils::Status has(const concordUtils::Sliver& key) const override {
+    using namespace std::placeholders;
+    std::function<Status(const concordUtils::Sliver&)> f = std::bind(&Client::object_exists_internal, this, _1);
+    concordUtils::Status res = concordUtils::Status::OK();
+    do_with_retry(res, f, key);
+    return res;
+  }
+
+  concordUtils::Status del(const concordUtils::Sliver& key) override;
+
+  concordUtils::Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) override {
+    Assert(_keysVec.size() == _valuesVec.size());
+
+    for (KeysVector::size_type i = 0; i < _keysVec.size(); ++i)
+      if (Status s = get(_keysVec[i], _valuesVec[i]); !s.isOK()) return s;
+
+    return concordUtils::Status::OK();
+  }
+
+  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override {
+    ITransaction::Guard g(beginTransaction());
+    for (auto&& pair : _keyValueMap) g.txn()->put(pair.first, pair.second);
+
+    return concordUtils::Status::OK();
+  }
+
+  concordUtils::Status multiDel(const KeysVector& _keysVec) override {
+    for (auto&& key : _keysVec)
+      if (Status s = del(key); !s.isOK()) return s;
+    return concordUtils::Status::OK();
+  }
+
+  bool isNew() override { throw std::logic_error("isNew()  Not implemented for ECS S3 object store"); }
+
+  IDBClient::IDBClientIterator* getIterator() const override {
+    Assert("getIterator() Not implemented for ECS S3 object store" && false);
+    throw std::logic_error("getIterator() Not implemented for ECS S3 object store");
+  }
+
+  concordUtils::Status freeIterator(IDBClientIterator* _iter) const override {
+    throw std::logic_error("freeIterator() Not implemented for ECS S3 object store");
+  }
+
+  ITransaction* beginTransaction() override { return new Transaction(this); }
+
+  ///////////////////////// protected /////////////////////////////
+ protected:
+  // retry forever, increasing the waiting timeout until it reaches the defined maximum
+  template <typename F, typename... Args>
+  void do_with_retry(Status& r, F&& f, Args&&... args) const {
+    uint16_t delay = initialDelay_;
+    do {
+      r = std::forward<F>(f)(std::forward<Args>(args)...);
+      if (!r.isGeneralError()) break;
+      if (delay < config_.maxWaitTime) delay *= delayFactor_;
+      LOG_INFO(logger_, "retrying " << typeid(f).name() << " after delay: " << delay);
+      std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+    } while (!r.isOK() || !r.isNotFound());
+  }
+
+  concordUtils::Status get_internal(const concordUtils::Sliver& _key, OUT concordUtils::Sliver& _outValue) const;
+
+  concordUtils::Status put_internal(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value);
+
+  concordUtils::Status object_exists_internal(const concordUtils::Sliver& key) const;
+
+  concordUtils::Status test_bucket_internal();
+
+  struct ResponseData {
+    S3Status status = S3Status::S3StatusOK;
+    std::string errorMessage;
+  };
+
+  /**
+   * @brief Represents intermidiate data for get operation and is passed to
+   * the lambda callback.
+   *
+   */
+  struct GetObjectResponseData : public ResponseData {
+    GetObjectResponseData(size_t linitialLength) : data(new char[linitialLength]), dataLength(linitialLength) {}
+
+    void CheckAndResize(int& nextReadLength) {
+      if (readLength + nextReadLength <= dataLength) return;
+
+      dataLength *= 2;
+      char* newData = new char[dataLength];
+      memcpy(newData, data, readLength);
+      delete[] data;
+      data = newData;
+    }
+
+    void Write(const char* _data, int& dataSize) {
+      CheckAndResize(dataSize);
+      memcpy(data + readLength, _data, dataSize);
+      readLength += dataSize;
+    }
+
+    ~GetObjectResponseData() { delete[] data; }
+
+    char* data = nullptr;
+    size_t dataLength = 0;
+    size_t readLength = 0;
+  };
+
+  /**
+   * @brief Represents intermidiate data for put operation and is passed to
+   * the lambda callback.
+   *
+   */
+  struct PutObjectResponseData : public ResponseData {
+    PutObjectResponseData(const char* _data, size_t&& _dataLength) : data(_data), dataLength(_dataLength) {}
+
+    const char* data;
+    size_t dataLength;
+    size_t putCount = 0;
+  };
+
+  static void responseCompleteCallback(S3Status status, const S3ErrorDetails* error, void* callbackData) {
+    ResponseData* cb = nullptr;
+    if (callbackData) {
+      cb = static_cast<ResponseData*>(callbackData);
+      cb->status = status;
+    }
+    if (error) {
+      if (error->message) {
+        if (cb) cb->errorMessage = std::string(error->message);
+      }
+    }
+  }
+
+  static S3Status propertiesCallback(const S3ResponseProperties* properties, void* callbackData) {
+    return S3Status::S3StatusOK;
+  }
+
+  S3ResponseHandler responseHandler = {NULL, &responseCompleteCallback};
+  StoreConfig config_;
+  S3BucketContext context_;
+  bool init_ = false;
+  const uint32_t kInitialGetBufferSize_ = 25000;
+  std::mutex initLock_;
+  concordlogger::Logger logger_ = concordlogger::Log::getLogger("concord.storage.s3");
+
+  uint16_t initialDelay_ = 100;
+  const double delayFactor_ = 1.5;
+};
+
+}  // namespace concord::storage::s3

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -57,6 +57,7 @@ class IDBClient {
   virtual void init(bool readOnly = false) = 0;
   virtual Status get(const Sliver& _key, OUT Sliver& _outValue) const = 0;
   virtual Status get(const Sliver& _key, OUT char*& buf, uint32_t bufSize, OUT uint32_t& _size) const = 0;
+  virtual Status has(const Sliver& _key) const = 0;
   virtual Status put(const Sliver& _key, const Sliver& _value) = 0;
   virtual Status del(const Sliver& _key) = 0;
   virtual Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) = 0;

--- a/storage/include/storage/db_types.h
+++ b/storage/include/storage/db_types.h
@@ -22,7 +22,7 @@ inline namespace v1DirectKeyValue {
 namespace detail {
 
 enum class EDBKeyType : std::uint8_t {
-  E_DB_KEY_TYPE_FIRST = 1,
+  E_DB_KEY_TYPE_FIRST = 65,
   E_DB_KEY_TYPE_BLOCK = E_DB_KEY_TYPE_FIRST,
   E_DB_KEY_TYPE_KEY,
   E_DB_KEY_TYPE_BFT_METADATA_KEY,

--- a/storage/include/storage/key_manipulator.hpp
+++ b/storage/include/storage/key_manipulator.hpp
@@ -12,29 +12,29 @@
 namespace concord::storage {
 
 inline namespace v1DirectKeyValue {
-class DBKeyManipulatorBase {
+class DBKeyGeneratorBase {
  protected:
-  static bool copyToAndAdvance(char *_buf, size_t *_offset, size_t _maxOffset, char *_src, size_t _srcSize);
-  static concordlogger::Logger &logger() {
+  static bool copyToAndAdvance(char* buf, size_t* offset, size_t _maxOffset, const char* _src, const size_t& _srcSize);
+  static concordlogger::Logger& logger() {
     static concordlogger::Logger logger_ = concordlogger::Log::getLogger("concord.storage.blockchain.DBKeyManipulator");
     return logger_;
   }
 };
 
-class MetadataKeyManipulator : public DBKeyManipulatorBase {
+class MetadataKeyManipulator : public DBKeyGeneratorBase {
  public:
   static concordUtils::Sliver generateMetadataKey(ObjectId objectId);
 };
 
-class STKeyManipulator : public DBKeyManipulatorBase {
+class STKeyManipulator : public DBKeyGeneratorBase {
  public:
   static concordUtils::Sliver generateStateTransferKey(ObjectId objectId);
   static concordUtils::Sliver generateSTPendingPageKey(uint32_t pageid);
   static concordUtils::Sliver generateSTCheckpointDescriptorKey(uint64_t chkpt);
   static concordUtils::Sliver generateSTReservedPageStaticKey(uint32_t pageid, uint64_t chkpt);
   static concordUtils::Sliver generateSTReservedPageDynamicKey(uint32_t pageid, uint64_t chkpt);
-  static uint64_t extractCheckPointFromKey(const char *_key_data, size_t _key_length);
-  static std::pair<uint32_t, uint64_t> extractPageIdAndCheckpointFromKey(const char *_key_data, size_t _key_length);
+  static uint64_t extractCheckPointFromKey(const char* _key_data, size_t _key_length);
+  static std::pair<uint32_t, uint64_t> extractPageIdAndCheckpointFromKey(const char* _key_data, size_t _key_length);
 
  private:
   static Sliver generateReservedPageKey(detail::EDBKeyType, uint32_t pageid, uint64_t chkpt);

--- a/storage/src/key_manipulator.cpp
+++ b/storage/src/key_manipulator.cpp
@@ -111,8 +111,8 @@ Sliver STKeyManipulator::generateReservedPageKey(EDBKeyType keyType, uint32_t pa
   return Sliver(keyBuf, keySize);
 }
 
-bool DBKeyManipulatorBase::copyToAndAdvance(
-    char *_buf, size_t *_offset, size_t _maxOffset, char *_src, size_t _srcSize) {
+bool DBKeyGeneratorBase::copyToAndAdvance(
+    char *_buf, size_t *_offset, size_t _maxOffset, const char *_src, const size_t &_srcSize) {
   if (!_buf && !_offset && !_src) assert(false);
 
   if (*_offset >= _maxOffset && _srcSize > 0) assert(false);

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -59,6 +59,11 @@ Status Client::get(const Sliver &_key, OUT char *&buf, uint32_t bufSize, OUT uin
   return status;
 }
 
+Status Client::has(const Sliver &_key) const {
+  Sliver dummy_out;
+  return get(_key, dummy_out);
+}
+
 /**
  * @brief Returns reference to a new object of IDBClientIterator.
  *

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -178,6 +178,11 @@ Status Client::get(const Sliver &_key, OUT char *&buf, uint32_t bufSize, OUT uin
   return Status::OK();
 }
 
+Status Client::has(const Sliver &_key) const {
+  Sliver dummy_out;
+  return get(_key, dummy_out);
+}
+
 /**
  * @brief Returns a RocksDBClientIterator object.
  *

--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -1,0 +1,207 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+// This convenience header combines different block implementations.
+
+#include "s3/client.hpp"
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <functional>
+#include "Logger.hpp"
+#include "assertUtils.hpp"
+#include "storage/db_interface.h"
+
+namespace concord::storage::s3 {
+
+using namespace std;
+using namespace concordUtils;
+
+/**
+ * @brief Initializing underlying libs3. The S3_initialize function must be
+ * called exactly once and only from 1 thread
+ *
+ * @param readOnly
+ */
+void Client::init(bool readOnly) {
+  std::lock_guard<std::mutex> g(initLock_);
+  Assert(!init_);  // we may return here instead of firing assert failure, but
+                   // probably we want to catch bugs?
+  context_.hostName = config_.url.c_str();
+  context_.protocol = (config_.protocol == "HTTP" ? S3ProtocolHTTP : S3ProtocolHTTPS);
+  context_.uriStyle = S3UriStylePath;
+  /* In ECS terms, this is your object user */
+  context_.accessKeyId = config_.accessKey.c_str();
+  context_.secretAccessKey = config_.secretKey.c_str();
+  /* The name of a bucket to use */
+  context_.bucketName = config_.bucketName.c_str();
+
+  S3Status st = S3_initialize(NULL, S3_INIT_ALL, NULL);
+  if (S3Status::S3StatusOK != st) {
+    LOG_FATAL(logger_, "libs3 init failed, status: " + to_string(st));
+    Assert("libs3 init failed" && false);
+  }
+  LOG_INFO(logger_, "libs3 initialized");
+  init_ = true;
+  log4cplus::Logger::getInstance("concord.storage.s3").setLogLevel(log4cplus::DEBUG_LOG_LEVEL);
+}
+
+Status Client::del(const Sliver& key) {
+  assert(init_);
+  ResponseData rData;
+  S3ResponseHandler rHandler;
+  rHandler.completeCallback = responseCompleteCallback;
+  rHandler.propertiesCallback = propertiesCallback;
+  S3_delete_object(&context_, string(key.data()).c_str(), NULL, &rHandler, &rData);
+  LOG_DEBUG(logger_,
+            "del key: " << string(key.data()) << ", status: " << rData.status << ", msg: " << rData.errorMessage);
+  if (rData.status == S3Status::S3StatusOK)
+    return Status::OK();
+  else {
+    LOG_ERROR(logger_,
+              "del key: " << string(key.data()) << ", status: " << rData.status << ", msg: " << rData.errorMessage);
+    if (rData.status == S3Status::S3StatusHttpErrorNotFound || rData.status == S3Status::S3StatusErrorNoSuchBucket ||
+        rData.status == S3Status::S3StatusErrorNoSuchKey)
+      return Status::NotFound("Status: " + to_string(rData.status) + "msg: " + rData.errorMessage);
+
+    return Status::GeneralError("Status: " + to_string(rData.status) + "msg: " + rData.errorMessage);
+  }
+}
+
+Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
+  Assert(init_);
+  LOG_INFO(logger_, "get key: " << _key.toString());
+  GetObjectResponseData cbData(kInitialGetBufferSize_);
+  S3GetObjectHandler getObjectHandler;
+  getObjectHandler.responseHandler = responseHandler;
+
+  // libs3 uses multiple calls to this callaback to append chunks of data from
+  // the stream
+  auto f = [](int buf_len, const char* buf, void* cb) -> S3Status {
+    GetObjectResponseData* cbData = static_cast<GetObjectResponseData*>(cb);
+    Assert(cbData->data != nullptr);
+    cbData->Write(buf, buf_len);
+    return S3Status::S3StatusOK;
+  };
+  getObjectHandler.getObjectDataCallback = f;
+  S3_get_object(&context_, _key.data(), NULL, 0, 0, NULL, &getObjectHandler, &cbData);
+  if (cbData.status == S3Status::S3StatusOK) {
+    _outValue = Sliver::copy(reinterpret_cast<const char*>(cbData.data), cbData.readLength);
+    return Status::OK();
+  } else {
+    LOG_INFO(logger_, "get status: " << S3_get_status_name(cbData.status));
+    if (cbData.status == S3Status::S3StatusHttpErrorNotFound || cbData.status == S3Status::S3StatusErrorNoSuchBucket ||
+        cbData.status == S3Status::S3StatusErrorNoSuchKey)
+      return Status::NotFound("Status: " + std::string(S3_get_status_name(cbData.status)) +
+                              "msg: " + cbData.errorMessage);
+
+    return Status::GeneralError("Status: " + std::string(S3_get_status_name(cbData.status)) +
+                                "msg: " + cbData.errorMessage);
+  }
+}
+
+Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
+  Assert(init_);
+  PutObjectResponseData cbData(_value.data(), _value.length());
+  S3PutObjectHandler putObjectHandler;
+  putObjectHandler.responseHandler = responseHandler;
+
+  // libs3 uses multiple calls to this callaback to append chunks of data to
+  // the stream
+  auto f = [](int buf_len, char* buf, void* cb) {
+    PutObjectResponseData* cbData = static_cast<PutObjectResponseData*>(cb);
+    int toSend = 0;
+    if (cbData->dataLength) {
+      toSend = std::min(cbData->dataLength, (size_t)buf_len);
+      std::memcpy(buf, cbData->data + cbData->putCount, toSend);
+    }
+    cbData->putCount += toSend;
+    cbData->dataLength -= toSend;
+    return toSend;
+  };
+  putObjectHandler.putObjectDataCallback = f;
+  string s = string(_key.data());
+  S3_put_object(&context_, string(_key.data()).c_str(), _value.length(), NULL, NULL, &putObjectHandler, &cbData);
+  if (cbData.status == S3Status::S3StatusOK)
+    return Status::OK();
+  else {
+    LOG_ERROR(logger_, "put status: " << cbData.status);
+    if (cbData.status == S3Status::S3StatusHttpErrorNotFound || cbData.status == S3Status::S3StatusErrorNoSuchBucket)
+      return Status::NotFound("Status: " + to_string(cbData.status) + "msg: " + cbData.errorMessage);
+
+    return Status::GeneralError("Status: " + to_string(cbData.status) + "msg: " + cbData.errorMessage);
+  }
+}
+
+Status Client::object_exists_internal(const Sliver& key) const {
+  Assert(init_);
+  ResponseData rData;
+  S3ResponseHandler rHandler;
+  rHandler.completeCallback = responseCompleteCallback;
+  rHandler.propertiesCallback = propertiesCallback;
+
+  S3_head_object(&context_, string(key.data()).c_str(), NULL, &rHandler, &rData);
+  LOG_DEBUG(
+      logger_,
+      "object_exist key: " << string(key.data()) << ", status: " << rData.status << ", msg: " << rData.errorMessage);
+  if (rData.status == S3Status::S3StatusOK)
+    return Status::OK();
+  else {
+    LOG_ERROR(
+        logger_,
+        "object_exist key: " << string(key.data()) << ", status: " << rData.status << ", msg: " << rData.errorMessage);
+    if (rData.status == S3Status::S3StatusHttpErrorNotFound || rData.status == S3Status::S3StatusErrorNoSuchBucket ||
+        rData.status == S3Status::S3StatusErrorNoSuchKey)
+      return Status::NotFound("Status: " + to_string(rData.status) + "msg: " + rData.errorMessage);
+
+    return Status::GeneralError("Status: " + to_string(rData.status) + "msg: " + rData.errorMessage);
+  }
+}
+
+Status Client::test_bucket_internal() {
+  Assert(init_);
+  ResponseData rData;
+  S3ResponseHandler rHandler;
+  rHandler.completeCallback = responseCompleteCallback;
+  rHandler.propertiesCallback = propertiesCallback;
+  char location[100];
+
+  S3_test_bucket(context_.protocol,
+                 context_.uriStyle,
+                 context_.accessKeyId,
+                 context_.secretAccessKey,
+                 context_.hostName,
+                 context_.bucketName,
+                 100,
+                 location,
+                 NULL,
+                 &rHandler,
+                 &rData);
+  LOG_DEBUG(
+      logger_,
+      "test_bucket bucket: " << context_.bucketName << ", status: " << rData.status << ", msg: " << rData.errorMessage);
+  if (rData.status == S3Status::S3StatusOK)
+    return Status::OK();
+  else {
+    LOG_ERROR(logger_,
+              "test_bucket bucket: " << context_.bucketName << ", status: " << rData.status
+                                     << ", msg: " << rData.errorMessage);
+    if (rData.status == S3Status::S3StatusHttpErrorNotFound || rData.status == S3Status::S3StatusErrorNoSuchBucket)
+      return Status::NotFound("Status: " + to_string(rData.status) + "msg: " + rData.errorMessage);
+
+    return Status::GeneralError("Status: " + to_string(rData.status) + "msg: " + rData.errorMessage);
+  }
+}
+
+}  // namespace concord::storage::s3

--- a/storage/test/ecs_s3_test.cpp
+++ b/storage/test/ecs_s3_test.cpp
@@ -1,0 +1,370 @@
+// Copyright 2019 VMware, all rights reserved
+//
+// Unit tests for ECS S3 object store replication
+// IMPORTANT: the test assume that the S3 storage is up.
+
+#include <memory>
+#include "gtest/gtest.h"
+#include "object_store/object_store_client.hpp"
+#include "s3/client.hpp"
+
+using namespace concord::storage;
+
+namespace concord::storage::test {
+
+/**
+ * This class is used to tell the ObjectStore client impl to simulate network failure for predefined
+ * ammount of time. Also it can be used for controlling deletion of objects (useful for tests)
+ */
+class ObjectStoreBehavior {
+ private:
+  bool allowNetworkFailure_ = false;
+  std::chrono::time_point<std::chrono::steady_clock> startTimeForNetworkFailure_;
+  bool doNetworkFailure_ = false;
+  uint64_t doNetworkFailureDurMilli_ = 0;
+
+ public:
+  ObjectStoreBehavior(bool canSimulateNetFailure) : allowNetworkFailure_{canSimulateNetFailure} {}
+  // set network failure flag and duration
+  void set_do_net_failure(bool value, uint64_t durationMilli) {
+    doNetworkFailure_ = value;
+    doNetworkFailureDurMilli_ = durationMilli;
+    startTimeForNetworkFailure_ = std::chrono::steady_clock::now();
+  }
+  bool get_do_net_failure() const { return doNetworkFailure_; }
+  // used to assert whether its possible to simulate network failure
+  bool can_simulate_net_failure() const { return allowNetworkFailure_; }
+  // returns whether the network failure period has been elapsed
+  bool has_finished() const {
+    std::chrono::time_point<std::chrono::steady_clock> time = std::chrono::steady_clock::now();
+    auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(time - startTimeForNetworkFailure_).count();
+    return diff > 0 && (uint64_t)diff > doNetworkFailureDurMilli_;
+  }
+};
+/**
+ * Ecs S3 test client
+ */
+class EcsS3TestClient : public concord::storage::s3::Client {
+ public:
+  EcsS3TestClient(const S3_StoreConfig &config, const ObjectStoreBehavior &b)
+      : concord::storage::s3::Client(config), bh_{b} {}
+
+  Status del(const Sliver &key) override {
+    if (should_net_fail()) return Status::GeneralError("Network failure simulated");
+    return concord::storage::s3::Client::del(key);
+  }
+
+  Status get_internal(const Sliver &_key, OUT Sliver &_outValue) const override {
+    if (should_net_fail()) return Status::GeneralError("Network failure simulated");
+    return concord::storage::s3::Client::get_internal(_key, _outValue);
+  }
+
+  Status put_internal(const Sliver &_key, const Sliver &_value) override {
+    if (this->should_net_fail()) return Status::GeneralError("Network failure simulated");
+    return concord::storage::s3::Client::put_internal(_key, _value);
+  }
+
+  Status object_exists_internal(const Sliver &key) const override {
+    if (should_net_fail()) return Status::GeneralError("Network failure simulated");
+    return concord::storage::s3::Client::object_exists_internal(key);
+  }
+  Status test_bucket_internal() override {
+    if (should_net_fail()) return Status::GeneralError("Network failure simulated");
+    return concord::storage::s3::Client::test_bucket_internal();
+  }
+
+ protected:
+  bool should_net_fail() const {
+    bool b1 = bh_.can_simulate_net_failure();
+    if (!b1) return false;
+    bool b3 = bh_.get_do_net_failure();
+    if (!b3) return false;
+    bool b2 = bh_.has_finished();
+    if (b2) return false;
+    return true;
+  }
+
+ protected:
+  ObjectStoreBehavior bh_;
+};
+/**
+ * object store test client
+ */
+class ObjectStoreTestClient : public concord::storage::ObjectStoreClient {
+ public:
+  ObjectStoreTestClient(IDBClient *impl) : concord::storage::ObjectStoreClient(impl) {}
+  Status test_bucket() { return dynamic_pointer_cast<EcsS3TestClient>(pImpl_)->test_bucket(); }
+
+ protected:
+};
+
+/**
+ * Ecs test fixture
+ */
+class EcsS3Test : public ::testing::Test {
+ protected:
+  EcsS3Test() {
+    config.bucketName = "blockchain-dev-asx";
+    config.accessKey = "blockchain-dev";
+    config.protocol = "HTTP";
+    config.url = "10.70.30.244:9020";
+    config.secretKey = "Rz0mdbUNGJBxqdzprn5XGSXPr2AfkgcQsYS4y698";
+    config.maxWaitTime = 10000;
+  }
+
+  void SetClient(ObjectStoreBehavior b = ObjectStoreBehavior(false)) {
+    client.reset(new ObjectStoreTestClient(new EcsS3TestClient(config, b)));
+    client->init();
+  }
+
+  void SetBucketName(std::string name) { config.bucketName = name; }
+
+  S3_StoreConfig config;
+  std::shared_ptr<ObjectStoreTestClient> client = nullptr;
+};
+
+/**
+ * @brief put and get regular string object
+ *
+ */
+TEST_F(EcsS3Test, PutGetStringObject) {
+  SetClient();
+
+  Sliver key("unit_test_key");
+  Sliver value("unit_test_object");
+  Status s = client->put(key, value);
+
+  ASSERT_EQ(s, Status::OK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(value, rvalue);
+}
+
+/**
+ * @brief put and get several regular string objects in batch
+ *
+ */
+TEST_F(EcsS3Test, multiPut) {
+  SetClient();
+  SetOfKeyValuePairs pairs;
+  for (int i = 0; i < 10; ++i) pairs["multiPutKey" + std::to_string(i)] = "multiPutValue" + std::to_string(i);
+
+  ASSERT_EQ(client->multiPut(pairs), Status::OK());
+
+  KeysVector keys;
+  for (int i = 0; i < 10; ++i) keys.push_back("multiPutKey" + std::to_string(i));
+
+  ValuesVector values(10);
+  ASSERT_EQ(client->multiGet(keys, values), Status::OK());
+  for (int i = 0; i < 10; ++i)
+    ASSERT_STRCASEEQ(values[i].toString().c_str(), std::string("multiPutValue" + std::to_string(i)).c_str());
+
+  ASSERT_EQ(client->multiDel(keys), Status::OK());
+}
+
+/**
+ * @brief put and get regular string object with retry
+ *
+ */
+TEST_F(EcsS3Test, PutGetStringObjectRetryOK) {
+  ObjectStoreBehavior b(true);
+  b.set_do_net_failure(true, config.maxWaitTime / 2);
+  SetClient(b);
+
+  Sliver key("unit_test_key");
+  Sliver value("unit_test_object");
+
+  Status s = client->put(key, value);
+
+  ASSERT_EQ(s, Status::OK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(value, rvalue);
+}
+
+/**
+ * @brief try to put object into non existing bucket
+ *
+ */
+TEST_F(EcsS3Test, PutObjectBucketNotExists) {
+  SetBucketName("non_existing_bucket");
+  SetClient();
+
+  Sliver key("unit_test_key");
+  Sliver value("unit_test_object");
+  Status s = client->put(key, value);
+  ASSERT_TRUE(s.isNotFound());
+}
+
+/**
+ * @brief try to get object from non existing bucket
+ *
+ */
+TEST_F(EcsS3Test, GetObjectBucketNotExists) {
+  SetBucketName("non_existing_bucket");
+  SetClient();
+
+  Sliver key("unit_test_key");
+  Sliver v;
+  Status s = client->get(key, v);
+  ASSERT_TRUE(s.isNotFound());
+  ASSERT_EQ(v.length(), 0);
+}
+
+TEST_F(EcsS3Test, GetObjectNotExists) {
+  SetClient();
+
+  Sliver key("unit_test_key12345");
+  Sliver value;
+  Status s = client->get(key, value);
+  ASSERT_TRUE(s.isNotFound());
+  ASSERT_EQ(value.length(), 0);
+}
+
+/**
+ * @brief put and get binary object
+ *
+ */
+TEST_F(EcsS3Test, PutGetBinaryObject) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[250];
+  for (int i = 0; i < 250; i++) _value[i] = i;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 250);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(wvalue, rvalue);
+}
+
+/**
+ * @brief Put and get large binary object when 25000 is maximum preallocated
+ * memory for sending the data
+ *
+ */
+TEST_F(EcsS3Test, PutGetLargeBinaryObject) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[25000];
+  for (int i = 0; i < 25000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 25000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_EQ(wvalue, rvalue);
+}
+
+/**
+ * @brief Put and get large binary object when 25000 is maximum preallocated
+ * memory for sending the data expecting the buffer to grow exactly 4 times
+ *
+ */
+TEST_F(EcsS3Test, PutGetLargeBinaryObjectWithResize) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[100000];
+  for (int i = 0; i < 100000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 100000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver rvalue;
+  s = client->get(key, rvalue);
+  ASSERT_TRUE(s.isOK());
+  ASSERT_TRUE(wvalue == rvalue);
+}
+
+/**
+ * @brief Check retrieving object headers functionality
+ *
+ */
+TEST_F(EcsS3Test, ObjectExists) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[100000];
+  for (int i = 0; i < 100000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 100000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  s = client->has(key);
+  ASSERT_TRUE(s.isOK());
+}
+
+/**
+ * @brief Check retrieving object headers functionality
+ *
+ */
+TEST_F(EcsS3Test, ObjectNotExists) {
+  SetClient();
+
+  uint8_t *_key = new uint8_t[30];
+  for (int i = 0; i < 30; i++) _key[i] = i + 1;
+
+  uint8_t *_value = new uint8_t[100000];
+  for (int i = 0; i < 100000; i++) _value[i] = 'a' + 0;
+
+  Sliver key((const char *)_key, 30);
+  Sliver wvalue((const char *)_value, 100000);
+  Status s = client->put(key, wvalue);
+  ASSERT_TRUE(s.isOK());
+  Sliver key2("non_existing_key");
+  s = client->has(key2);
+  ASSERT_TRUE(s.isNotFound());
+}
+
+/**
+ * @brief Check retrieving object headers functionality
+ *
+ */
+TEST_F(EcsS3Test, TestBucketExists) {
+  SetClient();
+  Status s = client->test_bucket();
+  ASSERT_TRUE(s.isOK());
+}
+
+TEST_F(EcsS3Test, TestBucketExistsRetryOK) {
+  ObjectStoreBehavior b{true};
+  b.set_do_net_failure(true, config.maxWaitTime / 2);
+  SetClient(b);
+  Status s = client->test_bucket();
+  ASSERT_EQ(s, Status::OK());
+}
+
+TEST_F(EcsS3Test, TestBucketNotExists) {
+  SetBucketName("non_existing_bucket");
+  SetClient();
+  Status s = client->test_bucket();
+  ASSERT_TRUE(s.isNotFound());
+}
+
+}  // namespace concord::storage::test
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto exitCode = RUN_ALL_TESTS();
+  return exitCode;
+}

--- a/tests/simpleKVBC/TesterReplica/CMakeLists.txt
+++ b/tests/simpleKVBC/TesterReplica/CMakeLists.txt
@@ -15,6 +15,10 @@ if(${USE_COMM_TLS_TCP})
 	target_compile_definitions(skvbc_replica PUBLIC USE_COMM_TLS_TCP)
 endif()
 
+if(BUILD_ROCKSDB_STORAGE)
+	target_compile_definitions(skvbc_replica PUBLIC "USE_ROCKSDB=1")
+endif()
+
 target_link_libraries(skvbc_replica PUBLIC kvbc corebft threshsign util test_config_lib $<TARGET_OBJECTS:logging_dev>)
 
 target_include_directories(skvbc_replica PUBLIC ..)

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -18,8 +18,9 @@
 #include "sliver.hpp"
 #include "simpleKVBTestsBuilder.hpp"
 #include "db_interfaces.h"
-#include "KVBCInterfaces.h"
 #include "block_metadata.hpp"
+#include "KVBCInterfaces.h"
+#include <memory>
 
 class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
  public:

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -14,18 +14,25 @@
 #pragma once
 
 #include <memory>
-
+#include <utility>
 #include "ReplicaConfig.hpp"
 #include "ICommunication.hpp"
 #include "Logger.hpp"
 #include "MetricsServer.hpp"
+#include "config/test_parameters.hpp"
 
-namespace concord {
-namespace kvbc {
+namespace concord::storage {
+class IDBClient;
+}
+
+namespace concord::kvbc {
+class IDbAdapter;
 
 class TestSetup {
  public:
   static std::unique_ptr<TestSetup> ParseArgs(int argc, char** argv);
+
+  std::tuple<std::shared_ptr<concord::storage::IDBClient>, IDbAdapter*> get_db_configuration();
 
   bftEngine::ReplicaConfig& GetReplicaConfig() { return replica_config_; }
   bftEngine::ICommunication* GetCommunication() const { return communication_.get(); }
@@ -46,6 +53,7 @@ class TestSetup {
         use_persistent_storage_(use_persistent_storage) {}
   TestSetup() = delete;
 
+  std::tuple<std::shared_ptr<concord::storage::IDBClient>, IDbAdapter*> get_inmem_db_configuration();
   bftEngine::ReplicaConfig replica_config_;
   std::unique_ptr<bftEngine::ICommunication> communication_;
   concordlogger::Logger logger_;
@@ -53,5 +61,4 @@ class TestSetup {
   bool use_persistent_storage_;
 };
 
-}  // namespace kvbc
-}  // namespace concord
+}  // namespace concord::kvbc

--- a/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
+++ b/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
@@ -16,7 +16,10 @@ cleanup
 ../TesterReplica/skvbc_replica -k ro_config_ -i 1 -p &
 ../TesterReplica/skvbc_replica -k ro_config_ -i 2 -p &
 ../TesterReplica/skvbc_replica -k ro_config_ -i 3 -p &
-#../TesterReplica/skvbc_replica -k ro_config_ -i 4 -p &
+../TesterReplica/skvbc_replica -k ro_config_ -i 4 -p -o 1 &
+
+echo "Sleeping for 5 seconds"
+sleep 5
 
 time ../TesterClient/skvbc_client -f 1 -c 0 -p 1800 -i 5
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -10,6 +10,10 @@ add_library(util STATIC
     src/sliver.cpp
     src/hex_tools.cpp)
 
+if(BUILD_ROCKSDB_STORAGE)
+    target_compile_definitions(util PUBLIC "USE_ROCKSDB=1")
+endif()
+
 target_link_libraries(util PUBLIC Threads::Threads)
 target_include_directories(util PUBLIC include)
 

--- a/util/include/Handoff.hpp
+++ b/util/include/Handoff.hpp
@@ -1,0 +1,97 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <queue>
+#include <thread>
+#include <mutex>
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <exception>
+#include "Logger.hpp"
+
+namespace concord::util {
+/**
+ * Simple handing off to a dedicated thread functionality.
+ * Implemented by passing a function with a trivial signature void(void).
+ * Parameters are bound to an arbitrary function by a caller.
+ */
+class Handoff {
+  typedef std::lock_guard<std::mutex> guard;
+  typedef std::function<void()> func_type;
+
+ public:
+  Handoff() {
+    thread_ = std::thread([this] {
+      try {
+        for (;;) pop()();
+      } catch (ThreadCanceledException& e) {
+        LOG_DEBUG(getLogger(), "thread stopped " << std::this_thread::get_id());
+      } catch (const std::exception& e) {
+        LOG_ERROR(getLogger(), "exception: " << e.what());
+        // TODO [TK] should we allow different behavior for exception handling?
+      }
+    });
+  }
+  ~Handoff() {
+    stopped_ = true;
+    queue_cond_.notify_one();
+    auto tid = thread_.get_id();
+    thread_.join();
+    LOG_DEBUG(getLogger(), "thread joined " << tid);
+  }
+
+  void push(func_type f) {
+    {
+      guard g(queue_lock_);
+      task_queue_.push(f);
+    }
+    queue_cond_.notify_one();
+  }
+
+ protected:
+  class ThreadCanceledException : public std::runtime_error {
+   public:
+    ThreadCanceledException() : std::runtime_error("thread cancelled") {}
+    const char* what() const noexcept override { return std::runtime_error::what(); }
+  };
+
+  func_type pop() {
+    while (true) {
+      std::unique_lock<std::mutex> ul(queue_lock_);
+      queue_cond_.wait(ul, [this] { return !(task_queue_.empty() && !stopped_); });
+      LOG_TRACE(getLogger(), "notified stopped_: " << stopped_ << " queue size: " << task_queue_.size());
+
+      if (!stopped_ || (stopped_ && !task_queue_.empty())) {
+        func_type f = task_queue_.front();
+        task_queue_.pop();
+        return f;
+      }
+      throw ThreadCanceledException();
+    }
+  }
+
+  static concordlogger::Logger getLogger() {
+    static concordlogger::Logger logger_ = concordlogger::Log::getLogger("concord.util.handoff");
+    return logger_;
+  }
+
+ protected:
+  std::queue<func_type> task_queue_;
+  std::mutex queue_lock_;
+  std::condition_variable queue_cond_;
+  std::atomic_bool stopped_;
+  std::thread thread_;
+};
+
+}  // namespace concord::util


### PR DESCRIPTION
Introducing S3-compatible external object store support.
Co-authored-by: @salieri11 
Co-authored-by: @toly-kournik 
Key points:
 S3:
- concord::storage::s3::client with S3KeyGenerator
- handing off state transfer messages in BCStateTransfer if used with remote object store

General:
- kvbc::ReplicaImp implements IAppState
- removed ReplicaImp::StorageWrapperForIdleMode
