### PR TITLE
Avoid parallel pre-execution retries on a primary replica

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -336,7 +336,7 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
       return;
     }
     clientEntry->reqProcessingStatePtr->handlePreProcessReplyMsg(preProcessReplyMsg);
-    result = clientEntry->reqProcessingStatePtr->getPreProcessingConsensusResult();
+    result = clientEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
   }
   handleReqPreProcessedByOneReplica(cid, result, clientId, reqSeqNum);
 }
@@ -537,7 +537,7 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId, ReqId reqSeqNum
 PreProcessingResult PreProcessor::getPreProcessingConsensusResult(uint16_t clientId) {
   const auto &clientEntry = ongoingRequests_[clientId];
   lock_guard<mutex> lock(clientEntry->mutex);
-  return clientEntry->reqProcessingStatePtr->getPreProcessingConsensusResult();
+  return clientEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
 }
 
 ReqId PreProcessor::getOngoingReqIdForClient(uint16_t clientId) {
@@ -564,7 +564,7 @@ void PreProcessor::handlePreProcessedReqByPrimary(PreProcessRequestMsgSharedPtr 
     lock_guard<mutex> lock(clientEntry->mutex);
     if (clientEntry->reqProcessingStatePtr) {
       clientEntry->reqProcessingStatePtr->handlePrimaryPreProcessed(getPreProcessResultBuffer(clientId), resultBufLen);
-      result = clientEntry->reqProcessingStatePtr->getPreProcessingConsensusResult();
+      result = clientEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
       cid = clientEntry->reqProcessingStatePtr->getPreProcessRequest()->getCid();
     } else
       LOG_WARN(GL, "No reqProcessingStatePtr found for clientId=" << clientId);

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -118,20 +118,20 @@ bool RequestProcessingState::isPreProcessReqMsgReceivedInTime() const {
   return true;
 }
 
-PreProcessingResult RequestProcessingState::getPreProcessingConsensusResult() const {
+PreProcessingResult RequestProcessingState::getPreProcessingConsensusResult() {
   if (numOfReceivedReplies_ < numOfRequiredEqualReplies_) return CONTINUE;
 
   uint16_t maxNumOfEqualHashes = 0;
   auto itOfChosenHash = calculateMaxNbrOfEqualHashes(maxNumOfEqualHashes);
   if (maxNumOfEqualHashes >= numOfRequiredEqualReplies_) {
     if (itOfChosenHash->first == primaryPreProcessResultHash_) return COMPLETE;  // Pre-execution consensus reached
-
-    if (primaryPreProcessResultLen_ != 0) {
+    if (primaryPreProcessResultLen_ != 0 && !retrying_) {
       // Primary replica calculated hash is different from a hash that passed pre-execution consensus => we don't have
       // correct pre-processed results. Let's launch a pre-processing retry.
       LOG_WARN(GL,
                "Primary replica pre-processing result hash is different from one passed the consensus for reqSeqNum="
                    << reqSeqNum_ << "; retry pre-processing on primary replica");
+      retrying_ = true;
       return RETRY_PRIMARY;
     }
 

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -118,7 +118,7 @@ bool RequestProcessingState::isPreProcessReqMsgReceivedInTime() const {
   return true;
 }
 
-PreProcessingResult RequestProcessingState::getPreProcessingConsensusResult() {
+PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult() {
   if (numOfReceivedReplies_ < numOfRequiredEqualReplies_) return CONTINUE;
 
   uint16_t maxNumOfEqualHashes = 0;

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -38,7 +38,7 @@ class RequestProcessingState {
   void setPreProcessRequest(PreProcessRequestMsgSharedPtr preProcessReqMsg);
   PreProcessRequestMsgSharedPtr getPreProcessRequest() const { return preProcessRequestMsg_; }
   const SeqNum getReqSeqNum() const { return reqSeqNum_; }
-  PreProcessingResult getPreProcessingConsensusResult() const;
+  PreProcessingResult getPreProcessingConsensusResult();
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut() const;
@@ -70,6 +70,7 @@ class RequestProcessingState {
   concord::util::SHA3_256::Digest primaryPreProcessResultHash_;
   // Maps result hash to the number of equal hashes
   std::map<concord::util::SHA3_256::Digest, int> preProcessingResultHashes_;
+  bool retrying_ = false;
 };
 
 typedef std::unique_ptr<RequestProcessingState> RequestProcessingStateUniquePtr;

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -38,7 +38,7 @@ class RequestProcessingState {
   void setPreProcessRequest(PreProcessRequestMsgSharedPtr preProcessReqMsg);
   PreProcessRequestMsgSharedPtr getPreProcessRequest() const { return preProcessRequestMsg_; }
   const SeqNum getReqSeqNum() const { return reqSeqNum_; }
-  PreProcessingResult getPreProcessingConsensusResult();
+  PreProcessingResult definePreProcessingConsensusResult();
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut() const;
@@ -59,6 +59,8 @@ class RequestProcessingState {
   static uint16_t numOfRequiredEqualReplies_;
   static uint16_t preProcessReqWaitTimeMilli_;
 
+  // The use of the class data members is thread-safe. The PreProcessor class uses a per-instance mutex lock for
+  // the RequestProcessingState objects.
   const uint16_t numOfReplicas_;
   const ReqId reqSeqNum_;
   const uint64_t entryTime_;

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -345,10 +345,10 @@ TEST(requestPreprocessingState_test, notEnoughRepliesReceived) {
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
   for (auto i = 1; i < numOfRequiredReplies; i++) {
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
-    Assert(reqState.getPreProcessingConsensusResult() == CONTINUE);
+    Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
   }
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.getPreProcessingConsensusResult() == CONTINUE);
+  Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
 }
 
 TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCollected) {
@@ -358,11 +358,11 @@ TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCol
   memset(buf, '5', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
   for (auto i = 1; i < replicaConfig.numReplicas; i++) {
-    if (i != replicaConfig.numReplicas - 1) Assert(reqState.getPreProcessingConsensusResult() == CONTINUE);
+    if (i != replicaConfig.numReplicas - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     memset(buf, i, bufLen);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
-  Assert(reqState.getPreProcessingConsensusResult() == CANCEL);
+  Assert(reqState.definePreProcessingConsensusResult() == CANCEL);
 }
 
 TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
@@ -371,11 +371,11 @@ TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
   memset(buf, '5', bufLen);
   for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != numOfRequiredReplies - 1) Assert(reqState.getPreProcessingConsensusResult() == CONTINUE);
+    if (i != numOfRequiredReplies - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.getPreProcessingConsensusResult() == COMPLETE);
+  Assert(reqState.definePreProcessingConsensusResult() == COMPLETE);
 }
 
 TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
@@ -385,14 +385,14 @@ TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
   memset(buf, '5', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
   for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != replicaConfig.numReplicas - 1) Assert(reqState.getPreProcessingConsensusResult() == CONTINUE);
+    if (i != replicaConfig.numReplicas - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     memset(buf, '4', bufLen);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
-  Assert(reqState.getPreProcessingConsensusResult() == RETRY_PRIMARY);
+  Assert(reqState.definePreProcessingConsensusResult() == RETRY_PRIMARY);
   memset(buf, '4', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.getPreProcessingConsensusResult() == COMPLETE);
+  Assert(reqState.definePreProcessingConsensusResult() == COMPLETE);
 }
 
 TEST(requestPreprocessingState_test, primaryReplicaDidNotCompletePreProcessingWhileNonPrimariesDid) {
@@ -401,14 +401,14 @@ TEST(requestPreprocessingState_test, primaryReplicaDidNotCompletePreProcessingWh
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
   memset(buf, '5', bufLen);
   for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != replicaConfig.numReplicas - 1) Assert(reqState.getPreProcessingConsensusResult() == CONTINUE);
+    if (i != replicaConfig.numReplicas - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     memset(buf, '4', bufLen);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
-  Assert(reqState.getPreProcessingConsensusResult() == CONTINUE);
+  Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
   memset(buf, '4', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.getPreProcessingConsensusResult() == COMPLETE);
+  Assert(reqState.definePreProcessingConsensusResult() == COMPLETE);
 }
 
 TEST(requestPreprocessingState_test, clientPreProcessMessageConversion) {

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -30,7 +30,7 @@ def start_replica_cmd(builddir, replica_id):
     """
 
     status_timer_milli = "500"
-    view_change_timeout_milli = "5000"
+    view_change_timeout_milli = "10000"
 
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
@@ -58,15 +58,15 @@ class SkvbcPreExecutionTest(unittest.TestCase):
                 pass
             await trio.sleep(.1)
 
-    async def send_single_write_with_pre_execution_and_kv(self, skvbc, kv, client):
-        reply = await client.write(skvbc.write_req([], kv, 0), pre_process=True)
+    async def send_single_write_with_pre_execution_and_kv(self, skvbc, write_set, client):
+        reply = await client.write(skvbc.write_req([], write_set, 0), pre_process=True)
         reply = skvbc.parse_reply(reply)
         self.assertTrue(reply.success)
 
     async def send_single_write_with_pre_execution(self, skvbc, client):
-        kv = [(skvbc.random_key(), skvbc.random_value()),
-              (skvbc.random_key(), skvbc.random_value())]
-        await self.send_single_write_with_pre_execution_and_kv(skvbc, kv, client)
+        write_set = [(skvbc.random_key(), skvbc.random_value()),
+                     (skvbc.random_key(), skvbc.random_value())]
+        await self.send_single_write_with_pre_execution_and_kv(skvbc, write_set, client)
 
     async def run_concurrent_pre_execution_requests(self, skvbc, clients, num_of_requests, write_weight=.90):
         sent = 0
@@ -123,9 +123,9 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         client = random.choice(list(clients))
         key_before_vc = skvbc.random_key()
         value_before_vc = skvbc.random_value()
-        kv = [(key_before_vc, value_before_vc)]
+        write_set = [(key_before_vc, value_before_vc)]
 
-        await self.send_single_write_with_pre_execution_and_kv(skvbc, kv, client)
+        await self.send_single_write_with_pre_execution_and_kv(skvbc, write_set, client)
         await skvbc.assert_kv_write_executed(key_before_vc, value_before_vc)
 
         initial_primary = 0


### PR DESCRIPTION
- In case the primary replica's calculated pre-execution result is different from that reached a consensus, we retry the pre-execution on the primary. Pre-execution consensus requires the collection of (f + 1) equal responses. When additional responses arrive after we reached the consensus, pre-execution retry should not be triggered again.

- Added Apollo test for verifying a view change while running the pre-execution

https://jira.eng.vmware.com/browse/BC-2694
https://jira.eng.vmware.com/browse/BC-2535