### PR TITLE
Add client id to the client metrics component

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -36,8 +36,8 @@ enum ClientMsgFlag : uint8_t { EMPTY_FLAGS_REQ = 0x0, READ_ONLY_REQ = 0x1, PRE_P
 
 class SimpleClient {
  public:
-  SimpleClient()
-      : metrics_{"clientMetrics", std::make_shared<concordMetrics::Aggregator>()},
+  SimpleClient(uint16_t clientId)
+      : metrics_{"clientMetrics_" + std::to_string(clientId), std::make_shared<concordMetrics::Aggregator>()},
         client_metrics_{{metrics_.RegisterCounter("retransmissions")},
                         {metrics_.RegisterGauge("retransmissionTimer", 0)}} {
     metrics_.Register();

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -146,7 +146,8 @@ static std::set<ReplicaId> generateSetOfReplicas_helpFunc(const int16_t numberOf
 
 SimpleClientImp::SimpleClientImp(
     ICommunication* communication, uint16_t clientId, uint16_t fVal, uint16_t cVal, SimpleClientParams& p)
-    : clientId_{clientId},
+    : SimpleClient(clientId),
+      clientId_{clientId},
       fVal_{fVal},
       cVal_{cVal},
       replicas_{generateSetOfReplicas_helpFunc(3 * fVal + 2 * cVal + 1)},

--- a/tests/simpleTest/simple_test_client.hpp
+++ b/tests/simpleTest/simple_test_client.hpp
@@ -211,13 +211,14 @@ class SimpleTestClient {
 
     // After all requests have been issued, stop communication and clean up.
     comm->Stop();
+    std::string metric_comp_name = "clientMetrics_" + std::to_string(id);
     LOG_INFO(clientLogger,
-             "clientMetrics::retransmissions " << aggregator->GetCounter("clientMetrics", "retransmissions").Get());
+             "clientMetrics::retransmissions " << aggregator->GetCounter(metric_comp_name, "retransmissions").Get());
     LOG_INFO(
         clientLogger,
-        "clientMetrics::retransmissionTimer " << aggregator->GetGauge("clientMetrics", "retransmissionTimer").Get());
-    test_assert(aggregator->GetCounter("clientMetrics", "retransmissions").Get() >= 0, "retransmissions <" << 0);
-    test_assert(aggregator->GetGauge("clientMetrics", "retransmissionTimer").Get() >= 0, "retransmissionTimer <" << 0);
+        "clientMetrics::retransmissionTimer " << aggregator->GetGauge(metric_comp_name, "retransmissionTimer").Get());
+    test_assert(aggregator->GetCounter(metric_comp_name, "retransmissions").Get() >= 0, "retransmissions <" << 0);
+    test_assert(aggregator->GetGauge(metric_comp_name, "retransmissionTimer").Get() >= 0, "retransmissionTimer <" << 0);
     delete pSeqGen;
     delete client;
     delete comm;


### PR DESCRIPTION
Needed to distinguish between clients that run on the same process.