### PR TITLE
Opentracing wrapper

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(util STATIC
     src/histogram.cpp
     src/status.cpp
     src/sliver.cpp
-    src/hex_tools.cpp)
+    src/hex_tools.cpp
+    src/OpenTracing.cpp)
 
 if(BUILD_ROCKSDB_STORAGE)
     target_compile_definitions(util PUBLIC "USE_ROCKSDB=1")

--- a/util/include/OpenTracing.hpp
+++ b/util/include/OpenTracing.hpp
@@ -1,0 +1,56 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license,
+// as noted in the LICENSE file.
+
+#ifndef OPENTRACING_UTILS_HPP
+#define OPENTRACING_UTILS_HPP
+
+#ifdef USE_OPENTRACING
+#include <memory>
+#include <opentracing/span.h>
+#endif
+#include <string>
+
+namespace concordUtils {
+
+using SpanContext = std::string;
+
+class SpanWrapper {
+ public:
+  SpanWrapper() {}
+  SpanWrapper(const SpanWrapper&) = delete;
+  SpanWrapper& operator=(const SpanWrapper&) = delete;
+  SpanWrapper(SpanWrapper&&) = default;
+  SpanWrapper& operator=(SpanWrapper&&) = default;
+
+  void setTag(const std::string& name, const std::string& value);
+  void finish();
+  SpanContext context() const;
+
+  friend SpanWrapper startSpan(const std::string& operation_name);
+  friend SpanWrapper startChildSpan(const std::string& operation_name, const SpanWrapper& parent_span);
+  friend SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name);
+
+ private:
+#ifdef USE_OPENTRACING
+  using SpanPtr = std::unique_ptr<opentracing::Span>;
+  SpanWrapper(SpanPtr&& span) : span_ptr_(std::move(span)) {}
+  const SpanPtr& impl() const { return span_ptr_; }
+  /* data */
+  SpanPtr span_ptr_;
+#endif
+};
+
+SpanWrapper startSpan(const std::string& operation_name);
+SpanWrapper startChildSpan(const std::string& child_operation_name, const SpanWrapper& parent_span);
+SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name);
+}  // namespace concordUtils
+#endif /* end of include guard: OPENTRACING_UTILS_HPP */

--- a/util/src/OpenTracing.cpp
+++ b/util/src/OpenTracing.cpp
@@ -1,0 +1,107 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license,
+// as noted in the LICENSE file.
+
+#include "OpenTracing.hpp"
+
+#ifdef USE_OPENTRACING
+#include <opentracing/tracer.h>
+#include <sstream>
+#endif
+
+namespace concordUtils {
+void SpanWrapper::setTag(const std::string& name, const std::string& value) {
+#ifdef USE_OPENTRACING
+  span_ptr_->SetTag(name, value);
+#else
+  (void)name;
+  (void)value;
+#endif
+}
+
+void SpanWrapper::finish() {
+#ifdef USE_OPENTRACING
+  span_ptr_->Finish();
+#endif
+}
+
+SpanContext SpanWrapper::context() const {
+#ifdef USE_OPENTRACING
+  if (!impl()) {
+    // Span is not initialized
+    return SpanContext{};
+  }
+  std::ostringstream context;
+  impl()->tracer().Inject(impl()->context(), context);
+  return SpanContext{context.str()};
+#else
+  return SpanContext{};
+#endif
+}
+
+SpanWrapper startSpan(const std::string& operation_name) {
+#ifdef USE_OPENTRACING
+  auto tracer = opentracing::Tracer::Global();
+  if (!tracer) {
+    // Tracer is not initialized by the parent
+    return SpanWrapper{};
+  } else {
+    return SpanWrapper{tracer->StartSpan(operation_name)};
+  }
+#else
+  (void)operation_name;
+  return SpanWrapper{};
+#endif
+}
+
+SpanWrapper startChildSpan(const std::string& child_operation_name, const SpanWrapper& parent_span) {
+#ifdef USE_OPENTRACING
+  auto tracer = opentracing::Tracer::Global();
+  if (!tracer) {
+    // Tracer is not initialized by the parent
+    return SpanWrapper{};
+  }
+  if (!parent_span.impl()) {
+    return SpanWrapper{};
+  }
+  return SpanWrapper{tracer->StartSpan(child_operation_name, {opentracing::ChildOf(&parent_span.impl()->context())})};
+#else
+  (void)child_operation_name;
+  (void)parent_span;
+  return SpanWrapper{};
+#endif
+}
+
+SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name) {
+#ifdef USE_OPENTRACING
+  auto tracer = opentracing::Tracer::Global();
+  if (!tracer) {
+    // Tracer is not initialized by the parent
+    return SpanWrapper{};
+  }
+  if (context.empty()) {
+    return SpanWrapper{};
+  }
+  std::istringstream context_stream{context};
+  auto parent_span_context = tracer->Extract(context_stream);
+  if (!parent_span_context) {
+    std::ostringstream stream;
+    stream << "Failed to extract span, error:" << parent_span_context.error();
+    throw std::runtime_error(stream.str());
+  }
+  return SpanWrapper{tracer->StartSpan(child_operation_name, {opentracing::ChildOf(parent_span_context->get())})};
+#else
+  (void)context;
+  (void)child_operation_name;
+  return SpanWrapper{};
+#endif
+}
+}  // namespace concordUtils


### PR DESCRIPTION
This commit adds a wrapper around Opentracing classes and functions.
Rationale:
* If the feature is compiled out(`-DUSE_OPENTRACING=OFF`), the wrapper has to behave as a dummy object.
* If the tracer is not initialized by the user of Concord-BFT library, the wrapper has to handle it.

Changes:
[+] `SpanWrapper` class with a few free functions for a span creation