### PR TITLE
CMFC: Hide functions for C++ generated code

### DIFF
--- a/messages/compiler/cpp/cpp_visitor.py
+++ b/messages/compiler/cpp/cpp_visitor.py
@@ -23,20 +23,20 @@ struct {name} {{
 
 def serialize_start(name):
     return f"""
-void serialize(std::vector<uint8_t>& output, const {name}& t) {{
+static void serialize(std::vector<uint8_t>& output, const {name}& t) {{
 """
 
 
 def deserialize_start(name):
     return f"""
-void deserialize(uint8_t*& input, const uint8_t* end, {name}& t) {{
+static void deserialize(uint8_t*& input, const uint8_t* end, {name}& t) {{
 """
 
 
 def deserialize_end(name):
     return f"""}}
 
-void deserialize(const std::vector<uint8_t>& input, {name}& t) {{
+static void deserialize(const std::vector<uint8_t>& input, {name}& t) {{
     auto* begin = const_cast<uint8_t*>(input.data());
     deserialize(begin, begin + input.size(), t);
 }}
@@ -61,7 +61,7 @@ def deserialize_field(name, type):
 
 def variant_serialize(variant):
     return f"""\
-void serialize(std::vector<uint8_t>& output, const {variant}& val) {{
+static void serialize(std::vector<uint8_t>& output, const {variant}& val) {{
   std::visit([&output](auto&& arg){{
     cmf::serialize(output, arg.id);
     serialize(output, arg);
@@ -71,7 +71,7 @@ void serialize(std::vector<uint8_t>& output, const {variant}& val) {{
 
 def variant_deserialize(variant, msgs):
     s = f"""
-void deserialize(uint8_t*& start, const uint8_t* end, {variant}& val) {{
+static void deserialize(uint8_t*& start, const uint8_t* end, {variant}& val) {{
   uint32_t id;
   cmf::deserialize(start, end, id);
 """
@@ -95,7 +95,7 @@ def equalop_str(msg_name, fields):
     """ Create an 'operator==' function for the current message struct """
     comparison = " && ".join([f"l.{f} == r.{f}" for f in fields])
     return f"""\
-bool operator==(const {msg_name}& l, const {msg_name}& r) {{
+static bool operator==(const {msg_name}& l, const {msg_name}& r) {{
   return {comparison};
 }}"""
 

--- a/messages/compiler/cpp/serialize.h
+++ b/messages/compiler/cpp/serialize.h
@@ -51,7 +51,7 @@ class NoDataLeftError : public DeserializeError {
  * All integers are encoded in little endian
  ******************************************************************************/
 template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-void serialize(std::vector<uint8_t>& output, const T& t) {
+static void serialize(std::vector<uint8_t>& output, const T& t) {
   if constexpr (std::is_same_v<T, bool>) {
     output.push_back(t ? 1 : 0);
   } else {
@@ -62,7 +62,7 @@ void serialize(std::vector<uint8_t>& output, const T& t) {
 }
 
 template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-void deserialize(uint8_t*& start, const uint8_t* end, T& t) {
+static void deserialize(uint8_t*& start, const uint8_t* end, T& t) {
   if constexpr (std::is_same_v<T, bool>) {
     if (start + 1 > end) {
       throw NoDataLeftError();
@@ -86,14 +86,14 @@ void deserialize(uint8_t*& start, const uint8_t* end, T& t) {
  *
  * Strings are preceded by a uint32_t length
  ******************************************************************************/
-void serialize(std::vector<uint8_t>& output, const std::string& s) {
+static void serialize(std::vector<uint8_t>& output, const std::string& s) {
   assert(s.size() <= 0xFFFFFFFF);
   uint32_t length = s.size() & 0xFFFFFFFF;
   serialize(output, length);
   std::copy(s.begin(), s.end(), std::back_inserter(output));
 }
 
-void deserialize(uint8_t*& start, const uint8_t* end, std::string& s) {
+static void deserialize(uint8_t*& start, const uint8_t* end, std::string& s) {
   uint32_t length;
   deserialize(start, end, length);
   if (start + length > end) {
@@ -108,27 +108,27 @@ void deserialize(uint8_t*& start, const uint8_t* end, std::string& s) {
  ******************************************************************************/
 // Lists
 template <typename T>
-void serialize(std::vector<uint8_t>& output, const std::vector<T>& v);
+static void serialize(std::vector<uint8_t>& output, const std::vector<T>& v);
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::vector<T>& v);
+static void deserialize(uint8_t*& start, const uint8_t* end, std::vector<T>& v);
 
 // KVPairs
 template <typename K, typename V>
-void serialize(std::vector<uint8_t>& output, const std::pair<K, V>& kvpair);
+static void serialize(std::vector<uint8_t>& output, const std::pair<K, V>& kvpair);
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair);
+static void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair);
 
 // Maps
 template <typename K, typename V>
-void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m);
+static void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m);
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::map<K, V>& m);
+static void deserialize(uint8_t*& start, const uint8_t* end, std::map<K, V>& m);
 
 // Optionals
 template <typename T>
-void serialize(std::vector<uint8_t>& output, const std::optional<T>& t);
+static void serialize(std::vector<uint8_t>& output, const std::optional<T>& t);
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t);
+static void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t);
 
 /******************************************************************************
  * Lists are modeled as std::vectors
@@ -136,7 +136,7 @@ void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t);
  * Lists are preceded by a uint32_t length
  ******************************************************************************/
 template <typename T>
-void serialize(std::vector<uint8_t>& output, const std::vector<T>& v) {
+static void serialize(std::vector<uint8_t>& output, const std::vector<T>& v) {
   assert(v.size() <= 0xFFFFFFFF);
   uint32_t length = v.size() & 0xFFFFFFFF;
   serialize(output, length);
@@ -146,7 +146,7 @@ void serialize(std::vector<uint8_t>& output, const std::vector<T>& v) {
 }
 
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::vector<T>& v) {
+static void deserialize(uint8_t*& start, const uint8_t* end, std::vector<T>& v) {
   uint32_t length;
   deserialize(start, end, length);
   if constexpr (std::is_integral_v<T> && sizeof(T) == 1) {
@@ -169,13 +169,13 @@ void deserialize(uint8_t*& start, const uint8_t* end, std::vector<T>& v) {
  * KVPairs are modeled as std::pairs.
  ******************************************************************************/
 template <typename K, typename V>
-void serialize(std::vector<uint8_t>& output, const std::pair<K, V>& kvpair) {
+static void serialize(std::vector<uint8_t>& output, const std::pair<K, V>& kvpair) {
   serialize(output, kvpair.first);
   serialize(output, kvpair.second);
 }
 
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair) {
+static void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair) {
   deserialize(start, end, kvpair.first);
   deserialize(start, end, kvpair.second);
 }
@@ -186,7 +186,7 @@ void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair) {
  * Maps are preceded by a uint32_t size
  ******************************************************************************/
 template <typename K, typename V>
-void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m) {
+static void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m) {
   assert(m.size() <= 0xFFFFFFFF);
   uint32_t size = m.size() & 0xFFFFFFFF;
   serialize(output, size);
@@ -196,7 +196,7 @@ void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m) {
 }
 
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::map<K, V>& m) {
+static void deserialize(uint8_t*& start, const uint8_t* end, std::map<K, V>& m) {
   uint32_t size;
   deserialize(start, end, size);
   for (auto i = 0u; i < size; i++) {
@@ -212,7 +212,7 @@ void deserialize(uint8_t*& start, const uint8_t* end, std::map<K, V>& m) {
  * Optionals are preceded by a bool indicating whether a value is present or not.
  ******************************************************************************/
 template <typename T>
-void serialize(std::vector<uint8_t>& output, const std::optional<T>& t) {
+static void serialize(std::vector<uint8_t>& output, const std::optional<T>& t) {
   serialize(output, t.has_value());
   if (t.has_value()) {
     serialize(output, t.value());
@@ -220,7 +220,7 @@ void serialize(std::vector<uint8_t>& output, const std::optional<T>& t) {
 }
 
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t) {
+static void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t) {
   bool has_value;
   deserialize(start, end, has_value);
   if (has_value) {


### PR DESCRIPTION
At compile time, the linker will complain if multiple object files contain the
same function definitions. All generated C++ code ends up in one header file.
Later, we can consider separating declaration and defintion but for now we go
with the one-header-file approach and therefore make functions static.