### PR TITLE
Store and load replicas keys from reserved pages

### DIFF
--- a/bftengine/include/bftengine/IReservedPages.hpp
+++ b/bftengine/include/bftengine/IReservedPages.hpp
@@ -1,0 +1,24 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <cstdint>
+
+class IReservedPages {
+ public:
+  virtual ~IReservedPages(){};
+  virtual uint32_t numberOfReservedPages() const = 0;
+  virtual uint32_t sizeOfReservedPage() const = 0;
+  virtual bool loadReservedPage(uint32_t reservedPageId, uint32_t copyLength, char *outReservedPage) const = 0;
+  virtual void saveReservedPage(uint32_t reservedPageId, uint32_t copyLength, const char *inReservedPage) = 0;
+  virtual void zeroReservedPage(uint32_t reservedPageId) = 0;
+};

--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -16,11 +16,12 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include "IReservedPages.hpp"
 
 namespace bftEngine {
 class IReplicaForStateTransfer;  // forward definition
 
-class IStateTransfer {
+class IStateTransfer : public IReservedPages {
  public:
   virtual ~IStateTransfer() {}
 
@@ -48,13 +49,6 @@ class IStateTransfer {
   virtual void startCollectingState() = 0;
 
   virtual bool isCollectingState() const = 0;
-
-  // working with reserved pages
-  virtual uint32_t numberOfReservedPages() const = 0;
-  virtual uint32_t sizeOfReservedPage() const = 0;
-  virtual bool loadReservedPage(uint32_t reservedPageId, uint32_t copyLength, char *outReservedPage) const = 0;
-  virtual void saveReservedPage(uint32_t reservedPageId, uint32_t copyLength, const char *inReservedPage) = 0;
-  virtual void zeroReservedPage(uint32_t reservedPageId) = 0;
 
   // timer (for simple implementation, a state transfer module can use its own
   // timers and threads)

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -18,6 +18,7 @@
 #include "PersistentStorage.hpp"
 #include "ClientsManager.hpp"
 #include "MsgsCommunicator.hpp"
+#include "KeyStore.h"
 
 using concordUtil::Timers;
 
@@ -43,6 +44,7 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
   ClientsManager::setNumResPages(
       (config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
       ClientsManager::reservedPagesPerClient(config.sizeOfReservedPage, config.maxReplyMessageSize));
+  ClusterKeyStore::setNumResPages(config.numReplicas);
 }
 
 void ReadOnlyReplica::start() {

--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -34,6 +34,7 @@ extern logging::Logger GL;
 extern logging::Logger CNSUS;
 extern logging::Logger THRESHSIGN_LOG;
 extern logging::Logger BLS_LOG;
+extern logging::Logger KEY_EX_LOG;
 extern logging::Logger VC_LOG;
 
 namespace logging {

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -26,4 +26,5 @@ logging::Logger GL = logging::getLogger("concord");
 logging::Logger CNSUS = logging::getLogger("concord.bft.consensus");
 logging::Logger THRESHSIGN_LOG = logging::getLogger("concord.threshsign");
 logging::Logger BLS_LOG = logging::getLogger("concord.threshsign.bls");
+logging::Logger KEY_EX_LOG = logging::getLogger("concord.key-exchange");
 logging::Logger VC_LOG = logging::getLogger("concord.viewchange");


### PR DESCRIPTION
- Extracting the reserved pages operations to a dedicated interface.

- Implementing reserved pages support at the ClusterStore class: load on: start and state transfer complete, store on: push and rotate.

- Defining a new logger for key exchange.

- Adding UT for the reserve pages operations

