### PR TITLE
Add thread-safe errno string generation

### DIFF
--- a/bftengine/src/communication/PlainUDPCommunication.cpp
+++ b/bftengine/src/communication/PlainUDPCommunication.cpp
@@ -13,6 +13,8 @@
 #include "Logger.hpp"
 #include "CommDefs.hpp"
 
+#include "errnoString.hpp"
+
 #include <iostream>
 #include <cstddef>
 #include <cassert>
@@ -180,7 +182,7 @@ class PlainUDPCommunication::PlainUdpImpl {
     if (error < 0) {
       LOG_FATAL(_logger,
                 "Error while binding: IP=" << sAddr.sin_addr.s_addr << ", Port=" << sAddr.sin_port
-                                           << ", errno=" << strerror(errno));
+                                           << ", errno=" << concordUtils::errnoString(errno));
       Assert(false, "Failure occurred while binding the socket!");
       exit(1);  // TODO(GG): not really ..... change this !
     }
@@ -256,8 +258,7 @@ class PlainUDPCommunication::PlainUdpImpl {
 
     if (error < 0) {
       /** -1 return value means underlying socket error. */
-      string err = strerror(errno);
-      LOG_INFO(_logger, "Error while sending: " << strerror(errno));
+      LOG_INFO(_logger, "Error while sending: " << concordUtils::errnoString(errno));
     } else if (error < (int)messageLength) {
       /** Mesage was partially sent. Unclear why this would happen, perhaps
        * due to oversized messages (?). */

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -14,6 +14,8 @@
 #include "FileStorage.hpp"
 #include "ObjectsMetadataHandler.hpp"
 
+#include "errnoString.hpp"
+
 #include <cstring>
 #include <exception>
 #include <unistd.h>
@@ -89,7 +91,7 @@ void FileStorage::read(void *dataPtr, size_t offset, size_t itemSize, size_t cou
   fseek(dataStream_, offset, SEEK_SET);
   size_t read_ = fread(dataPtr, itemSize, count, dataStream_);
   int err = ferror(dataStream_);
-  if (err) throw runtime_error("FileStorage::read " + std::string(strerror(errno)));
+  if (err) throw runtime_error("FileStorage::read " + concordUtils::errnoString(errno));
   if (feof(dataStream_)) throw runtime_error("FileStorage::read EOF");
   if (read_ != count) throw runtime_error("FileStorage::read " + std::string(errorMsg));
 }

--- a/util/include/errnoString.hpp
+++ b/util/include/errnoString.hpp
@@ -6,7 +6,8 @@
 // compliance with the Apache 2.0 License.
 //
 // This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
-// these subcompo
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
 
 #pragma once
 

--- a/util/include/errnoString.hpp
+++ b/util/include/errnoString.hpp
@@ -1,0 +1,40 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcompo
+
+#pragma once
+
+#include <string.h>
+
+#include <string>
+
+namespace concordUtils {
+
+// Thread-safe errno string generation.
+inline std::string errnoString(int errNum) {
+  constexpr auto size = 128 + 1;
+  char buf[size];
+#ifdef _GNU_SOURCE
+  const auto ret = strerror_r(errNum, buf, size);
+  // Documentation on the return value of the GNU version is not clear - assume it can return nullptr.
+  if (ret) {
+    return ret;
+  }
+#else
+  if (strerror_r(errNum, buf, size) == 0) {
+    // POSIX documentation is not clear on whether the buffer is always null-terminated. Be conservative and terminate
+    // it, even if it will contain some garbage data.
+    buf[size - 1] = '\0';
+    return buf;
+  }
+#endif
+  return std::string{};
+}
+
+}  // namespace concordUtils

--- a/util/src/MetricsServer.cpp
+++ b/util/src/MetricsServer.cpp
@@ -17,6 +17,7 @@
 #include <arpa/inet.h>
 
 #include "MetricsServer.hpp"
+#include "errnoString.hpp"
 
 namespace concordMetrics {
 
@@ -36,12 +37,13 @@ void Server::Start() {
     char addr[INET_ADDRSTRLEN];
     if (inet_ntop(AF_INET, &servaddr.sin_addr.s_addr, addr, INET_ADDRSTRLEN)) {
       LOG_FATAL(logger_,
-                "Error binding UDP socket: IP=" << addr << ", Port=" << listenPort_ << ", errno=" << strerror(errno));
+                "Error binding UDP socket: IP=" << addr << ", Port=" << listenPort_
+                                                << ", errno=" << concordUtils::errnoString(errno));
     } else {
       LOG_FATAL(logger_,
                 "Error binding UDP socket: IP="
                     << "unknown"
-                    << ", Port=" << listenPort_ << ", errno=" << strerror(errno));
+                    << ", Port=" << listenPort_ << ", errno=" << concordUtils::errnoString(errno));
     }
     exit(1);
   }
@@ -84,7 +86,7 @@ void Server::RecvLoop() {
     len = recvfrom(sock_, buf_, MAX_MSG_SIZE, 0, (sockaddr*)&cliaddr, &addrlen);
 
     if (len < 0) {
-      LOG_ERROR(logger_, "Failed to recv msg: " << strerror(errno));
+      LOG_ERROR(logger_, "Failed to recv msg: " << concordUtils::errnoString(errno));
       continue;
     }
 
@@ -110,7 +112,7 @@ void Server::sendReply(std::string data, sockaddr_in* cliaddr, socklen_t addrlen
   memcpy(buf_ + sizeof(Header), data.data(), data.size());
   auto len = sendto(sock_, buf_, data.size() + sizeof(Header), 0, (const struct sockaddr*)cliaddr, addrlen);
   if (len < 0) {
-    LOG_ERROR(logger_, "Failed to send reply msg: " << strerror(errno));
+    LOG_ERROR(logger_, "Failed to send reply msg: " << concordUtils::errnoString(errno));
   }
 }
 
@@ -122,7 +124,7 @@ void Server::sendError(sockaddr_in* cliaddr, socklen_t addrlen) {
   memcpy(buf_ + sizeof(Header), msg, msglen);
   auto len = sendto(sock_, buf_, msglen + sizeof(Header), 0, (const struct sockaddr*)cliaddr, addrlen);
   if (len < 0) {
-    LOG_ERROR(logger_, "Failed to send error msg: " << strerror(errno));
+    LOG_ERROR(logger_, "Failed to send error msg: " << concordUtils::errnoString(errno));
   }
 }
 


### PR DESCRIPTION
Introduce the concordUtils::errnoString() function that supports
thread-safe errno string generation. Use it instead of the thread-unsafe
strerror() one in multiple cases in the codebase.