### PR TITLE
Diagnostics: Add a StatusHandler for ReplicaImp

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -23,6 +23,7 @@
 #include "PersistentStorage.hpp"
 #include "OpenTracing.hpp"
 #include "diagnostics.h"
+#include "TimeUtils.hpp"
 
 #include "messages/ClientRequestMsg.hpp"
 #include "messages/PrePrepareMsg.hpp"
@@ -47,6 +48,22 @@ using namespace std::chrono;
 using namespace std::placeholders;
 
 namespace bftEngine::impl {
+
+void ReplicaImp::registerStatusHandlers() {
+  auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+  auto &msgQueue = getIncomingMsgsStorage();
+
+  concord::diagnostics::StatusHandler state_handler(
+      "replica", "Internal state of the concord-bft replica", [&msgQueue]() {
+        GetStatus get_status{"replica", std::promise<std::string>()};
+        auto result = get_status.output.get_future();
+        // Send a GetStatus InternalMessage to ReplicaImp, then wait for the result to be published.
+        msgQueue.pushInternalMsg(std::move(get_status));
+        return result.get();
+      });
+
+  registrar.registerStatusHandler(state_handler);
+}
 
 void ReplicaImp::registerMsgHandlers() {
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint, bind(&ReplicaImp::messageHandler<CheckpointMsg>, this, _1));
@@ -897,7 +914,61 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
     return retransmissionsManager->OnProcessingComplete();
   }
 
+  // Handle a status request for the diagnostics subsystem
+  if (auto *get_status = std::get_if<GetStatus>(&msg)) {
+    return onInternalMsg(*get_status);
+  }
+
   assert(false);
+}
+
+std::string ReplicaImp::getReplicaState() const {
+  auto primary = getReplicasInfo().primaryOfView(curView);
+  std::ostringstream oss;
+  oss << "Replica ID: " << getReplicasInfo().myId() << std::endl;
+  oss << "Primary: " << primary << std::endl;
+  oss << "View Change: "
+      << KVLOG(viewChangeProtocolEnabled,
+               autoPrimaryRotationEnabled,
+               curView,
+               utcstr(timeOfLastViewEntrance),
+               lastAgreedView,
+               utcstr(timeOfLastAgreedView),
+               viewChangeTimerMilli,
+               autoPrimaryRotationTimerMilli)
+      << std::endl
+      << std::endl;
+  oss << "Sequence Numbers: "
+      << KVLOG(primaryLastUsedSeqNum,
+               lastStableSeqNum,
+               strictLowerBoundOfSeqNums,
+               maxSeqNumTransferredFromPrevViews,
+               mainLog->currentActiveWindow().first,
+               mainLog->currentActiveWindow().second,
+               lastViewThatTransferredSeqNumbersFullyExecuted)
+      << std::endl
+      << std::endl;
+  oss << "Other: "
+      << KVLOG(restarted_,
+               requestsQueueOfPrimary.size(),
+               maxNumberOfPendingRequestsInRecentHistory,
+               batchingFactor,
+               utcstr(lastTimeThisReplicaSentStatusReportMsgToAllPeerReplicas),
+               utcstr(timeOfLastStateSynch),
+               recoveringFromExecutionOfRequests,
+               checkpointsLog->currentActiveWindow().first,
+               checkpointsLog->currentActiveWindow().second,
+               clientsManager->numberOfRequiredReservedPages())
+      << std::endl;
+  return oss.str();
+}
+
+void ReplicaImp::onInternalMsg(GetStatus &status) const {
+  if (status.key == "replica") {
+    return status.output.set_value(getReplicaState());
+  }
+  // We must always return something to unblock the future.
+  return status.output.set_value("** - Invalid Key - **");
 }
 
 void ReplicaImp::onInternalMsg(FullCommitProofMsg *msg) {
@@ -2898,6 +2969,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
   Assert(firstTime || ((sigMgr != nullptr) && (replicasInfo != nullptr) && (viewsMgr != nullptr)));
 
   registerMsgHandlers();
+  registerStatusHandlers();
+
   // Register metrics component with the default aggregator.
   metrics_.Register();
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -135,10 +135,11 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   Time timeOfLastStateSynch;    // last time the replica received a new state (via the state transfer mechanism)
   Time timeOfLastViewEntrance;  // last time the replica entered to a new view
 
-  //
-  ViewNum lastAgreedView = 0;  // latest view number v such that the replica received 2f+2c+1 ViewChangeMsg messages
-                               // with view >= v
-  Time timeOfLastAgreedView;   // last time we changed lastAgreedView
+  // latest view number v such that the replica received 2f+2c+1 ViewChangeMsg messages
+  // with view >= v
+  ViewNum lastAgreedView = 0;
+  // last time we changed lastAgreedView
+  Time timeOfLastAgreedView;
 
   // timers
   concordUtil::Timers::Handle retranTimer_;
@@ -261,6 +262,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
              shared_ptr<MsgHandlersRegistrator>,
              concordUtil::Timers& timers);
 
