### PR TITLE
 Print expression values in asserts when possible

### DIFF
--- a/util/include/kvstream.h
+++ b/util/include/kvstream.h
@@ -1,0 +1,232 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <sstream>
+
+// Take up to 16 values and output them to a stream as key value pairs.
+//
+// This stringizes the value passed in and uses it as the key. If you want a specific key, just create an alias
+// variable.
+//
+// Usage looks like the following:
+//   KVLOG(seq_num, view, firstStoredCheckpoint)
+//
+// Output looks like:
+//   "seq_num: <VAL>, view: <VAL>, firstStoredCheckpoint: <VAL>"
+//
+#define GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, NAME, ...) NAME
+#define KVLOG(...)       \
+  GET_MACRO(__VA_ARGS__, \
+            KVLOG16,     \
+            KVLOG15,     \
+            KVLOG14,     \
+            KVLOG13,     \
+            KVLOG12,     \
+            KVLOG11,     \
+            KVLOG10,     \
+            KVLOG9,      \
+            KVLOG8,      \
+            KVLOG7,      \
+            KVLOG6,      \
+            KVLOG5,      \
+            KVLOG4,      \
+            KVLOG3,      \
+            KVLOG2,      \
+            KVLOG1)      \
+  (__VA_ARGS__)
+#define KVLOG16(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16) \
+  KvLog(#_16,                                                                          \
+        _16,                                                                           \
+        #_15,                                                                          \
+        _15,                                                                           \
+        #_14,                                                                          \
+        _14,                                                                           \
+        #_13,                                                                          \
+        _13,                                                                           \
+        #_12,                                                                          \
+        _12,                                                                           \
+        #_11,                                                                          \
+        _11,                                                                           \
+        #_10,                                                                          \
+        _10,                                                                           \
+        #_9,                                                                           \
+        _9,                                                                            \
+        #_8,                                                                           \
+        _8,                                                                            \
+        #_7,                                                                           \
+        _7,                                                                            \
+        #_6,                                                                           \
+        _6,                                                                            \
+        #_5,                                                                           \
+        _5,                                                                            \
+        #_4,                                                                           \
+        _4,                                                                            \
+        #_3,                                                                           \
+        _3,                                                                            \
+        #_2,                                                                           \
+        _2,                                                                            \
+        #_1,                                                                           \
+        _1)
+#define KVLOG15(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15) \
+  KvLog(#_15,                                                                     \
+        _15,                                                                      \
+        #_14,                                                                     \
+        _14,                                                                      \
+        #_13,                                                                     \
+        _13,                                                                      \
+        #_12,                                                                     \
+        _12,                                                                      \
+        #_11,                                                                     \
+        _11,                                                                      \
+        #_10,                                                                     \
+        _10,                                                                      \
+        #_9,                                                                      \
+        _9,                                                                       \
+        #_8,                                                                      \
+        _8,                                                                       \
+        #_7,                                                                      \
+        _7,                                                                       \
+        #_6,                                                                      \
+        _6,                                                                       \
+        #_5,                                                                      \
+        _5,                                                                       \
+        #_4,                                                                      \
+        _4,                                                                       \
+        #_3,                                                                      \
+        _3,                                                                       \
+        #_2,                                                                      \
+        _2,                                                                       \
+        #_1,                                                                      \
+        _1)
+#define KVLOG14(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14) \
+  KvLog(#_14,                                                                \
+        _14,                                                                 \
+        #_13,                                                                \
+        _13,                                                                 \
+        #_12,                                                                \
+        _12,                                                                 \
+        #_11,                                                                \
+        _11,                                                                 \
+        #_10,                                                                \
+        _10,                                                                 \
+        #_9,                                                                 \
+        _9,                                                                  \
+        #_8,                                                                 \
+        _8,                                                                  \
+        #_7,                                                                 \
+        _7,                                                                  \
+        #_6,                                                                 \
+        _6,                                                                  \
+        #_5,                                                                 \
+        _5,                                                                  \
+        #_4,                                                                 \
+        _4,                                                                  \
+        #_3,                                                                 \
+        _3,                                                                  \
+        #_2,                                                                 \
+        _2,                                                                  \
+        #_1,                                                                 \
+        _1)
+#define KVLOG13(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13) \
+  KvLog(#_13,                                                           \
+        _13,                                                            \
+        #_12,                                                           \
+        _12,                                                            \
+        #_11,                                                           \
+        _11,                                                            \
+        #_10,                                                           \
+        _10,                                                            \
+        #_9,                                                            \
+        _9,                                                             \
+        #_8,                                                            \
+        _8,                                                             \
+        #_7,                                                            \
+        _7,                                                             \
+        #_6,                                                            \
+        _6,                                                             \
+        #_5,                                                            \
+        _5,                                                             \
+        #_4,                                                            \
+        _4,                                                             \
+        #_3,                                                            \
+        _3,                                                             \
+        #_2,                                                            \
+        _2,                                                             \
+        #_1,                                                            \
+        _1)
+#define KVLOG12(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12) \
+  KvLog(#_12,                                                      \
+        _12,                                                       \
+        #_11,                                                      \
+        _11,                                                       \
+        #_10,                                                      \
+        _10,                                                       \
+        #_9,                                                       \
+        _9,                                                        \
+        #_8,                                                       \
+        _8,                                                        \
+        #_7,                                                       \
+        _7,                                                        \
+        #_6,                                                       \
+        _6,                                                        \
+        #_5,                                                       \
+        _5,                                                        \
+        #_4,                                                       \
+        _4,                                                        \
+        #_3,                                                       \
+        _3,                                                        \
+        #_2,                                                       \
+        _2,                                                        \
+        #_1,                                                       \
+        _1)
+#define KVLOG11(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11) \
+  KvLog(#_11, _11, #_10, _10, #_9, _9, #_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG10(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) \
+  KvLog(#_10, _10, #_9, _9, #_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG9(_1, _2, _3, _4, _5, _6, _7, _8, _9) \
+  KvLog(#_9, _9, #_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG8(_1, _2, _3, _4, _5, _6, _7, _8) \
+  KvLog(#_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG7(_1, _2, _3, _4, _5, _6, _7) KvLog(#_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG6(_1, _2, _3, _4, _5, _6) KvLog(#_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG5(_1, _2, _3, _4, _5) KvLog(#_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG4(_1, _2, _3, _4) KvLog(#_4, _4, #_3, _3, #_2, _2, #_1, _1)
+#define KVLOG3(_1, _2, _3) KvLog(#_3, _3, #_2, _2, #_1, _1)
+#define KVLOG2(_1, _2) KvLog(#_2, _2, #_1, _1)
+#define KVLOG1(_1) KvLog(#_1, _1)
+
+// These are recurisive variadic template functions for generating formatted key-value pairs that
+// can be attached to the end of log messages. The entrypoint is the KVLog function at the bottom
+// that only takes a variadic arg.
+//
+// Right now the entrypoint returns a string, because of the way our logging macros are implemented.
+// We could change them to take an extra parameter that's a stringstream and prevent the additional
+// allocation and copy from returning a string. We'll deal with that if its needed.
+template <typename K, typename V>
+void KvLog(std::stringstream &ss, K &&key, V &&val) {
+  ss << std::forward<K>(key) << ": " << std::forward<V>(val);
+}
+
+template <typename K, typename V, typename... KVPAIRS>
+void KvLog(std::stringstream &ss, K &&key, V &&val, KVPAIRS &&... kvpairs) {
+  ss << std::forward<K>(key) << ": " << std::forward<V>(val) << ", ";
+  KvLog(ss, std::forward<KVPAIRS>(kvpairs)...);
+}
+
+template <typename... KVPAIRS>
+std::string KvLog(KVPAIRS &&... kvpairs) {
+  std::stringstream ss;
+  ss << "| ";
+  KvLog(ss, std::forward<KVPAIRS>(kvpairs)...);
+  return ss.str();
+}

--- a/util/include/type_traits.h
+++ b/util/include/type_traits.h
@@ -13,6 +13,7 @@
 #pragma once
 #include <set>
 #include <vector>
+#include <type_traits>
 
 namespace concord {
 
@@ -38,5 +39,18 @@ struct is_std_container : std_container<bool, is_set<T>::value || is_vector<T>::
 
 template <class T, T v>
 constexpr const T std_container<T, v>::value;
+
+// Taken from https://stackoverflow.com/a/22759544
+template <typename S, typename T>
+class is_streamable {
+  template <typename SS, typename TT>
+  static auto test(int) -> decltype(std::declval<SS&>() << std::declval<TT>(), std::true_type());
+
+  template <typename, typename>
+  static auto test(...) -> std::false_type;
+
+ public:
+  static const bool value = decltype(test<S, T>(0))::value;
+};
 
 }  // namespace concord


### PR DESCRIPTION
### This includes the commit for #616. Thats should be merged first.

Currently our assert macros only print the value of expressions for
boolean parameters.

However, this is insufficient for our macros that take 2 parameters,
where we want to know what the value of each parameter is: e.g.
`AssertEQ`, `AssertGE`, `AssertGT`, `AssertLT`, `AssertLE`, and the
newly added `AssertNE`.

The macros listed above will now print the values as well as the
expressions in a key value form of "expression: value" for each
expression parameter, if the expression is capable of being written to a
stream. In other words, the value will be written if expression has an
`<<` operator. Otherwise, the value will be written as an underscore,
`_`.

This enhancement for tolerating unprintable values was made to the KvLog
template functions in kvstream.h introduced in #616. Those functions
will now no longer prevent compilation if someone adds an unprintable
type to a KvLog call. This is somewhat unfortunate, but necessary to
allow the macro wrappers in assertUtils.h to work AFAICT.

I tested this with a few different AssertEQ calls:

```
// Two unprintable lvalues
auto busted_replicas = psd_->getReplicas();
busted_replicas.insert(33);
AssertEQ(replicas_, busted_replicas);

// Log output:
53: 3|05-23-2020 22:31:04.544|139700104681984|FATAL|concord|void bftEngine::SimpleBlockchainStateTransfer::impl::BCStateTran::checkConsistency(bool)| AssertEQ| busted_replicas: _, replicas_: _ in function checkConsistency (/home/andrewstone/concord-bft/bftengine/src/bcstatetransfer/BCStateTran.cpp 2131)
```

```
// Two printable lvalues
auto busted_replica_id = 50;
AssertEQ(config_.myReplicaId, busted_replica_id);

// Log output:
53: 3|05-23-2020 22:34:30.500|140625076410880|FATAL|concord|void bftEngine::SimpleBlockchainStateTransfer::impl::BCStateTran::checkConsistency(bool)| AssertEQ| busted_replica_id: 50, config_.myReplicaId: 3 in function checkConsistency (/home/andrewstone/concord-bft/bftengine/src/bcstatetransfer/BCStateTran.cpp 2133)
```

```
// A printable lvalue, and a printable rvalue
auto busted_replica_id = 50;
AssertEQ(config_.myReplicaId, busted_replica_id + 1);

// Log output:
53: 2|05-23-2020 22:43:02.692|140552776358400|FATAL|concord|void bftEngine::SimpleBlockchainStateTransfer::impl::BCStateTran::checkConsistency(bool)| AssertEQ| busted_replica_id + 1: 51, config_.myReplicaId: 2 in function checkConsistency (/home/andrewstone/concord-bft/bftengine/src/bcstatetransfer/BCStateTran.cpp 2133)
```