### PR TITLE
Avoid unneeded pre-processing retries

### DIFF
--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -39,6 +39,7 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual bool isCurrentPrimary() const = 0;
   virtual bool currentViewIsActive() const = 0;
   virtual ReqId seqNumberOfLastReplyToClient(NodeIdType clientId) const = 0;
+  virtual bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const = 0;
 
   virtual IncomingMsgsStorage& getIncomingMsgsStorage() = 0;
   virtual util::SimpleThreadPool& getInternalThreadPool() = 0;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -261,6 +261,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   ReqId seqNumberOfLastReplyToClient(NodeIdType clientId) const override {
     return clientsManager->seqNumberOfLastReplyToClient(clientId);
   }
+  bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const override {
+    return !clientsManager->noPendingAndRequestCanBecomePending(clientId, reqSeqNum);
+  }
 
  protected:
   ReplicaImp(bool firstTime,

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -92,14 +92,15 @@ class DummyReplica : public InternalReplicaApi {
   explicit DummyReplica(bftEngine::impl::ReplicasInfo replicasInfo) : replicasInfo_(move(replicasInfo)) {}
 
   const bftEngine::impl::ReplicasInfo& getReplicasInfo() const override { return replicasInfo_; }
-  bool isValidClient(NodeIdType client) const override { return true; }
-  bool isIdOfReplica(NodeIdType id) const override { return false; }
+  bool isValidClient(NodeIdType) const override { return true; }
+  bool isIdOfReplica(NodeIdType) const override { return false; }
   const set<ReplicaId>& getIdsOfPeerReplicas() const override { return replicaIds_; }
   ViewNum getCurrentView() const override { return 0; }
   ReplicaId currentPrimary() const override { return replicaConfig.replicaId; }
   bool isCurrentPrimary() const override { return primary_; }
   bool currentViewIsActive() const override { return true; }
-  ReqId seqNumberOfLastReplyToClient(NodeIdType client) const override { return 1; }
+  ReqId seqNumberOfLastReplyToClient(NodeIdType) const override { return 1; }
+  bool isClientRequestInProcess(NodeIdType, ReqId) const override { return false; }
 
   IncomingMsgsStorage& getIncomingMsgsStorage() override { return *incomingMsgsStorage_; }
   util::SimpleThreadPool& getInternalThreadPool() override { return pool_; }


### PR DESCRIPTION
PreProcessor should reject client retries in case the system is busy with consensus/PostExec.