### PR TITLE
clang-tidy: make performance-move-const-arg happy

### DIFF
--- a/bftclient/src/matcher.cpp
+++ b/bftclient/src/matcher.cpp
@@ -16,7 +16,7 @@ namespace bft::client {
 std::optional<Match> Matcher::onReply(UnmatchedReply&& reply) {
   if (!valid(reply)) return std::nullopt;
 
-  auto key = MatchKey{std::move(reply.metadata), std::move(reply.data)};
+  auto key = MatchKey{reply.metadata, std::move(reply.data)};
   const auto [it, success] = matches_[key].insert_or_assign(reply.rsi.from, std::move(reply.rsi.data));
   (void)it;  // unused variable hack needed by GCC
   if (!success) {
@@ -34,7 +34,7 @@ std::optional<Match> Matcher::match() {
     return match.second.size() == config_.quorum.wait_for;
   });
   if (result == matches_.end()) return std::nullopt;
-  return Match{Reply{std::move(result->first.data), std::move(result->second)}, result->first.metadata.primary};
+  return Match{Reply{result->first.data, std::move(result->second)}, result->first.metadata.primary};
 }
 
 bool Matcher::valid(const UnmatchedReply& reply) const {


### PR DESCRIPTION
1. /concord-bft/bftclient/src/matcher.cpp:19:23: error: std::move of the
expression of the trivially-copyable type 'bft::client::ReplyMetadata'
has no effect
2. /concord-bft/bftclient/src/matcher.cpp:37:22: error: std::move of the const expression has no effect; remove std::move()