### PR TITLE
Have a separate logger for the preprocessor module

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -116,6 +116,11 @@ class PreProcessor {
   void cancelTimers();
   void onRequestsStatusCheckTimer(concordUtil::Timers::Handle timer);
 
+  static logging::Logger &logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
+    return logger_;
+  }
+
  private:
   static std::vector<std::shared_ptr<PreProcessor>> preProcessors_;  // The place holder for PreProcessor objects
 

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -50,8 +50,11 @@ class RequestProcessingState {
  private:
   static concord::util::SHA3_256::Digest convertToArray(
       const uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES]);
-
   static uint64_t getMonotonicTimeMilli();
+  static logging::Logger& logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
+    return logger_;
+  }
   auto calculateMaxNbrOfEqualHashes(uint16_t& maxNumOfEqualHashes) const;
 
  private:

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -54,7 +54,7 @@ void PreProcessReplyMsg::setParams(NodeIdType senderId, uint16_t clientId, ReqId
   msgBody()->senderId = senderId;
   msgBody()->reqSeqNum = reqSeqNum;
   msgBody()->clientId = clientId;
-  LOG_DEBUG(GL, "senderId=" << senderId << " clientId=" << clientId << " reqSeqNum=" << reqSeqNum);
+  LOG_DEBUG(logger(), "senderId=" << senderId << " clientId=" << clientId << " reqSeqNum=" << reqSeqNum);
 }
 
 void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen, const std::string& cid) {
@@ -71,7 +71,7 @@ void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen, const st
   msgBody()->cidLength = cid.size();
   msgSize_ = headerSize + sigSize + msgBody()->cidLength;
   msgBody()->replyLength = sigSize;
-  LOG_DEBUG(GL,
+  LOG_DEBUG(logger(),
             "senderId=" << msgBody()->senderId << " clientId=" << msgBody()->clientId
                         << " reqSeqNum=" << msgBody()->reqSeqNum << " headerSize=" << headerSize
                         << " sigSize=" << sigSize << " cidSize=" << cid.size() << " msgSize_=" << msgSize_);

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -48,6 +48,10 @@ class PreProcessReplyMsg : public MessageBase {
 #pragma pack(pop)
 
  private:
+  static logging::Logger& logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
+    return logger_;
+  }
   void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum);
   Header* msgBody() const { return ((Header*)msgBody_); }
 

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -33,7 +33,7 @@ PreProcessRequestMsg::PreProcessRequestMsg(NodeIdType senderId,
   position += reqLength;
   memcpy(position, cid.c_str(), cid.size());
   uint64_t msgLength = sizeof(Header) + span_context.size() + reqLength + cid.size();
-  LOG_DEBUG(GL,
+  LOG_DEBUG(logger(),
             "senderId=" << senderId << " clientId=" << clientId << " reqSeqNum=" << reqSeqNum
                         << " headerSize=" << sizeof(Header) << " reqLength=" << reqLength << " cidSize=" << cid.size()
                         << " msgLength=" << msgLength);

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "messages/MessageBase.hpp"
+#include "Logger.hpp"
 #include <memory>
 
 namespace preprocessor {
@@ -48,6 +49,10 @@ class PreProcessRequestMsg : public MessageBase {
 #pragma pack(pop)
 
  private:
+  static logging::Logger& logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
+    return logger_;
+  }
   void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength);
 
  private:


### PR DESCRIPTION
Introduce a separate logger: "concord.preprocessor" for the preprocessor module. This allows configuring preprocessor logs on a module-level.