### PR TITLE
Fix log4cplus compatibility with concord-bft users

### DIFF
--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -89,7 +89,11 @@ bool Logger::config(const std::string& configFileName) {
 #include <log4cplus/helpers/property.h>
 #include <log4cplus/consoleappender.h>
 #include <log4cplus/fileappender.h>
+
+// This is only valid for log4cplus 2.0+ which we currently only use during testing.
+#ifdef TEST
 #include <log4cplus/initializer.h>
+#endif
 
 using namespace log4cplus;
 


### PR DESCRIPTION
Some external apps are using v1.x of log4cplus, and so we only want to
initialize 2.0+ for concord-bft tests. This PR makes sure an include
that doesn't exist in 1.x is only used in tests.