### PR TITLE
WIP: Remove 7 replicas from test config

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -56,7 +56,7 @@ def interesting_configs(selected=None):
 
     bft_configs = [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 30},
                    {'n': 6, 'f': 1, 'c': 1, 'num_clients': 30},
-                   {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
+                   # {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 30}
                    # {'n': 12, 'f': 3, 'c': 1, 'num_clients': 30}
                    ]


### PR DESCRIPTION
Github Actions VMs have 7GB RAM.
Tester replica memory consumption:
```
   VSZ  RSS
1530336 34700
```
7 replicas running in parallel makes the testing system unstable