### PR TITLE
Add support for state transfer complete callbacks

### DIFF
--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -74,7 +74,7 @@ class IStateTransfer {
   // Accepts the checkpoint number as a parameter.
   // Callbacks must not throw.
   // Multiple callbacks can be added.
-  virtual void addOnTransferringCompleteCallback(std::function<void(int64_t)>) = 0;
+  virtual void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) = 0;
 };
 
 // This interface may only be used when the state transfer module is runnning

--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 
 namespace bftEngine {
@@ -68,6 +69,12 @@ class IStateTransfer {
   // Return the internal state (member variables, etc...) of the state transfer module as a string. This is used by the
   // diagnostics subsystem.
   virtual std::string getStatus() { return ""; };
+
+  // Registers a function that is called every time State Transfer completes.
+  // Accepts the checkpoint number as a parameter.
+  // Callbacks must not throw.
+  // Multiple callbacks can be added.
+  virtual void addOnTransferringCompleteCallback(std::function<void(int64_t)>) = 0;
 };
 
 // This interface may only be used when the state transfer module is runnning

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -253,7 +253,7 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
   // Make sure that the internal IReplicaForStateTransfer callback is always registered, alongside any user-supplied
   // callbacks.
   on_transferring_complete_cb_registry_.registerCallback(
-      [this](int64_t checkpoint_num) { replicaForStateTransfer_->onTransferringComplete(checkpoint_num); });
+      [this](uint64_t checkpoint_num) { replicaForStateTransfer_->onTransferringComplete(checkpoint_num); });
 }
 
 BCStateTran::~BCStateTran() {
@@ -687,7 +687,7 @@ std::string BCStateTran::getStatus() {
   return oss.str();
 }
 
-void BCStateTran::addOnTransferringCompleteCallback(std::function<void(int64_t)> callback) {
+void BCStateTran::addOnTransferringCompleteCallback(std::function<void(uint64_t)> callback) {
   on_transferring_complete_cb_registry_.registerCallback(std::move(callback));
 }
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -250,9 +250,9 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
     messageHandler_ = std::bind(&BCStateTran::handleStateTransferMessageImp, this, _1, _2, _3);
   }
 
-  // Make sure that the internal IReplicaForStateTransfer callback is always registered, alongside any user-supplied
+  // Make sure that the internal IReplicaForStateTransfer callback is always added, alongside any user-supplied
   // callbacks.
-  on_transferring_complete_cb_registry_.registerCallback(
+  on_transferring_complete_cb_registry_.add(
       [this](uint64_t checkpoint_num) { replicaForStateTransfer_->onTransferringComplete(checkpoint_num); });
 }
 
@@ -688,7 +688,7 @@ std::string BCStateTran::getStatus() {
 }
 
 void BCStateTran::addOnTransferringCompleteCallback(std::function<void(uint64_t)> callback) {
-  on_transferring_complete_cb_registry_.registerCallback(std::move(callback));
+  on_transferring_complete_cb_registry_.add(std::move(callback));
 }
 
 void BCStateTran::handoff(char *msg, uint32_t msgLen, uint16_t senderId) {

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -84,7 +84,7 @@ class BCStateTran : public IStateTransfer {
 
   std::string getStatus() override;
 
-  void addOnTransferringCompleteCallback(std::function<void(int64_t)>) override;
+  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) override;
 
  protected:
   std::function<void(char*, uint32_t, uint16_t)> messageHandler_;
@@ -393,7 +393,7 @@ class BCStateTran : public IStateTransfer {
 
   mutable Metrics metrics_;
 
-  concord::util::CallbackRegistry<int64_t> on_transferring_complete_cb_registry_;
+  concord::util::CallbackRegistry<uint64_t> on_transferring_complete_cb_registry_;
 };
 
 }  // namespace bftEngine::SimpleBlockchainStateTransfer::impl

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -32,6 +32,7 @@
 #include "STDigest.hpp"
 #include "Metrics.hpp"
 #include "SourceSelector.hpp"
+#include "callback_registry.hpp"
 
 using std::set;
 using std::map;
@@ -82,6 +83,8 @@ class BCStateTran : public IStateTransfer {
   void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override;
 
   std::string getStatus() override;
+
+  void addOnTransferringCompleteCallback(std::function<void(int64_t)>) override;
 
  protected:
   std::function<void(char*, uint32_t, uint16_t)> messageHandler_;
@@ -389,6 +392,8 @@ class BCStateTran : public IStateTransfer {
   };
 
   mutable Metrics metrics_;
+
+  concord::util::CallbackRegistry<int64_t> on_transferring_complete_cb_registry_;
 };
 
 }  // namespace bftEngine::SimpleBlockchainStateTransfer::impl

