### PR TITLE
Pre-execution: resend PreProcessRequestMsg to replicas that have previously rejected it

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -80,6 +80,8 @@ class PreProcessor {
   template <typename T>
   void onMessage(T *msg);
 
+  bool registerReplicaDependentRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+                                       PreProcessRequestMsgSharedPtr &preProcessRequestMsg);
   bool registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
                        PreProcessRequestMsgSharedPtr preProcessRequestMsg);
   void releaseClientPreProcessRequestSafe(uint16_t clientId, PreProcessingResult result);
@@ -89,11 +91,17 @@ class PreProcessor {
   bool validateMessage(MessageBase *msg) const;
   void registerMsgHandlers();
   bool checkClientMsgCorrectness(const ClientPreProcessReqMsgUniquePtr &clientReqMsg, ReqId reqSeqNum) const;
-  void handleClientPreProcessRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg);
-  void handleClientPreProcessRequestByPrimary(ClientPreProcessReqMsgUniquePtr clientReqMsg);
+  void handleClientPreProcessRequestByPrimary(PreProcessRequestMsgSharedPtr preProcessRequestMsg);
   void handleClientPreProcessRequestByNonPrimary(ClientPreProcessReqMsgUniquePtr msg);
   void sendMsg(char *msg, NodeIdType dest, uint16_t msgType, MsgSize msgSize);
   void sendPreProcessRequestToAllReplicas(const PreProcessRequestMsgSharedPtr &preProcessReqMsg);
+  void resendPreProcessRequest(const RequestProcessingStateUniquePtr &clientReqStatePtr);
+  void sendRejectPreProcessReplyMsg(NodeIdType clientId,
+                                    NodeIdType senderId,
+                                    SeqNum reqSeqNum,
+                                    SeqNum ongoingReqSeqNum,
+                                    const std::string &cid,
+                                    const std::string &ongoingCid);
   uint16_t getClientReplyBufferId(uint16_t clientId) const { return clientId - numOfReplicas_; }
   const char *getPreProcessResultBuffer(uint16_t clientId) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -23,6 +23,7 @@ namespace preprocessor {
 // This class collects and stores data relevant to the processing of one specific client request by all replicas.
 
 typedef enum { NONE, CONTINUE, COMPLETE, CANCEL, RETRY_PRIMARY } PreProcessingResult;
+typedef std::vector<ReplicaId> ReplicaIdsList;
 
 class RequestProcessingState {
  public:
@@ -51,6 +52,8 @@ class RequestProcessingState {
   std::string getReqCid() const { return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->getCid() : ""; }
   void detectNonDeterministicPreProcessing(const uint8_t* newHash, NodeIdType newSenderId) const;
   void releaseResources();
+  ReplicaIdsList getRejectedReplicasList() { return rejectedReplicaIds_; }
+  void resetRejectedReplicasList() { rejectedReplicaIds_.clear(); }
 
   static void init(uint16_t numOfRequiredReplies);
 
@@ -79,6 +82,7 @@ class RequestProcessingState {
   ClientPreProcessReqMsgUniquePtr clientPreProcessReqMsg_;
   PreProcessRequestMsgSharedPtr preProcessRequestMsg_;
   uint16_t numOfReceivedReplies_ = 0;
+  ReplicaIdsList rejectedReplicaIds_;
   const char* primaryPreProcessResult_ = nullptr;  // This memory is statically pre-allocated per client in PreProcessor
   uint32_t primaryPreProcessResultLen_ = 0;
   concord::util::SHA3_256::Digest primaryPreProcessResultHash_;

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -17,6 +17,8 @@
 
 namespace preprocessor {
 
+typedef enum { STATUS_GOOD, STATUS_REJECT } ReplyStatus;
+
 class PreProcessReplyMsg : public MessageBase {
  public:
   PreProcessReplyMsg(bftEngine::impl::SigManagerSharedPtr sigManager,
@@ -24,13 +26,14 @@ class PreProcessReplyMsg : public MessageBase {
                      uint16_t clientId,
                      uint64_t reqSeqNum);
 
-  void setupMsgBody(const char* buf, uint32_t bufLen, const std::string& cid);
+  void setupMsgBody(const char* buf, uint32_t bufLen, const std::string& cid, ReplyStatus status);
 
   void validate(const bftEngine::impl::ReplicasInfo&) const override;
   const uint16_t clientId() const { return msgBody()->clientId; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
   const uint32_t replyLength() const { return msgBody()->replyLength; }
   const uint8_t* resultsHash() const { return msgBody()->resultsHash; }
+  const uint8_t status() const { return msgBody()->status; }
   std::string getCid() const;
 
  protected:
@@ -40,6 +43,7 @@ class PreProcessReplyMsg : public MessageBase {
     SeqNum reqSeqNum;
     NodeIdType senderId;
     uint16_t clientId;
+    uint8_t status;
     uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES];
     uint32_t replyLength;
     uint32_t cidLength;

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -55,16 +55,16 @@ char buf[bufLen];
 SigManagerSharedPtr sigManager_[numOfReplicas_4];
 
 class DummyRequestsHandler : public IRequestsHandler {
-  int execute(uint16_t client,
-              uint64_t sequenceNum,
-              uint8_t flags,
-              uint32_t requestSize,
-              const char* request,
-              uint32_t maxReplySize,
-              char* outReply,
+  int execute(uint16_t,
+              uint64_t,
+              uint8_t,
+              uint32_t,
+              const char*,
+              uint32_t,
+              char*,
               uint32_t& outActualReplySize,
-              uint32_t& outActualReplicaSpecificInfoSize,
-              concordUtils::SpanWrapper& span) override {
+              uint32_t&,
+              concordUtils::SpanWrapper&) override {
     outActualReplySize = 256;
     return 0;
   }
@@ -319,7 +319,7 @@ void setUpCommunication() {
 
 PreProcessReplyMsgSharedPtr preProcessNonPrimary(NodeIdType replicaId, const bftEngine::impl::ReplicasInfo& repInfo) {
   auto preProcessReplyMsg = make_shared<PreProcessReplyMsg>(sigManager_[replicaId], replicaId, clientId, reqSeqNum);
-  preProcessReplyMsg->setupMsgBody(buf, bufLen, "");
+  preProcessReplyMsg->setupMsgBody(buf, bufLen, "", STATUS_GOOD);
   preProcessReplyMsg->validate(repInfo);
   return preProcessReplyMsg;
 }

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -160,8 +160,9 @@ class UdpClient:
         """Reset any state that must be reset during retries"""
         self.primary = None
         self.retries += 1
-        self.rsi_replies = dict()
-        self.replies_manager.clear_replies()
+        if self.retries % 30 == 0:
+            self.rsi_replies = dict()
+            self.replies_manager.clear_replies()
 
     def reset_on_new_request(self):
         """Reset any state that must be reset during new requests"""


### PR DESCRIPTION
In case non-primary replicas are busy processing requests, they reject PreProcessRequestMsg and this could cause a primary never collecting enough replies for the pre-execution consensus. This fix changes the pre-execution protocol adding a response status field to the PreProcessReply message , which could contain REJECT value. In this case the primary replica resends the PreProcessRequestMsg message.