### PR TITLE
Add a key deletion test when using memorydb only

### DIFF
--- a/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -1332,9 +1332,10 @@ const auto refBlockchainTestParams = ::testing::Values(
 #else
 const auto customBlockchainTestsParams = ::testing::Values(std::make_shared<DbAdapterTest<TestMemoryDb>>());
 
-const auto refBlockchainTestParams =
-    ::testing::Values(std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::NoEmptyBlocks>>(),
-                      std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::WithEmptyBlocks>>());
+const auto refBlockchainTestParams = ::testing::Values(
+    std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::NoEmptyBlocks>>(),
+    std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::WithEmptyBlocks>>(),
+    std::make_shared<DbAdapterTest<TestMemoryDb, ReferenceBlockchainType::WithEmptyBlocksAndKeyDeletes>>());
 #endif
 
 // Instantiate tests with memorydb and RocksDB clients and with custom (test-specific) blockchains.


### PR DESCRIPTION
If the system is compiled with memorydb only (no RocksDB support
compiled in), test with a reference blockchain of type
'WithEmptyBlocksAndKeyDeletes' too in the merkle tree DB adapter unit
test.