### PR TITLE
Build all CI via Makefile

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,15 +1,6 @@
 name: Build
 on: [push, pull_request]
 
-env:
-    DOCKER_REPO: concordbft
-    DOCKER_IMAGE: concord-bft
-    DOCKER_WORK_DIR: /concord-bft
-    DOCKER_IMAGE_VER: 0.6
-    CMAKE_CXX_FLAGS: "-DCMAKE_CXX_FLAGS_RELEASE=-O3 -g"
-    USE_LOG4CPP: -DUSE_LOG4CPP=TRUE
-    USE_ROCKSDB: -DBUILD_ROCKSDB_STORAGE=TRUE
-
 jobs:
   build:
     name: Build
@@ -18,8 +9,8 @@ jobs:
         fail-fast: false
         matrix:
             compiler:
-                - "CC=gcc CXX=g++"
-                - "CC=clang CXX=clang++"
+                - "CONCORD_BFT_CONTAINER_CC=gcc CONCORD_BFT_CONTAINER_CXX=g++"
+                - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
             ci_build_type:
                 - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v1direct"
                 - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle"
@@ -28,8 +19,6 @@ jobs:
                 - "-DUSE_S3_OBJECT_STORE=ON"
                 - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
-        - name: Pull docker image
-          run: docker pull ${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_VER }}
         - name: Checkout
           uses: actions/checkout@v2
         - name: Create artifact directory
@@ -45,23 +34,20 @@ jobs:
             #  uses: mxschmitt/action-tmate@v2
         - name: Build and test
           run: >
-            docker run --rm --privileged=true
-            --cap-add NET_ADMIN --cap-add=SYS_PTRACE --ulimit core=-1
-            --workdir=${{ env.DOCKER_WORK_DIR }} --name=${{ env.DOCKER_IMAGE }}
-            --mount type=bind,source=${PWD},target=${{ env.DOCKER_WORK_DIR }}
-            --mount type=bind,source=${{ github.workspace }}/artifact/cores,target=/cores
-            ${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_VER }}
-            /bin/bash -c "mkdir build && cd build &&
-            ${{ matrix.compiler }}
-            cmake ${{ env.CMAKE_CXX_FLAGS }}
-            ${{ matrix.ci_build_type }}
-            ${{ env.USE_LOG4CPP }}
-            ${{ env.USE_ROCKSDB }}
-            ${{ matrix.use_s3_obj_store }} .. &&
-            make format-check &&
-            make -j$(nproc) &&
-            ctest --timeout 3000 --output-on-failure" 2>&1 | tee ${{ github.workspace }}/artifact/build.log ;
-            exit ${PIPESTATUS[0]}
+              script -q -e -c "make build \
+                              ${{ matrix.compiler}} \
+                              CONCORD_BFT_CMAKE_FLAGS=\"\
+                              ${{ matrix.ci_build_type }} \
+                              -DBUILD_TESTING=ON \
+                              -DBUILD_COMM_TCP_PLAIN=FALSE \
+                              -DBUILD_COMM_TCP_TLS=FALSE \
+                              -DCMAKE_CXX_FLAGS_RELEASE=-O3 -g \
+                              -DUSE_LOG4CPP=TRUE \
+                              -DBUILD_ROCKSDB_STORAGE=TRUE \
+                              ${{ matrix.use_s3_obj_store }} \
+                              -DUSE_OPENTRACING=ON \
+                              -DOMIT_TEST_OUTPUT=OFF\" "\
+              && script -q -e -c "make test"
         - name: Prepare artifacts
           if: failure()
           run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,17 +1,6 @@
 name: clang-tidy
 on: [push, pull_request]
 
-env:
-    DOCKER_REPO: concordbft
-    DOCKER_IMAGE: concord-bft
-    DOCKER_WORK_DIR: /concord-bft
-    DOCKER_IMAGE_VER: 0.6
-    CMAKE_CXX_FLAGS: "-DCMAKE_CXX_FLAGS_RELEASE=-O3 -g"
-    USE_LOG4CPP: -DUSE_LOG4CPP=TRUE
-    USE_ROCKSDB: -DBUILD_ROCKSDB_STORAGE=TRUE
-    USE_CONAN: -DUSE_CONAN=OFF
-    USE_S3_OBJECT_STORE: -DUSE_S3_OBJECT_STORE=OFF
-
 jobs:
   clang-tidy:
     runs-on: ubuntu-18.04
@@ -19,30 +8,29 @@ jobs:
         fail-fast: false
         matrix:
             compiler:
-                - "CC=clang CXX=clang++"
+                - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
             ci_build_type:
                 - "-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle"
     steps:
-        - name: Pull docker image
-          run: docker pull ${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_VER }}
         - name: Checkout
           uses: actions/checkout@v2
         - name: Build and test
+          # Script is used to simulate tty:
+          # https://github.com/actions/runner/issues/241
           run: >
