### PR TITLE
[Apollo] Edge scenarios with f isolated replicas

### DIFF
--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -75,6 +75,7 @@ class UdpClient:
         self.retries = 0
         self.msgs_sent = 0
         self.reply_quorum = 2*config.f + config.c + 1
+        self.port = BASE_PORT + 2*self.client_id
         self.sock_bound = False
 
     async def write(self, msg, seq_num=None, cid=None, pre_process=False):
@@ -144,8 +145,7 @@ class UdpClient:
 
     async def bind(self):
         # Each port is a function of its client_id
-        port = BASE_PORT + 2*self.client_id
-        await self.sock.bind(("127.0.0.1", port))
+        await self.sock.bind(("127.0.0.1", self.port))
         self.sock_bound = True
 
     async def send_loop(self, data, read_only):


### PR DESCRIPTION
This PR introduces a new type of adversary, capable of isolating a subset of replicas from the others, as well as from the clients.

Using this new adversary, we implement two "edge" scenarios:
1) Make sure the presence of the adversary triggers the slow consensus path. Once the adversary is gone, the isolated replicas resume request processing.
2) If a checkpoint was triggered during the presence of the adversary, make sure the isolated replicas catch up via state transfer, once the adversary is deactivated.