### PR TITLE
[Apollo/Hermes] PyTest to ignore SkvbcPreExecutionTest

### DIFF
--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -53,6 +53,8 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcPreExecutionTest(unittest.TestCase):
 
+    __test__ = False  # so that PyTest ignores this test scenario
+
     async def send_single_read(self, skvbc, client):
         req = skvbc.read_req(skvbc.random_keys(1))
         await client.read(req)


### PR DESCRIPTION
This is needed, in order for the Apollo pre-execution tests to run as part of Hermes and product CI.