### PR TITLE
[Apollo] Mix reads and writes for pre-execution tests

### DIFF
--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -424,6 +424,6 @@ class SkvbcPreExecutionTest(unittest.TestCase):
     async def issue_tracked_ops_to_the_system(self, tracker):
         try:
             with trio.move_on_after(seconds=30):
-                await tracker.run_concurrent_ops(50, write_weight=1)
+                await tracker.run_concurrent_ops(50, write_weight=.70)
         except trio.TooSlowError:
             pass


### PR DESCRIPTION
This change increases the value of linearizability checks for pre-execution, by mixing reads and writes when issuing random concurrent ops to the system.