### PR TITLE
Stabilize control state tests

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2379,11 +2379,16 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
   }
 }
 
-void ReplicaImp::onSeqNumIsSuperStable(SeqNum newSuperStableSeqNum) {
+void ReplicaImp::onSeqNumIsSuperStable(SeqNum superStableSeqNum) {
   auto seq_num_to_stop_at = controlStateManager_->getCheckpointToStopAt();
-  if (seq_num_to_stop_at.has_value() && seq_num_to_stop_at.value() == newSuperStableSeqNum) {
-    if (getRequestsHandler()->getControlHandlers())
+  if (seq_num_to_stop_at.has_value() && seq_num_to_stop_at.value() == superStableSeqNum) {
+    LOG_INFO(GL, "Informing control state manager that consensus should be stopped: " << KVLOG(superStableSeqNum));
+    if (getRequestsHandler()->getControlHandlers()) {
+      metric_on_call_back_of_super_stable_cp_.Get().Set(1);
+      // TODO: With state transfered replica, this maight be called twice. Consider to clean the reserved page at the
+      // end of this method
       getRequestsHandler()->getControlHandlers()->onSuperStableCheckpoint();
+    }
   }
 }
 void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformation, bool oldSeqNum) {
@@ -2746,6 +2751,17 @@ void ReplicaImp::onInfoRequestTimer(Timers::Handle timer) {
   metric_info_request_timer_.Get().Set(dynamicUpperLimitOfRounds->upperLimit() / 2);
 }
 
+void ReplicaImp::onSuperStableCheckpointTimer(concordUtil::Timers::Handle) {
+  if (!isSeqNumToStopAt(lastExecutedSeqNum)) return;
+  if (!checkpointsLog->insideActiveWindow(lastExecutedSeqNum)) return;
+  CheckpointMsg *cpMsg = checkpointsLog->get(lastExecutedSeqNum).selfCheckpointMsg();
+  // At this point the cpMsg cannot be evacuated
+  if (!cpMsg) return;
+  LOG_INFO(GL,
+           "sending checkpoint message to help other replicas to reach super stable checkpoint"
+               << KVLOG(lastExecutedSeqNum));
+  sendToAllOtherReplicas(cpMsg, true);
+}
 template <>
 void ReplicaImp::onMessage<SimpleAckMsg>(SimpleAckMsg *msg) {
   metric_received_simple_acks_.Get().Inc();
@@ -3045,6 +3061,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_current_primary_{metrics_.RegisterGauge("currentPrimary", curView % config_.numReplicas)},
       metric_concurrency_level_{metrics_.RegisterGauge("concurrencyLevel", config_.concurrencyLevel)},
       metric_primary_last_used_seq_num_{metrics_.RegisterGauge("primaryLastUsedSeqNum", primaryLastUsedSeqNum)},
+      metric_on_call_back_of_super_stable_cp_{metrics_.RegisterGauge("OnCallBackOfSuperStableCP", 0)},
       metric_first_commit_path_{metrics_.RegisterStatus(
           "firstCommitPath", CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath))},
       metric_slow_path_count_{metrics_.RegisterCounter("slowPathCount", 0)},
@@ -3207,7 +3224,7 @@ void ReplicaImp::stop() {
   timers_.cancel(infoReqTimer_);
   timers_.cancel(statusReportTimer_);
   if (viewChangeProtocolEnabled) timers_.cancel(viewChangeTimer_);
-
+  if (enableRetransmitSuperStableCheckpoint_) timers_.cancel(superStableCheckpointRetransmitTimer_);
   ReplicaForStateTransfer::stop();
 }
 
@@ -3524,12 +3541,6 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
   auto span = concordUtils::startChildSpan("bft_execute_next_committed_requests", parent_span);
 
   while (lastExecutedSeqNum < lastStableSeqNum + kWorkWindowSize) {
-    if (!stopAtNextCheckpoint_ && controlStateManager_->getCheckpointToStopAt().has_value()) {
-      // If, following the last execution, we discover that we need to jump to the
-      // next checkpoint, the primary sends noop commands until filling the working window.
-      bringTheSystemToCheckpointBySendingNoopCommands(controlStateManager_->getCheckpointToStopAt().value());
-      stopAtNextCheckpoint_ = true;
-    }
     SeqNum nextExecutedSeqNum = lastExecutedSeqNum + 1;
     SeqNumInfo &seqNumInfo = mainLog->get(nextExecutedSeqNum);
 
@@ -3557,7 +3568,17 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
       metric_total_fastPath_.Get().Inc();
     }
   }
-
+  if (!stopAtNextCheckpoint_ && controlStateManager_->getCheckpointToStopAt().has_value()) {
+    // If, following the last execution, we discover that we need to jump to the
+    // next checkpoint, the primary sends noop commands until filling the working window.
+    bringTheSystemToCheckpointBySendingNoopCommands(controlStateManager_->getCheckpointToStopAt().value());
+    stopAtNextCheckpoint_ = true;
+    // Enable retransmitting of the super stable checkpoint to help weak connected replicas to reach the super stable
+    // checkpoint
+    enableRetransmitSuperStableCheckpoint_ = true;
+    superStableCheckpointRetransmitTimer_ = timers_.add(
+        milliseconds(1000), Timers::Timer::RECURRING, [this](Timers::Handle h) { onSuperStableCheckpointTimer(h); });
+  }
   if (isCurrentPrimary() && requestsQueueOfPrimary.size() > 0) tryToSendPrePrepareMsg(true);
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -149,6 +149,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concordUtil::Timers::Handle viewChangeTimer_;
   concordUtil::Timers::Handle superStableCheckpointRetransmitTimer_;
 
+  int timeoutOfSuperStableCheckpointTimerMs_ = 1000;
   bool enableRetransmitSuperStableCheckpoint_ = false;
   int viewChangeTimerMilli = 0;
   int autoPrimaryRotationTimerMilli = 0;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -147,7 +147,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concordUtil::Timers::Handle infoReqTimer_;
   concordUtil::Timers::Handle statusReportTimer_;
   concordUtil::Timers::Handle viewChangeTimer_;
+  concordUtil::Timers::Handle superStableCheckpointRetransmitTimer_;
 
+  bool enableRetransmitSuperStableCheckpoint_ = false;
   int viewChangeTimerMilli = 0;
   int autoPrimaryRotationTimerMilli = 0;
 
@@ -157,7 +159,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   Bitmap mapOfRequestsThatAreBeingRecovered;
 
   SeqNum seqNumToStopAt_ = 0;
-
   //******** METRICS ************************************
   GaugeHandle metric_view_;
   GaugeHandle metric_last_stable_seq_num_;
@@ -172,6 +173,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   GaugeHandle metric_current_primary_;
   GaugeHandle metric_concurrency_level_;
   GaugeHandle metric_primary_last_used_seq_num_;
+  GaugeHandle metric_on_call_back_of_super_stable_cp_;
 
   // The first commit path being attempted for a new request.
   StatusHandle metric_first_commit_path_;
@@ -335,7 +337,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
       bool oldSeqNum = false  // true IFF sequence number newStableSeqNum+kWorkWindowSize has already been executed
   );
 
