### PR TITLE
Introduce preExecMaxResultSize configuration parameter

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -82,6 +82,9 @@ struct ReplicaConfig {
   // If equals to 0, a default number of min(thread::hardware_concurrency(), numOfClients) is used
   uint16_t preExecConcurrencyLevel = 0;
 
+  // The pre-execution result is sent to the replicas as a part of the PrePrepare message replacing an original request
+  uint32_t preExecMaxResultSize = 16777216;
+
   // public keys of all replicas. map from replica identifier to a public key
   std::set<std::pair<uint16_t, const std::string>> publicKeysOfReplicas;
 
@@ -149,6 +152,7 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
      << "preExecutionFeatureEnabled: " << rc.preExecutionFeatureEnabled << "\n"
      << "preExecReqStatusCheckTimerMillisec: " << rc.preExecReqStatusCheckTimerMillisec << "\n"
      << "preExecConcurrencyLevel: " << rc.preExecConcurrencyLevel << "\n"
+     << "preExecMaxResultSize: " << rc.preExecMaxResultSize << "\n"
      << "debugPersistentStorageEnabled: " << rc.debugPersistentStorageEnabled << "\n"
      << "maxExternalMessageSize: " << rc.maxExternalMessageSize << "\n"
      << "maxReplyMessageSize: " << rc.maxReplyMessageSize << "\n"
@@ -190,6 +194,7 @@ class ReplicaConfigSingleton {
   bool GetPreExecutionFeatureEnabled() const { return config_->preExecutionFeatureEnabled; }
   uint64_t GetPreExecReqStatusCheckTimerMillisec() const { return config_->preExecReqStatusCheckTimerMillisec; }
   uint16_t GetPreExecConcurrencyLevel() const { return config_->preExecConcurrencyLevel; }
+  uint32_t GetPreExecMaxResultSize() const { return config_->preExecMaxResultSize; }
   std::string GetReplicaPrivateKey() const { return config_->replicaPrivateKey; }
 
   IThresholdSigner const* GetThresholdSignerForExecution() const { return config_->thresholdSignerForExecution; }

--- a/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
+++ b/bftengine/src/bftengine/ReplicaConfigSerializer.cpp
@@ -28,8 +28,8 @@ uint32_t ReplicaConfigSerializer::maxSize(uint32_t numOfReplicas) {
           sizeof(config_->viewChangeProtocolEnabled) + sizeof(config_->viewChangeTimerMillisec) +
           sizeof(config_->autoPrimaryRotationEnabled) + sizeof(config_->autoPrimaryRotationTimerMillisec) +
           sizeof(config_->preExecutionFeatureEnabled) + sizeof(config_->preExecReqStatusCheckTimerMillisec) +
-          sizeof(config_->preExecConcurrencyLevel) + MaxSizeOfPrivateKey + numOfReplicas * MaxSizeOfPublicKey +
-          IThresholdSigner::maxSize() * 3 + IThresholdVerifier::maxSize() * 3 +
+          sizeof(config_->preExecConcurrencyLevel) + sizeof(config_->preExecMaxResultSize) + MaxSizeOfPrivateKey +
+          numOfReplicas * MaxSizeOfPublicKey + IThresholdSigner::maxSize() * 3 + IThresholdVerifier::maxSize() * 3 +
           sizeof(config_->maxExternalMessageSize) + sizeof(config_->maxReplyMessageSize) +
           sizeof(config_->maxNumOfReservedPages) + sizeof(config_->sizeOfReservedPage) +
           sizeof(config_->debugPersistentStorageEnabled) + sizeof(config_->metricsDumpIntervalSeconds) +
@@ -106,6 +106,9 @@ void ReplicaConfigSerializer::serializeDataMembers(ostream &outStream) const {
   // Serialize preExecConcurrencyLevel
   outStream.write((char *)&config_->preExecConcurrencyLevel, sizeof(config_->preExecConcurrencyLevel));
 
+  // Serialize preExecMaxResultSize
+  outStream.write((char *)&config_->preExecMaxResultSize, sizeof(config_->preExecMaxResultSize));
+
   // Serialize public keys
   auto numOfPublicKeys = (int64_t)config_->publicKeysOfReplicas.size();
   outStream.write((char *)&numOfPublicKeys, sizeof(numOfPublicKeys));
@@ -172,6 +175,7 @@ bool ReplicaConfigSerializer::operator==(const ReplicaConfigSerializer &other) c
        (other.config_->preExecutionFeatureEnabled == config_->preExecutionFeatureEnabled) &&
        (other.config_->preExecReqStatusCheckTimerMillisec == config_->preExecReqStatusCheckTimerMillisec) &&
        (other.config_->preExecConcurrencyLevel == config_->preExecConcurrencyLevel) &&
+       (other.config_->preExecMaxResultSize == config_->preExecMaxResultSize) &&
        (other.config_->replicaPrivateKey == config_->replicaPrivateKey) &&
        (other.config_->publicKeysOfReplicas == config_->publicKeysOfReplicas) &&
        (other.config_->debugPersistentStorageEnabled == config_->debugPersistentStorageEnabled) &&
@@ -238,6 +242,9 @@ void ReplicaConfigSerializer::deserializeDataMembers(istream &inStream) {
 
   // Deserialize preExecConcurrencyLevel
   inStream.read((char *)&config.preExecConcurrencyLevel, sizeof(config.preExecConcurrencyLevel));
+
+  // Deserialize preExecMaxResultSize
+  inStream.read((char *)&config.preExecMaxResultSize, sizeof(config.preExecMaxResultSize));
 
   // Deserialize public keys
   int64_t numOfPublicKeys = 0;

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -99,7 +99,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       requestsHandler_(requestsHandler),
       myReplica_(myReplica),
       myReplicaId_(myReplica.getReplicaConfig().replicaId),
-      maxReplyMsgSize_(myReplica.getReplicaConfig().maxReplyMessageSize - sizeof(ClientReplyMsgHeader)),
+      maxPreExecResultSize_(myReplica.getReplicaConfig().preExecMaxResultSize),
       idsOfPeerReplicas_(myReplica.getIdsOfPeerReplicas()),
       numOfReplicas_(myReplica.getReplicaConfig().numReplicas),
       numOfClients_(myReplica.getReplicaConfig().numOfExternalClients +
@@ -130,7 +130,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   }
   // Allocate a buffer for the pre-execution result per client
   for (auto id = 0; id < numOfClients_; id++) {
-    preProcessResultBuffers_.push_back(Sliver(new char[maxReplyMsgSize_], maxReplyMsgSize_));
+    preProcessResultBuffers_.push_back(Sliver(new char[maxPreExecResultSize_], maxPreExecResultSize_));
   }
   uint64_t numOfThreads = myReplica.getReplicaConfig().preExecConcurrencyLevel;
   if (!numOfThreads) numOfThreads = min((uint16_t)thread::hardware_concurrency(), numOfClients_);
@@ -552,7 +552,7 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
                                          PRE_PROCESS_FLAG,
                                          reqLength,
                                          reqBuf,
-                                         maxReplyMsgSize_,
+                                         maxPreExecResultSize_,
                                          (char *)getPreProcessResultBuffer(clientId),
                                          resultLen,
                                          replicaSpecificInfoLen,

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -140,7 +140,7 @@ class PreProcessor {
   bftEngine::IRequestsHandler &requestsHandler_;
   const InternalReplicaApi &myReplica_;
   const ReplicaId myReplicaId_;
-  const uint32_t maxReplyMsgSize_;
+  const uint32_t maxPreExecResultSize_;
   const std::set<ReplicaId> &idsOfPeerReplicas_;
   const uint16_t numOfReplicas_;
   const uint16_t numOfClients_;


### PR DESCRIPTION
The pre-execution result buffer size should be configurable independently from maxReplyMessageSize. This way we don't increase a number of reserved pages required to store client reply messages, as pre-execution result does not return to the clients.