### PR TITLE
Add infrastructure for bft multi KeyExchange msg

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -57,6 +57,8 @@ set(corebft_source_files
     src/bftengine/messages/ViewChangeMsg.cpp
     src/bftengine/messages/ReplicaStatusMsg.cpp
     src/bftengine/messages/StateTransferMsg.cpp
+    src/bftengine/KeyManager.cpp
+    src/bftengine/RequestHandler.cpp
     src/bftengine/ControlStateManager.cpp
 )
 

--- a/bftengine/include/bftengine/IBasicClient.h
+++ b/bftengine/include/bftengine/IBasicClient.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "status.hpp"
+#include <chrono>
+#include <string>
+
+namespace bftEngine {
+
+class IBasicClient {
+ public:
+  virtual ~IBasicClient() = default;
+  virtual concordUtils::Status invokeCommandSynch(const char* request,
+                                                  uint32_t requestSize,
+                                                  uint8_t flags,
+                                                  std::chrono::milliseconds timeout,
+                                                  uint32_t replySize,
+                                                  char* outReply,
+                                                  uint32_t* outActualReplySize,
+                                                  const std::string& cid = "",
+                                                  const std::string& span_context = "") = 0;
+};
+
+}  // namespace bftEngine

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -32,7 +32,8 @@ enum MsgFlag : uint8_t {
   EMPTY_FLAGS = 0x0,
   READ_ONLY_FLAG = 0x1,
   PRE_PROCESS_FLAG = 0x2,
-  HAS_PRE_PROCESSED_FLAG = 0x4
+  HAS_PRE_PROCESSED_FLAG = 0x4,
+  KEY_EXCHANGE_FLAG = 0x8
 };
 
 // The ControlHandlers is a group of method that enables the userRequestHandler to perform infrastructure

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -118,6 +118,8 @@ struct ReplicaConfig {
 
   // Metrics dump interval
   uint64_t metricsDumpIntervalSeconds = 600;
+
+  bool keyExchangeOnStart = false;
   /**
    * create a singleton instance from this object
    * call to this function will have effect only for the first time
@@ -148,7 +150,8 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
      << "maxNumOfReservedPages: " << rc.maxNumOfReservedPages << "\n"
      << "sizeOfReservedPage: " << rc.sizeOfReservedPage << "\n"
      << "debugStatisticsEnabled: " << rc.debugStatisticsEnabled << "\n"
-     << "metricsDumpIntervalSeconds: " << rc.metricsDumpIntervalSeconds << "\n";
+     << "metricsDumpIntervalSeconds: " << rc.metricsDumpIntervalSeconds << "\n"
+     << "keyExchangeOnStart: " << rc.keyExchangeOnStart << "\n";
   return os;
 }
 
@@ -165,6 +168,7 @@ class ReplicaConfigSingleton {
 
   uint16_t GetFVal() const { return config_->fVal; }
   uint16_t GetCVal() const { return config_->cVal; }
+  uint16_t GetNumReplicas() const { return config_->numReplicas; }
   uint16_t GetReplicaId() const { return config_->replicaId; }
   uint16_t GetNumOfClientProxies() const { return config_->numOfClientProxies; }
   uint16_t GetNumOfExternalClients() const { return config_->numOfExternalClients; }
@@ -209,6 +213,8 @@ class ReplicaConfigSingleton {
   uint64_t GetMetricsDumpInterval() const { return config_->metricsDumpIntervalSeconds; }
 
   bool GetDebugStatisticsEnabled() const { return config_->debugStatisticsEnabled; }
+
+  bool GetKeyExchangeOnStart() const { return config_->keyExchangeOnStart; }
 
  private:
   friend struct ReplicaConfig;

--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -1,0 +1,75 @@
+#include "KeyManager.h"
+#include "thread"
+#include "ReplicaImp.hpp"
+#include "ReplicaConfig.hpp"
+
+const std::string KeyManager::KeyExchangeMsg::getVersion() const { return "1"; }
+
+KeyManager::KeyExchangeMsg KeyManager::KeyExchangeMsg::deserializeMsg(const char* serializedMsg, const uint32_t& size) {
+  std::stringstream ss;
+  KeyManager::KeyExchangeMsg ke;
+  ss.write(serializedMsg, std::streamsize(size));
+  deserialize(ss, ke);
+  return ke;
+}
+
+void KeyManager::KeyExchangeMsg::serializeDataMembers(std::ostream& outStream) const {
+  serialize(outStream, key);
+  LOG_TRACE(GL, "KEY EXCHANGE MANAGER  ser  key_ " << key);
+  serialize(outStream, signature);
+  LOG_TRACE(GL, "KEY EXCHANGE MANAGER  ser  signature_ " << signature);
+  serialize(outStream, repID);
+  LOG_TRACE(GL, "KEY EXCHANGE MANAGER  ser  repID_ " << repID);
+}
+
+void KeyManager::KeyExchangeMsg::deserializeDataMembers(std::istream& inStream) {
+  deserialize(inStream, key);
+  deserialize(inStream, signature);
+  deserialize(inStream, repID);
+}
+
+std::string KeyManager::KeyExchangeMsg::toString() const {
+  std::stringstream ss;
+  ss << "key [" << key << "] signature [" << signature << "] replica id [" << repID << "]";
+  return ss.str();
+}
+
+void KeyManager::set(bftEngine::IBasicClient* cl, const int& id) {
+  cl_ = cl;
+  repID_ = id;
+}
+
+/*
+Usage:
+  KeyExchangeMsg msg{key,sig,id};
+  std::stringstream ss;
+  concord::serialize::Serializable::serialize(ss, msg);
+  auto strMsg = ss.str();
+  char buff[128];
+  uint32_t actSize{};
+  // magic numbers, need to check valid values.
+  cl_->invokeCommandSynch(strMsg.c_str(),
+                          strMsg.size(),
+                          bftEngine::KEY_EXCHANGE_FLAG,
+                          std::chrono::milliseconds(60000),
+                          44100,
+                          buff,
+                          &actSize);
+*/
+void KeyManager::sendKeyExchange() { LOG_DEBUG(GL, "KEY EXCHANGE MANAGER  send msg"); }
+
+std::string KeyManager::onKeyExchange(const KeyExchangeMsg& kemsg) {
+  static int counter = 0;
+  counter++;
+  LOG_DEBUG(GL, "KEY EXCHANGE MANAGER  msg " << kemsg.toString());
+  auto numRep = bftEngine::ReplicaConfigSingleton::GetInstance().GetNumReplicas();
+  if (counter < numRep) {
+    LOG_DEBUG(GL, "Exchanged [" << counter << "] out of [" << numRep << "]");
+  } else if (counter == numRep) {
+    LOG_INFO(GL, "KEY EXCHANGE: start accepting msgs");
+    keysExchanged = true;
+  }
+  return "ok";
+}
+
+void KeyManager::onCheckpoint(const int& num) { LOG_DEBUG(GL, "KEY EXCHANGE MANAGER check point  " << num); }

--- a/bftengine/src/bftengine/KeyManager.h
+++ b/bftengine/src/bftengine/KeyManager.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Serializable.h"
+#include "IBasicClient.h"
+
+class KeyManager {
+ public:
+  struct KeyExchangeMsg : public concord::serialize::SerializableFactory<KeyExchangeMsg> {
+    std::string key;
+    std::string signature;
+    uint32_t repID;
+    std::string toString() const;
+    static KeyExchangeMsg deserializeMsg(const char* serStr, const uint32_t& size);
+
+   protected:
+    const std::string getVersion() const;
+    void serializeDataMembers(std::ostream& outStream) const;
+    void deserializeDataMembers(std::istream& inStream);
+  };
+
+ private:
+  bftEngine::IBasicClient* cl_{nullptr};
+  int repID_{};
+  KeyManager() {}
+  KeyManager(const KeyManager&) = delete;
+  KeyManager(const KeyManager&&) = delete;
+  KeyManager& operator=(const KeyManager&) = delete;
+  KeyManager& operator=(const KeyManager&&) = delete;
+
+ public:
+  std::atomic_bool keysExchanged{false};
+  void set(bftEngine::IBasicClient* cl, const int& id);
+  void sendKeyExchange();
+  std::string onKeyExchange(const KeyExchangeMsg& kemsg);
+  void onCheckpoint(const int& num);
+
+  static KeyManager& get() {
+    static KeyManager km;
+    return km;
+  }
+};

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -32,7 +32,7 @@ uint32_t ReplicaConfigSerializer::maxSize(uint32_t numOfReplicas) {
           IThresholdVerifier::maxSize() * 3 + sizeof(config_->maxExternalMessageSize) +
           sizeof(config_->maxReplyMessageSize) + sizeof(config_->maxNumOfReservedPages) +
           sizeof(config_->sizeOfReservedPage) + sizeof(config_->debugPersistentStorageEnabled) +
-          sizeof(config_->metricsDumpIntervalSeconds));
+          sizeof(config_->metricsDumpIntervalSeconds) + sizeof(config_->keyExchangeOnStart));
 }
 
 ReplicaConfigSerializer::ReplicaConfigSerializer(ReplicaConfig *config) {
@@ -135,6 +135,8 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
 
   // Serialize metricsDumpIntervalSeconds
   outStream.write((char *)&config_->metricsDumpIntervalSeconds, sizeof(config_->metricsDumpIntervalSeconds));
+
+  outStream.write((char *)&config_->keyExchangeOnStart, sizeof(config_->keyExchangeOnStart));
 }
 
 void ReplicaConfigSerializer::serializePointer(Serializable *ptrToClass, ostream &outStream) const {
@@ -172,7 +174,8 @@ bool ReplicaConfigSerializer::operator==(const ReplicaConfigSerializer &other) c
        (other.config_->maxReplyMessageSize == config_->maxReplyMessageSize) &&
        (other.config_->maxNumOfReservedPages == config_->maxNumOfReservedPages) &&
        (other.config_->sizeOfReservedPage == config_->sizeOfReservedPage) &&
-       (other.config_->metricsDumpIntervalSeconds == config_->metricsDumpIntervalSeconds));
+       (other.config_->metricsDumpIntervalSeconds == config_->metricsDumpIntervalSeconds) &&
+       (other.config_->keyExchangeOnStart == config_->keyExchangeOnStart));
   return result;
 }
 
