### PR TITLE
TLS communication - open new connection for the same id

### DIFF
--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -1070,10 +1070,9 @@ class TlsTCPCommunication::TlsTcpImpl : public std::enable_shared_from_this<TlsT
     if (_connections.find(id) != _connections.end()) {
       LOG_ERROR(_logger,
                 "new incoming connection with peer id that already "
-                "exists, destroying both, peer: "
+                "exists, destroying old connection, peer: "
                     << id);
       _connections.erase(id);
-      return;
     }
 
     conn->setReceiver(id, _pReceiver);


### PR DESCRIPTION
The TLS comm behavior on a new communication request is to check if this id is already connected, today if it happens the connection is closed for both old connection and the new connection.
This PR change it to close the old connection but to create the new one.
This stage is after TLS certs verification so its ok to assume its not byzantine entity.

The scenario that caused to me:
Client pool is running on participant node than the VM of the participant node is shutting down, the replicas don't know that the client connection is closed, after the VM comes up again the clients trying to connect again to the replicas but than both connections are closed and wee cannot send requests through the participant node.