### PR TITLE
Properly initialize log4cplus 2.0+

### DIFF
--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -480,6 +480,7 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  logging::initLogger("logging.properties");
   setUpConfiguration_4();
   RequestProcessingState::init(numOfRequiredReplies);
   const chrono::milliseconds msgTimeOut(20000);

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -89,6 +89,7 @@ bool Logger::config(const std::string& configFileName) {
 #include <log4cplus/helpers/property.h>
 #include <log4cplus/consoleappender.h>
 #include <log4cplus/fileappender.h>
+#include <log4cplus/initializer.h>
 
 using namespace log4cplus;
 
@@ -99,6 +100,11 @@ const char* logPattern = "%X{rid}|%d{%m-%d-%Y %H:%M:%S.%q}|%-5p|%c|%X{thread}|%M
 // first lookup a configuration file in the current directory
 // if not found - use default configuration
 void initLogger(const std::string& configFileName) {
+// Only initialize the logger for tests. Different users may use different versions of log4cplus.
+#ifdef TEST
+  log4cplus::Initializer initializer;
+#endif
+
   std::ifstream infile(configFileName);
   if (!infile.is_open()) {
     std::cerr << __PRETTY_FUNCTION__ << ": can't open " << configFileName << " using default configuration."


### PR DESCRIPTION
See https://sourceforge.net/p/log4cplus/wiki/CodeExamples/

This is to prevent the periodic errors we see when running tests:

  log4cplus:ERROR No appenders could be found for logger (concord).
  log4cplus:ERROR Please initialize the log4cplus system properly.