### PR TITLE
State Transfer: transfer only "dirty" reserved pages in virtual block

### DIFF
--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -374,7 +374,6 @@ void DBDataStore::deleteCoveredResPageInSmallerCheckpointsTxn(uint64_t minChkp, 
   auto pages = inmem_->getPagesMap();
   auto it = pages.begin();
   uint32_t prevItemPageId = it->first.pageId;
-  assert(prevItemPageId == 0);
   bool prevItemIsInLastRelevantCheckpoint = (it->first.checkpoint <= minChkp);
   it++;
   for (; it != pages.end(); ++it) {

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -104,23 +104,14 @@ class DBDataStore : public DataStore {
   ResPagesDescriptor* getResPagesDescriptor(uint64_t inCheckpoint) override {
     return inmem_->getResPagesDescriptor(inCheckpoint);
   }
-  void getResPage(uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint) override {
-    inmem_->getResPage(inPageId, inCheckpoint, outActualCheckpoint);
-  }
-  void getResPage(uint32_t inPageId,
-                  uint64_t inCheckpoint,
-                  uint64_t* outActualCheckpoint,
-                  char* outPage,
-                  uint32_t copylength) override {
-    inmem_->getResPage(inPageId, inCheckpoint, outActualCheckpoint, outPage, copylength);
-  }
-  void getResPage(uint32_t inPageId,
+
+  bool getResPage(uint32_t inPageId,
                   uint64_t inCheckpoint,
                   uint64_t* outActualCheckpoint,
                   STDigest* outPageDigest,
                   char* outPage,
                   uint32_t copylength) override {
-    inmem_->getResPage(inPageId, inCheckpoint, outActualCheckpoint, outPageDigest, outPage, copylength);
+    return inmem_->getResPage(inPageId, inCheckpoint, outActualCheckpoint, outPageDigest, outPage, copylength);
   }
 
  protected:
@@ -236,7 +227,7 @@ class DBDataStore : public DataStore {
   Sliver genKey(const ObjectId& objId) const { return keymanip_->generateStateTransferKey(objId); }
   /** ****************************************************************************************************************/
   concordlogger::Logger& logger() {
-    static concordlogger::Logger logger_ = concordlogger::Log::getLogger("DBDataStore");
+    static concordlogger::Logger logger_ = concordlogger::Log::getLogger("bft.st.dbdatastore");
     return logger_;
   }
 

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -99,10 +99,14 @@ class DataStore : public std::enable_shared_from_this<DataStore> {
                           uint64_t inCheckpoint,
                           const STDigest& inPageDigest,
                           const char* inPage) = 0;
-  virtual void getResPage(uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint) = 0;
-  virtual void getResPage(
-      uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint, char* outPage, uint32_t copylength) = 0;
-  virtual void getResPage(uint32_t inPageId,
+  virtual bool getResPage(uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint) {
+    return getResPage(inPageId, inCheckpoint, outActualCheckpoint, nullptr, nullptr, 0);
+  }
+  virtual bool getResPage(
+      uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint, char* outPage, uint32_t copylength) {
+    return getResPage(inPageId, inCheckpoint, outActualCheckpoint, nullptr, outPage, copylength);
+  }
+  virtual bool getResPage(uint32_t inPageId,
                           uint64_t inCheckpoint,
                           uint64_t* outActualCheckpoint,
                           STDigest* outPageDigest,
@@ -228,17 +232,7 @@ class DataStoreTransaction : public DataStore, public ITransaction {
   void getPendingResPage(uint32_t inPageId, char* outPage, uint32_t pageLen) override {
     return ds_->getPendingResPage(inPageId, outPage, pageLen);
   }
-  void getResPage(uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint) override {
-    return ds_->getResPage(inPageId, inCheckpoint, outActualCheckpoint);
-  }
-  void getResPage(uint32_t inPageId,
-                  uint64_t inCheckpoint,
-                  uint64_t* outActualCheckpoint,
-                  char* outPage,
-                  uint32_t copylength) override {
-    return ds_->getResPage(inPageId, inCheckpoint, outActualCheckpoint, outPage, copylength);
-  }
-  void getResPage(uint32_t inPageId,
+  bool getResPage(uint32_t inPageId,
                   uint64_t inCheckpoint,
                   uint64_t* outActualCheckpoint,
                   STDigest* outPageDigest,

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -19,6 +19,7 @@
 
 #include "DataStore.hpp"
 #include "STDigest.hpp"
+#include "Logger.hpp"
 
 using std::map;
 
@@ -106,13 +107,8 @@ class InMemoryDataStore : public DataStore {
                                              const STDigest& inPageDigest) override;
 
   void setResPage(uint32_t inPageId, uint64_t inCheckpoint, const STDigest& inPageDigest, const char* inPage) override;
-  void getResPage(uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint) override;
-  void getResPage(uint32_t inPageId,
-                  uint64_t inCheckpoint,
-                  uint64_t* outActualCheckpoint,
-                  char* outPage,
-                  uint32_t copylength) override;
-  void getResPage(uint32_t inPageId,
+
+  bool getResPage(uint32_t inPageId,
                   uint64_t inCheckpoint,
                   uint64_t* outActualCheckpoint,
                   STDigest* outPageDigest,
@@ -196,6 +192,10 @@ class InMemoryDataStore : public DataStore {
   const map<uint32_t, char*>& getPendingPagesMap() const { return pendingPages; }
 
   void setInitialized(bool init) { wasInit_ = init; }
+  concordlogger::Logger& logger() {
+    static concordlogger::Logger logger_ = concordlogger::Log::getLogger("bft.st.inmem");
+    return logger_;
+  }
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -68,7 +68,7 @@ void ClientsManager::clearReservedPages() {
 void ClientsManager::loadInfoFromReservedPages() {
   for (std::pair<NodeIdType, uint16_t> e : clientIdToIndex_) {
     const uint32_t firstPageId = e.second * reservedPagesPerClient_;
-    // to deal with a situation when restarting before state transfer first checkpoint reached
+
     if (!stateTransfer_->loadReservedPage(firstPageId, sizeOfReservedPage_, scratchPage_)) continue;
 
     ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2179,9 +2179,11 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
   Assert(hasStateInformation || oldSeqNum);  // !hasStateInformation ==> oldSeqNum
   Assert(newStableSeqNum % checkpointWindowSize == 0);
 
-  if (newStableSeqNum <= lastStableSeqNum) return;
+  LOG_DEBUG(GL,
+            "lastStableSeqNum was: " << lastStableSeqNum << " now: " << newStableSeqNum
+                                     << " hasStateInfo: " << hasStateInformation << " oldSeqNum: " << oldSeqNum);
 
-  LOG_DEBUG_F(GL, "onSeqNumIsStable: lastStableSeqNum is now == %" PRId64 "", newStableSeqNum);
+  if (newStableSeqNum <= lastStableSeqNum) return;
 
   if (ps_) ps_->beginWriteTran();
 
@@ -2907,10 +2909,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
 
   clientsManager->init(stateTransfer.get());
 
-  if (!firstTime || config_.debugPersistentStorageEnabled)
-    clientsManager->loadInfoFromReservedPages();
-  else
-    clientsManager->clearReservedPages();
+  if (!firstTime || config_.debugPersistentStorageEnabled) clientsManager->loadInfoFromReservedPages();
 
   // autoPrimaryRotationEnabled implies viewChangeProtocolEnabled
   // Note: "p=>q" is equivalent to "not p or q"

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -233,8 +233,9 @@ class SkvbcPersistenceTest(unittest.TestCase):
            except trio.TooSlowError:
                # We never made it to fetching state. Are we done?
                try:
-                   await bft_network.wait_for_state_transfer_to_stop(
+                    await bft_network.wait_for_state_transfer_to_stop(
                        up_to_date_node, stale_node)
+                    break
                except trio.TooSlowError:
                    self.fail("State transfer did not complete, " +
                              "but we are not fetching either!")


### PR DESCRIPTION
**State Transfer: transfer only "dirty" reserved pages in virtual block**
This significantly decreases the vblock size.
It also solves the first checkpoint delay problem, when all the pending pages were written to the persistent storage.

**BCStateTransfer**
- loads reserved page only if it exists in persistent storage
- vblock consists only of “dirty” reserved pages
- removed function names in log messages as they appear automatically

**InMemoryDataStore**
- reserved pages descriptor always contains only “dirty” reserved pages

**kvbc::ReplicaImp**
- don’t clear reserved pages through client manager in order not to initialise them

**ReplicaLoader**
- BUG: deal with a situation when previous stable ckeckpoints may be not set after ST

**test_skvbc_persistence.py**
- test_st_when_fetcher_crashes - finish after ST complete