### PR TITLE
Path prefix for S3 object store is set as configuration parameter

### DIFF
--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -82,8 +82,7 @@ IStorageFactory::DatabaseSet S3StorageFactory::newDatabaseSet() const {
   ret.dataDBClient = std::make_shared<storage::ObjectStoreClient>(new storage::s3::Client{s3Conf_});
   ret.dataDBClient->init();
 
-  const auto prefix = std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count());
-  auto dataKeyGenerator = std::make_unique<S3KeyGenerator>(prefix);
+  auto dataKeyGenerator = std::make_unique<S3KeyGenerator>(s3Conf_.pathPrefix);
   ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient, std::move(dataKeyGenerator), true);
 
   return ret;

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -133,3 +133,15 @@ target_link_libraries(sparse_merkle_db_editor_test PUBLIC
     stdc++fs
 )
 endif(BUILD_ROCKSDB_STORAGE)
+
+if(USE_S3_OBJECT_STORE)
+add_executable(s3_storage_factory_test s3_storage_factory_test.cpp )
+add_test(s3_storage_factory_test s3_storage_factory_test)
+target_include_directories(s3_storage_factory_test PUBLIC
+    kvbc
+)
+target_link_libraries(s3_storage_factory_test PUBLIC
+    GTest::Main
+    kvbc
+)
+endif(USE_S3_OBJECT_STORE)

--- a/kvbc/test/s3_storage_factory_test.cpp
+++ b/kvbc/test/s3_storage_factory_test.cpp
@@ -1,0 +1,35 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "direct_kv_storage_factory.h"
+#include "direct_kv_db_adapter.h"
+#include "s3/client.hpp"
+
+TEST(s3, key_generation) {
+  const auto pathPrefix{"s3_prefix"};
+  const auto keyName{"test_key"};
+  const auto keyHex{"746573745f6b6579"};  // hex representation of the key
+  const auto blockId = concord::kvbc::BlockId{1};
+  const auto delim = std::string{"/"};
+  auto keygen = std::make_unique<concord::kvbc::v1DirectKeyValue::S3KeyGenerator>(pathPrefix);
+
+  auto blockKey = keygen->blockKey(blockId);
+  ASSERT_EQ(blockKey.toString(), pathPrefix + delim + std::to_string(blockId) + std::string{"/raw_block"});
+
+  auto dataKey = keygen->dataKey(concord::kvbc::Key{keyName}, blockId);
+  ASSERT_EQ(dataKey.toString(), pathPrefix + delim + std::to_string(blockId) + delim + keyHex);
+
+  auto mdtKey = keygen->mdtKey(concord::kvbc::Key{keyName});
+  ASSERT_EQ(mdtKey.toString(), pathPrefix + std::string{"/metadata/"} + keyName);
+}

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -33,6 +33,7 @@ struct StoreConfig {
   std::string secretKey;      // from the customer
   std::string accessKey;      // from the customer
   std::uint32_t maxWaitTime;  // in milliseconds
+  std::string pathPrefix;     // optional path prefix used in the bucket
 };
 
 /**

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -186,7 +186,7 @@ concord::storage::s3::StoreConfig TestSetup::ParseS3Config(const std::string& s3
     if (v.size()) {
       return v[0];
     } else {
-      throw std::runtime_error("failed to parse" + s3ConfigFile + ": " + key + " is not set.");
+      throw std::runtime_error("failed to parse " + s3ConfigFile + ": " + key + " is not set.");
     }
   };
 
@@ -196,6 +196,7 @@ concord::storage::s3::StoreConfig TestSetup::ParseS3Config(const std::string& s3
   config.protocol = get_config_value("s3-protocol");
   config.url = get_config_value("s3-url");
   config.secretKey = get_config_value("s3-secret-key");
+  config.pathPrefix = get_config_value("s3-path-prefix");
 
   LOG_INFO(logger_,
            "\nS3 Configuration:"

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -196,7 +196,15 @@ concord::storage::s3::StoreConfig TestSetup::ParseS3Config(const std::string& s3
   config.protocol = get_config_value("s3-protocol");
   config.url = get_config_value("s3-url");
   config.secretKey = get_config_value("s3-secret-key");
-  config.pathPrefix = get_config_value("s3-path-prefix");
+  try {
+    // TesterReplica is used for Apollo tests. Each test is executed against new blockchain, so we need brand new
+    // bucket for the RO replica. To achieve this we use a hack - set the prefix to a uniqe value so each RO replica
+    // writes in the same bucket but in different directory.
+    // So if s3-path-prefix is NOT SET it is initialised to a unique value based on current time.
+    config.pathPrefix = get_config_value("s3-path-prefix");
+  } catch (std::runtime_error& e) {
+    config.pathPrefix = std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+  }
 
   LOG_INFO(logger_,
            "\nS3 Configuration:"

--- a/tests/simpleKVBC/scripts/test_s3_config.txt
+++ b/tests/simpleKVBC/scripts/test_s3_config.txt
@@ -4,3 +4,4 @@ s3-access-key: concordbft
 s3-protocol: HTTP
 s3-url: 127.0.0.1:9000
 s3-secret-key: concordbft
+s3-path-prefix: concord

--- a/tests/simpleKVBC/scripts/test_s3_config_prefix.txt
+++ b/tests/simpleKVBC/scripts/test_s3_config_prefix.txt
@@ -4,3 +4,4 @@ s3-access-key: concordbft
 s3-protocol: HTTP
 s3-url: 127.0.0.1:9000
 s3-secret-key: concordbft
+s3-path-prefix: concord


### PR DESCRIPTION
Path prefix is additional key (consider it something like a directory)
created in the target S3 bucket.
This patch changes its creation from random value to value specified in
the S3 configuration. The prefix can't be a random value because all
fetched state in S3 is lost on RO replica restart.