### PR TITLE
Fix another reincarnation of State Transfer bug when checkpoint message is not set

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2741,7 +2741,11 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
     const CheckData &e = ld.checkWinArr[i];
 
     Assert(checkpointsLog->insideActiveWindow(s));
-    Assert(e.isCheckpointMsgSet() || (s > ld.lastStableSeqNum || s == 0));
+    Assert(s == 0 ||                                                         // no checkpoints yet
+           s > ld.lastStableSeqNum ||                                        // not stable
+           e.isCheckpointMsgSet() ||                                         // if stable need to be set
+           ld.lastStableSeqNum == ld.lastExecutedSeqNum - kWorkWindowSize);  // after ST last executed may be on the
+                                                                             // upper working window boundary
 
     if (!e.isCheckpointMsgSet()) continue;
 


### PR DESCRIPTION
after State Transfer not all previous checkpoint messages may be set