### PR TITLE
Replace assert with Assert

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks:             '-*,bugprone-*,
                     -bugprone-branch-clone,
                     -bugprone-exception-escape,
+                    -bugprone-lambda-function-name,
                     -bugprone-misplaced-widening-cast,
                     -bugprone-not-null-terminated-result,
                     performance-*,
@@ -13,6 +14,7 @@ Checks:             '-*,bugprone-*,
 WarningsAsErrors:   'bugprone-*,
                     -bugprone-branch-clone,
                     -bugprone-exception-escape,
+                    -bugprone-lambda-function-name,
                     -bugprone-misplaced-widening-cast,
                     -bugprone-not-null-terminated-result,
                     performance-*,
@@ -23,6 +25,7 @@ WarningsAsErrors:   'bugprone-*,
                     '
 # -bugprone-branch-clone - does not work well with switch cases
 # -bugprone-exception-escape - main functions throwing exceptions are OK: we prefer to analyze core dumps
+# -bugprone-lambda-function-name - Assert macro leads to many false positives
 # -bugprone-misplaced-widening-cast - does not seem to be a big issue
 # -bugprone-not-null-terminated-result - many false positives when std::string is used for storing raw bytes
 # -misc-non-private-member-variables-in-classes - seems irrelevant

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -42,8 +42,7 @@ jobs:
             ${{ env.USE_ROCKSDB }}
             ${{ env.USE_CONAN }}
             ${{ env.USE_S3_OBJECT_STORE }} .. &&
-            run-clang-tidy-10 &&
-            ! grep -rn --color=auto --exclude-dir={build,.git,.github} -E \"NOLINTNEXTLINE(\s+|$)|NOLINT(\s+|$)\" .."
+            run-clang-tidy-10 && ../scripts/check-forbidden-usage.sh .."
         - name: Print failure info
           if: failure()
           run: |

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ tidy-check: ## Runs clang-tidy
 		CC=${CONCORD_BFT_CONTAINER_CC} CXX=${CONCORD_BFT_CONTAINER_CXX} \
 		cmake ${CONCORD_BFT_CMAKE_FLAGS} .. && \
 		run-clang-tidy-10 &> clang-tidy-report.txt && \
-		! grep -rn --color=auto --exclude-dir={build,.git,.github} -E \"NOLINTNEXTLINE(\s+|$$)|NOLINT(\s+|$$)\" .." \
+		../scripts/check-forbidden-usage.sh .." \
 		&& (echo "\nClang-tidy finished successfully.") \
 		|| ( echo "\nClang-tidy failed. The report is in ${CURDIR}/${CONCORD_BFT_BUILD_DIR}/clang-tidy-report.txt. \
 			 \nFor detail information about the checks, please refer to https://clang.llvm.org/extra/clang-tidy/checks/list.html" \

--- a/bftclient/test/bft_client_test.cpp
+++ b/bftclient/test/bft_client_test.cpp
@@ -12,6 +12,7 @@
 
 #include "gtest/gtest.h"
 
+#include "assertUtils.hpp"
 #include "bftengine/ClientMsgs.hpp"
 
 #include "msg_receiver.h"
