### PR TITLE
clang-tidy: additional bugprone checks, p2

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,27 +1,20 @@
 ---
 Checks:             '-*,bugprone-*,
                     -bugprone-branch-clone,
-                    -bugprone-infinite-loop,
-                    -bugprone-integer-division,
-                    -bugprone-lambda-function-name,
-                    -bugprone-macro-parentheses,
+                    -bugprone-exception-escape,
                     -bugprone-misplaced-widening-cast,
-                    -bugprone-narrowing-conversions,
-                    -bugprone-not-null-terminated-result,
-                    -bugprone-exception-escape
+                    -bugprone-not-null-terminated-result
                     '
 WarningsAsErrors:   'bugprone-*,
                     -bugprone-branch-clone,
-                    -bugprone-infinite-loop,
-                    -bugprone-integer-division,
-                    -bugprone-lambda-function-name,
-                    -bugprone-macro-parentheses,
+                    -bugprone-exception-escape,
                     -bugprone-misplaced-widening-cast,
-                    -bugprone-narrowing-conversions,
-                    -bugprone-not-null-terminated-result,
-                    -bugprone-exception-escape
+                    -bugprone-not-null-terminated-result
                     '
-# -bugprone-exception-escape - main functions throwing exceptions are OK: we prefer analyze core dumps
+# -bugprone-branch-clone - does not work well with switch cases
+# -bugprone-exception-escape - main functions throwing exceptions are OK: we prefer to analyze core dumps
+# -bugprone-misplaced-widening-cast - does not seem to be a big issue
+# -bugprone-not-null-terminated-result - many false positives when std::string is used for storing raw bytes
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -42,7 +42,8 @@ jobs:
             ${{ env.USE_ROCKSDB }}
             ${{ env.USE_CONAN }}
             ${{ env.USE_S3_OBJECT_STORE }} .. &&
-            run-clang-tidy-10"
+            run-clang-tidy-10 &&
+            ! grep -rn --color=auto --exclude-dir={build,.git,.github} -E \"NOLINTNEXTLINE(\s+|$)|NOLINT(\s+|$)\" .."
         - name: Print failure info
           if: failure()
           run: |

--- a/Makefile
+++ b/Makefile
@@ -133,9 +133,10 @@ tidy-check: ## Runs clang-tidy
 		cd ${CONCORD_BFT_BUILD_DIR} && \
 		CC=${CONCORD_BFT_CONTAINER_CC} CXX=${CONCORD_BFT_CONTAINER_CXX} \
 		cmake ${CONCORD_BFT_CMAKE_FLAGS} .. && \
-		run-clang-tidy-10 &> clang-tidy-report.txt" \
+		run-clang-tidy-10 &> clang-tidy-report.txt && \
+		! grep -rn --color=auto --exclude-dir={build,.git,.github} -E \"NOLINTNEXTLINE(\s+|$$)|NOLINT(\s+|$$)\" .." \
 		&& (echo "\nClang-tidy finished successfully.") \
-		|| ( echo "\nClang-tidy failed. The report is in ${CURDIR}/${CONCORD_BFT_BUILD_DIR}/clang-tidy-report.txt \
+		|| ( echo "\nClang-tidy failed. The report is in ${CURDIR}/${CONCORD_BFT_BUILD_DIR}/clang-tidy-report.txt. \
 			 \nFor detail information about the checks, please refer to https://clang.llvm.org/extra/clang-tidy/checks/list.html" \
 			 ; exit 1)
 

