### PR TITLE
Replaced maxSizeOf.*MsgInLocalBuffer with maxMessageSizeInLocalBuffer

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
@@ -62,7 +62,7 @@ struct DescriptorOfLastExitFromView {
     uint32_t elementsNum;
     uint8_t msgFilledFlag;
     return (sizeof(view) + sizeof(lastStable) + sizeof(lastExecuted) + sizeof(stableLowerBoundWhenEnteredToView) +
-            sizeof(msgFilledFlag) + ViewChangeMsg::maxSizeOfViewChangeMsgInLocalBuffer() + sizeof(elementsNum));
+            sizeof(msgFilledFlag) + maxMessageSizeInLocalBuffer<ViewChangeMsg>() + sizeof(elementsNum));
   }
 
   static uint32_t maxElementSize() {
@@ -131,13 +131,13 @@ struct DescriptorOfLastNewView {
   static uint32_t simpleParamsSize() {
     uint8_t msgFilledFlag;
     return (sizeof(view) + sizeof(maxSeqNumTransferredFromPrevViews) + 2 * sizeof(msgFilledFlag) +
-            sizeof(stableLowerBoundWhenEnteredToView) + NewViewMsg::maxSizeOfNewViewMsgInLocalBuffer() +
-            ViewChangeMsg::maxSizeOfViewChangeMsgInLocalBuffer());
+            sizeof(stableLowerBoundWhenEnteredToView) + maxMessageSizeInLocalBuffer<NewViewMsg>() +
+            maxMessageSizeInLocalBuffer<ViewChangeMsg>());
   }
 
   static uint32_t maxElementSize() {
     uint8_t msgFilledFlag;
-    return sizeof(msgFilledFlag) + ViewChangeMsg::maxSizeOfViewChangeMsgInLocalBuffer();
+    return sizeof(msgFilledFlag) + maxMessageSizeInLocalBuffer<ViewChangeMsg>();
   }
 
   static uint32_t maxSize(uint32_t numOfReplicas) { return simpleParamsSize() + maxElementSize() * numOfReplicas; }

--- a/bftengine/src/bftengine/PersistentStorageWindows.cpp
+++ b/bftengine/src/bftengine/PersistentStorageWindows.cpp
@@ -13,6 +13,8 @@
 
 #include "PersistentStorageWindows.hpp"
 
+static constexpr size_t EMPTY_MESSAGE_FLAG_SIZE = sizeof(bool);
+
 namespace bftEngine {
 namespace impl {
 
@@ -108,28 +110,24 @@ bool SeqNumData::equals(const SeqNumData &other) const {
 }
 
 uint32_t SeqNumData::maxSize() {
-  return (maxPrePrepareMsgSize() + maxFullCommitProofMsgSize() + maxPrepareFullMsgSize() + maxCommitFullMsgSize() +
-          sizeof(slowStarted_) + sizeof(forceCompleted_));
+  return maxPrePrepareMsgSize() + maxFullCommitProofMsgSize() + maxPrepareFullMsgSize() + maxCommitFullMsgSize() +
+         sizeof(slowStarted_) + sizeof(forceCompleted_);
 }
 
 uint32_t SeqNumData::maxPrePrepareMsgSize() {
-  bool msgEmptyFlag;
-  return (PrePrepareMsg::maxSizeOfPrePrepareMsgInLocalBuffer() + sizeof(msgEmptyFlag));
+  return maxMessageSizeInLocalBuffer<PrePrepareMsg>() + EMPTY_MESSAGE_FLAG_SIZE;
 }
 
 uint32_t SeqNumData::maxFullCommitProofMsgSize() {
-  bool msgEmptyFlag;
-  return (FullCommitProofMsg::maxSizeOfFullCommitProofMsgInLocalBuffer() + sizeof(msgEmptyFlag));
+  return maxMessageSizeInLocalBuffer<FullCommitProofMsg>() + EMPTY_MESSAGE_FLAG_SIZE;
 }
 
 uint32_t SeqNumData::maxPrepareFullMsgSize() {
-  bool msgEmptyFlag;
-  return (PrepareFullMsg::maxSizeOfPrepareFullInLocalBuffer() + sizeof(msgEmptyFlag));
+  return maxMessageSizeInLocalBuffer<PrepareFullMsg>() + EMPTY_MESSAGE_FLAG_SIZE;
 }
 
 uint32_t SeqNumData::maxCommitFullMsgSize() {
-  bool msgEmptyFlag;
-  return (CommitFullMsg::maxSizeOfCommitFullInLocalBuffer() + sizeof(msgEmptyFlag));
+  return maxMessageSizeInLocalBuffer<CommitFullMsg>() + EMPTY_MESSAGE_FLAG_SIZE;
 }
 
 /*****************************************************************************/
@@ -194,7 +192,7 @@ uint32_t CheckData::maxSize() { return (maxCheckpointMsgSize() + sizeof(complete
 
 uint32_t CheckData::maxCheckpointMsgSize() {
   bool msgEmptyFlag;
-  return (CheckpointMsg::maxSizeOfCheckpointMsgInLocalBuffer() + sizeof(msgEmptyFlag));
+  return maxMessageSizeInLocalBuffer<CheckpointMsg>() + sizeof(msgEmptyFlag);
 }
 
 }  // namespace impl

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -38,8 +38,8 @@ bool ViewsManager::PrevViewInfo::equals(const PrevViewInfo& other) const {
 }
 
 uint32_t ViewsManager::PrevViewInfo::maxSize() {
-  return (PrePrepareMsg::maxSizeOfPrePrepareMsgInLocalBuffer() + PrepareFullMsg::maxSizeOfPrepareFullInLocalBuffer() +
-          sizeof(hasAllRequests));
+  return maxMessageSizeInLocalBuffer<PrePrepareMsg>() + maxMessageSizeInLocalBuffer<PrepareFullMsg>() +
+         sizeof(hasAllRequests);
 }
 
 ViewsManager::ViewsManager(const ReplicasInfo* const r,

--- a/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
@@ -19,10 +19,6 @@ namespace bftEngine::impl {
 
 class AskForCheckpointMsg : public MessageBase {
  public:
-  static MsgSize maxSizeOfAskForCheckpointMsgInLocalBuffer() {
-    return maxMessageSize<AskForCheckpointMsg>() + sizeof(RawHeaderOfObjAndMsg);
-  }
-
   AskForCheckpointMsg(ReplicaId senderId, const std::string& spanContext = "")
       : MessageBase(senderId, MsgCode::AskForCheckpoint, spanContext.size(), sizeof(Header)) {
     char* position = body() + sizeof(Header);

--- a/bftengine/src/bftengine/messages/CheckpointMsg.cpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.cpp
@@ -36,9 +36,5 @@ void CheckpointMsg::validate(const ReplicasInfo& repInfo) const {
   // TODO(GG): consider to protect against messages that are larger than needed (here and in other messages)
 }
 
-MsgSize CheckpointMsg::maxSizeOfCheckpointMsgInLocalBuffer() {
-  return maxMessageSize<CheckpointMsg>() + sizeof(RawHeaderOfObjAndMsg);
-}
-
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.hpp
@@ -19,8 +19,6 @@ namespace impl {
 
 class CheckpointMsg : public MessageBase {
  public:
-  static MsgSize maxSizeOfCheckpointMsgInLocalBuffer();
-
   CheckpointMsg(ReplicaId senderId,
                 SeqNum seqNum,
                 const Digest& stateDigest,

--- a/bftengine/src/bftengine/messages/FullCommitProofMsg.cpp
+++ b/bftengine/src/bftengine/messages/FullCommitProofMsg.cpp
@@ -40,9 +40,5 @@ void FullCommitProofMsg::validate(const ReplicasInfo& repInfo) const {
   // TODO(GG): TBD - check something about the collectors identity (and in other similar messages)
 }
 
-MsgSize FullCommitProofMsg::maxSizeOfFullCommitProofMsgInLocalBuffer() {
-  return maxMessageSize<FullCommitProofMsg>() + sizeof(RawHeaderOfObjAndMsg);
-}
-
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/FullCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/messages/FullCommitProofMsg.hpp
@@ -19,8 +19,6 @@ namespace impl {
 // TODO(GG): use SignedShareBase
 class FullCommitProofMsg : public MessageBase {
  public:
-  static MsgSize maxSizeOfFullCommitProofMsgInLocalBuffer();
-
   FullCommitProofMsg(ReplicaId senderId,
                      ViewNum v,
                      SeqNum s,

--- a/bftengine/src/bftengine/messages/MessageBase.hpp
+++ b/bftengine/src/bftengine/messages/MessageBase.hpp
@@ -99,6 +99,9 @@ class MessageBase {
   template <typename MessageT>
   friend MsgSize maxMessageSize();
 
+  template <typename MessageT>
+  friend MsgSize maxMessageSizeInLocalBuffer();
+
   static constexpr uint64_t SPAN_CONTEXT_MAX_SIZE{1024};
 #pragma pack(push, 1)
   struct RawHeaderOfObjAndMsg {
@@ -118,6 +121,11 @@ size_t sizeOfHeader() {
 template <typename MessageT>
 MsgSize maxMessageSize() {
   return sizeOfHeader<MessageT>() + MessageBase::SPAN_CONTEXT_MAX_SIZE;
+}
+
+template <typename MessageT>
+MsgSize maxMessageSizeInLocalBuffer() {
+  return maxMessageSize<MessageT>() + sizeof(MessageBase::RawHeaderOfObjAndMsg);
 }
 
 }  // namespace impl

--- a/bftengine/src/bftengine/messages/NewViewMsg.cpp
+++ b/bftengine/src/bftengine/messages/NewViewMsg.cpp
@@ -101,9 +101,5 @@ bool NewViewMsg::includesViewChangeFromReplica(ReplicaId replicaId, const Digest
   return false;
 }
 
-MsgSize NewViewMsg::maxSizeOfNewViewMsgInLocalBuffer() {
-  return maxMessageSize<NewViewMsg>() + sizeof(RawHeaderOfObjAndMsg);
-}
-
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/messages/NewViewMsg.hpp
@@ -20,8 +20,6 @@ namespace impl {
 
 class NewViewMsg : public MessageBase {
  public:
-  static MsgSize maxSizeOfNewViewMsgInLocalBuffer();
-
   NewViewMsg(ReplicaId senderId, ViewNum newView, const std::string& spanContext = "");
 
   void addElement(ReplicaId replicaId, Digest& viewChangeDigest);

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
@@ -26,10 +26,6 @@ static Digest nullDigest(0x18);
 // PrePrepareMsg
 ///////////////////////////////////////////////////////////////////////////////
 
-MsgSize PrePrepareMsg::maxSizeOfPrePrepareMsgInLocalBuffer() {
-  return maxMessageSize<PrePrepareMsg>() + sizeof(RawHeaderOfObjAndMsg);
-}
-
 PrePrepareMsg* PrePrepareMsg::createNullPrePrepareMsg(
     ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, const std::string& spanContext) {
   PrePrepareMsg* p = new PrePrepareMsg(sender, v, s, firstPath, spanContext, true);

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -54,8 +54,6 @@ class PrePrepareMsg : public MessageBase {
  public:
   // static
 
-  static MsgSize maxSizeOfPrePrepareMsgInLocalBuffer();
-
   static PrePrepareMsg* createNullPrePrepareMsg(ReplicaId sender,
                                                 ViewNum v,
                                                 SeqNum s,

--- a/bftengine/src/bftengine/messages/SignedShareMsgs.cpp
+++ b/bftengine/src/bftengine/messages/SignedShareMsgs.cpp
@@ -108,10 +108,6 @@ void PreparePartialMsg::validate(const ReplicasInfo& repInfo) const {
 // PrepareFullMsg
 ///////////////////////////////////////////////////////////////////////////////
 
-MsgSize PrepareFullMsg::maxSizeOfPrepareFullInLocalBuffer() {
-  return maxMessageSize<PrepareFullMsg>() + sizeof(RawHeaderOfObjAndMsg);
-}
-
 PrepareFullMsg* PrepareFullMsg::create(
     ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext) {
   return (PrepareFullMsg*)SignedShareBase::create(MsgCode::PrepareFull, v, s, senderId, sig, sigLen, spanContext);
@@ -145,10 +141,6 @@ void CommitPartialMsg::validate(const ReplicasInfo& repInfo) const {
 ///////////////////////////////////////////////////////////////////////////////
 // CommitFullMsg
 ///////////////////////////////////////////////////////////////////////////////
-
-MsgSize CommitFullMsg::maxSizeOfCommitFullInLocalBuffer() {
-  return maxMessageSize<CommitFullMsg>() + sizeof(RawHeaderOfObjAndMsg);
-}
 
 CommitFullMsg* CommitFullMsg::create(
     ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext) {

--- a/bftengine/src/bftengine/messages/SignedShareMsgs.hpp
+++ b/bftengine/src/bftengine/messages/SignedShareMsgs.hpp
@@ -99,7 +99,6 @@ class PrepareFullMsg : public SignedShareBase {
   friend MsgSize maxMessageSize();
 
  public:
-  static MsgSize maxSizeOfPrepareFullInLocalBuffer();
   static PrepareFullMsg* create(
       ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext = "");
   void validate(const ReplicasInfo&) const override;
@@ -140,7 +139,6 @@ class CommitFullMsg : public SignedShareBase {
   friend MsgSize maxMessageSize();
 
  public:
-  static MsgSize maxSizeOfCommitFullInLocalBuffer();
   static CommitFullMsg* create(
       ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext = "");
   void validate(const ReplicasInfo&) const override;

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
@@ -266,9 +266,5 @@ bool ViewChangeMsg::ElementsIterator::goToAtLeast(SeqNum lowerBound) {
   return validElement;
 }
 
-MsgSize ViewChangeMsg::maxSizeOfViewChangeMsgInLocalBuffer() {
-  return maxMessageSize<ViewChangeMsg>() + sizeof(RawHeaderOfObjAndMsg);
-}
-
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
@@ -40,8 +40,6 @@ class ViewChangeMsg : public MessageBase {
 
   ViewChangeMsg(ReplicaId srcReplicaId, ViewNum newView, SeqNum lastStableSeq, const std::string& spanContext = "");
 
-  static MsgSize maxSizeOfViewChangeMsgInLocalBuffer();
-
   void setNewViewNumber(ViewNum newView);
 
   uint16_t idOfGeneratedReplica() const {


### PR DESCRIPTION
The PR replaces all the functions `maxSizeOf.*MsgInLocalBuffer` with a template function `maxMessageSizeInLocalBuffer`