### PR TITLE
Fix a vector size bug in the merkle benchmark

### DIFF
--- a/kvbc/benchmark/sparse_merkle_benchmark.cpp
+++ b/kvbc/benchmark/sparse_merkle_benchmark.cpp
@@ -98,7 +98,7 @@ std::vector<std::uint8_t> randomBuffer(std::size_t size) {
   auto gen = std::mt19937{rd()};
   auto dis = std::uniform_int_distribution<std::uint16_t>{0, 255};
   auto buf = std::vector<std::uint8_t>{};
-  buf.resize(size);
+  buf.reserve(size);
   for (auto i = 0ull; i < size; ++i) {
     buf.push_back(dis(gen));
   }


### PR DESCRIPTION
Call std::vector::reserve() rather than std::vector::resize() in
randomBuffer() in the sparse merkle benchmark. Calling resize()
generates a vector with an incorrect size.