### PR TITLE
Remove add_submodule function from CMakeTests.list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
 project(concord-bft VERSION 0.1.0.0 LANGUAGES CXX)
-set(MIN_BOOST_VERSION 1.64)
-option(USE_CONAN "use conan package manager" ON)
 
 #
 # C++ options
@@ -14,6 +12,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(IS_LEAKCHECK FALSE)
 set(SLEEP_FOR_DBG FALSE)
 
+set(MIN_BOOST_VERSION 1.64)
+option(USE_CONAN "use conan package manager" ON)
 
 # Default to debug builds
 # Release builds can be enabled by running cmake with -DCMAKE_BUILD_TYPE=Release
@@ -78,14 +78,14 @@ string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fstack-protector-all")
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
     string(APPEND CMAKE_CXX_FLAGS " -ferror-limit=3")
-    
+
     # Our RELIC library used in threshsign is in the habit of picking generic
     # macro names like HASH and ALIGNED, which conflicts with our own code or
     # other libraries. Even worse, compilers don't show 'macro redefined' warnings
     # for system header files such as our installed RELIC library. So we do this:
     # TODO: [TK] move to the threshsign module
-    string(APPEND CMAKE_CXX_FLAGS " --no-system-header-prefix relic")    
-    
+    string(APPEND CMAKE_CXX_FLAGS " --no-system-header-prefix relic")
+
     string(APPEND CMAKE_CXX_FLAGS " -Wmacro-redefined")
     string(APPEND CMAKE_CXX_FLAGS " -Wsign-compare")
 
@@ -107,28 +107,7 @@ if (USE_CONAN)
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
     set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/.conan/cmake_helpers ${CMAKE_MODULE_PATH})
-    set(MIN_BOOST_VERSION 1.64.0)
 endif()
-
-# Initialize submodules and update a specific one
-# This allows us to only pull in dependencies when needed.
-function(add_submodule path)
-    file(GLOB RESULT ${path}/*)
-    list(LENGTH RESULT RES_LEN)
-    if(NOT RES_LEN EQUAL 0)
-        message(STATUS "Submodule ${path} already initialized. Skipping.")
-        return()
-    endif()
-    message(STATUS "Submodule update ${path}")
-    execute_process(
-        COMMAND git submodule update --init --recursive ${path}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        RESULT_VARIABLE GIT_SUBMOD_RESULT)
-    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-        message(FATAL_ERROR "git submodule update --init failed with
-            ${GIT_SUBMOD_RESULT}, please checkout submodules")
-    endif()
-endfunction()
 
 include(CTest)
 #


### PR DESCRIPTION
We don't use submodules for dependencies anymore, so remove the
unnecessary function that initializes them.

Also move boost and conan related options closer to the other options.

Remove duplication of boost minimum version inside the conan
configuration.