### PR TITLE
Add support for range delete in IDBClient

### DIFF
--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -80,6 +80,7 @@ class Client : public IDBClient {
   concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) override;
   concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap) override;
   concordUtils::Status multiDel(const KeysVector &_keysVec) override;
+  concordUtils::Status rangeDel(const Sliver &_beginKey, const Sliver &_endKey) override;
   bool isNew() override { return true; }
   ITransaction *beginTransaction() override;
   TKVStore &getMap() { return map_; }

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -84,6 +84,7 @@ class Client : public concord::storage::IDBClient {
   concordUtils::Status multiGet(const KeysVector& _keysVec, ValuesVector& _valuesVec) override;
   concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override;
   concordUtils::Status multiDel(const KeysVector& _keysVec) override;
+  concordUtils::Status rangeDel(const Sliver& _beginKey, const Sliver& _endKey) override;
   ::rocksdb::Iterator* getNewRocksDbIterator() const;
   bool isNew() override;
   ITransaction* beginTransaction() override;
@@ -91,6 +92,7 @@ class Client : public concord::storage::IDBClient {
  private:
   concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob);
   concordUtils::Status get(const concordUtils::Sliver& _key, std::string& _value) const;
+  bool keyIsBefore(const concordUtils::Sliver& _lhs, const concordUtils::Sliver& _rhs) const;
 
  private:
   static concordlogger::Logger& logger() {

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -62,6 +62,11 @@ class IDBClient {
   virtual Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) = 0;
   virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap) = 0;
   virtual Status multiDel(const KeysVector& _keysVec) = 0;
+  // Delete keys in the [_beginKey, _endKey) range (_beginKey included and _endKey excluded). If an inavlid range has
+  // been passed (i.e. _endKey < _beginKey), the behavior is undefined. If _beginKey == _endKey, the call will not have
+  // an effect. If no keys have been deleted, the operation is still successful. If there is an error, the returned
+  // status will reflect it.
+  virtual Status rangeDel(const Sliver& _beginKey, const Sliver& _endKey) = 0;
   virtual bool isNew() = 0;
 
   // the caller is responsible for transaction object lifetime


### PR DESCRIPTION
Add support for the the rangeDel() method that deletes keys in the
[beginKey, endKey) range. Provide implementations for memorydb and
RocksDB.

In order to simplify the interface, the user is required to pass a valid
range as a precondition. If an invalid range is passed, the behavior is
documented as undefined. In terms of current implementations, it results
in an assert. Rationale is that the user should be aware of key ordering
when using the range delete functionality.

Finally, add tests for the RocksDB implementation in the multiIO_test
unit test.