### PR TITLE
Fix memory leak

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -52,13 +52,14 @@ class IRequestsHandler {
 
 class IReplica {
  public:
-  static IReplica *createNewReplica(
+  using IReplicaPtr = std::unique_ptr<IReplica>;
+  static IReplicaPtr createNewReplica(
       ReplicaConfig *, IRequestsHandler *, IStateTransfer *, bft::communication::ICommunication *, MetadataStorage *);
 
-  static IReplica *createNewRoReplica(ReplicaConfig *,
-                                      IStateTransfer *,
-                                      bft::communication::ICommunication *,
-                                      MetadataStorage *);
+  static IReplicaPtr createNewRoReplica(ReplicaConfig *,
+                                        IStateTransfer *,
+                                        bft::communication::ICommunication *,
+                                        MetadataStorage *);
 
   virtual ~IReplica() = default;
 

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -109,11 +109,11 @@ void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
 
 namespace bftEngine {
 
-IReplica *IReplica::createNewReplica(ReplicaConfig *replicaConfig,
-                                     IRequestsHandler *requestsHandler,
-                                     IStateTransfer *stateTransfer,
-                                     bft::communication::ICommunication *communication,
-                                     MetadataStorage *metadataStorage) {
+IReplica::IReplicaPtr IReplica::createNewReplica(ReplicaConfig *replicaConfig,
+                                                 IRequestsHandler *requestsHandler,
+                                                 IStateTransfer *stateTransfer,
+                                                 bft::communication::ICommunication *communication,
+                                                 MetadataStorage *metadataStorage) {
   {
     std::lock_guard<std::mutex> lock(mutexForCryptoInitialization);
     if (!cryptoInitialized) {
@@ -143,7 +143,7 @@ IReplica *IReplica::createNewReplica(ReplicaConfig *replicaConfig,
     ((PersistentStorageImp *)persistentStoragePtr.get())->init(move(metadataStoragePtr));
   }
 
-  auto replicaInternal = new ReplicaInternal();
+  auto replicaInternal = std::make_unique<ReplicaInternal>();
   shared_ptr<MsgHandlersRegistrator> msgHandlersPtr(new MsgHandlersRegistrator());
   auto incomingMsgsStorageImpPtr =
       std::make_unique<IncomingMsgsStorageImp>(msgHandlersPtr, timersResolution, replicaConfig->replicaId);
@@ -185,10 +185,10 @@ IReplica *IReplica::createNewReplica(ReplicaConfig *replicaConfig,
   return replicaInternal;
 }
 
-IReplica *IReplica::createNewRoReplica(ReplicaConfig *replicaConfig,
-                                       IStateTransfer *stateTransfer,
-                                       bft::communication::ICommunication *communication,
-                                       MetadataStorage *metadataStorage) {
+IReplica::IReplicaPtr IReplica::createNewRoReplica(ReplicaConfig *replicaConfig,
+                                                   IStateTransfer *stateTransfer,
+                                                   bft::communication::ICommunication *communication,
+                                                   MetadataStorage *metadataStorage) {
   {
     std::lock_guard<std::mutex> lock(mutexForCryptoInitialization);
     if (!cryptoInitialized) {
@@ -199,7 +199,7 @@ IReplica *IReplica::createNewRoReplica(ReplicaConfig *replicaConfig,
 
   // Initialize the configuration singleton here to use correct values during persistent storage initialization.
   replicaConfig->singletonFromThis();
-  auto replicaInternal = new ReplicaInternal();
+  auto replicaInternal = std::make_unique<ReplicaInternal>();
   auto msgHandlers = std::make_shared<MsgHandlersRegistrator>();
   auto incomingMsgsStorageImpPtr =
       std::make_unique<IncomingMsgsStorageImp>(msgHandlers, timersResolution, replicaConfig->replicaId);

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -127,7 +127,7 @@ class ReplicaImp : public IReplica,
   std::shared_ptr<storage::IDBClient> m_metadataDBClient;
   bft::communication::ICommunication *m_ptrComm = nullptr;
   bftEngine::ReplicaConfig m_replicaConfig;
-  bftEngine::IReplica *m_replicaPtr = nullptr;
+  bftEngine::IReplica::IReplicaPtr m_replicaPtr = nullptr;
   ICommandsHandler *m_cmdHandler = nullptr;
   bftEngine::IStateTransfer *m_stateTransfer = nullptr;
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -216,7 +216,6 @@ ReplicaImp::~ReplicaImp() {
     if (m_replicaPtr->isRunning()) {
       m_replicaPtr->stop();
     }
-    delete m_replicaPtr;
   }
 }
 

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -141,7 +141,7 @@ class SimpleAppState : public IRequestsHandler {
 class SimpleTestReplica {
  private:
   ICommunication *comm;
-  bftEngine::IReplica *replica = nullptr;
+  bftEngine::IReplica::IReplicaPtr replica = nullptr;
   ReplicaConfig replicaConfig;
   std::thread *runnerThread = nullptr;
   ISimpleTestReplicaBehavior *behaviorPtr;
@@ -159,9 +159,8 @@ class SimpleTestReplica {
   }
 
   ~SimpleTestReplica() {
-    if (replica) {
-      delete replica;
-    }
+    // TODO(DD): Reset manually because apparently the order matters - fixit
+    replica.reset();
     if (comm) {
       comm->Stop();
       delete comm;


### PR DESCRIPTION
In the function `IReplica::createNewReplica` in case
`ReplicaLoader::loadReplica` fails the `replicaInternal` is not
released.