### PR TITLE
[EXPERIMENTAL] Reduce the active window size

### DIFF
--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -43,17 +43,17 @@ constexpr int MaxNumberOfReplicas = 64;
 // Work windows and intervals
 ///////////////////////////////////////////////////////////////////////////////
 
-constexpr uint16_t kWorkWindowSize = 300;
+constexpr uint16_t kWorkWindowSize = 30;
 
-constexpr uint16_t checkpointWindowSize = 150;
+constexpr uint16_t checkpointWindowSize = 15;
 static_assert(kWorkWindowSize == 2 * checkpointWindowSize, "kWorkWindowSize != 2 * checkpointWindowSize");
 
 // TODO(GG): check the value in config:
 // (maxConcurrentAgreementsByPrimary should be <= maxLegalConcurrentAgreementsByPrimary)
-constexpr uint16_t maxLegalConcurrentAgreementsByPrimary = 16;
+constexpr uint16_t maxLegalConcurrentAgreementsByPrimary = 8;
 
 // Maximum number of fast paths that are simultaneously in progress.
-constexpr uint16_t MaxConcurrentFastPaths = 75;
+constexpr uint16_t MaxConcurrentFastPaths = 10;
 static_assert(kWorkWindowSize > MaxConcurrentFastPaths + checkpointWindowSize,
               "Violation of kWorkWindowSize > MaxConcurrentFastPaths + checkpointWindowSize");
 static_assert(maxLegalConcurrentAgreementsByPrimary < MaxConcurrentFastPaths,

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -202,8 +202,8 @@ void testInit() {
 
 void testCheckWindowSetUp(const SeqNum shift, bool toSet) {
   const SeqNum checkpointSeqNum0 = 0;
-  const SeqNum checkpointSeqNum1 = 150;
-  const SeqNum checkpointSeqNum2 = 300;
+  const SeqNum checkpointSeqNum1 = 15;
+  const SeqNum checkpointSeqNum2 = 30;
 
   ReplicaId sender = 3;
   Digest stateDigest;
@@ -250,18 +250,18 @@ void testSeqNumWindowSetUp(const SeqNum shift, bool toSet) {
   CommitPath firstPath = CommitPath::FAST_WITH_THRESHOLD;
   PrePrepareMsg prePrepareNullMsg(sender, view, prePrepareMsgSeqNum, firstPath, 0);
 
-  const SeqNum slowStartedSeqNum = 144;
+  const SeqNum slowStartedSeqNum = 14;
   bool slowStarted = true;
 
-  const SeqNum prePrepareFullSeqNum = 101;
+  const SeqNum prePrepareFullSeqNum = 10;
   PrepareFullMsg *prePrepareFullInitialMsg = PrepareFullMsg::create(view, prePrepareFullSeqNum, sender, nullptr, 0);
 
-  const SeqNum fullCommitProofSeqNum = 160;
+  const SeqNum fullCommitProofSeqNum = 16;
   FullCommitProofMsg fullCommitProofInitialMsg(sender, view, fullCommitProofSeqNum, nullptr, 0);
 
   const bool forceCompleted = true;
 
-  const SeqNum commitFullSeqNum = 240;
+  const SeqNum commitFullSeqNum = 24;
   CommitFullMsg *commitFullInitialMsg = CommitFullMsg::create(view, commitFullSeqNum, sender, nullptr, 0);
 
   if (toSet) {
@@ -330,7 +330,7 @@ void testWindows(bool init) {
 }
 
 void testWindowsAdvance() {
-  const SeqNum moveToSeqNum = 150;
+  const SeqNum moveToSeqNum = 15;
   persistentStorageImp->beginWriteTran();
   persistentStorageImp->setLastStableSeqNum(moveToSeqNum);
   persistentStorageImp->endWriteTran();

--- a/bftengine/tests/testViewChange/testViewChange.cpp
+++ b/bftengine/tests/testViewChange/testViewChange.cpp
@@ -149,7 +149,7 @@ void setUpConfiguration_4() {
 }
 
 TEST(testViewchangeSafetyLogic_test, computeRestrictions) {
-  bftEngine::impl::SeqNum lastStableSeqNum = 150;
+  bftEngine::impl::SeqNum lastStableSeqNum = 15;
   const uint32_t kRequestLength = 2;
 
   uint64_t expectedLastValue = 12345;
@@ -338,7 +338,7 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_for_s
 // ViewChangeSafetyLogic::computeRestrictions.
 TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_one_ignored) {
   char buff[32]{};
-  bftEngine::impl::SeqNum lastStableSeqNum = 300;
+  bftEngine::impl::SeqNum lastStableSeqNum = 30;
   const uint32_t kRequestLength = 2;
 
   uint64_t expectedLastValue1 = 12345;

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_view_change_tests_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change 2>&1 > /dev/null"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_auto_view_change_tests_${STORAGE_TYPE} COMMAND sh -c

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_view_change_tests_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change 2>&1 > /dev/null"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_auto_view_change_tests_${STORAGE_TYPE} COMMAND sh -c

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -268,7 +268,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
         stale_node = random.choice(bft_network.all_replicas(without={0}))
 
         client, known_key, known_val, known_kv = \
-            await tracker.tracked_prime_for_state_transfer(checkpoints_num=4,
+            await tracker.tracked_prime_for_state_transfer(checkpoints_num=40,
                                                            stale_nodes={stale_node})
 
         # exclude the primary and the stale node
@@ -393,7 +393,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
         stale_replica = n - 1
 
         client, known_key, known_val, known_kv = \
-            await tracker.tracked_prime_for_state_transfer(checkpoints_num=2,
+            await tracker.tracked_prime_for_state_transfer(checkpoints_num=20,
                                                            stale_nodes={stale_replica})
         view = await bft_network.wait_for_view(
             replica_id=0,

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -144,7 +144,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                         except KeyError:
                             continue
                         else:
-                            if lastStableSeqNum >= 150:
+                            if lastStableSeqNum >= 15:
                                 #enough requests
                                 print("Consensus: lastStableSeqNum:" + str(lastStableSeqNum))
                                 nursery.cancel_scope.cancel()
@@ -161,7 +161,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                         continue
                     else:
                         # success!
-                        if lastExecutedSeqNum >= 150:
+                        if lastExecutedSeqNum >= 15:
                             print("Replica " + str(ro_replica_id) + ": lastExecutedSeqNum:" + str(lastExecutedSeqNum))
                             break
 
@@ -193,7 +193,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                             continue
                         else:
                             # success!
-                            if lastExecutedSeqNum >= 150:
+                            if lastExecutedSeqNum >= 15:
                                 print("Replica" + str(ro_replica_id) + " : lastExecutedSeqNum:" + str(lastExecutedSeqNum))
                                 nursery.cancel_scope.cancel()
                                 

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -46,6 +46,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
+    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_request_block_not_written_primary_down(self, bft_network):
@@ -99,8 +100,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
             new_last_block = skvbc.parse_reply(await client.read(skvbc.get_last_block_req()))
             self.assertEqual(new_last_block, last_block)
 
-
-
+    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability
@@ -121,6 +121,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
             num_consecutive_failing_primaries=1
         )
 
+    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability
@@ -170,6 +171,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         await tracker.run_concurrent_ops(100)
 
+    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability
@@ -363,6 +365,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         await bft_network.wait_for_slow_path_to_be_prevalent(
             replica_id=current_primary)
 
+    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs = lambda n,f,c : f >= 2)

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -46,7 +46,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_request_block_not_written_primary_down(self, bft_network):
@@ -100,7 +99,8 @@ class SkvbcViewChangeTest(unittest.TestCase):
             new_last_block = skvbc.parse_reply(await client.read(skvbc.get_last_block_req()))
             self.assertEqual(new_last_block, last_block)
 
-    @unittest.skip("debugging")
+
+
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability
@@ -121,7 +121,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
             num_consecutive_failing_primaries=1
         )
 
-    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability
@@ -171,7 +170,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         await tracker.run_concurrent_ops(100)
 
-    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability
@@ -366,7 +364,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
         await bft_network.wait_for_slow_path_to_be_prevalent(
             replica_id=current_primary)
 
-    @unittest.skip("debugging")
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs = lambda n,f,c : f >= 2)

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -280,13 +280,13 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         await bft_network.wait_for_view(
             replica_id=unstable_replica,
-            expected=lambda v: v >= current_primary,  # the >= is required because of https://jira.eng.vmware.com/browse/BC-3028
+            expected=lambda v: v == current_primary,
             err_msg="Make sure the unstable replica works in the new view."
         )
 
         await bft_network.wait_for_view(
             replica_id=initial_primary,
-            expected=lambda v: v >= current_primary,  # the >= is required because of https://jira.eng.vmware.com/browse/BC-3028
+            expected=lambda v: v == current_primary,
             err_msg="Make sure the initial primary activates the new view."
         )
 

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -183,7 +183,7 @@ class SimpleKVBCProtocol:
 
     async def prime_for_state_transfer(
             self, stale_nodes,
-            checkpoints_num=2,
+            checkpoints_num=20,
             persistency_enabled=True):
         initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
         self.bft_network.start_all_replicas()
@@ -220,7 +220,7 @@ class SimpleKVBCProtocol:
         checkpoint_before = await self.bft_network.wait_for_checkpoint(
             replica_id=random.choice(initial_nodes))
         # Write enough data to checkpoint and create a need for state transfer
-        for i in range (1 + checkpoint_num * 150):
+        for i in range (1 + checkpoint_num * 15):
             key = self.random_key()
             val = self.random_value()
             reply = await client.write([], [(key, val)])

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -949,7 +949,7 @@ class SkvbcTracker:
 
     async def tracked_prime_for_state_transfer(
             self, stale_nodes,
-            checkpoints_num=2,
+            checkpoints_num=20,
             persistency_enabled=True):
         initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
         [self.bft_network.start_replica(i) for i in initial_nodes]
@@ -964,7 +964,7 @@ class SkvbcTracker:
         # there.
         client1 = self.bft_network.random_client()
         # Write enough data to checkpoint and create a need for state transfer
-        for i in range(1 + checkpoints_num * 150):
+        for i in range(1 + checkpoints_num * 15):
             key = self.skvbc.random_key()
             val = self.skvbc.random_value()
             kv = [(key, val)]
@@ -1083,7 +1083,7 @@ class PassThroughSkvbcTracker:
 
     async def tracked_prime_for_state_transfer(
             self, stale_nodes,
-            checkpoints_num=2,
+            checkpoints_num=20,
             persistency_enabled=True):
         initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
         [self.bft_network.start_replica(i) for i in initial_nodes]
@@ -1098,7 +1098,7 @@ class PassThroughSkvbcTracker:
         # there.
         client1 = self.bft_network.random_client()
         # Write enough data to checkpoint and create a need for state transfer
-        for i in range(1 + checkpoints_num * 150):
+        for i in range(1 + checkpoints_num * 15):
             key = self.skvbc.random_key()
             val = self.skvbc.random_value()
             kv = [(key, val)]


### PR DESCRIPTION
This PR is an experimental fix for https://jira.eng.vmware.com/browse/BC-3028.

As discussed with Ittai and Guy, making a first attempt to reduce the window size from 300 to 30. As a consequence, checkpoints will also happen 10 times more frequently. 

Still, practically speaking if a replica is 30 sequence numbers behind, it would also likely lag even further (probably because it has crashed or there is network partitioning). So, despite the active window advancing 10x faster than before, we don't expect state transfer to happen much more frequently than it did previously.

Also, by doing this we expect to significantly (10x) speed-up view change, especially in the part where it rebuilds the active window.