### PR TITLE
Add span to addBlock method

### DIFF
--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <atomic>
 
+#include "OpenTracing.hpp"
 #include "communication/ICommunication.hpp"
 #include "communication/CommFactory.hpp"
 #include "bftengine/Replica.hpp"
@@ -53,7 +54,9 @@ class ReplicaImp : public IReplica,
   Status mayHaveConflictBetween(const Sliver &key, BlockId fromBlock, BlockId toBlock, bool &outRes) const override;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IBlocksAppender implementation
-  Status addBlock(const concord::storage::SetOfKeyValuePairs &updates, BlockId &outBlockId) override;
+  Status addBlock(const concord::storage::SetOfKeyValuePairs &updates,
+                  BlockId &outBlockId,
+                  const concordUtils::SpanWrapper &parent_span) override;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "OpenTracing.hpp"
 #include "kv_types.hpp"
 #include "status.hpp"
 
@@ -34,7 +35,9 @@ class ILocalKeyValueStorageReadOnly {
  */
 class IBlocksAppender {
  public:
-  virtual concordUtils::Status addBlock(const SetOfKeyValuePairs& updates, BlockId& outBlockId) = 0;
+  virtual concordUtils::Status addBlock(const SetOfKeyValuePairs& updates,
+                                        BlockId& outBlockId,
+                                        const concordUtils::SpanWrapper& parent_span = concordUtils::SpanWrapper{}) = 0;
 
   virtual ~IBlocksAppender() = default;
 };

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -145,7 +145,9 @@ Status ReplicaImp::mayHaveConflictBetween(const Sliver &key, BlockId fromBlock, 
   return s;
 }
 
-Status ReplicaImp::addBlock(const SetOfKeyValuePairs &updates, BlockId &outBlockId) {
+Status ReplicaImp::addBlock(const SetOfKeyValuePairs &updates,
+                            BlockId &outBlockId,
+                            const concordUtils::SpanWrapper & /*parent_span*/) {
   // TODO(GG): check legality of operation (the method should be invoked from
   // the replica's internal thread)
 

--- a/util/include/OpenTracing.hpp
+++ b/util/include/OpenTracing.hpp
@@ -25,7 +25,7 @@ using SpanContext = std::string;
 
 class SpanWrapper {
  public:
-  SpanWrapper() {}
+  SpanWrapper() = default;
   SpanWrapper(const SpanWrapper&) = delete;
   SpanWrapper& operator=(const SpanWrapper&) = delete;
   SpanWrapper(SpanWrapper&&) = default;
@@ -58,6 +58,10 @@ class SpanWrapper {
   friend SpanWrapper startSpan(const std::string& operation_name);
   friend SpanWrapper startChildSpan(const std::string& operation_name, const SpanWrapper& parent_span);
   friend SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name);
+#ifdef USE_OPENTRACING
+  friend SpanWrapper startChildSpanFromContext(const opentracing::SpanContext& context,
+                                               const std::string& child_operation_name);
+#endif
 
 #ifdef USE_OPENTRACING
   using SpanPtr = std::unique_ptr<opentracing::Span>;
@@ -73,4 +77,7 @@ class SpanWrapper {
 SpanWrapper startSpan(const std::string& operation_name);
 SpanWrapper startChildSpan(const std::string& child_operation_name, const SpanWrapper& parent_span);
 SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name);
+#ifdef USE_OPENTRACING
+SpanWrapper startChildSpanFromContext(const opentracing::SpanContext& context, const std::string& child_operation_name);
+#endif
 }  // namespace concordUtils

--- a/util/src/OpenTracing.cpp
+++ b/util/src/OpenTracing.cpp
@@ -80,4 +80,13 @@ SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::str
   return SpanWrapper{};
 #endif
 }
+
+#ifdef USE_OPENTRACING
+SpanWrapper startChildSpanFromContext(const opentracing::SpanContext& context,
+                                      const std::string& child_operation_name) {
+  auto tracer = opentracing::Tracer::Global();
+  auto span = tracer->StartSpan(child_operation_name, {opentracing::ChildOf(&context)});
+  return {std::move(span)};
+}
+#endif
 }  // namespace concordUtils


### PR DESCRIPTION
Reason:
The method `addBlock` is overridden in the product and its performance is measured by Opentracing.
The initial implementation did not change the base method but used a tricky workaround based on
saving the parent span between the calls of the `execute` method.

After introducing Pre-execution the method `execute` may be called in the context of different threads.
Unfortunately, spans' behavior is undefined while used together with multithreading.

Solution:
The solution is to avoid saving spans and to create them on demand which involves the change in the base API.

Changes:
* Added `SpanWrapper` to the `addBlock` method.
* Minor changes in the Opentracing utilities.