### PR TITLE
Long run test: add VC test case

### DIFF
--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -71,7 +71,7 @@ class SkvbcFastPathTest(unittest.TestCase):
 
         await tracker.run_concurrent_ops(num_ops=numops, write_weight=write_weight)
 
-        await bft_network.assert_fast_path_prevalent(nb_slow_paths_so_far=nb_slow_path)
+        await bft_network.wait_for_fast_path_to_be_prevalent(nb_slow_paths_so_far=nb_slow_path)
 
     @with_trio
     @with_bft_network(start_replica_cmd)

--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -9,7 +9,7 @@
 # notices and license terms. Your use of these subcomponents is subject to the
 # terms and conditions of the subcomponent's license, as noted in the LICENSE
 # file.
-
+import itertools
 import os.path
 import unittest
 import trio
@@ -51,9 +51,8 @@ class SkvbcLongRunningTest(unittest.TestCase):
                       selected_configs=lambda n, f, c: n == 7)
     async def test_stability(self, bft_network):
         bft_network.start_all_replicas()
-        i=0
-        with trio.move_on_after(seconds=EIGHT_HOURS_IN_SECONDS):
-            while True:
+        with trio.move_on_after(seconds=EIGHT_HOURS_IN_SECONDS/2):
+            for i in itertools.count():
                 await SkvbcTest().test_get_block_data\
                     (bft_network=bft_network, already_in_trio=True)
                 await trio.sleep(seconds=10)
@@ -67,4 +66,3 @@ class SkvbcLongRunningTest(unittest.TestCase):
                     await SkvbcViewChangeTest().test_single_vc_only_primary_down \
                       (bft_network=bft_network, already_in_trio=True, disable_linearizability_checks=True)
                     await trio.sleep(seconds=10)
-                i += 1

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -319,16 +319,17 @@ class SkvbcViewChangeTest(unittest.TestCase):
         bft_network.start_all_replicas()
 
         initial_primary = await bft_network.get_current_primary()
-        replcas_to_stop = [ v for v in range((initial_primary % bft_network.config.n),
-                                             (initial_primary % bft_network.config.n) + num_consecutive_failing_primaries) ]
+        initial_view = await bft_network.get_current_view()
+        replcas_to_stop = [ v for v in range(initial_primary,
+                                             initial_primary + num_consecutive_failing_primaries) ]
         
-        expected_final_view = (initial_primary + num_consecutive_failing_primaries)
+        expected_final_view = initial_view + num_consecutive_failing_primaries
 
         await self._send_random_writes(tracker)
 
         await bft_network.wait_for_view(
-            replica_id=initial_primary % bft_network.config.n,
-            expected=lambda v: v == initial_primary,
+            replica_id=initial_primary,
+            expected=lambda v: v == initial_view,
             err_msg="Make sure we are in the initial view "
                     "before crashing the primary."
         )

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -602,6 +602,21 @@ class BftTestNetwork:
                         # slow path prevalent - done.
                         break
 
+    async def wait_for_fast_path_to_be_prevalent(
+            self, nb_slow_paths_so_far=0, replica_id=0):
+        with trio.fail_after(seconds=5):
+            while True:
+                with trio.move_on_after(seconds=.5):
+                    try:
+                        await self.assert_fast_path_prevalent(
+                            nb_slow_paths_so_far, replica_id)
+                    except KeyError:
+                        # metrics not yet available, continue looping
+                        continue
+                    else:
+                        # fast path prevalent - done.
+                        break
+
     async def assert_state_transfer_not_started_all_up_nodes(self, up_replica_ids):
         with trio.fail_after(METRICS_TIMEOUT_SEC):
             # Check metrics for all started nodes in parallel

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -356,10 +356,7 @@ class BftTestNetwork:
         """
         Returns the current primary replica id
         """
-        live_replica = random.choice(self.get_live_replicas())
-        current_primary = await self.wait_for_view(
-            replica_id=live_replica, expected=None)
-
+        current_primary = await self.get_current_view()
         return current_primary % self.config.n
 
     async def get_current_view(self):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -360,7 +360,17 @@ class BftTestNetwork:
         current_primary = await self.wait_for_view(
             replica_id=live_replica, expected=None)
 
-        return current_primary
+        return current_primary % self.config.n
+
+    async def get_current_view(self):
+        """
+        Returns the current view number
+        """
+        live_replica = random.choice(self.get_live_replicas())
+        current_view = await self.wait_for_view(
+            replica_id=live_replica, expected=None)
+
+        return current_view
 
     async def wait_for_view(self, replica_id, expected=None,
                             err_msg="Expected view not reached"):
@@ -614,7 +624,7 @@ class BftTestNetwork:
                         # metrics not yet available, continue looping
                         continue
                     else:
-                        # fast path prevalent - done.
+                        # fastf path prevalent - done.
                         break
 
     async def assert_state_transfer_not_started_all_up_nodes(self, up_replica_ids):


### PR DESCRIPTION
1) on VC test case change the variable name to expected next view, until now when we ran test cases it always remain primary number == view number but on a long run, it's not always true because 0<=primary<=number of replicas, but 0<=view<= infinity so I made the requested changes.

2)Add wait for fast path to be prevalent - tries for 5 seconds to get in a fast path.

3)Run long-run tests for 2 hours locally.