### PR TITLE
[Apollo] Refactor checkpoint helper functions

### DIFF
--- a/tests/apollo/test_skvbc_backup_restore.py
+++ b/tests/apollo/test_skvbc_backup_restore.py
@@ -23,10 +23,8 @@ def start_replica_cmd(builddir, replica_id):
     """
     Return a command that starts an skvbc replica when passed to
     subprocess.Popen.
-
     The replica is started with a short view change timeout and with RocksDB
     persistence enabled (-p).
-
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
@@ -73,7 +71,7 @@ class SkvbcBackupRestoreTest(unittest.TestCase):
 
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
-            checkpoint_num=1,
+            num_of_checkpoints_to_add=1,
             verify_checkpoint_persistency=False
         )
 
@@ -84,7 +82,9 @@ class SkvbcBackupRestoreTest(unittest.TestCase):
         await self._start_random_replicas_with_delay(bft_network, stopped_replicas)
 
         # verify checkpoint persistence
-        await bft_network.wait_for_replicas_to_checkpoint(stopped_replicas, checkpoint_before + 1)
+        await bft_network.wait_for_replicas_to_checkpoint(
+            stopped_replicas,
+            expected_checkpoint_num=lambda ecn: ecn == checkpoint_before + 1)
 
         # verify current view is stable
         for replica in bft_network.all_replicas():
@@ -97,7 +97,7 @@ class SkvbcBackupRestoreTest(unittest.TestCase):
         # create second checkpoint and wait for checkpoint propagation
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
-            checkpoint_num=1,
+            num_of_checkpoints_to_add=1,
             verify_checkpoint_persistency=False
         )
 

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -360,7 +360,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
         checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=replica_to_read_from)
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=initial_nodes,
-            checkpoint_num=checkpoint_num,
+            num_of_checkpoints_to_add=checkpoint_num,
             verify_checkpoint_persistency=verify_checkpoint_persistency,
             assert_state_transfer_not_started=assert_state_transfer_not_started
         )

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -172,7 +172,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
 
             await skvbc.fill_and_wait_for_checkpoint(
                 initial_nodes=list(live_replicas),
-                checkpoint_num=1,
+                num_of_checkpoints_to_add=1,
                 verify_checkpoint_persistency=False
             )
 

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -268,8 +268,8 @@ class SkvbcPersistenceTest(unittest.TestCase):
         stale_node = random.choice(bft_network.all_replicas(without={0}))
 
         client, known_key, known_val, known_kv = \
-            await tracker.tracked_prime_for_state_transfer(checkpoints_num=4,
-                                                           stale_nodes={stale_node})
+            await tracker.tracked_prime_for_state_transfer(stale_nodes={stale_node},
+                                                           num_of_checkpoints_to_add=4)
 
         # exclude the primary and the stale node
         unstable_replicas = bft_network.all_replicas(without={0, stale_node})
@@ -393,8 +393,8 @@ class SkvbcPersistenceTest(unittest.TestCase):
         stale_replica = n - 1
 
         client, known_key, known_val, known_kv = \
-            await tracker.tracked_prime_for_state_transfer(checkpoints_num=2,
-                                                           stale_nodes={stale_replica})
+            await tracker.tracked_prime_for_state_transfer(stale_nodes={stale_replica},
+                                                           num_of_checkpoints_to_add=2)
         view = await bft_network.wait_for_view(
             replica_id=0,
             expected=lambda v: v == 0,

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -140,7 +140,9 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         """
         bft_network.start_all_replicas()
         # TODO replace the below function with the library function:
-        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(initial_nodes=bft_network.all_replicas(), checkpoint_num=1)
+        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(
+        # initial_nodes=bft_network.all_replicas(),
+        # num_of_checkpoints_to_add=1)
         with trio.fail_after(seconds=60):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(tracker.send_indefinite_tracked_ops)
@@ -189,7 +191,9 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         ro_replica_id = bft_network.config.n
         bft_network.start_replica(ro_replica_id)
         # TODO replace the below function with the library function:
-        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(initial_nodes=bft_network.all_replicas(), checkpoint_num=1)     
+        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(
+        # initial_nodes=bft_network.all_replicas(),
+        # num_of_checkpoints_to_add=1)
         with trio.fail_after(seconds=60):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(tracker.send_indefinite_tracked_ops, .7, .1)
@@ -231,7 +235,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
 
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
-            checkpoint_num=1,
+            num_of_checkpoints_to_add=1,
             verify_checkpoint_persistency=False
         )
 
@@ -262,7 +266,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
 
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
-            checkpoint_num=1,
+            num_of_checkpoints_to_add=1,
             verify_checkpoint_persistency=False
         )
 
