### PR TITLE
Enhance the Conan package for RapidCheck

### DIFF
--- a/.conan/cmake_helpers/Findrapidcheck.cmake
+++ b/.conan/cmake_helpers/Findrapidcheck.cmake
@@ -6,5 +6,11 @@ find_package_handle_standard_args(RAPIDCHECK DEFAULT_MSG RAPIDCHECK_INCLUDE_DIR 
 
 if(RAPIDCHECK_FOUND)
     set(RAPIDCHECK_LIBRARIES ${RAPIDCHECK_LIBRARY})
-    set(RAPIDCHECK_INCLUDE_DIRS ${RAPIDCHECK_INCLUDE_DIR})
+    # Support includes in the form of:
+    #  * #include "rapidcheck/rapidcheck.h"
+    #  * #include "rapidcheck/extras/gtest.h"
+    #  * #include "rapidcheck/extras/gmock.h"
+    # In order to do so, set both the include dir returned by Conan and its /rapidcheck subdirectory.
+    # The latter is needed, because rapidcheck internally includes as #include "rapidcheck/xyz.h" .
+    set(RAPIDCHECK_INCLUDE_DIRS ${RAPIDCHECK_INCLUDE_DIR} ${RAPIDCHECK_INCLUDE_DIR}/rapidcheck)
 endif()

--- a/.conan/rapidcheck_pkg/conanfile.py
+++ b/.conan/rapidcheck_pkg/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, CMake, tools
-
+from os import path
 
 class RapidCheckConan(ConanFile):
     scm = {
@@ -18,11 +18,18 @@ class RapidCheckConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["RC_ENABLE_GTEST"] = "ON"
+        cmake.definitions["RC_ENABLE_GMOCK"] = "ON"
         cmake.configure()
         cmake.build()
 
     def package(self):
         self.copy("*.h", dst="rapidcheck", src="include")
+        self.copy("*.hpp", dst="rapidcheck", src="include")
+        self.copy("*.h", dst="rapidcheck/extras", src="extras/gtest/include/rapidcheck")
+        self.copy("*.hpp", dst="rapidcheck/extras", src="extras/gtest/include/rapidcheck")
+        self.copy("*.h", dst="rapidcheck/extras", src="extras/gmock/include/rapidcheck")
+        self.copy("*.hpp", dst="rapidcheck/extras", src="extras/gmock/include/rapidcheck")
         self.copy("*.lib", dst="lib", keep_path=False)
         self.copy("*.dll", dst="bin", keep_path=False)
         self.copy("*.so*", dst="lib", keep_path=False)
@@ -31,4 +38,4 @@ class RapidCheckConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["rapidcheck"]
-        self.cpp_info.includedirs = [self.package_folder]
+        self.cpp_info.includedirs = [path.join(self.package_folder, "rapidcheck")]


### PR DESCRIPTION
Enhance the following:
 * support includes in the form of:
   - #include "rapidcheck/rapidcheck.h"
   - #include "rapidcheck/extras/gtest.h"
   - #include "rapidcheck/extras/gmock.h"
 * add missing *.hpp files in the conanfile
 * add support for the Google Test and Google Mock extras
 * set self.cpp_info.includedirs to the correct rapidcheck subdirectory

Since existing unit tests use Google Test, it might be convenient to
write tests in the form of:
```
RC_GTEST_PROP(tc1, t1, (const std::string& str)) {
  const auto copy = str;
  RC_ASSERT(copy == str);
}
```