### PR TITLE
Adding support in reading rocksdb options configuration file

### DIFF
--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -106,6 +106,8 @@ class Client : public concord::storage::IDBClient {
   }
   // Database path on directory (used for connection).
   std::string m_dbPath;
+
+  std::string default_opt_config_name = "OPTIONS_DEFAULT.ini";
   // Database object (created on connection).
   std::unique_ptr<::rocksdb::DB> dbInstance_;
   ::rocksdb::TransactionDB* txn_db_ = nullptr;

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -101,9 +101,15 @@ void Client::init(bool readOnly) {
   // Thus, we don't need to persist our custom configuration file.
   auto s_opt = ::rocksdb::LoadLatestOptions(m_dbPath, ::rocksdb::Env::Default(), &options, &cf_descs);
   if (!s_opt.ok()) {
+    const char kPathSeparator =
+#ifdef _WIN32
+        '\\';
+#else
+        '/';
+#endif
     // If we couldn't read the stored configuration file, try to read the default configuration file.
     s_opt = ::rocksdb::LoadOptionsFromFile(
-        m_dbPath + "/" + default_opt_config_name, ::rocksdb::Env::Default(), &options, &cf_descs);
+        m_dbPath + kPathSeparator + default_opt_config_name, ::rocksdb::Env::Default(), &options, &cf_descs);
   }
   if (!s_opt.ok()) {
     // If we couldn't read the stored configuration and not the default configuration file, then create


### PR DESCRIPTION
Add support to read in rocksdb client an automated stored configuration file (if exist) or a new custom configuration file (which will be residing in the rocksdb folder).
This will help to tune rocksdb properly.

see 
https://github.com/facebook/rocksdb/wiki/RocksDB-Options-File
https://github.com/facebook/rocksdb/blob/v6.8.1/examples/rocksdb_option_file_example.ini
