### PR TITLE
AsyncTlsConnection: Fix allocation loop

### DIFF
--- a/bftengine/src/communication/TlsTCPCommunication.cpp
+++ b/bftengine/src/communication/TlsTCPCommunication.cpp
@@ -1086,8 +1086,6 @@ class TlsTCPCommunication::TlsTcpImpl : public std::enable_shared_from_this<TlsT
     }
   }
 
-  // here need to check how "this" passed to handlers behaves if the object is
-  // deleted.
   void start_accept() {
     LOG_DEBUG(_logger, "start_accept, node: " << _selfId);
     auto conn = AsyncTlsConnection::create(
@@ -1103,9 +1101,8 @@ class TlsTCPCommunication::TlsTcpImpl : public std::enable_shared_from_this<TlsT
         _statusCallback,
         _nodes,
         _cipherSuite);
-    _pAcceptor->async_accept(
-        conn->get_socket().lowest_layer(),
-        boost::bind(&TlsTcpImpl::on_accept, shared_from_this(), conn, boost::asio::placeholders::error));
+    _pAcceptor->async_accept(conn->get_socket().lowest_layer(),
+                             boost::bind(&TlsTcpImpl::on_accept, this, conn, boost::asio::placeholders::error));
   }
 
   TlsTcpImpl(const TlsTcpImpl &) = delete;


### PR DESCRIPTION
This class allocates memory in the constructor and frees it when the destructor
is called. If the accept callback is invoked with an error then we create a new
connection object and pass on the existing connection via a shared pointer.
During manual testing we have encountered a scenario in which we keep getting
errors and hence keep creating new connection objects. Eventually, we will run
out of memory. This change replaces the shared pointer so that the previous
connection object can be freed.