### PR TITLE
Add server side support for ReplicaSpecificInfo

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -44,6 +44,7 @@ class IRequestsHandler {
                       uint32_t maxReplySize,
                       char *outReply,
                       uint32_t &outActualReplySize,
+                      uint32_t &outReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &parent_span) = 0;
 
   virtual void onFinishExecutingReadWriteRequests() {}

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -57,7 +57,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
  protected:
   const bool viewChangeProtocolEnabled;
   const bool autoPrimaryRotationEnabled;
-  const bool supportDirectProofs = false;  // TODO(GG): add support
 
   // If this replica was restarted and loaded data from persistent storage.
   bool restarted_ = false;

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.cpp
@@ -22,6 +22,7 @@ ClientReplyMsg::ClientReplyMsg(ReplicaId primaryId, ReqId reqSeqNum, ReplicaId r
   b()->reqSeqNum = reqSeqNum;
   b()->currentPrimaryId = primaryId;
   b()->replyLength = 0;
+  b()->replicaSpecificInfoLength = 0;
   setMsgSize(sizeof(ClientReplyMsgHeader));
 }
 
@@ -48,6 +49,11 @@ void ClientReplyMsg::setReplyLength(uint32_t replyLength) {
   Assert(replyLength <= maxReplyLength());
   b()->replyLength = replyLength;
   setMsgSize(sizeof(ClientReplyMsgHeader) + replyLength);
+}
+
+void ClientReplyMsg::setReplicaSpecificInfoLength(uint32_t length) {
+  Assert(length <= maxReplyLength());
+  b()->replicaSpecificInfoLength = length;
 }
 
 void ClientReplyMsg::setPrimaryId(ReplicaId primaryId) { b()->currentPrimaryId = primaryId; }

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
@@ -45,6 +45,8 @@ class ClientReplyMsg : public MessageBase {
 
   void setReplyLength(uint32_t replyLength);
 
+  void setReplicaSpecificInfoLength(uint32_t length);
+
   void setPrimaryId(ReplicaId primaryId);
 
   uint64_t debugHash() const;

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -531,6 +531,8 @@ void PreProcessor::launchAsyncReqPreProcessingJob(const PreProcessRequestMsgShar
 uint32_t PreProcessor::launchReqPreProcessing(
     uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength, char *reqBuf, const std::string &span_context) {
   uint32_t resultLen = 0;
+  // Unused for now. Replica Specific Info not currently supported in pre-execution.
+  uint32_t replicaSpecificInfoLen = 0;
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
   requestsHandler_.execute(clientId,
                            reqSeqNum,
@@ -540,6 +542,7 @@ uint32_t PreProcessor::launchReqPreProcessing(
                            maxReplyMsgSize_,
                            (char *)getPreProcessResultBuffer(clientId),
                            resultLen,
+                           replicaSpecificInfoLen,
                            span);
   if (!resultLen)
     throw std::runtime_error("Actual result length is 0 for clientId: " + to_string(clientId) +

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -63,6 +63,7 @@ class DummyRequestsHandler : public IRequestsHandler {
               uint32_t maxReplySize,
               char* outReply,
               uint32_t& outActualReplySize,
+              uint32_t& outActualReplicaSpecificInfoSize,
               concordUtils::SpanWrapper& span) override {
     outActualReplySize = 256;
     return 0;

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -135,6 +135,7 @@ class ICommandsHandler : public bftEngine::IRequestsHandler {
               uint32_t maxReplySize,
               char* outReply,
               uint32_t& outActualReplySize,
+              uint32_t& outActualReplicaSpecificInfoSize,
               concordUtils::SpanWrapper& span) override = 0;
   ~ICommandsHandler() override = default;
 };

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -39,7 +39,10 @@ int InternalCommandsHandler::execute(uint16_t clientId,
                                      uint32_t maxReplySize,
                                      char *outReply,
                                      uint32_t &outActualReplySize,
+                                     uint32_t &outActualReplicaSpecificInfoSize,
                                      concordUtils::SpanWrapper &span) {
+  // ReplicaSpecificInfo is not currently used in the TesterReplica
+  outActualReplicaSpecificInfoSize = 0;
   int res;
   if (requestSize < sizeof(SimpleRequest)) {
     LOG_ERROR(

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -39,6 +39,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                       uint32_t maxReplySize,
                       char *outReply,
                       uint32_t &outActualReplySize,
+                      uint32_t &outActualReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &span) override;
 
  private:

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -79,7 +79,11 @@ class SimpleAppState : public IRequestsHandler {
               uint32_t maxReplySize,
               char *outReply,
               uint32_t &outActualReplySize,
+              uint32_t &outActualReplicaSpecificInfoSize,
               concordUtils::SpanWrapper &span) override {
+    // Not currently used
+    outActualReplicaSpecificInfoSize = 0;
+
     bool readOnly = flags & READ_ONLY_FLAG;
     if (readOnly) {
       // Our read-only request includes only a type, no argument.


### PR DESCRIPTION
Execution handlers can now return ReplicaSpecificInfo by specifying its
size and embedding it in the reply buffer. The field is already
supported in ClientReplyMsgHeaders and does not have to be used. Any
execution handler may choose to simply ignore it and let it default to
0.

ReplicaSpecificInfo is not currently supported or used for
pre-execution. It is also not currently used in our test binaries.
Nonetheless, the field is mandatory and was added to all usage of the
`execute` callback. A corresponding change will need to be made in the
product, and will be made before this is merged in.

Additionally, an unused code path related to direct proofs, which we do
not intend to support, was removed.