### PR TITLE
[Apollo] Increase and unify view change timeout across test cases

### DIFF
--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -29,7 +29,7 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "10000"
+    viewChangeTimeoutMilli = "20000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -34,7 +34,7 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "3000"
+    viewChangeTimeoutMilli = "20000"
 
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,

--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -32,7 +32,7 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "10000"
+    viewChangeTimeoutMilli = "20000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -35,7 +35,7 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "10000"
+    viewChangeTimeoutMilli = "20000"
 
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
@@ -66,7 +66,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
         https://github.com/vmware/concord-bft/issues/194.
         """
         [bft_network.start_replica(i) for i in range(1, bft_network.config.n - 1)]
-        with trio.fail_after(60):  # seconds
+        with trio.fail_after(120):  # seconds
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(
                     tracker.send_indefinite_tracked_ops)

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -35,7 +35,7 @@ def start_replica_cmd(builddir, replica_id):
     """
 
     status_timer_milli = "500"
-    view_change_timeout_milli = "10000"
+    view_change_timeout_milli = "20000"
 
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -38,7 +38,7 @@ def start_replica_cmd(builddir, replica_id, config):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "10000"
+    viewChangeTimeoutMilli = "20000"
     ro_params = [ "--s3-config-file",
                     os.path.join(builddir, "tests", "simpleKVBC", "scripts", "test_s3_config.txt")
                 ]

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -27,7 +27,7 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "3000"
+    viewChangeTimeoutMilli = "20000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -29,7 +29,7 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "10000"
+    viewChangeTimeoutMilli = "20000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -454,7 +454,7 @@ class BftTestNetwork:
         Wait for the last agreed view to match the "expected" predicate
         """
         last_agreed_view = None
-        with trio.fail_after(seconds=30):
+        with trio.fail_after(seconds=60):
             while True:
                 try:
                     with trio.move_on_after(seconds=1):
@@ -472,7 +472,7 @@ class BftTestNetwork:
         """
         Wait for a view to become active on enough (n-f) replicas
         """
-        with trio.fail_after(seconds=30):
+        with trio.fail_after(seconds=60):
             while True:
                 nb_replicas_in_view = await self._count_replicas_in_view(view)
 


### PR DESCRIPTION
In certain cases where the system is under load, or the replicas are starving for compute resources (e.g. CI), undesirable view changes may be triggered, compromising the liveness of the system under test, and altering test results.

To mitigate this risk, I'm increasing the view change timeout from 10 to 20 seconds where applicable. This, by the way, is the value currently used in the product.