-  void onSeqNumIsSuperStable(SeqNum newSuperStableSeqNum);
+  void onSeqNumIsSuperStable(SeqNum superStableSeqNum);
   void onTransferringCompleteImp(SeqNum) override;
 
   template <typename T>
@@ -377,6 +379,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void onStatusReportTimer(concordUtil::Timers::Handle);
   void onSlowPathTimer(concordUtil::Timers::Handle);
   void onInfoRequestTimer(concordUtil::Timers::Handle);
+  void onSuperStableCheckpointTimer(concordUtil::Timers::Handle);
 
   // handlers for internal messages
 

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -67,6 +67,10 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
           "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+  add_test(NAME skvbc_control_commands_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_control_commands ${TEST_OUTPUT}"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
   if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests_${STORAGE_TYPE} COMMAND sh -c
             "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
@@ -77,4 +81,3 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 endforeach()
-

--- a/tests/apollo/test_skvbc_control_commands.py
+++ b/tests/apollo/test_skvbc_control_commands.py
@@ -42,7 +42,7 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcControlCommandsTest(unittest.TestCase):
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command(self, bft_network):
         """
              Sends a wedge command and check that the system stops from processing new requests.
@@ -72,7 +72,7 @@ class SkvbcControlCommandsTest(unittest.TestCase):
 
     # @unittest.skip("Test case assumes the happy path")
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command_with_state_transfer(self, bft_network):
         """
             This test checks that even a replica that received the super stable checkpoint via the state transfer mechanism

--- a/tests/apollo/test_skvbc_control_commands.py
+++ b/tests/apollo/test_skvbc_control_commands.py
@@ -70,7 +70,6 @@ class SkvbcControlCommandsTest(unittest.TestCase):
 
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
 
-    # @unittest.skip("Test case assumes the happy path")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command_with_state_transfer(self, bft_network):

