### PR TITLE
State Transfer persistence inconsistency bug fix

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -33,6 +33,7 @@
 #include "Metrics.hpp"
 #include "SourceSelector.hpp"
 #include "callback_registry.hpp"
+#include "Handoff.hpp"
 
 using std::set;
 using std::map;
@@ -122,7 +123,7 @@ class BCStateTran : public IStateTransfer {
   uint64_t numberOfReservedPages_;
 
   std::atomic<bool> running_ = false;
-
+  std::unique_ptr<concord::util::Handoff> handoff_;
   IReplicaForStateTransfer* replicaForStateTransfer_ = nullptr;
 
   char* buffer_;  // temporary buffer

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -121,7 +121,7 @@ class BCStateTran : public IStateTransfer {
   uint64_t maxNumOfStoredCheckpoints_;
   uint64_t numberOfReservedPages_;
 
-  bool running_ = false;
+  std::atomic<bool> running_ = false;
 
   IReplicaForStateTransfer* replicaForStateTransfer_ = nullptr;
 

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -232,7 +232,7 @@ class DBDataStore : public DataStore {
   Sliver genKey(const ObjectId& objId) const { return keymanip_->generateStateTransferKey(objId); }
   /** ****************************************************************************************************************/
   logging::Logger& logger() {
-    static logging::Logger logger_ = logging::getLogger("bft.st.dbdatastore");
+    static logging::Logger logger_ = logging::getLogger("concord.bft.st.dbdatastore");
     return logger_;
   }
 

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -223,10 +223,6 @@ class DBDataStore : public DataStore {
   Sliver dynamicResPageKey(uint32_t pageid, uint64_t chkpt) const {
     return keymanip_->generateSTReservedPageDynamicKey(pageid, chkpt);
   }
-  Sliver staticResPageKey(uint32_t pageid, uint64_t chkpt) const {
-    static uint64_t maxStored = inmem_->getMaxNumOfStoredCheckpoints();
-    return keymanip_->generateSTReservedPageStaticKey(pageid, chkpt % maxStored + 1);
-  }
   Sliver pendingPageKey(uint32_t pageid) const { return keymanip_->generateSTPendingPageKey(pageid); }
   Sliver chkpDescKey(uint64_t chkpt) const { return keymanip_->generateSTCheckpointDescriptorKey(chkpt); }
   Sliver genKey(const ObjectId& objId) const { return keymanip_->generateStateTransferKey(objId); }

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -19,6 +19,7 @@
 #include "assertUtils.hpp"
 #include "storage/db_interface.h"
 #include "STDigest.hpp"
+#include "Logger.hpp"
 
 using std::set;
 using concord::storage::ITransaction;
@@ -131,6 +132,15 @@ class DataStore : public std::enable_shared_from_this<DataStore> {
     static size_t size(uint32_t numberOfPages) {
       ConcordAssert(numberOfPages > 0);
       return sizeof(ResPagesDescriptor) + (numberOfPages - 1) * sizeof(SingleResPageDesc);
+    }
+    std::string toString(const std::string& digest) const {
+      std::ostringstream oss;
+      oss << "\nReserved pages descriptor: #pages: " << std::to_string(numOfPages) << "\n";
+      oss << "digest\t" << digest << "\n";
+      for (uint32_t i = 0; i < numOfPages; ++i)
+        if (d[i].relevantCheckpoint > 0)
+          oss << "[" << d[i].pageId << ":" << d[i].relevantCheckpoint << "]\t" << d[i].pageDigest.toString() << "\n";
+      return oss.str();
     }
   };
 

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -15,10 +15,12 @@
 
 #include <map>
 #include <set>
+#include <functional>
 
 #include "DataStore.hpp"
 #include "STDigest.hpp"
 #include "Logger.hpp"
+#include "kvstream.h"
 
 using std::map;
 
@@ -179,7 +181,7 @@ class InMemoryDataStore : public DataStore {
       if (pageId != rhs.pageId)
         return pageId < rhs.pageId;
       else
-        return rhs.checkpoint < checkpoint;
+        return checkpoint > rhs.checkpoint;
     }
   };
 
@@ -190,6 +192,12 @@ class InMemoryDataStore : public DataStore {
 
   map<ResPageKey, ResPageVal> pages;
 
+  std::string getPagesForLog() {
+    std::ostringstream oss("reserved pages: ");
+    for (auto&& it : pages) oss << "[" << it.first.pageId << ":" << it.first.checkpoint << "]";
+    return oss.str();
+  }
+
   friend class DBDataStore;
   const uint32_t getSizeOfReservedPage() const { return sizeOfReservedPage_; }
   const map<uint64_t, CheckpointDesc>& getDescMap() const { return descMap; }
@@ -198,7 +206,7 @@ class InMemoryDataStore : public DataStore {
 
   void setInitialized(bool init) { wasInit_ = init; }
   logging::Logger& logger() {
-    static logging::Logger logger_ = logging::getLogger("bft.st.inmem");
+    static logging::Logger logger_ = logging::getLogger("concord.bft.st.inmem");
     return logger_;
   }
 };

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -193,8 +193,9 @@ class InMemoryDataStore : public DataStore {
   map<ResPageKey, ResPageVal> pages;
 
   std::string getPagesForLog() {
-    std::ostringstream oss("reserved pages: ");
-    for (auto&& it : pages) oss << "[" << it.first.pageId << ":" << it.first.checkpoint << "]";
+    std::ostringstream oss;
+    oss << "reserved pages: ";
+    for (auto it : pages) oss << "[" << it.first.pageId << ":" << it.first.checkpoint << "]";
     return oss.str();
   }
 

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -52,9 +52,9 @@ class BcStTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // uncomment if needed
-    //      log4cplus::Logger::getInstance( LOG4CPLUS_TEXT("serializable")).setLogLevel(log4cplus::TRACE_LOG_LEVEL);
-    //      log4cplus::Logger::getInstance( LOG4CPLUS_TEXT("DBDataStore")).setLogLevel(log4cplus::TRACE_LOG_LEVEL);
-    //      log4cplus::Logger::getInstance( LOG4CPLUS_TEXT("rocksdb")).setLogLevel(log4cplus::TRACE_LOG_LEVEL);
+//    logging::Logger::getInstance("serializable").setLogLevel(TRACE_LOG_LEVEL);
+//    logging::Logger::getInstance("concord.bft.st.dbdatastore").setLogLevel(TRACE_LOG_LEVEL);
+//    logging::Logger::getInstance("rocksdb").setLogLevel(TRACE_LOG_LEVEL);
 
     config_ = TestConfig();
     auto* db_key_comparator = new concord::kvbc::v1DirectKeyValue::DBKeyComparator();
@@ -70,6 +70,7 @@ class BcStTest : public ::testing::Test {
     auto* datastore = new InMemoryDataStore(config_.sizeOfReservedPage);
 #endif
     st_ = new BCStateTran(config_, &app_state_, datastore);
+    st_->init(3, 32, 4096);
     ASSERT_FALSE(st_->isRunning());
     st_->startRunning(&replica_);
     ASSERT_TRUE(st_->isRunning());

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -52,9 +52,9 @@ class BcStTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // uncomment if needed
-//    logging::Logger::getInstance("serializable").setLogLevel(TRACE_LOG_LEVEL);
-//    logging::Logger::getInstance("concord.bft.st.dbdatastore").setLogLevel(TRACE_LOG_LEVEL);
-//    logging::Logger::getInstance("rocksdb").setLogLevel(TRACE_LOG_LEVEL);
+    //    logging::Logger::getInstance("serializable").setLogLevel(TRACE_LOG_LEVEL);
+    //    logging::Logger::getInstance("concord.bft.st.dbdatastore").setLogLevel(TRACE_LOG_LEVEL);
+    //    logging::Logger::getInstance("rocksdb").setLogLevel(TRACE_LOG_LEVEL);
 
     config_ = TestConfig();
     auto* db_key_comparator = new concord::kvbc::v1DirectKeyValue::DBKeyComparator();

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -124,9 +124,8 @@ int DBKeyComparator::composedKeyComparison(const char *_a_data,
       bChkpt = storage::v1DirectKeyValue::STKeyManipulator::extractCheckPointFromKey(_b_data, _b_length);
       return (aChkpt > bChkpt) ? 1 : (bChkpt > aChkpt) ? -1 : 0;
     }
-    case EDBKeyType::E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_STATIC_KEY:
     case EDBKeyType::E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_DYNAMIC_KEY: {
-      // Pages are sorted in ascending order, checkpoints in descending order
+      // Pages are sorted in ascending order, checkpoints in ascending order
       uint32_t aPageId, bPageId;
       uint64_t aChkpt, bChkpt;
       std::tie(aPageId, aChkpt) =
@@ -134,7 +133,7 @@ int DBKeyComparator::composedKeyComparison(const char *_a_data,
       std::tie(bPageId, bChkpt) =
           storage::v1DirectKeyValue::STKeyManipulator::extractPageIdAndCheckpointFromKey(_b_data, _b_length);
       if (aPageId != bPageId) return (aPageId > bPageId) ? 1 : (bPageId > aPageId) ? -1 : 0;
-      return (aChkpt < bChkpt) ? 1 : (aChkpt > bChkpt) ? -1 : 0;
+      return (aChkpt < bChkpt) ? -1 : (aChkpt > bChkpt) ? 1 : 0;
     }
     case EDBKeyType::E_DB_KEY_TYPE_KEY: {
       int keyComp = DBKeyManipulator::compareKeyPartOfComposedKey(_a_data, _a_length, _b_data, _b_length);

--- a/kvbc/src/merkle_tree_key_manipulator.cpp
+++ b/kvbc/src/merkle_tree_key_manipulator.cpp
@@ -152,8 +152,6 @@ EBFTSubtype DBKeyManipulator::getBftSubtype(const Sliver &s) {
       return EBFTSubtype::ST;
     case toChar(EBFTSubtype::STPendingPage):
       return EBFTSubtype::STPendingPage;
-    case toChar(EBFTSubtype::STReservedPageStatic):
-      return EBFTSubtype::STReservedPageStatic;
     case toChar(EBFTSubtype::STReservedPageDynamic):
       return EBFTSubtype::STReservedPageDynamic;
     case toChar(EBFTSubtype::STCheckpointDescriptor):

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -196,16 +196,6 @@ TEST(key_manipulator, st_chkpt_desc_key) {
 }
 
 // Expected key structure with respective bit sizes:
-// [EDBKeyType::BFT: 8, EBFTSubtype::STReservedPageStatic: 8, pageId: 32, chkpt: 64]
-TEST(key_manipulator, st_res_page_static_key) {
-  const auto key = stKeyManip.generateSTReservedPageStaticKey(defaultPageId, defaultChkpt);
-  const auto expected = toSliver(serializeEnum(EDBKeyType::BFT) + serializeEnum(EBFTSubtype::STReservedPageStatic) +
-                                 serializeIntegral(defaultPageId) + serializeIntegral(defaultChkpt));
-  ASSERT_EQ(key.length(), 1 + 1 + 4 + 8);
-  ASSERT_TRUE(key == expected);
-}
-
-// Expected key structure with respective bit sizes:
 // [EDBKeyType::BFT: 8, EBFTSubtype::STReservedPageDynamic: 8, pageId: 32, chkpt: 64]
 TEST(key_manipulator, st_res_page_dynamic_key) {
   const auto key = stKeyManip.generateSTReservedPageDynamicKey(defaultPageId, defaultChkpt);

--- a/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
@@ -67,7 +67,6 @@ SetOfKeyValuePairs generateMetadataAndStateTransfer() {
   updates[st_manipulator.generateStateTransferKey(1)] = std::string{"val"};
   updates[st_manipulator.generateSTPendingPageKey(1)] = std::string{"val"};
   updates[st_manipulator.generateSTCheckpointDescriptorKey(1)] = std::string{"val"};
-  updates[st_manipulator.generateSTReservedPageStaticKey(1, 1)] = std::string{"val"};
   updates[st_manipulator.generateSTReservedPageDynamicKey(1, 1)] = std::string{"val"};
   return updates;
 }

--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -25,17 +25,13 @@
 #include "Logging4cplus.hpp"
 #endif
 
-/**
- * For development purposes anyone can link with $<TARGET_OBJECTS:logging_dev>
- * and get a default initializations for both loggers.
- */
-
 extern logging::Logger GL;
 extern logging::Logger CNSUS;
 extern logging::Logger THRESHSIGN_LOG;
 extern logging::Logger BLS_LOG;
 extern logging::Logger KEY_EX_LOG;
 extern logging::Logger VC_LOG;
+extern logging::Logger STLogger;
 
 namespace logging {
 
@@ -58,7 +54,6 @@ class ScopedMdc {
  * The duration of this adding is the scope where SCOPED_MDC was called - when reaching to the end of this scope,
  * the key-value will be automatically removed.
  */
-
 #define SCOPED_MDC(k, v) logging::ScopedMdc __s_mdc__(k, v)
 #define SCOPED_MDC_CID(v) logging::ScopedMdc __s_mdc_cid__(MDC_CID_KEY, v)
 #define SCOPED_MDC_SEQ_NUM(v) logging::ScopedMdc __s_mdc_seq_num__(MDC_SEQ_NUM_KEY, v)

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -22,9 +22,10 @@ ScopedMdc::~ScopedMdc() { MDC_REMOVE(key_); }
 }  // namespace logging
 
 // globally defined loggers
-logging::Logger GL = logging::getLogger("concord");
+logging::Logger GL = logging::getLogger("concord.bft");
 logging::Logger CNSUS = logging::getLogger("concord.bft.consensus");
-logging::Logger THRESHSIGN_LOG = logging::getLogger("concord.threshsign");
-logging::Logger BLS_LOG = logging::getLogger("concord.threshsign.bls");
-logging::Logger KEY_EX_LOG = logging::getLogger("concord.key-exchange");
-logging::Logger VC_LOG = logging::getLogger("concord.viewchange");
+logging::Logger THRESHSIGN_LOG = logging::getLogger("concord.bft.threshsign");
+logging::Logger BLS_LOG = logging::getLogger("concord.bft.threshsign.bls");
+logging::Logger KEY_EX_LOG = logging::getLogger("concord.bft.key-exchange");
+logging::Logger VC_LOG = logging::getLogger("concord.bft.viewchange");
+logging::Logger STLogger = logging::getLogger("concord.bft.st");

--- a/storage/include/storage/db_types.h
+++ b/storage/include/storage/db_types.h
@@ -27,7 +27,6 @@ enum class EDBKeyType : std::uint8_t {
   E_DB_KEY_TYPE_BFT_METADATA_KEY,
   E_DB_KEY_TYPE_BFT_ST_KEY,
   E_DB_KEY_TYPE_BFT_ST_PENDING_PAGE_KEY,
-  E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_STATIC_KEY,
   E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_DYNAMIC_KEY,
   E_DB_KEY_TYPE_BFT_ST_CHECKPOINT_DESCRIPTOR_KEY,
   E_DB_KEY_TYPE_LAST
@@ -60,7 +59,6 @@ enum class EBFTSubtype : std::uint8_t {
   Metadata,
   ST,
   STPendingPage,
-  STReservedPageStatic,
   STReservedPageDynamic,
   STCheckpointDescriptor,
   STTempBlock,

--- a/storage/include/storage/direct_kv_key_manipulator.h
+++ b/storage/include/storage/direct_kv_key_manipulator.h
@@ -32,8 +32,8 @@ class STKeyManipulator : public DBKeyGeneratorBase, public ISTKeyManipulator {
   concordUtils::Sliver generateStateTransferKey(ObjectId objectId) const override;
   concordUtils::Sliver generateSTPendingPageKey(uint32_t pageid) const override;
   concordUtils::Sliver generateSTCheckpointDescriptorKey(uint64_t chkpt) const override;
-  concordUtils::Sliver generateSTReservedPageStaticKey(uint32_t pageid, uint64_t chkpt) const override;
   concordUtils::Sliver generateSTReservedPageDynamicKey(uint32_t pageid, uint64_t chkpt) const override;
+  concordUtils::Sliver getReservedPageKeyPrefix() const override;
 
   static uint64_t extractCheckPointFromKey(const char* _key_data, size_t _key_length);
   static std::pair<uint32_t, uint64_t> extractPageIdAndCheckpointFromKey(const char* _key_data, size_t _key_length);

--- a/storage/include/storage/key_manipulator_interface.h
+++ b/storage/include/storage/key_manipulator_interface.h
@@ -31,8 +31,8 @@ class ISTKeyManipulator {
   virtual concordUtils::Sliver generateStateTransferKey(ObjectId objectId) const = 0;
   virtual concordUtils::Sliver generateSTPendingPageKey(uint32_t pageid) const = 0;
   virtual concordUtils::Sliver generateSTCheckpointDescriptorKey(uint64_t chkpt) const = 0;
-  virtual concordUtils::Sliver generateSTReservedPageStaticKey(uint32_t pageId, uint64_t chkpt) const = 0;
   virtual concordUtils::Sliver generateSTReservedPageDynamicKey(uint32_t pageId, uint64_t chkpt) const = 0;
+  virtual concordUtils::Sliver getReservedPageKeyPrefix() const = 0;
   virtual ~ISTKeyManipulator() = default;
 };
 

--- a/storage/include/storage/merkle_tree_key_manipulator.h
+++ b/storage/include/storage/merkle_tree_key_manipulator.h
@@ -27,8 +27,8 @@ class STKeyManipulator : public ISTKeyManipulator {
   concordUtils::Sliver generateStateTransferKey(ObjectId objectId) const override;
   concordUtils::Sliver generateSTPendingPageKey(uint32_t pageid) const override;
   concordUtils::Sliver generateSTCheckpointDescriptorKey(uint64_t chkpt) const override;
-  concordUtils::Sliver generateSTReservedPageStaticKey(uint32_t pageId, uint64_t chkpt) const override;
   concordUtils::Sliver generateSTReservedPageDynamicKey(uint32_t pageId, uint64_t chkpt) const override;
+  concordUtils::Sliver getReservedPageKeyPrefix() const override;
 };
 
 }  // namespace concord::storage::v2MerkleTree

--- a/storage/src/direct_kv_key_manipulator.cpp
+++ b/storage/src/direct_kv_key_manipulator.cpp
@@ -84,17 +84,17 @@ Sliver STKeyManipulator::generateSTCheckpointDescriptorKey(uint64_t chkpt) const
   copyToAndAdvance(keyBuf, &offset, keySize, (char *)&chkpt, sizeof(chkpt));
   return Sliver(keyBuf, keySize);
 }
-/**
- * Format : Key Type | Page Id | Checkpoint
- */
-Sliver STKeyManipulator::generateSTReservedPageStaticKey(uint32_t pageid, uint64_t chkpt) const {
-  return generateReservedPageKey(EDBKeyType::E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_STATIC_KEY, pageid, chkpt);
-}
+
 /**
  * Format : Key Type | Page Id | Checkpoint
  */
 Sliver STKeyManipulator::generateSTReservedPageDynamicKey(uint32_t pageid, uint64_t chkpt) const {
   return generateReservedPageKey(EDBKeyType::E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_DYNAMIC_KEY, pageid, chkpt);
+}
+
+Sliver STKeyManipulator::getReservedPageKeyPrefix() const {
+  static Sliver s(std::string(1, static_cast<char>(EDBKeyType::E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_DYNAMIC_KEY)));
+  return s;
 }
 /**
  * Format : Key Type | Page Id | Checkpoint

--- a/storage/src/merkle_tree_key_manipulator.cpp
+++ b/storage/src/merkle_tree_key_manipulator.cpp
@@ -49,14 +49,13 @@ Sliver STKeyManipulator::generateSTCheckpointDescriptorKey(uint64_t chkpt) const
   return serialize(EBFTSubtype::STCheckpointDescriptor) + toBigEndianStringBuffer(chkpt);
 }
 
-Sliver STKeyManipulator::generateSTReservedPageStaticKey(uint32_t pageId, uint64_t chkpt) const {
-  return serialize(EBFTSubtype::STReservedPageStatic) + toBigEndianStringBuffer(pageId) +
-         toBigEndianStringBuffer(chkpt);
-}
-
 Sliver STKeyManipulator::generateSTReservedPageDynamicKey(uint32_t pageId, uint64_t chkpt) const {
   return serialize(EBFTSubtype::STReservedPageDynamic) + toBigEndianStringBuffer(pageId) +
          toBigEndianStringBuffer(chkpt);
+}
+Sliver STKeyManipulator::getReservedPageKeyPrefix() const {
+  static Sliver s(serialize(EBFTSubtype::STReservedPageDynamic));
+  return s;
 }
 
 }  // namespace concord::storage::v2MerkleTree

--- a/tools/DBEditor.cpp
+++ b/tools/DBEditor.cpp
@@ -194,7 +194,6 @@ void parseAndPrint(const ::rocksdb::Slice &key, const ::rocksdb::Slice &val) {
       //      return (aChkpt > bChkpt) ? 1 : (bChkpt > aChkpt) ? -1 : 0;
       break;
     }
-    case detail::EDBKeyType::E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_STATIC_KEY:
     case detail::EDBKeyType::E_DB_KEY_TYPE_BFT_ST_RESERVED_PAGE_DYNAMIC_KEY: {
       //      // Pages are sorted in ascending order, checkpoints in descending order
       //       uint32_t aPageId, bPageId;


### PR DESCRIPTION
- Remove usage of key indirection in DBDataStore.
- Add concord::storage::ISTKeyManipulator::getReservedPageKeyPrefix().
- Improved a way Handoff is shutting down.
- Logging improvements.