### PR TITLE
Long run tests: Remove RocksDB variable

### DIFF
--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -39,9 +39,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""]
+            "-p"]
 
 
 class SkvbcLongRunningTest(unittest.TestCase):


### PR DESCRIPTION
Remove the check of rocks DB on the start replica command.