@@ -271,7 +275,9 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
 
     async def _wait_for_st(self, bft_network, ro_replica_id):
         # TODO replace the below function with the library function:
-        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(initial_nodes=bft_network.all_replicas(), checkpoint_num=1)     
+        # await tracker.skvbc.tracked_fill_and_wait_for_checkpoint(
+        # initial_nodes=bft_network.all_replicas(),
+        # num_of_checkpoints_to_add=1)
         with trio.fail_after(seconds=70):
             # the ro replica should be able to survive these failures
             while True:

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -114,7 +114,7 @@ def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None,
         def start_replica_cmd(builddir, replica_id)
     or
         def start_replica_cmd(builddir, replica_id, config)
-    If you want the bft test network configuration to be passed to your callback you should add 
+    If you want the bft test network configuration to be passed to your callback you should add
     third parameter named 'config' (the exact name is important!).
     If you don't need this configuration - use two parameters callback with any names you want.
     """
@@ -213,10 +213,10 @@ class BftTestNetwork:
             clients = {},
             metrics = None
         )
-        
+
         #copy loggging.properties file
         shutil.copy(os.path.abspath("../simpleKVBC/scripts/logging.properties"), testdir);
-        
+
         print("Running test in {}".format(bft_network.testdir))
 
         os.chdir(bft_network.testdir)
@@ -225,7 +225,6 @@ class BftTestNetwork:
         bft_network._init_metrics()
         bft_network._create_clients()
 
-       
         return bft_network
 
     @classmethod
@@ -297,8 +296,8 @@ class BftTestNetwork:
     def start_replica_cmd(self, replica_id):
         """
         Returns command line to start replica with the given id
-        If the callback accepts three parameters and one of them 
-        is named 'config' - pass the netowork configuration too.
+        If the callback accepts three parameters and one of them
+        is named 'config' - pass the network configuration too.
         """
         start_replica_fn_args = inspect.getfullargspec(self.config.start_replica_cmd).args
         if "config" in start_replica_fn_args and len(start_replica_fn_args) == 3:
@@ -363,7 +362,6 @@ class BftTestNetwork:
 
         return self.replicas[replica_id]
 
-
     def stop_replica(self, replica_id):
         """
         Stop a replica if it is running.
@@ -404,7 +402,7 @@ class BftTestNetwork:
             exclude_replicas = random_replicas | without
             random_replicas.add(random.choice(self.all_replicas(without=exclude_replicas)))
         return random_replicas
-    
+
     def get_live_replicas(self):
         """
         Returns the id-s of all live replicas
@@ -623,9 +621,11 @@ class BftTestNetwork:
                         if n != last_n:
                             last_n = n
                             checkpoint = ['bc_state_transfer',
-                                    'Gauges', 'last_stored_checkpoint']
+                                          'Gauges',
+                                          'last_stored_checkpoint']
                             on_transferring_complete = ['bc_state_transfer',
-                                    'Counters', 'on_transferring_complete']
+                                                        'Counters',
+                                                        'on_transferring_complete']
                             print("wait_for_st_to_stop: expected_seq_num={} "
                                   "last_stored_checkpoint={} "
                                   "on_transferring_complete_count={}".format(
@@ -635,9 +635,9 @@ class BftTestNetwork:
                                             *on_transferring_complete)))
                         # Exit condition
                         if n >= expected_seq_num:
-                           return
+                            return
 
-    async def wait_for_replicas_to_checkpoint(self, replica_ids, checkpoint_num):
+    async def wait_for_replicas_to_checkpoint(self, replica_ids, expected_checkpoint_num):
         """
         Wait for every replica in `replicas` to take a checkpoint.
         Check every .5 seconds and give fail after 30 seconds.
@@ -645,8 +645,7 @@ class BftTestNetwork:
         with trio.fail_after(30): # seconds
             async with trio.open_nursery() as nursery:
                 for replica_id in replica_ids:
