### PR TITLE
Make install.sh idempotent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 set -e
 set -u
 
@@ -9,12 +9,29 @@ install_basic_deps() {
   python3 -m pip install --upgrade trio
 }
 
+default_profile_exists() {
+  local exists="false"
+  for profile in `conan profile list`; do
+    if [[ "$profile" == "default" ]]; then
+      exists="true"
+      break
+    fi
+  done
+  echo $exists
+}
+
 install_conan() {
   echo "Using Conan build..."
   echo "Installing Conan..."
   python3 -m pip install --upgrade conan
-  conan profile new default --detect
-  conan profile update settings.compiler.libcxx=libstdc++11 default
+  result=$(default_profile_exists)
+  if [[ "$result" == "true" ]]; then
+     echo "Default profile exists. Skipping."
+  else
+    echo "Creating default profile..."
+    conan profile new default --detect
+    conan profile update settings.compiler.libcxx=libstdc++11 default
+  fi
 }
 
 install_basic_deps


### PR DESCRIPTION
The only existing part that wasn't idempotent was creating a default
profile for conan. `install.sh` now checks if the default profile exists
before attempting to create it.