@@ -252,6 +255,8 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
 
   // Deserialize metricsDumpIntervalSeconds
   inStream.read((char *)&config.metricsDumpIntervalSeconds, sizeof(config.metricsDumpIntervalSeconds));
+
+  inStream.read((char *)&config.keyExchangeOnStart, sizeof(config.keyExchangeOnStart));
 }
 
 SerializablePtr ReplicaConfigSerializer::deserializePointer(std::istream &inStream) {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -38,6 +38,7 @@
 #include "messages/FullCommitProofMsg.hpp"
 #include "messages/ReplicaStatusMsg.hpp"
 #include "messages/AskForCheckpointMsg.hpp"
+#include "KeyManager.h"
 
 #include <string>
 #include <type_traits>
@@ -164,6 +165,16 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
   span.setTag("rid", config_.replicaId);
   span.setTag("cid", m->getCid());
   span.setTag("seq_num", reqSeqNum);
+
+  if (ReplicaConfigSingleton::GetInstance().GetKeyExchangeOnStart()) {
+    // If Multi sig keys havn't been replaced for all replicas and it's not a key ex msg
+    // then don't accept the msg.
+    if (!KeyManager::get().keysExchanged && !(flags & KEY_EXCHANGE_FLAG)) {
+      LOG_INFO(GL, "KEY EXCHANGE didn't complete yet, dropping msg");
+      delete m;
+      return;
+    }
+  }
 
   if (isCollectingState()) {
     LOG_INFO(GL,
@@ -2341,7 +2352,7 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
 
 void ReplicaImp::onSeqNumIsSuperStable(SeqNum newSuperStableSeqNum) {
   if (controlStateManager_->getStopCheckpointToStopAt() == newSuperStableSeqNum) {
-    if (userRequestsHandler->getControlHandlers()) userRequestsHandler->getControlHandlers()->onSuperStableCheckpoint();
+    if (bftRequestsHandler_.getControlHandlers()) bftRequestsHandler_.getControlHandlers()->onSuperStableCheckpoint();
   }
 }
 void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformation, bool oldSeqNum) {
@@ -2986,7 +2997,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       autoPrimaryRotationEnabled{config.autoPrimaryRotationEnabled},
       restarted_{!firstTime},
       replyBuffer{(char *)std::malloc(config_.maxReplyMessageSize - sizeof(ClientReplyMsgHeader))},
-      userRequestsHandler{requestsHandler},
+      bftRequestsHandler_{requestsHandler},
       timeOfLastStateSynch{getMonotonicTime()},    // TODO(GG): TBD
       timeOfLastViewEntrance{getMonotonicTime()},  // TODO(GG): TBD
       timeOfLastAgreedView{getMonotonicTime()},    // TODO(GG): TBD
@@ -3243,16 +3254,16 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
   uint32_t actualReplyLength = 0;
   uint32_t actualReplicaSpecificInfoLength = 0;
 
-  error = userRequestsHandler->execute(clientId,
-                                       lastExecutedSeqNum,
-                                       READ_ONLY_FLAG,
-                                       request->requestLength(),
-                                       request->requestBuf(),
-                                       reply.maxReplyLength(),
-                                       reply.replyBuf(),
-                                       actualReplyLength,
-                                       actualReplicaSpecificInfoLength,
-                                       span);
+  error = bftRequestsHandler_.execute(clientId,
+                                      lastExecutedSeqNum,
+                                      READ_ONLY_FLAG,
+                                      request->requestLength(),
+                                      request->requestBuf(),
+                                      reply.maxReplyLength(),
+                                      reply.replyBuf(),
+                                      actualReplyLength,
+                                      actualReplicaSpecificInfoLength,
+                                      span);
 
   LOG_DEBUG(GL,
             "Executed read only request. " << KVLOG(clientId,
@@ -3373,7 +3384,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
 
       uint32_t actualReplyLength = 0;
       uint32_t actualReplicaSpecificInfoLength = 0;
-      userRequestsHandler->execute(
+      bftRequestsHandler_.execute(
           clientId,
           lastExecutedSeqNum + 1,
           req.flags(),
@@ -3397,8 +3408,9 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
     }
   }
 
+  uint64_t checkpointNum{};
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {
-    const uint64_t checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;
+    checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;
     stateTransfer->createCheckpointOfCurrentState(checkpointNum);
   }
 
@@ -3444,11 +3456,13 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
     if (checkInfo.isCheckpointSuperStable()) {
       onSeqNumIsSuperStable(lastStableSeqNum);
     }
+
+    KeyManager::get().onCheckpoint(checkpointNum);
   }
 
   if (ps_) ps_->endWriteTran();
 
-  if (numOfRequests > 0) userRequestsHandler->onFinishExecutingReadWriteRequests();
+  if (numOfRequests > 0) bftRequestsHandler_.onFinishExecutingReadWriteRequests();
 
   sendCheckpointIfNeeded();
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -30,6 +30,7 @@
 #include "SimpleThreadPool.hpp"
 #include "Bitmap.hpp"
 #include "OpenTracing.hpp"
+#include "RequestHandler.h"
 
 namespace bftEngine::impl {
 
@@ -121,7 +122,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   size_t maxNumberOfPendingRequestsInRecentHistory = 0;
   size_t batchingFactor = 1;
 
-  IRequestsHandler* const userRequestsHandler = nullptr;
+  RequestHandler bftRequestsHandler_;
 
   // used to dynamically estimate a upper bound for consensus rounds
   DynamicUpperLimitWithSimpleFilter<int64_t>* dynamicUpperLimitOfRounds = nullptr;
@@ -234,7 +235,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   virtual bool isReadOnly() const override { return false; }
 
   shared_ptr<PersistentStorage> getPersistentStorage() const { return ps_; }
-  IRequestsHandler* getRequestsHandler() const { return userRequestsHandler; }
+  IRequestsHandler* getRequestsHandler() { return &bftRequestsHandler_; }
 
   void processMessages();
 

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -121,6 +121,7 @@ void setDynamicallyConfigurableParameters(ReplicaConfig &config) {
   config.sizeOfReservedPage = ReplicaConfigSingleton::GetInstance().GetSizeOfReservedPage();
   config.debugStatisticsEnabled = ReplicaConfigSingleton::GetInstance().GetDebugStatisticsEnabled();
   config.metricsDumpIntervalSeconds = ReplicaConfigSingleton::GetInstance().GetMetricsDumpInterval();
+  config.keyExchangeOnStart = ReplicaConfigSingleton::GetInstance().GetKeyExchangeOnStart();
 }
 
 ReplicaLoader::ErrorCode loadConfig(shared_ptr<PersistentStorage> &p, LoadedReplicaData &ld) {

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -1,0 +1,51 @@
+#include <RequestHandler.h>
+#include <KeyManager.h>
+#include <sstream>
+
+namespace bftEngine {
+
+int RequestHandler::execute(uint16_t clientId,
+                            uint64_t sequenceNum,
+                            uint8_t flags,
+                            uint32_t requestSize,
+                            const char *request,
+                            uint32_t maxReplySize,
+                            char *outReply,
+                            uint32_t &outActualReplySize,
+                            uint32_t &outReplicaSpecificInfoSize,
+                            concordUtils::SpanWrapper &parent_span) {
+  if (flags & KEY_EXCHANGE_FLAG) {
+    KeyManager::KeyExchangeMsg ke = KeyManager::KeyExchangeMsg::deserializeMsg(request, requestSize);
+    LOG_DEBUG(GL, "BFT handler received KEY_EXCHANGE msg " << ke.toString());
+    auto resp = KeyManager::get().onKeyExchange(ke);
+    if (resp.size() <= maxReplySize) {
+      std::copy(resp.begin(), resp.end(), outReply);
+      outActualReplySize = resp.size();
+    } else {
+      LOG_ERROR(GL, "KEY_EXCHANGE response is too large, response " << resp);
+      outActualReplySize = 0;
+    }
+    return 0;
+  }
+
+  return userRequestsHandler_->execute(clientId,
+                                       sequenceNum,
+                                       flags,
+                                       requestSize,
+                                       request,
+                                       maxReplySize,
+                                       outReply,
+                                       outActualReplySize,
+                                       outReplicaSpecificInfoSize,
+                                       parent_span);
+}
+
+void RequestHandler::onFinishExecutingReadWriteRequests() {
+  userRequestsHandler_->onFinishExecutingReadWriteRequests();
+}
+
+std::shared_ptr<ControlHandlers> RequestHandler::getControlHandlers() {
+  return userRequestsHandler_->getControlHandlers();
+}
+
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -1,0 +1,28 @@
+#include <Replica.hpp>
+
+#pragma once
+
+namespace bftEngine {
+
+class RequestHandler : public IRequestsHandler {
+ public:
+  RequestHandler(IRequestsHandler *userHdlr) : userRequestsHandler_(userHdlr) {}
+  virtual int execute(uint16_t clientId,
+                      uint64_t sequenceNum,
+                      uint8_t flags,
+                      uint32_t requestSize,
+                      const char *request,
+                      uint32_t maxReplySize,
+                      char *outReply,
+                      uint32_t &outActualReplySize,
+                      uint32_t &outReplicaSpecificInfoSize,
+                      concordUtils::SpanWrapper &parent_span) override;
+  virtual void onFinishExecutingReadWriteRequests() override;
+
+  virtual std::shared_ptr<ControlHandlers> getControlHandlers() override;
+
+ private:
+  IRequestsHandler *const userRequestsHandler_ = nullptr;
+};
+
+}  // namespace bftEngine

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -21,6 +21,7 @@
 #include "db_interfaces.h"
 #include "bftengine/Replica.hpp"
 #include "kv_types.hpp"
+#include "IBasicClient.h"
 
 namespace concord::kvbc {
 
@@ -50,23 +51,13 @@ struct ClientConfig {
 /////////////////////////////////////////////////////////////////////////////
 
 // Represents a client of the blockchain database
-class IClient {
+class IClient : public bftEngine::IBasicClient {
  public:
   virtual ~IClient() = default;
   virtual Status start() = 0;
   virtual Status stop() = 0;
 
   virtual bool isRunning() = 0;
-
-  virtual Status invokeCommandSynch(const char* request,
-                                    uint32_t requestSize,
-                                    uint8_t flags,
-                                    std::chrono::milliseconds timeout,
-                                    uint32_t replySize,
-                                    char* outReply,
-                                    uint32_t* outActualReplySize,
-                                    const std::string& cid = "",
-                                    const std::string& span_context = "") = 0;
 
   virtual void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) = 0;
 };


### PR DESCRIPTION
- KeyManager singleton class, that manages all related multi-signature functionality e.g. generates keys, initiates the client request using its ICLient member, etc.

- BFT handler the wraps the user handler and forward requests to it as before, unless the request is a BFT msg such as KeyExchange msg.

- A feature flag to enable this feature.

- Once the feature is enabled, the BFT won't accept any msgs other then KeyExchange msgs until all replicas have published there newly generated key.

- Call back is called each checkpoint.

- KeyExchange struct.