### PR TITLE
Persist an empty sparse merkle tree root

### DIFF
--- a/kvbc/include/sparse_merkle/walker.h
+++ b/kvbc/include/sparse_merkle/walker.h
@@ -54,6 +54,8 @@ class Walker {
   // remove current_node_ and ascend up the tree if not at the root.
   std::optional<Nibble> removeCurrentNode();
 
+  void insertEmptyRootAtCurrentVersion();
+
  private:
   void ascend();
   std::pair<Nibble, Hash> pop();

--- a/kvbc/src/sparse_merkle/tree.cpp
+++ b/kvbc/src/sparse_merkle/tree.cpp
@@ -79,6 +79,9 @@ void removeBatchedInternalNode(Walker& walker, const std::optional<LeafChild>& p
   } else {
     if (walker.atRoot() && walker.currentNode().safeToRemove()) {
       walker.removeCurrentNode();
+      // Ensure monotonically increasing root versions even in the case of the current root being removed (e.g. when all
+      // keys are removed) by persisting an empty root at the current version.
+      walker.insertEmptyRootAtCurrentVersion();
     } else {
       walker.ascendToRoot();
     }

--- a/kvbc/src/sparse_merkle/walker.cpp
+++ b/kvbc/src/sparse_merkle/walker.cpp
@@ -71,6 +71,12 @@ std::optional<Nibble> Walker::removeCurrentNode() {
   return std::nullopt;
 }
 
+void Walker::insertEmptyRootAtCurrentVersion() {
+  auto children = BatchedInternalNode::Children{};
+  children[0] = InternalChild{PLACEHOLDER_HASH, cache_.version()};
+  cache_.put(NibblePath{}, BatchedInternalNode{children});
+}
+
 std::pair<Nibble, Hash> Walker::pop() {
   Hash hash = current_node_.hash();
   Nibble child_key = nibble_path_.popBack();


### PR DESCRIPTION
Persist an empty sparse merkle tree root even in the case of the current
root being removed (e.g. when all keys are removed). Rationale is that
we want a monotonically increasing root (tree) versions in all cases.

Implement by inserting an empty root at the current version in the
cache in case the current root is being removed.

Add tests to cover cases that remove all keys in the tree.