### PR TITLE
Use local S3 service for Apollo RO replica tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ env:
     - USE_LOG4CPP=-DUSE_LOG4CPP=TRUE
     - USE_ROCKSDB=-DBUILD_ROCKSDB_STORAGE=TRUE
     - USE_CONAN=-DUSE_CONAN=ON
+    - USE_S3_OBJECT_STORE=-DUSE_S3_OBJECT_STORE=ON
   matrix:
     - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v1direct"
     - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v1direct"
     - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle"
     - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle"
 script:
-  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $CI_BUILD_TYPE $USE_LOG4CPP $USE_ROCKSDB $USE_CONAN .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest --output-on-failure
-
+  - cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake $CMAKE_CXX_FLAGS $CI_BUILD_TYPE $USE_LOG4CPP $USE_ROCKSDB $USE_CONAN $USE_S3_OBJECT_STORE .. && make format-check && make -j $(getconf _NPROCESSORS_ONLN) && ctest --output-on-failure
 
 cache:
   ccache: true

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -1,4 +1,23 @@
-set(APOLLO_TEST_ENV "BUILD_ROCKSDB_STORAGE=${BUILD_ROCKSDB_STORAGE}")
+set(APOLLO_TEST_ENV "BUILD_ROCKSDB_STORAGE=${BUILD_ROCKSDB_STORAGE} USE_S3_OBJECT_STORE=${USE_S3_OBJECT_STORE}")
+set(MINIO_BINARY_PATH "${CMAKE_BINARY_DIR}/minio")
+
+if(USE_S3_OBJECT_STORE)
+        find_program(CHMOD_PROG chmod)
+        if(NOT CHMOD_PROG)
+                message(FATAL_ERROR "chmod not found")
+        endif()
+        
+        if(NOT EXISTS ${MINIO_BINARY_PATH})
+                message(STATUS "Downloading minio binary")
+                file(DOWNLOAD "https://dl.min.io/server/minio/release/linux-amd64/minio" ${MINIO_BINARY_PATH} SHOW_PROGRESS)
+                execute_process(COMMAND ${CHMOD_PROG} 755 ${MINIO_BINARY_PATH})
+        else()
+                message(STATUS "minio binary exists - skipping download")
+        endif()
+
+        # This env var is used by apollo tests to locate the path to the binary
+        set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} CONCORD_BFT_MINIO_BINARY_PATH=${MINIO_BINARY_PATH}")
+endif()
 
 set(STORAGE_TYPES "v1direct" "v2merkle")
 if (CI_TEST_STORAGE_TYPE)
@@ -36,11 +55,12 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
 
   if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests_${STORAGE_TYPE} COMMAND sh -c
-            "env STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"
+            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence 2>&1 > /dev/null"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_test(NAME skvbc_ro_replica_tests_${STORAGE_TYPE} COMMAND sh -c
-            "env STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica 2>&1 > /dev/null"
+            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica 2>&1 > /dev/null"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 endforeach()
+

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -12,8 +12,11 @@
 
 import unittest
 import trio
-import os.path
+import os
 import random
+import subprocess
+import tempfile
+import shutil
 
 from util import bft
 from util import skvbc as kvbc
@@ -23,8 +26,7 @@ from math import inf
 
 from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network
 
