### PR TITLE
Apollo time improvement

### DIFF
--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -65,8 +65,7 @@ class SkvbcChaosTest(unittest.TestCase):
         self.skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         self.bft_network = bft_network
         self.bft_network.start_all_replicas()
-        async with trio.open_nursery() as nursery:
-            nursery.start_soon(tracker.run_concurrent_ops, num_ops)
+        await tracker.run_concurrent_ops(num_ops)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -87,8 +86,7 @@ class SkvbcChaosTest(unittest.TestCase):
 
             adversary.interfere()
 
-            async with trio.open_nursery() as nursery:
-                nursery.start_soon(tracker.run_concurrent_ops, num_ops)
+            await tracker.run_concurrent_ops(num_ops)
 
     @with_trio
     @with_bft_network(start_replica_cmd)

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -159,8 +159,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
             await tracker.tracked_read_your_writes()
 
-            async with trio.open_nursery() as nursery:
-                nursery.start_soon(tracker.run_concurrent_ops, 100)
+            await tracker.run_concurrent_ops(100)
 
     @with_trio
     @with_bft_network(start_replica_cmd)
@@ -209,8 +208,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         await tracker.tracked_read_your_writes()
 
-        async with trio.open_nursery() as nursery:
-            nursery.start_soon(tracker.run_concurrent_ops, 100)
+        await tracker.run_concurrent_ops(100)
 
     @unittest.skip("unstable scenario")
     @with_trio

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -909,7 +909,7 @@ class SkvbcTracker:
                     if random.random() < write_weight:
                         nursery.start_soon(self.send_tracked_write, client, max_size)
                     else:
-                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                        nursery.start_soon(self.send_tracked_read, client, max_size)
                 except:
                     pass
                 await trio.sleep(.01)

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -904,14 +904,15 @@ class SkvbcTracker:
         max_size = len(self.skvbc.keys) // 2
         while True:
             client = self.bft_network.random_client()
-            try:
-                if random.random() < write_weight:
-                    await self.send_tracked_write(client, max_size)
-                else:
-                    await self.send_tracked_read(client, max_size)
-            except:
-                pass
-            await trio.sleep(.1)
+            async with trio.open_nursery() as nursery:
+                try:
+                    if random.random() < write_weight:
+                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                    else:
+                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                except:
+                    pass
+                await trio.sleep(.01)
 
     async def write_and_track_known_kv(self, kv, client):
         read_version = self.read_block_id()

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -904,15 +904,14 @@ class SkvbcTracker:
         max_size = len(self.skvbc.keys) // 2
         while True:
             client = self.bft_network.random_client()
-            async with trio.open_nursery() as nursery:
-                try:
-                    if random.random() < write_weight:
-                        nursery.start_soon(self.send_tracked_write, client, max_size)
-                    else:
-                        nursery.start_soon(self.send_tracked_read, client, max_size)
-                except:
-                    pass
-                await trio.sleep(.01)
+            try:
+                if random.random() < write_weight:
+                    await self.send_tracked_write(client, max_size)
+                else:
+                    await self.send_tracked_read(client, max_size)
+            except:
+                pass
+            await trio.sleep(.1)
 
     async def write_and_track_known_kv(self, kv, client):
         read_version = self.read_block_id()

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -904,14 +904,15 @@ class SkvbcTracker:
         max_size = len(self.skvbc.keys) // 2
         while True:
             client = self.bft_network.random_client()
-            try:
-                if random.random() < write_weight:
-                    await self.send_tracked_write(client, max_size)
-                else:
-                    await self.send_tracked_read(client, max_size)
-            except:
-                pass
-            await trio.sleep(.1)
+            async with trio.open_nursery() as nursery:
+                try:
+                    if random.random() < write_weight:
+                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                    else:
+                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                except:
+                    pass
+                await trio.sleep(.01)
 
     async def write_and_track_known_kv(self, kv, client):
         read_version = self.read_block_id()
@@ -961,14 +962,22 @@ class SkvbcTracker:
         # Fill up the initial nodes with data, checkpoint them and stop
         # them. Then bring them back up and ensure the checkpoint data is
         # there.