+  void registerStatusHandlers();
   void registerMsgHandlers();
 
   template <typename T>
@@ -282,11 +284,15 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   friend class DebugStatistics;
   friend class PreProcessor;
 
+  // Generate diagnostics status replies
+  std::string getReplicaState() const;
+
   template <typename T>
   void onMessage(T* msg);
 
   void onInternalMsg(InternalMessage&& msg);
   void onInternalMsg(FullCommitProofMsg* m);
+  void onInternalMsg(GetStatus& msg) const;
 
   bool handledByRetransmissionsManager(const ReplicaId sourceReplica,
                                        const ReplicaId destReplica,

--- a/bftengine/src/bftengine/TimeUtils.hpp
+++ b/bftengine/src/bftengine/TimeUtils.hpp
@@ -20,6 +20,8 @@
 #pragma once
 
 #include <chrono>
+#include <ctime>
+#include <iomanip>
 
 namespace bftEngine {
 namespace impl {
@@ -35,6 +37,15 @@ const Time MaxTime = std::chrono::steady_clock::time_point::max();
 const Time MinTime = std::chrono::steady_clock::time_point();
 
 #define getMonotonicTime std::chrono::steady_clock::now
+
+// Make a steady clock printable in UTC
+inline std::string utcstr(const std::chrono::steady_clock::time_point &time_point) {
+  time_t systime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now() +
+                                                        (time_point - std::chrono::steady_clock::now()));
+  std::ostringstream os;
+  os << std::put_time(std::gmtime(&systime), "%c %Z");
+  return os.str();
+}
 
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/InternalMessage.hpp
+++ b/bftengine/src/bftengine/messages/InternalMessage.hpp
@@ -11,22 +11,30 @@
 
 #pragma once
 
+#include <future>
 #include <variant>
+
 #include "messages/FullCommitProofMsg.hpp"
 #include "messages/RetranProcResultInternalMsg.hpp"
 #include "SignatureInternalMsgs.hpp"
 
 namespace bftEngine::impl {
 
+struct GetStatus {
+  std::string key;
+  std::promise<std::string> output;
+};
+
 // An InternalMessage is a value type sent from threads to the ReplicaImp over the IncomingMsgsStorage channel.
 //
 // All internal messages should be included in this variant.
 //
-// The purpose of using a variant is to explicitly encode the set of internal messages as a closed type. We know all the
-// internal messages, and it is a bug if a message outside of this set is ever sent or received. By encoding it in a
-// variant, the compiler makes it impossible to even build the software if we attempt to send a message that is not
-// included. While this doesn't enforce actually being able to handle the message, adding a message and its
-// corresponding handler can now be looked for in the same review.
+// The purpose of using a variant is to explicitly encode the set of internal messages as a closed
+// type. We know all the internal messages, and it is a bug if a message outside of this set is ever
+// sent or received. By encoding it in a variant, the compiler makes it impossible to even build the
+// software if we attempt to send a message that is not included. While this doesn't enforce
+// actually being able to handle the message, adding a message and its corresponding handler can now
+// be looked for in the same review.
 //
 // It also provides a nice quick visual inspection of where to look to see which messages there are, and for small
 // messages prevents the need to allocate on the heap. Note that the size of a variant is the size of its largest member
@@ -45,6 +53,9 @@ using InternalMessage = std::variant<FullCommitProofMsg*,
                                      VerifyCombinedCommitSigResultInternalMsg,
 
                                      // Retransmission manager related
-                                     RetranProcResultInternalMsg>;
+                                     RetranProcResultInternalMsg,
+
+                                     // Diagnostics related
+                                     GetStatus>;
 
 }  // namespace bftEngine::impl

--- a/diagnostics/concord-ctl
+++ b/diagnostics/concord-ctl
@@ -1,13 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import socket
 import sys
-import os
 
 port = 6888
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect(("127.0.0.1", port))
-cmd = b' '.join([os.fsencode(arg) for arg in sys.argv[1:]]) + b'\n'
+cmd = b' '.join(sys.argv[1:]) + b'\n'
 s.send(cmd)
 data = s.recv(64*1024)
 print(data.decode())

--- a/diagnostics/include/diagnostics.h
+++ b/diagnostics/include/diagnostics.h
@@ -75,6 +75,12 @@ class Registrar {
     return output;
   }
 
+  // DO NOT USE THIS IN PRODUCTION. THIS IS ONLY FOR TESTING, SO THAT WE CAN CLEAR THE SINGLETON AND REREGISTER.
+  void clearStatusHandlers() {
+    std::lock_guard<std::mutex> guard(mutex_);
+    status_handlers_.clear();
+  }
+
  private:
   std::map<std::string, StatusHandler> status_handlers_;
   mutable std::mutex mutex_;

--- a/diagnostics/include/protocol.h
+++ b/diagnostics/include/protocol.h
@@ -58,7 +58,7 @@ std::string run(const std::vector<std::string>& tokens, const Registrar& registr
       if (tokens.size() == 2) {
         return registrar.describeStatus();
       } else {
-        return accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
+        return diagnostics::accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
           return registrar.describeStatus(key);
         });
       }
@@ -66,7 +66,7 @@ std::string run(const std::vector<std::string>& tokens, const Registrar& registr
 
     if (command == "get") {
       if (tokens.size() < 3) return usage();
-      return accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
+      return diagnostics::accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
         return registrar.getStatus(key);
       });
     }

