### PR TITLE
Add metrics for phase1 - client metrics

### DIFF
--- a/kvbc/include/ClientImp.h
+++ b/kvbc/include/ClientImp.h
@@ -35,6 +35,8 @@ class ClientImp : public IClient {
                                     uint32_t* outActualReplySize,
                                     const std::string& = "") override;
 
+  virtual void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override;
+
  protected:
   ClientImp() = default;
   ~ClientImp() override = default;

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -67,6 +67,8 @@ class IClient {
                                     char* outReply,
                                     uint32_t* outActualReplySize,
                                     const std::string& cid = "") = 0;
+
+  virtual void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) = 0;
 };
 
 // creates a new Client object

--- a/kvbc/src/ClientImp.cpp
+++ b/kvbc/src/ClientImp.cpp
@@ -81,5 +81,8 @@ Status ClientImp::invokeCommandSynch(const char* request,
   else
     return Status::InvalidArgument("small buffer");
 }
+void ClientImp::setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
+  bftClient_->setAggregator(aggregator);
+}
 }  // namespace kvbc
 }  // namespace concord


### PR DESCRIPTION
In this PR we have added a metrics framework to the bft client, including two metrics:
1. number of retransmission per client
2. the retransmission timer

Note that different clients can't use the same aggregator.