### PR TITLE
Support empty values and key deletion in v2 Merkle

### DIFF
--- a/kvbc/include/direct_kv_block.h
+++ b/kvbc/include/direct_kv_block.h
@@ -45,6 +45,9 @@ concord::kvbc::SetOfKeyValuePairs getData(const concordUtils::Sliver &block);
 // Returns the parent digest of size BLOCK_DIGEST_SIZE bytes.
 BlockDigest getParentDigest(const concordUtils::Sliver &block);
 
+// Returns the passed user data when creating the block. Will be empty if no user data has been passed.
+concordUtils::Sliver getUserData(const concordUtils::Sliver &block);
+
 struct Header {
   std::uint32_t numberOfElements;
   std::uint32_t parentDigestLength;

--- a/kvbc/include/kv_types.hpp
+++ b/kvbc/include/kv_types.hpp
@@ -15,6 +15,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <map>
+#include <set>
 #include <vector>
 #include <functional>
 #include <cstdint>
@@ -30,6 +31,7 @@ typedef std::pair<Key, Value> KeyValuePair;
 typedef std::unordered_map<Key, Value> SetOfKeyValuePairs;
 typedef std::map<Key, Value> OrderedSetOfKeyValuePairs;
 typedef std::vector<Key> KeysVector;
+typedef std::set<Key> OrderedKeysSet;
 typedef KeysVector ValuesVector;
 typedef std::uint64_t BlockId;
 

--- a/kvbc/include/merkle_tree_block.h
+++ b/kvbc/include/merkle_tree_block.h
@@ -17,7 +17,7 @@ RawBlock create(const SetOfKeyValuePairs &updates,
                 const BlockDigest &parentDigest,
                 const sparse_merkle::Hash &stateHash);
 
-// Creates a block that adds a set of key/values and a deletes a set of keys.
+// Creates a block from a set of key/value pairs and a set of keys to delete.
 RawBlock create(const SetOfKeyValuePairs &updates,
                 const OrderedKeysSet &deletes,
                 const BlockDigest &parentDigest,
@@ -93,14 +93,14 @@ inline bool operator==(const Node &lhs, const Node &rhs) {
 }
 
 // Merkle-specific data added to raw blocks.
-struct RawBlockMerklelData {
+struct RawBlockMerkleData {
   static constexpr auto MIN_SIZE = sparse_merkle::Hash::SIZE_IN_BYTES;
   static constexpr auto STATE_HASH_SIZE = sparse_merkle::Hash::SIZE_IN_BYTES;
   static constexpr auto MIN_KEY_SIZE = sizeof(KeyLengthType);
 
-  RawBlockMerklelData() = default;
+  RawBlockMerkleData() = default;
 
-  RawBlockMerklelData(const sparse_merkle::Hash &pStateHash, const OrderedKeysSet &pDeletedKeys = OrderedKeysSet{})
+  RawBlockMerkleData(const sparse_merkle::Hash &pStateHash, const OrderedKeysSet &pDeletedKeys = OrderedKeysSet{})
       : stateHash{pStateHash}, deletedKeys{pDeletedKeys} {}
 
   sparse_merkle::Hash stateHash;
@@ -108,7 +108,7 @@ struct RawBlockMerklelData {
   OrderedKeysSet deletedKeys;
 };
 
-inline bool operator==(const RawBlockMerklelData &lhs, const RawBlockMerklelData &rhs) {
+inline bool operator==(const RawBlockMerkleData &lhs, const RawBlockMerkleData &rhs) {
   return lhs.stateHash == rhs.stateHash && lhs.deletedKeys == rhs.deletedKeys;
 }
 

--- a/kvbc/include/merkle_tree_serialization.h
+++ b/kvbc/include/merkle_tree_serialization.h
@@ -179,8 +179,8 @@ inline std::string serializeImp(const block::detail::Node &node) {
   return buf;
 }
 
-inline std::string serializeImp(block::detail::RawBlockMerklelData data) {
-  auto dataSize = block::detail::RawBlockMerklelData::MIN_SIZE;
+inline std::string serializeImp(block::detail::RawBlockMerkleData data) {
+  auto dataSize = block::detail::RawBlockMerkleData::MIN_SIZE;
   for (const auto &key : data.deletedKeys) {
     dataSize += (sizeof(block::detail::KeyLengthType) + key.length());
   }
@@ -368,31 +368,31 @@ inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::
 }
 
 template <>
-inline block::detail::RawBlockMerklelData deserialize<block::detail::RawBlockMerklelData>(
+inline block::detail::RawBlockMerkleData deserialize<block::detail::RawBlockMerkleData>(
     const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= block::detail::RawBlockMerklelData::MIN_SIZE);
+  Assert(buf.length() >= block::detail::RawBlockMerkleData::MIN_SIZE);
 
   auto offset = std::size_t{0};
-  auto data = block::detail::RawBlockMerklelData{};
+  auto data = block::detail::RawBlockMerkleData{};
 
   // State hash.
   data.stateHash = sparse_merkle::Hash{reinterpret_cast<const std::uint8_t *>(buf.data()) + offset};
-  offset += block::detail::RawBlockMerklelData::STATE_HASH_SIZE;
+  offset += block::detail::RawBlockMerkleData::STATE_HASH_SIZE;
 
   // Deleted keys follow.
   auto keyBuffer = concordUtils::Sliver{
-      buf, block::detail::RawBlockMerklelData::MIN_SIZE, buf.length() - block::detail::RawBlockMerklelData::MIN_SIZE};
+      buf, block::detail::RawBlockMerkleData::MIN_SIZE, buf.length() - block::detail::RawBlockMerkleData::MIN_SIZE};
   while (!keyBuffer.empty()) {
-    Assert(keyBuffer.length() >= block::detail::RawBlockMerklelData::MIN_KEY_SIZE);
+    Assert(keyBuffer.length() >= block::detail::RawBlockMerkleData::MIN_KEY_SIZE);
 
     // Key length.
     const auto keyLen = concordUtils::fromBigEndianBuffer<block::detail::KeyLengthType>(keyBuffer.data());
-    Assert(keyLen <= (keyBuffer.length() - block::detail::RawBlockMerklelData::MIN_KEY_SIZE));
-    data.deletedKeys.insert(concordUtils::Sliver{keyBuffer, block::detail::RawBlockMerklelData::MIN_KEY_SIZE, keyLen});
+    Assert(keyLen <= (keyBuffer.length() - block::detail::RawBlockMerkleData::MIN_KEY_SIZE));
+    data.deletedKeys.insert(concordUtils::Sliver{keyBuffer, block::detail::RawBlockMerkleData::MIN_KEY_SIZE, keyLen});
 
     keyBuffer = concordUtils::Sliver{keyBuffer,
-                                     block::detail::RawBlockMerklelData::MIN_KEY_SIZE + keyLen,
-                                     keyBuffer.length() - (block::detail::RawBlockMerklelData::MIN_KEY_SIZE + keyLen)};
+                                     block::detail::RawBlockMerkleData::MIN_KEY_SIZE + keyLen,
+                                     keyBuffer.length() - (block::detail::RawBlockMerkleData::MIN_KEY_SIZE + keyLen)};
   }
 
   return data;

--- a/kvbc/include/merkle_tree_serialization.h
+++ b/kvbc/include/merkle_tree_serialization.h
@@ -24,7 +24,6 @@
 #include "storage/db_types.h"
 #include "string.hpp"
 
-#include <algorithm>
 #include <cstdint>
 #include <iterator>
 #include <limits>
@@ -180,8 +179,35 @@ inline std::string serializeImp(const block::detail::Node &node) {
   return buf;
 }
 
+inline std::string serializeImp(block::detail::RawBlockMerklelData data) {
+  auto dataSize = block::detail::RawBlockMerklelData::MIN_SIZE;
+  for (const auto &key : data.deletedKeys) {
+    dataSize += (sizeof(block::detail::KeyLengthType) + key.length());
+  }
+
+  std::string buf;
+  buf.reserve(dataSize);
+
+  // State hash.
+  buf.append(reinterpret_cast<const char *>(data.stateHash.data()), data.stateHash.size());
+
+  // Sorted deleted keys in [length, key] encoding.
+  for (const auto &key : data.deletedKeys) {
+    buf += concordUtils::toBigEndianStringBuffer(static_cast<block::detail::KeyLengthType>(key.length()));
+    buf.append(key.data(), key.length());
+  }
+
+  return buf;
+}
+
 inline std::string serializeImp(const DatabaseLeafValue &val) {
-  return serializeImp(val.blockId) + val.leafNode.value.toString();
+  auto buf = serializeImp(val.addedInBlockId);
+  if (val.deletedInBlockId.has_value()) {
+    buf += serializeImp(*val.deletedInBlockId);
+  } else {
+    buf += serializeImp(detail::INVALID_BLOCK_ID);
+  }
+  return buf + val.leafNode.value.toString();
 }
 
 inline std::string serialize() { return std::string{}; }
@@ -341,6 +367,37 @@ inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::
   return node;
 }
 
+template <>
+inline block::detail::RawBlockMerklelData deserialize<block::detail::RawBlockMerklelData>(
+    const concordUtils::Sliver &buf) {
+  Assert(buf.length() >= block::detail::RawBlockMerklelData::MIN_SIZE);
+
+  auto offset = std::size_t{0};
+  auto data = block::detail::RawBlockMerklelData{};
+
+  // State hash.
+  data.stateHash = sparse_merkle::Hash{reinterpret_cast<const std::uint8_t *>(buf.data()) + offset};
+  offset += block::detail::RawBlockMerklelData::STATE_HASH_SIZE;
+
+  // Deleted keys follow.
+  auto keyBuffer = concordUtils::Sliver{
+      buf, block::detail::RawBlockMerklelData::MIN_SIZE, buf.length() - block::detail::RawBlockMerklelData::MIN_SIZE};
+  while (!keyBuffer.empty()) {
+    Assert(keyBuffer.length() >= block::detail::RawBlockMerklelData::MIN_KEY_SIZE);
+
+    // Key length.
+    const auto keyLen = concordUtils::fromBigEndianBuffer<block::detail::KeyLengthType>(keyBuffer.data());
+    Assert(keyLen <= (keyBuffer.length() - block::detail::RawBlockMerklelData::MIN_KEY_SIZE));
+    data.deletedKeys.insert(concordUtils::Sliver{keyBuffer, block::detail::RawBlockMerklelData::MIN_KEY_SIZE, keyLen});
+
+    keyBuffer = concordUtils::Sliver{keyBuffer,
+                                     block::detail::RawBlockMerklelData::MIN_KEY_SIZE + keyLen,
+                                     keyBuffer.length() - (block::detail::RawBlockMerklelData::MIN_KEY_SIZE + keyLen)};
+  }
+
+  return data;
+}
+
 // Deserializes the state root version from a serialized block::detail::Node .
 inline sparse_merkle::Version deserializeStateRootVersion(const concordUtils::Sliver &buf) {
   Assert(buf.length() >= block::detail::Node::MIN_SIZE);
@@ -351,10 +408,17 @@ inline sparse_merkle::Version deserializeStateRootVersion(const concordUtils::Sl
 
 template <>
 inline DatabaseLeafValue deserialize<DatabaseLeafValue>(const concordUtils::Sliver &buf) {
-  constexpr auto blockIdSize = sizeof(DatabaseLeafValue::blockId);
-  Assert(buf.length() >= blockIdSize);
-  return DatabaseLeafValue{concordUtils::fromBigEndianBuffer<decltype(DatabaseLeafValue::blockId)>(buf.data()),
-                           sparse_merkle::LeafNode{concordUtils::Sliver{buf, blockIdSize, buf.length() - blockIdSize}}};
+  Assert(buf.length() >= DatabaseLeafValue::MIN_SIZE);
+  constexpr auto blockIdSize = sizeof(DatabaseLeafValue::BlockIdType);
+  const auto addedInBlock = concordUtils::fromBigEndianBuffer<DatabaseLeafValue::BlockIdType>(buf.data());
+  const auto deletedInBlock =
+      concordUtils::fromBigEndianBuffer<DatabaseLeafValue::BlockIdType>(buf.data() + blockIdSize);
+  const auto leafNode = sparse_merkle::LeafNode{
+      concordUtils::Sliver{buf, DatabaseLeafValue::MIN_SIZE, buf.length() - DatabaseLeafValue::MIN_SIZE}};
+  if (deletedInBlock != detail::INVALID_BLOCK_ID) {
+    return DatabaseLeafValue{addedInBlock, leafNode, deletedInBlock};
+  }
+  return DatabaseLeafValue{addedInBlock, leafNode};
 }
 
 }  // namespace detail

--- a/kvbc/src/direct_kv_block.cpp
+++ b/kvbc/src/direct_kv_block.cpp
@@ -129,7 +129,6 @@ Sliver getUserData(const Sliver &block) {
 
   // If there are no elements, we only have a Header and, optionally, user data.
   if (header->numberOfElements == 0) {
-    assert(block.length() >= headerSize);
     return Sliver{block, headerSize, block.length() - headerSize};
   }
 

--- a/kvbc/src/direct_kv_block.cpp
+++ b/kvbc/src/direct_kv_block.cpp
@@ -114,12 +114,31 @@ SetOfKeyValuePairs getData(const Sliver &block) {
   return retVal;
 }
 
-BlockDigest getParentDigest(const concordUtils::Sliver &block) {
+BlockDigest getParentDigest(const Sliver &block) {
   const auto *bh = reinterpret_cast<const detail::Header *>(block.data());
   assert(BLOCK_DIGEST_SIZE == bh->parentDigestLength);
   BlockDigest digest;
   std::memcpy(digest.data(), bh->parentDigest, BLOCK_DIGEST_SIZE);
   return digest;
+}
+
+Sliver getUserData(const Sliver &block) {
+  constexpr auto headerSize = sizeof(detail::Header);
+  assert(block.length() >= headerSize);
+  const auto header = reinterpret_cast<const detail::Header *>(block.data());
+
+  // If there are no elements, we only have a Header and, optionally, user data.
+  if (header->numberOfElements == 0) {
+    assert(block.length() >= headerSize);
+    return Sliver{block, headerSize, block.length() - headerSize};
+  }
+
+  // Calculate the user data offset by adding the offset of the last value and its length.
+  const auto entries = reinterpret_cast<const detail::Entry *>(block.data() + sizeof(detail::Header));
+  const auto lastEntry = entries[header->numberOfElements - 1];
+  const auto userDataOffset = lastEntry.valOffset + lastEntry.valSize;
+  assert(block.length() >= userDataOffset);
+  return Sliver{block, userDataOffset, block.length() - userDataOffset};
 }
 
 }  // namespace detail

--- a/kvbc/src/merkle_tree_block.cpp
+++ b/kvbc/src/merkle_tree_block.cpp
@@ -16,7 +16,7 @@ using ::concordUtils::Sliver;
 // users are not expected to interpret the returned buffer themselves.
 
 RawBlock create(const SetOfKeyValuePairs &updates, const BlockDigest &parentDigest, const Hash &stateHash) {
-  const auto merkleData = v2MerkleTree::detail::serialize(RawBlockMerklelData{stateHash});
+  const auto merkleData = v2MerkleTree::detail::serialize(RawBlockMerkleData{stateHash});
   auto out = SetOfKeyValuePairs{};
   return v1DirectKeyValue::block::detail::create(updates, out, parentDigest, merkleData.data(), merkleData.size());
 }
@@ -25,7 +25,7 @@ RawBlock create(const SetOfKeyValuePairs &updates,
                 const OrderedKeysSet &deletes,
                 const BlockDigest &parentDigest,
                 const Hash &stateHash) {
-  const auto merkleData = v2MerkleTree::detail::serialize(RawBlockMerklelData{stateHash, deletes});
+  const auto merkleData = v2MerkleTree::detail::serialize(RawBlockMerkleData{stateHash, deletes});
   auto out = SetOfKeyValuePairs{};
   return v1DirectKeyValue::block::detail::create(updates, out, parentDigest, merkleData.data(), merkleData.size());
 }
@@ -33,14 +33,14 @@ RawBlock create(const SetOfKeyValuePairs &updates,
 SetOfKeyValuePairs getData(const RawBlock &block) { return v1DirectKeyValue::block::detail::getData(block); }
 
 OrderedKeysSet getDeletedKeys(const RawBlock &block) {
-  return v2MerkleTree::detail::deserialize<RawBlockMerklelData>(v1DirectKeyValue::block::detail::getUserData(block))
+  return v2MerkleTree::detail::deserialize<RawBlockMerkleData>(v1DirectKeyValue::block::detail::getUserData(block))
       .deletedKeys;
 }
 
 BlockDigest getParentDigest(const RawBlock &block) { return v1DirectKeyValue::block::detail::getParentDigest(block); }
 
 Hash getStateHash(const RawBlock &block) {
-  return v2MerkleTree::detail::deserialize<RawBlockMerklelData>(v1DirectKeyValue::block::detail::getUserData(block))
+  return v2MerkleTree::detail::deserialize<RawBlockMerkleData>(v1DirectKeyValue::block::detail::getUserData(block))
       .stateHash;
 }
 

--- a/kvbc/src/merkle_tree_block.cpp
+++ b/kvbc/src/merkle_tree_block.cpp
@@ -12,22 +12,36 @@ namespace concord::kvbc::v2MerkleTree::block::detail {
 using sparse_merkle::Hash;
 using ::concordUtils::Sliver;
 
-// Use the v1DirectKeyValue implementation and just add the state hash at the back. We want that so it is included in
-// the block digest. We can do that, because users are not expected to interpret the returned buffer themselves.
+// Use the v1DirectKeyValue implementation and just add the merkle-specific data at the back. We can do that, because
+// users are not expected to interpret the returned buffer themselves.
+
 RawBlock create(const SetOfKeyValuePairs &updates, const BlockDigest &parentDigest, const Hash &stateHash) {
-  SetOfKeyValuePairs out;
-  return v1DirectKeyValue::block::detail::create(
-      updates, out, parentDigest, stateHash.dataArray().data(), stateHash.dataArray().size());
+  const auto merkleData = v2MerkleTree::detail::serialize(RawBlockMerklelData{stateHash});
+  auto out = SetOfKeyValuePairs{};
+  return v1DirectKeyValue::block::detail::create(updates, out, parentDigest, merkleData.data(), merkleData.size());
+}
+
+RawBlock create(const SetOfKeyValuePairs &updates,
+                const OrderedKeysSet &deletes,
+                const BlockDigest &parentDigest,
+                const Hash &stateHash) {
+  const auto merkleData = v2MerkleTree::detail::serialize(RawBlockMerklelData{stateHash, deletes});
+  auto out = SetOfKeyValuePairs{};
+  return v1DirectKeyValue::block::detail::create(updates, out, parentDigest, merkleData.data(), merkleData.size());
 }
 
 SetOfKeyValuePairs getData(const RawBlock &block) { return v1DirectKeyValue::block::detail::getData(block); }
 
+OrderedKeysSet getDeletedKeys(const RawBlock &block) {
+  return v2MerkleTree::detail::deserialize<RawBlockMerklelData>(v1DirectKeyValue::block::detail::getUserData(block))
+      .deletedKeys;
+}
+
 BlockDigest getParentDigest(const RawBlock &block) { return v1DirectKeyValue::block::detail::getParentDigest(block); }
 
 Hash getStateHash(const RawBlock &block) {
-  Assert(block.length() >= Hash::SIZE_IN_BYTES);
-  const auto data = reinterpret_cast<const std::uint8_t *>(block.data());
-  return Hash{data + (block.length() - Hash::SIZE_IN_BYTES)};
+  return v2MerkleTree::detail::deserialize<RawBlockMerklelData>(v1DirectKeyValue::block::detail::getUserData(block))
+      .stateHash;
 }
 
 Sliver createNode(const Node &node) { return v2MerkleTree::detail::serialize(node); }

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -48,6 +48,8 @@ if(RAPIDCHECK_FOUND)
 add_executable(sparse_merkle_storage_db_adapter_property_test
     sparse_merkle_storage/db_adapter_property_test.cpp $<TARGET_OBJECTS:logging_dev>)
 add_test(sparse_merkle_storage_db_adapter_property_test sparse_merkle_storage_db_adapter_property_test)
+# Decrease both the input size and test count from the default value of 100 to 50 in order to speed up this test.
+set_property(TEST sparse_merkle_storage_db_adapter_property_test PROPERTY ENVIRONMENT RC_PARAMS=max_size=50\ max_success=50)
 target_include_directories(sparse_merkle_storage_db_adapter_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
 target_link_libraries(sparse_merkle_storage_db_adapter_property_test PUBLIC
     GTest::Main

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -422,30 +422,30 @@ TEST(block, state_root_deserialization) {
 TEST(block, raw_block_merkle_data_equality) {
   // Default-constructed ones are equal.
   {
-    const auto d1 = block::detail::RawBlockMerklelData{};
-    const auto d2 = block::detail::RawBlockMerklelData{};
+    const auto d1 = block::detail::RawBlockMerkleData{};
+    const auto d2 = block::detail::RawBlockMerkleData{};
     ASSERT_TRUE(d1 == d2);
   }
 
   // Hash-only - equal.
   {
-    const auto d1 = block::detail::RawBlockMerklelData{defaultHash};
-    const auto d2 = block::detail::RawBlockMerklelData{defaultHash};
+    const auto d1 = block::detail::RawBlockMerkleData{defaultHash};
+    const auto d2 = block::detail::RawBlockMerkleData{defaultHash};
     ASSERT_TRUE(d1 == d2);
   }
 
   // Hash-only - not equal.
   {
-    const auto d1 = block::detail::RawBlockMerklelData{getHash("1")};
-    const auto d2 = block::detail::RawBlockMerklelData{getHash("2")};
+    const auto d1 = block::detail::RawBlockMerkleData{getHash("1")};
+    const auto d2 = block::detail::RawBlockMerkleData{getHash("2")};
     ASSERT_FALSE(d1 == d2);
   }
 
   // Equal hash and keys.
   {
     const auto keys = OrderedKeysSet{Key{"k1"}, Key{"k2"}};
-    const auto d1 = block::detail::RawBlockMerklelData{defaultHash, keys};
-    const auto d2 = block::detail::RawBlockMerklelData{defaultHash, keys};
+    const auto d1 = block::detail::RawBlockMerkleData{defaultHash, keys};
+    const auto d2 = block::detail::RawBlockMerkleData{defaultHash, keys};
     ASSERT_TRUE(d1 == d2);
   }
 
@@ -453,16 +453,16 @@ TEST(block, raw_block_merkle_data_equality) {
   {
     const auto keys1 = OrderedKeysSet{Key{"k1"}, Key{"k2"}};
     const auto keys2 = OrderedKeysSet{Key{"k1"}};
-    const auto d1 = block::detail::RawBlockMerklelData{defaultHash, keys1};
-    const auto d2 = block::detail::RawBlockMerklelData{defaultHash, keys2};
+    const auto d1 = block::detail::RawBlockMerkleData{defaultHash, keys1};
+    const auto d2 = block::detail::RawBlockMerkleData{defaultHash, keys2};
     ASSERT_FALSE(d1 == d2);
   }
 
   // Different hash, same keys.
   {
     const auto keys = OrderedKeysSet{Key{"k1"}, Key{"k2"}};
-    const auto d1 = block::detail::RawBlockMerklelData{getHash("1"), keys};
-    const auto d2 = block::detail::RawBlockMerklelData{getHash("2"), keys};
+    const auto d1 = block::detail::RawBlockMerkleData{getHash("1"), keys};
+    const auto d2 = block::detail::RawBlockMerkleData{getHash("2"), keys};
     ASSERT_FALSE(d1 == d2);
   }
 }
@@ -470,31 +470,31 @@ TEST(block, raw_block_merkle_data_equality) {
 TEST(block, raw_block_merkle_data_serialization) {
   // No keys.
   {
-    const auto data = block::detail::RawBlockMerklelData{defaultHash};
+    const auto data = block::detail::RawBlockMerkleData{defaultHash};
     const auto dataSliver = Sliver{serialize(data)};
-    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerkleData>(dataSliver), data);
   }
 
   // Non-empty keys.
   {
-    const auto data = block::detail::RawBlockMerklelData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{"k2"}}};
+    const auto data = block::detail::RawBlockMerkleData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{"k2"}}};
     const auto dataSliver = Sliver{serialize(data)};
-    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerkleData>(dataSliver), data);
   }
 
   // With empty keys.
   {
-    const auto data = block::detail::RawBlockMerklelData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{}, Key{"k3"}}};
+    const auto data = block::detail::RawBlockMerkleData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{}, Key{"k3"}}};
     const auto dataSliver = Sliver{serialize(data)};
-    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerkleData>(dataSliver), data);
   }
 
   // Different key sizes.
   {
     const auto data =
-        block::detail::RawBlockMerklelData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{"key12"}, Key{"333333"}}};
+        block::detail::RawBlockMerkleData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{"key12"}, Key{"333333"}}};
     const auto dataSliver = Sliver{serialize(data)};
