### PR TITLE
clang-tidy: additional bugprone checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,11 +8,6 @@ Checks:             '-*,bugprone-*,
                     -bugprone-misplaced-widening-cast,
                     -bugprone-narrowing-conversions,
                     -bugprone-not-null-terminated-result,
-                    -bugprone-signed-char-misuse,
-                    -bugprone-suspicious-string-compare,
-                    -bugprone-undefined-memory-manipulation,
-                    -bugprone-unused-return-value,
-                    -bugprone-too-small-loop-variable,
                     -bugprone-exception-escape
                     '
 WarningsAsErrors:   'bugprone-*,
@@ -24,16 +19,11 @@ WarningsAsErrors:   'bugprone-*,
                     -bugprone-misplaced-widening-cast,
                     -bugprone-narrowing-conversions,
                     -bugprone-not-null-terminated-result,
-                    -bugprone-signed-char-misuse,
-                    -bugprone-suspicious-string-compare,
-                    -bugprone-undefined-memory-manipulation,
-                    -bugprone-unused-return-value,
-                    -bugprone-too-small-loop-variable,
                     -bugprone-exception-escape
                     '
+# -bugprone-exception-escape - main functions throwing exceptions are OK: we prefer analyze core dumps
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
 ...
-

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -526,13 +526,13 @@ void BCStateTran::getDigestOfCheckpoint(uint64_t checkpointNumber, uint16_t size
   STDigest checkpointDigest;
   DigestContext c;
   c.update(reinterpret_cast<char *>(&desc), sizeof(desc));
-  c.writeDigest(reinterpret_cast<char *>(&checkpointDigest));
+  c.writeDigest(checkpointDigest.getForUpdate());
 
   LOG_INFO(STLogger,
            KVLOG(desc.checkpointNum, desc.digestOfLastBlock, desc.digestOfResPagesDescriptor, checkpointDigest));
 
   uint16_t s = std::min((uint16_t)sizeof(STDigest), sizeOfDigestBuffer);
-  memcpy(outDigestBuffer, &checkpointDigest, s);
+  memcpy(outDigestBuffer, checkpointDigest.get(), s);
   if (s < sizeOfDigestBuffer) {
     memset(outDigestBuffer + s, 0, sizeOfDigestBuffer - s);
   }

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
@@ -141,6 +141,8 @@ DataStore::CheckpointDesc InMemoryDataStore::getCheckpointBeingFetched() {
 bool InMemoryDataStore::hasCheckpointBeingFetched() { return (checkpointBeingFetched.checkpointNum != 0); }
 
 void InMemoryDataStore::deleteCheckpointBeingFetched() {
+  // TODO(DD): Create a ctor for CheckpointDesc?
+  // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
   memset(&checkpointBeingFetched, 0, sizeof(checkpointBeingFetched));
 
   assert(checkpointBeingFetched.checkpointNum == 0);

--- a/bftengine/src/bcstatetransfer/STDigest.cpp
+++ b/bftengine/src/bcstatetransfer/STDigest.cpp
@@ -30,7 +30,9 @@ std::string STDigest::toString() const {
   char t[3];
   static_assert(sizeof(t) == 3, "");
   for (size_t i = 0; i < BLOCK_DIGEST_SIZE; i++) {
-    unsigned int b = (unsigned int)content[i];
+    // TODO(DD): Is it by design?
+    // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+    unsigned int b = (unsigned char)content[i];
     snprintf(t, sizeof(t), "%02X", b);
     c[i * 2] = t[0];
     c[i * 2 + 1] = t[1];

--- a/bftengine/src/bftengine/Digest.cpp
+++ b/bftengine/src/bftengine/Digest.cpp
@@ -24,6 +24,8 @@ std::string Digest::toString() const {
   char c[DIGEST_SIZE * 2];
   char t[3];
   for (size_t i = 0; i < DIGEST_SIZE; i++) {
+    // TODO(DD): Is it by design?
+    // NOLINTNEXTLINE(bugprone-signed-char-misuse)
     unsigned int b = (unsigned int)d[i];
     snprintf(t, 3, "%02X", b);
     c[i * 2] = t[0];

--- a/bftengine/src/bftengine/Digest.hpp
+++ b/bftengine/src/bftengine/Digest.hpp
@@ -47,6 +47,9 @@ class Digest {
   }
 
   Digest& operator=(const Digest& other) {
+    if (this == &other) {
+      return *this;
+    }
     memcpy(d, other.d, DIGEST_SIZE);
     return *this;
   }

--- a/bftengine/src/bftengine/NullStateTransfer.cpp
+++ b/bftengine/src/bftengine/NullStateTransfer.cpp
@@ -65,7 +65,7 @@ void NullStateTransfer::getDigestOfCheckpoint(uint64_t checkpointNumber,
 
   DigestUtil::compute((char*)&checkpointNumber, sizeof(checkpointNumber), (char*)&d, sizeof(d));
 
-  memcpy(outDigestBuffer, &d, sizeof(d));
+  memcpy(outDigestBuffer, d.content(), sizeof(d));
 }
 
 void NullStateTransfer::startCollectingState() {

--- a/diagnostics/test/diagnostics_tests.cpp
+++ b/diagnostics/test/diagnostics_tests.cpp
@@ -51,7 +51,8 @@ StatusHandler async_handler2(async_handler_name2, async_handler_description, [](
   // promise to the replica thread, and then waiting on the future.
   std::promise<std::string> promise;
   auto future = promise.get_future();
-  std::async([promise = std::move(promise)]() mutable { promise.set_value(async_handler_status); });
+  auto f = std::async([promise = std::move(promise)]() mutable { promise.set_value(async_handler_status); });
+  f.wait();
   return future.get();
 });
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -257,7 +257,7 @@ bool ReplicaImp::putBlock(const uint64_t blockId, const char *block_data, const 
   if (m_bcDbAdapter->hasBlock(blockId)) {
     // if we already have a block with the same ID
     RawBlock existingBlock = m_bcDbAdapter->getRawBlock(blockId);
-    if (existingBlock.length() != block.length() || memcmp(existingBlock.data(), block.data(), block.length())) {
+    if (existingBlock.length() != block.length() || memcmp(existingBlock.data(), block.data(), block.length()) != 0) {
       // the replica is corrupted !
       LOG_ERROR(logger,
                 "found block " << blockId << ", size in db is " << existingBlock.length() << ", inserted is "

--- a/threshsign/src/bls/relic/BlsThresholdSigner.cpp
+++ b/threshsign/src/bls/relic/BlsThresholdSigner.cpp
@@ -68,7 +68,7 @@ bool BlsThresholdSigner::operator==(const BlsThresholdSigner &other) const {
   else
     cout << "params_" << endl;
   if (other.sigSize_ != sigSize_) cout << "sigSize_" << endl;
-  if (memcmp(other.serializedId_, serializedId_, sizeof(ShareID))) cout << "serializedId_" << endl;
+  if (memcmp(other.serializedId_, serializedId_, sizeof(ShareID)) != 0) cout << "serializedId_" << endl;
   if (other.hTmp_ != hTmp_) cout << "hTmp_" << endl;
   if (other.sigTmp_ != sigTmp_) cout << "sigTmp_" << endl;
   if (other.secretKey_ == secretKey_)


### PR DESCRIPTION
Checks added:
+bugprone-unused-return-value - [only for certain types of objects](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-unused-return-value.html)
+bugprone-too-small-loop-variable
+bugprone-undefined-memory-manipulation
+bugprone-suspicious-string-compare
+bugprone-signed-char-misuse

For detailed information, please refer to https://clang.llvm.org/extra/clang-tidy/checks/list.html.