### PR TITLE
Add new BFT Client support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ MakefileCustom
 
 # Apollo test output
 */apollo/Testing/*
+Testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,8 @@ add_subdirectory(kvbc)
 add_subdirectory(storage)
 add_subdirectory(scripts)
 add_subdirectory(diagnostics)
+add_subdirectory(bftclient)
+
 #
 # Setup testing
 #

--- a/bftclient/CMakeLists.txt
+++ b/bftclient/CMakeLists.txt
@@ -1,0 +1,16 @@
+project (bftclient LANGUAGES CXX)
+
+add_library(bftclient2 STATIC
+  src/bft_client.cpp
+  src/msg_receiver.cpp
+  src/matcher.cpp
+  src/quorums.cpp
+)
+
+target_include_directories(bftclient2 PUBLIC include)
+target_include_directories(bftclient2 PRIVATE src)
+target_link_libraries(bftclient2 PUBLIC bftcommunication bftheaders)
+
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()

--- a/bftclient/include/bftclient/base_types.h
+++ b/bftclient/include/bftclient/base_types.h
@@ -1,0 +1,55 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use
+// this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license
+// terms. Your use of these subcomponents is subject to the terms and conditions of the
+// subcomponent's license, as noted in the LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace bft::client {
+
+// A typesafe replica id.
+struct ReplicaId {
+  uint16_t val;
+
+  bool operator==(const ReplicaId& other) const { return val == other.val; }
+  bool operator!=(const ReplicaId& other) const { return val != other.val; }
+  bool operator<(const ReplicaId& other) const { return val < other.val; }
+};
+
+// A typesafe client id.
+struct ClientId {
+  uint16_t val;
+
+  bool operator==(const ClientId& other) const { return val == other.val; }
+  bool operator!=(const ClientId& other) const { return val != other.val; }
+  bool operator<(const ClientId& other) const { return val < other.val; }
+};
+
+enum Flags : uint8_t { EMPTY_FLAGS_REQ = 0x0, READ_ONLY_REQ = 0x1, PRE_PROCESS_REQ = 0x2 };
+
+struct ReplicaSpecificInfo {
+  ReplicaId from;
+  std::vector<uint8_t> data;
+};
+
+typedef std::vector<uint8_t> Msg;
+
+// `matched_data` contains any data that must be identical for a quorum of replicas
+// `rsi` contains replica specific information that was received for each replying replica.
+struct Reply {
+  Msg matched_data;
+  std::map<ReplicaId, Msg> rsi;
+};
+
+}  // namespace bft::client

--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -1,0 +1,96 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "communication/ICommunication.hpp"
+#include "Logger.hpp"
+#include "DynamicUpperLimitWithSimpleFilter.hpp"
+
+#include "bftclient/config.h"
+#include "matcher.h"
+#include "msg_receiver.h"
+#include "exception.h"
+
+namespace bft::client {
+
+class Client {
+ public:
+  Client(std::unique_ptr<bft::communication::ICommunication> comm, const ClientConfig& config)
+      : communication_(std::move(comm)),
+        config_(config),
+        quorum_converter_(config_.all_replicas, config_.f_val, config_.c_val),
+        expected_commit_time_ms_(config_.retry_timeout_config.initial_retry_timeout.count(),
+                                 config_.retry_timeout_config.number_of_standard_deviations_to_tolerate,
+                                 config_.retry_timeout_config.max_retry_timeout.count(),
+                                 config_.retry_timeout_config.min_retry_timeout.count(),
+                                 config_.retry_timeout_config.samples_per_evaluation,
+                                 config_.retry_timeout_config.samples_until_reset,
+                                 config_.retry_timeout_config.max_increasing_factor,
+                                 config_.retry_timeout_config.max_decreasing_factor) {
+    communication_->setReceiver(config_.id.val, &receiver_);
+    communication_->Start();
+  }
+
+  void stop() { communication_->Stop(); }
+
+  // Send a message where the reply gets allocated by the callee and returned in a vector.
+  // The message to be sent is moved into the caller to prevent unnecessary copies.
+  //
+  // Throws a BftClientException on error.
+  Reply send(const WriteConfig& config, Msg&& request);
+  Reply send(const ReadConfig& config, Msg&& request);
+
+  // Useful for testing. Shouldn't be relied on in production.
+  std::optional<ReplicaId> primary() { return primary_; }
+
+ private:
+  // Generic function for sending a read or write message.
+  Reply send(const MatchConfig& match_config, const RequestConfig& request_config, Msg&& request, bool read_only);
+
+  // Wait for messages until we get a quorum or a retry timeout.
+  //
+  // Return a Reply on quorum, or std::nullopt on timeout.
+  std::optional<Reply> wait();
+
+  // Send a Msg to all destinations in the configured quorum.
+  void sendToGroup(const MatchConfig& config, const Msg& msg);
+
+  // Extract a matcher configurations from operational configurations
+  //
+  // Throws BftClientException on error.
+  MatchConfig writeConfigToMatchConfig(const WriteConfig&);
+  MatchConfig readConfigToMatchConfig(const ReadConfig&);
+
+  MsgReceiver receiver_;
+
+  std::unique_ptr<bft::communication::ICommunication> communication_;
+  ClientConfig config_;
+  logging::Logger logger_ = logging::getLogger("bftclient");
+
+  // The client doesn't always know the current primary.
+  std::optional<ReplicaId> primary_;
+
+  // Each outstanding request matches replies using a new matcher.
+  // If there are no outstanding requests, then this is a nullopt;
+  std::optional<Matcher> outstanding_request_;
+
+  // A class that takes all Quorum types and converts them to an MofN quorum, with validation.
+  QuorumConverter quorum_converter_;
+
+  // A utility for calculating dynamic timeouts for replies.
+  bftEngine::impl::DynamicUpperLimitWithSimpleFilter<uint64_t> expected_commit_time_ms_;
+};
+
+}  // namespace bft::client

--- a/bftclient/include/bftclient/config.h
+++ b/bftclient/include/bftclient/config.h
@@ -1,0 +1,90 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <chrono>
+#include <map>
+#include <set>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "bftclient/base_types.h"
+#include "bftclient/quorums.h"
+
+using namespace std::chrono_literals;
+
+namespace bft::client {
+
+// This config is based on the parameters to the DynamicUpperLimitWithSimpleFilter.
+// The defaults are set to the original defaults in SimpleClientImp.
+struct RetryTimeoutConfig {
+  // The starting retry timeout before we have any calculations.
+  std::chrono::milliseconds initial_retry_timeout = 150ms;
+
+  // The minimum that the timeout can be set to dynamically.
+  std::chrono::milliseconds min_retry_timeout = 50ms;
+
+  // The maximum that the timeout can be set to dynamically.
+  std::chrono::milliseconds max_retry_timeout = 1s;
+
+  // The number of standard deviations within the average that we expect reply times to fall into.
+  uint16_t number_of_standard_deviations_to_tolerate = 2;
+
+  // The number of replies we sample before we attempt to recalculate the rolling average and variance.
+  uint16_t samples_per_evaluation = 32;
+
+  // The number of samples before we reset the rolling average and variance to its empty state
+  // A negative number will turn off resets.
+  int16_t samples_until_reset = 1000;
+
+  // The scaling factor at which the timeout can be increased. A factor of 2 means that the upper
+  // limit can be doubled on each evaluation period.
+  double max_increasing_factor = 2;
+
+  // The scaling factor at which the timeout can be decreased. A factor of 2 means that the upper
+  // limit can be halved on each evaluation period.
+  double max_decreasing_factor = 2;
+};
+
+// The configuration for a single instance of a client.
+struct ClientConfig {
+  ClientId id;
+  std::set<ReplicaId> all_replicas;
+  uint16_t f_val;
+  uint16_t c_val;
+  RetryTimeoutConfig retry_timeout_config;
+};
+
+// Generic per-request configuration shared by reads and writes.
+struct RequestConfig {
+  bool pre_execute = false;
+  uint64_t sequence_number;
+  uint32_t max_reply_size = 64 * 1024;
+  std::chrono::milliseconds timeout = 5s;
+  std::string correlation_id = "";
+  std::string span_context = "";
+};
+
+// The configuration for a single write request.
+struct WriteConfig {
+  RequestConfig request;
+  WriteQuorum quorum;
+};
+
+// The configuration for a single read request.
+struct ReadConfig {
+  RequestConfig request;
+  ReadQuorum quorum;
+};
+
+}  // namespace bft::client

--- a/bftclient/include/bftclient/exception.h
+++ b/bftclient/include/bftclient/exception.h
@@ -1,0 +1,46 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include "bftclient/config.h"
+
+namespace bft::client {
+
+class BftClientException : public std::runtime_error::runtime_error {
+ public:
+  explicit BftClientException(const std::string& what) : runtime_error(what) {}
+};
+
+class BadQuorumConfigException : public BftClientException {
+ public:
+  BadQuorumConfigException(const std::string& what) : BftClientException(what) {}
+};
+
+class InvalidDestinationException : public BftClientException {
+ public:
+  InvalidDestinationException(ReplicaId replica_id)
+      : BftClientException("Replica: " + std::to_string(replica_id.val) + " is not part of the cluster.") {}
+
+  InvalidDestinationException() : BftClientException("MofN quorums must have destinations") {}
+};
+
+class TimeoutException : public BftClientException {
+ public:
+  TimeoutException(uint64_t seq_num, std::string cid)
+      : BftClientException("Timeout for request sequence number: " + std::to_string(seq_num) +
+                           ", and correlation id: " + cid) {}
+};
+
+}  // namespace bft::client

--- a/bftclient/include/bftclient/quorums.h
+++ b/bftclient/include/bftclient/quorums.h
@@ -1,0 +1,82 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <set>
+#include <variant>
+
+#include "bftclient/base_types.h"
+
+namespace bft::client {
+
+// A quorum of 2F + C + 1 matching replies from `destination` must be received for the `send` call
+// to complete.
+struct LinearizableQuorum {
+  std::set<ReplicaId> destinations;
+};
+
+// A quorum of F + 1 matching replies from `destination` must be received for the `send` call to complete.
+struct ByzantineSafeQuorum {
+  std::set<ReplicaId> destinations;
+};
+
+// A matching reply from every replica in `destination` must be received for the `send` call to complete.
+struct All {
+  std::set<ReplicaId> destinations;
+};
+
+// A matching reply from `wait_for` number of replicas from `destination` must be received for the
+// `send` call to complete.
+struct MofN {
+  size_t wait_for;
+  std::set<ReplicaId> destinations;
+};
+
+// Reads and writes support different types of quorums.
+typedef std::variant<LinearizableQuorum, ByzantineSafeQuorum, All, MofN> ReadQuorum;
+typedef std::variant<LinearizableQuorum, ByzantineSafeQuorum> WriteQuorum;
+
+// Convert a ReadQuorum or a WriteQuorum to an MofN Quorum, given:
+//  * All replicas in the cluster
+//  * F value
+//  * C value
+class QuorumConverter {
+ public:
+  QuorumConverter(const std::set<ReplicaId>& all_replicas, uint16_t f_val, uint16_t c_val)
+      : all_replicas_(all_replicas),
+        linearizable_quorum_size_(2 * f_val + c_val + 1),
+        bft_safe_quorum_size_(f_val + 1) {}
+
+  // Convert Quorums to a compatible MofN quorum for use by the matcher.
+  //
+  // This conversion handles quorum validation.
+  // The conversion from MofN to MofN only does validation.
+  //
+  // Throws BftClientException on error.
+  MofN toMofN(const LinearizableQuorum& quorum) const;
+  MofN toMofN(const ByzantineSafeQuorum& quorum) const;
+  MofN toMofN(const All& quorum) const;
+  MofN toMofN(const MofN& quorum) const;
+
+ private:
+  // Ensure that each replica in `destination` is part of `all_replicas`
+  //
+  // Throws an InvalidDestinationException if validation fails.
+  void validateDestinations(const std::set<ReplicaId>& destinations) const;
+
+  std::set<ReplicaId> all_replicas_;
+
+  size_t linearizable_quorum_size_;
+  size_t bft_safe_quorum_size_;
+};
+
+}  // namespace bft::client

--- a/bftclient/include/bftclient/seq_num_generator.h
+++ b/bftclient/include/bftclient/seq_num_generator.h
@@ -1,0 +1,82 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use
+// this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license
+// terms. Your use of these subcomponents is subject to the terms and conditions of the
+// subcomponent's license, as noted in the LICENSE file.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+#include "assertUtils.hpp"
+#include "base_types.h"
+
+namespace bft::client {
+
+// This is a basic implementation of a monotonic clock based sequence number.
+//
+// Using this class is safe, but not necessarily live. It is safe because messages from a client
+// with an old (or identical) sequence number are simply ignored. It may not be live because if your machine
+// reboots, its clock may be set "backwards". Within a few seconds however, given NTP,
+// things should be back to normal and new requests will be handled. This is actually a very
+// unlikely scenario, as reboots will generally take longer than any possible clock drift. Therefore
+// this is a good default sequence number generator.
+//
+// Users are allowed to generate their own sequence numbers (they do not
+// have to use this class). Other examples of ways to do this include:
+// (1) A simple counter + store the last counter in a persistent storage
+// (2) A mechanism to retrieve the last used sequence number from the replicas on restart. No such
+//     mechanism is cucrrently implemented, buf if necessary we will add it.
+class SeqNumberGenerator {
+  SeqNumberGenerator(ClientId client_id) : client_id_(client_id) {}
+
+  uint64_t unique() {
+    std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+    return unique(now);
+  }
+
+  uint64_t unique(std::chrono::time_point<std::chrono::system_clock> now) {
+    uint64_t milli = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+
+    if (milli > lastMilliOfUniqueFetchID_) {
+      lastMilliOfUniqueFetchID_ = milli;
+      lastCountOfUniqueFetchID_ = 0;
+    } else {
+      if (lastCountOfUniqueFetchID_ == LAST_COUNT_LIMIT) {
+        LOG_WARN(logger_, "Client SeqNum Counter reached max value. " << KVLOG(client_id_));
+        lastMilliOfUniqueFetchID_++;
+        lastCountOfUniqueFetchID_ = 0;
+      } else {
+        // increase last count to preserve uniqueness.
+        lastCountOfUniqueFetchID_++;
+      }
+    }
+    // shift lastMilli by 22 (0x3FFFFF) in order to 'bitwise or' with lastCount
+    // and preserve uniqueness and monotonicity.
+    uint64_t r = (lastMilliOfUniqueFetchID_ << (64 - 42));
+    Assert(lastCountOfUniqueFetchID_ <= LAST_COUNT_LIMIT);
+    r = r | ((uint64_t)lastCountOfUniqueFetchID_);
+
+    return r;
+  }
+
+ private:
+  // limited to the size lastMilli shifted.
+  const uint64_t LAST_COUNT_LIMIT = 0x3FFFFF;
+  // lastMilliOfUniqueFetchID_ holds the last SN generated,
+  uint64_t lastMilliOfUniqueFetchID_ = 0;
+  // lastCount used to preserve uniqueness.
+  uint32_t lastCountOfUniqueFetchID_ = 0;
+
+  ClientId client_id_;
+
+  logging::Logger logger_ = logging::getLogger("bftclient.seqnum");
+};
+
+}  // namespace bft::client

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -1,0 +1,165 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use
+// this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license
+// terms. Your use of these subcomponents is subject to the terms and conditions of the
+// subcomponent's license, as noted in the LICENSE file.
+
+#include "bftclient/bft_client.h"
+#include "bftengine/ClientMsgs.hpp"
+#include "assertUtils.hpp"
+
+namespace bft::client {
+
+// This function creates a ClientRequestMsg or a ClientPreProcessRequestMsg depending upon config.
+//
+// Since both of these are just instances of a `ClientRequestMsgHeader` followed by the message
+// data, we construct them here, rather than relying on the type constructors embedded into the
+// bftEngine impl. This allows us to not have to link with the bftengine library, and also allows us
+// to return the messages as vectors with proper RAII based memory management.
+Msg makeClientMsg(const RequestConfig& config, Msg&& request, bool read_only, uint16_t client_id) {
+  uint8_t flags = read_only ? READ_ONLY_REQ : EMPTY_FLAGS_REQ;
+  if (config.pre_execute) {
+    flags |= PRE_PROCESS_REQ;
+  }
+
+  auto header_size = sizeof(bftEngine::ClientRequestMsgHeader);
+
+  Msg msg(header_size + request.size());
+  bftEngine::ClientRequestMsgHeader* header = reinterpret_cast<bftEngine::ClientRequestMsgHeader*>(msg.data());
+  header->msgType = config.pre_execute ? PRE_PROCESS_REQUEST_MSG_TYPE : REQUEST_MSG_TYPE;
+  header->spanContextSize = config.span_context.size();
+  header->idOfClientProxy = client_id;
+  header->flags = flags;
+  header->reqSeqNum = config.sequence_number;
+  header->requestLength = msg.size();
+  header->timeoutMilli = config.timeout.count();
+  header->cid_length = config.correlation_id.size();
+
+  auto* position = msg.data() + header_size;
+
+  // Copy the span context
+  std::memcpy(position, config.span_context.data(), config.span_context.size());
+  position += config.span_context.size();
+
+  // Copy the request data
+  std::memcpy(position, request.data(), request.size());
+  position += request.size();
+
+  // Copy the correlation ID
+  std::memcpy(position, config.correlation_id.data(), config.correlation_id.size());
+
+  return msg;
+}
+
+Reply Client::send(const WriteConfig& config, Msg&& request) {
+  Assert(!outstanding_request_.has_value());
+  auto match_config = writeConfigToMatchConfig(config);
+  bool read_only = false;
+  return send(match_config, config.request, std::move(request), read_only);
+}
+
+Reply Client::send(const ReadConfig& config, Msg&& request) {
+  Assert(!outstanding_request_.has_value());
+  auto match_config = readConfigToMatchConfig(config);
+  bool read_only = true;
+  return send(match_config, config.request, std::move(request), read_only);
+}
+
+Reply Client::send(const MatchConfig& match_config,
+                   const RequestConfig& request_config,
+                   Msg&& request,
+                   bool read_only) {
+  outstanding_request_ = Matcher(match_config);
+  receiver_.activate(request_config.max_reply_size);
+  const auto msg = makeClientMsg(request_config, std::move(request), read_only, config_.id.val);
+  auto start = std::chrono::steady_clock::now();
+  auto end = start + request_config.timeout;
+  while (std::chrono::steady_clock::now() < end) {
+    if (primary_ && !read_only) {
+      communication_->sendAsyncMessage(primary_.value().val, (const char*)msg.data(), msg.size());
+    } else {
+      sendToGroup(match_config, msg);
+    }
+
+    if (auto reply = wait()) {
+      expected_commit_time_ms_.add(
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count());
+      return reply.value();
+    }
+  }
+
+  expected_commit_time_ms_.add(request_config.timeout.count());
+  outstanding_request_ = std::nullopt;
+  throw TimeoutException(request_config.sequence_number, request_config.correlation_id);
+}
+
+std::optional<Reply> Client::wait() {
+  auto now = std::chrono::steady_clock::now();
+  auto retry_timeout = std::chrono::milliseconds(expected_commit_time_ms_.upperLimit());
+  auto end_wait = now + retry_timeout;
+
+  // Keep trying to receive messages until we get quorum or a retry timeout.
+  while ((now = std::chrono::steady_clock::now()) < end_wait) {
+    auto wait_time = std::chrono::duration_cast<std::chrono::milliseconds>(end_wait - now);
+    auto unmatched_requests = receiver_.wait(wait_time);
+    for (auto&& req : unmatched_requests) {
+      if (auto match = outstanding_request_->onReply(std::move(req))) {
+        primary_ = match->primary;
+        outstanding_request_ = std::nullopt;
+        return match->reply;
+      }
+    }
+  }
+  // If there are multiple distinct replies, we may want to clear any replies to free memory. This really only matters
+  // for long running/indefinite requests.
+  static constexpr size_t CLEAR_MATCHER_REPLIES_THRESHOLD = 5;
+  if (outstanding_request_->numDifferentReplies() > CLEAR_MATCHER_REPLIES_THRESHOLD) {
+    outstanding_request_->clearReplies();
+  }
+  primary_ = std::nullopt;
+  return std::nullopt;
+}
+
+void Client::sendToGroup(const MatchConfig& config, const Msg& msg) {
+  for (auto dest : config.quorum.destinations) {
+    communication_->sendAsyncMessage(dest.val, (const char*)msg.data(), msg.size());
+  }
+}
+
+MatchConfig Client::writeConfigToMatchConfig(const WriteConfig& write_config) {
+  MatchConfig mc;
+  mc.sequence_number = write_config.request.sequence_number;
+
+  if (std::holds_alternative<LinearizableQuorum>(write_config.quorum)) {
+    mc.quorum = quorum_converter_.toMofN(std::get<LinearizableQuorum>(write_config.quorum));
+  } else {
+    mc.quorum = quorum_converter_.toMofN(std::get<ByzantineSafeQuorum>(write_config.quorum));
+  }
+  return mc;
+}
+
+MatchConfig Client::readConfigToMatchConfig(const ReadConfig& read_config) {
+  MatchConfig mc;
+  mc.sequence_number = read_config.request.sequence_number;
+
+  if (std::holds_alternative<LinearizableQuorum>(read_config.quorum)) {
+    mc.quorum = quorum_converter_.toMofN(std::get<LinearizableQuorum>(read_config.quorum));
+
+  } else if (std::holds_alternative<ByzantineSafeQuorum>(read_config.quorum)) {
+    mc.quorum = quorum_converter_.toMofN(std::get<ByzantineSafeQuorum>(read_config.quorum));
+
+  } else if (std::holds_alternative<All>(read_config.quorum)) {
+    mc.quorum = quorum_converter_.toMofN(std::get<All>(read_config.quorum));
+
+  } else {
+    mc.quorum = quorum_converter_.toMofN(std::get<MofN>(read_config.quorum));
+  }
+  return mc;
+}
+
+}  // namespace bft::client

--- a/bftclient/src/matcher.cpp
+++ b/bftclient/src/matcher.cpp
@@ -1,0 +1,61 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "matcher.h"
+
+namespace bft::client {
+
+std::optional<Match> Matcher::onReply(UnmatchedReply&& reply) {
+  if (!valid(reply)) return std::nullopt;
+
+  auto key = MatchKey{std::move(reply.metadata), std::move(reply.data)};
+  const auto [it, success] = matches_[key].insert_or_assign(reply.rsi.from, std::move(reply.rsi.data));
+  (void)it;  // unused variable hack needed by GCC
+  if (!success) {
+    LOG_ERROR(logger_,
+              "Received two different pieces of replica specific information from: " << reply.rsi.from.val
+                                                                                     << ". Keeping the new one.");
+    return std::nullopt;
+  }
+
+  return match();
+}
+
+std::optional<Match> Matcher::match() {
+  auto result = std::find_if(matches_.begin(), matches_.end(), [this](const auto& match) {
+    return match.second.size() == config_.quorum.wait_for;
+  });
+  if (result == matches_.end()) return std::nullopt;
+  return Match{Reply{std::move(result->first.data), std::move(result->second)}, result->first.metadata.primary};
+}
+
+bool Matcher::valid(const UnmatchedReply& reply) const {
+  if (config_.sequence_number != reply.metadata.seq_num) {
+    LOG_WARN(logger_,
+             "Received msg with mismatched sequence number. Expected: " << config_.sequence_number
+                                                                        << ", got: " << reply.metadata.seq_num);
+    return false;
+  }
+
+  if (!validSource(reply.rsi.from)) {
+    LOG_WARN(logger_, "Received reply from invalid source: " << reply.rsi.from.val);
+    return false;
+  }
+
+  return true;
+}
+
+bool Matcher::validSource(const ReplicaId& source) const {
+  const auto& valid_sources = config_.quorum.destinations;
+  return std::find(valid_sources.begin(), valid_sources.end(), source) != valid_sources.end();
+}
+
+}  // namespace bft::client

--- a/bftclient/src/matcher.h
+++ b/bftclient/src/matcher.h
@@ -1,0 +1,95 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <algorithm>
+#include <map>
+#include <optional>
+#include <set>
+
+#include "Logger.hpp"
+#include "bftclient/config.h"
+#include "msg_receiver.h"
+
+namespace bft::client {
+
+struct MatchConfig {
+  // All quorums can be distilled into an MofN quorum.
+  MofN quorum;
+  uint64_t sequence_number;
+};
+
+// The parts of data that must match in a reply for quorum to be reached
+struct MatchKey {
+  ReplyMetadata metadata;
+  Msg data;
+
+  bool operator==(const MatchKey& other) const { return metadata == other.metadata && data == other.data; }
+  bool operator!=(const MatchKey& other) const { return !(*this == other); }
+  bool operator<(const MatchKey& other) const {
+    if (metadata < other.metadata) {
+      return true;
+    }
+    if (metadata == other.metadata && data < other.data) {
+      return true;
+    }
+    return false;
+  }
+};
+
+// A successful match
+struct Match {
+  Reply reply;
+  std::optional<ReplicaId> primary;
+};
+
+// Match replies for a given quorum.
+class Matcher {
+ public:
+  Matcher(const MatchConfig& config) : config_(config) {}
+
+  std::optional<Match> onReply(UnmatchedReply&& reply);
+
+  // Return the number of replies from replicas that don't match, excluding RSI. When this number
+  // exceeds a threshold, we may want to clear all replies to free memory, if a request is expected to
+  // go on for a long time.
+  size_t numDifferentReplies() const { return matches_.size(); }
+
+  void clearReplies() { matches_.clear(); }
+
+ private:
+  // Check the validity of a reply
+  bool valid(const UnmatchedReply& reply) const;
+
+  // Is the reply from a source listed in the quorum's destination?
+  bool validSource(const ReplicaId& source) const;
+
+  // Check for a quorum based on config_ and matches_
+  std::optional<Match> match();
+
+  MatchConfig config_;
+  std::optional<uint16_t> primary_;
+
+  logging::Logger logger_ = logging::getLogger("bftclient.matcher");
+
+  // A map from a MatchKey to ReplicaSpecificInfo
+  //
+  // We store it as a nested map so that in case a replica returns different ReplicaSpecificInfo.data, we don't count it
+  // as 2 replies.
+  //
+  // In case this occurs, the replica is buggy or malicious, and we should log it and reject any replies from that
+  // replica. In the future we can keep track of this across future requests, but for now, we just log it and worry
+  // about it for the current match.
+  std::map<MatchKey, std::map<ReplicaId, Msg>> matches_;
+};
+
+}  // namespace bft::client

--- a/bftclient/src/msg_receiver.cpp
+++ b/bftclient/src/msg_receiver.cpp
@@ -1,0 +1,100 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use
+// this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license
+// terms. Your use of these subcomponents is subject to the terms and conditions of the
+// subcomponent's license, as noted in the LICENSE file.
+
+#include "kvstream.h"
+#include "assertUtils.hpp"
+#include "bftengine/ClientMsgs.hpp"
+#include "msg_receiver.h"
+
+namespace bft::client {
+
+void UnmatchedReplyQueue::push(UnmatchedReply&& reply) {
+  {
+    std::lock_guard<std::mutex> guard(lock_);
+    msgs_.push_back(std::move(reply));
+  }
+  cond_var_.notify_one();
+}
+
+std::vector<UnmatchedReply> UnmatchedReplyQueue::wait(std::chrono::milliseconds timeout) {
+  std::vector<UnmatchedReply> new_msgs;
+  std::unique_lock<std::mutex> lock(lock_);
+  cond_var_.wait_for(lock, timeout, [this] { return !msgs_.empty(); });
+  if (!msgs_.empty()) {
+    msgs_.swap(new_msgs);
+  }
+  return new_msgs;
+}
+
+void UnmatchedReplyQueue::clear() {
+  std::lock_guard<std::mutex> guard(lock_);
+  msgs_.clear();
+}
+
+void MsgReceiver::onNewMessage(const bft::communication::NodeNum source,
+                               const char* const message,
+                               const size_t msg_len) {
+  auto max_reply_size = max_reply_size_.load();
+  if (max_reply_size == 0) {
+    // There are no outstanding requests, so any replies are stale.
+    return;
+  }
+
+  if (msg_len > max_reply_size) {
+    LOG_WARN(logger_, "Invalid message received. Message is too large. " << KVLOG(msg_len, max_reply_size));
+    return;
+  }
+
+  if (msg_len < sizeof(bftEngine::ClientReplyMsgHeader)) {
+    LOG_WARN(logger_, "Invalid message received. Message is too small. " << KVLOG(msg_len));
+    return;
+  }
+
+  auto* header = reinterpret_cast<const bftEngine::ClientReplyMsgHeader*>(message);
+  if (header->msgType != REPLY_MSG_TYPE) {
+    LOG_WARN(logger_, "Invalid message received. Incorrect Header Type. " << KVLOG(header->msgType));
+    return;
+  }
+
+  auto metadata = ReplyMetadata{};
+  metadata.primary = ReplicaId{header->currentPrimaryId};
+  metadata.seq_num = header->reqSeqNum;
+
+  auto data_len = header->replyLength - sizeof(bftEngine::ClientReplyMsgHeader);
+  const char* start_of_body = message + sizeof(bftEngine::ClientReplyMsgHeader);
+  const char* start_of_rsi = start_of_body + (data_len - header->replicaSpecificInfoLength);
+  const char* end_of_rsi = start_of_rsi + header->replicaSpecificInfoLength;
+
+  auto rsi = ReplicaSpecificInfo{};
+  rsi.from = ReplicaId{static_cast<uint16_t>(source)};
+  rsi.data = Msg(start_of_rsi, end_of_rsi);
+
+  auto reply = UnmatchedReply{};
+  reply.metadata = metadata;
+  reply.rsi = std::move(rsi);
+  reply.data = Msg(start_of_body, start_of_rsi);
+
+  queue_.push(std::move(reply));
+}
+
+void MsgReceiver::activate(uint32_t max_reply_size) {
+  AssertNE(max_reply_size, 0);
+  max_reply_size_ = max_reply_size;
+}
+
+void MsgReceiver::deactivate() {
+  max_reply_size_ = 0;
+  queue_.clear();
+}
+
+std::vector<UnmatchedReply> MsgReceiver::wait(std::chrono::milliseconds timeout) { return queue_.wait(timeout); }
+
+}  // namespace bft::client

--- a/bftclient/src/msg_receiver.h
+++ b/bftclient/src/msg_receiver.h
@@ -1,0 +1,115 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use
+// this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license
+// terms. Your use of these subcomponents is subject to the terms and conditions of the
+// subcomponent's license, as noted in the LICENSE file.
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <queue>
+
+#include "communication/ICommunication.hpp"
+#include "Logger.hpp"
+#include "bftclient/config.h"
+
+namespace bft::client {
+
+// Metadata stripped from a ClientReplyMsgHeader
+//
+// This makes the metadata independent of the structure of the messages, allowing us to change them
+// later without changing the matcher.
+struct ReplyMetadata {
+  ReplicaId primary;
+  uint64_t seq_num;
+
+  bool operator==(const ReplyMetadata& other) const { return primary == other.primary && seq_num == other.seq_num; }
+  bool operator!=(const ReplyMetadata& other) const { return !(*this == other); }
+  bool operator<(const ReplyMetadata& other) const {
+    if (primary < other.primary) {
+      return true;
+    }
+    if (primary == other.primary && seq_num < other.seq_num) {
+      return true;
+    }
+    return false;
+  }
+};
+
+// A Reply that has been received, but not yet matched.
+struct UnmatchedReply {
+  ReplyMetadata metadata;
+  Msg data;
+  ReplicaSpecificInfo rsi;
+};
+
+// A thread-safe queue that allows the ASIO thread to push newly received messages and the client
+// send thread to wait for those messages to be received.
+class UnmatchedReplyQueue {
+ public:
+  // Push a new msg on the queue
+  //
+  // This function is thread safe.
+  void push(UnmatchedReply&& reply);
+
+  // Wait for any messages to be pushed.
+  //
+  // This function is thread safe.
+  std::vector<UnmatchedReply> wait(std::chrono::milliseconds timeout);
+
+  // Clear the queue.
+  //
+  // This is only used when the receiver is deactivated.
+  // This function is threadsafe, but expected to be called by the client send thread when there is
+  // no waiter.
+  void clear();
+
+ private:
+  std::vector<UnmatchedReply> msgs_;
+  std::mutex lock_;
+  std::condition_variable cond_var_;
+};
+
+// A message receiver receives packed ClientReplyMsg structs off the wire. This is a
+// ClientReplyMsgHeader followed by opaque reply data.
+//
+// We want to destructure the reply into something sane for the rest of the client to handle.
+class MsgReceiver : public bft::communication::IReceiver {
+ public:
+  // IReceiver methods
+  // These are called from the ASIO thread when a new message is received.
+  void onNewMessage(const bft::communication::NodeNum sourceNode,
+                    const char* const message,
+                    const size_t messageLength) override;
+
+  void onConnectionStatusChanged(const bft::communication::NodeNum node,
+                                 const bft::communication::ConnectionStatus newStatus) override {}
+
+  // Wait for messages to be received.
+  //
+  // Return all received messages.
+  // Return an empty queue if timeout occurs.
+  //
+  // This should be called from the thread that calls `Client::send`.
+  std::vector<UnmatchedReply> wait(std::chrono::milliseconds timeout);
+
+  // We want to drop all replies when there isn't an outstanding request. We also want to know the
+  // max size of a reply for an outstanding request so we can drop replies that are too large. This
+  // method informs us that a request is in progress. A max_reply_size of 0 means no request is in
+  // progress and we should drop everything. Activate should never be called with max_reply_size of 0.
+  void activate(uint32_t max_reply_size);
+  void deactivate();
+
+ private:
+  std::atomic<uint32_t> max_reply_size_ = 0;
+  UnmatchedReplyQueue queue_;
+  logging::Logger logger_ = logging::getLogger("bftclient.msgreceiver");
+};
+
+}  // namespace bft::client

--- a/bftclient/src/quorums.cpp
+++ b/bftclient/src/quorums.cpp
@@ -1,0 +1,91 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use
+// this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license
+// terms. Your use of these subcomponents is subject to the terms and conditions of the
+// subcomponent's license, as noted in the LICENSE file.
+
+#include <algorithm>
+
+#include "bftclient/quorums.h"
+#include "bftclient/exception.h"
+
+namespace bft::client {
+
+MofN QuorumConverter::toMofN(const LinearizableQuorum& quorum) const {
+  MofN new_quorum;
+  new_quorum.wait_for = linearizable_quorum_size_;
+  if (quorum.destinations.empty()) {
+    // If the user doesn't provide destinations, send to all replicas
+    new_quorum.destinations = all_replicas_;
+  } else if (quorum.destinations.size() < new_quorum.wait_for) {
+    throw BadQuorumConfigException(
+        "Destination does not contain enough replicas for a linearizable quorum. Destination size: " +
+        std::to_string(quorum.destinations.size()) +
+        "is less than 2f + c + 1 = " + std::to_string(new_quorum.wait_for));
+  } else {
+    validateDestinations(quorum.destinations);
+    new_quorum.destinations = quorum.destinations;
+  }
+  return new_quorum;
+}
+
+MofN QuorumConverter::toMofN(const ByzantineSafeQuorum& quorum) const {
+  MofN new_quorum;
+  new_quorum.wait_for = bft_safe_quorum_size_;
+  if (quorum.destinations.empty()) {
+    // If the user doesn't provide a destination, send to all replicas
+    new_quorum.destinations = all_replicas_;
+  } else if (quorum.destinations.size() < new_quorum.wait_for) {
+    throw BadQuorumConfigException(
+        "Destination does not contain enough replicas for a byzantine fault tolerant quorum. Destination size: " +
+        std::to_string(quorum.destinations.size()) + "is less than f + 1 = " + std::to_string(new_quorum.wait_for));
+  } else {
+    validateDestinations(quorum.destinations);
+    new_quorum.destinations = quorum.destinations;
+  }
+  return new_quorum;
+}
+
+MofN QuorumConverter::toMofN(const All& quorum) const {
+  MofN new_quorum;
+  if (quorum.destinations.empty()) {
+    // If the user doesn't provide a destination, send to all replicas
+    new_quorum.wait_for = all_replicas_.size();
+    new_quorum.destinations = all_replicas_;
+  } else {
+    validateDestinations(quorum.destinations);
+    new_quorum.wait_for = quorum.destinations.size();
+    new_quorum.destinations = quorum.destinations;
+  }
+  return new_quorum;
+}
+
+MofN QuorumConverter::toMofN(const MofN& quorum) const {
+  if (quorum.wait_for > quorum.destinations.size()) {
+    throw BadQuorumConfigException("Invalid MofN config: wait_for: " + std::to_string(quorum.wait_for) +
+                                   " > destinations.size(): " + std::to_string(quorum.destinations.size()));
+  }
+  validateDestinations(quorum.destinations);
+  return quorum;
+}
+
+void QuorumConverter::validateDestinations(const std::set<ReplicaId>& destinations) const {
+  if (destinations.empty()) {
+    throw InvalidDestinationException();
+  }
+
+  ReplicaId captured;
+  if (std::any_of(destinations.begin(), destinations.end(), [this, &captured](auto replica_id) {
+        captured = replica_id;
+        return all_replicas_.count(replica_id) == 0;
+      })) {
+    throw InvalidDestinationException(captured);
+  }
+}
+
+}  // namespace bft::client

--- a/bftclient/test/CMakeLists.txt
+++ b/bftclient/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+find_package(GTest REQUIRED)
+
+add_executable(bft_client_test bft_client_test.cpp)
+add_test(bft_client_test bft_client_test)
+target_include_directories(bft_client_test PRIVATE ../src)
+target_link_libraries(bft_client_test PRIVATE
+  GTest::Main
+  GTest::GTest
+  bftclient2
+)
+
+add_executable(bft_client_api_tests bft_client_api_tests.cpp)
+add_test(bft_client_api_tests bft_client_api_tests)
+target_include_directories(bft_client_api_tests PRIVATE ../src)
+target_link_libraries(bft_client_api_tests PRIVATE
+  GTest::Main
+  GTest::GTest
+  bftclient2
+)

--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -1,0 +1,336 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the 'License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include <cstring>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "bftengine/ClientMsgs.hpp"
+#include "bftclient/bft_client.h"
+#include "msg_receiver.h"
+
+using namespace bft::client;
+using namespace bft::communication;
+
+// A message sent from a client
+struct MsgFromClient {
+  ReplicaId destination;
+  Msg data;
+};
+
+// A message queue used to send messages to the behavior thread faking the replicas
+class BehaviorQueue {
+ public:
+  // send a message from the client to the behavior thread
+  void push(MsgFromClient&& msg) {
+    {
+      std::lock_guard<std::mutex> guard(lock_);
+      msgs_.push_back(std::move(msg));
+    }
+    cond_var_.notify_one();
+  }
+
+  // Wait for client messages on the behavior thread
+  std::vector<MsgFromClient> wait(std::chrono::milliseconds timeout) {
+    std::vector<MsgFromClient> new_msgs;
+    std::unique_lock<std::mutex> lock(lock_);
+    cond_var_.wait_for(lock, timeout, [this] { return !msgs_.empty(); });
+    if (!msgs_.empty()) {
+      msgs_.swap(new_msgs);
+    }
+    return new_msgs;
+  }
+
+ private:
+  std::vector<MsgFromClient> msgs_;
+  std::mutex lock_;
+  std::condition_variable cond_var_;
+};
+
+using Behavior = std::function<void(MsgFromClient, IReceiver*)>;
+
+// Take a callable behavior and run it when a message is received that is intended for a replica.
+class BehaviorThreadRunner {
+ public:
+  BehaviorThreadRunner(Behavior&& b) : behavior_(std::move(b)) {}
+
+  // Replies to the client from the behavior thread are sent using this receiver
+  void setClientReceiver(IReceiver* receiver) { receiver_ = receiver; }
+
+  // send messages to the behavior thread
+  void send(MsgFromClient&& msg) { msg_queue_.push(std::move(msg)); }
+
+  void operator()() {
+    while (!stop_) {
+      auto received = msg_queue_.wait(1s);
+      for (const auto& msg : received) {
+        behavior_(msg, receiver_);
+      }
+    }
+  }
+
+  void stop() { stop_ = true; }
+
+ private:
+  IReceiver* receiver_;
+  std::atomic<bool> stop_ = false;
+
+  Behavior behavior_;
+
+  // This is used to receive messages sent from the client thread with sendAsyncMessage.
+  BehaviorQueue msg_queue_;
+};
+
+// This communication fake takes a Behavior callback parameterized by each test. This callback
+// receives messages sent into the network via sendAsyncMessage. Depending on the test specific
+// behavior it replies with the appropriate reply messages to the receiver.
+//
+// sendAsyncMessage is called by the client thread (the test itself). Any receiver callbacks must be run in another
+// thread or a deadlock will result over the locking of the underlying queue in the receiver. The client thread waits
+// on the queue, while the communication thread puts received messages (from fake BFT servers) on the queue by calling
+// receiver_->onNewMessage();
+class FakeCommunication : public bft::communication::ICommunication {
+ public:
+  FakeCommunication(Behavior&& behavior) : runner_(std::move(behavior)) {}
+
+  int getMaxMessageSize() override { return 1024; }
+  int Start() override {
+    runner_.setClientReceiver(receiver_);
+    fakeCommThread_ = std::thread(std::ref(runner_));
+    return 0;
+  }
+  int Stop() override {
+    runner_.stop();
+    fakeCommThread_.join();
+    return 0;
+  }
+  bool isRunning() const override { return true; }
+  ConnectionStatus getCurrentConnectionStatus(NodeNum node) override { return ConnectionStatus{}; }
+
+  int sendAsyncMessage(const NodeNum dest, const char* const msg, const size_t len) override {
+    runner_.send(MsgFromClient{ReplicaId{(uint16_t)dest}, Msg(msg, msg + len)});
+    return 0;
+  }
+
+  void setReceiver(NodeNum id, IReceiver* receiver) override { receiver_ = receiver; }
+
+ private:
+  IReceiver* receiver_;
+  BehaviorThreadRunner runner_;
+  std::thread fakeCommThread_;
+};
+
+ClientConfig test_config{
+    ClientId{5}, {ReplicaId{0}, ReplicaId{1}, ReplicaId{2}, ReplicaId{3}}, 1, 0, RetryTimeoutConfig{}};
+
+// Just print all received messages from a client
+#include <iostream>
+void PrintBehavior(const MsgFromClient& msg, IReceiver* client_receiver) {
+  std::cout << "Received message for " << msg.destination.val << std::endl;
+}
+
+TEST(client_api_tests, print_received_messages_and_timeout) {
+  std::unique_ptr<FakeCommunication> comm(new FakeCommunication(PrintBehavior));
+  Client client(std::move(comm), test_config);
+  ReadConfig read_config{RequestConfig{false, 1}, All{}};
+  read_config.request.timeout = 500ms;
+  ASSERT_THROW(client.send(read_config, Msg({1, 2, 3, 4, 5})), TimeoutException);
+  client.stop();
+}
+
+Msg replyFromRequest(const MsgFromClient& request) {
+  const auto* req_header = reinterpret_cast<const bftEngine::ClientRequestMsgHeader*>(request.data.data());
+  std::string reply_data = "world";
+  auto reply_header_size = sizeof(bftEngine::ClientReplyMsgHeader);
+  Msg reply(reply_header_size + reply_data.size());
+
+  auto* reply_header = reinterpret_cast<bftEngine::ClientReplyMsgHeader*>(reply.data());
+  reply_header->currentPrimaryId = 0;
+  reply_header->msgType = REPLY_MSG_TYPE;
+  reply_header->replicaSpecificInfoLength = 0;
+  reply_header->replyLength = reply.size();
+  reply_header->reqSeqNum = req_header->reqSeqNum;
+  reply_header->spanContextSize = 0;
+
+  // Copy the reply data;
+  std::memcpy(reply.data() + reply_header_size, reply_data.data(), reply_data.size());
+
+  return reply;
+}
+
+Msg replyFromRequestWithRSI(const MsgFromClient& request, const Msg& rsi) {
+  const auto* req_header = reinterpret_cast<const bftEngine::ClientRequestMsgHeader*>(request.data.data());
+  std::string reply_data = "world";
+  auto reply_header_size = sizeof(bftEngine::ClientReplyMsgHeader);
+  Msg reply(reply_header_size + reply_data.size() + rsi.size());
+
+  auto* reply_header = reinterpret_cast<bftEngine::ClientReplyMsgHeader*>(reply.data());
+  reply_header->currentPrimaryId = 0;
+  reply_header->msgType = REPLY_MSG_TYPE;
+  reply_header->replicaSpecificInfoLength = rsi.size();
+  reply_header->replyLength = reply.size();
+  reply_header->reqSeqNum = req_header->reqSeqNum;
+  reply_header->spanContextSize = 0;
+
+  // Copy the reply data;
+  std::memcpy(reply.data() + reply_header_size, reply_data.data(), reply_data.size());
+
+  // Copy the RSI data
+  std::memcpy(reply.data() + reply_header_size + reply_data.size(), rsi.data(), rsi.size());
+
+  return reply;
+}
+
+// Wait for a single retry then return all replies
+class RetryBehavior {
+ public:
+  void operator()(const MsgFromClient& msg, IReceiver* client_receiver) {
+    not_heard_from_yet.erase(msg.destination);
+    if (not_heard_from_yet.empty()) {
+      auto reply = replyFromRequest(msg);
+      client_receiver->onNewMessage((NodeNum)msg.destination.val, (const char*)reply.data(), reply.size());
+    }
+  }
+
+ private:
+  std::set<ReplicaId> not_heard_from_yet = test_config.all_replicas;
+};
+
+TEST(client_api_tests, receive_reply_after_retry_timeout) {
+  std::unique_ptr<FakeCommunication> comm(new FakeCommunication(RetryBehavior{}));
+  Client client(std::move(comm), test_config);
+  ReadConfig read_config{RequestConfig{false, 1}, All{}};
+  read_config.request.timeout = 1s;
+  auto reply = client.send(read_config, Msg({'h', 'e', 'l', 'l', 'o'}));
+  Msg expected{'w', 'o', 'r', 'l', 'd'};
+  ASSERT_EQ(expected, reply.matched_data);
+  for (auto& rsi : reply.rsi) {
+    ASSERT_TRUE(rsi.second.empty());
+  }
+  client.stop();
+}
+
+static constexpr NodeNum bad_replica_id = 0xbad1d;
+
+TEST(client_api_tests, test_ignore_reply_from_wrong_replica) {
+  std::atomic<bool> sent_reply_from_wrong_replica = false;
+  std::atomic<bool> sent_reply_from_correct_replica = false;
+  auto WrongReplicaBehavior = [&](const MsgFromClient& msg, IReceiver* client_receiver) {
+    auto reply = replyFromRequest(msg);
+    if (!sent_reply_from_wrong_replica) {
+      client_receiver->onNewMessage(bad_replica_id, (const char*)reply.data(), reply.size());
+      sent_reply_from_wrong_replica = true;
+    } else {
+      // We have to update the bool first, since this runs in a separate thread from the test below. Otherwise we could
+      // check the value of the bool after the match, but before the bool was set. Setting it early does no harm, as the
+      // intention is just to show that the callback fired, which it clearly will. The code will block until the
+      // callback fires anyway. Comment out the callback and rerun if you don't believe me :)
+      sent_reply_from_correct_replica = true;
+      client_receiver->onNewMessage((NodeNum)msg.destination.val, (const char*)reply.data(), reply.size());
+    }
+  };
+
+  std::unique_ptr<FakeCommunication> comm(new FakeCommunication(WrongReplicaBehavior));
+  Client client(std::move(comm), test_config);
+  ReadConfig read_config{RequestConfig{false, 1}, All{{ReplicaId{1}}}};
+  read_config.request.timeout = 1s;
+  auto reply = client.send(read_config, Msg({'h', 'e', 'l', 'l', 'o'}));
+  Msg expected{'w', 'o', 'r', 'l', 'd'};
+  ASSERT_EQ(expected, reply.matched_data);
+  ASSERT_EQ(reply.rsi.size(), 1);
+  ASSERT_EQ(reply.rsi.count(ReplicaId{1}), 1);
+  ASSERT_TRUE(sent_reply_from_wrong_replica);
+  ASSERT_TRUE(sent_reply_from_correct_replica);
+  client.stop();
+}
+
+TEST(client_api_tests, primary_gets_learned_on_successful_write_and_cleared_on_timeout) {
+  // Writes should initially go to all replicas
+  std::atomic<bool> quorum_of_replies_sent = false;
+
+  auto WriteBehavior = [&](const MsgFromClient& msg, IReceiver* client_receiver) {
+    static std::set<ReplicaId> not_heard_from_yet = test_config.all_replicas;
+    auto reply = replyFromRequest(msg);
+    // Check for linearizable quorum
+    if (not_heard_from_yet.size() != 1) {
+      not_heard_from_yet.erase(msg.destination);
+      if (not_heard_from_yet.size() == 1) {
+        quorum_of_replies_sent = true;
+      }
+      client_receiver->onNewMessage((NodeNum)msg.destination.val, (const char*)reply.data(), reply.size());
+    }
+  };
+
+  std::unique_ptr<FakeCommunication> comm(new FakeCommunication(WriteBehavior));
+  Client client(std::move(comm), test_config);
+  WriteConfig config{RequestConfig{false, 1}, LinearizableQuorum{}};
+  config.request.timeout = 500ms;
+  auto reply = client.send(config, Msg({'h', 'e', 'l', 'l', 'o'}));
+  Msg expected{'w', 'o', 'r', 'l', 'd'};
+  ASSERT_EQ(expected, reply.matched_data);
+  ASSERT_EQ(reply.rsi.size(), 3);
+  ASSERT_TRUE(quorum_of_replies_sent);
+  ASSERT_EQ(client.primary(), ReplicaId{0});
+  ASSERT_THROW(client.send(config, Msg({1, 2, 3, 4, 5})), TimeoutException);
+  ASSERT_FALSE(client.primary().has_value());
+  client.stop();
+}
+
+TEST(client_api_tests, write_f_plus_one) {
+  auto WriteBehavior = [&](const MsgFromClient& msg, IReceiver* client_receiver) {
+    auto reply = replyFromRequest(msg);
+    client_receiver->onNewMessage((NodeNum)msg.destination.val, (const char*)reply.data(), reply.size());
+  };
+
+  std::unique_ptr<FakeCommunication> comm(new FakeCommunication(WriteBehavior));
+  Client client(std::move(comm), test_config);
+  // Ensure we only wait for F+1 replies (ByzantineSafeQuorum)
+  WriteConfig config{RequestConfig{false, 1}, ByzantineSafeQuorum{}};
+  config.request.timeout = 500ms;
+  auto reply = client.send(config, Msg({'h', 'e', 'l', 'l', 'o'}));
+  Msg expected{'w', 'o', 'r', 'l', 'd'};
+  ASSERT_EQ(expected, reply.matched_data);
+  ASSERT_EQ(reply.rsi.size(), 2);
+  ASSERT_EQ(client.primary(), ReplicaId{0});
+  client.stop();
+}
+
+TEST(client_api_tests, write_f_plus_one_get_differnt_rsi) {
+  std::map<ReplicaId, Msg> rsi = {{ReplicaId{0}, {0}}, {ReplicaId{1}, {1}}};
+  auto WriteBehavior = [&](const MsgFromClient& msg, IReceiver* client_receiver) {
+    if (msg.destination.val == 0 || msg.destination.val == 1) {
+      auto reply = replyFromRequestWithRSI(msg, rsi[msg.destination]);
+      client_receiver->onNewMessage((NodeNum)msg.destination.val, (const char*)reply.data(), reply.size());
+    }
+  };
+
+  std::unique_ptr<FakeCommunication> comm(new FakeCommunication(WriteBehavior));
+  Client client(std::move(comm), test_config);
+  // Ensure we only wait for F+1 replies (ByzantineSafeQuorum)
+  WriteConfig config{RequestConfig{false, 1}, ByzantineSafeQuorum{}};
+  config.request.timeout = 500ms;
+  auto reply = client.send(config, Msg({'h', 'e', 'l', 'l', 'o'}));
+  Msg expected{'w', 'o', 'r', 'l', 'd'};
+  ASSERT_EQ(expected, reply.matched_data);
+  ASSERT_EQ(reply.rsi.size(), 2);
+  ASSERT_EQ(reply.rsi, rsi);
+  ASSERT_EQ(client.primary(), ReplicaId{0});
+  client.stop();
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/bftclient/test/bft_client_test.cpp
+++ b/bftclient/test/bft_client_test.cpp
@@ -1,0 +1,361 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the 'License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "bftengine/ClientMsgs.hpp"
+
+#include "msg_receiver.h"
+#include "bftclient/bft_client.h"
+
+using namespace bft::client;
+
+TEST(msg_receiver_tests, unmatched_replies_returned_no_rsi) {
+  MsgReceiver receiver;
+  receiver.activate(64 * 1024);
+  auto data_len = 20u;
+  std::vector<char> reply(sizeof(bftEngine::ClientReplyMsgHeader) + data_len);
+
+  // Fill in the header part of the reply
+  auto* header = reinterpret_cast<bftEngine::ClientReplyMsgHeader*>(reply.data());
+  header->msgType = REPLY_MSG_TYPE;
+  header->currentPrimaryId = 1;
+  header->reqSeqNum = 100;
+  header->replyLength = sizeof(bftEngine::ClientReplyMsgHeader) + data_len;
+  header->replicaSpecificInfoLength = 0;
+
+  // Handle the message
+  auto source = 1;
+  receiver.onNewMessage(source, reply.data(), reply.size());
+
+  // Wait to see that the message gets properly unpacked and delivered.
+  auto replies = receiver.wait(1ms);
+
+  ASSERT_EQ(1, replies.size());
+  ASSERT_EQ(header->currentPrimaryId, replies[0].metadata.primary.val);
+  ASSERT_EQ(header->reqSeqNum, replies[0].metadata.seq_num);
+  ASSERT_EQ(Msg(data_len), replies[0].data);
+  ASSERT_EQ(1, replies[0].rsi.from.val);
+  ASSERT_EQ(0, replies[0].rsi.data.size());
+}
+
+TEST(msg_receiver_tests, unmatched_replies_with_rsi) {
+  MsgReceiver receiver;
+  receiver.activate(64 * 1024);
+  auto data_len = 20u;
+  std::vector<char> reply(sizeof(bftEngine::ClientReplyMsgHeader) + data_len);
+
+  // Fill in the header part of the reply
+  auto* header = reinterpret_cast<bftEngine::ClientReplyMsgHeader*>(reply.data());
+  header->msgType = REPLY_MSG_TYPE;
+  header->currentPrimaryId = 1;
+  header->reqSeqNum = 100;
+  header->replyLength = sizeof(bftEngine::ClientReplyMsgHeader) + data_len;
+  header->replicaSpecificInfoLength = 5;
+
+  // Handle the message
+  auto source = 1;
+  receiver.onNewMessage(source, reply.data(), reply.size());
+
+  // Wait to see that the message gets properly unpacked and delivered.
+  auto replies = receiver.wait(1ms);
+
+  ASSERT_EQ(1, replies.size());
+  ASSERT_EQ(header->currentPrimaryId, replies[0].metadata.primary.val);
+  ASSERT_EQ(header->reqSeqNum, replies[0].metadata.seq_num);
+  ASSERT_EQ(Msg(data_len - header->replicaSpecificInfoLength), replies[0].data);
+  ASSERT_EQ(1, replies[0].rsi.from.val);
+  ASSERT_EQ(Msg(header->replicaSpecificInfoLength), replies[0].rsi.data);
+}
+
+TEST(msg_receiver_tests, no_replies_small_msg) {
+  MsgReceiver receiver;
+  receiver.activate(64 * 1024);
+  std::vector<char> reply(sizeof(bftEngine::ClientReplyMsgHeader) - 1);
+
+  // Handle the message
+  auto source = 1;
+  receiver.onNewMessage(source, reply.data(), reply.size());
+
+  // Wait to see that the message gets properly unpacked and delivered.
+  auto replies = receiver.wait(1ms);
+
+  ASSERT_EQ(0, replies.size());
+}
+
+TEST(msg_receiver_tests, no_replies_bad_msg_type) {
+  MsgReceiver receiver;
+  receiver.activate(64 * 1024);
+  std::vector<char> reply(sizeof(bftEngine::ClientReplyMsgHeader) + 20);
+
+  // Fill in the header part of the reply
+  auto* header = reinterpret_cast<bftEngine::ClientReplyMsgHeader*>(reply.data());
+  header->msgType = REQUEST_MSG_TYPE;
+
+  // Handle the message
+  auto source = 1;
+  receiver.onNewMessage(source, reply.data(), reply.size());
+
+  // Wait to see that the message gets properly unpacked and delivered.
+  auto replies = receiver.wait(1ms);
+  ASSERT_EQ(0, replies.size());
+}
+
+std::set<ReplicaId> destinations(uint16_t n) {
+  std::set<ReplicaId> replicas;
+  for (uint16_t i = 0; i < n; i++) {
+    replicas.insert(ReplicaId{i});
+  }
+  return replicas;
+}
+
+std::vector<ReplicaSpecificInfo> create_rsi(uint16_t n) {
+  std::vector<ReplicaSpecificInfo> rsi;
+  for (uint16_t i = 0; i < n; i++) {
+    rsi.push_back(ReplicaSpecificInfo{ReplicaId{i}, {(uint8_t)i}});
+  }
+  return rsi;
+}
+
+std::vector<UnmatchedReply> unmatched_replies(uint16_t n,
+                                              ReplyMetadata metadata,
+                                              const Msg& msg,
+                                              const std::vector<ReplicaSpecificInfo>& rsi) {
+  assert(n <= rsi.size());
+  std::vector<UnmatchedReply> replies;
+  for (uint16_t i = 0; i < n; i++) {
+    replies.emplace_back(UnmatchedReply{metadata, msg, rsi[i]});
+  }
+  return replies;
+}
+
+TEST(matcher_tests, wait_for_1_out_of_1) {
+  ReplicaId source{1};
+  uint64_t seq_num = 5;
+  MatchConfig config{MofN{1, {source}}, seq_num};
+  Matcher matcher(config);
+
+  Msg msg = {'h', 'e', 'l', 'l', 'o'};
+  auto rsi = ReplicaSpecificInfo{source, {'r', 's', 'i'}};
+
+  ReplicaId primary{1};
+  UnmatchedReply reply{ReplyMetadata{primary, seq_num}, msg, rsi};
+  auto match = matcher.onReply(std::move(reply));
+  ASSERT_TRUE(match.has_value());
+  ASSERT_EQ(match.value().reply.matched_data, msg);
+  ASSERT_EQ(match.value().reply.rsi[source], rsi.data);
+  ASSERT_EQ(match.value().primary.value(), primary);
+}
+
+TEST(matcher_tests, wait_for_3_out_of_4) {
+  uint64_t seq_num = 5;
+  auto sources = destinations(4);
+  MatchConfig config{MofN{3, sources}, seq_num};
+  Matcher matcher(config);
+  ReplicaId primary{1};
+  Msg msg = {'h', 'e', 'l', 'l', 'o'};
+  auto unmatched = unmatched_replies(4, ReplyMetadata{primary, seq_num}, msg, create_rsi(4));
+
+  // The first two replies don't have quorum. So we get back a nullopt;
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(unmatched[0])));
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(unmatched[1])));
+
+  // The third matching reply should trigger success
+  auto match = matcher.onReply(std::move(unmatched[2]));
+  ASSERT_TRUE(match.has_value());
+  ASSERT_EQ(match.value().reply.matched_data, msg);
+  ASSERT_EQ(match.value().primary.value(), primary);
+  ASSERT_EQ(3, match.value().reply.rsi.size());
+  for (auto i = 0u; i < match.value().reply.rsi.size(); i++) {
+    const auto& rsi_data = match.value().reply.rsi[ReplicaId{(uint16_t)i}];
+    Msg expected{(uint8_t)i};
+    ASSERT_EQ(expected, rsi_data);
+  }
+}
+
+TEST(matcher_tests, wait_for_3_out_of_4_with_mismatches_and_dupes) {
+  uint64_t seq_num = 5;
+  auto sources = destinations(4);
+  MatchConfig config{MofN{3, sources}, seq_num};
+  Matcher matcher(config);
+  ReplicaId primary{1};
+  Msg msg = {'h', 'e', 'l', 'l', 'o'};
+  auto unmatched = unmatched_replies(4, ReplyMetadata{primary, seq_num}, msg, create_rsi(4));
+
+  auto dup = unmatched[1];
+
+  auto diff_rsi = dup;
+  diff_rsi.rsi.data = {'x'};
+
+  auto bad_seq_num = dup;
+  bad_seq_num.metadata.seq_num = 4;
+
+  auto non_matching_data = unmatched[3];
+  non_matching_data.data.push_back('x');
+
+  // The first two replies don't have quorum. So we get back a nullopt;
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(unmatched[0])));
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(unmatched[1])));
+
+  // Inserting a duplicate of the last message doesn't trigger quorum.
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(dup)));
+
+  // Inserting the same message but with different rsi doesn't trigger quorum (it overwrites).
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(diff_rsi)));
+
+  // Inserting the same message but with diff sequence number doesn't trigger quorum
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(bad_seq_num)));
+
+  // Inserting a message from a new replica, but where the data doesn't match doesn't trigger quorum
+  ASSERT_EQ(std::nullopt, matcher.onReply(std::move(non_matching_data)));
+
+  // Finally, inserting a 3rd match triggers success
+  auto match = matcher.onReply(std::move(unmatched[2]));
+  ASSERT_TRUE(match.has_value());
+  ASSERT_EQ(match.value().reply.matched_data, msg);
+  ASSERT_EQ(match.value().primary.value(), primary);
+  ASSERT_EQ(3, match.value().reply.rsi.size());
+  for (auto i = 0u; i < match.value().reply.rsi.size(); i++) {
+    const auto& rsi_data = match.value().reply.rsi[ReplicaId{(uint16_t)i}];
+    Msg expected{(uint8_t)i};
+    if (i == 1) {
+      ASSERT_EQ(Msg{'x'}, rsi_data);
+    } else {
+      ASSERT_EQ(expected, rsi_data);
+    }
+  }
+}
+
+TEST(quorum_tests, valid_quorums_without_destinations) {
+  auto all_replicas = destinations(4);
+  uint16_t f_val = 1;
+  uint16_t c_val = 0;
+
+  QuorumConverter qc(all_replicas, f_val, c_val);
+
+  // Quorums without destinations should always work, unless they are MofN.
+  {
+    auto quorum = LinearizableQuorum{};
+    auto output = qc.toMofN(quorum);
+    ASSERT_EQ(3, output.wait_for);
+    ASSERT_EQ(all_replicas, output.destinations);
+  }
+  {
+    auto quorum = ByzantineSafeQuorum{};
+    auto output = qc.toMofN(quorum);
+    ASSERT_EQ(2, output.wait_for);
+    ASSERT_EQ(all_replicas, output.destinations);
+  }
+  {
+    auto quorum = All{};
+    auto output = qc.toMofN(quorum);
+    ASSERT_EQ(4, output.wait_for);
+    ASSERT_EQ(all_replicas, output.destinations);
+  }
+
+  // MofN Quorums must have destinations
+  {
+    auto quorum = MofN{};
+    ASSERT_THROW(qc.toMofN(quorum), InvalidDestinationException);
+  }
+}
+
+TEST(quorum_tests, valid_quorums_with_destinations) {
+  auto all_replicas = destinations(4);
+  uint16_t f_val = 1;
+  uint16_t c_val = 0;
+
+  QuorumConverter qc(all_replicas, f_val, c_val);
+
+  {
+    auto quorum = LinearizableQuorum{destinations(3)};
+    auto output = qc.toMofN(quorum);
+    ASSERT_EQ(3, output.wait_for);
+    ASSERT_EQ(destinations(3), output.destinations);
+  }
+  {
+    auto quorum = ByzantineSafeQuorum{destinations(2)};
+    auto output = qc.toMofN(quorum);
+    ASSERT_EQ(2, output.wait_for);
+    ASSERT_EQ(destinations(2), output.destinations);
+  }
+  {
+    auto quorum = All{destinations(1)};
+    auto output = qc.toMofN(quorum);
+    ASSERT_EQ(1, output.wait_for);
+    ASSERT_EQ(destinations(1), output.destinations);
+  }
+
+  {
+    auto quorum = MofN{2, destinations(3)};
+    auto output = qc.toMofN(quorum);
+    ASSERT_EQ(2, output.wait_for);
+    ASSERT_EQ(destinations(3), output.destinations);
+  }
+}
+
+TEST(quorum_tests, invalid_destinations) {
+  auto all_replicas = destinations(4);
+  uint16_t f_val = 1;
+  uint16_t c_val = 0;
+
+  QuorumConverter qc(all_replicas, f_val, c_val);
+
+  auto invalid_replicas = destinations(2);
+  invalid_replicas.insert(ReplicaId{7});
+  {
+    auto quorum = LinearizableQuorum{invalid_replicas};
+    ASSERT_THROW(qc.toMofN(quorum), InvalidDestinationException);
+  }
+  {
+    auto quorum = ByzantineSafeQuorum{invalid_replicas};
+    ASSERT_THROW(qc.toMofN(quorum), InvalidDestinationException);
+  }
+  {
+    auto quorum = All{invalid_replicas};
+    ASSERT_THROW(qc.toMofN(quorum), InvalidDestinationException);
+  }
+  {
+    auto quorum = MofN{1, invalid_replicas};
+    ASSERT_THROW(qc.toMofN(quorum), InvalidDestinationException);
+  }
+}
+
+TEST(quorum_tests, bad_quorum_configs) {
+  auto all_replicas = destinations(4);
+  uint16_t f_val = 1;
+  uint16_t c_val = 0;
+
+  QuorumConverter qc(all_replicas, f_val, c_val);
+
+  {
+    // Destinations is less than 2F + C + 1
+    auto quorum = LinearizableQuorum{destinations(2)};
+    ASSERT_THROW(qc.toMofN(quorum), BadQuorumConfigException);
+  }
+  {
+    // Destinations is less than F + 1
+    auto quorum = ByzantineSafeQuorum{destinations(1)};
+    ASSERT_THROW(qc.toMofN(quorum), BadQuorumConfigException);
+  }
+  {
+    // wait_for > destinations.size()
+    auto wait_for = 3u;
+    auto quorum = MofN{wait_for, destinations(1)};
+    ASSERT_THROW(qc.toMofN(quorum), BadQuorumConfigException);
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -71,6 +71,8 @@ find_package(Threads REQUIRED)
 add_library(corebft STATIC ${corebft_source_files})
 add_library(bftclient STATIC src/bftengine/SimpleClientImp)
 add_library(bftclient_shared SHARED src/bftengine/SimpleClientImp)
+add_library(bftheaders INTERFACE)
+target_include_directories(bftheaders INTERFACE include)
 
 find_package(cryptopp REQUIRED)
 

--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -15,6 +15,7 @@
 
 #define REQUEST_MSG_TYPE (700)
 #define REPLY_MSG_TYPE (800)
+#define PRE_PROCESS_REQUEST_MSG_TYPE (500)
 
 namespace bftEngine {
 
@@ -39,8 +40,16 @@ struct ClientReplyMsgHeader {
   uint32_t spanContextSize = 0u;
   uint16_t currentPrimaryId;
   uint64_t reqSeqNum;
+
+  // Reply length is the total length of the reply, including any replica specific info.
   uint32_t replyLength;
+
+  // This is the size of the replica specific information. If it is 0, there is no replica specific
+  // information. The offset of the replica specific information from the start of the reply message
+  // is `replyLength - replicaSpecificInfoLength`.
+  uint32_t replicaSpecificInfoLength = 0;
 };
+
 #pragma pack(pop)
 
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
@@ -17,14 +17,14 @@
 namespace bftEngine {
 namespace impl {
 
-// TODO(GG): rename class
+// A ClientReplyMsg is simply a ClientReplyMessageHeader: header, followed by an opaque body of
+// length header.replyLength.
 class ClientReplyMsg : public MessageBase {
   static_assert((uint16_t)REPLY_MSG_TYPE == (uint16_t)MsgCode::ClientReply, "");
   static_assert(sizeof(ClientReplyMsgHeader::msgType) == sizeof(MessageBase::Header::msgType), "");
   static_assert(sizeof(ClientReplyMsgHeader::reqSeqNum) == sizeof(ReqId), "");
   static_assert(sizeof(ClientReplyMsgHeader::currentPrimaryId) == sizeof(ReplicaId), "");
-  static_assert(sizeof(ClientReplyMsgHeader) == 20, "ClientRequestMsgHeader is 20B");
-  // TODO(GG): more asserts
+  static_assert(sizeof(ClientReplyMsgHeader) == 24, "ClientRequestMsgHeader is 24B");
 
  public:
   ClientReplyMsg(ReplicaId primaryId, ReqId reqSeqNum, ReplicaId replicaId);

--- a/bftengine/src/bftengine/messages/MsgCode.hpp
+++ b/bftengine/src/bftengine/messages/MsgCode.hpp
@@ -39,7 +39,7 @@ class MsgCode {
     ReqMissingData,
     StateTransfer,
 
-    ClientPreProcessRequest,
+    ClientPreProcessRequest = 500,
     PreProcessRequest,
     PreProcessReply,
 

--- a/util/include/DynamicUpperLimitWithSimpleFilter.hpp
+++ b/util/include/DynamicUpperLimitWithSimpleFilter.hpp
@@ -28,7 +28,7 @@ class DynamicUpperLimitWithSimpleFilter {
                                     int16_t resetPoint,
                                     double maxIncreasingFactor,
                                     double maxDecreasingFactor)
-      : numOfS{s},
+      : numOfStdDeviations{s},
         maxLimit{maxUpperLimit},
         minLimit{minUpperLimit},
         evalPeriod{evalPeriod},
@@ -60,7 +60,7 @@ class DynamicUpperLimitWithSimpleFilter {
     const double var = avgAndVar.var();
     const double sd = ((var > 0) ? sqrt(var) : 0);
 
-    double newLimit = avg + numOfS * sd;
+    double newLimit = avg + numOfStdDeviations * sd;
 
     if (((T)newLimit) > maxVal)
       currentUpperLimit = maxVal;
@@ -75,7 +75,7 @@ class DynamicUpperLimitWithSimpleFilter {
   virtual T upperLimit() { return currentUpperLimit; }
 
  protected:
-  const int16_t numOfS;
+  const int16_t numOfStdDeviations;
 
   const T maxLimit;
   const T minLimit;


### PR DESCRIPTION
This new client is intended to be the canonical BFT client for C++
applications. It's expected that in the future other languages will
have their own clients. A future commit will modify the existing Python
client used in Apollo tests to have the same capabilities as this client.

This client introduces support for variably sized quorums and replica
specific information (RSI). Replica specific information is data
specific to each replica returned with a reply, that is excluded from
quorum matching. The RSI for each replica is returned along with the
respons to a `Client::Send` call. The client API exists in
`bft_client.h`, with the primary functionality being the blocking `Send`
function. Send is split into 2 different overloads: one for reading and
one for writing. This enables compiler driven typechecks, since reads
and writes support different quorums. Writes only support `Linearizable`
(2F+c+1) and `ByzantineSafe` (F+1) quorums, while reads support both of
those plus `All` and `MofN` quorums.

The four types of quorums are defined in quorum.h and each can be
parameterized by the destinations to send to. If no destinations are
given, then all replicas in the `ClientConfig` struct are used. If
specific destinations are given, they must contain enough replicas to be
safe. For example, in a `ClientConfig` that contains 4 replicas with an
`f_val` of 1, a `LinearizableQuorum` must contain at least 3
unique destinations, and those destinations must be replicas listed in
the ClientConfig. Additionally, all quorums can be converted to MofN
quorums. This conversion is done internally so that the `Matcher`
component does not need to work with multiple quorums. The reason we
don't just pass an MofN quorum is both for legibility, type safety in
Client::Send calls and to allow reasonable defaults. For example, all
current code is expected to issue writes with `LinearizableQuorums`, and
not need to fill in the destinations. This mimics SimpleClient.

There are 2 primary threads that communicate with each other in client
operations. The user of the client has a thread that calls
`Client::Send`. This thread blocks, waiting for a quorum of matching
replies from the caller. The other thread is the thread running the
`Communication` instance. It sends and receives raw messages to/from the
network. Received messages are translated into `UnmatchedReply` structs
and put on a queue to be sent to the Client::Thread where they can be
matched and quorum can be checked. The loop for this is done in
`bft_client.cpp` and utilizes a `Client::Wait` call to get replies.

This code base is split up into a few files containing core classes:

 * `bft_client.h/.cpp` - The main API of the client.
 * `base_types.h` - Types used throughout the rest of the
 client
 * `config.h` - All configuration structs. Each of these should
 be self explanatory. The top level configurations are `WriteConfig` and
 `ReadConfig` that get passed to the `Client::Send` function, which is
 the main API function of the library.
 * `exception.h` - Exceptions that can be thrown by the library
 * `quorums.h/.cpp` - All quorum structs, validation, and conversion
 *  `seq_num_generator.h` - The mechanism for generating sequence
 numbers used by SimpleClient. It's a separate class/file to emphasize
 that it is optional for users of the client.
 * `matcher.h/.cpp` - Matches a quorum of replies to ensure it can
 return them to the caller of ClientSend.
 * `msg_receiver.h/.cpp` - The implementation of the `IReceiver`
 interface of the communication module. Raw replies received from the
 network are handled in `MsgReceiver::onNewMessage`, converted to a
 message independent format, `UnmatchedReply`, and put onto a queue so
 they can be matched.

There are also unit tests for the MsgReceiver, Matcher, and quorums in
`bft_client_test.cpp`. There are higher level unit tests for the Client
API in `bft_client_api_tests.cpp`. These tests mock out the
communication layer, and utilize `Behaviors` which pretend to be the
replica network and send replies to client requests. A Behavior is just
a callback function that can send replies. The behavior runs in the
context of the `FakeCommunication` thread and therefore must communicate
with the real client API by using the msg receiver to return replies.