### PR TITLE
Fix hexPrint()'s output when input is negative

### DIFF
--- a/util/src/hex_tools.cpp
+++ b/util/src/hex_tools.cpp
@@ -2,6 +2,7 @@
 
 #include "hex_tools.h"
 
+#include <cstdint>
 #include <iomanip>
 #include <ios>
 #include <ostream>
@@ -15,7 +16,9 @@ std::ostream &hexPrint(std::ostream &s, const char *data, size_t size) {
   std::ios::fmtflags f(s.flags());
   s << "0x";
   for (size_t i = 0; i < size; i++) {
-    s << std::hex << std::setw(2) << std::setfill('0') << (uint)data[i];
+    // Convert from signed char to std::uint8_t and then to an unsigned non-char type so that it prints as an integer.
+    const auto u = static_cast<std::uint8_t>(data[i]);
+    s << std::hex << std::setw(2) << std::setfill('0') << static_cast<std::uint16_t>(u);
   }
   // restore current state
   s.flags(f);


### PR DESCRIPTION
Convert from signed char to std::uint8_t and then to an unsigned
non-char type so that it prints as an integer.

Previous code was converting from char to uint directly, leading to big
integer values and unexpected hex output.