### PR TITLE
bftclient: Make src dir publically included

### DIFF
--- a/bftclient/CMakeLists.txt
+++ b/bftclient/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(bftclient_new STATIC
 )
 
 target_include_directories(bftclient_new PUBLIC include)
-target_include_directories(bftclient_new PRIVATE src)
+target_include_directories(bftclient_new PUBLIC src)
 target_link_libraries(bftclient_new PUBLIC bftcommunication bftheaders)
 
 if (BUILD_TESTING)


### PR DESCRIPTION
This enables proper finding of files in external projects without
requiring more than a target_link_libraries call.