### PR TITLE
Use binary assert macros in BCStateTran

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -91,12 +91,9 @@ class BCStateTran : public IStateTransfer {
   ///////////////////////////////////////////////////////////////////////////
   // Constants
   ///////////////////////////////////////////////////////////////////////////
-
-  static const uint64_t kMaxNumOfStoredCheckpoints = 10;
-
-  static const uint16_t kMaxVBlocksInCache = 28;  // TBD
-
-  static const uint32_t kResetCount_AskForCheckpointSummaries = 4;  // TBD
+  static constexpr uint64_t kMaxNumOfStoredCheckpoints = 10;
+  static constexpr uint16_t kMaxVBlocksInCache = 28;                    // TBD
+  static constexpr uint32_t kResetCount_AskForCheckpointSummaries = 4;  // TBD
 
   ///////////////////////////////////////////////////////////////////////////
   // External interfaces
@@ -153,7 +150,7 @@ class BCStateTran : public IStateTransfer {
  public:
   enum class FetchingState { NotFetching, GettingCheckpointSummaries, GettingMissingBlocks, GettingMissingResPages };
 
-  string stateName(FetchingState fs);
+  static string stateName(FetchingState fs);
 
   FetchingState getFetchingState() const;
   bool isFetching() const;

--- a/bftengine/src/bcstatetransfer/STDigest.hpp
+++ b/bftengine/src/bcstatetransfer/STDigest.hpp
@@ -60,6 +60,11 @@ class STDigest : StateTransferDigest {
   char* getForUpdate() { return content; }
 };
 
+inline std::ostream& operator<<(std::ostream& os, const STDigest& digest) {
+  os << digest.toString();
+  return os;
+}
+
 class DigestContext {
  public:
   DigestContext();


### PR DESCRIPTION
Where possible, all asserts were changed to use the more specific binary macros
rather than just Assert in BCStateTran. This allows values to be printed
when they implement `std::ostream&<<`.

Additionally, `std::ostream&<<` was implemented for STDigest and
FetchingState types.