### PR TITLE
Update clang-format-7 to clang-format-9

### DIFF
--- a/diagnostics/include/diagnostics.h
+++ b/diagnostics/include/diagnostics.h
@@ -57,8 +57,8 @@ class Registrar {
   std::string describeStatus() const {
     std::lock_guard<std::mutex> guard(mutex_);
     std::string output;
-    for (const auto& [_, handler]: status_handlers_) {
-      (void)_; // undefined variable hack
+    for (const auto& [_, handler] : status_handlers_) {
+      (void)_;  // undefined variable hack
       output += "\n" + handler.name + "\n  ";
       output += handler.description + "\n";
     }
@@ -68,8 +68,8 @@ class Registrar {
   std::string listStatusKeys() const {
     std::lock_guard<std::mutex> guard(mutex_);
     std::string output;
-    for (const auto& [key, _]: status_handlers_) {
-      (void)_; // unused variable hack
+    for (const auto& [key, _] : status_handlers_) {
+      (void)_;  // unused variable hack
       output += key + "\n";
     }
     return output;
@@ -81,4 +81,3 @@ class Registrar {
 };
 
 }  // namespace concord::diagnostics
-

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -u
 
 install_basic_deps() {
   sudo apt-get update
-  sudo apt-get install -y ccache cmake clang clang-format-7 python3-pip python3-setuptools libgmp3-dev g++ parallel
+  sudo apt-get install -y ccache cmake clang clang-format-9 python3-pip python3-setuptools libgmp3-dev g++ parallel
   python3 -m pip install --upgrade wheel
   python3 -m pip install --upgrade trio
 }

--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -33,7 +33,7 @@ FILES_TO_FORMAT=$(find ${ABS_CONCORD_PATH} \
 
 if [ -n "$2" ]; then
   if [ "$2" = "--is-required" ]; then
-    NUM_CHANGES=$(clang-format-7 \
+    NUM_CHANGES=$(clang-format-9 \
       -verbose \
       -style=file \
       -fallback-style=none \
@@ -52,5 +52,5 @@ if [ -n "$2" ]; then
   >&2 echo "ERROR: Unknown parameter \"$2\""
   return 1
 else
-  clang-format-7 -verbose -style=file -fallback-style=none -i ${FILES_TO_FORMAT}
+  clang-format-9 -verbose -style=file -fallback-style=none -i ${FILES_TO_FORMAT}
 fi

--- a/util/test/timers_tests.cpp
+++ b/util/test/timers_tests.cpp
@@ -33,9 +33,10 @@ TEST(TimersTest, Basic) {
 
   // Create a oneshot and a recurring timer and add them to the heap. Each one
   // will fire a callback when it expires that increments a counter.
-  timers.add(duration, Timers::Timer::ONESHOT, [&oneshot_counter](Handle h) { ++oneshot_counter; }, now);
-  auto recurring_handle =
-      timers.add(duration, Timers::Timer::RECURRING, [&recurring_counter](Handle h) { ++recurring_counter; }, now);
+  timers.add(
+      duration, Timers::Timer::ONESHOT, [&oneshot_counter](Handle h) { ++oneshot_counter; }, now);
+  auto recurring_handle = timers.add(
+      duration, Timers::Timer::RECURRING, [&recurring_counter](Handle h) { ++recurring_counter; }, now);
 
   // Clock hasn't advanced so no timers should fire
   timers.evaluate(now);
@@ -98,8 +99,8 @@ TEST(TimersTest, Basic) {
   // Add a third timer and ensure it fires.
   // This tests the monotonicity of counter ids as used by handles.
   bool third_timer_fired = false;
-  auto handle =
-      timers.add(duration, Timers::Timer::ONESHOT, [&third_timer_fired](Handle h) { third_timer_fired = true; }, now);
+  auto handle = timers.add(
+      duration, Timers::Timer::ONESHOT, [&third_timer_fired](Handle h) { third_timer_fired = true; }, now);
   now += duration;
   timers.evaluate(now);
   ASSERT_TRUE(third_timer_fired);


### PR DESCRIPTION
Because of a failing `make format` target due to C++ structured
bindings in .h files and a bug in clang-format-7 in such cases, update
to clang-format-9 that works properly.

A side note - C++ structured bindings work properly in .cpp and .hpp
files with the existing clang-format-7 version.