### PR TITLE
SimpleThreadPool is not ready to serve jobs after a start

### DIFF
--- a/util/include/SimpleThreadPool.hpp
+++ b/util/include/SimpleThreadPool.hpp
@@ -73,6 +73,9 @@ class SimpleThreadPool {
   std::mutex queue_lock_;
   std::condition_variable queue_cond_;
   std::atomic_bool stopped_;
+  int num_of_free_threads_ = 0;
+  std::mutex threads_startup_lock_;
+  std::condition_variable threads_startup_cond_;
   std::vector<std::thread> threads_;
 };
 


### PR DESCRIPTION
The SimpleThreadPool start() function should not return until all required threads are started, otherwise add() function could signal thread that is not waiting for it, and operation gets stuck.

https://jira.eng.vmware.com/browse/BC-2862
