### PR TITLE
WIP: Add control handlers for upgrade + calling to upgrade on super stable checkpoint

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -35,6 +35,11 @@ enum MsgFlag : uint8_t {
   HAS_PRE_PROCESSED_FLAG = 0x4
 };
 
+class IControlHandler {
+ public:
+  virtual void upgrade() = 0;
+};
+
 class IRequestsHandler {
  public:
   virtual int execute(uint16_t clientId,
@@ -50,6 +55,8 @@ class IRequestsHandler {
 
   virtual void onFinishExecutingReadWriteRequests() {}
   virtual ~IRequestsHandler() {}
+
+  virtual std::shared_ptr<IControlHandler> getControlHandlers() = 0;
 };
 
 class IReplica {

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -35,9 +35,21 @@ enum MsgFlag : uint8_t {
   HAS_PRE_PROCESSED_FLAG = 0x4
 };
 
-class IControlHandler {
+// The ControlHandlers is a group of method that enables the userRequestHandler to perform infrastructure
+// changes in the system.
+// For example, assuming we want to upgrade the system to new software version, then:
+// 1. We need to bring the system to a stable state (bft responsibility)
+// 2. We need to perform the actual upgrade process (the platform responsibility)
+// Thus, once the bft brings the system to the desired stable state, it needs to invoke the a callback of the user to
+// perform the actual upgrade.
+// More possible scenarios would be:
+// 1. Adding/removing node
+// 2. Key exchange
+// 3. Change DB scheme
+// and basically any management action that is handled by the layer that uses concord-bft.
+class ControlHandlers {
  public:
-  virtual void upgrade() = 0;
+  virtual void onSuperStableCheckpoint() = 0;
 };
 
 class IRequestsHandler {
@@ -56,7 +68,7 @@ class IRequestsHandler {
   virtual void onFinishExecutingReadWriteRequests() {}
   virtual ~IRequestsHandler() {}
 
-  virtual std::shared_ptr<IControlHandler> getControlHandlers() = 0;
+  virtual std::shared_ptr<ControlHandlers> getControlHandlers() = 0;
 };
 
 class IReplica {

--- a/bftengine/src/bftengine/CheckpointInfo.cpp
+++ b/bftengine/src/bftengine/CheckpointInfo.cpp
@@ -74,6 +74,7 @@ void CheckpointInfo::init(CheckpointInfo& i, void* d) {
 void CheckpointInfo::free(CheckpointInfo& i) { i.resetAndFree(); }
 
 void CheckpointInfo::reset(CheckpointInfo& i) { i.resetAndFree(); }
+bool CheckpointInfo::isCheckpointIsSuperStable() const { return checkpointCertificate->isFull(); }
 
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/CheckpointInfo.cpp
+++ b/bftengine/src/bftengine/CheckpointInfo.cpp
@@ -74,7 +74,7 @@ void CheckpointInfo::init(CheckpointInfo& i, void* d) {
 void CheckpointInfo::free(CheckpointInfo& i) { i.resetAndFree(); }
 
 void CheckpointInfo::reset(CheckpointInfo& i) { i.resetAndFree(); }
-bool CheckpointInfo::isCheckpointIsSuperStable() const { return checkpointCertificate->isFull(); }
+bool CheckpointInfo::isCheckpointSuperStable() const { return checkpointCertificate->isFull(); }
 
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -42,6 +42,9 @@ class CheckpointInfo {
 
   bool isCheckpointCertificateComplete() const;
 
+  // A replica considers a checkpoint to be super stable if it knows that all n/n replicas have reached to this
+  // checkpoint. This is in contrary to stable checkpoint which means that the replica knows that a byzantine quorum of
+  // replicas have reached to this checkpoint.
   bool isCheckpointSuperStable() const;
 
   CheckpointMsg* selfCheckpointMsg() const;

--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -31,7 +31,6 @@ class CheckpointInfo {
 
   Time executed;  // if != MinTime, represents the execution time of the corresponding sequnce number
 
-
  public:
   CheckpointInfo();
 

--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -42,7 +42,7 @@ class CheckpointInfo {
 
   bool isCheckpointCertificateComplete() const;
 
-  bool isCheckpointIsSuperStable() const;
+  bool isCheckpointSuperStable() const;
 
   CheckpointMsg* selfCheckpointMsg() const;
 

--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -31,6 +31,7 @@ class CheckpointInfo {
 
   Time executed;  // if != MinTime, represents the execution time of the corresponding sequnce number
 
+
  public:
   CheckpointInfo();
 
@@ -41,6 +42,8 @@ class CheckpointInfo {
   bool addCheckpointMsg(CheckpointMsg* msg, ReplicaId replicaId);
 
   bool isCheckpointCertificateComplete() const;
+
+  bool isCheckpointIsSuperStable() const;
 
   CheckpointMsg* selfCheckpointMsg() const;
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -332,6 +332,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
       bool oldSeqNum = false  // true IFF sequence number newStableSeqNum+kWorkWindowSize has already been executed
   );
 
+  void onSeqNumIsSuperStable(SeqNum newSuperStableSeqNum);
   void onTransferringCompleteImp(SeqNum) override;
 
   template <typename T>

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -101,7 +101,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // bounded log used to store information about checkpoints in the range [lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]
-  SequenceWithActiveWindow<kWorkWindowSize + checkpointWindowSize,
+  SequenceWithActiveWindow<kWorkWindowSize + 2 * checkpointWindowSize,
                            checkpointWindowSize,
                            SeqNum,
                            CheckpointInfo,

--- a/bftengine/src/bftengine/messages/MsgsCertificate.hpp
+++ b/bftengine/src/bftengine/messages/MsgsCertificate.hpp
@@ -287,6 +287,10 @@ void MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::a
     // reached the required amount of messages
     tryToMarkComplete();
   }
+
+  if (classInfo.size >= numOfReps) {
+    tryToMarkFull();
+  }
 }
 
 template <typename T, bool SelfTrust, bool SelfIsRequired, bool KeepAllMsgs, typename ExternalFunc>

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -68,6 +68,8 @@ class DummyRequestsHandler : public IRequestsHandler {
     outActualReplySize = 256;
     return 0;
   }
+
+  std::shared_ptr<IControlHandler> getControlHandlers() override { return nullptr; }
 };
 
 class DummyReceiver : public IReceiver {

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -69,7 +69,7 @@ class DummyRequestsHandler : public IRequestsHandler {
     return 0;
   }
 
-  std::shared_ptr<IControlHandler> getControlHandlers() override { return nullptr; }
+  std::shared_ptr<ControlHandlers> getControlHandlers() override { return nullptr; }
 };
 
 class DummyReceiver : public IReceiver {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -71,6 +71,8 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
 
   void addMetadataKeyValue(concord::storage::SetOfKeyValuePairs &updates, uint64_t sequenceNum) const;
 
+  std::shared_ptr<bftEngine::IControlHandler> getControlHandlers() override { return nullptr; }
+
  private:
   static concordUtils::Sliver buildSliverFromStaticBuf(char *buf);
 

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -71,7 +71,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
 
   void addMetadataKeyValue(concord::storage::SetOfKeyValuePairs &updates, uint64_t sequenceNum) const;
 
-  std::shared_ptr<bftEngine::IControlHandler> getControlHandlers() override { return nullptr; }
+  std::shared_ptr<bftEngine::ControlHandlers> getControlHandlers() override { return nullptr; }
 
  private:
   static concordUtils::Sliver buildSliverFromStaticBuf(char *buf);

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -66,7 +66,7 @@ class SimpleAppState : public IRequestsHandler {
   }
 
  public:
-  std::shared_ptr<IControlHandler> getControlHandlers() override { return nullptr; }
+  std::shared_ptr<ControlHandlers> getControlHandlers() override { return nullptr; }
 
   SimpleAppState(uint16_t numCl, uint16_t numRep)
       : statePtr{new SimpleAppState::State[numCl]}, numOfClients{numCl}, numOfReplicas{numRep} {}

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -66,6 +66,8 @@ class SimpleAppState : public IRequestsHandler {
   }
 
  public:
+  std::shared_ptr<IControlHandler> getControlHandlers() override { return nullptr; }
+
   SimpleAppState(uint16_t numCl, uint16_t numRep)
       : statePtr{new SimpleAppState::State[numCl]}, numOfClients{numCl}, numOfReplicas{numRep} {}
   ~SimpleAppState() { delete[] statePtr; }


### PR DESCRIPTION
In this PR we have three parts:
1. More functionality for checkpointInfo
2. Callbacks interface to IrequestHandler for control handlers and particular for an upgrade.
3. Identify super stable checkpoint and invoke the upgrade callback if exist

For part 3 we did the following:
We increased the size of the checkpoint log in one and instead of deleting the new lastStableCheckpoint from the log we delete the previous lastStableCheckpoint (if exist). This way we give time for the previous stableCheckpoint to become super stable (and this time is the time between two consecutive stable sequence numbers).