### PR TITLE
Use clang-format-9 in the 'format' make target

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_program(
   CLANG_FORMAT_EXE
-  clang-format
+  clang-format-9
   DOC "Path to clang-format"
 )
 find_program(


### PR DESCRIPTION
The 'format' make target doesn't work on a newly-installed system (one
that doesn't have clang-format installed). Fix that by explicitly
looking for clang-format-9 in the CMake file.