### PR TITLE
Add functionality for removing metadata before shutting a replica down.

### DIFF
--- a/bftengine/include/bftengine/DbMetadataStorage.hpp
+++ b/bftengine/include/bftengine/DbMetadataStorage.hpp
@@ -39,6 +39,7 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
     objectIdToSizeMap_[objectsNumParameterId_] = sizeof(objectsNum_);
   }
 
+  ~DBMetadataStorage();
   bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) override;
   void read(uint32_t objectId, uint32_t bufferSize, char *outBufferForObject, uint32_t &outActualObjectSize) override;
   void atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) override;
@@ -47,9 +48,11 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
   void commitAtomicWriteOnlyBatch() override;
   concordUtils::Status multiDel(const ObjectIdsVector &objectIds);
   bool isNewStorage() override;
+  void setDontLoadStorageOnStartupFlag() override;
 
  private:
   void verifyOperation(uint32_t objectId, uint32_t dataLen, const char *buffer, bool writeOperation) const;
+  void cleanDB();
 
  private:
   const char *WRONG_FLOW = "beginAtomicWriteOnlyBatch should be launched first";
@@ -64,6 +67,7 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
   ObjectIdToSizeMap objectIdToSizeMap_;
   uint32_t objectsNum_ = 0;
   std::unique_ptr<IMetadataKeyManipulator> metadataKeyManipulator_;
+  bool dontLoadStorageOnStartup = false;
 };
 
 }  // namespace storage

--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -48,6 +48,9 @@ class MetadataStorage {
   virtual void beginAtomicWriteOnlyBatch() = 0;
   virtual void writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) = 0;
   virtual void commitAtomicWriteOnlyBatch() = 0;
+
+  // In some cases, we would like to load a new metadata after a crash (for example, on reconfiguration actions).
+  virtual void setDontLoadStorageOnStartupFlag() = 0;
 };
 
 }  // namespace bftEngine

--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -401,6 +401,22 @@ void DBDataStore::deleteCoveredResPageInSmallerCheckpoints(uint64_t minChkp) {
   inmem_->deleteCoveredResPageInSmallerCheckpoints(minChkp);
 }
 
