### PR TITLE
[WIP] Reduce Apollo test replicas

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -56,7 +56,7 @@ def interesting_configs(selected=None):
 
     bft_configs = [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 30},
                    {'n': 6, 'f': 1, 'c': 1, 'num_clients': 30},
-                   {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
+                   # {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 30}
                    # {'n': 12, 'f': 3, 'c': 1, 'num_clients': 30}
                    ]


### PR DESCRIPTION
I suspect the CI failures we see in GitHub Actions are because of the lack of CPU cores. Running 7 replicas on 2 CPU cores may have "interesting" side effects.

My suggestion is to try reducing the number of replicas.