### PR TITLE
Support empty blocks in the merkle tree DBAdapter

### DIFF
--- a/storage/include/blockchain/merkle_tree_block.h
+++ b/storage/include/blockchain/merkle_tree_block.h
@@ -53,6 +53,8 @@ using Keys = std::unordered_map<concordUtils::Key, const KeyData>;
 // Represents a block node. The parentDigest pointer must point to a buffer that is at least BLOCK_DIGEST_SIZE bytes
 // long.
 struct Node {
+  using BlockIdType = concordUtils::BlockId;
+
   static constexpr auto PARENT_DIGEST_SIZE = BLOCK_DIGEST_SIZE;
 
   static constexpr auto STATE_HASH_SIZE = sparse_merkle::Hash::SIZE_IN_BYTES;
@@ -61,12 +63,11 @@ struct Node {
 
   static constexpr auto MIN_KEY_SIZE = 1 + sizeof(KeyLengthType);  // Add a byte of key data.
 
-  static constexpr auto MIN_SIZE =
-      sizeof(concordUtils::BlockId) + PARENT_DIGEST_SIZE + STATE_HASH_SIZE + STATE_ROOT_VERSION_SIZE;
+  static constexpr auto MIN_SIZE = sizeof(BlockIdType) + PARENT_DIGEST_SIZE + STATE_HASH_SIZE + STATE_ROOT_VERSION_SIZE;
 
   Node() = default;
 
-  Node(concordUtils::BlockId pBlockId,
+  Node(BlockIdType pBlockId,
        const void *pParentDigest,
        const sparse_merkle::Hash &pStateHash,
        const sparse_merkle::Version &pStateRootVersion,
@@ -80,7 +81,7 @@ struct Node {
     std::copy(parentDigestPtr, parentDigestPtr + BLOCK_DIGEST_SIZE, std::begin(parentDigest));
   }
 
-  concordUtils::BlockId blockId{0};
+  BlockIdType blockId{0};
   std::array<std::uint8_t, BLOCK_DIGEST_SIZE> parentDigest;
   sparse_merkle::Hash stateHash;
   sparse_merkle::Version stateRootVersion;

--- a/storage/include/blockchain/merkle_tree_db_adapter.h
+++ b/storage/include/blockchain/merkle_tree_db_adapter.h
@@ -110,13 +110,11 @@ class DBAdapter : public DBAdapterBase {
   const sparse_merkle::Hash &getStateHash() const { return smTree_.get_root_hash(); }
 
  private:
-  concordUtils::Sliver createBlockNode(const concordUtils::SetOfKeyValuePairs &updates,
-                                       BlockId blockId,
-                                       const sparse_merkle::Version &stateRootVersion) const;
+  concordUtils::Sliver createBlockNode(const concordUtils::SetOfKeyValuePairs &updates, BlockId blockId) const;
 
   // Returns a set of key/value pairs that represent the needed DB updates for adding a block as part of the blockchain.
-  concordUtils::SetOfKeyValuePairs lastReachableBlockkDbUpdates(const concordUtils::SetOfKeyValuePairs &updates,
-                                                                BlockId blockId);
+  concordUtils::SetOfKeyValuePairs lastReachableBlockDbUpdates(const concordUtils::SetOfKeyValuePairs &updates,
+                                                               BlockId blockId);
 
   // Try to link the ST temporary chain to the blockchain from the passed blockId up to getLatestBlock().
   concordUtils::Status linkSTChainFrom(BlockId blockId);
@@ -148,9 +146,7 @@ namespace detail {
 
 // Serialize leafs in the DB as the block ID the value was saved at and the value itself.
 struct DatabaseLeafValue {
-  using BlockIdType = BlockId;
-
-  BlockIdType blockId;
+  BlockId blockId;
   sparse_merkle::LeafNode leafNode;
 };
 

--- a/storage/include/blockchain/merkle_tree_serialization.h
+++ b/storage/include/blockchain/merkle_tree_serialization.h
@@ -360,9 +360,9 @@ inline sparse_merkle::Version deserializeStateRootVersion(const concordUtils::Sl
 
 template <>
 inline DatabaseLeafValue deserialize<DatabaseLeafValue>(const concordUtils::Sliver &buf) {
-  constexpr auto blockIdSize = sizeof(DatabaseLeafValue::BlockIdType);
+  constexpr auto blockIdSize = sizeof(DatabaseLeafValue::blockId);
   Assert(buf.length() >= blockIdSize);
-  return DatabaseLeafValue{concordUtils::fromBigEndianBuffer<DatabaseLeafValue::BlockIdType>(buf.data()),
+  return DatabaseLeafValue{concordUtils::fromBigEndianBuffer<decltype(DatabaseLeafValue::blockId)>(buf.data()),
                            sparse_merkle::LeafNode{concordUtils::Sliver{buf, blockIdSize, buf.length() - blockIdSize}}};
 }
 

--- a/storage/include/blockchain/merkle_tree_serialization.h
+++ b/storage/include/blockchain/merkle_tree_serialization.h
@@ -15,6 +15,7 @@
 
 #include <assertUtils.hpp>
 #include "blockchain/db_types.h"
+#include "blockchain/merkle_tree_db_adapter.h"
 #include "blockchain/merkle_tree_block.h"
 #include "endianness.hpp"
 #include "sliver.hpp"
@@ -188,6 +189,10 @@ inline std::string serializeImp(const block::detail::Node &node) {
   return buf;
 }
 
+inline std::string serializeImp(const DatabaseLeafValue &val) {
+  return serializeImp(val.blockId) + val.leafNode.value.toString();
+}
+
 inline std::string serialize() { return std::string{}; }
 
 template <typename T1, typename... T>
@@ -305,8 +310,8 @@ inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::
   auto node = block::detail::Node{};
 
   // Block ID.
-  node.blockId = concordUtils::fromBigEndianBuffer<concordUtils::BlockId>(buf.data() + offset);
-  offset += sizeof(concordUtils::BlockId);
+  node.blockId = concordUtils::fromBigEndianBuffer<block::detail::Node::BlockIdType>(buf.data() + offset);
+  offset += sizeof(block::detail::Node::BlockIdType);
 
   // Parent digest.
   node.setParentDigest(buf.data() + offset);
@@ -343,6 +348,22 @@ inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::
   }
 
   return node;
+}
+
+// Deserializes the state root version from a serialized block::detail::Node .
+inline sparse_merkle::Version deserializeStateRootVersion(const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= block::detail::Node::MIN_SIZE);
+  constexpr auto offset = sizeof(block::detail::Node::BlockIdType) + block::detail::Node::PARENT_DIGEST_SIZE +
+                          block::detail::Node::STATE_HASH_SIZE;
+  return concordUtils::fromBigEndianBuffer<sparse_merkle::Version::Type>(buf.data() + offset);
+}
+
+template <>
+inline DatabaseLeafValue deserialize<DatabaseLeafValue>(const concordUtils::Sliver &buf) {
+  constexpr auto blockIdSize = sizeof(DatabaseLeafValue::BlockIdType);
+  Assert(buf.length() >= blockIdSize);
+  return DatabaseLeafValue{concordUtils::fromBigEndianBuffer<DatabaseLeafValue::BlockIdType>(buf.data()),
+                           sparse_merkle::LeafNode{concordUtils::Sliver{buf, blockIdSize, buf.length() - blockIdSize}}};
 }
 
 }  // namespace detail

--- a/storage/include/sparse_merkle/db_reader.h
+++ b/storage/include/sparse_merkle/db_reader.h
@@ -34,11 +34,6 @@ class IDBReader {
   //
   // Throws a std::out_of_range exception if the internal node does not exist.
   virtual BatchedInternalNode get_internal(const InternalNodeKey&) const = 0;
-
-  // Retrieve a LeafNode given a LeafKey.
-  //
-  // Throws a std::out_of_range exception if the leaf does not exist.
-  virtual LeafNode get_leaf(const LeafKey&) const = 0;
 };
 
 }  // namespace sparse_merkle

--- a/storage/include/sparse_merkle/keys.h
+++ b/storage/include/sparse_merkle/keys.h
@@ -99,6 +99,8 @@ struct LeafNode {
   concordUtils::Sliver value;
 };
 
+inline bool operator==(const LeafNode& lhs, const LeafNode& rhs) { return (lhs.value == rhs.value); }
+
 }  // namespace sparse_merkle
 }  // namespace storage
 }  // namespace concord

