### PR TITLE
Reject empty values in merkle DBAdapter

### DIFF
--- a/storage/include/blockchain/merkle_tree_db_adapter.h
+++ b/storage/include/blockchain/merkle_tree_db_adapter.h
@@ -72,6 +72,8 @@ class DBAdapter : public DBAdapterBase {
   // - adding the whole block (raw block) in its own key
   // - calculating and filling in the parent digest.
   // Typically called by the application when adding a new block.
+  // Empty values are not supported and an error status will be returned if one is passed.
+  // Empty blocks (i.e. an empty 'updates' set) are supported.
   concordUtils::Status addLastReachableBlock(const concord::kvbc::SetOfKeyValuePairs &updates);
 
   // Adds a block from its raw representation and a block ID.

--- a/storage/src/merkle_tree_db_adapter.cpp
+++ b/storage/src/merkle_tree_db_adapter.cpp
@@ -397,6 +397,14 @@ BatchedInternalNode DBAdapter::Reader::get_internal(const InternalNodeKey &key) 
 }
 
 Status DBAdapter::addLastReachableBlock(const SetOfKeyValuePairs &updates) {
+  for (const auto &kv : updates) {
+    if (kv.second.empty()) {
+      const auto msg = "Adding empty values in a block is not supported";
+      LOG_ERROR(logger_, msg);
+      return Status::IllegalOperation(msg);
+    }
+  }
+
   const auto blockId = getLastReachableBlock() + 1;
   return db_->multiPut(lastReachableBlockDbUpdates(updates, blockId));
 }

--- a/storage/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/storage/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -624,6 +624,14 @@ struct DbAdapterTest : public IDbAdapterTest {
 using db_adapter_custom_blockchain = ParametrizedTest<std::shared_ptr<IDbAdapterTest>>;
 using db_adapter_ref_blockchain = ParametrizedTest<std::shared_ptr<IDbAdapterTest>>;
 
+// Test that empty values in blocks are not allowed.
+TEST_P(db_adapter_custom_blockchain, reject_empty_values) {
+  auto adapter = DBAdapter{GetParam()->db()};
+  const auto updates =
+      SetOfKeyValuePairs{std::make_pair(Sliver{"k1"}, defaultSliver), std::make_pair(Sliver{"k2"}, Sliver{})};
+  ASSERT_TRUE(adapter.addLastReachableBlock(updates).isIllegalOperation());
+}
+
 // Test the last reachable block functionality.
 TEST_P(db_adapter_custom_blockchain, get_last_reachable_block) {
   auto adapter = DBAdapter{GetParam()->db()};


### PR DESCRIPTION
Since we would like to support a functionality that allows users to
delete keys and we would like it to operate seamlessly and without
changes to state transfer, we designate a key with an empty value in
block nodes as a deleted key. Therefore, we reject requests to add a
block with a key that has an empty value in this PR.

This limitation can be lifted in the future if there is a need.