### PR TITLE
Adopt view change test for PrePrepareMsg

### DIFF
--- a/bftengine/tests/testViewChange/testViewChange.cpp
+++ b/bftengine/tests/testViewChange/testViewChange.cpp
@@ -165,7 +165,8 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions) {
                                              kRequestLength,
                                              (const char*)requestBuffer,
                                              (uint64_t)1000000);
-  auto* pp = new PrePrepareMsg(0, curView, assignedSeqNum, bftEngine::impl::CommitPath::SLOW, false);
+  auto* pp =
+      new PrePrepareMsg(0, curView, assignedSeqNum, bftEngine::impl::CommitPath::SLOW, false, clientRequest->size());
   pp->addRequest(clientRequest->body(), clientRequest->size());
   pp->finishAddingRequests();
 


### PR DESCRIPTION
My last PR broke the view change test due to we require to know the total size
of all requests upfront before creating a PrePrepareMsg. This change adds the
client request size to the PrePrepareMsg creation.