@@ -130,7 +131,7 @@ std::vector<UnmatchedReply> unmatched_replies(uint16_t n,
                                               ReplyMetadata metadata,
                                               const Msg& msg,
                                               const std::vector<ReplicaSpecificInfo>& rsi) {
-  assert(n <= rsi.size());
+  Assert(n <= rsi.size());
   std::vector<UnmatchedReply> replies;
   for (uint16_t i = 0; i < n; i++) {
     replies.emplace_back(UnmatchedReply{metadata, msg, rsi[i]});

--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -244,7 +244,7 @@ void DBDataStore::deserializeResPage(
   outPageDigest = STDigest(dgst);
   std::uint32_t sizeOfReseredPage;
   Serializable::deserialize(is, sizeOfReseredPage);
-  assert(sizeOfReseredPage == inmem_->getSizeOfReservedPage());
+  Assert(sizeOfReseredPage == inmem_->getSizeOfReservedPage());
   Serializable::deserialize(is, outPage, sizeOfReseredPage);
 }
 void DBDataStore::loadResPages() {
@@ -350,7 +350,7 @@ void DBDataStore::associatePendingResPageWithCheckpointTxn(uint32_t inPageId,
                      << " txn: " << txn->getId());
   auto& pendingPages = inmem_->getPendingPagesMap();
   auto page = pendingPages.find(inPageId);
-  assert(page != pendingPages.end());
+  Assert(page != pendingPages.end());
 
   setResPageTxn(inPageId, inCheckpoint, inPageDigest, page->second, txn);
   txn->del(pendingPageKey(inPageId));
@@ -379,7 +379,7 @@ void DBDataStore::deleteCoveredResPageInSmallerCheckpointsTxn(uint64_t minChkp, 
   it++;
   for (; it != pages.end(); ++it) {
     if (it->first.pageId == prevItemPageId && prevItemIsInLastRelevantCheckpoint) {
-      assert(it->second.page != nullptr);
+      Assert(it->second.page != nullptr);
       LOG_DEBUG(logger(),
                 "delete: [" << it->first.pageId << ":" << it->first.checkpoint << "] "
                             << dynamicResPageKey(it->first.pageId, it->first.checkpoint));

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <string>
 #include <set>
+#include "assertUtils.hpp"
 #include "storage/db_interface.h"
 #include "STDigest.hpp"
 
@@ -128,7 +129,7 @@ class DataStore : public std::enable_shared_from_this<DataStore> {
     size_t size() const { return size(numOfPages); }
 
     static size_t size(uint32_t numberOfPages) {
-      assert(numberOfPages > 0);
+      Assert(numberOfPages > 0);
       return sizeof(ResPagesDescriptor) + (numberOfPages - 1) * sizeof(SingleResPageDesc);
     }
   };
@@ -256,7 +257,7 @@ class DataStoreTransaction : public DataStore, public ITransaction {
   // You can't begin a transaction from within a transaction. However, since we
   // inherit from DataStore, we must implement this method.
   DataStoreTransaction* beginTransaction() override {
-    assert(false);
+    Assert(false);
     return nullptr;
   }
   std::shared_ptr<DataStore> ds_;

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
@@ -14,6 +14,7 @@
 #include <set>
 
 #include "InMemoryDataStore.hpp"
+#include "assertUtils.hpp"
 
 namespace bftEngine {
 namespace SimpleBlockchainStateTransfer {
@@ -28,56 +29,56 @@ bool InMemoryDataStore::initialized() { return wasInit_; }
 void InMemoryDataStore::setAsInitialized() { wasInit_ = true; }
 
 void InMemoryDataStore::setReplicas(const set<uint16_t> replicas) {
-  assert(replicas_.empty());
+  Assert(replicas_.empty());
   replicas_ = replicas;
 }
 
 set<uint16_t> InMemoryDataStore::getReplicas() {
-  assert(!replicas_.empty());
+  Assert(!replicas_.empty());
   return replicas_;
 }
 
 void InMemoryDataStore::setMyReplicaId(uint16_t id) {
-  assert(myReplicaId_ == UINT16_MAX);
+  Assert(myReplicaId_ == UINT16_MAX);
   myReplicaId_ = id;
 }
 
 uint16_t InMemoryDataStore::getMyReplicaId() {
-  assert(myReplicaId_ != UINT16_MAX);
+  Assert(myReplicaId_ != UINT16_MAX);
   return myReplicaId_;
 }
 
 void InMemoryDataStore::setFVal(uint16_t fVal) {
-  assert(fVal_ == UINT16_MAX);
+  Assert(fVal_ == UINT16_MAX);
   fVal_ = fVal;
 }
 
 uint16_t InMemoryDataStore::getFVal() {
-  assert(fVal_ != UINT16_MAX);
+  Assert(fVal_ != UINT16_MAX);
   return fVal_;
 }
 
 void InMemoryDataStore::setMaxNumOfStoredCheckpoints(uint64_t numChecks) {
-  assert(numChecks > 0);
+  Assert(numChecks > 0);
 
-  assert(maxNumOfStoredCheckpoints_ == UINT64_MAX);
+  Assert(maxNumOfStoredCheckpoints_ == UINT64_MAX);
   maxNumOfStoredCheckpoints_ = numChecks;
 }
 
 uint64_t InMemoryDataStore::getMaxNumOfStoredCheckpoints() const {
-  assert(maxNumOfStoredCheckpoints_ != UINT64_MAX);
+  Assert(maxNumOfStoredCheckpoints_ != UINT64_MAX);
   return maxNumOfStoredCheckpoints_;
 }
 
 void InMemoryDataStore::setNumberOfReservedPages(uint32_t numResPages) {
-  assert(numResPages > 0);
+  Assert(numResPages > 0);
 
-  assert(numberOfReservedPages_ == UINT32_MAX);
+  Assert(numberOfReservedPages_ == UINT32_MAX);
   numberOfReservedPages_ = numResPages;
 }
 
 uint32_t InMemoryDataStore::getNumberOfReservedPages() {
-  assert(numberOfReservedPages_ != UINT32_MAX);
+  Assert(numberOfReservedPages_ != UINT32_MAX);
   return numberOfReservedPages_;
 }
 
@@ -90,20 +91,20 @@ void InMemoryDataStore::setFirstStoredCheckpoint(uint64_t c) { firstStoredCheckp
 uint64_t InMemoryDataStore::getFirstStoredCheckpoint() { return firstStoredCheckpoint; }
 
 void InMemoryDataStore::setCheckpointDesc(uint64_t checkpoint, const CheckpointDesc& desc) {
-  assert(checkpoint == desc.checkpointNum);
-  assert(descMap.count(checkpoint) == 0);
+  Assert(checkpoint == desc.checkpointNum);
+  Assert(descMap.count(checkpoint) == 0);
 
   descMap[checkpoint] = desc;
 
-  //  assert(descMap.size() < 21);  // TODO(GG): delete - debug only
+  //  Assert(descMap.size() < 21);  // TODO(GG): delete - debug only
 }
 
 DataStore::CheckpointDesc InMemoryDataStore::getCheckpointDesc(uint64_t checkpoint) {
   auto p = descMap.find(checkpoint);
 
-  assert(p != descMap.end());
+  Assert(p != descMap.end());
 
-  assert(p->first == p->second.checkpointNum);
+  Assert(p->first == p->second.checkpointNum);
 
   return p->second;
 }
@@ -117,7 +118,7 @@ bool InMemoryDataStore::hasCheckpointDesc(uint64_t checkpoint) {
 void InMemoryDataStore::deleteDescOfSmallerCheckpoints(uint64_t checkpoint) {
   auto p = descMap.begin();
   while ((p != descMap.end()) && (p->first < checkpoint)) {
-    assert(p->first == p->second.checkpointNum);
+    Assert(p->first == p->second.checkpointNum);
     p = descMap.erase(p);
   }
 }
@@ -127,13 +128,13 @@ void InMemoryDataStore::setIsFetchingState(bool b) { fetching = b; }
 bool InMemoryDataStore::getIsFetchingState() { return fetching; }
 
 void InMemoryDataStore::setCheckpointBeingFetched(const CheckpointDesc& c) {
-  assert(checkpointBeingFetched.checkpointNum == 0);
+  Assert(checkpointBeingFetched.checkpointNum == 0);
 
   checkpointBeingFetched = c;
 }
 
 DataStore::CheckpointDesc InMemoryDataStore::getCheckpointBeingFetched() {
-  assert(checkpointBeingFetched.checkpointNum != 0);
+  Assert(checkpointBeingFetched.checkpointNum != 0);
 
   return checkpointBeingFetched;
 }
@@ -145,7 +146,7 @@ void InMemoryDataStore::deleteCheckpointBeingFetched() {
   // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
   memset(&checkpointBeingFetched, 0, sizeof(checkpointBeingFetched));
 
-  assert(checkpointBeingFetched.checkpointNum == 0);
+  Assert(checkpointBeingFetched.checkpointNum == 0);
 }
 
 void InMemoryDataStore::setFirstRequiredBlock(uint64_t i) { firstRequiredBlock = i; }
@@ -158,7 +159,7 @@ uint64_t InMemoryDataStore::getLastRequiredBlock() { return lastRequiredBlock; }
 
 void InMemoryDataStore::setPendingResPage(uint32_t inPageId, const char* inPage, uint32_t inPageLen) {
   LOG_DEBUG(logger(), inPageId);
-  assert(inPageLen <= sizeOfReservedPage_);
+  Assert(inPageLen <= sizeOfReservedPage_);
 
   auto pos = pendingPages.find(inPageId);
 
@@ -179,11 +180,11 @@ void InMemoryDataStore::setPendingResPage(uint32_t inPageId, const char* inPage,
 bool InMemoryDataStore::hasPendingResPage(uint32_t inPageId) { return (pendingPages.count(inPageId) > 0); }
 
 void InMemoryDataStore::getPendingResPage(uint32_t inPageId, char* outPage, uint32_t pageLen) {
-  assert(pageLen <= sizeOfReservedPage_);
+  Assert(pageLen <= sizeOfReservedPage_);
 
   auto pos = pendingPages.find(inPageId);
 
-  assert(pos != pendingPages.end());
+  Assert(pos != pendingPages.end());
 
   memcpy(outPage, pos->second, pageLen);
 }
@@ -210,12 +211,12 @@ void InMemoryDataStore::associatePendingResPageWithCheckpoint(uint32_t inPageId,
   LOG_DEBUG(logger(), "pageId: " << inPageId << " checkpoint: " << inCheckpoint);
   // find in pendingPages
   auto pendingPos = pendingPages.find(inPageId);
-  assert(pendingPos != pendingPages.end());
-  assert(pendingPos->second != nullptr);
+  Assert(pendingPos != pendingPages.end());
+  Assert(pendingPos->second != nullptr);
 
   // create key, and make sure that we don't already have this element
   ResPageKey key = {inPageId, inCheckpoint};
-  assert(pages.count(key) == 0);
+  Assert(pages.count(key) == 0);
 
   // create value
   ResPageVal val = {inPageDigest, pendingPos->second};
@@ -233,7 +234,7 @@ void InMemoryDataStore::setResPage(uint32_t inPageId,
   LOG_DEBUG(logger(), "pageId: " << inPageId << " checkpoint: " << inCheckpoint);
   // create key, and make sure that we don't already have this element
   ResPageKey key = {inPageId, inCheckpoint};
-  assert(pages.count(key) == 0);
+  Assert(pages.count(key) == 0);
 
   // prepare page
   char* page = reinterpret_cast<char*>(std::malloc(sizeOfReservedPage_));
@@ -252,9 +253,9 @@ bool InMemoryDataStore::getResPage(uint32_t inPageId,
                                    STDigest* outPageDigest,
                                    char* outPage,
                                    uint32_t copylength) {
-  assert(copylength <= sizeOfReservedPage_);
+  Assert(copylength <= sizeOfReservedPage_);
 
-  assert(inCheckpoint <= lastStoredCheckpoint);
+  Assert(inCheckpoint <= lastStoredCheckpoint);
 
   ResPageKey key = {inPageId, inCheckpoint};
 
@@ -262,7 +263,7 @@ bool InMemoryDataStore::getResPage(uint32_t inPageId,
 
   if (p == pages.end() || p->first.pageId > inPageId) return false;
 
-  assert(p->first.checkpoint <= inCheckpoint);
+  Assert(p->first.checkpoint <= inCheckpoint);
 
   if (outActualCheckpoint != nullptr) *outActualCheckpoint = p->first.checkpoint;
 
@@ -273,7 +274,7 @@ bool InMemoryDataStore::getResPage(uint32_t inPageId,
                        << " digest: " << p->second.pageDigest.toString());
 
   if (outPage != nullptr) {
-    assert(copylength > 0);
+    Assert(copylength > 0);
     memcpy(outPage, p->second.page, copylength);
   }
   return true;
@@ -292,7 +293,7 @@ void InMemoryDataStore::deleteCoveredResPageInSmallerCheckpoints(uint64_t inMinR
   while (iter != pages.end()) {
     if (iter->first.pageId == prevItemPageId && prevItemIsInLastRelevantCheckpoint) {
       // delete
-      assert(iter->second.page != nullptr);
+      Assert(iter->second.page != nullptr);
       std::free(iter->second.page);
       iter = pages.erase(iter);
     } else {
@@ -302,7 +303,7 @@ void InMemoryDataStore::deleteCoveredResPageInSmallerCheckpoints(uint64_t inMinR
     }
   }
 
-  assert(pages.size() <= (numberOfReservedPages_ * (maxNumOfStoredCheckpoints_ + 1)));
+  Assert(pages.size() <= (numberOfReservedPages_ * (maxNumOfStoredCheckpoints_ + 1)));
 }
 
 DataStore::ResPagesDescriptor* InMemoryDataStore::getResPagesDescriptor(uint64_t inCheckpoint) {
@@ -319,7 +320,7 @@ DataStore::ResPagesDescriptor* InMemoryDataStore::getResPagesDescriptor(uint64_t
     if (iter.first.checkpoint <= inCheckpoint) {
       SingleResPageDesc& singleDesc = desc->d[iter.first.pageId];
       if (singleDesc.relevantCheckpoint > 0) {
-        assert(singleDesc.relevantCheckpoint > iter.first.checkpoint);
+        Assert(singleDesc.relevantCheckpoint > iter.first.checkpoint);
         continue;  // we already have a description for this pageId with a greater checkpoint num
       }
       singleDesc.pageId = iter.first.pageId;
@@ -335,7 +336,7 @@ DataStore::ResPagesDescriptor* InMemoryDataStore::getResPagesDescriptor(uint64_t
 }
 
 void InMemoryDataStore::free(ResPagesDescriptor* desc) {
-  assert(desc->numOfPages == numberOfReservedPages_);
+  Assert(desc->numOfPages == numberOfReservedPages_);
   void* p = desc;
   std::free(p);
 }

--- a/bftengine/src/bcstatetransfer/STDigest.cpp
+++ b/bftengine/src/bcstatetransfer/STDigest.cpp
@@ -12,6 +12,7 @@
 // file.
 
 #include "STDigest.hpp"
+#include "assertUtils.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
@@ -49,13 +50,13 @@ DigestContext::DigestContext() {
 }
 
 void DigestContext::update(const char* data, size_t len) {
-  assert(internalState != NULL);
+  Assert(internalState != nullptr);
   CryptoPP::SHA256* p = (CryptoPP::SHA256*)internalState;
   p->Update(reinterpret_cast<CryptoPP::byte*>(const_cast<char*>(data)), len);
 }
 
 void DigestContext::writeDigest(char* outDigest) {
-  assert(internalState != NULL);
+  Assert(internalState != nullptr);
   CryptoPP::SHA256* p = (CryptoPP::SHA256*)internalState;
   CryptoPP::SecByteBlock digest(CryptoPP::SHA256::DIGESTSIZE);
   p->Final(digest);
@@ -63,14 +64,14 @@ void DigestContext::writeDigest(char* outDigest) {
   memcpy(outDigest, h, CryptoPP::SHA256::DIGESTSIZE);
 
   delete p;
-  internalState = NULL;
+  internalState = nullptr;
 }
 
 DigestContext::~DigestContext() {
-  if (internalState != NULL) {
+  if (internalState != nullptr) {
     CryptoPP::SHA256* p = (CryptoPP::SHA256*)internalState;
     delete p;
-    internalState = NULL;
+    internalState = nullptr;
   }
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -929,7 +929,7 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
     return onInternalMsg(*get_status);
   }
 
-  assert(false);
+  Assert(false);
 }
 
 std::string ReplicaImp::getReplicaState() const {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1687,7 +1687,6 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
       if (msg->hasListOfMissingViewChangeMsgForViewChange() &&
           msg->isMissingViewChangeMsgForViewChange(config_.replicaId)) {
         ViewChangeMsg *myVC = viewsManager->getMyLatestViewChangeMsg();
-        // NOLINTNEXTLINE(bugprone-lambda-function-name)
         AssertNE(myVC, nullptr);
         sendAndIncrementMetric(myVC, msgSenderId, metric_sent_viewchange_msg_due_to_status_);
       }

--- a/bftengine/src/bftengine/ViewChangeSafetyLogic.cpp
+++ b/bftengine/src/bftengine/ViewChangeSafetyLogic.cpp
@@ -339,7 +339,7 @@ bool ViewChangeSafetyLogic::computeRestrictionsForSeqNum(SeqNum s,
       continue;
     }  // no need to advance iterator
 
-    assert(elem->seqNum == s);
+    Assert(elem->seqNum == s);
 
     currIter->gotoNext();
 

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -48,7 +48,7 @@ class TestAppState : public IAppState {
   };
 
   bool getPrevDigestFromBlock(uint64_t blockId, StateTransferDigest* outPrevBlockDigest) override {
-    assert(blockId > 0);
+    Assert(blockId > 0);
     auto it = blocks_.find(blockId - 1);
     if (it == blocks_.end()) return false;
     std::memcpy(outPrevBlockDigest, &it->second.digest, BLOCK_DIGEST_SIZE);
@@ -56,7 +56,7 @@ class TestAppState : public IAppState {
   };
 
   bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) override {
-    assert(blockId < last_block_);
+    Assert(blockId < last_block_);
     Block bl;
     computeBlockDigest(blockId, block, blockSize, &bl.digest);
     memcpy(&bl.block, block, blockSize);

--- a/bftengine/tests/messages/AskForCheckpointMsg_test.cpp
+++ b/bftengine/tests/messages/AskForCheckpointMsg_test.cpp
@@ -11,6 +11,7 @@
 
 #include "gtest/gtest.h"
 
+#include "assertUtils.hpp"
 #include "helper.hpp"
 #include "messages/MsgCode.hpp"
 #include "messages/AskForCheckpointMsg.hpp"

--- a/bftengine/tests/simpleStorage/main.cpp
+++ b/bftengine/tests/simpleStorage/main.cpp
@@ -49,10 +49,10 @@ void verifyData(FileStorage &fileStorage, uint32_t objId) {
       objIn.elem2,
       objIn.elem3,
       objIn.elem4);
-  assert(objIn.elem1 == ELEM1);
-  assert(objIn.elem2 == ELEM2);
-  assert(objIn.elem3 == ELEM3);
-  assert(objIn.elem4 == ELEM4);
+  Assert(objIn.elem1 == ELEM1);
+  Assert(objIn.elem2 == ELEM2);
+  Assert(objIn.elem3 == ELEM3);
+  Assert(objIn.elem4 == ELEM4);
 }
 
 // The tests verify that all MetadataStorage interfaces work correctly using file-based storage.

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -166,27 +166,27 @@ SeqNumWindow seqNumWindow{1};
 CheckWindow checkWindow{0};
 
 void testInit() {
-  assert(persistentStorageImp->getStoredVersion() == persistentStorageImp->getCurrentVersion());
-  assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecutedSeqNum);
-  assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == primaryLastUsedSeqNum);
-  assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == strictLowerBoundOfSeqNums);
-  assert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == lastViewTransferredSeqNum);
-  assert(persistentStorageImp->getLastStableSeqNum() == lastStableSeqNum);
+  Assert(persistentStorageImp->getStoredVersion() == persistentStorageImp->getCurrentVersion());
+  Assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecutedSeqNum);
+  Assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == primaryLastUsedSeqNum);
+  Assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == strictLowerBoundOfSeqNums);
+  Assert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == lastViewTransferredSeqNum);
+  Assert(persistentStorageImp->getLastStableSeqNum() == lastStableSeqNum);
 
   DescriptorOfLastExitFromView lastExitFromView = persistentStorageImp->getAndAllocateDescriptorOfLastExitFromView();
-  assert(lastExitFromView.equals(*descriptorOfLastExitFromView));
+  Assert(lastExitFromView.equals(*descriptorOfLastExitFromView));
   bool descHasSet = persistentStorageImp->hasDescriptorOfLastExitFromView();
   Assert(!descHasSet);
 
   DescriptorOfLastNewView lastNewView = persistentStorageImp->getAndAllocateDescriptorOfLastNewView();
-  assert(lastNewView.equals(*descriptorOfLastNewView));
+  Assert(lastNewView.equals(*descriptorOfLastNewView));
   descHasSet = persistentStorageImp->hasDescriptorOfLastNewView();
-  assert(!descHasSet);
+  Assert(!descHasSet);
 
   DescriptorOfLastExecution lastExecution = persistentStorageImp->getDescriptorOfLastExecution();
-  assert(lastExecution.equals(*descriptorOfLastExecution));
+  Assert(lastExecution.equals(*descriptorOfLastExecution));
   descHasSet = persistentStorageImp->hasDescriptorOfLastExecution();
-  assert(!descHasSet);
+  Assert(!descHasSet);
 
   descriptorOfLastExitFromView->clean();
   lastExitFromView.clean();
@@ -194,10 +194,10 @@ void testInit() {
   lastNewView.clean();
 
   SharedPtrCheckWindow storedCheckWindow = persistentStorageImp->getCheckWindow();
-  assert(storedCheckWindow.get()->equals(checkWindow));
+  Assert(storedCheckWindow.get()->equals(checkWindow));
 
   SharedPtrSeqNumWindow storedSeqNumWindow = persistentStorageImp->getSeqNumWindow();
-  assert(storedSeqNumWindow.get()->equals(seqNumWindow));
+  Assert(storedSeqNumWindow.get()->equals(seqNumWindow));
 }
 
 void testCheckWindowSetUp(const SeqNum shift, bool toSet) {
@@ -382,19 +382,19 @@ void testSetDescriptors(bool toSet) {
   }
 
   DescriptorOfLastExecution lastExecution = persistentStorageImp->getDescriptorOfLastExecution();
-  assert(lastExecution.equals(lastExecutionDesc));
+  Assert(lastExecution.equals(lastExecutionDesc));
   bool descHasSet = persistentStorageImp->hasDescriptorOfLastExecution();
   Assert(descHasSet);
 
   DescriptorOfLastNewView lastNewView = persistentStorageImp->getAndAllocateDescriptorOfLastNewView();
-  assert(lastNewView.equals(lastNewViewDesc));
+  Assert(lastNewView.equals(lastNewViewDesc));
   descHasSet = persistentStorageImp->hasDescriptorOfLastNewView();
-  assert(descHasSet);
+  Assert(descHasSet);
 
   DescriptorOfLastExitFromView lastExitFromView = persistentStorageImp->getAndAllocateDescriptorOfLastExitFromView();
-  assert(lastExitFromView.equals(lastExitFromViewDesc));
+  Assert(lastExitFromView.equals(lastExitFromViewDesc));
   descHasSet = persistentStorageImp->hasDescriptorOfLastExitFromView();
-  assert(descHasSet);
+  Assert(descHasSet);
 
   for (auto *v : msgs) {
     delete v;
@@ -423,10 +423,10 @@ void testSetSimpleParams(bool toSet) {
     persistentStorageImp->endWriteTran();
   }
 
-  assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecSeqNum);
-  assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == lastUsedSeqNum);
-  assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == lowBoundSeqNum);
-  assert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == view);
+  Assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecSeqNum);
+  Assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == lastUsedSeqNum);
+  Assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == lowBoundSeqNum);
+  Assert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == view);
 }
 
 void fillReplicaConfig() {

--- a/communication/src/PlainTcpCommunication.cpp
+++ b/communication/src/PlainTcpCommunication.cpp
@@ -671,7 +671,7 @@ class PlainTCPCommunication::PlainTcpImpl {
       // *listen* port, we should expect to be able to resolve our own name, or
       // shutdown otherwise.
       tcp::resolver::iterator results = resolver.resolve(query);
-      assert(results != tcp::resolver::iterator());
+      Assert(results != tcp::resolver::iterator());
       // Use the first result
       tcp::endpoint ep = *results;
       LOG_INFO(_logger, "Resolved " << _listenHost << ":" << _listenPort << " to " << ep);

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -10,6 +10,7 @@
 // terms and conditions of the subcomponent's license, as noted in the
 // LICENSE file.
 
+#include "assertUtils.hpp"
 #include "Logger.hpp"
 #include "communication/CommDefs.hpp"
 
@@ -24,8 +25,6 @@
 #include <mutex>
 #include <thread>
 #include <functional>
-
-#define Assert(cond, txtMsg) assert((cond) && (txtMsg))
 
 using namespace std;
 
@@ -106,8 +105,8 @@ class PlainUDPCommunication::PlainUdpImpl {
         endpoints{config.nodes},
         statusCallback{config.statusCallback},
         selfId{config.selfId} {
-    Assert(config.listenPort > 0, "Port should not be negative!");
-    Assert(config.nodes.size() > 0, "No communication endpoints specified!");
+    Assert((config.listenPort > 0) && "Port should not be negative!");
+    Assert((config.nodes.size() > 0) && "No communication endpoints specified!");
 
     LOG_DEBUG(
         _logger,
@@ -176,8 +175,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       LOG_FATAL(_logger,
                 "Error while binding: IP=" << sAddr.sin_addr.s_addr << ", Port=" << sAddr.sin_port
                                            << ", errno=" << concordUtils::errnoString(errno));
-      // NOLINTNEXTLINE(misc-static-assert)
-      Assert(false, "Failure occurred while binding the socket!");
+      Assert(false && "Failure occurred while binding the socket!");
       exit(1);  // TODO(GG): not really ..... change this !
     }
 
@@ -247,9 +245,9 @@ class PlainUDPCommunication::PlainUdpImpl {
 
     const Addr *to = &nodes2addresses[destNode];
 
-    Assert(to != NULL, "The destination endpoint does not exist!");
-    Assert(messageLength > 0, "The message length must be positive!");
-    Assert(message != NULL, "No message provided!");
+    Assert((to != NULL) && "The destination endpoint does not exist!");
+    Assert((messageLength > 0) && "The message length must be positive!");
+    Assert((message != NULL) && "No message provided!");
 
     LOG_DEBUG(_logger,
               " Sending " << messageLength << " bytes to " << destNode << " (" << inet_ntoa(to->sin_addr) << ":"
@@ -307,8 +305,8 @@ class PlainUDPCommunication::PlainUdpImpl {
   }
 
   void recvThreadRoutine() {
-    Assert(udpSockFd != 0, "Unable to start receiving: socket not define!");
-    Assert(receiverRef != 0, "Unable to start receiving: receiver not defined!");
+    Assert((udpSockFd != 0) && "Unable to start receiving: socket not define!");
+    Assert((receiverRef != 0) && "Unable to start receiving: receiver not defined!");
 
     /** The main receive loop. */
     Addr fromAddress;

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -230,7 +230,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     asio::ip::tcp::no_delay option;
     get_socket().set_option(boost::asio::ip::tcp::no_delay(true));
     get_socket().get_option(option);
-    assert(true == option.value());
+    Assert(true == option.value());
   }
 
   /**
@@ -285,7 +285,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
    * generic error handling function
    */
   void handle_error() {
-    assert(_connType != ConnType::NotDefined);
+    Assert(_connType != ConnType::NotDefined);
 
     if (_statusCallback) {
       bool isReplica = check_replica(_expectedDestId);
@@ -327,7 +327,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     set_authenticated(true);
     _connectTimer.expires_at(boost::posix_time::pos_infin);
     _currentTimeout = _minTimeout;
-    assert(_destId == _expectedDestId);
+    Assert(_destId == _expectedDestId);
     _fOnTlsReady(_destId, shared_from_this());
     read_msg_length_async();
   }
@@ -359,7 +359,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   }
 
   void set_tls() {
-    assert(_connType != ConnType::NotDefined);
+    Assert(_connType != ConnType::NotDefined);
 
     if (ConnType::Incoming == _connType)
       set_tls_server();
@@ -630,7 +630,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     // if first is true - we came from partial reading, no timer was started
     if (!first) {
       __attribute__((unused)) auto res = _readTimer.expires_at(boost::posix_time::pos_infin);
-      assert(res < 2);  // can cancel at most 1 pending async_wait
+      Assert(res < 2);  // can cancel at most 1 pending async_wait
     }
     if (_disposed) {
       return;
@@ -662,7 +662,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
 
     __attribute__((unused)) auto res =
         _readTimer.expires_from_now(boost::posix_time::milliseconds(READ_TIME_OUT_MILLI));
-    assert(res == 0);  // can cancel at most 1 pending async_wait
+    Assert(res == 0);  // can cancel at most 1 pending async_wait
 
     _readTimer.async_wait(
         boost::bind(&AsyncTlsConnection::on_read_timer_expired, shared_from_this(), boost::asio::placeholders::error));
@@ -698,7 +698,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
    */
   void read_msg_async_completed(const boost::system::error_code &ec, size_t bytesRead) {
     __attribute__((unused)) auto res = _readTimer.expires_at(boost::posix_time::pos_infin);
-    assert(res < 2);  // can cancel at most 1 pending async_wait
+    Assert(res < 2);  // can cancel at most 1 pending async_wait
     if (_disposed) {
       return;
     }
@@ -713,7 +713,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
       return;
     }
 
-    assert(_destId == _expectedDestId);
+    Assert(_destId == _expectedDestId);
     try {
       if (_receiver) {
         _receiver->onNewMessage(_destId, _inBuffer, bytesRead);
@@ -801,7 +801,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     // start the timer to handle the write timeout
     __attribute__((unused)) auto res =
         _writeTimer.expires_from_now(boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
-    assert(res == 0);  // should not cancel any pending async wait
+    Assert(res == 0);  // should not cancel any pending async wait
     _writeTimer.expires_from_now(boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
     _writeTimer.async_wait(
         boost::bind(&AsyncTlsConnection::on_write_timer_expired, shared_from_this(), boost::asio::placeholders::error));
@@ -812,7 +812,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
    */
   void async_write_complete(const B_ERROR_CODE &ec, size_t bytesWritten) {
     __attribute__((unused)) auto res = _writeTimer.expires_at(boost::posix_time::pos_infin);
-    assert(res < 2);  // can cancel at most 1 pending async_wait
+    Assert(res < 2);  // can cancel at most 1 pending async_wait
     _writeTimer.expires_at(boost::posix_time::pos_infin);
     if (_disposed) {
       return;

--- a/diagnostics/include/diagnostics_server.h
+++ b/diagnostics/include/diagnostics_server.h
@@ -28,6 +28,7 @@
 #include <thread>
 #include <unistd.h>
 
+#include "assertUtils.hpp"
 #include "Logger.hpp"
 #include "errnoString.hpp"
 #include "protocol.h"
@@ -135,7 +136,7 @@ class Server {
         auto rv = select(listen_sock_ + 1, &read_fds, NULL, NULL, &tv);
         if (rv == 0) continue;  // timeout
         if (rv < 0 && errno == EINTR) continue;
-        assert(rv > 0);
+        Assert(rv > 0);
         int sock = accept(listen_sock_, NULL, NULL);
         // We must bind the result future or else this call blocks.
         auto _ = std::async(std::launch::async, [&]() { handleRequest(registrar, sock); });
@@ -152,7 +153,7 @@ class Server {
  private:
   void listen() {
     listen_sock_ = socket(AF_INET, SOCK_STREAM, 0);
-    assert(listen_sock_ >= 0);
+    Assert(listen_sock_ >= 0);
     bzero(&servaddr_, sizeof(servaddr_));
     servaddr_.sin_family = AF_INET;
     // LOCALHOST ONLY, FOR SECURITY PURPOSES. DO NOT CHANGE THIS!!!

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <exception>
 #include <utility>
+#include "assertUtils.hpp"
 #include "communication/CommDefs.hpp"
 #include "kv_types.hpp"
 #include "hex_tools.h"
@@ -275,7 +276,7 @@ bool ReplicaImp::putBlock(const uint64_t blockId, const char *block_data, const 
 }
 
 RawBlock ReplicaImp::getBlockInternal(BlockId blockId) const {
-  assert(blockId <= getLastBlockNum());
+  Assert(blockId <= getLastBlockNum());
   return m_bcDbAdapter->getRawBlock(blockId);
 }
 
@@ -293,11 +294,11 @@ bool ReplicaImp::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSi
 bool ReplicaImp::hasBlock(BlockId blockId) const { return m_bcDbAdapter->hasBlock(blockId); }
 
 bool ReplicaImp::getPrevDigestFromBlock(BlockId blockId, StateTransferDigest *outPrevBlockDigest) {
-  assert(blockId > 0);
+  Assert(blockId > 0);
   try {
     RawBlock result = getBlockInternal(blockId);
     auto parentDigest = m_bcDbAdapter->getParentDigest(result);
-    assert(outPrevBlockDigest);
+    Assert(outPrevBlockDigest != nullptr);
     static_assert(parentDigest.size() == BLOCK_DIGEST_SIZE);
     static_assert(sizeof(StateTransferDigest) == BLOCK_DIGEST_SIZE);
     memcpy(outPrevBlockDigest, parentDigest.data(), BLOCK_DIGEST_SIZE);

--- a/kvbc/src/direct_kv_block.cpp
+++ b/kvbc/src/direct_kv_block.cpp
@@ -1,3 +1,4 @@
+#include "assertUtils.hpp"
 #include "direct_kv_block.h"
 #include "kv_types.hpp"
 #include "Logger.hpp"
@@ -23,7 +24,7 @@ Sliver create(const SetOfKeyValuePairs &updates,
   // TODO(GG): overflow handling ....
   // TODO(SG): How? Right now - will put empty block instead
 
-  assert(outUpdatesInNewBlock.size() == 0);
+  Assert(outUpdatesInNewBlock.size() == 0);
 
   std::uint32_t blockBodySize = 0;
   const std::uint16_t numOfElements = updates.size();
@@ -74,14 +75,14 @@ Sliver create(const SetOfKeyValuePairs &updates,
 
       idx++;
     }
-    assert(idx == numOfElements);
+    Assert(idx == numOfElements);
 
     if (userDataSize) {
       std::memcpy(blockBuffer + currentOffset, userData, userDataSize);
       currentOffset += userDataSize;
     }
 
-    assert((std::uint32_t)currentOffset == blockSize);
+    Assert((std::uint32_t)currentOffset == blockSize);
 
     return blockSliver;
   } catch (const std::bad_alloc &ba) {  // TODO: do we really want to mask this failure?
@@ -115,7 +116,7 @@ SetOfKeyValuePairs getData(const Sliver &block) {
 
 BlockDigest getParentDigest(const Sliver &block) {
   const auto *bh = reinterpret_cast<const detail::Header *>(block.data());
-  assert(BLOCK_DIGEST_SIZE == bh->parentDigestLength);
+  Assert(BLOCK_DIGEST_SIZE == bh->parentDigestLength);
   BlockDigest digest;
   std::memcpy(digest.data(), bh->parentDigest, BLOCK_DIGEST_SIZE);
   return digest;
@@ -123,7 +124,7 @@ BlockDigest getParentDigest(const Sliver &block) {
 
 Sliver getUserData(const Sliver &block) {
   constexpr auto headerSize = sizeof(detail::Header);
-  assert(block.length() >= headerSize);
+  Assert(block.length() >= headerSize);
   const auto header = reinterpret_cast<const detail::Header *>(block.data());
 
   // If there are no elements, we only have a Header and, optionally, user data.
@@ -135,7 +136,7 @@ Sliver getUserData(const Sliver &block) {
   const auto entries = reinterpret_cast<const detail::Entry *>(block.data() + sizeof(detail::Header));
   const auto lastEntry = entries[header->numberOfElements - 1];
   const auto userDataOffset = lastEntry.valOffset + lastEntry.valSize;
-  assert(block.length() >= userDataOffset);
+  Assert(block.length() >= userDataOffset);
   return Sliver{block, userDataOffset, block.length() - userDataOffset};
 }
 

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -154,7 +154,7 @@ int DBKeyComparator::composedKeyComparison(const char *_a_data,
     }
     default:
       LOG_ERROR(logger(), "invalid key type: " << (char)aType);
-      assert(false);
+      Assert(false);
       throw std::runtime_error("DBKeyComparator::composedKeyComparison: invalid key type");
   }  // switch
 }
@@ -241,7 +241,7 @@ EDBKeyType DBKeyManipulator::extractTypeFromKey(const Key &_key) {
  */
 EDBKeyType DBKeyManipulator::extractTypeFromKey(const char *_key_data) {
   static_assert(sizeof(EDBKeyType) == 1, "Let's avoid byte-order problems.");
-  assert((_key_data[0] < (char)EDBKeyType::E_DB_KEY_TYPE_LAST) &&
+  Assert((_key_data[0] < (char)EDBKeyType::E_DB_KEY_TYPE_LAST) &&
          (_key_data[0] >= (char)EDBKeyType::E_DB_KEY_TYPE_FIRST));
   return (EDBKeyType)_key_data[0];
 }
@@ -270,7 +270,7 @@ ObjectId DBKeyManipulator::extractObjectIdFromKey(const Key &_key) {
  * @return The object id of the composite database key.
  */
 ObjectId DBKeyManipulator::extractObjectIdFromKey(const char *_key_data, size_t _key_length) {
-  assert(_key_length >= sizeof(ObjectId));
+  Assert(_key_length >= sizeof(ObjectId));
   size_t offset = _key_length - sizeof(ObjectId);
   ObjectId id = *(ObjectId *)(_key_data + offset);
 
@@ -309,8 +309,8 @@ int DBKeyManipulator::compareKeyPartOfComposedKey(const char *a_data,
                                                   size_t a_length,
                                                   const char *b_data,
                                                   size_t b_length) {
-  assert(a_length >= sizeof(BlockId) + sizeof(EDBKeyType));
-  assert(b_length >= sizeof(BlockId) + sizeof(EDBKeyType));
+  Assert(a_length >= sizeof(BlockId) + sizeof(EDBKeyType));
+  Assert(b_length >= sizeof(BlockId) + sizeof(EDBKeyType));
 
   const char *a_key = a_data + sizeof(EDBKeyType);
   const size_t a_key_length = a_length - sizeof(BlockId) - sizeof(EDBKeyType);

--- a/scripts/check-forbidden-usage.sh
+++ b/scripts/check-forbidden-usage.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+! grep -rn \
+    --color=auto \
+    --include=\*.{h,hpp,cpp} \
+    --exclude-dir={build,.git,.github} \
+    -E \
+    "NOLINTNEXTLINE(\s+|$)|NOLINT(\s+|$)|\sassert\(" $1

--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -57,7 +57,7 @@ void Client::init(bool readOnly) {
 }
 
 Status Client::del(const Sliver& key) {
-  assert(init_);
+  Assert(init_);
   ResponseData rData;
   S3ResponseHandler rHandler;
   rHandler.completeCallback = responseCompleteCallback;

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -177,7 +177,7 @@ concord::storage::s3::StoreConfig TestSetup::ParseS3Config(const std::string& s3
   ConfigFileParser parser(logger_, s3ConfigFile);
   if (!parser.Parse()) throw std::runtime_error("failed to parse" + s3ConfigFile);
 
-  auto get_config_value = [&s3ConfigFile, &parser](std::string key) {
+  auto get_config_value = [&s3ConfigFile, &parser](const std::string& key) {
     std::vector<std::string> v = parser.GetValues(key);
     if (v.size()) {
       return v[0];

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -14,6 +14,7 @@
 #ifndef CONCORD_BFT_SIMPLE_TEST_REPLICA_HPP
 #define CONCORD_BFT_SIMPLE_TEST_REPLICA_HPP
 
+#include "assertUtils.hpp"
 #include "OpenTracing.hpp"
 #include "communication/CommFactory.hpp"
 #include "Replica.hpp"
@@ -36,7 +37,7 @@ logging::Logger replicaLogger = logging::getLogger("simpletest.replica");
   {                                                                      \
     if (!(statement)) {                                                  \
       LOG_FATAL(replicaLogger, "assert fail with message: " << message); \
-      assert(false);                                                     \
+      Assert(false);                                                     \
     }                                                                    \
   }
 

--- a/tools/DBEditor.cpp
+++ b/tools/DBEditor.cpp
@@ -23,6 +23,7 @@
 
 #define USE_ROCKSDB 1
 
+#include "assertUtils.hpp"
 #include "Logger.hpp"
 #include "rocksdb/key_comparator.h"
 #include "rocksdb/client.h"
@@ -229,7 +230,7 @@ void parseAndPrint(const ::rocksdb::Slice &key, const ::rocksdb::Slice &val) {
     }
     default:
       LOG_ERROR(logger, "invalid key type: " << (char)aType);
-      assert(false);
+      Assert(false);
 
   }  // switch
 }
@@ -244,7 +245,7 @@ void dumpAllValues() {
     //    printf("\n");
     parseAndPrint(it->key(), it->value());
   }
-  assert(it->status().ok());
+  Assert(it->status().ok());
   delete it;
 }
 

--- a/util/include/assertUtils.hpp
+++ b/util/include/assertUtils.hpp
@@ -72,7 +72,7 @@ inline void printCallStack() {
                   << #expr2 << "' is " << result2.c_str() << " in function " << __FUNCTION__ << " (" << __FILE__ \
                   << " " << __LINE__ << ")");                                                                    \
     printCallStack();                                                                                            \
-    assert(false); /*NOLINT(misc-static-assert)*/                                                                \
+    std::terminate();                                                                                            \
   }
 
 #define PRINT_DATA_AND_ASSERT(expr1, expr2, assertMacro)                                                      \
@@ -81,7 +81,7 @@ inline void printCallStack() {
               " " << assertMacro << KVLOG_FOR_ASSERT(expr1, expr2) << " in function " << __FUNCTION__ << " (" \
                   << __FILE__ << " " << __LINE__ << ")");                                                     \
     printCallStack();                                                                                         \
-    assert(false); /*NOLINT(misc-static-assert)*/                                                             \
+    std::terminate();                                                                                         \
   }
 
 #define Assert(expr)                                                                                              \
@@ -91,7 +91,7 @@ inline void printCallStack() {
                 " Assert: expression '" << #expr << "' is false in function " << __FUNCTION__ << " (" << __FILE__ \
                                         << " " << __LINE__ << ")");                                               \
       printCallStack();                                                                                           \
-      assert(false); /*NOLINT(misc-static-assert)*/                                                               \
+      std::terminate();                                                                                           \
     }                                                                                                             \
   }
 // Assert (expr1 == expr2)

--- a/util/include/assertUtils.hpp
+++ b/util/include/assertUtils.hpp
@@ -63,25 +63,25 @@ inline void printCallStack() {
   }
 }
 
-#define PRINT_DATA_AND_ASSERT_BOOL_EXPR(expr1, expr2, assertMacro)                                               \
-  {                                                                                                              \
-    std::string result1 = (expr1) ? "true" : "false";                                                            \
-    std::string result2 = (expr2) ? "true" : "false";                                                            \
-    LOG_FATAL(GL,                                                                                                \
-              " " << assertMacro << ": expression '" << #expr1 << "' is " << result1.c_str() << ", expression '" \
-                  << #expr2 << "' is " << result2.c_str() << " in function " << __FUNCTION__ << " (" << __FILE__ \
-                  << " " << __LINE__ << ")");                                                                    \
-    printCallStack();                                                                                            \
-    std::terminate();                                                                                            \
+#define PRINT_DATA_AND_ASSERT_BOOL_EXPR(expr1, expr2, assertMacro)                                                 \
+  {                                                                                                                \
+    std::string result1 = (expr1) ? "true" : "false";                                                              \
+    std::string result2 = (expr2) ? "true" : "false";                                                              \
+    LOG_FATAL(GL,                                                                                                  \
+              " " << (assertMacro) << ": expression '" << #expr1 << "' is " << result1.c_str() << ", expression '" \
+                  << #expr2 << "' is " << result2.c_str() << " in function " << __FUNCTION__ << " (" << __FILE__   \
+                  << " " << __LINE__ << ")");                                                                      \
+    printCallStack();                                                                                              \
+    std::terminate();                                                                                              \
   }
 
-#define PRINT_DATA_AND_ASSERT(expr1, expr2, assertMacro)                                                      \
-  {                                                                                                           \
-    LOG_FATAL(GL,                                                                                             \
-              " " << assertMacro << KVLOG_FOR_ASSERT(expr1, expr2) << " in function " << __FUNCTION__ << " (" \
-                  << __FILE__ << " " << __LINE__ << ")");                                                     \
-    printCallStack();                                                                                         \
-    std::terminate();                                                                                         \
+#define PRINT_DATA_AND_ASSERT(expr1, expr2, assertMacro)                                                        \
+  {                                                                                                             \
+    LOG_FATAL(GL,                                                                                               \
+              " " << (assertMacro) << KVLOG_FOR_ASSERT(expr1, expr2) << " in function " << __FUNCTION__ << " (" \
+                  << __FILE__ << " " << __LINE__ << ")");                                                       \
+    printCallStack();                                                                                           \
+    std::terminate();                                                                                           \
   }
 
 #define Assert(expr)                                                                                              \
@@ -95,37 +95,37 @@ inline void printCallStack() {
     }                                                                                                             \
   }
 // Assert (expr1 == expr2)
-#define AssertEQ(expr1, expr2)                                           \
-  {                                                                      \
-    if (expr1 != expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertEQ"); \
+#define AssertEQ(expr1, expr2)                                               \
+  {                                                                          \
+    if ((expr1) != (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertEQ"); \
   }
 // Assert (expr1 != expr2)
-#define AssertNE(expr1, expr2)                                           \
-  {                                                                      \
-    if (expr1 == expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertNE"); \
+#define AssertNE(expr1, expr2)                                               \
+  {                                                                          \
+    if ((expr1) == (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertNE"); \
   }
 // Assert (expr1 >= expr2)
-#define AssertGE(expr1, expr2)                                          \
-  {                                                                     \
-    if (expr1 < expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGE"); \
+#define AssertGE(expr1, expr2)                                              \
+  {                                                                         \
+    if ((expr1) < (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGE"); \
   }
 
 // Assert (expr1 > expr2)
-#define AssertGT(expr1, expr2)                                           \
-  {                                                                      \
-    if (expr1 <= expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGT"); \
+#define AssertGT(expr1, expr2)                                               \
+  {                                                                          \
+    if ((expr1) <= (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGT"); \
   }
 
 // Assert (expr1 < expr2)
-#define AssertLT(expr1, expr2)                                           \
-  {                                                                      \
-    if (expr1 >= expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLT"); \
+#define AssertLT(expr1, expr2)                                               \
+  {                                                                          \
+    if ((expr1) >= (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLT"); \
   }
 
 // Assert (expr1 <= expr2)
-#define AssertLE(expr1, expr2)                                          \
-  {                                                                     \
-    if (expr1 > expr2) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLE"); \
+#define AssertLE(expr1, expr2)                                              \
+  {                                                                         \
+    if ((expr1) > (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLE"); \
   }
 
 // Assert(expr1 || expr2)

--- a/util/include/demangle.hpp
+++ b/util/include/demangle.hpp
@@ -16,12 +16,13 @@
 #include <cxxabi.h>
 #include <memory>
 #include <assert.h>
+#include "assertUtils.hpp"
 
 struct demangler {
   static std::string demangle(const char* name) {
     int status = -4;
     std::unique_ptr<char, decltype(&std::free)> res{abi::__cxa_demangle(name, NULL, NULL, &status), std::free};
-    assert(status == 0);
+    Assert(status == 0);
     return res.get();
   }
 

--- a/util/include/kvstream.h
+++ b/util/include/kvstream.h
@@ -70,7 +70,7 @@ template <bool Strict,
           typename K,
           typename V,
           typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type *>
-void KvLog(std::stringstream &ss, K &&key, V &&val) {
+void KvLog(std::stringstream &ss, K &&key, V &&) {
   static_assert(!Strict, "Cannot log types that do not implement ostream::operator<<");
   ss << std::forward<K>(key) << ": _";
 }
@@ -80,7 +80,7 @@ template <bool Strict,
           typename V,
           typename... KVPAIRS,
           typename std::enable_if<!concord::is_streamable<std::ostream, V>::value>::type *>
-void KvLog(std::stringstream &ss, K &&key, V &&val, KVPAIRS &&... kvpairs) {
+void KvLog(std::stringstream &ss, K &&key, V &&, KVPAIRS &&... kvpairs) {
   static_assert(!Strict, "Cannot log types that do not implement ostream::operator<<");
   ss << std::forward<K>(key) << ": _, ";
   KvLog<Strict>(ss, std::forward<KVPAIRS>(kvpairs)...);

--- a/util/include/string.hpp
+++ b/util/include/string.hpp
@@ -14,9 +14,9 @@
 #pragma once
 
 #include <string>
-#include <assert.h>
 #include <algorithm>
 #include <type_traits>
+#include "assertUtils.hpp"
 
 namespace concord {
 namespace util {
@@ -27,7 +27,7 @@ namespace util {
  */
 template <typename T>
 T to(const std::string& s) {
-  assert(false && "no suitable specialization");
+  Assert(false && "no suitable specialization");
   return static_cast<T>(0);
 }
 


### PR DESCRIPTION
Rationale:
The standard `assert` is ignored if `NDEBUG` compilation flag is set.
Since Concord-BFT uses the `assert` extensively to ensure the consistency of the flow, ignoring it is unacceptable.

Changes:
* Replaced usage of `assert` with `Assert` all over the code base.
* Replaced `assert(false)` with `std::terminate()` in the assertUtils.hpp file