### PR TITLE
PrePrepareMsg: Allocate based on requests

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -286,8 +286,8 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
 
   controller->onSendingPrePrepare((primaryLastUsedSeqNum + 1), firstPath);
 
-  PrePrepareMsg *pp = new PrePrepareMsg(config_.replicaId, curView, (primaryLastUsedSeqNum + 1), firstPath, false,
-                                        primaryCombinedReqSize);
+  PrePrepareMsg *pp = new PrePrepareMsg(
+      config_.replicaId, curView, (primaryLastUsedSeqNum + 1), firstPath, false, primaryCombinedReqSize);
 
   ClientRequestMsg *nextRequest = requestsQueueOfPrimary.front();
   while (nextRequest != nullptr && nextRequest->size() <= pp->remainingSizeForRequests()) {

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -91,6 +91,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // requests queue (used by the primary)
   std::queue<ClientRequestMsg*> requestsQueueOfPrimary;  // only used by the primary
+  size_t primaryCombinedReqSize = 0;  // only used by the primary
 
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -91,7 +91,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // requests queue (used by the primary)
   std::queue<ClientRequestMsg*> requestsQueueOfPrimary;  // only used by the primary
-  size_t primaryCombinedReqSize = 0;  // only used by the primary
+  size_t primaryCombinedReqSize = 0;                     // only used by the primary
 
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
@@ -77,10 +77,11 @@ void PrePrepareMsg::validate(const ReplicasInfo& repInfo) const {
 }
 
 PrePrepareMsg::PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, bool isNull, size_t size)
-    : MessageBase(sender, MsgCode::PrePrepare,
-                  (((size + sizeof(PrePrepareMsgHeader)) < maxSizeOfPrePrepareMsg())
-                   ? (size + sizeof(PrePrepareMsgHeader))
-                   : maxSizeOfPrePrepareMsg()))
+    : MessageBase(
+          sender,
+          MsgCode::PrePrepare,
+          (((size + sizeof(PrePrepareMsgHeader)) < maxSizeOfPrePrepareMsg()) ? (size + sizeof(PrePrepareMsgHeader))
+                                                                             : maxSizeOfPrePrepareMsg()))
 
 {
   b()->viewNum = v;

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
@@ -76,8 +76,11 @@ void PrePrepareMsg::validate(const ReplicasInfo& repInfo) const {
   if (d != b()->digestOfRequests) throw std::runtime_error(__PRETTY_FUNCTION__ + std::string(": digest"));
 }
 
-PrePrepareMsg::PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, bool isNull)
-    : MessageBase(sender, MsgCode::PrePrepare, (isNull ? sizeof(PrePrepareMsgHeader) : maxSizeOfPrePrepareMsg()))
+PrePrepareMsg::PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, bool isNull, size_t size)
+    : MessageBase(sender, MsgCode::PrePrepare,
+                  (((size + sizeof(PrePrepareMsgHeader)) < maxSizeOfPrePrepareMsg())
+                   ? (size + sizeof(PrePrepareMsgHeader))
+                   : maxSizeOfPrePrepareMsg()))
 
 {
   b()->viewNum = v;

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -64,8 +64,7 @@ class PrePrepareMsg : public MessageBase {
 
   // ctor and other build methods
 
-  PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath,
-                bool isNull = false, size_t size = 0);
+  PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, bool isNull = false, size_t size = 0);
 
   uint32_t remainingSizeForRequests() const;
 

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -64,7 +64,8 @@ class PrePrepareMsg : public MessageBase {
 
   // ctor and other build methods
 
-  PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, bool isNull = false);
+  PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath,
+                bool isNull = false, size_t size = 0);
 
   uint32_t remainingSizeForRequests() const;
 


### PR DESCRIPTION
Prior to this change, every (non-null) PrePrepareMsg allocates the maximum
message size upfront. Depending on the maximum this introduces a lot of
overhead. With this change, we allocate the amount of memory based on all
client requests that are in the queue. However, we still won't allocate more
than the maximum external message size.