### PR TITLE
[Apollo] Stabilize pre-execution view change test

### DIFF
--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -180,17 +180,6 @@ class SkvbcPreExecutionTest(unittest.TestCase):
                                             expected=lambda v: v == expected_next_primary,
                                             err_msg="Make sure view change has been triggered.")
 
-        new_last_block = 0
-        for retry in range(60):
-            try:
-                new_last_block = await tracker.get_last_block_id(client)
-            except trio.TooSlowError:
-                continue
-            else:
-                break
-
-        self.assertEqual(new_last_block, last_block)
-
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)


### PR DESCRIPTION
In some cases, if the view change happens fast enough, and depending on the BFT client's retry policy, a block may eventually get created. So I'm removing the assertion that makes sure no blocks are created during pre-execution with a crashed primary.