-    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerkleData>(dataSliver), data);
   }
 }
 

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -1,3 +1,16 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
 #include "gtest/gtest.h"
 
 #include "storage_test_common.h"
@@ -26,6 +39,8 @@ using namespace ::concord::storage::v2MerkleTree::detail;
 using ::concordUtils::Sliver;
 
 using ::concord::kvbc::BlockId;
+using ::concord::kvbc::Key;
+using ::concord::kvbc::OrderedKeysSet;
 using ::concord::kvbc::SetOfKeyValuePairs;
 using ::concord::kvbc::sparse_merkle::BatchedInternalNode;
 using ::concord::kvbc::sparse_merkle::InternalChild;
@@ -404,6 +419,85 @@ TEST(block, state_root_deserialization) {
   }
 }
 
+TEST(block, raw_block_merkle_data_equality) {
+  // Default-constructed ones are equal.
+  {
+    const auto d1 = block::detail::RawBlockMerklelData{};
+    const auto d2 = block::detail::RawBlockMerklelData{};
+    ASSERT_TRUE(d1 == d2);
+  }
+
+  // Hash-only - equal.
+  {
+    const auto d1 = block::detail::RawBlockMerklelData{defaultHash};
+    const auto d2 = block::detail::RawBlockMerklelData{defaultHash};
+    ASSERT_TRUE(d1 == d2);
+  }
+
+  // Hash-only - not equal.
+  {
+    const auto d1 = block::detail::RawBlockMerklelData{getHash("1")};
+    const auto d2 = block::detail::RawBlockMerklelData{getHash("2")};
+    ASSERT_FALSE(d1 == d2);
+  }
+
+  // Equal hash and keys.
+  {
+    const auto keys = OrderedKeysSet{Key{"k1"}, Key{"k2"}};
+    const auto d1 = block::detail::RawBlockMerklelData{defaultHash, keys};
+    const auto d2 = block::detail::RawBlockMerklelData{defaultHash, keys};
+    ASSERT_TRUE(d1 == d2);
+  }
+
+  // Same hash, different keys.
+  {
+    const auto keys1 = OrderedKeysSet{Key{"k1"}, Key{"k2"}};
+    const auto keys2 = OrderedKeysSet{Key{"k1"}};
+    const auto d1 = block::detail::RawBlockMerklelData{defaultHash, keys1};
+    const auto d2 = block::detail::RawBlockMerklelData{defaultHash, keys2};
+    ASSERT_FALSE(d1 == d2);
+  }
+
+  // Different hash, same keys.
+  {
+    const auto keys = OrderedKeysSet{Key{"k1"}, Key{"k2"}};
+    const auto d1 = block::detail::RawBlockMerklelData{getHash("1"), keys};
+    const auto d2 = block::detail::RawBlockMerklelData{getHash("2"), keys};
+    ASSERT_FALSE(d1 == d2);
+  }
+}
+
+TEST(block, raw_block_merkle_data_serialization) {
+  // No keys.
+  {
+    const auto data = block::detail::RawBlockMerklelData{defaultHash};
+    const auto dataSliver = Sliver{serialize(data)};
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+  }
+
+  // Non-empty keys.
+  {
+    const auto data = block::detail::RawBlockMerklelData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{"k2"}}};
+    const auto dataSliver = Sliver{serialize(data)};
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+  }
+
+  // With empty keys.
+  {
+    const auto data = block::detail::RawBlockMerklelData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{}, Key{"k3"}}};
+    const auto dataSliver = Sliver{serialize(data)};
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+  }
+
+  // Different key sizes.
+  {
+    const auto data =
+        block::detail::RawBlockMerklelData{defaultHash, OrderedKeysSet{Key{"k1"}, Key{"key12"}, Key{"333333"}}};
+    const auto dataSliver = Sliver{serialize(data)};
+    ASSERT_EQ(deserialize<block::detail::RawBlockMerklelData>(dataSliver), data);
+  }
+}
+
 TEST(block, block_serialization) {
   SetOfKeyValuePairs updates;
   for (auto i = 1u; i <= maxNumKeys; ++i) {
@@ -552,16 +646,79 @@ TEST(batched_internal, serialization) {
   }
 }
 
+TEST(database_leaf_value, equality) {
+  // Default-constructed leaf values are equal
+  {
+    const auto v1 = detail::DatabaseLeafValue{};
+    const auto v2 = detail::DatabaseLeafValue{};
+    ASSERT_TRUE(v1 == v2);
+  }
+
+  // Non-deleted equal leaf values.
+  {
+    const auto v1 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}};
+    const auto v2 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}};
+    ASSERT_TRUE(v1 == v2);
+  }
+
+  // Non-deleted leaf values that differ in the block ID only.
+  {
+    const auto v1 = detail::DatabaseLeafValue{defaultBlockId + 1, LeafNode{defaultSliver}};
+    const auto v2 = detail::DatabaseLeafValue{defaultBlockId + 2, LeafNode{defaultSliver}};
+    ASSERT_FALSE(v1 == v2);
+  }
+
+  // Non-deleted leaf values that differ in the value only.
+  {
+    const auto v1 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{Sliver{"v1"}}};
+    const auto v2 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{Sliver{"v2"}}};
+    ASSERT_FALSE(v1 == v2);
+  }
+
+  // Deleted equal leaf values.
+  {
+    const auto v1 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}, defaultBlockId};
+    const auto v2 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}, defaultBlockId};
+    ASSERT_TRUE(v1 == v2);
+  }
+
+  // Deleted and non-deleted leaf values are not equal.
+  {
+    const auto v1 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}};
+    const auto v2 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}, defaultBlockId};
+    ASSERT_FALSE(v1 == v2);
+  }
+
+  // Deleted in different blocks are not equal.
+  {
+    const auto v1 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}, defaultBlockId + 1};
+    const auto v2 = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}, defaultBlockId + 2};
+    ASSERT_FALSE(v1 == v2);
+  }
+}
+
 TEST(database_leaf_value, serialization) {
-  // Non-empty value.
+  // Non-deleted with a non-empty value.
   {
     const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}};
     ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
   }
 
