### PR TITLE
Destroy the DBAdapter instance in the merkle benchmark

### DIFF
--- a/kvbc/benchmark/sparse_merkle_benchmark.cpp
+++ b/kvbc/benchmark/sparse_merkle_benchmark.cpp
@@ -286,7 +286,7 @@ struct Blockchain : benchmark::Fixture {
     return updates;
   }
 
-  void TearDown(const benchmark::State &) override { adapter.release(); }
+  void TearDown(const benchmark::State &) override { adapter.reset(); }
 
   std::uint64_t currentKeyValue{0};
   std::unique_ptr<DBAdapter> adapter;


### PR DESCRIPTION
Call std::unique_ptr::reset() instead of std::unique_ptr::release() in
the test's TearDown() method. That will gracefully close the DB and will
fix a memory leak.