### PR TITLE
[Apollo] Bug fixes following preliminary runs of the checkpoint test …

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -440,7 +440,7 @@ STDigest BCStateTran::checkpointReservedPages(uint64_t checkpointNumber, DataSto
 // Remove old checkpoints from the data store
 void BCStateTran::deleteOldCheckpoints(uint64_t checkpointNumber, DataStoreTransaction *txn) {
   uint64_t minRelevantCheckpoint = 0;
-  if (checkpointNumber > maxNumOfStoredCheckpoints_) {
+  if (checkpointNumber >= maxNumOfStoredCheckpoints_) {
     minRelevantCheckpoint = checkpointNumber - maxNumOfStoredCheckpoints_ + 1;
   }
 

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -530,10 +530,13 @@ class BftTestNetwork:
         """
         while True:
             with trio.move_on_after(.5): # seconds
-                key = ['replica', 'Counters', 'receivedStateTransferMsgs']
-                n = await self.metrics.get(replica.id, *key)
-                if n > 0:
-                    cancel_scope.cancel()
+                try:
+                    key = ['replica', 'Counters', 'receivedStateTransferMsgs']
+                    n = await self.metrics.get(replica.id, *key)
+                    if n > 0:
+                        cancel_scope.cancel()
+                except KeyError:
+                    continue # metrics not yet available, continue looping
 
     async def wait_for_state_transfer_to_stop(
             self,


### PR DESCRIPTION
…in product CI

This PR contains the following fixes:
- [BFT code] Fix a corner case when `checkpointNumber` is equal to `maxNumOfStoredCheckpoints_`, resulting in a breach of the following invariant: `[Assert(lastStoredCheckpoint - firstStoredCheckpoint + 1 <= maxNumOfStoredCheckpoints_);`
https://github.com/vmware/concord-bft/blob/master/bftengine/src/bcstatetransfer/BCStateTran.cpp#L2123
- [Test code] Made `_wait_to_receive_st_msgs()` more robust around replica restarts, when the metrics are not immediately available