--- a/bftengine/src/bftengine/NullStateTransfer.hpp
+++ b/bftengine/src/bftengine/NullStateTransfer.hpp
@@ -42,7 +42,7 @@ class NullStateTransfer : public IStateTransfer {
   virtual void onTimer() override;
   virtual void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override;
 
-  void addOnTransferringCompleteCallback(std::function<void(int64_t)>) override{};
+  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) override{};
 
   virtual ~NullStateTransfer();
 

--- a/bftengine/src/bftengine/NullStateTransfer.hpp
+++ b/bftengine/src/bftengine/NullStateTransfer.hpp
@@ -42,6 +42,8 @@ class NullStateTransfer : public IStateTransfer {
   virtual void onTimer() override;
   virtual void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override;
 
+  void addOnTransferringCompleteCallback(std::function<void(int64_t)>) override{};
+
   virtual ~NullStateTransfer();
 
  protected:

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -77,7 +77,7 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
   void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override;
 
-  void addOnTransferringCompleteCallback(std::function<void(int64_t)>) override {}
+  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) override {}
 
   //////////////////////////////////////////////////////////////////////////
   // ISimpleInMemoryStateTransfer methods

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -77,6 +77,8 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
   void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override;
 
+  void addOnTransferringCompleteCallback(std::function<void(int64_t)>) override {}
+
   //////////////////////////////////////////////////////////////////////////
   // ISimpleInMemoryStateTransfer methods
   //////////////////////////////////////////////////////////////////////////

--- a/util/include/callback_registry.hpp
+++ b/util/include/callback_registry.hpp
@@ -1,0 +1,96 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <list>
+#include <functional>
+#include <utility>
+
+namespace concord::util {
+
+// A move-only opaque callback handle. Supports callback invocation.
+template <typename Iterator>
+class GenericCallbackHandle {
+ public:
+  GenericCallbackHandle(const GenericCallbackHandle&) = delete;
+  GenericCallbackHandle& operator=(const GenericCallbackHandle&) = delete;
+  GenericCallbackHandle(GenericCallbackHandle&&) = default;
+  GenericCallbackHandle& operator=(GenericCallbackHandle&&) = default;
+
+  template <typename... InvokeArgs>
+  void invoke(InvokeArgs&&... args) const {
+    iter_->operator()(std::forward<InvokeArgs>(args)...);
+  }
+
+  bool operator==(const GenericCallbackHandle& other) const { return (iter_ == other.iter_); }
+  bool operator!=(const GenericCallbackHandle& other) const { return !(*this == other); }
+
+ private:
+  GenericCallbackHandle(Iterator iter) : iter_{iter} {};
+
+ private:
+  Iterator iter_;
+
+  template <typename...>
+  friend class CallbackRegistry;
+};
+
+// A callback registry that supports registration, deregistration and invocation of callbacks. Supports arbitrary
+// callback parameters. Callback return type is void.
+template <typename... Args>
+class CallbackRegistry {
+ private:
+  // Use an std::list in order to preserve iterators in handles after erase() calls.
+  using Callback = std::function<void(Args...)>;
+  using CallbackContainer = std::list<Callback>;
+  using Iterator = typename CallbackContainer::const_iterator;
+
+ public:
+  using CallbackHandle = GenericCallbackHandle<Iterator>;
+
+  CallbackRegistry() = default;
+  CallbackRegistry(const CallbackRegistry&) = delete;
+  CallbackRegistry& operator=(const CallbackRegistry&) = delete;
+
+  // Registers a callback and returns a handle to it. Handles are only valid for the registry instance that created
+  // them. Additionally, handles are invalidated when the registry is destructed.
+  template <typename Func>
+  CallbackHandle registerCallback(Func&& callback) {
+    callbacks_.emplace_back(std::forward<Func>(callback));
+    auto it = callbacks_.cend();
+    return --it;
+  }
+
+  // Deregisters a callback. The corresponding handle is invalidated if this method returns. If the passed handle is
+  // invalid, the behavior is undefined.
+  void deregisterCallback(CallbackHandle handle) { callbacks_.erase(handle.iter_); }
+
+  // Invokes all callbacks in the registry. Exceptions from callbacks are propagated to callers of this method.
+  // Invocation stops at the first exception thrown, without invoking further callbacks.
+  template <typename... InvokeArgs>
+  void invokeAll(InvokeArgs&&... args) const {
+    for (auto& callback : callbacks_) {
+      callback(std::forward<InvokeArgs>(args)...);
+    }
+  }
+
+  bool empty() const { return callbacks_.empty(); }
+  std::size_t size() const { return callbacks_.size(); }
+
+ private:
+  CallbackContainer callbacks_;
+};
+
+}  // namespace concord::util

