### PR TITLE
Fix wrong parameter name in PlainTCPCommunication

### DIFF
--- a/communication/src/PlainTcpCommunication.cpp
+++ b/communication/src/PlainTcpCommunication.cpp
@@ -758,7 +758,7 @@ class PlainTCPCommunication::PlainTcpImpl {
     return true;
   }
 
-  ConnectionStatus getCurrentConnectionStatus(const NodeNum node) {
+  ConnectionStatus getCurrentConnectionStatus(const NodeNum destNode) {
     if (!isRunning()) return ConnectionStatus::Disconnected;
     lock_guard<recursive_mutex> lock(_connectionsGuard);
     const auto &conn = _connections.find(destNode);


### PR DESCRIPTION
PlainTCPCommunication is not a part of a regular compilation process and not used in the tests, but it still needs to be supported.