### PR TITLE
Additional view change edge scenarios

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -292,11 +292,16 @@ void ClientsManager::clearAllPendingRequests() {
 Time ClientsManager::timeOfEarliestPendingRequest() const  // TODO(GG): naive implementation - consider to optimize
 {
   Time t = MaxTime;
+  ClientInfo earliestClientWithPendingRequest = indexToClientInfo_.at(0);
 
   for (const ClientInfo& c : indexToClientInfo_) {
-    if (c.timeOfCurrentPendingRequest != MinTime && t > c.timeOfCurrentPendingRequest)
+    if (c.timeOfCurrentPendingRequest != MinTime && t > c.timeOfCurrentPendingRequest) {
       t = c.timeOfCurrentPendingRequest;
+      earliestClientWithPendingRequest = c;
+    }
   }
+
+  LOG_INFO(GL, "Earliest pending client request: " << KVLOG(earliestClientWithPendingRequest.currentPendingRequest));
 
   return t;
 }


### PR DESCRIPTION
This PR introduces the following view change "edge" scenarios:
1) Make sure a replica that was down during view change, catches up and works in the new view when restarted
2) Make sure a replica successfully restarts after view change, and works in the new view

Additionally, this PR introduces certain log INFO level improvements, which have helped in the manual log analysis part while running the above test cases.