### PR TITLE
Add initialization of Handoff's 'stopped_' flag

### DIFF
--- a/util/include/Handoff.hpp
+++ b/util/include/Handoff.hpp
@@ -92,7 +92,7 @@ class Handoff {
   std::queue<func_type> task_queue_;
   std::mutex queue_lock_;
   std::condition_variable queue_cond_;
-  std::atomic_bool stopped_;
+  std::atomic_bool stopped_{false};
   std::thread thread_;
 };
 


### PR DESCRIPTION
Explicitly initialize the 'stopped_' atomic flag to false when
constructing a Handoff object. std::atomic objects are not initialized
to zero (or false) automatically as the default ctor is trivial. That
could lead to the thread stopping prematurely and causing an infinite
wait for results from users when push() is called.
Reference: https://en.cppreference.com/w/cpp/atomic/atomic/atomic