### PR TITLE
Prevent replicas from initiating consensus if we decided to stop

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -34,10 +34,14 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   ControlStateManager(const ControlStateManager&) = delete;
   ~ControlStateManager() {}
 
+  void disable() { enabled_ = false; }
+  void enable() { enabled_ = true; }
+
  private:
   IStateTransfer* state_transfer_;
   const uint32_t sizeOfReservedPage_;
   std::string scratchPage_;
+  bool enabled_ = true;
 
   // In the control handler manager reserved pages space, each control data should has its own page.
   // This struct define the index of each page in this space.

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -103,7 +103,6 @@ void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
                                   persistentStorage,
                                   replicaImp->getMsgHandlersRegistrator(),
                                   replicaImp->timers()));
-    replica_->setControlStateManager(replicaImp->getControlStateManager());
 
   } else {
     //  TODO [TK] rep.reset(new ReadOnlyReplicaImp());

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -103,6 +103,8 @@ void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
                                   persistentStorage,
                                   replicaImp->getMsgHandlersRegistrator(),
                                   replicaImp->timers()));
+    replica_->setControlStateManager(replicaImp->getControlStateManager());
+
   } else {
     //  TODO [TK] rep.reset(new ReadOnlyReplicaImp());
   }

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -24,6 +24,7 @@ namespace bftEngine {
  * given sequence number and mark it as a checkpoint to stop at in the reserved pages.
  */
 void ControlStateManager::setStopAtNextCheckpoint(int64_t currentSeqNum) {
+  if (!enabled_) return;
   uint64_t seq_num_to_stop_at = (currentSeqNum + 2 * checkpointWindowSize);
   seq_num_to_stop_at = seq_num_to_stop_at - (seq_num_to_stop_at % checkpointWindowSize);
   std::ostringstream outStream;
@@ -34,6 +35,7 @@ void ControlStateManager::setStopAtNextCheckpoint(int64_t currentSeqNum) {
 }
 
 std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
+  if (!enabled_) return {};
   if (!state_transfer_->loadReservedPage(getUpdateReservedPageIndex(), sizeOfReservedPage_, scratchPage_.data())) {
     return {};
   }

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -12,6 +12,7 @@
 // file.
 
 #include "ControlStateManager.hpp"
+#include "Logger.hpp"
 namespace bftEngine {
 
 /*
@@ -43,7 +44,10 @@ std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
   inStream.str(scratchPage_);
   controlStateMessages::StopAtNextCheckpointMessage msg;
   concord::serialize::Serializable::deserialize(inStream, msg);
-  if (msg.seqNumToStopAt_ < 0) return {};
+  if (msg.seqNumToStopAt_ < 0) {
+    LOG_WARN(GL, "sequence num to stop at is negative!");
+    return {};
+  }
   return msg.seqNumToStopAt_;
 }
 

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -41,6 +41,7 @@ std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
   inStream.str(scratchPage_);
   controlStateMessages::StopAtNextCheckpointMessage msg;
   concord::serialize::Serializable::deserialize(inStream, msg);
+  if (msg.seqNumToStopAt_ < 0) return {};
   return msg.seqNumToStopAt_;
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -450,9 +450,11 @@ void ReplicaImp::bringTheSystemToCheckpointBySendingNoopCommands(SeqNum seqNumTo
 }
 
 bool ReplicaImp::isSeqNumToStopAt(SeqNum seq_num) {
+  // There might be a race condition between the time the replica starts to the time the controlStateManager is
+  // initiated.
+  if (!controlStateManager_) return false;
   if (seqNumToStopAt_ > 0 && seq_num == seqNumToStopAt_) return true;
   if (seqNumToStopAt_ > 0 && seq_num > seqNumToStopAt_) return false;
-
   auto seq_num_to_stop_at = controlStateManager_->getCheckpointToStopAt();
   if (seq_num_to_stop_at.has_value()) {
     seqNumToStopAt_ = seq_num_to_stop_at.value();

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -156,6 +156,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   bool recoveringFromExecutionOfRequests = false;
   Bitmap mapOfRequestsThatAreBeingRecovered;
 
+  SeqNum seqNumToStopAt_ = 0;
+
   //******** METRICS ************************************
   GaugeHandle metric_view_;
   GaugeHandle metric_last_stable_seq_num_;
@@ -403,6 +405,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void startConsensusProcess(PrePrepareMsg* pp);
   void sendInternalNoopPrePrepareMsg(CommitPath firstPath = CommitPath::SLOW);
   void bringTheSystemToCheckpointBySendingNoopCommands(SeqNum seqNumToStopAt, CommitPath firstPath = CommitPath::SLOW);
+  bool isSeqNumToStopAt(SeqNum seq_num);
 };
 
 }  // namespace bftEngine::impl

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -196,6 +196,7 @@ class SimpleTestReplica {
   void start() {
     replica->start();
     control_state_manager_ = std::make_shared<ControlStateManager>(inMemoryST_, inMemoryST_->numberOfReservedPages());
+    control_state_manager_->disable();
     replica->setControlStateManager(control_state_manager_);
   }
 

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -223,6 +223,7 @@ class SimpleTestReplica {
           uint32_t downTime = behaviorPtr->get_down_time_millis();
           LOG_INFO(replicaLogger, "Restarting replica");
           replica->restartForDebug(downTime);
+          replica->setControlStateManager(control_state_manager_);
           behaviorPtr->on_restarted();
           LOG_INFO(replicaLogger, "Replica restarted");
         }


### PR DESCRIPTION
If a replica discovers that it needs to stop on the current checkpoint but this checkpoint is not yet super stable checkpoint, we want this replica to stop participating in the consensus protocol (but not the state transfer, for example).

For that, a replica checks in three places whether it should stop:
1. primary - on try to send pre-prepare message
2. non-primary - on receiving pre-prepare message
3. all - on receiving a client request

We also added an enable/disable flag for the controlStateManager to the cases when we don't want to use it (for example, in some of the simple tests)