### PR TITLE
View change test fixes

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1807,7 +1807,6 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
   Assert(lastExecutedSeqNum >= lastStableSeqNum);  // we moved to the new state, only after synchronizing the state
 
   timeOfLastViewEntrance = getMonotonicTime();  // TODO(GG): handle restart/pause
-  metric_current_active_view_.Get().Set(curView);
 
   NewViewMsg *newNewViewMsgToSend = nullptr;
 
@@ -1914,6 +1913,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
   LOG_INFO(GL, "**************** Start working in view " << curView);
 
   controller->onNewView(curView, primaryLastUsedSeqNum);
+  metric_current_active_view_.Get().Set(curView);
 }
 
 void ReplicaImp::sendCheckpointIfNeeded() {

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -158,7 +158,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
                 err_msg="Make sure view change has been triggered."
             )
 
-            await tracker.tracked_read_your_writes()
+            await self._wait_for_read_your_writes_success(tracker)
 
             await tracker.run_concurrent_ops(100)
 
@@ -207,7 +207,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
             err_msg="Make sure view change has been triggered."
         )
 
-        await tracker.tracked_read_your_writes()
+        await self._wait_for_read_your_writes_success(tracker)
 
         await tracker.run_concurrent_ops(100)
 
@@ -344,9 +344,20 @@ class SkvbcViewChangeTest(unittest.TestCase):
             err_msg="Make sure view change has been triggered."
         )
 
-        await tracker.tracked_read_your_writes()
+        await self._wait_for_read_your_writes_success(tracker)
 
         await tracker.run_concurrent_ops(100)
+
+    async def _wait_for_read_your_writes_success(self, tracker):
+        with trio.fail_after(seconds=60):
+            while True:
+                with trio.move_on_after(seconds=5):
+                    try:
+                        await tracker.tracked_read_your_writes()
+                    except Exception:
+                        continue
+                    else:
+                        break
 
     async def _send_random_writes(self, tracker):
         with trio.move_on_after(seconds=1):


### PR DESCRIPTION
The failures were happening because once the replicas agree on the new view and activate it, they go ahead and rebuild the entire active window by exchanging `ReqMissingDataMsg`. This may take a significant amount of time (10-s of seconds for 7 replicas) - especially problematic if the 7 replicas are running on 4 cores as in Travis... 

Essentially, this means right after view change has been agreed, the replicas are **practically staggered**, until this active window rebuilding process completes. The test wouldn't previously take this into account. In some cases it would pass if 2f+1 replicas had rebuilt their active window faster than the others. However, in some cases 5 seconds (the UDP client's request timeout) wouldn't be enough, and the test would fail intermittently.

The following fixes are suggested as part of this PR:
* fixing the "current active view" metric to be incremented when we actually start working in the new view
* retry the post-view change write (fails initially because the replicas are rebuilding the active window after the view change and a 2f+1 reply quorum cannot be reached)