### PR TITLE
[Apollo] Accelerate test scenarios, while preserving stability

### DIFF
--- a/tests/apollo/test_skvbc_backup_restore.py
+++ b/tests/apollo/test_skvbc_backup_restore.py
@@ -102,7 +102,8 @@ class SkvbcBackupRestoreTest(unittest.TestCase):
         )
 
     @staticmethod
-    async def _stop_random_replicas_with_delay(bft_network, replica_set_size, delay=10, exclude_replicas=None):
+    async def _stop_random_replicas_with_delay(
+            bft_network, replica_set_size, delay=5, exclude_replicas=None):
         random_replicas = bft_network.random_set_of_replicas(size=replica_set_size, without=exclude_replicas)
         for replica in random_replicas:
             bft_network.stop_replica(replica)
@@ -110,7 +111,8 @@ class SkvbcBackupRestoreTest(unittest.TestCase):
         return list(random_replicas)
 
     @staticmethod
-    async def _start_random_replicas_with_delay(bft_network, stopped_replicas, delay=10):
+    async def _start_random_replicas_with_delay(
+            bft_network, stopped_replicas, delay=5):
         random.shuffle(stopped_replicas)
         for replica in stopped_replicas:
             bft_network.start_replica(replica)

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -218,7 +218,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
             )
 
             # waiting for the active window to be rebuilt after the view change
-            await trio.sleep(seconds=10)
+            await trio.sleep(seconds=5)
 
         # the adversary is not active anymore:
         # make sure the isolated replicas activate the new view

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -221,7 +221,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         )
 
         # waiting for the active window to be rebuilt after the view change
-        await trio.sleep(seconds=10)
+        await trio.sleep(seconds=5)
 
         # restart the unstable replica and make sure it works in the new view
         bft_network.start_replica(unstable_replica)
@@ -266,7 +266,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         bft_network.start_replica(initial_primary)
 
         # waiting for the active window to be rebuilt after the view change
-        await trio.sleep(seconds=10)
+        await trio.sleep(seconds=5)
 
         unstable_replica = random.choice(
             bft_network.all_replicas(without={current_primary, initial_primary}))

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0


### PR DESCRIPTION
Once again, we have hit the 50 min limitation for Travis job executions. This PR aims to unblock the pipeline.

PS: Ultimately, we should focus on stabilizing GitHub Actions runs, and drop Travis CI altogether.