### PR TITLE
Enhance key-rotation infrastructure

### DIFF
--- a/bftengine/include/bftengine/IKeyExchanger.hpp
+++ b/bftengine/include/bftengine/IKeyExchanger.hpp
@@ -1,0 +1,22 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <string>
+#include <cstdint>
+
+// Interface for objects that need to be notified on key rotation
+class IKeyExchanger {
+ public:
+  virtual ~IKeyExchanger() {}
+  virtual void onPublicKeyExchange(const std::string& msg, const std::uint16_t& signerIndex) = 0;
+  virtual void onPrivateKeyExchange(const std::string& secretKey, const std::string& verificationKey) = 0;
+};

--- a/bftengine/include/bftengine/IPathDetector.hpp
+++ b/bftengine/include/bftengine/IPathDetector.hpp
@@ -1,0 +1,19 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <cstdint>
+
+class IPathDetector {
+ public:
+  virtual ~IPathDetector(){};
+  virtual bool isSlowPath(const uint64_t& sn) = 0;
+};

--- a/bftengine/src/bftengine/InternalBFTClient.cpp
+++ b/bftengine/src/bftengine/InternalBFTClient.cpp
@@ -10,7 +10,7 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include "InternalBFTClient.h"
+#include "InternalBFTClient.hpp"
 #include "messages/ClientRequestMsg.hpp"
 #include "chrono"
 #include "Logger.hpp"

