### PR TITLE
Fix for post-view change replica restart

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -31,6 +31,8 @@ void DescriptorOfLastExitFromView::clean() {
 }
 
 bool DescriptorOfLastExitFromView::equals(const DescriptorOfLastExitFromView &other) const {
+  if (other.isDefault != isDefault) return false;
+
   if (other.elements.size() != elements.size()) return false;
 
   if ((other.myViewChangeMsg && !myViewChangeMsg) || (!other.myViewChangeMsg && myViewChangeMsg)) return false;
@@ -45,6 +47,10 @@ bool DescriptorOfLastExitFromView::equals(const DescriptorOfLastExitFromView &ot
 
 void DescriptorOfLastExitFromView::serializeSimpleParams(char *buf, size_t bufLen, size_t &actualSize) const {
   Assert(bufLen >= simpleParamsSize());
+
+  size_t isDefaultSize = sizeof(isDefault);
+  memcpy(buf, &isDefault, isDefaultSize);
+  buf += isDefaultSize;
 
   size_t viewSize = sizeof(view);
   memcpy(buf, &view, viewSize);
@@ -68,7 +74,7 @@ void DescriptorOfLastExitFromView::serializeSimpleParams(char *buf, size_t bufLe
   size_t elementsNumSize = sizeof(elementsNum);
   memcpy(buf, &elementsNum, elementsNumSize);
 
-  actualSize = viewSize + lastStableSize + lastExecutedSize + stableLowerBoundWhenEnteredToViewSize +
+  actualSize = isDefaultSize + viewSize + lastStableSize + lastExecutedSize + stableLowerBoundWhenEnteredToViewSize +
                myViewChangeMsgSize + elementsNumSize;
 }
 
@@ -91,6 +97,10 @@ void DescriptorOfLastExitFromView::serializeElement(uint32_t id, char *buf, size
 void DescriptorOfLastExitFromView::deserializeSimpleParams(char *buf, size_t bufLen, uint32_t &actualSize) {
   actualSize = 0;
   Assert(bufLen >= simpleParamsSize());
+
+  size_t isDefaultSize = sizeof(isDefault);
+  memcpy(&isDefault, buf, isDefaultSize);
+  buf += isDefaultSize;
 
   size_t viewSize = sizeof(view);
   memcpy(&view, buf, viewSize);
@@ -117,8 +127,8 @@ void DescriptorOfLastExitFromView::deserializeSimpleParams(char *buf, size_t buf
 
   if (elementsNum) elements.resize(elementsNum);
 
-  actualSize = viewSize + lastStableSize + lastExecutedSize + stableLowerBoundWhenEnteredToViewSize + actualMsgSize +
-               elementsNumSize;
+  actualSize = isDefaultSize + viewSize + lastStableSize + lastExecutedSize + stableLowerBoundWhenEnteredToViewSize +
+               actualMsgSize + elementsNumSize;
 }
 
 void DescriptorOfLastExitFromView::deserializeElement(uint32_t id, char *buf, size_t bufLen, uint32_t &actualSize) {
@@ -146,6 +156,7 @@ void DescriptorOfLastExitFromView::deserializeElement(uint32_t id, char *buf, si
 uint32_t DescriptorOfLastNewView::viewChangeMsgsNum = 0;
 
 DescriptorOfLastNewView::DescriptorOfLastNewView() {
+  isDefault = true;
   for (uint32_t i = 0; i < viewChangeMsgsNum; ++i) viewChangeMsgs.push_back(nullptr);
 }
 
@@ -159,6 +170,8 @@ void DescriptorOfLastNewView::clean() {
 }
 
 bool DescriptorOfLastNewView::equals(const DescriptorOfLastNewView &other) const {
+  if (other.isDefault != isDefault) return false;
+
   if ((other.newViewMsg && !newViewMsg) || (!other.newViewMsg && newViewMsg)) return false;
   bool res = newViewMsg ? (other.newViewMsg->equals(*newViewMsg)) : true;
   if (!res) return false;
@@ -183,6 +196,10 @@ void DescriptorOfLastNewView::serializeSimpleParams(char *buf, size_t bufLen, si
   actualSize = 0;
   Assert(bufLen >= simpleParamsSize());
 
+  size_t isDefaultSize = sizeof(isDefault);
+  memcpy(buf, &isDefault, isDefaultSize);
+  buf += isDefaultSize;
+
   size_t viewSize = sizeof(view);
   memcpy(buf, &view, viewSize);
   buf += viewSize;
@@ -198,7 +215,8 @@ void DescriptorOfLastNewView::serializeSimpleParams(char *buf, size_t bufLen, si
   size_t newViewMsgSize = MessageBase::serializeMsg(buf, newViewMsg);
 
   size_t myViewChangeMsgSize = MessageBase::serializeMsg(buf, myViewChangeMsg);
-  actualSize = viewSize + maxSeqNumSize + stableLowerBoundWhenEnteredToViewSize + newViewMsgSize + myViewChangeMsgSize;
+  actualSize = isDefaultSize + viewSize + maxSeqNumSize + stableLowerBoundWhenEnteredToViewSize + newViewMsgSize +
+               myViewChangeMsgSize;
 }
 
 void DescriptorOfLastNewView::serializeElement(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) const {
@@ -213,6 +231,10 @@ void DescriptorOfLastNewView::serializeElement(uint32_t id, char *buf, size_t bu
 void DescriptorOfLastNewView::deserializeSimpleParams(char *buf, size_t bufLen, uint32_t &actualSize) {
   actualSize = 0;
   Assert(bufLen >= simpleParamsSize());
+
+  size_t isDefaultSize = sizeof(isDefault);
+  memcpy(&isDefault, buf, isDefaultSize);
+  buf += isDefaultSize;
 
   size_t viewSize = sizeof(view);
   memcpy(&view, buf, viewSize);
@@ -231,7 +253,8 @@ void DescriptorOfLastNewView::deserializeSimpleParams(char *buf, size_t bufLen, 
 
   size_t myViewChangeMsgSize = 0;
   myViewChangeMsg = (ViewChangeMsg *)MessageBase::deserializeMsg(buf, bufLen, myViewChangeMsgSize);
-  actualSize = viewSize + maxSeqNumSize + stableLowerBoundWhenEnteredToViewSize + newViewMsgSize + myViewChangeMsgSize;
+  actualSize = isDefaultSize + viewSize + maxSeqNumSize + stableLowerBoundWhenEnteredToViewSize + newViewMsgSize +
+               myViewChangeMsgSize;
 }
 
 void DescriptorOfLastNewView::deserializeElement(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) {

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
@@ -40,14 +40,15 @@ struct DescriptorOfLastExitFromView {
                                PrevViewInfoElements elements,
                                ViewChangeMsg *viewChangeMsg,
                                SeqNum stableLowerBound)
-      : view(viewNum),
+      : isDefault(false),
+        view(viewNum),
         lastStable(stableNum),
         lastExecuted(execNum),
         stableLowerBoundWhenEnteredToView(stableLowerBound),
         myViewChangeMsg(viewChangeMsg),
         elements(move(elements)) {}
 
-  DescriptorOfLastExitFromView() = default;
+  DescriptorOfLastExitFromView() : isDefault(true){};
 
   void clean();
   void serializeSimpleParams(char *buf, size_t bufLen, size_t &actualSize) const;
@@ -61,8 +62,9 @@ struct DescriptorOfLastExitFromView {
   static uint32_t simpleParamsSize() {
     uint32_t elementsNum;
     uint8_t msgFilledFlag;
-    return (sizeof(view) + sizeof(lastStable) + sizeof(lastExecuted) + sizeof(stableLowerBoundWhenEnteredToView) +
-            sizeof(msgFilledFlag) + maxMessageSizeInLocalBuffer<ViewChangeMsg>() + sizeof(elementsNum));
+    return (sizeof(isDefault) + sizeof(view) + sizeof(lastStable) + sizeof(lastExecuted) +
+            sizeof(stableLowerBoundWhenEnteredToView) + sizeof(msgFilledFlag) +
+            maxMessageSizeInLocalBuffer<ViewChangeMsg>() + sizeof(elementsNum));
   }
 
   static uint32_t maxElementSize() {
@@ -73,6 +75,9 @@ struct DescriptorOfLastExitFromView {
   static uint32_t maxSize() { return simpleParamsSize() + maxElementSize() * kWorkWindowSize; }
 
   // Simple parameters - serialized together
+
+  // whether this is a default descriptor instance
+  bool isDefault;
 
   // view >= 0
   ViewNum view = 0;
@@ -106,7 +111,8 @@ struct DescriptorOfLastNewView {
                           ViewChangeMsg *viewChangeMsg,
                           SeqNum stableLowerBound,
                           SeqNum maxSeqNum)
-      : view(viewNum),
+      : isDefault(false),
+        view(viewNum),
         maxSeqNumTransferredFromPrevViews(maxSeqNum),
         stableLowerBoundWhenEnteredToView(stableLowerBound),
         newViewMsg(newMsg),
@@ -130,7 +136,7 @@ struct DescriptorOfLastNewView {
 
   static uint32_t simpleParamsSize() {
     uint8_t msgFilledFlag;
-    return (sizeof(view) + sizeof(maxSeqNumTransferredFromPrevViews) + 2 * sizeof(msgFilledFlag) +
+    return (sizeof(isDefault) + sizeof(view) + sizeof(maxSeqNumTransferredFromPrevViews) + 2 * sizeof(msgFilledFlag) +
             sizeof(stableLowerBoundWhenEnteredToView) + maxMessageSizeInLocalBuffer<NewViewMsg>() +
             maxMessageSizeInLocalBuffer<ViewChangeMsg>());
   }
@@ -145,6 +151,9 @@ struct DescriptorOfLastNewView {
   static uint32_t viewChangeMsgsNum;
 
   // Simple parameters - serialized together
+
+  // whether this is a default descriptor instance
+  bool isDefault;
 
   // view >= 1
   ViewNum view = 0;

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -629,22 +629,18 @@ DescriptorOfLastExecution PersistentStorageImp::getDescriptorOfLastExecution() {
 
 bool PersistentStorageImp::hasDescriptorOfLastExitFromView() {
   if (!hasDescriptorOfLastExitFromView_) {
-    DescriptorOfLastExitFromView defaultDesc;
     DescriptorOfLastExitFromView storedDesc = getAndAllocateDescriptorOfLastExitFromView();
-    if (!storedDesc.equals(defaultDesc)) hasDescriptorOfLastExitFromView_ = true;
+    if (!storedDesc.isDefault) hasDescriptorOfLastExitFromView_ = true;
     storedDesc.clean();
-    defaultDesc.clean();
   }
   return hasDescriptorOfLastExitFromView_;
 }
 
 bool PersistentStorageImp::hasDescriptorOfLastNewView() {
   if (!hasDescriptorOfLastNewView_) {
-    DescriptorOfLastNewView defaultDesc;
     DescriptorOfLastNewView storedDesc = getAndAllocateDescriptorOfLastNewView();
-    if (!storedDesc.equals(defaultDesc)) hasDescriptorOfLastNewView_ = true;
+    if (!storedDesc.isDefault) hasDescriptorOfLastNewView_ = true;
     storedDesc.clean();
-    defaultDesc.clean();
   }
   return hasDescriptorOfLastNewView_;
 }

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -172,6 +172,14 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
 
   if (hasDescOfLastNewView) descriptorOfLastNewView = p->getAndAllocateDescriptorOfLastNewView();
 
+  const auto replicaId = ld.repConfig.replicaId;
+  const auto lastExitedView = descriptorOfLastExitFromView.view;
+  const auto lastNewView = descriptorOfLastNewView.view;
+
+  LOG_INFO(GL,
+           "View change descriptors: " << KVLOG(
+               replicaId, hasDescLastExitFromView, hasDescOfLastNewView, lastExitedView, lastNewView));
+
   ReplicaLoader::ErrorCode stat = checkViewDesc(hasDescLastExitFromView ? &descriptorOfLastExitFromView : nullptr,
                                                 hasDescOfLastNewView ? &descriptorOfLastNewView : nullptr);
 
@@ -237,6 +245,9 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
 
     ld.maxSeqNumTransferredFromPrevViews = descriptorOfLastNewView.maxSeqNumTransferredFromPrevViews;
   } else {
+    LOG_ERROR(GL,
+              "Failed to load view (inconsistent state): " << KVLOG(
+                  replicaId, hasDescLastExitFromView, hasDescOfLastNewView, lastExitedView, lastNewView));
     return InconsistentErr;
   }
 


### PR DESCRIPTION
## Overview
Certain replica start-up scenarios, such as starting replicas with delays in-between, results in one or more view changes. If a replica is restarted during/after this process, it is unable to load its state from persistent storage.

When a replica initiates view change by calling `MoveToHigherView()`, it persists a `DescriptorOfLastExitFromView` in its metadata store. Later on, if and when a new view is agreed, it persists a `DescriptorOfLastNewView`. If the replica is restarted, it uses those descriptors to load its view.

The problem is, as initially there are insufficient replicas for consensus, the `MoveToHigherView()` happens when the initial replicas haven't processed any requests. This is why, the persisted `DescriptorOfLastExitFromView` is exactly equal to the default one. After restarting the replica, this messes up the logic that calculates `hasDescLastExitFromView`, and the `ReplicaLoader::loadViewInfo()` method returns `InconsistentErr`. This results in the replica being unable to boot (becomes unrecoverable). See the final `else` clause below:

```
if (!hasDescLastExitFromView && !hasDescOfLastNewView) {
  ...
} else if (hasDescLastExitFromView && !hasDescOfLastNewView) {
  ...
} else if (hasDescLastExitFromView && hasDescOfLastNewView &&
		 (descriptorOfLastExitFromView.view == descriptorOfLastNewView.view)) {
  ...
} else if (hasDescLastExitFromView && hasDescOfLastNewView &&
  ...
} else {
  LOG_ERROR(GL,
		  "Failed to load view (inconsistent state): " << KVLOG(
			  replicaId, hasDescLastExitFromView, hasDescOfLastNewView, lastExitedView, lastNewView));
  return InconsistentErr;
}
```

## Suggested fix
In the persistent store, we need to be able to distinguish between a default `DescriptorOfLastExitFromView`, and one which has the same content, but was persisted as a result of a view change. This is why, in this PR I suggest introducing a `isDefault` boolean field which is also persisted, and allows the replica to correctly determine whether the descriptor is default.

Note:The same change is applied to `DescriptorOfLastNewView`, mostly for the sake of symmetry, as a similar problem could occur there, although I haven't actually observed it.

Additionally, I've updated the "delayed replica start-up" Apollo test, to restart a random non-primary after the view change has occurred and make sure it continues participating in consensus within the new view.