### PR TITLE
fix bug in bftclient

### DIFF
--- a/bftclient/include/bftclient/seq_num_generator.h
+++ b/bftclient/include/bftclient/seq_num_generator.h
@@ -34,6 +34,7 @@ namespace bft::client {
 // (2) A mechanism to retrieve the last used sequence number from the replicas on restart. No such
 //     mechanism is cucrrently implemented, buf if necessary we will add it.
 class SeqNumberGenerator {
+ public:
   SeqNumberGenerator(ClientId client_id) : client_id_(client_id) {}
 
   uint64_t unique() {

--- a/bftclient/src/msg_receiver.cpp
+++ b/bftclient/src/msg_receiver.cpp
@@ -68,8 +68,8 @@ void MsgReceiver::onNewMessage(const bft::communication::NodeNum source,
   metadata.primary = ReplicaId{header->currentPrimaryId};
   metadata.seq_num = header->reqSeqNum;
 
-  auto data_len = header->replyLength - sizeof(bftEngine::ClientReplyMsgHeader);
-  const char* start_of_body = message + sizeof(bftEngine::ClientReplyMsgHeader);
+  auto data_len = header->replyLength;
+  const char* start_of_body = message + sizeof(bftEngine::ClientReplyMsgHeader) + header->spanContextSize;
   const char* start_of_rsi = start_of_body + (data_len - header->replicaSpecificInfoLength);
   const char* end_of_rsi = start_of_rsi + header->replicaSpecificInfoLength;
 

--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -161,7 +161,7 @@ Msg replyFromRequest(const MsgFromClient& request) {
   reply_header->currentPrimaryId = 0;
   reply_header->msgType = REPLY_MSG_TYPE;
   reply_header->replicaSpecificInfoLength = 0;
-  reply_header->replyLength = reply.size();
+  reply_header->replyLength = reply_data.size();
   reply_header->reqSeqNum = req_header->reqSeqNum;
   reply_header->spanContextSize = 0;
 
@@ -181,7 +181,7 @@ Msg replyFromRequestWithRSI(const MsgFromClient& request, const Msg& rsi) {
   reply_header->currentPrimaryId = 0;
   reply_header->msgType = REPLY_MSG_TYPE;
   reply_header->replicaSpecificInfoLength = rsi.size();
-  reply_header->replyLength = reply.size();
+  reply_header->replyLength = reply_data.size() + rsi.size();
   reply_header->reqSeqNum = req_header->reqSeqNum;
   reply_header->spanContextSize = 0;
 

--- a/bftclient/test/bft_client_test.cpp
+++ b/bftclient/test/bft_client_test.cpp
@@ -31,7 +31,7 @@ TEST(msg_receiver_tests, unmatched_replies_returned_no_rsi) {
   header->msgType = REPLY_MSG_TYPE;
   header->currentPrimaryId = 1;
   header->reqSeqNum = 100;
-  header->replyLength = sizeof(bftEngine::ClientReplyMsgHeader) + data_len;
+  header->replyLength = data_len;
   header->replicaSpecificInfoLength = 0;
 
   // Handle the message
@@ -60,7 +60,7 @@ TEST(msg_receiver_tests, unmatched_replies_with_rsi) {
   header->msgType = REPLY_MSG_TYPE;
   header->currentPrimaryId = 1;
   header->reqSeqNum = 100;
-  header->replyLength = sizeof(bftEngine::ClientReplyMsgHeader) + data_len;
+  header->replyLength = data_len;
   header->replicaSpecificInfoLength = 5;
 
   // Handle the message


### PR DESCRIPTION
The `replyLength` field holds the actual data length while the `msg_len` is the overall message size (including the header).
Also, although not in use yet, we should add the `spanContextSize` to reach the actual data location in the message.

Finally, the seqNumGenerator was not useable due to a lack of public declaration. 