### PR TITLE
WIP: Compute parent block hash in parallel for v2Merkle

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -655,7 +655,7 @@ void BCStateTran::handleStateTransferMessage(char *msg, uint32_t msgLen, uint16_
 }
 
 void BCStateTran::handoff(char *msg, uint32_t msgLen, uint16_t senderId) {
-  static concord::util::Handoff handoff_("handoff", config_.myReplicaId);
+  static concord::util::Handoff handoff_("state-transfer", config_.myReplicaId);
   handoff_.push(std::bind(&BCStateTran::handleStateTransferMessageImp, this, msg, msgLen, senderId));
 }
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -655,7 +655,7 @@ void BCStateTran::handleStateTransferMessage(char *msg, uint32_t msgLen, uint16_
 }
 
 void BCStateTran::handoff(char *msg, uint32_t msgLen, uint16_t senderId) {
-  static concord::util::Handoff handoff_(config_.myReplicaId);
+  static concord::util::Handoff handoff_("handoff", config_.myReplicaId);
   handoff_.push(std::bind(&BCStateTran::handleStateTransferMessageImp, this, msg, msgLen, senderId));
 }
 

--- a/kvbc/benchmark/sparse_merkle_benchmark.cpp
+++ b/kvbc/benchmark/sparse_merkle_benchmark.cpp
@@ -261,6 +261,8 @@ struct Blockchain : benchmark::Fixture {
     return updates;
   }
 
+  void TearDown(const benchmark::State &) override { adapter.release(); }
+
   std::uint64_t currentKeyValue{0};
   std::unique_ptr<DBAdapter> adapter;
   const std::uint64_t blockCount{32};

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -15,6 +15,7 @@
 
 #include "assertUtils.hpp"
 #include "db_adapter_interface.h"
+#include "Handoff.hpp"
 #include "kv_types.hpp"
 #include "Logger.hpp"
 #include "merkle_tree_block.h"
@@ -155,7 +156,8 @@ class DBAdapter : public IDbAdapter {
  private:
   concordUtils::Sliver createBlockNode(const SetOfKeyValuePairs &updates,
                                        const OrderedKeysSet &deletes,
-                                       BlockId blockId) const;
+                                       BlockId blockId,
+                                       const BlockDigest &parentBlockDigest) const;
 
   // Try to link the ST temporary chain to the blockchain from the passed blockId up to getLatestBlock().
   void linkSTChainFrom(BlockId blockId);
@@ -196,6 +198,7 @@ class DBAdapter : public IDbAdapter {
   logging::Logger logger_;
   std::shared_ptr<storage::IDBClient> db_;
   sparse_merkle::Tree smTree_;
+  concord::util::Handoff asyncExecutor_{"merkle-async-executor"};
 };
 
 namespace detail {

--- a/util/test/multithreading.cpp
+++ b/util/test/multithreading.cpp
@@ -96,7 +96,7 @@ class HandoffFixture : public testing::Test {
   // Sets up the test fixture.
   virtual void SetUp() {
     ASSERT_GT(std::thread::hardware_concurrency(), 1);
-    handoff_ = new concord::util::Handoff(0);
+    handoff_ = new concord::util::Handoff("handoff", 0);
   }
 
   concord::util::Handoff* handoff_;


### PR DESCRIPTION
In order to improve performance, compute the parent block hash in
parallel for v2Merkle. This is possible as the parent block hash is not
needed for updating the tree and it can be done during that time, on a
separate thread.

Getting the parent raw block is not done in a separate thread as not
all IDBClient implementations may be thread-safe (an example is
memorydb).

Support a user-supplied thread name and an optional replica ID in
concord::util::Handoff .

Implement the TearDown() method that destructs the DBAdapter in the
'Blockchain' benchmark fixutre as Handoff uses a static storage duration
logger whose destructor will be in a race with Handoff's thread. Reason
for that is that the DBAdapter has a Handoff member.

On my box (i7-9750H CPU @ 2.60GHz), adding a block with 2048
key/value pairs, key size of 32 bytes and value size of 4096 bytes
(i.e. block size is ~8MB), the speedup is around 20-30% .