### PR TITLE
Fix include in S3 client

### DIFF
--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -15,6 +15,7 @@
 
 #include <libs3.h>
 #include <cstring>
+#include <mutex>
 #include <thread>
 #include "Logger.hpp"
 #include "assertUtils.hpp"


### PR DESCRIPTION
In some cases, the file is not compiled because <mutex> is not included.
Line 291: `std::mutex initLock_;`