### PR TITLE
Long run test: add basic fast path test case

### DIFF
--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -67,9 +67,11 @@ class SkvbcFastPathTest(unittest.TestCase):
         write_weight = .50
         numops = 20
 
+        nb_slow_path = await bft_network.num_of_slow_path()
+
         await tracker.run_concurrent_ops(num_ops=numops, write_weight=write_weight)
 
-        await bft_network.assert_fast_path_prevalent()
+        await bft_network.assert_fast_path_prevalent(nb_slow_paths_so_far=nb_slow_path)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -143,3 +145,4 @@ class SkvbcFastPathTest(unittest.TestCase):
         await trio.sleep(5)
         await bft_network.assert_fast_path_prevalent(
             nb_slow_paths_so_far=slow_path_writes)
+

--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -16,10 +16,7 @@ import trio
 from os import environ
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from test_skvbc import SkvbcTest
-from test_skvbc_auto_view_change import SkvbcAutoViewChangeTest
 from test_skvbc_fast_path import SkvbcFastPathTest
-from test_skvbc_slow_path import SkvbcSlowPathTest
-from test_skvbc_view_change import SkvbcViewChangeTest
 
 # Time consts
 EIGHT_HOURS_IN_SECONDS = 8 * 60 * 60
@@ -34,14 +31,12 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
-    autoPrimaryRotationTimeoutMilli = "10000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-a", autoPrimaryRotationTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
                  else ""]

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -666,7 +666,7 @@ class BftTestNetwork:
 
     async def num_of_slow_path(self):
         nb_slow_path = 0
-        with trio.move_on_after(seconds=.1):
+        with trio.move_on_after(seconds=.5):
             try:
                 metric_key = ['replica', 'Counters', 'slowPathCount']
                 nb_slow_path = await self.metrics.get(0, *metric_key)

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -264,13 +264,14 @@ class BftTestNetwork:
         return self.config.stop_replica_cmd(replica_id)
 
     def start_all_replicas(self):
-        try:
-            [self.start_replica(i) for i in range(0, self.config.n)]
-        except AlreadyRunningError:
-            if not self.is_existing:
-                raise
-        finally:
-            assert len(self.procs) == self.config.n
+        for i in range(0, self.config.n):
+            try:
+                self.start_replica(i)
+            except AlreadyRunningError:
+                if not self.is_existing:
+                    raise
+
+        assert len(self.procs) == self.config.n
 
     def stop_all_replicas(self):
         """ Stop all running replicas"""
@@ -298,7 +299,7 @@ class BftTestNetwork:
         if replica_id in self.procs:
             raise AlreadyRunningError(replica_id)
 
-        if self.is_existing:
+        if self.is_existing and self.config.stop_replica_cmd is not None:
             self.procs[replica_id] = self._start_external_replica(replica_id)
         else:
             self.procs[replica_id] = subprocess.Popen(
@@ -322,7 +323,7 @@ class BftTestNetwork:
         if replica_id not in self.procs.keys():
             raise AlreadyStoppedError(replica_id)
 
-        if self.is_existing:
+        if self.is_existing and self.config.stop_replica_cmd is not None:
             self._stop_external_replica(replica_id)
         else:
             p = self.procs[replica_id]
@@ -661,3 +662,15 @@ class BftTestNetwork:
                 with trio.move_on_after(interval):
                     if await predicate():
                         return
+
+
+    async def num_of_slow_path(self):
+        nb_slow_path = 0
+        with trio.move_on_after(seconds=.1):
+            try:
+                metric_key = ['replica', 'Counters', 'slowPathCount']
+                nb_slow_path = await self.metrics.get(0, *metric_key)
+            except KeyError:
+                # metrics not yet available, continue looping
+                pass
+        return nb_slow_path


### PR DESCRIPTION
1) add a basic test case of fast path scenario - read your writes with an assertion that all the writes on the fast path.

2) adjust start_all_replicas to go through all replicas and try to start if its part of long-run testing.

I tested this long-run scenario for 2 hours on my local machine