### PR TITLE
[Apollo] Fast and slow commit path test improvements

### DIFF
--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -59,7 +59,7 @@ class SkvbcLongRunningTest(unittest.TestCase):
                 await SkvbcTest().test_conflicting_write\
                     (bft_network=bft_network, already_in_trio=True)
                 await trio.sleep(seconds=10)
-                await SkvbcFastPathTest().test_fast_path_read_your_write \
+                await SkvbcFastPathTest().test_fast_path_only \
                     (bft_network=bft_network, already_in_trio=True, disable_linearizability_checks=True)
                 await trio.sleep(seconds=10)
                 end = time.time()


### PR DESCRIPTION
The following improvements are made to the existing tests:
- make the tests non-trivial by increasing the number of processed requests
- make them more stable and deterministic
- accelerate by removing static `trio.sleep()` statements
- where possible, make the tests idempotent, so they can run as part of product CI, or even long-running tests.