### PR TITLE
[Apollo] Fix pre-execution tests with constant load in the background

### DIFF
--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -147,7 +147,6 @@ class SkvbcPreExecutionTest(unittest.TestCase):
                                                 err_msg="Make sure the view did not change.")
                 await trio.sleep(seconds=5)
 
-    @unittest.skip("Unstable")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
@@ -157,6 +156,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         concurrently with a constant system load in the background.
         """
         bft_network.start_all_replicas()
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
 
         write_set = [(skvbc.random_key(), skvbc.random_value()),
                      (skvbc.random_key(), skvbc.random_value())]
@@ -244,7 +244,6 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         print(f"Finished at block {final_block_count}.")
         self.assertTrue(rw[0] + rw[1] >= num_of_requests)
 
-    @unittest.skip("Unstable")
     @with_trio
     @with_bft_network(start_replica_cmd)
     @with_constant_load
@@ -256,8 +255,9 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         This test validates that pre-execution and normal execution coexist correctly.
         """
         bft_network.start_all_replicas()
-        num_preexecution_requests = 200
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
 
+        num_preexecution_requests = 200
         clients = bft_network.random_clients(MAX_CONCURRENCY)
         await self.run_concurrent_pre_execution_requests(
             skvbc, clients, num_preexecution_requests, write_weight=1)

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -160,7 +160,7 @@ class UdpClient:
         """Reset any state that must be reset during retries"""
         self.primary = None
         self.retries += 1
-        if self.retries % 30 == 0:
+        if self.replies_manager.num_distinct_replies() > self.config.f:
             self.rsi_replies = dict()
             self.replies_manager.clear_replies()
 
@@ -226,7 +226,7 @@ class UdpClient:
             header, reply = rsi_msg.get_common_reply()
             if self.valid_reply(header, rsi_msg.get_sender_id(), replicas_ids):
                 quorum_size = self.replies_manager.add_reply(rsi_msg)
-                if quorum_size == required_replies:
+                if quorum_size >= required_replies:
                     self.reply = reply
                     self.rsi_replies = self.replies_manager.get_rsi_replies(rsi_msg.get_matched_reply_key())
                     self.primary = self.replicas[header.primary_id]


### PR DESCRIPTION
The proposed solution is to wait for the pre-processor's thread pool to become ready. The two following improvements are suggested for the BFT client:
* BFT client should not clean replies received so far, unless byzantine replies are detected (more than f non-matching replies). This mimics the behavior of the C++ SimpleClientImp.
* (trivial) we still have quorum, if we have received more than 2f+1 replies