### PR TITLE
Add Apollo's logs to GitHub Action artifacts

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
                               ${{ matrix.use_s3_obj_store }} \
                               -DUSE_OPENTRACING=ON \
                               -DOMIT_TEST_OUTPUT=OFF\" "\
-              && script -q -e -c "make test"
+              && script -q -e -c "make test -DKEEP_APOLLO_LOGS=TRUE"
         - name: Prepare artifacts
           if: failure()
           run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,14 +46,14 @@ jobs:
                               -DBUILD_ROCKSDB_STORAGE=TRUE \
                               ${{ matrix.use_s3_obj_store }} \
                               -DUSE_OPENTRACING=ON \
-                              -DOMIT_TEST_OUTPUT=OFF\" "\
-              && script -q -e -c "make test -DKEEP_APOLLO_LOGS=TRUE"
+                              -DOMIT_TEST_OUTPUT=OFF\
+                              -DKEEP_APOLLO_LOGS=TRUE\" "\
+              && script -q -e -c "make test"
         - name: Prepare artifacts
           if: failure()
           run: |
             sudo chown -R $USER:$GROUP ${PWD}/build
             mv ${PWD}/build ${{ github.workspace }}/artifact/
-            cp /tmp/apollo ${{ github.workspace }}/artifact/
             ls -lh ${{ github.workspace }}/artifact/cores
             sudo chown -R $USER:$GROUP ${{ github.workspace }}/artifact/
         - name: Upload artifacts

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,6 +53,7 @@ jobs:
           run: |
             sudo chown -R $USER:$GROUP ${PWD}/build
             mv ${PWD}/build ${{ github.workspace }}/artifact/
+            cp /tmp/apollo ${{ github.workspace }}/artifact/
             ls -lh ${{ github.workspace }}/artifact/cores
             sudo chown -R $USER:$GROUP ${{ github.workspace }}/artifact/
         - name: Upload artifacts

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ CONCORD_BFT_CMAKE_FLAGS:= \
 			-DUSE_S3_OBJECT_STORE=TRUE \
 			-DUSE_OPENTRACING=ON \
 			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-			-DOMIT_TEST_OUTPUT=OFF
