### PR TITLE
Makefile: build target to start docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ sudo make test
 * Build:
 ```sh
 cd concord-bft
-make run-c      # run container in background
-make build      # build sources
-make test       # run tests
+make
+make test
 ```
 Run `make help` to see more commands.
 


### PR DESCRIPTION
Changes:
Start docker container if not running
`make build` is the default target now, so a developer can just run `make`.