### PR TITLE
Add support in Prometheus summary

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -9,7 +9,10 @@ set(util_source_files
     src/status.cpp
     src/sliver.cpp
     src/hex_tools.cpp
-    src/OpenTracing.cpp)
+    src/OpenTracing.cpp
+    src/summary.cpp
+    src/time_window_quantiles.cpp
+    src/ckms_quantiles.cpp)
 
 add_library(util STATIC
     ${util_source_files}

--- a/util/include/ckms_quantiles.hpp
+++ b/util/include/ckms_quantiles.hpp
@@ -1,0 +1,66 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+namespace concordMetrics {
+namespace prometheusMetrics {
+
+class CKMSQuantiles {
+ public:
+  class Quantile {
+   public:
+    const double quantile;
+    const double error;
+    const double u;
+    const double v;
+
+    Quantile(double quantile, double error);
+  };
+
+ private:
+  class Item {
+   public:
+    double value;
+    int g;
+    int delta;
+    explicit Item(double value, int lower_delta, int delta);
+  };
+
+ public:
+  explicit CKMSQuantiles(const std::vector<Quantile>& quantiles);
+  void insert(double value);
+  double get(double q);
+  void reset();
+
+ private:
+  double allowableError(int rank);
+  bool insertBatch();
+  void compress();
+
+ private:
+  const std::reference_wrapper<const std::vector<Quantile>> quantiles_;
+
+  std::size_t count_;
+  std::vector<Item> sample_;
+  std::array<double, 500> buffer_;
+  std::size_t buffer_count_;
+};
+
+}  // namespace prometheusMetrics
+}  // namespace concordMetrics

--- a/util/include/summary.hpp
+++ b/util/include/summary.hpp
@@ -1,0 +1,88 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include "ckms_quantiles.hpp"
+#include "time_window_quantiles.hpp"
+
+namespace concordMetrics {
+namespace prometheusMetrics {
+class Summary {
+ public:
+  struct Quantile {
+    double quantile = 0.0;
+    double value = 0.0;
+  };
+
+  struct SummaryDescription {
+    std::uint64_t sample_count = 0;
+    double sample_sum = 0.0;
+    std::vector<Quantile> quantile;
+  };
+
+  using Quantiles = std::vector<CKMSQuantiles::Quantile>;
+
+  /// \brief Create a summary metric.
+  ///
+  /// \param quantiles A list of 'targeted' Phi-quantiles. A targeted
+  /// Phi-quantile is specified in the form of a Phi-quantile and tolerated
+  /// error. For example a Quantile{0.5, 0.1} means that the median (= 50th
+  /// percentile) should be returned with 10 percent error or a Quantile{0.2,
+  /// 0.05} means the 20th percentile with 5 percent tolerated error. Note that
+  /// percentiles and quantiles are the same concept, except percentiles are
+  /// expressed as percentages. The Phi-quantile must be in the interval [0, 1].
+  /// Note that a lower tolerated error for a Phi-quantile results in higher
+  /// usage of resources (memory and cpu) to calculate the summary.
+  ///
+  /// The Phi-quantiles are calculated over a sliding window of time. The
+  /// sliding window of time is configured by max_age and age_buckets.
+  ///
+  /// \param max_age Set the duration of the time window, i.e., how long
+  /// observations are kept before they are discarded. The default value is 60
+  /// seconds.
+  ///
+  /// \param age_buckets Set the number of buckets of the time window. It
+  /// determines the number of buckets used to exclude observations that are
+  /// older than max_age from the summary, e.g., if max_age is 60 seconds and
+  /// age_buckets is 5, buckets will be switched every 12 seconds. The value is
+  /// a trade-off between resources (memory and cpu for maintaining the bucket)
+  /// and how smooth the time window is moved. With only one age bucket it
+  /// effectively results in a complete reset of the summary each time max_age
+  /// has passed. The default value is 5.
+  Summary(Quantiles& quantiles, std::chrono::milliseconds max_age = std::chrono::seconds{60}, int age_buckets = 5);
+
+  /// \brief Observe the given amount.
+  void Observe(double value);
+
+  /// \brief Get the current value of the summary.
+  ///
+  /// Collect is called by the Registry when collecting metrics.
+  SummaryDescription Collect();
+
+  std::string ToJson();
+
+ private:
+  const Quantiles quantiles_;
+  std::uint64_t count_;
+  double sum_;
+  TimeWindowQuantiles quantile_values_;
+};
+
+}  // namespace prometheusMetrics
+}  // namespace concordMetrics

--- a/util/include/time_window_quantiles.hpp
+++ b/util/include/time_window_quantiles.hpp
@@ -1,0 +1,46 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <vector>
+
+#include "ckms_quantiles.hpp"
+namespace concordMetrics {
+namespace prometheusMetrics {
+
+class TimeWindowQuantiles {
+  using Clock = std::chrono::steady_clock;
+
+ public:
+  TimeWindowQuantiles(const std::vector<CKMSQuantiles::Quantile>& quantiles,
+                      Clock::duration max_age_seconds,
+                      int age_buckets);
+
+  double get(double q);
+  void insert(double value);
+
+ private:
+  CKMSQuantiles& rotate();
+
+  const std::vector<CKMSQuantiles::Quantile>& quantiles_;
+  std::vector<CKMSQuantiles> ckms_quantiles_;
+  std::size_t current_bucket_;
+
+  Clock::time_point last_rotation_;
+  const Clock::duration rotation_interval_;
+};
+}  // namespace prometheusMetrics
+}  // namespace concordMetrics

--- a/util/src/ckms_quantiles.cpp
+++ b/util/src/ckms_quantiles.cpp
@@ -1,0 +1,158 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "ckms_quantiles.hpp"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace concordMetrics {
+namespace prometheusMetrics {
+
+CKMSQuantiles::Quantile::Quantile(double quantile, double error)
+    : quantile(quantile), error(error), u(2.0 * error / (1.0 - quantile)), v(2.0 * error / quantile) {}
+
+CKMSQuantiles::Item::Item(double value, int lower_delta, int delta) : value(value), g(lower_delta), delta(delta) {}
+
+CKMSQuantiles::CKMSQuantiles(const std::vector<Quantile>& quantiles)
+    : quantiles_(quantiles), count_(0), buffer_{}, buffer_count_(0) {}
+
+void CKMSQuantiles::insert(double value) {
+  buffer_[buffer_count_] = value;
+  ++buffer_count_;
+
+  if (buffer_count_ == buffer_.size()) {
+    insertBatch();
+    compress();
+  }
+}
+
+double CKMSQuantiles::get(double q) {
+  insertBatch();
+  compress();
+
+  if (sample_.empty()) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  int rankMin = 0;
+  const auto desired = static_cast<int>(q * count_);
+  const auto bound = desired + (allowableError(desired) / 2);
+
+  auto it = sample_.begin();
+  decltype(it) prev;
+  auto cur = it++;
+
+  while (it != sample_.end()) {
+    prev = cur;
+    cur = it++;
+
+    rankMin += prev->g;
+
+    if (rankMin + cur->g + cur->delta > bound) {
+      return prev->value;
+    }
+  }
+
+  return sample_.back().value;
+}
+
+void CKMSQuantiles::reset() {
+  count_ = 0;
+  sample_.clear();
+  buffer_count_ = 0;
+}
+
+double CKMSQuantiles::allowableError(int rank) {
+  auto size = sample_.size();
+  double minError = size + 1;
+
+  for (const auto& q : quantiles_.get()) {
+    double error;
+    if (rank <= q.quantile * size) {
+      error = q.u * (size - rank);
+    } else {
+      error = q.v * rank;
+    }
+    if (error < minError) {
+      minError = error;
+    }
+  }
+
+  return minError;
+}
+
+bool CKMSQuantiles::insertBatch() {
+  if (buffer_count_ == 0) {
+    return false;
+  }
+
+  std::sort(buffer_.begin(), buffer_.begin() + buffer_count_);
+
+  std::size_t start = 0;
+  if (sample_.empty()) {
+    sample_.emplace_back(buffer_[0], 1, 0);
+    ++start;
+    ++count_;
+  }
+
+  std::size_t idx = 0;
+  std::size_t item = idx++;
+
+  for (std::size_t i = start; i < buffer_count_; ++i) {
+    double v = buffer_[i];
+    while (idx < sample_.size() && sample_[item].value < v) {
+      item = idx++;
+    }
+
+    if (sample_[item].value > v) {
+      --idx;
+    }
+
+    int delta;
+    if (idx - 1 == 0 || idx + 1 == sample_.size()) {
+      delta = 0;
+    } else {
+      delta = static_cast<int>(std::floor(allowableError(idx + 1))) + 1;
+    }
+
+    sample_.emplace(sample_.begin() + idx, v, 1, delta);
+    count_++;
+    item = idx++;
+  }
+
+  buffer_count_ = 0;
+  return true;
+}
+
+void CKMSQuantiles::compress() {
+  if (sample_.size() < 2) {
+    return;
+  }
+
+  std::size_t idx = 0;
+  std::size_t prev;
+  std::size_t next = idx++;
+
+  while (idx < sample_.size()) {
+    prev = next;
+    next = idx++;
+
+    if (sample_[prev].g + sample_[next].g + sample_[next].delta <= allowableError(idx - 1)) {
+      sample_[next].g += sample_[prev].g;
+      sample_.erase(sample_.begin() + prev);
+    }
+  }
+}
+}  // namespace prometheusMetrics
+}  // namespace concordMetrics

--- a/util/src/ckms_quantiles.cpp
+++ b/util/src/ckms_quantiles.cpp
@@ -75,12 +75,12 @@ void CKMSQuantiles::reset() {
 
 double CKMSQuantiles::allowableError(int rank) {
   auto size = sample_.size();
-  double minError = size + 1;
+  double minError = (double)(size + 1);
 
   for (const auto& q : quantiles_.get()) {
     double error;
     if (rank <= q.quantile * size) {
-      error = q.u * (size - rank);
+      error = q.u * (double)(size - rank);
     } else {
       error = q.v * rank;
     }
@@ -123,7 +123,7 @@ bool CKMSQuantiles::insertBatch() {
     if (idx - 1 == 0 || idx + 1 == sample_.size()) {
       delta = 0;
     } else {
-      delta = static_cast<int>(std::floor(allowableError(idx + 1))) + 1;
+      delta = static_cast<int>(std::floor(allowableError((int)idx + 1))) + 1;
     }
 
     sample_.emplace(sample_.begin() + idx, v, 1, delta);
@@ -148,7 +148,7 @@ void CKMSQuantiles::compress() {
     prev = next;
     next = idx++;
 
-    if (sample_[prev].g + sample_[next].g + sample_[next].delta <= allowableError(idx - 1)) {
+    if (sample_[prev].g + sample_[next].g + sample_[next].delta <= allowableError((int)idx - 1)) {
       sample_[next].g += sample_[prev].g;
       sample_.erase(sample_.begin() + prev);
     }

--- a/util/src/summary.cpp
+++ b/util/src/summary.cpp
@@ -1,0 +1,58 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "summary.hpp"
+#include <sstream>
+
+namespace concordMetrics {
+namespace prometheusMetrics {
+Summary::Summary(Quantiles& quantiles, const std::chrono::milliseconds max_age, const int age_buckets)
+    : quantiles_{std::move(quantiles)}, count_{0}, sum_{0}, quantile_values_{quantiles_, max_age, age_buckets} {}
+
+void Summary::Observe(const double value) {
+  count_ += 1;
+  sum_ += value;
+  quantile_values_.insert(value);
+}
+
+Summary::SummaryDescription Summary::Collect() {
+  auto metric = Summary::SummaryDescription{};
+
+  for (const auto& quantile : quantiles_) {
+    auto metricQuantile = Summary::Quantile{};
+    metricQuantile.quantile = quantile.quantile;
+    metricQuantile.value = quantile_values_.get(quantile.quantile);
+    metric.quantile.push_back(std::move(metricQuantile));
+  }
+  metric.sample_count = count_;
+  metric.sample_sum = sum_;
+
+  return metric;
+}
+
+std::string Summary::ToJson() {
+  auto data = Collect();
+  std::ostringstream oss;
+  oss << "{\"Quantiles\":{";
+  for (uint32_t i = 0; i < data.quantile.size(); i++) {
+    if (i != 0) oss << ",";
+    oss << "\"" << data.quantile[i].quantile << "\":" << data.quantile[i].value << "";
+  }
+  oss << "}";
+  oss << ", \"Sample_sum\":" << data.sample_sum;
+  oss << ", \"Sample_count:\"" << data.sample_count;
+  oss << "}";
+  return oss.str();
+}
+}  // namespace prometheusMetrics
+}  // namespace concordMetrics

--- a/util/src/summary.cpp
+++ b/util/src/summary.cpp
@@ -17,7 +17,7 @@
 namespace concordMetrics {
 namespace prometheusMetrics {
 Summary::Summary(Quantiles& quantiles, const std::chrono::milliseconds max_age, const int age_buckets)
-    : quantiles_{std::move(quantiles)}, count_{0}, sum_{0}, quantile_values_{quantiles_, max_age, age_buckets} {}
+    : quantiles_{quantiles}, count_{0}, sum_{0}, quantile_values_{quantiles_, max_age, age_buckets} {}
 
 void Summary::Observe(const double value) {
   count_ += 1;
@@ -32,7 +32,7 @@ Summary::SummaryDescription Summary::Collect() {
     auto metricQuantile = Summary::Quantile{};
     metricQuantile.quantile = quantile.quantile;
     metricQuantile.value = quantile_values_.get(quantile.quantile);
-    metric.quantile.push_back(std::move(metricQuantile));
+    metric.quantile.push_back(metricQuantile);
   }
   metric.sample_count = count_;
   metric.sample_sum = sum_;

--- a/util/src/time_window_quantiles.cpp
+++ b/util/src/time_window_quantiles.cpp
@@ -1,0 +1,56 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <time_window_quantiles.hpp>
+
+#include "time_window_quantiles.hpp"
+namespace concordMetrics {
+namespace prometheusMetrics {
+
+TimeWindowQuantiles::TimeWindowQuantiles(const std::vector<CKMSQuantiles::Quantile>& quantiles,
+                                         const Clock::duration max_age,
+                                         const int age_buckets)
+    : quantiles_(quantiles),
+      ckms_quantiles_(age_buckets, CKMSQuantiles(quantiles_)),
+      current_bucket_(0),
+      last_rotation_(Clock::now()),
+      rotation_interval_(max_age / age_buckets) {}
+
+double TimeWindowQuantiles::get(double q) {
+  CKMSQuantiles& current_bucket = rotate();
+  return current_bucket.get(q);
+}
+
+void TimeWindowQuantiles::insert(double value) {
+  rotate();
+  for (auto& bucket : ckms_quantiles_) {
+    bucket.insert(value);
+  }
+}
+
+CKMSQuantiles& TimeWindowQuantiles::rotate() {
+  auto delta = Clock::now() - last_rotation_;
+  while (delta > rotation_interval_) {
+    ckms_quantiles_[current_bucket_].reset();
+
+    if (++current_bucket_ >= ckms_quantiles_.size()) {
+      current_bucket_ = 0;
+    }
+
+    delta -= rotation_interval_;
+    last_rotation_ += rotation_interval_;
+  }
+  return ckms_quantiles_[current_bucket_];
+}
+}  // namespace prometheusMetrics
+}  // namespace concordMetrics


### PR DESCRIPTION
In this PR we add support in Prometheus Summaries in concord-bft.
For that, and to avoid dependencies, we adjusted the relevant code from the Prometheus-cpp project (https://github.com/jupp0r/prometheus-cpp) to our concord-bft needs.

Note that the Prometheus-project is under MIT license so there is no problem with taking the relevant parts to our code.