### PR TITLE
Attempt a fix for hanging CI jobs

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -356,7 +356,7 @@ class BftTestNetwork:
             self._stop_external_replica(replica_id)
         else:
             p = self.procs[replica_id]
-            p.terminate()
+            p.kill()
             p.wait()
 
         del self.procs[replica_id]


### PR DESCRIPTION
My initial suspicion is the recently introduced use of SIGTERM instead of SIGKILL for stopping replicas.