### PR TITLE
Add an IStateTransfer getter in kvbc::ReplicaImp

### DIFF
--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -80,6 +80,8 @@ class ReplicaImp : public IReplica,
 
   void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 
+  bftEngine::IStateTransfer &getStateTransfer() { return *m_stateTransfer; }
+
   ~ReplicaImp() override;
 
  protected:


### PR DESCRIPTION
Add the kvbc::ReplicaImp::getStateTransfer() getter. Rationale is that
users of kvbc::ReplicaImp might want to interact with state transfer
(ST). For example, the pruning state machine might want to subscribe
to ST-related events.

The current implementation exposes the whole IStateTransfer interface to
higher layers. That is an overkill. Future commits should split the
IStateTransfer interface so that ST internals are not exposed to users.
That will require substantial refactoring.