### PR TITLE
WIP: Fix: Include "assertUtils.hpp"

### DIFF
--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -31,7 +31,6 @@
 #include <chrono>
 #include <mutex>
 #include <regex>
-#include <cassert>
 #include <deque>
 
 #include "boost/bind.hpp"
@@ -46,6 +45,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include "Logger.hpp"
+#include "assertUtils.hpp"
 
 using namespace std;
 using namespace logging;


### PR DESCRIPTION
The  Concord-BFT repo was successfully compiled without specifying the header file.
However, the compilation of the product has failed.