### PR TITLE
Manage SeqNumberGeneratorForClientRequests

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <set>
 #include <chrono>
+#include <memory>
 
 #include "Metrics.hpp"
 #include "communication/ICommunication.hpp"
@@ -96,7 +97,7 @@ class SimpleClient {
 //     support them.]
 class SeqNumberGeneratorForClientRequests {
  public:
-  static SeqNumberGeneratorForClientRequests* createSeqNumberGeneratorForClientRequests();
+  static std::unique_ptr<SeqNumberGeneratorForClientRequests> createSeqNumberGeneratorForClientRequests();
 
   virtual uint64_t generateUniqueSequenceNumberForRequest() = 0;
 

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -507,8 +507,9 @@ SimpleClient* SimpleClient::createSimpleClient(ICommunication* communication,
 
 SimpleClient::~SimpleClient() = default;
 
-SeqNumberGeneratorForClientRequests* SeqNumberGeneratorForClientRequests::createSeqNumberGeneratorForClientRequests() {
-  return new impl::SeqNumberGeneratorForClientRequestsImp();
+std::unique_ptr<SeqNumberGeneratorForClientRequests>
+SeqNumberGeneratorForClientRequests::createSeqNumberGeneratorForClientRequests() {
+  return std::make_unique<impl::SeqNumberGeneratorForClientRequestsImp>();
 }
 
 }  // namespace bftEngine

--- a/kvbc/include/ClientImp.h
+++ b/kvbc/include/ClientImp.h
@@ -43,7 +43,7 @@ class ClientImp : public IClient {
   ~ClientImp() override = default;
 
   ClientConfig config_;
-  bftEngine::SeqNumberGeneratorForClientRequests* seqGen_ = nullptr;
+  std::unique_ptr<bftEngine::SeqNumberGeneratorForClientRequests> seqGen_;
   bft::communication::ICommunication* comm_ = nullptr;
 
   bftEngine::SimpleClient* bftClient_ = nullptr;

--- a/tests/simpleTest/simple_test_client.hpp
+++ b/tests/simpleTest/simple_test_client.hpp
@@ -52,7 +52,7 @@ class SimpleTestClient {
 
     // Concord clients must tag each request with a unique sequence number. This
     // generator handles that for us.
-    SeqNumberGeneratorForClientRequests* pSeqGen =
+    std::unique_ptr<SeqNumberGeneratorForClientRequests> pSeqGen =
         SeqNumberGeneratorForClientRequests::createSeqNumberGeneratorForClientRequests();
 
     TestCommConfig testCommConfig(clientLogger);
@@ -217,7 +217,6 @@ class SimpleTestClient {
         "clientMetrics::retransmissionTimer " << aggregator->GetGauge(metric_comp_name, "retransmissionTimer").Get());
     test_assert(aggregator->GetCounter(metric_comp_name, "retransmissions").Get() >= 0, "retransmissions <" << 0);
     test_assert(aggregator->GetGauge(metric_comp_name, "retransmissionTimer").Get() >= 0, "retransmissionTimer <" << 0);
-    delete pSeqGen;
     delete client;
     delete comm;
 


### PR DESCRIPTION
Raw pointers shouldn't imply ownership of the underlying memory. Instead, smart
pointers is the way to go. As a side effect, this change fixes a small memory
leak.