### PR TITLE
Make intermediate calls to onTransferComplete during state transfer

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1392,7 +1392,7 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
 
   Assert(sourceSelector_.isPreferred(replicaId));
 
-  LOG_WARN(STLogger, "Removing replica " << replicaId << " from preferred replicasa");
+  LOG_WARN(STLogger, "Removing replica " << replicaId << " from preferred replicas");
   sourceSelector_.removeCurrentReplica();
   metrics_.current_source_replica_.Get().Set(NO_REPLICA);
   metrics_.preferred_replicas_.Get().Set(sourceSelector_.preferredReplicasToString());
@@ -1997,6 +1997,8 @@ void BCStateTran::processData() {
         Assert(getFetchingState() == FetchingState::GettingMissingResPages);
 
         LOG_DEBUG(STLogger, "moved to GettingMissingResPages");
+        DataStore::CheckpointDesc cp = g.txn()->getCheckpointBeingFetched();
+        replicaForStateTransfer_->onTransferringComplete(cp.checkpointNum);
         sendFetchResPagesMsg(0);
         break;
       }


### PR DESCRIPTION
If a client generates requests indefinitely the RO replica never tries
to catch up and lastExectuedSeqNum metric is never updated.
This patch changes this behaviour so that onTransferComplete is called
after a Checkpoint is transferred suqqessfully. As a result
lastExecutedSeqNum slowly increases.