### PR TITLE
Crash the replica in case of pre-execution failure

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -567,9 +567,8 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
                                          replicaSpecificInfoLen,
                                          span);
   if (status != 0 || !resultLen) {
-    throw std::runtime_error("Pre-execution failed for clientId: " + to_string(clientId) + ", cid: " + cid +
-                             ", requestSeqNum: " + to_string(reqSeqNum) + ", status: " + to_string(status) +
-                             ", resultLen: " + to_string(resultLen));
+    LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, cid, reqSeqNum, status, resultLen));
+    ConcordAssert(false);
   }
   return resultLen;
 }

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -180,7 +180,7 @@ bool PreProcessor::checkClientMsgCorrectness(const ClientPreProcessReqMsgUniqueP
                                              ReqId reqSeqNum) const {
   if (myReplica_.isCollectingState()) {
     LOG_INFO(logger(),
-             "ClientPreProcessRequestMsg "
+             "ClientPreProcessRequestMsg"
                  << KVLOG(reqSeqNum)
                  << " is ignored because the replica is collecting missing state from other replicas");
     return false;
@@ -240,22 +240,20 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
     lock_guard<mutex> lock(clientEntry->mutex);
     if (clientEntry->reqProcessingStatePtr) {
       const ReqId &ongoingReqSeqNum = clientEntry->reqProcessingStatePtr->getReqSeqNum();
-      LOG_DEBUG(logger(),
-                KVLOG(reqSeqNum, clientId) << " is ignored: " << KVLOG(ongoingReqSeqNum) << " is in progress");
+      LOG_DEBUG(logger(), KVLOG(reqSeqNum, clientId) << " is ignored:" << KVLOG(ongoingReqSeqNum) << " is in progress");
       preProcessorMetrics_.preProcReqIgnored.Get().Inc();
       return;
     }
   }
   const ReqId &seqNumberOfLastReply = myReplica_.seqNumberOfLastReplyToClient(clientId);
   LOG_INFO(logger(),
-           "Going to process ClientPreProcessRequestMsg "
+           "Going to process ClientPreProcessRequestMsg"
                << KVLOG(reqSeqNum, clientId, senderId)
                << ", reqTimeoutMilli: " << clientPreProcessReqMsg->requestTimeoutMilli());
   if (seqNumberOfLastReply < reqSeqNum) {
     // Verify that request is not passing consensus/PostExec right now
     if (myReplica_.isCurrentPrimary() && myReplica_.isClientRequestInProcess(clientId, reqSeqNum)) {
-      LOG_INFO(logger(),
-               "ClientPreProcessRequestMsg " << KVLOG(reqSeqNum) << " has been processing right now - ignore");
+      LOG_INFO(logger(), "ClientPreProcessRequestMsg" << KVLOG(reqSeqNum) << " has been processing right now - ignore");
       return;
     }
     return handleClientPreProcessRequest(move(clientPreProcessReqMsg));
@@ -263,13 +261,13 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
 
   if (seqNumberOfLastReply == reqSeqNum) {
     LOG_INFO(logger(),
-             "ClientPreProcessRequestMsg "
+             "ClientPreProcessRequestMsg"
                  << KVLOG(reqSeqNum) << " has already been executed - let replica to decide how to proceed further");
     return incomingMsgsStorage_->pushExternalMsg(clientPreProcessReqMsg->convertToClientRequestMsg(false));
   }
 
   LOG_INFO(logger(),
-           "ClientPreProcessRequestMsg " << KVLOG(reqSeqNum) << " is ignored because request is old/duplicated");
+           "ClientPreProcessRequestMsg" << KVLOG(reqSeqNum) << " is ignored because request is old/duplicated");
   preProcessorMetrics_.preProcReqIgnored.Get().Inc();
 }
 
@@ -281,12 +279,12 @@ void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
   const NodeIdType &senderId = preProcessReqMsg->senderId();
   const SeqNum &reqSeqNum = preProcessReqMsg->reqSeqNum();
   const NodeIdType &clientId = preProcessReqMsg->clientId();
