### PR TITLE
BftClient: Init sequence_number to 0 in config

### DIFF
--- a/bftclient/include/bftclient/config.h
+++ b/bftclient/include/bftclient/config.h
@@ -68,7 +68,7 @@ struct ClientConfig {
 // Generic per-request configuration shared by reads and writes.
 struct RequestConfig {
   bool pre_execute = false;
-  uint64_t sequence_number;
+  uint64_t sequence_number = 0;
   uint32_t max_reply_size = 64 * 1024;
   std::chrono::milliseconds timeout = 5s;
   std::string correlation_id = "";


### PR DESCRIPTION
A default allows wrapper code to check if it was set, and initialize if
not.

Also, this was the only member without a default, so it makes sense to
set one.