### PR TITLE
Add sequence number to recoverRequest flow

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3308,6 +3308,7 @@ void ReplicaImp::recoverRequests() {
     PrePrepareMsg *pp = seqNumInfo.getPrePrepareMsg();
     ConcordAssertNE(pp, nullptr);
     auto span = concordUtils::startSpan("bft_recover_requests_on_start");
+    SCOPED_MDC_SEQ_NUM(std::to_string(pp->seqNumber()));
     executeRequestsInPrePrepareMsg(span, pp, true);
     metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
     metric_total_finished_consensuses_.Get().Inc();


### PR DESCRIPTION
Logging inconsistency was observed in testing.

It seems that when a replica tries to recover a request,
the logs in the flow in which the request is executed, miss a sequence number.
I have added the sequence number to the logs.