### PR TITLE
WIP: Initial efforts for sending noops commands

### DIFF
--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -16,7 +16,7 @@ namespace bftEngine {
 
 void ControlStateManager::setStopAtNextCheckpoint() {}
 
-std::optional<uint64_t> ControlStateManager::getStopCheckpointToStopAt() { return UINT64_MAX; }
+std::optional<uint64_t> ControlStateManager::getStopCheckpointToStopAt() { return {}; }
 
 ControlStateManager::ControlStateManager(IStateTransfer& state_transfer) : state_transfer_{state_transfer} {
   state_transfer_.getStatus();  // Temporary, to escape not-used compilation error

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -128,7 +128,7 @@ class ReplicaBase {
   ///////////////////////////////////////////////////
   // ControlStateManger
   std::shared_ptr<ControlStateManager> controlStateManager_;
-  bool stopAtNextChecnpoint = false;
+  bool stopAtNextChecknpoint_ = false;
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -128,7 +128,7 @@ class ReplicaBase {
   ///////////////////////////////////////////////////
   // ControlStateManger
   std::shared_ptr<ControlStateManager> controlStateManager_;
-  bool stopAtNextChecknpoint_ = false;
+  bool stopAtNextCheckpoint_ = false;
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -128,6 +128,7 @@ class ReplicaBase {
   ///////////////////////////////////////////////////
   // ControlStateManger
   std::shared_ptr<ControlStateManager> controlStateManager_;
+  bool stopAtNextChecnpoint = false;
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -419,6 +419,10 @@ void ReplicaImp::sendInternalNoopsPrePrepareMsg(CommitPath firstPath) {
 
 void ReplicaImp::bringTheSystemToTheNextCheckpointBySendingNoopsCommands(CommitPath firstPath) {
   if (!isCurrentPrimary()) return;
+  // TODO: According to Ittai, it is better to reach to the next next checkpoint to prevent the follwing:
+  // 1. The current sequence number is 290 (next checkpoint is 300)
+  // 2. We decide on 291 --> 291 + concurrency level - 1 (say 29)
+  // 3. We decide on 290
   while (primaryLastUsedSeqNum % checkpointWindowSize != 0) {
     sendInternalNoopsPrePrepareMsg(firstPath);
   }
@@ -3443,6 +3447,12 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
   auto span = concordUtils::startChildSpan("bft_execute_next_committed_requests", parent_span);
 
   while (lastExecutedSeqNum < lastStableSeqNum + kWorkWindowSize) {
+    if (!stopAtNextChecnpoint && controlStateManager_->getStopCheckpointToStopAt().has_value()) {
+      // If, following the last execution, we discover that we need to jump to the
+      // next checkpoint, the primary sends noop commands until filling the working window.
+      bringTheSystemToTheNextCheckpointBySendingNoopsCommands();
+      stopAtNextChecnpoint = true;
+    }
     SeqNum nextExecutedSeqNum = lastExecutedSeqNum + 1;
     SeqNumInfo &seqNumInfo = mainLog->get(nextExecutedSeqNum);
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3447,11 +3447,11 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
   auto span = concordUtils::startChildSpan("bft_execute_next_committed_requests", parent_span);
 
   while (lastExecutedSeqNum < lastStableSeqNum + kWorkWindowSize) {
-    if (!stopAtNextChecknpoint_ && controlStateManager_->getStopCheckpointToStopAt().has_value()) {
+    if (!stopAtNextCheckpoint_ && controlStateManager_->getStopCheckpointToStopAt().has_value()) {
       // If, following the last execution, we discover that we need to jump to the
       // next checkpoint, the primary sends noop commands until filling the working window.
       bringTheSystemToTheNextCheckpointBySendingNoopCommands();
-      stopAtNextChecknpoint_ = true;
+      stopAtNextCheckpoint_ = true;
     }
     SeqNum nextExecutedSeqNum = lastExecutedSeqNum + 1;
     SeqNumInfo &seqNumInfo = mainLog->get(nextExecutedSeqNum);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -399,8 +399,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
  private:
   void addTimers();
   void startConsensusProcess(PrePrepareMsg* pp);
-  void sendInternalNoopsPrePrepareMsg(CommitPath firstPath = CommitPath::SLOW);
-  void bringTheSystemToTheNextCheckpointBySendingNoopsCommands(CommitPath firstPath = CommitPath::SLOW);
+  void sendInternalNoopPrePrepareMsg(CommitPath firstPath = CommitPath::SLOW);
+  void bringTheSystemToTheNextCheckpointBySendingNoopCommands(CommitPath firstPath = CommitPath::SLOW);
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -398,6 +398,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
  private:
   void addTimers();
+  void startConsensusProcess(PrePrepareMsg* pp);
+  void sendInternalNoopsPrePrepareMsg(CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
+  void bringTheSystemToTheNextCheckpointBySendingNoopsCommands(CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -399,8 +399,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
  private:
   void addTimers();
   void startConsensusProcess(PrePrepareMsg* pp);
-  void sendInternalNoopsPrePrepareMsg(CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
-  void bringTheSystemToTheNextCheckpointBySendingNoopsCommands(CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
+  void sendInternalNoopsPrePrepareMsg(CommitPath firstPath = CommitPath::SLOW);
+  void bringTheSystemToTheNextCheckpointBySendingNoopsCommands(CommitPath firstPath = CommitPath::SLOW);
 };
 
 }  // namespace bftEngine::impl


### PR DESCRIPTION
In this PR we add a basic functionality for creating no-ops commands by the replica itself.

This can be helpful for cases in which the primary decides to bring the system for the next checkpoint as soon as possible (for example, when realizing that an upgrade process is about to start).

The way it works is very simple:
Once the primary decides to "jump" the system to the next checkpoint it creates empty preprepare messages and initiates consensus for each one of them.

We may consider other solutions (such as filling the client requests queue with fake messages) but I believe that the above is the simplest and fastest solution.

EDITING:
I've also added call to the method that fills the working window with noops.
Note that currently, if we have viewchange while sending this noops the new primary won't necessarily continue to send them.
Yet, IMO as we assume the happy path + our very initial stage of development, we can leave it as it is for now.