### PR TITLE
Additional logs to view change process

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1906,7 +1906,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
   // send messages
 
   if (newNewViewMsgToSend != nullptr) {
-    LOG_INFO(GL, "Sending NewView message to all replicas.");
+    LOG_INFO(GL, "**************** Sending NewView message for view=" << curView << "to all replicas.");
     sendToAllOtherReplicas(newNewViewMsgToSend);
   }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1906,7 +1906,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
   // send messages
 
   if (newNewViewMsgToSend != nullptr) {
-    LOG_INFO(GL, "**************** Sending NewView message for view=" << curView << "to all replicas.");
+    LOG_INFO(GL, "**************** Sending NewView message for view=" << curView << " to all replicas");
     sendToAllOtherReplicas(newNewViewMsgToSend);
   }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1905,7 +1905,10 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
 
   // send messages
 
-  if (newNewViewMsgToSend != nullptr) sendToAllOtherReplicas(newNewViewMsgToSend);
+  if (newNewViewMsgToSend != nullptr) {
+    LOG_INFO(GL, "Sending NewView message to all replicas.");
+    sendToAllOtherReplicas(newNewViewMsgToSend);
+  }
 
   for (size_t i = 0; i < prePreparesForNewView.size(); i++) {
     PrePrepareMsg *pp = prePreparesForNewView[i];

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -571,13 +571,13 @@ bool ViewsManager::tryToEnterView(ViewNum v,
 
   if (currentLastExecuted < currentLastStable) {
     // we don't have state, let's wait for state synchronization...
-    LOG_INFO(GL, "Waiting for state synchronization before entering view ...");
+    LOG_INFO(GL, "**************** Waiting for state synchronization before entering view=" << v << " ...");
     return false;
   }
 
   if (currentLastStable < lowerBoundStableForPendingView) {
     // we don't have the latest stable point, let's wait for more information
-    LOG_INFO(GL, "Waiting for latest stable point before entering view ...");
+    LOG_INFO(GL, "**************** Waiting for latest stable point before entering view=" << v << " ...");
     return false;
   }
 
@@ -602,7 +602,9 @@ bool ViewsManager::tryToEnterView(ViewNum v,
 
     if (currentLastStable < lowerBoundStableForPendingView) {
       // we don't have the latest stable point, let's wait for more information
-      LOG_INFO(GL, "New pending view. Waiting for latest stable point before entering view ...");
+      LOG_INFO(GL,
+               "**************** New pending view. The previous pending view was "
+                   << myLatestPendingView << ". Waiting for latest stable point before entering view=" << v << " ...");
       return false;
     }
   }
@@ -646,12 +648,12 @@ bool ViewsManager::tryToEnterView(ViewNum v,
 
   // return if we don't have restrictions
   if (stat != Stat::PENDING_WITH_RESTRICTIONS) {
-    LOG_INFO(GL, "Waiting for restrictions before entering view ...");
+    LOG_INFO(GL, "**************** Waiting for restrictions before entering view=" << v << " ...");
     return false;
   }
   // return if some messages are missing
   if (hasMissingMsgs(currentLastStable)) {
-    LOG_INFO(GL, "Waiting for missing messages before entering view ...");
+    LOG_INFO(GL, "**************** Waiting for missing messages before entering view=" << v << " ...");
     return false;
   }
   ///////////////////////////////////////////////////////////////////////////
@@ -754,7 +756,8 @@ bool ViewsManager::tryMoveToPendingViewAsPrimary(ViewNum v) {
   }
 
   if (relatedVCMsgs.size() < SMAJOR) {
-    LOG_INFO(GL, "Waiting for sufficient ViewChange messages to entering view as primary ...");
+    LOG_INFO(GL,
+             "**************** Waiting for sufficient ViewChange messages to entering view=" << v << " as primary ...");
     return false;
   }
 
@@ -818,7 +821,7 @@ bool ViewsManager::tryMoveToPendingViewAsNonPrimary(ViewNum v) {
   }
 
   if (relatedVCMsgs.size() < MAJOR) {
-    LOG_INFO(GL, "Waiting for sufficient ViewChange messages to entering view ...");
+    LOG_INFO(GL, "**************** Waiting for sufficient ViewChange messages to entering view=" << v << " ...");
     return false;
   }
   Assert(relatedVCMsgs.size() == MAJOR);

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -608,26 +608,29 @@ bool ViewsManager::tryToEnterView(ViewNum v,
     stat = Stat::PENDING_WITH_RESTRICTIONS;
 
     // BEGIN DEBUG CODE
-
-    printf("\n\n\nRestrictions for pending view %" PRId64 ":", this->myLatestPendingView);
+    LOG_DEBUG(GL,
+              "Restrictions for pending view=" << this->myLatestPendingView
+                                               << ", minSeq=" << minRestrictionOfPendingView
+                                               << ", maxSeq=" << maxRestrictionOfPendingView << ".");
 
     if (minRestrictionOfPendingView == 0) {
-      printf("None\n");
+      LOG_DEBUG(GL, "No Restrictions of pending view\n");
     } else {
       for (SeqNum i = minRestrictionOfPendingView; i <= maxRestrictionOfPendingView; i++) {
         uint64_t idx = i - minRestrictionOfPendingView;
-        printf("\n");
-        printf("Seqnum=%" PRId64 ", isNull=%d, digestPrefix=%d .     ",
-               i,
-               static_cast<int>(restrictionsOfPendingView[idx].isNull),
-               *reinterpret_cast<int*>(restrictionsOfPendingView[idx].digest.content()));
-        if (prePrepareMsgsOfRestrictions[idx] == nullptr)
-          printf("PP=null .");
-        else
-          printf("PP seq=%" PRId64 ", digestPrefix=%d .",
-                 prePrepareMsgsOfRestrictions[idx]->seqNumber(),
-                 *reinterpret_cast<int*>(prePrepareMsgsOfRestrictions[idx]->digestOfRequests().content()));
-        printf("\n");
+        bool bHasPP = (prePrepareMsgsOfRestrictions[idx] != nullptr);
+        LOG_DEBUG(
+            GL,
+            "Seqnum=" << i << ", isNull=" << static_cast<int>(restrictionsOfPendingView[idx].isNull)
+                      << ", digestPrefix=" << *reinterpret_cast<int*>(restrictionsOfPendingView[idx].digest.content())
+                      << (bHasPP ? " ." : ", PP=null ."));
+        if (bHasPP) {
+          LOG_DEBUG(
+              GL,
+              "PP seq=" << prePrepareMsgsOfRestrictions[idx]->seqNumber() << ", digestPrefix="
+                        << *reinterpret_cast<int*>(prePrepareMsgsOfRestrictions[idx]->digestOfRequests().content())
+                        << " .");
+        }
       }
     }
 


### PR DESCRIPTION
- printf-s replaced by LOG_DEBUG in ViewsManager.cpp
- added log when primary for next View sends NewView message to all replicas.
- added logs when a Replica has to wait for additional information before entering View.