### PR TITLE
Simplify Conan based builds

### DIFF
--- a/.conan/hdrhistogram_pkg/conanfile.py
+++ b/.conan/hdrhistogram_pkg/conanfile.py
@@ -14,19 +14,12 @@ class HdrhistogramConan(ConanFile):
     url = "http://github.com/HdrHistogram/HdrHistogram_c"
     description = "A HDR histogram library"
     topics = ("HDR histogram")
-    generators = "cmake"
 
     def requirements(self):
         self.requires("zlib/1.2.11@conan/stable")
 
     def configure(self):
         self.options["zlib"].shared = True
-
-    def source(self):
-        tools.replace_in_file("CMakeLists.txt", 'project("hdr_histogram")',
-                              '''project("hdr_histogram")
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()''')
 
     def build(self):
         cmake = CMake(self)

--- a/.conan/relic_pkg/conanfile.py
+++ b/.conan/relic_pkg/conanfile.py
@@ -17,22 +17,6 @@ class RelicConan(ConanFile):
                   "RELIC can be used to build efficient and usable cryptographic toolkits tailored for specific " \
                   "security levels and algorithmic choices."
 
-    generators = "cmake"
-
-    # def requirements(self):
-    #     self.requires("gmp/6.1.2@bincrafters/stable")
-    #
-    # #
-    # def configure(self):
-    #     self.options["gmp"].shared = False
-
-    def source(self):
-        tools.replace_in_file("CMakeLists.txt", 'project(RELIC C CXX)',
-                              '''project(RELIC C CXX)
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-''')
-
     def build(self):
         self.run('CC=/usr/bin/gcc CXX=/usr/bin/g++ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DALLOC=AUTO -DWSIZE=64 -DRAND=UDEV -DSHLIB=ON -DSTLIB=ON -DSTBIN=OFF -DTIMER=HREAL -DCHECK=on -DVERBS=on -DARITH=x64-asm-254 -DFP_PRIME=254 -DFP_METHD="INTEG;INTEG;INTEG;MONTY;LOWER;SLIDE" -DCOMP="-O3 -funroll-loops -fomit-frame-pointer -finline-small-functions -march=native -mtune=native" -DFP_PMERS=off -DFP_QNRES=on -DFPX_METHD="INTEG;INTEG;LAZYR" -DPP_METHD="LAZYR;OATEP"')
         self.run('CC=/usr/bin/gcc CXX=/usr/bin/g++ make')
@@ -44,8 +28,6 @@ conan_basic_setup()
         self.copy("*.so*", dst="lib", keep_path=False)
         self.copy("*.dylib", dst="lib", keep_path=False)
         self.copy("*.a", dst="lib", keep_path=False)
-
-
 
     def package_info(self):
         self.cpp_info.libs = ["relic"]

--- a/.conan/rocksdb_pkg/conanfile.py
+++ b/.conan/rocksdb_pkg/conanfile.py
@@ -17,8 +17,6 @@ class RocksdbConan(ConanFile):
     description = "RocksDB is developed and maintained by Facebook Database Engineering Team." \
                   "It is built on earlier work on LevelDB by Sanjay Ghemawat (sanjay@google.com) " \
                   "and Jeff Dean (jeff@google.com)"
-    generators = "cmake"
-
 
     def requirements(self):
         self.requires("zlib/1.2.11@conan/stable")
@@ -33,13 +31,6 @@ class RocksdbConan(ConanFile):
         self.options["lz4"].shared = True
         self.options["snappy"].shared = True
         self.options["zstd"].shared = True
-
-    def source(self):
-        tools.replace_in_file("CMakeLists.txt", 'project(rocksdb)',
-          '''project(rocksdb)
-          include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-          conan_basic_setup()
-            ''')
 
     def build(self):
         autotools = AutoToolsBuildEnvironment(self)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,15 +98,12 @@ endif()
 
 if (USE_CONAN)
     message("Using conan package manager")
-    include(${CMAKE_SOURCE_DIR}/.conan/cmake_helpers//conan.cmake)
-    execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/.conan/install_conan_pkgs.sh)
-    conan_cmake_run(CONANFILE
-            conanfile.txt
-            BUILD_TYPE "Release"
-            BUILD missing)
-    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
     set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/.conan/cmake_helpers ${CMAKE_MODULE_PATH})
+    include(${CMAKE_SOURCE_DIR}/.conan/cmake_helpers/conan.cmake)
+    execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/.conan/install_conan_pkgs.sh)
+    conan_cmake_run(CONANFILE conanfile.txt
+            BASIC_SETUP CMAKE_TARGETS NO_OUTPUT_DIRS
+            BUILD missing)
 endif()
 
 include(CTest)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -14,9 +14,6 @@ rocksdb/5.7.3
 hdr_histogram/0.9.12
 rapidcheck/258d907da00a0855f92c963d8f76eef115531716
 
-[generators]
-cmake
-
 [options]
 OpenSSL:shared=True
 boost:without_atomic=True

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -34,6 +34,5 @@ target_link_libraries(timers_tests GTest::Main util)
 
 add_executable(sha3_256_tests sha3_256_tests.cpp)
 add_test(sha3_256_tests sha3_256_tests)
-target_include_directories(sha3_256_tests PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(sha3_256_tests GTest::Main util OpenSSL::Crypto
         $<TARGET_OBJECTS:logging_dev>)


### PR DESCRIPTION
* Remove unnecessary source methods from dependencies.
* Move the direct call to conan_basic_setup into conan_cmake_run.
* Remove CMake generator from conan files
    Since we use [cmake-conan](https://github.com/conan-io/cmake-conan), the
    CMake generator is used automatically. We don't need to add it to
    conanfile.txt or include the generated `conanbuildinfo.cmake` in
    CMakeLists.txt. Also remove the `generators=cmake` line from each of
    conanfile.py dependencies. It has no effect there for our project, as
    it's a top level setting.
* Remove unnecessary `target_include_directories` call in
`util/test/CMakeLists.txt`