### PR TITLE
Activate Merkle Tree storage testing in Apollo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,12 @@ env:
     - USE_ROCKSDB=-DBUILD_ROCKSDB_STORAGE=TRUE
     - USE_CONAN=-DUSE_CONAN=ON
   matrix:
-    - DEBUG=-DCMAKE_BUILD_TYPE=DEBUG
-    - RELEASE=-DCMAKE_BUILD_TYPE=RELEASE
+    - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v1direct"
+    - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v1direct"
+    - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle"
+    - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle"
 script:
-  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $DEBUG $RELEASE $USE_LOG4CPP $USE_ROCKSDB $USE_CONAN .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest --output-on-failure
+  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $CI_BUILD_TYPE $USE_LOG4CPP $USE_ROCKSDB $USE_CONAN .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest --output-on-failure
 
 
 cache:

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -1,6 +1,11 @@
 set(APOLLO_TEST_ENV "BUILD_ROCKSDB_STORAGE=${BUILD_ROCKSDB_STORAGE}")
 
-foreach(STORAGE_TYPE "v1direct" "v2merkle")
+set(STORAGE_TYPES "v1direct" "v2merkle")
+if (CI_TEST_STORAGE_TYPE)
+  set(STORAGE_TYPES ${CI_TEST_STORAGE_TYPE})
+endif()
+
+foreach(STORAGE_TYPE ${STORAGE_TYPES})
   add_test(NAME skvbc_basic_tests_${STORAGE_TYPE} COMMAND sh -c
           "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc 2>&1 > /dev/null"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -1,39 +1,41 @@
 set(APOLLO_TEST_ENV "BUILD_ROCKSDB_STORAGE=${BUILD_ROCKSDB_STORAGE}")
 
-add_test(NAME skvbc_basic_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} python3 -m unittest test_skvbc 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+foreach(STORAGE_TYPE "v1direct" "v2merkle")
+  add_test(NAME skvbc_basic_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc 2>&1 > /dev/null"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_linearizability_tests COMMAND sudo sh -c
-        "env ${APOLLO_TEST_ENV} python3 -m unittest test_skvbc_history_tracker test_skvbc_linearizability 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME skvbc_linearizability_tests_${STORAGE_TYPE} COMMAND sudo sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_history_tracker test_skvbc_linearizability 2>&1 > /dev/null"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_fast_path_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} python3 -m unittest test_skvbc_fast_path 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME skvbc_fast_path_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_fast_path 2>&1 > /dev/null"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_slow_path_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} python3 -m unittest test_skvbc_slow_path 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME skvbc_slow_path_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_slow_path 2>&1 > /dev/null"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_view_change_tests COMMAND sudo sh -c
-        "env ${APOLLO_TEST_ENV} python3 -m unittest test_skvbc_view_change 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME skvbc_view_change_tests_${STORAGE_TYPE} COMMAND sudo sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change 2>&1 > /dev/null"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_auto_view_change_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} python3 -m unittest test_skvbc_auto_view_change 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME skvbc_auto_view_change_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_auto_view_change 2>&1 > /dev/null"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_preexecution_tests COMMAND sh -c
-        "python3 -m unittest test_skvbc_preexecution 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME skvbc_preexecution_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_preexecution 2>&1 > /dev/null"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-if (BUILD_ROCKSDB_STORAGE)
-    add_test(NAME skvbc_persistence_tests COMMAND sh -c
-            "python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"
+  if (BUILD_ROCKSDB_STORAGE)
+    add_test(NAME skvbc_persistence_tests_${STORAGE_TYPE} COMMAND sh -c
+            "env STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_ro_replica_tests COMMAND sh -c
-        "python3 -m unittest test_skvbc_ro_replica 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
+    add_test(NAME skvbc_ro_replica_tests_${STORAGE_TYPE} COMMAND sh -c
+            "env STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica 2>&1 > /dev/null"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+endforeach()

--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -36,7 +36,8 @@ def start_replica_cmd(builddir, replica_id):
             "-s", statusTimerMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else ""]
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
 
 
 class SkvbcTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_auto_view_change.py
+++ b/tests/apollo/test_skvbc_auto_view_change.py
@@ -38,7 +38,8 @@ def start_replica_cmd(builddir, replica_id):
             "-a", autoPrimaryRotationTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else ""]
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
 
 
 class SkvbcAutoViewChangeTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -33,7 +33,8 @@ def start_replica_cmd(builddir, replica_id):
             "-s", statusTimerMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else ""]
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
 
 
 class SkvbcFastPathTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -44,7 +44,8 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else ""]
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
 
 
 class SkvbcChaosTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -39,7 +39,8 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-p"]
