### PR TITLE
Added option GRACEFUL_SHUTDOWN to control the shutdown of Replicas in…

### DIFF
--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -13,7 +13,10 @@ if(USE_S3_OBJECT_STORE)
         set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} CONCORD_BFT_MINIO_BINARY_PATH=${MINIO_BINARY_PATH}")
 endif()
 
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} LEAKCHECK=${LEAKCHECK}")
+if(LEAKCHECK)
+  # For Leak Sanitizers to report errors we need to shut down processes gracefully
+  set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} GRACEFUL_SHUTDOWN=true")
+endif()
 
 set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} KEEP_APOLLO_LOGS=${KEEP_APOLLO_LOGS}")
 

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -410,7 +410,7 @@ class BftTestNetwork:
             self._stop_external_replica(replica_id)
         else:
             p = self.procs[replica_id]
-            if os.environ.get('LEAKCHECK', "").lower() in set(["true", "on"]):
+            if os.environ.get('GRACEFUL_SHUTDOWN', "").lower() in set(["true", "on"]):
                 p.terminate()
             else:
                 p.kill()


### PR DESCRIPTION
… Apollo tests.

This option is set to TRUE if LEAKCHECK=TRUE, because it is needed in order to
get reports from Sanitizers.
GRACEFUL_SHUTDOWN=TRUE - shutdown with SIGTERM
GRACEFUL_SHUTDOWN=FALSE - shutdown with SIGKILL