-            docker run --rm --privileged=true
-            --cap-add NET_ADMIN --cap-add=SYS_PTRACE --ulimit core=-1
-            --workdir=${{ env.DOCKER_WORK_DIR }} --name=${{ env.DOCKER_IMAGE }}
-            --mount type=bind,source=${PWD},target=${{ env.DOCKER_WORK_DIR }}
-            ${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_VER }}
-            /bin/bash -c "mkdir build && cd build &&
-            ${{ matrix.compiler }}
-            cmake ${{ env.CMAKE_CXX_FLAGS }}
-            ${{ matrix.ci_build_type }}
-            ${{ env.USE_LOG4CPP }}
-            ${{ env.USE_ROCKSDB }}
-            ${{ env.USE_CONAN }}
-            ${{ env.USE_S3_OBJECT_STORE }} .. &&
-            run-clang-tidy-10 && ../scripts/check-forbidden-usage.sh .."
+            script -q -e -c "make tidy-check \
+                            ${{ matrix.compiler}} \
+                            CONCORD_BFT_CMAKE_FLAGS=\"\
+                            ${{ matrix.ci_build_type }} \
+                            -DBUILD_TESTING=ON \
+                            -DBUILD_COMM_TCP_PLAIN=FALSE \
+                            -DBUILD_COMM_TCP_TLS=FALSE \
+                            -DCMAKE_CXX_FLAGS_RELEASE=-O3 -g \
+                            -DUSE_LOG4CPP=TRUE \
+                            -DBUILD_ROCKSDB_STORAGE=TRUE \
+                            -DUSE_S3_OBJECT_STORE=TRUE \
+                            -DUSE_OPENTRACING=ON \
+                            -DOMIT_TEST_OUTPUT=OFF\" "
         - name: Print failure info
           if: failure()
           run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,37 +6,23 @@ compiler:
   - gcc
   - clang
 env:
-  global:
-    # We purposefully leave asserts on by excluding -NDEBUG
-    - DOCKER_REPO=concordbft
-    - DOCKER_IMAGE=concord-bft
-    - DOCKER_IMAGE_VER=0.6
-    - DOCKER_WORK_DIR=/concord-bft
-    - CMAKE_CXX_FLAGS="-DCMAKE_CXX_FLAGS_RELEASE=-O3 -g"
-    - USE_LOG4CPP=-DUSE_LOG4CPP=ON
-    - USE_ROCKSDB=-DBUILD_ROCKSDB_STORAGE=ON
-    - USE_S3_OBJECT_STORE=-DUSE_S3_OBJECT_STORE=OFF
-    - USE_OPENTRACING=-DUSE_OPENTRACING=ON
-    - OMIT_TEST_OUTPUT=-DOMIT_TEST_OUTPUT=ON
   matrix:
     - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v1direct"
     - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle"
     - CI_BUILD_TYPE="-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle"
-install:
-  - docker pull ${DOCKER_REPO}/${DOCKER_IMAGE}:${DOCKER_IMAGE_VER}
 script:
   - >
-    docker run --rm --cap-add NET_ADMIN --workdir=${DOCKER_WORK_DIR} --name=${DOCKER_IMAGE}
-    --mount type=bind,source=${TRAVIS_BUILD_DIR},target=${DOCKER_WORK_DIR} ${DOCKER_REPO}/${DOCKER_IMAGE}:${DOCKER_IMAGE_VER}
-    /bin/bash -c "mkdir -p ${DOCKER_WORK_DIR}/build && cd build &&
-    CC=${CC} CXX=${CXX}
-    cmake ${CMAKE_CXX_FLAGS}
-    ${CI_BUILD_TYPE}
-    ${USE_LOG4CPP}
-    ${USE_ROCKSDB}
-    ${USE_S3_OBJECT_STORE}
-    ${USE_OPENTRACING}
-    ${OMIT_TEST_OUTPUT} .. &&
-    make format-check &&
-    make -j $(getconf _NPROCESSORS_ONLN) &&
-    ctest --timeout 3000 --output-on-failure"
+    script -q -e -c "make build \
+                    CONCORD_BFT_CONTAINER_CC=${CC} CONCORD_BFT_CONTAINER_CXX=${CXX} \
+                    CONCORD_BFT_CMAKE_FLAGS=\"\
+                    ${CI_BUILD_TYPE} \
+                    -DBUILD_TESTING=ON \
+                    -DBUILD_COMM_TCP_PLAIN=FALSE \
+                    -DBUILD_COMM_TCP_TLS=FALSE \
+                    -DCMAKE_CXX_FLAGS_RELEASE=-O3 -g \
+                    -DUSE_LOG4CPP=TRUE \
+                    -DBUILD_ROCKSDB_STORAGE=TRUE \
+                    -DUSE_S3_OBJECT_STORE=OFF \
+                    -DUSE_OPENTRACING=ON \
+                    -DOMIT_TEST_OUTPUT=ON\" "\
+    && script -q -e -c "make test"

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,4 @@ build-docker-image: ## Re-build the container without caching
 	@echo "Build finished. Docker image name: \"${CONCORD_BFT_DOCKER_IMAGE}:latest\"."
 	@echo "Before you push it to Docker Hub, please tag it(CONCORD_BFT_DOCKER_IMAGE_VERSION + 1)."
 	@echo "If you want the image to be the default, please update the following variables:"
-	@echo "1. ${CURDIR}/Makefile: CONCORD_BFT_DOCKER_IMAGE_VERSION"
-	@echo "2. ${CURDIR}/.travis.yml: DOCKER_IMAGE_VER"
-	@echo "3. ${CURDIR}/.github/workflows/build_and_test.yml: DOCKER_IMAGE_VER"
+	@echo "${CURDIR}/Makefile: CONCORD_BFT_DOCKER_IMAGE_VERSION"


### PR DESCRIPTION
Reason:
* Simplify the CI configuration by having a single way to configure and run Concord-BFT build and tests
* A single place to set docker image version

Changes:
* Removed global environments from GitHub workflows and Travis
* `make` is launched via `script -e -q -c` to simulate `tty` which is mandatory to run`docker -t`.
* Updated Makefile