### PR TITLE
Remove unused functions

### DIFF
--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -88,23 +88,6 @@ class DummyReplica : public InternalReplicaApi {
  public:
   explicit DummyReplica(bftEngine::impl::ReplicasInfo replicasInfo) : replicasInfo_(move(replicasInfo)) {}
 
-  void onPrepareCombinedSigFailed(SeqNum seqNumber, ViewNum view, const set<uint16_t>& replicasWithBadSigs) {}
-  void onPrepareCombinedSigSucceeded(
-      SeqNum seqNumber, ViewNum view, const char* combinedSig, uint16_t combinedSigLen, const std::string&) {}
-  void onPrepareVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view, bool isValid) {}
-
-  void onCommitCombinedSigFailed(SeqNum seqNumber, ViewNum view, const set<uint16_t>& replicasWithBadSigs) {}
-  void onCommitCombinedSigSucceeded(
-      SeqNum seqNumber, ViewNum view, const char* combinedSig, uint16_t combinedSigLen, const std::string&) {}
-  void onCommitVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view, bool isValid) {}
-
-  void onInternalMsg(FullCommitProofMsg* m) {}
-  void onMerkleExecSignature(ViewNum view, SeqNum seqNum, uint16_t signatureLength, const char* signature) {}
-
-  void onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqNum,
-                                          const ViewNum relatedViewNumber,
-                                          const forward_list<RetSuggestion>* const suggestedRetransmissions) {}
-
   const bftEngine::impl::ReplicasInfo& getReplicasInfo() const override { return replicasInfo_; }
   bool isValidClient(NodeIdType client) const override { return true; }
   bool isIdOfReplica(NodeIdType id) const override { return false; }
@@ -117,7 +100,6 @@ class DummyReplica : public InternalReplicaApi {
 
   IncomingMsgsStorage& getIncomingMsgsStorage() override { return *incomingMsgsStorage_; }
   util::SimpleThreadPool& getInternalThreadPool() override { return pool_; }
-  void updateMetricsForInternalMessage() {}
   bool isCollectingState() const override { return false; }
 
   const ReplicaConfig& getReplicaConfig() const override { return replicaConfig; }


### PR DESCRIPTION
Remove functions that are not a part of the base class anymore and thus should not be overridden.