### PR TITLE
Increase default rocksdb memtable size

### DIFF
--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -120,7 +120,7 @@ void Client::init(bool readOnly) {
   options.statistics = ::rocksdb::CreateDBStatistics();
   options.statistics->set_stats_level(::rocksdb::StatsLevel::kExceptHistogramOrTimers);
 
-  options.write_buffer_size = 512 << 21; // set default memtable size to 512mb to improve perf
+  options.write_buffer_size = 512 << 21;  // set default memtable size to 512mb to improve perf
 
   // If a comparator is passed, use it. If not, use the default one.
   if (comparator_) {

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -120,7 +120,7 @@ void Client::init(bool readOnly) {
   options.statistics = ::rocksdb::CreateDBStatistics();
   options.statistics->set_stats_level(::rocksdb::StatsLevel::kExceptHistogramOrTimers);
 
-  options.write_buffer_size = 512 << 21;  // set default memtable size to 512mb to improve perf
+  options.write_buffer_size = 512 << 20;  // set default memtable size to 512mb to improve perf
 
   // If a comparator is passed, use it. If not, use the default one.
   if (comparator_) {

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -120,6 +120,8 @@ void Client::init(bool readOnly) {
   options.statistics = ::rocksdb::CreateDBStatistics();
   options.statistics->set_stats_level(::rocksdb::StatsLevel::kExceptHistogramOrTimers);
 
+  options.write_buffer_size = 512 << 21; // set default memtable size to 512mb to improve perf
+
   // If a comparator is passed, use it. If not, use the default one.
   if (comparator_) {
     options.comparator = comparator_.get();


### PR DESCRIPTION
This PR increases default rocksdb memtable size from 64mb to 512mb. As was observed in performance tests, this change is essential for high loads.