### PR TITLE
Do not add existing blocks during state transfer

### DIFF
--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -233,9 +233,9 @@ bool ReplicaImp::putBlock(const uint64_t blockId, const char *block_data, const 
       m_bcDbAdapter->deleteBlock(blockId);
       throw std::runtime_error(__PRETTY_FUNCTION__ + std::string("data corrupted blockId: ") + std::to_string(blockId));
     }
+  } else {
+    m_bcDbAdapter->addRawBlock(block, blockId);
   }
-
-  m_bcDbAdapter->addRawBlock(block, blockId);
 
   return true;
 }


### PR DESCRIPTION
Existing code adds a raw block during state transfer even if the block
already exists in storage and is bit-equal to the incoming state
transfer block. This PR makes it so that the block is only added if a
block with the same ID doesn't exist in storage. That is both an
optimization and a requirement for the v2MerkleTree::DBAdapter that
doesn't support adding existing blocks (overwriting them).