### PR TITLE
chore: replace exit(1) with std::terminate

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ signed our contributor license agreement (CLA), our bot will update the issue wh
 questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq). For more detailed information,
 refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Notes
+The library calls `std::terminate()` when it cannot continue in a safe manner.
+In that way, users can install a handler that does something different than just calling `std::abort()`.
+
 ## Community
 
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <list>
 #include <set>
 #include <string>
@@ -335,7 +336,7 @@ void BCStateTran::init(uint64_t maxNumOfRequiredStoredCheckpoints,
     }
   } catch (const std::exception &e) {
     LOG_FATAL(STLogger, e.what());
-    exit(1);
+    std::terminate();
   }
 }
 

--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
@@ -156,7 +156,7 @@ void IncomingMsgsStorageImp::dispatchMessages(std::promise<void>& signalStarted)
     }
   } catch (const std::exception& e) {
     LOG_FATAL(GL, "Exception: " << e.what() << "exiting ...");
-    exit(1);
+    std::terminate();
   }
 }
 

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -176,7 +176,7 @@ class PlainUDPCommunication::PlainUdpImpl {
                 "Error while binding: IP=" << sAddr.sin_addr.s_addr << ", Port=" << sAddr.sin_port
                                            << ", errno=" << concordUtils::errnoString(errno));
       ConcordAssert(false && "Failure occurred while binding the socket!");
-      exit(1);  // TODO(GG): not really ..... change this !
+      std::terminate();
     }
 
 #ifdef WIN32

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -429,10 +429,10 @@ void DBAdapter::addRawBlock(const RawBlock &block, const BlockId &blockId) {
       linkSTChainFrom(blockId + 1);
     } catch (const std::exception &e) {
       LOG_FATAL(logger_, "Aborting due to failure to link chains after block has been added, reason: "s + e.what());
-      std::exit(1);
+      std::terminate();
     } catch (...) {
       LOG_FATAL(logger_, "Aborting due to failure to link chains after block has been added");
-      std::exit(1);
+      std::terminate();
     }
 
     return;

--- a/util/include/Handoff.hpp
+++ b/util/include/Handoff.hpp
@@ -41,7 +41,7 @@ class Handoff {
         LOG_DEBUG(getLogger(), "thread stopped " << std::this_thread::get_id());
       } catch (const std::exception& e) {
         LOG_FATAL(getLogger(), "exception: " << e.what());
-        exit(1);
+        std::terminate();
       }
     });
   }

--- a/util/src/MetricsServer.cpp
+++ b/util/src/MetricsServer.cpp
@@ -13,6 +13,7 @@
 
 #include <string.h>
 #include <unistd.h>
+#include <exception>
 #include <iostream>
 #include <arpa/inet.h>
 
@@ -24,7 +25,7 @@ namespace concordMetrics {
 void Server::Start() {
   if ((sock_ = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
     LOG_FATAL(logger_, "Error creating UDP socket");
-    exit(1);
+    std::terminate();
   }
 
   struct sockaddr_in servaddr;
@@ -45,7 +46,7 @@ void Server::Start() {
                     << "unknown"
                     << ", Port=" << listenPort_ << ", errno=" << concordUtils::errnoString(errno));
     }
-    exit(1);
+    std::terminate();
   }
 
   running_lock_.lock();
@@ -111,7 +112,7 @@ void Server::RecvLoop() {
 
     if (json.size() > MAX_MSG_SIZE - sizeof(Header)) {
       LOG_FATAL(logger_, "Aggregator data too large to be transmitted!");
-      exit(1);
+      std::terminate();
     }
 
     sendReply(json, &cliaddr, addrlen);


### PR DESCRIPTION
Rationale:
Exit code 1 usually means that the process has failed in a controlled way.
For example: `grep -r "non-existing string" .` returns 1 which
means that it failed to find the string but did not crash.
In Concord-BFT `exit(1)` is mostly used when an unexpected exception is caught and the library has to crash.
`std::terminate` crashes the process with `SIGABRT` and generates a core dump.
However, if a user of Concord-BFT would like to change the behavior they can set a custom terminate handler[1].

[1] - https://en.cppreference.com/w/cpp/error/set_terminate