### PR TITLE
Parameterize diagnostics server with host and port

### DIFF
--- a/diagnostics/concord-ctl
+++ b/diagnostics/concord-ctl
@@ -1,12 +1,38 @@
 #!/usr/bin/env python
 
+import argparse
 import socket
 import sys
 
-port = 6888
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.connect(("127.0.0.1", port))
-cmd = b' '.join(sys.argv[1:]) + b'\n'
-s.send(cmd)
-data = s.recv(64*1024)
-print(data.decode())
+
+def main(params):
+    parser = args_parser()
+    args, remaining = parser.parse_known_args(params)
+    run(args.host, args.port, remaining)
+
+
+def run(host, port, remaining_args):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+    cmd = (' '.join(remaining_args) + '\n').encode('utf-8')
+    s.send(cmd)
+    data = s.recv(64 * 1024)
+    print(data.decode())
+
+
+def args_parser():
+    parser = argparse.ArgumentParser(description="Concord Diagnostics CLI")
+    parser.add_argument(
+        '--host',
+        help='Host that the diagnostics server is listening on',
+        default="127.0.0.1")
+    parser.add_argument(
+        '--port',
+        help='Port that the diagnostics server is listening on',
+        type=int,
+        default=6888)
+    return parser
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/diagnostics/test/main.cpp
+++ b/diagnostics/test/main.cpp
@@ -19,6 +19,8 @@
 
 using namespace concord::diagnostics;
 
+static constexpr uint16_t PORT = 6888;
+
 int main() {
   Registrar registrar;
 
@@ -29,7 +31,7 @@ int main() {
   registrar.registerStatusHandler(handler2);
 
   concord::diagnostics::Server diagnostics_server;
-  diagnostics_server.start(registrar);
+  diagnostics_server.start(registrar, INADDR_LOOPBACK, PORT);
 
   // Keep the diagnostics_server alive indefinitely
   while (true) {


### PR DESCRIPTION
This allows flexibility for docker deployments, such accessing the
server from other containers on the same host.