### PR TITLE
Support correlation ID in pre-execution

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -428,7 +428,7 @@ ReqId PreProcessor::getOngoingReqIdForClient(uint16_t clientId) {
   return 0;
 }
 
-void PreProcessor::handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum, const std::string& cid) {
+void PreProcessor::handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum, const std::string &cid) {
   if (getPreProcessingConsensusResult(clientId) == COMPLETE)
     finalizePreProcessing(clientId, cid);
   else
@@ -452,7 +452,10 @@ void PreProcessor::handlePreProcessedReqByPrimary(PreProcessRequestMsgSharedPtr 
   handleReqPreProcessedByOneReplica(cid, result, clientId, preProcessReqMsg->reqSeqNum());
 }
 
-void PreProcessor::handlePreProcessedReqByNonPrimary(uint16_t clientId, ReqId reqSeqNum, uint32_t resBufLen, const std::string& cid) {
+void PreProcessor::handlePreProcessedReqByNonPrimary(uint16_t clientId,
+                                                     ReqId reqSeqNum,
+                                                     uint32_t resBufLen,
+                                                     const std::string &cid) {
   auto replyMsg = make_shared<PreProcessReplyMsg>(sigManager_, myReplicaId_, clientId, reqSeqNum);
   replyMsg->setupMsgBody(getPreProcessResultBuffer(clientId), resBufLen, cid);
   sendMsg(replyMsg->body(), myReplica_.currentPrimary(), replyMsg->type(), replyMsg->size());

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -320,7 +320,7 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, const std::string 
                                                      reqSeqNum,
                                                      clientEntry->clientReqInfoPtr->getPrimaryPreProcessedResultLen(),
                                                      clientEntry->clientReqInfoPtr->getPrimaryPreProcessedResult(),
-                                                     1000,
+                                                     clientEntry->clientReqInfoPtr->getReqTimeoutMilli(),
                                                      cid);
   }
   incomingMsgsStorage_->pushExternalMsg(move(clientRequestMsg));

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -244,10 +244,10 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
   const NodeIdType &senderId = preProcessReplyMsg->senderId();
   const NodeIdType &clientId = preProcessReplyMsg->clientId();
   const SeqNum &reqSeqNum = preProcessReplyMsg->reqSeqNum();
-  MDC_CID_PUT(GL, preProcessReplyMsg->getCid());
+  string cid = preProcessReplyMsg->getCid();
+  MDC_CID_PUT(GL, cid);
   auto &clientEntry = ongoingRequests_[clientId];
   PreProcessingResult result = CANCEL;
-  string cid;
   LOG_DEBUG(GL, "reqSeqNum=" << preProcessReplyMsg->reqSeqNum() << " received from replica=" << senderId);
   {
     lock_guard<mutex> lock(clientEntry->mutex);
@@ -259,7 +259,6 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
     }
     clientEntry->clientReqInfoPtr->handlePreProcessReplyMsg(preProcessReplyMsg);
     result = clientEntry->clientReqInfoPtr->getPreProcessingConsensusResult();
-    cid = clientEntry->clientReqInfoPtr->getPreProcessRequest()->getCid();
   }
   handleReqPreProcessedByOneReplica(cid, result, clientId, reqSeqNum);
 }

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -87,11 +87,11 @@ class PreProcessor {
   void launchAsyncReqPreProcessingJob(PreProcessRequestMsgSharedPtr preProcessReqMsg, bool isPrimary, bool isRetry);
   uint32_t launchReqPreProcessing(uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength, char *reqBuf);
   void handleReqPreProcessingJob(PreProcessRequestMsgSharedPtr preProcessReqMsg, bool isPrimary, bool isRetry);
-  void handlePreProcessedReqByNonPrimary(uint16_t clientId, ReqId reqSeqNum, uint32_t resBufLen);
+  void handlePreProcessedReqByNonPrimary(uint16_t clientId, ReqId reqSeqNum, uint32_t resBufLen, const std::string& cid);
   void handlePreProcessedReqByPrimary(PreProcessRequestMsgSharedPtr preProcessReqMsg,
                                       uint16_t clientId,
                                       uint32_t resultBufLen);
-  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum);
+  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum, const std::string& cid);
   void finalizePreProcessing(NodeIdType clientId, const std::string &cid);
   void cancelPreProcessing(NodeIdType clientId);
   PreProcessingResult getPreProcessingConsensusResult(uint16_t clientId);

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -94,8 +94,8 @@ class PreProcessor {
   void handlePreProcessedReqByPrimary(PreProcessRequestMsgSharedPtr preProcessReqMsg,
                                       uint16_t clientId,
                                       uint32_t resultBufLen);
-  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum, const std::string &cid);
-  void finalizePreProcessing(NodeIdType clientId, const std::string &cid);
+  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum);
+  void finalizePreProcessing(NodeIdType clientId);
   void cancelPreProcessing(NodeIdType clientId);
   PreProcessingResult getPreProcessingConsensusResult(uint16_t clientId);
   void handleReqPreProcessedByOneReplica(const std::string &cid,

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -87,11 +87,14 @@ class PreProcessor {
   void launchAsyncReqPreProcessingJob(PreProcessRequestMsgSharedPtr preProcessReqMsg, bool isPrimary, bool isRetry);
   uint32_t launchReqPreProcessing(uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength, char *reqBuf);
   void handleReqPreProcessingJob(PreProcessRequestMsgSharedPtr preProcessReqMsg, bool isPrimary, bool isRetry);
-  void handlePreProcessedReqByNonPrimary(uint16_t clientId, ReqId reqSeqNum, uint32_t resBufLen, const std::string& cid);
+  void handlePreProcessedReqByNonPrimary(uint16_t clientId,
+                                         ReqId reqSeqNum,
+                                         uint32_t resBufLen,
+                                         const std::string &cid);
   void handlePreProcessedReqByPrimary(PreProcessRequestMsgSharedPtr preProcessReqMsg,
                                       uint16_t clientId,
                                       uint32_t resultBufLen);
-  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum, const std::string& cid);
+  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum, const std::string &cid);
   void finalizePreProcessing(NodeIdType clientId, const std::string &cid);
   void cancelPreProcessing(NodeIdType clientId);
   PreProcessingResult getPreProcessingConsensusResult(uint16_t clientId);

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -42,7 +42,8 @@ class RequestProcessingInfo {
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut() const;
-  uint64_t getReqTimeoutMilli() { return clientPreProcessReqMsg_->requestTimeoutMilli(); }
+  uint64_t getReqTimeoutMilli() const { return clientPreProcessReqMsg_->requestTimeoutMilli(); }
+  std::string getReqCid() const { return clientPreProcessReqMsg_->getCid(); }
  private:
   static concord::util::SHA3_256::Digest convertToArray(
       const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -42,7 +42,7 @@ class RequestProcessingInfo {
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut() const;
-
+  uint64_t getReqTimeoutMilli() { return clientPreProcessReqMsg_->requestTimeoutMilli(); }
  private:
   static concord::util::SHA3_256::Digest convertToArray(
       const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);

--- a/bftengine/src/preprocessor/RequestProcessingInfo.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingInfo.hpp
@@ -44,6 +44,7 @@ class RequestProcessingInfo {
   bool isReqTimedOut() const;
   uint64_t getReqTimeoutMilli() const { return clientPreProcessReqMsg_->requestTimeoutMilli(); }
   std::string getReqCid() const { return clientPreProcessReqMsg_->getCid(); }
+
  private:
   static concord::util::SHA3_256::Digest convertToArray(
       const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -72,7 +72,7 @@ void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen, const st
   msgBody()->replyLength = sigSize;
 }
 std::string PreProcessReplyMsg::getCid() const {
-  return std::string(body() + sizeof(PreProcessReplyMsg) + replyLength(), msgBody()->cidLength);
+  return std::string(body() + msgSize_ - msgBody()->cidLength, msgBody()->cidLength);
 }
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -56,7 +56,7 @@ void PreProcessReplyMsg::setParams(NodeIdType senderId, uint16_t clientId, ReqId
   LOG_DEBUG(GL, "senderId=" << senderId << " clientId=" << clientId << " reqSeqNum=" << reqSeqNum);
 }
 
-void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen) {
+void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen, const std::string& cid) {
   const uint16_t sigSize = sigManager_->getMySigLength();
   const uint16_t headerSize = sizeof(PreProcessReplyMsgHeader);
 
@@ -66,8 +66,13 @@ void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen) {
 
   // Sign hash
   sigManager_->sign((char*)hash.data(), SHA3_256::SIZE_IN_BYTES, body() + headerSize, sigSize);
-  msgSize_ = headerSize + sigSize;
+  memcpy(body() + headerSize + sigSize, cid.c_str(), cid.size());
+  msgBody()->cidLength = cid.size();
+  msgSize_ = headerSize + sigSize + msgBody()->cidLength;
   msgBody()->replyLength = sigSize;
+}
+std::string PreProcessReplyMsg::getCid() const {
+  return std::string(body() + sizeof(PreProcessReplyMsg) + replyLength() , msgBody()->cidLength);
 }
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -72,7 +72,7 @@ void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen, const st
   msgBody()->replyLength = sigSize;
 }
 std::string PreProcessReplyMsg::getCid() const {
-  return std::string(body() + sizeof(PreProcessReplyMsg) + replyLength() , msgBody()->cidLength);
+  return std::string(body() + sizeof(PreProcessReplyMsg) + replyLength(), msgBody()->cidLength);
 }
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -25,6 +25,7 @@ struct PreProcessReplyMsgHeader {
   uint16_t clientId;
   uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES];
   uint32_t replyLength;
+  uint32_t cidLength;
 };
 // The pre-executed results' hash signature resides in the message body
 #pragma pack(pop)
@@ -36,14 +37,14 @@ class PreProcessReplyMsg : public MessageBase {
                      uint16_t clientId,
                      uint64_t reqSeqNum);
 
-  void setupMsgBody(const char* buf, uint32_t bufLen);
+  void setupMsgBody(const char* buf, uint32_t bufLen, const std::string& cid);
 
   void validate(const bftEngine::impl::ReplicasInfo&) const override;
   const uint16_t clientId() const { return msgBody()->clientId; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
   const uint32_t replyLength() const { return msgBody()->replyLength; }
   const uint8_t* resultsHash() const { return msgBody()->resultsHash; }
-
+  std::string getCid() const;
  private:
   void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum);
   PreProcessReplyMsgHeader* msgBody() const { return ((PreProcessReplyMsgHeader*)msgBody_); }

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -45,6 +45,7 @@ class PreProcessReplyMsg : public MessageBase {
   const uint32_t replyLength() const { return msgBody()->replyLength; }
   const uint8_t* resultsHash() const { return msgBody()->resultsHash; }
   std::string getCid() const;
+
  private:
   void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum);
   PreProcessReplyMsgHeader* msgBody() const { return ((PreProcessReplyMsgHeader*)msgBody_); }

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -233,7 +233,7 @@ void setUpConfiguration_7() {
 
 PreProcessReplyMsgSharedPtr preProcessNonPrimary(NodeIdType replicaId, const bftEngine::impl::ReplicasInfo& repInfo) {
   auto preProcessReplyMsg = make_shared<PreProcessReplyMsg>(sigManager_[replicaId], replicaId, clientId, reqSeqNum);
-  preProcessReplyMsg->setupMsgBody(buf, bufLen);
+  preProcessReplyMsg->setupMsgBody(buf, bufLen, "");
   preProcessReplyMsg->validate(repInfo);
   return preProcessReplyMsg;
 }


### PR DESCRIPTION
This PR introduces correlation ID support in pre-execution.
* Adding correlation ID to PreProcessReplyMsg.
* Adding correlation ID logging when receiving messages and in the background threads
* Fix a little bug in pre-execution