### PR TITLE
Unit test for 'seqNumGeneratorForClientRequestsImp'

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <set>
 #include "ICommunication.hpp"
+#include <chrono>
 
 namespace bftEngine {
 // Parameters // TODO(GG): move to client configuration
@@ -73,6 +74,8 @@ class SeqNumberGeneratorForClientRequests {
   static SeqNumberGeneratorForClientRequests* createSeqNumberGeneratorForClientRequests();
 
   virtual uint64_t generateUniqueSequenceNumberForRequest() = 0;
+
+  virtual uint64_t generateUniqueSequenceNumberForRequest(std::chrono::time_point<std::chrono::system_clock> now) = 0;
 
   virtual ~SeqNumberGeneratorForClientRequests() = default;
 };

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -421,6 +421,8 @@ void SimpleClientImp::sendPendingRequest() {
 
 class SeqNumberGeneratorForClientRequestsImp : public SeqNumberGeneratorForClientRequests {
   virtual uint64_t generateUniqueSequenceNumberForRequest() override;
+  virtual uint64_t generateUniqueSequenceNumberForRequest(
+      std::chrono::time_point<std::chrono::system_clock> now) override;
 
  protected:
   uint64_t lastMilliOfUniqueFetchID_ = 0;
@@ -428,9 +430,13 @@ class SeqNumberGeneratorForClientRequestsImp : public SeqNumberGeneratorForClien
 };
 
 uint64_t SeqNumberGeneratorForClientRequestsImp::generateUniqueSequenceNumberForRequest() {
-  std::chrono::time_point<std::chrono::system_clock> n = std::chrono::system_clock::now();
+  std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+  return generateUniqueSequenceNumberForRequest(now);
+}
 
-  uint64_t milli = std::chrono::duration_cast<std::chrono::milliseconds>(n.time_since_epoch()).count();
+uint64_t SeqNumberGeneratorForClientRequestsImp::generateUniqueSequenceNumberForRequest(
+    std::chrono::time_point<std::chrono::system_clock> now) {
+  uint64_t milli = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 
   if (milli > lastMilliOfUniqueFetchID_) {
     lastMilliOfUniqueFetchID_ = milli;

--- a/bftengine/tests/testSeqNumForClientRequest/CMakeLists.txt
+++ b/bftengine/tests/testSeqNumForClientRequest/CMakeLists.txt
@@ -3,6 +3,11 @@ find_package(GTest REQUIRED)
 add_executable(seqNumForClientRequest_test seqNumForClientRequest_test.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(seqNumForClientRequest_test seqNumForClientRequest_test)
 
+target_include_directories(seqNumForClientRequest_test
+        PRIVATE
+        ${bftengine_SOURCE_DIR}/src/preprocessor
+
+        )
 
 target_link_libraries(seqNumForClientRequest_test PUBLIC
         GTest::Main

--- a/bftengine/tests/testSeqNumForClientRequest/seqNumForClientRequest_test.cpp
+++ b/bftengine/tests/testSeqNumForClientRequest/seqNumForClientRequest_test.cpp
@@ -1,8 +1,96 @@
 #include "gtest/gtest.h"
+#include "SimpleClientImp.cpp"
+#include <list>
 
-TEST(seqNumForClientRequest_test, initial_test) {}
+using namespace std;
+using namespace bftEngine;
 
-int main(int argc, char* argv[]) {
+namespace {
+
+class MockSeqNumGenerator : public SeqNumberGeneratorForClientRequestsImp {
+ public:
+  uint32_t getLastCountOfUniqueFetchID() { return lastCountOfUniqueFetchID_; }
+
+  void setLastCountOfUniqueFetchID(uint64_t count) { lastCountOfUniqueFetchID_ = count; }
+};
+
+TEST(seqNumForClientRequest_test, monotonicity_check) {
+  SeqNumberGeneratorForClientRequests *seqNumGen = new MockSeqNumGenerator();
+  std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+  list<u_int64_t> seqNums;
+
+  for (int i = 0; i < 10; i++) {
+    seqNums.push_back(seqNumGen->generateUniqueSequenceNumberForRequest(now));
+    now.operator+=(chrono::milliseconds(1000));
+    usleep(1000);
+  }
+
+  // Checks that generated SN is monotonically increasing.
+  Assert(is_sorted(seqNums.begin(), seqNums.end()));
+  now.operator+=(std::chrono::hours(24));
+  auto newSeqNum = seqNumGen->generateUniqueSequenceNumberForRequest(now);
+  auto lastSeqNum = seqNums.back();
+
+  // Two SN generated on same time in different days, stays monotonic.
+  ASSERT_TRUE(newSeqNum > lastSeqNum);
+  delete seqNumGen;
+}
+
+TEST(seqNumForClientRequest_test, send_requests_same_time_uniqueness_preserved) {
+  SeqNumberGeneratorForClientRequests *seqNumGen = new MockSeqNumGenerator();
+  std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+  set<u_int64_t> seqNums;
+
+  for (int i = 0; i < 10; i++) {
+    seqNums.insert(seqNumGen->generateUniqueSequenceNumberForRequest(now));
+  }
+
+  // assert 10 unique SN was generated, although practically sent at the same time.
+  Assert(seqNums.size() == 10);
+  delete seqNumGen;
+}
+
+TEST(seqNumForClientRequest_test, exceed_counter_limit_uniqueness_preserved) {
+  SeqNumberGeneratorForClientRequests *seqNumGen = new MockSeqNumGenerator();
+  std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+  set<u_int64_t> seqNums;
+
+  seqNums.insert(seqNumGen->generateUniqueSequenceNumberForRequest(now));
+  auto mockSeqNumGen = dynamic_cast<MockSeqNumGenerator *>(seqNumGen);
+
+  // Set lastCount biggest value.
+  mockSeqNumGen->setLastCountOfUniqueFetchID(0x3FFFFF);
+  seqNums.insert(seqNumGen->generateUniqueSequenceNumberForRequest(now));
+
+  // assert unique SN was generated, although counter limit exceeded.
+  ASSERT_EQ(seqNums.size(), 2);
+  delete seqNumGen;
+}
+
+TEST(seqNumForClientRequest_test, invoke_counter_increasement) {
+  SeqNumberGeneratorForClientRequests *seqNumGen = new MockSeqNumGenerator();
+  set<u_int64_t> seqNums;
+
+  // generate bunch of sequence numbers
+  for (int i = 0; i < 10; i++) {
+    seqNums.insert(seqNumGen->generateUniqueSequenceNumberForRequest());
+    usleep(1000);
+  }
+  // assert 10 unique sequence numbers was generated.
+  ASSERT_EQ(seqNums.size(), 10);
+
+  std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+  now.operator-=(chrono::milliseconds(1000));
+  seqNums.insert(seqNumGen->generateUniqueSequenceNumberForRequest(now));
+  auto mockSeqNumGen = dynamic_cast<MockSeqNumGenerator *>(seqNumGen);
+
+  // assert 'lastCountOfUniqueFetchID_' variable increased.
+  ASSERT_EQ(mockSeqNumGen->getLastCountOfUniqueFetchID(), 1);
+  delete seqNumGen;
+}
+}  // namespace
+
+int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
In order to test 'seqNumGeneratorForClientRequestsImp' I have made few changes:

1. For 'seqNumGeneratorForClientRequestsImp' to be testsable, I added another, name identical, function. The initial one gets one time_point parameter and the new one won't get params.
This way we can preserve the initial behaviour, but can send specific time_point and be more flexible in the unit tests.

2. Created mock class of the 'seqNumGeneratorForClientRequestsImp' with basic functionalities 
needed, in order to test different behaviours.

3 Included dir in the cmake file, for using 'SimpleClientImp.cpp'.

4. Wrote unit-tests.