+void DBDataStore::clearDataStoreData() {
+  del(Initialized);
+  del(MyReplicaId);
+  del(MaxNumOfStoredCheckpoints);
+  del(NumberOfReservedPages);
+  del(LastStoredCheckpoint);
+  del(FirstStoredCheckpoint);
+  del(IsFetchingState);
+  del(fVal);
+  del(FirstRequiredBlock);
+  del(LastRequiredBlock);
+  del(Replicas);
+  del(CheckpointBeingFetched);
+  deleteAllPendingPages();
+}
+
 /** ******************************************************************************************************************/
 }  // namespace impl
 }  // namespace SimpleBlockchainStateTransfer

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -53,7 +53,7 @@ class DBDataStore : public DataStore {
       try {
         clearDataStoreData();
       } catch (std::exception& e) {
-        LOG_ERROR(logger(), e.what());
+        LOG_FATAL(logger(), e.what());
         std::terminate();
       }
     }

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -48,7 +48,16 @@ class DBDataStore : public DataStore {
       : inmem_(new InMemoryDataStore(sizeOfReservedPage)), dbc_(dbc), keymanip_{keyManip} {
     load();
   }
-
+  ~DBDataStore() {
+    if (clearDataStoreFlag) {
+      try {
+        clearDataStoreData();
+      } catch (std::exception& e) {
+        LOG_ERROR(logger(), e.what());
+        std::terminate();
+      }
+    }
+  }
   DataStoreTransaction* beginTransaction() override {
     concord::storage::ITransaction* txn(dbc_->beginTransaction());
     std::shared_ptr<DBDataStore> tnxDataStore(new DBDataStore(*this));
@@ -113,6 +122,10 @@ class DBDataStore : public DataStore {
                   uint32_t copylength) override {
     return inmem_->getResPage(inPageId, inCheckpoint, outActualCheckpoint, outPageDigest, outPage, copylength);
   }
+  void setClearDataStoreFlag() override { clearDataStoreFlag = true; }
+
+ private:
+  void clearDataStoreData();
 
  protected:
   DBDataStore(const DBDataStore&) = default;
@@ -236,6 +249,7 @@ class DBDataStore : public DataStore {
   ITransaction* txn_ = nullptr;
   IDBClient::ptr dbc_;
   std::shared_ptr<concord::storage::ISTKeyManipulator> keymanip_;
+  bool clearDataStoreFlag = false;
 };
 
 }  // namespace impl

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -157,6 +157,10 @@ class DataStore : public std::enable_shared_from_this<DataStore> {
 
   // Transaction support
   virtual DataStoreTransaction* beginTransaction() = 0;
+
+  // Somtimes we would want to clear the metadata when the state transfer is shutting down (i.e on various
+  // reconfiguration actions)
+  virtual void setClearDataStoreFlag() = 0;
 };
 
 /** *******************************************************************************************************************
@@ -252,6 +256,8 @@ class DataStoreTransaction : public DataStore, public ITransaction {
   void put(const concordUtils::Sliver& key, const concordUtils::Sliver& value) override { txn_->put(key, value); }
   std::string get(const concordUtils::Sliver& key) override { return txn_->get(key); }
   void del(const concordUtils::Sliver& key) override { txn_->del(key); }
+
+  void setClearDataStoreFlag() override { ds_->setClearDataStoreFlag(); }
 
  private:
   // You can't begin a transaction from within a transaction. However, since we

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -139,6 +139,7 @@ class InMemoryDataStore : public DataStore {
     // only be one transaction at a time.
     return new DataStoreTransaction(this->shared_from_this(), new NullTransaction());
   }
+  void setClearDataStoreFlag() override {}
 
  protected:
   const uint32_t sizeOfReservedPage_;

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -159,7 +159,12 @@ void DBMetadataStorage::cleanDB() {
 
 DBMetadataStorage::~DBMetadataStorage() {
   if (dontLoadStorageOnStartup) {
-    cleanDB();
+    try {
+      cleanDB();
+    } catch (std::exception &e) {
+      LOG_ERROR(logger_, e.what());
+      std::terminate();
+    }
   }
 }
 

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -162,7 +162,7 @@ DBMetadataStorage::~DBMetadataStorage() {
     try {
       cleanDB();
     } catch (std::exception &e) {
-      LOG_ERROR(logger_, e.what());
+      LOG_FATAL(logger_, e.what());
       std::terminate();
     }
   }

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -149,16 +149,8 @@ Status DBMetadataStorage::multiDel(const ObjectIdsVector &objectIds) {
 void DBMetadataStorage::setDontLoadStorageOnStartupFlag() { dontLoadStorageOnStartup = true; }
 void DBMetadataStorage::cleanDB() {
   // Note that this method is called from the destructor, we don't need to use the mutex
-  // First, Set the number of stored items to 0 such that when the replica startup it won't load the already stored
-  // metadata (see isNewStorage method);
-  uint32_t zero = 0;
-  atomicWrite(objectsNumParameterId_, (char *)&zero, sizeof(zero));
-  LOG_INFO(logger_,
-           "set the number of metadata storage to 0. This was done in order to load a fresh metadata on the next "
-           "replica startup");
-
-  // Second, to clean things up, clear all the records from the DB
-  ObjectIdsVector objectIds;
+  // Clear all the records from the DB
+  ObjectIdsVector objectIds = {objectsNumParameterId_};
   for (const auto &id : objectIdToSizeMap_) {
     objectIds.push_back(id.first);
   }

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -146,6 +146,30 @@ Status DBMetadataStorage::multiDel(const ObjectIdsVector &objectIds) {
   }
   return dbClient_->multiDel(keysVec);
 }
+void DBMetadataStorage::setDontLoadStorageOnStartupFlag() { dontLoadStorageOnStartup = true; }
+void DBMetadataStorage::cleanDB() {
+  // Note that this method is called from the destructor, we don't need to use the mutex
+  // First, Set the number of stored items to 0 such that when the replica startup it won't load the already stored
+  // metadata (see isNewStorage method);
+  uint32_t zero = 0;
+  atomicWrite(objectsNumParameterId_, (char *)&zero, sizeof(zero));
+  LOG_INFO(logger_,
+           "set the number of metadata storage to 0. This was done in order to load a fresh metadata on the next "
+           "replica startup");
+
+  // Second, to clean things up, clear all the records from the DB
+  ObjectIdsVector objectIds;
+  for (const auto &id : objectIdToSizeMap_) {
+    objectIds.push_back(id.first);
+  }
+  multiDel(objectIds);
+}
+
+DBMetadataStorage::~DBMetadataStorage() {
+  if (dontLoadStorageOnStartup) {
+    cleanDB();
+  }
+}
 
 }  // namespace storage
 }  // namespace concord

--- a/bftengine/tests/metadataStorage/CMakeLists.txt
+++ b/bftengine/tests/metadataStorage/CMakeLists.txt
@@ -9,5 +9,6 @@ if (BUILD_ROCKSDB_STORAGE)
         util
         kvbc
         corebft
+        stdc++fs
     )
 endif(BUILD_ROCKSDB_STORAGE)

--- a/bftengine/tests/metadataStorage/metadataStorage_test.cpp
+++ b/bftengine/tests/metadataStorage/metadataStorage_test.cpp
@@ -39,9 +39,12 @@ uint8_t *createAndFillBuf(size_t length) {
   return buffer;
 }
 
-uint8_t *writeRandomData(const ObjectId &objectId, const uint32_t &dataLen) {
+uint8_t *writeRandomData(const ObjectId &objectId, const uint32_t &dataLen, DBMetadataStorage *db = nullptr) {
+  if (db == nullptr) {
+    db = metadataStorage;
+  }
   uint8_t *data = createAndFillBuf(dataLen);
-  metadataStorage->atomicWrite(objectId, (char *)data, dataLen);
+  db->atomicWrite(objectId, (char *)data, dataLen);
   return data;
 }
 
@@ -49,6 +52,19 @@ uint8_t *writeInTransaction(const ObjectId &objectId, const uint32_t &dataLen) {
   uint8_t *data = createAndFillBuf(dataLen);
   metadataStorage->writeInBatch(objectId, (char *)data, dataLen);
   return data;
+}
+
+DBMetadataStorage *initiateMetadataStorage(Client *dbClient, const std::string &dbPath, bool remove_old_file) {
+  if (remove_old_file) remove(dbPath.c_str());
+  DBMetadataStorage *metadataStorage_ =
+      new DBMetadataStorage(dbClient, std::make_unique<concord::storage::v1DirectKeyValue::MetadataKeyManipulator>());
+  bftEngine::MetadataStorage::ObjectDesc objectDesc[objectsNum];
+  for (uint32_t id = initialObjectId; id < objectsNum; ++id) {
+    objectDesc[id].id = id;
+    objectDesc[id].maxSize = maxObjDataSize;
+  }
+  metadataStorage_->initMaxSizeOfObjects(objectDesc, objectsNum);
+  return metadataStorage_;
 }
 
 bool is_match(const uint8_t *exp, const uint8_t *actual, const size_t len) {
@@ -92,22 +108,64 @@ TEST(metadataStorage_test, multi_write) {
   }
 }
 
+uint8_t *createUpdateAndCloseDB(Client *client, bool clear_db = false) {
+  auto db = initiateMetadataStorage(client, "./metadataStorage_test_db_recover", true);
+  auto *inBuf = writeRandomData(initialObjectId, initialObjDataSize, db);
+  if (clear_db) {
+    db->setDontLoadStorageOnStartupFlag();
+  }
+  delete db;
+  return inBuf;
+}
+
+TEST(metadataStorage_test, recovering_test) {
+  Client *dbClient_ = new Client("./metadataStorage_test_db_recover", make_unique<KeyComparator>(new DBKeyComparator));
+  dbClient_->init();
+  // We create a db in a different path and close it after writing a single object.
+  auto inBuf = createUpdateAndCloseDB(dbClient_);
+
+  // We will now verify that the written object is available if we load the DB from the file.
+  auto db = initiateMetadataStorage(dbClient_, "./metadataStorage_test_db_recover", false);
+
+  auto *outBuf = new uint8_t[initialObjDataSize];
+  uint32_t realSize = 0;
+  db->read(initialObjectId, initialObjDataSize, (char *)outBuf, realSize);
+  ASSERT_TRUE(initialObjDataSize == realSize);
+  ASSERT_TRUE(is_match(inBuf, outBuf, realSize));
+
+  delete[] outBuf;
+  delete[] inBuf;
+  delete db;
+  delete dbClient_;
+}
+
+TEST(metadataStorage_test, clear_db_test) {
+  Client *dbClient_ = new Client("./metadataStorage_test_db_recover", make_unique<KeyComparator>(new DBKeyComparator));
+  dbClient_->init();
+  // We create a db in a different path and close it after writing a single object. Also, we tell the DB to delete its
+  // metadata before closing.
+  auto inBuf = createUpdateAndCloseDB(dbClient_, true);
+
+  // We will now verify that the written object is not available if we load the DB from the file.
+  auto db = initiateMetadataStorage(dbClient_, "./metadataStorage_test_db_recover", false);
+
+  auto *outBuf = new uint8_t[initialObjDataSize];
+  uint32_t realSize = 0;
+  db->read(initialObjectId, initialObjDataSize, (char *)outBuf, realSize);
+  ASSERT_TRUE(realSize == 0);
+
+  delete[] outBuf;
+  delete[] inBuf;
+  delete db;
+  delete dbClient_;
+}
 }  // end namespace
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  const string dbPath = "./metadataStorage_test_db";
-  remove(dbPath.c_str());
-  Client *dbClient = new Client(dbPath, make_unique<KeyComparator>(new DBKeyComparator));
+  Client *dbClient = new Client("./metadataStorage_test_db", make_unique<KeyComparator>(new DBKeyComparator));
   dbClient->init();
-  metadataStorage =
-      new DBMetadataStorage(dbClient, std::make_unique<concord::storage::v1DirectKeyValue::MetadataKeyManipulator>());
-  bftEngine::MetadataStorage::ObjectDesc objectDesc[objectsNum];
-  for (uint32_t id = initialObjectId; id < objectsNum; ++id) {
-    objectDesc[id].id = id;
-    objectDesc[id].maxSize = maxObjDataSize;
-  }
-  metadataStorage->initMaxSizeOfObjects(objectDesc, objectsNum);
+  metadataStorage = initiateMetadataStorage(dbClient, "./metadataStorage_test_db", true);
   int res = RUN_ALL_TESTS();
   return res;
 }

--- a/bftengine/tests/metadataStorage/metadataStorage_test.cpp
+++ b/bftengine/tests/metadataStorage/metadataStorage_test.cpp
@@ -13,6 +13,8 @@
 #include "direct_kv_db_adapter.h"
 #include "storage/direct_kv_key_manipulator.h"
 
+#include <experimental/filesystem>
+
 using namespace std;
 
 using concord::storage::ObjectId;
@@ -55,7 +57,9 @@ uint8_t *writeInTransaction(const ObjectId &objectId, const uint32_t &dataLen) {
 }
 
 DBMetadataStorage *initiateMetadataStorage(Client *dbClient, const std::string &dbPath, bool remove_old_file) {
-  if (remove_old_file) remove(dbPath.c_str());
+  if (remove_old_file) {
+    std::experimental::filesystem::remove_all(dbPath.c_str());
+  }
   DBMetadataStorage *metadataStorage_ =
       new DBMetadataStorage(dbClient, std::make_unique<concord::storage::v1DirectKeyValue::MetadataKeyManipulator>());
   bftEngine::MetadataStorage::ObjectDesc objectDesc[objectsNum];

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -44,7 +44,12 @@ FileStorage::FileStorage(Logger &logger, const string &fileName) : logger_(logge
 
 FileStorage::~FileStorage() {
   if (dontLoadStorageOnStartup) {
-    cleanStorage();
+    try {
+      cleanStorage();
+    } catch (std::exception &e) {
+      LOG_ERROR(logger_, e.what());
+      std::terminate();
+    }
   }
   if (dataStream_) {
     fclose(dataStream_);

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -47,7 +47,7 @@ FileStorage::~FileStorage() {
     try {
       cleanStorage();
     } catch (std::exception &e) {
-      LOG_ERROR(logger_, e.what());
+      LOG_FATAL(logger_, e.what());
       std::terminate();
     }
   }

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -42,6 +42,7 @@ class FileStorage : public MetadataStorage {
   void writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) override;
 
   void commitAtomicWriteOnlyBatch() override;
+  void setDontLoadStorageOnStartupFlag() override;
 
  private:
   void read(void *dataPtr, size_t offset, size_t itemSize, size_t count, const char *errorMsg);
@@ -54,6 +55,7 @@ class FileStorage : public MetadataStorage {
   void updateFileObjectMetadata(MetadataObjectInfo &objectInfo);
   void verifyFileMetadataSetup() const;
   void verifyOperation(uint32_t objectId, uint32_t dataLen, const char *buffer) const;
+  void cleanStorage();
 
  private:
   const char *WRONG_NUM_OF_OBJ_READ = "Failed to read a number of objects or it is 0";
@@ -74,6 +76,7 @@ class FileStorage : public MetadataStorage {
   ObjectsMetadataHandler *objectsMetadata_ = nullptr;
   ObjectIdToRequestMap *transaction_ = nullptr;
   std::mutex ioMutex_;
+  bool dontLoadStorageOnStartup = false;
 };
 
 }  // namespace bftEngine


### PR DESCRIPTION
In some cases, we want to remove the metadata storage before shutting the replica down.
For example:
1. On removing a node we want the replicas to load a different configuration file than the one it has.
2. On adding a node we want the replicas to load a different configuration file than the one it has.

For that, we have added a core functionality for removing metadata of a replica.
A replica that removes its metadata before shutting down will be reloaded with all its previous state but without stored metadata.
Instead, it will consume the metadata from the configuration file. 