### PR TITLE
Fix memory leaks reported from tests/simpleTest/persistency_test:

### DIFF
--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -31,8 +31,8 @@ class InMemoryDataStore : public DataStore {
   explicit InMemoryDataStore(uint32_t sizeOfReservedPage);
   ~InMemoryDataStore() override {
     deleteAllPendingPages();
-    for (auto& [k, v] : pages) {
-      ::free(v.page);
+    for (auto& p : pages) {
+      ::free(p.second.page);
     }
   }
 

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -29,7 +29,12 @@ namespace impl {
 class InMemoryDataStore : public DataStore {
  public:
   explicit InMemoryDataStore(uint32_t sizeOfReservedPage);
-  ~InMemoryDataStore() override {}
+  ~InMemoryDataStore() override {
+    deleteAllPendingPages();
+    for (auto& [k, v] : pages) {
+      ::free(v.page);
+    }
+  }
 
   //////////////////////////////////////////////////////////////////////////
   // config

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2976,6 +2976,10 @@ ReplicaImp::~ReplicaImp() {
   delete dynamicUpperLimitOfRounds;
   delete mainLog;
   delete checkpointsLog;
+  delete clientsManager;
+  delete sigManager;
+  delete repsInfo;
+  free(replyBuffer);
 
   if (config_.debugStatisticsEnabled) {
     DebugStatistics::freeDebugStatisticsData();

--- a/bftengine/src/bftengine/messages/PartialProofsSet.cpp
+++ b/bftengine/src/bftengine/messages/PartialProofsSet.cpp
@@ -256,7 +256,10 @@ class AsynchProofCreationJob : public util::SimpleThreadPool::Job {
     LOG_DEBUG_F(GL, "PartialProofsSet::AsynchProofCreationJob::execute - end (for seqNumber %" PRId64 ")", seqNumber);
   }
 
-  virtual void release() {}
+  virtual void release() {
+    delete acc;
+    delete this;
+  }
 
  private:
   InternalReplicaApi* me;

--- a/threshsign/include/threshsign/ThresholdAccumulatorBase.h
+++ b/threshsign/include/threshsign/ThresholdAccumulatorBase.h
@@ -15,6 +15,7 @@
 #include "IThresholdAccumulator.h"
 #include "VectorOfShares.h"
 
+#include <memory>
 #include <vector>
 
 /**
@@ -28,7 +29,7 @@ template <class VerificationKey, class NumType, typename SigShareParserFunc>
 class ThresholdAccumulatorBase : public IThresholdAccumulator {
  protected:
   // The expected digest that is being threshold-signed and its size
-  unsigned char* expectedDigest;
+  std::shared_ptr<unsigned char[]> expectedDigest;
   int expectedDigestLen;
 
   // The # of required/threshold signers and # of total signers
@@ -58,11 +59,7 @@ class ThresholdAccumulatorBase : public IThresholdAccumulator {
         pendingShares(static_cast<size_t>(totalSigners + 1)),
         validShares(static_cast<size_t>(totalSigners + 1)) {}
 
-  virtual ~ThresholdAccumulatorBase() {
-    if (expectedDigest != nullptr) {
-      delete[] expectedDigest;
-    }
-  }
+  virtual ~ThresholdAccumulatorBase() {}
 
   /**
    * New virtual methods introduced by this class (both public and protected)

--- a/threshsign/src/ThresholdAccumulatorBase.tpp
+++ b/threshsign/src/ThresholdAccumulatorBase.tpp
@@ -24,8 +24,8 @@ void ThresholdAccumulatorBase<VerificationKey, NumType, SigShareParserFunc>::set
     assertStrictlyPositive(len);
 
     if(hasExpectedDigest() == false) {
-        expectedDigest = new unsigned char[len];
-        memcpy(reinterpret_cast<void*>(expectedDigest),
+        expectedDigest.reset(new unsigned char[len]);
+        memcpy(reinterpret_cast<void*>(expectedDigest.get()),
                 reinterpret_cast<const void*>(msg),
                 static_cast<unsigned long>(len));
         expectedDigestLen = len;
@@ -47,9 +47,9 @@ void ThresholdAccumulatorBase<VerificationKey, NumType, SigShareParserFunc>::set
             throw std::runtime_error("Cannot reset expected digest with different length");
         }
 
-        if(memcmp(expectedDigest, msg, static_cast<size_t>(len)) != 0) {
+        if(memcmp(expectedDigest.get(), msg, static_cast<size_t>(len)) != 0) {
             LOG_ERROR(GL, "Attempted to reset expected digest to a different one. "
-                          << "Previously had '" << Utils::bin2hex(expectedDigest, len)
+                          << "Previously had '" << Utils::bin2hex(expectedDigest.get(), len)
                           << "', you gave '" << Utils::bin2hex(msg, len) << "'");
             throw std::runtime_error("Cannot reset expected digest to a different one");
         }

--- a/threshsign/src/bls/relic/BlsAccumulatorBase.cpp
+++ b/threshsign/src/bls/relic/BlsAccumulatorBase.cpp
@@ -58,7 +58,7 @@ void BlsAccumulatorBase::onExpectedDigestSet() {
   assertNotNull(expectedDigest);
   assertStrictlyPositive(expectedDigestLen);
 
-  g1_map(hash, expectedDigest, expectedDigestLen);
+  g1_map(hash, static_cast<const uint8_t*>(expectedDigest.get()), expectedDigestLen);
 }
 
 bool BlsAccumulatorBase::verifyShare(ShareID id, const G1T& sigShare) {


### PR DESCRIPTION
 - InMemoryDataStore.hpp: proper cleanup in destructor
 - PartialProofsSet.cpp: added cleanup in release() method for AsynchProofCreationJob.
   all other jobs seem to implement the release method correctly, except AsynchExecProofCreationJob.
 - ReplicaImp.cpp: proper cleanup in destructor
 - simple_test_replica.hpp: proper cleanup in destructor
 - ThresholdAccumulatorBase.h, ThresholdAccumulatorBase.tpp, BlsAccumulatorBase.cpp:
   Because proper deinicialization was added in AsynchProofCreationJob double free errors started
   showing up because BlsAccumulatorBase msg-s are being copyed and share a pointer "expectedDigest",
   which is deleted once by each cloned object.