### PR TITLE
Pruning-aware replica state sync

### DIFF
--- a/kvbc/include/db_adapter_interface.h
+++ b/kvbc/include/db_adapter_interface.h
@@ -43,6 +43,11 @@ class IDbAdapter {
   // Throws if an error occurs.
   virtual void deleteBlock(const BlockId& blockId) = 0;
 
+  // Deletes the last reachable block.
+  // If the blockchain is empty, the call has no effect.
+  // Throws if an error occurs.
+  virtual void deleteLastReachableBlock() = 0;
+
   // Checks whether block exists
   virtual bool hasBlock(const BlockId& blockId) const = 0;
 

--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -144,6 +144,8 @@ class DBAdapter : public IDbAdapter {
 
   void deleteBlock(const BlockId &) override;
 
+  void deleteLastReachableBlock() override;
+
   bool hasBlock(const BlockId &blockId) const override;
 
   BlockId getGenesisBlockId() const override { return (getLastReachableBlockId() ? INITIAL_GENESIS_BLOCK_ID : 0); }

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -119,6 +119,12 @@ class DBAdapter : public IDbAdapter {
   //    only has a single blockchain block.
   void deleteBlock(const BlockId &blockId) override;
 
+  // Deletes the last reachable block.
+  // If the blockchain is empty, the call has no effect.
+  // If there is only 1 block in the blockchain, it will be deleted (as opposed to calling deleteBlock()).
+  // Throws if an error occurs.
+  void deleteLastReachableBlock() override;
+
   // Returns the block data in the form of a set of key/value pairs.
   SetOfKeyValuePairs getBlockData(const RawBlock &rawBlock) const override;
 
@@ -164,6 +170,8 @@ class DBAdapter : public IDbAdapter {
 
   std::optional<std::pair<Key, Value>> getLeafKeyValAtMostVersion(const Key &key,
                                                                   const sparse_merkle::Version &version) const;
+
+  void deleteKeysForBlock(const KeysVector &keys, BlockId blockId) const;
 
   class Reader : public sparse_merkle::IDBReader {
    public:

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -457,6 +457,17 @@ void DBAdapter::deleteBlock(const BlockId &blockId) {
 }
 
 /**
+ * @brief Deletes the last reachable block.
+ */
+void DBAdapter::deleteLastReachableBlock() {
+  const auto lastReachableBlockId = getLastReachableBlockId();
+  if (lastReachableBlockId == 0) {
+    return;
+  }
+  deleteBlock(lastReachableBlockId);
+}
+
+/**
  * @brief Searches for record in the database by the read version.
  *
  * Read version is used as the block id for generating a composite database key


### PR DESCRIPTION
Since the genesis block ID might change due to pruning and be different
from 1, improve replica state sync so that it takes this fact into
account. In particular, change the ReplicaStateSyncImp::execute()
method.

Introduce the IDbAdapter::deleteLastReachabeBlock() method that
explicitly deletes the last reachable block. Rationale is that the
v2MerkleTree::DBAdapter doesn't support deleting the only block in the
blockchain, while IDbAdapter::deleteLastReachabeBlock() does support it
and that is currently required by replica state sync. The
IDbAdapter::deleteLastReachableBlock() method is only meant to be
called on startup and not by the pruning process.

Future commits might change these interfaces. For example, we currently
keep the IDbAdapter::deleteBlock(BlockId) method as the
v1DirectKeyValue::DBAdapter implementation that can be used for both
local and remote (object store) storage can delete arbitrary blocks from
the blockchain. Additionally, if we were to provide
IDbAdapter::deleteGenesisBlock(), it would not make sense for the
v1DirectKeyValue::DBAdapter implementation. Therefore, further work is
needed to improve these interfaces.

Provide a unit test for the IDbAdapter::deleteLastReachabeBlock()
method.