### PR TITLE
Expose block manipulation methods in IDbAdapter

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -57,10 +57,9 @@ void computeBlockDigest(const uint64_t blockId,
                         const uint32_t blockSize,
                         StateTransferDigest *outDigest);
 
-void computeBlockDigest(const uint64_t blockId,
-                        const char *block,
-                        const uint32_t blockSize,
-                        std::array<std::uint8_t, BLOCK_DIGEST_SIZE> &outDigest);
+std::array<std::uint8_t, BLOCK_DIGEST_SIZE> computeBlockDigest(const uint64_t blockId,
+                                                               const char *block,
+                                                               const uint32_t blockSize);
 
 // This interface should be implemented by the application/storage layer.
 // It is used by the state transfer module.

--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -14,6 +14,7 @@
 #ifndef BFTENGINE_SRC_BCSTATETRANSFER_SIMPLEBCSTATETRANSFER_HPP_
 #define BFTENGINE_SRC_BCSTATETRANSFER_SIMPLEBCSTATETRANSFER_HPP_
 
+#include <array>
 #include <cstdint>
 #include <set>
 #include <memory>
@@ -55,6 +56,11 @@ void computeBlockDigest(const uint64_t blockId,
                         const char *block,
                         const uint32_t blockSize,
                         StateTransferDigest *outDigest);
+
+void computeBlockDigest(const uint64_t blockId,
+                        const char *block,
+                        const uint32_t blockSize,
+                        std::array<std::uint8_t, BLOCK_DIGEST_SIZE> &outDigest);
 
 // This interface should be implemented by the application/storage layer.
 // It is used by the state transfer module.

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -47,11 +47,10 @@ void computeBlockDigest(const uint64_t blockId,
   return impl::BCStateTran::computeDigestOfBlock(blockId, block, blockSize, (impl::STDigest *)outDigest);
 }
 
