### PR TITLE
Link the ST chain in the merkle DBAdapter ctor

### DIFF
--- a/storage/include/blockchain/merkle_tree_db_adapter.h
+++ b/storage/include/blockchain/merkle_tree_db_adapter.h
@@ -60,7 +60,12 @@ class DBKeyManipulator : public DBKeyManipulatorBase {
 // getLastReachableBlock() + 1. Additionally, ReachableSTBlock <= getLastBlock().
 class DBAdapter : public DBAdapterBase {
  public:
-  DBAdapter(const std::shared_ptr<IDBClient> &db, bool readOnly = false);
+  // The constructor will try to link the blockchain with any blocks in the temporary state transfer chain. This is done
+  // so that the DBAdapter will operate correctly in case a crash or an abnormal shutdown has occurred prior to startup
+  // (construction). Note that only a single DBAdapter instance should operate on a database and access to all methods
+  // should be either done from a single thread or serialized via a mutex or another mechanism. The constructor throws
+  // on errors.
+  DBAdapter(const std::shared_ptr<IDBClient> &db);
 
   // Adds a block to the end of the blockchain from a set of key/value pairs. Includes:
   // - adding the key/value pairs in separate keys


### PR DESCRIPTION
Make sure that if linkSTChainFrom() has been interrupted (e.g. a crash
or an abnormal shutdown), all DBAdapter methods will return the correct
values. For example, if state transfer had completed and
linkSTChainFrom() was interrupted, getLastBlock() should be equal to
getLastReachableBlock() on the next startup. Another example is
getKeyByReadVersion() that returns keys from the blockchain only and
ignores keys in the temporary state transfer chain.