### PR TITLE
Diagnostic tool - print answer to file

### DIFF
--- a/diagnostics/concord-ctl
+++ b/diagnostics/concord-ctl
@@ -10,3 +10,6 @@ cmd = b' '.join(sys.argv[1:]) + b'\n'
 s.send(cmd)
 data = s.recv(64*1024)
 print(data.decode())
+f = open("status.txt", "w")
+f.write(data.decode())
+f.close()


### PR DESCRIPTION
I've added a print to file to the concord-ctl since it requested by the deployment team.
They need it in order to parse the answer from the file and not from the console.
currently, they want to use the diagnostic tool to know the replica health status by sending:
`./concord-ctl status get replica`

After my change, it will print to the console and also always save the last answer to a file.