### PR TITLE
Logging improvements:

### DIFF
--- a/bftengine/src/preprocessor/tests/CMakeLists.txt
+++ b/bftengine/src/preprocessor/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest REQUIRED)
 
-add_executable(preprocessor_test preprocessor_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(preprocessor_test preprocessor_test.cpp )
 add_test(preprocessor_test preprocessor_test)
 
 target_include_directories(preprocessor_test PUBLIC ..)

--- a/bftengine/tests/bcstatetransfer/CMakeLists.txt
+++ b/bftengine/tests/bcstatetransfer/CMakeLists.txt
@@ -12,5 +12,5 @@ target_include_directories(bcstatetransfer_tests
 
 target_link_libraries(bcstatetransfer_tests GTest::Main)
 #TODO [TK] this test uses kvbc and should be moved from bftengine
-target_link_libraries(bcstatetransfer_tests corebft kvbc $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(bcstatetransfer_tests corebft kvbc )
 target_compile_options(bcstatetransfer_tests PUBLIC "-Wno-sign-compare")

--- a/bftengine/tests/controllerWithSimpleHistory/CMakeLists.txt
+++ b/bftengine/tests/controllerWithSimpleHistory/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest REQUIRED)
 
-add_executable(ControllerWithSimpleHistory_test ControllerWithSimpleHistory_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(ControllerWithSimpleHistory_test ControllerWithSimpleHistory_test.cpp )
 add_test(ControllerWithSimpleHistory_test ControllerWithSimpleHistory_test)
 
 target_link_libraries(ControllerWithSimpleHistory_test PUBLIC

--- a/bftengine/tests/messages/CMakeLists.txt
+++ b/bftengine/tests/messages/CMakeLists.txt
@@ -5,7 +5,7 @@ target_include_directories(ClientRequestMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(ClientRequestMsg_test GTest::Main)
-target_link_libraries(ClientRequestMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(ClientRequestMsg_test corebft )
 target_compile_options(ClientRequestMsg_test PUBLIC "-Wno-sign-compare")
 
 
@@ -16,7 +16,7 @@ target_include_directories(PrePrepareMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(PrePrepareMsg_test GTest::Main)
-target_link_libraries(PrePrepareMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(PrePrepareMsg_test corebft )
 target_compile_options(PrePrepareMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(PartialCommitProofMsg_test PartialCommitProofMsg_test.cpp helper.cpp)
@@ -26,7 +26,7 @@ target_include_directories(PartialCommitProofMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(PartialCommitProofMsg_test GTest::Main)
-target_link_libraries(PartialCommitProofMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(PartialCommitProofMsg_test corebft )
 target_compile_options(PartialCommitProofMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(SignedShareBase_test SignedShareBase_test.cpp helper.cpp)
@@ -36,7 +36,7 @@ target_include_directories(SignedShareBase_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(SignedShareBase_test GTest::Main)
-target_link_libraries(SignedShareBase_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(SignedShareBase_test corebft )
 target_compile_options(SignedShareBase_test PUBLIC "-Wno-sign-compare")
 
 add_executable(CheckpointMsg_test CheckpointMsg_test.cpp helper.cpp)
@@ -46,7 +46,7 @@ target_include_directories(CheckpointMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(CheckpointMsg_test GTest::Main)
-target_link_libraries(CheckpointMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(CheckpointMsg_test corebft )
 target_compile_options(CheckpointMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(ReqMissingDataMsg_test ReqMissingDataMsg_test.cpp helper.cpp)
@@ -56,7 +56,7 @@ target_include_directories(ReqMissingDataMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(ReqMissingDataMsg_test GTest::Main)
-target_link_libraries(ReqMissingDataMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(ReqMissingDataMsg_test corebft )
 target_compile_options(ReqMissingDataMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(ViewChangeMsg_test ViewChangeMsg_test.cpp helper.cpp)
@@ -67,7 +67,7 @@ target_include_directories(ViewChangeMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(ViewChangeMsg_test GTest::Main)
-target_link_libraries(ViewChangeMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(ViewChangeMsg_test corebft )
 target_compile_options(ViewChangeMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(StartSlowCommitMsg_test StartSlowCommitMsg_test.cpp helper.cpp)
@@ -77,7 +77,7 @@ target_include_directories(StartSlowCommitMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(StartSlowCommitMsg_test GTest::Main)
-target_link_libraries(StartSlowCommitMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(StartSlowCommitMsg_test corebft )
 target_compile_options(StartSlowCommitMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(ReplicaStatusMsg_test ReplicaStatusMsg_test.cpp helper.cpp)
@@ -87,7 +87,7 @@ target_include_directories(ReplicaStatusMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(ReplicaStatusMsg_test GTest::Main)
-target_link_libraries(ReplicaStatusMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(ReplicaStatusMsg_test corebft )
 target_compile_options(ReplicaStatusMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(AskForCheckpointMsg_test AskForCheckpointMsg_test.cpp helper.cpp)
@@ -97,7 +97,7 @@ target_include_directories(AskForCheckpointMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(AskForCheckpointMsg_test GTest::Main)
-target_link_libraries(AskForCheckpointMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(AskForCheckpointMsg_test corebft )
 target_compile_options(AskForCheckpointMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(FullCommitProofMsg_test FullCommitProofMsg_test.cpp helper.cpp)
@@ -107,7 +107,7 @@ target_include_directories(FullCommitProofMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(FullCommitProofMsg_test GTest::Main)
-target_link_libraries(FullCommitProofMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(FullCommitProofMsg_test corebft )
 target_compile_options(FullCommitProofMsg_test PUBLIC "-Wno-sign-compare")
 
 add_executable(NewViewMsg_test NewViewMsg_test.cpp helper.cpp)
@@ -117,5 +117,5 @@ target_include_directories(NewViewMsg_test
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine)
 target_link_libraries(NewViewMsg_test GTest::Main)
-target_link_libraries(NewViewMsg_test corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(NewViewMsg_test corebft )
 target_compile_options(NewViewMsg_test PUBLIC "-Wno-sign-compare")

--- a/bftengine/tests/metadataStorage/CMakeLists.txt
+++ b/bftengine/tests/metadataStorage/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (BUILD_ROCKSDB_STORAGE)
     find_package(GTest REQUIRED)
-    add_executable(metadataStorage_test metadataStorage_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_executable(metadataStorage_test metadataStorage_test.cpp )
     add_test(metadataStorage_test metadataStorage_test)
 
     target_link_libraries(metadataStorage_test PUBLIC

--- a/bftengine/tests/simpleStorage/CMakeLists.txt
+++ b/bftengine/tests/simpleStorage/CMakeLists.txt
@@ -11,6 +11,6 @@ add_executable(simple_file_storage ${simple_file_storage_source_files})
 
 add_library(simple_file_storage_lib ${simple_file_storage_source_files_lib})
 
-target_link_libraries(simple_file_storage PUBLIC corebft  $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(simple_file_storage PUBLIC corebft  )
 
 target_link_libraries(simple_file_storage_lib PUBLIC corebft)

--- a/bftengine/tests/testMsgsCertificate/CMakeLists.txt
+++ b/bftengine/tests/testMsgsCertificate/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest REQUIRED)
 
-add_executable(msgsCertificate_test msgsCertificate_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(msgsCertificate_test msgsCertificate_test.cpp )
 add_test(msgsCertificate_test msgsCertificate_test)
 
 target_include_directories(msgsCertificate_test

--- a/bftengine/tests/testSeqNumForClientRequest/CMakeLists.txt
+++ b/bftengine/tests/testSeqNumForClientRequest/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest REQUIRED)
 
-add_executable(seqNumForClientRequest_test seqNumForClientRequest_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(seqNumForClientRequest_test seqNumForClientRequest_test.cpp )
 add_test(seqNumForClientRequest_test seqNumForClientRequest_test)
 
 target_include_directories(seqNumForClientRequest_test

--- a/bftengine/tests/testSerialization/CMakeLists.txt
+++ b/bftengine/tests/testSerialization/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(test_serialization
 target_include_directories(test_serialization PUBLIC
     ${bftengine_SOURCE_DIR}/src/bftengine)
 
-target_link_libraries(test_serialization PUBLIC corebft $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(test_serialization PUBLIC corebft )
 add_test(NAME test_serialization COMMAND test_serialization)

--- a/bftengine/tests/testViewChange/CMakeLists.txt
+++ b/bftengine/tests/testViewChange/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(GTest REQUIRED)
 
 add_executable(ViewChange_tests 
                 testViewChange.cpp
-                $<TARGET_OBJECTS:logging_dev>
+                
                 ${concord_bft_tools_SOURCE_DIR}/KeyfileIOUtils.cpp)
 
 add_test(ViewChange_tests ViewChange_tests)

--- a/diagnostics/test/CMakeLists.txt
+++ b/diagnostics/test/CMakeLists.txt
@@ -5,5 +5,5 @@ add_executable(diagnostics_tests diagnostics_tests.cpp)
 add_test(diagnostics_tests diagnostics_tests)
 target_link_libraries(diagnostics_tests PRIVATE GTest::Main diagnostics)
 
-add_executable(diagnostics_server_main main.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(diagnostics_server_main main.cpp )
 target_link_libraries(diagnostics_server_main PRIVATE diagnostics Threads::Threads)

--- a/kvbc/benchmark/CMakeLists.txt
+++ b/kvbc/benchmark/CMakeLists.txt
@@ -5,7 +5,7 @@
 find_package(benchmark QUIET)
 
 if(benchmark_FOUND)
-    add_executable(sparse_merkle_benchmark sparse_merkle_benchmark.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_executable(sparse_merkle_benchmark sparse_merkle_benchmark.cpp )
     target_link_libraries(sparse_merkle_benchmark PUBLIC
         benchmark
         util

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(GTest REQUIRED)
 find_package(rapidcheck)
 
 if(Boost_FOUND)
-    add_executable(blockchain_view_test blockchain_view_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_executable(blockchain_view_test blockchain_view_test.cpp )
     add_test(blockchain_view_test blockchain_view_test)
     target_include_directories(blockchain_view_test PRIVATE ${Boost_INCLUDE_DIRS})
     target_link_libraries(blockchain_view_test PUBLIC
@@ -12,18 +12,18 @@ if(Boost_FOUND)
     )
 endif()
 
-add_executable(order_test order_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(order_test order_test.cpp )
 add_test(order_test order_test)
 target_link_libraries(order_test GTest::Main kvbc util)
 target_compile_options(order_test PUBLIC -Wno-sign-compare)
 
-add_executable(kvbc_dbadapter_test kvbc_dbadapter_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(kvbc_dbadapter_test kvbc_dbadapter_test.cpp )
 add_test(kvbc_dbadapter_test kvbc_dbadapter_test)
 target_link_libraries(kvbc_dbadapter_test GTest::Main kvbc util)
 
 
 add_executable(sparse_merkle_storage_db_adapter_unit_test
-    sparse_merkle_storage/db_adapter_unit_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    sparse_merkle_storage/db_adapter_unit_test.cpp )
 add_test(sparse_merkle_storage_db_adapter_unit_test sparse_merkle_storage_db_adapter_unit_test)
 target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
     GTest::Main
@@ -35,7 +35,7 @@ target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
 )
 
 add_executable(sparse_merkle_storage_serialization_unit_test
-    sparse_merkle_storage/serialization_unit_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    sparse_merkle_storage/serialization_unit_test.cpp )
 add_test(sparse_merkle_storage_serialization_unit_test sparse_merkle_storage_serialization_unit_test)
 target_link_libraries(sparse_merkle_storage_serialization_unit_test PUBLIC
     GTest::Main
@@ -46,7 +46,7 @@ target_link_libraries(sparse_merkle_storage_serialization_unit_test PUBLIC
 
 if(RAPIDCHECK_FOUND)
 add_executable(sparse_merkle_storage_db_adapter_property_test
-    sparse_merkle_storage/db_adapter_property_test.cpp $<TARGET_OBJECTS:logging_dev>)
+    sparse_merkle_storage/db_adapter_property_test.cpp )
 add_test(sparse_merkle_storage_db_adapter_property_test sparse_merkle_storage_db_adapter_property_test)
 # Decrease both the input size and test count from the default value of 100 to 50 in order to speed up this test.
 set_property(TEST sparse_merkle_storage_db_adapter_property_test PROPERTY ENVIRONMENT RC_PARAMS=max_size=50\ max_success=50)
@@ -62,7 +62,7 @@ target_link_libraries(sparse_merkle_storage_db_adapter_property_test PUBLIC
     )
 
 add_executable(sparse_merkle_internal_node_property_test sparse_merkle/internal_node_property_tests.cpp
-$<TARGET_OBJECTS:logging_dev>)
+)
 add_test(sparse_merkle_internal_node_property_test sparse_merkle_internal_node_property_test)
 target_include_directories(sparse_merkle_internal_node_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
 target_link_libraries(sparse_merkle_internal_node_property_test PUBLIC
@@ -76,7 +76,7 @@ target_link_libraries(sparse_merkle_internal_node_property_test PUBLIC
 endif ()
 
 add_executable(sparse_merkle_base_types_test sparse_merkle/base_types_test.cpp
-    $<TARGET_OBJECTS:logging_dev>)
+    )
 add_test(sparse_merkle_base_types_test sparse_merkle_base_types_test)
 target_link_libraries(sparse_merkle_base_types_test PUBLIC
     GTest::Main
@@ -87,7 +87,7 @@ target_link_libraries(sparse_merkle_base_types_test PUBLIC
 
 find_package(OpenSSL REQUIRED)
 add_executable(sparse_merkle_internal_node_test sparse_merkle/internal_node_test.cpp
-    $<TARGET_OBJECTS:logging_dev>)
+    )
 add_test(sparse_merkle_internal_node_test sparse_merkle_internal_node_test)
 target_link_libraries(sparse_merkle_internal_node_test PUBLIC
     GTest::Main
@@ -99,7 +99,7 @@ target_link_libraries(sparse_merkle_internal_node_test PUBLIC
 
 find_package(OpenSSL REQUIRED)
 add_executable(sparse_merkle_tree_test sparse_merkle/tree_test.cpp
-    $<TARGET_OBJECTS:logging_dev>)
+    )
 add_test(sparse_merkle_tree_test sparse_merkle_tree_test)
 target_link_libraries(sparse_merkle_tree_test PUBLIC
     GTest::Main
@@ -110,7 +110,7 @@ target_link_libraries(sparse_merkle_tree_test PUBLIC
 )
 
 if (BUILD_ROCKSDB_STORAGE)
-add_executable(multiIO_test multiIO_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(multiIO_test multiIO_test.cpp )
 add_test(multiIO_test multiIO_test)
 
 target_link_libraries(multiIO_test PUBLIC

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -1,114 +1,62 @@
-if (USE_CONAN)
-  add_library(logging INTERFACE)
-  target_include_directories(logging INTERFACE include/)
+project(logging  LANGUAGES CXX)
 
-  #######################################################################################################################
-  # Default CONCORD_LOGGER_NAME to "concord"
+add_library(logging STATIC src/Logger.cpp )
+target_include_directories(logging PUBLIC include/)
 
-  if(NOT CONCORD_LOGGER_NAME)
-      set(CONCORD_LOGGER_NAME "concord" CACHE STRING "Set concord logger name" FORCE)
-  endif()
+set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY LINK_LIBRARIES logging)
 
-  #######################################################################################################################
-  #export all the way up to the top level directory
-  if(USE_LOG4CPP)
-    find_package(log4cplus REQUIRED)
-  endif()
+if(USE_LOG4CPP)
+	message(STATUS "USE_LOG4CPP")
+	if (USE_CONAN)
+ 	   find_package(log4cplus REQUIRED)
+	else(USE_CONAN)
+ 		###############################################################################################################
+  		#  Find log4cplus
+  		#  Once done this will define
+  		#  LOG4CPLUS_FOUND        - System has log4cplus
+  		#  LOG4CPLUS_INCLUDE_DIRS - The log4cplus include directories
+  		#  LOG4CPLUS_LIBRARY      - The libraries needed to use log4cplus
+  		#  LOG4CPLUS_DEFINITIONS  - Compiler switches required for using log4cplus
 
-  set(current_dir ${CMAKE_CURRENT_SOURCE_DIR})
-  while(NOT current_dir STREQUAL "")
-    message(STATUS "setting logger compile definitions for [${current_dir}]")
-    if(USE_LOG4CPP)
-      set_property(DIRECTORY ${current_dir} APPEND PROPERTY LINK_LIBRARIES ${LOG4CPLUS_LIBRARY})
-      set_property(DIRECTORY ${current_dir} APPEND PROPERTY INCLUDE_DIRECTORIES ${LOG4CPLUS_INCLUDE_DIRS})
-      set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_DEFINITIONS USE_LOG4CPP)
-    endif()
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_DEFINITIONS DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}")
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:logging,INTERFACE_INCLUDE_DIRECTORIES>")
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_OPTIONS "-Wformat=2")
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_OPTIONS "-Wno-deprecated") # TODO delete when upgrading to a newer version
-    get_property(current_dir DIRECTORY ${current_dir} PROPERTY PARENT_DIRECTORY)
-  endwhile()
-  #######################################################################################################################
-  #default logger initialization for tests
+		# First try pkg-config piggybacking
+   		find_package(PkgConfig)
+		if (PKG_CONFIG_FOUND)
+      		message(STATUS "Trying to find log4cplus using PkgConfig")
+      		pkg_check_modules(PC_LOG4CPLUS log4cplus)
+      		if (PC_LOG4CPLUS_FOUND)
+        		if (NOT PC_LOG4CPLUS_LINK_LIBRARIES) # for older cmake versions
+          			set ( PC_LOG4CPLUS_LINK_LIBRARIES "${PC_LOG4CPLUS_LIBDIR}/lib${PC_LOG4CPLUS_LIBRARIES}.so")
+				endif()
+        	endif(PC_LOG4CPLUS_FOUND)
+        	set(LOG4CPLUS_LIBRARY    	${PC_LOG4CPLUS_LINK_LIBRARIES})
+        	set(LOG4CPLUS_INCLUDE_DIRS	${PC_LOG4CPLUS_INCLUDE_DIRS}  )
+      	endif(PKG_CONFIG_FOUND)
 
-  add_library(logging_dev OBJECT src/Logger.cpp )
-  #current version of log4cplus uses deprecated std::auto_ptr
-  target_compile_options(logging_dev PUBLIC -Wno-deprecated-declarations)
-  target_include_directories(logging_dev PUBLIC include/)
-else()
-  add_library(logging INTERFACE)
-  target_include_directories(logging INTERFACE include/)
+	    if (NOT PC_LOG4CPLUS_FOUND)
+			message(STATUS "Trying to find log4cplus without PkgConfig")
+			find_path(LOG4CPLUS_INCLUDE_DIRS log4cplus/config.hxx
+            		  HINTS ${CMAKE_INSTALL_PREFIX}	PATH_SUFFIXES include)
 
-  #######################################################################################################################
-  #  Find log4cplus TODO [TK] drop when use conan
-  #  Once done this will define
-  #  LOG4CPLUS_FOUND        - System has log4cplus
-  #  LOG4CPLUS_INCLUDE_DIRS - The log4cplus include directories
-  #  LOG4CPLUS_LIBRARIES    - The libraries needed to use log4cplus
-  #  LOG4CPLUS_DEFINITIONS  - Compiler switches required for using log4cplus
+      		find_library(LOG4CPLUS_LIBRARY NAMES log4cplus
+            			 HINTS ${CMAKE_INSTALL_PREFIX}  PATH_SUFFIXES lib)
 
-  if(USE_LOG4CPP)
-    message(STATUS "USE_LOG4CPP")
-    # First try pkg-config piggybacking
-    find_package(PkgConfig)
-    if (PKG_CONFIG_FOUND)
-      message(STATUS "Trying to find log4cplus using PkgConfig")
-      pkg_check_modules(PC_LOG4CPLUS log4cplus)
-      if (PC_LOG4CPLUS_FOUND)
-        if (NOT PC_LOG4CPLUS_LINK_LIBRARIES) # for older cmake versions
-          set ( PC_LOG4CPLUS_LINK_LIBRARIES "${PC_LOG4CPLUS_LIBDIR}/lib${PC_LOG4CPLUS_LIBRARIES}.so")
-        endif()
-        set(LOG4CPLUS_LIBRARIES    ${PC_LOG4CPLUS_LINK_LIBRARIES})
-        set(LOG4CPLUS_INCLUDE_DIRS ${PC_LOG4CPLUS_INCLUDE_DIRS}  )
-      endif()
-    endif()
+      		include(FindPackageHandleStandardArgs)
+      		find_package_handle_standard_args(LOG4CPLUS DEFAULT_MSG LOG4CPLUS_LIBRARIES LOG4CPLUS_INCLUDE_DIRS)
+    	endif(NOT PC_LOG4CPLUS_FOUND)
+  	endif(USE_CONAN)
+  	
+  	###################################################################################################################
+  	# Export all the way down from the most top level directory
+  	# So that logging is automatically linked everywhere.
+  	
+    set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY LINK_LIBRARIES ${LOG4CPLUS_LIBRARY})
+    set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY INCLUDE_DIRECTORIES ${LOG4CPLUS_INCLUDE_DIRS})
+    set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY COMPILE_DEFINITIONS USE_LOG4CPP)
+  	
+endif(USE_LOG4CPP)
 
-    if (NOT PC_LOG4CPLUS_FOUND)
-      message(STATUS "Trying to find log4cplus without PkgConfig")
-      find_path(LOG4CPLUS_INCLUDE_DIRS log4cplus/config.hxx
-              HINTS ${CMAKE_INSTALL_PREFIX}
-              PATH_SUFFIXES include)
+ 
 
-      find_library(LOG4CPLUS_LIBRARIES NAMES log4cplus
-              HINTS ${CMAKE_INSTALL_PREFIX}
-              PATH_SUFFIXES lib)
-
-      include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(LOG4CPLUS DEFAULT_MSG LOG4CPLUS_LIBRARIES LOG4CPLUS_INCLUDE_DIRS)
-    endif()
-  endif()
-  #######################################################################################################################
-  # Default CONCORD_LOGGER_NAME to "concord"
-
-  if(NOT CONCORD_LOGGER_NAME)
-    set(CONCORD_LOGGER_NAME "concord" CACHE STRING "Set concord logger name" FORCE)
-  endif()
-
-  #######################################################################################################################
-  #export all the way up to the top level directory
-
-  set(current_dir ${CMAKE_CURRENT_SOURCE_DIR})
-  while(NOT current_dir STREQUAL "")
-    message(STATUS "setting logger compile definitions for [${current_dir}]")
-    if(USE_LOG4CPP)
-      set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_DEFINITIONS USE_LOG4CPP)
-      set_property(DIRECTORY ${current_dir} APPEND PROPERTY LINK_LIBRARIES      ${LOG4CPLUS_LIBRARIES})
-      set_property(DIRECTORY ${current_dir} APPEND PROPERTY INCLUDE_DIRECTORIES ${LOG4CPLUS_INCLUDE_DIRS})
-    endif()
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_DEFINITIONS DEFAULT_LOGGER_NAME="${CONCORD_LOGGER_NAME}")
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:logging,INTERFACE_INCLUDE_DIRECTORIES>")
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_OPTIONS "-Wformat=2")
-    set_property(DIRECTORY ${current_dir} APPEND PROPERTY COMPILE_OPTIONS "-Wno-deprecated") # TODO delete when upgrading to a newer version
-    get_property(current_dir DIRECTORY ${current_dir} PROPERTY PARENT_DIRECTORY)
-  endwhile()
-
-  #######################################################################################################################
-  #default logger initialization for tests
-
-  add_library(logging_dev OBJECT src/Logger.cpp)
-  #current version of log4cplus uses deprecated std::auto_ptr
-  target_compile_options(logging_dev PUBLIC -Wno-deprecated-declarations)
-  target_include_directories(logging_dev PUBLIC include/)
-endif()
-
+  
+ 

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -111,7 +111,7 @@ void initLogger(const std::string& configFileName) {
               << std::endl;
 
     SharedAppenderPtr ca_ptr = SharedAppenderPtr(new ConsoleAppender(false, true));
-    ca_ptr->setLayout(std::auto_ptr<Layout>(new PatternLayout(logPattern)));
+    ca_ptr->setLayout(std::unique_ptr<Layout>(new PatternLayout(logPattern)));
 
     Logger::getRoot().addAppender(ca_ptr);
     Logger::getRoot().setLogLevel(INFO_LOG_LEVEL);
@@ -135,5 +135,5 @@ ScopedMdc::~ScopedMdc() { MDC_REMOVE(key_); }
 
 }  // namespace logging
 
-logging::Logger GL = logging::getLogger(DEFAULT_LOGGER_NAME);
+logging::Logger GL = logging::getLogger("concord");
 logging::Logger CNSUS = logging::getLogger("concord.bft.consensus");

--- a/tests/simpleKVBC/TesterClient/CMakeLists.txt
+++ b/tests/simpleKVBC/TesterClient/CMakeLists.txt
@@ -18,7 +18,7 @@ if(${USE_COMM_TLS_TCP})
     target_compile_definitions(skvbc_client PUBLIC USE_COMM_TLS_TCP)
 endif()
 
-target_link_libraries(skvbc_client PUBLIC kvbc corebft threshsign util test_config_lib $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(skvbc_client PUBLIC kvbc corebft threshsign util test_config_lib )
 
 target_include_directories(skvbc_client PUBLIC ..)
 target_include_directories(skvbc_client PUBLIC ../..)

--- a/tests/simpleKVBC/TesterReplica/CMakeLists.txt
+++ b/tests/simpleKVBC/TesterReplica/CMakeLists.txt
@@ -19,7 +19,7 @@ if(BUILD_ROCKSDB_STORAGE)
 	target_compile_definitions(skvbc_replica PUBLIC "USE_ROCKSDB=1")
 endif()
 
-target_link_libraries(skvbc_replica PUBLIC kvbc corebft threshsign util test_config_lib $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(skvbc_replica PUBLIC kvbc corebft threshsign util test_config_lib )
 
 target_include_directories(skvbc_replica PUBLIC ..)
 target_include_directories(skvbc_replica PUBLIC ../..)

--- a/tests/simpleTest/CMakeLists.txt
+++ b/tests/simpleTest/CMakeLists.txt
@@ -6,7 +6,7 @@ set(simpleTest_client_source_files
 )
 find_package(GTest REQUIRED)
 
-add_executable(simpleTest_client $<TARGET_OBJECTS:logging_dev> ${simpleTest_client_source_files} )
+add_executable(simpleTest_client  ${simpleTest_client_source_files} )
 
 target_include_directories(simpleTest_client
                            PRIVATE
@@ -28,7 +28,7 @@ set(simpleTest_replica_source_files
 )
 
 add_executable(simpleTest_server 
-               $<TARGET_OBJECTS:logging_dev>
+               
                ${simpleTest_replica_source_files}
 )
 
@@ -47,7 +47,7 @@ target_link_libraries(simpleTest_server PUBLIC corebft
 set_target_properties(simpleTest_server PROPERTIES OUTPUT_NAME server)
 
 # config test
-add_executable(configTest config_file_parser_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(configTest config_file_parser_test.cpp )
 target_link_libraries(configTest PUBLIC corebft test_config_lib)
 target_include_directories(configTest
                            PRIVATE
@@ -75,7 +75,7 @@ target_link_libraries(persistency_test PUBLIC
         GTest::Main
         GTest::GTest
         test_config_lib
-        $<TARGET_OBJECTS:logging_dev>
+        
         simple_file_storage_lib)
 
 add_test(NAME persistency_test COMMAND persistency_test )

--- a/threshsign/CMakeLists.txt
+++ b/threshsign/CMakeLists.txt
@@ -84,7 +84,7 @@ endfunction()
 function(add_relic_executable appName appSrc appDir)
 
     # Add compile target
-    add_executable(${appName} ${appSrc} $<TARGET_OBJECTS:bench> $<TARGET_OBJECTS:bls_relic> $<TARGET_OBJECTS:common> $<TARGET_OBJECTS:logging_dev>)
+    add_executable(${appName} ${appSrc} $<TARGET_OBJECTS:bench> $<TARGET_OBJECTS:bls_relic> $<TARGET_OBJECTS:common> )
     target_include_directories(${appName} PRIVATE
         ${threshsign_SOURCE_DIR}/src
         #${threshsign_SOURCE_DIR}/src/bls/relic
@@ -101,7 +101,7 @@ endfunction()
 
 function(add_threshsign_executable appName appSrc appDir)
     # Add compile target
-    add_executable(${appName} ${appSrc} $<TARGET_OBJECTS:logging_dev>)
+    add_executable(${appName} ${appSrc} )
     # SbftKeygenApp depends on some RSA/Shoup internal functions/classes for generating primes
     target_include_directories(${appName} PRIVATE ${threshsign_SOURCE_DIR}/src ${threshsign_SOURCE_DIR}/lib ${threshsign_SOURCE_DIR}/include)
     target_link_libraries(${appName} PRIVATE mainapp)
@@ -173,18 +173,18 @@ add_subdirectory(test)
 #
 
 # This creates the <Package>Config.cmake file and installs it
-install(TARGETS threshsign EXPORT threshsignConfig
-    ARCHIVE DESTINATION lib)
-install(EXPORT threshsignConfig DESTINATION lib/cmake/threshsign)
-
+#install(TARGETS threshsign EXPORT threshsignConfig
+#    ARCHIVE DESTINATION lib)
+#install(EXPORT threshsignConfig DESTINATION lib/cmake/threshsign)
+#
 # This installs the static or (/and?) dynamic library
-install(TARGETS threshsign
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-)
-
-
-
+#install(TARGETS threshsign
+#    ARCHIVE DESTINATION lib
+#    LIBRARY DESTINATION lib
+#)
+#
+#
+#
 # This installs the headers
 # NOTE: Don't add / at the end. No slash means threshsign/ directory is created in the destination path
-install(DIRECTORY include/threshsign DESTINATION include)
+#install(DIRECTORY include/threshsign DESTINATION include)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(GenerateConcordKeys
                GenerateConcordKeys.cpp
                KeyfileIOUtils.hpp
                KeyfileIOUtils.cpp
-               $<TARGET_OBJECTS:logging_dev>)
+               )
 
 target_include_directories(GenerateConcordKeys
                            PRIVATE
@@ -33,7 +33,7 @@ add_executable(TestGeneratedKeys
                TestGeneratedKeys.cpp
                KeyfileIOUtils.hpp
                KeyfileIOUtils.cpp
-               $<TARGET_OBJECTS:logging_dev>)
+               )
 
 target_include_directories(TestGeneratedKeys
                            PRIVATE
@@ -57,9 +57,9 @@ set_target_properties(TestGeneratedKeys
                       .)
 
 if (BUILD_ROCKSDB_STORAGE)
-    add_executable(skvb_db_editor DBEditor.cpp $<TARGET_OBJECTS:logging_dev>)
+    add_executable(skvb_db_editor DBEditor.cpp )
     target_include_directories(skvb_db_editor PUBLIC
-        ${PROJECT_SOURCE_DIR}/src include $<TARGET_PROPERTY:logging,INTERFACE_INCLUDE_DIRECTORIES>)
+        ${PROJECT_SOURCE_DIR}/src include)
     target_link_libraries(skvb_db_editor kvbc corebft concordbft_storage)
 endif(BUILD_ROCKSDB_STORAGE)
 

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -6,7 +6,7 @@ add_test(metric_tests metric_tests)
 target_link_libraries(metric_tests GTest::Main util)
 target_compile_options(metric_tests PUBLIC -Wno-sign-compare)
 
-add_executable(metric_server MetricServerTestMain.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(metric_server MetricServerTestMain.cpp )
 target_link_libraries(metric_server util)
 
 add_test(NAME metric_server_tests COMMAND python3 -m unittest
@@ -15,28 +15,28 @@ add_test(NAME metric_server_tests COMMAND python3 -m unittest
 
 add_executable(mt_tests multithreading.cpp)
 add_test(util_mt_tests mt_tests)
-target_link_libraries(mt_tests GTest::Main util $<TARGET_OBJECTS:logging_dev>)
+target_link_libraries(mt_tests GTest::Main util )
 target_compile_options(mt_tests PUBLIC -Wno-sign-compare)
 
-add_executable(sliver_test sliver_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(sliver_test sliver_test.cpp )
 add_test(sliver_test sliver_test)
 target_link_libraries(sliver_test GTest::Main util)
 target_compile_options(sliver_test PUBLIC -Wno-sign-compare)
 
-add_executable(serializable_test serializable_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(serializable_test serializable_test.cpp )
 add_test(serializable_test serializable_test)
 target_link_libraries(serializable_test GTest::Main util)
 target_compile_options(serializable_test PUBLIC -Wno-sign-compare)
 
-add_executable(timers_tests timers_tests.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(timers_tests timers_tests.cpp )
 add_test(timers_tests timers_tests)
 target_link_libraries(timers_tests GTest::Main util)
 
 add_executable(sha3_256_tests sha3_256_tests.cpp)
 add_test(sha3_256_tests sha3_256_tests)
 target_link_libraries(sha3_256_tests GTest::Main util OpenSSL::Crypto
-        $<TARGET_OBJECTS:logging_dev>)
+        )
 
-add_executable(RollingAvgAndVar_test RollingAvgAndVar_test.cpp $<TARGET_OBJECTS:logging_dev>)
+add_executable(RollingAvgAndVar_test RollingAvgAndVar_test.cpp )
 add_test(RollingAvgAndVar_test RollingAvgAndVar_test)
 target_link_libraries(RollingAvgAndVar_test GTest::Main util)


### PR DESCRIPTION
- Moved logging from an object to a static library;
- Removed deprecated auto_ptr, as we moved to a latest version of log4cplus;
- All executables are implicitly linked against logging.