-                    nursery.start_soon(self.wait_for_checkpoint, replica_id,
-                            checkpoint_num)
+                    nursery.start_soon(self.wait_for_checkpoint, replica_id, expected_checkpoint_num)
 
     async def wait_for_checkpoint(self, replica_id, expected_checkpoint_num=None):
         """
@@ -654,12 +653,13 @@ class BftTestNetwork:
         If none is provided, return the last stored checkpoint.
         """
         key = ['bc_state_transfer', 'Gauges', 'last_stored_checkpoint']
+        if expected_checkpoint_num is None:
+            expected_checkpoint_num = lambda _: True
         with trio.fail_after(30):
             while True:
                 with trio.move_on_after(.5): # seconds
                     last_stored_checkpoint = await self.metrics.get(replica_id, *key)
-                    if expected_checkpoint_num is None \
-                            or last_stored_checkpoint == expected_checkpoint_num:
+                    if expected_checkpoint_num(last_stored_checkpoint):
                         return last_stored_checkpoint
 
     async def wait_for_slow_path_to_be_prevalent(
@@ -765,7 +765,6 @@ class BftTestNetwork:
                 with trio.move_on_after(interval):
                     if await predicate():
                         return
-
 
     async def num_of_slow_path(self):
         """

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -983,7 +983,7 @@ class SkvbcTracker:
 
     async def tracked_prime_for_state_transfer(
             self, stale_nodes,
-            checkpoints_num=2,
+            num_of_checkpoints_to_add=2,
             persistency_enabled=True):
         initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
         [self.bft_network.start_replica(i) for i in initial_nodes]
@@ -998,13 +998,16 @@ class SkvbcTracker:
         # there.
         client1 = self.bft_network.random_client()
         # Write enough data to checkpoint and create a need for state transfer
-        for i in range(1 + checkpoints_num * 150):
+        for i in range(1 + num_of_checkpoints_to_add * 150):
             key = self.skvbc.random_key()
             val = self.skvbc.random_value()
             kv = [(key, val)]
             await self.write_and_track_known_kv(kv, client1)
 
-        await self.skvbc.network_wait_for_checkpoint(initial_nodes, checkpoints_num, persistency_enabled)
+        await self.skvbc.network_wait_for_checkpoint(
+            initial_nodes,
+            expected_checkpoint_num=lambda ecn: ecn == num_of_checkpoints_to_add,
+            verify_checkpoint_persistency=persistency_enabled)
 
         return client, known_key, known_val, known_kv
 
@@ -1148,7 +1151,7 @@ class PassThroughSkvbcTracker:
 
     async def tracked_prime_for_state_transfer(
             self, stale_nodes,
-            checkpoints_num=2,
+            num_of_checkpoints_to_add=2,
             persistency_enabled=True):
         initial_nodes = self.bft_network.all_replicas(without=stale_nodes)
         [self.bft_network.start_replica(i) for i in initial_nodes]
@@ -1163,13 +1166,16 @@ class PassThroughSkvbcTracker:
         # there.
         client1 = self.bft_network.random_client()
         # Write enough data to checkpoint and create a need for state transfer
-        for i in range(1 + checkpoints_num * 150):
+        for i in range(1 + num_of_checkpoints_to_add * 150):
             key = self.skvbc.random_key()
             val = self.skvbc.random_value()
             kv = [(key, val)]
             await self.write_and_track_known_kv(kv, client1)
 
-        await self.skvbc.network_wait_for_checkpoint(initial_nodes, checkpoints_num, persistency_enabled)
+        await self.skvbc.network_wait_for_checkpoint(
+            initial_nodes,
+            expected_checkpoint_num=lambda ecn: ecn == num_of_checkpoints_to_add,
+            verify_checkpoint_persistency=persistency_enabled)
 
         return client, known_key, known_val, known_kv
 


### PR DESCRIPTION
This PR includes the following inter-related changes -
1.  Allow wait_for_checkpoint to accept lambda function as an argument for the parameter expected_checkpoint_num. This will be useful when running tests under constant load with long wait times as that is when it becomes difficult to estimate an exact expected_checkpoint_num.
2. Update parameter names for readability -
   - checkpoint_num to expected_checkpoint_num in wait_for_replicas_to_checkpoint method.
   - checkpoint_num to num_of_checkpoints_to_add in fill_and_wait_for_checkpoint method.
	
3. Refactor rest of the code to reflect the changes.