### PR TITLE
Add merkle tree storage microbenchmarks

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -30,3 +30,5 @@ target_link_libraries(kvbc PRIVATE ${OPENSSL_LIBRARIES})
 if (BUILD_TESTING)
     add_subdirectory(test)
 endif()
+
+add_subdirectory(benchmark)

--- a/kvbc/benchmark/CMakeLists.txt
+++ b/kvbc/benchmark/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(benchmark)
+
+if(benchmark_FOUND)
+    add_executable(sparse_merkle_benchmark sparse_merkle_benchmark.cpp $<TARGET_OBJECTS:logging_dev>)
+    target_link_libraries(sparse_merkle_benchmark PUBLIC
+        benchmark
+        util
+        corebft
+        kvbc
+    )
+endif()

--- a/kvbc/benchmark/sparse_merkle_benchmark.cpp
+++ b/kvbc/benchmark/sparse_merkle_benchmark.cpp
@@ -1,0 +1,363 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+// This file contains a number of microbenchmarks of merkle tree storage components.
+
+#include <benchmark/benchmark.h>
+
+#include "endianness.hpp"
+#include "Logger.hpp"
+#include "memorydb/client.h"
+#include "merkle_tree_db_adapter.h"
+#include "merkle_tree_key_manipulator.h"
+#include "merkle_tree_serialization.h"
+#include "sha3_256.h"
+#include "sparse_merkle/base_types.h"
+#include "sparse_merkle/internal_node.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <vector>
+#include <utility>
+
+namespace {
+
+using namespace ::concord::kvbc::sparse_merkle;
+using namespace ::concord::kvbc::v2MerkleTree;
+using namespace ::concord::kvbc::v2MerkleTree::detail;
+using namespace ::concord::storage::memorydb;
+using namespace ::concord::util;
+
+using ::concord::kvbc::OrderedKeysSet;
+using ::concord::kvbc::SetOfKeyValuePairs;
+
+using ::concordUtils::fromBigEndianBuffer;
+using ::concordUtils::Sliver;
+using ::concordUtils::toBigEndianStringBuffer;
+
+Hash hash(const std::string &value) {
+  auto hasher = Hasher{};
+  return hasher.hash(value.data(), value.size());
+}
+
+Hash hash(const char *value) { return hash(std::string{value}); }
+
+Hash hash(const Hash &value) {
+  auto hasher = Hasher{};
+  return hasher.hash(value.data(), value.size());
+}
+
+template <typename T>
+Hash hash(const T &value) {
+  static_assert(std::is_arithmetic_v<T>);
+  auto hasher = Hasher{};
+  return hasher.hash(&value, sizeof(value));
+}
+
+const auto internalChild = InternalChild{hash(42), 42};
+const auto leafChild = LeafChild{hash("data1"), LeafKey{hash("data2"), 42}};
+
+BatchedInternalNode createBatchedInternalNode() {
+  constexpr auto internalCount = 15;
+  constexpr auto leafCount = 16;
+  auto children = BatchedInternalNode::Children{};
+  static_assert(internalCount + leafCount == children.size());
+  for (auto i = 0ull; i < internalCount; ++i) {
+    children[i] = InternalChild{hash(i), i};
+  }
+  for (auto i = 0ull; i < leafCount; ++i) {
+    const auto idx = internalCount + i;
+    const auto hashChild = hash(idx);
+    const auto hashKey = hash(hashChild);
+    children[idx] = LeafChild{hashChild, LeafKey{hashKey, idx}};
+  }
+  return children;
+}
+
+const auto batchedInternalNode = createBatchedInternalNode();
+
+std::vector<std::uint8_t> randomBuffer(std::size_t size) {
+  auto rd = std::random_device{};
+  auto gen = std::mt19937{rd()};
+  auto dis = std::uniform_int_distribution<std::uint16_t>{0, 255};
+  auto buf = std::vector<std::uint8_t>{};
+  buf.resize(size);
+  for (auto i = 0ull; i < size; ++i) {
+    buf.push_back(dis(gen));
+  }
+  return buf;
+}
+
+std::string randomString(std::size_t size) {
+  const auto buf = randomBuffer(size);
+  return std::string{std::cbegin(buf), std::cend(buf)};
+}
+
+void createSubsliver(benchmark::State &state) {
+  const auto src = Sliver{std::string(state.range(0), 'a')};
+
+  for (auto _ : state) {
+    const auto copy = Sliver{src, 0, src.length()};
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void fromBigEndian(benchmark::State &state) {
+  const auto src = toBigEndianStringBuffer(std::uint64_t{42});
+
+  for (auto _ : state) {
+    const auto val = fromBigEndianBuffer<std::uint64_t>(src.data());
+    benchmark::DoNotOptimize(val);
+  }
+}
+
+void copyInternalChild(benchmark::State &state) {
+  for (auto _ : state) {
+    const auto copy = internalChild;
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void copyLeafChild(benchmark::State &state) {
+  for (auto _ : state) {
+    const auto copy = leafChild;
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void copyChildVariantContainingLeafChild(benchmark::State &state) {
+  const Child src = leafChild;
+
+  for (auto _ : state) {
+    const auto copy = src;
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void copyChildVariantContainingInteranlChild(benchmark::State &state) {
+  const Child src = internalChild;
+
+  for (auto _ : state) {
+    const auto copy = src;
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void assignLeafChildToChildVariant(benchmark::State &state) {
+  for (auto _ : state) {
+    const auto copy = Child{leafChild};
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void assignInternalChildToChildVariant(benchmark::State &state) {
+  for (auto _ : state) {
+    const auto copy = Child{internalChild};
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void copyBatchedInternalNode(benchmark::State &state) {
+  for (auto _ : state) {
+    const auto copy = batchedInternalNode;
+    benchmark::DoNotOptimize(copy);
+  }
+}
+
+void deserializeInternalChild(benchmark::State &state) {
+  const auto ser = Sliver{serialize(internalChild)};
+
+  for (auto _ : state) {
+    const auto deser = deserialize<InternalChild>(ser);
+    benchmark::DoNotOptimize(deser);
+  }
+}
+
+void deserializeLeafChild(benchmark::State &state) {
+  const auto ser = Sliver{serialize(leafChild)};
+
+  for (auto _ : state) {
+    const auto deser = deserialize<LeafChild>(ser);
+    benchmark::DoNotOptimize(deser);
+  }
+}
+
+void deserializeHash(benchmark::State &state) {
+  const auto ser = Sliver{serialize(hash(42))};
+
+  for (auto _ : state) {
+    const auto deser = deserialize<Hash>(ser);
+    benchmark::DoNotOptimize(deser);
+  }
+}
+
+void deserializeLeafKey(benchmark::State &state) {
+  const auto ser = Sliver{serialize(LeafKey{hash(42), 42})};
+
+  for (auto _ : state) {
+    const auto deser = deserialize<LeafKey>(ser);
+    benchmark::DoNotOptimize(deser);
+  }
+}
+
+void deserializeBatchedInternalNode(benchmark::State &state) {
+  const auto ser = Sliver{serialize(batchedInternalNode)};
+
+  for (auto _ : state) {
+    const auto deser = deserialize<BatchedInternalNode>(ser);
+    benchmark::DoNotOptimize(deser);
+  }
+}
+
+void calculateSha3(benchmark::State &state) {
+  const auto value = randomBuffer(state.range(0));
+  auto hasher = SHA3_256{};
+
+  for (auto _ : state) {
+    const auto hash = hasher.digest(value.data(), value.size());
+    benchmark::DoNotOptimize(hash);
+  }
+}
+
+struct Blockchain : benchmark::Fixture {
+  void SetUp(const benchmark::State &state) override {
+    keyCount = state.range(0);
+    keySize = state.range(1);
+    valueSize = state.range(2);
+
+    auto db = std::make_shared<Client>();
+    db->init();
+    adapter = std::make_unique<DBAdapter>(db);
+
+    for (auto i = 0ull; i < blockCount; ++i) {
+      adapter->addBlock(createBlockUpdates(keyCount, keySize, valueSize));
+    }
+  }
+
+  SetOfKeyValuePairs createBlockUpdates(std::size_t keyCount, std::size_t keySize, std::size_t valueSize) {
+    auto updates = SetOfKeyValuePairs{};
+    for (auto j = 0ull; j < keyCount; ++j) {
+      auto key = toBigEndianStringBuffer(currentKeyValue++);
+      if (keySize > sizeof(currentKeyValue)) {
+        key += std::string(keySize - sizeof(currentKeyValue), 'a');
+      }
+      updates[std::move(key)] = randomString(valueSize);
+    }
+    return updates;
+  }
+
+  std::uint64_t currentKeyValue{0};
+  std::unique_ptr<DBAdapter> adapter;
+  const std::uint64_t blockCount{32};
+  std::int64_t keyCount{0};
+  std::int64_t keySize{0};
+  std::int64_t valueSize{0};
+};
+
+BENCHMARK_DEFINE_F(Blockchain, addBlock)(benchmark::State &state) {
+  const auto updates = createBlockUpdates(keyCount, keySize, valueSize);
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(adapter->addBlock(updates));
+    state.PauseTiming();
+    adapter->deleteLastReachableBlock();
+    state.ResumeTiming();
+  }
+}
+
+BENCHMARK_DEFINE_F(Blockchain, getInternalFromCache)(benchmark::State &state) {
+  const auto updates = createBlockUpdates(keyCount, keySize, valueSize);
+  const auto internalNodes = adapter->updateTree(updates, OrderedKeysSet{}).second.internalNodes();
+  const auto nibblePath = (--internalNodes.cend())->first;
+
+  for (auto _ : state) {
+    auto it = internalNodes.find(nibblePath);
+    benchmark::DoNotOptimize(it);
+  }
+}
+
+BENCHMARK_DEFINE_F(Blockchain, getInternalFromDb)(benchmark::State &state) {
+  const auto updates = createBlockUpdates(keyCount, keySize, valueSize);
+  auto cache = adapter->updateTree(updates, OrderedKeysSet{}).second;
+  auto &internalNodes = cache.internalNodes();
+
+  // First, make sure the key is not in the cache.
+  const auto lastIt = --internalNodes.cend();
+  const auto [nibblePath, internalNode] = *lastIt;
+  internalNodes.erase(lastIt);
+  const auto internalNodeKey = InternalNodeKey{cache.version(), nibblePath};
+
+  // Secondly, persist it.
+  adapter->getDb()->put(DBKeyManipulator::genInternalDbKey(internalNodeKey), serialize(internalNode));
+
+  for (auto _ : state) {
+    // Look it up from the DB, knowing the cache has other elements, but not the requested one.
+    const auto found = cache.getInternalNode(internalNodeKey);
+    benchmark::DoNotOptimize(found);
+  }
+}
+
+BENCHMARK_DEFINE_F(Blockchain, updateCachePut)(benchmark::State &state) {
+  const auto updates = createBlockUpdates(keyCount, keySize, valueSize);
+  auto cache = adapter->updateTree(updates, OrderedKeysSet{}).second;
+  auto &internalNodes = cache.internalNodes();
+
+  for (auto _ : state) {
+    // Delete the last element.
+    state.PauseTiming();
+    auto lastIt = --internalNodes.cend();
+    const auto [nibblePath, internalNode] = *lastIt;
+    internalNodes.erase(lastIt);
+    state.ResumeTiming();
+
+    // Insert the last element.
+    const auto res = internalNodes.emplace(nibblePath, internalNode);
+    benchmark::DoNotOptimize(res);
+  }
+}
+
+// Blockchain ranges for:
+//  - key count
+//  - key size
+//  - value size
+const auto blockchainRanges =
+    std::vector<std::pair<std::int64_t, std::int64_t>>{{128, 2048}, {4, 32}, {1024, 4 * 1024}};
+
+}  // namespace
+
+BENCHMARK(createSubsliver)->Range(8, 8 * 1024);
+BENCHMARK(fromBigEndian);
+BENCHMARK(copyInternalChild);
+BENCHMARK(copyLeafChild);
+BENCHMARK(copyChildVariantContainingLeafChild);
+BENCHMARK(copyChildVariantContainingInteranlChild);
+BENCHMARK(assignInternalChildToChildVariant);
+BENCHMARK(assignLeafChildToChildVariant);
+BENCHMARK(copyBatchedInternalNode);
+BENCHMARK(deserializeInternalChild);
+BENCHMARK(deserializeLeafChild);
+BENCHMARK(deserializeHash);
+BENCHMARK(deserializeLeafKey);
+BENCHMARK(deserializeBatchedInternalNode);
+BENCHMARK(calculateSha3)->Range(8, 40 * 1024 * 1024);
+BENCHMARK_REGISTER_F(Blockchain, addBlock)->Ranges(blockchainRanges);
+BENCHMARK_REGISTER_F(Blockchain, getInternalFromCache)->Ranges(blockchainRanges);
+BENCHMARK_REGISTER_F(Blockchain, getInternalFromDb)->Ranges(blockchainRanges);
+BENCHMARK_REGISTER_F(Blockchain, updateCachePut)->Ranges(blockchainRanges);
+
+BENCHMARK_MAIN();

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -148,6 +148,10 @@ class DBAdapter : public IDbAdapter {
                                                  const OrderedKeysSet &deletes,
                                                  BlockId blockId);
 
+  // Execute an update to the tree without persisting the result. This method is made public for testing purposes only.
+  std::pair<sparse_merkle::UpdateBatch, sparse_merkle::detail::UpdateCache> updateTree(
+      const SetOfKeyValuePairs &updates, const OrderedKeysSet &deletes);
+
  private:
   concordUtils::Sliver createBlockNode(const SetOfKeyValuePairs &updates,
                                        const OrderedKeysSet &deletes,

--- a/kvbc/include/sparse_merkle/tree.h
+++ b/kvbc/include/sparse_merkle/tree.h
@@ -16,6 +16,7 @@
 #include <array>
 #include <map>
 #include <stack>
+#include <utility>
 
 #include "assertUtils.hpp"
 #include "kv_types.hpp"
@@ -24,6 +25,7 @@
 #include "sparse_merkle/db_reader.h"
 #include "sparse_merkle/internal_node.h"
 #include "sparse_merkle/update_batch.h"
+#include "sparse_merkle/update_cache.h"
 
 namespace concord {
 namespace kvbc {
@@ -60,12 +62,20 @@ class Tree {
     return update(no_updates, deletes);
   }
 
+  // In addition to the batch, returns the cache object used for the update. Used for testing purposes.
+  std::pair<UpdateBatch, detail::UpdateCache> update_with_cache(const concord::kvbc::SetOfKeyValuePairs& updates,
+                                                                const concord::kvbc::KeysVector& deleted_keys);
+
  private:
   // Reset the tree to the latest version.
   //
   // This is necessary to do before updates, as we only allow updating the
   // latest tree.
   void reset() { root_ = db_reader_->get_latest_root(); }
+
+  UpdateBatch update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
+                          const concord::kvbc::KeysVector& deleted_keys,
+                          detail::UpdateCache& cache);
 
   std::shared_ptr<IDBReader> db_reader_;
   BatchedInternalNode root_;

--- a/kvbc/include/sparse_merkle/update_cache.h
+++ b/kvbc/include/sparse_merkle/update_cache.h
@@ -41,6 +41,9 @@ class UpdateCache {
   const auto& internalNodes() const { return internal_nodes_; }
   Version version() const { return version_; }
 
+  // Used for testing purposes only.
+  auto& internalNodes() { return internal_nodes_; }
+
   // Return the root if it's been updated and stored in the cache. Otherwise
   // return the root at the time of cache creation.
   const BatchedInternalNode& getRoot();

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -220,7 +220,7 @@ KeyValuePair ClientIterator::last() {
 KeyValuePair ClientIterator::seekAtLeast(const Sliver &_searchKey) {
   m_current = m_parentClient->getMap().lower_bound(_searchKey);
   if (m_current == m_parentClient->getMap().end()) {
-    LOG_WARN(logger, "Key " << _searchKey << " not found");
+    LOG_TRACE(logger, "Key " << _searchKey << " not found");
     return KeyValuePair();
   }
 
@@ -239,7 +239,7 @@ KeyValuePair ClientIterator::seekAtMost(const Sliver &_searchKey) {
   const auto &map = m_parentClient->getMap();
   if (map.empty()) {
     m_current = map.end();
-    LOG_WARN(logger, "Key " << _searchKey << " not found");
+    LOG_TRACE(logger, "Key " << _searchKey << " not found");
     return KeyValuePair();
   }
 


### PR DESCRIPTION
Add merkle tree storage component microbenchmarks using the
Google::Benchmark library. Intentions for them are to provide insights
into the implementation and serve as a basis for optimizations.

Test performance-critical functions such as:
 * copying Slivers - essentially bumping ref counts
 * copying and deserializing node representations (InternalChild,
   LeafChild, BatchedInternalNode, etc.)
 * copying/assigning to variants of different node types
 * SHA3-256 calculation
 * higher-level functionality such as adding blocks, looking up internal
   nodes from cache and DB, updating the internal node cache

The Google::Benchmark library is optional. If not present, the
microbenchmarks will not compile.

Add a number of public methods to the sparse merkle tree and the
corresponding DB adapter implementation. They serve as helpers for
testing/benchmarking and are not intended for use by clients.

Fix a call done in an assert statement to a function that is part of the
actual flow in the DB adapter.

Do not std::move() the stale node indexes into the returned update batch
as the requirements on the returned cache (for testing purposes) are for
it to be intact. Moreover, the cache returns the stale node indexes by a
const reference and the std::move() call would not have any impact. A
future commit may optimize that part of the flow.

Bump the logs in the seekAtLeast() and seekAtMost() methods in memorydb
to TRACE level as a missing key should not be a warning. Moreover, these
log messages interfere with benchmark outputs.

Future commits will add more benchmarks.

Note: This PR includes the changes in https://github.com/vmware/concord-bft/pull/613 . If there are any further changes, this PR will track them.