### PR TITLE
Fix builds without RocksDB

### DIFF
--- a/bftengine/tests/metadataStorage/CMakeLists.txt
+++ b/bftengine/tests/metadataStorage/CMakeLists.txt
@@ -1,11 +1,13 @@
-find_package(GTest REQUIRED)
-add_executable(metadataStorage_test metadataStorage_test.cpp $<TARGET_OBJECTS:logging_dev>)
-add_test(metadataStorage_test metadataStorage_test)
+if (BUILD_ROCKSDB_STORAGE)
+    find_package(GTest REQUIRED)
+    add_executable(metadataStorage_test metadataStorage_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_test(metadataStorage_test metadataStorage_test)
 
-target_link_libraries(metadataStorage_test PUBLIC
-    GTest::Main
-    GTest::GTest
-    util
-    kvbc
-    corebft
-)
+    target_link_libraries(metadataStorage_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        kvbc
+        corebft
+    )
+endif(BUILD_ROCKSDB_STORAGE)

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -80,13 +80,15 @@ target_link_libraries(sparse_merkle_tree_test PUBLIC
     ${OPENSSL_LIBRARIES}
 )
 
-add_executable(multiIO_test multiIO_test.cpp $<TARGET_OBJECTS:logging_dev>)
-add_test(multiIO_test multiIO_test)
+if (BUILD_ROCKSDB_STORAGE)
+    add_executable(multiIO_test multiIO_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_test(multiIO_test multiIO_test)
 
-target_link_libraries(multiIO_test PUBLIC
-    GTest::Main
-    GTest::GTest
-    util
-    kvbc
-    corebft
-)
+    target_link_libraries(multiIO_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        kvbc
+        corebft
+    )
+endif(BUILD_ROCKSDB_STORAGE)

--- a/kvbc/test/sparse_merkle_storage/db_adapter_property_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_property_test.cpp
@@ -292,16 +292,22 @@ TEST_P(db_adapter_kv_tests, get_all_keys_at_last_version) {
   ASSERT_TRUE(rc::check(test));
 }
 
+#ifdef USE_ROCKSDB
+using TestDbType = TestRocksDb;
+#else
+using TestDbType = TestMemoryDb;
+#endif
+
 INSTANTIATE_TEST_CASE_P(db_adapter_block_tests_case,
                         db_adapter_block_tests,
-                        ::testing::Values(std::make_shared<DbAdapterTest<TestRocksDb>>()),
+                        ::testing::Values(std::make_shared<DbAdapterTest<TestDbType>>()),
                         TypePrinter{});
 
 // Test with and without multiple-versioned keys.
 INSTANTIATE_TEST_CASE_P(db_adapter_kv_tests_case,
                         db_adapter_kv_tests,
-                        ::testing::Values(std::make_shared<DbAdapterTest<TestRocksDb, false>>(),
-                                          std::make_shared<DbAdapterTest<TestRocksDb, true>>()),
+                        ::testing::Values(std::make_shared<DbAdapterTest<TestDbType, false>>(),
+                                          std::make_shared<DbAdapterTest<TestDbType, true>>()),
                         TypePrinter{});
 
 }  // namespace

--- a/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -1258,22 +1258,34 @@ TEST_P(db_adapter_ref_blockchain, state_transfer_unordered_with_blockchain_block
   }
 }
 
-// Instantiate tests with memorydb and RocksDB clients and with custom (test-specific) blockchains.
-INSTANTIATE_TEST_CASE_P(db_adapter_tests_custom_blockchain,
-                        db_adapter_custom_blockchain,
-                        ::testing::Values(std::make_shared<DbAdapterTest<TestMemoryDb>>(),
-                                          std::make_shared<DbAdapterTest<TestRocksDb>>()),
-                        TypePrinter{});
+#ifdef USE_ROCKSDB
+const auto customBlockchainTestsParams =
+    ::testing::Values(std::make_shared<DbAdapterTest<TestMemoryDb>>(), std::make_shared<DbAdapterTest<TestRocksDb>>());
 
-// Instantiate tests with memorydb and RocksDB clients and with reference blockchains (with and without empty blocks).
-INSTANTIATE_TEST_CASE_P(
-    db_adapter_tests_ref_blockchain,
-    db_adapter_ref_blockchain,
+const auto refBlockchainTestParams =
     ::testing::Values(std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::NoEmptyBlocks>>(),
                       std::make_shared<DbAdapterTest<TestRocksDb, ReferenceBlockchainType::NoEmptyBlocks>>(),
                       std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::WithEmptyBlocks>>(),
-                      std::make_shared<DbAdapterTest<TestRocksDb, ReferenceBlockchainType::WithEmptyBlocks>>()),
-    TypePrinter{});
+                      std::make_shared<DbAdapterTest<TestRocksDb, ReferenceBlockchainType::WithEmptyBlocks>>());
+#else
+const auto customBlockchainTestsParams = ::testing::Values(std::make_shared<DbAdapterTest<TestMemoryDb>>());
+
+const auto refBlockchainTestParams =
+    ::testing::Values(std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::NoEmptyBlocks>>(),
+                      std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::WithEmptyBlocks>>());
+#endif
+
+// Instantiate tests with memorydb and RocksDB clients and with custom (test-specific) blockchains.
+INSTANTIATE_TEST_CASE_P(db_adapter_tests_custom_blockchain,
+                        db_adapter_custom_blockchain,
+                        customBlockchainTestsParams,
+                        TypePrinter{});
+
+// Instantiate tests with memorydb and RocksDB clients and with reference blockchains (with and without empty blocks).
+INSTANTIATE_TEST_CASE_P(db_adapter_tests_ref_blockchain,
+                        db_adapter_ref_blockchain,
+                        refBlockchainTestParams,
+                        TypePrinter{});
 
 }  // namespace
 


### PR DESCRIPTION
Fix tests that failed to build when BUILD_ROCKSDB_STORAGE is not set:
 * multiIO_test and metadataStorage_test - do not build at all
 * sparse_merkle_storage_db_adapter_unit_test - run with memorydb
 * sparse_merkle_storage_db_adapter_property_test - run with memorydb