### PR TITLE
add phase-1 metrics (partially)

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -264,7 +264,10 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
     if (minBatchSize > maxReasonableMinBatchSize) minBatchSize = maxReasonableMinBatchSize;
   }
 
-  if (requestsInQueue < minBatchSize) return;
+  if (requestsInQueue < minBatchSize) {
+    metric_not_enough_client_requests_event_.Get().Inc();
+    return;
+  }
 
   // update batchingFactor
   if (((primaryLastUsedSeqNum + 1) % kWorkWindowSize) ==
@@ -1490,6 +1493,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
       // TODO(GG): warning
     } else {
       send(checkMsg, msgSenderId);
+      metric_sent_checkpoint_msg_due_to_status_.Get().Inc();
     }
 
     delete msg;
@@ -1509,7 +1513,10 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
 
       for (SeqNum i = beginRange; i <= endRange; i = i + checkpointWindowSize) {
         CheckpointMsg *checkMsg = checkpointsLog->get(i).selfCheckpointMsg();
-        if (checkMsg != nullptr) send(checkMsg, msgSenderId);
+        if (checkMsg != nullptr) {
+          send(checkMsg, msgSenderId);
+          metric_sent_checkpoint_msg_due_to_status_.Get().Inc();
+        }
       }
     }
   }
@@ -1522,6 +1529,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
     ViewChangeMsg *myVC = viewsManager->getMyLatestViewChangeMsg();
     Assert(myVC != nullptr);  // because curView>0
     send(myVC, msgSenderId);
+    metric_sent_viewchange_msg_due_to_status_.Get().Inc();
   }
 
   /////////////////////////////////////////////////////////////////////////
@@ -1539,6 +1547,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
           ViewChangeMsg *myVC = viewsManager->getMyLatestViewChangeMsg();
           Assert(myVC != nullptr);
           send(myVC, msgSenderId);
+          metric_sent_viewchange_msg_due_to_status_.Get().Inc();
         }
       } else  // I am the primary of curView
       {
@@ -1547,6 +1556,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
           NewViewMsg *nv = viewsManager->getMyNewViewMsgForCurrentView();
           Assert(nv != nullptr);
           send(nv, msgSenderId);
+          metric_sent_newview_msg_due_to_status_.Get().Inc();
         }
 
         // send ViewChangeMsg
@@ -1555,6 +1565,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
           ViewChangeMsg *myVC = viewsManager->getMyLatestViewChangeMsg();
           Assert(myVC != nullptr);
           send(myVC, msgSenderId);
+          metric_sent_viewchange_msg_due_to_status_.Get().Inc();
         }
         // TODO(GG): send all VC msgs that can help making progress (needed because the original senders may not send
         // the ViewChangeMsg msgs used by the primary)
@@ -1568,7 +1579,10 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
           for (SeqNum i = msgLastStable + 1; i <= msgLastStable + kWorkWindowSize; i++) {
             if (mainLog->insideActiveWindow(i) && msg->isMissingPrePrepareMsgForViewChange(i)) {
               PrePrepareMsg *prePrepareMsg = mainLog->get(i).getPrePrepareMsg();
-              if (prePrepareMsg != nullptr) send(prePrepareMsg, msgSenderId);
+              if (prePrepareMsg != nullptr) {
+                send(prePrepareMsg, msgSenderId);
+                metric_sent_preprepare_msg_due_to_status_.Get().Inc();
+              }
             }
           }
         }
@@ -1580,7 +1594,10 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
               PrePrepareMsg *prePrepareMsg =
                   viewsManager->getPrePrepare(i);  // TODO(GG): we can avoid sending misleading message by using the
                                                    // digest of the expected pre prepare message
-              if (prePrepareMsg != nullptr) send(prePrepareMsg, msgSenderId);
+              if (prePrepareMsg != nullptr) {
+                send(prePrepareMsg, msgSenderId);
+                metric_sent_preprepare_msg_due_to_status_.Get().Inc();
+              }
             }
           }
         }
@@ -1605,7 +1622,10 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
           if (msg->isPrePrepareInActiveWindow(i)) continue;
 
           PrePrepareMsg *prePrepareMsg = mainLog->get(i).getSelfPrePrepareMsg();
-          if (prePrepareMsg != 0) send(prePrepareMsg, msgSenderId);
+          if (prePrepareMsg != nullptr) {
+            send(prePrepareMsg, msgSenderId);
+            metric_sent_preprepare_msg_due_to_status_.Get().Inc();
+          }
         }
       } else {
         tryToSendStatusReport();
@@ -1626,7 +1646,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
   delete msg;
 }
 
