### PR TITLE
Exit on non-existent DB in sparse_merkle_db_editor

### DIFF
--- a/kvbc/tools/sparse_merkle_db/CMakeLists.txt
+++ b/kvbc/tools/sparse_merkle_db/CMakeLists.txt
@@ -4,5 +4,5 @@ target_include_directories(lib_sparse_merkle_db_editor INTERFACE include)
 
 if(BUILD_ROCKSDB_STORAGE)
 add_executable(sparse_merkle_db_editor src/sparse_merkle_db_editor.cpp)
-target_link_libraries(sparse_merkle_db_editor PUBLIC lib_sparse_merkle_db_editor util kvbc)
+target_link_libraries(sparse_merkle_db_editor PUBLIC lib_sparse_merkle_db_editor util kvbc stdc++fs)
 endif()


### PR DESCRIPTION
If any of the passed RocksDB DBs to sparse_merkle_db_editor are
non-existent or empty, exit with an error instead of reporting empty
values. Prior to this change, the editor was first creating an empty DB
and then all commands were working by reporting default/empty values.

Since RocksDB doesn't offer a consistent method for checking if a DB
exists at a given path, first check if the passed directory exists. If
it doesn't, report an error. If it does, check if there are any keys in
the DB - if there are none, report an error. Above behavior can be
simplified when the following RocksDB issue is resolved:
https://github.com/facebook/rocksdb/issues/5029

Add tests for non-existent and empty databases for commands accepting
both one and two DB paths.