### PR TITLE
Fix uninitialized memory issues in Key Store

### DIFF
--- a/bftengine/src/bftengine/KeyStore.cpp
+++ b/bftengine/src/bftengine/KeyStore.cpp
@@ -11,6 +11,8 @@
 
 #include "KeyStore.h"
 
+#include "assertUtils.hpp"
+
 namespace bftEngine::impl {
 
 ////////////////////////////// KEY EXCHANGE MSG//////////////////////////////
@@ -132,6 +134,7 @@ ClusterKeyStore::ClusterKeyStore(const uint32_t& clusterSize,
                                  IReservedPages& reservedPages,
                                  const uint32_t& sizeOfReservedPage)
     : clusterKeys_(clusterSize), reservedPages_(reservedPages), buffer_(sizeOfReservedPage, 0) {
+  ConcordAssertGT(sizeOfReservedPage, 0);
   loadAllReplicasKeyStoresFromReservedPages();
 }
 
@@ -154,11 +157,6 @@ void ClusterKeyStore::loadAllReplicasKeyStoresFromReservedPages() {
 
 std::optional<ReplicaKeyStore> ClusterKeyStore::loadReplicaKeyStoreFromReserevedPages(const uint16_t& repID) {
   reservedPages_.loadReservedPage(resPageOffset() + repID, buffer_.size(), buffer_.data());
-  if (buffer_.empty()) {
-    LOG_INFO(KEY_EX_LOG, "Empty replica key store [" << repID << "] from reserved pages, first start?");
-    return {};
-  }
-
   try {
     return ReplicaKeyStore::deserializeReplicaKeyStore(buffer_.c_str(), buffer_.size());
   } catch (std::exception& e) {

--- a/bftengine/src/bftengine/KeyStore.cpp
+++ b/bftengine/src/bftengine/KeyStore.cpp
@@ -82,6 +82,7 @@ void ReplicaKeyStore::deserializeDataMembers(std::istream& inStream) {
 }
 
 ReplicaKeyStore ReplicaKeyStore::deserializeReplicaKeyStore(const char* serializedRepStore, const int& size) {
+  ConcordAssertGT(size, 0);
   std::stringstream ss;
   ReplicaKeyStore ks;
   ss.write(serializedRepStore, std::streamsize(size));
@@ -153,6 +154,11 @@ void ClusterKeyStore::loadAllReplicasKeyStoresFromReservedPages() {
 
 std::optional<ReplicaKeyStore> ClusterKeyStore::loadReplicaKeyStoreFromReserevedPages(const uint16_t& repID) {
   reservedPages_.loadReservedPage(resPageOffset() + repID, buffer_.size(), buffer_.data());
+  if (buffer_.empty()) {
+    LOG_INFO(KEY_EX_LOG, "Empty replica key store [" << repID << "] from reserved pages, first start?");
+    return {};
+  }
+
   try {
     return ReplicaKeyStore::deserializeReplicaKeyStore(buffer_.c_str(), buffer_.size());
   } catch (std::exception& e) {

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -237,7 +237,7 @@ TEST(ClusterKeyStore, push) {
   std::vector<IKeyExchanger*> v;
   v.push_back(&em);
   ReservedPagesMock rpm(7, true);
-  ClusterKeyStore cks{7, rpm, 0};
+  ClusterKeyStore cks{7, rpm, 4094};
   {
     KeyExchangeMsg kem;
     kem.key = "a";
@@ -286,7 +286,7 @@ TEST(ClusterKeyStore, push) {
 
 TEST(ClusterKeyStore, rotate) {
   ReservedPagesMock rpm(7, true);
-  ClusterKeyStore cks{7, rpm, 0};
+  ClusterKeyStore cks{7, rpm, 4094};
   ExchangerMock em;
   std::vector<IKeyExchanger*> v;
   v.push_back(&em);

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -102,6 +102,7 @@ TEST(ReplicaKeyStore, ser_der) {
   kem.key = "ytrewq";
   kem.signature = "098765";
   kem.repID = 2;
+  kem2.repID = 2;
   rks.push(kem, 34);
   rks.push(kem2, 222);
 


### PR DESCRIPTION
Make sure we don't call `ReplicaKeyStore::deserializeReplicaKeyStore()`
with an empty buffer. Doing so silently fails and leaves the
deserialized object in an arbitrary state. A number of failures in the
Key Manager test in CI were observed.

Make sure a `repID` member is initialized properly in the Key Manager
ReplicaKeyStore.ser_der test. Reported by valgrind.