--- a/util/include/callback_registry.hpp
+++ b/util/include/callback_registry.hpp
@@ -76,7 +76,7 @@ class GenericCallbackHandle {
   friend class CallbackRegistry;
 };
 
-// A callback registry that supports registration, deregistration and invocation of callbacks. Supports arbitrary
+// A callback registry that supports adding, removing and invoking callbacks. Supports arbitrary
 // callback parameters. Callback return type is void.
 template <typename... Args>
 class CallbackRegistry {
@@ -97,18 +97,18 @@ class CallbackRegistry {
   // them. Additionally, handles are invalidated when the registry is destructed. Using handles across registries or
   // after their corresponding registry has been destructed causes undefined bahavior.
   template <typename Func>
-  CallbackHandle registerCallback(Func&& callback) {
+  CallbackHandle add(Func&& callback) {
     callbacks_.emplace_back(std::forward<Func>(callback));
     auto it = callbacks_.cend();
     return --it;
   }
 
-  // Deregisters a callback. If the passed handle is invalid, an exception is thrown.
-  void deregisterCallback(CallbackHandle handle) {
+  // Removes a registered callback. If the passed handle is invalid, an exception is thrown.
+  void remove(CallbackHandle handle) {
     if (handle.iter_.has_value()) {
       callbacks_.erase(*handle.iter_);
     } else {
-      throw std::invalid_argument{"deregisterCallback() called with an invalid CallbackHandle"};
+      throw std::invalid_argument{"CallbackRegistry::remove() called with an invalid CallbackHandle"};
     }
   }
 

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -48,3 +48,7 @@ target_link_libraries(thread_pool_test GTest::Main util)
 add_executable(hex_tools_test hex_tools_test.cpp)
 add_test(hex_tools_test hex_tools_test)
 target_link_libraries(hex_tools_test GTest::Main util)
+
+add_executable(callback_registry_test callback_registry_test.cpp)
+add_test(callback_registry_test callback_registry_test)
+target_link_libraries(callback_registry_test GTest::Main util)

--- a/util/test/callback_registry_test.cpp
+++ b/util/test/callback_registry_test.cpp
@@ -1,0 +1,150 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "callback_registry.hpp"
+
+#include <exception>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using testing::InitGoogleTest;
+using namespace concord::util;
+
+constexpr auto answer = 42;
+auto global_calls = 0;
+void func(int, long) { ++global_calls; }
+
+TEST(callback_registry, lambda_no_args) {
+  auto calls = 0;
+  auto reg = CallbackRegistry<>{};
+  reg.registerCallback([&calls]() { ++calls; });
+  reg.invokeAll();
+  ASSERT_EQ(1, calls);
+}
+
+TEST(callback_registry, lambda_1_arg) {
+  auto calls = 0;
+  auto reg = CallbackRegistry<int>{};
+  reg.registerCallback([&calls](int arg) {
+    ++calls;
+    ASSERT_EQ(answer, arg);
+  });
+  reg.invokeAll(answer);
+  ASSERT_EQ(1, calls);
+}
+
+TEST(callback_registry, func_2_args) {
+  global_calls = 0;
+  auto reg = CallbackRegistry<int, long>{};
+  auto handle = reg.registerCallback(func);
+  handle.invoke(answer, answer);
+  reg.invokeAll(answer, answer);
+  ASSERT_EQ(2, global_calls);
+}
+
+TEST(callback_registry, std_function) {
+  auto calls = 0;
+  auto reg = CallbackRegistry<int>{};
+  auto func = std::function<void(int)>{[&calls](int arg) {
+    ++calls;
+    ASSERT_EQ(answer, arg);
+  }};
+  reg.registerCallback(func);
+  reg.invokeAll(answer);
+  ASSERT_EQ(1, calls);
+}
+
+TEST(callback_registry, handle_invoke) {
+  auto calls = 0;
+  auto reg = CallbackRegistry<>{};
+  auto handle = reg.registerCallback([&calls]() { ++calls; });
+  handle.invoke();
+  ASSERT_EQ(1, calls);
+}
+
+TEST(callback_registry, handle_invoke_and_invoke_all) {
+  auto calls = 0;
+  auto reg = CallbackRegistry<>{};
+  auto handle = reg.registerCallback([&calls]() { ++calls; });
+  reg.invokeAll();
+  handle.invoke();
+  ASSERT_EQ(2, calls);
+}
+
+TEST(callback_registry, handle_equality) {
+  auto reg = CallbackRegistry<>{};
+  auto handle1 = reg.registerCallback([]() {});
+  auto handle2 = reg.registerCallback([]() {});
+  ASSERT_EQ(handle1, handle1);
+  ASSERT_EQ(handle2, handle2);
+  ASSERT_NE(handle1, handle2);
+}
+
+TEST(callback_registry, multiple_callbacks) {
+  auto calls = 0;
+  const auto callback = [&calls] { ++calls; };
+  auto reg = CallbackRegistry<>{};
+  auto handles = std::vector<CallbackRegistry<>::CallbackHandle>{};
+  const auto callback_count = 5;
+  for (auto i = 0; i < callback_count; ++i) {
+    handles.push_back(reg.registerCallback(callback));
+  }
+  reg.invokeAll();
+  ASSERT_EQ(callback_count, calls);
+}
+
+TEST(callback_registry, deregister) {
+  auto calls = 0;
+  auto reg = CallbackRegistry<>{};
+  const auto callback = [&calls] { ++calls; };
+  auto handle1 = reg.registerCallback(callback);
+  auto handle2 = reg.registerCallback(callback);
+  // 2 calls
+  reg.invokeAll();
+  reg.deregisterCallback(std::move(handle1));
+  // 1 call
+  reg.invokeAll();
+  ASSERT_EQ(3, calls);
+  reg.deregisterCallback(std::move(handle2));
+  // no calls
+  reg.invokeAll();
+  ASSERT_EQ(3, calls);
+}
+
+TEST(callback_registry, size) {
+  auto reg = CallbackRegistry<>{};
+  auto handle = reg.registerCallback([]() {});
+  ASSERT_EQ(1, reg.size());
+  ASSERT_FALSE(reg.empty());
+  reg.deregisterCallback(std::move(handle));
+  ASSERT_EQ(0, reg.size());
+  ASSERT_TRUE(reg.empty());
+}
+
+TEST(callback_registry, propagate_exception) {
+  auto reg = CallbackRegistry<>{};
+  reg.registerCallback([]() { throw std::exception{}; });
+  ASSERT_THROW(reg.invokeAll(), std::exception);
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add support for a subscription mechanism for State Transfer (ST)
on-complete callbacks. Rationale is that multiple parts of the system
might want to know when ST completes so that they can act accordingly to
the newly-received state. Examples of such cases are pruning and time
management, to name a few.

Provide an implementation for BCStateTran only. Implementations for
NullStateTransfer and SimpleStateTran are not provided at that stage as
the use is unclear.

In order to implement, add a generic CallbackRegistry that supports
multiple registrations, deregistration and arbitrary parameters for the
callbacks.

Add an unit test for CallbackRegistry to demonstrate usage and test
common cases.