-void computeBlockDigest(const uint64_t blockId,
-                        const char *block,
-                        const uint32_t blockSize,
-                        std::array<std::uint8_t, BLOCK_DIGEST_SIZE> &outDigest) {
-  return impl::BCStateTran::computeDigestOfBlock(blockId, block, blockSize, outDigest);
+std::array<std::uint8_t, BLOCK_DIGEST_SIZE> computeBlockDigest(const uint64_t blockId,
+                                                               const char *block,
+                                                               const uint32_t blockSize) {
+  return impl::BCStateTran::computeDigestOfBlock(blockId, block, blockSize);
 }
 
 IStateTransfer *create(const Config &config,
@@ -2320,11 +2319,12 @@ void BCStateTran::computeDigestOfBlock(const uint64_t blockNum,
   computeDigestOfBlockImpl(blockNum, block, blockSize, reinterpret_cast<char *>(outDigest));
 }
 
-void BCStateTran::computeDigestOfBlock(const uint64_t blockNum,
-                                       const char *block,
-                                       const uint32_t blockSize,
-                                       std::array<std::uint8_t, BLOCK_DIGEST_SIZE> &outDigest) {
+std::array<std::uint8_t, BLOCK_DIGEST_SIZE> BCStateTran::computeDigestOfBlock(const uint64_t blockNum,
+                                                                              const char *block,
+                                                                              const uint32_t blockSize) {
+  std::array<std::uint8_t, BLOCK_DIGEST_SIZE> outDigest;
   computeDigestOfBlockImpl(blockNum, block, blockSize, reinterpret_cast<char *>(outDigest.data()));
+  return outDigest;
 }
 
 void BCStateTran::SetAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -313,10 +313,9 @@ class BCStateTran : public IStateTransfer {
                                    const uint32_t blockSize,
                                    STDigest* outDigest);
 
-  static void computeDigestOfBlock(const uint64_t blockNum,
-                                   const char* block,
-                                   const uint32_t blockSize,
-                                   std::array<std::uint8_t, BLOCK_DIGEST_SIZE>& outDigest);
+  static std::array<std::uint8_t, BLOCK_DIGEST_SIZE> computeDigestOfBlock(const uint64_t blockNum,
+                                                                          const char* block,
+                                                                          const uint32_t blockSize);
 
   ///////////////////////////////////////////////////////////////////////////
   // Metrics

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -21,6 +21,8 @@
 #include <cassert>
 #include <iostream>
 #include <string>
+#include <array>
+#include <cstdint>
 
 #include "Logger.hpp"
 #include "SimpleBCStateTransfer.hpp"
@@ -310,6 +312,11 @@ class BCStateTran : public IStateTransfer {
                                    const char* block,
                                    const uint32_t blockSize,
                                    STDigest* outDigest);
+
+  static void computeDigestOfBlock(const uint64_t blockNum,
+                                   const char* block,
+                                   const uint32_t blockSize,
+                                   std::array<std::uint8_t, BLOCK_DIGEST_SIZE>& outDigest);
 
   ///////////////////////////////////////////////////////////////////////////
   // Metrics

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -87,6 +87,8 @@ class ReplicaImp : public IReplica, public ILocalKeyValueStorageReadOnly, public
   IDbAdapter *getBcDbAdapter() const { return m_bcDbAdapter; }
 
  private:
+  friend class StorageWrapperForIdleMode;
+
   void createReplicaAndSyncState();
 
   // INTERNAL TYPES

--- a/kvbc/include/block_digest.h
+++ b/kvbc/include/block_digest.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+
+#include <array>
+#include <cstdint>
+
+namespace concord::kvbc {
+
+inline constexpr auto BLOCK_DIGEST_SIZE = bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
+
+using BlockDigest = std::array<std::uint8_t, BLOCK_DIGEST_SIZE>;
+
+}  // namespace concord::kvbc

--- a/kvbc/include/db_adapter.h
+++ b/kvbc/include/db_adapter.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "block_digest.h"
 #include "kv_types.hpp"
 #include <utility>
 
@@ -44,8 +45,13 @@ class IDbAdapter {
   // From ST perspective, this is maximal block number N such that all blocks
   // START <= i <= N exist, where START is usually 1, if pruning is not enabled.
   // In the normal state, it should be equal to last block ID.
-
   virtual BlockId getLastReachableBlockId() const = 0;
+
+  // Returns the block data in the form of a set of key/value pairs.
+  virtual SetOfKeyValuePairs getBlockData(const RawBlock& rawBlock) const = 0;
+
+  // Returns the parent digest of the passed block.
+  virtual BlockDigest getParentDigest(const RawBlock& rawBlock) const = 0;
 
   // TODO [TK] not sure it's needed for long term
   virtual std::shared_ptr<storage::IDBClient> getDb() const = 0;

--- a/kvbc/include/direct_kv_block.h
+++ b/kvbc/include/direct_kv_block.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "block_digest.h"
 #include "kv_types.hpp"
 #include "sliver.hpp"
 
@@ -25,29 +25,25 @@ namespace concord {
 namespace kvbc {
 inline namespace v1DirectKeyValue {
 namespace block {
-inline constexpr auto BLOCK_DIGEST_SIZE = bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
-
+namespace detail {
 // Creates a block with the user data appended at the end of the returned Sliver. The passed parentDigest buffer must be
 // of size BLOCK_DIGEST_SIZE bytes.
 concordUtils::Sliver create(const concord::kvbc::SetOfKeyValuePairs &updates,
                             concord::kvbc::SetOfKeyValuePairs &outUpdatesInNewBlock,
-                            const void *parentDigest,
+                            const BlockDigest &parentDigest,
                             const void *userData,
                             std::size_t userDataSize);
 
 // Creates a block. The passed parentDigest buffer must be of size BLOCK_DIGEST_SIZE bytes.
 concordUtils::Sliver create(const concord::kvbc::SetOfKeyValuePairs &updates,
                             concord::kvbc::SetOfKeyValuePairs &outUpdatesInNewBlock,
-                            const void *parentDigest);
+                            const BlockDigest &parentDigest);
 
 // Returns the block data in the form of a set of key/value pairs.
 concord::kvbc::SetOfKeyValuePairs getData(const concordUtils::Sliver &block);
 
 // Returns the parent digest of size BLOCK_DIGEST_SIZE bytes.
-const void *getParentDigest(const concordUtils::Sliver &block);
-
-// Block structure is an implementation detail. External users should not rely on it.
-namespace detail {
+BlockDigest getParentDigest(const concordUtils::Sliver &block);
 
 struct Header {
   std::uint32_t numberOfElements;
@@ -64,9 +60,7 @@ struct Entry {
 };
 
 }  // namespace detail
-
 }  // namespace block
-
 }  // namespace v1DirectKeyValue
 }  // namespace kvbc
 }  // namespace concord

--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -82,6 +82,12 @@ class DBAdapter : public IDbAdapter {
   BlockId getLatestBlockId() const override;
   BlockId getLastReachableBlockId() const override;
 
+  // Returns the block data in the form of a set of key/value pairs.
+  SetOfKeyValuePairs getBlockData(const RawBlock &rawBlock) const override;
+
+  // Returns the parent digest of the passed block.
+  BlockDigest getParentDigest(const RawBlock &rawBlock) const override;
+
   std::shared_ptr<storage::IDBClient> getDb() const override { return db_; }
 
  private:

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -112,6 +112,12 @@ class DBAdapter : public IDbAdapter {
   // Throws if an error occurs. Throws a ::concord::kvbc::NotFoundException if the block doesn't exist.
   void deleteBlock(const BlockId &blockId) override;
 
+  // Returns the block data in the form of a set of key/value pairs.
+  SetOfKeyValuePairs getBlockData(const RawBlock &rawBlock) const override;
+
+  // Returns the parent digest of the passed block.
+  BlockDigest getParentDigest(const RawBlock &rawBlock) const override;
+
   std::shared_ptr<storage::IDBClient> getDb() const override { return db_; }
 
   // Returns the current state hash from the internal merkle tree implementation.

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -341,8 +341,8 @@ BlockId DBAdapter::addBlock(const SetOfKeyValuePairs &kv) {
   auto blockDigest = BlockDigest{};
   if (blockId > 1) {
     const auto parentBlockData = getRawBlock(blockId - 1);
-    bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(
-        blockId - 1, reinterpret_cast<const char *>(parentBlockData.data()), parentBlockData.length(), blockDigest);
+    blockDigest = bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(
+        blockId - 1, reinterpret_cast<const char *>(parentBlockData.data()), parentBlockData.length());
   }
 
   SetOfKeyValuePairs outKv;

--- a/kvbc/src/merkle_tree_block.cpp
+++ b/kvbc/src/merkle_tree_block.cpp
@@ -7,22 +7,22 @@
 
 #include <cstdint>
 
-namespace concord::kvbc::v2MerkleTree::block {
+namespace concord::kvbc::v2MerkleTree::block::detail {
 
 using sparse_merkle::Hash;
 using ::concordUtils::Sliver;
 
 // Use the v1DirectKeyValue implementation and just add the state hash at the back. We want that so it is included in
 // the block digest. We can do that, because users are not expected to interpret the returned buffer themselves.
-RawBlock create(const SetOfKeyValuePairs &updates, const void *parentDigest, const Hash &stateHash) {
+RawBlock create(const SetOfKeyValuePairs &updates, const BlockDigest &parentDigest, const Hash &stateHash) {
   SetOfKeyValuePairs out;
-  return v1DirectKeyValue::block::create(
+  return v1DirectKeyValue::block::detail::create(
       updates, out, parentDigest, stateHash.dataArray().data(), stateHash.dataArray().size());
 }
 
-SetOfKeyValuePairs getData(const RawBlock &block) { return v1DirectKeyValue::block::getData(block); }
+SetOfKeyValuePairs getData(const RawBlock &block) { return v1DirectKeyValue::block::detail::getData(block); }
 
-const void *getParentDigest(const RawBlock &block) { return v1DirectKeyValue::block::getParentDigest(block); }
+BlockDigest getParentDigest(const RawBlock &block) { return v1DirectKeyValue::block::detail::getParentDigest(block); }
 
 Hash getStateHash(const RawBlock &block) {
   Assert(block.length() >= Hash::SIZE_IN_BYTES);
@@ -30,11 +30,8 @@ Hash getStateHash(const RawBlock &block) {
   return Hash{data + (block.length() - Hash::SIZE_IN_BYTES)};
 }
 
-namespace detail {
-
 Sliver createNode(const Node &node) { return v2MerkleTree::detail::serialize(node); }
 
 Node parseNode(const Sliver &buffer) { return v2MerkleTree::detail::deserialize<Node>(buffer); }
-}  // namespace detail
 
-}  // namespace concord::kvbc::v2MerkleTree::block
+}  // namespace concord::kvbc::v2MerkleTree::block::detail

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -303,7 +303,7 @@ Sliver DBAdapter::createBlockNode(const SetOfKeyValuePairs &updates, BlockId blo
   auto parentBlockDigest = BlockDigest{};
   if (blockId > 1) {
     const auto parentBlock = getRawBlock(blockId - 1);
-    computeBlockDigest(blockId - 1, parentBlock.data(), parentBlock.length(), parentBlockDigest);
+    parentBlockDigest = computeBlockDigest(blockId - 1, parentBlock.data(), parentBlock.length());
   }
 
   auto node = BlockNode{blockId, parentBlockDigest, smTree_.get_root_hash(), smTree_.get_version()};

--- a/kvbc/test/sparse_merkle_storage/storage_test_common.h
+++ b/kvbc/test/sparse_merkle_storage/storage_test_common.h
@@ -41,9 +41,7 @@ inline void cleanup() {}
 #endif
 
 inline ::concord::kvbc::BlockDigest blockDigest(concord::kvbc::BlockId blockId, const concordUtils::Sliver &block) {
-  auto digest = ::concord::kvbc::BlockDigest{};
-  ::bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(blockId, block.data(), block.length(), digest);
-  return digest;
+  return ::bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(blockId, block.data(), block.length());
 }
 
 struct TestMemoryDb {

--- a/kvbc/test/sparse_merkle_storage/storage_test_common.h
+++ b/kvbc/test/sparse_merkle_storage/storage_test_common.h
@@ -4,7 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "block_digest.h"
 #include "kv_types.hpp"
 #include "memorydb/client.h"
 #include "rocksdb/client.h"
@@ -40,11 +40,9 @@ inline void cleanup() { fs::remove_all(rocksDbPath()); }
 inline void cleanup() {}
 #endif
 
-inline ::bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest blockDigest(concord::kvbc::BlockId blockId,
-                                                                                   const concordUtils::Sliver &block) {
-  namespace st = ::bftEngine::SimpleBlockchainStateTransfer;
-  auto digest = st::StateTransferDigest{};
-  st::computeBlockDigest(blockId, block.data(), block.length(), &digest);
+inline ::concord::kvbc::BlockDigest blockDigest(concord::kvbc::BlockId blockId, const concordUtils::Sliver &block) {
+  auto digest = ::concord::kvbc::BlockDigest{};
+  ::bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(blockId, block.data(), block.length(), digest);
   return digest;
 }
 


### PR DESCRIPTION
In order to support polymorphic DB adapters, move the public block
manipulation functionality from the block namespace to the IDbAdapter
interface.

Change the parent digest type from a const void* to an std::array. Add
overloads to support digest computation with the new type.