### PR TITLE
Enable cancelling timed-out pre-execution requests

### DIFF
--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -25,6 +25,7 @@ struct ClientRequestMsgHeader {
   uint8_t flags;  // bit 0 == isReadOnly, bit 1 = preProcess, bits 2-7 are reserved
   uint64_t reqSeqNum;
   uint32_t requestLength;
+  uint64_t timeoutMilli;
   uint32_t cid_length = 0;
   // followed by the request (security information, such as signatures, should be part of the request)
 

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -54,17 +54,20 @@ struct ReplicaConfig {
   // 1 <= concurrencyLevel <= 30
   uint16_t concurrencyLevel = 0;
 
-  // viewChangeProtocolEnabled=true , if the view change protocol is enabled at all
+  // viewChangeProtocolEnabled=true, if the view change protocol is enabled at all
   bool viewChangeProtocolEnabled = false;
 
   // a time interval in milliseconds. represents the timeout used by the  view change protocol (TODO: add more details)
   uint16_t viewChangeTimerMillisec = 0;
 
-  // autoPrimaryRotationEnabled=true , if the automatic primary rotation is enabled
+  // autoPrimaryRotationEnabled=true, if the automatic primary rotation is enabled
   bool autoPrimaryRotationEnabled = false;
 
   // a time interval in milliseconds, represents the timeout for automatically replacing the primary
   uint16_t autoPrimaryRotationTimerMillisec = 0;
+
+  // a time interval in milliseconds represents the timeout for the detection of timed out pre-execution requests
+  uint64_t preexecReqStatusCheckTimerMillisec = 5000;
 
   // public keys of all replicas. map from replica identifier to a public key
   std::set<std::pair<uint16_t, const std::string>> publicKeysOfReplicas;
@@ -138,6 +141,7 @@ class ReplicaConfigSingleton {
   std::set<std::pair<uint16_t, const std::string>> GetPublicKeysOfReplicas() const {
     return config_->publicKeysOfReplicas;
   }
+  uint64_t GetPreexecReqStatusCheckTimerMillisec() const { return config_->preexecReqStatusCheckTimerMillisec; }
   std::string GetReplicaPrivateKey() const { return config_->replicaPrivateKey; }
 
   IThresholdSigner const* GetThresholdSignerForExecution() const { return config_->thresholdSignerForExecution; }

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -67,7 +67,7 @@ struct ReplicaConfig {
   uint16_t autoPrimaryRotationTimerMillisec = 0;
 
   // a time interval in milliseconds represents the timeout for the detection of timed out pre-execution requests
-  uint64_t preexecReqStatusCheckTimerMillisec = 5000;
+  uint64_t preExecReqStatusCheckTimerMillisec = 5000;
 
   // public keys of all replicas. map from replica identifier to a public key
   std::set<std::pair<uint16_t, const std::string>> publicKeysOfReplicas;
@@ -141,7 +141,7 @@ class ReplicaConfigSingleton {
   std::set<std::pair<uint16_t, const std::string>> GetPublicKeysOfReplicas() const {
     return config_->publicKeysOfReplicas;
   }
-  uint64_t GetPreexecReqStatusCheckTimerMillisec() const { return config_->preexecReqStatusCheckTimerMillisec; }
+  uint64_t GetPreExecReqStatusCheckTimerMillisec() const { return config_->preExecReqStatusCheckTimerMillisec; }
   std::string GetReplicaPrivateKey() const { return config_->replicaPrivateKey; }
 
   IThresholdSigner const* GetThresholdSignerForExecution() const { return config_->thresholdSignerForExecution; }

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -26,11 +26,12 @@ uint32_t ReplicaConfigSerializer::maxSize(uint32_t numOfReplicas) {
           sizeof(config_->numOfClientProxies) + sizeof(config_->statusReportTimerMillisec) +
           sizeof(config_->concurrencyLevel) + sizeof(config_->viewChangeProtocolEnabled) +
           sizeof(config_->viewChangeTimerMillisec) + sizeof(config_->autoPrimaryRotationEnabled) +
-          sizeof(config_->autoPrimaryRotationTimerMillisec) + MaxSizeOfPrivateKey + numOfReplicas * MaxSizeOfPublicKey +
-          IThresholdSigner::maxSize() * 3 + IThresholdVerifier::maxSize() * 3 +
-          sizeof(config_->maxExternalMessageSize) + sizeof(config_->maxReplyMessageSize) +
-          sizeof(config_->maxNumOfReservedPages) + sizeof(config_->sizeOfReservedPage) +
-          sizeof(config_->debugPersistentStorageEnabled) + sizeof(config_->metricsDumpIntervalSeconds));
+          sizeof(config_->autoPrimaryRotationTimerMillisec) + sizeof(config_->preexecReqStatusCheckTimerMillisec) +
+          MaxSizeOfPrivateKey + numOfReplicas * MaxSizeOfPublicKey + IThresholdSigner::maxSize() * 3 +
+          IThresholdVerifier::maxSize() * 3 + sizeof(config_->maxExternalMessageSize) +
+          sizeof(config_->maxReplyMessageSize) + sizeof(config_->maxNumOfReservedPages) +
+          sizeof(config_->sizeOfReservedPage) + sizeof(config_->debugPersistentStorageEnabled) +
+          sizeof(config_->metricsDumpIntervalSeconds));
 }
 
 ReplicaConfigSerializer::ReplicaConfigSerializer(ReplicaConfig *config) {
@@ -89,6 +90,10 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
   // Serialize autoPrimaryRotationTimerMillisec
   outStream.write((char *)&config_->autoPrimaryRotationTimerMillisec,
                   sizeof(config_->autoPrimaryRotationTimerMillisec));
+
+  // Serialize preexecReqStatusCheckTimerMillisec
+  outStream.write((char *)&config_->preexecReqStatusCheckTimerMillisec,
+                  sizeof(config_->preexecReqStatusCheckTimerMillisec));
 
   // Serialize public keys
   auto numOfPublicKeys = (int64_t)config_->publicKeysOfReplicas.size();
@@ -150,6 +155,7 @@ bool ReplicaConfigSerializer::operator==(const ReplicaConfigSerializer &other) c
        (other.config_->viewChangeTimerMillisec == config_->viewChangeTimerMillisec) &&
        (other.config_->autoPrimaryRotationEnabled == config_->autoPrimaryRotationEnabled) &&
        (other.config_->autoPrimaryRotationTimerMillisec == config_->autoPrimaryRotationTimerMillisec) &&
+       (other.config_->preexecReqStatusCheckTimerMillisec == config_->preexecReqStatusCheckTimerMillisec) &&
        (other.config_->replicaPrivateKey == config_->replicaPrivateKey) &&
        (other.config_->publicKeysOfReplicas == config_->publicKeysOfReplicas) &&
        (other.config_->debugPersistentStorageEnabled == config_->debugPersistentStorageEnabled) &&
@@ -203,6 +209,9 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
 
   // Deserialize autoPrimaryRotationTimerMillisec
   inStream.read((char *)&config.autoPrimaryRotationTimerMillisec, sizeof(config.autoPrimaryRotationTimerMillisec));
+
+  // Deserialize preexecReqStatusCheckTimerMillisec
+  inStream.read((char *)&config.preexecReqStatusCheckTimerMillisec, sizeof(config.preexecReqStatusCheckTimerMillisec));
 
   // Deserialize public keys
   int64_t numOfPublicKeys = 0;

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -26,7 +26,7 @@ uint32_t ReplicaConfigSerializer::maxSize(uint32_t numOfReplicas) {
           sizeof(config_->numOfClientProxies) + sizeof(config_->statusReportTimerMillisec) +
           sizeof(config_->concurrencyLevel) + sizeof(config_->viewChangeProtocolEnabled) +
           sizeof(config_->viewChangeTimerMillisec) + sizeof(config_->autoPrimaryRotationEnabled) +
-          sizeof(config_->autoPrimaryRotationTimerMillisec) + sizeof(config_->preexecReqStatusCheckTimerMillisec) +
+          sizeof(config_->autoPrimaryRotationTimerMillisec) + sizeof(config_->preExecReqStatusCheckTimerMillisec) +
           MaxSizeOfPrivateKey + numOfReplicas * MaxSizeOfPublicKey + IThresholdSigner::maxSize() * 3 +
           IThresholdVerifier::maxSize() * 3 + sizeof(config_->maxExternalMessageSize) +
           sizeof(config_->maxReplyMessageSize) + sizeof(config_->maxNumOfReservedPages) +
@@ -91,9 +91,9 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
   outStream.write((char *)&config_->autoPrimaryRotationTimerMillisec,
                   sizeof(config_->autoPrimaryRotationTimerMillisec));
 
-  // Serialize preexecReqStatusCheckTimerMillisec
-  outStream.write((char *)&config_->preexecReqStatusCheckTimerMillisec,
-                  sizeof(config_->preexecReqStatusCheckTimerMillisec));
+  // Serialize preExecReqStatusCheckTimerMillisec
+  outStream.write((char *)&config_->preExecReqStatusCheckTimerMillisec,
+                  sizeof(config_->preExecReqStatusCheckTimerMillisec));
 
   // Serialize public keys
   auto numOfPublicKeys = (int64_t)config_->publicKeysOfReplicas.size();
@@ -155,7 +155,7 @@ bool ReplicaConfigSerializer::operator==(const ReplicaConfigSerializer &other) c
        (other.config_->viewChangeTimerMillisec == config_->viewChangeTimerMillisec) &&
        (other.config_->autoPrimaryRotationEnabled == config_->autoPrimaryRotationEnabled) &&
        (other.config_->autoPrimaryRotationTimerMillisec == config_->autoPrimaryRotationTimerMillisec) &&
-       (other.config_->preexecReqStatusCheckTimerMillisec == config_->preexecReqStatusCheckTimerMillisec) &&
+       (other.config_->preExecReqStatusCheckTimerMillisec == config_->preExecReqStatusCheckTimerMillisec) &&
        (other.config_->replicaPrivateKey == config_->replicaPrivateKey) &&
        (other.config_->publicKeysOfReplicas == config_->publicKeysOfReplicas) &&
        (other.config_->debugPersistentStorageEnabled == config_->debugPersistentStorageEnabled) &&
@@ -210,8 +210,8 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
   // Deserialize autoPrimaryRotationTimerMillisec
   inStream.read((char *)&config.autoPrimaryRotationTimerMillisec, sizeof(config.autoPrimaryRotationTimerMillisec));
 
-  // Deserialize preexecReqStatusCheckTimerMillisec
-  inStream.read((char *)&config.preexecReqStatusCheckTimerMillisec, sizeof(config.preexecReqStatusCheckTimerMillisec));
+  // Deserialize preExecReqStatusCheckTimerMillisec
+  inStream.read((char *)&config.preExecReqStatusCheckTimerMillisec, sizeof(config.preExecReqStatusCheckTimerMillisec));
 
   // Deserialize public keys
   int64_t numOfPublicKeys = 0;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2884,7 +2884,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
                << ", viewChangeTimerMillisec=" << config_.viewChangeTimerMillisec
                << ", autoPrimaryRotationEnabled=" << config_.autoPrimaryRotationEnabled
                << ", autoPrimaryRotationTimerMillisec=" << config_.autoPrimaryRotationTimerMillisec
-               << ", preexecReqStatusCheckTimerMillisec=" << config_.preexecReqStatusCheckTimerMillisec
+               << ", preExecReqStatusCheckTimerMillisec=" << config_.preExecReqStatusCheckTimerMillisec
                << ", maxExternalMessageSize=" << config_.maxExternalMessageSize << ", maxReplyMessageSize="
                << config_.maxReplyMessageSize << ", maxNumOfReservedPages=" << config_.maxNumOfReservedPages
                << ", sizeOfReservedPage=" << config_.sizeOfReservedPage

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2884,6 +2884,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
                << ", viewChangeTimerMillisec=" << config_.viewChangeTimerMillisec
                << ", autoPrimaryRotationEnabled=" << config_.autoPrimaryRotationEnabled
                << ", autoPrimaryRotationTimerMillisec=" << config_.autoPrimaryRotationTimerMillisec
+               << ", preexecReqStatusCheckTimerMillisec=" << config_.preexecReqStatusCheckTimerMillisec
                << ", maxExternalMessageSize=" << config_.maxExternalMessageSize << ", maxReplyMessageSize="
                << config_.maxReplyMessageSize << ", maxNumOfReservedPages=" << config_.maxNumOfReservedPages
                << ", sizeOfReservedPage=" << config_.sizeOfReservedPage

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -109,8 +109,8 @@ void setDynamicallyConfigurableParameters(ReplicaConfig &config) {
   config.viewChangeTimerMillisec = ReplicaConfigSingleton::GetInstance().GetViewChangeTimerMillisec();
   config.autoPrimaryRotationEnabled = ReplicaConfigSingleton::GetInstance().GetAutoPrimaryRotationEnabled();
   config.autoPrimaryRotationTimerMillisec = ReplicaConfigSingleton::GetInstance().GetAutoPrimaryRotationTimerMillisec();
-  config.preexecReqStatusCheckTimerMillisec =
-      ReplicaConfigSingleton::GetInstance().GetPreexecReqStatusCheckTimerMillisec();
+  config.preExecReqStatusCheckTimerMillisec =
+      ReplicaConfigSingleton::GetInstance().GetPreExecReqStatusCheckTimerMillisec();
   config.maxExternalMessageSize = ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize();
   config.maxReplyMessageSize = ReplicaConfigSingleton::GetInstance().GetMaxReplyMessageSize();
   config.maxNumOfReservedPages = ReplicaConfigSingleton::GetInstance().GetMaxNumOfReservedPages();

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -109,6 +109,8 @@ void setDynamicallyConfigurableParameters(ReplicaConfig &config) {
   config.viewChangeTimerMillisec = ReplicaConfigSingleton::GetInstance().GetViewChangeTimerMillisec();
   config.autoPrimaryRotationEnabled = ReplicaConfigSingleton::GetInstance().GetAutoPrimaryRotationEnabled();
   config.autoPrimaryRotationTimerMillisec = ReplicaConfigSingleton::GetInstance().GetAutoPrimaryRotationTimerMillisec();
+  config.preexecReqStatusCheckTimerMillisec =
+      ReplicaConfigSingleton::GetInstance().GetPreexecReqStatusCheckTimerMillisec();
   config.maxExternalMessageSize = ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize();
   config.maxReplyMessageSize = ReplicaConfigSingleton::GetInstance().GetMaxReplyMessageSize();
   config.maxNumOfReservedPages = ReplicaConfigSingleton::GetInstance().GetMaxNumOfReservedPages();

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -216,9 +216,10 @@ int SimpleClientImp::sendRequest(uint8_t flags,
 
   ClientRequestMsg* reqMsg;
   if (isPreProcessRequired)
-    reqMsg = new preprocessor::ClientPreProcessRequestMsg(clientId_, reqSeqNum, lengthOfRequest, request, msgCid);
+    reqMsg = new preprocessor::ClientPreProcessRequestMsg(
+        clientId_, reqSeqNum, lengthOfRequest, request, timeoutMilli, msgCid);
   else
-    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lengthOfRequest, request, msgCid);
+    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lengthOfRequest, request, timeoutMilli, msgCid);
   pendingRequest_ = reqMsg;
 
   sendPendingRequest();

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -1,8 +1,8 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
 //
-// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
 //
 // This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
@@ -24,7 +24,7 @@ class ClientRequestMsg : public MessageBase {
   static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header), "");
   static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
   static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
-  static_assert(sizeof(ClientRequestMsgHeader) == 21, "ClientRequestMsgHeader size is 21B");
+  static_assert(sizeof(ClientRequestMsgHeader) == 29, "ClientRequestMsgHeader size is 29B");
 
   // TODO(GG): more asserts
 
@@ -34,9 +34,8 @@ class ClientRequestMsg : public MessageBase {
                    uint64_t reqSeqNum,
                    uint32_t requestLength,
                    const char* request,
+                   uint64_t reqTimeoutMilli,
                    const std::string& cid = "");
-
-  ClientRequestMsg(NodeIdType sender);
 
   ClientRequestMsg(ClientRequestMsgHeader* body);
 
@@ -52,16 +51,21 @@ class ClientRequestMsg : public MessageBase {
 
   char* requestBuf() const { return body() + sizeof(ClientRequestMsgHeader); }
 
-  void set(ReqId reqSeqNum, uint32_t requestLength, uint8_t flags);
-  const std::string getCid() const;
+  uint64_t requestTimeoutMilli() const { return msgBody()->timeoutMilli; }
+
+  std::string getCid() const;
   void validate(const ReplicasInfo&) const override;
 
  protected:
   ClientRequestMsgHeader* msgBody() const { return ((ClientRequestMsgHeader*)msgBody_); }
 
  private:
-  void setParams(NodeIdType sender, ReqId reqSeqNum, uint32_t requestLength, uint8_t flags);
-  void setParams(ReqId reqSeqNum, uint32_t requestLength, uint8_t flags);
+  void setParams(NodeIdType sender,
+                 ReqId reqSeqNum,
+                 uint32_t requestLength,
+                 uint8_t flags,
+                 const std::string& cid,
+                 uint64_t reqTimeoutMilli);
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -10,6 +10,7 @@
 // file.
 
 #include "PreProcessor.hpp"
+#include "InternalReplicaApi.hpp"
 #include "Logger.hpp"
 #include "MsgHandlersRegistrator.hpp"
 #include "TimersSingleton.hpp"
@@ -105,7 +106,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   }
   threadPool_.start(numOfClients_);
   requestsStatusCheckTimer_ = TimersSingleton::getInstance().add(
-      chrono::milliseconds(myReplica_.getReplicaConfig().preexecReqStatusCheckTimerMillisec),
+      chrono::milliseconds(myReplica_.getReplicaConfig().preExecReqStatusCheckTimerMillisec),
       Timers::Timer::RECURRING,
       [this](Timers::Handle h) { onRequestsStatusCheckTimer(h); });
 }
@@ -318,8 +319,8 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, const std::string 
     clientRequestMsg = make_unique<ClientRequestMsg>(clientId,
                                                      HAS_PRE_PROCESSED_FLAG,
                                                      reqSeqNum,
-                                                     clientEntry->clientReqInfoPtr->getMyPreProcessedResultLen(),
-                                                     clientEntry->clientReqInfoPtr->getMyPreProcessedResult(),
+                                                     clientEntry->clientReqInfoPtr->getPrimaryPreProcessedResultLen(),
+                                                     clientEntry->clientReqInfoPtr->getPrimaryPreProcessedResult(),
                                                      clientRequestMsg->requestTimeoutMilli(),
                                                      cid);
   }

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -111,7 +111,10 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
 }
 
 PreProcessor::~PreProcessor() {
-  TimersSingleton::getInstance().cancel(requestsStatusCheckTimer_);
+  try {
+    TimersSingleton::getInstance().cancel(requestsStatusCheckTimer_);
+  } catch (std::invalid_argument &e) {
+  }
   threadPool_.stop();
 }
 

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -22,6 +22,7 @@
 #include "sliver.hpp"
 #include "SigManager.hpp"
 #include "Metrics.hpp"
+#include "Timers.hpp"
 
 #include <mutex>
 
@@ -94,6 +95,7 @@ class PreProcessor {
                                          PreProcessingResult result,
                                          NodeIdType clientId,
                                          SeqNum reqSeqNum);
+  void onRequestsStatusCheckTimer(concordUtil::Timers::Handle timer);
 
  private:
   static std::vector<std::shared_ptr<PreProcessor>> preProcessors_;  // The place holder for PreProcessor objects
@@ -125,6 +127,7 @@ class PreProcessor {
     concordMetrics::CounterHandle preProcessRequestTimedout;
     concordMetrics::CounterHandle preProcReqSentForFurtherProcessing;
   } preProcessorMetrics_;
+  concordUtil::Timers::Handle requestsStatusCheckTimer_;  // Check for timed out requests
 };
 
 //**************** Class AsyncPreProcessJob ****************//

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -118,11 +118,12 @@ class PreProcessor {
   std::chrono::seconds metricsLastDumpTime_;
   std::chrono::seconds metricsDumpIntervalInSec_;
   struct PreProcessingMetrics {
-    concordMetrics::CounterHandle requestReceived;
-    concordMetrics::CounterHandle requestInvalid;
-    concordMetrics::CounterHandle requestIgnored;
-    concordMetrics::CounterHandle consensusNotReached;
-    concordMetrics::CounterHandle requestSentForFurtherProcessing;
+    concordMetrics::CounterHandle preProcReqReceived;
+    concordMetrics::CounterHandle preProcReqInvalid;
+    concordMetrics::CounterHandle preProcReqIgnored;
+    concordMetrics::CounterHandle preProcConsensusNotReached;
+    concordMetrics::CounterHandle preProcessRequestTimedout;
+    concordMetrics::CounterHandle preProcReqSentForFurtherProcessing;
   } preProcessorMetrics_;
 };
 

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -32,8 +32,8 @@ struct ClientRequestInfo {
   RequestProcessingInfoUniquePtr clientReqInfoPtr;
 };
 
-typedef std::unique_ptr<ClientRequestInfo> ClientRequestInfoUniquePtr;
-typedef std::unordered_map<uint16_t, ClientRequestInfoUniquePtr> OngoingReqMap;
+typedef std::shared_ptr<ClientRequestInfo> ClientRequestInfoSharedPtr;
+typedef std::unordered_map<uint16_t, ClientRequestInfoSharedPtr> OngoingReqMap;
 
 //**************** Class PreProcessor ****************//
 
@@ -59,6 +59,7 @@ class PreProcessor {
                                  InternalReplicaApi &myReplica);
 
   static void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
+  ReqId getOngoingReqIdForClient(uint16_t clientId);
 
  private:
   friend class AsyncPreProcessJob;
@@ -74,7 +75,7 @@ class PreProcessor {
   void registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
                        PreProcessRequestMsgSharedPtr preProcessRequestMsg);
   void releaseClientPreProcessRequestSafe(uint16_t clientId);
-  void releaseClientPreProcessRequest(ClientRequestInfoUniquePtr clientEntry, uint16_t clientId);
+  void releaseClientPreProcessRequest(ClientRequestInfoSharedPtr clientEntry, uint16_t clientId);
   bool validateMessage(MessageBase *msg) const;
   void registerMsgHandlers();
   bool checkClientMsgCorrectness(const ClientPreProcessReqMsgUniquePtr &clientReqMsg, ReqId reqSeqNum) const;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -15,7 +15,6 @@
 #include "messages/ClientPreProcessRequestMsg.hpp"
 #include "MsgsCommunicator.hpp"
 #include "MsgHandlersRegistrator.hpp"
-#include "InternalReplicaApi.hpp"
 #include "SimpleThreadPool.hpp"
 #include "Replica.hpp"
 #include "RequestProcessingInfo.hpp"

--- a/bftengine/src/preprocessor/RequestProcessingInfo.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.cpp
@@ -75,7 +75,7 @@ bool RequestProcessingInfo::isReqTimedOut() const {
     auto reqProcessingTime = getMonotonicTimeMilli() - entryTime_;
     if (reqProcessingTime > clientPreProcessReqMsg_->requestTimeoutMilli()) {
       LOG_WARN(GL,
-               "Request timeout of " << clientPreProcessReqMsg_->requestTimeoutMilli() << "ms expired for reqSeqNum="
+               "Request timeout of " << clientPreProcessReqMsg_->requestTimeoutMilli() << " ms expired for reqSeqNum="
                                      << reqSeqNum_ << "; reqProcessingTime=" << reqProcessingTime << "; abort request");
       return true;
     }

--- a/bftengine/src/preprocessor/RequestProcessingInfo.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.cpp
@@ -15,9 +15,15 @@
 namespace preprocessor {
 
 using namespace std;
+using namespace chrono;
 using namespace concord::util;
 
 uint16_t RequestProcessingInfo::numOfRequiredEqualReplies_ = 0;
+
+uint64_t RequestProcessingInfo::getMonotonicTimeMilli() {
+  steady_clock::time_point curTimePoint = steady_clock::now();
+  return duration_cast<milliseconds>(curTimePoint.time_since_epoch()).count();
+}
 
 RequestProcessingInfo::RequestProcessingInfo(uint16_t numOfReplicas,
                                              uint16_t numOfRequiredReplies,
@@ -26,6 +32,7 @@ RequestProcessingInfo::RequestProcessingInfo(uint16_t numOfReplicas,
                                              PreProcessRequestMsgSharedPtr preProcessRequestMsg)
     : numOfReplicas_(numOfReplicas),
       reqSeqNum_(reqSeqNum),
+      entryTime_(getMonotonicTimeMilli()),
       clientPreProcessReqMsg_(move(clientReqMsg)),
       preProcessRequestMsg_(preProcessRequestMsg) {
   numOfRequiredEqualReplies_ = numOfRequiredReplies;
@@ -49,33 +56,51 @@ SHA3_256::Digest RequestProcessingInfo::convertToArray(const uint8_t resultsHash
   return hashArray;
 }
 
-PreProcessingResult RequestProcessingInfo::getPreProcessingConsensusResult() const {
-  if (numOfReceivedReplies_ < numOfRequiredEqualReplies_) return CONTINUE;
-
-  uint16_t maxNumOfEqualHashes = 0;
+auto RequestProcessingInfo::calculateMaxNbrOfEqualHashes(uint16_t &maxNumOfEqualHashes) const {
   auto itOfChosenHash = preProcessingResultHashes_.begin();
-  // Calculate a maximum number of the same hashes calculated by non-primary replicas
+  // Calculate a maximum number of the same hashes received from non-primary replicas
   for (auto it = preProcessingResultHashes_.begin(); it != preProcessingResultHashes_.end(); it++) {
     if (it->second > maxNumOfEqualHashes) {
       maxNumOfEqualHashes = it->second;
       itOfChosenHash = it;
     }
   }
+  return itOfChosenHash;
+}
 
+bool RequestProcessingInfo::isReqTimedOut() const {
+  // Check request timeout once asynchronous primary pre-execution completed (to not abort the execution thread)
+  if (myPreProcessResultLen_ != 0) {
+    auto reqProcessingTime = getMonotonicTimeMilli() - entryTime_;
+    if (reqProcessingTime > clientPreProcessReqMsg_->requestTimeoutMilli()) {
+      LOG_WARN(GL,
+               "Request timeout of " << clientPreProcessReqMsg_->requestTimeoutMilli() << "ms expired for reqSeqNum="
+                                     << reqSeqNum_ << "; reqProcessingTime=" << reqProcessingTime << "; abort request");
+      return true;
+    }
+  }
+  return false;
+}
+
+PreProcessingResult RequestProcessingInfo::getPreProcessingConsensusResult() const {
+  if (numOfReceivedReplies_ < numOfRequiredEqualReplies_) return CONTINUE;
+
+  uint16_t maxNumOfEqualHashes = 0;
+  auto itOfChosenHash = calculateMaxNbrOfEqualHashes(maxNumOfEqualHashes);
   if (maxNumOfEqualHashes >= numOfRequiredEqualReplies_) {
-    if (itOfChosenHash->first == myPreProcessResultHash_)
-      return COMPLETE;  // Pre-execution consensus reached
-    else if (myPreProcessResultLen_ != 0) {
+    if (itOfChosenHash->first == myPreProcessResultHash_) return COMPLETE;  // Pre-execution consensus reached
+
+    if (myPreProcessResultLen_ != 0) {
       // Primary replica calculated hash is different from a hash that passed pre-execution consensus => we don't have
       // correct pre-processed results. Let's launch a pre-processing retry.
       LOG_WARN(GL,
                "Primary replica pre-processing result hash is different from one passed the consensus for reqSeqNum="
                    << reqSeqNum_ << "; retry pre-processing on primary replica");
       return RETRY_PRIMARY;
-    } else {
-      LOG_DEBUG(GL, "Primary replica did not complete pre-processing yet for reqSeqNum=" << reqSeqNum_ << "; continue");
-      return CONTINUE;
     }
+
+    LOG_DEBUG(GL, "Primary replica did not complete pre-processing yet for reqSeqNum=" << reqSeqNum_ << "; continue");
+    return CONTINUE;
   }
 
   if (numOfReceivedReplies_ == numOfReplicas_ - 1) {

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -39,8 +39,8 @@ class RequestProcessingInfo {
   PreProcessRequestMsgSharedPtr getPreProcessRequest() const { return preProcessRequestMsg_; }
   const SeqNum getReqSeqNum() const { return reqSeqNum_; }
   PreProcessingResult getPreProcessingConsensusResult() const;
-  const char* getMyPreProcessedResult() const { return myPreProcessResult_; }
-  uint32_t getMyPreProcessedResultLen() const { return myPreProcessResultLen_; }
+  const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
+  uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut() const;
 
  private:
@@ -59,9 +59,9 @@ class RequestProcessingInfo {
   ClientPreProcessReqMsgUniquePtr clientPreProcessReqMsg_;
   PreProcessRequestMsgSharedPtr preProcessRequestMsg_;
   uint16_t numOfReceivedReplies_ = 0;
-  const char* myPreProcessResult_ = nullptr;
-  uint32_t myPreProcessResultLen_ = 0;
-  concord::util::SHA3_256::Digest myPreProcessResultHash_;
+  const char* primaryPreProcessResult_ = nullptr;
+  uint32_t primaryPreProcessResultLen_ = 0;
+  concord::util::SHA3_256::Digest primaryPreProcessResultHash_;
   // Maps result hash to the number of equal hashes
   std::map<concord::util::SHA3_256::Digest, int> preProcessingResultHashes_;
 };

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -41,16 +41,21 @@ class RequestProcessingInfo {
   PreProcessingResult getPreProcessingConsensusResult() const;
   const char* getMyPreProcessedResult() const { return myPreProcessResult_; }
   uint32_t getMyPreProcessedResultLen() const { return myPreProcessResultLen_; }
+  bool isReqTimedOut() const;
 
  private:
   static concord::util::SHA3_256::Digest convertToArray(
       const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);
+
+  static uint64_t getMonotonicTimeMilli();
+  auto calculateMaxNbrOfEqualHashes(uint16_t& maxNumOfEqualHashes) const;
 
  private:
   static uint16_t numOfRequiredEqualReplies_;
 
   const uint16_t numOfReplicas_;
   const ReqId reqSeqNum_;
+  const uint64_t entryTime_;
   ClientPreProcessReqMsgUniquePtr clientPreProcessReqMsg_;
   PreProcessRequestMsgSharedPtr preProcessRequestMsg_;
   uint16_t numOfReceivedReplies_ = 0;

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -18,9 +18,13 @@ namespace preprocessor {
 using namespace std;
 using namespace bftEngine;
 
-ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(
-    NodeIdType sender, uint64_t reqSeqNum, uint32_t requestLength, const char* request, const std::string& cid)
-    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request, cid) {
+ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
+                                                       uint64_t reqSeqNum,
+                                                       uint32_t requestLength,
+                                                       const char* request,
+                                                       uint64_t reqTimeoutMilli,
+                                                       const std::string& cid)
+    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request, reqTimeoutMilli, cid) {
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -21,8 +21,12 @@ namespace preprocessor {
 
 class ClientPreProcessRequestMsg : public ClientRequestMsg {
  public:
-  ClientPreProcessRequestMsg(
-      NodeIdType sender, uint64_t reqSeqNum, uint32_t requestLength, const char* request, const std::string& cid);
+  ClientPreProcessRequestMsg(NodeIdType sender,
+                             uint64_t reqSeqNum,
+                             uint32_t requestLength,
+                             const char* request,
+                             uint64_t reqTimeoutMilli,
+                             const std::string& cid);
 
   std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag);
 };

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -24,9 +24,10 @@ namespace {
 ReplicaConfig replicaConfig;
 const uint16_t numOfReplicas = 4;
 const uint16_t numOfClients = 4;
-const uint16_t fval = 1;
-const uint16_t numOfRequiredReplies = fval + 1;
+const uint16_t fVal = 1;
+const uint16_t numOfRequiredReplies = fVal + 1;
 const uint32_t bufLen = 1024;
+const uint64_t reqTimeoutMilli = 1000;
 char buf[bufLen];
 ReqId reqSeqNum = 123456789;
 NodeIdType senderId = 2;
@@ -274,7 +275,7 @@ TEST(requestPreprocessingInfo_test, primaryReplicaDidNotCompletePreProcessingWhi
 
 TEST(requestPreprocessingInfo_test, clientPreProcessMessageConversion) {
   memset(buf, '8', bufLen);
-  ClientPreProcessRequestMsg clientPreProcReqMsg(senderId, reqSeqNum, bufLen, buf, cid);
+  ClientPreProcessRequestMsg clientPreProcReqMsg(senderId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
   unique_ptr<MessageBase> messageBase;
   {
     ClientPreProcessReqMsgUniquePtr clientPreProcReqUniq = make_unique<ClientPreProcessRequestMsg>(clientPreProcReqMsg);

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -116,7 +116,7 @@ class UdpClient:
         if cid is None:
             cid = str(seq_num)
         data = bft_msgs.pack_request(
-                    self.client_id, seq_num, read_only, cid, msg, pre_process)
+                    self.client_id, seq_num, read_only, self.config.req_timeout_milli, cid, msg, pre_process)
 
         # Raise a trio.TooSlowError exception if a quorum of replies
         with trio.fail_after(self.config.req_timeout_milli/1000):

--- a/util/pyclient/bft_msgs.py
+++ b/util/pyclient/bft_msgs.py
@@ -32,7 +32,7 @@ MSG_TYPE_SIZE = struct.calcsize(MSG_TYPE_FMT)
 # Little Endian format with no padding
 # We don't include the msg type here, since we have to read it first to
 # understand what message is incoming.
-REQUEST_HEADER_FMT = "<HBQLL"
+REQUEST_HEADER_FMT = "<HBQLQL"
 REQUEST_HEADER_SIZE = struct.calcsize(REQUEST_HEADER_FMT)
 
 # The struct definition of the client reply msg header
@@ -43,23 +43,23 @@ REPLY_HEADER_FMT = "<HQL"
 REPLY_HEADER_SIZE = struct.calcsize(REPLY_HEADER_FMT)
 
 RequestHeader = namedtuple('RequestHeader', ['client_id', 'flags',
-    'req_seq_num', 'length', 'cid'])
+    'req_seq_num', 'length', 'timeout_milli', 'cid'])
 
 ReplyHeader = namedtuple('ReplyHeader', ['primary_id',
     'req_seq_num', 'length'])
 
-def pack_request(client_id, req_seq_num, read_only, cid, msg, pre_process=False):
+def pack_request(client_id, req_seq_num, read_only, timeout_milli, cid, msg, pre_process=False):
     """Create and return a buffer with a header and message"""
     flags = 0x0
     if read_only:
         flags = 0x1
     elif pre_process:
         flags = 0x2
-    header = RequestHeader(client_id, flags, req_seq_num, len(msg), len(cid))
+    header = RequestHeader(client_id, flags, req_seq_num, len(msg), timeout_milli, len(cid))
     data = b''.join([pack_request_header(header), msg, cid.encode()])
     return data
 
-def pack_request_header(header,  pre_process=False):
+def pack_request_header(header, pre_process=False):
     """Take a RequestHeader and return a buffer"""
     msg_type = PRE_PROCESS_TYPE if pre_process else REQUEST_MSG_TYPE
     return b''.join([struct.pack(MSG_TYPE_FMT, msg_type),
@@ -69,7 +69,7 @@ def unpack_request(data, cid_size = 0):
     """Take a buffer and return a pair of the RequestHeader and app data"""
     start = MSG_TYPE_SIZE + REQUEST_HEADER_SIZE
     end = len(data) - cid_size
-    return (unpack_request_header(data), data[start:end], data[end:].decode())
+    return unpack_request_header(data), data[start:end], data[end:].decode()
 
 def unpack_request_header(data):
     """

--- a/util/pyclient/test_metrics_client.py
+++ b/util/pyclient/test_metrics_client.py
@@ -20,8 +20,8 @@ import trio
 from bft_config import Replica
 from bft_metrics_client import MetricsClient
 
-TIMEOUT_MILLI = 5000;
-CHECK_MILLI = 100;
+TIMEOUT_MILLI = 5000
+CHECK_MILLI = 100
 
 class MetricsClientTest(unittest.TestCase):
     """

--- a/util/pyclient/test_msgs.py
+++ b/util/pyclient/test_msgs.py
@@ -32,13 +32,15 @@ class TestPackUnpack(unittest.TestCase):
         client_id = 4
         req_seq_num = 1
         read_only = True
+        timeout_milli = 5000
         cid = str(req_seq_num)
-        packed = bft_msgs.pack_request(client_id, req_seq_num, read_only, cid, msg)
-        (header, unpacked_msg , cid_) = bft_msgs.unpack_request(packed, len(cid))
+        packed = bft_msgs.pack_request(client_id, req_seq_num, read_only, timeout_milli, cid, msg)
+        (header, unpacked_msg, cid_) = bft_msgs.unpack_request(packed, len(cid))
         self.assertEqual(cid, cid_)
         self.assertEqual(client_id, header.client_id)
         self.assertEqual(1, header.flags) # read_only = True
         self.assertEqual(req_seq_num, header.req_seq_num)
+        self.assertEqual(timeout_milli, header.timeout_milli)
         self.assertEqual(msg, unpacked_msg)
 
     def test_expect_msg_error(self):


### PR DESCRIPTION
The primary replica PreProcessor requests need to be freed from waiting forever for reply messages from non-primary replicas that are down or very slow. Add an ability to abort requests which timeout specified via client request expired.
1. Add configurable parameter preexecReqStatusCheckTimerMillisec for the detection of timed out pre-execution requests
2. Save client specified request timeout in ClientRequest message + adapt python code
3. Add preProcessRequestTimedout metric. Standardize metric names.
4. Add an ability to abort timed out ongoing requests
5. Add a unit test for the verification

https://jira.eng.vmware.com/browse/BC-1815