### PR TITLE
Support DB comparison in sparse_merkle_db_editor

### DIFF
--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -48,13 +48,18 @@ namespace concord::kvbc::v2MerkleTree {
 // getLastReachableBlockId() + 1. Additionally, ReachableSTBlock <= getLatestBlockId().
 class DBAdapter : public IDbAdapter {
  public:
-  // The constructor will try to link the blockchain with any blocks in the temporary state transfer chain. This is done
-  // so that the DBAdapter will operate correctly in case a crash or an abnormal shutdown has occurred prior to startup
-  // (construction). Only a single DBAdapter instance should operate on a database and access to all methods
-  // should be either done from a single thread or serialized via a mutex or another mechanism. The constructor throws
-  // if an error occurs.
-  // Note: The passed DB client must be initialized beforehand.
-  DBAdapter(const std::shared_ptr<concord::storage::IDBClient> &db);
+  // Unless explicitly turned off, the constructor will try to link the blockchain with any blocks in the temporary
+  // state transfer chain. This is done so that the DBAdapter will operate correctly in case a crash or an abnormal
+  // shutdown has occurred prior to startup (construction). Only a single DBAdapter instance should operate on a
+  // database and access to all methods should be either done from a single thread or serialized via a mutex or another
+  // mechanism. The constructor throws if an error occurs.
+  // Note1: The passed DB client must be initialized beforehand.
+  // Note2: The 'linkTempSTChain' parameter turns of chain linking and is used for testing/tooling purposes.
+  DBAdapter(const std::shared_ptr<concord::storage::IDBClient> &db, bool linkTempSTChain = true);
+
+  // Make the adapter non-copyable.
+  DBAdapter(const DBAdapter &) = delete;
+  DBAdapter &operator=(const DBAdapter &) = delete;
 
   // Adds a block to the end of the blockchain from a set of key/value pairs and a set of keys to delete. If a key is
   // present in both 'updates' and 'deletes' parameters, it will be present in the block with the value passed in

--- a/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
@@ -14,21 +14,21 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-#include "storage/db_types.h"
-#include "sparse_merkle_db_editor.hpp"
-#include "PersistentStorageImp.hpp"
-
-#include "storage/merkle_tree_key_manipulator.h"
-#include "storage_test_common.h"
-
+#include "db_adapter_interface.h"
 #include "endianness.hpp"
 #include "kv_types.hpp"
 #include "merkle_tree_db_adapter.h"
+#include "PersistentStorageImp.hpp"
 #include "sliver.hpp"
+#include "sparse_merkle_db_editor.hpp"
+#include "storage_test_common.h"
+#include "storage/db_types.h"
+#include "storage/merkle_tree_key_manipulator.h"
 
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <sstream>
 
 namespace {
@@ -36,6 +36,7 @@ namespace {
 using namespace concord::kvbc::tools::sparse_merkle_db;
 using namespace concord::kvbc::v2MerkleTree;
 using concord::kvbc::BlockId;
+using concord::kvbc::INITIAL_GENESIS_BLOCK_ID;
 using concord::kvbc::SetOfKeyValuePairs;
 using concordUtils::toBigEndianStringBuffer;
 using concordUtils::Sliver;
@@ -48,6 +49,8 @@ using testing::StartsWith;
 using testing::Test;
 
 using namespace std::string_literals;
+
+const auto kTestName = kToolName + "_test";
 
 Sliver getSliver(unsigned value) { return toBigEndianStringBuffer(value); }
 
@@ -69,115 +72,143 @@ SetOfKeyValuePairs generateMetadataAndStateTransfer() {
   return updates;
 }
 
-class SparseMerkleDbInspectorTests : public Test {
+class SparseMerkleDbEditorTests : public Test {
  public:
   void SetUp() override {
-    auto db = TestRocksDb::create();
+    CleanDbs();
+    CreateBlockchain(main_path_db_id_, num_blocks_);
+  }
+
+  void TearDown() override { CleanDbs(); }
+
+  void CleanDbs() {
+    TestRocksDb::cleanup(main_path_db_id_);
+    TestRocksDb::cleanup(other_path_db_id_);
+  }
+
+  void CreateBlockchain(std::size_t db_id, BlockId blocks, std::optional<BlockId> mismatch_at = std::nullopt) {
+    auto db = TestRocksDb::create(db_id);
     auto adapter = DBAdapter{db};
 
-    for (auto i = 0u; i < num_blocks_ - 1; ++i) {
+    const auto mismatch_kv = std::make_pair(getSliver(std::numeric_limits<unsigned>::max()), getSliver(42));
+
+    for (auto i = 1u; i <= blocks; ++i) {
       auto updates = SetOfKeyValuePairs{};
-      for (auto j = 0u; j < num_keys_; ++j) {
-        updates[getSliver((j + i) * num_blocks_)] = getSliver((j + i) * 2 * num_blocks_);
+      if (empty_block_id_ != i) {
+        for (auto j = 0u; j < num_keys_; ++j) {
+          updates[getSliver((j + i - 1) * kv_multiplier_)] = getSliver((j + i - 1) * 2 * kv_multiplier_);
+        }
+      }
+      // Add a key to simulate a mismatch.
+      if (mismatch_at.has_value() && *mismatch_at == i) {
+        updates.insert(mismatch_kv);
       }
       ASSERT_NO_THROW(adapter.addBlock(updates));
     }
-    // Add an empty block.
-    ASSERT_NO_THROW(adapter.addBlock(SetOfKeyValuePairs{}));
+
     const auto status = db->multiPut(generateMetadataAndStateTransfer());
     ASSERT_TRUE(status.isOK());
   }
 
-  void TearDown() override { cleanup(); }
+  void DeleteBlocksUntil(std::size_t db_id, BlockId until_block_id) {
+    auto db = TestRocksDb::create(db_id);
+    auto adapter = DBAdapter{db};
+
+    for (auto i = 1ull; i < until_block_id; ++i) {
+      adapter.deleteBlock(i);
+    }
+  }
 
  protected:
-  const unsigned num_blocks_{10};
-  const unsigned num_keys_{3};
+  static constexpr std::size_t main_path_db_id_{defaultDbId};
+  static constexpr std::size_t other_path_db_id_{main_path_db_id_ + 1};
+  static constexpr unsigned kv_multiplier_{10};
+  static constexpr BlockId empty_block_id_{10};
+  static constexpr BlockId num_blocks_{10};
+  static constexpr BlockId more_num_blocks_{16};
+  static constexpr BlockId first_mismatch_block_id_{7};
+  static constexpr unsigned num_keys_{3};
+
   std::stringstream out_;
   std::stringstream err_;
 };
 
-TEST_F(SparseMerkleDbInspectorTests, no_arguments) {
-  ASSERT_EQ(EXIT_FAILURE, run(CommandLineArguments{{"sparse_merkle_db_editor_test"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, no_arguments) {
+  ASSERT_EQ(EXIT_FAILURE, run(CommandLineArguments{{kTestName}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Usage:"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, invalid_command) {
-  ASSERT_EQ(EXIT_FAILURE, run(CommandLineArguments{{"sparse_merkle_db_editor_test", "unknownCommand"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, invalid_command) {
+  ASSERT_EQ(EXIT_FAILURE, run(CommandLineArguments{{kTestName, "unknownCommand"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Usage:"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_genesis_block_id) {
-  ASSERT_EQ(
-      EXIT_SUCCESS,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getGenesisBlockID"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, get_genesis_block_id) {
+  ASSERT_EQ(EXIT_SUCCESS,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getGenesisBlockID"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_EQ("{\n  \"genesisBlockID\": \"1\"\n}\n", out_.str());
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_last_reachable_block_id) {
-  ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getLastReachableBlockID"}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_last_reachable_block_id) {
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getLastReachableBlockID"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_EQ("{\n  \"lastReachableBlockID\": \""s + std::to_string(num_blocks_) + "\"\n}\n", out_.str());
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_last_block_id) {
+TEST_F(SparseMerkleDbEditorTests, get_last_block_id) {
   ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getLastBlockID"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getLastBlockID"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_EQ("{\n  \"lastBlockID\": \""s + std::to_string(num_blocks_) + "\"\n}\n", out_.str());
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block) {
+TEST_F(SparseMerkleDbEditorTests, get_raw_block) {
   ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlock", "5"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlock", "5"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_THAT(out_.str(), StartsWith("{\n  \"rawBlock\": \"0x"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_missing_block_id) {
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_missing_block_id) {
   ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlock"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlock"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getRawBlock], reason: Missing BLOCK-ID argument"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_invalid_block_id) {
-  ASSERT_EQ(
-      EXIT_FAILURE,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlock", "5ab"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_invalid_block_id) {
+  ASSERT_EQ(EXIT_FAILURE,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlock", "5ab"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getRawBlock], reason: Invalid BLOCK-ID: 5ab"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_full_range) {
-  ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test",
-                                      rocksDbPath(),
-                                      "getRawBlockRange",
-                                      "1",
-                                      std::to_string(num_blocks_ + 1)}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_full_range) {
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(
+          CommandLineArguments{
+              {kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "1", std::to_string(num_blocks_ + 1)}},
+          out_,
+          err_));
   ASSERT_TRUE(err_.str().empty());
   for (auto i = 1u; i <= num_blocks_; ++i) {
     ASSERT_THAT(out_.str(), HasSubstr("  \"rawBlock" + std::to_string(i) + "\": \"0x"));
   }
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_except_last) {
-  ASSERT_EQ(
-      EXIT_SUCCESS,
-      run(
-          CommandLineArguments{
-              {"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlockRange", "1", std::to_string(num_blocks_)}},
-          out_,
-          err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_except_last) {
+  ASSERT_EQ(EXIT_SUCCESS,
+            run(
+                CommandLineArguments{
+                    {kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "1", std::to_string(num_blocks_)}},
+                out_,
+                err_));
   ASSERT_TRUE(err_.str().empty());
   for (auto i = 1u; i < num_blocks_; ++i) {
     ASSERT_THAT(out_.str(), HasSubstr("  \"rawBlock" + std::to_string(i) + "\": \"0x"));
@@ -185,10 +216,10 @@ TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_except_last) {
   ASSERT_THAT(out_.str(), Not(HasSubstr("  \"rawBlock" + std::to_string(num_blocks_) + "\": \"0x")));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_whole_blockchain) {
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_whole_blockchain) {
   ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test",
-                                      rocksDbPath(),
+            run(CommandLineArguments{{kTestName,
+                                      rocksDbPath(main_path_db_id_),
                                       "getRawBlockRange",
                                       "1",
                                       std::to_string(std::numeric_limits<BlockId>::max())}},
@@ -200,85 +231,78 @@ TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_whole_blockchain) {
   }
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_single_block) {
-  ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlockRange", "2", "3"}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_single_block) {
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "2", "3"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_THAT(out_.str(), HasSubstr("  \"rawBlock2\": \"0x"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_non_existent) {
-  ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test",
-                                      rocksDbPath(),
-                                      "getRawBlockRange",
-                                      "0",
-                                      std::to_string(num_blocks_ + 1)}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_non_existent) {
+  ASSERT_EQ(
+      EXIT_FAILURE,
+      run(
+          CommandLineArguments{
+              {kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "0", std::to_string(num_blocks_ + 1)}},
+          out_,
+          err_));
   ASSERT_TRUE(out_.str().empty());
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_missing_range) {
-  ASSERT_EQ(
-      EXIT_FAILURE,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlockRange", "1"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_missing_range) {
+  ASSERT_EQ(EXIT_FAILURE,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "1"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(),
               StartsWith("Failed to execute command [getRawBlockRange], reason: Missing or invalid block range"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_invalid_range) {
-  ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlockRange", "2", "1"}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_invalid_range) {
+  ASSERT_EQ(
+      EXIT_FAILURE,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "2", "1"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getRawBlockRange], reason: Invalid block range"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_invalid_block_id_end) {
-  ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlockRange", "2", "0"}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_invalid_block_id_end) {
+  ASSERT_EQ(
+      EXIT_FAILURE,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "2", "0"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(),
               StartsWith("Failed to execute command [getRawBlockRange], reason: Invalid BLOCK-ID-END value"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_raw_block_range_invalid_range_stard_end_equal) {
-  ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getRawBlockRange", "2", "2"}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_raw_block_range_invalid_range_stard_end_equal) {
+  ASSERT_EQ(
+      EXIT_FAILURE,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getRawBlockRange", "2", "2"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getRawBlockRange], reason: Invalid block range"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_block_info) {
-  ASSERT_EQ(
-      EXIT_SUCCESS,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getBlockInfo", "5"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, get_block_info) {
+  ASSERT_EQ(EXIT_SUCCESS,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getBlockInfo", "5"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_THAT(out_.str(), HasSubstr("  \"sparseMerkleRootHash\": \"0x"));
   ASSERT_THAT(out_.str(), HasSubstr("  \"parentBlockDigest\": \"0x"));
   ASSERT_THAT(out_.str(), HasSubstr("  \"keyValueCount\": \"" + std::to_string(num_keys_) + '\"'));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_block_info_missing_block_id) {
+TEST_F(SparseMerkleDbEditorTests, get_block_info_missing_block_id) {
   ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getBlockInfo"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getBlockInfo"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getBlockInfo], reason: Missing BLOCK-ID argument"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_block_key_values) {
+TEST_F(SparseMerkleDbEditorTests, get_block_key_values) {
   ASSERT_EQ(
       EXIT_SUCCESS,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getBlockKeyValues", "5"}}, out_, err_));
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getBlockKeyValues", "5"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_THAT(out_.str(), StartsWith("{\n  \"0x"));
   ASSERT_THAT(out_.str(), HasSubstr("\"0x0000003c\": \"0x00000078\""));
@@ -287,124 +311,229 @@ TEST_F(SparseMerkleDbInspectorTests, get_block_key_values) {
   ASSERT_THAT(out_.str(), EndsWith("\"\n}\n"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_empty_block_key_values) {
+TEST_F(SparseMerkleDbEditorTests, get_empty_block_key_values) {
   ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getBlockKeyValues", "10"}},
+            run(
+                CommandLineArguments{
+                    {kTestName, rocksDbPath(main_path_db_id_), "getBlockKeyValues", std::to_string(empty_block_id_)}},
                 out_,
                 err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_EQ("{\n}\n", out_.str());
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_block_key_values_missing_block_id) {
-  ASSERT_EQ(
-      EXIT_FAILURE,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getBlockKeyValues"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, get_block_key_values_missing_block_id) {
+  ASSERT_EQ(EXIT_FAILURE,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getBlockKeyValues"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(),
               StartsWith("Failed to execute command [getBlockKeyValues], reason: Missing BLOCK-ID argument"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_latest) {
+TEST_F(SparseMerkleDbEditorTests, get_value_latest) {
   ASSERT_EQ(
       EXIT_SUCCESS,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "0x00000028"}}, out_, err_));
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "0x00000028"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_EQ("{\n  \"blockVersion\": \"5\",\n  \"value\": \"0x00000050\"\n}\n", out_.str());
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_with_block_version) {
-  ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "0x00000028", "5"}},
-                out_,
-                err_));
-  ASSERT_TRUE(err_.str().empty());
-  ASSERT_EQ("{\n  \"blockVersion\": \"5\",\n  \"value\": \"0x00000050\"\n}\n", out_.str());
-}
-
-TEST_F(SparseMerkleDbInspectorTests, get_value_key_without__0x) {
-  ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "00000028", "5"}},
-                out_,
-                err_));
-  ASSERT_TRUE(err_.str().empty());
-  ASSERT_EQ("{\n  \"blockVersion\": \"5\",\n  \"value\": \"0x00000050\"\n}\n", out_.str());
-}
-
-TEST_F(SparseMerkleDbInspectorTests, get_value_empty_key) {
+TEST_F(SparseMerkleDbEditorTests, get_value_with_block_version) {
   ASSERT_EQ(
-      EXIT_FAILURE,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "", "5"}}, out_, err_));
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "0x00000028", "5"}}, out_, err_));
+  ASSERT_TRUE(err_.str().empty());
+  ASSERT_EQ("{\n  \"blockVersion\": \"5\",\n  \"value\": \"0x00000050\"\n}\n", out_.str());
+}
+
+TEST_F(SparseMerkleDbEditorTests, get_value_key_without_0x) {
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "00000028", "5"}}, out_, err_));
+  ASSERT_TRUE(err_.str().empty());
+  ASSERT_EQ("{\n  \"blockVersion\": \"5\",\n  \"value\": \"0x00000050\"\n}\n", out_.str());
+}
+
+TEST_F(SparseMerkleDbEditorTests, get_value_empty_key) {
+  ASSERT_EQ(EXIT_FAILURE,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "", "5"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getValue], reason: "));
   ASSERT_THAT(err_.str(), Not(HasSubstr("Invalid hex string:")));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_with_version_0) {
-  ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "0x00000028", "0"}},
-                out_,
-                err_));
+TEST_F(SparseMerkleDbEditorTests, get_value_with_version_0) {
+  ASSERT_EQ(
+      EXIT_FAILURE,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "0x00000028", "0"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getValue], reason: "));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_missing_key) {
+TEST_F(SparseMerkleDbEditorTests, get_value_missing_key) {
   ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getValue], reason: Missing HEX-KEY argument"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_invalid_key_size) {
-  ASSERT_EQ(
-      EXIT_FAILURE,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "0xabc"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, get_value_invalid_key_size) {
+  ASSERT_EQ(EXIT_FAILURE,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "0xabc"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getValue], reason: Invalid hex string: 0xabc"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_invalid_key_chars_at_start) {
+TEST_F(SparseMerkleDbEditorTests, get_value_invalid_key_chars_at_start) {
   ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "0xjj"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "0xjj"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getValue], reason: Invalid hex string: 0xjj"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_invalid_key_chars_at_end) {
-  ASSERT_EQ(
-      EXIT_FAILURE,
-      run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "0xabcx"}}, out_, err_));
+TEST_F(SparseMerkleDbEditorTests, get_value_invalid_key_chars_at_end) {
+  ASSERT_EQ(EXIT_FAILURE,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "0xabcx"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getValue], reason: Invalid hex string: 0xabcx"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, get_value_invalid_key_chars_no_0x) {
+TEST_F(SparseMerkleDbEditorTests, get_value_invalid_key_chars_no_0x) {
   ASSERT_EQ(EXIT_FAILURE,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "getValue", "abck"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getValue", "abck"}}, out_, err_));
   ASSERT_TRUE(out_.str().empty());
   ASSERT_THAT(err_.str(), StartsWith("Failed to execute command [getValue], reason: Invalid hex string: abck"));
 }
 
-TEST_F(SparseMerkleDbInspectorTests, remove_metadata) {
+TEST_F(SparseMerkleDbEditorTests, compare_to_self) {
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "compareTo", rocksDbPath(main_path_db_id_)}},
+          out_,
+          err_));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(),
+              HasSubstr("\"comparedRangeFirstBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"comparedRangeLastBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"result\": \"equivalent\""));
+  ASSERT_TRUE(err_.str().empty());
+}
+
+TEST_F(SparseMerkleDbEditorTests, compare_to_partial_match) {
+  CreateBlockchain(other_path_db_id_, more_num_blocks_);
+  DeleteBlocksUntil(other_path_db_id_, INITIAL_GENESIS_BLOCK_ID + 1);
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "compareTo", rocksDbPath(other_path_db_id_)}},
+          out_,
+          err_));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainGenesisBlockId\": \"1\""));
+  ASSERT_THAT(out_.str(),
+              HasSubstr("\"otherGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID + 1) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherLastReachableBlockId\": \"" + std::to_string(more_num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(),
+              HasSubstr("\"comparedRangeFirstBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID + 1) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"comparedRangeLastBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"result\": \"equivalent\""));
+  ASSERT_TRUE(err_.str().empty());
+}
+
+TEST_F(SparseMerkleDbEditorTests, compare_to_mismatch_middle) {
+  CreateBlockchain(other_path_db_id_, num_blocks_, first_mismatch_block_id_);
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "compareTo", rocksDbPath(other_path_db_id_)}},
+          out_,
+          err_));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"result\": \"mismatch\""));
+  ASSERT_THAT(out_.str(),
+              HasSubstr("\"firstMismatchingBlockId\": \"" + std::to_string(first_mismatch_block_id_) + "\""));
+  ASSERT_TRUE(err_.str().empty());
+}
+
+TEST_F(SparseMerkleDbEditorTests, compare_to_mismatch_genesis) {
+  CreateBlockchain(other_path_db_id_, num_blocks_, INITIAL_GENESIS_BLOCK_ID);
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "compareTo", rocksDbPath(other_path_db_id_)}},
+          out_,
+          err_));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"result\": \"mismatch\""));
+  ASSERT_THAT(out_.str(),
+              HasSubstr("\"firstMismatchingBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_TRUE(err_.str().empty());
+}
+
+TEST_F(SparseMerkleDbEditorTests, compare_to_mismatch_last_reachable) {
+  CreateBlockchain(other_path_db_id_, num_blocks_, num_blocks_);
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "compareTo", rocksDbPath(other_path_db_id_)}},
+          out_,
+          err_));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"result\": \"mismatch\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"firstMismatchingBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_TRUE(err_.str().empty());
+}
+
+TEST_F(SparseMerkleDbEditorTests, compare_to_no_overlap) {
+  CreateBlockchain(other_path_db_id_, more_num_blocks_);
+  DeleteBlocksUntil(other_path_db_id_, num_blocks_ + 1);
+  ASSERT_EQ(
+      EXIT_SUCCESS,
+      run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "compareTo", rocksDbPath(other_path_db_id_)}},
+          out_,
+          err_));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainGenesisBlockId\": \"" + std::to_string(INITIAL_GENESIS_BLOCK_ID) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherGenesisBlockId\": \"" + std::to_string(num_blocks_ + 1) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"mainLastReachableBlockId\": \"" + std::to_string(num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"otherLastReachableBlockId\": \"" + std::to_string(more_num_blocks_) + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"result\": \"no-overlap\""));
+  ASSERT_TRUE(err_.str().empty());
+}
+
+TEST_F(SparseMerkleDbEditorTests, compare_to_missing_path) {
+  ASSERT_EQ(EXIT_FAILURE,
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "compareTo"}}, out_, err_));
+  ASSERT_TRUE(out_.str().empty());
+  ASSERT_THAT(err_.str(),
+              StartsWith("Failed to execute command [compareTo], reason: Missing PATH-TO-OTHER-DB argument"));
+}
+
+TEST_F(SparseMerkleDbEditorTests, remove_metadata) {
   ASSERT_EQ(EXIT_SUCCESS,
-            run(CommandLineArguments{{"sparse_merkle_db_editor_test", rocksDbPath(), "removeMetadata"}}, out_, err_));
+            run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "removeMetadata"}}, out_, err_));
   ASSERT_THAT(out_.str(), StartsWith(toJson(std::string{"result"}, std::string{"true"})));
   ASSERT_TRUE(err_.str().empty());
 
