### PR TITLE
revert: Ignore certain files in the CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,13 +1,5 @@
 name: Build
-on:
-    push:
-        paths-ignore:
-            - '**.md'
-            - '**.png'
-    pull_request:
-        paths-ignore:
-            - '**.md'
-            - '**.png'
+on: [push, pull_request]
 
 env:
     DOCKER_REPO: concordbft

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,15 +1,5 @@
 name: clang-tidy
-on:
-    push:
-        paths-ignore:
-            - '**.py'
-            - '**.md'
-            - '**.png'
-    pull_request:
-        paths-ignore:
-            - '**.py'
-            - '**.md'
-            - '**.png'
+on: [push, pull_request]
 
 env:
     DOCKER_REPO: concordbft


### PR DESCRIPTION
Reason:
A PR cannot be submitted if a required check did not run.
Even if the PR's content is ignored by the check.

More information:
https://github.com/actions/virtual-environments/issues/1281