### PR TITLE
[Pre-execution] Fix span context/cid order when creating PreProcessRequestMsg

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -484,8 +484,8 @@ void PreProcessor::handleClientPreProcessRequestByPrimary(ClientPreProcessReqMsg
                                         requestSeqNum,
                                         clientReqMsg->requestLength(),
                                         clientReqMsg->requestBuf(),
-                                        clientReqMsg->getCid(),
-                                        clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
+                                        clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>(),
+                                        clientReqMsg->getCid());
   if (registerRequest(move(clientReqMsg), preProcessRequestMsg)) {
     sendPreProcessRequestToAllReplicas(preProcessRequestMsg);
     // Pre-process the request and calculate a hash of the result


### PR DESCRIPTION
Both fields are `std::string`, which is why the compiler did not detect the wrong parameter order.