+            "-p",
+            "-t", os.environ.get('STORAGE_TYPE')]
 
 
 class SkvbcLongRunningTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -43,7 +43,8 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-p"
+            "-p",
+            "-t", os.environ.get('STORAGE_TYPE')
             ]
 
 

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -37,7 +37,8 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", status_timer_milli,
             "-v", view_change_timeout_milli,
-            "-p"
+            "-p",
+            "-t", os.environ.get('STORAGE_TYPE')
             ]
 
 

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -42,7 +42,8 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-p"
+            "-p",
+            "-t", os.environ.get('STORAGE_TYPE')
             ]
 
 class SkvbcReadOnlyReplicaTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -36,7 +36,8 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else ""]
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
 
 
 class SkvbcSlowPathTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -38,7 +38,8 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else ""]
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
 
 
 class SkvbcViewChangeTest(unittest.TestCase):

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -34,36 +34,44 @@ class TestSetup {
 
   std::unique_ptr<IStorageFactory> GetStorageFactory();
 
-  const bftEngine::ReplicaConfig& GetReplicaConfig() const { return replica_config_; }
+  const bftEngine::ReplicaConfig& GetReplicaConfig() const { return replicaConfig_; }
   bft::communication::ICommunication* GetCommunication() const { return communication_.get(); }
-  concordMetrics::Server& GetMetricsServer() { return metrics_server_; }
+  concordMetrics::Server& GetMetricsServer() { return metricsServer_; }
   concordlogger::Logger GetLogger() { return logger_; }
-  const bool UsePersistentStorage() const { return use_persistent_storage_; }
+  const bool UsePersistentStorage() const { return usePersistentStorage_; }
 
  private:
+  enum class StorageType {
+    V1DirectKeyValue,
+    V2MerkleTree,
+  };
+
   TestSetup(bftEngine::ReplicaConfig config,
             std::unique_ptr<bft::communication::ICommunication> comm,
             concordlogger::Logger logger,
-            uint16_t metrics_port,
-            bool use_persistent_storage,
-            std::string s3ConfigFile)
-      : replica_config_(config),
+            uint16_t metricsPort,
+            bool usePersistentStorage,
+            std::string s3ConfigFile,
+            StorageType storageType)
+      : replicaConfig_(config),
         communication_(std::move(comm)),
         logger_(logger),
-        metrics_server_(metrics_port),
-        use_persistent_storage_(use_persistent_storage),
-        s3ConfigFile_(s3ConfigFile) {}
+        metricsServer_(metricsPort),
+        usePersistentStorage_(usePersistentStorage),
+        s3ConfigFile_(s3ConfigFile),
+        storageType_(storageType) {}
   TestSetup() = delete;
 #ifdef USE_S3_OBJECT_STORE
   concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
 #endif
   std::unique_ptr<IStorageFactory> GetInMemStorageFactory() const;
-  bftEngine::ReplicaConfig replica_config_;
+  bftEngine::ReplicaConfig replicaConfig_;
   std::unique_ptr<bft::communication::ICommunication> communication_;
   concordlogger::Logger logger_;
-  concordMetrics::Server metrics_server_;
-  bool use_persistent_storage_;
+  concordMetrics::Server metricsServer_;
+  bool usePersistentStorage_;
   std::string s3ConfigFile_;
+  StorageType storageType_;
 };
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
Add support for the "--storage-type, -t" command line option in
TesterReplica with allowed values of "v1direct" and "v2merkle". Set the
default type to "v1direct".

A note on the "--storage-type, -t" option is that it is ignored when
running as an S3 read-only replica, because we upload block data in
S3-specific ways in that case and it doesn't make sense to specify a
storage type.

Run Apollo tests with both "v1direct" and "v2merkle" storage mechanisms.
In order to do so, pass the storage type to Python tests via the
STORAGE_TYPE environment variable and use it to set the
"--storage-type, -t" command line option for TesterReplica .

Unify naming in TesterReplica with regards to camelCase.