### PR TITLE
WIP: State Transfer:

### DIFF
--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -373,6 +373,7 @@ void DBDataStore::deleteCoveredResPageInSmallerCheckpointsTxn(uint64_t minChkp, 
   LOG_DEBUG(logger(), " min chkp: " << minChkp << " txn: " << txn->getId());
   auto pages = inmem_->getPagesMap();
   auto it = pages.begin();
+  if (it == pages.end()) return;
   uint32_t prevItemPageId = it->first.pageId;
   bool prevItemIsInLastRelevantCheckpoint = (it->first.checkpoint <= minChkp);
   it++;

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
@@ -281,6 +281,7 @@ void InMemoryDataStore::deleteCoveredResPageInSmallerCheckpoints(uint64_t inMinR
   if (inMinRelevantCheckpoint <= 1) return;  //  nothing to delete
 
   auto iter = pages.begin();
+  if (iter == pages.end()) return;
   uint32_t prevItemPageId = iter->first.pageId;
   bool prevItemIsInLastRelevantCheckpoint = (iter->first.checkpoint <= inMinRelevantCheckpoint);
 

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -36,8 +36,10 @@ class ITransaction {
   class Guard {
    public:
     Guard(ITransaction* t) : txn_(t) {}
-    virtual ~Guard() {
-      if (!std::uncaught_exception()) txn_->commit();
+    virtual ~Guard() noexcept(false) {
+      if (!std::uncaught_exception()) {
+        txn_->commit();
+      }
       delete txn_;
     }
     ITransaction* txn() const { return txn_; }

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -356,7 +356,7 @@ class BftTestNetwork:
             self._stop_external_replica(replica_id)
         else:
             p = self.procs[replica_id]
-            p.kill()
+            p.terminate()
             p.wait()
 
         del self.procs[replica_id]

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -71,6 +71,8 @@ int main(int argc, char** argv) {
   signal(SIGBUS, signal_handler);
   signal(SIGILL, signal_handler);
   signal(SIGFPE, signal_handler);
+  signal(SIGINT, signal_handler);
+  signal(SIGTERM, signal_handler);
 
   try {
     concord::kvbc::test::run_replica(argc, argv);

--- a/util/include/Handoff.hpp
+++ b/util/include/Handoff.hpp
@@ -39,8 +39,8 @@ class Handoff {
       } catch (ThreadCanceledException& e) {
         LOG_DEBUG(getLogger(), "thread stopped " << std::this_thread::get_id());
       } catch (const std::exception& e) {
-        LOG_ERROR(getLogger(), "exception: " << e.what());
-        // TODO [TK] should we allow different behavior for exception handling?
+        LOG_FATAL(getLogger(), "exception: " << e.what());
+        exit(1);
       }
     });
   }

--- a/util/include/assertUtils.hpp
+++ b/util/include/assertUtils.hpp
@@ -82,6 +82,35 @@ inline void printCallStack() {
       assert(false);                                                                                              \
     }                                                                                                             \
   }
+// Assert (expr1 == expr2)
+#define AssertEQ(expr1, expr2)                                           \
+  {                                                                      \
+    if (expr1 != expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertEQ"); \
+  }
+
+// Assert (expr1 >= expr2)
+#define AssertGE(expr1, expr2)                                          \
+  {                                                                     \
+    if (expr1 < expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGE"); \
+  }
+
+// Assert (expr1 > expr2)
+#define AssertGT(expr1, expr2)                                           \
+  {                                                                      \
+    if (expr1 <= expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGT"); \
+  }
+
+// Assert (expr1 < expr2)
+#define AssertLT(expr1, expr2)                                           \
+  {                                                                      \
+    if (expr1 >= expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLT"); \
+  }
+
+// Assert (expr1 <= expr2)
+#define AssertLE(expr1, expr2)                                          \
+  {                                                                     \
+    if (expr1 > expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLE"); \
+  }
 
 // Assert(expr1 || expr2)
 #define AssertOR(expr1, expr2)                                                               \


### PR DESCRIPTION
- Allow transferring empty vblock, i.e. vblock containing a header only.
  This is a very rare scenario wich happens in conjunction with a View Change. 
- Apollo: stop replicas with terminate() - SIGTERM rather than with kill() - SIGKILL in order to record the stop event in replica's log.
- Assert macros AssertGE, AssertGT, AssertEQ, AssertLT, AssertLE to record arguments in case of assert failure.