### PR TITLE
Add cid to the pre-execution logs, where it is missing

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -112,7 +112,7 @@ class PreProcessor {
   void handlePreProcessedReqByPrimary(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       uint16_t clientId,
                                       uint32_t resultBufLen);
-  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, SeqNum reqSeqNum);
+  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId);
   void finalizePreProcessing(NodeIdType clientId);
   void cancelPreProcessing(NodeIdType clientId);
   PreProcessingResult getPreProcessingConsensusResult(uint16_t clientId);

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -28,6 +28,7 @@ class RequestProcessingState {
  public:
   RequestProcessingState(uint16_t numOfReplicas,
                          uint16_t clientId,
+                         const std::string& cid,
                          ReqId reqSeqNum,
                          ClientPreProcessReqMsgUniquePtr clientReqMsg,
                          PreProcessRequestMsgSharedPtr preProcessRequestMsg);
@@ -44,8 +45,10 @@ class RequestProcessingState {
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut(bool isPrimary) const;
-  uint64_t getReqTimeoutMilli() const { return clientPreProcessReqMsg_->requestTimeoutMilli(); }
-  std::string getReqCid() const { return clientPreProcessReqMsg_->getCid(); }
+  uint64_t getReqTimeoutMilli() const {
+    return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->requestTimeoutMilli() : 0;
+  }
+  std::string getReqCid() const { return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->getCid() : ""; }
   void detectNonDeterministicPreProcessing(const uint8_t* newHash, NodeIdType newSenderId) const;
 
   static void init(uint16_t numOfRequiredReplies);
@@ -69,6 +72,7 @@ class RequestProcessingState {
   // the RequestProcessingState objects.
   const uint16_t numOfReplicas_;
   const uint16_t clientId_;
+  const std::string cid_;
   const ReqId reqSeqNum_;
   const uint64_t entryTime_;
   ClientPreProcessReqMsgUniquePtr clientPreProcessReqMsg_;

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -71,6 +71,7 @@ void PreProcessReplyMsg::setupMsgBody(const char* buf, uint32_t bufLen, const st
   msgBody()->cidLength = cid.size();
   msgSize_ = headerSize + sigSize + msgBody()->cidLength;
   msgBody()->replyLength = sigSize;
+  SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(),
             "senderId=" << msgBody()->senderId << " clientId=" << msgBody()->clientId
                         << " reqSeqNum=" << msgBody()->reqSeqNum << " headerSize=" << headerSize

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -33,6 +33,7 @@ PreProcessRequestMsg::PreProcessRequestMsg(NodeIdType senderId,
   position += reqLength;
   memcpy(position, cid.c_str(), cid.size());
   uint64_t msgLength = sizeof(Header) + span_context.data().size() + reqLength + cid.size();
+  SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(),
             "senderId=" << senderId << " clientId=" << clientId << " reqSeqNum=" << reqSeqNum
                         << " headerSize=" << sizeof(Header) << " reqLength=" << reqLength << " cidSize=" << cid.size()

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -331,6 +331,7 @@ PreProcessReplyMsgSharedPtr preProcessNonPrimary(NodeIdType replicaId, const bft
 TEST(requestPreprocessingState_test, notEnoughRepliesReceived) {
   RequestProcessingState reqState(replicaConfig.numReplicas,
                                   clientId,
+                                  cid,
                                   reqSeqNum,
                                   ClientPreProcessReqMsgUniquePtr(),
                                   PreProcessRequestMsgSharedPtr());
@@ -346,6 +347,7 @@ TEST(requestPreprocessingState_test, notEnoughRepliesReceived) {
 TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCollected) {
   RequestProcessingState reqState(replicaConfig.numReplicas,
                                   clientId,
+                                  cid,
                                   reqSeqNum,
                                   ClientPreProcessReqMsgUniquePtr(),
                                   PreProcessRequestMsgSharedPtr());
@@ -363,6 +365,7 @@ TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCol
 TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
   RequestProcessingState reqState(replicaConfig.numReplicas,
                                   clientId,
+                                  cid,
                                   reqSeqNum,
                                   ClientPreProcessReqMsgUniquePtr(),
                                   PreProcessRequestMsgSharedPtr());
@@ -379,6 +382,7 @@ TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
 TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
   RequestProcessingState reqState(replicaConfig.numReplicas,
                                   clientId,
+                                  cid,
                                   reqSeqNum,
                                   ClientPreProcessReqMsgUniquePtr(),
                                   PreProcessRequestMsgSharedPtr());
@@ -399,6 +403,7 @@ TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
 TEST(requestPreprocessingState_test, primaryReplicaDidNotCompletePreProcessingWhileNonPrimariesDid) {
   RequestProcessingState reqState(replicaConfig.numReplicas,
                                   clientId,
+                                  cid,
                                   reqSeqNum,
                                   ClientPreProcessReqMsgUniquePtr(),
                                   PreProcessRequestMsgSharedPtr());


### PR DESCRIPTION
It was discovered during pre-execution integration tests that some logs lack cid - fixing.

