### PR TITLE
OpenTracing: remove redundant tags/baggage items

### DIFF
--- a/util/include/OpenTracing.hpp
+++ b/util/include/OpenTracing.hpp
@@ -47,13 +47,6 @@ class SpanWrapper {
       return;
     }
     span_ptr_->SetTag(name, value);
-    // DD: tags are not passed to children spans,
-    // baggage items are stored in span context
-    if constexpr (std::is_same<ValueT, std::string>()) {
-      span_ptr_->SetBaggageItem(name, value);
-    } else {
-      span_ptr_->SetBaggageItem(name, std::to_string(value));
-    }
 #else
     (void)name;
     (void)value;


### PR DESCRIPTION
Rationale:
Since children spans do not inherit parent's tags, I've decided to transfer them via baggage items.
The idea was to have the same CID tag for all spans in a trace and to be able to filter them after the CID.
After further consideration, I've realized that transferring tags via baggage items is redundant and not aligned with OpenTelemetry philosophy.

Changes:
    Removed copy of tags via baggage items

How to find the trace by CID:
* In Wavefront filter by operation(for example, concord.*)
* Add filter "UnindexedTag" with key `cid` and value <your cid>
    => Wavefront will show the top-level span tagged with the CID together with its children

Note: Sometimes not all spans are reflected so do the following search:
* Copy TraceID of the top-level span
* Remove the "UnidexedTag" filter
* Add "TraceID" filter and with the value of the top-level span's trace id
    => Wavefront will show the whole trace

Note: The top-level span MUST be tagged with appropriate tags such as
`cid`, `rid`, `seq_num` etc.