### PR TITLE
Reject client requests in case the system is not ready

### DIFF
--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -62,7 +62,7 @@ struct BaseCommConfig {
         statusCallback{_statusCallback},
         selfId{_selfId} {}
 
-  virtual ~BaseCommConfig() {}
+  virtual ~BaseCommConfig() = default;
 };
 
 struct PlainUdpConfig : BaseCommConfig {
@@ -122,13 +122,13 @@ class PlainUDPCommunication : public ICommunication {
   int Start() override;
   int Stop() override;
   bool isRunning() const override;
-  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const override;
+  ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) override;
+  int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  virtual ~PlainUDPCommunication();
+  ~PlainUDPCommunication() override;
 
  private:
   class PlainUdpImpl;
@@ -147,13 +147,13 @@ class PlainTCPCommunication : public ICommunication {
   int Start() override;
   int Stop() override;
   bool isRunning() const override;
-  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const override;
+  ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) override;
+  int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  virtual ~PlainTCPCommunication();
+  ~PlainTCPCommunication() override;
 
  private:
   class PlainTcpImpl;
@@ -170,13 +170,13 @@ class TlsTCPCommunication : public ICommunication {
   int Start() override;
   int Stop() override;
   bool isRunning() const override;
-  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const override;
+  ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) override;
+  int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  virtual ~TlsTCPCommunication();
+  ~TlsTCPCommunication() override;
 
  private:
   class TlsTcpImpl;

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -25,12 +25,12 @@ class IReceiver {
   // Invoked when a new message is received
   // Notice that the memory pointed by message may be freed immediately
   // after the execution of this method.
-  virtual void onNewMessage(const NodeNum sourceNode, const char *const message, const size_t messageLength) = 0;
+  virtual void onNewMessage(NodeNum sourceNode, const char *const message, size_t messageLength) = 0;
 
   // Invoked when the known status of a connection is changed.
   // For each NodeNum, this method will never be concurrently
   // executed by two different threads.
-  virtual void onConnectionStatusChanged(const NodeNum node, const ConnectionStatus newStatus) = 0;
+  virtual void onConnectionStatusChanged(NodeNum node, ConnectionStatus newStatus) = 0;
 };
 
 class ICommunication {
@@ -48,15 +48,15 @@ class ICommunication {
 
   virtual bool isRunning() const = 0;
 
-  virtual ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const = 0;
+  virtual ConnectionStatus getCurrentConnectionStatus(NodeNum node) = 0;
 
   // Sends a message on the underlying communication layer to a given
   // destination node. Asynchronous (non-blocking) method.
   // Returns 0 on success.
-  virtual int sendAsyncMessage(const NodeNum destNode, const char *const message, const size_t messageLength) = 0;
+  virtual int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) = 0;
 
   virtual void setReceiver(NodeNum receiverNum, IReceiver *receiver) = 0;
 
-  virtual ~ICommunication(){};
+  virtual ~ICommunication() = default;
 };
 }  // namespace bft::communication

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -229,7 +229,10 @@ class PlainUDPCommunication::PlainUdpImpl {
 
   void setReceiver(NodeNum &receiverNum, IReceiver *pRcv) { receiverRef = pRcv; }
 
-  ConnectionStatus getCurrentConnectionStatus(const NodeNum &node) const { return ConnectionStatus::Unknown; }
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum &node) {
+    if (isRunning()) return ConnectionStatus::Connected;
+    return ConnectionStatus::Disconnected;
+  }
 
   int sendAsyncMessage(const NodeNum &destNode, const char *const message, const size_t &messageLength) {
     int error = 0;
@@ -389,7 +392,7 @@ int PlainUDPCommunication::Stop() {
 
 bool PlainUDPCommunication::isRunning() const { return _ptrImpl->isRunning(); }
 
-ConnectionStatus PlainUDPCommunication::getCurrentConnectionStatus(const NodeNum node) const {
+ConnectionStatus PlainUDPCommunication::getCurrentConnectionStatus(const NodeNum node) {
   return _ptrImpl->getCurrentConnectionStatus(node);
 }
 

--- a/kvbc/include/ClientImp.h
+++ b/kvbc/include/ClientImp.h
@@ -21,22 +21,22 @@ namespace concord::kvbc {
 class ClientImp : public IClient {
  public:
   // IClient methods
-  virtual Status start() override;
-  virtual Status stop() override;
+  Status start() override;
+  Status stop() override;
 
-  virtual bool isRunning() override;
+  bool isRunning() override;
 
-  virtual Status invokeCommandSynch(const char* request,
-                                    uint32_t requestSize,
-                                    uint8_t flags,
-                                    std::chrono::milliseconds timeout,
-                                    uint32_t replySize,
-                                    char* outReply,
-                                    uint32_t* outActualReplySize,
-                                    const std::string& cid = "",
-                                    const std::string& span_context = "") override;
+  Status invokeCommandSynch(const char* request,
+                            uint32_t requestSize,
+                            uint8_t flags,
+                            std::chrono::milliseconds timeout,
+                            uint32_t replySize,
+                            char* outReply,
+                            uint32_t* outActualReplySize,
+                            const std::string& cid,
+                            const std::string& span_context) override;
 
-  virtual void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override;
+  void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override;
 
  protected:
   ClientImp() = default;

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -22,8 +22,7 @@
 #include "bftengine/Replica.hpp"
 #include "kv_types.hpp"
 
-namespace concord {
-namespace kvbc {
+namespace concord::kvbc {
 
 using concordUtils::Status;
 using concordUtils::Sliver;
@@ -88,7 +87,7 @@ class IReplica {
  public:
   virtual Status start() = 0;
   virtual Status stop() = 0;
-  virtual ~IReplica() {}
+  virtual ~IReplica() = default;
 
   enum class RepStatus  // status of the replica
   { UnknownError = -1,
@@ -128,16 +127,16 @@ class IReplica {
 
 class ICommandsHandler : public bftEngine::IRequestsHandler {
  public:
-  virtual int execute(uint16_t clientId,
-                      uint64_t sequenceNum,
-                      uint8_t flags,
-                      uint32_t requestSize,
-                      const char* request,
-                      uint32_t maxReplySize,
-                      char* outReply,
-                      uint32_t& outActualReplySize,
-                      concordUtils::SpanWrapper& span) = 0;
-  virtual ~ICommandsHandler() = default;
+  int execute(uint16_t clientId,
+              uint64_t sequenceNum,
+              uint8_t flags,
+              uint32_t requestSize,
+              const char* request,
+              uint32_t maxReplySize,
+              char* outReply,
+              uint32_t& outActualReplySize,
+              concordUtils::SpanWrapper& span) override = 0;
+  ~ICommandsHandler() override = default;
 };
-}  // namespace kvbc
-}  // namespace concord
+
+}  // namespace concord::kvbc

--- a/util/include/status.hpp
+++ b/util/include/status.hpp
@@ -14,10 +14,11 @@ namespace concordUtils {
 class Status {
  public:
   static Status OK() { return Status(ok, ""); }
-  static Status NotFound(std::string msg) { return Status(notFound, msg); }
-  static Status InvalidArgument(std::string msg) { return Status(invalidArgument, msg); }
-  static Status IllegalOperation(std::string msg) { return Status(illegalOperation, msg); }
-  static Status GeneralError(std::string msg) { return Status(generalError, msg); }
+  static Status NotFound(const std::string& msg) { return Status(notFound, msg); }
+  static Status InvalidArgument(const std::string& msg) { return Status(invalidArgument, msg); }
+  static Status IllegalOperation(const std::string& msg) { return Status(illegalOperation, msg); }
+  static Status GeneralError(const std::string& msg) { return Status(generalError, msg); }
+  static Status InterimError(const std::string& msg) { return Status(interimError, msg); }
 
   bool isOK() const { return type == ok; }
   bool isNotFound() const { return type == notFound; }
@@ -34,12 +35,12 @@ class Status {
   bool operator==(const Status& status) const { return type == status.type; };
 
  private:
-  enum statusType { ok, notFound, invalidArgument, illegalOperation, generalError };
+  enum statusType { ok, notFound, invalidArgument, illegalOperation, generalError, interimError };
 
   statusType type;
   std::string message;
 
-  Status(statusType t, std::string msg) : type(t), message(msg) {}
+  Status(statusType t, std::string msg) : type(t), message(move(msg)) {}
 
   std::string messagePrefix() const {
     switch (type) {
@@ -53,6 +54,8 @@ class Status {
         return "Illegal Operation: ";
       case generalError:
         return "General Error: ";
+      case interimError:
+        return "Interim Error: ";
       default:
         return "Unknown Error Type: ";
     }


### PR DESCRIPTION
When the system starts up the replicas become available within a few minutes and not all together, which causes the system to start a chain of view-changes. To avoid this behavior, SimpleCLient should verify that there are enough live connections to the replicas before starting request handling.

https://jira.eng.vmware.com/browse/BC-2827