### PR TITLE
Add a diagnostics server and client

### DIFF
--- a/diagnostics/concord-ctl
+++ b/diagnostics/concord-ctl
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import socket
+import sys
+import os
+
+port = 6888
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect(("127.0.0.1", port))
+cmd = b' '.join([os.fsencode(arg) for arg in sys.argv[1:]]) + b'\n'
+s.send(cmd)
+data = s.recv(64*1024)
+print(data.decode())

--- a/diagnostics/include/diagnostics.h
+++ b/diagnostics/include/diagnostics.h
@@ -55,8 +55,8 @@ class Registrar {
   }
 
   std::string describeStatus() const {
-    std::lock_guard<std::mutex> guard(mutex_);
     std::string output;
+    std::lock_guard<std::mutex> guard(mutex_);
     for (const auto& [_, handler] : status_handlers_) {
       (void)_;  // undefined variable hack
       output += "\n" + handler.name + "\n  ";
@@ -78,6 +78,22 @@ class Registrar {
  private:
   std::map<std::string, StatusHandler> status_handlers_;
   mutable std::mutex mutex_;
+};
+
+// Singleton wrapper class for a Registrar.
+class RegistrarSingleton {
+ public:
+  static Registrar& getInstance() {
+    static Registrar registrar_;
+    return registrar_;
+  }
+
+  RegistrarSingleton(const RegistrarSingleton&) = delete;
+  RegistrarSingleton& operator=(const RegistrarSingleton&) = delete;
+
+ private:
+  RegistrarSingleton() = default;
+  ~RegistrarSingleton() = default;
 };
 
 }  // namespace concord::diagnostics

--- a/diagnostics/include/diagnostics_server.h
+++ b/diagnostics/include/diagnostics_server.h
@@ -1,0 +1,172 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+// This file contains a tcp server listening on localhost that handles the messages in protocol.h.
+
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <sstream>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <thread>
+#include <unistd.h>
+
+#include "Logger.hpp"
+#include "errnoString.hpp"
+#include "protocol.h"
+
+using concordUtils::errnoString;
+
+namespace concord::diagnostics {
+
+static constexpr uint16_t PORT = 6888;
+static constexpr int BACKLOG = 5;
+static constexpr size_t MAX_INPUT_SIZE = 1024;
+
+static concordlogger::Logger logger = concordlogger::Log::getLogger("concord.diagnostics");
+
+// Returns a successfully read line as a string.
+// Throws a std::runtime_error on error.
+std::string readline(int sock) {
+  std::array<char, MAX_INPUT_SIZE> buf;
+  buf.fill(0);
+  int count = 0;
+  auto start = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::microseconds(999999);
+  auto remaining = timeout;
+  while (true) {
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    FD_SET(sock, &read_fds);
+    timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = remaining.count();
+    auto rv = select(sock + 1, &read_fds, NULL, NULL, &tv);
+    if (rv == 0) {
+      throw std::runtime_error("timeout");
+    }
+    if (rv < 0 && errno == EINTR) continue;
+    if (rv < 0) {
+      throw std::runtime_error("select failed: " + errnoString(rv));
+    }
+
+    if (count == MAX_INPUT_SIZE) {
+      throw std::runtime_error("Request exceeded max size: " + std::to_string(MAX_INPUT_SIZE));
+    }
+
+    rv = read(sock, &buf + count, buf.size() - count);
+    if (rv <= 0) {
+      throw std::runtime_error("read failed: " + errnoString(rv));
+    }
+    count += rv;
+
+    // Check to see if we have a complete command
+    auto it = std::find(buf.begin(), buf.end(), '\n');
+    if (it != buf.end()) {
+      return std::string(buf.begin(), it);
+    }
+
+    // We may not have received all the data yet. Update the timeout.
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    remaining = timeout - duration;
+  }
+}
+
+void handleRequest(const Registrar& registrar, int sock) {
+  try {
+    std::stringstream ss(readline(sock));
+    std::vector<std::string> tokens;
+    std::string token;
+    while (std::getline(ss, token, ' ')) {
+      tokens.push_back(token);
+    }
+    std::string output = run(tokens, registrar);
+    if (write(sock, output.data(), output.size()) < 0) {
+      LOG_WARN(logger, "Failed to write to client socket: " << errnoString(errno));
+    }
+    close(sock);
+  } catch (const std::exception& e) {
+    std::string out = std::string("Error: ") + e.what() + "\n";
+    if (write(sock, out.data(), out.size()) < 0) {
+      LOG_WARN(logger, "Failed to write to client socket: " << errnoString(errno));
+    }
+    close(sock);
+  }
+}
+
+// Each request creates a separate connection and spawns a thread.
+//
+// The purposes behind this decision are simplicity and expediency. If performance becomes a problem
+// we can maintain persistent connections and/or create a thread pool. We can also switch to using
+// async connections via boost ASIO if necessary, although this seems extremely heavy handed for the
+// use case.
+class Server {
+ public:
+  void start(const Registrar& registrar) {
+    shutdown_.store(false);
+    listen_thread_ = std::thread([this, &registrar]() {
+      listen();
+
+      while (!shutdown_.load()) {
+        fd_set read_fds;
+        FD_ZERO(&read_fds);
+        FD_SET(listen_sock_, &read_fds);
+        timeval tv;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
+        auto rv = select(listen_sock_ + 1, &read_fds, NULL, NULL, &tv);
+        if (rv == 0) continue;  // timeout
+        if (rv < 0 && errno == EINTR) continue;
+        assert(rv > 0);
+        int sock = accept(listen_sock_, NULL, NULL);
+        // We must bind the result future or else this call blocks.
+        auto _ = std::async(std::launch::async, [&]() { handleRequest(registrar, sock); });
+        (void)_;  // unused variable hack
+      }
+    });
+  }
+
+  void stop() {
+    shutdown_.store(true);
+    listen_thread_.join();
+  };
+
+ private:
+  void listen() {
+    listen_sock_ = socket(AF_INET, SOCK_STREAM, 0);
+    assert(listen_sock_ >= 0);
+    bzero(&servaddr_, sizeof(servaddr_));
+    servaddr_.sin_family = AF_INET;
+    // LOCALHOST ONLY, FOR SECURITY PURPOSES. DO NOT CHANGE THIS!!!
+    servaddr_.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    servaddr_.sin_port = htons(PORT);
+    int enable = 1;
+    assert(setsockopt(listen_sock_, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) == 0);
+    assert(bind(listen_sock_, (sockaddr*)&servaddr_, sizeof(servaddr_)) == 0);
+    assert(::listen(listen_sock_, BACKLOG) == 0);
+  }
+
+  int listen_sock_;
+  sockaddr_in servaddr_;
+  std::thread listen_thread_;
+  std::atomic<bool> shutdown_;
+};
+
+}  // namespace concord::diagnostics

--- a/diagnostics/include/protocol.h
+++ b/diagnostics/include/protocol.h
@@ -48,7 +48,7 @@ std::string accumulate(Iterator begin, Iterator end, Fun f) {
 }
 
 // Take protocol input as a split string, along with a registrar and return diagnostics or a usage string.
-std::string run(const std::vector<std::string>& tokens, Registrar& registrar) {
+std::string run(const std::vector<std::string>& tokens, const Registrar& registrar) {
   if (tokens.size() < 2) return usage();
 
   auto& subject = tokens[0];

--- a/diagnostics/test/CMakeLists.txt
+++ b/diagnostics/test/CMakeLists.txt
@@ -1,6 +1,9 @@
 find_package(GTest REQUIRED)
+find_package(Threads REQUIRED)
 
 add_executable(diagnostics_tests diagnostics_tests.cpp)
 add_test(diagnostics_tests diagnostics_tests)
 target_link_libraries(diagnostics_tests PRIVATE GTest::Main diagnostics)
 
+add_executable(diagnostics_server_main main.cpp $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(diagnostics_server_main PRIVATE diagnostics Threads::Threads)

--- a/diagnostics/test/main.cpp
+++ b/diagnostics/test/main.cpp
@@ -1,0 +1,40 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <unistd.h>
+
+#include "diagnostics.h"
+#include "diagnostics_server.h"
+
+using namespace concord::diagnostics;
+
+int main() {
+  Registrar registrar;
+
+  StatusHandler handler1("handler1", "handler 1 description", []() { return "handler1 called"; });
+  StatusHandler handler2("handler2", "handler 2 description", []() { return "handler2 called"; });
+
+  registrar.registerStatusHandler(handler1);
+  registrar.registerStatusHandler(handler2);
+
+  concord::diagnostics::Server diagnostics_server;
+  diagnostics_server.start(registrar);
+
+  // Keep the diagnostics_server alive indefinitely
+  while (true) {
+    sleep(1);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
We have a diagnostics Registrar that allows us to add status handlers
useful for debugging a live system. This commit adds a TCP server
designated to listen on localhost, that can process commands destined
for the status registrar and return the output over a socket. For
simplicity, and because this is supposed to be a user driven
operation, each client connection is only allowed to send one
command. The client should then wait for the response and exit.

Additionally, a cli client, `concord-ctl`, is provided that takes
arguments on the command line and forwards them as commands to the
server.

Note that neither the registrar or server is integrated in either
concord-bft or the product yet. This will come in follow up commits,
which will also contain real status handlers.

A test server executable that registers 2 dummy status handlers was created for manual testing.

The server can be run from the build directory:
`./build/diagnostics/test/diagnostics_server_main`

The corresponding client can be run from `concord-bft/diagnostics`. Some
examples are shown below.

```
andrewstone@ubuntu:~/concord-bft/diagnostics$ ./concord-ctl
Usage: concord-ctl <SUBJECT> <COMMAND> [ARGS]

  status <COMMAND> [ARGS]

    status get <KEY1> [KEY2]..[KEY_N]
        Get the status of the given key(s).

    status describe [KEY1] [KEY2]..[KEY_N]
        Get the description of the given keys, or all keys if none is given.

    status list-keys
        List all status keys.

andrewstone@ubuntu:~/concord-bft/diagnostics$ ./concord-ctl status list-keys
handler1
handler2

andrewstone@ubuntu:~/concord-bft/diagnostics$ ./concord-ctl status get handler1
handler1 called

andrewstone@ubuntu:~/concord-bft/diagnostics$ ./concord-ctl status get handler2
handler2 called

andrewstone@ubuntu:~/concord-bft/diagnostics$ ./concord-ctl status get handler1 handler2
handler1 called
handler2 called

andrewstone@ubuntu:~/concord-bft/diagnostics$ ./concord-ctl status describe handler1 handler2
handler 1 description
handler 2 description

andrewstone@ubuntu:~/concord-bft/diagnostics$ ./concord-ctl status describe

handler1
  handler 1 description

handler2
  handler 2 description
```

Finally, testing for timeouts and large messages was done directly from
a python shell.

```
>>> s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
>>> s.connect(("127.0.0.1", 6888))
>>> s.send(too_large)
1025
>>> data = s.recv(1024)
>>> print(data)
b'Error: Request exceeded max size: 1024\n'
>>> s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

>>> s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
>>> s.connect(("127.0.0.1", 6888))
>>> data = s.recv(1024)
>>> print(data)
b'Error: timeout\n'
```