### PR TITLE
Compute value hashes in parallel for v2Merkle

### DIFF
--- a/kvbc/benchmark/sparse_merkle_benchmark.cpp
+++ b/kvbc/benchmark/sparse_merkle_benchmark.cpp
@@ -286,7 +286,7 @@ struct Blockchain : benchmark::Fixture {
     return updates;
   }
 
-  void TearDown(const benchmark::State &) override { adapter.release(); }
+  void TearDown(const benchmark::State &) override { adapter.reset(); }
 
   std::uint64_t currentKeyValue{0};
   std::unique_ptr<DBAdapter> adapter;


### PR DESCRIPTION
Spawn a separate thread to compute value hashes while updating the
sparse merkle tree. Idea is to have the current value hash ready for the
update while the separate thread is computing another one.

Implement by using std::promise/future pairs. Introduce the ValueHashes
type to encapsulate the mapping between keys, values, promises and
futures.

Assume the same order for subsequent iterations of SetOfKeyValuePairs
objects, provided that we don't mutate them in any way. That, combined
with the assumption that the tree update takes longer than value hash
calculation, should ensure that this change is actually an optimization.
Note: The documentation for std::unordered_map (SetOfKeyValuePairs)
states that read-only operations do not invalidate iterators. Therefore,
we can expect that subsequent iterations will have the same order.

Benchmark data on an i7-9750H CPU @ 2.60GHz:
Before:
```
-----------------------------------------------------------------------
Benchmark                                Time          CPU   Iterations
-----------------------------------------------------------------------
Blockchain/addBlock/128/4/1024    4456033 ns      4456167 ns        154
Blockchain/addBlock/512/32/1024   24865546 ns     24865500 ns        29
Blockchain/addBlock/2048/8/4096  159640857 ns    159627593 ns         4

```
After:
```
-----------------------------------------------------------------------
Benchmark                                Time          CPU   Iterations
-----------------------------------------------------------------------
Blockchain/addBlock/128/4/1024    4051238 ns      3924905 ns        175
Blockchain/addBlock/512/32/1024   22804525 ns     22655801 ns        32
Blockchain/addBlock/2048/8/4096  119120398 ns    118909535 ns         6
```

Remove unused <iostream> include and 'using namespace std' directive.