### PR TITLE
[Apollo] Improve pre-execution test coverage

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -488,8 +488,9 @@ class BftTestNetwork:
             print(f'Matching view #{matching_view} has been agreed among replicas.')
 
             nb_replicas_in_matching_view = await self._wait_for_active_view(matching_view)
-            print(f'View #{matching_view} has been activated by '
-                  f'{nb_replicas_in_matching_view} >= n-f = {self.config.n - self.config.f}')
+            print(f'View #{matching_view} is active on '
+                  f'{nb_replicas_in_matching_view} replicas '
+                  f'({nb_replicas_in_matching_view} >= n-f = {self.config.n - self.config.f}).')
 
             return matching_view
         except trio.TooSlowError:


### PR DESCRIPTION
This PR revises/adds tests for the pre-execution feature. The goal is to incorporate some of the learnings from E2E testing into the Apollo suite (incl. coexistence of pre-execution and normal execution).