--- a/storage/include/sparse_merkle/tree.h
+++ b/storage/include/sparse_merkle/tree.h
@@ -42,7 +42,7 @@ class Tree {
 
   const Hash& get_root_hash() const { return root_.hash(); }
   Version get_version() const { return root_.version(); }
-  const BatchedInternalNode& get_root() const { return root_; }
+  bool empty() const { return root_.numChildren() == 0; }
 
   // Add or update key-value pairs given in `updates`, and remove keys in
   // `deleted_keys`.

--- a/storage/include/sparse_merkle/tree.h
+++ b/storage/include/sparse_merkle/tree.h
@@ -42,6 +42,7 @@ class Tree {
 
   const Hash& get_root_hash() const { return root_.hash(); }
   Version get_version() const { return root_.version(); }
+  const BatchedInternalNode& get_root() const { return root_; }
 
   // Add or update key-value pairs given in `updates`, and remove keys in
   // `deleted_keys`.

--- a/storage/src/merkle_tree_db_adapter.cpp
+++ b/storage/src/merkle_tree_db_adapter.cpp
@@ -32,6 +32,7 @@ using BlockKeyData = block::detail::KeyData;
 
 using ::concordUtils::fromBigEndianBuffer;
 using ::concordUtils::Key;
+using ::concordUtils::SetOfKeyValuePairs;
 using ::concordUtils::Sliver;
 using ::concordUtils::Status;
 
@@ -52,7 +53,7 @@ using namespace detail;
 constexpr auto MAX_BLOCK_ID = std::numeric_limits<BlockId>::max();
 
 // Converts the updates as returned by the merkle tree to key/value pairs suitable for the DB.
-SetOfKeyValuePairs batchToDbUpdates(const sparse_merkle::UpdateBatch &batch) {
+SetOfKeyValuePairs batchToDbUpdates(const sparse_merkle::UpdateBatch &batch, BlockId blockId) {
   SetOfKeyValuePairs updates;
   const Sliver emptySliver;
 
@@ -77,7 +78,7 @@ SetOfKeyValuePairs batchToDbUpdates(const sparse_merkle::UpdateBatch &batch) {
   // Leaf nodes.
   for (const auto &[leafKey, leafNode] : batch.leaf_nodes) {
     const auto key = DBKeyManipulator::genDataDbKey(leafKey);
-    updates[key] = leafNode.value;
+    updates[key] = detail::serialize(detail::DatabaseLeafValue{blockId, leafNode});
   }
 
   return updates;
@@ -229,31 +230,44 @@ DBAdapter::DBAdapter(const std::shared_ptr<IDBClient> &db)
   }
 }
 
-Status DBAdapter::getKeyByReadVersion(BlockId version, const Key &key, Sliver &outValue, BlockId &actualVersion) const {
+Status DBAdapter::getKeyByReadVersion(BlockId blockVersion,
+                                      const Key &key,
+                                      Sliver &outValue,
+                                      BlockId &actualBlockVersion) const {
   outValue = Sliver{};
-  actualVersion = 0;
+  actualBlockVersion = 0;
+
+  auto stateRootVersion = sparse_merkle::Version{};
+  // Find a block with an ID that is less than or equal to the requested block version and extract the state root
+  // version from it.
+  {
+    const auto blockKey = DBKeyManipulator::genBlockDbKey(blockVersion);
+    auto iter = db_->getIteratorGuard();
+    const auto [foundBlockKey, foundBlockValue] = iter->seekAtMost(blockKey);
+    if (!foundBlockKey.empty() && getDBKeyType(foundBlockKey) == EDBKeyType::Block) {
+      stateRootVersion = detail::deserializeStateRootVersion(foundBlockValue);
+    } else {
+      return Status::OK();
+    }
+  }
 
   auto iter = db_->getIteratorGuard();
-  const auto dbKey = DBKeyManipulator::genDataDbKey(key, version);
+  const auto leafKey = DBKeyManipulator::genDataDbKey(key, stateRootVersion.value());
 
-  // Seek for a key that is less than or equal to the requested one.
-  //
-  // Since leaf keys are ordered lexicographically, first by hash and then by version, then if there is a key having
-  // the same hash and a lower version, it should directly precede the found one.
-  const auto &[foundKey, foundValue] = iter->seekAtMost(dbKey);
-  if (foundKey == dbKey) {
-    // We have an exact match.
-    outValue = foundValue;
-    actualVersion = version;
+  // Seek for a leaf key with a version that is less than or equal to the state root version from the found block.
+  // Since leaf keys are ordered lexicographically, first by hash and then by state root version, then if there is a key
+  // having the same hash and a lower version, it should directly precede the found one.
+  const auto [foundKey, foundValue] = iter->seekAtMost(leafKey);
+  // Make sure we only process leaf keys that have the same hash as the hash of the key the user has passed. The state
+  // root version can be less than the one we seek for.
+  const auto isLeafKey =
+      !foundKey.empty() && getDBKeyType(foundKey) == EDBKeyType::Key && getKeySubtype(foundKey) == EKeySubtype::Leaf;
+  if (isLeafKey && DBKeyManipulator::extractHashFromLeafKey(foundKey) == hash(key)) {
+    const auto dbLeafVal = detail::deserialize<detail::DatabaseLeafValue>(foundValue);
+    outValue = dbLeafVal.leafNode.value;
+    actualBlockVersion = dbLeafVal.blockId;
   }
-  // Make sure we process leaf keys only that have the same hash as the hash of the passed key (i.e. is the same key
-  // the user has requested).
-  else if (!foundKey.empty() && getDBKeyType(foundKey) == EDBKeyType::Key &&
-           getKeySubtype(foundKey) == EKeySubtype::Leaf &&
-           DBKeyManipulator::extractHashFromLeafKey(foundKey) == hash(key)) {
-    outValue = foundValue;
-    actualVersion = DBKeyManipulator::extractBlockIdFromKey(foundKey);
-  }
+
   return Status::OK();
 }
 
@@ -328,12 +342,15 @@ Status DBAdapter::getBlockById(BlockId blockId, Sliver &block) const {
   for (const auto &[key, keyData] : blockNode.keys) {
     if (!keyData.deleted) {
       Sliver value;
-      if (const auto status = db_->get(DBKeyManipulator::genDataDbKey(key, blockId), value); !status.isOK()) {
+      if (const auto status = db_->get(DBKeyManipulator::genDataDbKey(key, blockNode.stateRootVersion.value()), value);
+          !status.isOK()) {
         // If the key is not found, treat as corrupted storage and abort.
         Assert(!status.isNotFound());
         return status;
       }
-      keyValues[key] = value;
+      const auto dbLeafVal = detail::deserialize<detail::DatabaseLeafValue>(value);
+      Assert(dbLeafVal.blockId == blockId);
+      keyValues[key] = dbLeafVal.leafNode.value;
     }
   }
 
@@ -341,12 +358,14 @@ Status DBAdapter::getBlockById(BlockId blockId, Sliver &block) const {
   return Status::OK();
 }
 
-concordUtils::SetOfKeyValuePairs DBAdapter::lastReachableBlockkDbUpdates(const SetOfKeyValuePairs &updates,
-                                                                         BlockId blockId) {
-  const auto updateBatch = smTree_.update(updates);
-
-  // Key updates.
-  auto dbUpdates = batchToDbUpdates(updateBatch);
+SetOfKeyValuePairs DBAdapter::lastReachableBlockkDbUpdates(const SetOfKeyValuePairs &updates, BlockId blockId) {
+  auto dbUpdates = SetOfKeyValuePairs{};
+  // Create a block with the same state root as the previous one if there are no updates.
+  if (!updates.empty()) {
+    // Key updates.
+    const auto updateBatch = smTree_.update(updates);
+    dbUpdates = batchToDbUpdates(updateBatch, blockId);
+  }
 
   // Block key.
   dbUpdates[DBKeyManipulator::genBlockDbKey(blockId)] = createBlockNode(updates, blockId, smTree_.get_version());
@@ -362,8 +381,13 @@ BatchedInternalNode DBAdapter::Reader::get_latest_root() const {
 
   auto blockNodeSliver = Sliver{};
   Assert(adapter_.getDb()->get(DBKeyManipulator::genBlockDbKey(lastBlock), blockNodeSliver).isOK());
-  const auto blockNode = block::detail::parseNode(blockNodeSliver);
-  return get_internal(InternalNodeKey::root(blockNode.stateRootVersion));
+  const auto stateRootVersion = detail::deserializeStateRootVersion(blockNodeSliver);
+  if (stateRootVersion == 0) {
+    // A version of 0 means that the tree is empty and we return an empty BatchedInternalNode in that case.
+    return BatchedInternalNode{};
+  }
+
+  return get_internal(InternalNodeKey::root(stateRootVersion));
 }
 
 BatchedInternalNode DBAdapter::Reader::get_internal(const InternalNodeKey &key) const {
@@ -375,22 +399,7 @@ BatchedInternalNode DBAdapter::Reader::get_internal(const InternalNodeKey &key) 
   return deserialize<BatchedInternalNode>(res);
 }
 
-LeafNode DBAdapter::Reader::get_leaf(const LeafKey &key) const {
-  LeafNode leaf;
-  const auto status = adapter_.getDb()->get(DBKeyManipulator::genDataDbKey(key), leaf.value);
-  if (status.isNotFound()) {
-    throw std::out_of_range{"Could not find the requested merkle tree leaf"};
-  } else if (!status.isOK()) {
-    throw std::runtime_error{"Failed to get the requested merkle tree leaf"};
-  }
-  return leaf;
-}
-
 Status DBAdapter::addLastReachableBlock(const SetOfKeyValuePairs &updates) {
-  if (updates.empty()) {
-    return Status::IllegalOperation("Adding empty blocks is not allowed");
-  }
-
   const auto blockId = getLastReachableBlock() + 1;
   return db_->multiPut(lastReachableBlockkDbUpdates(updates, blockId));
 }

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -17,9 +17,9 @@ target_link_libraries(metadataStorage_test PUBLIC
     concordbft_storage
 )
 
-add_executable(merkleTreeAdapter_test merkleTreeAdapter_test.cpp $<TARGET_OBJECTS:logging_dev>)
-add_test(merkleTreeAdapter_test merkleTreeAdapter_test)
-target_link_libraries(merkleTreeAdapter_test PUBLIC
+add_executable(sparse_merkle_storage_db_adapter_unit_test sparse_merkle_storage/db_adapter_unit_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_test(sparse_merkle_storage_db_adapter_unit_test sparse_merkle_storage_db_adapter_unit_test)
+target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
     GTest::Main
     GTest::GTest
     util

--- a/storage/test/merkleTreeAdapter_test.cpp
+++ b/storage/test/merkleTreeAdapter_test.cpp
@@ -54,6 +54,7 @@ using ::concord::storage::sparse_merkle::InternalChild;
 using ::concord::storage::sparse_merkle::InternalNodeKey;
 using ::concord::storage::sparse_merkle::LeafChild;
 using ::concord::storage::sparse_merkle::LeafKey;
+using ::concord::storage::sparse_merkle::LeafNode;
 using ::concord::storage::sparse_merkle::NibblePath;
 using ::concord::storage::sparse_merkle::Version;
 
@@ -121,12 +122,19 @@ SetOfKeyValuePairs getDeterministicBlockUpdates(std::uint32_t count) {
   return updates;
 }
 
-ValuesVector createBlockchain(const std::shared_ptr<IDBClient> &db, std::size_t length) {
+ValuesVector createBlockchain(const std::shared_ptr<IDBClient> &db, std::size_t length, bool includeEmpty = false) {
   auto adapter = DBAdapter{db};
   ValuesVector blockchain;
 
+  auto emptyToggle = true;
   for (auto i = 1u; i <= length; ++i) {
-    Assert(adapter.addLastReachableBlock(getDeterministicBlockUpdates(i * 2)).isOK());
+    if (includeEmpty && emptyToggle) {
+      Assert(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+    } else {
+      Assert(adapter.addLastReachableBlock(getDeterministicBlockUpdates(i * 2)).isOK());
+    }
+    emptyToggle = !emptyToggle;
+
     auto block = Sliver{};
     Assert(adapter.getBlockById(i, block).isOK());
     blockchain.push_back(block);
@@ -418,6 +426,27 @@ TEST(block, block_node_serialization) {
   }
 }
 
+TEST(block, state_root_deserialization) {
+  // No keys.
+  {
+    const auto node = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash, defaultVersion};
+    const auto nodeSliver = block::detail::createNode(node);
+    ASSERT_EQ(deserializeStateRootVersion(nodeSliver), defaultVersion);
+  }
+
+  // Multiple keys with different sizes and deleted flags.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest.data(), defaultHash, defaultVersion};
+    auto deleted = false;
+    for (auto i = 1u; i <= maxNumKeys; ++i) {
+      node.keys.emplace(getSliverOfSize(i), block::detail::KeyData{deleted});
+      deleted = !deleted;
+    }
+    const auto nodeSliver = block::detail::createNode(node);
+    ASSERT_EQ(deserializeStateRootVersion(nodeSliver), defaultVersion);
+  }
+}
+
 TEST(block, block_serialization) {
   SetOfKeyValuePairs updates;
   for (auto i = 1u; i <= maxNumKeys; ++i) {
@@ -566,35 +595,69 @@ TEST(batched_internal, serialization) {
   }
 }
 
-struct IDbClientFactory {
+TEST(database_leaf_value, serialization) {
+  // Non-empty value.
+  {
+    const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}};
+    ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
+  }
+
+  // Empty value.
+  {
+    const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{Sliver{}}};
+    ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
+  }
+}
+
+struct IDbAdapterTest {
   virtual std::shared_ptr<IDBClient> db() const = 0;
   virtual std::string type() const = 0;
-  virtual ~IDbClientFactory() noexcept = default;
+  virtual ValuesVector referenceBlockchain(const std::shared_ptr<IDBClient> &db, std::size_t length) const = 0;
+  virtual ~IDbAdapterTest() noexcept = default;
 };
 
-struct MemoryDbClientFactory : public IDbClientFactory {
+template <bool emptyBlocks = false>
+struct MemoryDbTestFactory : public IDbAdapterTest {
   std::shared_ptr<IDBClient> db() const override { return std::make_shared<::concord::storage::memorydb::Client>(); }
 
-  std::string type() const override { return "memorydb"; }
+  std::string type() const override {
+    const auto blocksType = emptyBlocks ? std::string{"hasEmptyInRef"} : std::string{"noEmptyInRef"};
+    return "memorydb_" + blocksType;
+  }
+
+  ValuesVector referenceBlockchain(const std::shared_ptr<IDBClient> &db, std::size_t length) const override {
+    return createBlockchain(db, length, emptyBlocks);
+  }
 };
 
-struct RocksDbClientFactory : public IDbClientFactory {
+template <bool emptyBlocks = false>
+struct RocksDbTestFactory : public IDbAdapterTest {
   std::shared_ptr<IDBClient> db() const override {
     fs::remove_all(rocksDbPath());
     // Create the RocksDB client with the default lexicographical comparator.
     return std::make_shared<::concord::storage::rocksdb::Client>(rocksDbPath());
   }
 
-  std::string type() const override { return "RocksDB"; }
+  std::string type() const override {
+    const auto blocksType = emptyBlocks ? std::string{"hasEmptyInRef"} : std::string{"noEmptyInRef"};
+    return "RocksDB_" + blocksType;
+  }
+
+  ValuesVector referenceBlockchain(const std::shared_ptr<IDBClient> &db, std::size_t length) const override {
+    return createBlockchain(db, length, emptyBlocks);
+  }
 };
 
-class db_adapter : public ::testing::TestWithParam<std::shared_ptr<IDbClientFactory>> {
+class db_adapter_base : public ::testing::TestWithParam<std::shared_ptr<IDbAdapterTest>> {
   void SetUp() override { fs::remove_all(rocksDbPath()); }
   void TearDown() override { fs::remove_all(rocksDbPath()); }
 };
 
-// Test the last reachable block functionality that relies on key ordering.
-TEST_P(db_adapter, get_last_reachable_block) {
+class db_adapter_custom_blockchain : public db_adapter_base {};
+class db_adapter_ref_blockchain : public db_adapter_base {};
+
+// Test the last reachable block functionality.
+TEST_P(db_adapter_custom_blockchain, get_last_reachable_block) {
   auto adapter = DBAdapter{GetParam()->db()};
   const auto updates = SetOfKeyValuePairs{std::make_pair(defaultSliver, defaultSliver)};
   ASSERT_TRUE(adapter.addLastReachableBlock(updates).isOK());
@@ -603,7 +666,20 @@ TEST_P(db_adapter, get_last_reachable_block) {
   ASSERT_EQ(adapter.getLastReachableBlock(), 3);
 }
 
-TEST_P(db_adapter, get_key_by_ver_1_key) {
+// Test the last reachable block functionality with empty blocks.
+TEST_P(db_adapter_custom_blockchain, get_last_reachable_block_empty_blocks) {
+  auto adapter = DBAdapter{GetParam()->db()};
+  const auto updates = SetOfKeyValuePairs{std::make_pair(defaultSliver, defaultSliver)};
+  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(updates).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(updates).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(updates).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+  ASSERT_EQ(adapter.getLastReachableBlock(), 6);
+}
+
+TEST_P(db_adapter_custom_blockchain, get_key_by_ver_1_key) {
   const auto key = defaultSliver;
   const auto keyData = defaultData;
   auto adapter = DBAdapter{GetParam()->db()};
@@ -683,7 +759,7 @@ TEST_P(db_adapter, get_key_by_ver_1_key) {
     ASSERT_EQ(actualVersion, 3);
   }
 
-  // Get a key with a version bigger than the last one and expect the last one.
+  // Get the key at a version bigger than the last one and expect the last one.
   {
     Sliver out;
     BlockId actualVersion;
@@ -694,11 +770,134 @@ TEST_P(db_adapter, get_key_by_ver_1_key) {
   }
 }
 
+TEST_P(db_adapter_custom_blockchain, get_key_by_ver_1_key_empty_blocks) {
+  const auto key = defaultSliver;
+  const auto keyData = defaultData;
+  auto adapter = DBAdapter{GetParam()->db()};
+  const auto data2 = Sliver{"data2"};
+  const auto updates2 = SetOfKeyValuePairs{std::make_pair(key, data2)};
+  const auto data5 = Sliver{"data5"};
+  const auto updates5 = SetOfKeyValuePairs{std::make_pair(key, data5)};
+
+  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(updates2).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(updates5).isOK());
+  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isOK());
+
+  // Get a non-existent key with a hash that is after the existent key.
+  {
+    const auto after = Sliver{"dummy"};
+    ASSERT_TRUE(getHash(keyData) < getHash(after));
+
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(1, after, out, actualVersion);
+    ASSERT_TRUE(status == Status::OK());
+    ASSERT_TRUE(out.empty());
+    ASSERT_EQ(actualVersion, 0);
+  }
+
+  // Get a non-existent key with a hash that is before the existent key.
+  {
+    const auto before = Sliver{"aa"};
+    ASSERT_TRUE(getHash(before) < getHash(keyData));
+
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(1, before, out, actualVersion);
+    ASSERT_TRUE(status == Status::OK());
+    ASSERT_TRUE(out.empty());
+    ASSERT_EQ(actualVersion, 0);
+  }
+
+  // Get a key with a version smaller than the first version and expect an empty response.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(0, key, out, actualVersion);
+    ASSERT_TRUE(status == Status::OK());
+    ASSERT_TRUE(out.empty());
+    ASSERT_EQ(actualVersion, 0);
+  }
+
+  // Get the key at the first empty block and expect an empty response.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(1, key, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out.empty());
+    ASSERT_EQ(actualVersion, 0);
+  }
+
+  // Get the key at the second block.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(2, key, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data2);
+    ASSERT_EQ(actualVersion, 2);
+  }
+
+  // Get the key at the third empty block and expect at the second.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(3, key, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data2);
+    ASSERT_EQ(actualVersion, 2);
+  }
+
+  // Get the key at the fourth empty block and expect at the second.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(4, key, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data2);
+    ASSERT_EQ(actualVersion, 2);
+  }
+
+  // Get the key at the fifth block.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(5, key, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data5);
+    ASSERT_EQ(actualVersion, 5);
+  }
+
+  // Get the key at the sixth empty block and expect at the fifth.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(6, key, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data5);
+    ASSERT_EQ(actualVersion, 5);
+  }
+
+  // Get the key at a version bigger than the last one and expect at the last one.
+  {
+    Sliver out;
+    BlockId actualVersion;
+    const auto status = adapter.getKeyByReadVersion(42, key, out, actualVersion);
+    ASSERT_TRUE(status.isOK());
+    ASSERT_TRUE(out == data5);
+    ASSERT_EQ(actualVersion, 5);
+  }
+}
+
 // Test the getKeyByReadVersion() method with multiple keys, including ones that are ordered before and after the keys
 // in the system.
 // Note: Leaf keys are ordered first on the key hash and then on the version. See db_types.h and
 // merkle_tree_serialization.h for more information.
-TEST_P(db_adapter, get_key_by_ver_multiple_keys) {
+TEST_P(db_adapter_custom_blockchain, get_key_by_ver_multiple_keys) {
   const auto key = defaultSliver;
   const auto keyData = defaultData;
   const auto before = Sliver{"aa"};
@@ -837,7 +1036,7 @@ TEST_P(db_adapter, get_key_by_ver_multiple_keys) {
   }
 }
 
-TEST_P(db_adapter, add_and_get_block) {
+TEST_P(db_adapter_custom_blockchain, add_and_get_block) {
   for (auto numKeys = 1u; numKeys <= maxNumKeys; ++numKeys) {
     auto adapter = DBAdapter{GetParam()->db()};
 
@@ -884,22 +1083,22 @@ TEST_P(db_adapter, add_and_get_block) {
   }
 }
 
-TEST_P(db_adapter, add_multiple_deterministic_blocks) {
-  auto adapter = DBAdapter{GetParam()->db()};
-
+TEST_P(db_adapter_ref_blockchain, add_multiple_deterministic_blocks) {
   const auto numBlocks = 16;
-  auto count = std::uint16_t{0};
+  const auto referenceBlockchain = GetParam()->referenceBlockchain(GetParam()->db(), numBlocks);
+  auto adapter = DBAdapter{GetParam()->db()};
   for (auto i = 1u; i <= numBlocks; ++i) {
-    ASSERT_TRUE(adapter.addLastReachableBlock(getDeterministicBlockUpdates(count + 1)).isOK());
+    ASSERT_TRUE(adapter.addLastReachableBlock(block::getData(referenceBlockchain[i - 1])).isOK());
     ASSERT_EQ(adapter.getLastReachableBlock(), i);
-    ++count;
   }
 
-  count = 0;
   for (auto i = 1u; i <= numBlocks; ++i) {
     auto block = Sliver{};
     ASSERT_TRUE(adapter.getBlockById(i, block).isOK());
     ASSERT_FALSE(block.empty());
+
+    const auto &referenceBlock = referenceBlockchain[i - 1];
+    ASSERT_TRUE(block == referenceBlock);
 
     // Expect a zero parent digest for block 1.
     if (i == 1) {
@@ -911,19 +1110,11 @@ TEST_P(db_adapter, add_multiple_deterministic_blocks) {
       ASSERT_TRUE(blockDigest(i - 1, parentBlock) == block::getParentDigest(block));
     }
 
-    const auto updates = getDeterministicBlockUpdates(count + 1);
-    ASSERT_TRUE(block::getData(block) == updates);
-
-    ++count;
+    ASSERT_TRUE(block::getData(block) == block::getData(referenceBlock));
   }
 }
 
-TEST_P(db_adapter, add_empty_block) {
-  auto adapter = DBAdapter{GetParam()->db()};
-  ASSERT_TRUE(adapter.addLastReachableBlock(SetOfKeyValuePairs{}).isIllegalOperation());
-}
-
-TEST_P(db_adapter, no_blocks) {
+TEST_P(db_adapter_custom_blockchain, no_blocks) {
   const auto adapter = DBAdapter{GetParam()->db()};
 
   ASSERT_EQ(adapter.getLastReachableBlock(), 0);
@@ -935,20 +1126,16 @@ TEST_P(db_adapter, no_blocks) {
 
   auto value = Sliver{};
   auto actualVersion = BlockId{};
-  ASSERT_TRUE(
-      adapter
-          .getKeyByReadVersion(
-              defaultBlockId, DBKeyManipulator::genDataDbKey(defaultSliver, defaultBlockId), value, actualVersion)
-          .isOK());
+  ASSERT_TRUE(adapter.getKeyByReadVersion(defaultBlockId, defaultSliver, value, actualVersion).isOK());
   ASSERT_EQ(actualVersion, 0);
   ASSERT_TRUE(value.empty());
 }
 
-TEST_P(db_adapter, state_transfer_reverse_order_with_blockchain_blocks) {
+TEST_P(db_adapter_ref_blockchain, state_transfer_reverse_order_with_blockchain_blocks) {
   const auto numBlockchainBlocks = 5;
   const auto numStBlocks = 7;
   const auto numTotalBlocks = numBlockchainBlocks + numStBlocks;
-  const auto referenceBlockchain = createBlockchain(GetParam()->db(), numTotalBlocks);
+  const auto referenceBlockchain = GetParam()->referenceBlockchain(GetParam()->db(), numTotalBlocks);
 
   auto adapter = DBAdapter{GetParam()->db()};
 
@@ -1004,9 +1191,9 @@ TEST_P(db_adapter, state_transfer_reverse_order_with_blockchain_blocks) {
   }
 }
 
-TEST_P(db_adapter, state_transfer_fetch_whole_blockchain_in_reverse_order) {
+TEST_P(db_adapter_ref_blockchain, state_transfer_fetch_whole_blockchain_in_reverse_order) {
   const auto numBlocks = 7;
-  const auto referenceBlockchain = createBlockchain(GetParam()->db(), numBlocks);
+  const auto referenceBlockchain = GetParam()->referenceBlockchain(GetParam()->db(), numBlocks);
 
   auto adapter = DBAdapter{GetParam()->db()};
 
@@ -1038,11 +1225,11 @@ TEST_P(db_adapter, state_transfer_fetch_whole_blockchain_in_reverse_order) {
   }
 }
 
-TEST_P(db_adapter, state_transfer_unordered_with_blockchain_blocks) {
+TEST_P(db_adapter_ref_blockchain, state_transfer_unordered_with_blockchain_blocks) {
   const auto numBlockchainBlocks = 5;
   const auto numStBlocks = 3;
   const auto numTotalBlocks = numBlockchainBlocks + numStBlocks;
-  const auto referenceBlockchain = createBlockchain(GetParam()->db(), numTotalBlocks);
+  const auto referenceBlockchain = GetParam()->referenceBlockchain(GetParam()->db(), numTotalBlocks);
 
   auto adapter = DBAdapter{GetParam()->db()};
 
@@ -1109,11 +1296,20 @@ struct TypePrinter {
   }
 };
 
-// Test DBAdapter with both memory and RocksDB clients.
-INSTANTIATE_TEST_CASE_P(db_adapter_tests,
-                        db_adapter,
-                        ::testing::Values(std::make_shared<MemoryDbClientFactory>(),
-                                          std::make_shared<RocksDbClientFactory>()),
+// Instantiate tests with memorydb and RocksDB clients and with custom (test-specific) blockchains.
+INSTANTIATE_TEST_CASE_P(db_adapter_tests_custom_blockchain,
+                        db_adapter_custom_blockchain,
+                        ::testing::Values(std::make_shared<MemoryDbTestFactory<>>(),
+                                          std::make_shared<RocksDbTestFactory<>>()),
+                        TypePrinter{});
+
+// Instantiate tests with memorydb and RocksDB clients and with reference blockchains (with and without empty blocks).
+INSTANTIATE_TEST_CASE_P(db_adapter_tests_ref_blockchain,
+                        db_adapter_ref_blockchain,
+                        ::testing::Values(std::make_shared<MemoryDbTestFactory<false>>(),
+                                          std::make_shared<RocksDbTestFactory<false>>(),
+                                          std::make_shared<MemoryDbTestFactory<true>>(),
+                                          std::make_shared<RocksDbTestFactory<true>>()),
                         TypePrinter{});
 
 }  // namespace

--- a/storage/test/sparse_merkle/test_db.h
+++ b/storage/test/sparse_merkle/test_db.h
@@ -39,8 +39,6 @@ class TestDB : public concord::storage::sparse_merkle::IDBReader {
 
   BatchedInternalNode get_internal(const InternalNodeKey& key) const override { return internal_nodes_.at(key); }
 
-  LeafNode get_leaf(const LeafKey& key) const override { return leaf_nodes_.at(key); }
-
  private:
   Version latest_version_ = 0;
   map<LeafKey, LeafNode> leaf_nodes_;

--- a/storage/test/sparse_merkle/tree_test.cpp
+++ b/storage/test/sparse_merkle/tree_test.cpp
@@ -170,17 +170,13 @@ TEST(tree_tests, empty_db) {
   ASSERT_EQ(PLACEHOLDER_HASH, root.hash());
 }
 
-// Ensure that getting the latest root from an empty db through the tree returns an empty
-// BatchedInternalNode
+// Ensure that the tree is in an empty state when used with an empty db
 TEST(tree_tests, empty_db_from_tree) {
   std::shared_ptr<TestDB> db(new TestDB);
   Tree tree(db);
-  const auto& root = tree.get_root();
-  ASSERT_EQ(Version(0), root.version());
-  ASSERT_EQ(0, root.numChildren());
-  ASSERT_EQ(PLACEHOLDER_HASH, root.hash());
   ASSERT_EQ(Version(0), tree.get_version());
   ASSERT_EQ(PLACEHOLDER_HASH, tree.get_root_hash());
+  ASSERT_TRUE(tree.empty());
 }
 
 // Ensure that we can insert a single leaf to an empty tree

--- a/storage/test/sparse_merkle/tree_test.cpp
+++ b/storage/test/sparse_merkle/tree_test.cpp
@@ -161,13 +161,26 @@ void debug_print(const UpdateBatch& batch) {
 }
 
 // Ensure that getting the latest root from an empty db returns an empty
-// BatchedInternalNode;
+// BatchedInternalNode
 TEST(tree_tests, empty_db) {
   TestDB db;
   auto root = db.get_latest_root();
   ASSERT_EQ(Version(0), root.version());
   ASSERT_EQ(0, root.numChildren());
   ASSERT_EQ(PLACEHOLDER_HASH, root.hash());
+}
+
+// Ensure that getting the latest root from an empty db through the tree returns an empty
+// BatchedInternalNode
+TEST(tree_tests, empty_db_from_tree) {
+  std::shared_ptr<TestDB> db(new TestDB);
+  Tree tree(db);
+  const auto& root = tree.get_root();
+  ASSERT_EQ(Version(0), root.version());
+  ASSERT_EQ(0, root.numChildren());
+  ASSERT_EQ(PLACEHOLDER_HASH, root.hash());
+  ASSERT_EQ(Version(0), tree.get_version());
+  ASSERT_EQ(PLACEHOLDER_HASH, tree.get_root_hash());
 }
 
 // Ensure that we can insert a single leaf to an empty tree

--- a/storage/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/storage/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -1256,14 +1256,6 @@ TEST_P(db_adapter_ref_blockchain, state_transfer_unordered_with_blockchain_block
   }
 }
 
-// Generate test name suffixes based on the DB client type.
-struct TypePrinter {
-  template <typename T>
-  std::string operator()(const testing::TestParamInfo<T> &info) const {
-    return info.param->type();
-  }
-};
-
 // Instantiate tests with memorydb and RocksDB clients and with custom (test-specific) blockchains.
 INSTANTIATE_TEST_CASE_P(db_adapter_tests_custom_blockchain,
                         db_adapter_custom_blockchain,

--- a/storage/test/sparse_merkle_storage/storage_test_common.h
+++ b/storage/test/sparse_merkle_storage/storage_test_common.h
@@ -55,3 +55,11 @@ class ParametrizedTest : public ::testing::TestWithParam<ParamType> {
   void SetUp() override { fs::remove_all(rocksDbPath()); }
   void TearDown() override { fs::remove_all(rocksDbPath()); }
 };
+
+// Generate test name suffixes based on the DB client type.
+struct TypePrinter {
+  template <typename ParamType>
+  std::string operator()(const ::testing::TestParamInfo<ParamType> &info) const {
+    return info.param->type();
+  }
+};

--- a/storage/test/sparse_merkle_storage/storage_test_common.h
+++ b/storage/test/sparse_merkle_storage/storage_test_common.h
@@ -1,0 +1,57 @@
+// Copyright 2020 VMware, all rights reserved
+
+#pragma once
+
+#include "gtest/gtest.h"
+
+#include "memorydb/client.h"
+#include "storage/db_interface.h"
+#include "rocksdb/client.h"
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing filesystem support"
+#endif
+
+inline const auto rocksDbPathPrefix = std::string{"/tmp/sparse_merkle_storage_test_rocksdb"};
+
+// Support multithreaded runs by appending the thread ID to the RocksDB path.
+inline std::string rocksDbPath() {
+  std::stringstream ss;
+  ss << std::this_thread::get_id();
+  return rocksDbPathPrefix + ss.str();
+}
+
+struct TestMemoryDb {
+  static std::shared_ptr<concord::storage::IDBClient> create() {
+    return std::make_shared<concord::storage::memorydb::Client>();
+  }
+
+  static std::string type() { return "memorydb"; }
+};
+
+struct TestRocksDb {
+  static std::shared_ptr<::concord::storage::IDBClient> create() {
+    fs::remove_all(rocksDbPath());
+    // Create the RocksDB client with the default lexicographical comparator.
+    return std::make_shared<::concord::storage::rocksdb::Client>(rocksDbPath());
+  }
+
+  static std::string type() { return "RocksDB"; }
+};
+
+template <typename ParamType>
+class ParametrizedTest : public ::testing::TestWithParam<ParamType> {
+  void SetUp() override { fs::remove_all(rocksDbPath()); }
+  void TearDown() override { fs::remove_all(rocksDbPath()); }
+};


### PR DESCRIPTION
Rationale for supporting empty blocks:
 * not imposing restrictions on users
 * support for marking that an event has happened without any data.

Please note that support for empty blocks with regards to client
filtering is a separate topic and will be added in future commits.

When a request for creating an empty block comes in, we create a block
node without any keys and with a state merkle tree root equal to the one
of the previous non-empty block. Additionally, when saving a leaf into
the DB, we serialize it as a concatenation of the block ID the value was
saved at and the value itself. This allows us to maintain a mapping
between merkle tree versions and block IDs and enables the
implementation of getKeyByReadVersion() and its support for returning
the actual block version of the key that is being searched for.

Remove sparse_merkle::IDBReader::get_leaf() as it is not being used.

Provide a specific unit test to prove empty blocks work as expected.
Additionally, enhance a number of existing tests with empty block cases.