### PR TITLE
clang-tidy: Add misc-* checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,8 +5,10 @@ Checks:             '-*,bugprone-*,
                     -bugprone-misplaced-widening-cast,
                     -bugprone-not-null-terminated-result,
                     performance-*,
-                    -performance-unnecessary-value-param,
-                    -performance-noexcept-move-constructor
+                    -performance-noexcept-move-constructor,
+                    misc-*,
+                    -misc-non-private-member-variables-in-classes,
+                    -misc-unused-parameters
                     '
 WarningsAsErrors:   'bugprone-*,
                     -bugprone-branch-clone,
@@ -14,15 +16,20 @@ WarningsAsErrors:   'bugprone-*,
                     -bugprone-misplaced-widening-cast,
                     -bugprone-not-null-terminated-result,
                     performance-*,
-                    -performance-unnecessary-value-param,
-                    -performance-noexcept-move-constructor
+                    -performance-noexcept-move-constructor,
+                    misc-*,
+                    -misc-non-private-member-variables-in-classes,
+                    -misc-unused-parameters
                     '
 # -bugprone-branch-clone - does not work well with switch cases
 # -bugprone-exception-escape - main functions throwing exceptions are OK: we prefer to analyze core dumps
 # -bugprone-misplaced-widening-cast - does not seem to be a big issue
 # -bugprone-not-null-terminated-result - many false positives when std::string is used for storing raw bytes
+# -misc-non-private-member-variables-in-classes - seems irrelevant
+# -misc-unused-parameters - too many errors, fix later
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
-FormatStyle:     none
+FormatStyle:     file
 CheckOptions:
