### PR TITLE
Remove implicitly deleted move-assignment operator

### DIFF
--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -101,7 +101,6 @@ class IDBClient {
       Guard(const Guard&) = delete;
       Guard& operator=(const Guard&) = delete;
       Guard(Guard&&) = default;
-      Guard& operator=(Guard&&) = default;
       ~Guard() noexcept {
         try {
           db_.freeIterator(&iter_);


### PR DESCRIPTION
Since the class has the const reference `const IDBClient& db_` as
private member, the move-assignmanet operator is implicitly removed.

For more details refer to: https://en.cppreference.com/w/cpp/language/move_assignment
Section: Deleted implicitly-declared move assignment operator