### PR TITLE
Change a new client lib name to avoid target duplication in the product

### DIFF
--- a/bftclient/CMakeLists.txt
+++ b/bftclient/CMakeLists.txt
@@ -1,15 +1,15 @@
 project (bftclient LANGUAGES CXX)
 
-add_library(bftclient2 STATIC
+add_library(bftclient_new STATIC
   src/bft_client.cpp
   src/msg_receiver.cpp
   src/matcher.cpp
   src/quorums.cpp
 )
 
-target_include_directories(bftclient2 PUBLIC include)
-target_include_directories(bftclient2 PRIVATE src)
-target_link_libraries(bftclient2 PUBLIC bftcommunication bftheaders)
+target_include_directories(bftclient_new PUBLIC include)
+target_include_directories(bftclient_new PRIVATE src)
+target_link_libraries(bftclient_new PUBLIC bftcommunication bftheaders)
 
 if (BUILD_TESTING)
     add_subdirectory(test)

--- a/bftclient/test/CMakeLists.txt
+++ b/bftclient/test/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(bft_client_test PRIVATE ../src)
 target_link_libraries(bft_client_test PRIVATE
   GTest::Main
   GTest::GTest
-  bftclient2
+  bftclient_new
 )
 
 add_executable(bft_client_api_tests bft_client_api_tests.cpp)
@@ -15,5 +15,5 @@ target_include_directories(bft_client_api_tests PRIVATE ../src)
 target_link_libraries(bft_client_api_tests PRIVATE
   GTest::Main
   GTest::GTest
-  bftclient2
+  bftclient_new
 )


### PR DESCRIPTION
bftclient2 is an existing target in the product - renaming to bftclient_new