### PR TITLE
Add metrics functionality

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2866,7 +2866,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
           metrics_.RegisterCounter("sentCommitFullMsgDueToReqMissingData")},
       metric_sent_fullCommitProof_msg_due_to_reqMissingData_{
           metrics_.RegisterCounter("sentFullCommitProofMsgDueToReqMissingData")},
-      metric_not_enough_client_requests_event_{metrics_.RegisterCounter("notEnoughClientRequestsEvent")} {
+      metric_not_enough_client_requests_event_{metrics_.RegisterCounter("notEnoughClientRequestsEvent")},
+      metric_total_finished_consensuses_{metrics_.RegisterCounter("totalOrderedRequests")} {
   Assert(config_.replicaId < config_.numReplicas);
   // TODO(GG): more asserts on params !!!!!!!!!!!
 
@@ -3192,6 +3193,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
   lastExecutedSeqNum = lastExecutedSeqNum + 1;
 
   metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
+  metric_total_finished_consensuses_.Get().Inc();
   if (config_.debugStatisticsEnabled) {
     DebugStatistics::onLastExecutedSequenceNumberChanged(lastExecutedSeqNum);
   }

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -199,6 +199,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_sent_commitFull_msg_due_to_reqMissingData_;
   CounterHandle metric_sent_fullCommitProof_msg_due_to_reqMissingData_;
   CounterHandle metric_not_enough_client_requests_event_;
+  CounterHandle metric_total_finished_consensuses_;
   //*****************************************************
  public:
   ReplicaImp(const ReplicaConfig&,

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -21,7 +21,6 @@
 #include <memory>
 #include <list>
 #include <variant>
-#include "histogram.hpp"
 
 namespace concordMetrics {
 
@@ -110,7 +109,7 @@ class Counter {
 struct metric_ {
   std::string component;
   std::string name;
-  std::variant<Counter, Gauge, Status, concordUtils::Histogram> value;
+  std::variant<Counter, Gauge, Status> value;
 };
 
 class Values {

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <memory>
 #include <list>
+#include <variant>
 
 namespace concordMetrics {
 
@@ -36,7 +37,7 @@ class Counter;
 typedef struct {
   std::string component;
   std::string name;
-  uint64_t value;
+  std::variant<uint64_t, std::string> value;
 } Metric;
 // An aggregator maintains metrics for multiple components. Components
 // maintain a handle to the aggregator and update it periodically with
@@ -54,6 +55,7 @@ class Aggregator {
 
   std::list<Metric> CollectGauges();
   std::list<Metric> CollectCounters();
+  std::list<Metric> CollectStatuses();
 
   // Generate a JSON formatted string
   std::string ToJson();
@@ -168,6 +170,7 @@ class Component {
   Handle<Counter> RegisterCounter(const std::string& name) { return RegisterCounter(name, 0); }
   std::list<Metric> CollectGauges();
   std::list<Metric> CollectCounters();
+  std::list<Metric> CollectStatuses();
   // Register the component with the aggregator.
   // This *must* be done after all values are registered in this component.
   // If registration happens before all registration of the values, then the

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <list>
 #include <variant>
+#include "histogram.hpp"
 
 namespace concordMetrics {
 
@@ -30,15 +31,8 @@ class Values;
 class Gauge;
 class Status;
 class Counter;
+typedef struct metric_ Metric;
 
-// A generic struct that may represent a counter or a gauge
-// the motivation is to eliminate that need to know the exact
-// metric name before getting it from the aggregator
-typedef struct {
-  std::string component;
-  std::string name;
-  std::variant<uint64_t, std::string> value;
-} Metric;
 // An aggregator maintains metrics for multiple components. Components
 // maintain a handle to the aggregator and update it periodically with
 // all their metric values. Therefore, the state of all metrics is eventually
@@ -108,6 +102,15 @@ class Counter {
 
  private:
   uint64_t val_;
+};
+
+// A generic struct that may represent a counter or a gauge
+// the motivation is to eliminate that need to know the exact
+// metric name before getting it from the aggregator
+struct metric_ {
+  std::string component;
+  std::string name;
+  std::variant<Counter, Gauge, Status, concordUtils::Histogram> value;
 };
 
 class Values {

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <mutex>
 #include <memory>
+#include <list>
 
 namespace concordMetrics {
 
@@ -29,6 +30,14 @@ class Gauge;
 class Status;
 class Counter;
 
+// A generic struct that may represent a counter or a gauge
+// the motivation is to eliminate that need to know the exact
+// metric name before getting it from the aggregator
+typedef struct {
+  std::string component;
+  std::string name;
+  uint64_t value;
+} Metric;
 // An aggregator maintains metrics for multiple components. Components
 // maintain a handle to the aggregator and update it periodically with
 // all their metric values. Therefore, the state of all metrics is eventually
@@ -42,6 +51,9 @@ class Aggregator {
   Gauge GetGauge(const std::string& component_name, const std::string& val_name);
   Status GetStatus(const std::string& component_name, const std::string& val_name);
   Counter GetCounter(const std::string& component_name, const std::string& val_name);
+
+  std::list<Metric> CollectGauges();
+  std::list<Metric> CollectCounters();
 
   // Generate a JSON formatted string
   std::string ToJson();

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -166,7 +166,8 @@ class Component {
   Handle<Status> RegisterStatus(const std::string& name, const std::string& val);
   Handle<Counter> RegisterCounter(const std::string& name, const uint64_t val);
   Handle<Counter> RegisterCounter(const std::string& name) { return RegisterCounter(name, 0); }
-
+  std::list<Metric> CollectGauges();
+  std::list<Metric> CollectCounters();
   // Register the component with the aggregator.
   // This *must* be done after all values are registered in this component.
   // If registration happens before all registration of the values, then the

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -56,7 +56,7 @@ Component::Handle<Counter> Component::RegisterCounter(const string& name, const 
 std::list<Metric> Component::CollectGauges() {
   std::list<Metric> ret;
   for (size_t i = 0; i < names_.gauge_names_.size(); i++) {
-    ret.emplace_back(Metric{name_, names_.gauge_names_[i], values_.gauges_[i].Get()});
+    ret.emplace_back(Metric{name_, names_.gauge_names_[i], values_.gauges_[i]});
   }
   return ret;
 }
@@ -64,7 +64,7 @@ std::list<Metric> Component::CollectGauges() {
 std::list<Metric> Component::CollectCounters() {
   std::list<Metric> ret;
   for (size_t i = 0; i < names_.counter_names_.size(); i++) {
-    ret.emplace_back(Metric{name_, names_.counter_names_[i], values_.counters_[i].Get()});
+    ret.emplace_back(Metric{name_, names_.counter_names_[i], values_.counters_[i]});
   }
   return ret;
 }
@@ -72,7 +72,7 @@ std::list<Metric> Component::CollectCounters() {
 std::list<Metric> Component::CollectStatuses() {
   std::list<Metric> ret;
   for (size_t i = 0; i < names_.status_names_.size(); i++) {
-    ret.emplace_back(Metric{name_, names_.status_names_[i], values_.statuses_[i].Get()});
+    ret.emplace_back(Metric{name_, names_.status_names_[i], values_.statuses_[i]});
   }
   return ret;
 }

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -69,6 +69,14 @@ std::list<Metric> Component::CollectCounters() {
   return ret;
 }
 
+std::list<Metric> Component::CollectStatuses() {
+  std::list<Metric> ret;
+  for (size_t i = 0; i < names_.status_names_.size(); i++) {
+    ret.emplace_back(Metric{name_, names_.status_names_[i], values_.statuses_[i].Get()});
+  }
+  return ret;
+}
+
 void Aggregator::RegisterComponent(Component& component) {
   std::lock_guard<std::mutex> lock(lock_);
   components_.insert(make_pair(component.Name(), component));
@@ -138,6 +146,16 @@ std::list<Metric> Aggregator::CollectCounters() {
   for (auto& comp : components_) {
     const auto& counters = comp.second.CollectCounters();
     ret.insert(ret.end(), counters.begin(), counters.end());
+  }
+  return ret;
+}
+
+std::list<Metric> Aggregator::CollectStatuses() {
+  std::lock_guard<std::mutex> lock(lock_);
+  std::list<Metric> ret;
+  for (auto& comp : components_) {
+    const auto& statuses = comp.second.CollectStatuses();
+    ret.insert(ret.end(), statuses.begin(), statuses.end());
   }
   return ret;
 }

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -107,6 +107,27 @@ std::string Aggregator::ToJson() {
 
   return oss.str();
 }
+std::list<Metric> Aggregator::CollectGauges() {
+  std::lock_guard<std::mutex> lock(lock_);
+  std::list<Metric> ret;
+  for (auto& comp : components_) {
+    for (size_t i = 0; i < comp.second.names_.gauge_names_.size(); i++) {
+      ret.emplace_back(Metric{comp.first, comp.second.names_.gauge_names_[i], comp.second.values_.gauges_[i].Get()});
+    }
+  }
+  return ret;
+}
+std::list<Metric> Aggregator::CollectCounters() {
+  std::lock_guard<std::mutex> lock(lock_);
+  std::list<Metric> ret;
+  for (auto& comp : components_) {
+    for (size_t i = 0; i < comp.second.names_.counter_names_.size(); i++) {
+      ret.emplace_back(
+          Metric{comp.first, comp.second.names_.counter_names_[i], comp.second.values_.counters_[i].Get()});
+    }
+  }
+  return ret;
+}
 
 // Generate a JSON string of the component. To save space we don't add any
 // newline characters.

--- a/util/test/metric_test.cpp
+++ b/util/test/metric_test.cpp
@@ -115,15 +115,15 @@ TEST(MetricTest, CollectGauges) {
   for (auto& g : gauges) {
     if (g.component == "replica") {
       if (g.name == "connected_peers") {
-        ASSERT_EQ(std::get<uint64_t>(g.value), 3);
+        ASSERT_EQ(std::get<Gauge>(g.value).Get(), 3);
         numOfGaugesInReplica++;
       } else if (g.name == "total_peers") {
-        ASSERT_EQ(std::get<uint64_t>(g.value), 4);
+        ASSERT_EQ(std::get<Gauge>(g.value).Get(), 4);
         numOfGaugesInReplica++;
       }
     } else if (g.component == "state-transfer") {
       if (g.name == "blocks-remaining") {
-        ASSERT_EQ(std::get<uint64_t>(g.value), 5);
+        ASSERT_EQ(std::get<Gauge>(g.value).Get(), 5);
         numOfGaugesInStateTransfer++;
       }
     }
@@ -149,15 +149,15 @@ TEST(MetricTest, CollectCounters) {
   for (auto& cn : counters) {
     if (cn.component == "replica") {
       if (cn.name == "connected_peers") {
-        ASSERT_EQ(std::get<uint64_t>(cn.value), 3);
+        ASSERT_EQ(std::get<Counter>(cn.value).Get(), 3);
         numOfCountersInReplica++;
       } else if (cn.name == "total_peers") {
-        ASSERT_EQ(std::get<uint64_t>(cn.value), 4);
+        ASSERT_EQ(std::get<Counter>(cn.value).Get(), 4);
         numOfCountersInReplica++;
       }
     } else if (cn.component == "state-transfer") {
       if (cn.name == "blocks-remaining") {
-        ASSERT_EQ(std::get<uint64_t>(cn.value), 5);
+        ASSERT_EQ(std::get<Counter>(cn.value).Get(), 5);
         numOfCountersInStateTransfer++;
       }
     }
@@ -177,21 +177,21 @@ TEST(MetricTest, CollectStatuses) {
   c2.RegisterStatus("blocks-remaining", "123");
   c2.Register();
 
-  auto gauges = aggregator->CollectStatuses();
+  auto statuses = aggregator->CollectStatuses();
   int numOfGaugesInReplica = 0;
   int numOfGaugesInStateTransfer = 0;
-  for (auto& g : gauges) {
-    if (g.component == "replica") {
-      if (g.name == "connected_peers") {
-        ASSERT_EQ(std::get<std::string>(g.value), "abc");
+  for (auto& s : statuses) {
+    if (s.component == "replica") {
+      if (s.name == "connected_peers") {
+        ASSERT_EQ(std::get<Status>(s.value).Get(), "abc");
         numOfGaugesInReplica++;
-      } else if (g.name == "total_peers") {
-        ASSERT_EQ(std::get<std::string>(g.value), "efg");
+      } else if (s.name == "total_peers") {
+        ASSERT_EQ(std::get<Status>(s.value).Get(), "efg");
         numOfGaugesInReplica++;
       }
-    } else if (g.component == "state-transfer") {
-      if (g.name == "blocks-remaining") {
-        ASSERT_EQ(std::get<std::string>(g.value), "123");
+    } else if (s.component == "state-transfer") {
+      if (s.name == "blocks-remaining") {
+        ASSERT_EQ(std::get<Status>(s.value).Get(), "123");
         numOfGaugesInStateTransfer++;
       }
     }

--- a/util/test/metric_test.cpp
+++ b/util/test/metric_test.cpp
@@ -98,4 +98,72 @@ TEST(MetricTest, ToJson) {
   ASSERT_EQ(0, system(oss.str().c_str()));
 }
 
+TEST(MetricTest, CollectGauges) {
+  auto aggregator = std::make_shared<Aggregator>();
+  Component c("replica", aggregator);
+  c.RegisterGauge("connected_peers", 3);
+  c.RegisterGauge("total_peers", 4);
+  c.Register();
+
+  Component c2("state-transfer", aggregator);
+  c2.RegisterGauge("blocks-remaining", 5);
+  c2.Register();
+
+  auto gauges = aggregator->CollectGauges();
+  int numOfGaugesInReplica = 0;
+  int numOfGaugesInStateTransfer = 0;
+  for (auto& g : gauges) {
+    if (g.component == "replica") {
+      if (g.name == "connected_peers") {
+        ASSERT_EQ(g.value, 3);
+        numOfGaugesInReplica++;
+      } else if (g.name == "total_peers") {
+        ASSERT_EQ(g.value, 4);
+        numOfGaugesInReplica++;
+      }
+    } else if (g.component == "state-transfer") {
+      if (g.name == "blocks-remaining") {
+        ASSERT_EQ(g.value, 5);
+        numOfGaugesInStateTransfer++;
+      }
+    }
+  }
+  ASSERT_EQ(numOfGaugesInReplica, 2);
+  ASSERT_EQ(numOfGaugesInStateTransfer, 1);
+}
+
+TEST(MetricTest, CollectCounters) {
+  auto aggregator = std::make_shared<Aggregator>();
+  Component c("replica", aggregator);
+  c.RegisterCounter("connected_peers", 3);
+  c.RegisterCounter("total_peers", 4);
+  c.Register();
+
+  Component c2("state-transfer", aggregator);
+  c2.RegisterCounter("blocks-remaining", 5);
+  c2.Register();
+
+  auto counters = aggregator->CollectCounters();
+  int numOfCountersInReplica = 0;
+  int numOfCountersInStateTransfer = 0;
+  for (auto& cn : counters) {
+    if (cn.component == "replica") {
+      if (cn.name == "connected_peers") {
+        ASSERT_EQ(cn.value, 3);
+        numOfCountersInReplica++;
+      } else if (cn.name == "total_peers") {
+        ASSERT_EQ(cn.value, 4);
+        numOfCountersInReplica++;
+      }
+    } else if (cn.component == "state-transfer") {
+      if (cn.name == "blocks-remaining") {
+        ASSERT_EQ(cn.value, 5);
+        numOfCountersInStateTransfer++;
+      }
+    }
+  }
+  ASSERT_EQ(numOfCountersInReplica, 2);
+  ASSERT_EQ(numOfCountersInStateTransfer, 1);
+}
+
 }  // namespace concordMetrics


### PR DESCRIPTION
We have added to the concord metrics framework the opportunity to get numeric metrics in a generic struct named Metrics (in the same way as with Prometheus metrics).

The main purpose of it is to get rid of the metrics configuration file in the product.