### PR TITLE
[Apollo] Fixes for running against a containerized SKVBC deployment

### DIFF
--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -181,7 +181,8 @@ class SimpleKVBCProtocol:
             checkpoints_num=2,
             persistency_enabled=True):
         initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
-        [self.bft_network.start_replica(i) for i in initial_nodes]
+        self.bft_network.start_all_replicas()
+        self.bft_network.stop_replicas(stale_nodes)
         client = SkvbcClient(self.bft_network.random_client())
         # Write a KV pair with a known value
         known_key = self.max_key()

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -53,9 +53,8 @@ int InternalCommandsHandler::execute(uint16_t clientId,
 }
 
 void InternalCommandsHandler::addMetadataKeyValue(SetOfKeyValuePairs &updates, uint64_t sequenceNum) const {
-  concord::kvbc::BlockMetadata metadata(*m_storage);
-  Sliver metadataKey = metadata.getKey();
-  Sliver metadataValue = metadata.serialize(sequenceNum);
+  Sliver metadataKey = m_blockMetadata->getKey();
+  Sliver metadataValue = m_blockMetadata->serialize(sequenceNum);
   updates.insert(KeyValuePair(metadataKey, metadataValue));
 }
 
@@ -187,8 +186,7 @@ bool InternalCommandsHandler::executeGetBlockDataCommand(
   pReply->header.type = READ;
   pReply->numOfItems = numOfElements;
 
-  concord::kvbc::BlockMetadata metadata(*m_storage);
-  const Sliver metadataKey = metadata.getKey();
+  const Sliver metadataKey = m_blockMetadata->getKey();
 
   auto i = 0;
   for (auto kv : outBlockData) {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -19,13 +19,15 @@
 #include "simpleKVBTestsBuilder.hpp"
 #include "blockchain/db_interfaces.h"
 #include "KVBCInterfaces.h"
+#include "block_metadata.hpp"
 
 class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
  public:
   InternalCommandsHandler(concord::storage::blockchain::ILocalKeyValueStorageReadOnly *storage,
                           concord::storage::blockchain::IBlocksAppender *blocksAppender,
+                          concord::kvbc::IBlockMetadata *blockMetadata,
                           concordlogger::Logger &logger)
-      : m_storage(storage), m_blocksAppender(blocksAppender), m_logger(logger) {}
+      : m_storage(storage), m_blocksAppender(blocksAppender), m_blockMetadata(blockMetadata), m_logger(logger) {}
 
   virtual int execute(uint16_t clientId,
                       uint64_t sequenceNum,
@@ -69,6 +71,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
  private:
   concord::storage::blockchain::ILocalKeyValueStorageReadOnly *m_storage;
   concord::storage::blockchain::IBlocksAppender *m_blocksAppender;
+  concord::kvbc::IBlockMetadata *m_blockMetadata;
   concordlogger::Logger &m_logger;
   size_t m_readsCounter = 0;
   size_t m_writesCounter = 0;

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -54,14 +54,15 @@ int main(int argc, char** argv) {
   auto* dbAdapter = new concord::storage::blockchain::DBAdapter(db);
   auto* replica = new ReplicaImp(
       setup->GetCommunication(), setup->GetReplicaConfig(), dbAdapter, setup->GetMetricsServer().GetAggregator());
-  replica->setReplicaStateSync(new ReplicaStateSyncImp(new BlockMetadata(*replica)));
+  auto* blockMetadata = new concord::kvbc::BlockMetadata(*replica);
+  replica->setReplicaStateSync(new ReplicaStateSyncImp(blockMetadata));
 
   // Start metrics server after creation of the replica so that we ensure
   // registration of metrics from the replica with the aggregator and don't
   // return empty metrics from the metrics server.
   setup->GetMetricsServer().Start();
 
-  InternalCommandsHandler cmdHandler(replica, replica, logger);
+  InternalCommandsHandler cmdHandler(replica, replica, blockMetadata, logger);
   replica->set_command_handler(&cmdHandler);
   replica->start();
 


### PR DESCRIPTION
This PR introduces the following improvements:
- [TesterReplica] enable injecting a custom `IBlockMetadata` implementation via the InternalCommandsHandler's constructor. This is required for running SKVBC in the product - which has its own `IBlockMetadata` implementation - `ConcordBlockMetadata`.
- [Python] enable "priming" the SKVBC for state transfer in case of an existing deployment