### PR TITLE
Added MakefileCustom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/*
 tags
 compile_commands.json
 *__pycache__
+MakefileCustom
 
 # VIM swap.
 # Copied from https://github.com/github/gitignore/blob/master/Global/Vim.gitignore


### PR DESCRIPTION
The file may be used for adding custom targets or overriding default
values

Changes:
* Added variables:
    ```
    CONCORD_BFT_DOCKER_CONTAINER:=concord-bft
    CONCORD_BFT_ADDITIONAL_RUN_PARAMS:=
    CONCORD_BFT_ADDITIONAL_RUN_COMMANDS:=
    ```
* MakefileCustom is included to Makefile
* Container workdir is configured as part of `docker run` command