### PR TITLE
Introduce a diagnostics library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ add_subdirectory(tools)
 add_subdirectory(kvbc)
 add_subdirectory(storage)
 add_subdirectory(scripts)
+add_subdirectory(diagnostics)
 #
 # Setup testing
 #

--- a/diagnostics/CMakeLists.txt
+++ b/diagnostics/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required (VERSION 3.2)
+project(libdiagnostics VERSION 0.1.0.0 LANGUAGES CXX)
+
+add_library(diagnostics INTERFACE)
+target_link_libraries(diagnostics INTERFACE)
+target_include_directories(diagnostics INTERFACE include)
+
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()

--- a/diagnostics/README.md
+++ b/diagnostics/README.md
@@ -1,0 +1,4 @@
+This library is used for building interactive diagnostics for applications built
+on top of concord-bft. The goal is to allow retrieving the status of concord-bft
+subsystems and application subsystems.
+

--- a/diagnostics/include/diagnostics.h
+++ b/diagnostics/include/diagnostics.h
@@ -1,0 +1,84 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <functional>
+#include <map>
+#include <mutex>
+#include <stdexcept>
+
+namespace concord::diagnostics {
+
+// Every component that can return status should register a status handler with the Registrar.
+struct StatusHandler {
+  StatusHandler(std::string name, std::string description, std::function<std::string()> fun)
+      : name(std::move(name)), description(std::move(description)), f(std::move(fun)) {}
+  std::string name;
+  std::string description;
+  std::function<std::string()> f;
+};
+
+class Registrar {
+ public:
+  void registerStatusHandler(StatusHandler handler) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (status_handlers_.count(handler.name)) {
+      throw std::invalid_argument(std::string("StatusHandler already exists: ") + handler.name);
+    }
+    status_handlers_.insert({handler.name, handler});
+  }
+
+  std::string getStatus(const std::string& name) const {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (status_handlers_.count(name)) {
+      return status_handlers_.at(name).f();
+    }
+    return "*--STATUS_NOT_FOUND--*";
+  }
+
+  std::string describeStatus(const std::string& name) const {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (status_handlers_.count(name)) {
+      return status_handlers_.at(name).description;
+    }
+    return "*--DESCRIPTION_NOT_FOUND--*";
+  }
+
+  std::string describeStatus() const {
+    std::lock_guard<std::mutex> guard(mutex_);
+    std::string output;
+    for (const auto& [_, handler]: status_handlers_) {
+      (void)_; // undefined variable hack
+      output += "\n" + handler.name + "\n  ";
+      output += handler.description + "\n";
+    }
+    return output;
+  }
+
+  std::string listStatusKeys() const {
+    std::lock_guard<std::mutex> guard(mutex_);
+    std::string output;
+    for (const auto& [key, _]: status_handlers_) {
+      (void)_; // unused variable hack
+      output += key + "\n";
+    }
+    return output;
+  }
+
+ private:
+  std::map<std::string, StatusHandler> status_handlers_;
+  mutable std::mutex mutex_;
+};
+
+}  // namespace concord::diagnostics
+

--- a/diagnostics/include/protocol.h
+++ b/diagnostics/include/protocol.h
@@ -1,0 +1,83 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+// This file describes the wire protocol for the diagnostics server. The protocol is an ASCII based
+// protocol as it is expected to be interacted with over the command line. For security purposes we
+// expect to only run the protocol over a local unix domain socket.
+
+#pragma once
+
+#include <array>
+#include <variant>
+
+#include "diagnostics.h"
+
+namespace concord::diagnostics {
+
+std::string usage() {
+  // TODO: Make the name of the program dynamic
+  std::string usage = "Usage: concord-ctl <SUBJECT> <COMMAND> [ARGS]\n\n";
+  usage += "  status <COMMAND> [ARGS]\n\n";
+  usage += "    status get <KEY1> [KEY2]..[KEY_N]\n";
+  usage += "        Get the status of the given key(s).\n\n";
+  usage += "    status describe [KEY1] [KEY2]..[KEY_N]\n";
+  usage += "        Get the description of the given keys, or all keys if none is given.\n\n";
+  usage += "    status list-keys\n";
+  usage += "        List all status keys.";
+  return usage;
+}
+
+template <typename Iterator, typename Fun>
+std::string accumulate(Iterator begin, Iterator end, Fun f) {
+  std::string output;
+  for (auto it = begin; it != end; it++) {
+    output += f(*it) + "\n";
+  }
+  return output;
+}
+
+// Take protocol input as a split string, along with a registrar and return diagnostics or a usage string.
+std::string run(const std::vector<std::string>& tokens, Registrar& registrar) {
+  if (tokens.size() < 2) return usage();
+
+  auto& subject = tokens[0];
+  auto& command = tokens[1];
+  if (subject == "status") {
+    if (command == "describe") {
+      if (tokens.size() == 2) {
+        return registrar.describeStatus();
+      } else {
+        return accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
+          return registrar.describeStatus(key);
+        });
+      }
+    }
+
+    if (command == "get") {
+      if (tokens.size() < 3) return usage();
+      return accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
+        return registrar.getStatus(key);
+      });
+    }
+
+    if (command == "list-keys") {
+      if (tokens.size() != 2) return usage();
+      return registrar.listStatusKeys();
+    }
+  }
+
+  return usage();
+}
+
+}  // namespace concord::diagnostics

--- a/diagnostics/test/CMakeLists.txt
+++ b/diagnostics/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+find_package(GTest REQUIRED)
+
+add_executable(diagnostics_tests diagnostics_tests.cpp)
+add_test(diagnostics_tests diagnostics_tests)
+target_link_libraries(diagnostics_tests PRIVATE GTest::Main diagnostics)
+

