### PR TITLE
[Apollo] Pre-execution test fixes for product CI

### DIFF
--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -396,14 +396,15 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         """
         Launch pre-process conflicting request and make sure that conflicting requests are not committed
         """
+        bft_network.start_all_replicas()
+
         n = bft_network.config.n
         f = bft_network.config.f
         c = bft_network.config.c
 
         initial_primary = 0
         crashed_replicas = bft_network.random_set_of_replicas(f, without={initial_primary})
-        correct_replicas = bft_network.all_replicas(without=crashed_replicas)
-        bft_network.start_replicas(replicas=correct_replicas)
+        bft_network.stop_replicas(replicas=crashed_replicas)
 
         read_client = bft_network.random_client()
         start_block = await tracker.get_last_block_id(read_client)

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -1047,6 +1047,10 @@ class PassThroughSkvbcTracker:
 
         self.bft_network = bft_network
 
+    async def get_last_block_id(self, client):
+        msg = kvbc.SimpleKVBCProtocol.get_last_block_req()
+        return kvbc.SimpleKVBCProtocol.parse_reply(await client.read(msg))
+
     async def send_tracked_write(self, client, max_set_size, long_exec=False):
         max_read_set_size = 0 if self.no_conflicts else max_set_size
         readset = self.readset(0, max_read_set_size)


### PR DESCRIPTION
This PR introduces two minor improvements that enable Apollo/Hermes integration:
- add a `get_last_block_id()` method to the PassThroughSkvbcTracker
- in `test_conflicting_requests_with_f_failures()`, start all replicas, then stop the crashed ones. This change is necessary because in Hermes all replicas are started initially.