-
-def start_replica_cmd(builddir, replica_id):
+def start_replica_cmd(builddir, replica_id, config):
     """
     Return a command that starts an skvbc replica when passed to
     subprocess.Popen.
@@ -36,17 +38,64 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
-
+    ro_params = [ "--s3-config-file",
+                    os.path.join(builddir, "tests", "simpleKVBC", "scripts", "test_s3_config.txt")
+                ]
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
-    return [path,
+    ret = [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-p",
             "-t", os.environ.get('STORAGE_TYPE')
             ]
+    if replica_id >= config.n and replica_id < config.n + config.num_ro_replicas and os.environ["USE_S3_OBJECT_STORE"]:
+        ret.extend(ro_params)
+        
+    return ret
 
 class SkvbcReadOnlyReplicaTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.environ["USE_S3_OBJECT_STORE"]:
+            return
+
+        # We need a temp dir for data and binaries - this is cls.dest_dir
+        # self.dest_dir will contain data dir for minio buckets and the minio binary
+        # if there are any directories inside data dir - they become buckets
+        cls.work_dir = "/tmp/concord_bft_minio_datadir_" + next(tempfile._get_candidate_names())
+        minio_server_data_dir = os.path.join(cls.work_dir, "data")
+        os.makedirs(os.path.join(cls.work_dir, "data", "blockchain"))     # create all dirs in one call
+
+        print(f"Working in {cls.work_dir}")
+
+        # Start server
+        print("Starting server")
+        server_env = os.environ.copy()
+        server_env["MINIO_ACCESS_KEY"] = "concordbft"
+        server_env["MINIO_SECRET_KEY"] = "concordbft"
+
+        minio_server_fname = os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH")
+        if minio_server_fname is None:
+            shutil.rmtree(cls.work_dir)
+            raise RuntimeError("Please set path to minio binary to CONCORD_BFT_MINIO_BINARY_PATH env variable")
+
+        cls.minio_server_proc = subprocess.Popen([minio_server_fname, "server", minio_server_data_dir], 
+                                                    env = server_env, 
+                                                    close_fds=True)
+        print("Initialisation complete")
+
+    @classmethod
+    def tearDownClass(cls):
+        if not os.environ["USE_S3_OBJECT_STORE"]:
+            return
+
+        # First stop the server
+        cls.minio_server_proc.terminate()
+
+        # Delete workdir dir
+        shutil.rmtree(cls.work_dir)
 
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd, num_ro_replicas=1)
@@ -112,7 +161,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(initial_nodes=bft_network.all_replicas(), checkpoint_num=1)     
         with trio.fail_after(seconds=60):
             async with trio.open_nursery() as nursery:
-                nursery.start_soon(tracker.send_indefinite_tracked_ops)
+                nursery.start_soon(tracker.run_concurrent_ops, 900, 1)
                 while True:
                     with trio.move_on_after(seconds=.5):
                         try:
@@ -122,6 +171,6 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                             continue
                         else:
                             # success!
-                            if lastExecutedSeqNum >= 150:
+                            if lastExecutedSeqNum >= 50:
                                 print("Replica" + str(ro_replica_id) + " : lastExecutedSeqNum:" + str(lastExecutedSeqNum))
                                 nursery.cancel_scope.cancel()

--- a/tests/simpleKVBC/scripts/test_s3_config.txt
+++ b/tests/simpleKVBC/scripts/test_s3_config.txt
@@ -1,6 +1,6 @@
 # test configuration for S3-compatible storage
-s3-bucket-name: blockchain-dev-asx
-s3-access-key: blockchain-dev
+s3-bucket-name: blockchain
+s3-access-key: concordbft
 s3-protocol: HTTP
-s3-url: 10.70.30.244:9020
-s3-secret-key: Rz0mdbUNGJBxqdzprn5XGSXPr2AfkgcQsYS4y698
+s3-url: 127.0.0.1:9000
+s3-secret-key: concordbft


### PR DESCRIPTION
Recreating this PR (https://github.com/vmware/concord-bft/pull/549) due to travis issues.

The patch contains the following changes:
* The S3 service is minio.
* If concord-bft is compiled with USE_S3_OBJECT_STORE enabled, the
latest version of the minio binary is downloaded in build dir, while
configuring the build.
* Each RO replica started by Apollo uses special S3 configuration
pointing to the local minio instance. Note that this is true if and only
if concord-bft is compiled with USE_S3_OBJECT_STORE.
* Apollo's BftTestNetwork class is modified to pass the test network
configuration to the start_replica callback. This is required for
distinguishing RO and regular replicas.

I'd like to point out some concerns I have got:
* The minio server binary is fetched during cmake configures the build system. I don't like this solution very much but this is the best automated approach I can think of. Another solution is to just use find_program() and throw an error if the binary is missing, but it will require manual work.
* The minio binary is executed locally as separate process. The alternative is to use Docker but I think it's an overkill. Nice side effect of this approach is that the S3 bucket is just a dir on the filesystem and it can be easily inspected from a test.