--- a/diagnostics/test/diagnostics_tests.cpp
+++ b/diagnostics/test/diagnostics_tests.cpp
@@ -1,0 +1,117 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <cstring>
+#include <iostream>
+#include <future>
+#include <thread>
+
+#include "gtest/gtest.h"
+#include "diagnostics.h"
+#include "protocol.h"
+
+using namespace concord::diagnostics;
+
+static const std::string sync_handler_name("sync_test_handler");
+static const std::string sync_handler_description("A syncrhonous status handler for this test");
+static const std::string sync_handler_status("Some synchronous status");
+
+static const std::string async_handler_name("async_test_handler");
+static const std::string async_handler_description("An asyncrhonous status handler for this test");
+static const std::string async_handler_status("Some asynchronous status");
+
+static const std::string async_handler_name2("async_test_handler2");
+
+static const std::string keylist = async_handler_name + "\n" + async_handler_name2 + "\n" + sync_handler_name + "\n";
+
+StatusHandler sync_handler(sync_handler_name, sync_handler_description, []() { return sync_handler_status; });
+
+StatusHandler async_handler(async_handler_name, async_handler_description, []() {
+  // This mimics some arbitrary asynch behavior, such as sending an internal message containing a
+  // promise to the replica thread, and then waiting on the future.
+  std::promise<std::string> promise;
+  auto future = promise.get_future();
+  std::thread t([&promise]() { promise.set_value(async_handler_status); });
+  t.join();
+  return future.get();
+});
+
+StatusHandler async_handler2(async_handler_name2, async_handler_description, []() {
+  // This mimics some arbitrary asynch behavior, such as sending an internal message containing a
+  // promise to the replica thread, and then waiting on the future.
+  std::promise<std::string> promise;
+  auto future = promise.get_future();
+  std::async([promise = std::move(promise)]() mutable { promise.set_value(async_handler_status); });
+  return future.get();
+});
+
+TEST(diagnostics_tests, status_registration) {
+  Registrar registrar;
+  registrar.registerStatusHandler(sync_handler);
+  registrar.registerStatusHandler(async_handler);
+  registrar.registerStatusHandler(async_handler2);
+  ASSERT_EQ(sync_handler_status, registrar.getStatus(sync_handler_name));
+  ASSERT_EQ(sync_handler_description, registrar.describeStatus(sync_handler_name));
+  ASSERT_EQ(async_handler_status, registrar.getStatus(async_handler_name));
+  ASSERT_EQ(async_handler_description, registrar.describeStatus(async_handler_name));
+  ASSERT_EQ(async_handler_status, registrar.getStatus(async_handler_name2));
+  ASSERT_EQ(async_handler_description, registrar.describeStatus(async_handler_name2));
+
+  ASSERT_EQ("*--STATUS_NOT_FOUND--*", registrar.getStatus("no such handler"));
+  ASSERT_EQ("*--DESCRIPTION_NOT_FOUND--*", registrar.describeStatus("no such handler"));
+
+  ASSERT_EQ(keylist, registrar.listStatusKeys());
+  std::cout << registrar.describeStatus() << std::endl;
+  std::cout << registrar.listStatusKeys() << std::endl;
+}
+
+// This tests is really just for visual confirmation, since strings are always returned.
+TEST(diagnostics_tests, protocol) {
+  Registrar registrar;
+  registrar.registerStatusHandler(sync_handler);
+  registrar.registerStatusHandler(async_handler);
+  registrar.registerStatusHandler(async_handler2);
+
+  // No parameters trigger usage to be displayed.
+  ASSERT_EQ(0, std::memcmp("Usage:", run({}, registrar).c_str(), 6));
+
+  // Bad subject triggers usage
+  ASSERT_EQ(0, std::memcmp("Usage:", run({"no_such_subject"}, registrar).c_str(), 6));
+
+  // Good subject, bad command triggers usage
+  ASSERT_EQ(0, std::memcmp("Usage:", run({"status", "bad_command"}, registrar).c_str(), 6));
+
+  // Listing keys works
+  ASSERT_EQ(keylist, run({"status", "list-keys"}, registrar));
+
+  // Describing a status handler works
+  ASSERT_EQ(async_handler_description + "\n", run({"status", "describe", async_handler_name}, registrar));
+
+  // Multiple descriptions works
+  auto expected = async_handler_description + "\n" + async_handler_description + "\n";
+  ASSERT_EQ(expected, run({"status", "describe", async_handler_name, async_handler_name2}, registrar));
+
+  // Getting status works
+  ASSERT_EQ(async_handler_status + "\n", run({"status", "get", async_handler_name}, registrar));
+
+  // Getting status for multiple handlers works
+  expected = async_handler_status + "\n" + async_handler_status + "\n";
+  ASSERT_EQ(expected, run({"status", "get", async_handler_name, async_handler_name2}, registrar));
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int res = RUN_ALL_TESTS();
+  return res;
+}


### PR DESCRIPTION
This commit is the start of a diagnostics library for building
interactive CLI programs for interacting with an individual replica
built on concord-bft. The first part of the diagnostics library focuses
on retrieving status from different parts of the system in a thread-safe
manner.

This commit introduces the first two components of this library:
 * A `Registrar`, which allows registering `StatusHandler`s and
 operating on those handlers.
 * A `protocol` which defines a string based protocol for
 interacting with command line clients.

 Both of these components are tested in diagnostics_tests, which also
 serves to demonstrate usage.

 Future commits will include:
  * A unix domain socket based server for handling protocol requests
  * A simple bash or python client script for interacting with server
  * Initialization of a global Registrar
  * Implementation and registration of StatusHandlers