### PR TITLE
Fix RocksDB Client to take ownership of Comparator object.

### DIFF
--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -60,7 +60,7 @@ class BcStTest : public ::testing::Test {
     auto* db_key_comparator = new concord::kvbc::v1DirectKeyValue::DBKeyComparator();
 #ifdef USE_ROCKSDB
     concord::storage::IDBClient::ptr dbc(
-        new concord::storage::rocksdb::Client("./bcst_db", new KeyComparator(db_key_comparator)));
+        new concord::storage::rocksdb::Client("./bcst_db", std::make_unique<KeyComparator>(db_key_comparator)));
     dbc->init();
     auto* datastore = new DBDataStore(
         dbc, config_.sizeOfReservedPage, std::make_shared<concord::storage::v1DirectKeyValue::STKeyManipulator>());

--- a/bftengine/tests/metadataStorage/metadataStorage_test.cpp
+++ b/bftengine/tests/metadataStorage/metadataStorage_test.cpp
@@ -96,10 +96,10 @@ TEST(metadataStorage_test, multi_write) {
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  KeyComparator *kk = new KeyComparator(new DBKeyComparator);
+  auto kk = make_unique<KeyComparator>(new DBKeyComparator);
   const string dbPath = "./metadataStorage_test_db";
   remove(dbPath.c_str());
-  Client *dbClient = new Client(dbPath, kk);
+  Client *dbClient = new Client(dbPath, std::move(kk));
   dbClient->init();
   metadataStorage =
       new DBMetadataStorage(dbClient, std::make_unique<concord::storage::v1DirectKeyValue::MetadataKeyManipulator>());

--- a/bftengine/tests/metadataStorage/metadataStorage_test.cpp
+++ b/bftengine/tests/metadataStorage/metadataStorage_test.cpp
@@ -96,10 +96,9 @@ TEST(metadataStorage_test, multi_write) {
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  auto kk = make_unique<KeyComparator>(new DBKeyComparator);
   const string dbPath = "./metadataStorage_test_db";
   remove(dbPath.c_str());
-  Client *dbClient = new Client(dbPath, std::move(kk));
+  Client *dbClient = new Client(dbPath, make_unique<KeyComparator>(new DBKeyComparator));
   dbClient->init();
   metadataStorage =
       new DBMetadataStorage(dbClient, std::make_unique<concord::storage::v1DirectKeyValue::MetadataKeyManipulator>());

--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -32,8 +32,8 @@ namespace {
 auto createRocksDBClient(const std::string &dbPath) {
   // Since the client doesn't own the comparator, use the same instance for all clients. This is RocksDB's default
   // behavior - using a static instance returned by BytewiseComparator(). See the ::rocksdb::Options class.
-  static const auto comparator = storage::rocksdb::KeyComparator{new DBKeyComparator{}};
-  return std::make_shared<storage::rocksdb::Client>(dbPath, &comparator);
+  return std::make_shared<storage::rocksdb::Client>(
+      dbPath, std::make_unique<storage::rocksdb::KeyComparator>(new DBKeyComparator{}));
 }
 #endif
 }  // namespace

--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -30,8 +30,6 @@ namespace concord::kvbc::v1DirectKeyValue {
 namespace {
 #ifdef USE_ROCKSDB
 auto createRocksDBClient(const std::string &dbPath) {
-  // Since the client doesn't own the comparator, use the same instance for all clients. This is RocksDB's default
-  // behavior - using a static instance returned by BytewiseComparator(). See the ::rocksdb::Options class.
   return std::make_shared<storage::rocksdb::Client>(
       dbPath, std::make_unique<storage::rocksdb::KeyComparator>(new DBKeyComparator{}));
 }

--- a/kvbc/test/multiIO_test.cpp
+++ b/kvbc/test/multiIO_test.cpp
@@ -64,8 +64,7 @@ class multiIO_test : public ::testing::Test {
  protected:
   void SetUp() override {
     keyGen_.reset(new concord::kvbc::v1DirectKeyValue::RocksKeyGenerator);
-    auto comparator_ = std::make_unique<KeyComparator>(new DBKeyComparator{});
-    dbClient.reset(new Client(dbPath_, std::move(comparator_)));
+    dbClient.reset(new Client(dbPath_, std::make_unique<KeyComparator>(new DBKeyComparator{})));
     dbClient->init();
   }
 

--- a/kvbc/test/multiIO_test.cpp
+++ b/kvbc/test/multiIO_test.cpp
@@ -64,14 +64,13 @@ class multiIO_test : public ::testing::Test {
  protected:
   void SetUp() override {
     keyGen_.reset(new concord::kvbc::v1DirectKeyValue::RocksKeyGenerator);
-    comparator_ = new KeyComparator(new DBKeyComparator());
-    dbClient.reset(new Client(dbPath_, comparator_));
+    auto comparator_ = std::make_unique<KeyComparator>(new DBKeyComparator{});
+    dbClient.reset(new Client(dbPath_, std::move(comparator_)));
     dbClient->init();
   }
 
   void TearDown() override {
     dbClient.reset();
-    delete comparator_;
     string cmd = string("rm -rf ") + dbPath_;
     if (system(cmd.c_str())) {
       ASSERT_TRUE(false);
@@ -115,7 +114,6 @@ class multiIO_test : public ::testing::Test {
 
   std::unique_ptr<concord::kvbc::v1DirectKeyValue::IDataKeyGenerator> keyGen_;
   const string dbPath_ = "./rocksdb_test";
-  KeyComparator *comparator_;
 };
 
 TEST_F(multiIO_test, single_put) {

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -59,8 +59,9 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
 
 class Client : public concord::storage::IDBClient {
  public:
-  Client(std::string _dbPath, const ::rocksdb::Comparator* comparator = nullptr)
-      : m_dbPath(_dbPath), comparator_(comparator) {}
+  Client(std::string _dbPath) : m_dbPath(_dbPath) {}
+  Client(std::string _dbPath, std::unique_ptr<const ::rocksdb::Comparator>&& comparator)
+      : m_dbPath(_dbPath), comparator_(std::move(comparator)) {}
 
   ~Client() {
     if (txn_db_) {
@@ -105,7 +106,7 @@ class Client : public concord::storage::IDBClient {
   // Database object (created on connection).
   std::unique_ptr<::rocksdb::DB> dbInstance_;
   ::rocksdb::TransactionDB* txn_db_ = nullptr;
-  const ::rocksdb::Comparator* comparator_ = nullptr;  // TODO unique?
+  std::unique_ptr<const ::rocksdb::Comparator> comparator_;
 };
 
 ::rocksdb::Slice toRocksdbSlice(const concordUtils::Sliver& _s);

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -96,7 +96,7 @@ void Client::init(bool readOnly) {
   options.create_if_missing = true;
   // If a comparator is passed, use it. If not, use the default one.
   if (comparator_) {
-    options.comparator = comparator_;
+    options.comparator = comparator_.get();
   }
   ::rocksdb::Status s;
   if (readOnly) {

--- a/tools/DBEditor.cpp
+++ b/tools/DBEditor.cpp
@@ -253,7 +253,7 @@ int main(int argc, char **argv) {
     setupDBEditorParams(argc, argv);
     verifyInputParams(argv);
 
-    dbClient = new Client(dbPath.str(), new KeyComparator(new DBKeyComparator()));
+    dbClient = new Client(dbPath.str(), std::make_unique<KeyComparator>(new DBKeyComparator{}));
     dbClient->init(dbOperation == DUMP_ALL_VALUES);
     if (dbOperation != DUMP_ALL_VALUES) setupMetadataStorage();
     bool res = false;


### PR DESCRIPTION
Make Client take ownership of the Comparator object it is passed in construction. Up until now Comparator object is allocated on the heap and not properly deallocated in most use cases.