### PR TITLE
Add -l option to simpleKVBC test replica

### DIFF
--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -31,7 +31,7 @@ namespace concord::kvbc::test {
 
 void run_replica(int argc, char** argv) {
   const auto setup = TestSetup::ParseArgs(argc, argv);
-  concordlogger::Log::initLogger("log4cplus.properties");
+  concordlogger::Log::initLogger(setup->GetLog4CPlusPropertiesFile());
   auto logger = setup->GetLogger();
   MDC_PUT(GL, "rid", std::to_string(setup->GetReplicaConfig().replicaId));
 

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -48,6 +48,8 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::string keysFilePrefix;
     std::string commConfigFile;
     std::string s3ConfigFile;
+    std::string log4cplusProperties = "log4cplus.properties";
+
     // Set StorageType::V1DirectKeyValue as the default storage type.
     auto storageType = StorageType::V1DirectKeyValue;
 
@@ -60,6 +62,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"s3-config-file", required_argument, 0, '3'},
                                           {"persistence-mode", no_argument, 0, 'p'},
                                           {"storage-type", required_argument, 0, 't'},
+                                          {"log4cplus-props", required_argument, 0, 'l'},
                                           {0, 0, 0, 0}};
 
     int o = 0;
@@ -107,6 +110,10 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
             throw std::runtime_error{"invalid argument for --storage-type"};
           }
         } break;
+        case 'l': {
+          log4cplusProperties = optarg;
+          break;
+        }
         case '?': {
           throw std::runtime_error("invalid arguments");
         } break;
@@ -147,7 +154,8 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                                     metricsPort,
                                                     persistMode == PersistencyMode::RocksDB,
                                                     s3ConfigFile,
-                                                    storageType});
+                                                    storageType,
+                                                    log4cplusProperties});
 
   } catch (const std::exception& e) {
     LOG_FATAL(GL, "failed to parse command line arguments: " << e.what());

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -39,6 +39,7 @@ class TestSetup {
   concordMetrics::Server& GetMetricsServer() { return metricsServer_; }
   concordlogger::Logger GetLogger() { return logger_; }
   const bool UsePersistentStorage() const { return usePersistentStorage_; }
+  std::string GetLog4CPlusPropertiesFile() const { return log4cplusProperties_; }
 
  private:
   enum class StorageType {
@@ -52,14 +53,16 @@ class TestSetup {
             uint16_t metricsPort,
             bool usePersistentStorage,
             std::string s3ConfigFile,
-            StorageType storageType)
+            StorageType storageType,
+            std::string log4cplusProperties)
       : replicaConfig_(config),
         communication_(std::move(comm)),
         logger_(logger),
         metricsServer_(metricsPort),
         usePersistentStorage_(usePersistentStorage),
         s3ConfigFile_(s3ConfigFile),
-        storageType_(storageType) {}
+        storageType_(storageType),
+        log4cplusProperties_(log4cplusProperties) {}
   TestSetup() = delete;
 #ifdef USE_S3_OBJECT_STORE
   concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
@@ -72,6 +75,7 @@ class TestSetup {
   bool usePersistentStorage_;
   std::string s3ConfigFile_;
   StorageType storageType_;
+  std::string log4cplusProperties_;
 };
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
-l is full path (dir+filename) to log4cplus properties file. This is a
more convenient way to use custom logging parameters.

My use case is custom logging for apollo test (yet to be commited).