### PR TITLE
Add spans to Concord-BFT

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "IStateTransfer.hpp"
+#include "OpenTracing.hpp"
 #include "communication/ICommunication.hpp"
 #include "MetadataStorage.hpp"
 #include "Metrics.hpp"
@@ -42,7 +43,8 @@ class IRequestsHandler {
                       const char *request,
                       uint32_t maxReplySize,
                       char *outReply,
-                      uint32_t &outActualReplySize) = 0;
+                      uint32_t &outActualReplySize,
+                      concordUtils::SpanWrapper &parent_span) = 0;
 
   virtual void onFinishExecutingReadWriteRequests() {}
   virtual ~IRequestsHandler() {}

--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -42,7 +42,8 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual void onPrepareCombinedSigSucceeded(SeqNum seqNumber,
                                              ViewNum view,
                                              const char* combinedSig,
-                                             uint16_t combinedSigLen) = 0;
+                                             uint16_t combinedSigLen,
+                                             const std::string& span_context) = 0;
   virtual void onPrepareVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view, bool isValid) = 0;
 
   virtual void onCommitCombinedSigFailed(SeqNum seqNumber,
@@ -51,7 +52,8 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual void onCommitCombinedSigSucceeded(SeqNum seqNumber,
                                             ViewNum view,
                                             const char* combinedSig,
-                                            uint16_t combinedSigLen) = 0;
+                                            uint16_t combinedSigLen,
+                                            const std::string& span_context) = 0;
   virtual void onCommitVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view, bool isValid) = 0;
 
   virtual void onInternalMsg(FullCommitProofMsg* m) = 0;

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -87,7 +87,8 @@ class SeqNumInfo {
   void onCompletionOfPrepareSignaturesProcessing(SeqNum seqNumber,
                                                  ViewNum viewNumber,
                                                  const char* combinedSig,
-                                                 uint16_t combinedSigLen);
+                                                 uint16_t combinedSigLen,
+                                                 const std::string& span_context);
   void onCompletionOfCombinedPrepareSigVerification(SeqNum seqNumber, ViewNum viewNumber, bool isValid);
 
   void onCompletionOfCommitSignaturesProcessing(SeqNum seqNumber,
@@ -99,8 +100,10 @@ class SeqNumInfo {
   void onCompletionOfCommitSignaturesProcessing(SeqNum seqNumber,
                                                 ViewNum viewNumber,
                                                 const char* combinedSig,
-                                                uint16_t combinedSigLen) {
-    commitMsgsCollector->onCompletionOfSignaturesProcessing(seqNumber, viewNumber, combinedSig, combinedSigLen);
+                                                uint16_t combinedSigLen,
+                                                const std::string& span_context) {
+    commitMsgsCollector->onCompletionOfSignaturesProcessing(
+        seqNumber, viewNumber, combinedSig, combinedSigLen, span_context);
   }
 
   void onCompletionOfCombinedCommitSigVerification(SeqNum seqNumber, ViewNum viewNumber, bool isValid) {
@@ -111,16 +114,24 @@ class SeqNumInfo {
   class ExFuncForPrepareCollector {
    public:
     // external messages
-    static PrepareFullMsg* createCombinedSignatureMsg(
-        void* context, SeqNum seqNumber, ViewNum viewNumber, const char* const combinedSig, uint16_t combinedSigLen);
+    static PrepareFullMsg* createCombinedSignatureMsg(void* context,
+                                                      SeqNum seqNumber,
+                                                      ViewNum viewNumber,
+                                                      const char* const combinedSig,
+                                                      uint16_t combinedSigLen,
+                                                      const std::string& span_context);
 
     // internal messages
     static InternalMessage* createInterCombinedSigFailed(void* context,
                                                          SeqNum seqNumber,
                                                          ViewNum viewNumber,
                                                          std::set<uint16_t> replicasWithBadSigs);
-    static InternalMessage* createInterCombinedSigSucceeded(
-        void* context, SeqNum seqNumber, ViewNum viewNumber, const char* combinedSig, uint16_t combinedSigLen);
+    static InternalMessage* createInterCombinedSigSucceeded(void* context,
+                                                            SeqNum seqNumber,
+                                                            ViewNum viewNumber,
+                                                            const char* combinedSig,
+                                                            uint16_t combinedSigLen,
+                                                            const std::string& span_context);
     static InternalMessage* createInterVerifyCombinedSigResult(void* context,
                                                                SeqNum seqNumber,
                                                                ViewNum viewNumber,
@@ -136,16 +147,24 @@ class SeqNumInfo {
   class ExFuncForCommitCollector {
    public:
     // external messages
-    static CommitFullMsg* createCombinedSignatureMsg(
-        void* context, SeqNum seqNumber, ViewNum viewNumber, const char* const combinedSig, uint16_t combinedSigLen);
+    static CommitFullMsg* createCombinedSignatureMsg(void* context,
+                                                     SeqNum seqNumber,
+                                                     ViewNum viewNumber,
+                                                     const char* const combinedSig,
+                                                     uint16_t combinedSigLen,
+                                                     const std::string& span_context);
 
     // internal messages
     static InternalMessage* createInterCombinedSigFailed(void* context,
                                                          SeqNum seqNumber,
                                                          ViewNum viewNumber,
                                                          std::set<uint16_t> replicasWithBadSigs);
-    static InternalMessage* createInterCombinedSigSucceeded(
-        void* context, SeqNum seqNumber, ViewNum viewNumber, const char* combinedSig, uint16_t combinedSigLen);
+    static InternalMessage* createInterCombinedSigSucceeded(void* context,
+                                                            SeqNum seqNumber,
+                                                            ViewNum viewNumber,
+                                                            const char* combinedSig,
+                                                            uint16_t combinedSigLen,
+                                                            const std::string& span_context);
     static InternalMessage* createInterVerifyCombinedSigResult(void* context,
                                                                SeqNum seqNumber,
                                                                ViewNum viewNumber,

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -92,7 +92,8 @@ class PreProcessor {
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,
                                       bool isRetry);
-  uint32_t launchReqPreProcessing(uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength, char *reqBuf);
+  uint32_t launchReqPreProcessing(
+      uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength, char *reqBuf, const std::string &span_context);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg, bool isPrimary, bool isRetry);
   void handlePreProcessedReqByNonPrimary(uint16_t clientId,
                                          ReqId reqSeqNum,

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -34,9 +34,6 @@ class PreProcessReplyMsg : public MessageBase {
   std::string getCid() const;
 
  protected:
-  template <typename MessageT>
-  friend size_t sizeOfHeader();
-
 #pragma pack(push, 1)
   struct Header {
     MessageBase::Header header;

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -23,10 +23,11 @@ class PreProcessRequestMsg : public MessageBase {
                        uint64_t reqSeqNum,
                        uint32_t reqLength,
                        const char* request,
+                       const std::string& span_context,
                        const std::string& cid);
 
   void validate(const bftEngine::impl::ReplicasInfo&) const override;
-  char* requestBuf() const { return body() + sizeof(Header); }
+  char* requestBuf() const { return body() + sizeof(Header) + spanContextSize(); }
   const uint32_t requestLength() const { return msgBody()->requestLength; }
   const uint16_t clientId() const { return msgBody()->clientId; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
@@ -34,8 +35,7 @@ class PreProcessRequestMsg : public MessageBase {
 
  protected:
   template <typename MessageT>
-  friend size_t sizeOfHeader();
-
+  friend size_t bftEngine::impl::sizeOfHeader();
 #pragma pack(push, 1)
   struct Header {
     MessageBase::Header header;

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -135,7 +135,8 @@ class ICommandsHandler : public bftEngine::IRequestsHandler {
                       const char* request,
                       uint32_t maxReplySize,
                       char* outReply,
-                      uint32_t& outActualReplySize) = 0;
+                      uint32_t& outActualReplySize,
+                      concordUtils::SpanWrapper& span) = 0;
   virtual ~ICommandsHandler() = default;
 };
 }  // namespace kvbc

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -12,6 +12,7 @@
 // file.
 
 #include "internalCommandsHandler.hpp"
+#include "OpenTracing.hpp"
 #include "assertUtils.hpp"
 #include "sliver.hpp"
 #include "kv_types.hpp"
@@ -37,7 +38,8 @@ int InternalCommandsHandler::execute(uint16_t clientId,
                                      const char *request,
                                      uint32_t maxReplySize,
                                      char *outReply,
-                                     uint32_t &outActualReplySize) {
+                                     uint32_t &outActualReplySize,
+                                     concordUtils::SpanWrapper &span) {
   int res;
   if (requestSize < sizeof(SimpleRequest)) {
     LOG_ERROR(

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -15,6 +15,7 @@
 #define INTERNAL_COMMANDS_HANDLER_HPP
 
 #include "Logger.hpp"
+#include "OpenTracing.hpp"
 #include "sliver.hpp"
 #include "simpleKVBTestsBuilder.hpp"
 #include "db_interfaces.h"
@@ -37,7 +38,8 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                       const char *request,
                       uint32_t maxReplySize,
                       char *outReply,
-                      uint32_t &outActualReplySize) override;
+                      uint32_t &outActualReplySize,
+                      concordUtils::SpanWrapper &span) override;
 
  private:
   bool executeWriteCommand(uint32_t requestSize,

--- a/tests/simpleTest/persistency_test.cpp
+++ b/tests/simpleTest/persistency_test.cpp
@@ -13,6 +13,7 @@
 
 // These tests are used as basic regression tests for meta data persistency
 
+#include "assertUtils.hpp"
 #include "gtest/gtest.h"
 #include <vector>
 #include "Logger.hpp"

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -14,6 +14,7 @@
 #ifndef CONCORD_BFT_SIMPLE_TEST_REPLICA_HPP
 #define CONCORD_BFT_SIMPLE_TEST_REPLICA_HPP
 
+#include "OpenTracing.hpp"
 #include "communication/CommFactory.hpp"
 #include "Replica.hpp"
 #include "ReplicaConfig.hpp"
@@ -77,7 +78,8 @@ class SimpleAppState : public IRequestsHandler {
               const char *request,
               uint32_t maxReplySize,
               char *outReply,
-              uint32_t &outActualReplySize) override {
+              uint32_t &outActualReplySize,
+              concordUtils::SpanWrapper &span) override {
     bool readOnly = flags & READ_ONLY_FLAG;
     if (readOnly) {
       // Our read-only request includes only a type, no argument.


### PR DESCRIPTION
This PR adds Opentracing spans for the consensus path:
* Span context arrives in Concord-BFT with ClientRequest message
* The span is transferred with the corresponding messages for both paths: regular(aka slow) and fast.
* Once `CommitFull` or `FullCommitProof` message is received,
    a span context is extracted and used for the creation of span.
    This span is passed to the `execute` method in the form of `concordUtils::SpanWrapper`.

Important notes:
* When Client requests are batched, only the span of the last request is sent as part of the PrePrepare message.
* The same applies to all the Partial* messages.