--- a/bftengine/src/bftengine/InternalBFTClient.hpp
+++ b/bftengine/src/bftengine/InternalBFTClient.hpp
@@ -16,12 +16,22 @@
 
 namespace bftEngine {
 namespace impl {
+class IInternalBFTClient {
+ public:
+  virtual ~IInternalBFTClient() {}
+  virtual NodeIdType getClientId() const = 0;
+  virtual void sendRquest(uint8_t flags, uint32_t requestLength, const char* request, const std::string& cid) = 0;
+  virtual uint32_t numOfConnectedReplicas(uint32_t clusterSize) = 0;
+  virtual bool isUdp() = 0;
+};
 
-class InternalBFTClient {
+class InternalBFTClient : public IInternalBFTClient {
  public:
   InternalBFTClient(const int& id, const NodeIdType& nonInternalNum, std::shared_ptr<MsgsCommunicator>& msgComm);
   inline NodeIdType getClientId() const { return repID_ + startIdForInternalClient_; };
   void sendRquest(uint8_t flags, uint32_t requestLength, const char* request, const std::string& cid);
+  uint32_t numOfConnectedReplicas(uint32_t clusterSize) { return msgComm_->numOfConnectedReplicas(clusterSize); }
+  bool isUdp() { return msgComm_->isUdp(); }
 
  private:
   uint32_t repID_{};

--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -18,15 +18,36 @@
 
 ////////////////////////////// KEY MANAGER//////////////////////////////
 namespace bftEngine::impl {
-KeyManager::KeyManager(InternalBFTClient* cl,
-                       const int& id,
-                       const uint32_t& clusterSize,
-                       IReservedPages* reservedPages,
-                       const uint32_t sizeOfReservedPage)
-    : repID_(id), clusterSize_(clusterSize), client_(cl), keyStore_{clusterSize, *reservedPages, sizeOfReservedPage} {
+KeyManager::KeyManager(InitData* id)
+    : repID_(id->id),
+      clusterSize_(id->clusterSize),
+      client_(id->cl),
+      keyStore_{id->clusterSize, *id->reservedPages, id->sizeOfReservedPage},
+      pathDetector_(id->pathDetect),
+      timers_(*(id->timers)) {
+  // If all keys were exchange on start
   if (keyStore_.exchangedReplicas.size() == clusterSize_) {
+    LOG_DEBUG(KEY_EX_LOG, "building crypto system ");
+    notifyRegistry();
     keysExchanged = true;
     LOG_INFO(KEY_EX_LOG, "All replicas keys loaded from reserved pages, can start accepting msgs");
+  }
+}
+
+void KeyManager::initMetrics(std::shared_ptr<concordMetrics::Aggregator> a, std::chrono::seconds interval) {
+  metrics_.reset(new Metrics(a, interval));
+  metrics_->component.Register();
+  metricsTimer_ = timers_.add(std::chrono::milliseconds(100), Timers::Timer::RECURRING, [this](Timers::Handle h) {
+    metrics_->component.UpdateAggregator();
+    auto currTime =
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch());
+    if (currTime - metrics_->lastMetricsDumpTime >= metrics_->metricsDumpIntervalInSec) {
+      metrics_->lastMetricsDumpTime = currTime;
+      LOG_INFO(KEY_EX_LOG, "-- KeyManager metrics dump--" + metrics_->component.ToJson());
+    }
+  });
+  for (uint32_t i = 0; i < (uint32_t)keyStore_.exchangedReplicas.size(); ++i) {
+    metrics_->keyExchangedOnStartCounter.Get().Inc();
   }
 }
 
@@ -39,44 +60,137 @@ std::string KeyManager::generateCid() {
   return cid;
 }
 
+// Key exchange msg for replica has been recieved:
+// update the replica public key store.
 std::string KeyManager::onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn) {
-  LOG_DEBUG(KEY_EX_LOG, "Recieved " << kemsg.toString() << " seq num " << sn);
+  LOG_INFO(KEY_EX_LOG, "Recieved onKeyExchange " << kemsg.toString() << " seq num " << sn);
   if (!keysExchanged) {
-    keyStore_.exchangedReplicas.insert(kemsg.repID);
-    LOG_DEBUG(KEY_EX_LOG, "Exchanged [" << keyStore_.exchangedReplicas.size() << "] out of [" << clusterSize_ << "]");
-    if (keyStore_.exchangedReplicas.size() == clusterSize_) {
-      keysExchanged = true;
-      LOG_INFO(KEY_EX_LOG, "All replics exchanged keys, can start accepting msgs");
-    }
+    onInitialKeyExchange(kemsg, sn);
+    return "ok";
   }
 
-  keyStore_.push(kemsg, sn, registryToExchange_);
+  if (!keyStore_.push(kemsg, sn)) return "ok";
+
+  metrics_->keyExchangedCounter.Get().Inc();
 
   return "ok";
 }
 
+// Responsible to open the gate when all keys where exchanged on start.
+// The consensus for the initial key exchange must be performed on the fast path i.e. to ensure that all replicas have
+// recieved the key. once the set contains all replicas the crypto system is being updated and the gate is open.
+void KeyManager::onInitialKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn) {
+  // For some reason we recieved a key for a replica that already exchanged it's key.
+  if (keyStore_.exchangedReplicas.find(kemsg.repID) != keyStore_.exchangedReplicas.end()) {
+    if (!pathDetector_->isSlowPath(sn)) {
+      // It shouldn't happen, that two keys from the same replica arrive in the fast path.
+      // It means that a race on a key between the replicas.
+      // The missing data mechanism can cause this, but it was handled to use slow path during key-exchange.
+      LOG_ERROR(KEY_EX_LOG, "Conflicting Keys for Replica [" << kemsg.repID << "] already exchanged initial key");
+      ConcordAssert(false);
+    }
+    LOG_DEBUG(KEY_EX_LOG, "Replica [" << kemsg.repID << "] already exchanged initial key");
+    return;
+  }
+  // If replicπcl id is not in set, check that it arrived in fast path in order to ensure n out of n.
+  // If arrived in slow path do not insert to data structure and if repID == this.repID re-send keyexchange.
+  // If arrived in fast path set private key to oustanding.
+  if (pathDetector_->isSlowPath(sn)) {
+    LOG_INFO(KEY_EX_LOG,
+             "Initial key exchanged for replica ["
+                 << kemsg.repID << "] is dropped, Consensus reached without n out of n participation");
+    if (kemsg.repID == repID_) {
+      waitForFullCommunication();
+      // In order not to bomb the system, send within 50-150 ms
+      srand(time(NULL));
+      auto millSleep = rand() % 100 + 50;
+      LOG_INFO(KEY_EX_LOG, "Resending initial key exchange within " << millSleep << "ms");
+      std::this_thread::sleep_for(std::chrono::milliseconds(millSleep));
+      sendKeyExchange();
+    }
+    metrics_->DroppedMsgsCounter.Get().Inc();
+    return;
+  }
+
+  keyStore_.push(kemsg, sn);
+  keyStore_.exchangedReplicas.insert(kemsg.repID);
+  metrics_->keyExchangedOnStartCounter.Get().Inc();
+  LOG_DEBUG(KEY_EX_LOG, "Exchanged [" << keyStore_.exchangedReplicas.size() << "] out of [" << clusterSize_ << "]");
+  if (keyStore_.exchangedReplicas.size() == clusterSize_) {
+    LOG_INFO(KEY_EX_LOG, "building crypto system ");
+    notifyRegistry();
+    keysExchanged = true;
+    LOG_INFO(KEY_EX_LOG, "All replicas exchanged keys, can start accepting msgs");
+  }
+}
+
+void KeyManager::notifyRegistry() {}
+
+// The checkpoint is the point where keys are rotated.
 void KeyManager::onCheckpoint(const int& num) {
-  if (!keyStore_.rotate(num, registryToExchange_)) return;
+  auto rotatedReplicas = keyStore_.rotate(num);
+  if (rotatedReplicas.empty()) return;
+
+  for (auto id : rotatedReplicas) {
+    metrics_->publicKeyRotated.Get().Inc();
+    if (id != repID_) continue;
+  }
   LOG_DEBUG(KEY_EX_LOG, "Check point  " << num << " trigerred rotation ");
+  LOG_DEBUG(KEY_EX_LOG, "building crypto system ");
+  notifyRegistry();
 }
 
 void KeyManager::registerForNotification(IKeyExchanger* ke) { registryToExchange_.push_back(ke); }
 
-KeyExchangeMsg KeyManager::getReplicaKey(const uint16_t& repID) const { return keyStore_.getReplicaKey(repID); }
+KeyExchangeMsg KeyManager::getReplicaPublicKey(const uint16_t& repID) const {
+  return keyStore_.getReplicaPublicKey(repID);
+}
 
-void KeyManager::loadKeysFromReservedPages() { keyStore_.loadAllReplicasKeyStoresFromReservedPages(); }
+void KeyManager::loadKeysFromReservedPages() {
+  if (!keyStore_.loadAllReplicasKeyStoresFromReservedPages()) return;
+  // TODO E.L  KeyRotation implementation will need to rotate privete keys here, checkpoint number will be essential
+  LOG_DEBUG(KEY_EX_LOG, "building crypto system ");
+  notifyRegistry();
+}
 
-/*
-Usage:
-  KeyExchangeMsg msg{"3c9dac7b594efaea8acd66a18f957f2e", "82c0700a4b907e189529fcc467fd8a1b", repID_};
+void KeyManager::sendKeyExchange() {
+  KeyExchangeMsg msg;
+  msg.key = "pub" + std::to_string(repID_);
+  msg.repID = repID_;
   std::stringstream ss;
   concord::serialize::Serializable::serialize(ss, msg);
   auto strMsg = ss.str();
   client_->sendRquest(bftEngine::KEY_EXCHANGE_FLAG, strMsg.size(), strMsg.c_str(), generateCid());
-*/
-void KeyManager::sendKeyExchange() {
-  (void)client_;
   LOG_DEBUG(KEY_EX_LOG, "Sending key exchange msg");
+}
+
+// First Key exchange is on start, in order not to trigger view change, we'll wait for all replicas to be connected.
+// In order not to block it's done as async operation.
+// If transport is UDP, we can't know the connection status, and we are in Apollo context therefore giving 2sec grace.
+void KeyManager::sendInitialKey() {
+  auto l = [this]() {
+    waitForFullCommunication();
+    if (keyStore_.exchangedReplicas.find(repID_) != keyStore_.exchangedReplicas.end()) return;
+    LOG_DEBUG(KEY_EX_LOG, "Didn't find replica's first generated keys, sending");
+    if (client_->isUdp()) {
+      LOG_INFO(KEY_EX_LOG, "UDP communication");
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+    }
+    sendKeyExchange();
+  };
+  futureRet = std::async(std::launch::async, l);
+}
+
+void KeyManager::waitForFullCommunication() {
+  auto avlble = client_->numOfConnectedReplicas(clusterSize_);
+  LOG_INFO(KEY_EX_LOG, "Consensus engine: " << avlble << " replicas are connected");
+  // Num of connections should be: (clusterSize - 1)
+  while (avlble < clusterSize_ - 1) {
+    LOG_INFO(KEY_EX_LOG, "Consensus engine not available, " << avlble << " replicas are connected");
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    avlble = client_->numOfConnectedReplicas(clusterSize_);
+  }
+  LOG_INFO(KEY_EX_LOG, "Consensus engine available, " << avlble << " replicas are connected");
 }
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/KeyManager.h
+++ b/bftengine/src/bftengine/KeyManager.h
@@ -11,51 +11,116 @@
 
 #pragma once
 
-#include "InternalBFTClient.h"
+#include "InternalBFTClient.hpp"
 #include "KeyStore.h"
+#include "bftengine/IPathDetector.hpp"
+#include "bftengine/IKeyExchanger.hpp"
+#include "Timers.hpp"
+#include "Metrics.hpp"
+#include "SequenceWithActiveWindow.hpp"
+#include "SeqNumInfo.hpp"
 
 namespace bftEngine::impl {
 class KeyManager {
  public:
-  static KeyManager& get(InternalBFTClient* cl = nullptr,
-                         const int id = 0,
-                         const uint32_t clusterSize = 0,
-                         IReservedPages* reservedPages = nullptr,
-                         const uint32_t sizeOfReservedPage = 0) {
-    static KeyManager km{cl, id, clusterSize, reservedPages, sizeOfReservedPage};
+  // Generates and publish key to consensus
+  void sendKeyExchange();
+  // Generates and publish the first key
+  void sendInitialKey();
+  // The execution handler implementation that is called when a key exchange msg has passed consensus.
+  std::string onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn);
+  // A callback that is called each checkpoint and can trigger rotation of keys.
+  void onCheckpoint(const int& num);
+  // Register a IKeyExchanger to notification whehn keys are rotated.
+  void registerForNotification(IKeyExchanger* ke);
+  KeyExchangeMsg getReplicaPublicKey(const uint16_t& repID) const;
+  void loadKeysFromReservedPages();
+
+  // loads the crypto system from a serialized key view.
+  std::atomic_bool keysExchanged{false};
+  std::future<void> futureRet;
+
+  struct InitData {
+    std::shared_ptr<IInternalBFTClient> cl;
+    int id{};
+    uint32_t clusterSize{};
+    IReservedPages* reservedPages{nullptr};
+    uint32_t sizeOfReservedPage{};
+    std::shared_ptr<IPathDetector> pathDetect;
+    concordUtil::Timers* timers{nullptr};
+    std::shared_ptr<concordMetrics::Aggregator> a;
+    std::chrono::seconds interval;
+  };
+
+  static KeyManager& get(InitData* id = nullptr) {
+    static KeyManager km{id};
     return km;
   }
 
-  void sendKeyExchange();
-  std::string onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn);
-  void onCheckpoint(const int& num);
-  void registerForNotification(IKeyExchanger* ke);
-  KeyExchangeMsg getReplicaKey(const uint16_t& repID) const;
-  void loadKeysFromReservedPages();
-
-  std::atomic_bool keysExchanged{false};
+  static void start(InitData* id) {
+    get(id);
+    get().initMetrics(id->a, id->interval);
+  }
 
  private:
-  KeyManager(InternalBFTClient* cl,
-             const int& id,
-             const uint32_t& clusterSize,
-             IReservedPages* reservedPages,
-             const uint32_t sizeOfReservedPage);
+  KeyManager(InitData* id);
 
   uint16_t repID_{};
   uint32_t clusterSize_{};
   std::string generateCid();
   // Raw pointer is ok, since this class does not manage this resource.
-  InternalBFTClient* client_{nullptr};
+  std::shared_ptr<IInternalBFTClient> client_;
 
   std::vector<IKeyExchanger*> registryToExchange_;
   ClusterKeyStore keyStore_;
 
+  std::shared_ptr<IPathDetector> pathDetector_;
+  void onInitialKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn);
+  void notifyRegistry();
+
+  // Samples periodically how many connections the replica has with other replicas.
+  // returns when num of connections is (clusterSize - 1) i.e. full communication.
+  void waitForFullCommunication();
+
+  //////////////////////////////////////////////////
+  // METRICS
+  struct Metrics {
+    std::chrono::seconds lastMetricsDumpTime;
+    std::chrono::seconds metricsDumpIntervalInSec;
+    std::shared_ptr<concordMetrics::Aggregator> aggregator;
+    concordMetrics::Component component;
+    concordMetrics::CounterHandle keyExchangedCounter;
+    concordMetrics::CounterHandle keyExchangedOnStartCounter;
+    concordMetrics::CounterHandle DroppedMsgsCounter;
+    concordMetrics::CounterHandle publicKeyRotated;
+    void setAggregator(std::shared_ptr<concordMetrics::Aggregator> a) {
+      aggregator = a;
+      component.SetAggregator(aggregator);
+    }
+    Metrics(std::shared_ptr<concordMetrics::Aggregator> a, std::chrono::seconds interval)
+        : lastMetricsDumpTime{0},
+          metricsDumpIntervalInSec{interval},
+          aggregator(a),
+          component{"KeyManager", aggregator},
+          keyExchangedCounter{component.RegisterCounter("KeyExchangedCounter")},
+          keyExchangedOnStartCounter{component.RegisterCounter("KeyExchangedOnStartCounter")},
+          DroppedMsgsCounter{component.RegisterCounter("DroppedMsgsCounter")},
+          publicKeyRotated{component.RegisterCounter("publicKeyRotated")} {}
+  };
+
+  std::unique_ptr<Metrics> metrics_;
+  void initMetrics(std::shared_ptr<concordMetrics::Aggregator> a, std::chrono::seconds interval);
+  ///////////////////////////////////////////////////
+  // Timers
+  concordUtil::Timers::Handle metricsTimer_;
+  concordUtil::Timers& timers_;
   // deleted
   KeyManager(const KeyManager&) = delete;
   KeyManager(const KeyManager&&) = delete;
   KeyManager& operator=(const KeyManager&) = delete;
   KeyManager& operator=(const KeyManager&&) = delete;
+
+  friend class TestKeyManager;
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/KeyStore.h
+++ b/bftengine/src/bftengine/KeyStore.h
@@ -31,13 +31,6 @@ struct KeyExchangeMsg : public concord::serialize::SerializableFactory<KeyExchan
   void deserializeDataMembers(std::istream& inStream);
 };
 
-// Interface for objects that need to be notified on key rotation
-class IKeyExchanger {
- public:
-  virtual void onExchange(const KeyExchangeMsg& msg) = 0;
-  virtual void onNewKey(const KeyExchangeMsg& msg) = 0;
-};
-
 // A replica's key store.
 // A queue with limit on its size.
 // Queue's object is the key msg and its corresponding seq num
@@ -86,14 +79,14 @@ class ReplicaKeyStore : public concord::serialize::SerializableFactory<ReplicaKe
 class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, 2> {
  public:
   ClusterKeyStore(const uint32_t& clusterSize, IReservedPages& reservedPages, const uint32_t& sizeOfReservedPage);
-  bool push(const KeyExchangeMsg& kem, const uint64_t& sn, const std::vector<IKeyExchanger*>& registryToExchange);
+  bool push(const KeyExchangeMsg& kem, const uint64_t& sn);
   // iterate on all replcias
-  bool rotate(const uint64_t& chknum, const std::vector<IKeyExchanger*>& registryToExchange);
-  KeyExchangeMsg getReplicaKey(const uint16_t& repID) const;
+  std::vector<uint16_t> rotate(const uint64_t& chknum);
+  KeyExchangeMsg getReplicaPublicKey(const uint16_t& repID) const;
   uint16_t numKeys(const uint16_t& repID) const { return clusterKeys_[repID].numKeys(); }
 
   // Reserved Pages
-  void loadAllReplicasKeyStoresFromReservedPages();
+  bool loadAllReplicasKeyStoresFromReservedPages();
   std::optional<ReplicaKeyStore> loadReplicaKeyStoreFromReserevedPages(const uint16_t& repID);
 
   void saveAllReplicasKeyStoresToReservedPages();

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -11,6 +11,7 @@
 
 #include "MsgsCommunicator.hpp"
 #include "assertUtils.hpp"
+#include "communication/CommDefs.hpp"
 
 namespace bftEngine::impl {
 
@@ -52,4 +53,17 @@ int MsgsCommunicator::sendAsyncMessage(NodeNum destNode, char* message, size_t m
   return communication_->sendAsyncMessage(destNode, message, messageLength);
 }
 
+uint32_t MsgsCommunicator::numOfConnectedReplicas(uint32_t clusterSize) {
+  uint32_t ret{0};
+  for (uint32_t i = 0; i < clusterSize; ++i) {
+    if (communication_->getCurrentConnectionStatus(i) == ConnectionStatus::Disconnected) continue;
+    ++ret;
+  }
+  return ret;
+}
+
+bool MsgsCommunicator::isUdp() {
+  if (dynamic_cast<PlainUDPCommunication*>(communication_) == nullptr) return false;
+  return true;
+}
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/MsgsCommunicator.hpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.hpp
@@ -29,6 +29,8 @@ class MsgsCommunicator {
   int stopCommunication();
   void startMsgsProcessing(uint16_t replicaId);
   void stopMsgsProcessing();
+  uint32_t numOfConnectedReplicas(uint32_t clusterSize);
+  bool isUdp();
 
   [[nodiscard]] bool isMsgsProcessingRunning() const { return incomingMsgsStorage_->isRunning(); }
   int sendAsyncMessage(bft::communication::NodeNum destNode, char* message, size_t messageLength);

--- a/bftengine/src/bftengine/PathDetector.hpp
+++ b/bftengine/src/bftengine/PathDetector.hpp
@@ -1,0 +1,29 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "bftengine/IPathDetector.hpp"
+#include "SequenceWithActiveWindow.hpp"
+#include "SysConsts.hpp"
+#include "SeqNumInfo.hpp"
+#include <memory>
+
+typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
+
+class PathDetector : public IPathDetector {
+  std::shared_ptr<WindowOfSeqNumInfo> windowOfSeqNums_;
+
+ public:
+  PathDetector(std::shared_ptr<WindowOfSeqNumInfo> win) : windowOfSeqNums_(win) {}
+  virtual bool isSlowPath(const uint64_t& sn) { return windowOfSeqNums_->get(sn).isCommittedInSlowPath(); }
+};

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -711,7 +711,10 @@ void ReplicaImp::tryToAskForMissingInfo() {
 
   for (SeqNum i = minSeqNum; i <= lastRelatedSeqNum; i++) {
     if (!recentViewChange) {
-      tryToSendReqMissingDataMsg(i);
+      // during exchange we need missing data to be performed in slow path
+      auto exchanging =
+          (!KeyManager::get().keysExchanged && ReplicaConfigSingleton::GetInstance().GetKeyExchangeOnStart());
+      tryToSendReqMissingDataMsg(i, exchanging);
     } else {
       if (isCurrentPrimary()) {
         tryToSendReqMissingDataMsg(i, true);  // This Replica is Primary, need to ask everyone else
@@ -940,6 +943,7 @@ void ReplicaImp::onMessage<FullCommitProofMsg>(FullCommitProofMsg *msg) {
           (msgSeqNum > lastExecutedSeqNum + config_.concurrencyLevel);  // TODO(GG): check/improve this logic
 
       auto execution_span = concordUtils::startChildSpan("bft_execute_committed_reqs", span);
+      seqNumInfo.setIsCommittedInSlowPath(false);
       executeNextCommittedRequests(execution_span, askForMissingInfoAboutCommittedItems);
       return;
     } else if (pps.hasFullProof()) {
@@ -2348,7 +2352,10 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
   timeOfLastStateSynch = getMonotonicTime();  // TODO(GG): handle restart/pause
 
   clientsManager->loadInfoFromReservedPages();
-  KeyManager::get().loadKeysFromReservedPages();
+
+  if (ReplicaConfigSingleton::GetInstance().GetKeyExchangeOnStart()) {
+    KeyManager::get().loadKeysFromReservedPages();
+  }
 
   if (newStateCheckpoint > lastStableSeqNum + kWorkWindowSize) {
     const SeqNum refPoint = newStateCheckpoint - kWorkWindowSize;
@@ -3234,8 +3241,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
   // TODO(GG): use config ...
   dynamicUpperLimitOfRounds = new DynamicUpperLimitWithSimpleFilter<int64_t>(400, 2, 2500, 70, 32, 1000, 2, 2);
 
-  mainLog =
-      new SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo>(1, (InternalReplicaApi *)this);
+  mainLog.reset(new WindowOfSeqNumInfo(1, (InternalReplicaApi *)this));
+  pathDetector_.reset(new PathDetector(mainLog));
 
   checkpointsLog = new SequenceWithActiveWindow<kWorkWindowSize + 2 * checkpointWindowSize,
                                                 checkpointWindowSize,
@@ -3281,7 +3288,6 @@ ReplicaImp::~ReplicaImp() {
   delete viewsManager;
   delete controller;
   delete dynamicUpperLimitOfRounds;
-  delete mainLog;
   delete checkpointsLog;
   delete clientsManager;
   delete sigManager;
@@ -3341,11 +3347,18 @@ void ReplicaImp::start() {
   ReplicaForStateTransfer::start();
 
   // requires the init of state transfer
-  KeyManager::get(internalBFTClient_.get(),
-                  config_.replicaId,
-                  config_.numReplicas,
-                  stateTransfer.get(),
-                  ReplicaConfigSingleton::GetInstance().GetSizeOfReservedPage());
+  KeyManager::InitData id{};
+  id.cl = internalBFTClient_;
+  id.id = config_.replicaId;
+  id.clusterSize = config_.numReplicas;
+  id.reservedPages = stateTransfer.get();
+  id.sizeOfReservedPage = ReplicaConfigSingleton::GetInstance().GetSizeOfReservedPage();
+  id.pathDetect = pathDetector_;
+  id.timers = &timers_;
+  id.a = aggregator_;
+  id.interval = std::chrono::seconds(config_.metricsDumpIntervalSeconds);
+
+  KeyManager::start(&id);
   if (!firstTime_ || config_.debugPersistentStorageEnabled) clientsManager->loadInfoFromReservedPages();
   addTimers();
   recoverRequests();
@@ -3353,6 +3366,9 @@ void ReplicaImp::start() {
   // The following line will start the processing thread.
   // It must happen after the replica recovers requests in the main thread.
   msgsCommunicator_->startMsgsProcessing(config_.replicaId);
+  if (ReplicaConfigSingleton::GetInstance().GetKeyExchangeOnStart()) {
+    KeyManager::get().sendInitialKey();
+  }
 }
 
 void ReplicaImp::recoverRequests() {
@@ -3643,8 +3659,10 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
 
     if (requestMissingInfo && !ready) {
       LOG_INFO(GL, "Asking for missing information: " << KVLOG(nextExecutedSeqNum, curView, lastStableSeqNum));
-
-      tryToSendReqMissingDataMsg(nextExecutedSeqNum);
+      // during exchange we need missing data to be performed in slow path
+      auto exchanging =
+          (!KeyManager::get().keysExchanged && ReplicaConfigSingleton::GetInstance().GetKeyExchangeOnStart());
+      tryToSendReqMissingDataMsg(nextExecutedSeqNum, exchanging);
     }
 
     if (!ready) break;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -31,7 +31,9 @@
 #include "Bitmap.hpp"
 #include "OpenTracing.hpp"
 #include "RequestHandler.h"
-#include "InternalBFTClient.h"
+#include "InternalBFTClient.hpp"
+#include "bftengine/IPathDetector.hpp"
+#include "PathDetector.hpp"
 
 namespace bftEngine::impl {
 
@@ -102,7 +104,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]
-  SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo>* mainLog = nullptr;
+  std::shared_ptr<WindowOfSeqNumInfo> mainLog;
+  std::shared_ptr<IPathDetector> pathDetector_;
 
   // bounded log used to store information about checkpoints in the range [lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]
@@ -118,7 +121,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // managing information about the clients
   ClientsManager* clientsManager = nullptr;
-  std::unique_ptr<InternalBFTClient> internalBFTClient_;
+  std::shared_ptr<InternalBFTClient> internalBFTClient_;
 
   // buffer used to store replies
   char* replyBuffer = nullptr;

--- a/bftengine/src/bftengine/SeqNumInfo.cpp
+++ b/bftengine/src/bftengine/SeqNumInfo.cpp
@@ -27,6 +27,7 @@ SeqNumInfo::SeqNumInfo()
       primary(false),
       forcedCompleted(false),
       slowPathHasStarted(false),
+      isCommittedInSlowPath_(true),
       firstSeenFromPrimary(MinTime),
       timeOfLastInfoRequest(MinTime),
       commitUpdateTime(MinTime) {}
@@ -52,6 +53,7 @@ void SeqNumInfo::resetAndFree() {
   forcedCompleted = false;
 
   slowPathHasStarted = false;
+  isCommittedInSlowPath_ = true;
 
   firstSeenFromPrimary = MinTime;
   timeOfLastInfoRequest = MinTime;

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -77,6 +77,8 @@ class SeqNumInfo {
   PartialProofsSet& partialProofs();
   void startSlowPath();
   bool slowPathStarted();
+  bool isCommittedInSlowPath() { return isCommittedInSlowPath_; }
+  void setIsCommittedInSlowPath(const bool isSlow) { isCommittedInSlowPath_ = isSlow; }
 
   void setTimeOfLastInfoRequest(Time t);
 
@@ -180,6 +182,8 @@ class SeqNumInfo {
   bool forcedCompleted;
 
   bool slowPathHasStarted;
+
+  bool isCommittedInSlowPath_;
 
   Time firstSeenFromPrimary;
   Time timeOfLastInfoRequest;

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -34,6 +34,10 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
           "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+  add_test(NAME skvbc_multi_sig_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
   add_test(NAME skvbc_linearizability_tests_${STORAGE_TYPE} COMMAND sudo sh -c
           "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_history_tracker test_skvbc_linearizability ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/apollo/test_skvbc_multi_sig.py
+++ b/tests/apollo/test_skvbc_multi_sig.py
@@ -1,0 +1,196 @@
+# Concord
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os.path
+import random
+import unittest
+import time
+import trio
+
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+from util.skvbc_history_tracker import verify_linearizability
+
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "3000"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-v", viewChangeTimeoutMilli,
+            "-e", str(True),
+            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
+                    in set(["true", "on"])
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
+
+
+class SkvbcMultiSig(unittest.TestCase):
+
+    __test__ = False  # so that PyTest ignores this test scenario
+
+    def setUp(self):
+        self.evaluation_period_seq_num = 64
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7    )
+    @verify_linearizability()
+    async def test_happy_initial_key_exchange(self, bft_network,tracker):
+        """
+        Validates that if all replicas are up and all key-exchnage msgs reached consensus via the fast path
+        then the counter of the exchanged keys is equal to the cluster size in all replicas.
+        """
+        bft_network.start_all_replicas()
+
+        with trio.fail_after(seconds=20):
+            for replica_id in range(bft_network.config.n):
+                while True:
+                    with trio.move_on_after(seconds=1):
+                        try:
+                            key = ['KeyManager', 'Counters', 'KeyExchangedOnStartCounter']
+                            value = await bft_network.metrics.get(replica_id, *key)
+                            if value < 7:
+                                continue
+                        except trio.TooSlowError:
+                            print(
+                                f"Replica {replica_id} was not able to exchange keys on start")
+                            self.assertTrue(False)
+                        else:
+                            self.assertEqual(value, 7)
+                            break
+        
+       
+
+        
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)   
+    async def test_rough_initial_key_exchange(self, bft_network):
+        """
+        Validates that if not all replicas are up, then key-exchnage msgs will be dropped and no execution will happen.
+        then when all replicas are available, key exchanged will be performed.
+        """
+        
+        replicas = bft_network.random_set_of_replicas(6, without={2})
+        bft_network.start_replicas(replicas)
+        
+        time.sleep(5)
+
+        for replica_id in replicas:
+            key = ['KeyManager', 'Counters', 'KeyExchangedOnStartCounter']
+            value = await bft_network.metrics.get(replica_id, *key)
+            lastExecutedKey = ['replica', 'Gauges', 'lastExecutedSeqNum']
+            lastExecutedVal = await bft_network.metrics.get(replica_id, *lastExecutedKey)
+            self.assertEqual(value, 0)
+            self.assertGreater(lastExecutedVal, 0)
+
+        bft_network.start_replica(2)
+        time.sleep(2)
+
+        
+        with trio.fail_after(seconds=20):
+            for replica_id in range(bft_network.config.n):
+                while True:
+                    with trio.move_on_after(seconds=1):
+                        try:
+                            key = ['KeyManager', 'Counters', 'KeyExchangedOnStartCounter']
+                            value = await bft_network.metrics.get(replica_id, *key)
+                            if value < 7:
+                                continue
+                        except trio.TooSlowError:
+                            print(
+                                f"Replica {replica_id} was not able to exchange keys on start")
+                            self.assertTrue(False)
+                        else:
+                            self.assertEqual(value, 7)
+                            break
+
+    # @with_trio
+    # @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)   
+    # @verify_linearizability()
+    # async def test_no_request_processing_till_initial_key_exchange(self, bft_network,tracker):
+    #     replicas = bft_network.random_set_of_replicas(6, without={2})
+    #     bft_network.start_replicas(replicas)
+        
+    #     time.sleep(1)
+            
+
+    #     write_weight = 1
+    #     await tracker.run_concurrent_ops(num_ops=10, write_weight=write_weight)
+
+    #     key = ['KeyManager', 'Counters', 'KeyExchangedOnStartCounter']
+    #     value = await bft_network.metrics.get(0, *key)
+    #     self.assertEqual(value, 0)
+
+    #     lastExecutedKey = ['replica', 'Gauges', 'lastExecutedSeqNum']
+    #     lastExecutedVal = await bft_network.metrics.get(0, *lastExecutedKey)
+    #     keyExDroppdMsgsKey = ['KeyManager', 'Counters', 'DroppedMsgsCounter']
+    #     keyExDroppdMsgsValue = await bft_network.metrics.get(0, *keyExDroppdMsgsKey)
+    #     self.assertGreaterEqual(keyExDroppdMsgsValue,lastExecutedVal)
+        
+    #     bft_network.start_replica(2)
+        
+    #     with trio.fail_after(seconds=120):
+    #         for replica_id in range(bft_network.config.n):
+    #             while True:
+    #                 with trio.move_on_after(seconds=1):
+    #                     try:
+    #                         key = ['KeyManager', 'Counters', 'KeyExchangedOnStartCounter']
+    #                         value = await bft_network.metrics.get(replica_id, *key)
+    #                         if value < 7:
+    #                             continue
+    #                     except trio.TooSlowError:
+    #                         print(
+    #                             f"Replica {replica_id} was not able to exchange keys on start")
+    #                         self.assertTrue(False)
+    #                     else:
+    #                         self.assertEqual(value, 7)
+    #                         break
+
+       
+    #     keyExDroppdMsgsKey = ['KeyManager', 'Counters', 'DroppedMsgsCounter']
+    #     keyExDroppdMsgsValueBefore = await bft_network.metrics.get(0, *keyExDroppdMsgsKey)                       
+    #     lastExecutedKey = ['replica', 'Gauges', 'lastExecutedSeqNum']
+    #     lastExecutedVal = await bft_network.metrics.get(replica_id, *lastExecutedKey)
+    #     await tracker.run_concurrent_ops(num_ops=100, write_weight=write_weight)
+        
+    #     with trio.fail_after(seconds=40):
+    #             while True:
+    #                 with trio.move_on_after(seconds=1):
+    #                     try:
+    #                         lastExecutedValAfter = await bft_network.metrics.get(replica_id, *lastExecutedKey)
+    #                         keyExDroppdMsgsValueAfter = await bft_network.metrics.get(0, *keyExDroppdMsgsKey)  
+    #                         if lastExecutedValAfter == lastExecutedVal:
+    #                             continue
+    #                     except trio.TooSlowError:
+    #                         print(
+    #                             f"couldn't prove that msgs were processed fter key exchange")
+    #                         self.assertTrue(False)
+    #                     else:
+    #                         self.assertGreater(lastExecutedValAfter,lastExecutedVal)
+    #                         self.assertEqual(keyExDroppdMsgsValueBefore, keyExDroppdMsgsValueAfter)
+    #                         break
+
+
+
+        
+        
+                    
+                    
+
+   

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -63,12 +63,13 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"persistence-mode", no_argument, 0, 'p'},
                                           {"storage-type", required_argument, 0, 't'},
                                           {"log-props-file", required_argument, 0, 'l'},
+                                          {"key-exchange-on-start", required_argument, 0, 'e'},
                                           {0, 0, 0, 0}};
 
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
-    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:l:", longOptions, &optionIndex)) != -1) {
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:l:e:", longOptions, &optionIndex)) != -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -95,6 +96,9 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         case '3': {
           if (optarg[0] == '-') throw std::runtime_error("invalid argument for --s3-config-file");
           s3ConfigFile = optarg;
+        } break;
+        case 'e': {
+          replicaConfig.keyExchangeOnStart = true;
         } break;
         // We can only toggle persistence on or off. It defaults to InMemory
         // unless -p flag is provided.


### PR DESCRIPTION
- Adding API for querying the communication layer on its connection status to other replicas. This API is used on the initial key exchange in order to start the exchange only when the replica has n-1 connections i.e. is connected to all other replicas.

- Adding metrics to the KeyManager.

- Adding an API and interface to detect whether a sequence number was committed in the slow/fast paths. Here as well, the API is being used in order to accept only fast path consensus on the initial key exchange. in order to ensure n out of n participation.

- send initial key exchange: is triggered once form the replicaImp start. it waits for all replicas to be connected and sends the key exchange.

- accept initial key exchange: accept if received in the fast path, otherwise do not accept and resend initial key-exchange (from the corresponding replica). if all replicas exchanged keys, open the flag to accept external requests.

- Add to Apollo the option to perform key-exchange on start, and adding two tests.