--- a/tests/simpleTest/persistency_test.cpp
+++ b/tests/simpleTest/persistency_test.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include "simple_test_client.hpp"
 #include "simple_test_replica.hpp"
+#include "diagnostics.h"
 
 namespace test::persistency {
 class PersistencyTest : public testing::Test {
@@ -49,6 +50,7 @@ class PersistencyTest : public testing::Test {
   }
 
   void create_and_run_replica(ReplicaParams rp, ISimpleTestReplicaBehavior *behv) {
+    concord::diagnostics::RegistrarSingleton::getInstance().clearStatusHandlers();
     rp.keysFilePrefix = "private_replica_";
     auto replica = std::shared_ptr<SimpleTestReplica>(SimpleTestReplica::create_replica(behv, rp, nullptr));
     replicas.push_back(replica);


### PR DESCRIPTION
A new InternalMessage, `GetStatus` was added. An instance of GetStatus
is created whenever the registered StatusHandler for "replica" is run. A
future/promise pair is created on callback and the promise is put in the
status message and sent to the ReplicaImp. The calling thread then
blocks waiting on the future, and returns the result when the promise is
fulfilled.

When the ReplicaImp receives the message it fills in the
promise state so that the future on the calling thread unblocks.

The StatusHandler is expected to be called in a unique thread as part of
a diagnostics server client request. The server is not instantiated in
concord-bft. A commit to the product will instantiate it and use the
registered handler. Output looks something like this, and any formatting
can be changed in a follow up PR. We can decide to standardize on JSON
or something like that as needed.

```
root@68340b2698c1:/concord# ./concord-ctl status get replica
Replica ID: 1
Primary: 0
View Change: | viewChangeProtocolEnabled: 1, autoPrimaryRotationEnabled: 0, curView: 0, utcstr(timeOfLastViewEntrance): Tue Jun  9 23:01:15 2020 GMT, lastAgreedView: 0, utcstr(timeOfLastAgreedView): Tue Jun  9 23:01:15 2020 GMT, viewChangeTimerMilli: 20000, autoPrimaryRotationTimerMilli: 0

Sequence Numbers: | primaryLastUsedSeqNum: 0, lastStableSeqNum: 0, strictLowerBoundOfSeqNums: 0, maxSeqNumTransferredFromPrevViews: 0, mainLog->currentActiveWindow().first: 1, mainLog->currentActiveWindow().second: 300, lastViewThatTransferredSeqNumbersFullyExecuted: 0

Other: | restarted_: 1, requestsQueueOfPrimary.size(): 0, maxNumberOfPendingRequestsInRecentHistory: 0, batchingFactor: 1, utcstr(lastTimeThisReplicaSentStatusReportMsgToAllPeerReplicas): Tue Jun  9 23:02:24 2020 GMT, utcstr(timeOfLastStateSynch): Tue Jun  9 23:01:15 2020 GMT, recoveringFromExecutionOfRequests: 0, checkpointsLog->currentActiveWindow().first: 0, checkpointsLog->currentActiveWindow().second: 449, clientsManager->numberOfRequiredReservedPages(): 32
```

This change also makes a change to `concord-ctl` to make it work with
python2. The unnecessary call to `os.fsencode` has been removed.