### PR TITLE
[SparseMerkle] Fix internal node property test

### DIFF
--- a/bftengine/tests/testViewChange/testViewChange.cpp
+++ b/bftengine/tests/testViewChange/testViewChange.cpp
@@ -193,7 +193,7 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions) {
   auto* theMsgStore = dynamic_cast<IncomingMsgsStorageImp*>(&(replica.getIncomingMsgsStorage()));
   theMsgStore->start();
   auto operation_status = replica.combine_operation_future.get();
-  assert(operation_status == DummyReplica::PrepareCombinedSigOperationStatus::OPERATION_SUCCEEDED);
+  Assert(operation_status == DummyReplica::PrepareCombinedSigOperationStatus::OPERATION_SUCCEEDED);
   auto pfMsg = replica.GetSeqNumInfo().getValidPrepareFullMsg();
 
   ViewChangeMsg** viewChangeMsgs = new ViewChangeMsg*[N];

--- a/kvbc/test/sparse_merkle/internal_node_property_tests.cpp
+++ b/kvbc/test/sparse_merkle/internal_node_property_tests.cpp
@@ -317,13 +317,14 @@ RC_GTEST_PROP(batched_internal_node_properties,
 }
 
 RC_GTEST_PROP(batched_internal_node_properties,
-              any_insert_order_of_unique_keys_maintains_same_keys,
+              any_insert_order_of_keys_with_same_version_maintains_same_keys,
               (Version version)) {
   auto node1 = BatchedInternalNode();
   auto node2 = BatchedInternalNode();
 
-  auto [children1, depth] =
-      *genKeysWithMatchingPrefixesUpToDepth(rc::gen::unique<std::vector<LeafChild>>(rc::gen::arbitrary<LeafChild>()));
+  // Make the children *mostly* unique.
+  auto unique_children_gen = rc::gen::unique<std::vector<LeafChild>>(rc::gen::arbitrary<LeafChild>());
+  auto [children1, depth] = *genKeysWithMatchingPrefixesUpToDepth(genLeafChildrenWithSameVersion(unique_children_gen));
 
   std::vector<LeafChild> children2 = children1;
   std::random_shuffle(children2.begin(), children2.end());


### PR DESCRIPTION
The test ``any_insert_order_of_unique_keys_maintains_same_keys` was
failing due to different version order of the LeafKeys. We must ignore
versions and only ensure the hashes of the keys are different for this
to work.

The seed of the failure for GCC builds only was: `5478480958984474772`.

Also, change the name of the fixed test to be more accurate.

Additionally, fix an unused variable error in release mode.