### PR TITLE
Do not send a ClientReplyMsg in case request execution failed

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3494,16 +3494,16 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
 
       if (status != 0) {
         const auto requestSeqNum = req.requestSeqNum();
-        LOG_DEBUG(CNSUS, "Request execution failed: " << KVLOG(clientId, requestSeqNum));
-        return;
+        LOG_WARN(CNSUS, "Request execution failed: " << KVLOG(clientId, requestSeqNum));
       } else {
         ClientReplyMsg *replyMsg = clientsManager->allocateNewReplyMsgAndWriteToStorage(
             clientId, req.requestSeqNum(), currentPrimary(), replyBuffer, actualReplyLength);
         replyMsg->setReplicaSpecificInfoLength(actualReplicaSpecificInfoLength);
         send(replyMsg, clientId);
         delete replyMsg;
-        clientsManager->removePendingRequestOfClient(clientId);
       }
+
+      clientsManager->removePendingRequestOfClient(clientId);
     }
   }
 


### PR DESCRIPTION
### Suggested change
Do not send a client reply if the execution engine reports a non-zero status. This means the request did not result in a block creation, i.e. a successful transition of the application state machine.

### Reasoning
The only way for a generic BFT client to know a request has succeeded, is to receive matching ClientReplyMsg-s from a quorum of replicas (usually 2f+1).
If this didn't happen, the client doesn't usually know the reason why. Possible reasons could include:
* execution engine failure/non-determinism
* faulty primary
* more than f faulty replicas

If one of the above happened, the client would retry the request. If the primary were faulty, the retry would trigger a view change, after which the BFT system would continue processing requests correctly.

In the case of pre-execution, one more reason of failure is added - a detected conflict at the post-execution phase. This can happen because pre-execution runs in parallel and it's possible that those parallel executions modify each other's assumed initial state.

If such a conflict were detected, at post execution, the only way for the replicas to let the client know is to not send a reply.
In that case, the client wouldn't know why it didn't receive enough replies, and would act as usual - by retrying the request.

If the reason were a conflict, at some point, the conflicting request would succeed as it would execute from a clean initial state. In case the contention is too strong, the client would give up at some point, and the failure would have to be managed at the "application" layer.