### PR TITLE
[Apollo] Adding timeout for start/stop external replica commands

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -306,12 +306,18 @@ class BftTestNetwork:
                                         close_fds=True)
 
     def _start_external_replica(self, replica_id):
-        subprocess.run(
-            self.start_replica_cmd(replica_id),
-            check=True
-        )
-
-        return self.replicas[replica_id]
+        try:
+            subprocess.run(
+                self.start_replica_cmd(replica_id),
+                check=True,
+                timeout=60  # seconds
+            )
+        except subprocess.TimeoutExpired:
+            print(f"Command for starting replica #{replica_id} timed out.")
+            raise
+        else:
+            print(f"Successfully started replica #{replica_id}.")
+            return self.replicas[replica_id]
 
 
     def stop_replica(self, replica_id):
@@ -332,10 +338,17 @@ class BftTestNetwork:
         del self.procs[replica_id]
 
     def _stop_external_replica(self, replica_id):
-        subprocess.run(
-            self.stop_replica_cmd(replica_id),
-            check=True
-        )
+        try:
+            subprocess.run(
+                self.stop_replica_cmd(replica_id),
+                check=True,
+                timeout=60  # seconds
+            )
+        except subprocess.TimeoutExpired:
+            print(f"Command for stopping replica #{replica_id} timed out.")
+            raise
+        else:
+            print(f"Successfully stopped replica #{replica_id}.")
 
     def all_replicas(self, without=None):
         """


### PR DESCRIPTION
In some (rare) cases the docker start/kill commands appear to just "hang". This results in Apollo BFT tests running in product CI to never complete.

The reason for this happening is unclear, but could be explained by Apollo frequently stopping and starting replicas. In order to further debug such cases, first of all we need the CI job to complete and collect logs.

This is why I suggest the changes in this PR, which introduce a timeout when executing the commands for starting/stopping external replicas.