### PR TITLE
PrePrepareMsg: Mandatory request size

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -286,8 +286,8 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
 
   controller->onSendingPrePrepare((primaryLastUsedSeqNum + 1), firstPath);
 
-  PrePrepareMsg *pp = new PrePrepareMsg(
-      config_.replicaId, curView, (primaryLastUsedSeqNum + 1), firstPath, false, primaryCombinedReqSize);
+  PrePrepareMsg *pp =
+      new PrePrepareMsg(config_.replicaId, curView, (primaryLastUsedSeqNum + 1), firstPath, primaryCombinedReqSize);
 
   ClientRequestMsg *nextRequest = requestsQueueOfPrimary.front();
   while (nextRequest != nullptr && nextRequest->size() <= pp->remainingSizeForRequests()) {

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -674,7 +674,7 @@ bool ViewsManager::tryToEnterView(ViewNum v,
       if (restrictionsOfPendingView[idx].isNull) {
         Assert(prePrepareMsgsOfRestrictions[idx] == nullptr);
         // TODO(GG): do we want to start from the slow path in these cases?
-        PrePrepareMsg* pp = PrePrepareMsg::createNullPrePrepareMsg(myId, myLatestActiveView, i);
+        PrePrepareMsg* pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, 0);
         outPrePrepareMsgsOfView->push_back(pp);
       } else {
         PrePrepareMsg* pp = prePrepareMsgsOfRestrictions[idx];

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -54,27 +54,15 @@ class PrePrepareMsg : public MessageBase {
  public:
   // static
 
-  static PrePrepareMsg* createNullPrePrepareMsg(ReplicaId sender,
-                                                ViewNum v,
-                                                SeqNum s,
-                                                CommitPath firstPath = CommitPath::SLOW,
-                                                const std::string& spanContext = "");  // TODO(GG): why static method ?
-
   static const Digest& digestOfNullPrePrepareMsg();
 
   void validate(const ReplicasInfo&) const override;
 
-  // ctor and other build methods
+  // size - total size of all requests that will be added
+  PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, size_t size);
 
-  PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, bool isNull = false, size_t size = 0);
-
-  PrePrepareMsg(ReplicaId sender,
-                ViewNum v,
-                SeqNum s,
-                CommitPath firstPath,
-                const std::string& spanContext,
-                bool isNull,
-                size_t size = 0);
+  PrePrepareMsg(
+      ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, const std::string& spanContext, size_t size);
 
   uint32_t remainingSizeForRequests() const;
 

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -248,7 +248,7 @@ void testSeqNumWindowSetUp(const SeqNum shift, bool toSet) {
   ReplicaId sender = 2;
   ViewNum view = 6;
   CommitPath firstPath = CommitPath::FAST_WITH_THRESHOLD;
-  PrePrepareMsg prePrepareInitialMsg(sender, view, prePrepareMsgSeqNum, firstPath);
+  PrePrepareMsg prePrepareNullMsg(sender, view, prePrepareMsgSeqNum, firstPath, 0);
 
   const SeqNum slowStartedSeqNum = 144;
   bool slowStarted = true;
@@ -266,7 +266,7 @@ void testSeqNumWindowSetUp(const SeqNum shift, bool toSet) {
 
   if (toSet) {
     persistentStorageImp->beginWriteTran();
-    persistentStorageImp->setPrePrepareMsgInSeqNumWindow(prePrepareMsgSeqNum, &prePrepareInitialMsg);
+    persistentStorageImp->setPrePrepareMsgInSeqNumWindow(prePrepareMsgSeqNum, &prePrepareNullMsg);
     persistentStorageImp->setSlowStartedInSeqNumWindow(slowStartedSeqNum, slowStarted);
     persistentStorageImp->setFullCommitProofMsgInSeqNumWindow(fullCommitProofSeqNum, &fullCommitProofInitialMsg);
     persistentStorageImp->setForceCompletedInSeqNumWindow(commitFullSeqNum, forceCompleted);
@@ -294,7 +294,7 @@ void testSeqNumWindowSetUp(const SeqNum shift, bool toSet) {
 
     if (!shift) {
       if (prePrepareMsgSeqNumShifted == shiftedSeqNum - 1) {
-        Assert(prePrepareMsg->equals(prePrepareInitialMsg));
+        Assert(prePrepareMsg->equals(prePrepareNullMsg));
       } else
         Assert(!prePrepareMsg);
 
@@ -351,7 +351,7 @@ void testSetDescriptors(bool toSet) {
   ViewsManager::PrevViewInfo element;
   ReplicaId senderId = 1;
   element.hasAllRequests = true;
-  element.prePrepare = new PrePrepareMsg(senderId, viewNum, lastExitExecNum, CommitPath::OPTIMISTIC_FAST, true);
+  element.prePrepare = new PrePrepareMsg(senderId, viewNum, lastExitExecNum, CommitPath::OPTIMISTIC_FAST, 0);
   element.prepareFull = PrepareFullMsg::create(viewNum, lastExitExecNum, senderId, nullptr, 0);
   for (uint32_t i = 0; i < kWorkWindowSize; ++i) {
     elements.push_back(element);

--- a/bftengine/tests/testViewChange/testViewChange.cpp
+++ b/bftengine/tests/testViewChange/testViewChange.cpp
@@ -168,7 +168,7 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions) {
   auto primary = pRepInfo->primaryOfView(view);
   // Generate the PrePrepare from the primary for the clientRequest
   auto* ppMsg =
-      new PrePrepareMsg(primary, view, assignedSeqNum, bftEngine::impl::CommitPath::SLOW, false, clientRequest->size());
+      new PrePrepareMsg(primary, view, assignedSeqNum, bftEngine::impl::CommitPath::SLOW, clientRequest->size());
   ppMsg->addRequest(clientRequest->body(), clientRequest->size());
   ppMsg->finishAddingRequests();
 
@@ -240,12 +240,8 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_for_s
                                               (uint64_t)1000000);
 
   // Generate the PrePrepare from the primary for the clientRequest1
-  auto* ppMsg1 = new PrePrepareMsg(pRepInfo->primaryOfView(view1),
-                                   view1,
-                                   assignedSeqNum,
-                                   bftEngine::impl::CommitPath::SLOW,
-                                   false,
-                                   clientRequest1->size());
+  auto* ppMsg1 = new PrePrepareMsg(
+      pRepInfo->primaryOfView(view1), view1, assignedSeqNum, bftEngine::impl::CommitPath::SLOW, clientRequest1->size());
   ppMsg1->addRequest(clientRequest1->body(), clientRequest1->size());
   ppMsg1->finishAddingRequests();
 
@@ -269,12 +265,8 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_for_s
                                               (uint64_t)1000000);
 
   // Generate the PrePrepare from the primary for the clientRequest2
-  auto* ppMsg2 = new PrePrepareMsg(pRepInfo->primaryOfView(view2),
-                                   view2,
-                                   assignedSeqNum,
-                                   bftEngine::impl::CommitPath::SLOW,
-                                   false,
-                                   clientRequest2->size());
+  auto* ppMsg2 = new PrePrepareMsg(
+      pRepInfo->primaryOfView(view2), view2, assignedSeqNum, bftEngine::impl::CommitPath::SLOW, clientRequest2->size());
   ppMsg2->addRequest(clientRequest2->body(), clientRequest2->size());
   ppMsg2->finishAddingRequests();
   // Here we generate a valid Prepare Certificate for clientRequest2 with
@@ -368,12 +360,8 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_one_i
                                               (uint64_t)1000000);
 
   // Generate the PrePrepare from the primary for the clientRequest1
-  auto* ppMsg1 = new PrePrepareMsg(pRepInfo->primaryOfView(view1),
-                                   view1,
-                                   assignedSeqNum,
-                                   bftEngine::impl::CommitPath::SLOW,
-                                   false,
-                                   clientRequest1->size());
+  auto* ppMsg1 = new PrePrepareMsg(
+      pRepInfo->primaryOfView(view1), view1, assignedSeqNum, bftEngine::impl::CommitPath::SLOW, clientRequest1->size());
   ppMsg1->addRequest(clientRequest1->body(), clientRequest1->size());
   ppMsg1->finishAddingRequests();
 
@@ -401,7 +389,6 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_one_i
                                    view2,
                                    assignedSeqNumIgnored,
                                    bftEngine::impl::CommitPath::SLOW,
-                                   false,
                                    clientRequest2->size());
   ppMsg2->addRequest(clientRequest2->body(), clientRequest2->size());
   ppMsg2->finishAddingRequests();


### PR DESCRIPTION
This change refactors the PrePrepareMsg constructor. Instead of taking an
optional `isNull` and `size` parameter, this change gets rid of the former and
makes the latter mandatory. With the required size parameter in place, there is
no need for a separate create-null-prepreparemsg function anymore due to the
parameter should make it clear.