### PR TITLE
Add -l option to simpleKVBC tester replica

### DIFF
--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -31,7 +31,7 @@ namespace concord::kvbc::test {
 
 void run_replica(int argc, char** argv) {
   const auto setup = TestSetup::ParseArgs(argc, argv);
-  logging::initLogger("logging.properties");
+  logging::initLogger(setup->getLogPropertiesFile());
   auto logger = setup->GetLogger();
   MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(setup->GetReplicaConfig().replicaId));
   MDC_PUT(MDC_THREAD_KEY, "main");

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -49,6 +49,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::string keysFilePrefix;
     std::string commConfigFile;
     std::string s3ConfigFile;
+    std::string logPropsFile = "logging.properties";
     // Set StorageType::V1DirectKeyValue as the default storage type.
     auto storageType = StorageType::V1DirectKeyValue;
 
@@ -61,12 +62,13 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"s3-config-file", required_argument, 0, '3'},
                                           {"persistence-mode", no_argument, 0, 'p'},
                                           {"storage-type", required_argument, 0, 't'},
+                                          {"log-props-file", required_argument, 0, 'l'},
                                           {0, 0, 0, 0}};
 
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
-    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:", longOptions, &optionIndex)) != -1) {
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:l:", longOptions, &optionIndex)) != -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -108,6 +110,10 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
             throw std::runtime_error{"invalid argument for --storage-type"};
           }
         } break;
+        case 'l': {
+          logPropsFile = optarg;
+          break;
+        }
         case '?': {
           throw std::runtime_error("invalid arguments");
         } break;
@@ -148,7 +154,8 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                                     metricsPort,
                                                     persistMode == PersistencyMode::RocksDB,
                                                     s3ConfigFile,
-                                                    storageType});
+                                                    storageType,
+                                                    logPropsFile});
 
   } catch (const std::exception& e) {
     LOG_FATAL(GL, "failed to parse command line arguments: " << e.what());

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -39,6 +39,7 @@ class TestSetup {
   concordMetrics::Server& GetMetricsServer() { return metricsServer_; }
   logging::Logger GetLogger() { return logger_; }
   const bool UsePersistentStorage() const { return usePersistentStorage_; }
+  std::string getLogPropertiesFile() { return logPropsFile_; }
 
  private:
   enum class StorageType {
@@ -52,14 +53,16 @@ class TestSetup {
             uint16_t metricsPort,
             bool usePersistentStorage,
             std::string s3ConfigFile,
-            StorageType storageType)
+            StorageType storageType,
+            std::string logPropsFile)
       : replicaConfig_(config),
         communication_(std::move(comm)),
         logger_(logger),
         metricsServer_(metricsPort),
         usePersistentStorage_(usePersistentStorage),
         s3ConfigFile_(s3ConfigFile),
-        storageType_(storageType) {}
+        storageType_(storageType),
+        logPropsFile_(logPropsFile) {}
   TestSetup() = delete;
 #ifdef USE_S3_OBJECT_STORE
   concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
@@ -72,6 +75,7 @@ class TestSetup {
   bool usePersistentStorage_;
   std::string s3ConfigFile_;
   StorageType storageType_;
+  std::string logPropsFile_;
 };
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
-l is full path (dir+filename) to log4cplus properties file. This is a
more convenient way to use custom logging parameters.