### PR TITLE
[Apollo] Enable 4-nodes BFT configuration for all tests

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -52,7 +52,7 @@ def interesting_configs(selected=None):
     if selected is None:
         selected=lambda *config: True
 
-    bft_configs = [#{'n': 4, 'f': 1, 'c': 0, 'num_clients': 30},
+    bft_configs = [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 30},
                    {'n': 6, 'f': 1, 'c': 1, 'num_clients': 30},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 30}


### PR DESCRIPTION
Given the significant CI performance gains obtained recently, we can safely re-enable coverage for a 4-nodes BFT network.
Originally, we disabled it because CI jobs were taking more than 50 min (the maximum in Travis CI).

Now we are at around 25 min on average (current PR included).