### PR TITLE
Add bash-completion support to concord-bft build image

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -15,6 +15,7 @@ WGET_FLAGS="--no-check-certificate -q"
 apt-get update && apt-get ${APT_GET_FLAGS} install \
     autoconf \
     automake \
+    bash-completion \
     build-essential \
     ccache \
     clang \
@@ -36,6 +37,13 @@ apt-get update && apt-get ${APT_GET_FLAGS} install \
 
 ln -fs /usr/bin/clang-format-9 /usr/bin/clang-format
 ln -fs /usr/bin/clang-format-diff-9 /usr/bin/clang-format-diff
+
+# Enable bash-completion
+cat <<EOT >> /root/.bashrc
+if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+    . /etc/bash_completion
+fi
+EOT
 
 # Install 3rd parties
 apt-get ${APT_GET_FLAGS} install \


### PR DESCRIPTION
Install bash-completion and enable it for the root user. This makes the
interactive work with the container more easy. E.g. autocompletion for
ctest test cases.