--- a/tests/apollo/test_skvbc_control_commands.py
+++ b/tests/apollo/test_skvbc_control_commands.py
@@ -1,0 +1,151 @@
+# Concord
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+import os.path
+import random
+import unittest
+from os import environ
+
+import trio
+
+from util import blinking_replica
+from util import skvbc as kvbc
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "10000"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-v", viewChangeTimeoutMilli,
+            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower() in set(["true", "on"]) else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
+
+
+class SkvbcControlCommandsTest(unittest.TestCase):
+    @with_trio
+    @with_bft_network(start_replica_cmd)
+    async def test_wedge_command(self, bft_network):
+        """
+             Sends a wedge command and check that the system stops from processing new requests.
+             Note that in this test we assume no failures and synchronized network.
+             The test does the following:
+             1. A client sends a wedge command
+             2. The client verify that the system reached to a super stable checkpoint
+             3. The client tries to initiate a new write bft command and fails
+         """
+        bft_network.start_all_replicas()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        client = bft_network.random_client()
+
+        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
+
+        await client.write(skvbc.write_req([], [], block_id=0, wedge_command=True))
+
+        for replica_id in range(bft_network.config.n):
+            with trio.fail_after(seconds=30):
+                while True:
+                    with trio.move_on_after(seconds=1):
+                        checkpoint_after = await bft_network.wait_for_checkpoint(replica_id=replica_id)
+                        if checkpoint_after == checkpoint_before + 2:
+                            break
+
+        await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
+
+    # @unittest.skip("Test case assumes the happy path")
+    @with_trio
+    @with_bft_network(start_replica_cmd)
+    async def test_wedge_command_with_state_transfer(self, bft_network):
+        """
+            This test checks that even a replica that received the super stable checkpoint via the state transfer mechanism
+            is able to stop at the super stable checkpoint.
+            The test does the following:
+            1. Start all replicas but 1
+            2. A client sends a wedge command
+            3. Validate that all started replicas reached to the next next checkpoint
+            4. Start the late replica
+            5. Validate that the late replica completed the state transfer
+            6. Validate that all replicas stopped at the super stable checkpoint and that new commands are not being processed
+        """
+        initial_prim = 0
+        late_replicas = bft_network.random_set_of_replicas(1, {initial_prim})
+        on_time_replicas = bft_network.all_replicas(without=late_replicas)
+        bft_network.start_replicas(on_time_replicas)
+
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+
+        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
+
+        client = bft_network.random_client()
+        await client.write(skvbc.write_req([], [], block_id=0, wedge_command=True))
+
+        for replica_id in on_time_replicas:
+            with trio.fail_after(seconds=30):
+                while True:
+                    with trio.move_on_after(seconds=1):
+                        checkpoint_after = await bft_network.wait_for_checkpoint(replica_id=replica_id)
+                        if checkpoint_after == checkpoint_before + 2:
+                            break
+
+        bft_network.start_replicas(late_replicas)
+
+        await bft_network.wait_for_state_transfer_to_start()
+        for r in late_replicas:
+            await bft_network.wait_for_state_transfer_to_stop(initial_prim,
+                                                              r,
+                                                              stop_on_stable_seq_num=True)
+
+        for replica_id in range(bft_network.config.n):
+            with trio.fail_after(seconds=30):
+                while True:
+                    with trio.move_on_after(seconds=1):
+                        checkpoint_after = await bft_network.wait_for_checkpoint(replica_id=replica_id)
+                        if checkpoint_after == checkpoint_before + 2:
+                            break
+
+        await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
+
+    async def validate_stop_on_super_stable_checkpoint(self, bft_network, skvbc):
+        for replica_id in range(bft_network.config.n):
+            with trio.fail_after(seconds=90):
+                while True:
+                    with trio.move_on_after(seconds=1):
+                        try:
+                            key = ['replica', 'Gauges', 'OnCallBackOfSuperStableCP']
+                            value = await bft_network.metrics.get(replica_id, *key)
+                            if value == 0:
+                                continue
+                        except trio.TooSlowError:
+                            print(f"Replica {replica_id} was not able to get to super stable checkpoint within the timeout")
+                            self.assertTrue(False)
+                        else:
+                            self.assertEqual(value, 1)
+                            break
+        try:
+            await skvbc.write_known_kv()
+        except trio.TooSlowError:
+            return
+        else:
+            self.assertTrue(False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -30,6 +30,7 @@ class SimpleKVBCProtocol:
     GET_LAST_BLOCK = 3
     GET_BLOCK_DATA = 4
     LONG_EXEC_WRITE = 5
+    WEDGE = 6
 
     """
     An implementation of the wire protocol for SimpleKVBC requests.
@@ -46,11 +47,13 @@ class SimpleKVBCProtocol:
         self.keys = self._create_keys()
 
     @classmethod
-    def write_req(cls, readset, writeset, block_id, long_exec=False):
+    def write_req(cls, readset, writeset, block_id, long_exec=False, wedge_command=False):
         data = bytearray()
         # A conditional write request type
         if long_exec is True:
             data.append(cls.LONG_EXEC_WRITE)
+        elif wedge_command is True:
+            data.append(cls.WEDGE)
         else:
             data.append(cls.WRITE)
         # SimpleConditionalWriteHeader

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -111,6 +111,10 @@ bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
                << " PRE_PROCESS_FLAG=" << ((flags & MsgFlag::PRE_PROCESS_FLAG) != 0 ? "true" : "false")
                << " HAS_PRE_PROCESSED_FLAG=" << ((flags & MsgFlag::HAS_PRE_PROCESSED_FLAG) != 0 ? "true" : "false"));
 
+  if (writeReq->header.type == WEDGE) {
+    LOG_INFO(m_logger, "A wedge command has been called" << KVLOG(sequenceNum));
+    controlStateManager_->setStopAtNextCheckpoint(sequenceNum);
+  }
   if (!(flags & MsgFlag::HAS_PRE_PROCESSED_FLAG)) {
     bool result = verifyWriteCommand(requestSize, *writeReq, maxReplySize, outReplySize);
     if (!result) ConcordAssert(0);

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -22,14 +22,25 @@
 #include "KVBCInterfaces.h"
 #include <memory>
 #include "ControlStateManager.hpp"
+#include <chrono>
+#include <thread>
 
+class InternalControlHandlers : public bftEngine::ControlHandlers {
+ public:
+  void onSuperStableCheckpoint() override {}
+  virtual ~InternalControlHandlers(){};
+};
 class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
  public:
   InternalCommandsHandler(concord::kvbc::ILocalKeyValueStorageReadOnly *storage,
                           concord::kvbc::IBlocksAppender *blocksAppender,
                           concord::kvbc::IBlockMetadata *blockMetadata,
                           logging::Logger &logger)
-      : m_storage(storage), m_blocksAppender(blocksAppender), m_blockMetadata(blockMetadata), m_logger(logger) {}
+      : m_storage(storage),
+        m_blocksAppender(blocksAppender),
+        m_blockMetadata(blockMetadata),
+        m_logger(logger),
+        controlHandlers_(std::make_shared<InternalControlHandlers>()) {}
 
   virtual int execute(uint16_t clientId,
                       uint64_t sequenceNum,
@@ -71,7 +82,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
 
   void addMetadataKeyValue(concord::storage::SetOfKeyValuePairs &updates, uint64_t sequenceNum) const;
 
-  std::shared_ptr<bftEngine::ControlHandlers> getControlHandlers() override { return nullptr; }
+  std::shared_ptr<bftEngine::ControlHandlers> getControlHandlers() override { return controlHandlers_; }
 
  private:
   static concordUtils::Sliver buildSliverFromStaticBuf(char *buf);
@@ -85,4 +96,5 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
   size_t m_writesCounter = 0;
   size_t m_getLastBlockCounter = 0;
   std::shared_ptr<bftEngine::ControlStateManager> controlStateManager_;
+  std::shared_ptr<bftEngine::ControlHandlers> controlHandlers_;
 };

--- a/tests/simpleKVBC/simpleKVBTestsBuilder.hpp
+++ b/tests/simpleKVBC/simpleKVBTestsBuilder.hpp
@@ -61,7 +61,8 @@ enum RequestType : char {
   COND_WRITE = 2,
   GET_LAST_BLOCK = 3,
   GET_BLOCK_DATA = 4,
-  LONG_EXEC_COND_WRITE = 5
+  LONG_EXEC_COND_WRITE = 5,
+  WEDGE = 6
 };
 
 struct SimpleRequest {


### PR DESCRIPTION
After enabling Apollo tests for the wedge command feature (#790) we discovered they were unstable for configurations with n > 4 replicas and we had to revert them (#802).

We suspect that due to the fact that CI runs with UDP configuration, part of the replicas were not able to receive n/n checkpoint messages.
For that, we added a retransmitting mechanism that is activated once the wedge flag is raised by the command handler.
We believe that this addition will help to stabilize the feature even when facing network errors and packages dropping.