### PR TITLE
Opentracing: type for span context

### DIFF
--- a/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
+++ b/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <set>
 
+#include "OpenTracing.hpp"
 #include "PrimitiveTypes.hpp"
 #include "Digest.hpp"
 #include "Crypto.hpp"
@@ -126,11 +127,12 @@ class CollectorOfThresholdSignatures {
     trySendToBkThread();
   }
 
-  void onCompletionOfSignaturesProcessing(SeqNum seqNumber,
-                                          ViewNum view,
-                                          const char* combinedSig,
-                                          uint16_t combinedSigLen,
-                                          const std::string& span_context)  // if we compute a valid combined signature
+  void onCompletionOfSignaturesProcessing(
+      SeqNum seqNumber,
+      ViewNum view,
+      const char* combinedSig,
+      uint16_t combinedSigLen,
+      const concordUtils::SpanContext& span_context)  // if we compute a valid combined signature
   {
     ConcordAssert(expectedSeqNumber == seqNumber);
     ConcordAssert(expectedView == view);
@@ -284,7 +286,7 @@ class CollectorOfThresholdSignatures {
       ReplicaId srcRepId;
       char* sigBody;
       uint16_t sigLength;
-      std::string span_context;
+      concordUtils::SpanContext span_context;
     };
 
     IThresholdVerifier* const verifier;
@@ -320,7 +322,10 @@ class CollectorOfThresholdSignatures {
       this->context = cnt;
     }
 
-    void add(ReplicaId srcRepId, const char* sigBody, uint16_t sigLength, const std::string& span_context) {
+    void add(ReplicaId srcRepId,
+             const char* sigBody,
+             uint16_t sigLength,
+             const concordUtils::SpanContext& span_context) {
       ConcordAssert(numOfDataItems < reqDataItems);
 
       SigData d;
@@ -354,7 +359,7 @@ class CollectorOfThresholdSignatures {
       std::vector<char> bufferForSigComputations(bufferSize);
 
       const auto& span_context_of_last_message =
-          (reqDataItems - 1) ? sigDataItems[reqDataItems - 1].span_context : std::string{};
+          (reqDataItems - 1) ? sigDataItems[reqDataItems - 1].span_context : concordUtils::SpanContext{};
       {
         IThresholdAccumulator* acc = verifier->newAccumulator(false);
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -364,7 +364,7 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
   controller->onSendingPrePrepare((primaryLastUsedSeqNum + 1), firstPath);
 
   ClientRequestMsg *nextRequest = (!requestsQueueOfPrimary.empty() ? requestsQueueOfPrimary.front() : nullptr);
-  const auto &span_context = nextRequest ? nextRequest->spanContext<ClientRequestMsg>() : std::string{};
+  const auto &span_context = nextRequest ? nextRequest->spanContext<ClientRequestMsg>() : concordUtils::SpanContext{};
 
   PrePrepareMsg *pp = new PrePrepareMsg(
       config_.replicaId, curView, (primaryLastUsedSeqNum + 1), firstPath, span_context, primaryCombinedReqSize);
@@ -1251,8 +1251,11 @@ void ReplicaImp::onPrepareCombinedSigFailed(SeqNum seqNumber,
   // TODO(GG): add logic that handles bad replicas ...
 }
 
-void ReplicaImp::onPrepareCombinedSigSucceeded(
-    SeqNum seqNumber, ViewNum view, const char *combinedSig, uint16_t combinedSigLen, const std::string &span_context) {
+void ReplicaImp::onPrepareCombinedSigSucceeded(SeqNum seqNumber,
+                                               ViewNum view,
+                                               const char *combinedSig,
+                                               uint16_t combinedSigLen,
+                                               const concordUtils::SpanContext &span_context) {
   SCOPED_MDC_PRIMARY(std::to_string(currentPrimary()));
   SCOPED_MDC_SEQ_NUM(std::to_string(seqNumber));
   SCOPED_MDC_PATH(CommitPathToMDCString(CommitPath::SLOW));
@@ -1341,8 +1344,11 @@ void ReplicaImp::onCommitCombinedSigFailed(SeqNum seqNumber,
   // TODO(GG): add logic that handles bad replicas ...
 }
 
-void ReplicaImp::onCommitCombinedSigSucceeded(
-    SeqNum seqNumber, ViewNum view, const char *combinedSig, uint16_t combinedSigLen, const std::string &span_context) {
+void ReplicaImp::onCommitCombinedSigSucceeded(SeqNum seqNumber,
+                                              ViewNum view,
+                                              const char *combinedSig,
+                                              uint16_t combinedSigLen,
+                                              const concordUtils::SpanContext &span_context) {
   SCOPED_MDC_PRIMARY(std::to_string(currentPrimary()));
   SCOPED_MDC_SEQ_NUM(std::to_string(seqNumber));
   SCOPED_MDC_PATH(CommitPathToMDCString(CommitPath::SLOW));

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -389,7 +389,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                      ViewNum view,
                                      const char* combinedSig,
                                      uint16_t combinedSigLen,
-                                     const std::string& span_context);
+                                     const concordUtils::SpanContext& span_context);
   void onPrepareVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view, bool isValid);
 
   void onCommitCombinedSigFailed(SeqNum seqNumber, ViewNum view, const std::set<uint16_t>& replicasWithBadSigs);
@@ -397,7 +397,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                     ViewNum view,
                                     const char* combinedSig,
                                     uint16_t combinedSigLen,
-                                    const std::string& span_context);
+                                    const concordUtils::SpanContext& span_context);
   void onCommitVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view, bool isValid);
 
   void onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqNum,

--- a/bftengine/src/bftengine/SeqNumInfo.cpp
+++ b/bftengine/src/bftengine/SeqNumInfo.cpp
@@ -11,6 +11,7 @@
 
 #include "SeqNumInfo.hpp"
 #include "InternalReplicaApi.hpp"
+#include "OpenTracing.hpp"
 #include "messages/SignatureInternalMsgs.hpp"
 
 namespace bftEngine {
@@ -277,7 +278,7 @@ void SeqNumInfo::onCompletionOfPrepareSignaturesProcessing(SeqNum seqNumber,
                                                            ViewNum viewNumber,
                                                            const char* combinedSig,
                                                            uint16_t combinedSigLen,
-                                                           const std::string& span_context) {
+                                                           const concordUtils::SpanContext& span_context) {
   prepareSigCollector->onCompletionOfSignaturesProcessing(
       seqNumber, viewNumber, combinedSig, combinedSigLen, span_context);
 }
@@ -290,12 +291,13 @@ void SeqNumInfo::onCompletionOfCombinedPrepareSigVerification(SeqNum seqNumber, 
 // class SeqNumInfo::ExFuncForPrepareCollector
 ///////////////////////////////////////////////////////////////////////////////
 
-PrepareFullMsg* SeqNumInfo::ExFuncForPrepareCollector::createCombinedSignatureMsg(void* context,
-                                                                                  SeqNum seqNumber,
-                                                                                  ViewNum viewNumber,
-                                                                                  const char* const combinedSig,
-                                                                                  uint16_t combinedSigLen,
-                                                                                  const std::string& span_context) {
+PrepareFullMsg* SeqNumInfo::ExFuncForPrepareCollector::createCombinedSignatureMsg(
+    void* context,
+    SeqNum seqNumber,
+    ViewNum viewNumber,
+    const char* const combinedSig,
+    uint16_t combinedSigLen,
+    const concordUtils::SpanContext& span_context) {
   InternalReplicaApi* r = (InternalReplicaApi*)context;
   return PrepareFullMsg::create(
       viewNumber, seqNumber, r->getReplicasInfo().myId(), combinedSig, combinedSigLen, span_context);
@@ -311,7 +313,7 @@ InternalMessage SeqNumInfo::ExFuncForPrepareCollector::createInterCombinedSigSuc
     ViewNum viewNumber,
     const char* combinedSig,
     uint16_t combinedSigLen,
-    const std::string& span_context) {
+    const concordUtils::SpanContext& span_context) {
   return CombinedSigSucceededInternalMsg(seqNumber, viewNumber, combinedSig, combinedSigLen, span_context);
 }
 
@@ -346,12 +348,13 @@ IncomingMsgsStorage& SeqNumInfo::ExFuncForPrepareCollector::incomingMsgsStorage(
 // class SeqNumInfo::ExFuncForCommitCollector
 ///////////////////////////////////////////////////////////////////////////////
 
-CommitFullMsg* SeqNumInfo::ExFuncForCommitCollector::createCombinedSignatureMsg(void* context,
-                                                                                SeqNum seqNumber,
-                                                                                ViewNum viewNumber,
-                                                                                const char* const combinedSig,
-                                                                                uint16_t combinedSigLen,
-                                                                                const std::string& span_context) {
+CommitFullMsg* SeqNumInfo::ExFuncForCommitCollector::createCombinedSignatureMsg(
+    void* context,
+    SeqNum seqNumber,
+    ViewNum viewNumber,
+    const char* const combinedSig,
+    uint16_t combinedSigLen,
+    const concordUtils::SpanContext& span_context) {
   InternalReplicaApi* r = (InternalReplicaApi*)context;
   return CommitFullMsg::create(
       viewNumber, seqNumber, r->getReplicasInfo().myId(), combinedSig, combinedSigLen, span_context);
@@ -362,11 +365,12 @@ InternalMessage SeqNumInfo::ExFuncForCommitCollector::createInterCombinedSigFail
   return CombinedCommitSigFailedInternalMsg(seqNumber, viewNumber, replicasWithBadSigs);
 }
 
-InternalMessage SeqNumInfo::ExFuncForCommitCollector::createInterCombinedSigSucceeded(SeqNum seqNumber,
-                                                                                      ViewNum viewNumber,
-                                                                                      const char* combinedSig,
-                                                                                      uint16_t combinedSigLen,
-                                                                                      const std::string& span_context) {
+InternalMessage SeqNumInfo::ExFuncForCommitCollector::createInterCombinedSigSucceeded(
+    SeqNum seqNumber,
+    ViewNum viewNumber,
+    const char* combinedSig,
+    uint16_t combinedSigLen,
+    const concordUtils::SpanContext& span_context) {
   return CombinedCommitSigSucceededInternalMsg(seqNumber, viewNumber, combinedSig, combinedSigLen, span_context);
 }
 

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -14,6 +14,7 @@
 #include <set>
 
 // TODO(GG): clean/move 'include' statements
+#include "OpenTracing.hpp"
 #include "PrimitiveTypes.hpp"
 #include "SysConsts.hpp"
 #include "messages/PrePrepareMsg.hpp"
@@ -86,7 +87,7 @@ class SeqNumInfo {
                                                  ViewNum viewNumber,
                                                  const char* combinedSig,
                                                  uint16_t combinedSigLen,
-                                                 const std::string& span_context);
+                                                 const concordUtils::SpanContext& span_context);
   void onCompletionOfCombinedPrepareSigVerification(SeqNum seqNumber, ViewNum viewNumber, bool isValid);
 
   void onCompletionOfCommitSignaturesProcessing(SeqNum seqNumber,
@@ -99,7 +100,7 @@ class SeqNumInfo {
                                                 ViewNum viewNumber,
                                                 const char* combinedSig,
                                                 uint16_t combinedSigLen,
-                                                const std::string& span_context) {
+                                                const concordUtils::SpanContext& span_context) {
     commitMsgsCollector->onCompletionOfSignaturesProcessing(
         seqNumber, viewNumber, combinedSig, combinedSigLen, span_context);
   }
@@ -117,7 +118,7 @@ class SeqNumInfo {
                                                       ViewNum viewNumber,
                                                       const char* const combinedSig,
                                                       uint16_t combinedSigLen,
-                                                      const std::string& span_context);
+                                                      const concordUtils::SpanContext& span_context);
 
     // internal messages
     static InternalMessage createInterCombinedSigFailed(SeqNum seqNumber,
@@ -127,7 +128,7 @@ class SeqNumInfo {
                                                            ViewNum viewNumber,
                                                            const char* combinedSig,
                                                            uint16_t combinedSigLen,
-                                                           const std::string& span_context);
+                                                           const concordUtils::SpanContext& span_context);
     static InternalMessage createInterVerifyCombinedSigResult(SeqNum seqNumber, ViewNum viewNumber, bool isValid);
 
     // from the Replica object
@@ -145,7 +146,7 @@ class SeqNumInfo {
                                                      ViewNum viewNumber,
                                                      const char* const combinedSig,
                                                      uint16_t combinedSigLen,
-                                                     const std::string& span_context);
+                                                     const concordUtils::SpanContext& span_context);
 
     // internal messages
     static InternalMessage createInterCombinedSigFailed(SeqNum seqNumber,
@@ -155,7 +156,7 @@ class SeqNumInfo {
                                                            ViewNum viewNumber,
                                                            const char* combinedSig,
                                                            uint16_t combinedSigLen,
-                                                           const std::string& span_context);
+                                                           const concordUtils::SpanContext& span_context);
     static InternalMessage createInterVerifyCombinedSigResult(SeqNum seqNumber, ViewNum viewNumber, bool isValid);
 
     // from the ReplicaImp object

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -16,6 +16,7 @@
 #include <condition_variable>
 
 #include "ClientMsgs.hpp"
+#include "OpenTracing.hpp"
 #include "SimpleClient.hpp"
 #include "assertUtils.hpp"
 #include "TimeUtils.hpp"
@@ -243,12 +244,12 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
   const Time beginTime = getMonotonicTime();
 
   ClientRequestMsg* reqMsg;
+  concordUtils::SpanContext ctx{span_context};
   if (isPreProcessRequired)
     reqMsg = new preprocessor::ClientPreProcessRequestMsg(
-        clientId_, reqSeqNum, lengthOfRequest, request, timeoutMilli, msgCid, span_context);
+        clientId_, reqSeqNum, lengthOfRequest, request, timeoutMilli, msgCid, ctx);
   else
-    reqMsg =
-        new ClientRequestMsg(clientId_, flags, reqSeqNum, lengthOfRequest, request, timeoutMilli, msgCid, span_context);
+    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lengthOfRequest, request, timeoutMilli, msgCid, ctx);
   pendingRequest_ = reqMsg;
 
   sendPendingRequest();

--- a/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
@@ -13,16 +13,17 @@
 
 #include "MessageBase.hpp"
 #include "Digest.hpp"
+#include "OpenTracing.hpp"
 #include "assertUtils.hpp"
 
 namespace bftEngine::impl {
 
 class AskForCheckpointMsg : public MessageBase {
  public:
-  AskForCheckpointMsg(ReplicaId senderId, const std::string& spanContext = "")
-      : MessageBase(senderId, MsgCode::AskForCheckpoint, spanContext.size(), sizeof(Header)) {
+  AskForCheckpointMsg(ReplicaId senderId, const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{})
+      : MessageBase(senderId, MsgCode::AskForCheckpoint, spanContext.data().size(), sizeof(Header)) {
     char* position = body() + sizeof(Header);
-    memcpy(position, spanContext.data(), spanContext.size());
+    memcpy(position, spanContext.data().data(), spanContext.data().size());
   }
 
   AskForCheckpointMsg* clone() { return new AskForCheckpointMsg(*this); }

--- a/bftengine/src/bftengine/messages/CheckpointMsg.cpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.cpp
@@ -15,14 +15,17 @@
 namespace bftEngine {
 namespace impl {
 
-CheckpointMsg::CheckpointMsg(
-    ReplicaId senderId, SeqNum seqNum, const Digest& stateDigest, bool stateIsStable, const std::string& spanContext)
-    : MessageBase(senderId, MsgCode::Checkpoint, spanContext.size(), sizeof(Header)) {
+CheckpointMsg::CheckpointMsg(ReplicaId senderId,
+                             SeqNum seqNum,
+                             const Digest& stateDigest,
+                             bool stateIsStable,
+                             const concordUtils::SpanContext& spanContext)
+    : MessageBase(senderId, MsgCode::Checkpoint, spanContext.data().size(), sizeof(Header)) {
   b()->seqNum = seqNum;
   b()->stateDigest = stateDigest;
   b()->flags = 0;
   if (stateIsStable) b()->flags |= 0x1;
-  std::memcpy(body() + sizeof(Header), spanContext.data(), spanContext.size());
+  std::memcpy(body() + sizeof(Header), spanContext.data().data(), spanContext.data().size());
 }
 
 void CheckpointMsg::validate(const ReplicasInfo& repInfo) const {

--- a/bftengine/src/bftengine/messages/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.hpp
@@ -23,7 +23,7 @@ class CheckpointMsg : public MessageBase {
                 SeqNum seqNum,
                 const Digest& stateDigest,
                 bool stateIsStable,
-                const std::string& spanContext = "");
+                const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   SeqNum seqNumber() const { return b()->seqNum; }
 

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -39,15 +39,15 @@ ClientRequestMsg::ClientRequestMsg(NodeIdType sender,
                                    const char* request,
                                    uint64_t reqTimeoutMilli,
                                    const std::string& cid,
-                                   const std::string& spanContext)
+                                   const concordUtils::SpanContext& spanContext)
     : MessageBase(sender,
                   MsgCode::ClientRequest,
-                  spanContext.size(),
+                  spanContext.data().size(),
                   (sizeof(ClientRequestMsgHeader) + requestLength + cid.size())) {
   setParams(sender, reqSeqNum, requestLength, flags, reqTimeoutMilli, cid);
   char* position = body() + sizeof(ClientRequestMsgHeader);
-  memcpy(position, spanContext.data(), spanContext.size());
-  position += spanContext.size();
+  memcpy(position, spanContext.data().data(), spanContext.data().size());
+  position += spanContext.data().size();
   memcpy(position, request, requestLength);
   position += requestLength;
   memcpy(position, cid.data(), cid.size());

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -36,7 +36,7 @@ class ClientRequestMsg : public MessageBase {
                    const char* request,
                    uint64_t reqTimeoutMilli,
                    const std::string& cid = "",
-                   const std::string& spanContext = "");
+                   const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   ClientRequestMsg(ClientRequestMsgHeader* body);
 

--- a/bftengine/src/bftengine/messages/FullCommitProofMsg.cpp
+++ b/bftengine/src/bftengine/messages/FullCommitProofMsg.cpp
@@ -21,14 +21,15 @@ FullCommitProofMsg::FullCommitProofMsg(ReplicaId senderId,
                                        SeqNum s,
                                        const char* commitProofSig,
                                        uint16_t commitProofSigLength,
-                                       const std::string& spanContext)
-    : MessageBase(senderId, MsgCode::FullCommitProof, spanContext.size(), sizeof(Header) + commitProofSigLength) {
+                                       const concordUtils::SpanContext& spanContext)
+    : MessageBase(
+          senderId, MsgCode::FullCommitProof, spanContext.data().size(), sizeof(Header) + commitProofSigLength) {
   b()->viewNum = v;
   b()->seqNum = s;
   b()->thresholSignatureLength = commitProofSigLength;
   auto position = body() + sizeof(Header);
-  memcpy(position, spanContext.data(), spanContext.size());
-  position += spanContext.size();
+  memcpy(position, spanContext.data().data(), spanContext.data().size());
+  position += spanContext.data().size();
   memcpy(position, commitProofSig, commitProofSigLength);
 }
 

--- a/bftengine/src/bftengine/messages/FullCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/messages/FullCommitProofMsg.hpp
@@ -24,7 +24,7 @@ class FullCommitProofMsg : public MessageBase {
                      SeqNum s,
                      const char* commitProofSig,
                      uint16_t commitProofSigLength,
-                     const std::string& spanContext = "");
+                     const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   ViewNum viewNumber() const { return b()->viewNum; }
 

--- a/bftengine/src/bftengine/messages/MessageBase.hpp
+++ b/bftengine/src/bftengine/messages/MessageBase.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <type_traits>
+#include "OpenTracing.hpp"
 #include "SysConsts.hpp"
 #include "PrimitiveTypes.hpp"
 #include "MsgCode.hpp"
@@ -65,8 +66,8 @@ class MessageBase {
   SpanContextSize spanContextSize() const { return msgBody_->spanContextSize; }
 
   template <typename MessageT>
-  std::string spanContext() const {
-    return std::string(body() + sizeOfHeader<MessageT>(), spanContextSize());
+  concordUtils::SpanContext spanContext() const {
+    return concordUtils::SpanContext{std::string(body() + sizeOfHeader<MessageT>(), spanContextSize())};
   }
 
   MessageBase *cloneObjAndMsg() const;

--- a/bftengine/src/bftengine/messages/NewViewMsg.cpp
+++ b/bftengine/src/bftengine/messages/NewViewMsg.cpp
@@ -15,14 +15,14 @@
 namespace bftEngine {
 namespace impl {
 
-NewViewMsg::NewViewMsg(ReplicaId senderId, ViewNum newView, const std::string& spanContext)
+NewViewMsg::NewViewMsg(ReplicaId senderId, ViewNum newView, const concordUtils::SpanContext& spanContext)
     : MessageBase(senderId,
                   MsgCode::NewView,
-                  spanContext.size(),
-                  ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize() - spanContext.size()) {
+                  spanContext.data().size(),
+                  ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize() - spanContext.data().size()) {
   b()->newViewNum = newView;
   b()->elementsCount = 0;
-  memcpy(body() + sizeof(Header), spanContext.data(), spanContext.size());
+  memcpy(body() + sizeof(Header), spanContext.data().data(), spanContext.data().size());
 }
 
 NewViewMsg::NewViewElement* NewViewMsg::elementsArray() const {

--- a/bftengine/src/bftengine/messages/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/messages/NewViewMsg.hpp
@@ -20,7 +20,9 @@ namespace impl {
 
 class NewViewMsg : public MessageBase {
  public:
-  NewViewMsg(ReplicaId senderId, ViewNum newView, const std::string& spanContext = "");
+  NewViewMsg(ReplicaId senderId,
+             ViewNum newView,
+             const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   void addElement(ReplicaId replicaId, Digest& viewChangeDigest);
 

--- a/bftengine/src/bftengine/messages/PartialCommitProofMsg.cpp
+++ b/bftengine/src/bftengine/messages/PartialCommitProofMsg.cpp
@@ -23,10 +23,10 @@ PartialCommitProofMsg::PartialCommitProofMsg(ReplicaId senderId,
                                              CommitPath commitPath,
                                              Digest& digest,
                                              IThresholdSigner* thresholdSigner,
-                                             const std::string& spanContext)
+                                             const concordUtils::SpanContext& spanContext)
     : MessageBase(senderId,
                   MsgCode::PartialCommitProof,
-                  spanContext.size(),
+                  spanContext.data().size(),
                   sizeof(Header) + thresholdSigner->requiredLengthForSignedData()) {
   uint16_t thresholSignatureLength = (uint16_t)thresholdSigner->requiredLengthForSignedData();
 
@@ -36,9 +36,9 @@ PartialCommitProofMsg::PartialCommitProofMsg(ReplicaId senderId,
   b()->thresholSignatureLength = thresholSignatureLength;
 
   char* position = body() + sizeof(Header);
-  memcpy(position, spanContext.data(), spanContext.size());
+  memcpy(position, spanContext.data().data(), spanContext.data().size());
 
-  position = position + spanContext.size();
+  position = position + spanContext.data().size();
   thresholdSigner->signData((const char*)(&(digest)), sizeof(Digest), position, thresholSignatureLength);
 }
 

--- a/bftengine/src/bftengine/messages/PartialCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/messages/PartialCommitProofMsg.hpp
@@ -28,7 +28,7 @@ class PartialCommitProofMsg : public MessageBase {
                         CommitPath commitPath,
                         Digest& digest,
                         IThresholdSigner* thresholdSigner,
-                        const std::string& spanContext = "");
+                        const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   ViewNum viewNumber() const { return b()->viewNum; }
 

--- a/bftengine/src/bftengine/messages/PartialProofsSet.cpp
+++ b/bftengine/src/bftengine/messages/PartialProofsSet.cpp
@@ -195,7 +195,7 @@ class AsynchProofCreationJob : public util::SimpleThreadPool::Job {
                          Digest& expectedDigest,
                          SeqNum seqNumber,
                          ViewNum viewNumber,
-                         const std::string& span_context) {
+                         const concordUtils::SpanContext& span_context) {
     this->me = myReplica;
     this->acc = acc;
     this->expectedDigest = expectedDigest;
@@ -262,7 +262,7 @@ class AsynchProofCreationJob : public util::SimpleThreadPool::Job {
   SeqNum seqNumber;
   ViewNum view;
   IThresholdVerifier* verifier;
-  std::string span_context_;
+  concordUtils::SpanContext span_context_;
 };
 
 void PartialProofsSet::tryToCreateFullProof() {

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -61,8 +61,12 @@ class PrePrepareMsg : public MessageBase {
   // size - total size of all requests that will be added
   PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, size_t size);
 
-  PrePrepareMsg(
-      ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, const std::string& spanContext, size_t size);
+  PrePrepareMsg(ReplicaId sender,
+                ViewNum v,
+                SeqNum s,
+                CommitPath firstPath,
+                const concordUtils::SpanContext& spanContext,
+                size_t size);
 
   uint32_t remainingSizeForRequests() const;
 

--- a/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
@@ -51,10 +51,10 @@ ReplicaStatusMsg::ReplicaStatusMsg(ReplicaId senderId,
                                    bool listOfPPInActiveWindow,
                                    bool listOfMissingVCForVC,
                                    bool listOfMissingPPForVC,
-                                   const std::string& spanContext)
+                                   const concordUtils::SpanContext& spanContext)
     : MessageBase(senderId,
                   MsgCode::ReplicaStatus,
-                  spanContext.size(),
+                  spanContext.data().size(),
                   calcSizeOfReplicaStatusMsg(listOfPPInActiveWindow, listOfMissingVCForVC, listOfMissingPPForVC)) {
   ConcordAssert(lastExecutedSeqNum >= lastStableSeqNum);
   ConcordAssert(lastStableSeqNum % checkpointWindowSize == 0);
@@ -79,7 +79,7 @@ ReplicaStatusMsg::ReplicaStatusMsg(ReplicaId senderId,
   } else if (listOfMissingPPForVC) {
     b()->flags |= powersOf2[4];
   }
-  std::memcpy(body() + sizeof(ReplicaStatusMsg::Header), spanContext.data(), spanContext.size());
+  std::memcpy(body() + sizeof(ReplicaStatusMsg::Header), spanContext.data().data(), spanContext.data().size());
   if (size() > sizeof(ReplicaStatusMsg::Header) + spanContextSize()) {
     // write zero to all bits in list
     MsgSize listSize = size() - payloadShift();

--- a/bftengine/src/bftengine/messages/ReplicaStatusMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReplicaStatusMsg.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "MessageBase.hpp"
+#include "OpenTracing.hpp"
 
 namespace bftEngine {
 namespace impl {
@@ -25,7 +26,7 @@ class ReplicaStatusMsg : public MessageBase {
                    bool listOfPrePrepareMsgsInActiveWindow,
                    bool listOfMissingViewChangeMsgForViewChange,
                    bool listOfMissingPrePrepareMsgForViewChange,
-                   const std::string& spanContext = "");
+                   const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   ViewNum getViewNumber() const;
 

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.cpp
@@ -17,12 +17,15 @@
 namespace bftEngine {
 namespace impl {
 
-ReqMissingDataMsg::ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string& spanContext)
-    : MessageBase(senderId, MsgCode::ReqMissingData, spanContext.size(), sizeof(Header)) {
+ReqMissingDataMsg::ReqMissingDataMsg(ReplicaId senderId,
+                                     ViewNum v,
+                                     SeqNum s,
+                                     const concordUtils::SpanContext& spanContext)
+    : MessageBase(senderId, MsgCode::ReqMissingData, spanContext.data().size(), sizeof(Header)) {
   b()->viewNum = v;
   b()->seqNum = s;
   resetFlags();
-  std::memcpy(body() + sizeof(Header), spanContext.data(), spanContext.size());
+  std::memcpy(body() + sizeof(Header), spanContext.data().data(), spanContext.data().size());
 }
 
 void ReqMissingDataMsg::resetFlags() { b()->flags.flags = 0; }

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
@@ -12,13 +12,17 @@
 #pragma once
 
 #include "MessageBase.hpp"
+#include "OpenTracing.hpp"
 
 namespace bftEngine {
 namespace impl {
 
 class ReqMissingDataMsg : public MessageBase {
  public:
-  ReqMissingDataMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string& spanContext = "");
+  ReqMissingDataMsg(ReplicaId senderId,
+                    ViewNum v,
+                    SeqNum s,
+                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   ViewNum viewNumber() const { return b()->viewNum; }
 

--- a/bftengine/src/bftengine/messages/SignatureInternalMsgs.hpp
+++ b/bftengine/src/bftengine/messages/SignatureInternalMsgs.hpp
@@ -14,6 +14,7 @@
 #include <set>
 #include <vector>
 
+#include "OpenTracing.hpp"
 #include "PrimitiveTypes.hpp"
 
 namespace bftEngine::impl {
@@ -31,10 +32,10 @@ struct CombinedSigSucceededInternalMsg {
   const SeqNum seqNumber;
   const ViewNum view;
   const std::vector<char> combinedSig;
-  std::string span_context_;
+  concordUtils::SpanContext span_context_;
 
   CombinedSigSucceededInternalMsg(
-      SeqNum s, ViewNum v, const char* sig, uint16_t sigLen, const std::string& span_context)
+      SeqNum s, ViewNum v, const char* sig, uint16_t sigLen, const concordUtils::SpanContext& span_context)
       : seqNumber{s}, view{v}, combinedSig(sig, sig + sigLen), span_context_{span_context} {}
 };
 
@@ -50,10 +51,10 @@ struct CombinedCommitSigSucceededInternalMsg {
   const SeqNum seqNumber;
   const ViewNum view;
   const std::vector<char> combinedSig;
-  std::string span_context_;
+  concordUtils::SpanContext span_context_;
 
   CombinedCommitSigSucceededInternalMsg(
-      SeqNum s, ViewNum v, const char* sig, uint16_t sigLen, const std::string& span_context)
+      SeqNum s, ViewNum v, const char* sig, uint16_t sigLen, const concordUtils::SpanContext& span_context)
       : seqNumber{s}, view{v}, combinedSig(sig, sig + sigLen), span_context_{span_context} {}
 };
 

--- a/bftengine/src/bftengine/messages/SignedShareMsgs.cpp
+++ b/bftengine/src/bftengine/messages/SignedShareMsgs.cpp
@@ -20,8 +20,11 @@ namespace impl {
 // SignedShareBase
 ///////////////////////////////////////////////////////////////////////////////
 
-SignedShareBase::SignedShareBase(ReplicaId sender, int16_t type, const std::string& spanContext, size_t msgSize)
-    : MessageBase(sender, type, spanContext.size(), msgSize) {}
+SignedShareBase::SignedShareBase(ReplicaId sender,
+                                 int16_t type,
+                                 const concordUtils::SpanContext& spanContext,
+                                 size_t msgSize)
+    : MessageBase(sender, type, spanContext.data().size(), msgSize) {}
 
 SignedShareBase* SignedShareBase::create(int16_t type,
                                          ViewNum v,
@@ -29,7 +32,7 @@ SignedShareBase* SignedShareBase::create(int16_t type,
                                          ReplicaId senderId,
                                          Digest& digest,
                                          IThresholdSigner* thresholdSigner,
-                                         const std::string& spanContext) {
+                                         const concordUtils::SpanContext& spanContext) {
   const size_t sigLen = thresholdSigner->requiredLengthForSignedData();
   size_t size = sizeof(Header) + sigLen;
 
@@ -43,8 +46,8 @@ SignedShareBase* SignedShareBase::create(int16_t type,
   Digest::calcCombination(digest, v, s, tmpDigest);
 
   auto position = m->body() + sizeof(Header);
-  std::memcpy(position, spanContext.data(), spanContext.size());
-  position += spanContext.size();
+  std::memcpy(position, spanContext.data().data(), spanContext.data().size());
+  position += spanContext.data().size();
 
   thresholdSigner->signData((const char*)(&(tmpDigest)), sizeof(Digest), position, sigLen);
 
@@ -57,7 +60,7 @@ SignedShareBase* SignedShareBase::create(int16_t type,
                                          ReplicaId senderId,
                                          const char* sig,
                                          uint16_t sigLen,
-                                         const std::string& spanContext) {
+                                         const concordUtils::SpanContext& spanContext) {
   size_t size = sizeof(Header) + sigLen;
 
   SignedShareBase* m = new SignedShareBase(senderId, type, spanContext, size);
@@ -67,8 +70,8 @@ SignedShareBase* SignedShareBase::create(int16_t type,
   m->b()->thresSigLength = sigLen;
 
   auto position = m->body() + sizeof(Header);
-  std::memcpy(position, spanContext.data(), spanContext.size());
-  position += spanContext.size();
+  std::memcpy(position, spanContext.data().data(), spanContext.data().size());
+  position += spanContext.data().size();
   memcpy(position, sig, sigLen);
 
   return m;
@@ -92,7 +95,7 @@ PreparePartialMsg* PreparePartialMsg::create(ViewNum v,
                                              ReplicaId senderId,
                                              Digest& ppDigest,
                                              IThresholdSigner* thresholdSigner,
-                                             const std::string& spanContext) {
+                                             const concordUtils::SpanContext& spanContext) {
   return (PreparePartialMsg*)SignedShareBase::create(
       MsgCode::PreparePartial, v, s, senderId, ppDigest, thresholdSigner, spanContext);
 }
@@ -108,8 +111,12 @@ void PreparePartialMsg::validate(const ReplicasInfo& repInfo) const {
 // PrepareFullMsg
 ///////////////////////////////////////////////////////////////////////////////
 
-PrepareFullMsg* PrepareFullMsg::create(
-    ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext) {
+PrepareFullMsg* PrepareFullMsg::create(ViewNum v,
+                                       SeqNum s,
+                                       ReplicaId senderId,
+                                       const char* sig,
+                                       uint16_t sigLen,
+                                       const concordUtils::SpanContext& spanContext) {
   return (PrepareFullMsg*)SignedShareBase::create(MsgCode::PrepareFull, v, s, senderId, sig, sigLen, spanContext);
 }
 
@@ -126,7 +133,7 @@ CommitPartialMsg* CommitPartialMsg::create(ViewNum v,
                                            ReplicaId senderId,
                                            Digest& ppDoubleDigest,
                                            IThresholdSigner* thresholdSigner,
-                                           const std::string& spanContext) {
+                                           const concordUtils::SpanContext& spanContext) {
   return (CommitPartialMsg*)SignedShareBase::create(
       MsgCode::CommitPartial, v, s, senderId, ppDoubleDigest, thresholdSigner, spanContext);
 }
@@ -142,8 +149,12 @@ void CommitPartialMsg::validate(const ReplicasInfo& repInfo) const {
 // CommitFullMsg
 ///////////////////////////////////////////////////////////////////////////////
 
-CommitFullMsg* CommitFullMsg::create(
-    ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext) {
+CommitFullMsg* CommitFullMsg::create(ViewNum v,
+                                     SeqNum s,
+                                     ReplicaId senderId,
+                                     const char* sig,
+                                     uint16_t sigLen,
+                                     const concordUtils::SpanContext& spanContext) {
   return (CommitFullMsg*)SignedShareBase::create(MsgCode::CommitFull, v, s, senderId, sig, sigLen, spanContext);
 }
 

--- a/bftengine/src/bftengine/messages/SignedShareMsgs.hpp
+++ b/bftengine/src/bftengine/messages/SignedShareMsgs.hpp
@@ -54,17 +54,17 @@ class SignedShareBase : public MessageBase {
                                  ReplicaId senderId,
                                  Digest& digest,
                                  IThresholdSigner* thresholdSigner,
-                                 const std::string& spanContext = "");
+                                 const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
   static SignedShareBase* create(int16_t type,
                                  ViewNum v,
                                  SeqNum s,
                                  ReplicaId senderId,
                                  const char* sig,
                                  uint16_t sigLen,
-                                 const std::string& spanContext = "");
+                                 const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
   void _validate(const ReplicasInfo& repInfo, int16_t type) const;
 
-  SignedShareBase(ReplicaId sender, int16_t type, const std::string& spanContext, size_t msgSize);
+  SignedShareBase(ReplicaId sender, int16_t type, const concordUtils::SpanContext& spanContext, size_t msgSize);
 
   Header* b() const { return (Header*)msgBody_; }
 };
@@ -83,7 +83,7 @@ class PreparePartialMsg : public SignedShareBase {
                                    ReplicaId senderId,
                                    Digest& ppDigest,
                                    IThresholdSigner* thresholdSigner,
-                                   const std::string& spanContext = "");
+                                   const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
   void validate(const ReplicasInfo&) const override;
 };
 
@@ -99,8 +99,12 @@ class PrepareFullMsg : public SignedShareBase {
   friend MsgSize maxMessageSize();
 
  public:
-  static PrepareFullMsg* create(
-      ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext = "");
+  static PrepareFullMsg* create(ViewNum v,
+                                SeqNum s,
+                                ReplicaId senderId,
+                                const char* sig,
+                                uint16_t sigLen,
+                                const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
   void validate(const ReplicasInfo&) const override;
 };
 
@@ -123,7 +127,7 @@ class CommitPartialMsg : public SignedShareBase {
                                   ReplicaId senderId,
                                   Digest& ppDoubleDigest,
                                   IThresholdSigner* thresholdSigner,
-                                  const std::string& spanContext = "");
+                                  const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
   void validate(const ReplicasInfo&) const override;
 };
 
@@ -139,8 +143,12 @@ class CommitFullMsg : public SignedShareBase {
   friend MsgSize maxMessageSize();
 
  public:
-  static CommitFullMsg* create(
-      ViewNum v, SeqNum s, ReplicaId senderId, const char* sig, uint16_t sigLen, const std::string& spanContext = "");
+  static CommitFullMsg* create(ViewNum v,
+                               SeqNum s,
+                               ReplicaId senderId,
+                               const char* sig,
+                               uint16_t sigLen,
+                               const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
   void validate(const ReplicasInfo&) const override;
 };
 

--- a/bftengine/src/bftengine/messages/StartSlowCommitMsg.cpp
+++ b/bftengine/src/bftengine/messages/StartSlowCommitMsg.cpp
@@ -16,11 +16,14 @@
 namespace bftEngine {
 namespace impl {
 
-StartSlowCommitMsg::StartSlowCommitMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string& spanContext)
-    : MessageBase(senderId, MsgCode::StartSlowCommit, spanContext.size(), sizeof(Header)) {
+StartSlowCommitMsg::StartSlowCommitMsg(ReplicaId senderId,
+                                       ViewNum v,
+                                       SeqNum s,
+                                       const concordUtils::SpanContext& spanContext)
+    : MessageBase(senderId, MsgCode::StartSlowCommit, spanContext.data().size(), sizeof(Header)) {
   b()->viewNum = v;
   b()->seqNum = s;
-  std::memcpy(body() + sizeof(Header), spanContext.data(), spanContext.size());
+  std::memcpy(body() + sizeof(Header), spanContext.data().data(), spanContext.data().size());
 }
 
 void StartSlowCommitMsg::validate(const ReplicasInfo& repInfo) const {

--- a/bftengine/src/bftengine/messages/StartSlowCommitMsg.hpp
+++ b/bftengine/src/bftengine/messages/StartSlowCommitMsg.hpp
@@ -14,13 +14,17 @@
 #include <locale>
 #include <string>
 #include "MessageBase.hpp"
+#include "OpenTracing.hpp"
 
 namespace bftEngine {
 namespace impl {
 
 class StartSlowCommitMsg : public MessageBase {
  public:
-  StartSlowCommitMsg(ReplicaId senderId, ViewNum v, SeqNum s, const std::string& spanContext = "");
+  StartSlowCommitMsg(ReplicaId senderId,
+                     ViewNum v,
+                     SeqNum s,
+                     const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   ViewNum viewNumber() const { return b()->viewNum; }
 

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
@@ -23,17 +23,17 @@ namespace impl {
 ViewChangeMsg::ViewChangeMsg(ReplicaId srcReplicaId,
                              ViewNum newView,
                              SeqNum lastStableSeq,
-                             const std::string& spanContext)
+                             const concordUtils::SpanContext& spanContext)
     : MessageBase(srcReplicaId,
                   MsgCode::ViewChange,
-                  spanContext.size(),
-                  ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize() - spanContext.size()) {
+                  spanContext.data().size(),
+                  ReplicaConfigSingleton::GetInstance().GetMaxExternalMessageSize() - spanContext.data().size()) {
   b()->genReplicaId = srcReplicaId;
   b()->newView = newView;
   b()->lastStable = lastStableSeq;
   b()->numberOfElements = 0;
   b()->locationAfterLast = 0;
-  std::memcpy(body() + sizeof(Header), spanContext.data(), spanContext.size());
+  std::memcpy(body() + sizeof(Header), spanContext.data().data(), spanContext.data().size());
 }
 
 void ViewChangeMsg::setNewViewNumber(ViewNum newView) {

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
@@ -13,6 +13,7 @@
 
 #include "MessageBase.hpp"
 #include "Digest.hpp"
+#include "OpenTracing.hpp"
 #include "ReplicasInfo.hpp"
 #include "ReplicaConfig.hpp"
 
@@ -38,7 +39,10 @@ class ViewChangeMsg : public MessageBase {
   static_assert(sizeof(Element) == (8 + DIGEST_SIZE + 8 + 1), "Element (View Change) is 49B");
   static_assert(sizeof(PreparedCertificate) == (8 + 2), "PreparedCertificate is 10B");
 
-  ViewChangeMsg(ReplicaId srcReplicaId, ViewNum newView, SeqNum lastStableSeq, const std::string& spanContext = "");
+  ViewChangeMsg(ReplicaId srcReplicaId,
+                ViewNum newView,
+                SeqNum lastStableSeq,
+                const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   void setNewViewNumber(ViewNum newView);
 

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -484,8 +484,8 @@ void PreProcessor::handleClientPreProcessRequestByPrimary(ClientPreProcessReqMsg
                                         requestSeqNum,
                                         clientReqMsg->requestLength(),
                                         clientReqMsg->requestBuf(),
-                                        clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>(),
-                                        clientReqMsg->getCid());
+                                        clientReqMsg->getCid(),
+                                        clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
   if (registerRequest(move(clientReqMsg), preProcessRequestMsg)) {
     sendPreProcessRequestToAllReplicas(preProcessRequestMsg);
     // Pre-process the request and calculate a hash of the result
@@ -529,8 +529,11 @@ void PreProcessor::launchAsyncReqPreProcessingJob(const PreProcessRequestMsgShar
   threadPool_.add(preProcessJob);
 }
 
-uint32_t PreProcessor::launchReqPreProcessing(
-    uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength, char *reqBuf, const std::string &span_context) {
+uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
+                                              ReqId reqSeqNum,
+                                              uint32_t reqLength,
+                                              char *reqBuf,
+                                              const concordUtils::SpanContext &span_context) {
   uint32_t resultLen = 0;
   // Unused for now. Replica Specific Info not currently supported in pre-execution.
   uint32_t replicaSpecificInfoLen = 0;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "OpenTracing.hpp"
 #include "messages/PreProcessRequestMsg.hpp"
 #include "messages/ClientPreProcessRequestMsg.hpp"
 #include "MsgsCommunicator.hpp"
@@ -98,8 +99,11 @@ class PreProcessor {
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,
                                       bool isRetry);
-  uint32_t launchReqPreProcessing(
-      uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength, char *reqBuf, const std::string &span_context);
+  uint32_t launchReqPreProcessing(uint16_t clientId,
+                                  ReqId reqSeqNum,
+                                  uint32_t reqLength,
+                                  char *reqBuf,
+                                  const concordUtils::SpanContext &span_context);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg, bool isPrimary, bool isRetry);
   void handlePreProcessedReqByNonPrimary(uint16_t clientId,
                                          ReqId reqSeqNum,

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -24,8 +24,8 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
                                                        const char* request,
                                                        uint64_t reqTimeoutMilli,
                                                        const std::string& cid,
-                                                       const std::string& span_context)
-    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request, reqTimeoutMilli, cid, span_context) {
+                                                       const concordUtils::SpanContext& spanContext)
+    : ClientRequestMsg(sender, PRE_PROCESS_REQ, reqSeqNum, requestLength, request, reqTimeoutMilli, cid, spanContext) {
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -27,7 +27,7 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
                              const char* request,
                              uint64_t reqTimeoutMilli,
                              const std::string& cid,
-                             const std::string& span_context = "");
+                             const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
   std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag);
 };

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -20,19 +20,19 @@ PreProcessRequestMsg::PreProcessRequestMsg(NodeIdType senderId,
                                            uint64_t reqSeqNum,
                                            uint32_t reqLength,
                                            const char* request,
-                                           const std::string& span_context,
-                                           const std::string& cid)
+                                           const std::string& cid,
+                                           const concordUtils::SpanContext& span_context)
     : MessageBase(
-          senderId, MsgCode::PreProcessRequest, span_context.size(), (sizeof(Header) + reqLength + cid.size())) {
+          senderId, MsgCode::PreProcessRequest, span_context.data().size(), (sizeof(Header) + reqLength + cid.size())) {
   setParams(senderId, clientId, reqSeqNum, reqLength);
   msgBody()->cidLength = cid.size();
   auto position = body() + sizeof(Header);
-  memcpy(position, span_context.data(), span_context.size());
-  position += span_context.size();
+  memcpy(position, span_context.data().data(), span_context.data().size());
+  position += span_context.data().size();
   memcpy(position, request, reqLength);
   position += reqLength;
   memcpy(position, cid.c_str(), cid.size());
-  uint64_t msgLength = sizeof(Header) + span_context.size() + reqLength + cid.size();
+  uint64_t msgLength = sizeof(Header) + span_context.data().size() + reqLength + cid.size();
   LOG_DEBUG(logger(),
             "senderId=" << senderId << " clientId=" << clientId << " reqSeqNum=" << reqSeqNum
                         << " headerSize=" << sizeof(Header) << " reqLength=" << reqLength << " cidSize=" << cid.size()

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "OpenTracing.hpp"
 #include "messages/MessageBase.hpp"
 #include "Logger.hpp"
 #include <memory>
@@ -24,8 +25,8 @@ class PreProcessRequestMsg : public MessageBase {
                        uint64_t reqSeqNum,
                        uint32_t reqLength,
                        const char* request,
-                       const std::string& span_context,
-                       const std::string& cid);
+                       const std::string& cid,
+                       const concordUtils::SpanContext& span_context = concordUtils::SpanContext{});
 
   void validate(const bftEngine::impl::ReplicasInfo&) const override;
   char* requestBuf() const { return body() + sizeof(Header) + spanContextSize(); }

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -43,7 +43,7 @@ const uint16_t reqWaitTimeoutMilli = 50;
 const ReqId reqSeqNum = 123456789;
 const uint16_t clientId = 9;
 const string cid = "abcd";
-const string sp = "span";
+const concordUtils::SpanContext span;
 const NodeIdType replica_0 = 0;
 const NodeIdType replica_1 = 1;
 const NodeIdType replica_2 = 2;
@@ -470,7 +470,7 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
 
   auto* preProcessReqMsg =
-      new PreProcessRequestMsg(replica.currentPrimary(), clientId, reqSeqNum, bufLen, buf, sp, cid);
+      new PreProcessRequestMsg(replica.currentPrimary(), clientId, reqSeqNum, bufLen, buf, cid, span);
   msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::PreProcessRequest);
   msgHandlerCallback(preProcessReqMsg);
   usleep(reqWaitTimeoutMilli * 1000 / 2);  // Wait for the pre-execution completion

--- a/bftengine/tests/messages/AskForCheckpointMsg_test.cpp
+++ b/bftengine/tests/messages/AskForCheckpointMsg_test.cpp
@@ -9,6 +9,7 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#include "OpenTracing.hpp"
 #include "gtest/gtest.h"
 
 #include "assertUtils.hpp"
@@ -26,7 +27,7 @@ TEST(AskForCheckpointMsg, base_methods) {
   ReplicaId senderId = 1u;
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  AskForCheckpointMsg msg(senderId, spanContext);
+  AskForCheckpointMsg msg(senderId, concordUtils::SpanContext{spanContext});
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   testMessageBaseMethods(msg, MsgCode::AskForCheckpoint, senderId, spanContext);
 }

--- a/bftengine/tests/messages/CheckpointMsg_test.cpp
+++ b/bftengine/tests/messages/CheckpointMsg_test.cpp
@@ -33,7 +33,7 @@ TEST(CheckpointMsg, base_methods) {
   const std::string correlationId = "correlationId";
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  CheckpointMsg msg(senderId, reqSeqNum, digest, isStable, spanContext);
+  CheckpointMsg msg(senderId, reqSeqNum, digest, isStable, concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.seqNumber(), reqSeqNum);
   EXPECT_EQ(msg.isStableState(), isStable);
   msg.setStateAsStable();

--- a/bftengine/tests/messages/ClientRequestMsg_test.cpp
+++ b/bftengine/tests/messages/ClientRequestMsg_test.cpp
@@ -31,8 +31,14 @@ TEST(ClientRequestMsg, create_and_compare) {
   const std::string correlationId = "correlationId";
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  ClientRequestMsg msg(
-      senderId, flags, reqSeqNum, sizeof(request), request, requestTimeoutMilli, correlationId, spanContext);
+  ClientRequestMsg msg(senderId,
+                       flags,
+                       reqSeqNum,
+                       sizeof(request),
+                       request,
+                       requestTimeoutMilli,
+                       correlationId,
+                       concordUtils::SpanContext{spanContext});
 
   EXPECT_EQ(msg.clientProxyId(), senderId);
   EXPECT_EQ(msg.flags(), flags);
@@ -41,7 +47,7 @@ TEST(ClientRequestMsg, create_and_compare) {
   EXPECT_NE(msg.requestBuf(), request);
   EXPECT_TRUE(std::memcmp(msg.requestBuf(), request, sizeof(request)) == 0u);
   EXPECT_EQ(msg.getCid(), correlationId);
-  EXPECT_EQ(msg.spanContext<ClientRequestMsg>(), spanContext);
+  EXPECT_EQ(msg.spanContext<ClientRequestMsg>().data(), spanContext);
   EXPECT_EQ(msg.requestTimeoutMilli(), requestTimeoutMilli);
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   destroyReplicaConfig(config);
@@ -58,8 +64,14 @@ TEST(ClientRequestMsg, create_and_compare_with_empty_span) {
   const std::string correlationId = "correlationId";
   const char rawSpanContext[] = {""};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  ClientRequestMsg msg(
-      senderId, flags, reqSeqNum, sizeof(request), request, requestTimeoutMilli, correlationId, spanContext);
+  ClientRequestMsg msg(senderId,
+                       flags,
+                       reqSeqNum,
+                       sizeof(request),
+                       request,
+                       requestTimeoutMilli,
+                       correlationId,
+                       concordUtils::SpanContext{spanContext});
 
   EXPECT_EQ(msg.clientProxyId(), senderId);
   EXPECT_EQ(msg.flags(), flags);
@@ -68,7 +80,7 @@ TEST(ClientRequestMsg, create_and_compare_with_empty_span) {
   EXPECT_NE(msg.requestBuf(), request);
   EXPECT_TRUE(std::memcmp(msg.requestBuf(), request, sizeof(request)) == 0u);
   EXPECT_EQ(msg.getCid(), correlationId);
-  EXPECT_EQ(msg.spanContext<ClientRequestMsg>(), spanContext);
+  EXPECT_EQ(msg.spanContext<ClientRequestMsg>().data(), spanContext);
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   destroyReplicaConfig(config);
 }
@@ -84,8 +96,14 @@ TEST(ClientRequestMsg, create_and_compare_with_empty_cid) {
   const std::string correlationId = "";
   const char rawSpanContext[] = {""};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  ClientRequestMsg msg(
-      senderId, flags, reqSeqNum, sizeof(request), request, requestTimeoutMilli, correlationId, spanContext);
+  ClientRequestMsg msg(senderId,
+                       flags,
+                       reqSeqNum,
+                       sizeof(request),
+                       request,
+                       requestTimeoutMilli,
+                       correlationId,
+                       concordUtils::SpanContext{spanContext});
 
   EXPECT_EQ(msg.clientProxyId(), senderId);
   EXPECT_EQ(msg.flags(), flags);
@@ -94,7 +112,7 @@ TEST(ClientRequestMsg, create_and_compare_with_empty_cid) {
   EXPECT_NE(msg.requestBuf(), request);
   EXPECT_TRUE(std::memcmp(msg.requestBuf(), request, sizeof(request)) == 0u);
   EXPECT_EQ(msg.getCid(), correlationId);
-  EXPECT_EQ(msg.spanContext<ClientRequestMsg>(), spanContext);
+  EXPECT_EQ(msg.spanContext<ClientRequestMsg>().data(), spanContext);
   EXPECT_EQ(msg.requestTimeoutMilli(), requestTimeoutMilli);
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   destroyReplicaConfig(config);
@@ -111,8 +129,14 @@ TEST(ClientRequestMsg, create_from_buffer) {
   const std::string correlationId = "correlationId";
   const char rawSpanContext[] = {""};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  ClientRequestMsg originalMsg(
-      senderId, flags, reqSeqNum, sizeof(request), request, requestTimeoutMilli, correlationId, spanContext);
+  ClientRequestMsg originalMsg(senderId,
+                               flags,
+                               reqSeqNum,
+                               sizeof(request),
+                               request,
+                               requestTimeoutMilli,
+                               correlationId,
+                               concordUtils::SpanContext{spanContext});
 
   ClientRequestMsg copy_msg((ClientRequestMsgHeader*)originalMsg.body());
 
@@ -123,7 +147,7 @@ TEST(ClientRequestMsg, create_from_buffer) {
   EXPECT_EQ(originalMsg.requestBuf(), copy_msg.requestBuf());
   EXPECT_TRUE(std::memcmp(originalMsg.requestBuf(), copy_msg.requestBuf(), sizeof(request)) == 0u);
   EXPECT_EQ(originalMsg.getCid(), copy_msg.getCid());
-  EXPECT_EQ(originalMsg.spanContext<ClientRequestMsg>(), copy_msg.spanContext<ClientRequestMsg>());
+  EXPECT_EQ(originalMsg.spanContext<ClientRequestMsg>().data(), copy_msg.spanContext<ClientRequestMsg>().data());
   EXPECT_EQ(originalMsg.requestTimeoutMilli(), requestTimeoutMilli);
   EXPECT_NO_THROW(originalMsg.validate(replicaInfo));
   destroyReplicaConfig(config);
@@ -141,8 +165,14 @@ TEST(ClientRequestMsg, base_methods) {
   const std::string correlationId = "correlationId";
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  ClientRequestMsg msg(
-      senderId, flags, reqSeqNum, sizeof(request), request, requestTimeoutMilli, correlationId, spanContext);
+  ClientRequestMsg msg(senderId,
+                       flags,
+                       reqSeqNum,
+                       sizeof(request),
+                       request,
+                       requestTimeoutMilli,
+                       correlationId,
+                       concordUtils::SpanContext{spanContext});
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   testMessageBaseMethods(msg, MsgCode::ClientRequest, senderId, spanContext);
   destroyReplicaConfig(config);

--- a/bftengine/tests/messages/FullCommitProofMsg_test.cpp
+++ b/bftengine/tests/messages/FullCommitProofMsg_test.cpp
@@ -33,7 +33,7 @@ TEST(FullCommitProofMsg, base_methods) {
                          seqNum,
                          commit_proof_signature.data(),
                          static_cast<uint16_t>(commit_proof_signature.size()),
-                         spanContext};
+                         concordUtils::SpanContext{spanContext}};
   EXPECT_EQ(msg.viewNumber(), viewNum);
   EXPECT_EQ(msg.seqNumber(), seqNum);
   EXPECT_EQ(commit_proof_signature, std::string(msg.thresholSignature(), msg.thresholSignatureLength()));

--- a/bftengine/tests/messages/NewViewMsg_test.cpp
+++ b/bftengine/tests/messages/NewViewMsg_test.cpp
@@ -30,7 +30,7 @@ TEST(NewViewMsg, base_methods) {
   std::string commitProofSignature{"commitProofSignature"};
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  NewViewMsg msg{senderId, viewNum, spanContext};
+  NewViewMsg msg{senderId, viewNum, concordUtils::SpanContext{spanContext}};
   EXPECT_EQ(msg.newView(), viewNum);
   EXPECT_EQ(msg.elementsCount(), 0);
 

--- a/bftengine/tests/messages/PartialCommitProofMsg_test.cpp
+++ b/bftengine/tests/messages/PartialCommitProofMsg_test.cpp
@@ -40,8 +40,13 @@ TEST(PartialCommitProofMsg, create_and_compare) {
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
   Digest tmpDigest;
-  PartialCommitProofMsg msg(
-      senderId, viewNum, seqNum, commitPath, tmpDigest, config.thresholdSignerForOptimisticCommit, spanContext);
+  PartialCommitProofMsg msg(senderId,
+                            viewNum,
+                            seqNum,
+                            commitPath,
+                            tmpDigest,
+                            config.thresholdSignerForOptimisticCommit,
+                            concordUtils::SpanContext{spanContext});
 
   EXPECT_EQ(msg.senderId(), senderId);
   EXPECT_EQ(msg.viewNumber(), viewNum);
@@ -67,8 +72,13 @@ TEST(PartialCommitProofMsg, base_methods) {
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
   Digest tmpDigest;
-  PartialCommitProofMsg msg(
-      senderId, viewNum, seqNum, commitPath, tmpDigest, config.thresholdSignerForOptimisticCommit, spanContext);
+  PartialCommitProofMsg msg(senderId,
+                            viewNum,
+                            seqNum,
+                            commitPath,
+                            tmpDigest,
+                            config.thresholdSignerForOptimisticCommit,
+                            concordUtils::SpanContext{spanContext});
   testMessageBaseMethods(msg, MsgCode::PartialCommitProof, senderId, spanContext);
   destroyReplicaConfig(config);
 }

--- a/bftengine/tests/messages/ReplicaStatusMsg_test.cpp
+++ b/bftengine/tests/messages/ReplicaStatusMsg_test.cpp
@@ -50,7 +50,7 @@ TEST(ReplicaStatusMsg, viewActiveNoLists) {
                        listOfPrePrepareMsgsInActiveWindow,
                        listOfMissingViewChangeMsgForViewChange,
                        listOfMissingPrePrepareMsgForViewChange,
-                       spanContext);
+                       concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.getViewNumber(), viewNum);
   EXPECT_EQ(msg.getLastStableSeqNum(), lastStable);
   EXPECT_EQ(msg.getLastExecutedSeqNum(), lastExecuted);
@@ -94,7 +94,7 @@ TEST(ReplicaStatusMsg, haslistOfPrePrepareMsgsInActiveWindow) {
                        listOfPrePrepareMsgsInActiveWindow,
                        listOfMissingViewChangeMsgForViewChange,
                        listOfMissingPrePrepareMsgForViewChange,
-                       spanContext);
+                       concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.getViewNumber(), viewNum);
   EXPECT_EQ(msg.getLastStableSeqNum(), lastStable);
   EXPECT_EQ(msg.getLastExecutedSeqNum(), lastExecuted);
@@ -146,7 +146,7 @@ TEST(ReplicaStatusMsg, listOfMissingViewChangeMsgForViewChange) {
                        listOfPrePrepareMsgsInActiveWindow,
                        listOfMissingViewChangeMsgForViewChange,
                        listOfMissingPrePrepareMsgForViewChange,
-                       spanContext);
+                       concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.getViewNumber(), viewNum);
   EXPECT_EQ(msg.getLastStableSeqNum(), lastStable);
   EXPECT_EQ(msg.getLastExecutedSeqNum(), lastExecuted);
@@ -193,7 +193,7 @@ TEST(ReplicaStatusMsg, listOfMissingPrePrepareMsgForViewChange) {
                        listOfPrePrepareMsgsInActiveWindow,
                        listOfMissingViewChangeMsgForViewChange,
                        listOfMissingPrePrepareMsgForViewChange,
-                       spanContext);
+                       concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.getViewNumber(), viewNum);
   EXPECT_EQ(msg.getLastStableSeqNum(), lastStable);
   EXPECT_EQ(msg.getLastExecutedSeqNum(), lastExecuted);

--- a/bftengine/tests/messages/ReqMissingDataMsg_test.cpp
+++ b/bftengine/tests/messages/ReqMissingDataMsg_test.cpp
@@ -35,7 +35,7 @@ TEST(ReqMissingDataMsg, base_methods) {
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
   Digest tmpDigest;
-  ReqMissingDataMsg msg(senderId, viewNum, seqNum, spanContext);
+  ReqMissingDataMsg msg(senderId, viewNum, seqNum, concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.viewNumber(), viewNum);
   EXPECT_EQ(msg.seqNumber(), seqNum);
   EXPECT_EQ(msg.getFlags(), 0);

--- a/bftengine/tests/messages/SignedShareBase_test.cpp
+++ b/bftengine/tests/messages/SignedShareBase_test.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <memory>
 
+#include "OpenTracing.hpp"
 #include "gtest/gtest.h"
 
 #include "Digest.hpp"
@@ -31,7 +32,6 @@ using namespace bftEngine::impl;
 static void testSignedShareBaseMethods(const SignedShareBase& msg,
                                        ViewNum v,
                                        SeqNum s,
-                                       const std::string& spanContext,
                                        const std::vector<char>& signature) {
   EXPECT_EQ(msg.viewNumber(), v);
   EXPECT_EQ(msg.seqNumber(), s);
@@ -50,10 +50,10 @@ TEST(PreparePartialMsg, PreparePartialMsg_test) {
   Digest digest;
   std::vector<char> signature(config.thresholdSignerForCommit->requiredLengthForSignedData());
   config.thresholdSignerForOptimisticCommit->signData(nullptr, 0, signature.data(), signature.size());
-  std::unique_ptr<PreparePartialMsg> msg{
-      PreparePartialMsg::create(v, s, id, digest, config.thresholdSignerForCommit, spanContext)};
+  std::unique_ptr<PreparePartialMsg> msg{PreparePartialMsg::create(
+      v, s, id, digest, config.thresholdSignerForCommit, concordUtils::SpanContext{spanContext})};
   EXPECT_NO_THROW(msg->validate(replicaInfo));
-  testSignedShareBaseMethods(*msg, v, s, spanContext, signature);
+  testSignedShareBaseMethods(*msg, v, s, signature);
   testMessageBaseMethods(*msg, MsgCode::PreparePartial, id, spanContext);
   destroyReplicaConfig(config);
 }
@@ -70,9 +70,9 @@ TEST(PrepareFullMsg, PrepareFullMsg_test) {
   std::vector<char> signature(config.thresholdSignerForCommit->requiredLengthForSignedData());
   config.thresholdSignerForOptimisticCommit->signData(nullptr, 0, signature.data(), signature.size());
   std::unique_ptr<PrepareFullMsg> msg{
-      PrepareFullMsg::create(v, s, id, signature.data(), signature.size(), spanContext)};
+      PrepareFullMsg::create(v, s, id, signature.data(), signature.size(), concordUtils::SpanContext{spanContext})};
   EXPECT_NO_THROW(msg->validate(replicaInfo));
-  testSignedShareBaseMethods(*msg, v, s, spanContext, signature);
+  testSignedShareBaseMethods(*msg, v, s, signature);
   testMessageBaseMethods(*msg, MsgCode::PrepareFull, id, spanContext);
   destroyReplicaConfig(config);
 }
@@ -88,10 +88,10 @@ TEST(CommitPartialMsg, CommitPartialMsg_test) {
   Digest digest;
   std::vector<char> signature(config.thresholdSignerForCommit->requiredLengthForSignedData());
   config.thresholdSignerForOptimisticCommit->signData(nullptr, 0, signature.data(), signature.size());
-  std::unique_ptr<CommitPartialMsg> msg{
-      CommitPartialMsg::create(v, s, id, digest, config.thresholdSignerForCommit, spanContext)};
+  std::unique_ptr<CommitPartialMsg> msg{CommitPartialMsg::create(
+      v, s, id, digest, config.thresholdSignerForCommit, concordUtils::SpanContext{spanContext})};
   EXPECT_NO_THROW(msg->validate(replicaInfo));
-  testSignedShareBaseMethods(*msg, v, s, spanContext, signature);
+  testSignedShareBaseMethods(*msg, v, s, signature);
   testMessageBaseMethods(*msg, MsgCode::CommitPartial, id, spanContext);
   destroyReplicaConfig(config);
 }
@@ -106,9 +106,10 @@ TEST(CommitFullMsg, CommitFullMsg_test) {
   Digest digest;
   std::vector<char> signature(config.thresholdSignerForCommit->requiredLengthForSignedData());
   config.thresholdSignerForOptimisticCommit->signData(nullptr, 0, signature.data(), signature.size());
-  std::unique_ptr<CommitFullMsg> msg{CommitFullMsg::create(v, s, id, signature.data(), signature.size(), spanContext)};
+  std::unique_ptr<CommitFullMsg> msg{
+      CommitFullMsg::create(v, s, id, signature.data(), signature.size(), concordUtils::SpanContext{spanContext})};
   EXPECT_NO_THROW(msg->validate(replicaInfo));
-  testSignedShareBaseMethods(*msg, v, s, spanContext, signature);
+  testSignedShareBaseMethods(*msg, v, s, signature);
   testMessageBaseMethods(*msg, MsgCode::CommitFull, id, spanContext);
   destroyReplicaConfig(config);
 }

--- a/bftengine/tests/messages/StartSlowCommitMsg_test.cpp
+++ b/bftengine/tests/messages/StartSlowCommitMsg_test.cpp
@@ -28,7 +28,7 @@ TEST(StartSlowCommitMsg, base_methods) {
   SeqNum seqNum = 3u;
   const char rawSpanContext[] = {"span_\0context"};
   const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
-  StartSlowCommitMsg msg(senderId, viewNum, seqNum, spanContext);
+  StartSlowCommitMsg msg(senderId, viewNum, seqNum, concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.viewNumber(), viewNum);
   EXPECT_EQ(msg.seqNumber(), seqNum);
   EXPECT_NO_THROW(msg.validate(replicaInfo));

--- a/bftengine/tests/messages/ViewChangeMsg_test.cpp
+++ b/bftengine/tests/messages/ViewChangeMsg_test.cpp
@@ -38,7 +38,7 @@ TEST(ViewChangeMsg, base_methods) {
                         config.replicaPrivateKey,
                         config.publicKeysOfReplicas);
   ViewsManager manager(&replicaInfo, &sigManager, config.thresholdVerifierForSlowPathCommit);
-  ViewChangeMsg msg(senderId, viewNum, seqNum, spanContext);
+  ViewChangeMsg msg(senderId, viewNum, seqNum, concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.idOfGeneratedReplica(), senderId);
   EXPECT_EQ(msg.newView(), viewNum);
   EXPECT_EQ(msg.lastStable(), seqNum);

--- a/bftengine/tests/messages/helper.hpp
+++ b/bftengine/tests/messages/helper.hpp
@@ -90,7 +90,7 @@ template <typename MessageT>
 void testMessageBaseMethods(const MessageT &tested, MsgType type, NodeIdType senderId, const std::string &spanContext) {
   EXPECT_EQ(tested.senderId(), senderId);
   EXPECT_EQ(tested.type(), type);
-  EXPECT_EQ(tested.template spanContext<MessageT>(), spanContext);
+  EXPECT_EQ(tested.template spanContext<MessageT>().data(), spanContext);
   EXPECT_EQ(tested.spanContextSize(), spanContext.size());
 
   std::unique_ptr<MessageBase> other{tested.cloneObjAndMsg()};

--- a/util/include/OpenTracing.hpp
+++ b/util/include/OpenTracing.hpp
@@ -21,7 +21,15 @@
 
 namespace concordUtils {
 
-using SpanContext = std::string;
+class SpanContext {
+ public:
+  SpanContext() = default;
+  explicit SpanContext(const std::string& data) : data_{data} {}
+  const std::string& data() const { return data_; }
+
+ private:
+  std::string data_;
+};
 
 class SpanWrapper {
  public:

--- a/util/src/OpenTracing.cpp
+++ b/util/src/OpenTracing.cpp
@@ -12,7 +12,6 @@
 
 #include "OpenTracing.hpp"
 #include <string>
-#include "Logger.hpp"
 
 #ifdef USE_OPENTRACING
 #include <opentracing/tracer.h>
@@ -60,10 +59,10 @@ SpanWrapper startChildSpan(const std::string& child_operation_name, const SpanWr
 
 SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name) {
 #ifdef USE_OPENTRACING
-  if (context.empty()) {
+  if (context.data().empty()) {
     return SpanWrapper{};
   }
-  std::istringstream context_stream{context};
+  std::istringstream context_stream{context.data()};
   auto tracer = opentracing::Tracer::Global();
   auto parent_span_context = tracer->Extract(context_stream);
   // DD: It might happen in 2 cases:


### PR DESCRIPTION
Rationale:
Originally `std::string` was used to store the span context.
Since the string is a generic type, there were several issues when arbitrary strings were passed instead of actual context(span name or `cid`).
In order to solve the issue, a new type is introduced.

Changes:
Added class `SpanContext`