-  auto db = std::make_shared<::concord::storage::rocksdb::Client>(rocksDbPath());
-  db->init(true);
+  const auto adapter = getAdapter(rocksDbPath(main_path_db_id_));
   const auto& kvp = generateMetadataAndStateTransfer();
   for (const auto& kv : kvp) {
-    ASSERT_TRUE(db->has(kv.first).isNotFound());
+    ASSERT_TRUE(adapter.getDb()->has(kv.first).isNotFound());
   }
 
-  auto adapter = DBAdapter{db};
   ASSERT_NO_THROW(adapter.getRawBlock(5));
   ASSERT_NE(adapter.getLastReachableBlockId(), 0);
   ASSERT_NE(adapter.getLastReachableBlockId(), concord::kvbc::INITIAL_GENESIS_BLOCK_ID);
   ASSERT_EQ(concord::kvbc::INITIAL_GENESIS_BLOCK_ID, adapter.getGenesisBlockId());
 }
+
 }  // namespace
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Add support for the `compareTo` command in sparse_merkle_db_editor that
compares two sparse merkle databases. Useful for debugging
non-determinism in a single or multiple replicas by comparing to a
deterministic one.

Outputs if the common block range is equivalent or there is a mismatch.
In case of a mismatch, the block ID of the first mismatch is returned.

Implement by exploiting the blockchain property and do a logaritmhic
search instead of a linear one.

Add an on/off flag for linking the State Transfer temporary chain to the
blockchain in v2MerkleTree::DBAdapter. Rationale is that we don't want
the editor to change the DB state.

Add tests for the `compareTo` command.

Add support for multiple storage test DBs by introducing a DB
identifier.

Remove the call to cleanup() when creating test databases.