### PR TITLE
Replace Apollo's print statements with Eliot's logs

### DIFF
--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -21,6 +21,7 @@ from util import bft_network_partitioning as net
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
+from util import eliot_logging as log
 
 
 def start_replica_cmd(builddir, replica_id):
@@ -203,7 +204,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
         expected_next_primary = 1 + initial_primary
         isolated_replicas = bft_network.random_set_of_replicas(f - 1, without={initial_primary, expected_next_primary})
 
-        print(f"Isolating network traffic to/from replicas {isolated_replicas}.")
+        log.log_message(message_type=f'Isolating network traffic to/from replicas {isolated_replicas}.')
         with net.ReplicaSubsetIsolatingAdversary(bft_network, isolated_replicas) as adversary:
             adversary.interfere()
 

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -18,6 +18,7 @@ import random
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load
 from util.skvbc_history_tracker import verify_linearizability
 import util.bft_network_partitioning as net
+import util.eliot_logging as log
 
 SKVBC_INIT_GRACE_TIME = 2
 NUM_OF_SEQ_WRITES = 100
@@ -237,11 +238,10 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         rw = await tracker.run_concurrent_ops(num_of_requests, write_weight=1)
         final_block_count = await tracker.get_last_block_id(read_client)
 
-        print("")
-        print(f"Randomly picked replica indexes {crash_targets} (nonprimary) to be stopped.")
-        print(f"Total of {num_of_requests} write pre-exec tx, "
+        log.log_message(message_type=f"Randomly picked replica indexes {crash_targets} (nonprimary) to be stopped.")
+        log.log_message(message_type=f"Total of {num_of_requests} write pre-exec tx, "
               f"concurrently submitted through {len(submit_clients)} clients.")
-        print(f"Finished at block {final_block_count}.")
+        log.log_message(message_type=f"Finished at block {final_block_count}.")
         self.assertTrue(rw[0] + rw[1] >= num_of_requests)
 
     @with_trio

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -20,6 +20,7 @@ from util import blinking_replica
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, TestConfig
 import sys
+from util import eliot_logging as log
 
 sys.path.append(os.path.abspath("../../util/pyclient"))
 
@@ -351,7 +352,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                             if value == 0:
                                 continue
                         except trio.TooSlowError:
-                            print(
+                            log.log_message(message_type=
                                 f"Replica {replica_id} was not able to get to super stable checkpoint within the timeout")
                             self.assertTrue(False)
                         else:

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -24,6 +24,7 @@ from util import skvbc as kvbc
 from util.skvbc import SimpleKVBCProtocol
 from util.skvbc_history_tracker import verify_linearizability
 from math import inf
+from util import eliot_logging as log
 
 from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network
 
@@ -64,7 +65,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
     """
     @classmethod
     def _start_s3_server(cls):
-        print("Starting server")
+        log.log_message(message_type="Starting server")
         server_env = os.environ.copy()
         server_env["MINIO_ACCESS_KEY"] = "concordbft"
         server_env["MINIO_SECRET_KEY"] = "concordbft"
@@ -81,10 +82,10 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):
-            print("CONCORD_BFT_MINIO_BINARY_PATH is not set. Running in RocksDB mode.")
+            log.log_message(message_type="CONCORD_BFT_MINIO_BINARY_PATH is not set. Running in RocksDB mode.")
             return
         
-        print("CONCORD_BFT_MINIO_BINARY_PATH is set. Running in S3 mode.")
+        log.log_message(message_type="CONCORD_BFT_MINIO_BINARY_PATH is set. Running in S3 mode.")
 
         # We need a temp dir for data and binaries - this is cls.dest_dir
         # self.dest_dir will contain data dir for minio buckets and the minio binary
@@ -93,12 +94,12 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         cls.minio_server_data_dir = os.path.join(cls.work_dir, "data")
         os.makedirs(os.path.join(cls.work_dir, "data", "blockchain"))     # create all dirs in one call
 
-        print(f"Working in {cls.work_dir}")
+        log.log_message(message_type=f"Working in {cls.work_dir}")
 
         # Start server
         cls._start_s3_server()
         
-        print("Initialisation complete")
+        log.log_message(message_type="Initialisation complete")
 
     @classmethod
     def tearDownClass(cls):
@@ -157,7 +158,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                         else:
                             if lastStableSeqNum >= 150:
                                 #enough requests
-                                print("Consensus: lastStableSeqNum:" + str(lastStableSeqNum))
+                                log.log_message(message_type="Consensus: lastStableSeqNum:" + str(lastStableSeqNum))
                                 nursery.cancel_scope.cancel()
         # start the read-only replica
         ro_replica_id = bft_network.config.n
@@ -173,7 +174,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                     else:
                         # success!
                         if lastExecutedSeqNum >= 150:
-                            print("Replica " + str(ro_replica_id) + ": lastExecutedSeqNum:" + str(lastExecutedSeqNum))
+                            log.log_message(message_type="Replica " + str(ro_replica_id) + ": lastExecutedSeqNum:" + str(lastExecutedSeqNum))
                             break
 
     @with_trio
@@ -207,7 +208,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                         else:
                             # success!
                             if lastExecutedSeqNum >= 150:
-                                print("Replica" + str(ro_replica_id) + " : lastExecutedSeqNum:" + str(lastExecutedSeqNum))
+                                log.log_message(message_type="Replica" + str(ro_replica_id) + " : lastExecutedSeqNum:" + str(lastExecutedSeqNum))
                                 nursery.cancel_scope.cancel()
                                 
     @with_trio
@@ -290,5 +291,5 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                     else:
                         # success!
                         if lastExecutedSeqNum >= 150:
-                            print("Replica" + str(ro_replica_id) + " : lastExecutedSeqNum:" + str(lastExecutedSeqNum))
+                            log.log_message(message_type="Replica" + str(ro_replica_id) + " : lastExecutedSeqNum:" + str(lastExecutedSeqNum))
                             break

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -18,6 +18,7 @@ import trio
 
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
+from util import eliot_logging as log
 
 
 def start_replica_cmd(builddir, replica_id):
@@ -165,7 +166,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
         randRep = random.choice(
                 bft_network.all_replicas(without={0}))
         
-        print("wait_for_view - Random replica {}".format(randRep))
+        log.log_message(f'wait_for_view - Random replica {randRep}')
 
         await bft_network.wait_for_view(
             replica_id=randRep,

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -21,6 +21,7 @@ from util import bft_network_partitioning as net
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
+from util import eliot_logging as log
 
 def start_replica_cmd(builddir, replica_id):
     """
@@ -206,7 +207,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
             err_msg="Make sure the unstable replica works in the initial view."
         )
 
-        print(f"Crash replica #{unstable_replica} before the view change.")
+        log.log_message(message_type=f"Crash replica #{unstable_replica} before the view change.")
         bft_network.stop_replica(unstable_replica)
 
         # trigger a view change
@@ -270,7 +271,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         unstable_replica = random.choice(
             bft_network.all_replicas(without={current_primary, initial_primary}))
-        print(f"Restart replica #{unstable_replica} after the view change.")
+        log.log_message(message_type=f"Restart replica #{unstable_replica} after the view change.")
 
         bft_network.stop_replica(unstable_replica)
         bft_network.start_replica(unstable_replica)

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -144,10 +144,6 @@ def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None,
                                                                      + "_n=" + str(bft_config['n']) \
                                                                      + "_f=" + str(bft_config['f']) \
                                                                      + "_c=" + str(bft_config['c'])
-                        print(f'Running {async_fn.__name__} '
-                              f'with n={config.n}, f={config.f}, c={config.c}, '
-                              f'num_clients={config.num_clients}, '
-                              f'num_ro_replicas={config.num_ro_replicas}')
                         with log.start_task(action_type=f"{bft_network.current_test}_num_clients={config.num_clients}"):
                             await async_fn(*args, **kwargs, bft_network=bft_network)
         return wrapper
@@ -235,7 +231,7 @@ class BftTestNetwork:
         #copy loggging.properties file
         shutil.copy(os.path.abspath("../simpleKVBC/scripts/logging.properties"), testdir)
 
-        print("Running test in {}".format(bft_network.testdir))
+        log.log_message(message_type=f"Running test in {bft_network.testdir}")
 
         os.chdir(bft_network.testdir)
         bft_network._generate_crypto_keys()
@@ -524,7 +520,7 @@ class BftTestNetwork:
                         value = await bft_network.metrics.get(replica_id, *key)
                     except KeyError:
                         # metrics not yet available, continue looping
-                        print(f"KeyError! '{mname}' not yet available.")
+                        log.log_message(message_type=f"KeyError! '{mname}' not yet available.")
                     else:
                         return value
 
@@ -539,7 +535,7 @@ class BftTestNetwork:
 
         In case of a timeout, fails with the provided err_msg
         """
-        with log.start_action(action_type="wait_for_view"):
+        with log.start_action(action_type="wait_for_view") as action:
             if expected is None:
                 expected = lambda _: True
 
@@ -547,10 +543,10 @@ class BftTestNetwork:
             nb_replicas_in_matching_view = 0
             try:
                 matching_view = await self._wait_for_matching_agreed_view(replica_id, expected)
-                print(f'Matching view #{matching_view} has been agreed among replicas.')
+                action.log(message_type=f'Matching view #{matching_view} has been agreed among replicas.')
 
                 nb_replicas_in_matching_view = await self._wait_for_active_view(matching_view)
-                print(f'View #{matching_view} is active on '
+                action.log(f'View #{matching_view} is active on '
                       f'{nb_replicas_in_matching_view} replicas '
                       f'({nb_replicas_in_matching_view} >= n-f = {self.config.n - self.config.f}).')
 
@@ -635,13 +631,13 @@ class BftTestNetwork:
         Bring down a sufficient number of replicas (excluding the primary),
         so that the remaining replicas form a quorum that includes replica_id
         """
-        with log.start_action(action_type="force_quorum_including_replica"):
+        with log.start_action(action_type="force_quorum_including_replica") as action:
             unstable_replicas = self.all_replicas(without={primary, replica_id})
 
             random.shuffle(unstable_replicas)
 
             for backup_replica_id in unstable_replicas:
-                print(f'Stopping backup replica {backup_replica_id} in order '
+                action.log(f'Stopping backup replica {backup_replica_id} in order '
                       f'to force a quorum including replica {replica_id}...')
                 self.stop_replica(backup_replica_id)
                 if len(self.procs) == 2 * self.config.f + self.config.c + 1:
@@ -714,7 +710,7 @@ class BftTestNetwork:
             up_to_date_node,
             stale_node,
             stop_on_stable_seq_num=False):
-        with log.start_action(action_type="wait_for_state_transfer_to_stop"):
+        with log.start_action(action_type="wait_for_state_transfer_to_stop") as action:
             with trio.fail_after(30): # seconds
                 # Get the lastExecutedSeqNumber from a started node
                 if stop_on_stable_seq_num:
@@ -741,7 +737,7 @@ class BftTestNetwork:
                                 on_transferring_complete = ['bc_state_transfer',
                                                             'Counters',
                                                             'on_transferring_complete']
-                                print("wait_for_st_to_stop: expected_seq_num={} "
+                                action.log(message_type="wait_for_st_to_stop: expected_seq_num={} "
                                       "last_stored_checkpoint={} "
                                       "on_transferring_complete_count={}".format(
                                             n,

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -33,6 +33,7 @@ import bft_config
 import bft_client
 import bft_metrics_client
 from util import bft_metrics, eliot_logging as log
+from util.eliot_logging import log_call
 from util import skvbc as kvbc
 from util.bft_test_exceptions import AlreadyRunningError, AlreadyStoppedError
 
@@ -49,6 +50,7 @@ TestConfig = namedtuple('TestConfig', [
 
 KEY_FILE_PREFIX = "replica_keys_"
 
+@log_call(action_type="Test_Configs", include_args=[])
 def interesting_configs(selected=None):
     if selected is None:
         selected=lambda *config: True

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -665,10 +665,9 @@ class BftTestNetwork:
 
     async def is_fetching(self, replica_id):
         """Return whether the current replica is fetching state"""
-        with log.start_action(action_type="is_fetching"):
-            key = ['bc_state_transfer', 'Statuses', 'fetching_state']
-            state = await self.metrics.get(replica_id, *key)
-            return state != "NotFetching"
+        key = ['bc_state_transfer', 'Statuses', 'fetching_state']
+        state = await self.metrics.get(replica_id, *key)
+        return state != "NotFetching"
 
     async def source_replica(self, replica_id):
         """Return whether the current replica has a source replica already set"""

--- a/tests/apollo/util/blinking_replica.py
+++ b/tests/apollo/util/blinking_replica.py
@@ -15,6 +15,7 @@
 
 import os
 import subprocess
+from util import eliot_logging as log
 
 
 class BlinkingReplica(object):
@@ -35,14 +36,14 @@ class BlinkingReplica(object):
     def start_blinking(self,start_replica_cmd):
         self.start_replica_cmd = start_replica_cmd
         self.blinker_process = subprocess.Popen(self._cmd_line(), close_fds=True)
-        print("Started blinking: {}".format(self._cmd_line()))
+        log.log_message(message_type=f'Started blinking: {self._cmd_line()}')
 
     def stop_blinking(self):
         if self.blinker_process:
             self.blinker_process.terminate()
             if self.blinker_process.wait() != 0:
                 raise Exception("Error occured while while stopping the blinker process")
-        print("Stopped blinking")
+        log.log_message(message_type="Stopped blinking")
 
     def _cmd_line(self):
         return ['python3',

--- a/tests/apollo/util/eliot_logging.py
+++ b/tests/apollo/util/eliot_logging.py
@@ -1,4 +1,4 @@
-from eliot import start_action, start_task, to_file, add_destinations, log_call
+from eliot import start_action, start_task, to_file, add_destinations, log_call, log_message
 from datetime import datetime
 import os
 import sys

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -347,14 +347,14 @@ class SimpleKVBCProtocol:
             return keys
 
     async def read_your_writes(self, test_class):
-        with log.start_action(action_type="read_your_writes"):
-            print("[READ-YOUR-WRITES] Starting 'read-your-writes' check...")
+        with log.start_action(action_type="read_your_writes") as action:
+            action.log(message_type="[READ-YOUR-WRITES] Starting 'read-your-writes' check...")
             client = self.bft_network.random_client()
             # Verify by "Read your write"
             # Perform write with the new primary
             last_block = self.parse_reply(
                 await client.read(self.get_last_block_req()))
-            print(f'[READ-YOUR-WRITES] Last block ID: #{last_block}')
+            action.log(message_type=f'[READ-YOUR-WRITES] Last block ID: #{last_block}')
             kv = [(self.keys[0], self.random_value()),
                   (self.keys[1], self.random_value())]
 
@@ -367,12 +367,12 @@ class SimpleKVBCProtocol:
 
             # Read the last write and check if equal
             # Get the kvpairs in the last written block
-            print(f'[READ-YOUR-WRITES] Checking if the {kv} entry is readable...')
+            action.log(message_type=f'[READ-YOUR-WRITES] Checking if the {kv} entry is readable...')
             data = await client.read(self.get_block_data_req(last_block))
             kv2 = self.parse_reply(data)
             test_class.assertDictEqual(kv2, dict(kv))
 
-            print(f'[READ-YOUR-WRITES] OK.')
+            action.log(message_type=f'[READ-YOUR-WRITES] OK.')
 
 
 class SkvbcClient:

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -16,7 +16,7 @@ from util import skvbc as kvbc, eliot_logging as log
 import trio
 import random
 from functools import wraps
-from util.skvbc_exceptions import (
+from util.skvbc_exceptions import(
     ConflictingBlockWriteError,
     StaleReadError,
     NoConflictError,
@@ -24,7 +24,7 @@ from util.skvbc_exceptions import (
     PhantomBlockError
 )
 
-MAX_LOOKBACK = 10
+MAX_LOOKBACK=10
 
 
 def verify_linearizability(pre_exec_enabled=False, no_conflicts=False):
@@ -32,7 +32,6 @@ def verify_linearizability(pre_exec_enabled=False, no_conflicts=False):
     Creates a tracker and provide it to the decorated method.
     In the end of the method it checks the linearizability of the resulting history.
     """
-
     def decorator(async_fn):
         @wraps(async_fn)
         async def wrapper(*args, **kwargs):
@@ -51,7 +50,6 @@ def verify_linearizability(pre_exec_enabled=False, no_conflicts=False):
                 await tracker.fill_missing_blocks_and_verify()
 
         return wrapper
-
     return decorator
 
 
@@ -59,7 +57,6 @@ class SkvbcWriteRequest:
     """
     A write request sent to an Skvbc cluster. A request may or may not complete.
     """
-
     def __init__(self, client_id, seq_num, readset, writeset, read_block_id=0):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -70,19 +67,17 @@ class SkvbcWriteRequest:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  timestamp={self.timestamp}\n'
-                f'  client_id={self.client_id}\n'
-                f'  seq_num={self.seq_num}\n'
-                f'  readset={self.readset}\n'
-                f'  writeset={self.writeset}\n'
-                f'  read_block_id={self.read_block_id}\n')
-
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  readset={self.readset}\n'
+           f'  writeset={self.writeset}\n'
+           f'  read_block_id={self.read_block_id}\n')
 
 class SkvbcReadRequest:
     """
     A read request sent to an Skvbc cluster. A request may or may not complete.
     """
-
     def __init__(self, client_id, seq_num, readset, read_block_id=0):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -92,19 +87,17 @@ class SkvbcReadRequest:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  timestamp={self.timestamp}\n'
-                f'  client_id={self.client_id}\n'
-                f'  seq_num={self.seq_num}\n'
-                f'  readset={self.readset}\n'
-                f'  read_block_id={self.read_block_id}\n')
-
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  readset={self.readset}\n'
+           f'  read_block_id={self.read_block_id}\n')
 
 class SkvbcGetLastBlockReq:
     """
     A GET_LAST_BLOCK request sent to an skvbc cluster. A request may or may not
     complete.
     """
-
     def __init__(self, client_id, seq_num):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -112,14 +105,12 @@ class SkvbcGetLastBlockReq:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  timestamp={self.timestamp}\n'
-                f'  client_id={self.client_id}\n'
-                f'  seq_num={self.seq_num}\n')
-
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n')
 
 class SkvbcWriteReply:
     """A reply to an outstanding write request sent to an Skvbc cluster."""
-
     def __init__(self, client_id, seq_num, reply):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -128,15 +119,13 @@ class SkvbcWriteReply:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  timestamp={self.timestamp}\n'
-                f'  client_id={self.client_id}\n'
-                f'  seq_num={self.seq_num}\n'
-                f'  reply={self.reply}\n')
-
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  reply={self.reply}\n')
 
 class SkvbcReadReply:
     """A reply to an outstanding read request sent to an Skvbc cluster."""
-
     def __init__(self, client_id, seq_num, kvpairs):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -145,17 +134,15 @@ class SkvbcReadReply:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  timestamp={self.timestamp}\n'
-                f'  client_id={self.client_id}\n'
-                f'  seq_num={self.seq_num}\n'
-                f'  kvpairs={self.kvpairs}\n')
-
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  kvpairs={self.kvpairs}\n')
 
 class SkvbcGetLastBlockReply:
     """
     A reply to an outstanding get last block request sent to an Skvbc cluster.
     """
-
     def __init__(self, client_id, seq_num, reply):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -164,22 +151,20 @@ class SkvbcGetLastBlockReply:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  timestamp={self.timestamp}\n'
-                f'  client_id={self.client_id}\n'
-                f'  seq_num={self.seq_num}\n'
-                f'  reply={self.reply}\n')
-
+           f'  timestamp={self.timestamp}\n'
+           f'  client_id={self.client_id}\n'
+           f'  seq_num={self.seq_num}\n'
+           f'  reply={self.reply}\n')
 
 class Result(Enum):
-    """
-    Whether an operation succeeded, failed, or the result is unknown
-    """
-    WRITE_SUCCESS = 1
-    WRITE_FAIL = 2
-    UNKNOWN_WRITE = 3
-    UNKNOWN_READ = 4
-    READ_REPLY = 5
-
+   """
+   Whether an operation succeeded, failed, or the result is unknown
+   """
+   WRITE_SUCCESS = 1
+   WRITE_FAIL = 2
+   UNKNOWN_WRITE = 3
+   UNKNOWN_READ = 4
+   READ_REPLY = 5
 
 class CompletedRead:
     def __init__(self, causal_state, kvpairs):
@@ -188,13 +173,11 @@ class CompletedRead:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  causal_state={self.causal_state}\n'
-                f'  kvpairs={self.kvpairs}\n')
-
+           f'  causal_state={self.causal_state}\n'
+           f'  kvpairs={self.kvpairs}\n')
 
 class CausalState:
     """Relevant state of the tracker before a request is started"""
-
     def __init__(self,
                  req_index,
                  last_known_block,
@@ -211,17 +194,15 @@ class CausalState:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'    req_index={self.req_index}\n'
-                f'    last_known_block={self.last_known_block}\n'
-                f'    last_consecutive_block={self.last_consecutive_block}\n'
-                f'    '
-                f'missing_intermediate_blocks={self.missing_intermediate_blocks}\n'
-                f'    causal state kvpairs={self.kvpairs}\n')
-
+           f'    req_index={self.req_index}\n'
+           f'    last_known_block={self.last_known_block}\n'
+           f'    last_consecutive_block={self.last_consecutive_block}\n'
+           f'    '
+           f'missing_intermediate_blocks={self.missing_intermediate_blocks}\n'
+           f'    causal state kvpairs={self.kvpairs}\n')
 
 class ConcurrentValue:
     """Track the state for a request / reply in self.concurrent"""
-
     def __init__(self, is_read):
         if is_read:
             self.result = Result.UNKNOWN_READ
@@ -234,9 +215,8 @@ class ConcurrentValue:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  result={self.result}\n'
-                f'  written_block_id={self.written_block_id}\n')
-
+           f'  result={self.result}\n'
+           f'  written_block_id={self.written_block_id}\n')
 
 class Block:
     def __init__(self, kvpairs, req_index=None):
@@ -245,16 +225,14 @@ class Block:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  kvpairs={self.kvpairs}\n'
-                f'  req_index={self.req_index}\n')
-
+           f'  kvpairs={self.kvpairs}\n'
+           f'  req_index={self.req_index}\n')
 
 class Status:
     """
     Status about the order of writes and reads.
     This is useful for debugging linearizability check failures.
     """
-
     def __init__(self, config):
         self.config = config
         self.start_time = time.monotonic()
@@ -274,13 +252,12 @@ class Status:
 
     def __str__(self):
         return (f'{self.__class__.__name__}:\n'
-                f'  config={self.config}\n'
-                f'  test_duration={self.end_time - self.start_time} seconds\n'
-                f'  time_since_last_client_reply='
-                f'{self.end_time - self.last_client_reply} seconds\n'
-                f'  client_timeouts={self.client_timeouts}\n'
-                f'  client_replies={self.client_replies}\n')
-
+           f'  config={self.config}\n'
+           f'  test_duration={self.end_time - self.start_time} seconds\n'
+           f'  time_since_last_client_reply='
+           f'{self.end_time - self.last_client_reply} seconds\n'
+           f'  client_timeouts={self.client_timeouts}\n'
+           f'  client_replies={self.client_replies}\n')
 
 class SkvbcTracker:
     """
@@ -400,7 +377,6 @@ class SkvbcTracker:
     clusters with lots of blocks, but we may want to add it as an optional check
     in the future.
     """
-
     def __init__(self, initial_kvpairs={}, skvbc=None, bft_network=None, pre_exec_all=False, no_conflicts=False):
 
         # If this flag is set to True, it means that all the tracker requests will
@@ -457,7 +433,7 @@ class SkvbcTracker:
     def send_write(self, client_id, seq_num, readset, writeset, read_block_id):
         """Track the send of a write request"""
         req = SkvbcWriteRequest(
-            client_id, seq_num, readset, writeset, read_block_id)
+                client_id, seq_num, readset, writeset, read_block_id)
         self._send_req(req, is_read=False)
 
     def send_read(self, client_id, seq_num, readset):
@@ -613,7 +589,7 @@ class SkvbcTracker:
         return writes
 
     def _verify_successful_writes(self):
-        for i in range(1, self.last_known_block + 1):
+        for i in range(1, self.last_known_block+1):
             req_index = self.blocks[i].req_index
             if req_index != None:
                 # A reply was received for this request that created the block
@@ -651,10 +627,10 @@ class SkvbcTracker:
                            causal_state.last_known_block + blocks_to_check + 1):
                 writeset = set(self.blocks[i].kvpairs.keys())
                 if len(failed_req.readset.intersection(writeset)) != 0:
-                    # We found a block that conflicts. We must
-                    # assume that failed_req was failed correctly.
-                    success = True
-                    break
+                       # We found a block that conflicts. We must
+                       # assume that failed_req was failed correctly.
+                       success = True
+                       break
 
             if not success:
                 # We didn't find any conflicting blocks.
@@ -670,7 +646,7 @@ class SkvbcTracker:
 
         If a read cannot be linearized, then raise an exception.
         """
-        for req_index, completed_read in self.completed_reads.items():
+        for req_index, completed_read  in self.completed_reads.items():
             cs = completed_read.causal_state
             kv = cs.kvpairs.copy()
 
@@ -724,8 +700,8 @@ class SkvbcTracker:
         count = 0
         for val in self.concurrent[req_index].values():
             if val.result == Result.WRITE_SUCCESS or \
-                    val.result == Result.UNKNOWN_WRITE:
-                count += 1
+               val.result == Result.UNKNOWN_WRITE:
+                   count += 1
         return count
 
     def _update_concurrent_requests(self, index, is_read):
@@ -829,33 +805,33 @@ class SkvbcTracker:
         return (self.history[index], index)
 
     async def fill_missing_blocks_and_verify(self):
-        try:
-            # Use a new client, since other clients may not be responsive due to
-            # past failed responses.
-            client = await self.skvbc.bft_network.new_client()
-            last_block_id = await self.get_last_block_id(client)
-            log.log_message(message_type=f'Last Block ID = {last_block_id}')
-            missing_block_ids = self.get_missing_blocks(last_block_id)
-            log.log_message(message_type=f'Missing Block IDs = {missing_block_ids}')
-            blocks = await self.get_blocks(client, missing_block_ids)
-            self.fill_missing_blocks(blocks)
-            self.verify()
-        except Exception as e:
-            log.log_message(message_type=f'retries = {client.retries}')
-            self.status.end_time = time.monotonic()
-            log.log_message(message_type="HISTORY...")
-            for i, entry in enumerate(self.history):
-                log.log_message(message_type=f'Index = {i}: {entry}\n')
-            log.log_message(message_type="BLOCKS...")
-            log.log_message(message_type=f'{self.blocks}\n')
-            log.log_message(message_type=str(self.status))
-            log.log_message(message_type="FAILURE...")
-            raise (e)
+       try:
+           # Use a new client, since other clients may not be responsive due to
+           # past failed responses.
+           client = await self.skvbc.bft_network.new_client()
+           last_block_id = await self.get_last_block_id(client)
+           print(f'Last Block ID = {last_block_id}')
+           missing_block_ids = self.get_missing_blocks(last_block_id)
+           print(f'Missing Block IDs = {missing_block_ids}')
+           blocks = await self.get_blocks(client, missing_block_ids)
+           self.fill_missing_blocks(blocks)
+           self.verify()
+       except Exception as e:
+           print(f'retries = {client.retries}')
+           self.status.end_time = time.monotonic()
+           print("HISTORY...")
+           for i, entry in enumerate(self.history):
+               print(f'Index = {i}: {entry}\n')
+           print("BLOCKS...")
+           print(f'{self.blocks}\n')
+           print(str(self.status), flush=True)
+           print("FAILURE...")
+           raise (e)
 
     async def get_blocks(self, client, block_ids):
         blocks = {}
         for block_id in block_ids:
-            retries = 12  # 60 seconds
+            retries = 12 # 60 seconds
             for i in range(0, retries):
                 try:
                     msg = kvbc.SimpleKVBCProtocol.get_block_data_req(block_id)
@@ -925,8 +901,7 @@ class SkvbcTracker:
         with log.start_action(action_type="run_concurrent_ops"):
             max_concurrency = len(self.bft_network.clients) // 2
             max_size = len(self.skvbc.keys) // 2
-            return await self.send_concurrent_ops(num_ops, max_concurrency, max_size, write_weight,
-                                                  create_conflicts=True)
+            return await self.send_concurrent_ops(num_ops, max_concurrency, max_size, write_weight, create_conflicts=True)
 
     async def run_concurrent_conflict_ops(self, num_ops, write_weight=.70):
         if self.no_conflicts is True:
@@ -1053,8 +1028,8 @@ class SkvbcTracker:
         kv = [(keys[0], self.skvbc.random_value()),
               (keys[1], self.skvbc.random_value())]
 
-        # reply = await client.write(self.write_req([], kv, 0))
-        # reply = self.parse_reply(reply)
+        #reply = await client.write(self.write_req([], kv, 0))
+        #reply = self.parse_reply(reply)
         reply = await self.write_and_track_known_kv(kv, client)
         assert reply.success
         assert last_block + 1 == reply.last_block_id
@@ -1067,7 +1042,6 @@ class SkvbcTracker:
         kv2 = self.skvbc.parse_reply(data)
 
         assert kv2 == dict(kv)
-
 
 class PassThroughSkvbcTracker:
 

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -16,7 +16,7 @@ from util import skvbc as kvbc, eliot_logging as log
 import trio
 import random
 from functools import wraps
-from util.skvbc_exceptions import(
+from util.skvbc_exceptions import (
     ConflictingBlockWriteError,
     StaleReadError,
     NoConflictError,
@@ -24,7 +24,7 @@ from util.skvbc_exceptions import(
     PhantomBlockError
 )
 
-MAX_LOOKBACK=10
+MAX_LOOKBACK = 10
 
 
 def verify_linearizability(pre_exec_enabled=False, no_conflicts=False):
@@ -32,6 +32,7 @@ def verify_linearizability(pre_exec_enabled=False, no_conflicts=False):
     Creates a tracker and provide it to the decorated method.
     In the end of the method it checks the linearizability of the resulting history.
     """
+
     def decorator(async_fn):
         @wraps(async_fn)
         async def wrapper(*args, **kwargs):
@@ -50,6 +51,7 @@ def verify_linearizability(pre_exec_enabled=False, no_conflicts=False):
                 await tracker.fill_missing_blocks_and_verify()
 
         return wrapper
+
     return decorator
 
 
@@ -57,6 +59,7 @@ class SkvbcWriteRequest:
     """
     A write request sent to an Skvbc cluster. A request may or may not complete.
     """
+
     def __init__(self, client_id, seq_num, readset, writeset, read_block_id=0):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -67,17 +70,19 @@ class SkvbcWriteRequest:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  timestamp={self.timestamp}\n'
-           f'  client_id={self.client_id}\n'
-           f'  seq_num={self.seq_num}\n'
-           f'  readset={self.readset}\n'
-           f'  writeset={self.writeset}\n'
-           f'  read_block_id={self.read_block_id}\n')
+                f'  timestamp={self.timestamp}\n'
+                f'  client_id={self.client_id}\n'
+                f'  seq_num={self.seq_num}\n'
+                f'  readset={self.readset}\n'
+                f'  writeset={self.writeset}\n'
+                f'  read_block_id={self.read_block_id}\n')
+
 
 class SkvbcReadRequest:
     """
     A read request sent to an Skvbc cluster. A request may or may not complete.
     """
+
     def __init__(self, client_id, seq_num, readset, read_block_id=0):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -87,17 +92,19 @@ class SkvbcReadRequest:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  timestamp={self.timestamp}\n'
-           f'  client_id={self.client_id}\n'
-           f'  seq_num={self.seq_num}\n'
-           f'  readset={self.readset}\n'
-           f'  read_block_id={self.read_block_id}\n')
+                f'  timestamp={self.timestamp}\n'
+                f'  client_id={self.client_id}\n'
+                f'  seq_num={self.seq_num}\n'
+                f'  readset={self.readset}\n'
+                f'  read_block_id={self.read_block_id}\n')
+
 
 class SkvbcGetLastBlockReq:
     """
     A GET_LAST_BLOCK request sent to an skvbc cluster. A request may or may not
     complete.
     """
+
     def __init__(self, client_id, seq_num):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -105,12 +112,14 @@ class SkvbcGetLastBlockReq:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  timestamp={self.timestamp}\n'
-           f'  client_id={self.client_id}\n'
-           f'  seq_num={self.seq_num}\n')
+                f'  timestamp={self.timestamp}\n'
+                f'  client_id={self.client_id}\n'
+                f'  seq_num={self.seq_num}\n')
+
 
 class SkvbcWriteReply:
     """A reply to an outstanding write request sent to an Skvbc cluster."""
+
     def __init__(self, client_id, seq_num, reply):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -119,13 +128,15 @@ class SkvbcWriteReply:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  timestamp={self.timestamp}\n'
-           f'  client_id={self.client_id}\n'
-           f'  seq_num={self.seq_num}\n'
-           f'  reply={self.reply}\n')
+                f'  timestamp={self.timestamp}\n'
+                f'  client_id={self.client_id}\n'
+                f'  seq_num={self.seq_num}\n'
+                f'  reply={self.reply}\n')
+
 
 class SkvbcReadReply:
     """A reply to an outstanding read request sent to an Skvbc cluster."""
+
     def __init__(self, client_id, seq_num, kvpairs):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -134,15 +145,17 @@ class SkvbcReadReply:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  timestamp={self.timestamp}\n'
-           f'  client_id={self.client_id}\n'
-           f'  seq_num={self.seq_num}\n'
-           f'  kvpairs={self.kvpairs}\n')
+                f'  timestamp={self.timestamp}\n'
+                f'  client_id={self.client_id}\n'
+                f'  seq_num={self.seq_num}\n'
+                f'  kvpairs={self.kvpairs}\n')
+
 
 class SkvbcGetLastBlockReply:
     """
     A reply to an outstanding get last block request sent to an Skvbc cluster.
     """
+
     def __init__(self, client_id, seq_num, reply):
         self.timestamp = time.monotonic()
         self.client_id = client_id
@@ -151,20 +164,22 @@ class SkvbcGetLastBlockReply:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  timestamp={self.timestamp}\n'
-           f'  client_id={self.client_id}\n'
-           f'  seq_num={self.seq_num}\n'
-           f'  reply={self.reply}\n')
+                f'  timestamp={self.timestamp}\n'
+                f'  client_id={self.client_id}\n'
+                f'  seq_num={self.seq_num}\n'
+                f'  reply={self.reply}\n')
+
 
 class Result(Enum):
-   """
-   Whether an operation succeeded, failed, or the result is unknown
-   """
-   WRITE_SUCCESS = 1
-   WRITE_FAIL = 2
-   UNKNOWN_WRITE = 3
-   UNKNOWN_READ = 4
-   READ_REPLY = 5
+    """
+    Whether an operation succeeded, failed, or the result is unknown
+    """
+    WRITE_SUCCESS = 1
+    WRITE_FAIL = 2
+    UNKNOWN_WRITE = 3
+    UNKNOWN_READ = 4
+    READ_REPLY = 5
+
 
 class CompletedRead:
     def __init__(self, causal_state, kvpairs):
@@ -173,11 +188,13 @@ class CompletedRead:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  causal_state={self.causal_state}\n'
-           f'  kvpairs={self.kvpairs}\n')
+                f'  causal_state={self.causal_state}\n'
+                f'  kvpairs={self.kvpairs}\n')
+
 
 class CausalState:
     """Relevant state of the tracker before a request is started"""
+
     def __init__(self,
                  req_index,
                  last_known_block,
@@ -194,15 +211,17 @@ class CausalState:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'    req_index={self.req_index}\n'
-           f'    last_known_block={self.last_known_block}\n'
-           f'    last_consecutive_block={self.last_consecutive_block}\n'
-           f'    '
-           f'missing_intermediate_blocks={self.missing_intermediate_blocks}\n'
-           f'    causal state kvpairs={self.kvpairs}\n')
+                f'    req_index={self.req_index}\n'
+                f'    last_known_block={self.last_known_block}\n'
+                f'    last_consecutive_block={self.last_consecutive_block}\n'
+                f'    '
+                f'missing_intermediate_blocks={self.missing_intermediate_blocks}\n'
+                f'    causal state kvpairs={self.kvpairs}\n')
+
 
 class ConcurrentValue:
     """Track the state for a request / reply in self.concurrent"""
+
     def __init__(self, is_read):
         if is_read:
             self.result = Result.UNKNOWN_READ
@@ -215,8 +234,9 @@ class ConcurrentValue:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  result={self.result}\n'
-           f'  written_block_id={self.written_block_id}\n')
+                f'  result={self.result}\n'
+                f'  written_block_id={self.written_block_id}\n')
+
 
 class Block:
     def __init__(self, kvpairs, req_index=None):
@@ -225,14 +245,16 @@ class Block:
 
     def __repr__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  kvpairs={self.kvpairs}\n'
-           f'  req_index={self.req_index}\n')
+                f'  kvpairs={self.kvpairs}\n'
+                f'  req_index={self.req_index}\n')
+
 
 class Status:
     """
     Status about the order of writes and reads.
     This is useful for debugging linearizability check failures.
     """
+
     def __init__(self, config):
         self.config = config
         self.start_time = time.monotonic()
@@ -252,12 +274,13 @@ class Status:
 
     def __str__(self):
         return (f'{self.__class__.__name__}:\n'
-           f'  config={self.config}\n'
-           f'  test_duration={self.end_time - self.start_time} seconds\n'
-           f'  time_since_last_client_reply='
-           f'{self.end_time - self.last_client_reply} seconds\n'
-           f'  client_timeouts={self.client_timeouts}\n'
-           f'  client_replies={self.client_replies}\n')
+                f'  config={self.config}\n'
+                f'  test_duration={self.end_time - self.start_time} seconds\n'
+                f'  time_since_last_client_reply='
+                f'{self.end_time - self.last_client_reply} seconds\n'
+                f'  client_timeouts={self.client_timeouts}\n'
+                f'  client_replies={self.client_replies}\n')
+
 
 class SkvbcTracker:
     """
@@ -377,6 +400,7 @@ class SkvbcTracker:
     clusters with lots of blocks, but we may want to add it as an optional check
     in the future.
     """
+
     def __init__(self, initial_kvpairs={}, skvbc=None, bft_network=None, pre_exec_all=False, no_conflicts=False):
 
         # If this flag is set to True, it means that all the tracker requests will
@@ -433,7 +457,7 @@ class SkvbcTracker:
     def send_write(self, client_id, seq_num, readset, writeset, read_block_id):
         """Track the send of a write request"""
         req = SkvbcWriteRequest(
-                client_id, seq_num, readset, writeset, read_block_id)
+            client_id, seq_num, readset, writeset, read_block_id)
         self._send_req(req, is_read=False)
 
     def send_read(self, client_id, seq_num, readset):
@@ -521,7 +545,7 @@ class SkvbcTracker:
         for i in range(self.last_known_block + 1, last_block_id + 1):
             missing_blocks.add(i)
 
-        print(f'{len(missing_blocks)} missing blocks found.')
+        log.log_message(message_type=f'{len(missing_blocks)} missing blocks found.')
         return missing_blocks
 
     def fill_missing_blocks(self, missing_blocks):
@@ -541,7 +565,7 @@ class SkvbcTracker:
             if block_id > self.last_known_block:
                 self.last_known_block = block_id
         self.filled_blocks = missing_blocks
-        print(f'{len(missing_blocks)} missing blocks filled.')
+        log.log_message(message_type=f'{len(missing_blocks)} missing blocks filled.')
 
     def verify(self):
         self._match_filled_blocks()
@@ -589,7 +613,7 @@ class SkvbcTracker:
         return writes
 
     def _verify_successful_writes(self):
-        for i in range(1, self.last_known_block+1):
+        for i in range(1, self.last_known_block + 1):
             req_index = self.blocks[i].req_index
             if req_index != None:
                 # A reply was received for this request that created the block
@@ -627,10 +651,10 @@ class SkvbcTracker:
                            causal_state.last_known_block + blocks_to_check + 1):
                 writeset = set(self.blocks[i].kvpairs.keys())
                 if len(failed_req.readset.intersection(writeset)) != 0:
-                       # We found a block that conflicts. We must
-                       # assume that failed_req was failed correctly.
-                       success = True
-                       break
+                    # We found a block that conflicts. We must
+                    # assume that failed_req was failed correctly.
+                    success = True
+                    break
 
             if not success:
                 # We didn't find any conflicting blocks.
@@ -646,7 +670,7 @@ class SkvbcTracker:
 
         If a read cannot be linearized, then raise an exception.
         """
-        for req_index, completed_read  in self.completed_reads.items():
+        for req_index, completed_read in self.completed_reads.items():
             cs = completed_read.causal_state
             kv = cs.kvpairs.copy()
 
@@ -700,8 +724,8 @@ class SkvbcTracker:
         count = 0
         for val in self.concurrent[req_index].values():
             if val.result == Result.WRITE_SUCCESS or \
-               val.result == Result.UNKNOWN_WRITE:
-                   count += 1
+                    val.result == Result.UNKNOWN_WRITE:
+                count += 1
         return count
 
     def _update_concurrent_requests(self, index, is_read):
@@ -805,33 +829,33 @@ class SkvbcTracker:
         return (self.history[index], index)
 
     async def fill_missing_blocks_and_verify(self):
-         try:
-             # Use a new client, since other clients may not be responsive due to
-             # past failed responses.
-             client = await self.skvbc.bft_network.new_client()
-             last_block_id = await self.get_last_block_id(client)
-             print(f'Last Block ID = {last_block_id}')
-             missing_block_ids = self.get_missing_blocks(last_block_id)
-             print(f'Missing Block IDs = {missing_block_ids}')
-             blocks = await self.get_blocks(client, missing_block_ids)
-             self.fill_missing_blocks(blocks)
-             self.verify()
-         except Exception as e:
-             print(f'retries = {client.retries}')
-             self.status.end_time = time.monotonic()
-             print("HISTORY...")
-             for i, entry in enumerate(self.history):
-                 print(f'Index = {i}: {entry}\n')
-             print("BLOCKS...")
-             print(f'{self.blocks}\n')
-             print(str(self.status), flush=True)
-             print("FAILURE...")
-             raise(e)
+        try:
+            # Use a new client, since other clients may not be responsive due to
+            # past failed responses.
+            client = await self.skvbc.bft_network.new_client()
+            last_block_id = await self.get_last_block_id(client)
+            log.log_message(message_type=f'Last Block ID = {last_block_id}')
+            missing_block_ids = self.get_missing_blocks(last_block_id)
+            log.log_message(message_type=f'Missing Block IDs = {missing_block_ids}')
+            blocks = await self.get_blocks(client, missing_block_ids)
+            self.fill_missing_blocks(blocks)
+            self.verify()
+        except Exception as e:
+            log.log_message(message_type=f'retries = {client.retries}')
+            self.status.end_time = time.monotonic()
+            log.log_message(message_type="HISTORY...")
+            for i, entry in enumerate(self.history):
+                log.log_message(message_type=f'Index = {i}: {entry}\n')
+            log.log_message(message_type="BLOCKS...")
+            log.log_message(message_type=f'{self.blocks}\n')
+            log.log_message(message_type=str(self.status))
+            log.log_message(message_type="FAILURE...")
+            raise (e)
 
     async def get_blocks(self, client, block_ids):
         blocks = {}
         for block_id in block_ids:
-            retries = 12 # 60 seconds
+            retries = 12  # 60 seconds
             for i in range(0, retries):
                 try:
                     msg = kvbc.SimpleKVBCProtocol.get_block_data_req(block_id)
@@ -840,7 +864,7 @@ class SkvbcTracker:
                 except trio.TooSlowError:
                     if i == retries - 1:
                         raise
-            print(f'Retrieved block {block_id}')
+            log.log_message(message_type=f'Retrieved block {block_id}')
         return blocks
 
     async def get_last_block_id(self, client):
@@ -901,11 +925,13 @@ class SkvbcTracker:
         with log.start_action(action_type="run_concurrent_ops"):
             max_concurrency = len(self.bft_network.clients) // 2
             max_size = len(self.skvbc.keys) // 2
-            return await self.send_concurrent_ops(num_ops, max_concurrency, max_size, write_weight, create_conflicts=True)
+            return await self.send_concurrent_ops(num_ops, max_concurrency, max_size, write_weight,
+                                                  create_conflicts=True)
 
     async def run_concurrent_conflict_ops(self, num_ops, write_weight=.70):
         if self.no_conflicts is True:
-            print("call to run_concurrent_conflict_ops with no_conflicts=True, calling run_concurrent_ops instead")
+            log.log_message(message_type="call to run_concurrent_conflict_ops with no_conflicts=True,"
+                                         " calling run_concurrent_ops instead")
             return await self.run_concurrent_ops(num_ops, write_weight)
         max_concurrency = len(self.bft_network.clients) // 2
         max_size = len(self.skvbc.keys) // 2
@@ -1027,8 +1053,8 @@ class SkvbcTracker:
         kv = [(keys[0], self.skvbc.random_value()),
               (keys[1], self.skvbc.random_value())]
 
-        #reply = await client.write(self.write_req([], kv, 0))
-        #reply = self.parse_reply(reply)
+        # reply = await client.write(self.write_req([], kv, 0))
+        # reply = self.parse_reply(reply)
         reply = await self.write_and_track_known_kv(kv, client)
         assert reply.success
         assert last_block + 1 == reply.last_block_id
@@ -1041,6 +1067,7 @@ class SkvbcTracker:
         kv2 = self.skvbc.parse_reply(data)
 
         assert kv2 == dict(kv)
+
 
 class PassThroughSkvbcTracker:
 
@@ -1097,7 +1124,8 @@ class PassThroughSkvbcTracker:
 
     async def run_concurrent_conflict_ops(self, num_ops, write_weight=.70):
         if self.no_conflicts is True:
-            print("call to run_concurrent_conflict_ops with no_conflicts=True, calling run_concurrent_ops instead")
+            log.log_message(message_type="call to run_concurrent_conflict_ops with no_conflicts=True,"
+                                         " calling run_concurrent_ops instead")
             await self.run_concurrent_ops(num_ops, write_weight)
             return
         max_concurrency = len(self.bft_network.clients) // 2


### PR DESCRIPTION
In this PR I replaced all Apollo's print statements with Eliot's log statements.
Added Eliot's `@log_call` decorator to `def interesting_configs(selected=None)` - prints the configurations under which the test will run. 

Decorator example:
![image](https://user-images.githubusercontent.com/45912772/94689385-7bcc4000-0337-11eb-9d47-80f003e2b3ae.png)



*Eliot's logs total size is 70MB.
56MB comes from one test 'test_skvbc_persistence.py' - can be decreased significantly by removing the action from `async def is_fetching(self, replica_id)`

*Removing the action mentioned above, reduced 24MB from Eliot's logs file.