### PR TITLE
Send span context via BFT Client

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -65,7 +65,8 @@ class SimpleClient {
                           uint32_t lengthOfReplyBuffer,
                           char* replyBuffer,
                           uint32_t& actualReplyLength,
-                          std::string cid = "") = 0;
+                          const std::string& cid = "",
+                          const std::string& span_context = "") = 0;
 
   virtual int sendRequestToResetSeqNum() = 0;
   virtual int sendRequestToReadLatestSeqNum(uint64_t timeoutMilli, uint64_t& outLatestReqSeqNum) = 0;

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -23,15 +23,22 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
                                                        uint32_t requestLength,
                                                        const char* request,
                                                        uint64_t reqTimeoutMilli,
-                                                       const std::string& cid)
-    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request, reqTimeoutMilli, cid) {
+                                                       const std::string& cid,
+                                                       const std::string& span_context)
+    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request, reqTimeoutMilli, cid, span_context) {
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 
 unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bool resetPreProcessFlag) {
   if (resetPreProcessFlag) msgBody()->flags &= ~(1 << 1);
-  unique_ptr<MessageBase> clientRequestMsg = make_unique<ClientRequestMsg>(
-      clientProxyId(), flags(), requestSeqNum(), requestLength(), requestBuf(), requestTimeoutMilli(), getCid());
+  unique_ptr<MessageBase> clientRequestMsg = make_unique<ClientRequestMsg>(clientProxyId(),
+                                                                           flags(),
+                                                                           requestSeqNum(),
+                                                                           requestLength(),
+                                                                           requestBuf(),
+                                                                           requestTimeoutMilli(),
+                                                                           getCid(),
+                                                                           spanContext<ClientRequestMsg>());
   return clientRequestMsg;
 }
 

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -26,7 +26,8 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
                              uint32_t requestLength,
                              const char* request,
                              uint64_t reqTimeoutMilli,
-                             const std::string& cid);
+                             const std::string& cid,
+                             const std::string& span_context = "");
 
   std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag);
 };

--- a/kvbc/include/ClientImp.h
+++ b/kvbc/include/ClientImp.h
@@ -33,7 +33,8 @@ class ClientImp : public IClient {
                                     uint32_t replySize,
                                     char* outReply,
                                     uint32_t* outActualReplySize,
-                                    const std::string& = "") override;
+                                    const std::string& cid = "",
+                                    const std::string& span_context = "") override;
 
   virtual void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override;
 

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -66,7 +66,8 @@ class IClient {
                                     uint32_t replySize,
                                     char* outReply,
                                     uint32_t* outActualReplySize,
-                                    const std::string& cid = "") = 0;
+                                    const std::string& cid = "",
+                                    const std::string& span_context = "") = 0;
 
   virtual void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) = 0;
 };

--- a/kvbc/src/ClientImp.cpp
+++ b/kvbc/src/ClientImp.cpp
@@ -58,7 +58,8 @@ Status ClientImp::invokeCommandSynch(const char* request,
                                      uint32_t replySize,
                                      char* outReply,
                                      uint32_t* outActualReplySize,
-                                     const std::string& cid) {
+                                     const std::string& cid,
+                                     const std::string& span_context) {
   if (!isRunning()) return Status::IllegalOperation("todo");
 
   uint64_t timeoutMs = timeout <= std::chrono::milliseconds::zero() ? SimpleClient::INFINITE_TIMEOUT : timeout.count();
@@ -71,7 +72,8 @@ Status ClientImp::invokeCommandSynch(const char* request,
                                      replySize,
                                      outReply,
                                      *outActualReplySize,
-                                     cid);
+                                     cid,
+                                     span_context);
   assert(res >= -2 && res < 1);
 
   if (res == 0)


### PR DESCRIPTION
The span context is added to the same methods and functions as the `correlation_id`.