### PR TITLE
Support block deletion in the merkle DB adapter

### DIFF
--- a/kvbc/include/db_adapter.h
+++ b/kvbc/include/db_adapter.h
@@ -20,6 +20,8 @@ class NotFoundException : public std::runtime_error {
   const char* what() const noexcept override { return std::runtime_error::what(); }
 };
 
+inline constexpr auto INITIAL_GENESIS_BLOCK_ID = BlockId{1};
+
 class IDbAdapter {
  public:
   // Returns the added block ID.
@@ -35,11 +37,18 @@ class IDbAdapter {
   // Return the actual version and the value for a key
   virtual std::pair<Value, BlockId> getValue(const Key& key, const BlockId& blockVersion) const = 0;
 
-  // Delete a block from the database
+  // Deletes the block with the passed ID.
+  // If the passed block ID doesn't exist, the call has no effect.
+  // Throws if an error occurs.
   virtual void deleteBlock(const BlockId& blockId) = 0;
 
   // Checks whether block exists
   virtual bool hasBlock(const BlockId& blockId) const = 0;
+
+  // Returns the genesis (first) block ID in the system. If the blockchain is empty or if there are no reachable blocks
+  // (getLastReachableBlock() == 0), 0 is returned.
+  // Throws on errors.
+  virtual BlockId getGenesisBlockId() const = 0;
 
   // Used to retrieve the latest block.
   virtual BlockId getLatestBlockId() const = 0;

--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -147,6 +147,7 @@ class DBAdapter : public IDbAdapter {
 
   bool hasBlock(const BlockId &blockId) const override;
 
+  BlockId getGenesisBlockId() const override { return (getLastReachableBlockId() ? INITIAL_GENESIS_BLOCK_ID : 0); }
   BlockId getLatestBlockId() const override { return lastBlockId_; }
   BlockId getLastReachableBlockId() const override { return lastReachableBlockId_; }
 

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -27,6 +27,10 @@ class DBKeyManipulator {
   static Key genInternalDbKey(const sparse_merkle::InternalNodeKey &key);
   static Key genStaleDbKey(const sparse_merkle::InternalNodeKey &key, const sparse_merkle::Version &staleSinceVersion);
   static Key genStaleDbKey(const sparse_merkle::LeafKey &key, const sparse_merkle::Version &staleSinceVersion);
+  // Version-only stale keys do not exist in the DB. They are used as a placeholder for searching through the stale
+  // index. Rationale is that they are a lower bound of all stale keys for a specific version due to lexicographical
+  // ordering, the fact that the version comes first and that real stale keys are longer and always follow version-only
+  // ones.
   static Key genStaleDbKey(const sparse_merkle::Version &staleSinceVersion);
   static Key generateMetadataKey(storage::ObjectId objectId);
   static Key generateStateTransferKey(storage::ObjectId objectId);

--- a/kvbc/include/merkle_tree_serialization.h
+++ b/kvbc/include/merkle_tree_serialization.h
@@ -44,11 +44,6 @@ constexpr auto toChar(E e) {
 
 namespace detail {
 
-// Specifies the key type. Used when serializing the stale node index.
-enum class StaleKeyType : std::uint8_t {
-  Internal,
-  Leaf,
-};
 using concord::storage::v2MerkleTree::detail::EDBKeyType;   // TODO [TK] TMP
 using concord::storage::v2MerkleTree::detail::EKeySubtype;  // TODO [TK] TMP
 using concord::storage::v2MerkleTree::detail::EBFTSubtype;  // TODO [TK] TMP
@@ -83,8 +78,6 @@ inline std::string serializeImp(EDBKeyType type) { return std::string{toChar(typ
 inline std::string serializeImp(EKeySubtype type) { return std::string{toChar(EDBKeyType::Key), toChar(type)}; }
 
 inline std::string serializeImp(EBFTSubtype type) { return std::string{toChar(EDBKeyType::BFT), toChar(type)}; }
-
-inline std::string serializeImp(StaleKeyType type) { return std::string{toChar(type)}; }
 
 inline std::string serializeImp(const std::vector<std::uint8_t> &v) {
   return std::string{std::cbegin(v), std::cend(v)};

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -369,7 +369,7 @@ BlockId DBAdapter::addBlock(const SetOfKeyValuePairs &kv) {
   BlockId blockId = getLastReachableBlockId() + 1;
   // Make sure the digest is zero-initialized by using {} initialization.
   auto blockDigest = BlockDigest{};
-  if (blockId > 1) {
+  if (blockId > INITIAL_GENESIS_BLOCK_ID) {
     const auto parentBlockData = getRawBlock(blockId - 1);
     blockDigest = bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest(
         blockId - 1, reinterpret_cast<const char *>(parentBlockData.data()), parentBlockData.length());
@@ -544,7 +544,7 @@ BlockId DBAdapter::fetchLatestBlockId() const {
  *
  * Searches for the last reachable block.
  * From ST perspective, this is maximal block number N
- * such that all blocks 1 <= i <= N exist.
+ * such that all blocks INITIAL_GENESIS_BLOCK_ID <= i <= N exist.
  * In the normal state, it should be equal to last block ID
  *
  * @return Block ID of the last reachable block.

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -2,8 +2,6 @@
 
 #include <assertUtils.hpp>
 #include "bcstatetransfer/SimpleBCStateTransfer.hpp"
-#include "storage/db_types.h"
-#include "merkle_tree_block.h"
 #include "merkle_tree_db_adapter.h"
 #include "merkle_tree_serialization.h"
 #include "endianness.hpp"
@@ -16,6 +14,7 @@
 #include "hex_tools.h"
 
 #include <exception>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -25,9 +24,6 @@ namespace concord::kvbc::v2MerkleTree {
 namespace {
 
 using namespace ::std::string_literals;
-
-using BlockNode = block::detail::Node;
-using BlockKeyData = block::detail::KeyData;
 
 using ::concordUtils::fromBigEndianBuffer;
 using ::concordUtils::Sliver;
@@ -59,13 +55,13 @@ SetOfKeyValuePairs batchToDbUpdates(const sparse_merkle::UpdateBatch &batch, Blo
 
   // Internal stale node indexes. Use the index only and set the key to an empty sliver.
   for (const auto &intKey : batch.stale.internal_keys) {
-    const auto key = DBKeyManipulator::genStaleDbKey(intKey, batch.stale.stale_since_version.value());
+    const auto key = DBKeyManipulator::genStaleDbKey(intKey, batch.stale.stale_since_version);
     updates[key] = emptySliver;
   }
 
   // Leaf stale node indexes. Use the index only and set the key to an empty sliver.
   for (const auto &leafKey : batch.stale.leaf_keys) {
-    const auto key = DBKeyManipulator::genStaleDbKey(leafKey, batch.stale.stale_since_version.value());
+    const auto key = DBKeyManipulator::genStaleDbKey(leafKey, batch.stale.stale_since_version);
     updates[key] = emptySliver;
   }
 
@@ -84,72 +80,31 @@ SetOfKeyValuePairs batchToDbUpdates(const sparse_merkle::UpdateBatch &batch, Blo
   return updates;
 }
 
-// Undefined behavior if an incorrect type is read from the buffer.
-EDBKeyType getDBKeyType(const Sliver &s) {
-  Assert(!s.empty());
-
-  switch (s[0]) {
-    case toChar(EDBKeyType::Block):
-      return EDBKeyType::Block;
-    case toChar(EDBKeyType::Key):
-      return EDBKeyType::Key;
-    case toChar(EDBKeyType::BFT):
-      return EDBKeyType::BFT;
-  }
-  Assert(false);
-
-  // Dummy return to silence the compiler.
-  return EDBKeyType::Block;
-}
-
-// Undefined behavior if an incorrect type is read from the buffer.
-EKeySubtype getKeySubtype(const Sliver &s) {
-  Assert(s.length() > 1);
-
-  switch (s[1]) {
-    case toChar(EKeySubtype::Internal):
-      return EKeySubtype::Internal;
-    case toChar(EKeySubtype::Stale):
-      return EKeySubtype::Stale;
-    case toChar(EKeySubtype::Leaf):
-      return EKeySubtype::Leaf;
-  }
-  Assert(false);
-
-  // Dummy return to silence the compiler.
-  return EKeySubtype::Internal;
-}
-
-// Undefined behavior if an incorrect type is read from the buffer.
-EBFTSubtype getBftSubtype(const Sliver &s) {
-  Assert(s.length() > 1);
-
-  switch (s[1]) {
-    case toChar(EBFTSubtype::Metadata):
-      return EBFTSubtype::Metadata;
-    case toChar(EBFTSubtype::ST):
-      return EBFTSubtype::ST;
-    case toChar(EBFTSubtype::STPendingPage):
-      return EBFTSubtype::STPendingPage;
-    case toChar(EBFTSubtype::STReservedPageStatic):
-      return EBFTSubtype::STReservedPageStatic;
-    case toChar(EBFTSubtype::STReservedPageDynamic):
-      return EBFTSubtype::STReservedPageDynamic;
-    case toChar(EBFTSubtype::STCheckpointDescriptor):
-      return EBFTSubtype::STCheckpointDescriptor;
-    case toChar(EBFTSubtype::STTempBlock):
-      return EBFTSubtype::STTempBlock;
-  }
-  Assert(false);
-
-  // Dummy return to silence the compiler.
-  return EBFTSubtype::Metadata;
-}
-
 auto hash(const Sliver &buf) {
   auto hasher = Hasher{};
   return hasher.hash(buf.data(), buf.length());
 }
+
+template <typename VersionExtractor>
+KeysVector keysForVersion(const std::shared_ptr<IDBClient> &db,
+                          const Key &firstKey,
+                          const Version &version,
+                          EKeySubtype keySubtype,
+                          const VersionExtractor &extractVersion) {
+  auto keys = KeysVector{};
+  auto iter = db->getIteratorGuard();
+  // Rely on the fact that keys are ordered lexicographically by version and keys with a version only precede any keys
+  // with a value (as they are longer). Loop until a different key type or a key with the next version is encountered.
+  auto currentKey = iter->seekAtLeast(firstKey).first;
+  while (!currentKey.empty() && DBKeyManipulator::getDBKeyType(currentKey) == EDBKeyType::Key &&
+         DBKeyManipulator::getKeySubtype(currentKey) == keySubtype && extractVersion(currentKey) == version) {
+    keys.push_back(currentKey);
+    currentKey = iter->next().first;
+  }
+  return keys;
+}
+
+void add(KeysVector &to, const KeysVector &src) { to.insert(std::end(to), std::cbegin(src), std::cend(src)); }
 
 }  // namespace
 
@@ -157,21 +112,23 @@ Key DBKeyManipulator::genBlockDbKey(BlockId version) { return serialize(EDBKeyTy
 
 Key DBKeyManipulator::genDataDbKey(const LeafKey &key) { return serialize(EKeySubtype::Leaf, key); }
 
-Key DBKeyManipulator::genDataDbKey(const Key &key, BlockId version) {
+Key DBKeyManipulator::genDataDbKey(const Key &key, const Version &version) {
   auto hasher = Hasher{};
   return genDataDbKey(LeafKey{hasher.hash(key.data(), key.length()), version});
 }
 
 Key DBKeyManipulator::genInternalDbKey(const InternalNodeKey &key) { return serialize(EKeySubtype::Internal, key); }
 
-Key DBKeyManipulator::genStaleDbKey(const InternalNodeKey &key, BlockId staleSinceVersion) {
-  // Use a serialization type to discriminate between internal and leaf keys.
-  return serialize(EKeySubtype::Stale, staleSinceVersion, StaleKeyType::Internal, key);
+Key DBKeyManipulator::genStaleDbKey(const InternalNodeKey &key, const Version &staleSinceVersion) {
+  return serialize(EKeySubtype::Stale, staleSinceVersion.value(), EKeySubtype::Internal, key);
 }
 
-Key DBKeyManipulator::genStaleDbKey(const LeafKey &key, BlockId staleSinceVersion) {
-  // Use a serialization type to discriminate between internal and leaf keys.
-  return serialize(EKeySubtype::Stale, staleSinceVersion, StaleKeyType::Leaf, key);
+Key DBKeyManipulator::genStaleDbKey(const LeafKey &key, const Version &staleSinceVersion) {
+  return serialize(EKeySubtype::Stale, staleSinceVersion.value(), EKeySubtype::Leaf, key);
+}
+
+Key DBKeyManipulator::genStaleDbKey(const Version &staleSinceVersion) {
+  return serialize(EKeySubtype::Stale, staleSinceVersion.value());
 }
 
 Key DBKeyManipulator::generateMetadataKey(ObjectId objectId) { return serialize(EBFTSubtype::Metadata, objectId); }
@@ -211,19 +168,100 @@ BlockId DBKeyManipulator::extractBlockIdFromKey(const Key &key) {
 Hash DBKeyManipulator::extractHashFromLeafKey(const Key &key) {
   constexpr auto keyTypeOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype);
   Assert(key.length() > keyTypeOffset + Hash::SIZE_IN_BYTES);
-  Assert(getDBKeyType(key) == EDBKeyType::Key);
-  Assert(getKeySubtype(key) == EKeySubtype::Leaf);
+  Assert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
+  Assert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Leaf);
   return Hash{reinterpret_cast<const uint8_t *>(key.data() + keyTypeOffset)};
+}
+
+Version DBKeyManipulator::extractVersionFromStaleKey(const Key &key) {
+  constexpr auto keyTypeOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype);
+  Assert(key.length() >= keyTypeOffset + Version::SIZE_IN_BYTES);
+  Assert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
+  Assert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Stale);
+  return fromBigEndianBuffer<Version::Type>(key.data() + keyTypeOffset);
+}
+
+Key DBKeyManipulator::extractKeyFromStaleKey(const Key &key) {
+  constexpr auto keyOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype) + Version::SIZE_IN_BYTES;
+  Assert(key.length() > keyOffset);
+  Assert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
+  Assert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Stale);
+  return Key{key, keyOffset, key.length() - keyOffset};
+}
+
+Version DBKeyManipulator::extractVersionFromInternalKey(const Key &key) {
+  constexpr auto keyOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype);
+  Assert(key.length() > keyOffset);
+  return deserialize<InternalNodeKey>(Sliver{key, keyOffset, key.length() - keyOffset}).version();
+}
+
+// Undefined behavior if an incorrect type is read from the buffer.
+EDBKeyType DBKeyManipulator::getDBKeyType(const Sliver &s) {
+  Assert(!s.empty());
+
+  switch (s[0]) {
+    case toChar(EDBKeyType::Block):
+      return EDBKeyType::Block;
+    case toChar(EDBKeyType::Key):
+      return EDBKeyType::Key;
+    case toChar(EDBKeyType::BFT):
+      return EDBKeyType::BFT;
+  }
+  Assert(false);
+
+  // Dummy return to silence the compiler.
+  return EDBKeyType::Block;
+}
+
+// Undefined behavior if an incorrect type is read from the buffer.
+EKeySubtype DBKeyManipulator::getKeySubtype(const Sliver &s) {
+  Assert(s.length() > 1);
+
+  switch (s[1]) {
+    case toChar(EKeySubtype::Internal):
+      return EKeySubtype::Internal;
+    case toChar(EKeySubtype::Stale):
+      return EKeySubtype::Stale;
+    case toChar(EKeySubtype::Leaf):
+      return EKeySubtype::Leaf;
+  }
+  Assert(false);
+
+  // Dummy return to silence the compiler.
+  return EKeySubtype::Internal;
+}
+
+// Undefined behavior if an incorrect type is read from the buffer.
+EBFTSubtype DBKeyManipulator::getBftSubtype(const Sliver &s) {
+  Assert(s.length() > 1);
+
+  switch (s[1]) {
+    case toChar(EBFTSubtype::Metadata):
+      return EBFTSubtype::Metadata;
+    case toChar(EBFTSubtype::ST):
+      return EBFTSubtype::ST;
+    case toChar(EBFTSubtype::STPendingPage):
+      return EBFTSubtype::STPendingPage;
+    case toChar(EBFTSubtype::STReservedPageStatic):
+      return EBFTSubtype::STReservedPageStatic;
+    case toChar(EBFTSubtype::STReservedPageDynamic):
+      return EBFTSubtype::STReservedPageDynamic;
+    case toChar(EBFTSubtype::STCheckpointDescriptor):
+      return EBFTSubtype::STCheckpointDescriptor;
+    case toChar(EBFTSubtype::STTempBlock):
+      return EBFTSubtype::STTempBlock;
+  }
+  Assert(false);
+
+  // Dummy return to silence the compiler.
+  return EBFTSubtype::Metadata;
 }
 
 DBAdapter::DBAdapter(const std::shared_ptr<IDBClient> &db)
     : logger_{concordlogger::Log::getLogger("concord.kvbc.v2MerkleTree.DBAdapter")},
       // The smTree_ member needs an initialized DB. Therefore, do that in the initializer list before constructing
       // smTree_ .
-      db_{[&db]() {
-        db->init(false);
-        return db;
-      }()},
+      db_{db},
       smTree_{std::make_shared<Reader>(*this)} {
   // Make sure that if linkSTChainFrom() has been interrupted (e.g. a crash or an abnormal shutdown), all DBAdapter
   // methods will return the correct values. For example, if state transfer had completed and linkSTChainFrom() was
@@ -234,14 +272,14 @@ DBAdapter::DBAdapter(const std::shared_ptr<IDBClient> &db)
 }
 
 std::pair<Value, BlockId> DBAdapter::getValue(const Key &key, const BlockId &blockVersion) const {
-  auto stateRootVersion = sparse_merkle::Version{};
+  auto stateRootVersion = Version{};
   // Find a block with an ID that is less than or equal to the requested block version and extract the state root
   // version from it.
   {
     const auto blockKey = DBKeyManipulator::genBlockDbKey(blockVersion);
     auto iter = db_->getIteratorGuard();
     const auto [foundBlockKey, foundBlockValue] = iter->seekAtMost(blockKey);
-    if (!foundBlockKey.empty() && getDBKeyType(foundBlockKey) == EDBKeyType::Block) {
+    if (!foundBlockKey.empty() && DBKeyManipulator::getDBKeyType(foundBlockKey) == EDBKeyType::Block) {
       stateRootVersion = detail::deserializeStateRootVersion(foundBlockValue);
     } else {
       throw NotFoundException{"Couldn't find a value by key and block version = " + std::to_string(blockVersion)};
@@ -249,7 +287,7 @@ std::pair<Value, BlockId> DBAdapter::getValue(const Key &key, const BlockId &blo
   }
 
   auto iter = db_->getIteratorGuard();
-  const auto leafKey = DBKeyManipulator::genDataDbKey(key, stateRootVersion.value());
+  const auto leafKey = DBKeyManipulator::genDataDbKey(key, stateRootVersion);
 
   // Seek for a leaf key with a version that is less than or equal to the state root version from the found block.
   // Since leaf keys are ordered lexicographically, first by hash and then by state root version, then if there is a key
@@ -257,14 +295,25 @@ std::pair<Value, BlockId> DBAdapter::getValue(const Key &key, const BlockId &blo
   const auto [foundKey, foundValue] = iter->seekAtMost(leafKey);
   // Make sure we only process leaf keys that have the same hash as the hash of the key the user has passed. The state
   // root version can be less than the one we seek for.
-  const auto isLeafKey =
-      !foundKey.empty() && getDBKeyType(foundKey) == EDBKeyType::Key && getKeySubtype(foundKey) == EKeySubtype::Leaf;
+  const auto isLeafKey = !foundKey.empty() && DBKeyManipulator::getDBKeyType(foundKey) == EDBKeyType::Key &&
+                         DBKeyManipulator::getKeySubtype(foundKey) == EKeySubtype::Leaf;
   if (isLeafKey && DBKeyManipulator::extractHashFromLeafKey(foundKey) == hash(key)) {
     const auto dbLeafVal = detail::deserialize<detail::DatabaseLeafValue>(foundValue);
+    // If the block at which the value is found has been deleted (i.e. its is less than the current genesis block ID),
+    // return the genesis block ID as a version.
     return std::make_pair(dbLeafVal.leafNode.value, dbLeafVal.blockId);
   }
 
   throw NotFoundException{"Couldn't find a value by key and block version = " + std::to_string(blockVersion)};
+}
+
+BlockId DBAdapter::getGenesisBlockId() const {
+  auto iter = db_->getIteratorGuard();
+  const auto key = iter->seekAtLeast(DBKeyManipulator::genBlockDbKey(INITIAL_GENESIS_BLOCK_ID)).first;
+  if (!key.empty() && DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Block) {
+    return DBKeyManipulator::extractBlockIdFromKey(key);
+  }
+  return 0;
 }
 
 BlockId DBAdapter::getLastReachableBlockId() const {
@@ -275,7 +324,7 @@ BlockId DBAdapter::getLastReachableBlockId() const {
   // allowed block ID.
   const auto foundKey = iter->seekAtMost(maxBlockKey).first;
   // Consider block keys only.
-  if (!foundKey.empty() && getDBKeyType(foundKey) == EDBKeyType::Block) {
+  if (!foundKey.empty() && DBKeyManipulator::getDBKeyType(foundKey) == EDBKeyType::Block) {
     const auto blockId = DBKeyManipulator::extractBlockIdFromKey(foundKey);
     LOG_TRACE(logger_, "Latest reachable block ID " << blockId);
     return blockId;
@@ -288,8 +337,8 @@ BlockId DBAdapter::getLatestBlockId() const {
   const auto latestBlockKey = DBKeyManipulator::generateSTTempBlockKey(MAX_BLOCK_ID);
   auto iter = db_->getIteratorGuard();
   const auto foundKey = iter->seekAtMost(latestBlockKey).first;
-  if (!foundKey.empty() && getDBKeyType(foundKey) == EDBKeyType::BFT &&
-      getBftSubtype(foundKey) == EBFTSubtype::STTempBlock) {
+  if (!foundKey.empty() && DBKeyManipulator::getDBKeyType(foundKey) == EDBKeyType::BFT &&
+      DBKeyManipulator::getBftSubtype(foundKey) == EBFTSubtype::STTempBlock) {
     const auto blockId = DBKeyManipulator::extractBlockIdFromKey(foundKey);
     LOG_TRACE(logger_, "Latest block ID " << blockId);
     return blockId;
@@ -301,15 +350,15 @@ BlockId DBAdapter::getLatestBlockId() const {
 Sliver DBAdapter::createBlockNode(const SetOfKeyValuePairs &updates, BlockId blockId) const {
   // Make sure the digest is zero-initialized by using {} initialization.
   auto parentBlockDigest = BlockDigest{};
-  if (blockId > 1) {
+  if (blockId > INITIAL_GENESIS_BLOCK_ID) {
     const auto parentBlock = getRawBlock(blockId - 1);
     parentBlockDigest = computeBlockDigest(blockId - 1, parentBlock.data(), parentBlock.length());
   }
 
-  auto node = BlockNode{blockId, parentBlockDigest, smTree_.get_root_hash(), smTree_.get_version()};
+  auto node = block::detail::Node{blockId, parentBlockDigest, smTree_.get_root_hash(), smTree_.get_version()};
   for (const auto &[k, v] : updates) {
     // Treat empty values as deleted keys.
-    node.keys.emplace(k, BlockKeyData{v.empty()});
+    node.keys.emplace(k, block::detail::KeyData{v.empty()});
   }
   return block::detail::createNode(node);
 }
@@ -339,7 +388,7 @@ RawBlock DBAdapter::getRawBlock(const BlockId &blockId) const {
   for (const auto &[key, keyData] : blockNode.keys) {
     if (!keyData.deleted) {
       Sliver value;
-      if (const auto status = db_->get(DBKeyManipulator::genDataDbKey(key, blockNode.stateRootVersion.value()), value);
+      if (const auto status = db_->get(DBKeyManipulator::genDataDbKey(key, blockNode.stateRootVersion), value);
           !status.isOK()) {
         // If the key is not found, treat as corrupted storage and abort.
         Assert(!status.isNotFound());
@@ -484,12 +533,135 @@ void DBAdapter::addRawBlock(const RawBlock &block, const BlockId &blockId) {
   }
 }
 
-void DBAdapter::deleteBlock(const BlockId &blockId) { throw std::runtime_error{"Not implemented"}; }
+void DBAdapter::deleteBlock(const BlockId &blockId) {
+  const auto latestBlockId = getLatestBlockId();
+  if (latestBlockId == 0 || blockId > latestBlockId) {
+    return;
+  }
+
+  const auto lastReachableBlockId = getLastReachableBlockId();
+  if (blockId > lastReachableBlockId) {
+    const auto status = db_->del(DBKeyManipulator::generateSTTempBlockKey(blockId));
+    if (!status.isOK() && !status.isNotFound()) {
+      const auto msg = "Failed to delete a temporary state transfer block with ID = " + std::to_string(blockId) +
+                       ", reason: " + status.toString();
+      LOG_ERROR(logger_, msg);
+      throw std::runtime_error{msg};
+    }
+    return;
+  }
+
+  auto keysToDelete = KeysVector{};
+  const auto genesisBlockId = getGenesisBlockId();
+  if (blockId == lastReachableBlockId && blockId == genesisBlockId) {
+    throw std::logic_error{"Deleting the only block in the system is not supported"};
+  } else if (blockId == lastReachableBlockId) {
+    keysToDelete = lastReachableBlockKeyDeletes(blockId);
+  } else if (blockId == genesisBlockId) {
+    keysToDelete = genesisBlockKeyDeletes(blockId);
+  } else {
+    throw std::invalid_argument{"Cannot delete blocks in the middle of the blockchain"};
+  }
+
+  const auto status = db_->multiDel(keysToDelete);
+  if (!status.isOK()) {
+    const auto msg =
+        "Failed to delete blockchain block with ID = " + std::to_string(blockId) + ", reason: " + status.toString();
+    LOG_ERROR(logger_, msg);
+    throw std::runtime_error{msg};
+  }
+}
+
+block::detail::Node DBAdapter::getBlockNode(BlockId blockId) const {
+  const auto blockNodeKey = DBKeyManipulator::genBlockDbKey(blockId);
+  auto blockNodeSliver = Sliver{};
+  const auto status = db_->get(blockNodeKey, blockNodeSliver);
+  if (!status.isOK()) {
+    const auto msg =
+        "Failed to get block node for block ID = " + std::to_string(blockId) + ", reason: " + status.toString();
+    LOG_ERROR(logger_, msg);
+    throw std::runtime_error{msg};
+  }
+  return block::detail::parseNode(blockNodeSliver);
+}
+
+KeysVector DBAdapter::staleIndexKeysForVersion(const Version &version) const {
+  // Rely on the fact that stale keys are ordered lexicographically by version and keys with a version only precede any
+  // real ones (as they are longer). See stale key generation code.
+  return keysForVersion(db_, DBKeyManipulator::genStaleDbKey(version), version, EKeySubtype::Stale, [](const Key &key) {
+    return DBKeyManipulator::extractVersionFromStaleKey(key);
+  });
+}
+
+KeysVector DBAdapter::internalKeysForVersion(const Version &version) const {
+  // Rely on the fact that root internal keys always precede non-root ones - due to lexicographical ordering and root
+  // internal keys having empty nibble paths. See InternalNodeKey serialization code.
+  return keysForVersion(db_,
+                        DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version)),
+                        version,
+                        EKeySubtype::Internal,
+                        [](const Key &key) { return DBKeyManipulator::extractVersionFromInternalKey(key); });
+}
+
+KeysVector DBAdapter::lastReachableBlockKeyDeletes(BlockId blockId) const {
+  const auto blockNode = getBlockNode(blockId);
+  auto keysToDelete = KeysVector{};
+
+  // Delete leaf keys at the last version.
+  for (const auto &key : blockNode.keys) {
+    keysToDelete.push_back(DBKeyManipulator::genDataDbKey(key.first, blockNode.stateRootVersion));
+  }
+
+  // Delete internal keys at the last version.
+  add(keysToDelete, internalKeysForVersion(blockNode.stateRootVersion));
+
+  // Delete the block node key.
+  keysToDelete.push_back(DBKeyManipulator::genBlockDbKey(blockId));
+
+  // Clear the stale index for the last version.
+  add(keysToDelete, staleIndexKeysForVersion(blockNode.stateRootVersion));
+
+  return keysToDelete;
+}
+
+KeysVector DBAdapter::genesisBlockKeyDeletes(BlockId blockId) const {
+  const auto blockNode = getBlockNode(blockId);
+  auto keysToDelete = KeysVector{};
+
+  // Delete the block node key.
+  keysToDelete.push_back(DBKeyManipulator::genBlockDbKey(blockId));
+
+  // Delete stale keys.
+  const auto staleKeys = staleIndexKeysForVersion(blockNode.stateRootVersion);
+  for (const auto &staleKey : staleKeys) {
+    keysToDelete.push_back(DBKeyManipulator::extractKeyFromStaleKey(staleKey));
+  }
+
+  // Clear the stale index for the last version.
+  add(keysToDelete, staleKeys);
+
+  return keysToDelete;
+}
 
 SetOfKeyValuePairs DBAdapter::getBlockData(const RawBlock &rawBlock) const { return block::detail::getData(rawBlock); }
 
 BlockDigest DBAdapter::getParentDigest(const RawBlock &rawBlock) const {
   return block::detail::getParentDigest(rawBlock);
+}
+
+bool DBAdapter::hasBlock(const BlockId &blockId) const {
+  const auto statusNode = db_->has(DBKeyManipulator::genBlockDbKey(blockId));
+  if (statusNode.isNotFound()) {
+    const auto statusSt = db_->has(DBKeyManipulator::generateSTTempBlockKey(blockId));
+    if (statusSt.isNotFound()) {
+      return false;
+    } else if (!statusSt.isOK()) {
+      throw std::runtime_error{"Failed to check for existence of temporary ST block ID = " + std::to_string(blockId)};
+    }
+  } else if (!statusNode.isOK()) {
+    throw std::runtime_error{"Failed to check for existence of block node for block ID = " + std::to_string(blockId)};
+  }
+  return true;
 }
 
 }  // namespace concord::kvbc::v2MerkleTree

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -34,6 +34,16 @@ target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
     stdc++fs
 )
 
+add_executable(sparse_merkle_storage_serialization_unit_test
+    sparse_merkle_storage/serialization_unit_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_test(sparse_merkle_storage_serialization_unit_test sparse_merkle_storage_serialization_unit_test)
+target_link_libraries(sparse_merkle_storage_serialization_unit_test PUBLIC
+    GTest::Main
+    GTest::GTest
+    util
+    kvbc
+)
+
 if(RAPIDCHECK_FOUND)
 add_executable(sparse_merkle_storage_db_adapter_property_test
     sparse_merkle_storage/db_adapter_property_test.cpp $<TARGET_OBJECTS:logging_dev>)

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -1,0 +1,569 @@
+#include "gtest/gtest.h"
+
+#include "storage_test_common.h"
+
+#include "endianness.hpp"
+#include "kv_types.hpp"
+#include "merkle_tree_db_adapter.h"
+#include "merkle_tree_serialization.h"
+#include "sliver.hpp"
+#include "sparse_merkle/base_types.h"
+
+#include <stdint.h>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+using namespace ::concord::kvbc::v2MerkleTree;
+using namespace ::concord::kvbc::v2MerkleTree::detail;
+using namespace ::concord::storage::v2MerkleTree::detail;
+
+using ::concordUtils::Sliver;
+
+using ::concord::kvbc::BlockId;
+using ::concord::kvbc::SetOfKeyValuePairs;
+using ::concord::kvbc::sparse_merkle::BatchedInternalNode;
+using ::concord::kvbc::sparse_merkle::InternalChild;
+using ::concord::kvbc::sparse_merkle::InternalNodeKey;
+using ::concord::kvbc::sparse_merkle::LeafChild;
+using ::concord::kvbc::sparse_merkle::LeafKey;
+using ::concord::kvbc::sparse_merkle::LeafNode;
+using ::concord::kvbc::sparse_merkle::NibblePath;
+using ::concord::kvbc::sparse_merkle::Version;
+
+using ::concord::storage::ObjectId;
+
+Sliver toSliver(std::string b) { return Sliver{std::move(b)}; }
+
+template <typename E>
+std::string serializeEnum(E e) {
+  static_assert(std::is_enum_v<E>);
+  return std::string{static_cast<char>(e)};
+}
+
+template <typename T>
+std::string serializeIntegral(T v) {
+  v = concordUtils::hostToNet(v);
+  const auto data = reinterpret_cast<const char *>(&v);
+  return std::string{data, sizeof(v)};
+}
+
+const auto defaultVersion = Version{42};
+const auto defaultHash = getHash(defaultData);
+const auto defaultHashStrBuf = std::string{reinterpret_cast<const char *>(defaultHash.data()), defaultHash.size()};
+const auto defaultObjectId = ObjectId{42};
+const auto defaultPageId = uint32_t{42};
+const auto defaultChkpt = uint64_t{42};
+const auto defaultDigest = getBlockDigest(defaultData + defaultData);
+
+static_assert(sizeof(EDBKeyType) == 1);
+static_assert(sizeof(EKeySubtype) == 1);
+static_assert(sizeof(EBFTSubtype) == 1);
+static_assert(sizeof(BlockId) == 8);
+static_assert(sizeof(ObjectId) == 4);
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Block: 8, blockId: 64]
+TEST(key_manipulator, block_key) {
+  const auto key = DBKeyManipulator::genBlockDbKey(defaultBlockId);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::Block) + serializeIntegral(defaultBlockId));
+  ASSERT_EQ(key.length(), 1 + sizeof(defaultBlockId));
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Key: 8, EKeySubtype::Leaf: 8, keyHash: 256, keyVersion: 64]
+TEST(key_manipulator, data_key_leaf) {
+  const auto leafKey = LeafKey{defaultHash, defaultVersion};
+  const auto key = DBKeyManipulator::genDataDbKey(leafKey);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Leaf) + defaultHashStrBuf +
+                                 serializeIntegral(leafKey.version().value()));
+  ASSERT_EQ(key.length(), 1 + 1 + 32 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Key: 8, EKeySubtype::Leaf: 8, keyHash: 256, keyVersion: 64]
+TEST(key_manipulator, data_key_sliver) {
+  const auto version = 42ul;
+  const auto key = DBKeyManipulator::genDataDbKey(defaultSliver, version);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Leaf) + defaultHashStrBuf +
+                                 serializeIntegral(version));
+  ASSERT_EQ(key.length(), 1 + 1 + 32 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Key: 8, EKeySubtype::Internal: 8, version: 64, numNibbles: 8, nibbles: 16]
+TEST(key_manipulator, internal_key_even) {
+  auto path = NibblePath{};
+  // first byte of the nibble path is 0x12 (by appending 0x01 and 0x02)
+  path.append(0x01);
+  path.append(0x02);
+  // second byte of the nibble path is 0x34 (by appending 0x03 and 0x04)
+  path.append(0x03);
+  path.append(0x04);
+  const auto internalKey = InternalNodeKey{defaultVersion, path};
+  const auto key = DBKeyManipulator::genInternalDbKey(internalKey);
+  // Expect that two bytes of nibbles have been written.
+  const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
+                                 serializeIntegral(internalKey.version().value()) + serializeIntegral(std::uint8_t{4}) +
+                                 serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x34}));
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Key: 8, EKeySubtype::Internal: 8, version: 64, numNibbles: 8, nibbles: 16]
+TEST(key_manipulator, internal_key_odd) {
+  auto path = NibblePath{};
+  // first byte of the nibble path is 0x12 (by appending 0x01 and 0x02)
+  path.append(0x01);
+  path.append(0x02);
+  // second byte of the nibble path is 0x30 (by appending 0x03)
+  path.append(0x03);
+  const auto internalKey = InternalNodeKey{defaultVersion, path};
+  const auto key = DBKeyManipulator::genInternalDbKey(internalKey);
+  // Expect that two bytes of nibbles have been written.
+  const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
+                                 serializeIntegral(internalKey.version().value()) + serializeIntegral(std::uint8_t{3}) +
+                                 serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x30}));
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::BFT: 8, EBFTSubtype::Metadata: 8, objectId: 32]
+TEST(key_manipulator, metadata_key) {
+  const auto key = DBKeyManipulator::generateMetadataKey(defaultObjectId);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::Metadata) +
+                                 serializeIntegral(defaultObjectId));
+  ASSERT_EQ(key.length(), 1 + 1 + 4);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::BFT: 8, EBFTSubtype::ST: 8, objectId: 32]
+TEST(key_manipulator, st_key) {
+  const auto key = DBKeyManipulator::generateStateTransferKey(defaultObjectId);
+  const auto expected =
+      toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::ST) + serializeIntegral(defaultObjectId));
+  ASSERT_EQ(key.length(), 1 + 1 + 4);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::BFT: 8, EBFTSubtype::STPendingPage: 8, pageId: 32]
+TEST(key_manipulator, st_pending_page_key) {
+  const auto key = DBKeyManipulator::generateSTPendingPageKey(defaultPageId);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::STPendingPage) +
+                                 serializeIntegral(defaultPageId));
+  ASSERT_EQ(key.length(), 1 + 1 + 4);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::BFT: 8, EBFTSubtype::STCheckpointDescriptor: 8, chkpt: 64]
+TEST(key_manipulator, st_chkpt_desc_key) {
+  const auto key = DBKeyManipulator::generateSTCheckpointDescriptorKey(defaultChkpt);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::STCheckpointDescriptor) +
+                                 serializeIntegral(defaultChkpt));
+  ASSERT_EQ(key.length(), 1 + 1 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::BFT: 8, EBFTSubtype::STReservedPageStatic: 8, pageId: 32, chkpt: 64]
+TEST(key_manipulator, st_res_page_static_key) {
+  const auto key = DBKeyManipulator::generateSTReservedPageStaticKey(defaultPageId, defaultChkpt);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::STReservedPageStatic) +
+                                 serializeIntegral(defaultPageId) + serializeIntegral(defaultChkpt));
+  ASSERT_EQ(key.length(), 1 + 1 + 4 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::BFT: 8, EBFTSubtype::STReservedPageDynamic: 8, pageId: 32, chkpt: 64]
+TEST(key_manipulator, st_res_page_dynamic_key) {
+  const auto key = DBKeyManipulator::generateSTReservedPageDynamicKey(defaultPageId, defaultChkpt);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::STReservedPageDynamic) +
+                                 serializeIntegral(defaultPageId) + serializeIntegral(defaultChkpt));
+  ASSERT_EQ(key.length(), 1 + 1 + 4 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::BFT: 8, EBFTSubtype::STTempBlock: 8, blockId: 64]
+TEST(key_manipulator, st_temp_block_key) {
+  const auto key = DBKeyManipulator::generateSTTempBlockKey(defaultBlockId);
+  const auto expected = toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::STTempBlock) +
+                                 serializeIntegral(defaultBlockId));
+  ASSERT_EQ(key.length(), 1 + 1 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Key: 8, EKeySubtype::Stale: 8, staleSinceVersion: 64]
+TEST(key_manipulator, stale_db_key_empty) {
+  const auto key = DBKeyManipulator::genStaleDbKey(defaultVersion);
+  const auto expected =
+      toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Stale) + serializeIntegral(defaultBlockId));
+  ASSERT_EQ(key.length(), 1 + 1 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Key: 8, EKeySubtype::Stale: 8, staleSinceVersion: 64, EDBKeyType::Key: 8, EKeySubtype::internal: 8,
+// internalKeyVersion: 64, numNibbles: 8, nibbles: 16]
+TEST(key_manipulator, stale_db_key_internal) {
+  auto path = NibblePath{};
+  // first byte of the nibble path is 0x12 (by appending 0x01 and 0x02)
+  path.append(0x01);
+  path.append(0x02);
+  // second byte of the nibble path is 0x34 (by appending 0x03 and 0x04)
+  path.append(0x03);
+  path.append(0x04);
+  const auto internalKey = InternalNodeKey{defaultVersion, path};
+  const auto key = DBKeyManipulator::genStaleDbKey(internalKey, defaultVersion);
+  const auto expected =
+      toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Stale) + serializeIntegral(defaultBlockId) +
+               DBKeyManipulator::genInternalDbKey(internalKey).toString());
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 8 + 1 + 2);
+  ASSERT_TRUE(key == expected);
+}
+
+// Expected key structure with respective bit sizes:
+// [EDBKeyType::Key: 8, EKeySubtype::Stale: 8, staleSinceVersion: 64, EDBKeyType::Key: 8, EKeySubtype::Leaf: 8,
+// keyHash: 256, keyVersion: 64]
+TEST(key_manipulator, stale_db_key_leaf) {
+  const auto leafKey = LeafKey{defaultHash, defaultVersion};
+  const auto key = DBKeyManipulator::genStaleDbKey(leafKey, defaultVersion);
+  const auto expected =
+      toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Stale) + serializeIntegral(defaultBlockId) +
+               DBKeyManipulator::genDataDbKey(leafKey).toString());
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 32 + 8);
+  ASSERT_TRUE(key == expected);
+}
+
+TEST(block, key_data_equality) {
+  ASSERT_TRUE(block::detail::KeyData{true} == block::detail::KeyData{true});
+  ASSERT_FALSE(block::detail::KeyData{true} == block::detail::KeyData{false});
+}
+
+TEST(block, block_node_equality) {
+  // Non-key differences.
+  {
+    const auto node1 = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    const auto node2 = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    const auto node3 = block::detail::Node{defaultBlockId + 1, defaultDigest, defaultHash, defaultVersion};
+    const auto node4 = block::detail::Node{defaultBlockId, getBlockDigest("random data"), defaultHash, defaultVersion};
+    const auto node5 = block::detail::Node{defaultBlockId, defaultDigest, getHash("random data2"), defaultVersion};
+    const auto node6 = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion + 1};
+
+    ASSERT_EQ(node1.blockId, node2.blockId);
+    ASSERT_TRUE(node1.parentDigest == node2.parentDigest);
+    ASSERT_TRUE(node1.stateHash == node2.stateHash);
+    ASSERT_TRUE(node1.stateRootVersion == node2.stateRootVersion);
+    ASSERT_TRUE(node1.keys == node2.keys);
+
+    ASSERT_NE(node1.blockId, node3.blockId);
+    ASSERT_TRUE(node1.parentDigest == node3.parentDigest);
+    ASSERT_TRUE(node1.stateHash == node3.stateHash);
+    ASSERT_TRUE(node1.stateRootVersion == node3.stateRootVersion);
+    ASSERT_TRUE(node1.keys == node3.keys);
+
+    ASSERT_EQ(node1.blockId, node4.blockId);
+    ASSERT_FALSE(node1.parentDigest == node4.parentDigest);
+    ASSERT_TRUE(node1.stateHash == node4.stateHash);
+    ASSERT_TRUE(node1.stateRootVersion == node4.stateRootVersion);
+    ASSERT_TRUE(node1.keys == node4.keys);
+
+    ASSERT_EQ(node1.blockId, node5.blockId);
+    ASSERT_TRUE(node1.parentDigest == node5.parentDigest);
+    ASSERT_FALSE(node1.stateHash == node5.stateHash);
+    ASSERT_TRUE(node1.stateRootVersion == node5.stateRootVersion);
+    ASSERT_TRUE(node1.keys == node5.keys);
+
+    ASSERT_EQ(node1.blockId, node6.blockId);
+    ASSERT_TRUE(node1.parentDigest == node6.parentDigest);
+    ASSERT_TRUE(node1.stateHash == node6.stateHash);
+    ASSERT_FALSE(node1.stateRootVersion == node6.stateRootVersion);
+    ASSERT_TRUE(node1.keys == node6.keys);
+
+    ASSERT_TRUE(node1 == node2);
+    ASSERT_FALSE(node1 == node3);
+    ASSERT_FALSE(node1 == node4);
+    ASSERT_FALSE(node1 == node5);
+    ASSERT_FALSE(node1 == node6);
+  }
+
+  // Differences in keys only.
+  {
+    auto node1 = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    auto node2 = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    node2.keys.emplace(defaultSliver, block::detail::KeyData{false});
+    auto node3 = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    node3.keys.emplace(defaultSliver, block::detail::KeyData{true});
+    auto node4 = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    node4.keys.emplace(getSliverOfSize(42), block::detail::KeyData{true});
+
+    ASSERT_FALSE(node1 == node2);
+    ASSERT_FALSE(node1 == node3);
+    ASSERT_FALSE(node2 == node3);
+    ASSERT_FALSE(node3 == node4);
+    ASSERT_FALSE(node2 == node4);
+  }
+}
+
+TEST(block, block_node_serialization) {
+  // No keys.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // 1 non-deleted key.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    node.keys.emplace(defaultSliver, block::detail::KeyData{false});
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // 1 deleted key.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    node.keys.emplace(defaultSliver, block::detail::KeyData{true});
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // Empty key.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    node.keys.emplace(getSliverOfSize(0), block::detail::KeyData{true});
+    node.keys.emplace(getSliverOfSize(1), block::detail::KeyData{true});
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+
+  // Multiple keys with different sizes and deleted flags.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    auto deleted = false;
+    for (auto i = 1u; i <= maxNumKeys; ++i) {
+      node.keys.emplace(getSliverOfSize(i), block::detail::KeyData{deleted});
+      deleted = !deleted;
+    }
+
+    const auto nodeSliver = block::detail::createNode(node);
+    const auto parsedNode = block::detail::parseNode(nodeSliver);
+
+    ASSERT_TRUE(node == parsedNode);
+  }
+}
+
+TEST(block, state_root_deserialization) {
+  // No keys.
+  {
+    const auto node = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    const auto nodeSliver = block::detail::createNode(node);
+    ASSERT_EQ(deserializeStateRootVersion(nodeSliver), defaultVersion);
+  }
+
+  // Multiple keys with different sizes and deleted flags.
+  {
+    auto node = block::detail::Node{defaultBlockId, defaultDigest, defaultHash, defaultVersion};
+    auto deleted = false;
+    for (auto i = 1u; i <= maxNumKeys; ++i) {
+      node.keys.emplace(getSliverOfSize(i), block::detail::KeyData{deleted});
+      deleted = !deleted;
+    }
+    const auto nodeSliver = block::detail::createNode(node);
+    ASSERT_EQ(deserializeStateRootVersion(nodeSliver), defaultVersion);
+  }
+}
+
+TEST(block, block_serialization) {
+  SetOfKeyValuePairs updates;
+  for (auto i = 1u; i <= maxNumKeys; ++i) {
+    updates.emplace(getSliverOfSize(i), getSliverOfSize(i * 10));
+  }
+
+  const auto block = block::detail::create(updates, defaultDigest, defaultHash);
+  const auto parsedUpdates = block::detail::getData(block);
+  const auto parsedDigest = block::detail::getParentDigest(block);
+  const auto parsedStateHash = block::detail::getStateHash(block);
+
+  ASSERT_TRUE(updates == parsedUpdates);
+  ASSERT_TRUE(parsedDigest == defaultDigest);
+  ASSERT_TRUE(defaultHash == parsedStateHash);
+}
+
+// The serialization test doesn't take into account if the test nodes are semantically valid. Instead, it is only
+// focused on serialization/deserialization.
+TEST(batched_internal, serialization) {
+  // No children.
+  {
+    const auto node = BatchedInternalNode{};
+    const auto buf = Sliver{serialize(node)};
+    ASSERT_TRUE(buf.empty());
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(buf) == node);
+  }
+
+  // Full container with LeafChild children.
+  {
+    auto children = BatchedInternalNode::Children{};
+    for (auto &child : children) {
+      child = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    }
+
+    const auto node = BatchedInternalNode{children};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Full container with InternalChild children.
+  {
+    auto children = BatchedInternalNode::Children{};
+    auto count = 0;
+    for (auto &child : children) {
+      child = InternalChild{getHash("InternalChild"), defaultBlockId + count};
+      ++count;
+    }
+
+    const auto node = BatchedInternalNode{children};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Full container with alternating children.
+  {
+    auto children = BatchedInternalNode::Children{};
+    auto internal = false;
+    auto count = 0;
+    for (auto &child : children) {
+      if (internal) {
+        child = InternalChild{getHash("InternalChild" + std::to_string(count)), defaultBlockId + count};
+      } else {
+        child = LeafChild{getHash("LeafChild" + std::to_string(count)),
+                          LeafKey{getHash("LeafKey" + std::to_string(count)), defaultBlockId + count}};
+      }
+      ++count;
+    }
+
+    const auto node = BatchedInternalNode{children};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 LeafChild at the beginning.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[0] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 LeafChild at the end.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[children.size() - 1] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 InternalChild at the beginning.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[0] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 InternalChild at the end.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[children.size() - 1] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 LeafChild at the beginning and one InternalChild at the end.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[0] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    children[children.size() - 1] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // 1 InternalChild at the beginning and one LeafChild at the end.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[0] = InternalChild{getHash("InternalChild"), defaultBlockId};
+    children[children.size() - 1] = LeafChild{getHash("LeafChild"), LeafKey{getHash("LeafKey"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Children in the middle.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[15] = InternalChild{getHash("InternalChild1"), defaultBlockId};
+    children[16] = LeafChild{getHash("LeafChild1"), LeafKey{getHash("LeafKey1"), defaultBlockId}};
+    children[17] = InternalChild{getHash("InternalChild2"), defaultBlockId};
+    children[18] = LeafChild{getHash("LeafChild2"), LeafKey{getHash("LeafKey2"), defaultBlockId}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+
+  // Children at the beginning and end.
+  {
+    auto children = BatchedInternalNode::Children{};
+    children[0] = InternalChild{getHash("InternalChild1"), defaultBlockId + 1};
+    children[1] = LeafChild{getHash("LeafChild1"), LeafKey{getHash("LeafKey1"), defaultBlockId + 2}};
+    children[2] = InternalChild{getHash("InternalChild2"), defaultBlockId + 3};
+    children[3] = LeafChild{getHash("LeafChild2"), LeafKey{getHash("LeafKey2"), defaultBlockId + 4}};
+
+    children[30] = InternalChild{getHash("InternalChild3"), defaultBlockId + 5};
+    children[29] = LeafChild{getHash("LeafChild3"), LeafKey{getHash("LeafKey3"), defaultBlockId + 6}};
+    children[28] = InternalChild{getHash("InternalChild4"), defaultBlockId + 7};
+    children[27] = LeafChild{getHash("LeafChild4"), LeafKey{getHash("LeafKey4"), defaultBlockId + 8}};
+    const auto node = BatchedInternalNode{};
+    ASSERT_TRUE(deserialize<BatchedInternalNode>(serialize(node)) == node);
+  }
+}
+
+TEST(database_leaf_value, serialization) {
+  // Non-empty value.
+  {
+    const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}};
+    ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
+  }
+
+  // Empty value.
+  {
+    const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{Sliver{}}};
+    ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
+  }
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/kvbc/test/sparse_merkle_storage/storage_test_common.h
+++ b/kvbc/test/sparse_merkle_storage/storage_test_common.h
@@ -8,8 +8,11 @@
 #include "kv_types.hpp"
 #include "memorydb/client.h"
 #include "rocksdb/client.h"
+#include "sliver.hpp"
+#include "sparse_merkle/base_types.h"
 #include "storage/db_interface.h"
 
+#include <cstdint>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -47,7 +50,9 @@ inline ::concord::kvbc::BlockDigest blockDigest(concord::kvbc::BlockId blockId, 
 struct TestMemoryDb {
   static std::shared_ptr<concord::storage::IDBClient> create() {
     cleanup();
-    return std::make_shared<concord::storage::memorydb::Client>();
+    auto db = std::make_shared<concord::storage::memorydb::Client>();
+    db->init();
+    return db;
   }
 
   static std::string type() { return "memorydb"; }
@@ -58,7 +63,9 @@ struct TestRocksDb {
   static std::shared_ptr<::concord::storage::IDBClient> create() {
     cleanup();
     // Create the RocksDB client with the default lexicographical comparator.
-    return std::make_shared<::concord::storage::rocksdb::Client>(rocksDbPath());
+    auto db = std::make_shared<::concord::storage::rocksdb::Client>(rocksDbPath());
+    db->init();
+    return db;
   }
 
   static std::string type() { return "RocksDB"; }
@@ -78,3 +85,21 @@ struct TypePrinter {
     return info.param->type();
   }
 };
+
+inline auto getHash(const std::string &str) {
+  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
+  return hasher.hash(str.data(), str.size());
+}
+
+inline auto getHash(const concordUtils::Sliver &sliver) {
+  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
+  return hasher.hash(sliver.data(), sliver.length());
+}
+
+inline auto getBlockDigest(const std::string &data) { return getHash(data).dataArray(); }
+inline concordUtils::Sliver getSliverOfSize(std::size_t size, char content = 'a') { return std::string(size, content); }
+
+inline const auto defaultBlockId = ::concord::kvbc::BlockId{42};
+inline const auto defaultData = std::string{"defaultData"};
+inline const auto defaultSliver = concordUtils::Sliver::copy(defaultData.c_str(), defaultData.size());
+inline const auto maxNumKeys = 16u;

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -70,7 +70,7 @@ class Client : public IDBClient {
         comp_(comp),
         map_([this](const Sliver &a, const Sliver &b) { return comp_(a, b); }) {}
 
-  void init(bool readOnly) override;
+  void init(bool readOnly = false) override;
   concordUtils::Status get(const Sliver &_key, OUT Sliver &_outValue) const override;
   concordUtils::Status get(const Sliver &_key, OUT char *&buf, uint32_t bufSize, OUT uint32_t &_size) const override;
   concordUtils::Status has(const Sliver &_key) const override;

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -163,6 +163,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
 std::tuple<std::shared_ptr<concord::storage::IDBClient>, IDbAdapter*> TestSetup::get_inmem_db_configuration() {
   auto comparator = concord::storage::memorydb::KeyComparator(new DBKeyComparator());
   std::shared_ptr<concord::storage::IDBClient> db = std::make_shared<concord::storage::memorydb::Client>(comparator);
+  db->init();
   return std::make_tuple(db, new DBAdapter{db});
 }
 /** Get replica db configuration


### PR DESCRIPTION
Add support for block deletion in the merkle DB adapter. In general,
there are 3 main cases:
 * deleting the genesis block - after execution, the folliwng keys are
   deleted:
   - block node key
   - stale internal and leaf keys
   - stale index keys that represent the stale keys (cleaning the index)
 * deleting the last reachable block - after execution, all keys that
   were written when creating the block are deleted (i.e. as if this
   block was never added):
   - block node key
   - leaf keys that were generated from the keys in the block
   - internal keys that were generated from the keys in the block
   - stale index keys that were generated when creating the block
 * deleting temporary state transfer blocks - delete the single key that
   holds the raw block. Used by state transfer.

An important thing to note is that deleting the genesis block doesn't
delete its keys - they can be accessible until they are deleted as stale
in a subsequent delete call. A consequence from this fact is that the
DBAdapter::getValue() method can now return values for blocks that have
been deleted. In addition, the returned verison can also be a deleted
block version.

Deleting the only block in the blockchain is not supported. This is done
in order to preserve block ordering and prevent the creation of multiple
blocks with the same ID.

Since the genesis block ID can now change, support the
IDbAdapter::getGenesisBlockId() method in both DB adapters.

Remove the StaleKeyType enum and serialize the key contained in a stale
index key with the normal hierarchical structure - a EDBKeyType byte
and a EKeySubtype one.

Provide more methods for key manipulation in DBKeyManipulator. Also,
expose internal getters for key types for use in testing. The
DBKeyManipulator class will be simplified and split (or possibly
removed) in a future commit.

The merkle DBAdapter no longer initializes the passed database client.
Instead, it expects that the client is initialized beforehand. That is
done in order to mimic the behavior of the direct KV DBAdapter.

Split serialization unit tests from the DBAdapter unit test.

Provide unit tests for block deletion. Additionally, provide initial
property tests. Further property tests will be added in a future commit.