### PR TITLE
[Apollo] Explicitly defining the metrics port in the Replica object

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -176,7 +176,7 @@ class BftTestNetwork:
             builddir=builddir,
             toolsdir=toolsdir,
             procs={},
-            replicas=[bft_config.Replica(i, "127.0.0.1", 3710 + 2*i)
+            replicas=[bft_config.Replica(i, "127.0.0.1", 3710 + 2*i, 4710 + 2*i)
                 for i in range(0, config.n + config.num_ro_replicas)],
             clients = {},
             metrics = None
@@ -241,8 +241,7 @@ class BftTestNetwork:
     def _init_metrics(self):
         metric_clients = {}
         for r in self.replicas:
-            mr = bft_config.Replica(r.id, r.ip, r.port + 1000)
-            metric_clients[r.id] = bft_metrics_client.MetricsClient(mr)
+            metric_clients[r.id] = bft_metrics_client.MetricsClient(r)
         self.metrics = bft_metrics.BftMetrics(metric_clients)
 
     def random_client(self):

--- a/util/pyclient/bft_config.py
+++ b/util/pyclient/bft_config.py
@@ -16,4 +16,4 @@ from collections import namedtuple
 Config = namedtuple('Config', ['id', 'f', 'c', 'max_msg_size', 'req_timeout_milli',
     'retry_timeout_milli'])
 
-Replica = namedtuple('Replica', ['id', 'ip', 'port'])
+Replica = namedtuple('Replica', ['id', 'ip', 'port', 'metrics_port'])

--- a/util/pyclient/bft_metrics_client.py
+++ b/util/pyclient/bft_metrics_client.py
@@ -54,7 +54,7 @@ class MetricsClient:
         There is no explicit timeout here. Users should call `with
         trio.fail_after as necessary`.
         """
-        destination = (self.replica.ip,self.replica.port)
+        destination = (self.replica.ip, self.replica.metrics_port)
         await self.sock.sendto(self._req(), destination)
         while True:
             reply, _ = await self.sock.recvfrom(MAX_MSG_SIZE)

--- a/util/pyclient/test_client.py
+++ b/util/pyclient/test_client.py
@@ -41,7 +41,11 @@ class SimpleTest(unittest.TestCase):
         cls.generateKeys()
         cls.config = bft_config.Config(4, 1, 0, 4096, 1000, 50)
         cls.replicas = [
-                bft_config.Replica(i, "127.0.0.1", bft_client.BASE_PORT + 2*i) 
+                bft_config.Replica(
+                    id=i,
+                    ip="127.0.0.1",
+                    port=bft_client.BASE_PORT + 2*i,
+                    metrics_port=1000 + bft_client.BASE_PORT + 2*i)
                 for i in range(0,4)]
 
         print("Running tests in {}".format(cls.testdir))

--- a/util/pyclient/test_metrics_client.py
+++ b/util/pyclient/test_metrics_client.py
@@ -20,8 +20,8 @@ import trio
 from bft_config import Replica
 from bft_metrics_client import MetricsClient
 
-TIMEOUT_MILLI = 5000;
-CHECK_MILLI = 100;
+TIMEOUT_MILLI = 5000
+CHECK_MILLI = 100
 
 class MetricsClientTest(unittest.TestCase):
     """
@@ -32,7 +32,7 @@ class MetricsClientTest(unittest.TestCase):
     def setUp(self):
         self.server_path = os.path.abspath("../../build/util/test/metric_server")
         self.server = subprocess.Popen([self.server_path], close_fds=True)
-        self.replica = Replica(0, "127.0.0.1", 6161)
+        self.replica = Replica(id=0, ip="127.0.0.1", port=5161, metrics_port=6161)
 
     def tearDown(self):
         self.server.kill()


### PR DESCRIPTION
So far, the metrics (UDP) port was assumed to be the replica's listen port, incremented by 1000. This is true for the TesterReplicas used by Apollo's default BftTestNetwork. However, the port number may follow a different pattern when running against an external (containerized) BFT network.

This PR provides the option to set an arbitrary metrics port via the Replica object.