### PR TITLE
Initialize diagnostics::Server's 'shutdown' flag

### DIFF
--- a/diagnostics/include/diagnostics_server.h
+++ b/diagnostics/include/diagnostics_server.h
@@ -176,7 +176,7 @@ class Server {
   int listen_sock_;
   sockaddr_in servaddr_;
   std::thread listen_thread_;
-  std::atomic<bool> shutdown_;
+  std::atomic<bool> shutdown_{false};
 };
 
 }  // namespace concord::diagnostics


### PR DESCRIPTION
Explicitly initialize diagnostics::Server's 'shutdown' flag as the only
valid operations on a default-constructed std::atomic are destruction
and initialization by std::atomic_init().
Reference: https://en.cppreference.com/w/cpp/atomic/atomic/atomic