-        client1 = self.bft_network.random_client()
-        # Write enough data to checkpoint and create a need for state transfer
-        for i in range(1 + checkpoints_num * 150):
-            key = self.skvbc.random_key()
-            val = self.skvbc.random_value()
-            kv = [(key, val)]
-            await self.write_and_track_known_kv(kv, client1)
 
+        # Write enough data to checkpoint and create a need for state transfer
+        max_concurrency = len(self.bft_network.clients) // 2
+        clients = self.bft_network.random_clients(max_concurrency)
+        replica_id = 0
+        last_executed_seq_num = 0
+        keys = ['replica', 'Gauges', 'lastExecutedSeqNum']
+
+        while last_executed_seq_num < checkpoints_num * 150:
+            async with trio.open_nursery() as nursery:
+                for client in clients:
+                    key = self.skvbc.random_key()
+                    val = self.skvbc.random_value()
+                    kv = [(key, val)]
+                    nursery.start_soon(self.write_and_track_known_kv, kv, client)
+            last_executed_seq_num = await self.bft_network.metrics.get(replica_id, *keys)
         await self.skvbc.network_wait_for_checkpoint(initial_nodes, checkpoints_num, persistency_enabled)
 
         return client, known_key, known_val, known_kv

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -962,14 +962,22 @@ class SkvbcTracker:
         # Fill up the initial nodes with data, checkpoint them and stop
         # them. Then bring them back up and ensure the checkpoint data is
         # there.
-        client1 = self.bft_network.random_client()
-        # Write enough data to checkpoint and create a need for state transfer
-        for i in range(1 + checkpoints_num * 150):
-            key = self.skvbc.random_key()
-            val = self.skvbc.random_value()
-            kv = [(key, val)]
-            await self.write_and_track_known_kv(kv, client1)
 
+        # Write enough data to checkpoint and create a need for state transfer
+        max_concurrency = len(self.bft_network.clients) // 2
+        clients = self.bft_network.random_clients(max_concurrency)
+        replica_id = 0
+        last_executed_seq_num = 0
+        keys = ['replica', 'Gauges', 'lastExecutedSeqNum']
+
+        while last_executed_seq_num < checkpoints_num * 150:
+            async with trio.open_nursery() as nursery:
+                for client in clients:
+                    key = self.skvbc.random_key()
+                    val = self.skvbc.random_value()
+                    kv = [(key, val)]
+                    nursery.start_soon(self.write_and_track_known_kv, kv, client)
+            last_executed_seq_num = await self.bft_network.metrics.get(replica_id, *keys)
         await self.skvbc.network_wait_for_checkpoint(initial_nodes, checkpoints_num, persistency_enabled)
 
         return client, known_key, known_val, known_kv

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -121,7 +121,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
   replicaConfig.autoPrimaryRotationEnabled = rp.autoPrimaryRotationEnabled;
   replicaConfig.autoPrimaryRotationTimerMillisec = rp.autoPrimaryRotationTimeout;
   replicaConfig.statusReportTimerMillisec = rp.statusReportTimerMillisec;
-  replicaConfig.concurrencyLevel = 16;
+  replicaConfig.concurrencyLevel = 1;
   replicaConfig.debugStatisticsEnabled = true;
 
   uint16_t numOfReplicas = (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1);

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -121,7 +121,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
   replicaConfig.autoPrimaryRotationEnabled = rp.autoPrimaryRotationEnabled;
   replicaConfig.autoPrimaryRotationTimerMillisec = rp.autoPrimaryRotationTimeout;
   replicaConfig.statusReportTimerMillisec = rp.statusReportTimerMillisec;
-  replicaConfig.concurrencyLevel = 1;
+  replicaConfig.concurrencyLevel = 16;
   replicaConfig.debugStatisticsEnabled = true;
 
   uint16_t numOfReplicas = (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1);


### PR DESCRIPTION
I made some optimizations in Apollo's test, in order to decrease the tests duration.
The following changes are made:

1. I increased replicaConfig.concurrencyLevel to 16.
2. Optimized write operations to work in parallel.
3. Decreased trio.sleep functions.