### PR TITLE
Release pre-execution request memory before archiving

### DIFF
--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -59,6 +59,11 @@ void RequestProcessingState::handlePrimaryPreProcessed(const char *preProcessRes
       convertToArray(SHA3_256().digest(primaryPreProcessResult_, primaryPreProcessResultLen_).data());
 }
 
+void RequestProcessingState::releaseResources() {
+  clientPreProcessReqMsg_.reset();
+  preProcessRequestMsg_.reset();
+}
+
 void RequestProcessingState::detectNonDeterministicPreProcessing(const SHA3_256::Digest &newHash,
                                                                  NodeIdType newSenderId) const {
   SCOPED_MDC_CID(cid_);

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -50,6 +50,7 @@ class RequestProcessingState {
   }
   std::string getReqCid() const { return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->getCid() : ""; }
   void detectNonDeterministicPreProcessing(const uint8_t* newHash, NodeIdType newSenderId) const;
+  void releaseResources();
 
   static void init(uint16_t numOfRequiredReplies);
 
@@ -78,7 +79,7 @@ class RequestProcessingState {
   ClientPreProcessReqMsgUniquePtr clientPreProcessReqMsg_;
   PreProcessRequestMsgSharedPtr preProcessRequestMsg_;
   uint16_t numOfReceivedReplies_ = 0;
-  const char* primaryPreProcessResult_ = nullptr;
+  const char* primaryPreProcessResult_ = nullptr;  // This memory is statically pre-allocated per client in PreProcessor
   uint32_t primaryPreProcessResultLen_ = 0;
   concord::util::SHA3_256::Digest primaryPreProcessResultHash_;
   // Maps result hash to the number of equal hashes


### PR DESCRIPTION
- Archiving the full client messages is memory consuming and actually is not required => release them before saving in a history.
- Pass ClientPreProcessReqMsg to the primary replica only when registration passes to reduce unneeded request retries and lower network load.