### PR TITLE
Fix for stuck rebuild of the previous View working window.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -710,10 +710,15 @@ void ReplicaImp::tryToAskForMissingInfo() {
   }
 
   for (SeqNum i = minSeqNum; i <= lastRelatedSeqNum; i++) {
-    if (!recentViewChange)
+    if (!recentViewChange) {
       tryToSendReqMissingDataMsg(i);
-    else
-      tryToSendReqMissingDataMsg(i, true, currentPrimary());
+    } else {
+      if (isCurrentPrimary()) {
+        tryToSendReqMissingDataMsg(i, true);  // This Replica is Primary, need to ask everyone else
+      } else {
+        tryToSendReqMissingDataMsg(i, true, currentPrimary());  // Ask the Primary
+      }
+    }
   }
 }
 

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -280,13 +280,13 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         await bft_network.wait_for_view(
             replica_id=unstable_replica,
-            expected=lambda v: v >= current_primary,  # the >= is required because of https://jira.eng.vmware.com/browse/BC-3028
+            expected=lambda v: v == current_primary,
             err_msg="Make sure the unstable replica works in the new view."
         )
 
         await bft_network.wait_for_view(
             replica_id=initial_primary,
-            expected=lambda v: v >= current_primary,  # the >= is required because of https://jira.eng.vmware.com/browse/BC-3028
+            expected=lambda v: v == current_primary,
             err_msg="Make sure the initial primary activates the new view."
         )
 


### PR DESCRIPTION
In case the Primary has missing information for a given Sequence ID
it has to ask all other Replicas.