+			-DOMIT_TEST_OUTPUT=OFF \
+			-DKEEP_APOLLO_LOGS=TRUE
 
 # The consistency parameter makes sense only at MacOS.
 # It is ignored at all other platforms.

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -39,7 +39,11 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_linearizability_tests_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_history_tracker test_skvbc_linearizability ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+  add_test(NAME test_skvbc_history_tracker_${STORAGE_TYPE} COMMAND sudo sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_fast_path_tests_${STORAGE_TYPE} COMMAND sh -c

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -31,68 +31,68 @@ endif()
 
 foreach(STORAGE_TYPE ${STORAGE_TYPES})
   add_test(NAME skvbc_basic_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_basic_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_multi_sig_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_multi_sig_${STORAGE_TYPE} python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_linearizability_tests_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_linearizability_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME test_skvbc_history_tracker_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=test_skvbc_history_tracker_${STORAGE_TYPE} python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_fast_path_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_fast_path ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_fast_path_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_fast_path ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_slow_path_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_slow_path ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_slow_path_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_slow_path ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_view_change_tests_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_view_change_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_auto_view_change_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_auto_view_change_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_preexecution_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
+          "env STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_preexecution_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_network_partitioning_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_network_partitioning_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_checkpoints_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_checkpoints 2>&1 > /dev/null"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_checkpoints_${STORAGE_TYPE} python3 -m unittest test_skvbc_checkpoints 2>&1 > /dev/null"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_chaotic_startup_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_chaotic_startup 2>&1 > /dev/null"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_chaotic_startup_${STORAGE_TYPE} python3 -m unittest test_skvbc_chaotic_startup 2>&1 > /dev/null"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_backup_restore_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_backup_restore_${STORAGE_TYPE} python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   add_test(NAME skvbc_reconfiguration_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_reconfiguration_${STORAGE_TYPE} python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   if (BUILD_ROCKSDB_STORAGE)
     add_test(NAME skvbc_persistence_tests_${STORAGE_TYPE} COMMAND sh -c
-            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
+            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_persistence_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_test(NAME skvbc_ro_replica_tests_${STORAGE_TYPE} COMMAND sh -c
-            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
+            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} TEST_NAME=skvbc_ro_replica_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 endforeach()

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -397,24 +397,18 @@ class BftTestNetwork:
         with log.start_action(action_type="start_replica"):
             stdout_file = None
             stderr_file = None
-            storage_type = os.environ.get("STORAGE_TYPE")
-            tests_names = [m for m in sys.modules.keys() if m.startswith("test_")]
-            if len(tests_names) > 1:
-                # Multiple Apollo tests modules loaded, test name unknown.
-                now = datetime.now().strftime("%y-%m-%d_%H:%M:%S")
-                test_name = f"{now}_{self.current_test}"
-            else:
-                # Single Apollo module loaded, test name known.
-                test_name = f"{tests_names.pop()}_{storage_type}"
-
-            test_dir = f"/tmp/apollo/{test_name}/{self.current_test}/"
-            test_log = f"{test_dir}stdout_{replica_id}.log"
 
             if os.environ.get('KEEP_APOLLO_LOGS', "").lower() in ["true", "on"]:
-                try:
-                    os.makedirs(test_dir)
-                except FileExistsError:
-                    pass
+                test_name = os.environ.get('TEST_NAME')
+
+                if not test_name:
+                    now = datetime.now().strftime("%y-%m-%d_%H:%M:%S")
+                    test_name = f"{now}_{self.current_test}"
+
+                test_dir = f"{self.builddir}/tests/apollo/logs/{test_name}/{self.current_test}/"
+                test_log = f"{test_dir}stdout_{replica_id}.log"
+
+                os.makedirs(test_dir, exist_ok=True)
 
                 stdout_file = open(test_log, 'w+')
                 stderr_file = open(test_log, 'w+')

--- a/tests/apollo/util/eliot_logging.py
+++ b/tests/apollo/util/eliot_logging.py
@@ -19,7 +19,7 @@ def set_file_destination():
     test_dir = f'{logs_dir}{test_name}'
     test_log = f'{test_dir}/apollo_{test_name}.log'
 
-    if not os.path.isdir(logs_dir): #TODO check that it doesn't create conflicts with Hristo's dir creation.
+    if not os.path.isdir(logs_dir):
         # Create logs directory if not exist
         os.mkdir(logs_dir)
 

--- a/tests/apollo/util/eliot_logging.py
+++ b/tests/apollo/util/eliot_logging.py
@@ -5,19 +5,15 @@ import sys
 
 
 def set_file_destination():
-    storage_type = os.environ.get('STORAGE_TYPE')
-    tests_names = [m for m in sys.modules.keys() if m.startswith("test_")]
-    if len(tests_names) > 1:
-        # Multiple Apollo tests modules loaded, test name unknown.
+    test_name = os.environ.get('TEST_NAME')
+
+    if not test_name:
         now = datetime.now().strftime("%y-%m-%d_%H:%M:%S")
         test_name = f"apollo_run_{now}"
-    else:
-        # Single Apollo module loaded, test name known.
-        test_name = f"{tests_names.pop()}_{storage_type}"
 
-    logs_dir = '/tmp/apollo/'
+    logs_dir = '../../build/tests/apollo/logs/'
     test_dir = f'{logs_dir}{test_name}'
-    test_log = f'{test_dir}/apollo_{test_name}.log'
+    test_log = f'{test_dir}/{test_name}.log'
 
     if not os.path.isdir(logs_dir):
         # Create logs directory if not exist
@@ -41,5 +37,7 @@ def stdout(message):
         print(message)
 
 
-add_destinations(stdout)
-set_file_destination()
+if os.environ.get('KEEP_APOLLO_LOGS', "").lower() in ["true", "on"]:
+    # Uncomment to see logs in console
+    #add_destinations(stdout)
+    set_file_destination()

--- a/tests/apollo/util/eliot_logging.py
+++ b/tests/apollo/util/eliot_logging.py
@@ -6,8 +6,7 @@ import sys
 
 def set_file_destination():
     storage_type = os.environ.get('STORAGE_TYPE')
-    tests_names = [m for m in sys.modules.keys() if "test_" in m]
-
+    tests_names = [m for m in sys.modules.keys() if m.startswith("test_")]
     if len(tests_names) > 1:
         # Multiple Apollo tests modules loaded, test name unknown.
         now = datetime.now().strftime("%y-%m-%d_%H:%M:%S")
@@ -16,18 +15,24 @@ def set_file_destination():
         # Single Apollo module loaded, test name known.
         test_name = f"{tests_names.pop()}_{storage_type}"
 
-    # Create logs directory if not exist
-    if not os.path.isdir("logs"):
-        os.mkdir("logs")
+    logs_dir = '/tmp/apollo/'
+    test_dir = f'{logs_dir}{test_name}'
+    test_log = f'{test_dir}/apollo_{test_name}.log'
 
-    test_name = f"logs/{test_name}.log"
+    if not os.path.isdir(logs_dir): #TODO check that it doesn't create conflicts with Hristo's dir creation.
+        # Create logs directory if not exist
+        os.mkdir(logs_dir)
 
-    if os.path.isfile(test_name):
+    if not os.path.isdir(test_dir):
+        # Create directory for the test logs
+        os.mkdir(test_dir)
+
+    if os.path.isfile(test_log):
         # Clean logs if file already exist
-        open(test_name, "w").close()
+        open(test_log, "w").close()
 
     # Set the log file path
-    to_file(open(test_name, "a"))
+    to_file(open(test_log, "a"))
 
 
 # Set logs to the console


### PR DESCRIPTION
I added the replica and Eliot logs to GithubHub Action artifacts.

- Set "KEEP_APOLLO_LOGS"=True - saves the logs to /build/tests/apollo/logs directory.
- Set "KEEP_APOLLO_LOGS"=True when CI runs.
- Commented Eliot's logs to console option - Eliot's logs together with the replicas logs in unreadable in the console.

Re-arrange Apollo's logs.

- Separated between the replicas **v2merkle** and **v1direct** logs.
- Created two directories for each test, one for **v2merkle** and another one for **v1direct**.

*Each directory has Eliot’s logs and the replicas logs for each test configuration.

Example:
![Screen Shot 2020-09-24 at 17 18 49](https://user-images.githubusercontent.com/45912772/94166800-6fa63580-fe94-11ea-9118-041407033d3c.png)
