### PR TITLE
Obscure sensitive logs

### DIFF
--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -195,8 +195,8 @@ concord::storage::s3::StoreConfig TestSetup::ParseS3Config(const std::string& s3
 
   LOG_INFO(logger_,
            "\nS3 Configuration:"
-               << "\nbucket:\t\t" << config.bucketName << "\naccess key:\t" << config.accessKey << "\nprotocol:\t"
-               << config.protocol << "\nurl:\t\t" << config.url);
+               << "\nbucket:\t\t" << config.bucketName << "\nprotocol:\t" << config.protocol << "\nurl:\t\t"
+               << config.url);
   return config;
 }
 #endif

--- a/threshsign/bench/BenchLagrange.cpp
+++ b/threshsign/bench/BenchLagrange.cpp
@@ -46,6 +46,7 @@ int RelicAppMain(const Library& lib, const std::vector<std::string>& args) {
 
   unsigned int seed = static_cast<unsigned int>(time(NULL));
   LOG_INFO(GL, "Randomness seed passed to srand(): " << seed);
+  // NOTE: srand is not and should not be used for any cryptographic randomness.
   srand(seed);
 
 #ifdef NDEBUG

--- a/threshsign/bench/BenchMultiExp.cpp
+++ b/threshsign/bench/BenchMultiExp.cpp
@@ -43,6 +43,7 @@ int RelicAppMain(const Library& lib, const std::vector<std::string>& args) {
 
   unsigned int seed = static_cast<unsigned int>(time(NULL));
   LOG_INFO(GL, "Randomness seed passed to srand(): " << seed);
+  // NOTE: srand is not and should not be used for any cryptographic randomness.
   srand(seed);
 
   LOG_INFO(GL, "Benchmarking fast exponentiated multiplication in G1...");

--- a/threshsign/src/app/Main.cpp
+++ b/threshsign/src/app/Main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char *argv[]) {
 
   unsigned int seed = static_cast<unsigned int>(time(NULL));
   LOG_INFO(GL, "Randomness seed passed to srand(): " << seed);
+  // NOTE: srand is not and should not be used for any cryptographic randomness.
   srand(seed);
 
   // Call application-defined AppMain()


### PR DESCRIPTION
This PR is about obscuring sensitive information from the logs.
I wrote a script to find those sensitive logs and obscured them.

Changes:
- Removed access key config variable from the logs.

While searching for sensitive information, I have noticed we are logging ,in several files, seeds of PRNG.
Generally a seed shouldn't be logged and that is indeed sensitive information, but this seed is not used for cryptographic randomness, therefore in this case there is no security threat.
I added a comment to explicitly note this seed shouldn't be used for cryptographic randomness.