### PR TITLE
Improve logging: MDC

### DIFF
--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
@@ -126,7 +126,8 @@ IncomingMsg IncomingMsgsStorageImp::popThreadLocal() {
 
 void IncomingMsgsStorageImp::dispatchMessages(std::promise<void>& signalStarted) {
   signalStarted.set_value();
-  MDC_PUT(GL, "rid", std::to_string(replicaId_));
+  MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(replicaId_));
+  MDC_PUT(MDC_THREAD_KEY, "message-processing");
   try {
     while (!stopped_) {
       auto msg = getMsgForProcessing();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -133,7 +133,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
   const ReqId reqSeqNum = m->requestSeqNum();
   const uint8_t flags = m->flags();
 
-  MDC_CID_PUT(GL, m->getCid());
+  SCOPED_MDC_CID(m->getCid());
   LOG_DEBUG(GL,
             "Received ClientRequestMsg (clientId=" << clientId << " reqSeqNum=" << reqSeqNum << ", flags=" << (int)flags
                                                    << ") from senderId=" << senderId);
@@ -242,7 +242,7 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
   ClientRequestMsg *first = requestsQueueOfPrimary.front();
   while (first != nullptr &&
          !clientsManager->noPendingAndRequestCanBecomePending(first->clientProxyId(), first->requestSeqNum())) {
-    MDC_CID_PUT(GL, first->getCid());
+    SCOPED_MDC_CID(first->getCid());
     primaryCombinedReqSize -= first->size();
     delete first;
     requestsQueueOfPrimary.pop();
@@ -305,7 +305,7 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
 
   while (nextRequest != nullptr) {
     if (nextRequest->size() <= pp->remainingSizeForRequests()) {
-      MDC_CID_PUT(GL, nextRequest->getCid());
+      SCOPED_MDC_CID(nextRequest->getCid());
       if (clientsManager->noPendingAndRequestCanBecomePending(nextRequest->clientProxyId(),
                                                               nextRequest->requestSeqNum())) {
         pp->addRequest(nextRequest->body(), nextRequest->size());
@@ -336,9 +336,9 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
     DebugStatistics::onSendPrePrepareMessage(pp->numberOfRequests(), requestsQueueOfPrimary.size());
   }
   primaryLastUsedSeqNum++;
-  concordlogger::MDC sn(GL, SEQ_NUM_KEY, primaryLastUsedSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(primaryLastUsedSeqNum));
   {
-    concordlogger::MDC content(GL, "cid", "content: " + pp->getBatchCorrelationIdAsString());
+    SCOPED_MDC_CID("content: " + pp->getBatchCorrelationIdAsString());
     LOG_TRACE(GL, "map batch sequence number to correlation ids");
   }
   SeqNumInfo &seqNumInfo = mainLog->get(primaryLastUsedSeqNum);
@@ -399,7 +399,7 @@ template <>
 void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
   metric_received_pre_prepares_.Get().Inc();
   const SeqNum msgSeqNum = msg->seqNumber();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   LOG_DEBUG(GL,
             "Node " << config_.replicaId << " received PrePrepareMsg from node " << msg->senderId() << " for seqNumber "
                     << msgSeqNum << " (size=" << msg->size() << ")");
@@ -428,7 +428,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
 
     if (seqNumInfo.addMsg(msg)) {
       {
-        concordlogger::MDC content(GL, "cid", "content: " + msg->getBatchCorrelationIdAsString());
+        SCOPED_MDC_CID("content: " + msg->getBatchCorrelationIdAsString());
         LOG_TRACE(GL, "map batch sequence number to correlation ids");
       }
       msgAdded = true;
@@ -588,7 +588,7 @@ template <>
 void ReplicaImp::onMessage<StartSlowCommitMsg>(StartSlowCommitMsg *msg) {
   metric_received_start_slow_commits_.Get().Inc();
   const SeqNum msgSeqNum = msg->seqNumber();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   LOG_INFO(GL, "Received StartSlowCommitMsg for seqNumber=" << msgSeqNum);
 
   if (relevantMsgForActiveView(msg)) {
@@ -719,7 +719,7 @@ void ReplicaImp::onMessage<PartialCommitProofMsg>(PartialCommitProofMsg *msg) {
   const SeqNum msgSeqNum = msg->seqNumber();
   const SeqNum msgView = msg->viewNumber();
   const NodeIdType msgSender = msg->senderId();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   Assert(repsInfo->isIdOfPeerReplica(msgSender));
   Assert(repsInfo->isCollectorForPartialProofs(msgView, msgSeqNum));
 
@@ -751,7 +751,7 @@ void ReplicaImp::onMessage<FullCommitProofMsg>(FullCommitProofMsg *msg) {
             "Node " << config_.replicaId << " received FullCommitProofMsg message for seqNumber " << msg->seqNumber());
 
   const SeqNum msgSeqNum = msg->seqNumber();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   if (relevantMsgForActiveView(msg)) {
     SeqNumInfo &seqNumInfo = mainLog->get(msgSeqNum);
     PartialProofsSet &pps = seqNumInfo.partialProofs();
@@ -798,7 +798,7 @@ void ReplicaImp::onMessage<PreparePartialMsg>(PreparePartialMsg *msg) {
   metric_received_prepare_partials_.Get().Inc();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   bool msgAdded = false;
 
   if (relevantMsgForActiveView(msg)) {
@@ -844,7 +844,7 @@ void ReplicaImp::onMessage<CommitPartialMsg>(CommitPartialMsg *msg) {
   metric_received_commit_partials_.Get().Inc();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   bool msgAdded = false;
 
   if (relevantMsgForActiveView(msg)) {
@@ -884,7 +884,7 @@ void ReplicaImp::onMessage<PrepareFullMsg>(PrepareFullMsg *msg) {
   metric_received_prepare_fulls_.Get().Inc();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   bool msgAdded = false;
 
   if (relevantMsgForActiveView(msg)) {
@@ -923,7 +923,7 @@ void ReplicaImp::onMessage<CommitFullMsg>(CommitFullMsg *msg) {
   metric_received_commit_fulls_.Get().Inc();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   bool msgAdded = false;
 
   if (relevantMsgForActiveView(msg)) {
@@ -1132,7 +1132,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
   const SeqNum msgSeqNum = msg->seqNumber();
   const Digest msgDigest = msg->digestOfState();
   const bool msgIsStable = msg->isStableState();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   LOG_DEBUG(GL,
             "Node " << config_.replicaId << " received Checkpoint message from node " << msgSenderId
                     << " for seqNumber " << msgSeqNum << " (size=" << msg->size() << ", stable="
@@ -2242,7 +2242,7 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
   metric_received_req_missing_datas_.Get().Inc();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
-  concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msgSeqNum);
+  SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   LOG_INFO(GL,
            "Received ReqMissingDataMsg message from senderId=" << msgSender << " seqNumber=" << msgSeqNum
                                                                << ", flags=" << msg->getFlags());
@@ -2421,7 +2421,7 @@ void ReplicaImp::onMessage<SimpleAckMsg>(SimpleAckMsg *msg) {
   metric_received_simple_acks_.Get().Inc();
   if (retransmissionsLogicEnabled) {
     uint16_t relatedMsgType = (uint16_t)msg->ackData();  // TODO(GG): does this make sense ?
-    concordlogger::MDC seqNum(GL, SEQ_NUM_KEY, msg->seqNumber());
+    SCOPED_MDC_SEQ_NUM(std::to_string(msg->seqNumber()));
     LOG_DEBUG(GL,
               "Node " << config_.replicaId << " received SimpleAckMsg message from node " << msg->senderId()
                       << " for seqNumber " << msg->seqNumber() << " and type " << relatedMsgType);
@@ -2992,7 +2992,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
     if (!recoverFromErrorInRequestsExecution) {
       while (reqIter.getAndGoToNext(requestBody)) {
         ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
-        MDC_CID_PUT(GL, req.getCid());
+        SCOPED_MDC_CID(req.getCid());
         NodeIdType clientId = req.clientProxyId();
 
         const bool validClient = isValidClient(clientId);
@@ -3040,7 +3040,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(PrePrepareMsg *ppMsg, bool recov
       }
 
       ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
-      MDC_CID_PUT(GL, req.getCid());
+      SCOPED_MDC_CID(req.getCid());
       NodeIdType clientId = req.clientProxyId();
 
       uint32_t actualReplyLength = 0;

--- a/logging/include/Logging4cplus.hpp
+++ b/logging/include/Logging4cplus.hpp
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <log4cplus/loggingmacros.h>
+#include <log4cplus/mdc.h>
 #ifdef USE_LOG4CPP
 
 namespace concordlogger {
@@ -33,5 +34,8 @@ typedef log4cplus::Logger Logger;
 #define LOG_ERROR(l, s) LOG4CPLUS_ERROR(l, s)
 
 #define LOG_FATAL(l, s) LOG4CPLUS_FATAL(l, s)
+
+#define MDC_PUT(k, v) log4cplus::getMDC().put(k, v)
+#define MDC_REMOVE(k) log4cplus::getMDC().remove(k)
 
 #endif

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -33,7 +33,8 @@ void run_replica(int argc, char** argv) {
   const auto setup = TestSetup::ParseArgs(argc, argv);
   concordlogger::Log::initLogger("log4cplus.properties");
   auto logger = setup->GetLogger();
-  MDC_PUT(GL, "rid", std::to_string(setup->GetReplicaConfig().replicaId));
+  MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(setup->GetReplicaConfig().replicaId));
+  MDC_PUT(MDC_THREAD_KEY, "main");
 
   std::shared_ptr<ReplicaImp> replica = std::make_shared<ReplicaImp>(setup->GetCommunication(),
                                                                      setup->GetReplicaConfig(),
@@ -60,17 +61,11 @@ void run_replica(int argc, char** argv) {
 using namespace std;
 
 void signal_handler(int signal_num) {
-  LOG_FATAL(GL, "Program received signal " << signal_num);
-  printCallStack();
-  raise(SIGABRT);
-  exit(signal_num);
+  LOG_INFO(GL, "Program received signal " << signal_num);
+  exit(0);
 }
 
 int main(int argc, char** argv) {
-  signal(SIGSEGV, signal_handler);
-  signal(SIGBUS, signal_handler);
-  signal(SIGILL, signal_handler);
-  signal(SIGFPE, signal_handler);
   signal(SIGINT, signal_handler);
   signal(SIGTERM, signal_handler);
 

--- a/tests/simpleKVBC/scripts/log4cplus.properties
+++ b/tests/simpleKVBC/scripts/log4cplus.properties
@@ -3,14 +3,14 @@
 log4cplus.appender.STDOUT=log4cplus::ConsoleAppender
 log4cplus.appender.STDOUT.ImmediateFlush=true
 log4cplus.appender.STDOUT.layout=log4cplus::PatternLayout
-log4cplus.appender.STDOUT.layout.ConversionPattern=%X{rid}|%d{%d %m %Y %H:%M:%S.%q}|%t|%-5p|%c|%M|%m%n
+log4cplus.appender.STDOUT.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%-5p|%c|%X{thread}|%X{cid}|%X{sn}|%M|%m%n
 
 log4cplus.appender.R=log4cplus::RollingFileAppender
 log4cplus.appender.R.File=concord.log
 log4cplus.appender.R.MaxFileSize=10MB
 log4cplus.appender.R.MaxBackupIndex=10
 log4cplus.appender.R.layout=log4cplus::PatternLayout
-log4cplus.appender.R.layout.ConversionPattern=%X{rid}|%d{%d %m %Y %H:%M:%S.%q}|%t|%-5p|%c|%M|%m%n
+log4cplus.appender.R.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%-5p|%c|%X{thread}|%X{cid}|%X{sn}|%M|%m%n
 
 
 log4cplus.rootLogger=INFO, STDOUT, R

--- a/threshsign/CMakeLists.txt
+++ b/threshsign/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(Threads REQUIRED)
 #   TODO: change to set_target_properties?
 #   https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
 #
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/threshsign/bench/BenchThresholdBls.cpp
+++ b/threshsign/bench/BenchThresholdBls.cpp
@@ -105,13 +105,13 @@ class ThresholdBlsRelicBenchmark : public IThresholdSchemeBenchmark {
 
     // Compute signature sizes
     sigBits = verifier->requiredLengthForSignedData();
-    threshSig = new char[sigBits];
+    threshSig = new char[static_cast<size_t>(sigBits)];
     LOG_DEBUG(GL, "Signature size: " << sigBits << " bytes");
 
     // For BLS, sigshare size is just |sig| + ceil(\log_2{numSigners}), but we should probably not count that
     // since we can use the IP address in most application as the identifier.
     sigShareBits = dynamic_cast<BlsThresholdSigner*>(sks[1])->requiredLengthForSignedData();
-    for (size_t idx = 0; idx < shares.size(); idx++) shares[idx] = new char[sigShareBits];
+    for (size_t idx = 0; idx < shares.size(); idx++) shares[idx] = new char[static_cast<size_t>(sigShareBits)];
   }
 
  public:

--- a/threshsign/bench/lib/IThresholdSchemeBenchmark.cpp
+++ b/threshsign/bench/lib/IThresholdSchemeBenchmark.cpp
@@ -35,7 +35,7 @@ IThresholdSchemeBenchmark::IThresholdSchemeBenchmark(const IPublicParameters& p,
   LOG_TRACE(GL, "msgSize = " << msgSize);
   assertStrictlyGreaterThan(msgSize, 0);
 
-  msg = new unsigned char[msgSize];
+  msg = new unsigned char[static_cast<size_t>(msgSize)];
   // Pick 'some' message.
   for (int i = 0; i < msgSize; i++) {
     // Might overflow, we don't care.

--- a/threshsign/src/AutoBuf.h
+++ b/threshsign/src/AutoBuf.h
@@ -21,7 +21,7 @@ class AutoBuf {
   int len;
 
  public:
-  AutoBuf(int len) : buf(new T[len]), len(len) {}
+  AutoBuf(int len) : buf(new T[static_cast<size_t>(len)]), len(len) {}
 
   AutoBuf(const AutoBuf<T>& ab) : AutoBuf(ab.len) { std::copy(ab.buf, ab.buf + ab.len, buf); }
 

--- a/threshsign/src/ThresholdAccumulatorBase.tpp
+++ b/threshsign/src/ThresholdAccumulatorBase.tpp
@@ -24,7 +24,7 @@ void ThresholdAccumulatorBase<VerificationKey, NumType, SigShareParserFunc>::set
     assertStrictlyPositive(len);
 
     if(hasExpectedDigest() == false) {
-        expectedDigest.reset(new unsigned char[len]);
+        expectedDigest.reset(new unsigned char[static_cast<size_t>(len)]);
         memcpy(reinterpret_cast<void*>(expectedDigest.get()),
                 reinterpret_cast<const void*>(msg),
                 static_cast<unsigned long>(len));

--- a/threshsign/src/bls/relic/BlsThresholdSigner.cpp
+++ b/threshsign/src/bls/relic/BlsThresholdSigner.cpp
@@ -50,7 +50,7 @@ void BlsThresholdSigner::signData(const char *hash, int hashLen, char *outSig, i
 void BlsThresholdSigner::serializeDataMembers(ostream &outStream) const {
   params_.serialize(outStream);
   int32_t secretKeySize = secretKey_.x.getByteCount();
-  UniquePtrToUChar secretKeyBuf(new unsigned char[secretKeySize]);
+  UniquePtrToUChar secretKeyBuf(new unsigned char[static_cast<size_t>(secretKeySize)]);
   secretKey_.x.toBytes(secretKeyBuf.get(), secretKeySize);
   serialize(outStream, secretKeySize);
   outStream.write((char *)secretKeyBuf.get(), secretKeySize);
@@ -90,7 +90,7 @@ void BlsThresholdSigner::deserializeDataMembers(istream &inStream) {
   sigSize_ = params_.getSignatureSize();
   std::int32_t sizeOfSecretKey = 0;
   deserialize(inStream, sizeOfSecretKey);
-  UniquePtrToUChar secretKey(new unsigned char[sizeOfSecretKey]);
+  UniquePtrToUChar secretKey(new unsigned char[static_cast<size_t>(sizeOfSecretKey)]);
   inStream.read((char *)secretKey.get(), sizeOfSecretKey);
   BNT key(secretKey.get(), sizeOfSecretKey);
   secretKey_ = BlsSecretKey(BNT(secretKey.get(), sizeOfSecretKey));

--- a/threshsign/src/bls/relic/BlsThresholdVerifier.cpp
+++ b/threshsign/src/bls/relic/BlsThresholdVerifier.cpp
@@ -97,7 +97,7 @@ void BlsThresholdVerifier::serializePublicKey(const BlsPublicKey &key, std::ostr
   int publicKeySize = key.y.getByteCount();
   LOG_TRACE(logger(), "<<< public key size: " << publicKeySize);
   serialize(outStream, publicKeySize);
-  unsigned char *publicKeyBuf = new unsigned char[publicKeySize];
+  unsigned char *publicKeyBuf = new unsigned char[static_cast<size_t>(publicKeySize)];
   key.y.toBytes(publicKeyBuf, publicKeySize);
   outStream.write((char *)publicKeyBuf, publicKeySize);
   LOG_TRACE(logger(), "<<< public key buf: [" << key.y.toString() << "]");
@@ -128,7 +128,7 @@ G2T BlsThresholdVerifier::deserializePublicKey(istream &inStream) {
   int publicKeySize = 0;
   deserialize(inStream, publicKeySize);
   LOG_TRACE(concordlogger::Log::getLogger("serialize"), ">>> public key size: " << publicKeySize);
-  unsigned char *publicKeyBuf = new unsigned char[publicKeySize];
+  unsigned char *publicKeyBuf = new unsigned char[static_cast<size_t>(publicKeySize)];
   inStream.read((char *)publicKeyBuf, publicKeySize);
   G2T g2t_(publicKeyBuf, publicKeySize);
   LOG_TRACE(concordlogger::Log::getLogger("serialize"), ">>> public key buf: [" << g2t_.toString() << "]");

--- a/util/include/Handoff.hpp
+++ b/util/include/Handoff.hpp
@@ -34,7 +34,8 @@ class Handoff {
   Handoff(std::uint16_t replicaId) {
     thread_ = std::thread([this, replicaId] {
       try {
-        MDC_PUT(GL, "rid", std::to_string(replicaId));
+        MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(replicaId));
+        MDC_PUT(MDC_THREAD_KEY, "handoff");
         for (;;) pop()();
       } catch (ThreadCanceledException& e) {
         LOG_DEBUG(getLogger(), "thread stopped " << std::this_thread::get_id());


### PR DESCRIPTION
Before:
MDC didn't allow to add more than one value in the same scope and all MDC_PUT were scoped

Now:
- MDC_PUT is not scoped and put value in MDC until removed;
- Introduced SCOPED_MDC* macros for scoped MDC functionality;
- BFT logger changed to mimic the log4cplus behaviour and store MDC in
TLS context object;
- Added thread name to MDC;