### PR TITLE
Add logs to TlsTcpComm

### DIFF
--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -910,8 +910,15 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
    * @param length data length
    */
   void send(const char *data, uint32_t length) {
-    assert(data);
-    assert(length > 0 && length <= _maxMessageLength - MSG_HEADER_SIZE);
+    if (!data) {
+      LOG_ERROR(_logger, "Error, message has never been initialized")
+      throw std::invalid_argument("data = nullptr");
+    }
+
+    if (length <= 0 || length > _maxMessageLength - MSG_HEADER_SIZE) {
+      LOG_ERROR(_logger, "Error, exceeded payload size range, message length: " << std::to_string(length));
+      throw std::invalid_argument("Invalid payload size");
+    }
 
     char *buf = new char[length + MSG_HEADER_SIZE];
     memset(buf, 0, length + MSG_HEADER_SIZE);


### PR DESCRIPTION
After discussion with @salieri11, I replaced the assertions with log errors and exceptions.
Crashing the replica in this case seems to be the right way to handle this situation, if a replica send's message that exceeds the message range size, there is nothing we can do inside 'AsyncTlsConnection::send' function.
I replaced the asserts with exceptions because we would like the replica to stop in RELEASE mode as well.