### PR TITLE
Mechanism for registering Reserved Pages client.

### DIFF
--- a/bftengine/include/bftengine/ReservedPages.hpp
+++ b/bftengine/include/bftengine/ReservedPages.hpp
@@ -1,0 +1,117 @@
+// Concord
+//
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <typeindex>
+#include <algorithm>
+#include <tuple>
+#include <vector>
+#include <iostream>
+#include "demangle.hpp"
+
+namespace bftEngine {
+
+class ReservedPages {
+ public:
+  static uint32_t totalNumberOfPages() {
+    uint32_t numPages{0};
+    for (auto& elt : registry()) numPages += std::get<2>(elt);
+
+    return numPages;
+  }
+
+ protected:
+  // [idx, typeid, numberOfPages]
+  typedef std::vector<std::tuple<std::uint8_t, std::type_index, std::uint32_t>> Registry;
+
+  static Registry& registry() {
+    static Registry registry_;
+    return registry_;
+  }
+};
+/**
+ * Facility for registering Reserved Pages clients
+ *
+ * Become a Reserved Pages client by sub-classing:
+ * class MyClass: public ResPagesClient<MyClass, idx, requiredNumberOfPages> {};
+ * where idx is a unique integer used for dividing a reserved pages space into sub-spaces.
+ * If requiredNumberOfPages is not known at compile time call setNumResPages(requiredNumberOfPages).
+ */
+template <typename T, uint8_t Idx, uint32_t NumPages = 0>
+class ResPagesClient : public ReservedPages {
+ public:
+  ResPagesClient() { (void)registered_; }
+
+  static bool registerT() {
+    Registry& reg = registry();
+    auto it = std::find_if(reg.begin(), reg.end(), [](const Registry::value_type& v) { return std::get<0>(v) == Idx; });
+    if (it != reg.end()) {
+      std::cerr << "BUG: ResPagesClient<" << demangler::demangle(typeid(T).name()) << ", " << (int)Idx
+                << ">: index is used by " << demangler::demangle(std::get<1>(*it).name());
+      std::terminate();
+    }
+    reg.push_back(Registry::value_type(Idx, std::type_index(typeid(T)), NumPages));
+    // sorting by clients' index
+    std::sort(reg.begin(), reg.end(), [](const Registry::value_type& v1, const Registry::value_type& v2) {
+      return std::get<0>(v1) < std::get<0>(v2);
+    });
+
+    return true;
+  }
+  /**
+   * Should be called at initialization if number of pages is not known at compile time
+   */
+  static void setNumResPages(const uint32_t numPages) {
+    Registry& reg = registry();
+    auto it = std::find_if(reg.begin(), reg.end(), [](const Registry::value_type& v) {
+      return std::get<1>(v) == std::type_index(typeid(T));
+    });
+    if (it == reg.end()) {
+      std::cerr << __PRETTY_FUNCTION__
+                << " BUG: not registered: " << demangler::demangle(std::type_index(typeid(T)).name()) << std::endl;
+      std::terminate();
+    }
+    std::get<2>(*it) = numPages;
+  }
+
+ protected:
+  /**
+   * is called when calculating absolute pageId
+   */
+  uint32_t resPageOffset() {
+    static uint32_t offset_ = calcOffset();
+    return offset_;
+  }
+
+ private:
+  // is done once per client
+  uint32_t calcOffset() {
+    uint32_t offset = 0;
+    for (auto& elt : registry()) {
+      if (std::get<1>(elt) == std::type_index(typeid(T))) return offset;
+      offset += std::get<2>(elt);
+    }
+    std::cerr << __PRETTY_FUNCTION__ << " BUG: not registered: " << demangler::demangle(typeid(T).name()) << std::endl;
+    std::terminate();
+    return 0;
+  }
+  static bool registered_;
+};
+// static registration
+template <typename T, uint8_t Idx, uint32_t NumPages>
+bool ResPagesClient<T, Idx, NumPages>::registered_ = ResPagesClient<T, Idx, NumPages>::registerT();
+
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -62,14 +62,14 @@ void ClientsManager::init(IStateTransfer* stateTransfer) {
 uint32_t ClientsManager::numberOfRequiredReservedPages() const { return requiredNumberOfPages_; }
 
 void ClientsManager::clearReservedPages() {
-  for (uint32_t i = 0; i < requiredNumberOfPages_; i++) stateTransfer_->zeroReservedPage(i);
+  for (uint32_t i = 0; i < requiredNumberOfPages_; i++) stateTransfer_->zeroReservedPage(resPageOffset() + i);
 }
 
 void ClientsManager::loadInfoFromReservedPages() {
   for (std::pair<NodeIdType, uint16_t> e : clientIdToIndex_) {
     const uint32_t firstPageId = e.second * reservedPagesPerClient_;
 
-    if (!stateTransfer_->loadReservedPage(firstPageId, sizeOfReservedPage_, scratchPage_)) continue;
+    if (!stateTransfer_->loadReservedPage(resPageOffset() + firstPageId, sizeOfReservedPage_, scratchPage_)) continue;
 
     ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_;
     Assert(replyHeader->msgType == 0 || replyHeader->msgType == MsgCode::ClientReply);
@@ -141,7 +141,7 @@ ClientReplyMsg* ClientsManager::allocateNewReplyMsgAndWriteToStorage(
   for (uint32_t i = 0; i < numOfPages; i++) {
     const char* ptrPage = r->body() + i * sizeOfReservedPage_;
     const uint32_t sizePage = ((i < numOfPages - 1) ? sizeOfReservedPage_ : sizeLastPage);
-    stateTransfer_->saveReservedPage(firstPageId + i, sizePage, ptrPage);
+    stateTransfer_->saveReservedPage(resPageOffset() + firstPageId + i, sizePage, ptrPage);
   }
 
   // write currentPrimaryId to message (we don't store the currentPrimaryId in the reserved pages)
@@ -163,7 +163,7 @@ ClientReplyMsg* ClientsManager::allocateMsgWithLatestReply(NodeIdType clientId, 
 
   LOG_DEBUG(GL, "info.lastSeqNumberOfReply=" << info.lastSeqNumberOfReply << " firstPageId=" << firstPageId);
 
-  stateTransfer_->loadReservedPage(firstPageId, sizeOfReservedPage_, scratchPage_);
+  stateTransfer_->loadReservedPage(resPageOffset() + firstPageId, sizeOfReservedPage_, scratchPage_);
 
   ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_;
   Assert(replyHeader->msgType == MsgCode::ClientReply);
@@ -189,7 +189,7 @@ ClientReplyMsg* ClientsManager::allocateMsgWithLatestReply(NodeIdType clientId, 
   for (uint32_t i = 0; i < numOfPages; i++) {
     char* const ptrPage = r->body() + i * sizeOfReservedPage_;
     const uint32_t sizePage = ((i < numOfPages - 1) ? sizeOfReservedPage_ : sizeLastPage);
-    stateTransfer_->loadReservedPage(firstPageId + i, sizePage, ptrPage);
+    stateTransfer_->loadReservedPage(resPageOffset() + firstPageId + i, sizePage, ptrPage);
   }
 
   r->setPrimaryId(currentPrimaryId);

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -13,7 +13,7 @@
 
 #include "PrimitiveTypes.hpp"
 #include "TimeUtils.hpp"
-
+#include "ReservedPages.hpp"
 #include <map>
 #include <set>
 #include <vector>
@@ -25,7 +25,7 @@ namespace impl {
 class ClientReplyMsg;
 class ClientRequestMsg;
 
-class ClientsManager {
+class ClientsManager : public ResPagesClient<ClientsManager, 0> {
  public:
   ClientsManager(ReplicaId myId, std::set<NodeIdType>& clientsSet, uint32_t sizeOfReservedPage);
   ~ClientsManager();

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -16,6 +16,7 @@
 #include "CheckpointInfo.hpp"
 #include "Logger.hpp"
 #include "PersistentStorage.hpp"
+#include "ClientsManager.hpp"
 
 using concordUtil::Timers;
 
@@ -37,6 +38,9 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint,
                                    bind(&ReadOnlyReplica::messageHandler<CheckpointMsg>, this, std::placeholders::_1));
   metrics_.Register();
+  // must be initialized although is not used by ReadOnlyReplica for proper behavior of StateTransfer
+  ClientsManager::setNumResPages((config.numOfClientProxies + config.numOfExternalClients) *
+                                 config.maxReplyMessageSize / config.sizeOfReservedPage);
 }
 
 void ReadOnlyReplica::start() {

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -60,6 +60,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   Timers::Handle stateTranTimer_;
   CounterHandle metric_received_state_transfers_;
   GaugeHandle metric_state_transfer_timer_;
+  bool firstTime_;
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3027,13 +3027,11 @@ ReplicaImp::ReplicaImp(bool firstTime,
   std::set<NodeIdType> clientsSet;
   const auto numOfEntities = config_.numReplicas + config_.numOfClientProxies + config_.numOfExternalClients;
   for (uint16_t i = config_.numReplicas; i < numOfEntities; i++) clientsSet.insert(i);
-
   clientsManager =
       new ClientsManager(config_.replicaId, clientsSet, ReplicaConfigSingleton::GetInstance().GetSizeOfReservedPage());
-
+  clientsManager->setNumResPages((config_.numOfClientProxies + config_.numOfExternalClients) *
+                                 config_.maxReplyMessageSize / config_.sizeOfReservedPage);
   clientsManager->init(stateTransfer.get());
-
-  if (!firstTime || config_.debugPersistentStorageEnabled) clientsManager->loadInfoFromReservedPages();
 
   // autoPrimaryRotationEnabled implies viewChangeProtocolEnabled
   // Note: "p=>q" is equivalent to "not p or q"
@@ -3155,6 +3153,7 @@ void ReplicaImp::addTimers() {
 
 void ReplicaImp::start() {
   ReplicaForStateTransfer::start();
+  if (!firstTime_ || config_.debugPersistentStorageEnabled) clientsManager->loadInfoFromReservedPages();
   addTimers();
   processMessages();
 }


### PR DESCRIPTION
State Transfer provides basic operations on Reserved Pages, such as load(pageid), save(pageid), zero(pageid).
Different modules allocate different number of reserved pages for their needs and require their own "reserved page space" and therefore there's a need for a mechanism which will split this the whole page space between them.

