### PR TITLE
[Pre-execution] Throw an exception if pre-execution returns error code

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -538,19 +538,21 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   // Unused for now. Replica Specific Info not currently supported in pre-execution.
   uint32_t replicaSpecificInfoLen = 0;
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
-  requestsHandler_.execute(clientId,
-                           reqSeqNum,
-                           PRE_PROCESS_FLAG,
-                           reqLength,
-                           reqBuf,
-                           maxReplyMsgSize_,
-                           (char *)getPreProcessResultBuffer(clientId),
-                           resultLen,
-                           replicaSpecificInfoLen,
-                           span);
-  if (!resultLen)
-    throw std::runtime_error("Actual result length is 0 for clientId: " + to_string(clientId) +
-                             ", requestSeqNum: " + to_string(reqSeqNum));
+  auto error = requestsHandler_.execute(clientId,
+                                        reqSeqNum,
+                                        PRE_PROCESS_FLAG,
+                                        reqLength,
+                                        reqBuf,
+                                        maxReplyMsgSize_,
+                                        (char *)getPreProcessResultBuffer(clientId),
+                                        resultLen,
+                                        replicaSpecificInfoLen,
+                                        span);
+  if (error || !resultLen) {
+    throw std::runtime_error("Pre-execution failed for clientId: " + to_string(clientId) +
+                             ", requestSeqNum: " + to_string(reqSeqNum) + ", error code: " + to_string(error) +
+                             ", resultLen: " + to_string(resultLen));
+  }
 
   LOG_DEBUG(logger(), "Actual " << KVLOG(resultLen) << " for " << KVLOG(reqSeqNum, clientId));
   return resultLen;

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -538,19 +538,19 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   // Unused for now. Replica Specific Info not currently supported in pre-execution.
   uint32_t replicaSpecificInfoLen = 0;
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
-  auto error = requestsHandler_.execute(clientId,
-                                        reqSeqNum,
-                                        PRE_PROCESS_FLAG,
-                                        reqLength,
-                                        reqBuf,
-                                        maxReplyMsgSize_,
-                                        (char *)getPreProcessResultBuffer(clientId),
-                                        resultLen,
-                                        replicaSpecificInfoLen,
-                                        span);
-  if (error || !resultLen) {
+  auto status = requestsHandler_.execute(clientId,
+                                         reqSeqNum,
+                                         PRE_PROCESS_FLAG,
+                                         reqLength,
+                                         reqBuf,
+                                         maxReplyMsgSize_,
+                                         (char *)getPreProcessResultBuffer(clientId),
+                                         resultLen,
+                                         replicaSpecificInfoLen,
+                                         span);
+  if (status != 0 || !resultLen) {
     throw std::runtime_error("Pre-execution failed for clientId: " + to_string(clientId) +
-                             ", requestSeqNum: " + to_string(reqSeqNum) + ", error code: " + to_string(error) +
+                             ", requestSeqNum: " + to_string(reqSeqNum) + ", status: " + to_string(status) +
                              ", resultLen: " + to_string(resultLen));
   }
 


### PR DESCRIPTION
Our current implementations of IRequestsHandler::execute() return a non-empty response, even in case of execution failure. Errors are reported by the returned status code (0 meaning success).

Currently, the pre-processor does not interpret this status code and practically considers even failed executions successful, and hands them to post-execution to create blocks.

In this PR, we take a conservative approach by crashing the replica in case of non-zero status code in pre-execution.