-  // Empty value.
+  // Non-deleted with an empty value.
   {
     const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{Sliver{}}};
+    ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
+  }
+
+  // Deleted with a non-empty value.
+  {
+    const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{defaultSliver}, defaultBlockId + 1};
+    ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
+  }
+
+  // Deleted with an empty value.
+  {
+    const auto dbLeafVal = detail::DatabaseLeafValue{defaultBlockId, LeafNode{Sliver{}}, defaultBlockId + 1};
     ASSERT_TRUE(deserialize<detail::DatabaseLeafValue>(serialize(dbLeafVal)) == dbLeafVal);
   }
 }


### PR DESCRIPTION
Add support for empty values in the v2MerkleTree DBAdapter . Keys with
empty values are no longer treated as deleted keys.

In addition, support an explicit parameter with a set of keys to delete
in the DBAdapter . If a key is deleted in block N, find a leaf for the
same key with a previous version and, if there is such a leaf, mark it
as deleted in block N. When calling getValue() for block X, if we find a
leaf for the deleted key and its 'deleted in block' value is less than
or equal to X, throw a NotFoundException . Else, return the value as per
normal, even if it is marked as deleted.

Marking keys as deleted is done by serializing a 'deleted in block ID'
integer in the key's value itself (the 'DatabaseLeafValue' structure).

Keys passed to addBlock() for deletion that are not part of the
blockchain will not be saved in the new block and there will be no
information kept that the user tried to delete non-existent keys.

Deleted keys are serialized in raw blocks in order to support state
transfer. Deleted keys are ordered before serialization in order to have
deterministic raw blocks, having equal hashes.

Provide tests that prove the functionality works as expected.

Decrease both the max input size and the test count from the default
value of 100 to 50 for the merkle DBAdapter property test in order to
speed it up.