### PR TITLE
[Apollo] Prevent conflicts when generating random writes

### DIFF
--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -276,7 +276,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         bft_network.start_replica(unstable_replica)
         await trio.sleep(seconds=5)
 
-        await tracker.run_concurrent_ops(num_ops=50)
+        await tracker.run_concurrent_ops(num_ops=20)
 
         await bft_network.wait_for_view(
             replica_id=unstable_replica,

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -27,7 +27,7 @@ from util.skvbc_exceptions import(
 MAX_LOOKBACK=10
 
 
-def verify_linearizability(pre_exec_enabled=False, no_conflicts=False):
+def verify_linearizability(pre_exec_enabled=False, no_conflicts=True):
     """
     Creates a tracker and provide him to the decorated method.
     In the end of the method it checks the linearizability of the resulting history.


### PR DESCRIPTION
Generating write requests with conflicting read-sets only makes sense in the case of pre-execution.
Normal execution being sequential, conflicts cannot happen by definition.