### PR TITLE
Make KVLOG functionality more generic

### DIFF
--- a/util/include/assertUtils.hpp
+++ b/util/include/assertUtils.hpp
@@ -75,13 +75,13 @@ inline void printCallStack() {
     assert(false);                                                                                               \
   }
 
-#define PRINT_DATA_AND_ASSERT(expr1, expr2, assertMacro)                                                              \
-  {                                                                                                                   \
-    LOG_FATAL(GL,                                                                                                     \
-              " " << assertMacro << KVLOG(expr1, expr2) << " in function " << __FUNCTION__ << " (" << __FILE__ << " " \
-                  << __LINE__ << ")");                                                                                \
-    printCallStack();                                                                                                 \
-    assert(false);                                                                                                    \
+#define PRINT_DATA_AND_ASSERT(expr1, expr2, assertMacro)                                                      \
+  {                                                                                                           \
+    LOG_FATAL(GL,                                                                                             \
+              " " << assertMacro << KVLOG_FOR_ASSERT(expr1, expr2) << " in function " << __FUNCTION__ << " (" \
+                  << __FILE__ << " " << __LINE__ << ")");                                                     \
+    printCallStack();                                                                                         \
+    assert(false);                                                                                            \
   }
 
 #define Assert(expr)                                                                                              \
@@ -135,6 +135,9 @@ inline void printCallStack() {
   }
 
 // Assert(expr1 && expr2)
+// TODO: AJS - Remove this. This is doesn't take advantage of value printing in
+// PRINT_DATA_AND_ASSERT. All uses should be changed to be separate asserts.
+// Ideally we'd do similar for AssertOR, but this requires conditionals outside of asserts.
 #define AssertAND(expr1, expr2)                                                                         \
   {                                                                                                     \
     if ((expr1) != true || (expr2) != true) PRINT_DATA_AND_ASSERT_BOOL_EXPR(expr1, expr2, "AssertAND"); \

--- a/util/include/kvstream.h
+++ b/util/include/kvstream.h
@@ -1,254 +1,84 @@
-// Concord
-//
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
-//
-// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
-// compliance with the Apache 2.0 License.
-//
-// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
-// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
-// file.
-
 #pragma once
 
 #include <sstream>
+
+#include "macros.h"
 #include "type_traits.h"
 
-// Take up to 16 values and output them to a stream as key value pairs.
-//
-// This stringizes the value passed in and uses it as the key. If you want a specific key, just create an alias
-// variable.
-//
-// Usage looks like the following:
-//   KVLOG(seq_num, view, firstStoredCheckpoint)
-//
-// Output looks like:
-//   "seq_num: <VAL>, view: <VAL>, firstStoredCheckpoint: <VAL>"
-//
-#define GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, NAME, ...) NAME
-#define KVLOG(...)       \
-  GET_MACRO(__VA_ARGS__, \
-            KVLOG16,     \
-            KVLOG15,     \
-            KVLOG14,     \
-            KVLOG13,     \
-            KVLOG12,     \
-            KVLOG11,     \
-            KVLOG10,     \
-            KVLOG9,      \
-            KVLOG8,      \
-            KVLOG7,      \
-            KVLOG6,      \
-            KVLOG5,      \
-            KVLOG4,      \
-            KVLOG3,      \
-            KVLOG2,      \
-            KVLOG1)      \
-  (__VA_ARGS__)
-#define KVLOG16(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16) \
-  KvLog(#_16,                                                                          \
-        _16,                                                                           \
-        #_15,                                                                          \
-        _15,                                                                           \
-        #_14,                                                                          \
-        _14,                                                                           \
-        #_13,                                                                          \
-        _13,                                                                           \
-        #_12,                                                                          \
-        _12,                                                                           \
-        #_11,                                                                          \
-        _11,                                                                           \
-        #_10,                                                                          \
-        _10,                                                                           \
-        #_9,                                                                           \
-        _9,                                                                            \
-        #_8,                                                                           \
-        _8,                                                                            \
-        #_7,                                                                           \
-        _7,                                                                            \
-        #_6,                                                                           \
-        _6,                                                                            \
-        #_5,                                                                           \
-        _5,                                                                            \
-        #_4,                                                                           \
-        _4,                                                                            \
-        #_3,                                                                           \
-        _3,                                                                            \
-        #_2,                                                                           \
-        _2,                                                                            \
-        #_1,                                                                           \
-        _1)
-#define KVLOG15(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15) \
-  KvLog(#_15,                                                                     \
-        _15,                                                                      \
-        #_14,                                                                     \
-        _14,                                                                      \
-        #_13,                                                                     \
-        _13,                                                                      \
-        #_12,                                                                     \
-        _12,                                                                      \
-        #_11,                                                                     \
-        _11,                                                                      \
-        #_10,                                                                     \
-        _10,                                                                      \
-        #_9,                                                                      \
-        _9,                                                                       \
-        #_8,                                                                      \
-        _8,                                                                       \
-        #_7,                                                                      \
-        _7,                                                                       \
-        #_6,                                                                      \
-        _6,                                                                       \
-        #_5,                                                                      \
-        _5,                                                                       \
-        #_4,                                                                      \
-        _4,                                                                       \
-        #_3,                                                                      \
-        _3,                                                                       \
-        #_2,                                                                      \
-        _2,                                                                       \
-        #_1,                                                                      \
-        _1)
-#define KVLOG14(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14) \
-  KvLog(#_14,                                                                \
-        _14,                                                                 \
-        #_13,                                                                \
-        _13,                                                                 \
-        #_12,                                                                \
-        _12,                                                                 \
-        #_11,                                                                \
-        _11,                                                                 \
-        #_10,                                                                \
-        _10,                                                                 \
-        #_9,                                                                 \
-        _9,                                                                  \
-        #_8,                                                                 \
-        _8,                                                                  \
-        #_7,                                                                 \
-        _7,                                                                  \
-        #_6,                                                                 \
-        _6,                                                                  \
-        #_5,                                                                 \
-        _5,                                                                  \
-        #_4,                                                                 \
-        _4,                                                                  \
-        #_3,                                                                 \
-        _3,                                                                  \
-        #_2,                                                                 \
-        _2,                                                                  \
-        #_1,                                                                 \
-        _1)
-#define KVLOG13(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13) \
-  KvLog(#_13,                                                           \
-        _13,                                                            \
-        #_12,                                                           \
-        _12,                                                            \
-        #_11,                                                           \
-        _11,                                                            \
-        #_10,                                                           \
-        _10,                                                            \
-        #_9,                                                            \
-        _9,                                                             \
-        #_8,                                                            \
-        _8,                                                             \
-        #_7,                                                            \
-        _7,                                                             \
-        #_6,                                                            \
-        _6,                                                             \
-        #_5,                                                            \
-        _5,                                                             \
-        #_4,                                                            \
-        _4,                                                             \
-        #_3,                                                            \
-        _3,                                                             \
-        #_2,                                                            \
-        _2,                                                             \
-        #_1,                                                            \
-        _1)
-#define KVLOG12(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12) \
-  KvLog(#_12,                                                      \
-        _12,                                                       \
-        #_11,                                                      \
-        _11,                                                       \
-        #_10,                                                      \
-        _10,                                                       \
-        #_9,                                                       \
-        _9,                                                        \
-        #_8,                                                       \
-        _8,                                                        \
-        #_7,                                                       \
-        _7,                                                        \
-        #_6,                                                       \
-        _6,                                                        \
-        #_5,                                                       \
-        _5,                                                        \
-        #_4,                                                       \
-        _4,                                                        \
-        #_3,                                                       \
-        _3,                                                        \
-        #_2,                                                       \
-        _2,                                                        \
-        #_1,                                                       \
-        _1)
-#define KVLOG11(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11) \
-  KvLog(#_11, _11, #_10, _10, #_9, _9, #_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG10(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) \
-  KvLog(#_10, _10, #_9, _9, #_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG9(_1, _2, _3, _4, _5, _6, _7, _8, _9) \
-  KvLog(#_9, _9, #_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG8(_1, _2, _3, _4, _5, _6, _7, _8) \
-  KvLog(#_8, _8, #_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG7(_1, _2, _3, _4, _5, _6, _7) KvLog(#_7, _7, #_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG6(_1, _2, _3, _4, _5, _6) KvLog(#_6, _6, #_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG5(_1, _2, _3, _4, _5) KvLog(#_5, _5, #_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG4(_1, _2, _3, _4) KvLog(#_4, _4, #_3, _3, #_2, _2, #_1, _1)
-#define KVLOG3(_1, _2, _3) KvLog(#_3, _3, #_2, _2, #_1, _1)
-#define KVLOG2(_1, _2) KvLog(#_2, _2, #_1, _1)
-#define KVLOG1(_1) KvLog(#_1, _1)
+#define KVLOG(...) KvLog<true> KVARGS(__VA_ARGS__)
+
+// Don't check the to see if the KV arguments implement ostream::operator<<. We want to be able to use asserts on types
+// that are not printable.
+#define KVLOG_FOR_ASSERT(...) KvLog<false> KVARGS(__VA_ARGS__)
 
 // These are recurisive variadic template functions for generating formatted key-value pairs that
 // can be attached to the end of log messages. The entrypoint is the KVLog function at the bottom
 // that only takes a variadic arg.
 //
+// The mandatory `Strict` template parameter determines whether types that do not implement `std::ostream::operator<<`
+// are allowed. If Strict=true, a static_assert will fire.
+//
 // Right now the entrypoint returns a string, because of the way our logging macros are implemented.
 // We could change them to take an extra parameter that's a stringstream and prevent the additional
 // allocation and copy from returning a string. We'll deal with that if its needed.
-template <typename K,
+
+// Forward declaration
+template <bool Strict,
+          typename K,
+          typename V,
+          typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type * = nullptr>
+void KvLog(std::stringstream &ss, K &&key, V &&val);
+
+// Forward declaration
+template <bool Strict,
+          typename K,
+          typename V,
+          typename... KVPAIRS,
+          typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type * = nullptr>
+void KvLog(std::stringstream &ss, K &&key, V &&val, KVPAIRS &&... kvpairs);
+
+template <bool Strict,
+          typename K,
           typename V,
           typename std::enable_if<concord::is_streamable<std::ostream, V>::value>::type * = nullptr>
 void KvLog(std::stringstream &ss, K &&key, V &&val) {
   ss << std::forward<K>(key) << ": " << std::forward<V>(val);
 }
 
-template <typename K,
+template <bool Strict,
+          typename K,
           typename V,
           typename... KVPAIRS,
           typename std::enable_if<concord::is_streamable<std::ostream, V>::value>::type * = nullptr>
 void KvLog(std::stringstream &ss, K &&key, V &&val, KVPAIRS &&... kvpairs) {
   ss << std::forward<K>(key) << ": " << std::forward<V>(val) << ", ";
-  KvLog(ss, std::forward<KVPAIRS>(kvpairs)...);
+  KvLog<Strict>(ss, std::forward<KVPAIRS>(kvpairs)...);
 }
 
-template <typename K,
+template <bool Strict,
+          typename K,
           typename V,
-          typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type * = nullptr>
+          typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type *>
 void KvLog(std::stringstream &ss, K &&key, V &&val) {
+  static_assert(!Strict, "Cannot log types that do not implement ostream::operator<<");
   ss << std::forward<K>(key) << ": _";
 }
 
-template <typename K,
+template <bool Strict,
+          typename K,
           typename V,
           typename... KVPAIRS,
-          typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type * = nullptr>
+          typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type *>
 void KvLog(std::stringstream &ss, K &&key, V &&val, KVPAIRS &&... kvpairs) {
+  static_assert(!Strict, "Cannot log types that do not implement ostream::operator<<");
   ss << std::forward<K>(key) << ": _, ";
-  KvLog(ss, std::forward<KVPAIRS>(kvpairs)...);
+  KvLog<Strict>(ss, std::forward<KVPAIRS>(kvpairs)...);
 }
 
-template <typename... KVPAIRS>
+template <bool Strict, typename... KVPAIRS>
 std::string KvLog(KVPAIRS &&... kvpairs) {
   std::stringstream ss;
   ss << "| ";
-  KvLog(ss, std::forward<KVPAIRS>(kvpairs)...);
+  KvLog<Strict>(ss, std::forward<KVPAIRS>(kvpairs)...);
   return ss.str();
 }

--- a/util/include/macros.h
+++ b/util/include/macros.h
@@ -1,0 +1,181 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+// Take up to 16 values and create up to 32 function arguments, surrounded by parenthesis, where every other argument is
+// a key, and the following argument is a value.
+//
+// This stringizes the arguments passed in and uses them as the keys in each key value pair, with the argument as the
+// value. If you want a specific key, just create an alias variable.
+//
+// This is especially useful in generating key-value parameter lists such that they can be unpacked in variadic
+// templates.
+//
+// Example usage:
+// #define WRAPPER_MACRO(...) SomeCPPFunction KVARGS(__VA_ARGS__)
+#define GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, NAME, ...) NAME
+#define KVARGS(...)      \
+  GET_MACRO(__VA_ARGS__, \
+            KVARGS16,    \
+            KVARGS15,    \
+            KVARGS14,    \
+            KVARGS13,    \
+            KVARGS12,    \
+            KVARGS11,    \
+            KVARGS10,    \
+            KVARGS9,     \
+            KVARGS8,     \
+            KVARGS7,     \
+            KVARGS6,     \
+            KVARGS5,     \
+            KVARGS4,     \
+            KVARGS3,     \
+            KVARGS2,     \
+            KVARGS1,     \
+            UNUSED)      \
+  (__VA_ARGS__)
+#define KVARGS16(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16) \
+  (_1,                                                                                  \
+   #_1,                                                                                 \
+   _2,                                                                                  \
+   #_2,                                                                                 \
+   _3,                                                                                  \
+   #_3,                                                                                 \
+   _4,                                                                                  \
+   #_4,                                                                                 \
+   _5,                                                                                  \
+   #_5,                                                                                 \
+   _6,                                                                                  \
+   #_6,                                                                                 \
+   _7,                                                                                  \
+   #_7,                                                                                 \
+   _8,                                                                                  \
+   #_8,                                                                                 \
+   _9,                                                                                  \
+   #_9,                                                                                 \
+   _10,                                                                                 \
+   #_10,                                                                                \
+   _11,                                                                                 \
+   #_11,                                                                                \
+   _12,                                                                                 \
+   #_12,                                                                                \
+   _13,                                                                                 \
+   #_13,                                                                                \
+   _14,                                                                                 \
+   #_14,                                                                                \
+   _15,                                                                                 \
+   #_15,                                                                                \
+   _16,                                                                                 \
+   #_16)
+#define KVARGS15(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15) \
+  (_1,                                                                             \
+   #_1,                                                                            \
+   _2,                                                                             \
+   #_2,                                                                            \
+   _3,                                                                             \
+   #_3,                                                                            \
+   _4,                                                                             \
+   #_4,                                                                            \
+   _5,                                                                             \
+   #_5,                                                                            \
+   _6,                                                                             \
+   #_6,                                                                            \
+   _7,                                                                             \
+   #_7,                                                                            \
+   _8,                                                                             \
+   #_8,                                                                            \
+   _9,                                                                             \
+   #_9,                                                                            \
+   _10,                                                                            \
+   #_10,                                                                           \
+   _11,                                                                            \
+   #_11,                                                                           \
+   _12,                                                                            \
+   #_12,                                                                           \
+   _13,                                                                            \
+   #_13,                                                                           \
+   _14,                                                                            \
+   #_14,                                                                           \
+   _15,                                                                            \
+   #_15)
+#define KVARGS14(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14) \
+  (_1,                                                                        \
+   #_1,                                                                       \
+   _2,                                                                        \
+   #_2,                                                                       \
+   _3,                                                                        \
+   #_3,                                                                       \
+   _4,                                                                        \
+   #_4,                                                                       \
+   _5,                                                                        \
+   #_5,                                                                       \
+   _6,                                                                        \
+   #_6,                                                                       \
+   _7,                                                                        \
+   #_7,                                                                       \
+   _8,                                                                        \
+   #_8,                                                                       \
+   _9,                                                                        \
+   #_9,                                                                       \
+   _10,                                                                       \
+   #_10,                                                                      \
+   _11,                                                                       \
+   #_11,                                                                      \
+   _12,                                                                       \
+   #_12,                                                                      \
+   _13,                                                                       \
+   #_13,                                                                      \
+   _14,                                                                       \
+   #_14)
+#define KVARGS13(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13) \
+  (_1,                                                                   \
+   #_1,                                                                  \
+   _2,                                                                   \
+   #_2,                                                                  \
+   _3,                                                                   \
+   #_3,                                                                  \
+   _4,                                                                   \
+   #_4,                                                                  \
+   _5,                                                                   \
+   #_5,                                                                  \
+   _6,                                                                   \
+   #_6,                                                                  \
+   _7,                                                                   \
+   #_7,                                                                  \
+   _8,                                                                   \
+   #_8,                                                                  \
+   _9,                                                                   \
+   #_9,                                                                  \
+   _10,                                                                  \
+   #_10,                                                                 \
+   _11,                                                                  \
+   #_11,                                                                 \
+   _12,                                                                  \
+   #_12,                                                                 \
+   _13,                                                                  \
+   #_13)
+#define KVARGS12(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12) \
+  (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5, #_6, _6, #_7, _7, #_8, _8, #_9, _9, #_10, _10, #_11, _11, #_12, _12)
+#define KVARGS11(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11) \
+  (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5, #_6, _6, #_7, _7, #_8, _8, #_9, _9, #_10, _10, #_11, _11)
+#define KVARGS10(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) \
+  (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5, #_6, _6, #_7, _7, #_8, _8, #_9, _9, #_10, _10)
+#define KVARGS9(_1, _2, _3, _4, _5, _6, _7, _8, _9) \
+  (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5, #_6, _6, #_7, _7, #_8, _8, #_9, _9)
+#define KVARGS8(_1, _2, _3, _4, _5, _6, _7, _8) (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5, #_6, _6, #_7, _7, #_8, _8)
+#define KVARGS7(_1, _2, _3, _4, _5, _6, _7) (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5, #_6, _6, #_7, _7)
+#define KVARGS6(_1, _2, _3, _4, _5, _6) (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5, #_6, _6)
+#define KVARGS5(_1, _2, _3, _4, _5) (#_1, _1, #_2, _2, #_3, _3, #_4, _4, #_5, _5)
+#define KVARGS4(_1, _2, _3, _4) (#_1, _1, #_2, _2, #_3, _3, #_4, _4)
+#define KVARGS3(_1, _2, _3) (#_1, _1, #_2, _2, #_3, _3)
+#define KVARGS2(_1, _2) (#_1, _1, #_2, _2)
+#define KVARGS1(_1) (#_1, _1)


### PR DESCRIPTION
Rather than using KvLog calls inside the KVLOG macro, create a generic
KVARGS macro that generates just a parameter list of key-value
parameters for the given string. We can then pass this to any function
with a wrapper macro.

The KVARGS macro was moved to macros.h in util. We can add other system
level macros there when needed.

Additionally, a bugfix was made to allow KVARGS calls with a single
argument, via the use of the `UNUSED` parameter. This is to prevent
errors about variadic macros requiring one argument.

Add forward declarations for KvLog functions so that recursion works
properly at compile time when jumping between printable and
non-printable types.

This change also adds a `Strict` boolean template parameter to the KvLog
function so that we can statically assert in normal KVLOG calls when
passed an argument that is not printable. We add a separate
`KVLOG_FOR_ASSERT` macro that sets this strict parameter to false and allows
asserting on types that are not printable, and only printing the ones
that are. In this latter case we give priority to the Assert over the
printability.

Also, reverse KVARGS macros so args are in correct order.