-void ReplicaImp::tryToSendStatusReport() {
+void ReplicaImp::tryToSendStatusReport(bool onTimer) {
   // TODO(GG): in some cases, we can limit the amount of such messages by using information about
   // connection/disconnection (from the communication module)
   // TODO(GG): explain that the current "Status Report" approch is relatively simple (it can be more efficient and
@@ -1686,6 +1706,7 @@ void ReplicaImp::tryToSendStatusReport() {
   }
 
   sendToAllOtherReplicas(&msg);
+  if (!onTimer) metric_sent_status_msgs_not_due_timer_.Get().Inc();
 }
 
 template <>
@@ -2322,6 +2343,7 @@ void ReplicaImp::tryToSendReqMissingDataMsg(SeqNum seqNumber, bool slowPathOnly,
                (unsigned int)reqData.getFlags());
 
     send(&reqData, destRep);
+    metric_sent_req_for_missing_data_.Get().Inc();
   }
 }
 
@@ -2345,12 +2367,16 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
     if (config_.replicaId == currentPrimary()) {
       PrePrepareMsg *pp = seqNumInfo.getSelfPrePrepareMsg();
       if (msg->getPrePrepareIsMissing()) {
-        if (pp != 0) send(pp, msgSender);
+        if (pp != nullptr) {
+          send(pp, msgSender);
+          metric_sent_preprepare_msg_due_to_reqMissingData_.Get().Inc();
+        }
       }
 
       if (seqNumInfo.slowPathStarted() && !msg->getSlowPathHasStarted()) {
         StartSlowCommitMsg startSlowMsg(config_.replicaId, curView, msgSeqNum);
         send(&startSlowMsg, msgSender);
+        metric_sent_startSlowPath_msg_due_to_reqMissingData_.Get().Inc();
       }
     }
 
@@ -2359,34 +2385,50 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
 
       PartialCommitProofMsg *pcf = seqNumInfo.partialProofs().getSelfPartialCommitProof();
 
