### PR TITLE
SimpleThreadPool: fix data race

### DIFF
--- a/util/include/SimpleThreadPool.hpp
+++ b/util/include/SimpleThreadPool.hpp
@@ -72,7 +72,7 @@ class SimpleThreadPool {
   std::queue<SimpleThreadPool::Job*> job_queue_;
   std::mutex queue_lock_;
   std::condition_variable queue_cond_;
-  std::atomic_bool stopped_;
+  bool stopped_;
   int num_of_free_threads_ = 0;
   std::mutex threads_startup_lock_;
   std::condition_variable threads_startup_cond_;


### PR DESCRIPTION
Since `stopped_` is an atomic but not protected by the mutex,
there was a situation where a job was popped from the job queue but was not executed or released.
In the method:
```
bool SimpleThreadPool::load(Job*& outJob) {
  std::unique_lock<std::mutex> ul(queue_lock_);
  queue_cond_.wait(ul, [this] { return !(job_queue_.empty() && !stopped_); });
  if (!stopped_) {                          << stopped_ == false
    outJob = job_queue_.front();
    job_queue_.pop();                       << job is popped
  }
  return !stopped_;                         << stopped_ is already true
}
```

And later in the thread loop:
```
while (load(j)) {                           << load returns false
  execute(j);
  j->release();
  j = nullptr;
}
```
As a result, the job was not executed and its memory not released.

P.S. Probably, we may replace `SimpleThreadPool` with the implementation by @dartdart26.