### PR TITLE
clang-tidy: Add performance-* checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,13 +3,19 @@ Checks:             '-*,bugprone-*,
                     -bugprone-branch-clone,
                     -bugprone-exception-escape,
                     -bugprone-misplaced-widening-cast,
-                    -bugprone-not-null-terminated-result
+                    -bugprone-not-null-terminated-result,
+                    performance-*,
+                    -performance-unnecessary-value-param,
+                    -performance-noexcept-move-constructor
                     '
 WarningsAsErrors:   'bugprone-*,
                     -bugprone-branch-clone,
                     -bugprone-exception-escape,
                     -bugprone-misplaced-widening-cast,
-                    -bugprone-not-null-terminated-result
+                    -bugprone-not-null-terminated-result,
+                    performance-*,
+                    -performance-unnecessary-value-param,
+                    -performance-noexcept-move-constructor
                     '
 # -bugprone-branch-clone - does not work well with switch cases
 # -bugprone-exception-escape - main functions throwing exceptions are OK: we prefer to analyze core dumps

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
@@ -315,7 +315,7 @@ DataStore::ResPagesDescriptor* InMemoryDataStore::getResPagesDescriptor(uint64_t
 
   desc->numOfPages = numberOfReservedPages_;
 
-  for (auto iter : pages) {
+  for (const auto& iter : pages) {
     if (iter.first.checkpoint <= inCheckpoint) {
       SingleResPageDesc& singleDesc = desc->d[iter.first.pageId];
       if (singleDesc.relevantCheckpoint > 0) {

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -138,7 +138,7 @@ ReplicaLoader::ErrorCode loadConfig(shared_ptr<PersistentStorage> &p, LoadedRepl
 
   std::set<SigManager::PublicKeyDesc> replicasSigPublicKeys;
 
-  for (auto e : ld.repConfig.publicKeysOfReplicas) {
+  for (const auto &e : ld.repConfig.publicKeysOfReplicas) {
     SigManager::PublicKeyDesc keyDesc = {e.first, e.second};
     replicasSigPublicKeys.insert(keyDesc);
   }

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -404,7 +404,7 @@ void SimpleStateTran::createCheckpointOfCurrentState(uint64_t checkpointNumber) 
     }
   }
 
-  for (std::pair<uint32_t, std::set<uint32_t> > g : pagesMap) {
+  for (const auto& g : pagesMap) {
     Assert(g.first < numberOfMetadataPages_);
 
     internalST_->loadReservedPage(medataPageToInternalPage(g.first), pageSize_, tempBuffer_);

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -103,7 +103,7 @@ class PlainUDPCommunication::PlainUdpImpl {
   PlainUdpImpl(const PlainUdpConfig &config)
       : maxMsgSize{config.bufferLength},
         udpListenPort{config.listenPort},
-        endpoints{std::move(config.nodes)},
+        endpoints{config.nodes},
         statusCallback{config.statusCallback},
         selfId{config.selfId} {
     Assert(config.listenPort > 0, "Port should not be negative!");

--- a/kvbc/src/direct_kv_block.cpp
+++ b/kvbc/src/direct_kv_block.cpp
@@ -39,7 +39,7 @@ Sliver create(const SetOfKeyValuePairs &updates,
   try {
     char *blockBuffer = new char[blockSize];
     std::memset(blockBuffer, 0, blockSize);
-    const Sliver blockSliver(blockBuffer, blockSize);
+    Sliver blockSliver(blockBuffer, blockSize);
 
     auto header = (detail::Header *)blockBuffer;
     std::memcpy(header->parentDigest, parentDigest.data(), BLOCK_DIGEST_SIZE);

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -199,7 +199,7 @@ bool InternalCommandsHandler::executeGetBlockDataCommand(
   const Sliver metadataKey = m_blockMetadata->getKey();
 
   auto i = 0;
-  for (auto kv : outBlockData) {
+  for (const auto &kv : outBlockData) {
     if (kv.first != metadataKey) {
       memcpy(pReply->items[i].simpleKey.key, kv.first.data(), KV_LEN);
       memcpy(pReply->items[i].simpleValue.value, kv.second.data(), KV_LEN);

--- a/tests/simpleTest/persistency_test.cpp
+++ b/tests/simpleTest/persistency_test.cpp
@@ -27,10 +27,10 @@ namespace test::persistency {
 class PersistencyTest : public testing::Test {
  protected:
   void TearDown() override {
-    for (auto it : replicas) {
+    for (const auto &it : replicas) {
       it->stop();
     }
-    for (auto it : replicaThreads) {
+    for (const auto &it : replicaThreads) {
       if (it->joinable()) {
         it->join();
       }

--- a/threshsign/bench/BenchRelic.cpp
+++ b/threshsign/bench/BenchRelic.cpp
@@ -147,7 +147,7 @@ int RelicAppMain(const Library& lib, const std::vector<std::string>& args) {
   lib.getPrecomputedInverses();
 
   BlsPublicParameters params = PublicParametersFactory::getWhatever();
-  BNT fieldOrder = params.getGroupOrder();
+  const auto& fieldOrder = params.getGroupOrder();
 
   LOG_INFO(GL, "");
 

--- a/threshsign/src/app/Main.cpp
+++ b/threshsign/src/app/Main.cpp
@@ -33,6 +33,7 @@ int main(int argc, char *argv[]) {
   LOG_DEBUG(GL, "Number of arguments: " << argc);
 
   std::vector<std::string> args;
+  args.reserve(static_cast<size_t>(argc));
   for (int i = 0; i < argc; i++) {
     args.push_back(std::string(argv[i]));
   }

--- a/tools/KeyfileIOUtils.cpp
+++ b/tools/KeyfileIOUtils.cpp
@@ -142,7 +142,7 @@ static bool expectEntries(const std::vector<std::string>& entries,
                           const std::unordered_map<std::string, std::string> map,
                           const std::string& filename,
                           const std::unordered_map<std::string, size_t> lineNumbers) {
-  for (auto entry : entries) {
+  for (const auto& entry : entries) {
     if (map.count(entry) < 1) {
       if (lineNumbers.count(entry) < 1) {
         std::cout << filename << ": Missing assignment for required parameter: " << entry << ".\n";
@@ -278,7 +278,7 @@ bool parseReplicaKeyfile(const std::string& filename,
   //    std::getline(input, line);
   for (std::string line; std::getline(input, line);) {
     // Ignore comments.
-    size_t commentStart = line.find_first_of("#");
+    size_t commentStart = line.find_first_of('#');
     if (commentStart != std::string::npos) {
       line = line.substr(0, commentStart);
     }
@@ -297,7 +297,7 @@ bool parseReplicaKeyfile(const std::string& filename,
 
     // Multiple :s are never expected in one line, so we will reject lines like
     // this here so that we do not have to handle them in both assignment cases.
-    if (line.find_first_of(":") != line.find_last_of(":")) {
+    if (line.find_first_of(':') != line.find_last_of(':')) {
       std::cout << getBadSyntaxMessage(filename, lineNumber);
       return false;
     }
@@ -319,7 +319,7 @@ bool parseReplicaKeyfile(const std::string& filename,
 
       // We will check that there is not a colon in the value because the use of
       // those is reserved to indicate assignments.
-      if (value.find_first_of(":") != std::string::npos) {
+      if (value.find_first_of(':') != std::string::npos) {
         std::cout << filename << ": line " << lineNumber
                   << ": Invalid list"
                      " entry: contains \":\".\n";
@@ -371,8 +371,8 @@ bool parseReplicaKeyfile(const std::string& filename,
 
       // Case of assignment of a value to an identifier. Format:
       // IDENTIFIER: VALUE
-    } else if ((line.length() >= 3) && (line.find_first_of(":") != std::string::npos)) {
-      size_t colonLoc = line.find_first_of(":");
+    } else if ((line.length() >= 3) && (line.find_first_of(':') != std::string::npos)) {
+      size_t colonLoc = line.find_first_of(':');
       std::string identifier = concord::util::trim(line.substr(0, colonLoc));
       std::string value = concord::util::trim(line.substr(colonLoc + 1, line.length() - (colonLoc + 1)));
 
@@ -608,11 +608,11 @@ bool inputReplicaKeyfile(const std::string& filename, bftEngine::ReplicaConfig& 
   // Verify that there were not any unexpected parameters specified in the
   // keyfile.
   if ((valueAssignments.size() > 0) || (listAssignments.size() > 0)) {
-    for (auto assignment : valueAssignments) {
+    for (const auto& assignment : valueAssignments) {
       std::cout << filename << ": line " << identifierLines[assignment.first]
                 << ": Unrecognized parameter: " << assignment.first << ".\n";
     }
-    for (auto assignment : listAssignments) {
+    for (const auto& assignment : listAssignments) {
       std::cout << filename << ": line " << identifierLines[assignment.first]
                 << ": Unrecognized parameter: " << assignment.first << ".\n";
     }

--- a/tools/TestGeneratedKeys.cpp
+++ b/tools/TestGeneratedKeys.cpp
@@ -270,7 +270,7 @@ static bool testRSAKeys(const std::vector<bftEngine::ReplicaConfig>& configs) {
     std::string privateKey = configs[i].replicaPrivateKey;
     std::string publicKey;
 
-    for (auto publicKeyEntry : configs[i].publicKeysOfReplicas) {
+    for (const auto& publicKeyEntry : configs[i].publicKeysOfReplicas) {
       if (publicKeyEntry.first == i) {
         publicKey = publicKeyEntry.second;
       }
@@ -282,7 +282,7 @@ static bool testRSAKeys(const std::vector<bftEngine::ReplicaConfig>& configs) {
 
     if (rsaPublicKeysSeen.count(publicKey) > 0) {
       uint16_t existingKeyholder;
-      for (auto publicKeyEntry : expectedPublicKeys) {
+      for (const auto& publicKeyEntry : expectedPublicKeys) {
         if (publicKeyEntry.second == publicKey) {
           existingKeyholder = publicKeyEntry.first;
         }
@@ -301,7 +301,7 @@ static bool testRSAKeys(const std::vector<bftEngine::ReplicaConfig>& configs) {
 
   // Verify that all replicas' keyfiles agree on the RSA public keys.
   for (uint16_t i = 0; i < numReplicas; ++i) {
-    for (auto publicKeyEntry : configs[i].publicKeysOfReplicas) {
+    for (const auto& publicKeyEntry : configs[i].publicKeysOfReplicas) {
       if (publicKeyEntry.second != expectedPublicKeys[publicKeyEntry.first]) {
         std::cout << "FAILURE: Replica " << i
                   << " has an"
@@ -427,7 +427,7 @@ static bool testThresholdSignature(const std::string& cryptosystemName,
 
   uint16_t participatingSigners = signersToTest.size();
 
-  for (auto hash : kHashesToTest) {
+  for (const auto& hash : kHashesToTest) {
     int hashLength = hash.length();
 
     IThresholdAccumulator* accumulator = nullptr;
@@ -601,7 +601,7 @@ static bool testThresholdCryptosystem(const std::string& name,
   size_t totalTests = signerCombinationsToTest.size();
 
   // Test that the threshold cryptosystem functions as expected.
-  for (auto signerCombination : signerCombinationsToTest) {
+  for (const auto& signerCombination : signerCombinationsToTest) {
     if (!testThresholdSignature(name, signers, referenceVerifier, signerCombination, numSigners, threshold)) {
       return false;
     }
@@ -729,7 +729,7 @@ static bool testThresholdKeys(const std::vector<bftEngine::ReplicaConfig>& confi
 // need to do in one of several places because it may return early in the event
 // of a failure.
 static void freeConfigs(const std::vector<bftEngine::ReplicaConfig>& configs) {
-  for (auto config : configs) {
+  for (const auto& config : configs) {
     if (config.thresholdSignerForExecution) {
       delete config.thresholdSignerForExecution;
     }

--- a/util/test/serializable_test.cpp
+++ b/util/test/serializable_test.cpp
@@ -144,6 +144,7 @@ TEST(serializable, VectorSerializableVectors) {
   std::vector<std::vector<TestSerializable>> vec_of_vecs, vec_of_vecs_out;
   for (int j = 0; j < 10; ++j) {
     std::vector<TestSerializable> v;
+    v.reserve(10);
     for (int i = 0; i < 10; ++i)
       v.push_back(TestSerializable{"testSerializable" + std::to_string(i),
                                    (std::uint8_t)(i + 1),
@@ -162,6 +163,7 @@ TEST(serializable, VectorSerializablePtrVectors) {
   std::vector<std::vector<TestSerializable*>> vec_of_vecs, vec_of_vecs_out;
   for (int j = 0; j < 10; ++j) {
     std::vector<TestSerializable*> v;
+    v.reserve(10);
     for (int i = 0; i < 10; ++i)
       v.push_back(new TestSerializable{"testSerializable" + std::to_string(i),
                                        (std::uint8_t)(i + 1),


### PR DESCRIPTION
Checks added:
```
+performance-faster-string-find
+performance-for-range-copy
+performance-implicit-conversion-in-loop
+performance-inefficient-algorithm
+performance-inefficient-vector-operation
+performance-move-const-arg
+performance-move-constructor-init
+performance-no-automatic-move
+performance-trivially-destructible
```
Checks ignored meanwhile:
```
-performance-unnecessary-value-param
-performance-noexcept-move-constructor
```
For detailed information, please refer to https://clang.llvm.org/extra/clang-tidy/checks/list.html.