### PR TITLE
Decrease amount of unneeded client request retries

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -38,7 +38,7 @@ struct ClientRequestState {
 };
 
 typedef std::shared_ptr<ClientRequestState> ClientRequestStateSharedPtr;
-typedef std::unordered_map<uint16_t, ClientRequestStateSharedPtr> OngoingReqMap;
+typedef std::unordered_map<uint16_t, ClientRequestStateSharedPtr> OngoingReqMap;  // clientId -> ClientRequestState map
 
 //**************** Class PreProcessor ****************//
 


### PR DESCRIPTION
As we have a distributed system and the replicas perform actions on their own, we always will have unneeded client request retries, but we have to minimize them to fit the feature performance requirements. 