### PR TITLE
Ignore certain files in the CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,13 +1,14 @@
 name: Build
-on: [push, pull_request]
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
-  # push:
-  #     branches:
-  #     - master
-  # pull_request:
-  #     branches:
-  #     - master
+on:
+    push:
+        paths-ignore:
+            - '**.md'
+            - '**.png'
+    pull_request:
+        paths-ignore:
+            - '**.md'
+            - '**.png'
+
 env:
     DOCKER_REPO: concordbft
     DOCKER_IMAGE: concord-bft

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,5 +1,15 @@
 name: clang-tidy
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - '**.py'
+            - '**.md'
+            - '**.png'
+    pull_request:
+        paths-ignore:
+            - '**.py'
+            - '**.md'
+            - '**.png'
 
 env:
     DOCKER_REPO: concordbft


### PR DESCRIPTION
Files ignored in GitHub Actions:

1. Build:
    -  png
    -  md
2. clang-tidy:
    -  png
    -  md
    -  py

More information about the [ignored paths](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths).

Unfortunately, Travis CI does not support this feature.
The only way to skip a build is to add a [special keyword](https://docs.travis-ci.com/user/customizing-the-build#skipping-a-build) to the commit message.