### PR TITLE
Implement async() functionality backed by a pool

### DIFF
--- a/util/include/thread_pool.hpp
+++ b/util/include/thread_pool.hpp
@@ -56,6 +56,8 @@ class ThreadPool {
 
  public:
   // Executes the passed function (or any callable) in a pool thread. Returns a future to the result.
+  // Note: The returned future's destructor doesn't block if the future value hasn't been retrieved. This is in contrast
+  // to the futures returned by std::async that block.
   template <class F>
   auto async(F&& func) {
     using ResultType = std::invoke_result_t<std::decay_t<F>>;

--- a/util/include/thread_pool.hpp
+++ b/util/include/thread_pool.hpp
@@ -1,0 +1,123 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+// Based on Mastering the C++17 STL, page 204:
+// https://books.google.bg/books?id=zJlGDwAAQBAJ&pg=PA205&lpg=PA205#
+
+#include <assertUtils.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace concord::util {
+
+// A thread pool that supports any callable object with any return type. Returns std::future objects to users.
+class ThreadPool {
+ private:
+  std::size_t nextQueueIndex() { return (queue_counter_++) % task_queues_.size(); }
+  auto& nextQueue() { return task_queues_[nextQueueIndex()]; }
+
+ public:
+  // Starts the thread pool with thread_count > 0 threads.
+  ThreadPool(unsigned int thread_count) : task_queues_{thread_count} {
+    Assert(thread_count > 0);
+    for (auto thread_index = 0u; thread_index < thread_count; ++thread_index) {
+      threads_.emplace_back([this, thread_index]() { loop(thread_index); });
+    }
+  }
+
+  // Starts the thread pool with the maximum number of concurrent threads supported by the implementation.
+  ThreadPool() : ThreadPool{std::thread::hardware_concurrency() ? std::thread::hardware_concurrency() : 1} {}
+
+  // Stops the thread pool. Waits for the currently executing tasks only (will not exhaust the queues).
+  ~ThreadPool() noexcept {
+    stop_ = true;
+    for (auto& q : task_queues_) {
+      q.cv.notify_one();
+    }
+    for (auto& t : threads_) {
+      t.join();
+    }
+  }
+
+ public:
+  // Executes the passed function (or any callable) in a pool thread. Returns a future to the result.
+  template <class F>
+  auto async(F&& func) {
+    using ResultType = std::invoke_result_t<std::decay_t<F>>;
+    auto ptask = std::packaged_task<ResultType()>{std::forward<F>(func)};
+    auto future = ptask.get_future();
+    auto task = GenericTask{[ptask = std::move(ptask)]() mutable { ptask(); }};
+    auto& queue = nextQueue();
+    {
+      auto lock = std::lock_guard{queue.mutex};
+      queue.tasks.push(std::move(task));
+    }
+    queue.cv.notify_one();
+    return future;
+  }
+
+ private:
+  using GenericTask = std::packaged_task<void()>;
+
+  void loop(std::size_t thread_index) noexcept {
+    auto& queue = task_queues_[thread_index];
+    while (true) {
+      auto lock = std::unique_lock{queue.mutex};
+      while (queue.tasks.empty() && !stop_) {
+        queue.cv.wait(lock);
+      }
+      if (stop_) break;
+      Assert(!queue.tasks.empty());
+      auto task = std::move(queue.tasks.front());
+      queue.tasks.pop();
+      lock.unlock();
+      task();
+    }
+  }
+
+ private:
+  // Represents a per-thread task queue.
+  struct TaskQueue {
+    // A queue of tasks for execution.
+    std::queue<GenericTask> tasks;
+
+    // A mutex for the queue.
+    std::mutex mutex;
+
+    // A condition variable to signal the queue.
+    std::condition_variable cv;
+  };
+
+  // Each thread has its own queue - rationale is that doing so will lessen the contention compared to having a single
+  // queue.
+  std::vector<TaskQueue> task_queues_;
+
+  // A counter used for distributing tasks among queues. Relies on unsigned wraparound.
+  std::atomic<unsigned int> queue_counter_{0};
+
+  // A global stop flag.
+  std::atomic_bool stop_{false};
+
+  // A list of threads.
+  std::vector<std::thread> threads_;
+};
+
+}  // namespace concord::util

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -40,3 +40,7 @@ target_link_libraries(sha3_256_tests GTest::Main util OpenSSL::Crypto
 add_executable(RollingAvgAndVar_test RollingAvgAndVar_test.cpp )
 add_test(RollingAvgAndVar_test RollingAvgAndVar_test)
 target_link_libraries(RollingAvgAndVar_test GTest::Main util)
+
+add_executable(thread_pool_test thread_pool_test.cpp)
+add_test(thread_pool_test thread_pool_test)
+target_link_libraries(thread_pool_test GTest::Main util)

--- a/util/test/thread_pool_test.cpp
+++ b/util/test/thread_pool_test.cpp
@@ -1,0 +1,104 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "thread_pool.hpp"
+
+#include <functional>
+#include <future>
+#include <thread>
+#include <vector>
+
+using namespace concord::util;
+
+namespace {
+
+constexpr auto answer = 42;
+
+auto func() { return answer; }
+auto (*func_ptr)() = func;
+auto (&func_ref)() = func;
+
+// Make sure the pool can execute lambdas.
+TEST(thread_pool, lambda) {
+  auto pool = ThreadPool{};
+  auto future = pool.async([]() { return answer; });
+  ASSERT_EQ(answer, future.get());
+}
+
+// Make sure the pool can execute functions.
+TEST(thread_pool, functions) {
+  auto pool = ThreadPool{};
+  auto future1 = pool.async(func);
+  auto future2 = pool.async(&func);
+  auto future3 = pool.async(func_ptr);
+  auto future4 = pool.async(func_ref);
+  ASSERT_EQ(answer, future1.get());
+  ASSERT_EQ(answer, future2.get());
+  ASSERT_EQ(answer, future3.get());
+  ASSERT_EQ(answer, future4.get());
+}
+
+// Make sure the pool can execute std::function objects.
+TEST(thread_pool, std_func) {
+  auto pool = ThreadPool{};
+  auto std_func = std::function{func};
+  auto future = pool.async(std_func);
+  ASSERT_EQ(answer, future.get());
+}
+
+// Make sure exceptions from the user-passed function are correctly propagated.
+TEST(thread_pool, exception) {
+  auto pool = ThreadPool{};
+  auto future = pool.async([]() { throw answer; });
+  ASSERT_THROW(future.get(), decltype(answer));
+}
+
+// Make sure that the returned futures' desctructors don't block.
+TEST(thread_pool, non_blocking_future_dtors) {
+  auto pool = ThreadPool{};
+  auto future1 = pool.async(func);
+  ASSERT_TRUE(future1.valid());
+  auto future2 = pool.async(func);
+  ASSERT_EQ(answer, future2.get());
+  // future1's dtor doesn't block if get()/wait() hasn't been called.
+}
+
+// Make sure that adding more tasks than the concurrency supported by the system works.
+TEST(thread_pool, more_tasks_than_concurrency) {
+  auto pool = ThreadPool{};
+  const auto conc = std::thread::hardware_concurrency() * 10;
+  std::vector<std::future<int>> futures;
+  for (auto i = 0u; i < conc; ++i) {
+    futures.push_back(pool.async(func));
+  }
+  for (auto& future : futures) {
+    ASSERT_EQ(answer, future.get());
+  }
+}
+
+// Make sure that adding tasks from different threads works properly.
+TEST(thread_pool, add_tasks_from_different_threads) {
+  auto pool = ThreadPool{};
+  auto async_future = std::async(std::launch::async, [&pool]() { pool.async(func); });
+  auto pool_future = pool.async(func);
+  ASSERT_EQ(answer, pool_future.get());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Implement an std::async()-like functionality that is backed by a thread
pool. Return std::future objects with the result to users. Support any
callable object with any return type.

Provide unit tests that also serve as examples.

Based on Mastering the C++17 STL, page 204:
https://books.google.bg/books?id=zJlGDwAAQBAJ&pg=PA205&lpg=PA205#