### PR TITLE
Add an abstract channel type and bounded mpsc impl

### DIFF
--- a/util/include/channels/channel.h
+++ b/util/include/channels/channel.h
@@ -72,7 +72,7 @@ class NullSender {
   // channel is effectively destroyed.
   std::optional<Msg> send(Msg&& msg) { return std::nullopt; }
 
-  // Return how many elements are in the channels internal buffer. For some channels, only an
+  // Return how many elements are in the channel's internal buffer. For some channels, only an
   // estimate will be avaialable, and for some others (mainly lock-free/wait-free) channels, this
   // value will not be available at all. In those cases std::nullopt should be returned.
   std::optional<size_t> size() const { return std::nullopt; }
@@ -101,14 +101,14 @@ class NullReceiver {
   // Return std::nullopt if a timeout occurred.
   std::optional<Msg> recv(std::chrono::milliseconds timeout) { return std::nullopt; };
 
-  // Return how many elements are in the channels internal buffer. For some channels, only an
+  // Return how many elements are in the channel's internal buffer. For some channels, only an
   // estimate will be avaialable, and for some others (mainly lock-free/wait-free) channels, this
   // value will not be available at all. In those cases std::nullopt should be returned.
-  std::optional<size_t> size() { return std::nullopt; }
+  std::optional<size_t> size() const { return std::nullopt; }
 
   // Bounded channels should return how many messages they can store in their internal buffer.
   // Unbounded channels should return std::nullopt;
-  std::optional<size_t> capacity() { return std::nullopt; }
+  std::optional<size_t> capacity() const { return std::nullopt; }
 };
 
 }  // namespace concord::channel

--- a/util/include/channels/channel.h
+++ b/util/include/channels/channel.h
@@ -1,0 +1,114 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+#include <stdexcept>
+
+// A generic channel interface based around static polymorphism (templates).
+//
+// We expect to have multiple channel implementations for different purposes, but the sending and
+// receiving code should be agnostic to this fact. We want to be able to swap implementations based
+// on performance and/or capability.
+//
+// A channel is made up of a sender and receiver pair. This split prevents misuse of concrete
+// channels. For example, if we only returned an "IChannel" type, and the channel was an MPSC channel, we could
+// accidentally have two receivers for it, since we would be forced to allow cloning of the type so that we could have
+// multiple senders. With seperate sender and receiver types we make it so that we can make the sender copyable, but the
+// receiver unique.
+//
+// Since a channel is based on static polymorphism, and concepts aren't supported in C++ 17, we
+// define the interfaces below with an example "NullChannel". All channels should support this
+// interface. The rationale for static polymorphism is three fold:
+//    * Performance - avoiding virtual call overhead
+//    * Avoiding the need to expose the sender and receiver types as pointers or references
+//    * Dynamic polymorphism may not be particularly helpful, because we already must parameterize on a message type. It
+//      would require all channels to send the same type if stored in the same map, etc...
+//
+// These channels are also optimized for move operations and as such do not require Msg to be copyable, although in
+// almost all instances they will be. This means that if we implement this interface with something like
+// boost::lockfree::spsc_queue (which requires copying), and our messages are large, we will likely lose some speed.
+namespace concord::channel {
+
+// Thrown when receiver.recv() is called but there are no corresponding senders for the channel anymore.
+class NoSendersError : public std::runtime_error {
+ public:
+  NoSendersError() : std::runtime_error("All senders have been destructed.") {}
+};
+
+// Thrown when sender.send() is called but there are no corresponding receivers for the channel anymore.
+class NoReceiversError : public std::runtime_error {
+ public:
+  NoReceiversError() : std::runtime_error("All receivers have been destructed.") {}
+};
+
+// The interface for the sender side of a channel
+template <typename Msg>
+class NullSender {
+  // Send a message over a channel.
+  //
+  // Sending a message on a channel must be non-blocking to prevent distributed deadlocks as a
+  // result of cyclic topologies. To enable this, if the channel is full we return the message to
+  // the sender. The sender can then determine whether to drop it or buffer it and apply
+  // backpressure.
+  //
+  // Returns std::nullopt when the message is succesfully sent.
+  // Returns Msg when the channel is full.
+  //
+  // Throws NoReceiversError if all receivers have been destructed.
+  //
+  // It's important to note that there is a race condition, whereby a receiver can be destructed
+  // immediately after a successful send. There is no absolute guarantee of delivery. The
+  // purpose of returning an error is to prevent endlessly retrying and never noticing that the
+  // channel is effectively destroyed.
+  std::optional<Msg> send(Msg&& msg) { return std::nullopt; }
+
+  // Return how many elements are in the channels internal buffer. For some channels, only an
+  // estimate will be avaialable, and for some others (mainly lock-free/wait-free) channels, this
+  // value will not be available at all. In those cases std::nullopt should be returned.
+  std::optional<size_t> size() const { return std::nullopt; }
+
+  // Bounded channels should return how many messages they can store in their internal buffer.
+  // Unbounded channels should return std::nullopt;
+  std::optional<size_t> capacity() const { return std::nullopt; }
+};
+
+// The interface for the receiver side of a channel
+template <typename Msg>
+class NullReceiver {
+  // Receive a message over a channel.
+  // Block waiting indefinitely.
+  //
+  // This example implies that Msg must be default constructable. In a real channel this is not
+  // necessary.
+  //
+  // Throws NoSendersError if all senders have been destructed and there are no more messages left
+  // in the communication buffer.
+  Msg recv() { return Msg(); }
+
+  // Receive a message over a channel.
+  // Wait only until the timeout.
+  //
+  // Return std::nullopt if a timeout occurred.
+  std::optional<Msg> recv(std::chrono::milliseconds timeout) { return std::nullopt; };
+
+  // Return how many elements are in the channels internal buffer. For some channels, only an
+  // estimate will be avaialable, and for some others (mainly lock-free/wait-free) channels, this
+  // value will not be available at all. In those cases std::nullopt should be returned.
+  std::optional<size_t> size() { return std::nullopt; }
+
+  // Bounded channels should return how many messages they can store in their internal buffer.
+  // Unbounded channels should return std::nullopt;
+  std::optional<size_t> capacity() { return std::nullopt; }
+};
+
+}  // namespace concord::channel

