### PR TITLE
Add filter for F>=2 to test_restart_replica_after_view_change

### DIFF
--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -234,7 +234,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         )
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability()
     async def test_restart_replica_after_view_change(self, bft_network, tracker):
         """


### PR DESCRIPTION
because we get scenarios where we have 2 non participating Replicas
in execution quorums (due to recovery time of the 2 restarted replicas
including the time for them to enter the view), which causes additional
unexpected View Change.