+    - { key:  performance-unnecessary-value-param.AllowedTypes, value:  'shared_ptr;SharedPtr;[Ll]og;BlockId' }
 ...

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ make CONCORD_BFT_CONTAINER_CXX=g++ \
     build
 ```
 
+### C++ Linter
+
+The C++ code is statically checked by `clang-tidy` as part of the [CI](https://github.com/vmware/concord-bft/actions?query=workflow%3Aclang-tidy).
+<br>To check code before submitting PR, please run `make tidy-check`.
+
+[Detailed information about clang-tidy checks](https://clang.llvm.org/extra/clang-tidy/checks/list.html).
+
 ### Build Options
 
 In order to turn on or off various options, you need to change your cmake configuration. This is

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -391,7 +391,7 @@ bool BCStateTran::isRunning() const { return running_; }
 // This has the side effect of filling in buffer_ with the last block of app
 // data.
 DataStore::CheckpointDesc BCStateTran::createCheckpointDesc(uint64_t checkpointNumber,
-                                                            STDigest digestOfResPagesDescriptor) {
+                                                            const STDigest &digestOfResPagesDescriptor) {
   uint64_t lastBlock = as_->getLastReachableBlockNum();
   AssertEQ(lastBlock, as_->getLastBlockNum());
   metrics_.last_block_.Get().Set(lastBlock);

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -276,7 +276,7 @@ class BCStateTran : public IStateTransfer {
   // Helper methods
   ///////////////////////////////////////////////////////////////////////////
 
-  DataStore::CheckpointDesc createCheckpointDesc(uint64_t checkpointNumber, STDigest digestOfResPagesDescriptor);
+  DataStore::CheckpointDesc createCheckpointDesc(uint64_t checkpointNumber, const STDigest& digestOfResPagesDescriptor);
 
   STDigest checkpointReservedPages(uint64_t checkpointNumber, DataStoreTransaction* txn);
 

--- a/bftengine/src/bftengine/Crypto.cpp
+++ b/bftengine/src/bftengine/Crypto.cpp
@@ -70,14 +70,14 @@ void CryptographyWrapper::init() {
   CryptographyWrapper::init(seed.c_str());
 }
 
-void convert(Integer in, string& out) {
+void convert(const Integer& in, string& out) {
   out.clear();
   HexEncoder encoder(new StringSink(out));
   in.DEREncode(encoder);
   encoder.MessageEnd();
 }
 
-void convert(string in, Integer& out) {
+void convert(const string& in, Integer& out) {
   StringSource strSrc(in, true, new HexDecoder);
   out = Integer(strSrc);
 }

--- a/bftengine/src/bftengine/SeqNumInfo.cpp
+++ b/bftengine/src/bftengine/SeqNumInfo.cpp
@@ -302,7 +302,7 @@ PrepareFullMsg* SeqNumInfo::ExFuncForPrepareCollector::createCombinedSignatureMs
 }
 
 InternalMessage SeqNumInfo::ExFuncForPrepareCollector::createInterCombinedSigFailed(
-    SeqNum seqNumber, ViewNum viewNumber, std::set<uint16_t> replicasWithBadSigs) {
+    SeqNum seqNumber, ViewNum viewNumber, const std::set<uint16_t>& replicasWithBadSigs) {
   return CombinedSigFailedInternalMsg(seqNumber, viewNumber, replicasWithBadSigs);
 }
 
@@ -358,7 +358,7 @@ CommitFullMsg* SeqNumInfo::ExFuncForCommitCollector::createCombinedSignatureMsg(
 }
 
 InternalMessage SeqNumInfo::ExFuncForCommitCollector::createInterCombinedSigFailed(
-    SeqNum seqNumber, ViewNum viewNumber, std::set<uint16_t> replicasWithBadSigs) {
+    SeqNum seqNumber, ViewNum viewNumber, const std::set<uint16_t>& replicasWithBadSigs) {
   return CombinedCommitSigFailedInternalMsg(seqNumber, viewNumber, replicasWithBadSigs);
 }
 

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -122,7 +122,7 @@ class SeqNumInfo {
     // internal messages
     static InternalMessage createInterCombinedSigFailed(SeqNum seqNumber,
                                                         ViewNum viewNumber,
-                                                        std::set<uint16_t> replicasWithBadSigs);
+                                                        const std::set<uint16_t>& replicasWithBadSigs);
     static InternalMessage createInterCombinedSigSucceeded(SeqNum seqNumber,
                                                            ViewNum viewNumber,
                                                            const char* combinedSig,
@@ -150,7 +150,7 @@ class SeqNumInfo {
     // internal messages
     static InternalMessage createInterCombinedSigFailed(SeqNum seqNumber,
                                                         ViewNum viewNumber,
-                                                        std::set<uint16_t> replicasWithBadSigs);
+                                                        const std::set<uint16_t>& replicasWithBadSigs);
     static InternalMessage createInterCombinedSigSucceeded(SeqNum seqNumber,
                                                            ViewNum viewNumber,
                                                            const char* combinedSig,

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -18,8 +18,8 @@ namespace impl {
 
 SigManager::SigManager(ReplicaId myId,
                        int16_t numberOfReplicasAndClients,
-                       PrivateKeyDesc mySigPrivateKey,
-                       std::set<PublicKeyDesc> replicasSigPublicKeys)
+                       const PrivateKeyDesc& mySigPrivateKey,
+                       const std::set<PublicKeyDesc>& replicasSigPublicKeys)
     : myId_{myId} {
   // Assert(replicasSigPublicKeys.size() == numberOfReplicasAndClients); TODO(GG): change - here we don't care about
   // client signatures

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -30,8 +30,8 @@ class SigManager {
 
   SigManager(ReplicaId myId,
              int16_t numberOfReplicasAndClients,
-             PrivateKeyDesc mySigPrivateKey,
-             std::set<PublicKeyDesc> replicasSigPublicKeys);
+             const PrivateKeyDesc& mySigPrivateKey,
+             const std::set<PublicKeyDesc>& replicasSigPublicKeys);
 
   ~SigManager();
 

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.cpp
@@ -17,7 +17,7 @@
 namespace bftEngine {
 namespace impl {
 
-ReqMissingDataMsg::ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string spanContext)
+ReqMissingDataMsg::ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string& spanContext)
     : MessageBase(senderId, MsgCode::ReqMissingData, spanContext.size(), sizeof(Header)) {
   b()->viewNum = v;
   b()->seqNum = s;

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
@@ -18,7 +18,7 @@ namespace impl {
 
 class ReqMissingDataMsg : public MessageBase {
  public:
-  ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string spanContext = "");
+  ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string& spanContext = "");
 
   ViewNum viewNumber() const { return b()->viewNum; }
 

--- a/bftengine/src/bftengine/messages/SignatureInternalMsgs.hpp
+++ b/bftengine/src/bftengine/messages/SignatureInternalMsgs.hpp
@@ -62,7 +62,7 @@ struct CombinedCommitSigFailedInternalMsg {
   const ViewNum view;
   const std::set<uint16_t> replicasWithBadSigs;
 
-  CombinedCommitSigFailedInternalMsg(SeqNum s, ViewNum v, std::set<uint16_t>& repsWithBadSigs)
+  CombinedCommitSigFailedInternalMsg(SeqNum s, ViewNum v, const std::set<uint16_t>& repsWithBadSigs)
       : seqNumber{s}, view{v}, replicasWithBadSigs{repsWithBadSigs} {}
 };
 

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -88,7 +88,7 @@ class PlainUDPCommunication::PlainUdpImpl {
     return it->second.isReplica;
   }
 
-  string create_key(string ip, uint16_t port) {
+  string create_key(const string &ip, uint16_t port) {
     auto key = ip + ":" + to_string(port);
     return key;
   }
@@ -176,6 +176,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       LOG_FATAL(_logger,
                 "Error while binding: IP=" << sAddr.sin_addr.s_addr << ", Port=" << sAddr.sin_port
                                            << ", errno=" << concordUtils::errnoString(errno));
+      // NOLINTNEXTLINE(misc-static-assert)
       Assert(false, "Failure occurred while binding the socket!");
       exit(1);  // TODO(GG): not really ..... change this !
     }

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -83,7 +83,7 @@ class ReplicaImp : public IReplica,
 
  protected:
   Status addBlockInternal(const concord::storage::SetOfKeyValuePairs &updates, BlockId &outBlockId);
-  Status getInternal(BlockId readVersion, Key key, Sliver &outValue, BlockId &outBlock) const;
+  Status getInternal(BlockId readVersion, const Key &key, Sliver &outValue, BlockId &outBlock) const;
   void insertBlockInternal(BlockId blockId, Sliver block);
   RawBlock getBlockInternal(BlockId blockId) const;
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -23,10 +23,8 @@
 #include "bftengine/DbMetadataStorage.hpp"
 
 using bft::communication::ICommunication;
-using bftEngine::SimpleBlockchainStateTransfer::BLOCK_DIGEST_SIZE;
 using bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest;
 
-using concord::storage::IDBClient;
 using concord::storage::DBMetadataStorage;
 
 namespace concord::kvbc {
@@ -226,7 +224,7 @@ Status ReplicaImp::addBlockInternal(const SetOfKeyValuePairs &updates, BlockId &
   return Status::OK();
 }
 
-Status ReplicaImp::getInternal(BlockId readVersion, Key key, Sliver &outValue, BlockId &outBlock) const {
+Status ReplicaImp::getInternal(BlockId readVersion, const Key &key, Sliver &outValue, BlockId &outBlock) const {
   const auto clear = [&outValue, &outBlock]() {
     outValue = Sliver{};
     outBlock = 0;

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -32,8 +32,6 @@ namespace {
 
 using namespace ::std::string_literals;
 
-using ::concord::util::toChar;
-
 using ::concordUtils::Sliver;
 
 using ::concord::storage::IDBClient;
@@ -44,7 +42,6 @@ using ::concord::storage::v2MerkleTree::detail::EBFTSubtype;
 using ::bftEngine::SimpleBlockchainStateTransfer::computeBlockDigest;
 
 using sparse_merkle::BatchedInternalNode;
-using sparse_merkle::Hash;
 using sparse_merkle::Hasher;
 using sparse_merkle::InternalNodeKey;
 using sparse_merkle::Version;

--- a/kvbc/src/replica_state_sync_imp.cpp
+++ b/kvbc/src/replica_state_sync_imp.cpp
@@ -17,7 +17,6 @@
 #include "block_metadata.hpp"
 #include "kvstream.h"
 
-using concord::storage::DBMetadataStorage;
 using concord::kvbc::Key;
 
 namespace concord {

--- a/kvbc/test/kvbc_dbadapter_test.cpp
+++ b/kvbc/test/kvbc_dbadapter_test.cpp
@@ -16,7 +16,6 @@
 
 using namespace std;
 
-using concordUtils::Status;
 using concordUtils::Sliver;
 using concord::kvbc::KeysVector;
 using concord::kvbc::KeyValuePair;
@@ -25,9 +24,6 @@ using concord::kvbc::BlockDigest;
 using concord::kvbc::BlockId;
 // using concord::storage::rocksdb::Client;
 // using concord::storage::rocksdb::KeyComparator;
-using concord::storage::ITransaction;
-using concord::kvbc::v1DirectKeyValue::DBKeyManipulator;
-using concord::kvbc::v1DirectKeyValue::DBKeyComparator;
 using concord::kvbc::v1DirectKeyValue::block::detail::create;
 using concord::kvbc::v1DirectKeyValue::block::detail::getUserData;
 

--- a/kvbc/test/sparse_merkle/tree_test.cpp
+++ b/kvbc/test/sparse_merkle/tree_test.cpp
@@ -76,7 +76,9 @@ std::vector<K> keys(const std::vector<std::pair<K, V>>& kvpairs) {
   return ::testing::AssertionSuccess();
 }
 
-::testing::AssertionResult internalKeyExists(const char* path, uint64_t version, std::set<InternalNodeKey> keys) {
+::testing::AssertionResult internalKeyExists(const char* path,
+                                             uint64_t version,
+                                             const std::set<InternalNodeKey>& keys) {
   for (const auto& key : keys) {
     if (key.path().toString() == path && Version(version) == key.version()) {
       return ::testing::AssertionSuccess();

--- a/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -42,7 +42,6 @@ using ::concord::kvbc::OrderedKeysSet;
 using ::concord::kvbc::SetOfKeyValuePairs;
 using ::concord::kvbc::ValuesVector;
 using ::concordUtils::Sliver;
-using ::concordUtils::Status;
 
 // Make sure key updates and deletes partially overlap - see getDeterministicBlockDeletes() .
 SetOfKeyValuePairs getDeterministicBlockUpdates(std::uint32_t count) {

--- a/storage/src/direct_kv_key_manipulator.cpp
+++ b/storage/src/direct_kv_key_manipulator.cpp
@@ -21,7 +21,6 @@
 #include <cstring>
 
 using logging::Logger;
-using concordUtils::Status;
 using concordUtils::Sliver;
 using concordUtils::HexPrintBuffer;
 

--- a/storage/src/rocksdb_key_comparator.cpp
+++ b/storage/src/rocksdb_key_comparator.cpp
@@ -13,9 +13,7 @@
 
 #include <chrono>
 
-using concordUtils::Sliver;
 using logging::Logger;
-using concord::storage::rocksdb::copyRocksdbSlice;
 
 namespace concord {
 namespace storage {

--- a/tests/config/config_file_parser.cpp
+++ b/tests/config/config_file_parser.cpp
@@ -82,13 +82,13 @@ bool ConfigFileParser::Parse() {
   return true;
 }
 
-size_t ConfigFileParser::Count(const string key) {
+size_t ConfigFileParser::Count(const string& key) {
   size_t res = parameters_map_.count(key);
   LOG_INFO(logger_, "count() returns: " << res << " for key: " << key);
   return res;
 }
 
-vector<string> ConfigFileParser::GetValues(const string key) {
+vector<string> ConfigFileParser::GetValues(const string& key) {
   vector<string> values;
   pair<ParamsMultiMapIt, ParamsMultiMapIt> range = parameters_map_.equal_range(key);
   LOG_DEBUG(logger_, "getValues() for key: " << key);
@@ -101,7 +101,7 @@ vector<string> ConfigFileParser::GetValues(const string key) {
   return values;
 }
 
-std::vector<std::string> ConfigFileParser::SplitValue(std::string value_to_split, const char* delimiter) {
+std::vector<std::string> ConfigFileParser::SplitValue(const std::string& value_to_split, const char* delimiter) {
   LOG_DEBUG(logger_, "valueToSplit: " << value_to_split << ", delimiter: " << delimiter);
   char* rest = (char*)value_to_split.c_str();
   char* token;

--- a/tests/config/config_file_parser.hpp
+++ b/tests/config/config_file_parser.hpp
@@ -34,12 +34,12 @@ class ConfigFileParser {
   bool Parse();
 
   // Returns the number of elements matching specific key.
-  size_t Count(std::string key);
+  size_t Count(const std::string& key);
 
   // Returns a range of values that match specified key.
-  std::vector<std::string> GetValues(std::string key);
+  std::vector<std::string> GetValues(const std::string& key);
 
-  std::vector<std::string> SplitValue(std::string value_to_split, const char* delimiter);
+  std::vector<std::string> SplitValue(const std::string& value_to_split, const char* delimiter);
 
   void printAll();
 

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -31,9 +31,6 @@ using bft::communication::TlsTcpConfig;
 using bft::communication::NodeNum;
 using bft::communication::NodeInfo;
 using bftEngine::ReplicaConfig;
-using BLS::Relic::BlsThresholdFactory;
-using std::pair;
-using std::map;
 using std::string;
 using std::vector;
 

--- a/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
+++ b/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
@@ -25,8 +25,6 @@
 #include <unistd.h>
 #endif
 
-using std::list;
-using std::map;
 using std::set;
 using std::chrono::seconds;
 

--- a/tests/simpleTest/client.cpp
+++ b/tests/simpleTest/client.cpp
@@ -35,16 +35,6 @@
 #include "simple_test_client.hpp"
 #include "Logger.hpp"
 
-using bft::communication::ICommunication;
-using bft::communication::PlainUDPCommunication;
-using bft::communication::PlainUdpConfig;
-using bft::communication::PlainTCPCommunication;
-using bft::communication::PlainTcpConfig;
-using bft::communication::TlsTCPCommunication;
-using bft::communication::TlsTcpConfig;
-using bftEngine::SeqNumberGeneratorForClientRequests;
-using bftEngine::SimpleClient;
-
 logging::Logger clientLogger = logging::getLogger("simpletest.client");
 
 void parse_params(int argc, char **argv, ClientParams &cp, bftEngine::SimpleClientParams &scp) {

--- a/tests/simpleTest/replica.cpp
+++ b/tests/simpleTest/replica.cpp
@@ -60,15 +60,6 @@
 // bftEngine includes
 #include "Logger.hpp"
 
-using bft::communication::ICommunication;
-using bft::communication::PlainUDPCommunication;
-using bft::communication::PlainUdpConfig;
-using bft::communication::PlainTCPCommunication;
-using bft::communication::PlainTcpConfig;
-using bft::communication::TlsTcpConfig;
-using bftEngine::IReplica;
-using bftEngine::ReplicaConfig;
-using bftEngine::IRequestsHandler;
 using namespace std;
 using namespace bftEngine;
 

--- a/threshsign/bench/BenchRelic.cpp
+++ b/threshsign/bench/BenchRelic.cpp
@@ -34,7 +34,6 @@ extern "C" {
 }
 
 using namespace BLS::Relic;
-using std::endl;
 
 void printTime(const AveragingTimer& t, bool printAvg = false) {
   LOG_DEBUG(GL, t.numIterations() << " iters of " << t.getName() << ": " << t.totalLapTime() << " microsecs");

--- a/threshsign/src/app/RelicMain.cpp
+++ b/threshsign/src/app/RelicMain.cpp
@@ -16,7 +16,6 @@
 #include <memory>
 
 using BLS::Relic::Library;
-using std::endl;
 
 int AppMain(const std::vector<std::string>& args) {
   // Must call this outside TRY {} block

--- a/threshsign/src/bls/relic/BlsAlmostMultisigCoefficients.cpp
+++ b/threshsign/src/bls/relic/BlsAlmostMultisigCoefficients.cpp
@@ -26,8 +26,6 @@
 
 #include "Logger.hpp"
 
-using std::endl;
-
 namespace BLS {
 namespace Relic {
 

--- a/threshsign/src/bls/relic/BlsMultisigAccumulator.cpp
+++ b/threshsign/src/bls/relic/BlsMultisigAccumulator.cpp
@@ -20,8 +20,6 @@
 
 #include <vector>
 
-using std::endl;
-
 namespace BLS {
 namespace Relic {
 

--- a/threshsign/src/bls/relic/BlsMultisigKeygen.cpp
+++ b/threshsign/src/bls/relic/BlsMultisigKeygen.cpp
@@ -18,8 +18,6 @@
 
 #include "Logger.hpp"
 
-using std::endl;
-
 namespace BLS {
 namespace Relic {
 

--- a/threshsign/src/bls/relic/BlsThresholdFactory.cpp
+++ b/threshsign/src/bls/relic/BlsThresholdFactory.cpp
@@ -36,8 +36,6 @@
 
 #include "Logger.hpp"
 
-using std::endl;
-
 namespace BLS {
 namespace Relic {
 

--- a/threshsign/test/TestLagrange.cpp
+++ b/threshsign/test/TestLagrange.cpp
@@ -40,7 +40,7 @@ using namespace BLS::Relic;
 /**
  * Converts a sequence of +/- i's into a subset of signers.
  */
-void seqToSubset(VectorOfShares& signers, std::vector<int> seq) {
+void seqToSubset(VectorOfShares& signers, const std::vector<int>& seq) {
   for (int i : seq) {
     testAssertNotZero(i);
     testAssertLessThanOrEqual(i, MAX_NUM_OF_SHARES);

--- a/tools/KeyfileIOUtils.cpp
+++ b/tools/KeyfileIOUtils.cpp
@@ -139,9 +139,9 @@ static bool validateRSAPrivateKey(const std::string& key) {
 // variable map produced by parsing the keyfile, and prints errors if there
 // are not.
 static bool expectEntries(const std::vector<std::string>& entries,
-                          const std::unordered_map<std::string, std::string> map,
+                          const std::unordered_map<std::string, std::string>& map,
                           const std::string& filename,
-                          const std::unordered_map<std::string, size_t> lineNumbers) {
+                          const std::unordered_map<std::string, size_t>& lineNumbers) {
   for (const auto& entry : entries) {
     if (map.count(entry) < 1) {
       if (lineNumbers.count(entry) < 1) {

--- a/util/include/assertUtils.hpp
+++ b/util/include/assertUtils.hpp
@@ -72,7 +72,7 @@ inline void printCallStack() {
                   << #expr2 << "' is " << result2.c_str() << " in function " << __FUNCTION__ << " (" << __FILE__ \
                   << " " << __LINE__ << ")");                                                                    \
     printCallStack();                                                                                            \
-    assert(false);                                                                                               \
+    assert(false); /*NOLINT(misc-static-assert)*/                                                                \
   }
 
 #define PRINT_DATA_AND_ASSERT(expr1, expr2, assertMacro)                                                      \
@@ -81,7 +81,7 @@ inline void printCallStack() {
               " " << assertMacro << KVLOG_FOR_ASSERT(expr1, expr2) << " in function " << __FUNCTION__ << " (" \
                   << __FILE__ << " " << __LINE__ << ")");                                                     \
     printCallStack();                                                                                         \
-    assert(false);                                                                                            \
+    assert(false); /*NOLINT(misc-static-assert)*/                                                             \
   }
 
 #define Assert(expr)                                                                                              \
@@ -91,7 +91,7 @@ inline void printCallStack() {
                 " Assert: expression '" << #expr << "' is false in function " << __FUNCTION__ << " (" << __FILE__ \
                                         << " " << __LINE__ << ")");                                               \
       printCallStack();                                                                                           \
-      assert(false);                                                                                              \
+      assert(false); /*NOLINT(misc-static-assert)*/                                                               \
     }                                                                                                             \
   }
 // Assert (expr1 == expr2)

--- a/util/test/thread_pool_test.cpp
+++ b/util/test/thread_pool_test.cpp
@@ -133,6 +133,7 @@ TEST(thread_pool, multiple_arguments) {
 // Make sure exceptions from the user-passed function are correctly propagated.
 TEST(thread_pool, exception) {
   auto pool = ThreadPool{};
+  // NOLINTNEXTLINE(misc-throw-by-value-catch-by-reference)
   auto future = pool.async([]() { throw answer; });
   ASSERT_THROW(future.get(), decltype(answer));
 }


### PR DESCRIPTION
Changes:
1. Added `misc-*` checks
2. Ignored `misc-non-private-member-variables-in-classes` and `misc-unused-parameters`
3. Ignored `performance-unnecessary-value-param` for types `'shared_ptr;SharedPtr;[Ll]og;BlockId`
4. Function parameters that are used as `const` became constant reference
5. Removed unused `using`