--- a/util/include/channels/mpsc_bounded_channel.h
+++ b/util/include/channels/mpsc_bounded_channel.h
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include <cassert>
 #include <chrono>
 #include <condition_variable>
 #include <memory>
@@ -21,6 +20,7 @@
 #include <queue>
 #include <utility>
 
+#include "assertUtils.hpp"
 #include "channel.h"
 
 namespace concord::channel {
@@ -52,7 +52,7 @@ class BoundedMpscQueue {
     return buf_.size();
   }
 
-  std::optional<size_t> capacity() const {
+  size_t capacity() const {
     // No need for a lock, as capacity_ is immutable
     return capacity_;
   }
@@ -121,7 +121,7 @@ class BoundedMpscSender {
   }
 
   std::optional<size_t> size() const { return queue_->size(); }
-  std::optional<size_t> capacity() const { return queue_->capacity(); }
+  size_t capacity() const { return queue_->capacity(); }
 
   ~BoundedMpscSender() {
     // We must check if a queue still exists because of move semantics. A move doesn't alter the
@@ -205,7 +205,7 @@ class BoundedMpscReceiver {
   BoundedMpscReceiver(const std::shared_ptr<impl::BoundedMpscQueue<Msg>>& queue) : queue_(queue) {}
 
   Msg pop() {
-    assert(!queue_->buf_.empty());
+    ConcordAssert(!queue_->buf_.empty());
     auto msg = std::move(queue_->buf_.front());
     // This is exception unsafe if we change the underlying container to one where `pop` can throw.
     // When using the default deque, this is not possible, since this method is only called on

--- a/util/include/channels/mpsc_bounded_channel.h
+++ b/util/include/channels/mpsc_bounded_channel.h
@@ -131,10 +131,7 @@ class BoundedMpscSender {
   }
 
   BoundedMpscSender(const BoundedMpscSender& other) : BoundedMpscSender(other.queue_) {}
-  BoundedMpscSender& operator=(const BoundedMpscSender& other) {
-    *this = BoundedMpscSender(other);
-    return *this;
-  }
+  BoundedMpscSender& operator=(const BoundedMpscSender& other) = default;
   BoundedMpscSender(BoundedMpscSender&&) noexcept = default;
   BoundedMpscSender& operator=(BoundedMpscSender&&) noexcept = default;
 

--- a/util/include/channels/mpsc_bounded_channel.h
+++ b/util/include/channels/mpsc_bounded_channel.h
@@ -1,0 +1,226 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <utility>
+
+#include "channel.h"
+
+namespace concord::channel {
+
+// Forward declarations
+template <typename Msg>
+class BoundedMpscSender;
+template <typename Msg>
+class BoundedMpscReceiver;
+
+namespace impl {
+
+// A simple, non-optimized, lock based, bounded MPSC channel.
+//
+// This is an internal type used by the BoundedMpscSender and BoundedMpscReceiver and should not be exposed publicly.
+template <typename Msg>
+class BoundedMpscQueue {
+ public:
+  BoundedMpscQueue(size_t capacity) : capacity_(capacity) {}
+
+ private:
+  template <typename T>
+  friend class ::concord::channel::BoundedMpscSender;
+  template <typename T>
+  friend class ::concord::channel::BoundedMpscReceiver;
+
+  std::optional<size_t> size() {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return buf_.size();
+  }
+
+  std::optional<size_t> capacity() {
+    // No need for a lock, as capacity_ is immutable
+    return capacity_;
+  }
+
+  void addSender() {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    num_senders_++;
+  }
+
+  void removeSender() {
+    bool num_senders = 0;
+    {
+      const std::lock_guard<std::mutex> lock(mutex_);
+      num_senders_--;
+      num_senders = num_senders_;
+    }
+    if (num_senders == 0) {
+      // Signal the receiver to throw a NoSendersError.
+      cv_.notify_one();
+    }
+  }
+
+  void invalidateReceiver() {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    valid_receiver_ = false;
+  }
+
+  const size_t capacity_;
+  std::queue<Msg> buf_;
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  size_t num_senders_ = 0;
+  bool valid_receiver_ = true;
+};
+
+}  // namespace impl
+
+template <typename Msg>
+class BoundedMpscSender {
+ public:
+  // Try to send a message over a bounded channel.
+  //
+  // Return std::nullopt on sucess.
+  // Return the Msg if the buffer is full
+  //
+  // Throws NoReceiversError if the receiver has been destructed.
+  //
+  // It's important to note that there is a race condition, whereby the receiver can be destructed
+  // immediately after a successful send. There is no absolute guarantee of delivery. The
+  // purpose of returning an error is to prevent endlessly retrying and never noticing that the
+  // channel is effectively destroyed.
+  std::optional<Msg> send(Msg&& msg) {
+    {
+      std::lock_guard<std::mutex> lock(queue_->mutex_);
+      if (!queue_->valid_receiver_) {
+        throw NoReceiversError();
+      }
+      if (queue_->buf_.size() == queue_->capacity_) {
+        return msg;
+      }
+      queue_->buf_.push(std::move(msg));
+    }
+    queue_->cv_.notify_one();
+
+    return std::nullopt;
+  }
+
+  std::optional<size_t> size() { return queue_->size(); }
+  std::optional<size_t> capacity() { return queue_->capacity(); }
+
+  ~BoundedMpscSender() {
+    if (!queue_) return;
+    queue_->removeSender();
+  }
+
+  BoundedMpscSender(const BoundedMpscSender& other) : BoundedMpscSender(other.queue_) {}
+  BoundedMpscSender& operator=(const BoundedMpscSender& other) {
+    *this = BoundedMpscSender(other);
+    return *this;
+  }
+  BoundedMpscSender(BoundedMpscSender&&) noexcept = default;
+  BoundedMpscSender& operator=(BoundedMpscSender&&) noexcept = default;
+
+ private:
+  BoundedMpscSender(const std::shared_ptr<impl::BoundedMpscQueue<Msg>>& queue) : queue_(queue) { queue_->addSender(); }
+
+  std::shared_ptr<impl::BoundedMpscQueue<Msg>> queue_;
+
+  template <typename T>
+  friend std::pair<BoundedMpscSender<T>, BoundedMpscReceiver<T>> makeBoundedMpscChannel(size_t capacity);
+};  // namespace concord::channel
+
+template <typename Msg>
+class BoundedMpscReceiver {
+ public:
+  // Receive a message over a channel.
+  // Block waiting indefinitely.
+  //
+  // Throws NoSendersError if all senders have been destructed and there are no more messages left
+  // in the communication buffer.
+  Msg recv() {
+    std::unique_lock<std::mutex> lock(queue_->mutex_);
+    queue_->cv_.wait(lock, [this]() { return waitPred(); });
+
+    // Always return a value if it's available, even if there are no senders.
+    if (!queue_->buf_.empty()) {
+      return pop();
+    }
+    throw NoSendersError();
+  }
+
+  // Receive a message over a channel and return it.
+  // Return std::nullopt on timeout.
+  //
+  // Throws NoSendersError if all senders have been destructed and there are no more messages left
+  // in the communication buffer.
+  std::optional<Msg> recv(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(queue_->mutex_);
+    if (!queue_->cv_.wait_for(lock, timeout, [this]() { return waitPred(); })) {
+      // Timeout
+      return std::nullopt;
+    }
+
+    // Always return a value if it's available, even if there are no senders.
+    if (!queue_->buf_.empty()) {
+      return pop();
+    }
+    throw NoSendersError();
+  }
+
+  std::optional<size_t> size() { return queue_->size(); }
+  std::optional<size_t> capacity() { return queue_->capacity(); }
+
+  ~BoundedMpscReceiver() {
+    if (queue_) {
+      queue_->invalidateReceiver();
+    }
+  }
+
+  // You can't copy an MPSC receiver
+  BoundedMpscReceiver(const BoundedMpscReceiver&) = delete;
+  BoundedMpscReceiver& operator=(const BoundedMpscReceiver&) = delete;
+
+  // We do allow moving a receiver though
+  BoundedMpscReceiver(BoundedMpscReceiver&&) noexcept = default;
+  BoundedMpscReceiver& operator=(BoundedMpscReceiver&&) noexcept = default;
+
+ private:
+  BoundedMpscReceiver(const std::shared_ptr<impl::BoundedMpscQueue<Msg>>& queue) : queue_(queue) {}
+
+  Msg pop() {
+    auto msg = std::move(queue_->buf_.front());
+    queue_->buf_.pop();
+    return msg;
+  }
+
+  bool waitPred() { return queue_->num_senders_ == 0 || !queue_->buf_.empty(); }
+
+  std::shared_ptr<impl::BoundedMpscQueue<Msg>> queue_;
+
+  template <typename T>
+  friend std::pair<BoundedMpscSender<T>, BoundedMpscReceiver<T>> makeBoundedMpscChannel(size_t capacity);
+};
+
+template <typename Msg>
+std::pair<BoundedMpscSender<Msg>, BoundedMpscReceiver<Msg>> makeBoundedMpscChannel(size_t capacity) {
+  auto queue = std::make_shared<impl::BoundedMpscQueue<Msg>>(capacity);
+  auto pair = std::make_pair(BoundedMpscSender<Msg>(queue), BoundedMpscReceiver<Msg>(queue));
+  return pair;
+}
+
+}  // namespace concord::channel

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -52,3 +52,5 @@ target_link_libraries(hex_tools_test GTest::Main util)
 add_executable(callback_registry_test callback_registry_test.cpp)
 add_test(callback_registry_test callback_registry_test)
 target_link_libraries(callback_registry_test GTest::Main util)
+
+add_subdirectory(channels)

--- a/util/test/channels/CMakeLists.txt
+++ b/util/test/channels/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(mpsc_bounded_channel_test mpsc_bounded_channel_test.cpp )
+add_test(mpsc_bounded_channel_test mpsc_bounded_channel_test)
+target_link_libraries(mpsc_bounded_channel_test GTest::Main util)

--- a/util/test/channels/mpsc_bounded_channel_test.cpp
+++ b/util/test/channels/mpsc_bounded_channel_test.cpp
@@ -1,0 +1,119 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <thread>
+#include "gtest/gtest.h"
+#include "channels/mpsc_bounded_channel.h"
+
+using namespace std::literals::chrono_literals;
+
+#include <iostream>
+using namespace std;
+
+namespace concord::channel {
+
+TEST(ChannelsTest, same_thread_no_contention) {
+  auto [sender, receiver] = makeBoundedMpscChannel<int>(2);
+
+  // Sends 1 and 2 are successful
+  ASSERT_EQ(std::nullopt, sender.send(1));
+  ASSERT_EQ(std::nullopt, sender.send(2));
+
+  // A third send should fail due to a full buffer and return the message
+  ASSERT_EQ(3, sender.send(3).value());
+
+  // Receiving one value makes room for another
+  ASSERT_EQ(1, receiver.recv());
+  ASSERT_EQ(std::nullopt, sender.send(4));
+
+  // We should be able to pull 2 values off the channel
+  ASSERT_EQ(2, receiver.recv());
+  ASSERT_EQ(4, receiver.recv());
+
+  // A third pull should timeout
+  ASSERT_EQ(std::nullopt, receiver.recv(1ms));
+
+  // Adding another value will make it available.
+  ASSERT_EQ(std::nullopt, sender.send(5));
+  ASSERT_EQ(5, receiver.recv(1ms).value());
+}
+
+TEST(ChannelsTest, two_threads_one_sender_one_receiver) {
+  auto [sender, receiver] = makeBoundedMpscChannel<int>(2);
+
+  // Add a value before we start the receiving thread
+  ASSERT_EQ(std::nullopt, sender.send(1));
+
+  auto thread = std::thread([receiver = std::move(receiver)]() mutable {
+    ASSERT_EQ(1, receiver.recv());
+    ASSERT_EQ(2, receiver.recv());
+    ASSERT_EQ(3, receiver.recv());
+    ASSERT_EQ(4, receiver.recv());
+    ASSERT_THROW(receiver.recv(), NoSendersError);
+  });
+
+  ASSERT_EQ(std::nullopt, sender.send(2));
+
+  // Loop until the receive thread has pulled this value off the queue.
+  while (sender.send(3).has_value())
+    ;
+
+  // Move the sender into a new scope so that it gets destroyed. Then the receiver should see a
+  // NoSendersError.
+  {
+    auto s = std::move(sender);
+    // There's a race here. We need to ensure the value gets sent.
+    while (s.send(4).has_value())
+      ;
+  }
+
+  thread.join();
+}
+
+TEST(ChannelsTest, multiple_senders) {
+  auto [sender, receiver] = makeBoundedMpscChannel<size_t>(2);
+  auto receive_thread = std::thread([receiver = std::move(receiver)]() mutable {
+    // All received values are indexes into the received vector
+    std::vector<bool> received(5, false);
+    for (auto i = 0; i < 5; i++) {
+      received[receiver.recv(1s).value()] = true;
+    }
+    for (const auto& val : received) {
+      ASSERT_TRUE(val);
+    }
+  });
+
+  auto send_thread_1 = std::thread([sender = sender]() mutable {
+    while (sender.send(0).has_value())
+      ;
+    while (sender.send(1).has_value())
+      ;
+  });
+  auto send_thread_2 = std::thread([sender = sender]() mutable {
+    while (sender.send(2).has_value())
+      ;
+    while (sender.send(3).has_value())
+      ;
+    while (sender.send(4).has_value())
+      ;
+  });
+
+  receive_thread.join();
+
+  // Receiver should be destroyed here.
+  ASSERT_THROW(sender.send(5), NoReceiversError);
+
+  send_thread_1.join();
+  send_thread_2.join();
+}
+
+}  // namespace concord::channel


### PR DESCRIPTION
In order to allow separation of functionality into various threads, and
allow message passing across those threads, an abstract channel
interface was created in channel.h. The rationale for the design is
given in comments in channel.h. Please read that. It's important to call
out here that the design is reflective of expectations of communication
patterns among our components, such that we must deal with cyclic,
transitive flows, and cannot allow any sender to block arbitrarily.

A lock based, bounded MPSC channel implementation was created in
mpsc_bounded_channel.h. This is useful for an initial implemnentation,
so that we can get started, but also useful to serve as an example of
how to implement the interface defined in the NullChannel in channel.h.

It's expected that the interface can be implemented using any queue,
including non-blocking ones such as boost::lockfree::spsc_queue.

A test is provided that shows how to use the BoundedMpscSender and
BoundedMpscReceiver types that compose a BoundedMpscChannel.