### PR TITLE
Fix a number of preprocessor clients

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -119,7 +119,7 @@ class PreProcessor {
   void updateAggregatorAndDumpMetrics();
   void addTimers();
   void cancelTimers();
-  void onRequestsStatusCheckTimer(concordUtil::Timers::Handle timer);
+  void onRequestsStatusCheckTimer();
 
   static logging::Logger &logger() {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");


### PR DESCRIPTION
- numOfClientProxies already contains proxy clients for all replicas, no need to multiply it again by numReplicas
- Define a number of threads triggered by preprocessor as minimum between a number of vcpus in the system and a number of clients.