-      if (pcf != nullptr) send(pcf, msgSender);
+      if (pcf != nullptr) {
+        send(pcf, msgSender);
+        metric_sent_partialCommitProof_msg_due_to_reqMissingData_.Get().Inc();
+      }
     }
 
     if (msg->getPartialPrepareIsMissing() && (currentPrimary() == msgSender)) {
       PreparePartialMsg *pr = seqNumInfo.getSelfPreparePartialMsg();
 
-      if (pr != nullptr) send(pr, msgSender);
+      if (pr != nullptr) {
+        send(pr, msgSender);
+        metric_sent_preparePartial_msg_due_to_reqMissingData_.Get().Inc();
+      }
     }
 
     if (msg->getFullPrepareIsMissing()) {
       PrepareFullMsg *pf = seqNumInfo.getValidPrepareFullMsg();
 
-      if (pf != nullptr) send(pf, msgSender);
+      if (pf != nullptr) {
+        send(pf, msgSender);
+        metric_sent_prepareFull_msg_due_to_reqMissingData_.Get().Inc();
+      }
     }
 
     if (msg->getPartialCommitIsMissing() && (currentPrimary() == msgSender)) {
       CommitPartialMsg *c = mainLog->get(msgSeqNum).getSelfCommitPartialMsg();
-      if (c != nullptr) send(c, msgSender);
+      if (c != nullptr) {
+        send(c, msgSender);
+        metric_sent_commitPartial_msg_due_to_reqMissingData_.Get().Inc();
+      }
     }
 
     if (msg->getFullCommitIsMissing()) {
       CommitFullMsg *c = mainLog->get(msgSeqNum).getValidCommitFullMsg();
-      if (c != nullptr) send(c, msgSender);
+      if (c != nullptr) {
+        send(c, msgSender);
+        metric_sent_commitFull_msg_due_to_reqMissingData_.Get().Inc();
+      }
     }
 
     if (msg->getFullCommitProofIsMissing() && seqNumInfo.partialProofs().hasFullProof()) {
       FullCommitProofMsg *fcp = seqNumInfo.partialProofs().getFullProof();
       send(fcp, msgSender);
+      metric_sent_fullCommitProof_msg_due_to_reqMissingData_.Get().Inc();
     }
   } else {
     LOG_INFO_F(
@@ -2486,7 +2528,7 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
 }
 
 void ReplicaImp::onStatusReportTimer(Timers::Handle timer) {
-  tryToSendStatusReport();
+  tryToSendStatusReport(true);
 
 #ifdef DEBUG_MEMORY_MSG
   MessageBase::printLiveMessages();
@@ -2806,7 +2848,30 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_received_view_changes_{metrics_.RegisterCounter("receivedViewChangeMsgs")},
       metric_received_new_views_{metrics_.RegisterCounter("receivedNewViewMsgs")},
       metric_received_req_missing_datas_{metrics_.RegisterCounter("receivedReqMissingDataMsgs")},
-      metric_received_simple_acks_{metrics_.RegisterCounter("receivedSimpleAckMsgs")} {
+      metric_received_simple_acks_{metrics_.RegisterCounter("receivedSimpleAckMsgs")},
+      metric_sent_status_msgs_not_due_timer_{metrics_.RegisterCounter("sentStatusMsgsNotDueTime")},
+      metric_sent_req_for_missing_data_{metrics_.RegisterCounter("sentReqForMissingData")},
+      metric_sent_checkpoint_msg_due_to_status_{metrics_.RegisterCounter("sentCheckpointMsgDueToStatus")},
+      metric_sent_viewchange_msg_due_to_status_{metrics_.RegisterCounter("sentViewChangeMsgDueToTimer")},
+      metric_sent_newview_msg_due_to_status_{metrics_.RegisterCounter("sentNewviewMsgDueToCounter")},
+      metric_sent_preprepare_msg_due_to_status_{metrics_.RegisterCounter("sentPreprepareMsgDueToStatus")},
+      metric_sent_preprepare_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentPreprepareMsgDueToReqMissingData")},
+      metric_sent_startSlowPath_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentStartSlowPathMsgDueToReqMissingData")},
+      metric_sent_partialCommitProof_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentPartialCommitProofMsgDueToReqMissingData")},
+      metric_sent_preparePartial_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentPrepreparePartialMsgDueToReqMissingData")},
+      metric_sent_prepareFull_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentPrepareFullMsgDueToReqMissingData")},
+      metric_sent_commitPartial_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentCommitPartialMsgDueToRewMissingData")},
+      metric_sent_commitFull_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentCommitFullMsgDueToReqMissingData")},
+      metric_sent_fullCommitProof_msg_due_to_reqMissingData_{
+          metrics_.RegisterCounter("sentFullCommitProofMsgDueToReqMissingData")},
+      metric_not_enough_client_requests_event_{metrics_.RegisterCounter("notEnoughClientRequestsEvent")} {
   Assert(config_.replicaId < config_.numReplicas);
   // TODO(GG): more asserts on params !!!!!!!!!!!
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -179,6 +179,21 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_received_new_views_;
   CounterHandle metric_received_req_missing_datas_;
   CounterHandle metric_received_simple_acks_;
+  CounterHandle metric_sent_status_msgs_not_due_timer_;
+  CounterHandle metric_sent_req_for_missing_data_;
+  CounterHandle metric_sent_checkpoint_msg_due_to_status_;
+  CounterHandle metric_sent_viewchange_msg_due_to_status_;
+  CounterHandle metric_sent_newview_msg_due_to_status_;
+  CounterHandle metric_sent_preprepare_msg_due_to_status_;
+  CounterHandle metric_sent_preprepare_msg_due_to_reqMissingData_;
+  CounterHandle metric_sent_startSlowPath_msg_due_to_reqMissingData_;
+  CounterHandle metric_sent_partialCommitProof_msg_due_to_reqMissingData_;
+  CounterHandle metric_sent_preparePartial_msg_due_to_reqMissingData_;
+  CounterHandle metric_sent_prepareFull_msg_due_to_reqMissingData_;
+  CounterHandle metric_sent_commitPartial_msg_due_to_reqMissingData_;
+  CounterHandle metric_sent_commitFull_msg_due_to_reqMissingData_;
+  CounterHandle metric_sent_fullCommitProof_msg_due_to_reqMissingData_;
+  CounterHandle metric_not_enough_client_requests_event_;
   //*****************************************************
  public:
   ReplicaImp(const ReplicaConfig&,
@@ -246,7 +261,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void MoveToHigherView(ViewNum nextView);  // also sends the ViewChangeMsg message
   void GotoNextView();
 
-  void tryToSendStatusReport();
+  void tryToSendStatusReport(bool onTimer = false);
   void tryToSendReqMissingDataMsg(SeqNum seqNumber,
                                   bool slowPathOnly = false,
                                   uint16_t destReplicaId = ALL_OTHER_REPLICAS);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -255,6 +255,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void messageHandler(MessageBase* msg);
 
   void send(MessageBase*, NodeIdType) override;
+  void sendAndIncrementMetric(MessageBase*, NodeIdType, CounterHandle&);
 
   bool tryToEnterView();
   void onNewView(const std::vector<PrePrepareMsg*>& prePreparesForNewView);


### PR DESCRIPTION
Add new metrics to implement phase1 matrics plan.

We have added metrics that count the number of sent status messages and reqMissingData messages as well as counters for the messages that are being sent as a response for status and ReqMissingData.
see BC-2318 on jira