### PR TITLE
Make the rapidcheck dependency optional

### DIFF
--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(GTest REQUIRED)
-find_package(rapidcheck REQUIRED)
+find_package(rapidcheck)
 
 if(Boost_FOUND)
     add_executable(blockchain_view_test blockchain_view_test.cpp $<TARGET_OBJECTS:logging_dev>)
@@ -30,19 +30,21 @@ target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
     stdc++fs
 )
 
-add_executable(sparse_merkle_storage_db_adapter_property_test
-    sparse_merkle_storage/db_adapter_property_test.cpp $<TARGET_OBJECTS:logging_dev>)
-add_test(sparse_merkle_storage_db_adapter_property_test sparse_merkle_storage_db_adapter_property_test)
-target_include_directories(sparse_merkle_storage_db_adapter_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
-target_link_libraries(sparse_merkle_storage_db_adapter_property_test PUBLIC
-    GTest::Main
-    GTest::GTest
-    ${RAPIDCHECK_LIBRARIES}
-    util
-    corebft
-    kvbc
-    stdc++fs
-)
+if(RAPIDCHECK_FOUND)
+    add_executable(sparse_merkle_storage_db_adapter_property_test
+        sparse_merkle_storage/db_adapter_property_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_test(sparse_merkle_storage_db_adapter_property_test sparse_merkle_storage_db_adapter_property_test)
+    target_include_directories(sparse_merkle_storage_db_adapter_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
+    target_link_libraries(sparse_merkle_storage_db_adapter_property_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        ${RAPIDCHECK_LIBRARIES}
+        util
+        corebft
+        kvbc
+        stdc++fs
+    )
+endif ()
 
 add_executable(sparse_merkle_base_types_test sparse_merkle/base_types_test.cpp
     $<TARGET_OBJECTS:logging_dev>)


### PR DESCRIPTION
In order to support a smooth transition for pre-Conan users of the
library, make the rapidcheck dependency optional. Future commits may
make it required again.