### PR TITLE
Add readonly mode support for DatabaseSet

### DIFF
--- a/kvbc/include/direct_kv_storage_factory.h
+++ b/kvbc/include/direct_kv_storage_factory.h
@@ -29,6 +29,7 @@ class RocksDBStorageFactory : public IStorageFactory {
 
  public:
   DatabaseSet newDatabaseSet() const override;
+  DatabaseSet newDatabaseSet(bool readOnly) const override;
   std::unique_ptr<storage::IMetadataKeyManipulator> newMetadataKeyManipulator() const override;
   std::unique_ptr<storage::ISTKeyManipulator> newSTKeyManipulator() const override;
 
@@ -40,6 +41,7 @@ class RocksDBStorageFactory : public IStorageFactory {
 class MemoryDBStorageFactory : public IStorageFactory {
  public:
   DatabaseSet newDatabaseSet() const override;
+  DatabaseSet newDatabaseSet(bool readOnly) const override;
   std::unique_ptr<storage::IMetadataKeyManipulator> newMetadataKeyManipulator() const override;
   std::unique_ptr<storage::ISTKeyManipulator> newSTKeyManipulator() const override;
 };

--- a/kvbc/include/merkle_tree_storage_factory.h
+++ b/kvbc/include/merkle_tree_storage_factory.h
@@ -26,6 +26,7 @@ class RocksDBStorageFactory : public IStorageFactory {
 
  public:
   DatabaseSet newDatabaseSet() const override;
+  DatabaseSet newDatabaseSet(bool readOnly) const override;
   std::unique_ptr<storage::IMetadataKeyManipulator> newMetadataKeyManipulator() const override;
   std::unique_ptr<storage::ISTKeyManipulator> newSTKeyManipulator() const override;
 
@@ -37,6 +38,7 @@ class RocksDBStorageFactory : public IStorageFactory {
 class MemoryDBStorageFactory : public IStorageFactory {
  public:
   DatabaseSet newDatabaseSet() const override;
+  DatabaseSet newDatabaseSet(bool readOnly) const override;
   std::unique_ptr<storage::IMetadataKeyManipulator> newMetadataKeyManipulator() const override;
   std::unique_ptr<storage::ISTKeyManipulator> newSTKeyManipulator() const override;
 };

--- a/kvbc/include/storage_factory_interface.h
+++ b/kvbc/include/storage_factory_interface.h
@@ -41,6 +41,12 @@ class IStorageFactory {
   // Note: The returned DB clients and the adapter are initialized and ready to use.
   virtual DatabaseSet newDatabaseSet() const = 0;
 
+  // Create a set of database objects at once. Objects from one set can only be used throughout the system with other
+  // objects from the same set. Using objects from different sets is not supported and might lead to undefined behavior.
+  // Note: The returned DB clients and the adapter are initialized and ready to use.
+  // This overload will create read only data set
+  virtual DatabaseSet newDatabaseSet(bool readOnly) const = 0;
+
   // Create a metadata key manipulator. It is allowed to create multiple instances and use them together with objects
   // from the database set.
   virtual std::unique_ptr<storage::IMetadataKeyManipulator> newMetadataKeyManipulator() const = 0;

--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -37,13 +37,17 @@ auto createRocksDBClient(const std::string &dbPath) {
 }  // namespace
 
 #ifdef USE_ROCKSDB
-IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const {
+IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet(bool readOnly) const {
   auto ret = IStorageFactory::DatabaseSet{};
   ret.dataDBClient = createRocksDBClient(dbPath_);
-  ret.dataDBClient->init();
+  ret.dataDBClient->init(readOnly);
   ret.metadataDBClient = ret.dataDBClient;
   ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient);
   return ret;
+}
+
+IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const {
+  return newDatabaseSet(false);
 }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> RocksDBStorageFactory::newMetadataKeyManipulator() const {
@@ -55,14 +59,18 @@ std::unique_ptr<storage::ISTKeyManipulator> RocksDBStorageFactory::newSTKeyManip
 }
 #endif
 
-IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const {
+IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet(bool readOnly) const {
   auto ret = IStorageFactory::DatabaseSet{};
   const auto comparator = storage::memorydb::KeyComparator{new DBKeyComparator{}};
   ret.dataDBClient = std::make_shared<storage::memorydb::Client>(comparator);
-  ret.dataDBClient->init();
+  ret.dataDBClient->init(readOnly);
   ret.metadataDBClient = ret.dataDBClient;
   ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient);
   return ret;
+}
+
+IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const {
+  return newDatabaseSet(false);
 }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> MemoryDBStorageFactory::newMetadataKeyManipulator() const {

--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -46,9 +46,7 @@ IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet(bool readOnly
   return ret;
 }
 
-IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const {
-  return newDatabaseSet(false);
-}
+IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const { return newDatabaseSet(false); }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> RocksDBStorageFactory::newMetadataKeyManipulator() const {
   return std::make_unique<storage::v1DirectKeyValue::MetadataKeyManipulator>();
@@ -69,9 +67,7 @@ IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet(bool readOnl
   return ret;
 }
 
-IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const {
-  return newDatabaseSet(false);
-}
+IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const { return newDatabaseSet(false); }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> MemoryDBStorageFactory::newMetadataKeyManipulator() const {
   return std::make_unique<storage::v1DirectKeyValue::MetadataKeyManipulator>();

--- a/kvbc/src/merkle_tree_storage_factory.cpp
+++ b/kvbc/src/merkle_tree_storage_factory.cpp
@@ -31,9 +31,7 @@ IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet(bool readOnly
   return ret;
 }
 
-IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const {
-  return newDatabaseSet(false);
-}
+IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const { return newDatabaseSet(false); }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> RocksDBStorageFactory::newMetadataKeyManipulator() const {
   return std::make_unique<storage::v2MerkleTree::MetadataKeyManipulator>();
@@ -53,9 +51,7 @@ IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet(bool readOnl
   return ret;
 }
 
-IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const {
-  return newDatabaseSet(false);
-}
+IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const { return newDatabaseSet(false); }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> MemoryDBStorageFactory::newMetadataKeyManipulator() const {
   return std::make_unique<storage::v2MerkleTree::MetadataKeyManipulator>();

--- a/kvbc/src/merkle_tree_storage_factory.cpp
+++ b/kvbc/src/merkle_tree_storage_factory.cpp
@@ -22,13 +22,17 @@ namespace concord::kvbc::v2MerkleTree {
 #ifdef USE_ROCKSDB
 RocksDBStorageFactory::RocksDBStorageFactory(const std::string &dbPath) : dbPath_{dbPath} {}
 
-IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const {
+IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet(bool readOnly) const {
   auto ret = IStorageFactory::DatabaseSet{};
   ret.dataDBClient = std::make_shared<storage::rocksdb::Client>(dbPath_);
-  ret.dataDBClient->init();
+  ret.dataDBClient->init(readOnly);
   ret.metadataDBClient = ret.dataDBClient;
   ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient);
   return ret;
+}
+
+IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const {
+  return newDatabaseSet(false);
 }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> RocksDBStorageFactory::newMetadataKeyManipulator() const {
@@ -40,13 +44,17 @@ std::unique_ptr<storage::ISTKeyManipulator> RocksDBStorageFactory::newSTKeyManip
 }
 #endif
 
-IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const {
+IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet(bool readOnly) const {
   auto ret = IStorageFactory::DatabaseSet{};
   ret.dataDBClient = std::make_shared<storage::memorydb::Client>();
-  ret.dataDBClient->init();
+  ret.dataDBClient->init(readOnly);
   ret.metadataDBClient = ret.dataDBClient;
   ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient);
   return ret;
+}
+
+IStorageFactory::DatabaseSet MemoryDBStorageFactory::newDatabaseSet() const {
+  return newDatabaseSet(false);
 }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> MemoryDBStorageFactory::newMetadataKeyManipulator() const {

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -120,6 +120,10 @@ void Client::init(bool readOnly) {
   options.statistics = ::rocksdb::CreateDBStatistics();
   options.statistics->set_stats_level(::rocksdb::StatsLevel::kExceptHistogramOrTimers);
 
+  // setting mem table to high value. is essential for high speed writes. the default 64mb
+  // value causes to more flushes
+  options.write_buffer_size = 512 << 20;
+
   // If a comparator is passed, use it. If not, use the default one.
   if (comparator_) {
     options.comparator = comparator_.get();


### PR DESCRIPTION
This PR enables read only mode for any type of DatabaseSet. Especially it is critical when using rocksdb as underlying storage, for using concord DB from other utilities while the application is running.