--- a/bftengine/src/bftengine/ControllerWithSimpleHistory.cpp
+++ b/bftengine/src/bftengine/ControllerWithSimpleHistory.cpp
@@ -157,11 +157,12 @@ bool ControllerWithSimpleHistory::onEndOfEvaluationPeriod() {
           ControllerWithSimpleHistory_debugUpgradeFactorForFastOptimisticPath;                    // 0.95F;
       const float factorForFastPath = ControllerWithSimpleHistory_debugUpgradeFactorForFastPath;  //  0.85F;
 
-      if (cyclesWithFullCooperation >= (factorForFastOptimisticPath * EvaluationPeriod)) {
+      if (cyclesWithFullCooperation >= (factorForFastOptimisticPath * static_cast<float>(EvaluationPeriod))) {
         currentFirstPath = CommitPath::OPTIMISTIC_FAST;
         currentFirstPathChanged = true;
-      } else if (!onlyOptimisticFast &&
-                 (cyclesWithFullCooperation + cyclesWithPartialCooperation >= (factorForFastPath * EvaluationPeriod))) {
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions)
+      } else if (!onlyOptimisticFast && (cyclesWithFullCooperation + cyclesWithPartialCooperation >=
+                                         (factorForFastPath * static_cast<float>(EvaluationPeriod)))) {
         currentFirstPath = CommitPath::FAST_WITH_THRESHOLD;
         currentFirstPathChanged = true;
       }

--- a/bftengine/src/bftengine/DebugStatistics.cpp
+++ b/bftengine/src/bftengine/DebugStatistics.cpp
@@ -41,12 +41,12 @@ void DebugStatistics::onCycleCheck() {
 
   if (durationSec < seconds(DEBUG_STAT_PERIOD_SECONDS)) return;
 
-  double readThroughput = 0;
-  double writeThroughput = 0;
+  long double readThroughput = 0;
+  long double writeThroughput = 0;
 
-  if (d.completedReadOnlyRequests > 0) readThroughput = (d.completedReadOnlyRequests / durationSec.count());
+  if (d.completedReadOnlyRequests > 0) readThroughput = (double(d.completedReadOnlyRequests) / durationSec.count());
 
-  if (d.completedReadWriteRequests > 0) writeThroughput = (d.completedReadWriteRequests / durationSec.count());
+  if (d.completedReadWriteRequests > 0) writeThroughput = (double(d.completedReadWriteRequests) / durationSec.count());
 
   double avgBatchSize = 0;
   double avgPendingRequests = 0;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1687,6 +1687,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
       if (msg->hasListOfMissingViewChangeMsgForViewChange() &&
           msg->isMissingViewChangeMsgForViewChange(config_.replicaId)) {
         ViewChangeMsg *myVC = viewsManager->getMyLatestViewChangeMsg();
+        // NOLINTNEXTLINE(bugprone-lambda-function-name)
         AssertNE(myVC, nullptr);
         sendAndIncrementMetric(myVC, msgSenderId, metric_sent_viewchange_msg_due_to_status_);
       }

--- a/bftengine/tests/simpleStorage/main.cpp
+++ b/bftengine/tests/simpleStorage/main.cpp
@@ -22,18 +22,19 @@ using namespace bftEngine;
 
 struct Object {
   Object() : elem1(0), elem2(0), elem3(0), elem4(0) {}
-  Object(int e1, long e2, short e3, int e4) : elem1(e1), elem2(e2), elem3(e3), elem4(e4) {}
+  Object(unsigned int e1, unsigned long e2, unsigned short e3, unsigned int e4)
+      : elem1(e1), elem2(e2), elem3(e3), elem4(e4) {}
 
-  int elem1;
-  long elem2;
-  short elem3;
-  int elem4;
+  unsigned int elem1;
+  unsigned long elem2;
+  unsigned short elem3;
+  unsigned int elem4;
 };
 
-const int ELEM1 = 0xaaaaaaaa;
-const long ELEM2 = 0xbbbbbbbbbbbbbbb;
-const short ELEM3 = 0xccc;
-const int ELEM4 = 0xdddddddd;
+const unsigned int ELEM1 = 0xaaaaaaaa;
+const unsigned long ELEM2 = 0xbbbbbbbbbbbbbbb;
+const unsigned short ELEM3 = 0xccc;
+const unsigned int ELEM4 = 0xdddddddd;
 
 void verifyData(FileStorage &fileStorage, uint32_t objId) {
   Object objIn;

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -25,7 +25,7 @@
 #include <thread>
 #include <functional>
 
-#define Assert(cond, txtMsg) assert(cond && (txtMsg))
+#define Assert(cond, txtMsg) assert((cond) && (txtMsg))
 
 using namespace std;
 

--- a/kvbc/include/sparse_merkle/walker.h
+++ b/kvbc/include/sparse_merkle/walker.h
@@ -37,7 +37,7 @@ class Walker {
   BatchedInternalNode& currentNode() { return current_node_; }
   Version version() { return cache_.version(); }
   bool atRoot() { return nibble_path_.empty(); }
-  void appendEmptyNodes(const Hash& key, int nodes_to_create);
+  void appendEmptyNodes(const Hash& key, size_t nodes_to_create);
   void descend(const Hash& key, Version next_version);
 
   // Walk the stack of internal nodes upwards toward the root, updating the

--- a/kvbc/src/sparse_merkle/tree.cpp
+++ b/kvbc/src/sparse_merkle/tree.cpp
@@ -34,7 +34,7 @@ void insertComplete(Walker& walker, const BatchedInternalNode::InsertComplete& r
 // walking the prefix bits they have in common. Both successful inserts return
 // BatchedInternalNode::InsertComplete.
 void handleCollision(Walker& walker, const LeafChild& stored_child, const LeafChild& new_child) {
-  int nodes_to_create = new_child.key.hash().prefix_bits_in_common(stored_child.key.hash(), walker.depth()) / 4;
+  auto nodes_to_create = new_child.key.hash().prefix_bits_in_common(stored_child.key.hash(), walker.depth()) / 4;
   walker.appendEmptyNodes(new_child.key.hash(), nodes_to_create);
   walker.currentNode().insert(stored_child, walker.depth(), walker.version());
   auto result = walker.currentNode().insert(new_child, walker.depth(), walker.version());

--- a/kvbc/src/sparse_merkle/walker.cpp
+++ b/kvbc/src/sparse_merkle/walker.cpp
@@ -16,9 +16,9 @@ using namespace concordUtils;
 
 namespace concord::kvbc::sparse_merkle::detail {
 
-void Walker::appendEmptyNodes(const Hash& key, int nodes_to_create) {
+void Walker::appendEmptyNodes(const Hash& key, size_t nodes_to_create) {
   stack_.push(current_node_);
-  for (int i = 0; i < nodes_to_create - 1; i++) {
+  for (size_t i = 0; i < nodes_to_create - 1 && nodes_to_create > 0; i++) {
     Nibble next_nibble = key.getNibble(depth());
     nibble_path_.append(next_nibble);
     stack_.emplace(BatchedInternalNode());

--- a/util/test/sliver_test.cpp
+++ b/util/test/sliver_test.cpp
@@ -31,6 +31,7 @@ char* new_test_memory(size_t length) {
   char* buffer = new char[length];
 
   for (size_t i = 0; i < length; i++) {
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions)
     buffer[i] = i % 256;
   }
 

--- a/util/test/thread_pool_test.cpp
+++ b/util/test/thread_pool_test.cpp
@@ -150,6 +150,7 @@ TEST(thread_pool, non_blocking_future_dtors) {
   {
     auto future1 = pool.async([&]() {
       auto lock = std::unique_lock{mtx};
+      // NOLINTNEXTLINE(bugprone-infinite-loop)
       while (!future1_destroyed) {
         cv.wait(lock);
       }


### PR DESCRIPTION
New checks:
```
+bugprone-narrowing-conversions
+bugprone-macro-parentheses
+bugprone-integer-division
+bugprone-infinite-loop
+bugprone-lambda-function-name
```

Additional changes:
Fail if `NOLINT` or `NOLINTNEXTLINE` is used without a specific check or
checks mentioned. Applies to the CI and `make tidy-check`.