-  LOG_DEBUG(logger(), "Received PreProcessRequestMsg " << KVLOG(reqSeqNum, senderId, clientId));
+  LOG_DEBUG(logger(), "Received PreProcessRequestMsg" << KVLOG(reqSeqNum, senderId, clientId));
 
   if (myReplica_.isCurrentPrimary()) return;
 
   if (!myReplica_.currentViewIsActive()) {
-    LOG_INFO(logger(), "PreProcessRequestMsg is ignored because current view is inactive, " << KVLOG(reqSeqNum));
+    LOG_INFO(logger(), "PreProcessRequestMsg is ignored because current view is inactive," << KVLOG(reqSeqNum));
     return;
   }
   {
@@ -317,7 +315,7 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
   PreProcessingResult result = CANCEL;
   {
     SCOPED_MDC_CID(cid);
-    LOG_DEBUG(logger(), "Received PreProcessReplyMsg " << KVLOG(reqSeqNum, senderId, clientId));
+    LOG_DEBUG(logger(), "Received PreProcessReplyMsg" << KVLOG(reqSeqNum, senderId, clientId));
     const auto &clientEntry = ongoingRequests_[clientId];
     lock_guard<mutex> lock(clientEntry->mutex);
     if (!clientEntry->reqProcessingStatePtr || clientEntry->reqProcessingStatePtr->getReqSeqNum() != reqSeqNum) {
@@ -353,7 +351,7 @@ void PreProcessor::handlePreProcessReplyMsg(const string &cid,
       cancelPreProcessing(clientId);
       break;
     case RETRY_PRIMARY:  // Primary replica generated pre-processing result hash different that one passed consensus
-      LOG_INFO(logger(), "Retry primary replica pre-processing for " << KVLOG(reqSeqNum, clientId));
+      LOG_INFO(logger(), "Retry primary replica pre-processing for" << KVLOG(reqSeqNum, clientId));
       PreProcessRequestMsgSharedPtr preProcessRequestMsg;
       {
         const auto &clientEntry = ongoingRequests_[clientId];
@@ -374,9 +372,9 @@ void PreProcessor::cancelPreProcessing(NodeIdType clientId) {
     if (clientEntry->reqProcessingStatePtr) {
       reqSeqNum = clientEntry->reqProcessingStatePtr->getReqSeqNum();
       releaseClientPreProcessRequest(clientEntry, clientId, CANCEL);
-      LOG_WARN(logger(), "Pre-processing consensus not reached - abort request " << KVLOG(reqSeqNum, clientId));
+      LOG_WARN(logger(), "Pre-processing consensus not reached - abort request" << KVLOG(reqSeqNum, clientId));
     } else
-      LOG_INFO(logger(), "No ongoing pre-processing activity detected for " << KVLOG(clientId));
+      LOG_INFO(logger(), "No ongoing pre-processing activity detected for" << KVLOG(clientId));
   }
 }
 
@@ -401,7 +399,7 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId) {
       incomingMsgsStorage_->pushExternalMsg(move(clientRequestMsg));
       preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
       releaseClientPreProcessRequest(clientEntry, clientId, COMPLETE);
-      LOG_INFO(logger(), "Pre-processing completed for " << KVLOG(cid, reqSeqNum, clientId));
+      LOG_INFO(logger(), "Pre-processing completed for" << KVLOG(cid, reqSeqNum, clientId));
     }
   }
 }
@@ -435,7 +433,7 @@ bool PreProcessor::registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
       clientEntry->reqProcessingStatePtr->setPreProcessRequest(preProcessRequestMsg);
     else {
       LOG_INFO(logger(),
-               KVLOG(reqSeqNum) << " could not be registered: the entry for " << KVLOG(clientId)
+               KVLOG(reqSeqNum) << " could not be registered: the entry for" << KVLOG(clientId)
                                 << " is occupied by reqSeqNum: " << clientEntry->reqProcessingStatePtr->getReqSeqNum());
       return false;
     }
@@ -479,7 +477,7 @@ void PreProcessor::releaseClientPreProcessRequest(const ClientRequestStateShared
 void PreProcessor::sendMsg(char *msg, NodeIdType dest, uint16_t msgType, MsgSize msgSize) {
   int errorCode = msgsCommunicator_->sendAsyncMessage(dest, msg, msgSize);
   if (errorCode != 0) {
-    LOG_ERROR(logger(), "sendMsg: sendAsyncMessage returned error: " << errorCode << " for " << KVLOG(msgType));
+    LOG_ERROR(logger(), "sendMsg: sendAsyncMessage returned error: " << errorCode << " for" << KVLOG(msgType));
   }
 }
 
@@ -578,7 +576,7 @@ PreProcessingResult PreProcessor::getPreProcessingConsensusResult(uint16_t clien
   lock_guard<mutex> lock(clientEntry->mutex);
   if (clientEntry->reqProcessingStatePtr)
     return clientEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
-  LOG_INFO(logger(), "No ongoing pre-processing activity detected for " << KVLOG(clientId));
+  LOG_INFO(logger(), "No ongoing pre-processing activity detected for" << KVLOG(clientId));
   return NONE;
 }
 
@@ -623,9 +621,9 @@ void PreProcessor::handlePreProcessedReqByNonPrimary(uint16_t clientId,
   releaseClientPreProcessRequestSafe(clientId, COMPLETE);
   sendMsg(replyMsg->body(), myReplica_.currentPrimary(), replyMsg->type(), replyMsg->size());
   SCOPED_MDC_CID(cid);
-  LOG_DEBUG(logger(),
-            "Sent PreProcessReplyMsg with " << KVLOG(reqSeqNum)
-                                            << " to the primary replica: " << myReplica_.currentPrimary());
+  LOG_DEBUG(
+      logger(),
+      "Sent PreProcessReplyMsg with" << KVLOG(reqSeqNum) << " to the primary replica: " << myReplica_.currentPrimary());
 }
 
 void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -39,14 +39,14 @@ RequestProcessingState::RequestProcessingState(uint16_t numOfReplicas,
       entryTime_(getMonotonicTimeMilli()),
       clientPreProcessReqMsg_(move(clientReqMsg)),
       preProcessRequestMsg_(preProcessRequestMsg) {
-  LOG_DEBUG(logger(), "Created RequestProcessingState with " << KVLOG(reqSeqNum, numOfReplicas_));
+  LOG_DEBUG(logger(), "Created RequestProcessingState with" << KVLOG(reqSeqNum, numOfReplicas_));
 }
 
 void RequestProcessingState::setPreProcessRequest(PreProcessRequestMsgSharedPtr preProcessReqMsg) {
   if (preProcessRequestMsg_ != nullptr) {
     SCOPED_MDC_CID(preProcessReqMsg->getCid());
     const auto reqSeqNum = preProcessRequestMsg_->reqSeqNum();
-    LOG_ERROR(logger(), "preProcessRequestMsg_ is already set; " << KVLOG(reqSeqNum, clientId_));
+    LOG_ERROR(logger(), "preProcessRequestMsg_ is already set;" << KVLOG(reqSeqNum, clientId_));
     return;
   }
   preProcessRequestMsg_ = preProcessReqMsg;
@@ -65,7 +65,7 @@ void RequestProcessingState::detectNonDeterministicPreProcessing(const SHA3_256:
   for (auto &hashArray : preProcessingResultHashes_)
     if (newHash != hashArray.first) {
       LOG_WARN(logger(),
-               "Received pre-processing result hash is different from calculated by other replica "
+               "Received pre-processing result hash is different from calculated by other replica"
                    << KVLOG(reqSeqNum_, clientId_, newSenderId) << " newHash: " << newHash.data()
                    << " hash: " << hashArray.first.data());
     }
@@ -110,7 +110,7 @@ bool RequestProcessingState::isReqTimedOut(bool isPrimary) const {
     auto reqProcessingTime = getMonotonicTimeMilli() - entryTime_;
     if (reqProcessingTime > clientPreProcessReqMsg_->requestTimeoutMilli()) {
       LOG_WARN(logger(),
-               "Request timeout of " << clientPreProcessReqMsg_->requestTimeoutMilli() << " ms expired for "
+               "Request timeout of " << clientPreProcessReqMsg_->requestTimeoutMilli() << " ms expired for"
                                      << KVLOG(reqSeqNum_, clientId_, reqProcessingTime));
       return true;
     }
@@ -137,15 +137,14 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
       retrying_ = true;
       return RETRY_PRIMARY;
     }
-    LOG_DEBUG(logger(),
-              "Primary replica did not complete pre-processing yet for " << KVLOG(reqSeqNum_) << "; continue");
+    LOG_DEBUG(logger(), "Primary replica did not complete pre-processing yet for" << KVLOG(reqSeqNum_) << "; continue");
     return CONTINUE;
   }
 
   if (numOfReceivedReplies_ == numOfReplicas_ - 1) {
     // Replies from all replicas received, but not enough equal hashes collected => pre-execution consensus not
     // reached => cancel request.
-    LOG_WARN(logger(), "Not enough equal hashes collected for " << KVLOG(reqSeqNum_) << ", cancel request");
+    LOG_WARN(logger(), "Not enough equal hashes collected for" << KVLOG(reqSeqNum_) << ", cancel request");
     return CANCEL;
   }
   return CONTINUE;


### PR DESCRIPTION
When execute() function returns a zero-sized reply or error, the replica should crash to avoid a blockchain state corruption.
Initial fix for this issue for the pre-execution threw an exception, which was caught by the thread pool code and as a result, a replica did not crash. Now it throws an assert and crashes.