### PR TITLE
Use the numOfExternalClients configuration parameter instead of numOfClientProxies

### DIFF
--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -278,6 +278,7 @@ void setUpConfiguration_4() {
   replicaConfig.numOfClientProxies = numOfClients;
   replicaConfig.viewChangeTimerMillisec = viewChangeTimerMillisec;
   replicaConfig.preExecReqStatusCheckTimerMillisec = preExecReqStatusCheckTimerMillisec;
+  replicaConfig.numOfExternalClients = 5;
 
   replicaConfig.publicKeysOfReplicas.insert(pair<uint16_t, const string>(replica_0, publicKey_0));
   replicaConfig.publicKeysOfReplicas.insert(pair<uint16_t, const string>(replica_1, publicKey_1));

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -38,6 +38,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     // used to get info from parsing the key file
     bftEngine::ReplicaConfig replicaConfig;
     replicaConfig.numOfClientProxies = 100;
+    replicaConfig.numOfExternalClients = 30;
     replicaConfig.concurrencyLevel = 1;
     replicaConfig.debugStatisticsEnabled = true;
     replicaConfig.viewChangeTimerMillisec = 45 * 1000;


### PR DESCRIPTION
- A new parameter numOfExternalClients has been introduced by the BFT Client pool feature and it should be used by the internal Preprocessor configuration instead of numOfClientProxies.
- Configure a number of Preprocessor threads equal to the number of VM CPUs.

https://jira.eng.vmware.com/browse/BC-3095