### PR TITLE
Use designated logger for View Change - concord.viewchange.

### DIFF
--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -34,6 +34,7 @@ extern logging::Logger GL;
 extern logging::Logger CNSUS;
 extern logging::Logger THRESHSIGN_LOG;
 extern logging::Logger BLS_LOG;
+extern logging::Logger VC_LOG;
 
 namespace logging {
 

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -26,3 +26,4 @@ logging::Logger GL = logging::getLogger("concord");
 logging::Logger CNSUS = logging::getLogger("concord.bft.consensus");
 logging::Logger THRESHSIGN_LOG = logging::getLogger("concord.threshsign");
 logging::Logger BLS_LOG = logging::getLogger("concord.threshsign.bls");
+logging::Logger VC_LOG = logging::getLogger("concord.viewchange");


### PR DESCRIPTION
Note: ******************** notation is removed for view change messages.