### PR TITLE
Add minor improvements ot the kvbc library

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(kvbc  src/ClientImp.cpp
                   src/sparse_merkle/walker.cpp
 )
 
-target_link_libraries(kvbc PUBLIC threshsign util concordbft_storage)
+target_link_libraries(kvbc PUBLIC threshsign util concordbft_storage corebft)
 
 target_include_directories(kvbc PUBLIC include)
 target_include_directories(kvbc PUBLIC ${bftengine_SOURCE_DIR}/include)

--- a/kvbc/include/base_db_adapter.h
+++ b/kvbc/include/base_db_adapter.h
@@ -18,9 +18,9 @@ namespace concord::kvbc {
 
 class DBAdapterBase {
  protected:
-  DBAdapterBase(const std::shared_ptr<storage::IDBClient> db, bool readOnly)
-      : logger_(concordlogger::Log::getLogger("concord.kvbc.dbadapter")), db_(db) {
-    db_->init(readOnly);
+  DBAdapterBase(const std::shared_ptr<storage::IDBClient> db)
+      : logger_(concordlogger::Log::getLogger("concord.kvbc.dbadapter")), db_{db} {
+    db_->init(false);
   }
 
  public:

--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -70,7 +70,8 @@ class DBKeyManipulator : public DBKeyManipulatorBase {
 
 class DBAdapter : public DBAdapterBase {
  public:
-  DBAdapter(std::shared_ptr<storage::IDBClient>, IDataKeyGenerator *keyGen = new KeyGenerator, bool readOnly = false);
+  DBAdapter(std::shared_ptr<storage::IDBClient>,
+            std::unique_ptr<IDataKeyGenerator> keyGen = std::make_unique<KeyGenerator>());
 
   // Adds a block from a set of key/value pairs and a block ID. Includes:
   // - adding the key/value pairs in separate keys

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -438,8 +438,8 @@ std::pair<uint32_t, uint64_t> DBKeyManipulator::extractPageIdAndCheckpointFromKe
   return std::make_pair(pageId, chkp);
 }
 
-DBAdapter::DBAdapter(std::shared_ptr<storage::IDBClient> db, IDataKeyGenerator *keyGen, bool readOnly)
-    : DBAdapterBase{db, readOnly}, keyGen_(keyGen) {}
+DBAdapter::DBAdapter(std::shared_ptr<storage::IDBClient> db, std::unique_ptr<IDataKeyGenerator> keyGen)
+    : DBAdapterBase{db}, keyGen_{std::move(keyGen)} {}
 
 Status DBAdapter::addBlock(const SetOfKeyValuePairs &kv, BlockId blockId) {
   bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest stDigest;

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -221,7 +221,7 @@ Hash DBKeyManipulator::extractHashFromLeafKey(const Key &key) {
 }
 
 DBAdapter::DBAdapter(const std::shared_ptr<IDBClient> &db)
-    : DBAdapterBase{db, false}, smTree_{std::make_shared<Reader>(*this)} {
+    : DBAdapterBase{db}, smTree_{std::make_shared<Reader>(*this)} {
   // Make sure that if linkSTChainFrom() has been interrupted (e.g. a crash or an abnormal shutdown), all DBAdapter
   // methods will return the correct values. For example, if state transfer had completed and linkSTChainFrom() was
   // interrupted, getLatestBlock() should be equal to getLastReachableBlock() on the next startup. Another example is


### PR DESCRIPTION
Improve the following:
 * link corebft to kvbc as kvbc uses it
 * remove the readOnly parameter from DBAdapters - it doesn't make sense
   to use them in read-only mode
 * use an std::unique_ptr<IDataKeyGenerator> instead of a raw pointer in
   the v1DirectKeyValue::DBAdapter's ctor to make it clear that the
   adapter owns the generator