### PR TITLE
Add missing functional header

### DIFF
--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -14,6 +14,7 @@
 #include <set>
 #include <thread>
 #include <vector>
+#include <functional>
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Added header <functional> not getting included automatically for
the native build, otherwise causing a build error.