### PR TITLE
Rename Assert* to ConcordAssert*

### DIFF
--- a/bftclient/include/bftclient/seq_num_generator.h
+++ b/bftclient/include/bftclient/seq_num_generator.h
@@ -60,7 +60,7 @@ class SeqNumberGenerator {
     // shift lastMilli by 22 (0x3FFFFF) in order to 'bitwise or' with lastCount
     // and preserve uniqueness and monotonicity.
     uint64_t r = (lastMilliOfUniqueFetchID_ << (64 - 42));
-    Assert(lastCountOfUniqueFetchID_ <= LAST_COUNT_LIMIT);
+    ConcordAssert(lastCountOfUniqueFetchID_ <= LAST_COUNT_LIMIT);
     r = r | ((uint64_t)lastCountOfUniqueFetchID_);
 
     return r;

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -57,14 +57,14 @@ Msg makeClientMsg(const RequestConfig& config, Msg&& request, bool read_only, ui
 }
 
 Reply Client::send(const WriteConfig& config, Msg&& request) {
-  Assert(!outstanding_request_.has_value());
+  ConcordAssert(!outstanding_request_.has_value());
   auto match_config = writeConfigToMatchConfig(config);
   bool read_only = false;
   return send(match_config, config.request, std::move(request), read_only);
 }
 
 Reply Client::send(const ReadConfig& config, Msg&& request) {
-  Assert(!outstanding_request_.has_value());
+  ConcordAssert(!outstanding_request_.has_value());
   auto match_config = readConfigToMatchConfig(config);
   bool read_only = true;
   return send(match_config, config.request, std::move(request), read_only);

--- a/bftclient/src/msg_receiver.cpp
+++ b/bftclient/src/msg_receiver.cpp
@@ -86,7 +86,7 @@ void MsgReceiver::onNewMessage(const bft::communication::NodeNum source,
 }
 
 void MsgReceiver::activate(uint32_t max_reply_size) {
-  AssertNE(max_reply_size, 0);
+  ConcordAssertNE(max_reply_size, 0);
   max_reply_size_ = max_reply_size;
 }
 

--- a/bftclient/test/bft_client_test.cpp
+++ b/bftclient/test/bft_client_test.cpp
@@ -131,7 +131,7 @@ std::vector<UnmatchedReply> unmatched_replies(uint16_t n,
                                               ReplyMetadata metadata,
                                               const Msg& msg,
                                               const std::vector<ReplicaSpecificInfo>& rsi) {
-  Assert(n <= rsi.size());
+  ConcordAssert(n <= rsi.size());
   std::vector<UnmatchedReply> replies;
   for (uint16_t i = 0; i < n; i++) {
     replies.emplace_back(UnmatchedReply{metadata, msg, rsi[i]});

--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -244,7 +244,7 @@ void DBDataStore::deserializeResPage(
   outPageDigest = STDigest(dgst);
   std::uint32_t sizeOfReseredPage;
   Serializable::deserialize(is, sizeOfReseredPage);
-  Assert(sizeOfReseredPage == inmem_->getSizeOfReservedPage());
+  ConcordAssert(sizeOfReseredPage == inmem_->getSizeOfReservedPage());
   Serializable::deserialize(is, outPage, sizeOfReseredPage);
 }
 void DBDataStore::loadResPages() {
@@ -350,7 +350,7 @@ void DBDataStore::associatePendingResPageWithCheckpointTxn(uint32_t inPageId,
                      << " txn: " << txn->getId());
   auto& pendingPages = inmem_->getPendingPagesMap();
   auto page = pendingPages.find(inPageId);
-  Assert(page != pendingPages.end());
+  ConcordAssert(page != pendingPages.end());
 
   setResPageTxn(inPageId, inCheckpoint, inPageDigest, page->second, txn);
   txn->del(pendingPageKey(inPageId));
@@ -379,7 +379,7 @@ void DBDataStore::deleteCoveredResPageInSmallerCheckpointsTxn(uint64_t minChkp, 
   it++;
   for (; it != pages.end(); ++it) {
     if (it->first.pageId == prevItemPageId && prevItemIsInLastRelevantCheckpoint) {
-      Assert(it->second.page != nullptr);
+      ConcordAssert(it->second.page != nullptr);
       LOG_DEBUG(logger(),
                 "delete: [" << it->first.pageId << ":" << it->first.checkpoint << "] "
                             << dynamicResPageKey(it->first.pageId, it->first.checkpoint));

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -129,7 +129,7 @@ class DataStore : public std::enable_shared_from_this<DataStore> {
     size_t size() const { return size(numOfPages); }
 
     static size_t size(uint32_t numberOfPages) {
-      Assert(numberOfPages > 0);
+      ConcordAssert(numberOfPages > 0);
       return sizeof(ResPagesDescriptor) + (numberOfPages - 1) * sizeof(SingleResPageDesc);
     }
   };
@@ -257,7 +257,7 @@ class DataStoreTransaction : public DataStore, public ITransaction {
   // You can't begin a transaction from within a transaction. However, since we
   // inherit from DataStore, we must implement this method.
   DataStoreTransaction* beginTransaction() override {
-    Assert(false);
+    ConcordAssert(false);
     return nullptr;
   }
   std::shared_ptr<DataStore> ds_;

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
@@ -29,56 +29,56 @@ bool InMemoryDataStore::initialized() { return wasInit_; }
 void InMemoryDataStore::setAsInitialized() { wasInit_ = true; }
 
 void InMemoryDataStore::setReplicas(const set<uint16_t> replicas) {
-  Assert(replicas_.empty());
+  ConcordAssert(replicas_.empty());
   replicas_ = replicas;
 }
 
 set<uint16_t> InMemoryDataStore::getReplicas() {
-  Assert(!replicas_.empty());
+  ConcordAssert(!replicas_.empty());
   return replicas_;
 }
 
 void InMemoryDataStore::setMyReplicaId(uint16_t id) {
-  Assert(myReplicaId_ == UINT16_MAX);
+  ConcordAssert(myReplicaId_ == UINT16_MAX);
   myReplicaId_ = id;
 }
 
 uint16_t InMemoryDataStore::getMyReplicaId() {
-  Assert(myReplicaId_ != UINT16_MAX);
+  ConcordAssert(myReplicaId_ != UINT16_MAX);
   return myReplicaId_;
 }
 
 void InMemoryDataStore::setFVal(uint16_t fVal) {
-  Assert(fVal_ == UINT16_MAX);
+  ConcordAssert(fVal_ == UINT16_MAX);
   fVal_ = fVal;
 }
 
 uint16_t InMemoryDataStore::getFVal() {
-  Assert(fVal_ != UINT16_MAX);
+  ConcordAssert(fVal_ != UINT16_MAX);
   return fVal_;
 }
 
 void InMemoryDataStore::setMaxNumOfStoredCheckpoints(uint64_t numChecks) {
-  Assert(numChecks > 0);
+  ConcordAssert(numChecks > 0);
 
-  Assert(maxNumOfStoredCheckpoints_ == UINT64_MAX);
+  ConcordAssert(maxNumOfStoredCheckpoints_ == UINT64_MAX);
   maxNumOfStoredCheckpoints_ = numChecks;
 }
 
 uint64_t InMemoryDataStore::getMaxNumOfStoredCheckpoints() const {
-  Assert(maxNumOfStoredCheckpoints_ != UINT64_MAX);
+  ConcordAssert(maxNumOfStoredCheckpoints_ != UINT64_MAX);
   return maxNumOfStoredCheckpoints_;
 }
 
 void InMemoryDataStore::setNumberOfReservedPages(uint32_t numResPages) {
-  Assert(numResPages > 0);
+  ConcordAssert(numResPages > 0);
 
-  Assert(numberOfReservedPages_ == UINT32_MAX);
+  ConcordAssert(numberOfReservedPages_ == UINT32_MAX);
   numberOfReservedPages_ = numResPages;
 }
 
 uint32_t InMemoryDataStore::getNumberOfReservedPages() {
-  Assert(numberOfReservedPages_ != UINT32_MAX);
+  ConcordAssert(numberOfReservedPages_ != UINT32_MAX);
   return numberOfReservedPages_;
 }
 
@@ -91,20 +91,20 @@ void InMemoryDataStore::setFirstStoredCheckpoint(uint64_t c) { firstStoredCheckp
 uint64_t InMemoryDataStore::getFirstStoredCheckpoint() { return firstStoredCheckpoint; }
 
 void InMemoryDataStore::setCheckpointDesc(uint64_t checkpoint, const CheckpointDesc& desc) {
-  Assert(checkpoint == desc.checkpointNum);
-  Assert(descMap.count(checkpoint) == 0);
+  ConcordAssert(checkpoint == desc.checkpointNum);
+  ConcordAssert(descMap.count(checkpoint) == 0);
 
   descMap[checkpoint] = desc;
 
-  //  Assert(descMap.size() < 21);  // TODO(GG): delete - debug only
+  //  ConcordAssert(descMap.size() < 21);  // TODO(GG): delete - debug only
 }
 
 DataStore::CheckpointDesc InMemoryDataStore::getCheckpointDesc(uint64_t checkpoint) {
   auto p = descMap.find(checkpoint);
 
-  Assert(p != descMap.end());
+  ConcordAssert(p != descMap.end());
 
-  Assert(p->first == p->second.checkpointNum);
+  ConcordAssert(p->first == p->second.checkpointNum);
 
   return p->second;
 }
@@ -118,7 +118,7 @@ bool InMemoryDataStore::hasCheckpointDesc(uint64_t checkpoint) {
 void InMemoryDataStore::deleteDescOfSmallerCheckpoints(uint64_t checkpoint) {
   auto p = descMap.begin();
   while ((p != descMap.end()) && (p->first < checkpoint)) {
-    Assert(p->first == p->second.checkpointNum);
+    ConcordAssert(p->first == p->second.checkpointNum);
     p = descMap.erase(p);
   }
 }
@@ -128,13 +128,13 @@ void InMemoryDataStore::setIsFetchingState(bool b) { fetching = b; }
 bool InMemoryDataStore::getIsFetchingState() { return fetching; }
 
 void InMemoryDataStore::setCheckpointBeingFetched(const CheckpointDesc& c) {
-  Assert(checkpointBeingFetched.checkpointNum == 0);
+  ConcordAssert(checkpointBeingFetched.checkpointNum == 0);
 
   checkpointBeingFetched = c;
 }
 
 DataStore::CheckpointDesc InMemoryDataStore::getCheckpointBeingFetched() {
-  Assert(checkpointBeingFetched.checkpointNum != 0);
+  ConcordAssert(checkpointBeingFetched.checkpointNum != 0);
 
   return checkpointBeingFetched;
 }
@@ -146,7 +146,7 @@ void InMemoryDataStore::deleteCheckpointBeingFetched() {
   // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
   memset(&checkpointBeingFetched, 0, sizeof(checkpointBeingFetched));
 
-  Assert(checkpointBeingFetched.checkpointNum == 0);
+  ConcordAssert(checkpointBeingFetched.checkpointNum == 0);
 }
 
 void InMemoryDataStore::setFirstRequiredBlock(uint64_t i) { firstRequiredBlock = i; }
@@ -159,7 +159,7 @@ uint64_t InMemoryDataStore::getLastRequiredBlock() { return lastRequiredBlock; }
 
 void InMemoryDataStore::setPendingResPage(uint32_t inPageId, const char* inPage, uint32_t inPageLen) {
   LOG_DEBUG(logger(), inPageId);
-  Assert(inPageLen <= sizeOfReservedPage_);
+  ConcordAssert(inPageLen <= sizeOfReservedPage_);
 
   auto pos = pendingPages.find(inPageId);
 
@@ -180,11 +180,11 @@ void InMemoryDataStore::setPendingResPage(uint32_t inPageId, const char* inPage,
 bool InMemoryDataStore::hasPendingResPage(uint32_t inPageId) { return (pendingPages.count(inPageId) > 0); }
 
 void InMemoryDataStore::getPendingResPage(uint32_t inPageId, char* outPage, uint32_t pageLen) {
-  Assert(pageLen <= sizeOfReservedPage_);
+  ConcordAssert(pageLen <= sizeOfReservedPage_);
 
   auto pos = pendingPages.find(inPageId);
 
-  Assert(pos != pendingPages.end());
+  ConcordAssert(pos != pendingPages.end());
 
   memcpy(outPage, pos->second, pageLen);
 }
@@ -211,12 +211,12 @@ void InMemoryDataStore::associatePendingResPageWithCheckpoint(uint32_t inPageId,
   LOG_DEBUG(logger(), "pageId: " << inPageId << " checkpoint: " << inCheckpoint);
   // find in pendingPages
   auto pendingPos = pendingPages.find(inPageId);
-  Assert(pendingPos != pendingPages.end());
-  Assert(pendingPos->second != nullptr);
+  ConcordAssert(pendingPos != pendingPages.end());
+  ConcordAssert(pendingPos->second != nullptr);
 
   // create key, and make sure that we don't already have this element
   ResPageKey key = {inPageId, inCheckpoint};
-  Assert(pages.count(key) == 0);
+  ConcordAssert(pages.count(key) == 0);
 
   // create value
   ResPageVal val = {inPageDigest, pendingPos->second};
@@ -234,7 +234,7 @@ void InMemoryDataStore::setResPage(uint32_t inPageId,
   LOG_DEBUG(logger(), "pageId: " << inPageId << " checkpoint: " << inCheckpoint);
   // create key, and make sure that we don't already have this element
   ResPageKey key = {inPageId, inCheckpoint};
-  Assert(pages.count(key) == 0);
+  ConcordAssert(pages.count(key) == 0);
 
   // prepare page
   char* page = reinterpret_cast<char*>(std::malloc(sizeOfReservedPage_));
@@ -253,9 +253,9 @@ bool InMemoryDataStore::getResPage(uint32_t inPageId,
                                    STDigest* outPageDigest,
                                    char* outPage,
                                    uint32_t copylength) {
-  Assert(copylength <= sizeOfReservedPage_);
+  ConcordAssert(copylength <= sizeOfReservedPage_);
 
-  Assert(inCheckpoint <= lastStoredCheckpoint);
+  ConcordAssert(inCheckpoint <= lastStoredCheckpoint);
 
   ResPageKey key = {inPageId, inCheckpoint};
 
@@ -263,7 +263,7 @@ bool InMemoryDataStore::getResPage(uint32_t inPageId,
 
   if (p == pages.end() || p->first.pageId > inPageId) return false;
 
-  Assert(p->first.checkpoint <= inCheckpoint);
+  ConcordAssert(p->first.checkpoint <= inCheckpoint);
 
   if (outActualCheckpoint != nullptr) *outActualCheckpoint = p->first.checkpoint;
 
@@ -274,7 +274,7 @@ bool InMemoryDataStore::getResPage(uint32_t inPageId,
                        << " digest: " << p->second.pageDigest.toString());
 
   if (outPage != nullptr) {
-    Assert(copylength > 0);
+    ConcordAssert(copylength > 0);
     memcpy(outPage, p->second.page, copylength);
   }
   return true;
@@ -293,7 +293,7 @@ void InMemoryDataStore::deleteCoveredResPageInSmallerCheckpoints(uint64_t inMinR
   while (iter != pages.end()) {
     if (iter->first.pageId == prevItemPageId && prevItemIsInLastRelevantCheckpoint) {
       // delete
-      Assert(iter->second.page != nullptr);
+      ConcordAssert(iter->second.page != nullptr);
       std::free(iter->second.page);
       iter = pages.erase(iter);
     } else {
@@ -303,7 +303,7 @@ void InMemoryDataStore::deleteCoveredResPageInSmallerCheckpoints(uint64_t inMinR
     }
   }
 
-  Assert(pages.size() <= (numberOfReservedPages_ * (maxNumOfStoredCheckpoints_ + 1)));
+  ConcordAssert(pages.size() <= (numberOfReservedPages_ * (maxNumOfStoredCheckpoints_ + 1)));
 }
 
 DataStore::ResPagesDescriptor* InMemoryDataStore::getResPagesDescriptor(uint64_t inCheckpoint) {
@@ -320,7 +320,7 @@ DataStore::ResPagesDescriptor* InMemoryDataStore::getResPagesDescriptor(uint64_t
     if (iter.first.checkpoint <= inCheckpoint) {
       SingleResPageDesc& singleDesc = desc->d[iter.first.pageId];
       if (singleDesc.relevantCheckpoint > 0) {
-        Assert(singleDesc.relevantCheckpoint > iter.first.checkpoint);
+        ConcordAssert(singleDesc.relevantCheckpoint > iter.first.checkpoint);
         continue;  // we already have a description for this pageId with a greater checkpoint num
       }
       singleDesc.pageId = iter.first.pageId;
@@ -336,7 +336,7 @@ DataStore::ResPagesDescriptor* InMemoryDataStore::getResPagesDescriptor(uint64_t
 }
 
 void InMemoryDataStore::free(ResPagesDescriptor* desc) {
-  Assert(desc->numOfPages == numberOfReservedPages_);
+  ConcordAssert(desc->numOfPages == numberOfReservedPages_);
   void* p = desc;
   std::free(p);
 }

--- a/bftengine/src/bcstatetransfer/MsgsCertificate.hpp
+++ b/bftengine/src/bcstatetransfer/MsgsCertificate.hpp
@@ -174,7 +174,7 @@ void MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::a
     MsgClassInfo& cls = msgClasses[0];  // in this case, we have a single class
 
     auto pos = msgsFromReplicas.find(cls.representativeReplica);
-    // TODO(GG) Assert(pos is okay)
+    // TODO(GG) ConcordAssert(pos is okay)
     T* representativeMsg = pos->second;
 
     if (!ExternalFunc::equivalent(representativeMsg, cls.representativeReplica, msg, replicaId))
@@ -188,7 +188,7 @@ void MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::a
       MsgClassInfo& cls = msgClasses[i];
 
       auto pos = msgsFromReplicas.find(cls.representativeReplica);
-      // TODO(GG) Assert(pos is okay)
+      // TODO(GG) ConcordAssert(pos is okay)
       T* representativeMsg = pos->second;
 
       if (ExternalFunc::equivalent(representativeMsg, cls.representativeReplica, msg, replicaId)) {
@@ -244,7 +244,7 @@ void MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::a
     MsgClassInfo& cls = msgClasses[i];
 
     auto pos = msgsFromReplicas.find(cls.representativeReplica);
-    // TODO(GG) Assert(pos is okay)
+    // TODO(GG) ConcordAssert(pos is okay)
     T* representativeMsg = pos->second;
 
     if (ExternalFunc::equivalent(representativeMsg, cls.representativeReplica, msg, selfId)) {

--- a/bftengine/src/bcstatetransfer/STDigest.cpp
+++ b/bftengine/src/bcstatetransfer/STDigest.cpp
@@ -50,13 +50,13 @@ DigestContext::DigestContext() {
 }
 
 void DigestContext::update(const char* data, size_t len) {
-  Assert(internalState != nullptr);
+  ConcordAssert(internalState != nullptr);
   CryptoPP::SHA256* p = (CryptoPP::SHA256*)internalState;
   p->Update(reinterpret_cast<CryptoPP::byte*>(const_cast<char*>(data)), len);
 }
 
 void DigestContext::writeDigest(char* outDigest) {
-  Assert(internalState != nullptr);
+  ConcordAssert(internalState != nullptr);
   CryptoPP::SHA256* p = (CryptoPP::SHA256*)internalState;
   CryptoPP::SecByteBlock digest(CryptoPP::SHA256::DIGESTSIZE);
   p->Final(digest);

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -88,7 +88,7 @@ bool SourceSelector::shouldReplaceSource(uint64_t currTimeMilli, bool badDataFro
 
 void SourceSelector::selectSource(uint64_t currTimeMilli) {
   const size_t size = preferredReplicas_.size();
-  Assert(size > 0);
+  ConcordAssert(size > 0);
 
   auto i = preferredReplicas_.begin();
   if (size > 1) {

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -94,7 +94,7 @@ void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
     shared_ptr<PersistentStorage> persistentStorage(replicaImp->getPersistentStorage());
     ReplicaLoader::ErrorCode loadErrCode;
     LoadedReplicaData ld = ReplicaLoader::loadReplica(persistentStorage, loadErrCode);
-    Assert(loadErrCode == ReplicaLoader::ErrorCode::Success);
+    ConcordAssert(loadErrCode == ReplicaLoader::ErrorCode::Success);
 
     replica_.reset(new ReplicaImp(ld,
                                   replicaImp->getRequestsHandler(),

--- a/bftengine/src/bftengine/Bitmap.hpp
+++ b/bftengine/src/bftengine/Bitmap.hpp
@@ -60,7 +60,7 @@ class Bitmap {
 
   Bitmap(Bitmap&& other) : numBits_(other.numBits_), p_(other.p_) {
     if (numBits_ > 0) {
-      Assert(p_ != nullptr);
+      ConcordAssert(p_ != nullptr);
     }
 
     other.p_ = nullptr;
@@ -69,7 +69,7 @@ class Bitmap {
 
   ~Bitmap() {
     if (numBits_ > 0) {
-      Assert(p_ != nullptr);
+      ConcordAssert(p_ != nullptr);
       std::free(p_);
     }
   }
@@ -80,7 +80,7 @@ class Bitmap {
 
   Bitmap& operator=(const Bitmap& other) {
     if (numBits_ > 0) {
-      Assert(p_ != nullptr);
+      ConcordAssert(p_ != nullptr);
       std::free(p_);
     }
 
@@ -97,7 +97,7 @@ class Bitmap {
 
   Bitmap& operator=(Bitmap&& other) {
     if (numBits_ > 0) {
-      Assert(p_ != nullptr);
+      ConcordAssert(p_ != nullptr);
       std::free(p_);
     }
 
@@ -105,7 +105,7 @@ class Bitmap {
     p_ = other.p_;
 
     if (numBits_ > 0) {
-      Assert(p_ != nullptr);
+      ConcordAssert(p_ != nullptr);
     }
 
     other.p_ = nullptr;
@@ -117,28 +117,28 @@ class Bitmap {
   void zeroAll() {
     if (p_ == nullptr) return;
     const uint32_t s = realSize();
-    Assert(s > 0);
+    ConcordAssert(s > 0);
     memset((void*)p_, 0, s);
   }
 
   uint32_t numOfBits() const { return numBits_; }
 
   bool get(uint32_t i) const {
-    Assert(i < numBits_);
+    ConcordAssert(i < numBits_);
     const uint32_t byteIndex = i / 8;
     const unsigned char byteMask = (1 << (i % 8));
     return ((p_[byteIndex] & byteMask) != 0);
   }
 
   void set(uint32_t i) {
-    Assert(i < numBits_);
+    ConcordAssert(i < numBits_);
     const uint32_t byteIndex = i / 8;
     const unsigned char byteMask = (1 << (i % 8));
     p_[byteIndex] = p_[byteIndex] | byteMask;
   }
 
   void reset(uint32_t i) {
-    Assert(i < numBits_);
+    ConcordAssert(i < numBits_);
     const uint32_t byteIndex = i / 8;
     const unsigned char byteMask = ((unsigned char)0xFF) & ~(1 << (i % 8));
     p_[byteIndex] = p_[byteIndex] & byteMask;
@@ -146,7 +146,7 @@ class Bitmap {
 
   void writeToBuffer(char* buffer, uint32_t bufferLength, uint32_t* actualSize) const {
     const uint32_t sizeNeeded = sizeNeededInBuffer();
-    Assert(bufferLength >= sizeNeeded);
+    ConcordAssert(bufferLength >= sizeNeeded);
     uint32_t* pNumOfBits = (uint32_t*)buffer;
     char* pBitmap = buffer + sizeof(uint32_t);
     *pNumOfBits = numBits_;

--- a/bftengine/src/bftengine/CheckpointInfo.cpp
+++ b/bftengine/src/bftengine/CheckpointInfo.cpp
@@ -48,7 +48,7 @@ bool CheckpointInfo::checkpointSentAllOrApproved() const { return sentToAllOrApp
 Time CheckpointInfo::selfExecutionTime() const { return executed; }
 
 void CheckpointInfo::setSelfExecutionTime(Time t) {
-  Assert(executed == MinTime);
+  ConcordAssert(executed == MinTime);
   executed = t;
 }
 
@@ -65,7 +65,7 @@ void CheckpointInfo::init(CheckpointInfo& i, void* d) {
   const uint16_t numOfReps = info.numberOfReplicas();
   const uint16_t C = info.cVal();
   const uint16_t F = info.fVal();
-  Assert(numOfReps == 3 * F + 2 * C + 1);
+  ConcordAssert(numOfReps == 3 * F + 2 * C + 1);
 
   i.checkpointCertificate =
       new MsgsCertificate<CheckpointMsg, true, true, true, CheckpointMsgCmp>(numOfReps, F, 2 * F + C + 1, myId);

--- a/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
+++ b/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
@@ -28,7 +28,7 @@ namespace impl {
 
 template <typename PART, typename FULL, typename ExternalFunc>
 // TODO(GG): consider to enforce the requirements from PART, FULL and ExternalFunc
-// TODO(GG): add Assert(ExternalFunc::numberOfRequiredSignatures(context) > 1);
+// TODO(GG): add ConcordAssert(ExternalFunc::numberOfRequiredSignatures(context) > 1);
 class CollectorOfThresholdSignatures {
  public:
   CollectorOfThresholdSignatures(void* cnt) { this->context = cnt; }
@@ -36,7 +36,7 @@ class CollectorOfThresholdSignatures {
   ~CollectorOfThresholdSignatures() { resetAndFree(); }
 
   bool addMsgWithPartialSignature(PART* partialSigMsg, ReplicaId repId) {
-    Assert(partialSigMsg != nullptr);
+    ConcordAssert(partialSigMsg != nullptr);
 
     if ((combinedValidSignatureMsg != nullptr) || (replicasInfo.count(repId) > 0)) return false;
 
@@ -62,9 +62,9 @@ class CollectorOfThresholdSignatures {
   }
 
   void setExpected(SeqNum seqNumber, ViewNum view, Digest& digest) {
-    Assert(seqNumber != 0);
-    Assert(expectedSeqNumber == 0);
-    Assert(!processingSignaturesInTheBackground);
+    ConcordAssert(seqNumber != 0);
+    ConcordAssert(expectedSeqNumber == 0);
+    ConcordAssert(!processingSignaturesInTheBackground);
 
     expectedSeqNumber = seqNumber;
     expectedView = view;
@@ -110,10 +110,10 @@ class CollectorOfThresholdSignatures {
                                           ViewNum view,
                                           const std::set<ReplicaId>& replicasWithBadSigs)  // if we found bad signatures
   {
-    Assert(expectedSeqNumber == seqNumber);
-    Assert(expectedView == view);
-    Assert(processingSignaturesInTheBackground);
-    Assert(combinedValidSignatureMsg == nullptr);
+    ConcordAssert(expectedSeqNumber == seqNumber);
+    ConcordAssert(expectedView == view);
+    ConcordAssert(processingSignaturesInTheBackground);
+    ConcordAssert(combinedValidSignatureMsg == nullptr);
 
     processingSignaturesInTheBackground = false;
 
@@ -132,10 +132,10 @@ class CollectorOfThresholdSignatures {
                                           uint16_t combinedSigLen,
                                           const std::string& span_context)  // if we compute a valid combined signature
   {
-    Assert(expectedSeqNumber == seqNumber);
-    Assert(expectedView == view);
-    Assert(processingSignaturesInTheBackground);
-    Assert(combinedValidSignatureMsg == nullptr);
+    ConcordAssert(expectedSeqNumber == seqNumber);
+    ConcordAssert(expectedView == view);
+    ConcordAssert(processingSignaturesInTheBackground);
+    ConcordAssert(combinedValidSignatureMsg == nullptr);
 
     processingSignaturesInTheBackground = false;
 
@@ -149,11 +149,11 @@ class CollectorOfThresholdSignatures {
   }
 
   void onCompletionOfCombinedSigVerification(SeqNum seqNumber, ViewNum view, bool isValid) {
-    Assert(expectedSeqNumber == seqNumber);
-    Assert(expectedView == view);
-    Assert(processingSignaturesInTheBackground);
-    Assert(combinedValidSignatureMsg == nullptr);
-    Assert(candidateCombinedSignatureMsg != nullptr);
+    ConcordAssert(expectedSeqNumber == seqNumber);
+    ConcordAssert(expectedView == view);
+    ConcordAssert(processingSignaturesInTheBackground);
+    ConcordAssert(combinedValidSignatureMsg == nullptr);
+    ConcordAssert(candidateCombinedSignatureMsg != nullptr);
 
     processingSignaturesInTheBackground = false;
 
@@ -170,9 +170,9 @@ class CollectorOfThresholdSignatures {
 
   // init the expected values (seqNum, view and digest) directly (without sending to a background thread)
   void initExpected(SeqNum seqNumber, ViewNum view, Digest& digest) {
-    Assert(seqNumber != 0);
-    Assert(expectedSeqNumber == 0);
-    Assert(!processingSignaturesInTheBackground);
+    ConcordAssert(seqNumber != 0);
+    ConcordAssert(expectedSeqNumber == 0);
+    ConcordAssert(!processingSignaturesInTheBackground);
 
     expectedSeqNumber = seqNumber;
     expectedView = view;
@@ -181,14 +181,14 @@ class CollectorOfThresholdSignatures {
 
   // init the PART message directly (without sending to a background thread)
   bool initMsgWithPartialSignature(PART* partialSigMsg, ReplicaId repId) {
-    Assert(partialSigMsg != nullptr);
+    ConcordAssert(partialSigMsg != nullptr);
 
-    Assert(!processingSignaturesInTheBackground);
-    Assert(expectedSeqNumber != 0);
-    Assert(combinedValidSignatureMsg == nullptr);
-    Assert(candidateCombinedSignatureMsg == nullptr);
-    Assert(replicasInfo.count(repId) == 0);
-    Assert(numberOfUnknownSignatures == 0);  // we can use this method to add at most one PART message
+    ConcordAssert(!processingSignaturesInTheBackground);
+    ConcordAssert(expectedSeqNumber != 0);
+    ConcordAssert(combinedValidSignatureMsg == nullptr);
+    ConcordAssert(candidateCombinedSignatureMsg == nullptr);
+    ConcordAssert(replicasInfo.count(repId) == 0);
+    ConcordAssert(numberOfUnknownSignatures == 0);  // we can use this method to add at most one PART message
 
     // add partialSigMsg to replicasInfo
     RepInfo info = {partialSigMsg, SigState::Unknown};
@@ -201,22 +201,22 @@ class CollectorOfThresholdSignatures {
     if (numOfRequiredSigs == 0)  // init numOfRequiredSigs
       numOfRequiredSigs = ExternalFunc::numberOfRequiredSignatures(context);
 
-    Assert(numberOfUnknownSignatures < numOfRequiredSigs);  // because numOfRequiredSigs > 1
+    ConcordAssert(numberOfUnknownSignatures < numOfRequiredSigs);  // because numOfRequiredSigs > 1
 
     return true;
   }
 
   // init the FULL message directly (without sending to a background thread)
   bool initMsgWithCombinedSignature(FULL* combinedSigMsg) {
-    Assert(!processingSignaturesInTheBackground);
-    Assert(expectedSeqNumber != 0);
-    Assert(combinedValidSignatureMsg == nullptr);
-    Assert(candidateCombinedSignatureMsg == nullptr);
+    ConcordAssert(!processingSignaturesInTheBackground);
+    ConcordAssert(expectedSeqNumber != 0);
+    ConcordAssert(combinedValidSignatureMsg == nullptr);
+    ConcordAssert(candidateCombinedSignatureMsg == nullptr);
 
     IThresholdVerifier* const verifier = ExternalFunc::thresholdVerifier(context);
     bool succ = verifier->verify(
         (char*)&expectedDigest, sizeof(Digest), combinedSigMsg->signatureBody(), combinedSigMsg->signatureLen());
-    Assert(succ);  // we should verify this signature when it is loaded
+    ConcordAssert(succ);  // we should verify this signature when it is loaded
 
     combinedValidSignatureMsg = combinedSigMsg;
 
@@ -225,7 +225,7 @@ class CollectorOfThresholdSignatures {
 
  protected:
   void trySendToBkThread() {
-    Assert(combinedValidSignatureMsg == nullptr);
+    ConcordAssert(combinedValidSignatureMsg == nullptr);
 
     if (numOfRequiredSigs == 0)  // init numOfRequiredSigs
       numOfRequiredSigs = ExternalFunc::numberOfRequiredSignatures(context);
@@ -270,7 +270,7 @@ class CollectorOfThresholdSignatures {
         if (numOfPartSigsInJob == numOfRequiredSigs) break;
       }
 
-      Assert(numOfPartSigsInJob == numOfRequiredSigs);
+      ConcordAssert(numOfPartSigsInJob == numOfRequiredSigs);
 
       ExternalFunc::threadPool(context).add(bkJob);
     }
@@ -321,7 +321,7 @@ class CollectorOfThresholdSignatures {
     }
 
     void add(ReplicaId srcRepId, const char* sigBody, uint16_t sigLength, const std::string& span_context) {
-      Assert(numOfDataItems < reqDataItems);
+      ConcordAssert(numOfDataItems < reqDataItems);
 
       SigData d;
       d.srcRepId = srcRepId;
@@ -346,7 +346,7 @@ class CollectorOfThresholdSignatures {
     }
 
     virtual void execute() override {
-      Assert(numOfDataItems == reqDataItems);
+      ConcordAssert(numOfDataItems == reqDataItems);
 
       // TODO(GG): can utilize several threads (discuss with Alin)
 

--- a/bftengine/src/bftengine/ControllerWithSimpleHistory.cpp
+++ b/bftengine/src/bftengine/ControllerWithSimpleHistory.cpp
@@ -44,7 +44,7 @@ ControllerWithSimpleHistory::ControllerWithSimpleHistory(
 // The starting index is initialized to the next sequence number,
 // that is a multiplication of EvaluationPeriod plus one.
 void ControllerWithSimpleHistory::onBecomePrimary(ViewNum v, SeqNum s) {
-  Assert(isPrimary);
+  ConcordAssert(isPrimary);
 
   SeqNum nextFirstRelevantSeqNum;
   if (s % EvaluationPeriod == 0)
@@ -73,7 +73,7 @@ uint32_t ControllerWithSimpleHistory::slowPathsTimerMilli() {
 }
 
 void ControllerWithSimpleHistory::onNewView(ViewNum v, SeqNum s) {
-  Assert(v >= currentView);
+  ConcordAssert(v >= currentView);
   currentView = v;
   isPrimary = ((currentView % numOfReplicas) == myId);
 
@@ -168,7 +168,8 @@ bool ControllerWithSimpleHistory::onEndOfEvaluationPeriod() {
       }
     }
   } else {
-    Assert(currentFirstPath == CommitPath::OPTIMISTIC_FAST || currentFirstPath == CommitPath::FAST_WITH_THRESHOLD);
+    ConcordAssert(currentFirstPath == CommitPath::OPTIMISTIC_FAST ||
+                  currentFirstPath == CommitPath::FAST_WITH_THRESHOLD);
 
     size_t successfulFastPaths = 0;
     for (SeqNum i = minSeq; i <= maxSeq; i++) {

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -136,7 +136,7 @@ void DBMetadataStorage::commitAtomicWriteOnlyBatch() {
 
 Status DBMetadataStorage::multiDel(const ObjectIdsVector &objectIds) {
   size_t objectsNumber = objectIds.size();
-  AssertGE(objectsNum_, objectsNumber);
+  ConcordAssertGE(objectsNum_, objectsNumber);
   LOG_TRACE(logger_, "Going to perform multiple delete");
   KeysVector keysVec;
   for (size_t objectId = 0; objectId < objectsNumber; objectId++) {

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -28,87 +28,87 @@ DebugPersistentStorage::DebugPersistentStorage(uint16_t fVal, uint16_t cVal)
 uint8_t DebugPersistentStorage::beginWriteTran() { return ++numOfNestedTransactions; }
 
 uint8_t DebugPersistentStorage::endWriteTran() {
-  Assert(numOfNestedTransactions != 0);
+  ConcordAssert(numOfNestedTransactions != 0);
   return --numOfNestedTransactions;
 }
 
 bool DebugPersistentStorage::isInWriteTran() const { return (numOfNestedTransactions != 0); }
 
 void DebugPersistentStorage::setReplicaConfig(const ReplicaConfig &config) {
-  Assert(!hasConfig_);
-  Assert(isInWriteTran());
+  ConcordAssert(!hasConfig_);
+  ConcordAssert(isInWriteTran());
   hasConfig_ = true;
   config_ = config;
 }
 
 void DebugPersistentStorage::setLastExecutedSeqNum(SeqNum seqNum) {
-  Assert(setIsAllowed());
-  Assert(lastExecutedSeqNum_ <= seqNum);
+  ConcordAssert(setIsAllowed());
+  ConcordAssert(lastExecutedSeqNum_ <= seqNum);
   lastExecutedSeqNum_ = seqNum;
 }
 
 void DebugPersistentStorage::setPrimaryLastUsedSeqNum(const SeqNum seqNum) {
-  Assert(nonExecSetIsAllowed());
+  ConcordAssert(nonExecSetIsAllowed());
   primaryLastUsedSeqNum_ = seqNum;
 }
 
 void DebugPersistentStorage::setStrictLowerBoundOfSeqNums(const SeqNum seqNum) {
-  Assert(nonExecSetIsAllowed());
+  ConcordAssert(nonExecSetIsAllowed());
   strictLowerBoundOfSeqNums_ = seqNum;
 }
 
 void DebugPersistentStorage::setLastViewThatTransferredSeqNumbersFullyExecuted(const ViewNum view) {
-  Assert(nonExecSetIsAllowed());
-  Assert(lastViewThatTransferredSeqNumbersFullyExecuted_ <= view);
+  ConcordAssert(nonExecSetIsAllowed());
+  ConcordAssert(lastViewThatTransferredSeqNumbersFullyExecuted_ <= view);
   lastViewThatTransferredSeqNumbersFullyExecuted_ = view;
 }
 
 void DebugPersistentStorage::setDescriptorOfLastExitFromView(const DescriptorOfLastExitFromView &d) {
-  Assert(nonExecSetIsAllowed());
-  Assert(d.view >= 0);
+  ConcordAssert(nonExecSetIsAllowed());
+  ConcordAssert(d.view >= 0);
 
   // Here we assume that the first view is always 0
   // (even if we load the initial state from disk)
-  Assert(hasDescriptorOfLastNewView_ || d.view == 0);
+  ConcordAssert(hasDescriptorOfLastNewView_ || d.view == 0);
 
-  Assert(!hasDescriptorOfLastExitFromView_ || d.view > descriptorOfLastExitFromView_.view);
-  Assert(!hasDescriptorOfLastNewView_ || d.view == descriptorOfLastNewView_.view);
-  Assert(d.lastStable >= lastStableSeqNum_);
-  Assert(d.lastExecuted >= lastExecutedSeqNum_);
-  Assert(d.lastExecuted >= d.lastStable);
-  Assert(d.stableLowerBoundWhenEnteredToView >= 0 && d.lastStable >= d.stableLowerBoundWhenEnteredToView);
-  Assert(d.elements.size() <= kWorkWindowSize);
-  Assert(hasDescriptorOfLastExitFromView_ || descriptorOfLastExitFromView_.elements.size() == 0);
+  ConcordAssert(!hasDescriptorOfLastExitFromView_ || d.view > descriptorOfLastExitFromView_.view);
+  ConcordAssert(!hasDescriptorOfLastNewView_ || d.view == descriptorOfLastNewView_.view);
+  ConcordAssert(d.lastStable >= lastStableSeqNum_);
+  ConcordAssert(d.lastExecuted >= lastExecutedSeqNum_);
+  ConcordAssert(d.lastExecuted >= d.lastStable);
+  ConcordAssert(d.stableLowerBoundWhenEnteredToView >= 0 && d.lastStable >= d.stableLowerBoundWhenEnteredToView);
+  ConcordAssert(d.elements.size() <= kWorkWindowSize);
+  ConcordAssert(hasDescriptorOfLastExitFromView_ || descriptorOfLastExitFromView_.elements.size() == 0);
   if (d.view > 0) {
-    Assert(d.myViewChangeMsg != nullptr);
-    Assert(d.myViewChangeMsg->newView() == d.view);
-    // Assert(d.myViewChangeMsg->idOfGeneratedReplica() == myId); TODO(GG): add
-    Assert(d.myViewChangeMsg->lastStable() <= d.lastStable);
+    ConcordAssert(d.myViewChangeMsg != nullptr);
+    ConcordAssert(d.myViewChangeMsg->newView() == d.view);
+    // ConcordAssert(d.myViewChangeMsg->idOfGeneratedReplica() == myId); TODO(GG): add
+    ConcordAssert(d.myViewChangeMsg->lastStable() <= d.lastStable);
   } else {
-    Assert(d.myViewChangeMsg == nullptr);
+    ConcordAssert(d.myViewChangeMsg == nullptr);
   }
 
   std::vector<ViewsManager::PrevViewInfo> clonedElements(d.elements.size());
 
   for (size_t i = 0; i < d.elements.size(); i++) {
     const ViewsManager::PrevViewInfo &e = d.elements[i];
-    Assert(e.prePrepare != nullptr);
-    Assert(e.prePrepare->seqNumber() >= lastStableSeqNum_ + 1);
-    Assert(e.prePrepare->seqNumber() <= lastStableSeqNum_ + kWorkWindowSize);
-    Assert(e.prePrepare->viewNumber() == d.view);
-    Assert(e.prepareFull == nullptr || e.prepareFull->viewNumber() == d.view);
-    Assert(e.prepareFull == nullptr || e.prepareFull->seqNumber() == e.prePrepare->seqNumber());
+    ConcordAssert(e.prePrepare != nullptr);
+    ConcordAssert(e.prePrepare->seqNumber() >= lastStableSeqNum_ + 1);
+    ConcordAssert(e.prePrepare->seqNumber() <= lastStableSeqNum_ + kWorkWindowSize);
+    ConcordAssert(e.prePrepare->viewNumber() == d.view);
+    ConcordAssert(e.prepareFull == nullptr || e.prepareFull->viewNumber() == d.view);
+    ConcordAssert(e.prepareFull == nullptr || e.prepareFull->seqNumber() == e.prePrepare->seqNumber());
 
     PrePrepareMsg *clonedPrePrepareMsg = nullptr;
     if (e.prePrepare != nullptr) {
       clonedPrePrepareMsg = (PrePrepareMsg *)e.prePrepare->cloneObjAndMsg();
-      Assert(clonedPrePrepareMsg->type() == MsgCode::PrePrepare);
+      ConcordAssert(clonedPrePrepareMsg->type() == MsgCode::PrePrepare);
     }
 
     PrepareFullMsg *clonedPrepareFull = nullptr;
     if (e.prepareFull != nullptr) {
       clonedPrepareFull = (PrepareFullMsg *)e.prepareFull->cloneObjAndMsg();
-      Assert(clonedPrepareFull->type() == MsgCode::PrepareFull);
+      ConcordAssert(clonedPrepareFull->type() == MsgCode::PrepareFull);
     }
 
     clonedElements[i].prePrepare = clonedPrePrepareMsg;
@@ -122,7 +122,7 @@ void DebugPersistentStorage::setDescriptorOfLastExitFromView(const DescriptorOfL
   // delete messages from previous descriptor
   for (size_t i = 0; i < descriptorOfLastExitFromView_.elements.size(); i++) {
     const ViewsManager::PrevViewInfo &e = descriptorOfLastExitFromView_.elements[i];
-    Assert(e.prePrepare != nullptr);
+    ConcordAssert(e.prePrepare != nullptr);
     delete e.prePrepare;
     if (e.prepareFull != nullptr) delete e.prepareFull;
   }
@@ -134,41 +134,42 @@ void DebugPersistentStorage::setDescriptorOfLastExitFromView(const DescriptorOfL
 }
 
 void DebugPersistentStorage::setDescriptorOfLastNewView(const DescriptorOfLastNewView &d) {
-  Assert(nonExecSetIsAllowed());
-  Assert(d.view >= 1);
-  Assert(hasDescriptorOfLastExitFromView_);
-  Assert(d.view > descriptorOfLastExitFromView_.view);
+  ConcordAssert(nonExecSetIsAllowed());
+  ConcordAssert(d.view >= 1);
+  ConcordAssert(hasDescriptorOfLastExitFromView_);
+  ConcordAssert(d.view > descriptorOfLastExitFromView_.view);
 
-  Assert(d.newViewMsg != nullptr);
-  Assert(d.newViewMsg->newView() == d.view);
+  ConcordAssert(d.newViewMsg != nullptr);
+  ConcordAssert(d.newViewMsg->newView() == d.view);
 
-  Assert(d.myViewChangeMsg == nullptr || d.myViewChangeMsg->newView() == d.view);
+  ConcordAssert(d.myViewChangeMsg == nullptr || d.myViewChangeMsg->newView() == d.view);
 
   const size_t numOfVCMsgs = 2 * fVal_ + 2 * cVal_ + 1;
 
-  Assert(d.viewChangeMsgs.size() == numOfVCMsgs);
+  ConcordAssert(d.viewChangeMsgs.size() == numOfVCMsgs);
 
   std::vector<ViewChangeMsg *> clonedViewChangeMsgs(numOfVCMsgs);
 
   for (size_t i = 0; i < numOfVCMsgs; i++) {
     const ViewChangeMsg *vc = d.viewChangeMsgs[i];
-    Assert(vc != nullptr);
-    Assert(vc->newView() == d.view);
-    Assert(d.myViewChangeMsg == nullptr || d.myViewChangeMsg->idOfGeneratedReplica() != vc->idOfGeneratedReplica());
+    ConcordAssert(vc != nullptr);
+    ConcordAssert(vc->newView() == d.view);
+    ConcordAssert(d.myViewChangeMsg == nullptr ||
+                  d.myViewChangeMsg->idOfGeneratedReplica() != vc->idOfGeneratedReplica());
 
     Digest digestOfVCMsg;
     vc->getMsgDigest(digestOfVCMsg);
-    Assert(d.newViewMsg->includesViewChangeFromReplica(vc->idOfGeneratedReplica(), digestOfVCMsg));
+    ConcordAssert(d.newViewMsg->includesViewChangeFromReplica(vc->idOfGeneratedReplica(), digestOfVCMsg));
 
     ViewChangeMsg *clonedVC = (ViewChangeMsg *)vc->cloneObjAndMsg();
-    Assert(clonedVC->type() == MsgCode::ViewChange);
+    ConcordAssert(clonedVC->type() == MsgCode::ViewChange);
     clonedViewChangeMsgs[i] = clonedVC;
   }
 
   // TODO(GG): check thay we a message with the id of the current replica
 
   NewViewMsg *clonedNewViewMsg = (NewViewMsg *)d.newViewMsg->cloneObjAndMsg();
-  Assert(clonedNewViewMsg->type() == MsgCode::NewView);
+  ConcordAssert(clonedNewViewMsg->type() == MsgCode::NewView);
 
   ViewChangeMsg *clonedMyViewChangeMsg = nullptr;
   if (d.myViewChangeMsg != nullptr) clonedMyViewChangeMsg = (ViewChangeMsg *)d.myViewChangeMsg->cloneObjAndMsg();
@@ -178,7 +179,7 @@ void DebugPersistentStorage::setDescriptorOfLastNewView(const DescriptorOfLastNe
     delete descriptorOfLastNewView_.newViewMsg;
     delete descriptorOfLastNewView_.myViewChangeMsg;
 
-    Assert(descriptorOfLastNewView_.viewChangeMsgs.size() == numOfVCMsgs);
+    ConcordAssert(descriptorOfLastNewView_.viewChangeMsgs.size() == numOfVCMsgs);
 
     for (size_t i = 0; i < numOfVCMsgs; i++) {
       delete descriptorOfLastNewView_.viewChangeMsgs[i];
@@ -195,79 +196,79 @@ void DebugPersistentStorage::setDescriptorOfLastNewView(const DescriptorOfLastNe
 }
 
 void DebugPersistentStorage::setDescriptorOfLastExecution(const DescriptorOfLastExecution &d) {
-  Assert(setIsAllowed());
-  Assert(!hasDescriptorOfLastExecution_ || descriptorOfLastExecution_.executedSeqNum < d.executedSeqNum);
-  Assert(lastExecutedSeqNum_ + 1 == d.executedSeqNum);
-  Assert(d.validRequests.numOfBits() >= 1);
-  Assert(d.validRequests.numOfBits() <= maxNumOfRequestsInBatch);
+  ConcordAssert(setIsAllowed());
+  ConcordAssert(!hasDescriptorOfLastExecution_ || descriptorOfLastExecution_.executedSeqNum < d.executedSeqNum);
+  ConcordAssert(lastExecutedSeqNum_ + 1 == d.executedSeqNum);
+  ConcordAssert(d.validRequests.numOfBits() >= 1);
+  ConcordAssert(d.validRequests.numOfBits() <= maxNumOfRequestsInBatch);
 
   hasDescriptorOfLastExecution_ = true;
   descriptorOfLastExecution_ = DescriptorOfLastExecution{d.executedSeqNum, d.validRequests};
 }
 
 void DebugPersistentStorage::setLastStableSeqNum(SeqNum seqNum) {
-  Assert(seqNum >= lastStableSeqNum_);
+  ConcordAssert(seqNum >= lastStableSeqNum_);
   lastStableSeqNum_ = seqNum;
   seqNumWindow.advanceActiveWindow(lastStableSeqNum_ + 1);
   checkWindow.advanceActiveWindow(lastStableSeqNum_);
 }
 
 void DebugPersistentStorage::DebugPersistentStorage::clearSeqNumWindow() {
-  Assert(seqNumWindow.getBeginningOfActiveWindow() == lastStableSeqNum_ + 1);
+  ConcordAssert(seqNumWindow.getBeginningOfActiveWindow() == lastStableSeqNum_ + 1);
   seqNumWindow.resetAll(seqNumWindow.getBeginningOfActiveWindow());
 }
 
 void DebugPersistentStorage::setPrePrepareMsgInSeqNumWindow(SeqNum seqNum, PrePrepareMsg *msg) {
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   SeqNumData &seqNumData = seqNumWindow.get(seqNum);
-  Assert(!seqNumData.isPrePrepareMsgSet());
+  ConcordAssert(!seqNumData.isPrePrepareMsgSet());
   seqNumData.setPrePrepareMsg(msg->cloneObjAndMsg());
 }
 
 void DebugPersistentStorage::setSlowStartedInSeqNumWindow(SeqNum seqNum, bool slowStarted) {
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   SeqNumData &seqNumData = seqNumWindow.get(seqNum);
   seqNumData.setSlowStarted(slowStarted);
 }
 
 void DebugPersistentStorage::setFullCommitProofMsgInSeqNumWindow(SeqNum seqNum, FullCommitProofMsg *msg) {
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   SeqNumData &seqNumData = seqNumWindow.get(seqNum);
-  Assert(!seqNumData.isFullCommitProofMsgSet());
+  ConcordAssert(!seqNumData.isFullCommitProofMsgSet());
   seqNumData.setFullCommitProofMsg(msg->cloneObjAndMsg());
 }
 
 void DebugPersistentStorage::setForceCompletedInSeqNumWindow(SeqNum seqNum, bool forceCompleted) {
-  Assert(forceCompleted);
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(forceCompleted);
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   SeqNumData &seqNumData = seqNumWindow.get(seqNum);
   seqNumData.setForceCompleted(forceCompleted);
 }
 
 void DebugPersistentStorage::setPrepareFullMsgInSeqNumWindow(SeqNum seqNum, PrepareFullMsg *msg) {
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   SeqNumData &seqNumData = seqNumWindow.get(seqNum);
-  Assert(!seqNumData.isPrepareFullMsgSet());
+  ConcordAssert(!seqNumData.isPrepareFullMsgSet());
   seqNumData.setPrepareFullMsg(msg->cloneObjAndMsg());
 }
 
 void DebugPersistentStorage::setCommitFullMsgInSeqNumWindow(SeqNum seqNum, CommitFullMsg *msg) {
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   SeqNumData &seqNumData = seqNumWindow.get(seqNum);
-  Assert(!seqNumData.isCommitFullMsgSet());
+  ConcordAssert(!seqNumData.isCommitFullMsgSet());
   seqNumData.setCommitFullMsg(msg->cloneObjAndMsg());
 }
 
 void DebugPersistentStorage::setCheckpointMsgInCheckWindow(SeqNum s, CheckpointMsg *msg) {
-  Assert(checkWindow.insideActiveWindow(s));
+  ConcordAssert(checkWindow.insideActiveWindow(s));
   CheckData &checkData = checkWindow.get(s);
   checkData.deleteCheckpointMsg();
   checkData.setCheckpointMsg(msg->cloneObjAndMsg());
 }
 
 void DebugPersistentStorage::setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) {
-  Assert(mark == true);
-  Assert(checkWindow.insideActiveWindow(seqNum));
+  ConcordAssert(mark == true);
+  ConcordAssert(checkWindow.insideActiveWindow(seqNum));
   CheckData &checkData = checkWindow.get(seqNum);
   checkData.setCompletedMark(mark);
 }
@@ -275,39 +276,39 @@ void DebugPersistentStorage::setCompletedMarkInCheckWindow(SeqNum seqNum, bool m
 bool DebugPersistentStorage::hasReplicaConfig() const { return hasConfig_; }
 
 ReplicaConfig DebugPersistentStorage::getReplicaConfig() {
-  Assert(getIsAllowed());
-  Assert(hasConfig_);
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(hasConfig_);
   return config_;
 }
 
 SeqNum DebugPersistentStorage::getLastExecutedSeqNum() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return lastExecutedSeqNum_;
 }
 
 SeqNum DebugPersistentStorage::getPrimaryLastUsedSeqNum() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return primaryLastUsedSeqNum_;
 }
 
 SeqNum DebugPersistentStorage::getStrictLowerBoundOfSeqNums() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return strictLowerBoundOfSeqNums_;
 }
 
 ViewNum DebugPersistentStorage::getLastViewThatTransferredSeqNumbersFullyExecuted() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return lastViewThatTransferredSeqNumbersFullyExecuted_;
 }
 
 bool DebugPersistentStorage::hasDescriptorOfLastExitFromView() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return hasDescriptorOfLastExitFromView_;
 }
 
 DescriptorOfLastExitFromView DebugPersistentStorage::getAndAllocateDescriptorOfLastExitFromView() {
-  Assert(getIsAllowed());
-  Assert(hasDescriptorOfLastExitFromView_);
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(hasDescriptorOfLastExitFromView_);
 
   DescriptorOfLastExitFromView &d = descriptorOfLastExitFromView_;
 
@@ -323,7 +324,7 @@ DescriptorOfLastExitFromView DebugPersistentStorage::getAndAllocateDescriptorOfL
       elements[i].prepareFull = nullptr;
   }
 
-  Assert(d.myViewChangeMsg != nullptr || d.view == 0);
+  ConcordAssert(d.myViewChangeMsg != nullptr || d.view == 0);
   ViewChangeMsg *myVCMsg = nullptr;
   if (d.myViewChangeMsg != nullptr) myVCMsg = (ViewChangeMsg *)d.myViewChangeMsg->cloneObjAndMsg();
 
@@ -334,13 +335,13 @@ DescriptorOfLastExitFromView DebugPersistentStorage::getAndAllocateDescriptorOfL
 }
 
 bool DebugPersistentStorage::hasDescriptorOfLastNewView() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return hasDescriptorOfLastNewView_;
 }
 
 DescriptorOfLastNewView DebugPersistentStorage::getAndAllocateDescriptorOfLastNewView() {
-  Assert(getIsAllowed());
-  Assert(hasDescriptorOfLastNewView_);
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(hasDescriptorOfLastNewView_);
 
   DescriptorOfLastNewView &d = descriptorOfLastNewView_;
 
@@ -366,13 +367,13 @@ DescriptorOfLastNewView DebugPersistentStorage::getAndAllocateDescriptorOfLastNe
 }
 
 bool DebugPersistentStorage::hasDescriptorOfLastExecution() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return hasDescriptorOfLastExecution_;
 }
 
 DescriptorOfLastExecution DebugPersistentStorage::getDescriptorOfLastExecution() {
-  Assert(getIsAllowed());
-  Assert(hasDescriptorOfLastExecution_);
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(hasDescriptorOfLastExecution_);
 
   DescriptorOfLastExecution &d = descriptorOfLastExecution_;
 
@@ -380,95 +381,95 @@ DescriptorOfLastExecution DebugPersistentStorage::getDescriptorOfLastExecution()
 }
 
 SeqNum DebugPersistentStorage::getLastStableSeqNum() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return lastStableSeqNum_;
 }
 
 PrePrepareMsg *DebugPersistentStorage::getAndAllocatePrePrepareMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
 
   PrePrepareMsg *orgMsg = seqNumWindow.get(seqNum).getPrePrepareMsg();
   if (orgMsg == nullptr) return nullptr;
 
   PrePrepareMsg *m = (PrePrepareMsg *)orgMsg->cloneObjAndMsg();
-  Assert(m->type() == MsgCode::PrePrepare);
+  ConcordAssert(m->type() == MsgCode::PrePrepare);
   return m;
 }
 
 bool DebugPersistentStorage::getSlowStartedInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   bool b = seqNumWindow.get(seqNum).getSlowStarted();
   return b;
 }
 
 FullCommitProofMsg *DebugPersistentStorage::getAndAllocateFullCommitProofMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
 
   FullCommitProofMsg *orgMsg = seqNumWindow.get(seqNum).getFullCommitProofMsg();
   if (orgMsg == nullptr) return nullptr;
 
   FullCommitProofMsg *m = (FullCommitProofMsg *)orgMsg->cloneObjAndMsg();
-  Assert(m->type() == MsgCode::FullCommitProof);
+  ConcordAssert(m->type() == MsgCode::FullCommitProof);
   return m;
 }
 
 bool DebugPersistentStorage::getForceCompletedInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
   bool b = seqNumWindow.get(seqNum).getForceCompleted();
   return b;
 }
 
 PrepareFullMsg *DebugPersistentStorage::getAndAllocatePrepareFullMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
 
   PrepareFullMsg *orgMsg = seqNumWindow.get(seqNum).getPrepareFullMsg();
   if (orgMsg == nullptr) return nullptr;
 
   PrepareFullMsg *m = (PrepareFullMsg *)orgMsg->cloneObjAndMsg();
-  Assert(m->type() == MsgCode::PrepareFull);
+  ConcordAssert(m->type() == MsgCode::PrepareFull);
   return m;
 }
 
 CommitFullMsg *DebugPersistentStorage::getAndAllocateCommitFullMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
-  Assert(seqNumWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ + 1 == seqNumWindow.getBeginningOfActiveWindow());
+  ConcordAssert(seqNumWindow.insideActiveWindow(seqNum));
 
   CommitFullMsg *orgMsg = seqNumWindow.get(seqNum).getCommitFullMsg();
   if (orgMsg == nullptr) return nullptr;
 
   CommitFullMsg *m = (CommitFullMsg *)orgMsg->cloneObjAndMsg();
-  Assert(m->type() == MsgCode::CommitFull);
+  ConcordAssert(m->type() == MsgCode::CommitFull);
   return m;
 }
 
 CheckpointMsg *DebugPersistentStorage::getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ == checkWindow.getBeginningOfActiveWindow());
-  Assert(checkWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ == checkWindow.getBeginningOfActiveWindow());
+  ConcordAssert(checkWindow.insideActiveWindow(seqNum));
 
   CheckpointMsg *orgMsg = checkWindow.get(seqNum).getCheckpointMsg();
   if (orgMsg == nullptr) return nullptr;
 
   CheckpointMsg *m = (CheckpointMsg *)orgMsg->cloneObjAndMsg();
-  Assert(m->type() == MsgCode::Checkpoint);
+  ConcordAssert(m->type() == MsgCode::Checkpoint);
   return m;
 }
 
 bool DebugPersistentStorage::getCompletedMarkInCheckWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
-  Assert(lastStableSeqNum_ == checkWindow.getBeginningOfActiveWindow());
-  Assert(checkWindow.insideActiveWindow(seqNum));
+  ConcordAssert(getIsAllowed());
+  ConcordAssert(lastStableSeqNum_ == checkWindow.getBeginningOfActiveWindow());
+  ConcordAssert(checkWindow.insideActiveWindow(seqNum));
   bool b = checkWindow.get(seqNum).getCompletedMark();
   return b;
 }

--- a/bftengine/src/bftengine/DebugStatistics.cpp
+++ b/bftengine/src/bftengine/DebugStatistics.cpp
@@ -143,7 +143,7 @@ void DebugStatistics::clearCounters(DebugStatDesc& d) {
 #ifdef USE_TLS
 void DebugStatistics::initDebugStatisticsData() {
   ThreadLocalData* l = ThreadLocalData::Get();
-  Assert(l->debugStatData == nullptr);
+  ConcordAssert(l->debugStatData == nullptr);
   DebugStatDesc* dsd = new DebugStatDesc;
   l->debugStatData = dsd;
 }

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -26,7 +26,7 @@ int MsgsCommunicator::startCommunication(uint16_t replicaId) {
   replicaId_ = replicaId;
   communication_->setReceiver(replicaId_, msgReceiver_.get());
   int commStatus = communication_->Start();
-  Assert(commStatus == 0);
+  ConcordAssert(commStatus == 0);
   LOG_INFO(GL, "Communication for replica " << replicaId_ << " started");
   return commStatus;
 }

--- a/bftengine/src/bftengine/NullStateTransfer.cpp
+++ b/bftengine/src/bftengine/NullStateTransfer.cpp
@@ -20,7 +20,7 @@ namespace impl {
 void NullStateTransfer::init(uint64_t maxNumOfRequiredStoredCheckpoints,
                              uint32_t numberOfRequiredReservedPages,
                              uint32_t sizeOfReservedPage) {
-  Assert(!isInitialized());
+  ConcordAssert(!isInitialized());
 
   numOfReservedPages = numberOfRequiredReservedPages;
   sizeOfPage = sizeOfReservedPage;
@@ -29,20 +29,20 @@ void NullStateTransfer::init(uint64_t maxNumOfRequiredStoredCheckpoints,
 
   running = false;
 
-  Assert(reservedPages != nullptr);
+  ConcordAssert(reservedPages != nullptr);
 }
 
 void NullStateTransfer::startRunning(IReplicaForStateTransfer* r) {
-  Assert(isInitialized());
-  Assert(!running);
+  ConcordAssert(isInitialized());
+  ConcordAssert(!running);
 
   running = true;
   repApi = r;
 }
 
 void NullStateTransfer::stopRunning() {
-  Assert(isInitialized());
-  Assert(running);
+  ConcordAssert(isInitialized());
+  ConcordAssert(running);
 
   running = false;
 }
@@ -56,7 +56,7 @@ void NullStateTransfer::markCheckpointAsStable(uint64_t checkpointNumber) {}
 void NullStateTransfer::getDigestOfCheckpoint(uint64_t checkpointNumber,
                                               uint16_t sizeOfDigestBuffer,
                                               char* outDigestBuffer) {
-  Assert(sizeOfDigestBuffer >= sizeof(Digest));
+  ConcordAssert(sizeOfDigestBuffer >= sizeof(Digest));
   LOG_WARN(GL, "State digest is only based on sequence number (because state transfer module has not been loaded)");
 
   memset(outDigestBuffer, 0, sizeOfDigestBuffer);
@@ -84,7 +84,7 @@ uint32_t NullStateTransfer::numberOfReservedPages() const { return numOfReserved
 uint32_t NullStateTransfer::sizeOfReservedPage() const { return sizeOfPage; }
 
 bool NullStateTransfer::loadReservedPage(uint32_t reservedPageId, uint32_t copyLength, char* outReservedPage) const {
-  Assert(copyLength <= sizeOfPage);
+  ConcordAssert(copyLength <= sizeOfPage);
 
   char* page = reservedPages + (reservedPageId * sizeOfPage);
 
@@ -94,7 +94,7 @@ bool NullStateTransfer::loadReservedPage(uint32_t reservedPageId, uint32_t copyL
 }
 
 void NullStateTransfer::saveReservedPage(uint32_t reservedPageId, uint32_t copyLength, const char* inReservedPage) {
-  Assert(copyLength <= sizeOfPage);
+  ConcordAssert(copyLength <= sizeOfPage);
 
   char* page = reservedPages + (reservedPageId * sizeOfPage);
 

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -46,7 +46,7 @@ bool DescriptorOfLastExitFromView::equals(const DescriptorOfLastExitFromView &ot
 }
 
 void DescriptorOfLastExitFromView::serializeSimpleParams(char *buf, size_t bufLen, size_t &actualSize) const {
-  Assert(bufLen >= simpleParamsSize());
+  ConcordAssert(bufLen >= simpleParamsSize());
 
   size_t isDefaultSize = sizeof(isDefault);
   memcpy(buf, &isDefault, isDefaultSize);
@@ -80,8 +80,8 @@ void DescriptorOfLastExitFromView::serializeSimpleParams(char *buf, size_t bufLe
 
 void DescriptorOfLastExitFromView::serializeElement(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) const {
   actualSize = 0;
-  Assert(id < elements.size());
-  Assert(bufLen >= maxElementSize());
+  ConcordAssert(id < elements.size());
+  ConcordAssert(bufLen >= maxElementSize());
 
   PrePrepareMsg *prePrepareMsg = (id < elements.size()) ? elements[id].prePrepare : nullptr;
   PrepareFullMsg *prePrepareFullMsg = (id < elements.size()) ? elements[id].prepareFull : nullptr;
@@ -96,7 +96,7 @@ void DescriptorOfLastExitFromView::serializeElement(uint32_t id, char *buf, size
 
 void DescriptorOfLastExitFromView::deserializeSimpleParams(char *buf, size_t bufLen, uint32_t &actualSize) {
   actualSize = 0;
-  Assert(bufLen >= simpleParamsSize());
+  ConcordAssert(bufLen >= simpleParamsSize());
 
   size_t isDefaultSize = sizeof(isDefault);
   memcpy(&isDefault, buf, isDefaultSize);
@@ -142,8 +142,8 @@ void DescriptorOfLastExitFromView::deserializeElement(uint32_t id, char *buf, si
   size_t hasAllRequestsSize = sizeof(hasAllRequests);
   memcpy(&hasAllRequests, buf, hasAllRequestsSize);
 
-  Assert(elements[id].prePrepare == nullptr);
-  Assert(elements[id].prepareFull == nullptr);
+  ConcordAssert(elements[id].prePrepare == nullptr);
+  ConcordAssert(elements[id].prepareFull == nullptr);
 
   elements[id] = ViewsManager::PrevViewInfo(
       (PrePrepareMsg *)prePrepareMsgPtr, (PrepareFullMsg *)prepareFullMsgPtr, hasAllRequests);
@@ -194,7 +194,7 @@ bool DescriptorOfLastNewView::equals(const DescriptorOfLastNewView &other) const
 
 void DescriptorOfLastNewView::serializeSimpleParams(char *buf, size_t bufLen, size_t &actualSize) const {
   actualSize = 0;
-  Assert(bufLen >= simpleParamsSize());
+  ConcordAssert(bufLen >= simpleParamsSize());
 
   size_t isDefaultSize = sizeof(isDefault);
   memcpy(buf, &isDefault, isDefaultSize);
@@ -221,8 +221,8 @@ void DescriptorOfLastNewView::serializeSimpleParams(char *buf, size_t bufLen, si
 
 void DescriptorOfLastNewView::serializeElement(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) const {
   actualSize = 0;
-  Assert(id < viewChangeMsgsNum);
-  Assert(bufLen >= maxElementSize());
+  ConcordAssert(id < viewChangeMsgsNum);
+  ConcordAssert(bufLen >= maxElementSize());
 
   ViewChangeMsg *msg = (id < viewChangeMsgs.size()) ? viewChangeMsgs[id] : nullptr;
   actualSize = MessageBase::serializeMsg(buf, msg);
@@ -230,7 +230,7 @@ void DescriptorOfLastNewView::serializeElement(uint32_t id, char *buf, size_t bu
 
 void DescriptorOfLastNewView::deserializeSimpleParams(char *buf, size_t bufLen, uint32_t &actualSize) {
   actualSize = 0;
-  Assert(bufLen >= simpleParamsSize());
+  ConcordAssert(bufLen >= simpleParamsSize());
 
   size_t isDefaultSize = sizeof(isDefault);
   memcpy(&isDefault, buf, isDefaultSize);
@@ -259,10 +259,10 @@ void DescriptorOfLastNewView::deserializeSimpleParams(char *buf, size_t bufLen, 
 
 void DescriptorOfLastNewView::deserializeElement(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) {
   actualSize = 0;
-  Assert(id < viewChangeMsgsNum);
+  ConcordAssert(id < viewChangeMsgsNum);
 
   auto *msg = MessageBase::deserializeMsg(buf, bufLen, actualSize);
-  Assert(viewChangeMsgs[id] == nullptr);
+  ConcordAssert(viewChangeMsgs[id] == nullptr);
   viewChangeMsgs[id] = ((ViewChangeMsg *)msg);
 }
 
@@ -274,7 +274,7 @@ bool DescriptorOfLastExecution::equals(const DescriptorOfLastExecution &other) c
 
 void DescriptorOfLastExecution::serialize(char *&buf, size_t bufLen, size_t &actualSize) const {
   actualSize = 0;
-  Assert(bufLen >= maxSize());
+  ConcordAssert(bufLen >= maxSize());
 
   size_t executedSeqNumSize = sizeof(executedSeqNum);
   memcpy(buf, &executedSeqNum, executedSeqNumSize);
@@ -289,7 +289,7 @@ void DescriptorOfLastExecution::serialize(char *&buf, size_t bufLen, size_t &act
 void DescriptorOfLastExecution::deserialize(char *buf, size_t bufLen, uint32_t &actualSize) {
   actualSize = 0;
 
-  Assert(bufLen >= maxSize())
+  ConcordAssert(bufLen >= maxSize())
 
       size_t seqNumSize = sizeof(executedSeqNum);
   memcpy(&executedSeqNum, buf, seqNumSize);

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -133,7 +133,7 @@ uint8_t PersistentStorageImp::beginWriteTran() {
 }
 
 uint8_t PersistentStorageImp::endWriteTran() {
-  Assert(numOfNestedTransactions_ != 0);
+  ConcordAssert(numOfNestedTransactions_ != 0);
   if (--numOfNestedTransactions_ == 0) {
     metadataStorage_->commitAtomicWriteOnlyBatch();
   }
@@ -145,7 +145,7 @@ bool PersistentStorageImp::isInWriteTran() const { return (numOfNestedTransactio
 /***** Setters *****/
 
 void PersistentStorageImp::setReplicaConfig(const ReplicaConfig &config) {
-  Assert(isInWriteTran());
+  ConcordAssert(isInWriteTran());
   std::ostringstream oss;
   configSerializer_->setConfig(config);
   configSerializer_->serialize(oss);
@@ -153,7 +153,7 @@ void PersistentStorageImp::setReplicaConfig(const ReplicaConfig &config) {
 }
 
 void PersistentStorageImp::setVersion() const {
-  Assert(isInWriteTran());
+  ConcordAssert(isInWriteTran());
   const uint32_t sizeOfVersion = version_.size();
   const uint32_t sizeOfSizeOfVersion = sizeof(sizeOfVersion);
   const int64_t outBufSize = sizeOfVersion + sizeOfSizeOfVersion;
@@ -171,8 +171,8 @@ void PersistentStorageImp::setLastExecutedSeqNumInternal(SeqNum seqNum) {
 }
 
 void PersistentStorageImp::setLastExecutedSeqNum(SeqNum seqNum) {
-  Assert(setIsAllowed());
-  Assert(lastExecutedSeqNum_ <= seqNum);
+  ConcordAssert(setIsAllowed());
+  ConcordAssert(lastExecutedSeqNum_ <= seqNum);
   setLastExecutedSeqNumInternal(seqNum);
 }
 
@@ -182,7 +182,7 @@ void PersistentStorageImp::setPrimaryLastUsedSeqNumInternal(SeqNum seqNum) {
 }
 
 void PersistentStorageImp::setPrimaryLastUsedSeqNum(SeqNum seqNum) {
-  Assert(nonExecSetIsAllowed());
+  ConcordAssert(nonExecSetIsAllowed());
   setPrimaryLastUsedSeqNumInternal(seqNum);
 }
 
@@ -192,7 +192,7 @@ void PersistentStorageImp::setStrictLowerBoundOfSeqNumsInternal(SeqNum seqNum) {
 }
 
 void PersistentStorageImp::setStrictLowerBoundOfSeqNums(SeqNum seqNum) {
-  Assert(nonExecSetIsAllowed());
+  ConcordAssert(nonExecSetIsAllowed());
   setStrictLowerBoundOfSeqNumsInternal(seqNum);
 }
 
@@ -202,8 +202,8 @@ void PersistentStorageImp::setLastViewTransferredSeqNumbersInternal(ViewNum view
 }
 
 void PersistentStorageImp::setLastViewThatTransferredSeqNumbersFullyExecuted(ViewNum view) {
-  Assert(nonExecSetIsAllowed());
-  Assert(lastViewTransferredSeqNum_ <= view);
+  ConcordAssert(nonExecSetIsAllowed());
+  ConcordAssert(lastViewTransferredSeqNum_ <= view);
   setLastViewTransferredSeqNumbersInternal(view);
 }
 
@@ -223,9 +223,9 @@ void PersistentStorageImp::saveDescriptorOfLastExitFromView(const DescriptorOfLa
   UniquePtrToChar elementBuf(new char[maxElementSize]);
   for (size_t i = 0; i < elementsNum; ++i) {
     newDesc.serializeElement(i, elementBuf.get(), maxElementSize, actualElementSize);
-    Assert(actualElementSize != 0);
+    ConcordAssert(actualElementSize != 0);
     uint32_t itemId = LAST_EXIT_FROM_VIEW_DESC + 1 + i;
-    Assert(itemId < LAST_EXEC_DESC);
+    ConcordAssert(itemId < LAST_EXEC_DESC);
     metadataStorage_->writeInBatch(itemId, elementBuf.get(), actualElementSize);
   }
 }
@@ -261,7 +261,7 @@ void PersistentStorageImp::saveDescriptorOfLastNewView(const DescriptorOfLastNew
   UniquePtrToChar elementBuf(new char[maxElementSize]);
   for (uint32_t i = 0; i < numOfMessages; ++i) {
     newDesc.serializeElement(i, elementBuf.get(), maxElementSize, actualElementSize);
-    Assert(actualElementSize != 0);
+    ConcordAssert(actualElementSize != 0);
     metadataStorage_->writeInBatch(LAST_NEW_VIEW_DESC + 1 + i, elementBuf.get(), actualElementSize);
   }
 }
@@ -290,7 +290,7 @@ void PersistentStorageImp::saveDescriptorOfLastExecution(const DescriptorOfLastE
   char *descBufPtr = descBuf.get();
   size_t actualSize = 0;
   newDesc.serialize(descBufPtr, bufLen, actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
   metadataStorage_->writeInBatch(LAST_EXEC_DESC, descBuf.get(), actualSize);
 }
 
@@ -326,41 +326,41 @@ void PersistentStorageImp::setSeqNumDataElement(SeqNum index, const SeqNumData &
   char *movablePtr = buf.get();
   size_t actualSize = seqNumData.serializePrePrepareMsg(movablePtr);
   uint32_t itemId = BEGINNING_OF_SEQ_NUM_WINDOW + PRE_PREPARE_MSG + shift;
-  Assert(itemId < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(itemId < BEGINNING_OF_CHECK_WINDOW);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
 
   movablePtr = buf.get();
   actualSize = seqNumData.serializeFullCommitProofMsg(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + FULL_COMMIT_PROOF_MSG + shift;
-  Assert(itemId < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(itemId < BEGINNING_OF_CHECK_WINDOW);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
 
   movablePtr = buf.get();
   actualSize = seqNumData.serializePrepareFullMsg(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + PRE_PREPARE_FULL_MSG + shift;
-  Assert(itemId < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(itemId < BEGINNING_OF_CHECK_WINDOW);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
 
   movablePtr = buf.get();
   actualSize = seqNumData.serializeCommitFullMsg(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + COMMIT_FULL_MSG + shift;
-  Assert(itemId < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(itemId < BEGINNING_OF_CHECK_WINDOW);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
 
   movablePtr = buf.get();
   actualSize = seqNumData.serializeForceCompleted(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + FORCE_COMPLETED + shift;
-  Assert(itemId < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(itemId < BEGINNING_OF_CHECK_WINDOW);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
 
   movablePtr = buf.get();
   actualSize = seqNumData.serializeSlowStarted(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + SLOW_STARTED + shift;
-  Assert(itemId < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(itemId < BEGINNING_OF_CHECK_WINDOW);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
 }
 
@@ -377,13 +377,13 @@ void PersistentStorageImp::setCheckDataElement(SeqNum index, const CheckData &ch
   size_t actualSize = checkData.serializeCheckpointMsg(movablePtr);
 
   uint32_t itemId = BEGINNING_OF_CHECK_WINDOW + CHECK_DATA_FIRST_PARAM + shift;
-  Assert(itemId < WIN_PARAMETERS_NUM);
+  ConcordAssert(itemId < WIN_PARAMETERS_NUM);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
   movablePtr = buf.get();
   actualSize = checkData.serializeCompletedMark(movablePtr);
   itemId = BEGINNING_OF_CHECK_WINDOW + COMPLETED_MARK + shift;
-  Assert(itemId < WIN_PARAMETERS_NUM);
+  ConcordAssert(itemId < WIN_PARAMETERS_NUM);
   metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
 }
 
@@ -435,9 +435,9 @@ void PersistentStorageImp::setMsgInSeqNumWindow(SeqNum seqNum,
   UniquePtrToChar buf(new char[msgSize]);
   char *movablePtr = buf.get();
   const size_t actualSize = SeqNumData::serializeMsg(movablePtr, msg);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
   const SeqNum convertedIndex = BEGINNING_OF_SEQ_NUM_WINDOW + parameterId + convertSeqNumWindowIndex(seqNum);
-  Assert(convertedIndex < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(convertedIndex < BEGINNING_OF_CHECK_WINDOW);
   LOG_DEBUG(GL, "PersistentStorageImp::setMsgInSeqNumWindow convertedIndex=" << convertedIndex);
   metadataStorage_->writeInBatch(convertedIndex, buf.get(), actualSize);
 }
@@ -473,13 +473,13 @@ void PersistentStorageImp::setSlowStartedInSeqNumWindow(SeqNum seqNum, bool slow
 }
 
 void PersistentStorageImp::setCompletedMarkInCheckWindow(SeqNum seqNum, bool completed) {
-  Assert(completed);
+  ConcordAssert(completed);
   const size_t sizeOfCompleted = sizeof(uint8_t);
   char buf[sizeOfCompleted];
   char *movablePtr = buf;
   CheckData::serializeCompletedMark(movablePtr, completed);
   const SeqNum convertedIndex = BEGINNING_OF_CHECK_WINDOW + COMPLETED_MARK + convertCheckWindowIndex(seqNum);
-  Assert(convertedIndex < WIN_PARAMETERS_NUM);
+  ConcordAssert(convertedIndex < WIN_PARAMETERS_NUM);
   metadataStorage_->writeInBatch(convertedIndex, buf, sizeOfCompleted);
 }
 
@@ -488,9 +488,9 @@ void PersistentStorageImp::setCheckpointMsgInCheckWindow(SeqNum seqNum, Checkpoi
   UniquePtrToChar buf(new char[bufLen]);
   char *movablePtr = buf.get();
   size_t actualSize = CheckData::serializeCheckpointMsg(movablePtr, (CheckpointMsg *)msg);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
   const SeqNum convertedIndex = BEGINNING_OF_CHECK_WINDOW + CHECKPOINT_MSG + convertCheckWindowIndex(seqNum);
-  Assert(convertedIndex < WIN_PARAMETERS_NUM);
+  ConcordAssert(convertedIndex < WIN_PARAMETERS_NUM);
   LOG_DEBUG(GL, "PersistentStorageImp::setCheckpointMsgInCheckWindow convertedIndex=" << convertedIndex);
   metadataStorage_->writeInBatch(convertedIndex, buf.get(), actualSize);
 }
@@ -498,7 +498,7 @@ void PersistentStorageImp::setCheckpointMsgInCheckWindow(SeqNum seqNum, Checkpoi
 /***** Getters *****/
 
 string PersistentStorageImp::getStoredVersion() {
-  Assert(!isInWriteTran());
+  ConcordAssert(!isInWriteTran());
   uint32_t outActualObjectSize = 0;
   UniquePtrToChar outBuf(new char[maxVersionSize_]);
   char *outBufPtr = outBuf.get();
@@ -511,7 +511,7 @@ string PersistentStorageImp::getStoredVersion() {
   outBufPtr += sizeof(sizeOfVersion);
   string savedVersion;
   savedVersion.assign(outBufPtr, sizeOfVersion);
-  Assert(version_ == savedVersion);
+  ConcordAssert(version_ == savedVersion);
 
   return version_;
 }
@@ -529,31 +529,31 @@ ReplicaConfig PersistentStorageImp::getReplicaConfig() {
 }
 
 SeqNum PersistentStorageImp::getLastExecutedSeqNum() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   lastExecutedSeqNum_ = getSeqNum(LAST_EXEC_SEQ_NUM, sizeof(lastExecutedSeqNum_));
   return lastExecutedSeqNum_;
 }
 
 SeqNum PersistentStorageImp::getPrimaryLastUsedSeqNum() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   primaryLastUsedSeqNum_ = getSeqNum(PRIMARY_LAST_USED_SEQ_NUM, sizeof(primaryLastUsedSeqNum_));
   return primaryLastUsedSeqNum_;
 }
 
 SeqNum PersistentStorageImp::getStrictLowerBoundOfSeqNums() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   strictLowerBoundOfSeqNums_ = getSeqNum(LOWER_BOUND_OF_SEQ_NUM, sizeof(strictLowerBoundOfSeqNums_));
   return strictLowerBoundOfSeqNums_;
 }
 
 SeqNum PersistentStorageImp::getLastStableSeqNum() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   lastStableSeqNum_ = getSeqNum(LAST_STABLE_SEQ_NUM, sizeof(lastStableSeqNum_));
   return lastStableSeqNum_;
 }
 
 ViewNum PersistentStorageImp::getLastViewThatTransferredSeqNumbersFullyExecuted() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   lastViewTransferredSeqNum_ = getSeqNum(LAST_VIEW_TRANSFERRED_SEQ_NUM, sizeof(lastViewTransferredSeqNum_));
   return lastViewTransferredSeqNum_;
 }
@@ -563,7 +563,7 @@ bool PersistentStorageImp::hasReplicaConfig() const { return (!(*configSerialize
 /***** Descriptors handling *****/
 
 DescriptorOfLastExitFromView PersistentStorageImp::getAndAllocateDescriptorOfLastExitFromView() {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   DescriptorOfLastExitFromView dbDesc;
   const size_t simpleParamsSize = DescriptorOfLastExitFromView::simpleParamsSize();
   uint32_t sizeInDb = 0;
@@ -571,7 +571,7 @@ DescriptorOfLastExitFromView PersistentStorageImp::getAndAllocateDescriptorOfLas
   // Read first simple params.
   UniquePtrToChar simpleParamsBuf(new char[simpleParamsSize]);
   metadataStorage_->read(LAST_EXIT_FROM_VIEW_DESC, simpleParamsSize, simpleParamsBuf.get(), sizeInDb);
-  Assert(sizeInDb == simpleParamsSize);
+  ConcordAssert(sizeInDb == simpleParamsSize);
   uint32_t actualSize = 0;
   dbDesc.deserializeSimpleParams(simpleParamsBuf.get(), simpleParamsSize, actualSize);
 
@@ -581,10 +581,10 @@ DescriptorOfLastExitFromView PersistentStorageImp::getAndAllocateDescriptorOfLas
   uint32_t elementsNum = dbDesc.elements.size();
   for (uint32_t i = 0; i < elementsNum; ++i) {
     uint32_t itemId = LAST_EXIT_FROM_VIEW_DESC + 1 + i;
-    Assert(itemId < LAST_EXEC_DESC);
+    ConcordAssert(itemId < LAST_EXEC_DESC);
     metadataStorage_->read(itemId, maxElementSize, elementBuf.get(), actualSize);
     dbDesc.deserializeElement(i, elementBuf.get(), actualSize, actualElementSize);
-    Assert(actualElementSize != 0);
+    ConcordAssert(actualElementSize != 0);
   }
   return dbDesc;
 }
@@ -606,7 +606,7 @@ DescriptorOfLastNewView PersistentStorageImp::getAndAllocateDescriptorOfLastNewV
   for (uint32_t i = 0; i < viewChangeMsgsNum; ++i) {
     metadataStorage_->read(LAST_NEW_VIEW_DESC + 1 + i, maxElementSize, elementBuf.get(), actualSize);
     dbDesc.deserializeElement(i, elementBuf.get(), actualSize, actualElementSize);
-    Assert(actualElementSize != 0);
+    ConcordAssert(actualElementSize != 0);
   }
   return dbDesc;
 }
@@ -619,7 +619,7 @@ DescriptorOfLastExecution PersistentStorageImp::getDescriptorOfLastExecution() {
   UniquePtrToChar buf(new char[maxSize]);
   metadataStorage_->read(LAST_EXEC_DESC, maxSize, buf.get(), actualSize);
   dbDesc.deserialize(buf.get(), maxSize, actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
   if (!dbDesc.equals(emptyDescriptorOfLastExecution_)) {
     descriptorOfLastExecution_ = dbDesc;
     hasDescriptorOfLastExecution_ = true;
@@ -659,7 +659,7 @@ void PersistentStorageImp::readSeqNumDataElementFromDisk(SeqNum index, const Sha
   char *movablePtr = buf.get();
   for (auto i = 0; i < numOfSeqNumWinParameters; ++i) {
     uint32_t itemId = BEGINNING_OF_SEQ_NUM_WINDOW + SEQ_NUM_FIRST_PARAM + i + shift;
-    Assert(itemId < BEGINNING_OF_CHECK_WINDOW);
+    ConcordAssert(itemId < BEGINNING_OF_CHECK_WINDOW);
     metadataStorage_->read(itemId, SeqNumData::maxSize(), movablePtr, actualParameterSize);
     movablePtr += actualParameterSize;
     actualElementSize += actualParameterSize;
@@ -676,14 +676,14 @@ void PersistentStorageImp::readCheckDataElementFromDisk(SeqNum index, const Shar
   const SeqNum shift = index * numOfCheckWinParameters;
   for (auto i = 0; i < numOfCheckWinParameters; ++i) {
     uint32_t itemId = BEGINNING_OF_CHECK_WINDOW + CHECK_DATA_FIRST_PARAM + i + shift;
-    Assert(itemId < WIN_PARAMETERS_NUM);
+    ConcordAssert(itemId < WIN_PARAMETERS_NUM);
     metadataStorage_->read(itemId, CheckData::maxSize(), movablePtr, actualParameterSize);
     movablePtr += actualParameterSize;
     actualElementSize += actualParameterSize;
   }
   uint32_t actualSize = 0;
   checkWindow.get()->deserializeElement(index, buf.get(), CheckData::maxSize(), actualSize);
-  Assert(actualSize == actualElementSize);
+  ConcordAssert(actualSize == actualElementSize);
 }
 
 const SeqNum PersistentStorageImp::convertSeqNumWindowIndex(SeqNum seqNum) const {
@@ -698,7 +698,7 @@ uint8_t PersistentStorageImp::readOneByteFromDisk(SeqNum index, SeqNum parameter
   uint8_t oneByte = 0;
   uint32_t actualSize = 0;
   const SeqNum convertedIndex = BEGINNING_OF_SEQ_NUM_WINDOW + parameterId + convertSeqNumWindowIndex(index);
-  Assert(convertedIndex < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(convertedIndex < BEGINNING_OF_CHECK_WINDOW);
   metadataStorage_->read(convertedIndex, sizeof(oneByte), (char *)&oneByte, actualSize);
   return oneByte;
 }
@@ -707,13 +707,13 @@ MessageBase *PersistentStorageImp::readMsgFromDisk(SeqNum seqNum, SeqNum paramet
   UniquePtrToChar buf(new char[msgSize]);
   uint32_t actualMsgSize = 0;
   const SeqNum convertedIndex = BEGINNING_OF_SEQ_NUM_WINDOW + parameterId + convertSeqNumWindowIndex(seqNum);
-  Assert(convertedIndex < BEGINNING_OF_CHECK_WINDOW);
+  ConcordAssert(convertedIndex < BEGINNING_OF_CHECK_WINDOW);
   LOG_DEBUG(GL, "PersistentStorageImp::readMsgFromDisk seqNum=" << seqNum << " dbIndex=" << convertedIndex);
   metadataStorage_->read(convertedIndex, msgSize, buf.get(), actualMsgSize);
   size_t actualSize = 0;
   char *movablePtr = buf.get();
   auto *msg = SeqNumData::deserializeMsg(movablePtr, msgSize, actualSize);
-  Assert(actualSize == actualMsgSize);
+  ConcordAssert(actualSize == actualMsgSize);
   return msg;
 }
 
@@ -743,9 +743,9 @@ uint8_t PersistentStorageImp::readCompletedMarkFromDisk(SeqNum index) const {
   uint8_t completedMark = 0;
   uint32_t actualSize = 0;
   const SeqNum convertedIndex = BEGINNING_OF_CHECK_WINDOW + COMPLETED_MARK + convertCheckWindowIndex(index);
-  Assert(convertedIndex < WIN_PARAMETERS_NUM);
+  ConcordAssert(convertedIndex < WIN_PARAMETERS_NUM);
   metadataStorage_->read(convertedIndex, sizeof(completedMark), (char *)&completedMark, actualSize);
-  Assert(sizeof(completedMark) == actualSize);
+  ConcordAssert(sizeof(completedMark) == actualSize);
   return completedMark;
 }
 
@@ -754,13 +754,13 @@ CheckpointMsg *PersistentStorageImp::readCheckpointMsgFromDisk(SeqNum index) con
   UniquePtrToChar buf(new char[bufLen]);
   uint32_t actualMsgSize = 0;
   const SeqNum convertedIndex = BEGINNING_OF_CHECK_WINDOW + CHECKPOINT_MSG + convertCheckWindowIndex(index);
-  Assert(convertedIndex < WIN_PARAMETERS_NUM);
+  ConcordAssert(convertedIndex < WIN_PARAMETERS_NUM);
   LOG_DEBUG(GL, "PersistentStorageImp::readCheckpointMsgFromDisk convertedIndex=" << convertedIndex);
   metadataStorage_->read(convertedIndex, bufLen, buf.get(), actualMsgSize);
   size_t actualSize = 0;
   char *movablePtr = buf.get();
   auto *checkpointMsg = CheckData::deserializeCheckpointMsg(movablePtr, bufLen, actualSize);
-  Assert(actualSize == actualMsgSize);
+  ConcordAssert(actualSize == actualMsgSize);
   return checkpointMsg;
 }
 
@@ -769,7 +769,7 @@ SeqNum PersistentStorageImp::readBeginningOfActiveWindow(uint32_t index) const {
   uint32_t actualSize = 0;
   SeqNum beginningOfActiveWindow = 0;
   metadataStorage_->read(index, paramSize, (char *)&beginningOfActiveWindow, actualSize);
-  Assert(actualSize == paramSize);
+  ConcordAssert(actualSize == paramSize);
   return beginningOfActiveWindow;
 }
 
@@ -792,93 +792,93 @@ SharedPtrCheckWindow PersistentStorageImp::getCheckWindow() {
 }
 
 CheckpointMsg *PersistentStorageImp::getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readCheckpointMsgFromDisk(seqNum);
 }
 
 bool PersistentStorageImp::getCompletedMarkInCheckWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readCompletedMarkFromDisk(seqNum);
 }
 
 PrePrepareMsg *PersistentStorageImp::getAndAllocatePrePrepareMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readPrePrepareMsgFromDisk(seqNum);
 }
 
 FullCommitProofMsg *PersistentStorageImp::getAndAllocateFullCommitProofMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readFullCommitProofMsgFromDisk(seqNum);
 }
 
 PrepareFullMsg *PersistentStorageImp::getAndAllocatePrepareFullMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readPrepareFullMsgFromDisk(seqNum);
 }
 
 CommitFullMsg *PersistentStorageImp::getAndAllocateCommitFullMsgInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readCommitFullMsgFromDisk(seqNum);
 }
 
 bool PersistentStorageImp::getForceCompletedInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readOneByteFromDisk(seqNum, FORCE_COMPLETED);
 }
 
 bool PersistentStorageImp::getSlowStartedInSeqNumWindow(SeqNum seqNum) {
-  Assert(getIsAllowed());
+  ConcordAssert(getIsAllowed());
   return readOneByteFromDisk(seqNum, SLOW_STARTED);
 }
 
 /***** Verification/helper functions *****/
 
 void PersistentStorageImp::verifySetDescriptorOfLastExitFromView(const DescriptorOfLastExitFromView &desc) {
-  Assert(setIsAllowed());
-  Assert(desc.view >= 0);
+  ConcordAssert(setIsAllowed());
+  ConcordAssert(desc.view >= 0);
   // Here we assume that the first view is always 0
   // (even if we load the initial state from disk)
-  Assert(hasDescriptorOfLastNewView() || desc.view == 0);
-  Assert(desc.elements.size() <= kWorkWindowSize);
+  ConcordAssert(hasDescriptorOfLastNewView() || desc.view == 0);
+  ConcordAssert(desc.elements.size() <= kWorkWindowSize);
 }
 
 void PersistentStorageImp::verifyPrevViewInfo(const DescriptorOfLastExitFromView &desc) const {
   for (auto elem : desc.elements) {
-    Assert(elem.prePrepare->viewNumber() == desc.view);
-    Assert(elem.prepareFull == nullptr || elem.prepareFull->viewNumber() == desc.view);
-    Assert(elem.prepareFull == nullptr || elem.prepareFull->seqNumber() == elem.prePrepare->seqNumber());
+    ConcordAssert(elem.prePrepare->viewNumber() == desc.view);
+    ConcordAssert(elem.prepareFull == nullptr || elem.prepareFull->viewNumber() == desc.view);
+    ConcordAssert(elem.prepareFull == nullptr || elem.prepareFull->seqNumber() == elem.prePrepare->seqNumber());
   }
 }
 
 void PersistentStorageImp::verifyLastNewViewMsgs(const DescriptorOfLastNewView &desc) const {
   for (uint32_t i = 0; i < desc.viewChangeMsgs.size(); i++) {
     const ViewChangeMsg *viewChangeMsg = desc.viewChangeMsgs[i];
-    Assert(viewChangeMsg->newView() == desc.view);
+    ConcordAssert(viewChangeMsg->newView() == desc.view);
     Digest digestOfViewChangeMsg;
     viewChangeMsg->getMsgDigest(digestOfViewChangeMsg);
     const NewViewMsg *newViewMsg = desc.newViewMsg;
     if (newViewMsg->elementsCount())
-      Assert(newViewMsg->elementsCount() &&
-             newViewMsg->includesViewChangeFromReplica(viewChangeMsg->idOfGeneratedReplica(), digestOfViewChangeMsg));
+      ConcordAssert(newViewMsg->elementsCount() && newViewMsg->includesViewChangeFromReplica(
+                                                       viewChangeMsg->idOfGeneratedReplica(), digestOfViewChangeMsg));
   }
 }
 
 void PersistentStorageImp::verifySetDescriptorOfLastNewView(const DescriptorOfLastNewView &desc) {
-  Assert(setIsAllowed());
-  Assert(desc.view >= 1);
-  Assert(hasDescriptorOfLastExitFromView());
-  Assert(desc.newViewMsg->newView() == desc.view);
-  Assert(hasReplicaConfig());
+  ConcordAssert(setIsAllowed());
+  ConcordAssert(desc.view >= 1);
+  ConcordAssert(hasDescriptorOfLastExitFromView());
+  ConcordAssert(desc.newViewMsg->newView() == desc.view);
+  ConcordAssert(hasReplicaConfig());
   const size_t numOfVCMsgs = 2 * fVal_ + 2 * cVal_ + 1;
-  Assert(desc.viewChangeMsgs.size() == numOfVCMsgs);
+  ConcordAssert(desc.viewChangeMsgs.size() == numOfVCMsgs);
 }
 
 void PersistentStorageImp::verifyDescriptorOfLastExecution(const DescriptorOfLastExecution &desc) {
-  Assert(setIsAllowed());
-  Assert(!hasDescriptorOfLastExecution() || descriptorOfLastExecution_.executedSeqNum < desc.executedSeqNum);
-  Assert(lastExecutedSeqNum_ + 1 == desc.executedSeqNum);
-  Assert(desc.validRequests.numOfBits() >= 1);
-  Assert(desc.validRequests.numOfBits() <= maxNumOfRequestsInBatch);
+  ConcordAssert(setIsAllowed());
+  ConcordAssert(!hasDescriptorOfLastExecution() || descriptorOfLastExecution_.executedSeqNum < desc.executedSeqNum);
+  ConcordAssert(lastExecutedSeqNum_ + 1 == desc.executedSeqNum);
+  ConcordAssert(desc.validRequests.numOfBits() >= 1);
+  ConcordAssert(desc.validRequests.numOfBits() <= maxNumOfRequestsInBatch);
 }
 
 // Helper function for getting different kinds of sequence numbers.
@@ -886,7 +886,7 @@ SeqNum PersistentStorageImp::getSeqNum(ConstMetadataParameterIds id, uint32_t si
   uint32_t actualObjectSize = 0;
   SeqNum seqNum = 0;
   metadataStorage_->read(id, size, (char *)&seqNum, actualObjectSize);
-  Assert(actualObjectSize == size);
+  ConcordAssert(actualObjectSize == size);
   return seqNum;
 }
 

--- a/bftengine/src/bftengine/PersistentStorageWindows.cpp
+++ b/bftengine/src/bftengine/PersistentStorageWindows.cpp
@@ -55,7 +55,7 @@ size_t SeqNumData::serializeOneByte(char *&buf, const uint8_t &oneByte) {
 
 void SeqNumData::serialize(char *buf, uint32_t bufLen, size_t &actualSize) const {
   actualSize = 0;
-  Assert(bufLen >= maxSize());
+  ConcordAssert(bufLen >= maxSize());
   actualSize = serializePrePrepareMsg(buf) + serializeFullCommitProofMsg(buf) + serializePrepareFullMsg(buf) +
                serializeCommitFullMsg(buf) + serializeForceCompleted(buf) + serializeSlowStarted(buf);
 }
@@ -137,7 +137,7 @@ size_t CheckData::serializeCompletedMark(char *&buf, const uint8_t &completedMar
 
 void CheckData::serialize(char *buf, uint32_t bufLen, size_t &actualSize) const {
   actualSize = 0;
-  Assert(bufLen >= maxSize());
+  ConcordAssert(bufLen >= maxSize());
   actualSize += serializeCheckpointMsg(buf) + serializeCompletedMark(buf);
 }
 

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -119,7 +119,7 @@ void ReadOnlyReplica::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
       tableItrator++;
     }
   }
-  Assert(numRelevant == tableOfStableCheckpoints.size());
+  ConcordAssert(numRelevant == tableOfStableCheckpoints.size());
   LOG_INFO(GL, "numRelevant=" << numRelevant);
 
   // if enough - invoke state transfer

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -20,7 +20,7 @@
 
 #define Verify(expr, errorCode) \
   {                             \
-    Assert(expr);               \
+    ConcordAssert(expr);        \
     if ((expr) != true) {       \
       return errorCode;         \
     }                           \
@@ -28,7 +28,7 @@
 
 #define VerifyOR(expr1, expr2, errorCode)     \
   {                                           \
-    AssertOR(expr1, expr2);                   \
+    ConcordAssertOR(expr1, expr2);            \
     if ((expr1) != true && (expr2) != true) { \
       return errorCode;                       \
     }                                         \
@@ -36,7 +36,7 @@
 
 #define VerifyAND(expr1, expr2, errorCode)    \
   {                                           \
-    AssertAND(expr1, expr2);                  \
+    ConcordAssertAND(expr1, expr2);           \
     if ((expr1) != true || (expr2) != true) { \
       return errorCode;                       \
     }                                         \
@@ -124,7 +124,7 @@ void setDynamicallyConfigurableParameters(ReplicaConfig &config) {
 }
 
 ReplicaLoader::ErrorCode loadConfig(shared_ptr<PersistentStorage> &p, LoadedReplicaData &ld) {
-  Assert(p != nullptr);
+  ConcordAssert(p != nullptr);
 
   Verify(p->hasReplicaConfig(), NoDataErr);
 
@@ -161,9 +161,9 @@ ReplicaLoader::ErrorCode checkViewDesc(const DescriptorOfLastExitFromView *exitD
 }
 
 ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedReplicaData &ld) {
-  Assert(p != nullptr);
-  Assert(ld.repsInfo != nullptr) Assert(ld.repConfig.thresholdVerifierForSlowPathCommit != nullptr);
-  Assert(ld.viewsManager == nullptr);
+  ConcordAssert(p != nullptr);
+  ConcordAssert(ld.repsInfo != nullptr) ConcordAssert(ld.repConfig.thresholdVerifierForSlowPathCommit != nullptr);
+  ConcordAssert(ld.viewsManager == nullptr);
 
   DescriptorOfLastExitFromView descriptorOfLastExitFromView;
   DescriptorOfLastNewView descriptorOfLastNewView;
@@ -193,8 +193,8 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
     viewsManager =
         ViewsManager::createInsideViewZero(ld.repsInfo, ld.sigManager, ld.repConfig.thresholdVerifierForSlowPathCommit);
 
-    Assert(viewsManager->latestActiveView() == 0);
-    Assert(viewsManager->viewIsActive(0));
+    ConcordAssert(viewsManager->latestActiveView() == 0);
+    ConcordAssert(viewsManager->viewIsActive(0));
 
     ld.maxSeqNumTransferredFromPrevViews = 0;
   } else if (hasDescLastExitFromView && !hasDescOfLastNewView) {
@@ -259,7 +259,7 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
 }
 
 ReplicaLoader::ErrorCode loadReplicaData(shared_ptr<PersistentStorage> p, LoadedReplicaData &ld) {
-  Assert(p != nullptr);
+  ConcordAssert(p != nullptr);
 
   ReplicaLoader::ErrorCode stat = loadConfig(p, ld);
 
@@ -364,7 +364,7 @@ ReplicaLoader::ErrorCode loadReplicaData(shared_ptr<PersistentStorage> p, Loaded
       Verify(d.executedSeqNum <= ld.lastStableSeqNum + kWorkWindowSize, InconsistentErr);
 
       uint64_t idx = d.executedSeqNum - ld.lastStableSeqNum - 1;
-      Assert(idx < kWorkWindowSize);
+      ConcordAssert(idx < kWorkWindowSize);
 
       const SeqNumData &e = ld.seqNumWinArr[idx];
 
@@ -400,7 +400,7 @@ void freeReplicaData(LoadedReplicaData &ld) {
 }  // namespace
 
 LoadedReplicaData ReplicaLoader::loadReplica(shared_ptr<PersistentStorage> &p, ReplicaLoader::ErrorCode &outErrCode) {
-  Assert(p != nullptr);
+  ConcordAssert(p != nullptr);
   LoadedReplicaData ld;
   outErrCode = loadReplicaData(p, ld);
 

--- a/bftengine/src/bftengine/ReplicasInfo.cpp
+++ b/bftengine/src/bftengine/ReplicasInfo.cpp
@@ -41,7 +41,7 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
           if (i != config.replicaId) ret.insert(i);
         return ret;
       }()} {
-  Assert(_numberOfReplicas == (3 * _fVal + 2 * _cVal + 1));
+  ConcordAssert(_numberOfReplicas == (3 * _fVal + 2 * _cVal + 1));
 }
 
 bool ReplicasInfo::getCollectorsForPartialProofs(const ReplicaId refReplica,

--- a/bftengine/src/bftengine/RetransmissionsManager.cpp
+++ b/bftengine/src/bftengine/RetransmissionsManager.cpp
@@ -58,7 +58,7 @@ class RetransmissionsLogic {
   {
     pendingRetransmissionsHeap =
         std::priority_queue<PendingRetran, std::vector<PendingRetran>, PendingRetran::Comparator>();
-    Assert(pendingRetransmissionsHeap.empty());
+    ConcordAssert(pendingRetransmissionsHeap.empty());
   }
 
   void processSend(Time time, uint16_t replicaId, SeqNum msgSeqNum, uint16_t msgType, bool ignorePreviousAcks) {
@@ -134,7 +134,7 @@ class RetransmissionsLogic {
   }
 
   void getSuggestedRetransmissions(Time currentTime, std::forward_list<RetSuggestion>& outSuggestedRetransmissions) {
-    Assert(outSuggestedRetransmissions.empty());
+    ConcordAssert(outSuggestedRetransmissions.empty());
 
     if (pendingRetransmissionsHeap.empty()) return;
 
@@ -192,7 +192,7 @@ class RetransmissionsLogic {
             std::min((uint64_t)PARM::maxTimeBetweenRetranMilli, retranTimeMilli * PARM::maxIncreasingFactor);
         const uint64_t minVal =
             std::max((uint64_t)PARM::minTimeBetweenRetranMilli, retranTimeMilli / PARM::maxDecreasingFactor);
-        Assert(minVal <= maxVal);
+        ConcordAssert(minVal <= maxVal);
 
         const double avg = avgAndVarOfAckTime.avg();
         const double var = avgAndVarOfAckTime.var();
@@ -310,9 +310,9 @@ RetransmissionsManager::RetransmissionsManager(util::SimpleThreadPool* threadPoo
       incomingMsgs{incomingMsgsStorage},
       maxOutSeqNumbers{maxOutNumOfSeqNumbers},
       internalLogicInfo{new RetransmissionsLogic(maxOutNumOfSeqNumbers)} {
-  Assert(threadPool != nullptr);
-  Assert(incomingMsgsStorage != nullptr);
-  Assert(maxOutNumOfSeqNumbers > 0);
+  ConcordAssert(threadPool != nullptr);
+  ConcordAssert(incomingMsgsStorage != nullptr);
+  ConcordAssert(maxOutNumOfSeqNumbers > 0);
 
   lastStable = lastStableSeqNum;
 }
@@ -448,7 +448,7 @@ bool RetransmissionsManager::tryToStartProcessing() {
           else if (e.etype == RetransmissionsManager::EType::SENT_AND_IGNORE_PREV)
             logic->processSend(e.time, e.replicaId, e.msgSeqNum, e.msgType, true);
           else
-            Assert(false);
+            ConcordAssert(false);
         }
       }
 
@@ -492,8 +492,8 @@ bool RetransmissionsManager::tryToStartProcessing() {
 }
 
 void RetransmissionsManager::OnProcessingComplete() {
-  Assert(pool != nullptr);
-  Assert(bkProcessing);
+  ConcordAssert(pool != nullptr);
+  ConcordAssert(bkProcessing);
 
   bkProcessing = false;
 }

--- a/bftengine/src/bftengine/SeqNumInfo.cpp
+++ b/bftengine/src/bftengine/SeqNumInfo.cpp
@@ -68,9 +68,9 @@ void SeqNumInfo::getAndReset(PrePrepareMsg*& outPrePrepare, PrepareFullMsg*& out
 bool SeqNumInfo::addMsg(PrePrepareMsg* m, bool directAdd) {
   if (prePrepareMsg != nullptr) return false;
 
-  Assert(primary == false);
-  Assert(!forcedCompleted);
-  Assert(!prepareSigCollector->hasPartialMsgFromReplica(replica->getReplicasInfo().myId()));
+  ConcordAssert(primary == false);
+  ConcordAssert(!forcedCompleted);
+  ConcordAssert(!prepareSigCollector->hasPartialMsgFromReplica(replica->getReplicasInfo().myId()));
 
   prePrepareMsg = m;
 
@@ -89,13 +89,13 @@ bool SeqNumInfo::addMsg(PrePrepareMsg* m, bool directAdd) {
 }
 
 bool SeqNumInfo::addSelfMsg(PrePrepareMsg* m, bool directAdd) {
-  Assert(primary == false);
-  Assert(replica->getReplicasInfo().myId() == replica->getReplicasInfo().primaryOfView(m->viewNumber()));
-  Assert(!forcedCompleted);
-  Assert(prePrepareMsg == nullptr);
+  ConcordAssert(primary == false);
+  ConcordAssert(replica->getReplicasInfo().myId() == replica->getReplicasInfo().primaryOfView(m->viewNumber()));
+  ConcordAssert(!forcedCompleted);
+  ConcordAssert(prePrepareMsg == nullptr);
 
-  // Assert(me->id() == m->senderId()); // GG: incorrect assert - because after a view change it may has been sent by
-  // another replica
+  // ConcordAssert(me->id() == m->senderId()); // GG: incorrect assert - because after a view change it may has been
+  // sent by another replica
 
   prePrepareMsg = m;
   primary = true;
@@ -115,8 +115,8 @@ bool SeqNumInfo::addSelfMsg(PrePrepareMsg* m, bool directAdd) {
 }
 
 bool SeqNumInfo::addMsg(PreparePartialMsg* m) {
-  Assert(replica->getReplicasInfo().myId() != m->senderId());
-  Assert(!forcedCompleted);
+  ConcordAssert(replica->getReplicasInfo().myId() != m->senderId());
+  ConcordAssert(!forcedCompleted);
 
   bool retVal = prepareSigCollector->addMsgWithPartialSignature(m, m->senderId());
 
@@ -124,8 +124,8 @@ bool SeqNumInfo::addMsg(PreparePartialMsg* m) {
 }
 
 bool SeqNumInfo::addSelfMsg(PreparePartialMsg* m, bool directAdd) {
-  Assert(replica->getReplicasInfo().myId() == m->senderId());
-  Assert(!forcedCompleted);
+  ConcordAssert(replica->getReplicasInfo().myId() == m->senderId());
+  ConcordAssert(!forcedCompleted);
 
   bool r;
 
@@ -134,14 +134,14 @@ bool SeqNumInfo::addSelfMsg(PreparePartialMsg* m, bool directAdd) {
   else
     r = prepareSigCollector->initMsgWithPartialSignature(m, m->senderId());
 
-  Assert(r);
+  ConcordAssert(r);
 
   return true;
 }
 
 bool SeqNumInfo::addMsg(PrepareFullMsg* m, bool directAdd) {
-  Assert(directAdd || replica->getReplicasInfo().myId() != m->senderId());  // TODO(GG): TBD
-  Assert(!forcedCompleted);
+  ConcordAssert(directAdd || replica->getReplicasInfo().myId() != m->senderId());  // TODO(GG): TBD
+  ConcordAssert(!forcedCompleted);
 
   bool retVal;
   if (!directAdd)
@@ -153,8 +153,8 @@ bool SeqNumInfo::addMsg(PrepareFullMsg* m, bool directAdd) {
 }
 
 bool SeqNumInfo::addMsg(CommitPartialMsg* m) {
-  Assert(replica->getReplicasInfo().myId() != m->senderId());  // TODO(GG): TBD
-  Assert(!forcedCompleted);
+  ConcordAssert(replica->getReplicasInfo().myId() != m->senderId());  // TODO(GG): TBD
+  ConcordAssert(!forcedCompleted);
 
   bool r = commitMsgsCollector->addMsgWithPartialSignature(m, m->senderId());
 
@@ -164,8 +164,8 @@ bool SeqNumInfo::addMsg(CommitPartialMsg* m) {
 }
 
 bool SeqNumInfo::addSelfCommitPartialMsgAndDigest(CommitPartialMsg* m, Digest& commitDigest, bool directAdd) {
-  Assert(replica->getReplicasInfo().myId() == m->senderId());
-  Assert(!forcedCompleted);
+  ConcordAssert(replica->getReplicasInfo().myId() == m->senderId());
+  ConcordAssert(!forcedCompleted);
 
   Digest tmpDigest;
   Digest::calcCombination(commitDigest, m->viewNumber(), m->seqNumber(), tmpDigest);
@@ -177,15 +177,15 @@ bool SeqNumInfo::addSelfCommitPartialMsgAndDigest(CommitPartialMsg* m, Digest& c
     commitMsgsCollector->initExpected(m->seqNumber(), m->viewNumber(), tmpDigest);
     r = commitMsgsCollector->initMsgWithPartialSignature(m, m->senderId());
   }
-  Assert(r);
+  ConcordAssert(r);
   commitUpdateTime = getMonotonicTime();
 
   return true;
 }
 
 bool SeqNumInfo::addMsg(CommitFullMsg* m, bool directAdd) {
-  Assert(directAdd || replica->getReplicasInfo().myId() != m->senderId());  // TODO(GG): TBD
-  Assert(!forcedCompleted);
+  ConcordAssert(directAdd || replica->getReplicasInfo().myId() != m->senderId());  // TODO(GG): TBD
+  ConcordAssert(!forcedCompleted);
 
   bool r;
   if (!directAdd)
@@ -199,9 +199,9 @@ bool SeqNumInfo::addMsg(CommitFullMsg* m, bool directAdd) {
 }
 
 void SeqNumInfo::forceComplete() {
-  Assert(!forcedCompleted);
-  Assert(hasPrePrepareMsg());
-  Assert(this->partialProofsSet->hasFullProof());
+  ConcordAssert(!forcedCompleted);
+  ConcordAssert(hasPrePrepareMsg());
+  ConcordAssert(this->partialProofsSet->hasFullProof());
 
   forcedCompleted = true;
   commitUpdateTime = getMonotonicTime();

--- a/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
+++ b/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
@@ -37,7 +37,7 @@ class SequenceWithActiveWindow {
 
  public:
   SequenceWithActiveWindow(NumbersType windowFirst, void *initData) {
-    Assert(windowFirst % Resolution == 0);
+    ConcordAssert(windowFirst % Resolution == 0);
 
     beginningOfActiveWindow = windowFirst;
 
@@ -56,8 +56,8 @@ class SequenceWithActiveWindow {
   }
 
   ItemType &get(NumbersType n) {
-    Assert(n % Resolution == 0);
-    Assert(insideActiveWindow(n));
+    ConcordAssert(n % Resolution == 0);
+    ConcordAssert(insideActiveWindow(n));
 
     uint16_t i = ((n / Resolution) % numItems);
     return activeWindow[i];
@@ -71,7 +71,7 @@ class SequenceWithActiveWindow {
   }
 
   void resetAll(NumbersType windowFirst) {
-    Assert(windowFirst % Resolution == 0);
+    ConcordAssert(windowFirst % Resolution == 0);
 
     for (uint16_t i = 0; i < numItems; i++) ItemFuncs::reset(activeWindow[i]);
 
@@ -79,8 +79,8 @@ class SequenceWithActiveWindow {
   }
 
   void advanceActiveWindow(NumbersType newFirstIndexOfActiveWindow) {
-    Assert(newFirstIndexOfActiveWindow % Resolution == 0);
-    Assert(newFirstIndexOfActiveWindow >= beginningOfActiveWindow);
+    ConcordAssert(newFirstIndexOfActiveWindow % Resolution == 0);
+    ConcordAssert(newFirstIndexOfActiveWindow >= beginningOfActiveWindow);
 
     if (newFirstIndexOfActiveWindow == beginningOfActiveWindow) return;
 
@@ -97,7 +97,7 @@ class SequenceWithActiveWindow {
 
     const uint16_t resetSize = (inactiveBegin <= inactiveEnd) ? (inactiveEnd - inactiveBegin + 1)
                                                               : (inactiveEnd + 1 + numItems - inactiveBegin);
-    Assert(resetSize > 0 && resetSize < numItems);
+    ConcordAssert(resetSize > 0 && resetSize < numItems);
 
     uint16_t debugNumOfReset = 0;
     for (uint16_t i = inactiveBegin; i != activeBegin; (i = ((i + 1) % numItems))) {
@@ -105,7 +105,7 @@ class SequenceWithActiveWindow {
       debugNumOfReset++;
     }
 
-    Assert(debugNumOfReset == resetSize);
+    ConcordAssert(debugNumOfReset == resetSize);
     beginningOfActiveWindow = newFirstIndexOfActiveWindow;
   }
 

--- a/bftengine/src/bftengine/SerializableActiveWindow.cpp
+++ b/bftengine/src/bftengine/SerializableActiveWindow.cpp
@@ -23,7 +23,7 @@ namespace impl {
 
 template <TEMPLATE_PARAMS>
 SerializableActiveWindow<INPUT_PARAMS>::SerializableActiveWindow(const SeqNum &windowFirst) {
-  Assert(windowFirst % Resolution == 0);
+  ConcordAssert(windowFirst % Resolution == 0);
   beginningOfActiveWindow_ = windowFirst;
   for (uint32_t i = 0; i < numItems_; i++) activeWindow_[i].reset();
 }
@@ -48,10 +48,10 @@ void SerializableActiveWindow<INPUT_PARAMS>::deserializeElement(const SeqNum &in
                                                                 const size_t &bufLen,
                                                                 uint32_t &actualSize) {
   actualSize = 0;
-  Assert(insideActiveWindow(beginningOfActiveWindow_ + index));
+  ConcordAssert(insideActiveWindow(beginningOfActiveWindow_ + index));
   activeWindow_[index].reset();
   activeWindow_[index] = ItemType::deserialize(buf, bufLen, actualSize);
-  Assert(actualSize != 0);
+  ConcordAssert(actualSize != 0);
 }
 
 template <TEMPLATE_PARAMS>
@@ -73,8 +73,8 @@ SeqNum SerializableActiveWindow<INPUT_PARAMS>::convertIndex(const SeqNum &seqNum
 template <TEMPLATE_PARAMS>
 SeqNum SerializableActiveWindow<INPUT_PARAMS>::convertIndex(const SeqNum &seqNum,
                                                             const SeqNum &beginningOfActiveWindow) {
-  Assert(seqNum % Resolution == 0);
-  Assert(insideActiveWindow(seqNum, beginningOfActiveWindow));
+  ConcordAssert(seqNum % Resolution == 0);
+  ConcordAssert(insideActiveWindow(seqNum, beginningOfActiveWindow));
   SeqNum converted = (seqNum / Resolution) % numItems_;
   return converted;
 }
@@ -91,15 +91,15 @@ ItemType &SerializableActiveWindow<INPUT_PARAMS>::getByRealIndex(const SeqNum &i
 
 template <TEMPLATE_PARAMS>
 void SerializableActiveWindow<INPUT_PARAMS>::resetAll(const SeqNum &windowFirst) {
-  Assert(windowFirst % Resolution == 0);
+  ConcordAssert(windowFirst % Resolution == 0);
   for (uint32_t i = 0; i < numItems_; i++) activeWindow_[i].reset();
   beginningOfActiveWindow_ = windowFirst;
 }
 
 template <TEMPLATE_PARAMS>
 list<SeqNum> SerializableActiveWindow<INPUT_PARAMS>::advanceActiveWindow(const SeqNum &newFirstIndex) {
-  Assert(newFirstIndex % Resolution == 0);
-  Assert(newFirstIndex >= beginningOfActiveWindow_);
+  ConcordAssert(newFirstIndex % Resolution == 0);
+  ConcordAssert(newFirstIndex >= beginningOfActiveWindow_);
 
   list<SeqNum> cleanedItems;
   if (newFirstIndex == beginningOfActiveWindow_) return cleanedItems;
@@ -114,14 +114,14 @@ list<SeqNum> SerializableActiveWindow<INPUT_PARAMS>::advanceActiveWindow(const S
   const uint16_t inactiveEnd = ((activeBegin > 0) ? (activeBegin - 1) : (numItems_ - 1));
   const uint16_t resetSize = (inactiveBegin <= inactiveEnd) ? (inactiveEnd - inactiveBegin + 1)
                                                             : (inactiveEnd + 1 + numItems_ - inactiveBegin);
-  Assert(resetSize > 0 && resetSize < numItems_);
+  ConcordAssert(resetSize > 0 && resetSize < numItems_);
   uint16_t debugNumOfReset = 0;
   for (SeqNum i = inactiveBegin; i != activeBegin; (i = ((i + 1) % numItems_))) {
     activeWindow_[i].reset();
     debugNumOfReset++;
     cleanedItems.push_back(i);
   }
-  Assert(debugNumOfReset == resetSize);
+  ConcordAssert(debugNumOfReset == resetSize);
   beginningOfActiveWindow_ = newFirstIndex;
   return cleanedItems;
 }

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -21,18 +21,18 @@ SigManager::SigManager(ReplicaId myId,
                        const PrivateKeyDesc& mySigPrivateKey,
                        const std::set<PublicKeyDesc>& replicasSigPublicKeys)
     : myId_{myId} {
-  // Assert(replicasSigPublicKeys.size() == numberOfReplicasAndClients); TODO(GG): change - here we don't care about
-  // client signatures
+  // ConcordAssert(replicasSigPublicKeys.size() == numberOfReplicasAndClients); TODO(GG): change - here we don't care
+  // about client signatures
 
   mySigner_ = new RSASigner(mySigPrivateKey.c_str());
 
   for (const PublicKeyDesc& p : replicasSigPublicKeys) {
-    Assert(replicasVerifiers_.count(p.first) == 0);
+    ConcordAssert(replicasVerifiers_.count(p.first) == 0);
 
     RSAVerifier* verifier = new RSAVerifier(p.second.c_str());
     replicasVerifiers_[p.first] = verifier;
 
-    Assert(p.first != myId || mySigner_->signatureLength() == verifier->signatureLength());
+    ConcordAssert(p.first != myId || mySigner_->signatureLength() == verifier->signatureLength());
   }
 }
 
@@ -46,7 +46,7 @@ uint16_t SigManager::getSigLength(ReplicaId replicaId) const {
     return (uint16_t)mySigner_->signatureLength();
   } else {
     auto pos = replicasVerifiers_.find(replicaId);
-    Assert(pos != replicasVerifiers_.end());
+    ConcordAssert(pos != replicasVerifiers_.end());
 
     RSAVerifier* verifier = pos->second;
 
@@ -57,7 +57,7 @@ uint16_t SigManager::getSigLength(ReplicaId replicaId) const {
 bool SigManager::verifySig(
     ReplicaId replicaId, const char* data, size_t dataLength, const char* sig, uint16_t sigLength) const {
   auto pos = replicasVerifiers_.find(replicaId);
-  Assert(pos != replicasVerifiers_.end());
+  ConcordAssert(pos != replicasVerifiers_.end());
 
   RSAVerifier* verifier = pos->second;
 
@@ -69,7 +69,7 @@ bool SigManager::verifySig(
 void SigManager::sign(const char* data, size_t dataLength, char* outSig, uint16_t outSigLength) const {
   size_t actualSigSize = 0;
   mySigner_->sign(data, dataLength, outSig, outSigLength, actualSigSize);
-  Assert(outSigLength == actualSigSize);
+  ConcordAssert(outSigLength == actualSigSize);
 }
 
 uint16_t SigManager::getMySigLength() const { return (uint16_t)mySigner_->signatureLength(); }

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -124,8 +124,8 @@ bool SimpleClientImp::isSystemReady() const {
 void SimpleClientImp::onMessageFromReplica(MessageBase* msg) {
   ClientReplyMsg* replyMsg = static_cast<ClientReplyMsg*>(msg);
   replyMsg->validate(ReplicasInfo());
-  Assert(replyMsg != nullptr);
-  Assert(replyMsg->type() == REPLY_MSG_TYPE);
+  ConcordAssert(replyMsg != nullptr);
+  ConcordAssert(replyMsg->type() == REPLY_MSG_TYPE);
 
   LOG_DEBUG(logger_,
             "Client " << clientId_ << " received ClientReplyMsg with seqNum=" << replyMsg->reqSeqNum()
@@ -180,7 +180,7 @@ SimpleClientImp::SimpleClientImp(
       clientSendsRequestToAllReplicasFirstThresh_{p.clientSendsRequestToAllReplicasFirstThresh},
       clientSendsRequestToAllReplicasPeriodThresh_{p.clientSendsRequestToAllReplicasPeriodThresh},
       clientPeriodicResetThresh_{p.clientPeriodicResetThresh} {
-  Assert(fVal_ >= 1);
+  ConcordAssert(fVal_ >= 1);
 
   pendingRequest_ = nullptr;
   timeOfLastTransmission_ = MinTime;
@@ -192,11 +192,11 @@ SimpleClientImp::SimpleClientImp(
 }
 
 SimpleClientImp::~SimpleClientImp() {
-  Assert(replysCertificate_.isEmpty());
-  Assert(msgQueue_.empty());
-  Assert(pendingRequest_ == nullptr);
-  Assert(timeOfLastTransmission_ == MinTime);
-  Assert(numberOfTransmissions_ == 0);
+  ConcordAssert(replysCertificate_.isEmpty());
+  ConcordAssert(msgQueue_.empty());
+  ConcordAssert(pendingRequest_ == nullptr);
+  ConcordAssert(timeOfLastTransmission_ == MinTime);
+  ConcordAssert(numberOfTransmissions_ == 0);
 }
 
 OperationResult SimpleClientImp::sendRequest(uint8_t flags,
@@ -218,7 +218,7 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
                       << ", isPreProcess=" << isPreProcessRequired << " , request size=" << lengthOfRequest
                       << ", retransmissionMilli=" << limitOfExpectedOperationTime_.upperLimit()
                       << ", timeout=" << timeoutMilli << ", has span context=" << !span_context.empty());
-  Assert(!(isReadOnly && isPreProcessRequired));
+  ConcordAssert(!(isReadOnly && isPreProcessRequired));
 
   if (!communication_->isRunning()) {
     communication_->Start();  // TODO(GG): patch ................ change
@@ -232,11 +232,11 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
     return NOT_READY;
   }
 
-  Assert(replysCertificate_.isEmpty());
-  Assert(msgQueue_.empty());
-  Assert(pendingRequest_ == nullptr);
-  Assert(timeOfLastTransmission_ == MinTime);
-  Assert(numberOfTransmissions_ == 0);
+  ConcordAssert(replysCertificate_.isEmpty());
+  ConcordAssert(msgQueue_.empty());
+  ConcordAssert(pendingRequest_ == nullptr);
+  ConcordAssert(timeOfLastTransmission_ == MinTime);
+  ConcordAssert(numberOfTransmissions_ == 0);
 
   static const std::chrono::milliseconds timersRes(timersResolutionMilli_);
 
@@ -304,7 +304,7 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
   }
 
   if (requestCommitted) {
-    Assert(replysCertificate_.isComplete());
+    ConcordAssert(replysCertificate_.isComplete());
 
     uint64_t durationMilli = duration_cast<milliseconds>(getMonotonicTime() - beginTime).count();
     limitOfExpectedOperationTime_.add(durationMilli);
@@ -344,7 +344,7 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
     return TIMEOUT;
   }
 
-  Assert(false);
+  ConcordAssert(false);
   return SUCCESS;
 }
 
@@ -401,7 +401,7 @@ void SimpleClientImp::onNewMessage(NodeNum sourceNode, const char* const message
 void SimpleClientImp::onConnectionStatusChanged(const NodeNum node, const ConnectionStatus newStatus) {}
 
 void SimpleClientImp::sendPendingRequest() {
-  Assert(pendingRequest_ != nullptr);
+  ConcordAssert(pendingRequest_ != nullptr);
 
   timeOfLastTransmission_ = getMonotonicTime();
   numberOfTransmissions_++;
@@ -483,7 +483,7 @@ uint64_t SeqNumberGeneratorForClientRequestsImp::generateUniqueSequenceNumberFor
   // shift lastMilli by 22 (0x3FFFFF) in order to 'bitwise or' with lastCount
   // and preserve uniqueness and monotonicity.
   uint64_t r = (lastMilliOfUniqueFetchID_ << (64 - 42));
-  Assert(lastCountOfUniqueFetchID_ <= 0x3FFFFF);
+  ConcordAssert(lastCountOfUniqueFetchID_ <= 0x3FFFFF);
   r = r | ((uint64_t)lastCountOfUniqueFetchID_);
 
   return r;

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -48,8 +48,8 @@ ViewsManager::ViewsManager(const ReplicasInfo* const r,
                            IThresholdVerifier* const preparedCertificateVerifier)
     : replicasInfo(r), N(r->numberOfReplicas()), F(r->fVal()), C(r->cVal()), myId(r->myId()) {
   sigManager_ = sigmgr;
-  Assert(preparedCertificateVerifier != nullptr);
-  Assert(N == (3 * F + 2 * C + 1));
+  ConcordAssert(preparedCertificateVerifier != nullptr);
+  ConcordAssert(N == (3 * F + 2 * C + 1));
 
   viewChangeSafetyLogic =
       new ViewChangeSafetyLogic(N, F, C, preparedCertificateVerifier, PrePrepareMsg::digestOfNullPrePrepareMsg());
@@ -124,31 +124,31 @@ ViewsManager* ViewsManager::createOutsideView(const ReplicasInfo* const r,
                                               ViewChangeMsg* myLastViewChange,
                                               std::vector<PrevViewInfo>& elementsOfPrevView) {
   // check arguments
-  Assert(lastActiveView >= 0);
-  Assert(lastStable >= 0);
-  Assert(lastExecuted >= lastStable);
-  Assert(stableLowerBound >= 0 && lastStable >= stableLowerBound);
+  ConcordAssert(lastActiveView >= 0);
+  ConcordAssert(lastStable >= 0);
+  ConcordAssert(lastExecuted >= lastStable);
+  ConcordAssert(stableLowerBound >= 0 && lastStable >= stableLowerBound);
   if (lastActiveView > 0) {
-    Assert(myLastViewChange != nullptr);
-    Assert(myLastViewChange->idOfGeneratedReplica() == r->myId());
-    Assert(myLastViewChange->newView() == lastActiveView);
-    Assert(myLastViewChange->lastStable() <= lastStable);
+    ConcordAssert(myLastViewChange != nullptr);
+    ConcordAssert(myLastViewChange->idOfGeneratedReplica() == r->myId());
+    ConcordAssert(myLastViewChange->newView() == lastActiveView);
+    ConcordAssert(myLastViewChange->lastStable() <= lastStable);
   } else {
-    Assert(myLastViewChange == nullptr);
+    ConcordAssert(myLastViewChange == nullptr);
   }
 
-  Assert(elementsOfPrevView.size() <= kWorkWindowSize);
+  ConcordAssert(elementsOfPrevView.size() <= kWorkWindowSize);
   for (size_t i = 0; i < elementsOfPrevView.size(); i++) {
     const PrevViewInfo& pvi = elementsOfPrevView[i];
-    Assert(pvi.prePrepare != nullptr && pvi.prePrepare->viewNumber() == lastActiveView);
-    Assert(pvi.hasAllRequests == true);
-    Assert(pvi.prepareFull == nullptr || pvi.prepareFull->viewNumber() == lastActiveView);
-    Assert(pvi.prepareFull == nullptr || pvi.prepareFull->seqNumber() == pvi.prePrepare->seqNumber());
+    ConcordAssert(pvi.prePrepare != nullptr && pvi.prePrepare->viewNumber() == lastActiveView);
+    ConcordAssert(pvi.hasAllRequests == true);
+    ConcordAssert(pvi.prepareFull == nullptr || pvi.prepareFull->viewNumber() == lastActiveView);
+    ConcordAssert(pvi.prepareFull == nullptr || pvi.prepareFull->seqNumber() == pvi.prePrepare->seqNumber());
   }
 
   ViewsManager* v = new ViewsManager(r, sigMgr, preparedCertificateVerifier);
-  Assert(v->stat == Stat::IN_VIEW);
-  Assert(v->myLatestActiveView == 0);
+  ConcordAssert(v->stat == Stat::IN_VIEW);
+  ConcordAssert(v->myLatestActiveView == 0);
 
   v->myLatestActiveView = lastActiveView;
   v->myLatestPendingView = lastActiveView;
@@ -158,18 +158,18 @@ ViewsManager* ViewsManager::createOutsideView(const ReplicasInfo* const r,
   v->exitFromCurrentView(lastStable, lastExecuted, elementsOfPrevView);
 
   // check the new ViewsManager
-  Assert(v->stat == Stat::NO_VIEW);
-  Assert(v->myLatestActiveView == lastActiveView);
-  Assert(v->myLatestPendingView == lastActiveView);
+  ConcordAssert(v->stat == Stat::NO_VIEW);
+  ConcordAssert(v->myLatestActiveView == lastActiveView);
+  ConcordAssert(v->myLatestPendingView == lastActiveView);
   for (size_t i = 0; i < v->N; i++) {
-    Assert(v->viewChangeMessages[i] == nullptr || i == v->myId);
-    Assert(v->newViewMessages[i] == nullptr);
-    Assert(v->viewChangeMsgsOfPendingView[i] == nullptr);
+    ConcordAssert(v->viewChangeMessages[i] == nullptr || i == v->myId);
+    ConcordAssert(v->newViewMessages[i] == nullptr);
+    ConcordAssert(v->viewChangeMsgsOfPendingView[i] == nullptr);
   }
-  Assert(v->viewChangeMessages[v->myId]->idOfGeneratedReplica() == r->myId());
-  Assert(v->viewChangeMessages[v->myId]->newView() == lastActiveView + 1);
-  Assert(v->viewChangeMessages[v->myId]->lastStable() == lastStable);
-  Assert(v->newViewMsgOfOfPendingView == nullptr);
+  ConcordAssert(v->viewChangeMessages[v->myId]->idOfGeneratedReplica() == r->myId());
+  ConcordAssert(v->viewChangeMessages[v->myId]->newView() == lastActiveView + 1);
+  ConcordAssert(v->viewChangeMessages[v->myId]->lastStable() == lastStable);
+  ConcordAssert(v->newViewMsgOfOfPendingView == nullptr);
 
   return v;
 }
@@ -190,50 +190,50 @@ ViewsManager* ViewsManager::createInsideView(const ReplicasInfo* const r,
                                              ViewChangeMsg* myLastViewChange,
                                              std::vector<ViewChangeMsg*> viewChangeMsgs) {
   // check arguments
-  Assert(view >= 1);
-  Assert(stableLowerBound >= 0);
-  Assert(newViewMsg != nullptr);
-  Assert(newViewMsg->newView() == view);
-  Assert(viewChangeMsgs.size() == (size_t)(2 * r->fVal() + 2 * r->cVal() + 1));
+  ConcordAssert(view >= 1);
+  ConcordAssert(stableLowerBound >= 0);
+  ConcordAssert(newViewMsg != nullptr);
+  ConcordAssert(newViewMsg->newView() == view);
+  ConcordAssert(viewChangeMsgs.size() == (size_t)(2 * r->fVal() + 2 * r->cVal() + 1));
   std::set<ReplicaId> replicasWithVCMsg;
   for (size_t i = 0; i < viewChangeMsgs.size(); i++) {
-    Assert(viewChangeMsgs[i] != nullptr);
-    Assert(viewChangeMsgs[i]->newView() == view);
+    ConcordAssert(viewChangeMsgs[i] != nullptr);
+    ConcordAssert(viewChangeMsgs[i]->newView() == view);
     Digest msgDigest;
     viewChangeMsgs[i]->getMsgDigest(msgDigest);
     ReplicaId idOfGenReplica = viewChangeMsgs[i]->idOfGeneratedReplica();
-    Assert(newViewMsg->includesViewChangeFromReplica(idOfGenReplica, msgDigest) == true);
+    ConcordAssert(newViewMsg->includesViewChangeFromReplica(idOfGenReplica, msgDigest) == true);
     replicasWithVCMsg.insert(idOfGenReplica);
   }
-  Assert(replicasWithVCMsg.size() == viewChangeMsgs.size());
-  Assert(replicasWithVCMsg.count(r->myId()) == 1 || myLastViewChange != nullptr);
+  ConcordAssert(replicasWithVCMsg.size() == viewChangeMsgs.size());
+  ConcordAssert(replicasWithVCMsg.count(r->myId()) == 1 || myLastViewChange != nullptr);
   if (myLastViewChange != nullptr) {
-    Assert(myLastViewChange->newView() == view);
+    ConcordAssert(myLastViewChange->newView() == view);
     Digest msgDigest;
     myLastViewChange->getMsgDigest(msgDigest);
-    Assert(myLastViewChange->idOfGeneratedReplica() == r->myId());
-    Assert(newViewMsg->includesViewChangeFromReplica(r->myId(), msgDigest) == false);
+    ConcordAssert(myLastViewChange->idOfGeneratedReplica() == r->myId());
+    ConcordAssert(newViewMsg->includesViewChangeFromReplica(r->myId(), msgDigest) == false);
   }
 
   ViewsManager* v = new ViewsManager(r, sigMgr, preparedCertificateVerifier);
 
-  Assert(v->stat == Stat::IN_VIEW);
+  ConcordAssert(v->stat == Stat::IN_VIEW);
   v->myLatestActiveView = view;
   v->myLatestPendingView = view;
 
-  Assert(v->collectionOfPrePrepareMsgs.empty());
+  ConcordAssert(v->collectionOfPrePrepareMsgs.empty());
 
   for (size_t i = 0; i < viewChangeMsgs.size(); i++) {
     ViewChangeMsg* vcm = viewChangeMsgs[i];
 
-    Assert(v->viewChangeMsgsOfPendingView[vcm->idOfGeneratedReplica()] == nullptr);
+    ConcordAssert(v->viewChangeMsgsOfPendingView[vcm->idOfGeneratedReplica()] == nullptr);
     v->viewChangeMsgsOfPendingView[vcm->idOfGeneratedReplica()] = vcm;
   }
 
   v->newViewMsgOfOfPendingView = newViewMsg;
 
   if (v->viewChangeMsgsOfPendingView[v->myId] == nullptr) {
-    Assert(myLastViewChange != nullptr);
+    ConcordAssert(myLastViewChange != nullptr);
     v->viewChangeMessages[v->myId] = myLastViewChange;
   } else if (myLastViewChange != nullptr)
     delete myLastViewChange;
@@ -247,7 +247,7 @@ ViewChangeMsg* ViewsManager::getMyLatestViewChangeMsg() const {
   ViewChangeMsg* vc = viewChangeMsgsOfPendingView[myId];
   if (vc == nullptr) vc = viewChangeMessages[myId];
 
-  Assert(vc != nullptr || myLatestPendingView == 0);
+  ConcordAssert(vc != nullptr || myLatestPendingView == 0);
 
   return vc;
 }
@@ -257,8 +257,8 @@ bool ViewsManager::add(NewViewMsg* m) {
   const ViewNum v = m->newView();
 
   // these asserts should be verified before accepting this message
-  Assert(sId != myId);
-  Assert(sId == replicasInfo->primaryOfView(v));
+  ConcordAssert(sId != myId);
+  ConcordAssert(sId == replicasInfo->primaryOfView(v));
 
   if (v <= myLatestPendingView) {
     delete m;
@@ -276,7 +276,7 @@ bool ViewsManager::add(ViewChangeMsg* m) {
   const ViewNum v = m->newView();
   const uint16_t id = m->idOfGeneratedReplica();
 
-  Assert(id != myId);
+  ConcordAssert(id != myId);
 
   if (v <= myLatestPendingView) {
     delete m;
@@ -356,7 +356,7 @@ void ViewsManager::computeCorrectRelevantViewNumbers(ViewNum* outMaxKnownCorrect
 
   qsort(viewNumbers, numOfVC, sizeof(ViewNum), compareViews);
 
-  Assert(viewNumbers[0] >= viewNumbers[numOfVC - 1]);
+  ConcordAssert(viewNumbers[0] >= viewNumbers[numOfVC - 1]);
 
   *outMaxKnownCorrectView = viewNumbers[CORRECT - 1];
 
@@ -366,7 +366,7 @@ void ViewsManager::computeCorrectRelevantViewNumbers(ViewNum* outMaxKnownCorrect
 }
 
 bool ViewsManager::hasNewViewMessage(ViewNum v) {
-  Assert(v >= myLatestPendingView);
+  ConcordAssert(v >= myLatestPendingView);
 
   if (v == myLatestPendingView) return true;
 
@@ -378,7 +378,7 @@ bool ViewsManager::hasNewViewMessage(ViewNum v) {
 }
 
 bool ViewsManager::hasViewChangeMessageForFutureView(uint16_t repId) {
-  Assert(repId < N);
+  ConcordAssert(repId < N);
 
   if (stat != Stat::NO_VIEW) return true;
 
@@ -388,20 +388,20 @@ bool ViewsManager::hasViewChangeMessageForFutureView(uint16_t repId) {
 }
 
 NewViewMsg* ViewsManager::getMyNewViewMsgForCurrentView() {
-  Assert(stat == Stat::IN_VIEW);
-  Assert(myId == replicasInfo->primaryOfView(myLatestActiveView));
+  ConcordAssert(stat == Stat::IN_VIEW);
+  ConcordAssert(myId == replicasInfo->primaryOfView(myLatestActiveView));
 
   NewViewMsg* r = newViewMsgOfOfPendingView;
 
-  Assert(r != nullptr);
-  Assert(r->senderId() == myId);
-  Assert(r->newView() == myLatestActiveView);
+  ConcordAssert(r != nullptr);
+  ConcordAssert(r->senderId() == myId);
+  ConcordAssert(r->newView() == myLatestActiveView);
 
   return r;
 }
 
 vector<ViewChangeMsg*> ViewsManager::getViewChangeMsgsForCurrentView() {
-  Assert(stat == Stat::IN_VIEW);
+  ConcordAssert(stat == Stat::IN_VIEW);
 
   const uint16_t SMAJOR = (2 * F + 2 * C + 1);
 
@@ -411,12 +411,12 @@ vector<ViewChangeMsg*> ViewsManager::getViewChangeMsgsForCurrentView() {
   for (uint16_t i = 0; (i < N) && (j < SMAJOR); i++) {
     if (viewChangeMsgsOfPendingView[i] == nullptr) continue;
 
-    Assert(viewChangeMsgsOfPendingView[i]->newView() == myLatestActiveView);
+    ConcordAssert(viewChangeMsgsOfPendingView[i]->newView() == myLatestActiveView);
 
     retVal[j] = viewChangeMsgsOfPendingView[i];
     j++;
   }
-  Assert(j == SMAJOR);
+  ConcordAssert(j == SMAJOR);
 
   return retVal;
 }
@@ -441,30 +441,30 @@ vector<ViewChangeMsg*> ViewsManager::getViewChangeMsgsForView(ViewNum v) {
 }
 
 NewViewMsg* ViewsManager::getNewViewMsgForCurrentView() {
-  Assert(stat == Stat::IN_VIEW);
+  ConcordAssert(stat == Stat::IN_VIEW);
 
   NewViewMsg* r = newViewMsgOfOfPendingView;
 
-  Assert(r != nullptr);
-  Assert(r->newView() == myLatestActiveView);
+  ConcordAssert(r != nullptr);
+  ConcordAssert(r->newView() == myLatestActiveView);
 
   return r;
 }
 
 SeqNum ViewsManager::stableLowerBoundWhenEnteredToView() const {
-  Assert(stat == Stat::IN_VIEW);
+  ConcordAssert(stat == Stat::IN_VIEW);
   return lowerBoundStableForPendingView;
 }
 
 ViewChangeMsg* ViewsManager::exitFromCurrentView(SeqNum currentLastStable,
                                                  SeqNum currentLastExecuted,
                                                  const std::vector<PrevViewInfo>& prevViewInfo) {
-  Assert(stat == Stat::IN_VIEW);
-  Assert(myLatestActiveView == myLatestPendingView);
-  Assert(prevViewInfo.size() <= kWorkWindowSize);
-  Assert(collectionOfPrePrepareMsgs.empty());
+  ConcordAssert(stat == Stat::IN_VIEW);
+  ConcordAssert(myLatestActiveView == myLatestPendingView);
+  ConcordAssert(prevViewInfo.size() <= kWorkWindowSize);
+  ConcordAssert(collectionOfPrePrepareMsgs.empty());
 
-  Assert((currentLastStable >= debugHighestKnownStable));
+  ConcordAssert((currentLastStable >= debugHighestKnownStable));
   debugHighestKnownStable = currentLastStable;
 
   stat = Stat::NO_VIEW;
@@ -473,8 +473,8 @@ ViewChangeMsg* ViewsManager::exitFromCurrentView(SeqNum currentLastStable,
   ViewChangeMsg* myPreviousVC = viewChangeMsgsOfPendingView[myId];
   if (myPreviousVC == nullptr) myPreviousVC = viewChangeMessages[myId];
 
-  Assert(myLatestActiveView == 0 || myPreviousVC != nullptr);
-  Assert(myLatestActiveView == 0 || myPreviousVC->newView() == myLatestActiveView);
+  ConcordAssert(myLatestActiveView == 0 || myPreviousVC != nullptr);
+  ConcordAssert(myLatestActiveView == 0 || myPreviousVC->newView() == myLatestActiveView);
 
   ViewChangeMsg* myNewVC = new ViewChangeMsg(myId, myLatestActiveView + 1, currentLastStable);
 
@@ -484,19 +484,19 @@ ViewChangeMsg* ViewsManager::exitFromCurrentView(SeqNum currentLastStable,
   for (auto& it : prevViewInfo) {
     PrePrepareMsg* pp = it.prePrepare;
 
-    Assert(pp != nullptr);
-    Assert(pp->viewNumber() == myLatestActiveView);
+    ConcordAssert(pp != nullptr);
+    ConcordAssert(pp->viewNumber() == myLatestActiveView);
 
     const SeqNum s = pp->seqNumber();
-    Assert(s > lowerBoundStableForPendingView);
+    ConcordAssert(s > lowerBoundStableForPendingView);
 
-    Assert(s > debugExpected);  // ensures that the elements are sorted
+    ConcordAssert(s > debugExpected);  // ensures that the elements are sorted
     debugExpected = s;
 
     const PrepareFullMsg* pf = it.prepareFull;
     const bool allRequests = it.hasAllRequests;
     // assert ((pf != nullptr) ==> allRequests)
-    Assert(pf == nullptr || allRequests);
+    ConcordAssert(pf == nullptr || allRequests);
 
     const Digest& digest = pp->digestOfRequests();
 
@@ -507,22 +507,22 @@ ViewChangeMsg* ViewsManager::exitFromCurrentView(SeqNum currentLastStable,
       iterPrevVC.goToAtLeast(s);
       if (iterPrevVC.getCurrent(elemInPrev) && (elemInPrev->hasPreparedCertificate) && (elemInPrev->seqNum == s) &&
           (elemInPrev->prePrepareDigest == digest)) {
-        Assert(elemInPrev->originView <= myLatestActiveView);
+        ConcordAssert(elemInPrev->originView <= myLatestActiveView);
 
         // convert to PreparedCertificate
         char* x = reinterpret_cast<char*>(elemInPrev);
         x = x + sizeof(ViewChangeMsg::Element);
         preparedCertInPrev = (ViewChangeMsg::PreparedCertificate*)x;
 
-        Assert(preparedCertInPrev->certificateView <= elemInPrev->originView);
+        ConcordAssert(preparedCertInPrev->certificateView <= elemInPrev->originView);
       }
     }
 
     if (pf != nullptr) {
       // if we have prepare certificate from the recent view
-      Assert(allRequests);
-      Assert(s == pf->seqNumber());
-      Assert(pf->viewNumber() == myLatestActiveView);
+      ConcordAssert(allRequests);
+      ConcordAssert(s == pf->seqNumber());
+      ConcordAssert(pf->viewNumber() == myLatestActiveView);
 
       myNewVC->addElement(
           s, digest, myLatestActiveView, true, myLatestActiveView, pf->signatureLen(), pf->signatureBody());
@@ -550,7 +550,7 @@ ViewChangeMsg* ViewsManager::exitFromCurrentView(SeqNum currentLastStable,
       // lines, we still may add prepared certificate for null-op)
       myNewVC->addElement(s, digest, myLatestActiveView, false, 0, 0, nullptr);
     } else {
-      Assert((s > currentLastExecuted) || (pp->isNull()));
+      ConcordAssert((s > currentLastExecuted) || (pp->isNull()));
     }
 
     delete pf;  // we can't use this prepared certificate in the new view
@@ -561,7 +561,7 @@ ViewChangeMsg* ViewsManager::exitFromCurrentView(SeqNum currentLastStable,
       delete pp;
   }
 
-  Assert((debugExpected - currentLastStable) <= kWorkWindowSize);
+  ConcordAssert((debugExpected - currentLastStable) <= kWorkWindowSize);
 
   resetDataOfLatestPendingAndKeepMyViewChange();
 
@@ -578,13 +578,13 @@ bool ViewsManager::tryToEnterView(ViewNum v,
                                   SeqNum currentLastStable,
                                   SeqNum currentLastExecuted,
                                   std::vector<PrePrepareMsg*>* outPrePrepareMsgsOfView) {
-  Assert(stat != Stat::IN_VIEW);
-  Assert(v > myLatestActiveView);
-  Assert(v >= myLatestPendingView);
-  Assert(outPrePrepareMsgsOfView->empty());
+  ConcordAssert(stat != Stat::IN_VIEW);
+  ConcordAssert(v > myLatestActiveView);
+  ConcordAssert(v >= myLatestPendingView);
+  ConcordAssert(outPrePrepareMsgsOfView->empty());
 
   // debug lines
-  Assert((v >= debugHighestViewNumberPassedByClient) && (currentLastStable >= debugHighestKnownStable));
+  ConcordAssert((v >= debugHighestViewNumberPassedByClient) && (currentLastStable >= debugHighestKnownStable));
   debugHighestViewNumberPassedByClient = v;
   debugHighestKnownStable = currentLastStable;
 
@@ -628,7 +628,7 @@ bool ViewsManager::tryToEnterView(ViewNum v,
     }
   }
 
-  Assert(v == myLatestPendingView);
+  ConcordAssert(v == myLatestPendingView);
 
   if (stat == Stat::PENDING) {
     computeRestrictionsOfNewView(v);
@@ -695,7 +695,7 @@ bool ViewsManager::tryToEnterView(ViewNum v,
 
       PrePrepareMsg* pp = prePrepareMsgsOfRestrictions[idx];
       if (pp == nullptr) continue;
-      Assert(pp->seqNumber() == i);
+      ConcordAssert(pp->seqNumber() == i);
 
       prePrepareMsgsOfRestrictions[idx] = nullptr;
 
@@ -711,14 +711,14 @@ bool ViewsManager::tryToEnterView(ViewNum v,
     for (SeqNum i = firstRelevant; i <= maxRestrictionOfPendingView; i++) {
       const int64_t idx = i - minRestrictionOfPendingView;
       if (restrictionsOfPendingView[idx].isNull) {
-        Assert(prePrepareMsgsOfRestrictions[idx] == nullptr);
+        ConcordAssert(prePrepareMsgsOfRestrictions[idx] == nullptr);
         nbNoopPPs++;
         // TODO(GG): do we want to start from the slow path in these cases?
         PrePrepareMsg* pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, 0);
         outPrePrepareMsgsOfView->push_back(pp);
       } else {
         PrePrepareMsg* pp = prePrepareMsgsOfRestrictions[idx];
-        Assert(pp != nullptr && pp->seqNumber() == i);
+        ConcordAssert(pp != nullptr && pp->seqNumber() == i);
         nbActualRequestPPs++;
         // TODO(GG): do we want to start from the slow path in these cases?
         pp->updateView(myLatestActiveView);
@@ -744,10 +744,10 @@ bool ViewsManager::tryToEnterView(ViewNum v,
 }
 
 bool ViewsManager::tryMoveToPendingViewAsPrimary(ViewNum v) {
-  Assert(v > myLatestPendingView);
+  ConcordAssert(v > myLatestPendingView);
 
   const uint16_t relevantPrimary = replicasInfo->primaryOfView(v);
-  Assert(relevantPrimary == myId);
+  ConcordAssert(relevantPrimary == myId);
 
   const uint16_t SMAJOR = (2 * F + 2 * C + 1);
 
@@ -755,11 +755,11 @@ bool ViewsManager::tryMoveToPendingViewAsPrimary(ViewNum v) {
 
   // debug: check my last VC message
   ViewChangeMsg* myLastVC = viewChangeMessages[myId];
-  Assert(myLastVC != nullptr && myLastVC->newView() == v);
+  ConcordAssert(myLastVC != nullptr && myLastVC->newView() == v);
 
   // remove my old NV message
   NewViewMsg* prevNewView = newViewMessages[myId];
-  Assert(prevNewView == nullptr || prevNewView->newView() < v);
+  ConcordAssert(prevNewView == nullptr || prevNewView->newView() < v);
   if (prevNewView != nullptr) {
     delete prevNewView;
     newViewMessages[myId] = nullptr;
@@ -785,7 +785,7 @@ bool ViewsManager::tryMoveToPendingViewAsPrimary(ViewNum v) {
     return false;
   }
 
-  Assert(relatedVCMsgs.size() == SMAJOR);
+  ConcordAssert(relatedVCMsgs.size() == SMAJOR);
 
   // create NewViewMsg
   NewViewMsg* nv = new NewViewMsg(myId, v);
@@ -793,22 +793,22 @@ bool ViewsManager::tryMoveToPendingViewAsPrimary(ViewNum v) {
   for (uint16_t i : relatedVCMsgs) {
     ViewChangeMsg* vc = viewChangeMessages[i];
 
-    Assert(vc->newView() == v);
+    ConcordAssert(vc->newView() == v);
 
     Digest d;
     vc->getMsgDigest(d);
 
-    Assert(!d.isZero());
+    ConcordAssert(!d.isZero());
 
     nv->addElement(i, d);
 
-    Assert(viewChangeMsgsOfPendingView[i] == nullptr);
+    ConcordAssert(viewChangeMsgsOfPendingView[i] == nullptr);
 
     viewChangeMsgsOfPendingView[i] = vc;
     viewChangeMessages[i] = nullptr;
   }
 
-  Assert(newViewMsgOfOfPendingView == nullptr);
+  ConcordAssert(newViewMsgOfOfPendingView == nullptr);
 
   newViewMsgOfOfPendingView = nv;
 
@@ -818,10 +818,10 @@ bool ViewsManager::tryMoveToPendingViewAsPrimary(ViewNum v) {
 }
 
 bool ViewsManager::tryMoveToPendingViewAsNonPrimary(ViewNum v) {
-  Assert(v > myLatestPendingView);
+  ConcordAssert(v > myLatestPendingView);
 
   const uint16_t relevantPrimary = replicasInfo->primaryOfView(v);
-  Assert(relevantPrimary != myId);
+  ConcordAssert(relevantPrimary != myId);
 
   const uint16_t MAJOR = (2 * F + 2 * C + 1);
 
@@ -848,16 +848,16 @@ bool ViewsManager::tryMoveToPendingViewAsNonPrimary(ViewNum v) {
     LOG_INFO(GL, "**************** Waiting for sufficient ViewChange messages to entering view=" << v << " ...");
     return false;
   }
-  Assert(relatedVCMsgs.size() == MAJOR);
+  ConcordAssert(relatedVCMsgs.size() == MAJOR);
 
-  Assert(newViewMsgOfOfPendingView == nullptr);
+  ConcordAssert(newViewMsgOfOfPendingView == nullptr);
 
   newViewMsgOfOfPendingView = nv;
 
   newViewMessages[relevantPrimary] = nullptr;
 
   for (uint16_t i : relatedVCMsgs) {
-    Assert(viewChangeMsgsOfPendingView[i] == nullptr);
+    ConcordAssert(viewChangeMsgsOfPendingView[i] == nullptr);
     viewChangeMsgsOfPendingView[i] = viewChangeMessages[i];
     viewChangeMessages[i] = nullptr;
   }
@@ -868,11 +868,11 @@ bool ViewsManager::tryMoveToPendingViewAsNonPrimary(ViewNum v) {
 }
 
 void ViewsManager::computeRestrictionsOfNewView(ViewNum v) {
-  Assert(stat == Stat::PENDING);
-  Assert(myLatestPendingView == v);
+  ConcordAssert(stat == Stat::PENDING);
+  ConcordAssert(myLatestPendingView == v);
 
-  Assert(newViewMsgOfOfPendingView != nullptr);
-  Assert(newViewMsgOfOfPendingView->newView() == v);
+  ConcordAssert(newViewMsgOfOfPendingView != nullptr);
+  ConcordAssert(newViewMsgOfOfPendingView->newView() == v);
 
   viewChangeSafetyLogic->computeRestrictions(
       // Inputs
@@ -889,9 +889,9 @@ void ViewsManager::computeRestrictionsOfNewView(ViewNum v) {
     for (SeqNum i = minRestrictionOfPendingView; i <= maxRestrictionOfPendingView; i++) {
       const int64_t idx = (i - minRestrictionOfPendingView);
 
-      Assert(idx < kWorkWindowSize);
+      ConcordAssert(idx < kWorkWindowSize);
 
-      Assert(prePrepareMsgsOfRestrictions[idx] == nullptr);
+      ConcordAssert(prePrepareMsgsOfRestrictions[idx] == nullptr);
 
       if (restrictionsOfPendingView[idx].isNull) continue;
 
@@ -906,7 +906,7 @@ void ViewsManager::computeRestrictionsOfNewView(ViewNum v) {
 
 // TODO(GG): consider to optimize
 bool ViewsManager::hasMissingMsgs(SeqNum currentLastStable) {
-  Assert(stat == Stat::PENDING_WITH_RESTRICTIONS);
+  ConcordAssert(stat == Stat::PENDING_WITH_RESTRICTIONS);
 
   if (minRestrictionOfPendingView == 0) return false;
 
@@ -923,7 +923,7 @@ bool ViewsManager::hasMissingMsgs(SeqNum currentLastStable) {
 
 // TODO(GG): consider to optimize
 bool ViewsManager::getNumbersOfMissingPP(SeqNum currentLastStable, std::vector<SeqNum>* outMissingPPNumbers) {
-  Assert(outMissingPPNumbers->size() == 0);
+  ConcordAssert(outMissingPPNumbers->size() == 0);
 
   if (stat != Stat::PENDING_WITH_RESTRICTIONS) return false;
 
@@ -955,7 +955,7 @@ void ViewsManager::resetDataOfLatestPendingAndKeepMyViewChange() {
   if (minRestrictionOfPendingView != 0) {
     for (SeqNum i = minRestrictionOfPendingView; i <= maxRestrictionOfPendingView; i++) {
       int64_t idx = i - minRestrictionOfPendingView;
-      Assert(idx < kWorkWindowSize);
+      ConcordAssert(idx < kWorkWindowSize);
       auto pos = collectionOfPrePrepareMsgs.find(i);
       if (pos == collectionOfPrePrepareMsgs.end() || pos->second != prePrepareMsgsOfRestrictions[idx])
         delete prePrepareMsgsOfRestrictions[idx];
@@ -976,8 +976,8 @@ void ViewsManager::resetDataOfLatestPendingAndKeepMyViewChange() {
 }
 
 bool ViewsManager::addPotentiallyMissingPP(PrePrepareMsg* p, SeqNum currentLastStable) {
-  Assert(stat == Stat::PENDING_WITH_RESTRICTIONS);
-  Assert(!p->isNull());
+  ConcordAssert(stat == Stat::PENDING_WITH_RESTRICTIONS);
+  ConcordAssert(!p->isNull());
 
   const SeqNum s = p->seqNumber();
 
@@ -986,7 +986,7 @@ bool ViewsManager::addPotentiallyMissingPP(PrePrepareMsg* p, SeqNum currentLastS
 
   if (hasRelevantRestriction) {
     const int64_t idx = s - minRestrictionOfPendingView;
-    Assert(idx < kWorkWindowSize);
+    ConcordAssert(idx < kWorkWindowSize);
 
     ViewChangeSafetyLogic::Restriction& r = restrictionsOfPendingView[idx];
 
@@ -1004,7 +1004,7 @@ bool ViewsManager::addPotentiallyMissingPP(PrePrepareMsg* p, SeqNum currentLastS
 }
 
 PrePrepareMsg* ViewsManager::getPrePrepare(SeqNum s) {
-  Assert(stat != Stat::IN_VIEW);
+  ConcordAssert(stat != Stat::IN_VIEW);
 
   if (stat == Stat::PENDING_WITH_RESTRICTIONS) {
     bool hasRelevantRestriction =
@@ -1013,7 +1013,7 @@ PrePrepareMsg* ViewsManager::getPrePrepare(SeqNum s) {
     if (!hasRelevantRestriction) return nullptr;
 
     const int64_t idx = s - minRestrictionOfPendingView;
-    Assert(idx < kWorkWindowSize);
+    ConcordAssert(idx < kWorkWindowSize);
 
     ViewChangeSafetyLogic::Restriction& r = restrictionsOfPendingView[idx];
 
@@ -1021,7 +1021,7 @@ PrePrepareMsg* ViewsManager::getPrePrepare(SeqNum s) {
 
     PrePrepareMsg* p = prePrepareMsgsOfRestrictions[idx];
 
-    Assert(p == nullptr || ((p->seqNumber() == s) && (!p->isNull())));
+    ConcordAssert(p == nullptr || ((p->seqNumber() == s) && (!p->isNull())));
 
     return p;
   } else {
@@ -1031,7 +1031,7 @@ PrePrepareMsg* ViewsManager::getPrePrepare(SeqNum s) {
 
     PrePrepareMsg* p = pos->second;
 
-    Assert(p == nullptr || ((p->seqNumber() == s) && (!p->isNull())));
+    ConcordAssert(p == nullptr || ((p->seqNumber() == s) && (!p->isNull())));
 
     return p;
   }

--- a/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
@@ -28,8 +28,8 @@ class AskForCheckpointMsg : public MessageBase {
   AskForCheckpointMsg* clone() { return new AskForCheckpointMsg(*this); }
 
   void validate(const ReplicasInfo& repInfo) const override {
-    Assert(type() == MsgCode::AskForCheckpoint);
-    Assert(senderId() != repInfo.myId());
+    ConcordAssert(type() == MsgCode::AskForCheckpoint);
+    ConcordAssert(senderId() != repInfo.myId());
 
     if (size() > sizeof(Header) + spanContextSize()) {
       throw std::runtime_error(__PRETTY_FUNCTION__);

--- a/bftengine/src/bftengine/messages/CheckpointMsg.cpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.cpp
@@ -26,8 +26,8 @@ CheckpointMsg::CheckpointMsg(
 }
 
 void CheckpointMsg::validate(const ReplicasInfo& repInfo) const {
-  Assert(type() == MsgCode::Checkpoint);
-  Assert(senderId() != repInfo.myId());
+  ConcordAssert(type() == MsgCode::Checkpoint);
+  ConcordAssert(senderId() != repInfo.myId());
 
   if (size() < sizeof(Header) + spanContextSize() || (!repInfo.isIdOfReplica(senderId())) ||
       (seqNumber() % checkpointWindowSize != 0) || (digestOfState().isZero()))

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.cpp
@@ -46,13 +46,13 @@ ClientReplyMsg::ClientReplyMsg(ReplicaId replicaId, uint32_t replyLength)
 }
 
 void ClientReplyMsg::setReplyLength(uint32_t replyLength) {
-  Assert(replyLength <= maxReplyLength());
+  ConcordAssert(replyLength <= maxReplyLength());
   b()->replyLength = replyLength;
   setMsgSize(sizeof(ClientReplyMsgHeader) + replyLength);
 }
 
 void ClientReplyMsg::setReplicaSpecificInfoLength(uint32_t length) {
-  Assert(length <= maxReplyLength());
+  ConcordAssert(length <= maxReplyLength());
   b()->replicaSpecificInfoLength = length;
 }
 
@@ -68,12 +68,12 @@ uint64_t ClientReplyMsg::debugHash() const {
   uint64_t retVal = 0;
 
   uint32_t replyLen = replyLength();
-  Assert(replyLen > 0);
+  ConcordAssert(replyLen > 0);
 
   uint32_t firstWordLen = replyLen % sizeof(uint64_t);
   if (firstWordLen == 0) firstWordLen = sizeof(uint64_t);
 
-  Assert(((replyLen - firstWordLen) % sizeof(uint64_t)) == 0);
+  ConcordAssert(((replyLen - firstWordLen) % sizeof(uint64_t)) == 0);
   uint32_t numberOfWords = ((replyLen - firstWordLen) / sizeof(uint64_t)) + 1;
 
   char* repBuf = replyBuf();

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -59,7 +59,7 @@ ClientRequestMsg::ClientRequestMsg(ClientRequestMsgHeader* body)
 bool ClientRequestMsg::isReadOnly() const { return (msgBody()->flags & READ_ONLY_REQ) != 0; }
 
 void ClientRequestMsg::validate(const ReplicasInfo& repInfo) const {
-  Assert(senderId() != repInfo.myId());
+  ConcordAssert(senderId() != repInfo.myId());
   if (size() < sizeof(ClientRequestMsgHeader) ||
       size() < (sizeof(ClientRequestMsgHeader) + msgBody()->requestLength + msgBody()->cid_length + spanContextSize()))
     throw std::runtime_error(__PRETTY_FUNCTION__);

--- a/bftengine/src/bftengine/messages/MessageBase.cpp
+++ b/bftengine/src/bftengine/messages/MessageBase.cpp
@@ -52,7 +52,7 @@ MessageBase::~MessageBase() {
 }
 
 void MessageBase::shrinkToFit() {
-  Assert(owner_);
+  ConcordAssert(owner_);
 
   // TODO(GG): need to verify more conditions??
 
@@ -79,7 +79,7 @@ MessageBase::MessageBase(NodeIdType sender) {
 MessageBase::MessageBase(NodeIdType sender, MsgType type, MsgSize size) : MessageBase(sender, type, 0u, size) {}
 
 MessageBase::MessageBase(NodeIdType sender, MsgType type, SpanContextSize spanContextSize, MsgSize size) {
-  Assert(size > 0);
+  ConcordAssert(size > 0);
   size = size + spanContextSize;
   msgBody_ = (MessageBase::Header *)std::malloc(size);
   memset(msgBody_, 0, size);
@@ -108,8 +108,8 @@ MessageBase::MessageBase(NodeIdType sender, MessageBase::Header *body, MsgSize s
 }
 
 void MessageBase::setMsgSize(MsgSize size) {
-  Assert((msgBody_ != nullptr));
-  Assert(size <= storageSize_);
+  ConcordAssert((msgBody_ != nullptr));
+  ConcordAssert(size <= storageSize_);
 
   // TODO(GG): do we need to reset memory here?
   if (storageSize_ > size) memset(body() + size, 0, (storageSize_ - size));
@@ -118,8 +118,8 @@ void MessageBase::setMsgSize(MsgSize size) {
 }
 
 MessageBase *MessageBase::cloneObjAndMsg() const {
-  Assert(owner_);
-  Assert(msgSize_ > 0);
+  ConcordAssert(owner_);
+  ConcordAssert(msgSize_ > 0);
 
   void *msgBody = std::malloc(msgSize_);
   memcpy(msgBody, msgBody_, msgSize_);
@@ -130,12 +130,12 @@ MessageBase *MessageBase::cloneObjAndMsg() const {
 }
 
 void MessageBase::writeObjAndMsgToLocalBuffer(char *buffer, size_t bufferLength, size_t *actualSize) const {
-  Assert(owner_);
-  Assert(msgSize_ > 0);
+  ConcordAssert(owner_);
+  ConcordAssert(msgSize_ > 0);
 
   const size_t sizeNeeded = sizeof(RawHeaderOfObjAndMsg) + msgSize_;
 
-  Assert(sizeNeeded <= bufferLength);
+  ConcordAssert(sizeNeeded <= bufferLength);
 
   RawHeaderOfObjAndMsg *pHeader = (RawHeaderOfObjAndMsg *)buffer;
   pHeader->magicNum = magicNumOfRawFormat;
@@ -149,8 +149,8 @@ void MessageBase::writeObjAndMsgToLocalBuffer(char *buffer, size_t bufferLength,
 }
 
 size_t MessageBase::sizeNeededForObjAndMsgInLocalBuffer() const {
-  Assert(owner_);
-  Assert(msgSize_ > 0);
+  ConcordAssert(owner_);
+  ConcordAssert(msgSize_ > 0);
 
   const size_t sizeNeeded = sizeof(RawHeaderOfObjAndMsg) + msgSize_;
 
@@ -199,7 +199,7 @@ size_t MessageBase::serializeMsg(char *&buf, const MessageBase *msg) {
   if (msg) {
     uint32_t msgSize = msg->sizeNeededForObjAndMsgInLocalBuffer();
     msg->writeObjAndMsgToLocalBuffer(buf, msgSize, &actualMsgSize);
-    Assert(actualMsgSize != 0);
+    ConcordAssert(actualMsgSize != 0);
     buf += actualMsgSize;
   }
   return msgFilledFlagSize + actualMsgSize;
@@ -215,7 +215,7 @@ MessageBase *MessageBase::deserializeMsg(char *&buf, size_t bufLen, size_t &actu
   size_t msgSize = 0;
   if (msgFilledFlag) {
     msg = createObjAndMsgFromLocalBuffer(buf, bufLen, &msgSize);
-    Assert(msgSize != 0);
+    ConcordAssert(msgSize != 0);
     buf += msgSize;
   }
   actualSize = msgFilledFlagSize + msgSize;

--- a/bftengine/src/bftengine/messages/MsgsCertificate.hpp
+++ b/bftengine/src/bftengine/messages/MsgsCertificate.hpp
@@ -177,7 +177,7 @@ void MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::a
     MsgClassInfo& cls = msgClasses[0];  // in this case, we have a single class
 
     auto pos = msgsFromReplicas.find(cls.representativeReplica);
-    // TODO Assert(pos is okay)
+    // TODO ConcordAssert(pos is okay)
     T* representativeMsg = pos->second;
 
     if (!ExternalFunc::equivalent(representativeMsg, msg)) return;  // msg should be ignored
@@ -190,7 +190,7 @@ void MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::a
       MsgClassInfo& cls = msgClasses[i];
 
       auto pos = msgsFromReplicas.find(cls.representativeReplica);
-      // TODO Assert(pos is okay)
+      // TODO ConcordAssert(pos is okay)
       T* representativeMsg = pos->second;
 
       if (ExternalFunc::equivalent(representativeMsg, msg)) {
@@ -255,7 +255,7 @@ void MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::a
     MsgClassInfo& cls = msgClasses[i];
 
     auto pos = msgsFromReplicas.find(cls.representativeReplica);
-    // TODO Assert(pos is okay)
+    // TODO ConcordAssert(pos is okay)
     T* representativeMsg = pos->second;
 
     if (ExternalFunc::equivalent(representativeMsg, msg)) {

--- a/bftengine/src/bftengine/messages/NewViewMsg.cpp
+++ b/bftengine/src/bftengine/messages/NewViewMsg.cpp
@@ -36,13 +36,13 @@ void NewViewMsg::addElement(ReplicaId replicaId, Digest& viewChangeDigest) {
 
   // TODO(GG): we should reject configurations that may violate this assert. TODO(GG): we need something similar for the
   // VC message
-  Assert(requiredSize <=
-         ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize());  // not enough space in the message
+  ConcordAssert(requiredSize <=
+                ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize());  // not enough space in the message
 
   auto elements = elementsArray();
 
   // IDs should be unique and sorted
-  Assert((currNumOfElements == 0) || (replicaId > elements[currNumOfElements - 1].replicaId));
+  ConcordAssert((currNumOfElements == 0) || (replicaId > elements[currNumOfElements - 1].replicaId));
 
   elements[currNumOfElements].replicaId = replicaId;
   elements[currNumOfElements].viewChangeDigest = viewChangeDigest;
@@ -56,7 +56,7 @@ void NewViewMsg::finalizeMessage(const ReplicasInfo& repInfo) {
   const uint16_t F = repInfo.fVal();
   const uint16_t C = repInfo.cVal();
 
-  Assert(numOfElements == (2 * F + 2 * C + 1));
+  ConcordAssert(numOfElements == (2 * F + 2 * C + 1));
 
   const uint16_t tSize = sizeof(Header) + (numOfElements * sizeof(NewViewElement)) + spanContextSize();
 

--- a/bftengine/src/bftengine/messages/PartialProofsSet.cpp
+++ b/bftengine/src/bftengine/messages/PartialProofsSet.cpp
@@ -64,11 +64,11 @@ void PartialProofsSet::resetAndFree() {
 void PartialProofsSet::addSelfMsgAndPPDigest(PartialCommitProofMsg* m, Digest& digest) {
   const ReplicaId myId = m->senderId();
 
-  Assert(m != nullptr && myId == replica->getReplicasInfo().myId());
-  Assert(seqNumber == 0);
-  Assert(expectedDigest.isZero());
-  Assert(selfPartialCommitProof == nullptr);
-  Assert(fullCommitProof == nullptr);
+  ConcordAssert(m != nullptr && myId == replica->getReplicasInfo().myId());
+  ConcordAssert(seqNumber == 0);
+  ConcordAssert(expectedDigest.isZero());
+  ConcordAssert(selfPartialCommitProof == nullptr);
+  ConcordAssert(fullCommitProof == nullptr);
 
   seqNumber = m->seqNumber();
   expectedDigest = digest;
@@ -84,9 +84,9 @@ void PartialProofsSet::addSelfMsgAndPPDigest(PartialCommitProofMsg* m, Digest& d
 bool PartialProofsSet::addMsg(PartialCommitProofMsg* m) {
   const ReplicaId repId = m->senderId();
 
-  Assert(m != nullptr && repId != replica->getReplicasInfo().myId());
-  Assert((seqNumber == 0) || (seqNumber == m->seqNumber()));
-  Assert(replica->getReplicasInfo().isIdOfReplica(repId));
+  ConcordAssert(m != nullptr && repId != replica->getReplicasInfo().myId());
+  ConcordAssert((seqNumber == 0) || (seqNumber == m->seqNumber()));
+  ConcordAssert(replica->getReplicasInfo().isIdOfReplica(repId));
 
   CommitPath cPath = m->commitPath();
 
@@ -150,7 +150,7 @@ void PartialProofsSet::setTimeOfSelfPartialProof(const Time& t) { timeOfSelfPart
 Time PartialProofsSet::getTimeOfSelfPartialProof() { return timeOfSelfPartialProof; }
 
 bool PartialProofsSet::addMsg(FullCommitProofMsg* m) {
-  Assert(m != nullptr);
+  ConcordAssert(m != nullptr);
 
   if (fullCommitProof != nullptr) return false;
 
@@ -261,7 +261,7 @@ class AsynchProofCreationJob : public util::SimpleThreadPool::Job {
 };
 
 void PartialProofsSet::tryToCreateFullProof() {
-  Assert(fullCommitProof == nullptr);
+  ConcordAssert(fullCommitProof == nullptr);
 
   if (selfPartialCommitProof == nullptr) return;
 
@@ -280,7 +280,7 @@ void PartialProofsSet::tryToCreateFullProof() {
 
   if (!ready) return;
 
-  Assert(thresholdAccumulator != nullptr);
+  ConcordAssert(thresholdAccumulator != nullptr);
 
   {
     IThresholdAccumulator* acc = thresholdAccumulator->clone();
@@ -309,7 +309,7 @@ IThresholdVerifier* PartialProofsSet::thresholdVerifier(CommitPath cPath) {
     //} else {
   }
 
-  Assert(verifier != nullptr);
+  ConcordAssert(verifier != nullptr);
 
   return verifier;
 }

--- a/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
@@ -56,13 +56,14 @@ ReplicaStatusMsg::ReplicaStatusMsg(ReplicaId senderId,
                   MsgCode::ReplicaStatus,
                   spanContext.size(),
                   calcSizeOfReplicaStatusMsg(listOfPPInActiveWindow, listOfMissingVCForVC, listOfMissingPPForVC)) {
-  Assert(lastExecutedSeqNum >= lastStableSeqNum);
-  Assert(lastStableSeqNum % checkpointWindowSize == 0);
-  Assert(!viewIsActive || hasNewChangeMsg);         // viewIsActive --> hasNewChangeMsg
-  Assert(!viewIsActive || !listOfMissingVCForVC);   // viewIsActive --> !listOfMissingVCForVC
-  Assert(!viewIsActive || !listOfMissingPPForVC);   // viewIsActive --> !listOfMissingPPForVC
-  Assert(viewIsActive || !listOfPPInActiveWindow);  // !viewIsActive --> !listOfPPInActiveWindow
-  Assert((listOfPPInActiveWindow ? 1 : 0) + (listOfMissingVCForVC ? 1 : 0) + (listOfMissingPPForVC ? 1 : 0) <= 1);
+  ConcordAssert(lastExecutedSeqNum >= lastStableSeqNum);
+  ConcordAssert(lastStableSeqNum % checkpointWindowSize == 0);
+  ConcordAssert(!viewIsActive || hasNewChangeMsg);         // viewIsActive --> hasNewChangeMsg
+  ConcordAssert(!viewIsActive || !listOfMissingVCForVC);   // viewIsActive --> !listOfMissingVCForVC
+  ConcordAssert(!viewIsActive || !listOfMissingPPForVC);   // viewIsActive --> !listOfMissingPPForVC
+  ConcordAssert(viewIsActive || !listOfPPInActiveWindow);  // !viewIsActive --> !listOfPPInActiveWindow
+  ConcordAssert((listOfPPInActiveWindow ? 1 : 0) + (listOfMissingVCForVC ? 1 : 0) + (listOfMissingPPForVC ? 1 : 0) <=
+                1);
 
   b()->viewNumber = viewNumber;
   b()->lastStableSeqNum = lastStableSeqNum;
@@ -126,9 +127,9 @@ bool ReplicaStatusMsg::hasListOfMissingViewChangeMsgForViewChange() const { retu
 bool ReplicaStatusMsg::hasListOfMissingPrePrepareMsgForViewChange() const { return ((b()->flags & powersOf2[4]) != 0); }
 
 bool ReplicaStatusMsg::isPrePrepareInActiveWindow(SeqNum seqNum) const {
-  Assert(hasListOfPrePrepareMsgsInActiveWindow());
-  Assert(seqNum > b()->lastStableSeqNum);
-  Assert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
+  ConcordAssert(hasListOfPrePrepareMsgsInActiveWindow());
+  ConcordAssert(seqNum > b()->lastStableSeqNum);
+  ConcordAssert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
 
   size_t index = (size_t)(seqNum - b()->lastStableSeqNum - 1);
   size_t byteIndex = index / 8;
@@ -138,8 +139,8 @@ bool ReplicaStatusMsg::isPrePrepareInActiveWindow(SeqNum seqNum) const {
 }
 
 bool ReplicaStatusMsg::isMissingViewChangeMsgForViewChange(ReplicaId replicaId) const {
-  Assert(hasListOfMissingViewChangeMsgForViewChange());
-  Assert(replicaId < MaxNumberOfReplicas);
+  ConcordAssert(hasListOfMissingViewChangeMsgForViewChange());
+  ConcordAssert(replicaId < MaxNumberOfReplicas);
 
   size_t index = replicaId;
   size_t byteIndex = index / 8;
@@ -149,9 +150,9 @@ bool ReplicaStatusMsg::isMissingViewChangeMsgForViewChange(ReplicaId replicaId) 
 }
 
 bool ReplicaStatusMsg::isMissingPrePrepareMsgForViewChange(SeqNum seqNum) const {
-  Assert(hasListOfMissingPrePrepareMsgForViewChange());
-  Assert(seqNum > b()->lastStableSeqNum);
-  Assert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
+  ConcordAssert(hasListOfMissingPrePrepareMsgForViewChange());
+  ConcordAssert(seqNum > b()->lastStableSeqNum);
+  ConcordAssert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
 
   size_t index = (size_t)(seqNum - b()->lastStableSeqNum - 1);
   size_t byteIndex = index / 8;
@@ -161,9 +162,9 @@ bool ReplicaStatusMsg::isMissingPrePrepareMsgForViewChange(SeqNum seqNum) const 
 }
 
 void ReplicaStatusMsg::setPrePrepareInActiveWindow(SeqNum seqNum) const {
-  Assert(hasListOfPrePrepareMsgsInActiveWindow());
-  Assert(seqNum > b()->lastStableSeqNum);
-  Assert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
+  ConcordAssert(hasListOfPrePrepareMsgsInActiveWindow());
+  ConcordAssert(seqNum > b()->lastStableSeqNum);
+  ConcordAssert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
   size_t index = (size_t)(seqNum - b()->lastStableSeqNum - 1);
   size_t byteIndex = index / 8;
   size_t bitIndex = index % 8;
@@ -172,8 +173,8 @@ void ReplicaStatusMsg::setPrePrepareInActiveWindow(SeqNum seqNum) const {
 }
 
 void ReplicaStatusMsg::setMissingViewChangeMsgForViewChange(ReplicaId replicaId) {
-  Assert(hasListOfMissingViewChangeMsgForViewChange());
-  Assert(replicaId < MaxNumberOfReplicas);
+  ConcordAssert(hasListOfMissingViewChangeMsgForViewChange());
+  ConcordAssert(replicaId < MaxNumberOfReplicas);
   size_t index = replicaId;
   size_t byteIndex = index / 8;
   size_t bitIndex = index % 8;
@@ -182,9 +183,9 @@ void ReplicaStatusMsg::setMissingViewChangeMsgForViewChange(ReplicaId replicaId)
 }
 
 void ReplicaStatusMsg::setMissingPrePrepareMsgForViewChange(SeqNum seqNum) {
-  Assert(hasListOfMissingPrePrepareMsgForViewChange());
-  Assert(seqNum > b()->lastStableSeqNum);
-  Assert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
+  ConcordAssert(hasListOfMissingPrePrepareMsgForViewChange());
+  ConcordAssert(seqNum > b()->lastStableSeqNum);
+  ConcordAssert(seqNum <= b()->lastStableSeqNum + kWorkWindowSize);
   size_t index = (size_t)(seqNum - b()->lastStableSeqNum - 1);
   size_t byteIndex = index / 8;
   size_t bitIndex = index % 8;

--- a/bftengine/src/bftengine/messages/SignedShareMsgs.cpp
+++ b/bftengine/src/bftengine/messages/SignedShareMsgs.cpp
@@ -75,7 +75,7 @@ SignedShareBase* SignedShareBase::create(int16_t type,
 }
 
 void SignedShareBase::_validate(const ReplicasInfo& repInfo, int16_t type_) const {
-  Assert(type() == type_);
+  ConcordAssert(type() == type_);
   if (size() < sizeof(Header) + spanContextSize() ||
       size() < sizeof(Header) + signatureLen() + spanContextSize() ||  // size
       senderId() == repInfo.myId() ||                                  // sent from another replica

--- a/bftengine/src/bftengine/messages/StateTransferMsg.cpp
+++ b/bftengine/src/bftengine/messages/StateTransferMsg.cpp
@@ -15,7 +15,7 @@
 namespace bftEngine::impl {
 
 void StateTransferMsg::validate(const ReplicasInfo&) const {
-  Assert(type() == MsgCode::StateTransfer);
+  ConcordAssert(type() == MsgCode::StateTransfer);
   if (size() < sizeof(MessageBase::Header)) throw std::runtime_error(__PRETTY_FUNCTION__);
 }
 

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
@@ -37,7 +37,7 @@ ViewChangeMsg::ViewChangeMsg(ReplicaId srcReplicaId,
 }
 
 void ViewChangeMsg::setNewViewNumber(ViewNum newView) {
-  Assert(newView >= b()->newView);
+  ConcordAssert(newView >= b()->newView);
   b()->newView = newView;
 }
 
@@ -54,14 +54,14 @@ void ViewChangeMsg::addElement(SeqNum seqNum,
                                ViewNum certificateView,
                                uint16_t certificateSigLength,
                                const char* certificateSig) {
-  Assert(b()->numberOfElements < kWorkWindowSize);
-  Assert(b()->numberOfElements > 0 || b()->locationAfterLast == 0);
-  Assert(seqNum > b()->lastStable);
-  Assert(seqNum <= b()->lastStable + kWorkWindowSize);
+  ConcordAssert(b()->numberOfElements < kWorkWindowSize);
+  ConcordAssert(b()->numberOfElements > 0 || b()->locationAfterLast == 0);
+  ConcordAssert(seqNum > b()->lastStable);
+  ConcordAssert(seqNum <= b()->lastStable + kWorkWindowSize);
 
   if (b()->locationAfterLast == 0)  // if this is the first element
   {
-    Assert(b()->numberOfElements == 0);
+    ConcordAssert(b()->numberOfElements == 0);
     b()->locationAfterLast = sizeof(Header) + spanContextSize();
   }
 
@@ -70,7 +70,7 @@ void ViewChangeMsg::addElement(SeqNum seqNum,
 
   // TODO(GG): we should make sure that this assert will never be violated (by calculating the maximum  size of a
   // ViewChangeMsg message required for the actual configuration)
-  Assert((size_t)(requiredSpace + ViewsManager::sigManager_->getMySigLength()) <= (size_t)internalStorageSize());
+  ConcordAssert((size_t)(requiredSpace + ViewsManager::sigManager_->getMySigLength()) <= (size_t)internalStorageSize());
 
   Element* pElement = (Element*)(body() + b()->locationAfterLast);
   pElement->seqNum = seqNum;
@@ -105,7 +105,7 @@ void ViewChangeMsg::finalizeMessage() {
 
   bool b = checkElements((uint16_t)sigSize);
 
-  Assert(b);
+  ConcordAssert(b);
 }
 
 void ViewChangeMsg::validate(const ReplicasInfo& repInfo) const {
@@ -183,14 +183,14 @@ ViewChangeMsg::ElementsIterator::ElementsIterator(const ViewChangeMsg* const m) 
   } else {
     endLoc = m->b()->locationAfterLast;
     currLoc = sizeof(Header) + m->spanContextSize();
-    Assert(endLoc > currLoc);
+    ConcordAssert(endLoc > currLoc);
     nextElementNum = 1;
   }
 }
 
 bool ViewChangeMsg::ElementsIterator::end() {
   if (currLoc >= endLoc) {
-    Assert(msg == nullptr || ((nextElementNum - 1) == msg->numberOfElements()));
+    ConcordAssert(msg == nullptr || ((nextElementNum - 1) == msg->numberOfElements()));
     return true;
   }
 
@@ -204,14 +204,14 @@ bool ViewChangeMsg::ElementsIterator::getCurrent(Element*& pElement) {
 
   const uint16_t remainingbytes = (endLoc - currLoc);
 
-  Assert(remainingbytes >= sizeof(Element));
+  ConcordAssert(remainingbytes >= sizeof(Element));
 
   pElement = (Element*)(msg->body() + currLoc);
 
   if (pElement->hasPreparedCertificate) {
-    Assert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate));
+    ConcordAssert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate));
     PreparedCertificate* pCert = (PreparedCertificate*)(msg->body() + currLoc + sizeof(Element));
-    Assert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate) + pCert->certificateSigLength);
+    ConcordAssert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate) + pCert->certificateSigLength);
   }
 
   return true;
@@ -231,18 +231,18 @@ bool ViewChangeMsg::ElementsIterator::getAndGoToNext(Element*& pElement) {
 
   const uint16_t remainingbytes = (endLoc - currLoc);
 
-  Assert(remainingbytes >= sizeof(Element));
+  ConcordAssert(remainingbytes >= sizeof(Element));
 
   Element* p = (Element*)(msg->body() + currLoc);
 
   currLoc += sizeof(Element);
 
   if (p->hasPreparedCertificate) {
-    Assert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate));
+    ConcordAssert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate));
 
     PreparedCertificate* pCert = (PreparedCertificate*)(msg->body() + currLoc);
 
-    Assert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate) + pCert->certificateSigLength);
+    ConcordAssert(remainingbytes >= sizeof(Element) + sizeof(PreparedCertificate) + pCert->certificateSigLength);
 
     currLoc += (sizeof(PreparedCertificate) + pCert->certificateSigLength);
   }

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -31,13 +31,13 @@ PreProcessReplyMsg::PreProcessReplyMsg(SigManagerSharedPtr sigManager,
 }
 
 void PreProcessReplyMsg::validate(const ReplicasInfo& repInfo) const {
-  Assert(type() == MsgCode::PreProcessReply);
+  ConcordAssert(type() == MsgCode::PreProcessReply);
 
   const uint64_t headerSize = sizeof(Header);
   if (size() < headerSize || size() < headerSize + msgBody()->replyLength) throw runtime_error(__PRETTY_FUNCTION__);
 
   auto& msgHeader = *msgBody();
-  Assert(msgHeader.senderId != repInfo.myId());
+  ConcordAssert(msgHeader.senderId != repInfo.myId());
 
   uint16_t sigLen = sigManager_->getSigLength(msgHeader.senderId);
   if (size() < (sizeof(Header) + sigLen)) throw runtime_error(__PRETTY_FUNCTION__ + string(": size"));

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -40,8 +40,8 @@ PreProcessRequestMsg::PreProcessRequestMsg(NodeIdType senderId,
 }
 
 void PreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {
-  Assert(type() == MsgCode::PreProcessRequest);
-  Assert(senderId() != repInfo.myId());
+  ConcordAssert(type() == MsgCode::PreProcessRequest);
+  ConcordAssert(senderId() != repInfo.myId());
 
   if (size() < (sizeof(Header)) ||
       size() < (sizeof(Header) + spanContextSize() + msgBody()->requestLength + msgBody()->cidLength))

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -335,10 +335,10 @@ TEST(requestPreprocessingState_test, notEnoughRepliesReceived) {
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
   for (auto i = 1; i < numOfRequiredReplies; i++) {
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
-    Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
+    ConcordAssert(reqState.definePreProcessingConsensusResult() == CONTINUE);
   }
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
+  ConcordAssert(reqState.definePreProcessingConsensusResult() == CONTINUE);
 }
 
 TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCollected) {
@@ -351,11 +351,11 @@ TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCol
   memset(buf, '5', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
   for (auto i = 1; i < replicaConfig.numReplicas; i++) {
-    if (i != replicaConfig.numReplicas - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
+    if (i != replicaConfig.numReplicas - 1) ConcordAssert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     memset(buf, i, bufLen);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
-  Assert(reqState.definePreProcessingConsensusResult() == CANCEL);
+  ConcordAssert(reqState.definePreProcessingConsensusResult() == CANCEL);
 }
 
 TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
@@ -367,11 +367,11 @@ TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
   memset(buf, '5', bufLen);
   for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != numOfRequiredReplies - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
+    if (i != numOfRequiredReplies - 1) ConcordAssert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.definePreProcessingConsensusResult() == COMPLETE);
+  ConcordAssert(reqState.definePreProcessingConsensusResult() == COMPLETE);
 }
 
 TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
@@ -384,14 +384,14 @@ TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
   memset(buf, '5', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
   for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != replicaConfig.numReplicas - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
+    if (i != replicaConfig.numReplicas - 1) ConcordAssert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     memset(buf, '4', bufLen);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
-  Assert(reqState.definePreProcessingConsensusResult() == RETRY_PRIMARY);
+  ConcordAssert(reqState.definePreProcessingConsensusResult() == RETRY_PRIMARY);
   memset(buf, '4', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.definePreProcessingConsensusResult() == COMPLETE);
+  ConcordAssert(reqState.definePreProcessingConsensusResult() == COMPLETE);
 }
 
 TEST(requestPreprocessingState_test, primaryReplicaDidNotCompletePreProcessingWhileNonPrimariesDid) {
@@ -403,14 +403,14 @@ TEST(requestPreprocessingState_test, primaryReplicaDidNotCompletePreProcessingWh
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
   memset(buf, '5', bufLen);
   for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != replicaConfig.numReplicas - 1) Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
+    if (i != replicaConfig.numReplicas - 1) ConcordAssert(reqState.definePreProcessingConsensusResult() == CONTINUE);
     memset(buf, '4', bufLen);
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
   }
-  Assert(reqState.definePreProcessingConsensusResult() == CONTINUE);
+  ConcordAssert(reqState.definePreProcessingConsensusResult() == CONTINUE);
   memset(buf, '4', bufLen);
   reqState.handlePrimaryPreProcessed(buf, bufLen);
-  Assert(reqState.definePreProcessingConsensusResult() == COMPLETE);
+  ConcordAssert(reqState.definePreProcessingConsensusResult() == COMPLETE);
 }
 
 TEST(requestPreprocessingState_test, requestTimedOut) {
@@ -424,10 +424,10 @@ TEST(requestPreprocessingState_test, requestTimedOut) {
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
   msgHandlerCallback(clientReqMsg);
-  Assert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
+  ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
   usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
   timers.evaluate();
-  Assert(preProcessor.getOngoingReqIdForClient(clientId) == 0);
+  ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == 0);
 }
 
 TEST(requestPreprocessingState_test, primaryCrashDetected) {
@@ -443,11 +443,11 @@ TEST(requestPreprocessingState_test, primaryCrashDetected) {
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
   msgHandlerCallback(clientReqMsg);
-  Assert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
+  ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
 
   usleep(reqWaitTimeoutMilli * 1000);
   timers.evaluate();
-  Assert(preProcessor.getOngoingReqIdForClient(clientId) == 0);
+  ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == 0);
 }
 
 TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
@@ -465,14 +465,14 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
   msgHandlerCallback(clientReqMsg);
-  Assert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
+  ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
 
   auto* preProcessReqMsg =
       new PreProcessRequestMsg(replica.currentPrimary(), clientId, reqSeqNum, bufLen, buf, sp, cid);
   msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::PreProcessRequest);
   msgHandlerCallback(preProcessReqMsg);
   usleep(reqWaitTimeoutMilli * 1000 / 2);  // Wait for the pre-execution completion
-  Assert(preProcessor.getOngoingReqIdForClient(clientId) == 0);
+  ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == 0);
 }
 
 }  // end namespace

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -48,7 +48,7 @@ class TestAppState : public IAppState {
   };
 
   bool getPrevDigestFromBlock(uint64_t blockId, StateTransferDigest* outPrevBlockDigest) override {
-    Assert(blockId > 0);
+    ConcordAssert(blockId > 0);
     auto it = blocks_.find(blockId - 1);
     if (it == blocks_.end()) return false;
     std::memcpy(outPrevBlockDigest, &it->second.digest, BLOCK_DIGEST_SIZE);
@@ -56,7 +56,7 @@ class TestAppState : public IAppState {
   };
 
   bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) override {
-    Assert(blockId < last_block_);
+    ConcordAssert(blockId < last_block_);
     Block bl;
     computeBlockDigest(blockId, block, blockSize, &bl.digest);
     memcpy(&bl.block, block, blockSize);

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -136,7 +136,7 @@ bool FileStorage::initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_
                                                                            << maxFileSize);
   if (ftruncate(fileno(dataStream_), maxFileSize)) {
     LOG_ERROR(logger_, "Failed to truncate file: " << fileName_);
-    Assert(false);
+    ConcordAssert(false);
   }
   writeFileMetadata();
   LOG_DEBUG(logger_, "" << *objectsMetadata_);

--- a/bftengine/tests/simpleStorage/main.cpp
+++ b/bftengine/tests/simpleStorage/main.cpp
@@ -49,10 +49,10 @@ void verifyData(FileStorage &fileStorage, uint32_t objId) {
       objIn.elem2,
       objIn.elem3,
       objIn.elem4);
-  Assert(objIn.elem1 == ELEM1);
-  Assert(objIn.elem2 == ELEM2);
-  Assert(objIn.elem3 == ELEM3);
-  Assert(objIn.elem4 == ELEM4);
+  ConcordAssert(objIn.elem1 == ELEM1);
+  ConcordAssert(objIn.elem2 == ELEM2);
+  ConcordAssert(objIn.elem3 == ELEM3);
+  ConcordAssert(objIn.elem4 == ELEM4);
 }
 
 // The tests verify that all MetadataStorage interfaces work correctly using file-based storage.

--- a/bftengine/tests/testSeqNumForClientRequest/seqNumForClientRequest_test.cpp
+++ b/bftengine/tests/testSeqNumForClientRequest/seqNumForClientRequest_test.cpp
@@ -45,7 +45,7 @@ TEST(seqNumForClientRequest_test, monotonicity_check) {
   }
 
   // Checks that generated SN is monotonically increasing.
-  Assert(is_sorted(seqNums.begin(), seqNums.end()));
+  ConcordAssert(is_sorted(seqNums.begin(), seqNums.end()));
   now.operator+=(std::chrono::hours(24));
   auto newSeqNum = seqNumGen->generateUniqueSequenceNumberForRequest(now);
   auto lastSeqNum = seqNums.back();
@@ -65,7 +65,7 @@ TEST(seqNumForClientRequest_test, send_requests_same_time_uniqueness_preserved) 
   }
 
   // assert 10 unique SN was generated, although practically sent at the same time.
-  Assert(seqNums.size() == 10);
+  ConcordAssert(seqNums.size() == 10);
   delete seqNumGen;
 }
 

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -166,27 +166,27 @@ SeqNumWindow seqNumWindow{1};
 CheckWindow checkWindow{0};
 
 void testInit() {
-  Assert(persistentStorageImp->getStoredVersion() == persistentStorageImp->getCurrentVersion());
-  Assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecutedSeqNum);
-  Assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == primaryLastUsedSeqNum);
-  Assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == strictLowerBoundOfSeqNums);
-  Assert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == lastViewTransferredSeqNum);
-  Assert(persistentStorageImp->getLastStableSeqNum() == lastStableSeqNum);
+  ConcordAssert(persistentStorageImp->getStoredVersion() == persistentStorageImp->getCurrentVersion());
+  ConcordAssert(persistentStorageImp->getLastExecutedSeqNum() == lastExecutedSeqNum);
+  ConcordAssert(persistentStorageImp->getPrimaryLastUsedSeqNum() == primaryLastUsedSeqNum);
+  ConcordAssert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == strictLowerBoundOfSeqNums);
+  ConcordAssert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == lastViewTransferredSeqNum);
+  ConcordAssert(persistentStorageImp->getLastStableSeqNum() == lastStableSeqNum);
 
   DescriptorOfLastExitFromView lastExitFromView = persistentStorageImp->getAndAllocateDescriptorOfLastExitFromView();
-  Assert(lastExitFromView.equals(*descriptorOfLastExitFromView));
+  ConcordAssert(lastExitFromView.equals(*descriptorOfLastExitFromView));
   bool descHasSet = persistentStorageImp->hasDescriptorOfLastExitFromView();
-  Assert(!descHasSet);
+  ConcordAssert(!descHasSet);
 
   DescriptorOfLastNewView lastNewView = persistentStorageImp->getAndAllocateDescriptorOfLastNewView();
-  Assert(lastNewView.equals(*descriptorOfLastNewView));
+  ConcordAssert(lastNewView.equals(*descriptorOfLastNewView));
   descHasSet = persistentStorageImp->hasDescriptorOfLastNewView();
-  Assert(!descHasSet);
+  ConcordAssert(!descHasSet);
 
   DescriptorOfLastExecution lastExecution = persistentStorageImp->getDescriptorOfLastExecution();
-  Assert(lastExecution.equals(*descriptorOfLastExecution));
+  ConcordAssert(lastExecution.equals(*descriptorOfLastExecution));
   descHasSet = persistentStorageImp->hasDescriptorOfLastExecution();
-  Assert(!descHasSet);
+  ConcordAssert(!descHasSet);
 
   descriptorOfLastExitFromView->clean();
   lastExitFromView.clean();
@@ -194,10 +194,10 @@ void testInit() {
   lastNewView.clean();
 
   SharedPtrCheckWindow storedCheckWindow = persistentStorageImp->getCheckWindow();
-  Assert(storedCheckWindow.get()->equals(checkWindow));
+  ConcordAssert(storedCheckWindow.get()->equals(checkWindow));
 
   SharedPtrSeqNumWindow storedSeqNumWindow = persistentStorageImp->getSeqNumWindow();
-  Assert(storedSeqNumWindow.get()->equals(seqNumWindow));
+  ConcordAssert(storedSeqNumWindow.get()->equals(seqNumWindow));
 }
 
 void testCheckWindowSetUp(const SeqNum shift, bool toSet) {
@@ -231,16 +231,16 @@ void testCheckWindowSetUp(const SeqNum shift, bool toSet) {
   CheckData &element2 = checkWindowPtr.get()->getByRealIndex(2);
 
   if (!shift) {
-    Assert(element0.getCheckpointMsg()->equals(checkpointInitialMsg0));
-    Assert(completed == element0.getCompletedMark());
+    ConcordAssert(element0.getCheckpointMsg()->equals(checkpointInitialMsg0));
+    ConcordAssert(completed == element0.getCompletedMark());
   } else
-    Assert(element0.equals(CheckData()));
+    ConcordAssert(element0.equals(CheckData()));
 
-  Assert(element1.getCheckpointMsg()->equals(checkpointInitialMsg1));
-  Assert(element2.getCheckpointMsg()->equals(checkpointInitialMsg2));
+  ConcordAssert(element1.getCheckpointMsg()->equals(checkpointInitialMsg1));
+  ConcordAssert(element2.getCheckpointMsg()->equals(checkpointInitialMsg2));
 
-  Assert(completed == element1.getCompletedMark());
-  Assert(completed == element2.getCompletedMark());
+  ConcordAssert(completed == element1.getCompletedMark());
+  ConcordAssert(completed == element2.getCompletedMark());
 }
 
 void testSeqNumWindowSetUp(const SeqNum shift, bool toSet) {
@@ -294,30 +294,30 @@ void testSeqNumWindowSetUp(const SeqNum shift, bool toSet) {
 
     if (!shift) {
       if (prePrepareMsgSeqNumShifted == shiftedSeqNum - 1) {
-        Assert(prePrepareMsg->equals(prePrepareNullMsg));
+        ConcordAssert(prePrepareMsg->equals(prePrepareNullMsg));
       } else
-        Assert(!prePrepareMsg);
+        ConcordAssert(!prePrepareMsg);
 
       if (prePrepareFullSeqNumShifted == shiftedSeqNum - 1) {
-        Assert(prepareFullMsg->equals(*prePrepareFullInitialMsg));
+        ConcordAssert(prepareFullMsg->equals(*prePrepareFullInitialMsg));
       } else
-        Assert(!prepareFullMsg);
+        ConcordAssert(!prepareFullMsg);
 
-      if (commitFullSeqNumShifted == shiftedSeqNum - 1) Assert(forceCompleted == element.getForceCompleted());
-      if (slowStartedSeqNumShifted == shiftedSeqNum - 1) Assert(slowStarted == element.getSlowStarted());
+      if (commitFullSeqNumShifted == shiftedSeqNum - 1) ConcordAssert(forceCompleted == element.getForceCompleted());
+      if (slowStartedSeqNumShifted == shiftedSeqNum - 1) ConcordAssert(slowStarted == element.getSlowStarted());
     } else {
       if ((fullCommitProofSeqNumShifted != shiftedSeqNum - 1) && (commitFullSeqNumShifted != shiftedSeqNum - 1))
-        Assert(element.equals(emptySeqNumData));
+        ConcordAssert(element.equals(emptySeqNumData));
     }
     if (fullCommitProofSeqNumShifted == shiftedSeqNum - 1) {
-      Assert(fullCommitProofMsg->equals(fullCommitProofInitialMsg));
+      ConcordAssert(fullCommitProofMsg->equals(fullCommitProofInitialMsg));
     } else
-      Assert(!fullCommitProofMsg);
+      ConcordAssert(!fullCommitProofMsg);
 
     if (commitFullSeqNumShifted == shiftedSeqNum - 1) {
-      Assert(commitFullMsg->equals(*commitFullInitialMsg));
+      ConcordAssert(commitFullMsg->equals(*commitFullInitialMsg));
     } else
-      Assert(!commitFullMsg);
+      ConcordAssert(!commitFullMsg);
   }
 
   delete prePrepareFullInitialMsg;
@@ -335,7 +335,7 @@ void testWindowsAdvance() {
   persistentStorageImp->setLastStableSeqNum(moveToSeqNum);
   persistentStorageImp->endWriteTran();
 
-  Assert(moveToSeqNum == persistentStorageImp->getLastStableSeqNum());
+  ConcordAssert(moveToSeqNum == persistentStorageImp->getLastStableSeqNum());
   testCheckWindowSetUp(moveToSeqNum, false);
   testSeqNumWindowSetUp(moveToSeqNum, false);
 }
@@ -382,19 +382,19 @@ void testSetDescriptors(bool toSet) {
   }
 
   DescriptorOfLastExecution lastExecution = persistentStorageImp->getDescriptorOfLastExecution();
-  Assert(lastExecution.equals(lastExecutionDesc));
+  ConcordAssert(lastExecution.equals(lastExecutionDesc));
   bool descHasSet = persistentStorageImp->hasDescriptorOfLastExecution();
-  Assert(descHasSet);
+  ConcordAssert(descHasSet);
 
   DescriptorOfLastNewView lastNewView = persistentStorageImp->getAndAllocateDescriptorOfLastNewView();
-  Assert(lastNewView.equals(lastNewViewDesc));
+  ConcordAssert(lastNewView.equals(lastNewViewDesc));
   descHasSet = persistentStorageImp->hasDescriptorOfLastNewView();
-  Assert(descHasSet);
+  ConcordAssert(descHasSet);
 
   DescriptorOfLastExitFromView lastExitFromView = persistentStorageImp->getAndAllocateDescriptorOfLastExitFromView();
-  Assert(lastExitFromView.equals(lastExitFromViewDesc));
+  ConcordAssert(lastExitFromView.equals(lastExitFromViewDesc));
   descHasSet = persistentStorageImp->hasDescriptorOfLastExitFromView();
-  Assert(descHasSet);
+  ConcordAssert(descHasSet);
 
   for (auto *v : msgs) {
     delete v;
@@ -423,10 +423,10 @@ void testSetSimpleParams(bool toSet) {
     persistentStorageImp->endWriteTran();
   }
 
-  Assert(persistentStorageImp->getLastExecutedSeqNum() == lastExecSeqNum);
-  Assert(persistentStorageImp->getPrimaryLastUsedSeqNum() == lastUsedSeqNum);
-  Assert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == lowBoundSeqNum);
-  Assert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == view);
+  ConcordAssert(persistentStorageImp->getLastExecutedSeqNum() == lastExecSeqNum);
+  ConcordAssert(persistentStorageImp->getPrimaryLastUsedSeqNum() == lastUsedSeqNum);
+  ConcordAssert(persistentStorageImp->getStrictLowerBoundOfSeqNums() == lowBoundSeqNum);
+  ConcordAssert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == view);
 }
 
 void fillReplicaConfig() {
@@ -473,7 +473,7 @@ void testSetReplicaConfig(bool toSet) {
   ReplicaConfig storedConfig = persistentStorageImp->getReplicaConfig();
   ReplicaConfigSerializer storedConfigSerializer(&storedConfig);
   ReplicaConfigSerializer replicaConfigSerializer(&config);
-  Assert(storedConfigSerializer == replicaConfigSerializer);
+  ConcordAssert(storedConfigSerializer == replicaConfigSerializer);
 }
 
 int main() {

--- a/bftengine/tests/testViewChange/testViewChange.cpp
+++ b/bftengine/tests/testViewChange/testViewChange.cpp
@@ -197,10 +197,10 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions) {
 
   for (int i = 0; i < kWorkWindowSize; i++) {
     if (i == assignedSeqNum - min) {
-      Assert(!restrictions[assignedSeqNum - min].isNull);
-      Assert(ppMsg->digestOfRequests().toString() == restrictions[assignedSeqNum - min].digest.toString());
+      ConcordAssert(!restrictions[assignedSeqNum - min].isNull);
+      ConcordAssert(ppMsg->digestOfRequests().toString() == restrictions[assignedSeqNum - min].digest.toString());
     } else {
-      Assert(restrictions[i].isNull);
+      ConcordAssert(restrictions[i].isNull);
     }
   }
 
@@ -310,12 +310,12 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_for_s
 
   for (int i = 0; i < kWorkWindowSize; i++) {
     if (i == assignedSeqNum - min) {
-      Assert(!restrictions[assignedSeqNum - min].isNull);
-      Assert(ppMsg2->digestOfRequests().toString() != ppMsg1->digestOfRequests().toString());
+      ConcordAssert(!restrictions[assignedSeqNum - min].isNull);
+      ConcordAssert(ppMsg2->digestOfRequests().toString() != ppMsg1->digestOfRequests().toString());
       // Assert the prepare certificate with higher view number is selected for assignedSeqNum
-      Assert(ppMsg2->digestOfRequests().toString() == restrictions[assignedSeqNum - min].digest.toString());
+      ConcordAssert(ppMsg2->digestOfRequests().toString() == restrictions[assignedSeqNum - min].digest.toString());
     } else {
-      Assert(restrictions[i].isNull);
+      ConcordAssert(restrictions[i].isNull);
     }
   }
 
@@ -435,17 +435,17 @@ TEST(testViewchangeSafetyLogic_test, computeRestrictions_two_prepare_certs_one_i
   // Check that the reported lowest meaningful sequence number for the
   // View Change (min) is above the one that is below the last stable
   // (assignedSeqNumIgnored) used to generate pfMsg2.
-  Assert(min > assignedSeqNumIgnored);
+  ConcordAssert(min > assignedSeqNumIgnored);
 
   for (int i = 0; i < kWorkWindowSize; i++) {
     if (i == assignedSeqNum - min) {
       // Check that the sequence number above the last stable is considered
-      Assert(!restrictions[assignedSeqNum - min].isNull);
-      Assert(ppMsg1->digestOfRequests().toString() == restrictions[assignedSeqNum - min].digest.toString());
+      ConcordAssert(!restrictions[assignedSeqNum - min].isNull);
+      ConcordAssert(ppMsg1->digestOfRequests().toString() == restrictions[assignedSeqNum - min].digest.toString());
     } else {
       // Check that all others are NULL, and thus the Prepare Certificate
       // for the sequence number below the last stable is ignored.
-      Assert(restrictions[i].isNull);
+      ConcordAssert(restrictions[i].isNull);
     }
   }
 
@@ -524,7 +524,7 @@ TEST(testViewchangeSafetyLogic_test, empty_correct_VC_msgs) {
       N, F, C, replicaConfig[0].thresholdVerifierForSlowPathCommit, PrePrepareMsg::digestOfNullPrePrepareMsg());
 
   auto seqNum = VCS.calcLBStableForView(viewChangeMsgs);
-  Assert(seqNum == lastStableSeqNum);
+  ConcordAssert(seqNum == lastStableSeqNum);
 
   for (int i = 0; i < N; i++) {
     delete viewChangeMsgs[i];

--- a/communication/src/PlainTcpCommunication.cpp
+++ b/communication/src/PlainTcpCommunication.cpp
@@ -671,7 +671,7 @@ class PlainTCPCommunication::PlainTcpImpl {
       // *listen* port, we should expect to be able to resolve our own name, or
       // shutdown otherwise.
       tcp::resolver::iterator results = resolver.resolve(query);
-      Assert(results != tcp::resolver::iterator());
+      ConcordAssert(results != tcp::resolver::iterator());
       // Use the first result
       tcp::endpoint ep = *results;
       LOG_INFO(_logger, "Resolved " << _listenHost << ":" << _listenPort << " to " << ep);

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -105,8 +105,8 @@ class PlainUDPCommunication::PlainUdpImpl {
         endpoints{config.nodes},
         statusCallback{config.statusCallback},
         selfId{config.selfId} {
-    Assert((config.listenPort > 0) && "Port should not be negative!");
-    Assert((config.nodes.size() > 0) && "No communication endpoints specified!");
+    ConcordAssert((config.listenPort > 0) && "Port should not be negative!");
+    ConcordAssert((config.nodes.size() > 0) && "No communication endpoints specified!");
 
     LOG_DEBUG(
         _logger,
@@ -175,7 +175,7 @@ class PlainUDPCommunication::PlainUdpImpl {
       LOG_FATAL(_logger,
                 "Error while binding: IP=" << sAddr.sin_addr.s_addr << ", Port=" << sAddr.sin_port
                                            << ", errno=" << concordUtils::errnoString(errno));
-      Assert(false && "Failure occurred while binding the socket!");
+      ConcordAssert(false && "Failure occurred while binding the socket!");
       exit(1);  // TODO(GG): not really ..... change this !
     }
 
@@ -245,9 +245,9 @@ class PlainUDPCommunication::PlainUdpImpl {
 
     const Addr *to = &nodes2addresses[destNode];
 
-    Assert((to != NULL) && "The destination endpoint does not exist!");
-    Assert((messageLength > 0) && "The message length must be positive!");
-    Assert((message != NULL) && "No message provided!");
+    ConcordAssert((to != NULL) && "The destination endpoint does not exist!");
+    ConcordAssert((messageLength > 0) && "The message length must be positive!");
+    ConcordAssert((message != NULL) && "No message provided!");
 
     LOG_DEBUG(_logger,
               " Sending " << messageLength << " bytes to " << destNode << " (" << inet_ntoa(to->sin_addr) << ":"
@@ -305,8 +305,8 @@ class PlainUDPCommunication::PlainUdpImpl {
   }
 
   void recvThreadRoutine() {
-    Assert((udpSockFd != 0) && "Unable to start receiving: socket not define!");
-    Assert((receiverRef != 0) && "Unable to start receiving: receiver not defined!");
+    ConcordAssert((udpSockFd != 0) && "Unable to start receiving: socket not define!");
+    ConcordAssert((receiverRef != 0) && "Unable to start receiving: receiver not defined!");
 
     /** The main receive loop. */
     Addr fromAddress;

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -46,6 +46,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include "Logger.hpp"
+#include "assertUtils.hpp"
 
 using namespace std;
 using namespace logging;
@@ -230,7 +231,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     asio::ip::tcp::no_delay option;
     get_socket().set_option(boost::asio::ip::tcp::no_delay(true));
     get_socket().get_option(option);
-    Assert(true == option.value());
+    ConcordAssert(true == option.value());
   }
 
   /**
@@ -285,7 +286,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
    * generic error handling function
    */
   void handle_error() {
-    Assert(_connType != ConnType::NotDefined);
+    ConcordAssert(_connType != ConnType::NotDefined);
 
     if (_statusCallback) {
       bool isReplica = check_replica(_expectedDestId);
@@ -327,7 +328,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     set_authenticated(true);
     _connectTimer.expires_at(boost::posix_time::pos_infin);
     _currentTimeout = _minTimeout;
-    Assert(_destId == _expectedDestId);
+    ConcordAssert(_destId == _expectedDestId);
     _fOnTlsReady(_destId, shared_from_this());
     read_msg_length_async();
   }
@@ -359,7 +360,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   }
 
   void set_tls() {
-    Assert(_connType != ConnType::NotDefined);
+    ConcordAssert(_connType != ConnType::NotDefined);
 
     if (ConnType::Incoming == _connType)
       set_tls_server();
@@ -630,7 +631,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     // if first is true - we came from partial reading, no timer was started
     if (!first) {
       __attribute__((unused)) auto res = _readTimer.expires_at(boost::posix_time::pos_infin);
-      Assert(res < 2);  // can cancel at most 1 pending async_wait
+      ConcordAssert(res < 2);  // can cancel at most 1 pending async_wait
     }
     if (_disposed) {
       return;
@@ -662,7 +663,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
 
     __attribute__((unused)) auto res =
         _readTimer.expires_from_now(boost::posix_time::milliseconds(READ_TIME_OUT_MILLI));
-    Assert(res == 0);  // can cancel at most 1 pending async_wait
+    ConcordAssert(res == 0);  // can cancel at most 1 pending async_wait
 
     _readTimer.async_wait(
         boost::bind(&AsyncTlsConnection::on_read_timer_expired, shared_from_this(), boost::asio::placeholders::error));
@@ -698,7 +699,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
    */
   void read_msg_async_completed(const boost::system::error_code &ec, size_t bytesRead) {
     __attribute__((unused)) auto res = _readTimer.expires_at(boost::posix_time::pos_infin);
-    Assert(res < 2);  // can cancel at most 1 pending async_wait
+    ConcordAssert(res < 2);  // can cancel at most 1 pending async_wait
     if (_disposed) {
       return;
     }
@@ -713,7 +714,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
       return;
     }
 
-    Assert(_destId == _expectedDestId);
+    ConcordAssert(_destId == _expectedDestId);
     try {
       if (_receiver) {
         _receiver->onNewMessage(_destId, _inBuffer, bytesRead);
@@ -801,7 +802,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
     // start the timer to handle the write timeout
     __attribute__((unused)) auto res =
         _writeTimer.expires_from_now(boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
-    Assert(res == 0);  // should not cancel any pending async wait
+    ConcordAssert(res == 0);  // should not cancel any pending async wait
     _writeTimer.expires_from_now(boost::posix_time::milliseconds(WRITE_TIME_OUT_MILLI));
     _writeTimer.async_wait(
         boost::bind(&AsyncTlsConnection::on_write_timer_expired, shared_from_this(), boost::asio::placeholders::error));
@@ -812,7 +813,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
    */
   void async_write_complete(const B_ERROR_CODE &ec, size_t bytesWritten) {
     __attribute__((unused)) auto res = _writeTimer.expires_at(boost::posix_time::pos_infin);
-    Assert(res < 2);  // can cancel at most 1 pending async_wait
+    ConcordAssert(res < 2);  // can cancel at most 1 pending async_wait
     _writeTimer.expires_at(boost::posix_time::pos_infin);
     if (_disposed) {
       return;

--- a/diagnostics/include/diagnostics_server.h
+++ b/diagnostics/include/diagnostics_server.h
@@ -136,7 +136,7 @@ class Server {
         auto rv = select(listen_sock_ + 1, &read_fds, NULL, NULL, &tv);
         if (rv == 0) continue;  // timeout
         if (rv < 0 && errno == EINTR) continue;
-        Assert(rv > 0);
+        ConcordAssert(rv > 0);
         int sock = accept(listen_sock_, NULL, NULL);
         // We must bind the result future or else this call blocks.
         auto _ = std::async(std::launch::async, [&]() { handleRequest(registrar, sock); });
@@ -153,7 +153,7 @@ class Server {
  private:
   void listen() {
     listen_sock_ = socket(AF_INET, SOCK_STREAM, 0);
-    Assert(listen_sock_ >= 0);
+    ConcordAssert(listen_sock_ >= 0);
     bzero(&servaddr_, sizeof(servaddr_));
     servaddr_.sin_family = AF_INET;
     // LOCALHOST ONLY, FOR SECURITY PURPOSES. DO NOT CHANGE THIS!!!

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -223,7 +223,7 @@ struct DatabaseLeafValue {
                     const sparse_merkle::LeafNode &pLeafNode,
                     BlockIdType pDeletedInBlockId)
       : addedInBlockId{pAddedInBlockId}, leafNode{pLeafNode}, deletedInBlockId{pDeletedInBlockId} {
-    Assert(pDeletedInBlockId != INVALID_BLOCK_ID);
+    ConcordAssert(pDeletedInBlockId != INVALID_BLOCK_ID);
   }
 
   // The block ID this value was added in.

--- a/kvbc/include/merkle_tree_serialization.h
+++ b/kvbc/include/merkle_tree_serialization.h
@@ -41,7 +41,7 @@ namespace detail {
 enum class BatchedInternalNodeChildType : std::uint8_t { Internal, Leaf };
 
 inline BatchedInternalNodeChildType getInternalChildType(const concordUtils::Sliver &buf) {
-  Assert(!buf.empty());
+  ConcordAssert(!buf.empty());
 
   switch (buf[0]) {
     case concord::util::toChar(BatchedInternalNodeChildType::Internal):
@@ -50,7 +50,7 @@ inline BatchedInternalNodeChildType getInternalChildType(const concordUtils::Sli
       return BatchedInternalNodeChildType::Leaf;
   }
 
-  Assert(false);
+  ConcordAssert(false);
   return BatchedInternalNodeChildType::Internal;
 }
 
@@ -148,7 +148,7 @@ inline std::string serializeImp(const block::detail::Node &node) {
 
   auto nodeSize = block::detail::Node::MIN_SIZE;
   for (const auto &key : node.keys) {
-    Assert(key.first.length() <= std::numeric_limits<block::detail::KeyLengthType>::max());
+    ConcordAssert(key.first.length() <= std::numeric_limits<block::detail::KeyLengthType>::max());
     nodeSize += (sizeof(block::detail::KeyLengthType) + key.first.length() + 1);  // Add a byte of key data.
   }
 
@@ -222,13 +222,13 @@ T deserialize(const concordUtils::Sliver &buf);
 
 template <>
 inline sparse_merkle::Hash deserialize<sparse_merkle::Hash>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= sparse_merkle::Hash::SIZE_IN_BYTES);
+  ConcordAssert(buf.length() >= sparse_merkle::Hash::SIZE_IN_BYTES);
   return sparse_merkle::Hash{reinterpret_cast<const uint8_t *>(buf.data())};
 }
 
 template <>
 inline sparse_merkle::Version deserialize<sparse_merkle::Version>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= sparse_merkle::Version::SIZE_IN_BYTES);
+  ConcordAssert(buf.length() >= sparse_merkle::Version::SIZE_IN_BYTES);
   return concordUtils::fromBigEndianBuffer<sparse_merkle::Version::Type>(buf.data());
 }
 
@@ -243,7 +243,7 @@ inline std::vector<std::uint8_t> deserialize<std::vector<std::uint8_t>>(const co
 
 template <>
 inline sparse_merkle::NibblePath deserialize<sparse_merkle::NibblePath>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= sizeof(std::uint8_t));
+  ConcordAssert(buf.length() >= sizeof(std::uint8_t));
   const auto nibbleCount = static_cast<std::size_t>(buf[0]);
   const auto path = deserialize<std::vector<std::uint8_t>>(
       concordUtils::Sliver{buf, sizeof(std::uint8_t), buf.length() - sizeof(std::uint8_t)});
@@ -252,7 +252,7 @@ inline sparse_merkle::NibblePath deserialize<sparse_merkle::NibblePath>(const co
 
 template <>
 inline sparse_merkle::LeafKey deserialize<sparse_merkle::LeafKey>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= sparse_merkle::LeafKey::SIZE_IN_BYTES);
+  ConcordAssert(buf.length() >= sparse_merkle::LeafKey::SIZE_IN_BYTES);
   return sparse_merkle::LeafKey{deserialize<sparse_merkle::Hash>(buf),
                                 deserialize<sparse_merkle::Version>(concordUtils::Sliver{
                                     buf, sparse_merkle::Hash::SIZE_IN_BYTES, sparse_merkle::Version::SIZE_IN_BYTES})};
@@ -268,7 +268,7 @@ inline sparse_merkle::InternalNodeKey deserialize<sparse_merkle::InternalNodeKey
 
 template <>
 inline sparse_merkle::LeafChild deserialize<sparse_merkle::LeafChild>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= sparse_merkle::LeafChild::SIZE_IN_BYTES);
+  ConcordAssert(buf.length() >= sparse_merkle::LeafChild::SIZE_IN_BYTES);
   return sparse_merkle::LeafChild{deserialize<sparse_merkle::Hash>(buf),
                                   deserialize<sparse_merkle::LeafKey>(concordUtils::Sliver{
                                       buf, sparse_merkle::Hash::SIZE_IN_BYTES, sparse_merkle::LeafKey::SIZE_IN_BYTES})};
@@ -276,7 +276,7 @@ inline sparse_merkle::LeafChild deserialize<sparse_merkle::LeafChild>(const conc
 
 template <>
 inline sparse_merkle::InternalChild deserialize<sparse_merkle::InternalChild>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= sparse_merkle::InternalChild::SIZE_IN_BYTES);
+  ConcordAssert(buf.length() >= sparse_merkle::InternalChild::SIZE_IN_BYTES);
   return sparse_merkle::InternalChild{
       deserialize<sparse_merkle::Hash>(buf),
       deserialize<sparse_merkle::Version>(
@@ -290,7 +290,7 @@ inline sparse_merkle::BatchedInternalNode deserialize<sparse_merkle::BatchedInte
     return sparse_merkle::BatchedInternalNode{};
   }
 
-  Assert(buf.length() >= sizeof(BatchedInternalMaskType));
+  ConcordAssert(buf.length() >= sizeof(BatchedInternalMaskType));
   sparse_merkle::BatchedInternalNode::Children children;
   const auto mask = concordUtils::fromBigEndianBuffer<BatchedInternalMaskType>(buf.data());
   auto childrenBuf =
@@ -321,7 +321,7 @@ inline sparse_merkle::BatchedInternalNode deserialize<sparse_merkle::BatchedInte
 
 template <>
 inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= block::detail::Node::MIN_SIZE);
+  ConcordAssert(buf.length() >= block::detail::Node::MIN_SIZE);
 
   auto offset = std::size_t{0};
   auto node = block::detail::Node{};
@@ -346,7 +346,7 @@ inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::
   auto keyBuffer =
       concordUtils::Sliver{buf, block::detail::Node::MIN_SIZE, buf.length() - block::detail::Node::MIN_SIZE};
   while (!keyBuffer.empty()) {
-    Assert(keyBuffer.length() >= block::detail::Node::MIN_KEY_SIZE);
+    ConcordAssert(keyBuffer.length() >= block::detail::Node::MIN_KEY_SIZE);
 
     // Key data.
     block::detail::KeyData keyData;
@@ -356,7 +356,7 @@ inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::
 
     // Key length.
     const auto keyLen = concordUtils::fromBigEndianBuffer<block::detail::KeyLengthType>(keyBuffer.data() + 1);
-    Assert(keyLen <= (keyBuffer.length() - block::detail::Node::MIN_KEY_SIZE));
+    ConcordAssert(keyLen <= (keyBuffer.length() - block::detail::Node::MIN_KEY_SIZE));
     node.keys.emplace(concordUtils::Sliver{keyBuffer, block::detail::Node::MIN_KEY_SIZE, keyLen}, keyData);
 
     keyBuffer = concordUtils::Sliver{keyBuffer,
@@ -370,7 +370,7 @@ inline block::detail::Node deserialize<block::detail::Node>(const concordUtils::
 template <>
 inline block::detail::RawBlockMerkleData deserialize<block::detail::RawBlockMerkleData>(
     const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= block::detail::RawBlockMerkleData::MIN_SIZE);
+  ConcordAssert(buf.length() >= block::detail::RawBlockMerkleData::MIN_SIZE);
 
   auto offset = std::size_t{0};
   auto data = block::detail::RawBlockMerkleData{};
@@ -383,11 +383,11 @@ inline block::detail::RawBlockMerkleData deserialize<block::detail::RawBlockMerk
   auto keyBuffer = concordUtils::Sliver{
       buf, block::detail::RawBlockMerkleData::MIN_SIZE, buf.length() - block::detail::RawBlockMerkleData::MIN_SIZE};
   while (!keyBuffer.empty()) {
-    Assert(keyBuffer.length() >= block::detail::RawBlockMerkleData::MIN_KEY_SIZE);
+    ConcordAssert(keyBuffer.length() >= block::detail::RawBlockMerkleData::MIN_KEY_SIZE);
 
     // Key length.
     const auto keyLen = concordUtils::fromBigEndianBuffer<block::detail::KeyLengthType>(keyBuffer.data());
-    Assert(keyLen <= (keyBuffer.length() - block::detail::RawBlockMerkleData::MIN_KEY_SIZE));
+    ConcordAssert(keyLen <= (keyBuffer.length() - block::detail::RawBlockMerkleData::MIN_KEY_SIZE));
     data.deletedKeys.insert(concordUtils::Sliver{keyBuffer, block::detail::RawBlockMerkleData::MIN_KEY_SIZE, keyLen});
 
     keyBuffer = concordUtils::Sliver{keyBuffer,
@@ -400,7 +400,7 @@ inline block::detail::RawBlockMerkleData deserialize<block::detail::RawBlockMerk
 
 // Deserializes the state root version from a serialized block::detail::Node .
 inline sparse_merkle::Version deserializeStateRootVersion(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= block::detail::Node::MIN_SIZE);
+  ConcordAssert(buf.length() >= block::detail::Node::MIN_SIZE);
   constexpr auto offset = sizeof(block::detail::Node::BlockIdType) + block::detail::Node::PARENT_DIGEST_SIZE +
                           block::detail::Node::STATE_HASH_SIZE;
   return concordUtils::fromBigEndianBuffer<sparse_merkle::Version::Type>(buf.data() + offset);
@@ -408,7 +408,7 @@ inline sparse_merkle::Version deserializeStateRootVersion(const concordUtils::Sl
 
 template <>
 inline DatabaseLeafValue deserialize<DatabaseLeafValue>(const concordUtils::Sliver &buf) {
-  Assert(buf.length() >= DatabaseLeafValue::MIN_SIZE);
+  ConcordAssert(buf.length() >= DatabaseLeafValue::MIN_SIZE);
   constexpr auto blockIdSize = sizeof(DatabaseLeafValue::BlockIdType);
   const auto addedInBlock = concordUtils::fromBigEndianBuffer<DatabaseLeafValue::BlockIdType>(buf.data());
   const auto deletedInBlock =

--- a/kvbc/include/sparse_merkle/base_types.h
+++ b/kvbc/include/sparse_merkle/base_types.h
@@ -42,7 +42,7 @@ class Version {
   bool operator<(const Version& other) const { return value_ < other.value_; }
   Version operator+(const Version& other) const { return Version(value_ + other.value_); }
   Version operator+(const int other) const {
-    Assert(other > 0);
+    ConcordAssert(other > 0);
     return Version(value_ + other);
   }
   Type value() const { return value_; }
@@ -59,14 +59,14 @@ class Nibble {
   static constexpr size_t SIZE_IN_BITS = 4;
 
   Nibble(uint8_t byte) {
-    Assert((byte & 0xF0) == 0);
+    ConcordAssert((byte & 0xF0) == 0);
     data_ = byte;
   }
 
   // Get the bit of the Nibble starting from LSB.
   // Bits 0-3 are available.
   bool getBit(size_t bit) const {
-    Assert(bit < SIZE_IN_BITS);
+    ConcordAssert(bit < SIZE_IN_BITS);
     return (data_ >> bit) & 1;
   }
 
@@ -165,8 +165,8 @@ class Hash {
   void setNibble(const size_t n, Nibble nibble) { ::concord::kvbc::sparse_merkle::setNibble(n, buf_, nibble); }
 
   Nibble getNibble(const size_t n) const {
-    Assert(!buf_.empty());
-    Assert(n < MAX_NIBBLES);
+    ConcordAssert(!buf_.empty());
+    ConcordAssert(n < MAX_NIBBLES);
     return ::concord::kvbc::sparse_merkle::getNibble(n, buf_);
   }
 
@@ -196,7 +196,7 @@ class Hash {
   //
   // TODO: This can be optimized to only start searching from depth
   size_t prefix_bits_in_common(const Hash& other, size_t depth) const {
-    Assert(depth < Hash::MAX_NIBBLES);
+    ConcordAssert(depth < Hash::MAX_NIBBLES);
     auto total = prefix_bits_in_common(other);
     auto bits_to_depth = depth * Nibble::SIZE_IN_BITS;
     if (total > bits_to_depth) {
@@ -240,8 +240,8 @@ class NibblePath {
  public:
   NibblePath() : num_nibbles_(0) {}
   NibblePath(size_t num_nibbles, const std::vector<uint8_t>& path) : num_nibbles_(num_nibbles), path_(path) {
-    Assert(num_nibbles < Hash::MAX_NIBBLES);
-    Assert(path.size() == (num_nibbles % 2 ? (num_nibbles + 1) / 2 : num_nibbles / 2));
+    ConcordAssert(num_nibbles < Hash::MAX_NIBBLES);
+    ConcordAssert(path.size() == (num_nibbles % 2 ? (num_nibbles + 1) / 2 : num_nibbles / 2));
   }
 
   bool operator==(const NibblePath& other) const { return num_nibbles_ == other.num_nibbles_ && path_ == other.path_; }
@@ -270,7 +270,7 @@ class NibblePath {
   // Append a nibble to the path_
   void append(Nibble nibble) {
     // We don't want a NibblePath to ever be longer than a Hash
-    Assert(num_nibbles_ < Hash::MAX_NIBBLES - 1);
+    ConcordAssert(num_nibbles_ < Hash::MAX_NIBBLES - 1);
     if (num_nibbles_ % 2 == 0) {
       path_.push_back(nibble.data() << Nibble::SIZE_IN_BITS);
     } else {
@@ -281,7 +281,7 @@ class NibblePath {
 
   // Return the last nibble off the path
   Nibble back() const {
-    Assert(!empty());
+    ConcordAssert(!empty());
     if (num_nibbles_ % 2 == 0) {
       // We have a complete byte at the end of path_. Remove the lower nibble.
       return path_.back() & 0x0F;
@@ -292,7 +292,7 @@ class NibblePath {
 
   // Pop the last nibble off the path
   Nibble popBack() {
-    Assert(!empty());
+    ConcordAssert(!empty());
     uint8_t data = 0;
     if (num_nibbles_ % 2 == 0) {
       // We have a complete byte at the end of path_. Remove the lower nibble.
@@ -311,7 +311,7 @@ class NibblePath {
 
   // Get the nth nibble.
   Nibble get(size_t n) const {
-    Assert(n < num_nibbles_);
+    ConcordAssert(n < num_nibbles_);
     return ::concord::kvbc::sparse_merkle::getNibble(n, path_);
   }
 

--- a/kvbc/include/sparse_merkle/keys.h
+++ b/kvbc/include/sparse_merkle/keys.h
@@ -81,7 +81,7 @@ class LeafKey {
   std::string toString() const { return key_.toString() + "-" + version_.toString(); }
 
   Nibble getNibble(const size_t n) const {
-    Assert(n < Hash::MAX_NIBBLES);
+    ConcordAssert(n < Hash::MAX_NIBBLES);
     return key_.getNibble(n);
   }
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -282,7 +282,7 @@ bool ReplicaImp::putBlock(const uint64_t blockId, const char *block_data, const 
 }
 
 RawBlock ReplicaImp::getBlockInternal(BlockId blockId) const {
-  Assert(blockId <= getLastBlockNum());
+  ConcordAssert(blockId <= getLastBlockNum());
   return m_bcDbAdapter->getRawBlock(blockId);
 }
 
@@ -300,11 +300,11 @@ bool ReplicaImp::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSi
 bool ReplicaImp::hasBlock(BlockId blockId) const { return m_bcDbAdapter->hasBlock(blockId); }
 
 bool ReplicaImp::getPrevDigestFromBlock(BlockId blockId, StateTransferDigest *outPrevBlockDigest) {
-  Assert(blockId > 0);
+  ConcordAssert(blockId > 0);
   try {
     RawBlock result = getBlockInternal(blockId);
     auto parentDigest = m_bcDbAdapter->getParentDigest(result);
-    Assert(outPrevBlockDigest != nullptr);
+    ConcordAssert(outPrevBlockDigest != nullptr);
     static_assert(parentDigest.size() == BLOCK_DIGEST_SIZE);
     static_assert(sizeof(StateTransferDigest) == BLOCK_DIGEST_SIZE);
     memcpy(outPrevBlockDigest, parentDigest.data(), BLOCK_DIGEST_SIZE);

--- a/kvbc/src/direct_kv_block.cpp
+++ b/kvbc/src/direct_kv_block.cpp
@@ -24,7 +24,7 @@ Sliver create(const SetOfKeyValuePairs &updates,
   // TODO(GG): overflow handling ....
   // TODO(SG): How? Right now - will put empty block instead
 
-  Assert(outUpdatesInNewBlock.size() == 0);
+  ConcordAssert(outUpdatesInNewBlock.size() == 0);
 
   std::uint32_t blockBodySize = 0;
   const std::uint16_t numOfElements = updates.size();
@@ -75,14 +75,14 @@ Sliver create(const SetOfKeyValuePairs &updates,
 
       idx++;
     }
-    Assert(idx == numOfElements);
+    ConcordAssert(idx == numOfElements);
 
     if (userDataSize) {
       std::memcpy(blockBuffer + currentOffset, userData, userDataSize);
       currentOffset += userDataSize;
     }
 
-    Assert((std::uint32_t)currentOffset == blockSize);
+    ConcordAssert((std::uint32_t)currentOffset == blockSize);
 
     return blockSliver;
   } catch (const std::bad_alloc &ba) {  // TODO: do we really want to mask this failure?
@@ -116,7 +116,7 @@ SetOfKeyValuePairs getData(const Sliver &block) {
 
 BlockDigest getParentDigest(const Sliver &block) {
   const auto *bh = reinterpret_cast<const detail::Header *>(block.data());
-  Assert(BLOCK_DIGEST_SIZE == bh->parentDigestLength);
+  ConcordAssert(BLOCK_DIGEST_SIZE == bh->parentDigestLength);
   BlockDigest digest;
   std::memcpy(digest.data(), bh->parentDigest, BLOCK_DIGEST_SIZE);
   return digest;
@@ -124,7 +124,7 @@ BlockDigest getParentDigest(const Sliver &block) {
 
 Sliver getUserData(const Sliver &block) {
   constexpr auto headerSize = sizeof(detail::Header);
-  Assert(block.length() >= headerSize);
+  ConcordAssert(block.length() >= headerSize);
   const auto header = reinterpret_cast<const detail::Header *>(block.data());
 
   // If there are no elements, we only have a Header and, optionally, user data.
@@ -136,7 +136,7 @@ Sliver getUserData(const Sliver &block) {
   const auto entries = reinterpret_cast<const detail::Entry *>(block.data() + sizeof(detail::Header));
   const auto lastEntry = entries[header->numberOfElements - 1];
   const auto userDataOffset = lastEntry.valOffset + lastEntry.valSize;
-  Assert(block.length() >= userDataOffset);
+  ConcordAssert(block.length() >= userDataOffset);
   return Sliver{block, userDataOffset, block.length() - userDataOffset};
 }
 

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -154,7 +154,7 @@ int DBKeyComparator::composedKeyComparison(const char *_a_data,
     }
     default:
       LOG_ERROR(logger(), "invalid key type: " << (char)aType);
-      Assert(false);
+      ConcordAssert(false);
       throw std::runtime_error("DBKeyComparator::composedKeyComparison: invalid key type");
   }  // switch
 }
@@ -207,7 +207,7 @@ BlockId DBKeyManipulator::extractBlockIdFromKey(const Key &_key) {
  * @return The block id of the composite database key.
  */
 BlockId DBKeyManipulator::extractBlockIdFromKey(const char *_key_data, size_t _key_length) {
-  Assert(_key_length >= sizeof(BlockId));
+  ConcordAssert(_key_length >= sizeof(BlockId));
   const auto offset = _key_length - sizeof(BlockId);
   const auto id = *reinterpret_cast<const BlockId *>(_key_data + offset);
 
@@ -226,7 +226,7 @@ BlockId DBKeyManipulator::extractBlockIdFromKey(const char *_key_data, size_t _k
  * @return The type of the composite database key.
  */
 EDBKeyType DBKeyManipulator::extractTypeFromKey(const Key &_key) {
-  Assert(!_key.empty());
+  ConcordAssert(!_key.empty());
   return extractTypeFromKey(_key.data());
 }
 
@@ -241,8 +241,8 @@ EDBKeyType DBKeyManipulator::extractTypeFromKey(const Key &_key) {
  */
 EDBKeyType DBKeyManipulator::extractTypeFromKey(const char *_key_data) {
   static_assert(sizeof(EDBKeyType) == 1, "Let's avoid byte-order problems.");
-  Assert((_key_data[0] < (char)EDBKeyType::E_DB_KEY_TYPE_LAST) &&
-         (_key_data[0] >= (char)EDBKeyType::E_DB_KEY_TYPE_FIRST));
+  ConcordAssert((_key_data[0] < (char)EDBKeyType::E_DB_KEY_TYPE_LAST) &&
+                (_key_data[0] >= (char)EDBKeyType::E_DB_KEY_TYPE_FIRST));
   return (EDBKeyType)_key_data[0];
 }
 
@@ -270,7 +270,7 @@ ObjectId DBKeyManipulator::extractObjectIdFromKey(const Key &_key) {
  * @return The object id of the composite database key.
  */
 ObjectId DBKeyManipulator::extractObjectIdFromKey(const char *_key_data, size_t _key_length) {
-  Assert(_key_length >= sizeof(ObjectId));
+  ConcordAssert(_key_length >= sizeof(ObjectId));
   size_t offset = _key_length - sizeof(ObjectId);
   ObjectId id = *(ObjectId *)(_key_data + offset);
 
@@ -309,8 +309,8 @@ int DBKeyManipulator::compareKeyPartOfComposedKey(const char *a_data,
                                                   size_t a_length,
                                                   const char *b_data,
                                                   size_t b_length) {
-  Assert(a_length >= sizeof(BlockId) + sizeof(EDBKeyType));
-  Assert(b_length >= sizeof(BlockId) + sizeof(EDBKeyType));
+  ConcordAssert(a_length >= sizeof(BlockId) + sizeof(EDBKeyType));
+  ConcordAssert(b_length >= sizeof(BlockId) + sizeof(EDBKeyType));
 
   const char *a_key = a_data + sizeof(EDBKeyType);
   const size_t a_key_length = a_length - sizeof(BlockId) - sizeof(EDBKeyType);
@@ -449,7 +449,7 @@ void DBAdapter::deleteBlock(const BlockId &blockId) {
     if (Status s = db_->multiDel(keysVec); !s.isOK())
       throw std::runtime_error(__PRETTY_FUNCTION__ + std::string(": failed: blockId: ") + std::to_string(blockId) +
                                std::string(" reason: ") + s.toString());
-    if (blockId > 1) Assert(hasBlock(blockId - 1));
+    if (blockId > 1) ConcordAssert(hasBlock(blockId - 1));
     setLatestBlock(blockId - 1);
     setLastReachableBlockNum(blockId - 1);
   } catch (const NotFoundException &e) {

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -230,7 +230,7 @@ RawBlock DBAdapter::getRawBlock(const BlockId &blockId) const {
   }
 
   const auto blockNode = block::detail::parseNode(blockNodeSliver);
-  Assert(blockId == blockNode.blockId);
+  ConcordAssert(blockId == blockNode.blockId);
 
   auto keyValues = SetOfKeyValuePairs{};
   auto deletedKeys = OrderedKeysSet{};
@@ -240,11 +240,11 @@ RawBlock DBAdapter::getRawBlock(const BlockId &blockId) const {
       if (const auto status = db_->get(DBKeyManipulator::genDataDbKey(key, blockNode.stateRootVersion), value);
           !status.isOK()) {
         // If the key is not found, treat as corrupted storage and abort.
-        Assert(!status.isNotFound());
+        ConcordAssert(!status.isNotFound());
         throw std::runtime_error{"Failed to get value by key from DB, block node ID = " + std::to_string(blockId)};
       }
       const auto dbLeafVal = detail::deserialize<detail::DatabaseLeafValue>(value);
-      Assert(dbLeafVal.addedInBlockId == blockId);
+      ConcordAssert(dbLeafVal.addedInBlockId == blockId);
       keyValues[key] = dbLeafVal.leafNode.value;
     } else {
       deletedKeys.insert(key);
@@ -333,7 +333,7 @@ BatchedInternalNode DBAdapter::Reader::get_latest_root() const {
   auto blockNodeSliver = Sliver{};
   const auto getStatus = adapter_.getDb()->get(DBKeyManipulator::genBlockDbKey(lastBlock), blockNodeSliver);
   (void)getStatus;
-  Assert(getStatus.isOK());
+  ConcordAssert(getStatus.isOK());
   const auto stateRootVersion = detail::deserializeStateRootVersion(blockNodeSliver);
   if (stateRootVersion == 0) {
     // A version of 0 means that the tree is empty and we return an empty BatchedInternalNode in that case.

--- a/kvbc/src/merkle_tree_key_manipulator.cpp
+++ b/kvbc/src/merkle_tree_key_manipulator.cpp
@@ -64,7 +64,7 @@ Key DBKeyManipulator::genStaleDbKey(const Version &staleSinceVersion) {
 Key DBKeyManipulator::generateSTTempBlockKey(BlockId blockId) { return serialize(EBFTSubtype::STTempBlock, blockId); }
 
 BlockId DBKeyManipulator::extractBlockIdFromKey(const Key &key) {
-  Assert(key.length() > sizeof(BlockId));
+  ConcordAssert(key.length() > sizeof(BlockId));
 
   const auto offset = key.length() - sizeof(BlockId);
   const auto id = fromBigEndianBuffer<BlockId>(key.data() + offset);
@@ -77,37 +77,37 @@ BlockId DBKeyManipulator::extractBlockIdFromKey(const Key &key) {
 
 Hash DBKeyManipulator::extractHashFromLeafKey(const Key &key) {
   constexpr auto keyTypeOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype);
-  Assert(key.length() > keyTypeOffset + Hash::SIZE_IN_BYTES);
-  Assert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
-  Assert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Leaf);
+  ConcordAssert(key.length() > keyTypeOffset + Hash::SIZE_IN_BYTES);
+  ConcordAssert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
+  ConcordAssert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Leaf);
   return Hash{reinterpret_cast<const uint8_t *>(key.data() + keyTypeOffset)};
 }
 
 Version DBKeyManipulator::extractVersionFromStaleKey(const Key &key) {
   constexpr auto keyTypeOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype);
-  Assert(key.length() >= keyTypeOffset + Version::SIZE_IN_BYTES);
-  Assert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
-  Assert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Stale);
+  ConcordAssert(key.length() >= keyTypeOffset + Version::SIZE_IN_BYTES);
+  ConcordAssert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
+  ConcordAssert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Stale);
   return fromBigEndianBuffer<Version::Type>(key.data() + keyTypeOffset);
 }
 
 Key DBKeyManipulator::extractKeyFromStaleKey(const Key &key) {
   constexpr auto keyOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype) + Version::SIZE_IN_BYTES;
-  Assert(key.length() > keyOffset);
-  Assert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
-  Assert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Stale);
+  ConcordAssert(key.length() > keyOffset);
+  ConcordAssert(DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key);
+  ConcordAssert(DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Stale);
   return Key{key, keyOffset, key.length() - keyOffset};
 }
 
 Version DBKeyManipulator::extractVersionFromInternalKey(const Key &key) {
   constexpr auto keyOffset = sizeof(EDBKeyType) + sizeof(EKeySubtype);
-  Assert(key.length() > keyOffset);
+  ConcordAssert(key.length() > keyOffset);
   return deserialize<InternalNodeKey>(Sliver{key, keyOffset, key.length() - keyOffset}).version();
 }
 
 // Undefined behavior if an incorrect type is read from the buffer.
 EDBKeyType DBKeyManipulator::getDBKeyType(const Sliver &s) {
-  Assert(!s.empty());
+  ConcordAssert(!s.empty());
 
   switch (s[0]) {
     case toChar(EDBKeyType::Block):
@@ -117,7 +117,7 @@ EDBKeyType DBKeyManipulator::getDBKeyType(const Sliver &s) {
     case toChar(EDBKeyType::BFT):
       return EDBKeyType::BFT;
   }
-  Assert(false);
+  ConcordAssert(false);
 
   // Dummy return to silence the compiler.
   return EDBKeyType::Block;
@@ -125,7 +125,7 @@ EDBKeyType DBKeyManipulator::getDBKeyType(const Sliver &s) {
 
 // Undefined behavior if an incorrect type is read from the buffer.
 EKeySubtype DBKeyManipulator::getKeySubtype(const Sliver &s) {
-  Assert(s.length() > 1);
+  ConcordAssert(s.length() > 1);
 
   switch (s[1]) {
     case toChar(EKeySubtype::Internal):
@@ -135,7 +135,7 @@ EKeySubtype DBKeyManipulator::getKeySubtype(const Sliver &s) {
     case toChar(EKeySubtype::Leaf):
       return EKeySubtype::Leaf;
   }
-  Assert(false);
+  ConcordAssert(false);
 
   // Dummy return to silence the compiler.
   return EKeySubtype::Internal;
@@ -143,7 +143,7 @@ EKeySubtype DBKeyManipulator::getKeySubtype(const Sliver &s) {
 
 // Undefined behavior if an incorrect type is read from the buffer.
 EBFTSubtype DBKeyManipulator::getBftSubtype(const Sliver &s) {
-  Assert(s.length() > 1);
+  ConcordAssert(s.length() > 1);
 
   switch (s[1]) {
     case toChar(EBFTSubtype::Metadata):
@@ -161,7 +161,7 @@ EBFTSubtype DBKeyManipulator::getBftSubtype(const Sliver &s) {
     case toChar(EBFTSubtype::STTempBlock):
       return EBFTSubtype::STTempBlock;
   }
-  Assert(false);
+  ConcordAssert(false);
 
   // Dummy return to silence the compiler.
   return EBFTSubtype::Metadata;

--- a/kvbc/src/sparse_merkle/internal_node.cpp
+++ b/kvbc/src/sparse_merkle/internal_node.cpp
@@ -20,7 +20,7 @@ namespace kvbc {
 namespace sparse_merkle {
 
 void BatchedInternalNode::updateHashes(size_t index, Version version) {
-  Assert(index > 0);
+  ConcordAssert(index > 0);
   auto hasher = Hasher();
 
   while (true) {
@@ -127,7 +127,7 @@ BatchedInternalNode::InsertResult BatchedInternalNode::splitNode(size_t index, c
 
   // How many prefix bits do the two leaf key hashes have in common?
   auto prefix_bits_in_common = stored_leaf_child.key.hash().prefix_bits_in_common(child.key.hash(), depth);
-  Assert(prefix_bits_in_common > 0);
+  ConcordAssert(prefix_bits_in_common > 0);
 
   // Fill in this node with any necessary internal children.
   Nibble child_key = child.key.hash().getNibble(depth);
@@ -228,12 +228,12 @@ BatchedInternalNode::RemoveResult BatchedInternalNode::removeLeafChild(size_t in
                                                                        Version new_version,
                                                                        Version removed_version,
                                                                        size_t depth) {
-  Assert(index != 0);
+  ConcordAssert(index != 0);
   children_[index] = std::nullopt;
   auto peer_index = peerIndex(index);
   if (!peer_index) {
     // Only the root remains.
-    Assert(1 == numChildren());
+    ConcordAssert(1 == numChildren());
     updateHashes(index, new_version);
     return RemoveBatchedInternalNode(removed_version);
   }
@@ -314,12 +314,12 @@ std::optional<LeafChild> BatchedInternalNode::unlinkChild(Nibble child_key,
     if (!parent_index) {
       // We reached the root, so this BatchedInternalNode is going to be deleted.
       if (!children_[index]) {
-        Assert(numChildren() == 0);
+        ConcordAssert(numChildren() == 0);
         return std::nullopt;
       }
       auto rv = std::get<LeafChild>(children_[index].value());
       children_[index] = std::nullopt;
-      Assert(numChildren() == 0);
+      ConcordAssert(numChildren() == 0);
       return rv;
     }
     if (peer_index) {

--- a/kvbc/src/sparse_merkle/tree.cpp
+++ b/kvbc/src/sparse_merkle/tree.cpp
@@ -46,7 +46,7 @@ void handleCollision(Walker& walker, const LeafChild& stored_child, const LeafCh
 // the insert will succeed.
 void insert(Walker& walker, const LeafChild& child) {
   while (true) {
-    Assert(walker.depth() < Hash::MAX_NIBBLES);
+    ConcordAssert(walker.depth() < Hash::MAX_NIBBLES);
 
     auto result = walker.currentNode().insert(child, walker.depth(), walker.version());
 
@@ -74,7 +74,7 @@ void removeBatchedInternalNode(Walker& walker, const std::optional<LeafChild>& p
   // have walked back up the tree.
   if (promoted_after_unlink) {
     auto insertResult = walker.currentNode().insert(promoted_after_unlink.value(), walker.depth(), walker.version());
-    Assert(std::holds_alternative<BatchedInternalNode::InsertComplete>(insertResult));
+    ConcordAssert(std::holds_alternative<BatchedInternalNode::InsertComplete>(insertResult));
     walker.ascendToRoot();
   } else {
     if (walker.atRoot() && walker.currentNode().safeToRemove()) {
@@ -90,7 +90,7 @@ void removeBatchedInternalNode(Walker& walker, const std::optional<LeafChild>& p
 
 void remove(Walker& walker, const Hash& key_hash) {
   while (true) {
-    Assert(walker.depth() < Hash::MAX_NIBBLES);
+    ConcordAssert(walker.depth() < Hash::MAX_NIBBLES);
 
     auto result = walker.currentNode().remove(key_hash, walker.depth(), walker.version());
 

--- a/kvbc/src/sparse_merkle/walker.cpp
+++ b/kvbc/src/sparse_merkle/walker.cpp
@@ -51,7 +51,7 @@ void Walker::ascendToRoot(const std::optional<LeafKey>& key) {
 }
 
 void Walker::ascend() {
-  Assert(!stack_.empty());
+  ConcordAssert(!stack_.empty());
 
   markCurrentNodeStale();
   cacheCurrentNode();

--- a/kvbc/test/sparse_merkle/internal_node_test.cpp
+++ b/kvbc/test/sparse_merkle/internal_node_test.cpp
@@ -21,7 +21,7 @@ using namespace concord::kvbc::sparse_merkle;
 // Flip a given bit starting from the most significant bit. So bit 0 to be
 // flipped would be the first bit, bit 1, the second bit, etc...
 Hash flipByte0Bit(size_t bit, const Hash& hash) {
-  Assert(bit < 8);
+  ConcordAssert(bit < 8);
   // Flip the first bit so that key1_hash becomes a sibling of key2_hash
   std::array<uint8_t, Hash::SIZE_IN_BYTES> flipped;
   std::copy(hash.data(), hash.data() + hash.size(), flipped.begin());

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -157,7 +157,7 @@ class Client : public concord::storage::IDBClient {
   concordUtils::Status del(const concordUtils::Sliver& key) override;
 
   concordUtils::Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) override {
-    Assert(_keysVec.size() == _valuesVec.size());
+    ConcordAssert(_keysVec.size() == _valuesVec.size());
 
     for (KeysVector::size_type i = 0; i < _keysVec.size(); ++i)
       if (Status s = get(_keysVec[i], _valuesVec[i]); !s.isOK()) return s;
@@ -181,7 +181,7 @@ class Client : public concord::storage::IDBClient {
   bool isNew() override { throw std::logic_error("isNew()  Not implemented for S3 object store"); }
 
   IDBClient::IDBClientIterator* getIterator() const override {
-    Assert("getIterator() Not implemented for ECS S3 object store" && false);
+    ConcordAssert("getIterator() Not implemented for ECS S3 object store" && false);
     throw std::logic_error("getIterator() Not implemented for ECS S3 object store");
   }
 

--- a/storage/src/direct_kv_key_manipulator.cpp
+++ b/storage/src/direct_kv_key_manipulator.cpp
@@ -111,9 +111,9 @@ Sliver STKeyManipulator::generateReservedPageKey(EDBKeyType keyType, uint32_t pa
 
 bool DBKeyGeneratorBase::copyToAndAdvance(
     char *_buf, size_t *_offset, size_t _maxOffset, const char *_src, const size_t &_srcSize) {
-  if (!_buf && !_offset && !_src) Assert(false);
+  if (!_buf && !_offset && !_src) ConcordAssert(false);
 
-  if (*_offset >= _maxOffset && _srcSize > 0) Assert(false);
+  if (*_offset >= _maxOffset && _srcSize > 0) ConcordAssert(false);
 
   memcpy(_buf + *_offset, _src, _srcSize);
   *_offset += _srcSize;
@@ -122,7 +122,7 @@ bool DBKeyGeneratorBase::copyToAndAdvance(
 }
 
 uint64_t STKeyManipulator::extractCheckPointFromKey(const char *_key_data, size_t _key_length) {
-  Assert(_key_length >= sizeof(uint64_t));
+  ConcordAssert(_key_length >= sizeof(uint64_t));
   uint64_t chkp = *(uint64_t *)(_key_data + 1);
 
   LOG_TRACE(logger(), "checkpoint " << chkp << " from key " << (HexPrintBuffer{_key_data, _key_length}));
@@ -131,7 +131,7 @@ uint64_t STKeyManipulator::extractCheckPointFromKey(const char *_key_data, size_
 
 std::pair<uint32_t, uint64_t> STKeyManipulator::extractPageIdAndCheckpointFromKey(const char *_key_data,
                                                                                   size_t _key_length) {
-  Assert(_key_length >= sizeof(uint32_t) + sizeof(uint64_t));
+  ConcordAssert(_key_length >= sizeof(uint32_t) + sizeof(uint64_t));
 
   uint32_t pageId = *(uint32_t *)(_key_data + 1);
   uint64_t chkp = *(uint64_t *)(_key_data + sizeof(uint32_t) + 1);

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -163,7 +163,7 @@ Status Client::rangeDel(const Sliver &_beginKey, const Sliver &_endKey) {
   }
 
   // Make sure that _beginKey comes before _endKey .
-  Assert(comp_(_beginKey, _endKey));
+  ConcordAssert(comp_(_beginKey, _endKey));
 
   auto beginIt = map_.lower_bound(_beginKey);
   if (beginIt == std::end(map_)) {

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -370,7 +370,7 @@ Status Client::rangeDel(const Sliver &_beginKey, const Sliver &_endKey) {
   }
 
   // Make sure that _beginKey comes before _endKey .
-  Assert(keyIsBefore(_beginKey, _endKey));
+  ConcordAssert(keyIsBefore(_beginKey, _endKey));
 
   const auto status =
       dbInstance_->DeleteRange(::rocksdb::WriteOptions(), nullptr, toRocksdbSlice(_beginKey), toRocksdbSlice(_endKey));

--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -36,8 +36,8 @@ using namespace concordUtils;
  */
 void Client::init(bool readOnly) {
   std::lock_guard<std::mutex> g(initLock_);
-  Assert(!init_);  // we may return here instead of firing assert failure, but
-                   // probably we want to catch bugs?
+  ConcordAssert(!init_);  // we may return here instead of firing assert failure, but
+                          // probably we want to catch bugs?
   context_.hostName = config_.url.c_str();
   context_.protocol = (config_.protocol == "HTTP" ? S3ProtocolHTTP : S3ProtocolHTTPS);
   context_.uriStyle = S3UriStylePath;
@@ -50,14 +50,14 @@ void Client::init(bool readOnly) {
   S3Status st = S3_initialize(NULL, S3_INIT_ALL, NULL);
   if (S3Status::S3StatusOK != st) {
     LOG_FATAL(logger_, "libs3 init failed, status: " + to_string(st));
-    Assert("libs3 init failed" && false);
+    ConcordAssert("libs3 init failed" && false);
   }
   LOG_INFO(logger_, "libs3 initialized");
   init_ = true;
 }
 
 Status Client::del(const Sliver& key) {
-  Assert(init_);
+  ConcordAssert(init_);
   ResponseData rData;
   S3ResponseHandler rHandler;
   rHandler.completeCallback = responseCompleteCallback;
@@ -79,7 +79,7 @@ Status Client::del(const Sliver& key) {
 }
 
 Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
-  Assert(init_);
+  ConcordAssert(init_);
   LOG_DEBUG(logger_, "get key: " << _key.toString());
   GetObjectResponseData cbData(kInitialGetBufferSize_);
   S3GetObjectHandler getObjectHandler;
@@ -89,7 +89,7 @@ Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
   // the stream
   auto f = [](int buf_len, const char* buf, void* cb) -> S3Status {
     GetObjectResponseData* cbData = static_cast<GetObjectResponseData*>(cb);
-    Assert(cbData->data != nullptr);
+    ConcordAssert(cbData->data != nullptr);
     cbData->Write(buf, buf_len);
     return S3Status::S3StatusOK;
   };
@@ -111,7 +111,7 @@ Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
 }
 
 Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
-  Assert(init_);
+  ConcordAssert(init_);
   PutObjectResponseData cbData(_value.data(), _value.length());
   S3PutObjectHandler putObjectHandler;
   putObjectHandler.responseHandler = responseHandler;
@@ -144,7 +144,7 @@ Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
 }
 
 Status Client::object_exists_internal(const Sliver& key) const {
-  Assert(init_);
+  ConcordAssert(init_);
   ResponseData rData;
   S3ResponseHandler rHandler;
   rHandler.completeCallback = responseCompleteCallback;
@@ -169,7 +169,7 @@ Status Client::object_exists_internal(const Sliver& key) const {
 }
 
 Status Client::test_bucket_internal() {
-  Assert(init_);
+  ConcordAssert(init_);
   ResponseData rData;
   S3ResponseHandler rHandler;
   rHandler.completeCallback = responseCompleteCallback;

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -113,7 +113,7 @@ bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
 
   if (!(flags & MsgFlag::HAS_PRE_PROCESSED_FLAG)) {
     bool result = verifyWriteCommand(requestSize, *writeReq, maxReplySize, outReplySize);
-    if (!result) Assert(0);
+    if (!result) ConcordAssert(0);
     if (flags & MsgFlag::PRE_PROCESS_FLAG) {
       if (writeReq->header.type == LONG_EXEC_COND_WRITE) sleep(LONG_EXEC_CMD_TIME_IN_SEC);
       outReplySize = requestSize;
@@ -143,11 +143,11 @@ bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
     addMetadataKeyValue(updates, sequenceNum);
     BlockId newBlockId = 0;
     Status addSuccess = m_blocksAppender->addBlock(updates, newBlockId);
-    Assert(addSuccess.isOK());
-    Assert(newBlockId == currBlock + 1);
+    ConcordAssert(addSuccess.isOK());
+    ConcordAssert(newBlockId == currBlock + 1);
   }
 
-  Assert(sizeof(SimpleReply_ConditionalWrite) <= maxReplySize);
+  ConcordAssert(sizeof(SimpleReply_ConditionalWrite) <= maxReplySize);
   auto *reply = (SimpleReply_ConditionalWrite *)outReply;
   reply->header.type = COND_WRITE;
   reply->success = (!hasConflict);

--- a/tests/simpleKVBC/basicRandomTestsRunner.cpp
+++ b/tests/simpleKVBC/basicRandomTestsRunner.cpp
@@ -29,7 +29,7 @@ BasicRandomTestsRunner::BasicRandomTestsRunner(logging::Logger &logger, IClient 
     : logger_(logger), client_(client), numOfOperations_(numOfOperations) {
   // We have to start the client here, since construction of the TestsBuilder
   // uses the client.
-  Assert(!client_.isRunning());
+  ConcordAssert(!client_.isRunning());
   client_.start();
   testsBuilder_ = new TestsBuilder(logger_, client);
 }
@@ -45,7 +45,7 @@ void BasicRandomTestsRunner::run() {
 
   RequestsList requests = testsBuilder_->getRequests();
   RepliesList expectedReplies = testsBuilder_->getReplies();
-  Assert(requests.size() == expectedReplies.size());
+  ConcordAssert(requests.size() == expectedReplies.size());
 
   int ops = 0;
   while (!requests.empty()) {
@@ -64,7 +64,7 @@ void BasicRandomTestsRunner::run() {
 
     auto res = client_.invokeCommandSynch(
         (char *)request, requestSize, readOnly, seconds(0), expectedReplySize, reply.data(), &actualReplySize);
-    Assert(res.isOK());
+    ConcordAssert(res.isOK());
 
     if (isReplyCorrect(request->type, expectedReply, reply.data(), expectedReplySize, actualReplySize)) ops++;
   }
@@ -80,7 +80,7 @@ bool BasicRandomTestsRunner::isReplyCorrect(RequestType requestType,
                                             uint32_t actualReplySize) {
   if (actualReplySize != expectedReplySize) {
     LOG_ERROR(logger_, "*** Test failed: actual reply size != expected");
-    Assert(0);
+    ConcordAssert(0);
   }
   std::ostringstream error;
   switch (requestType) {
@@ -98,7 +98,7 @@ bool BasicRandomTestsRunner::isReplyCorrect(RequestType requestType,
   }
 
   LOG_ERROR(logger_, "*** Test failed: actual reply != expected; error: " << error.str());
-  Assert(0);
+  ConcordAssert(0);
   return false;
 }
 

--- a/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
+++ b/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
@@ -68,12 +68,12 @@ BlockId TestsBuilder::getInitialLastBlockId() {
                                         expectedReplySize,
                                         reply.data(),
                                         &actualReplySize);
-  Assert(res.isOK());
+  ConcordAssert(res.isOK());
 
   auto *replyObj = (SimpleReply_GetLastBlock *)reply.data();
   LOG_INFO(logger_, "Actual reply size = " << actualReplySize << ", expected reply size = " << expectedReplySize);
-  Assert(actualReplySize == expectedReplySize);
-  Assert(replyObj->header.type == GET_LAST_BLOCK);
+  ConcordAssert(actualReplySize == expectedReplySize);
+  ConcordAssert(replyObj->header.type == GET_LAST_BLOCK);
   SimpleGetLastBlockRequest::free(request);
   return replyObj->latestBlock;
 }
@@ -99,13 +99,13 @@ void TestsBuilder::retrieveExistingBlocksFromKVB() {
   // Infinite timeout
   auto res = client_.invokeCommandSynch(
       (char *)request, request->getSize(), true, seconds(0), expectedReplySize, reply.data(), &actualReplySize);
-  Assert(res.isOK());
+  ConcordAssert(res.isOK());
 
   auto *replyObj = (SimpleReply_Read *)reply.data();
   __attribute__((unused)) size_t numOfItems = replyObj->numOfItems;
-  Assert(actualReplySize == expectedReplySize);
-  Assert(replyObj->header.type == READ);
-  Assert(numOfItems == NUMBER_OF_KEYS);
+  ConcordAssert(actualReplySize == expectedReplySize);
+  ConcordAssert(replyObj->header.type == READ);
+  ConcordAssert(numOfItems == NUMBER_OF_KEYS);
 
   for (int key = 0; key < NUMBER_OF_KEYS; key++) {
     SimpleKeyBlockIdPair simpleKIDPair(replyObj->items[key].simpleKey, request->readVersion);
@@ -133,13 +133,13 @@ void TestsBuilder::create(size_t numOfRequests, size_t seed) {
     else if (percent <= 100)
       createAndInsertGetLastBlock();
     else
-      Assert(0);
+      ConcordAssert(0);
   }
 
   for (__attribute__((unused)) auto elem : internalBlockchain_) {
     __attribute__((unused)) BlockId blockId = elem.first;
     __attribute__((unused)) SimpleBlock *block = elem.second;
-    Assert(blockId == block->id);
+    ConcordAssert(blockId == block->id);
   }
 }
 
@@ -322,7 +322,7 @@ size_t TestsBuilder::sizeOfRequest(SimpleRequest *request) {
     case GET_LAST_BLOCK:
       return sizeof(SimpleRequest);
     default:
-      Assert(0);
+      ConcordAssert(0);
   }
   return 0;
 }
@@ -336,7 +336,7 @@ size_t TestsBuilder::sizeOfReply(SimpleReply *reply) {
     case GET_LAST_BLOCK:
       return sizeof(SimpleReply_GetLastBlock);
     default:
-      Assert(0);
+      ConcordAssert(0);
   }
   return 0;
 }

--- a/tests/simpleTest/config_file_parser_test.cpp
+++ b/tests/simpleTest/config_file_parser_test.cpp
@@ -45,17 +45,17 @@ int main(int argc, char **argv) {
   vector<std::string> split_values_vector = parser.SplitValue(values_to_split, values_to_split_delimiter.c_str());
 
   if (config_file == default_config_file) {
-    Assert(replicas_num == expected_replicas_num);
-    Assert(clients_num == expected_clients_num);
-    Assert(expected_replica1 == replicas[0]);
-    Assert(expected_replica2 == replicas[1]);
-    Assert(expected_replica3 == replicas[2]);
-    Assert(expected_replica4 == replicas[3]);
-    Assert(expected_client == clients[0]);
-    Assert(split_values_vector.size() == sizeof(expected_split_values) / sizeof(expected_split_values[0]));
-    Assert(split_values_vector[0] == expected_split_values[0]);
-    Assert(split_values_vector[1] == expected_split_values[1]);
-    Assert(split_values_vector[2] == expected_split_values[2]);
+    ConcordAssert(replicas_num == expected_replicas_num);
+    ConcordAssert(clients_num == expected_clients_num);
+    ConcordAssert(expected_replica1 == replicas[0]);
+    ConcordAssert(expected_replica2 == replicas[1]);
+    ConcordAssert(expected_replica3 == replicas[2]);
+    ConcordAssert(expected_replica4 == replicas[3]);
+    ConcordAssert(expected_client == clients[0]);
+    ConcordAssert(split_values_vector.size() == sizeof(expected_split_values) / sizeof(expected_split_values[0]));
+    ConcordAssert(split_values_vector[0] == expected_split_values[0]);
+    ConcordAssert(split_values_vector[1] == expected_split_values[1]);
+    ConcordAssert(split_values_vector[2] == expected_split_values[2]);
   }
   return 0;
 }

--- a/tests/simpleTest/simple_test_client.hpp
+++ b/tests/simpleTest/simple_test_client.hpp
@@ -31,7 +31,7 @@ using namespace std;
   {                                                                     \
     if (!(statement)) {                                                 \
       LOG_FATAL(clientLogger, "assert fail with message: " << message); \
-      Assert(false);                                                    \
+      ConcordAssert(false);                                             \
     }                                                                   \
   }
 

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -37,7 +37,7 @@ logging::Logger replicaLogger = logging::getLogger("simpletest.replica");
   {                                                                      \
     if (!(statement)) {                                                  \
       LOG_FATAL(replicaLogger, "assert fail with message: " << message); \
-      Assert(false);                                                     \
+      ConcordAssert(false);                                              \
     }                                                                    \
   }
 

--- a/tools/DBEditor.cpp
+++ b/tools/DBEditor.cpp
@@ -230,7 +230,7 @@ void parseAndPrint(const ::rocksdb::Slice &key, const ::rocksdb::Slice &val) {
     }
     default:
       LOG_ERROR(logger, "invalid key type: " << (char)aType);
-      Assert(false);
+      ConcordAssert(false);
 
   }  // switch
 }
@@ -245,7 +245,7 @@ void dumpAllValues() {
     //    printf("\n");
     parseAndPrint(it->key(), it->value());
   }
-  Assert(it->status().ok());
+  ConcordAssert(it->status().ok());
   delete it;
 }
 

--- a/util/include/assertUtils.hpp
+++ b/util/include/assertUtils.hpp
@@ -84,7 +84,7 @@ inline void printCallStack() {
     std::terminate();                                                                                           \
   }
 
-#define Assert(expr)                                                                                              \
+#define ConcordAssert(expr)                                                                                       \
   {                                                                                                               \
     if ((expr) != true) {                                                                                         \
       LOG_FATAL(GL,                                                                                               \
@@ -95,50 +95,50 @@ inline void printCallStack() {
     }                                                                                                             \
   }
 // Assert (expr1 == expr2)
-#define AssertEQ(expr1, expr2)                                               \
+#define ConcordAssertEQ(expr1, expr2)                                        \
   {                                                                          \
     if ((expr1) != (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertEQ"); \
   }
 // Assert (expr1 != expr2)
-#define AssertNE(expr1, expr2)                                               \
+#define ConcordAssertNE(expr1, expr2)                                        \
   {                                                                          \
     if ((expr1) == (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertNE"); \
   }
 // Assert (expr1 >= expr2)
-#define AssertGE(expr1, expr2)                                              \
+#define ConcordAssertGE(expr1, expr2)                                       \
   {                                                                         \
     if ((expr1) < (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGE"); \
   }
 
 // Assert (expr1 > expr2)
-#define AssertGT(expr1, expr2)                                               \
+#define ConcordAssertGT(expr1, expr2)                                        \
   {                                                                          \
     if ((expr1) <= (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertGT"); \
   }
 
 // Assert (expr1 < expr2)
-#define AssertLT(expr1, expr2)                                               \
+#define ConcordAssertLT(expr1, expr2)                                        \
   {                                                                          \
     if ((expr1) >= (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLT"); \
   }
 
 // Assert (expr1 <= expr2)
-#define AssertLE(expr1, expr2)                                              \
+#define ConcordAssertLE(expr1, expr2)                                       \
   {                                                                         \
     if ((expr1) > (expr2)) PRINT_DATA_AND_ASSERT(expr1, expr2, "AssertLE"); \
   }
 
-// Assert(expr1 || expr2)
-#define AssertOR(expr1, expr2)                                                                         \
+// Assert (expr1 || expr2)
+#define ConcordAssertOR(expr1, expr2)                                                                  \
   {                                                                                                    \
     if ((expr1) != true && (expr2) != true) PRINT_DATA_AND_ASSERT_BOOL_EXPR(expr1, expr2, "AssertOR"); \
   }
 
-// Assert(expr1 && expr2)
+// Assert (expr1 && expr2)
 // TODO: AJS - Remove this. This is doesn't take advantage of value printing in
 // PRINT_DATA_AND_ASSERT. All uses should be changed to be separate asserts.
 // Ideally we'd do similar for AssertOR, but this requires conditionals outside of asserts.
-#define AssertAND(expr1, expr2)                                                                         \
+#define ConcordAssertAND(expr1, expr2)                                                                  \
   {                                                                                                     \
     if ((expr1) != true || (expr2) != true) PRINT_DATA_AND_ASSERT_BOOL_EXPR(expr1, expr2, "AssertAND"); \
   }

--- a/util/include/demangle.hpp
+++ b/util/include/demangle.hpp
@@ -22,7 +22,7 @@ struct demangler {
   static std::string demangle(const char* name) {
     int status = -4;
     std::unique_ptr<char, decltype(&std::free)> res{abi::__cxa_demangle(name, NULL, NULL, &status), std::free};
-    Assert(status == 0);
+    ConcordAssert(status == 0);
     return res.get();
   }
 

--- a/util/include/sha3_256.h
+++ b/util/include/sha3_256.h
@@ -29,7 +29,7 @@ class SHA3_256 {
   static constexpr size_t SIZE_IN_BYTES = 32;
   typedef std::array<uint8_t, SIZE_IN_BYTES> Digest;
 
-  SHA3_256() : ctx_(EVP_MD_CTX_new()) { Assert(ctx_ != nullptr); }
+  SHA3_256() : ctx_(EVP_MD_CTX_new()) { ConcordAssert(ctx_ != nullptr); }
 
   ~SHA3_256() { EVP_MD_CTX_destroy(ctx_); }
 
@@ -43,16 +43,16 @@ class SHA3_256 {
   // This is the simplest way to hash something as all setup is done for you.
   // Use the 3 method mechanism below if you need to hash multiple buffers.
   Digest digest(const void* buf, size_t size) {
-    Assert(!updating_);
-    Assert(EVP_MD_CTX_reset(ctx_) == 1);
-    Assert(EVP_DigestInit_ex(ctx_, EVP_sha3_256(), NULL) == 1);
+    ConcordAssert(!updating_);
+    ConcordAssert(EVP_MD_CTX_reset(ctx_) == 1);
+    ConcordAssert(EVP_DigestInit_ex(ctx_, EVP_sha3_256(), NULL) == 1);
 
-    Assert(EVP_DigestUpdate(ctx_, buf, size) == 1);
+    ConcordAssert(EVP_DigestUpdate(ctx_, buf, size) == 1);
 
     Digest digest;
     unsigned int _digest_len;
-    Assert(EVP_DigestFinal_ex(ctx_, digest.data(), &_digest_len) == 1);
-    Assert(_digest_len == SIZE_IN_BYTES);
+    ConcordAssert(EVP_DigestFinal_ex(ctx_, digest.data(), &_digest_len) == 1);
+    ConcordAssert(_digest_len == SIZE_IN_BYTES);
     return digest;
   }
 
@@ -60,23 +60,23 @@ class SHA3_256 {
   // continuously appending new data to be hashed.
 
   void init() {
-    Assert(!updating_);
-    Assert(EVP_MD_CTX_reset(ctx_) == 1);
-    Assert(EVP_DigestInit_ex(ctx_, EVP_sha3_256(), NULL) == 1);
+    ConcordAssert(!updating_);
+    ConcordAssert(EVP_MD_CTX_reset(ctx_) == 1);
+    ConcordAssert(EVP_DigestInit_ex(ctx_, EVP_sha3_256(), NULL) == 1);
     updating_ = true;
   }
 
   // Add more data to a digest.
   void update(const void* buf, size_t size) {
-    Assert(updating_);
-    Assert(EVP_DigestUpdate(ctx_, buf, size) == 1);
+    ConcordAssert(updating_);
+    ConcordAssert(EVP_DigestUpdate(ctx_, buf, size) == 1);
   }
 
   Digest finish() {
     Digest digest;
     unsigned int _digest_len;
-    Assert(EVP_DigestFinal_ex(ctx_, digest.data(), &_digest_len) == 1);
-    Assert(_digest_len == SIZE_IN_BYTES);
+    ConcordAssert(EVP_DigestFinal_ex(ctx_, digest.data(), &_digest_len) == 1);
+    ConcordAssert(_digest_len == SIZE_IN_BYTES);
     updating_ = false;
     return digest;
   }

--- a/util/include/thread_pool.hpp
+++ b/util/include/thread_pool.hpp
@@ -32,7 +32,7 @@ class ThreadPool {
  public:
   // Starts the thread pool with thread_count > 0 threads.
   ThreadPool(unsigned int thread_count) noexcept {
-    Assert(thread_count > 0);
+    ConcordAssert(thread_count > 0);
     for (auto i = 0u; i < thread_count; ++i) {
       threads_.emplace_back([this]() { loop(); });
     }
@@ -86,7 +86,7 @@ class ThreadPool {
         task_queue_.cv.wait(lock);
       }
       if (task_queue_.stop) break;
-      Assert(!task_queue_.tasks.empty());
+      ConcordAssert(!task_queue_.tasks.empty());
       auto task = std::move(task_queue_.tasks.front());
       task_queue_.tasks.pop();
       lock.unlock();

--- a/util/src/sliver.cpp
+++ b/util/src/sliver.cpp
@@ -37,7 +37,7 @@ Sliver::Sliver() : data_(shared_ptr<const char[]>()), offset_(0), length_(0) {}
 Sliver::Sliver(const char* data, const size_t length)
     : data_(std::shared_ptr<const char[]>(data)), offset_(0), length_(length) {
   // Data must be non-null.
-  Assert(data != nullptr);
+  ConcordAssert(data != nullptr);
 }
 
 /**
@@ -49,9 +49,9 @@ Sliver::Sliver(const Sliver& base, const size_t offset, const size_t length)
       offset_(base.offset_ + offset),
       length_(length) {
   // This sliver must start no later than the end of the base sliver.
-  Assert(offset <= base.length_);
+  ConcordAssert(offset <= base.length_);
   // This sliver must end no later than the end of the base sliver.
-  Assert(length <= base.length_ - offset);
+  ConcordAssert(length <= base.length_ - offset);
 }
 
 /**
@@ -80,7 +80,7 @@ Sliver Sliver::copy(const char* data, const size_t length) {
 char Sliver::operator[](const size_t offset) const {
   const size_t total_offset = offset_ + offset;
   // This offset must be within this sliver.
-  Assert(offset < length_);
+  ConcordAssert(offset < length_);
 
   // The data for the requested offset is that many bytes after the offset from
   // the base sliver.

--- a/util/test/sha3_256_tests.cpp
+++ b/util/test/sha3_256_tests.cpp
@@ -28,7 +28,7 @@ SHA3_256::Digest string_to_array(const char* s) {
 
   for (size_t i = 0; i < SHA3_256::SIZE_IN_BYTES * 2; i++) {
     auto c = s[i];
-    Assert((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+    ConcordAssert((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
     uint8_t nibble = 0;
     ;
     if (c >= '0' && c <= '9') {


### PR DESCRIPTION
Reason:
The name `Assert` is not unique and conflicts with Google Test:
```
/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:295:36: error: too many arguments provided to function-like macro invocation
inline void Assert(bool condition, const char* file, int line,
```
Using `#undef` seems to be tricky.

The problem was discovered after `assert` was replaced with `Assert`.

Changes:
All the macros `Assert*` were renamed to `ConcordAssert*`.
Example, `AssertOR` -> `ConcordAssertOR`.

Feel free to propose other prefixes.