### PR TITLE
Diagnostics histograms

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -73,8 +73,8 @@ void ReplicaImp::registerStatusHandlers() {
   auto replica_handler = make_handler_callback("replica", "Internal state of the concord-bft replica");
   auto state_transfer_handler = make_handler_callback("state-transfer", "Status of blockchain state transfer");
 
-  registrar.registerStatusHandler(replica_handler);
-  registrar.registerStatusHandler(state_transfer_handler);
+  registrar.status.registerHandler(replica_handler);
+  registrar.status.registerHandler(state_transfer_handler);
 }
 
 void ReplicaImp::registerMsgHandlers() {

--- a/diagnostics/CMakeLists.txt
+++ b/diagnostics/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required (VERSION 3.2)
 project(libdiagnostics VERSION 0.1.0.0 LANGUAGES CXX)
 
-add_library(diagnostics src/status_handlers.cpp)
-target_include_directories(diagnostics PUBLIC include)
+find_path(HDR_HISTOGRAM_INCLUDE_DIR "hdr_interval_recorder.h" HINTS /usr/local/include/hdr REQUIRED)
+find_library(HDR_HISTOGRAM hdr_histogram HINTS /usr/local/lib REQUIRED)
+
+add_library(diagnostics src/status_handlers.cpp src/performance_handler.cpp)
+target_include_directories(diagnostics PUBLIC include ${HDR_HISTOGRAM_INCLUDE_DIR})
+target_link_libraries(diagnostics ${HDR_HISTOGRAM})
 
 if (BUILD_TESTING)
     add_subdirectory(test)

--- a/diagnostics/CMakeLists.txt
+++ b/diagnostics/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required (VERSION 3.2)
 project(libdiagnostics VERSION 0.1.0.0 LANGUAGES CXX)
 
-add_library(diagnostics INTERFACE)
-target_link_libraries(diagnostics INTERFACE)
-target_include_directories(diagnostics INTERFACE include)
+add_library(diagnostics src/status_handlers.cpp)
+target_include_directories(diagnostics PUBLIC include)
 
 if (BUILD_TESTING)
     add_subdirectory(test)

--- a/diagnostics/concord-ctl
+++ b/diagnostics/concord-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import socket

--- a/diagnostics/include/diagnostics.h
+++ b/diagnostics/include/diagnostics.h
@@ -17,12 +17,14 @@
 #include <mutex>
 #include <stdexcept>
 
+#include "performance_handler.h"
 #include "status_handlers.h"
 
 namespace concord::diagnostics {
 
 class Registrar {
  public:
+  PerformanceHandler perf;
   StatusHandlers status;
 };
 

--- a/diagnostics/include/diagnostics.h
+++ b/diagnostics/include/diagnostics.h
@@ -17,73 +17,13 @@
 #include <mutex>
 #include <stdexcept>
 
-namespace concord::diagnostics {
+#include "status_handlers.h"
 
-// Every component that can return status should register a status handler with the Registrar.
-struct StatusHandler {
-  StatusHandler(std::string name, std::string description, std::function<std::string()> fun)
-      : name(std::move(name)), description(std::move(description)), f(std::move(fun)) {}
-  std::string name;
-  std::string description;
-  std::function<std::string()> f;
-};
+namespace concord::diagnostics {
 
 class Registrar {
  public:
-  void registerStatusHandler(StatusHandler handler) {
-    std::lock_guard<std::mutex> guard(mutex_);
-    if (status_handlers_.count(handler.name)) {
-      throw std::invalid_argument(std::string("StatusHandler already exists: ") + handler.name);
-    }
-    status_handlers_.insert({handler.name, handler});
-  }
-
-  std::string getStatus(const std::string& name) const {
-    std::lock_guard<std::mutex> guard(mutex_);
-    if (status_handlers_.count(name)) {
-      return status_handlers_.at(name).f();
-    }
-    return "*--STATUS_NOT_FOUND--*";
-  }
-
-  std::string describeStatus(const std::string& name) const {
-    std::lock_guard<std::mutex> guard(mutex_);
-    if (status_handlers_.count(name)) {
-      return status_handlers_.at(name).description;
-    }
-    return "*--DESCRIPTION_NOT_FOUND--*";
-  }
-
-  std::string describeStatus() const {
-    std::string output;
-    std::lock_guard<std::mutex> guard(mutex_);
-    for (const auto& [_, handler] : status_handlers_) {
-      (void)_;  // undefined variable hack
-      output += "\n" + handler.name + "\n  ";
-      output += handler.description + "\n";
-    }
-    return output;
-  }
-
-  std::string listStatusKeys() const {
-    std::lock_guard<std::mutex> guard(mutex_);
-    std::string output;
-    for (const auto& [key, _] : status_handlers_) {
-      (void)_;  // unused variable hack
-      output += key + "\n";
-    }
-    return output;
-  }
-
-  // DO NOT USE THIS IN PRODUCTION. THIS IS ONLY FOR TESTING, SO THAT WE CAN CLEAR THE SINGLETON AND REREGISTER.
-  void clearStatusHandlers() {
-    std::lock_guard<std::mutex> guard(mutex_);
-    status_handlers_.clear();
-  }
-
- private:
-  std::map<std::string, StatusHandler> status_handlers_;
-  mutable std::mutex mutex_;
+  StatusHandlers status;
 };
 
 // Singleton wrapper class for a Registrar.

--- a/diagnostics/include/diagnostics_server.h
+++ b/diagnostics/include/diagnostics_server.h
@@ -90,7 +90,7 @@ std::string readline(int sock) {
   }
 }
 
-void handleRequest(const Registrar& registrar, int sock) {
+void handleRequest(Registrar& registrar, int sock) {
   try {
     std::stringstream ss(readline(sock));
     std::vector<std::string> tokens;
@@ -120,7 +120,7 @@ void handleRequest(const Registrar& registrar, int sock) {
 // use case.
 class Server {
  public:
-  void start(const Registrar& registrar, in_addr_t host, uint16_t port) {
+  void start(Registrar& registrar, in_addr_t host, uint16_t port) {
     shutdown_.store(false);
     listen_thread_ = std::thread([this, &registrar, host, port]() {
       listen(host, port);

--- a/diagnostics/include/performance_handler.h
+++ b/diagnostics/include/performance_handler.h
@@ -1,0 +1,245 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <map>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <stdexcept>
+
+#include <hdr/hdr_interval_recorder.h>
+
+#include "assertUtils.hpp"
+#include "Logger.hpp"
+
+namespace concord::diagnostics {
+
+static logging::Logger DIAG_LOGGER = logging::getLogger("concord.diagnostics");
+
+enum class Unit {
+  NANOSECONDS,
+  MICROSECONDS,
+  MILLISECONDS,
+  SECONDS,
+  MINUTES,
+
+  BYTES,
+  KB,
+  MB,
+  GB,
+
+  // Things like queue length, size of a map, etc..
+  COUNT
+};
+
+// A recorder is a thread-safe type that should always be created in a shared pointer to ensure
+// proper destruction. The recorder is used to add values to the histogram in the recording thread.
+// Interval histograms can be extracted in other threads.
+struct Recorder {
+  // These values, (except for unit), come directly from hdr histogram.
+  // https://github.com/HdrHistogram/HdrHistogram_c/blob/master/src/hdr_interval_recorder.h#L28-L32
+  Recorder(int64_t lowest_trackable_value, int64_t highest_trackable_value, int significant_figures, Unit unit)
+      : unit(unit) {
+    ConcordAssert(lowest_trackable_value > 0);
+    auto rv =
+        hdr_interval_recorder_init_all(&recorder, lowest_trackable_value, highest_trackable_value, significant_figures);
+    ConcordAssertEQ(0, rv);
+  }
+
+  ~Recorder() { hdr_interval_recorder_destroy(&recorder); }
+  Recorder(const Recorder&) = delete;
+  Recorder& operator=(const Recorder&) = delete;
+
+  void record(int64_t val) {
+    if (!hdr_interval_recorder_record_value(&(recorder), val)) {
+      // We don't track the name in recorder, which we would do just for this, which is almost impossible to hit.
+      LOG_WARN(DIAG_LOGGER, "Failed to record value: " << KVLOG(val, unit));
+    }
+  }
+
+  hdr_interval_recorder recorder;
+  Unit unit;
+};
+
+struct Histogram {
+  Histogram(const std::shared_ptr<Recorder>& recorder)
+      : recorder(recorder), start(std::chrono::system_clock::now()), snapshot_start(start), snapshot_end(start) {
+    snapshot = hdr_interval_recorder_sample_and_recycle(&(recorder->recorder), snapshot);
+    auto rv = hdr_init(
+        snapshot->lowest_trackable_value, snapshot->highest_trackable_value, snapshot->significant_figures, &history);
+    ConcordAssertEQ(0, rv);
+  }
+
+  ~Histogram() {
+    hdr_close(snapshot);
+    hdr_close(history);
+    snapshot = nullptr;
+    history = nullptr;
+  }
+
+  Histogram(const Histogram&) = delete;
+  Histogram& operator=(const Histogram&) = delete;
+
+  void takeSnapshot() {
+    snapshot_start = snapshot_end;
+    snapshot_end = std::chrono::system_clock::now();
+    // Add the previous snapshot to the history
+    if (int64_t discarded = hdr_add(history, snapshot) != 0) {
+      // This should be impossible to hit, according to hdrHistogram docs, since the histograms have the same
+      // trackable values.
+      LOG_ERROR(DIAG_LOGGER,
+                "Failed to update history: " << KVLOG(discarded,
+                                                      snapshot->lowest_trackable_value,
+                                                      snapshot->highest_trackable_value,
+                                                      history->lowest_trackable_value,
+                                                      history->highest_trackable_value));
+    }
+    snapshot = hdr_interval_recorder_sample_and_recycle(&(recorder->recorder), snapshot);
+  }
+
+  std::shared_ptr<Recorder> recorder;
+
+  std::chrono::system_clock::time_point start;
+  std::chrono::system_clock::time_point snapshot_start;
+  std::chrono::system_clock::time_point snapshot_end;
+
+  // The histogram interval starting from when the last snapshot was taken
+  hdr_histogram* snapshot = nullptr;
+
+  // History doesn't include the latest snapshot.
+  hdr_histogram* history = nullptr;
+};
+
+using Name = std::string;
+using Recorders = std::map<Name, std::shared_ptr<Recorder>>;
+using Histograms = std::map<Name, Histogram>;
+
+// Useful data extracted from hdr_histogram(s)
+//
+// By extracting this data we can return it in a thread-safe manner, without having to copy the
+// entire histogram.
+//
+// We specifically don't return the average, as it's a completely meaningless metric.
+struct HistogramValues {
+  HistogramValues(hdr_histogram* h) : memory_used(hdr_get_memory_size(h)) {
+    max = hdr_max(h);
+    if (max == 0) return;  // Histogram is empty
+    min = hdr_min(h);
+    count = h->total_count;
+    pct_10 = hdr_value_at_percentile(h, 10);
+    pct_25 = hdr_value_at_percentile(h, 25);
+    pct_50 = hdr_value_at_percentile(h, 50);
+    pct_75 = hdr_value_at_percentile(h, 75);
+    pct_90 = hdr_value_at_percentile(h, 90);
+    pct_95 = hdr_value_at_percentile(h, 95);
+    pct_99 = hdr_value_at_percentile(h, 99);
+    pct_99_9 = hdr_value_at_percentile(h, 99.9);
+    pct_99_99 = hdr_value_at_percentile(h, 99.99);
+    pct_99_999 = hdr_value_at_percentile(h, 99.999);
+  }
+
+  bool operator==(const HistogramValues& other) const {
+    return count == other.count && min == other.min && max == other.max && pct_10 == other.pct_10 &&
+           pct_25 == other.pct_25 && pct_50 == other.pct_50 && pct_75 == other.pct_75 && pct_90 == other.pct_90 &&
+           pct_95 == other.pct_95 && pct_99 == other.pct_99 && pct_99_9 == other.pct_99 &&
+           pct_99_99 == other.pct_99_99 && pct_99_999 == other.pct_99_999;
+  }
+  bool operator!=(const HistogramValues& other) const { return !(*this == other); }
+
+  size_t memory_used;
+  int64_t count = 0;
+  int64_t min = 0;
+  int64_t max = 0;
+  int64_t pct_10 = 0;
+  int64_t pct_25 = 0;
+  int64_t pct_50 = 0;
+  int64_t pct_75 = 0;
+  int64_t pct_90 = 0;
+  int64_t pct_95 = 0;
+  int64_t pct_99 = 0;
+  int64_t pct_99_9 = 0;
+  int64_t pct_99_99 = 0;
+  int64_t pct_99_999 = 0;
+};
+
+struct HistogramData {
+  HistogramData(const Histogram& h)
+      : HistogramData(h.start,
+                      h.snapshot_start,
+                      h.snapshot_end,
+                      h.recorder->unit,
+                      HistogramValues(h.history),
+                      HistogramValues(h.snapshot)) {}
+
+  HistogramData(const std::chrono::system_clock::time_point& start,
+                const std::chrono::system_clock::time_point& snapshot_start,
+                const std::chrono::system_clock::time_point& snapshot_end,
+                Unit unit,
+                const HistogramValues& history,
+                const HistogramValues& last_snapshot)
+      : start(start),
+        snapshot_start(snapshot_start),
+        snapshot_end(snapshot_end),
+        unit(unit),
+        history(history),
+        last_snapshot(last_snapshot) {}
+
+  bool operator==(const HistogramData& other) const {
+    return start == other.start && snapshot_start == other.snapshot_start && snapshot_end == other.snapshot_end &&
+           unit == other.unit && history == other.history && last_snapshot == other.last_snapshot;
+  }
+  bool operator!=(const HistogramData& other) const { return !(*this == other); }
+
+  std::chrono::system_clock::time_point start;
+  std::chrono::system_clock::time_point snapshot_start;
+  std::chrono::system_clock::time_point snapshot_end;
+  Unit unit;
+  HistogramValues history;
+  HistogramValues last_snapshot;
+};
+
+class PerformanceHandler {
+ public:
+  void registerComponent(const std::string& name, const Recorders&);
+
+  // List all components
+  std::string list() const;
+
+  // List all metrics for a given component
+  std::string list(const std::string& component_name) const;
+
+  std::map<Name, HistogramData> get(const std::string& component) const;
+  HistogramData get(const std::string& component, const std::string& histogram) const;
+
+  std::string toString(const std::map<Name, HistogramData>&) const;
+  std::string toString(const HistogramData&) const;
+
+  // Snapshot all histograms for the given component
+  void snapshot(const std::string& component);
+
+ private:
+  Histograms& getHistograms(const std::string& component_name);
+  Histogram& getHistogram(const std::string& component_name, const std::string& histogram_name);
+  const Histograms& getHistograms(const std::string& component_name) const;
+  const Histogram& getHistogram(const std::string& component_name, const std::string& histogram_name) const;
+
+  std::map<std::string, Histograms> components_;
+  mutable std::mutex mutex_;
+};
+
+std::ostream& operator<<(std::ostream& os, const HistogramValues&);
+std::ostream& operator<<(std::ostream& os, const HistogramData&);
+std::ostream& operator<<(std::ostream& os, const Unit&);
+
+}  // namespace concord::diagnostics

--- a/diagnostics/include/protocol.h
+++ b/diagnostics/include/protocol.h
@@ -34,7 +34,14 @@ std::string usage() {
   usage += "    status describe [KEY1] [KEY2]..[KEY_N]\n";
   usage += "        Get the description of the given keys, or all keys if none is given.\n\n";
   usage += "    status list-keys\n";
-  usage += "        List all status keys.";
+  usage += "        List all status keys.\n\n";
+  usage += "  perf <COMMAND> [ARGS]\n\n";
+  usage += "    perf get <COMPONENT> [HISTOGRAM]\n";
+  usage += "        Get all histograms for <COMPONENT> or a specific [HISTOGRAM]\n\n";
+  usage += "    perf list [COMPONENT]\n";
+  usage += "        List all components or all histograms for a given [COMPONENT]\n\n";
+  usage += "    perf snapshot <COMPONENT1> [COMPONENT2]...[COMPONENT_N]\n";
+  usage += "        Snapshot all histograms for the given components.";
   return usage;
 }
 
@@ -48,7 +55,7 @@ std::string accumulate(Iterator begin, Iterator end, Fun f) {
 }
 
 // Take protocol input as a split string, along with a registrar and return diagnostics or a usage string.
-std::string run(const std::vector<std::string>& tokens, const Registrar& registrar) {
+std::string run(const std::vector<std::string>& tokens, Registrar& registrar) {
   if (tokens.size() < 2) return usage();
 
   auto& subject = tokens[0];
@@ -74,6 +81,44 @@ std::string run(const std::vector<std::string>& tokens, const Registrar& registr
     if (command == "list-keys") {
       if (tokens.size() != 2) return usage();
       return registrar.status.listKeys();
+    }
+  }
+
+  if (subject == "perf") {
+    try {
+      if (command == "get") {
+        if (tokens.size() == 3) {
+          return registrar.perf.toString(registrar.perf.get(tokens[2]));
+        }
+        if (tokens.size() == 4) {
+          return registrar.perf.toString(registrar.perf.get(tokens[2], tokens[3]));
+        }
+        return usage();
+      }
+      if (command == "list") {
+        if (tokens.size() == 2) {
+          return registrar.perf.list();
+        }
+        if (tokens.size() == 3) {
+          return registrar.perf.list(tokens[2]);
+        }
+        return usage();
+      }
+      if (command == "snapshot") {
+        if (tokens.size() < 3) return usage();
+        // Eliminate duplicate components. Otherwise snapshots will occur multiple times, probably
+        // with no samples in between. This will almost always be due to a typo, and is a fairly
+        // useless behavior, so eliminate the possibility.
+        std::vector<std::string> components(tokens.begin() + 2, tokens.end());
+        std::sort(components.begin(), components.end());
+        components.erase(std::unique(components.begin(), components.end()), components.end());
+        for (auto it = components.begin(); it != components.end(); it++) {
+          registrar.perf.snapshot(*it);
+        }
+        return "";
+      }
+    } catch (const std::exception& e) {
+      return e.what();
     }
   }
 

--- a/diagnostics/include/protocol.h
+++ b/diagnostics/include/protocol.h
@@ -56,10 +56,10 @@ std::string run(const std::vector<std::string>& tokens, const Registrar& registr
   if (subject == "status") {
     if (command == "describe") {
       if (tokens.size() == 2) {
-        return registrar.describeStatus();
+        return registrar.status.describe();
       } else {
         return diagnostics::accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
-          return registrar.describeStatus(key);
+          return registrar.status.describe(key);
         });
       }
     }
@@ -67,13 +67,13 @@ std::string run(const std::vector<std::string>& tokens, const Registrar& registr
     if (command == "get") {
       if (tokens.size() < 3) return usage();
       return diagnostics::accumulate(tokens.begin() + 2, tokens.end(), [&registrar](const auto& key) -> std::string {
-        return registrar.getStatus(key);
+        return registrar.status.get(key);
       });
     }
 
     if (command == "list-keys") {
       if (tokens.size() != 2) return usage();
-      return registrar.listStatusKeys();
+      return registrar.status.listKeys();
     }
   }
 

--- a/diagnostics/include/status_handlers.h
+++ b/diagnostics/include/status_handlers.h
@@ -1,0 +1,50 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <functional>
+#include <map>
+#include <mutex>
+#include <stdexcept>
+
+namespace concord::diagnostics {
+
+// Every component that can return status should register a status handler with the Registrar.
+struct StatusHandler {
+  StatusHandler(std::string name, std::string description, std::function<std::string()> fun)
+      : name(std::move(name)), description(std::move(description)), f(std::move(fun)) {}
+  std::string name;
+  std::string description;
+  std::function<std::string()> f;
+};
+
+class StatusHandlers {
+ public:
+  void registerHandler(StatusHandler handler);
+  std::string get(const std::string& name) const;
+  std::string describe(const std::string& name) const;
+  std::string describe() const;
+  std::string listKeys() const;
+
+  // DO NOT USE THIS IN PRODUCTION. THIS IS ONLY FOR TESTING, SO THAT WE CAN CLEAR THE SINGLETON AND REREGISTER.
+  void clear() {
+    std::lock_guard<std::mutex> guard(mutex_);
+    status_handlers_.clear();
+  }
+
+  std::map<std::string, StatusHandler> status_handlers_;
+  mutable std::mutex mutex_;
+};
+
+}  // namespace concord::diagnostics

--- a/diagnostics/include/status_handlers.h
+++ b/diagnostics/include/status_handlers.h
@@ -31,7 +31,7 @@ struct StatusHandler {
 
 class StatusHandlers {
  public:
-  void registerHandler(StatusHandler handler);
+  void registerHandler(const StatusHandler& handler);
   std::string get(const std::string& name) const;
   std::string describe(const std::string& name) const;
   std::string describe() const;

--- a/diagnostics/src/performance_handler.cpp
+++ b/diagnostics/src/performance_handler.cpp
@@ -1,0 +1,200 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <iomanip>
+
+#include "performance_handler.h"
+
+namespace concord::diagnostics {
+
+void PerformanceHandler::registerComponent(const std::string& name, const Recorders& recorders) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (components_.count(name)) {
+    throw std::invalid_argument(std::string("Component already exists: ") + name);
+  }
+  Histograms histograms;
+  for (const auto& [name, recorder] : recorders) {
+    histograms.emplace(name, recorder);
+  }
+  components_.insert({name, std::move(histograms)});
+}
+
+std::string PerformanceHandler::list() const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  std::string output;
+  for (const auto& [name, _] : components_) {
+    (void)_;  // unused variable hack
+    output += name + "\n";
+  }
+  return output;
+}
+
+std::string PerformanceHandler::list(const std::string& component_name) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  std::string output;
+  for (const auto& [name, _] : getHistograms(component_name)) {
+    (void)_;  // unused variable hack
+    output += name + "\n";
+  }
+  return output;
+}
+
+std::map<Name, HistogramData> PerformanceHandler::get(const std::string& name) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  std::map<Name, HistogramData> data;
+  for (const auto& [name, histogram] : getHistograms(name)) {
+    data.try_emplace(name,
+                     histogram.start,
+                     histogram.snapshot_start,
+                     histogram.snapshot_end,
+                     histogram.recorder->unit,
+                     histogram.history,
+                     histogram.snapshot);
+  }
+  return data;
+}
+
+HistogramData PerformanceHandler::get(const std::string& component_name, const std::string& histogram_name) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  return HistogramData(getHistogram(component_name, histogram_name));
+}
+
+void PerformanceHandler::snapshot(const std::string& name) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  for (auto& h : getHistograms(name)) {
+    h.second.takeSnapshot();
+  }
+}
+
+Histograms& PerformanceHandler::getHistograms(const std::string& name) {
+  try {
+    return components_.at(name);
+  } catch (...) {
+    throw std::invalid_argument(std::string("Component Not Found: ") + name);
+  }
+}
+
+Histogram& PerformanceHandler::getHistogram(const std::string& component_name, const std::string& histogram_name) {
+  auto& histograms = getHistograms(component_name);
+  try {
+    return histograms.at(histogram_name);
+  } catch (...) {
+    throw std::invalid_argument(std::string("Histogram Not Found: ") + component_name + "/" + histogram_name);
+  }
+}
+
+const Histograms& PerformanceHandler::getHistograms(const std::string& name) const {
+  try {
+    return components_.at(name);
+  } catch (...) {
+    throw std::invalid_argument(std::string("Component Not Found: ") + name);
+  }
+}
+
+const Histogram& PerformanceHandler::getHistogram(const std::string& component_name,
+                                                  const std::string& histogram_name) const {
+  auto& histograms = getHistograms(component_name);
+  try {
+    return histograms.at(histogram_name);
+  } catch (...) {
+    throw std::invalid_argument(std::string("Histogram Not Found: ") + component_name + "/" + histogram_name);
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const HistogramValues& values) {
+  os << "Count: " << values.count << std::endl;
+  os << "Max: " << values.max << std::endl;
+  os << "Min: " << values.min << std::endl;
+  os << "Percentiles: " << std::endl;
+  os << "  10: " << values.pct_10 << std::endl;
+  os << "  25: " << values.pct_25 << std::endl;
+  os << "  50: " << values.pct_50 << std::endl;
+  os << "  75: " << values.pct_75 << std::endl;
+  os << "  90: " << values.pct_90 << std::endl;
+  os << "  95: " << values.pct_95 << std::endl;
+  os << "  99: " << values.pct_99 << std::endl;
+  os << "  99.9: " << values.pct_99_9 << std::endl;
+  os << "  99.99: " << values.pct_99_99 << std::endl;
+  os << "  99.999: " << values.pct_99_999 << std::endl;
+  return os;
+}
+
+using std::chrono::system_clock;
+
+std::ostream& operator<<(std::ostream& os, const HistogramData& data) {
+  auto start = system_clock::to_time_t(data.start);
+  auto snapshot_start = system_clock::to_time_t(data.snapshot_start);
+  auto snapshot_end = system_clock::to_time_t(data.snapshot_end);
+
+  os << "Start time (UTC): " << std::put_time(std::gmtime(&start), "%F %T") << std::endl;
+  os << "Snapshot Start time (UTC): " << std::put_time(std::gmtime(&snapshot_start), "%F %T") << std::endl;
+  os << "Snapshot End time (UTC): " << std::put_time(std::gmtime(&snapshot_end), "%F %T") << std::endl;
+  os << "Unit: " << data.unit << std::endl << std::endl;
+  os << "History" << std::endl << "--------------------" << std::endl;
+  os << data.history << std::endl;
+  os << "Snapshot" << std::endl << "--------------------" << std::endl;
+  os << data.last_snapshot;
+  return os;
+}
+
+std::string PerformanceHandler::toString(const std::map<Name, HistogramData>& hist_data) const {
+  std::ostringstream oss;
+  for (const auto& [name, data] : hist_data) {
+    oss << name << std::endl << "====================" << std::endl << data << std::endl;
+  }
+  return oss.str();
+}
+
+std::string PerformanceHandler::toString(const HistogramData& data) const {
+  std::ostringstream oss;
+  oss << data;
+  return oss.str();
+}
+
+std::ostream& operator<<(std::ostream& os, const Unit& unit) {
+  switch (unit) {
+    case Unit::NANOSECONDS:
+      os << "nanoseconds";
+      break;
+    case Unit::MICROSECONDS:
+      os << "microseconds";
+      break;
+    case Unit::MILLISECONDS:
+      os << "milliseconds";
+      break;
+    case Unit::SECONDS:
+      os << "seconds";
+      break;
+    case Unit::MINUTES:
+      os << "minutes";
+      break;
+    case Unit::BYTES:
+      os << "bytes";
+      break;
+    case Unit::KB:
+      os << "kb";
+      break;
+    case Unit::MB:
+      os << "mb";
+      break;
+    case Unit::GB:
+      os << "mb";
+      break;
+    case Unit::COUNT:
+      os << "count";
+      break;
+  }
+  return os;
+}
+
+}  // namespace concord::diagnostics

--- a/diagnostics/src/status_handlers.cpp
+++ b/diagnostics/src/status_handlers.cpp
@@ -1,0 +1,63 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "status_handlers.h"
+
+namespace concord::diagnostics {
+
+void StatusHandlers::registerHandler(StatusHandler handler) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (status_handlers_.count(handler.name)) {
+    throw std::invalid_argument(std::string("StatusHandler already exists: ") + handler.name);
+  }
+  status_handlers_.insert({handler.name, handler});
+}
+
+std::string StatusHandlers::get(const std::string& name) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (status_handlers_.count(name)) {
+    return status_handlers_.at(name).f();
+  }
+  return "*--STATUS_NOT_FOUND--*";
+}
+
+std::string StatusHandlers::describe(const std::string& name) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (status_handlers_.count(name)) {
+    return status_handlers_.at(name).description;
+  }
+  return "*--DESCRIPTION_NOT_FOUND--*";
+}
+
+std::string StatusHandlers::describe() const {
+  std::string output;
+  std::lock_guard<std::mutex> guard(mutex_);
+  for (const auto& [_, handler] : status_handlers_) {
+    (void)_;  // undefined variable hack
+    output += "\n" + handler.name + "\n  ";
+    output += handler.description + "\n";
+  }
+  return output;
+}
+
+std::string StatusHandlers::listKeys() const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  std::string output;
+  for (const auto& [key, _] : status_handlers_) {
+    (void)_;  // unused variable hack
+    output += key + "\n";
+  }
+  return output;
+}
+
+};  // namespace concord::diagnostics

--- a/diagnostics/src/status_handlers.cpp
+++ b/diagnostics/src/status_handlers.cpp
@@ -15,7 +15,7 @@
 
 namespace concord::diagnostics {
 
-void StatusHandlers::registerHandler(StatusHandler handler) {
+void StatusHandlers::registerHandler(const StatusHandler& handler) {
   std::lock_guard<std::mutex> guard(mutex_);
   if (status_handlers_.count(handler.name)) {
     throw std::invalid_argument(std::string("StatusHandler already exists: ") + handler.name);
@@ -60,4 +60,4 @@ std::string StatusHandlers::listKeys() const {
   return output;
 }
 
-};  // namespace concord::diagnostics
+}  // namespace concord::diagnostics

--- a/diagnostics/test/CMakeLists.txt
+++ b/diagnostics/test/CMakeLists.txt
@@ -7,3 +7,7 @@ target_link_libraries(diagnostics_tests PRIVATE GTest::Main diagnostics)
 
 add_executable(diagnostics_server_main main.cpp )
 target_link_libraries(diagnostics_server_main PRIVATE diagnostics Threads::Threads)
+
+add_executable(histogram_tests histogram_tests.cpp)
+add_test(histogram_tests histogram_tests)
+target_link_libraries(histogram_tests PRIVATE GTest::Main diagnostics)

--- a/diagnostics/test/diagnostics_tests.cpp
+++ b/diagnostics/test/diagnostics_tests.cpp
@@ -58,30 +58,30 @@ StatusHandler async_handler2(async_handler_name2, async_handler_description, [](
 
 TEST(diagnostics_tests, status_registration) {
   Registrar registrar;
-  registrar.registerStatusHandler(sync_handler);
-  registrar.registerStatusHandler(async_handler);
-  registrar.registerStatusHandler(async_handler2);
-  ASSERT_EQ(sync_handler_status, registrar.getStatus(sync_handler_name));
-  ASSERT_EQ(sync_handler_description, registrar.describeStatus(sync_handler_name));
-  ASSERT_EQ(async_handler_status, registrar.getStatus(async_handler_name));
-  ASSERT_EQ(async_handler_description, registrar.describeStatus(async_handler_name));
-  ASSERT_EQ(async_handler_status, registrar.getStatus(async_handler_name2));
-  ASSERT_EQ(async_handler_description, registrar.describeStatus(async_handler_name2));
+  registrar.status.registerHandler(sync_handler);
+  registrar.status.registerHandler(async_handler);
+  registrar.status.registerHandler(async_handler2);
+  ASSERT_EQ(sync_handler_status, registrar.status.get(sync_handler_name));
+  ASSERT_EQ(sync_handler_description, registrar.status.describe(sync_handler_name));
+  ASSERT_EQ(async_handler_status, registrar.status.get(async_handler_name));
+  ASSERT_EQ(async_handler_description, registrar.status.describe(async_handler_name));
+  ASSERT_EQ(async_handler_status, registrar.status.get(async_handler_name2));
+  ASSERT_EQ(async_handler_description, registrar.status.describe(async_handler_name2));
 
-  ASSERT_EQ("*--STATUS_NOT_FOUND--*", registrar.getStatus("no such handler"));
-  ASSERT_EQ("*--DESCRIPTION_NOT_FOUND--*", registrar.describeStatus("no such handler"));
+  ASSERT_EQ("*--STATUS_NOT_FOUND--*", registrar.status.get("no such handler"));
+  ASSERT_EQ("*--DESCRIPTION_NOT_FOUND--*", registrar.status.describe("no such handler"));
 
-  ASSERT_EQ(keylist, registrar.listStatusKeys());
-  std::cout << registrar.describeStatus() << std::endl;
-  std::cout << registrar.listStatusKeys() << std::endl;
+  ASSERT_EQ(keylist, registrar.status.listKeys());
+  std::cout << registrar.status.describe() << std::endl;
+  std::cout << registrar.status.listKeys() << std::endl;
 }
 
 // This tests is really just for visual confirmation, since strings are always returned.
 TEST(diagnostics_tests, protocol) {
   Registrar registrar;
-  registrar.registerStatusHandler(sync_handler);
-  registrar.registerStatusHandler(async_handler);
-  registrar.registerStatusHandler(async_handler2);
+  registrar.status.registerHandler(sync_handler);
+  registrar.status.registerHandler(async_handler);
+  registrar.status.registerHandler(async_handler2);
 
   // No parameters trigger usage to be displayed.
   ASSERT_EQ(0, std::memcmp("Usage:", run({}, registrar).c_str(), 6));

--- a/diagnostics/test/histogram_tests.cpp
+++ b/diagnostics/test/histogram_tests.cpp
@@ -1,0 +1,74 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "performance_handler.h"
+
+using namespace concord::diagnostics;
+
+// 5 Minutes
+static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60 * 5;
+
+TEST(histogram_tests, snapshots) {
+  auto recorder = std::make_shared<Recorder>(1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  PerformanceHandler handler;
+  const std::string component_name("test_replica");
+  const std::string hist_name("some_histogram");
+
+  handler.registerComponent(component_name, {{hist_name, recorder}});
+  auto data = handler.get(component_name);
+  // The histograms are empty
+  auto hist_data = data.at(hist_name);
+  auto hist_data2 = handler.get(component_name, hist_name);
+  ASSERT_EQ(0, hist_data.history.max);
+  ASSERT_EQ(0, hist_data.last_snapshot.max);
+  ASSERT_EQ(hist_data, hist_data2);
+  auto snapshot_end = hist_data.snapshot_end;
+
+  // Add a value to the histogram
+  recorder->record(1);
+
+  // We haven't taken a snapshot yet to synchronize with the recorder (another thread in production)
+
+  hist_data = handler.get(component_name).at(hist_name);
+  hist_data2 = handler.get(component_name, hist_name);
+  ASSERT_EQ(0, hist_data.history.max);
+  ASSERT_EQ(0, hist_data.last_snapshot.max);
+  ASSERT_EQ(snapshot_end, hist_data.snapshot_end);
+  ASSERT_EQ(hist_data, hist_data2);
+
+  // Take a snapshot. This should not update the history.
+  handler.snapshot(component_name);
+  hist_data = handler.get(component_name).at(hist_name);
+  hist_data2 = handler.get(component_name, hist_name);
+  ASSERT_EQ(0, hist_data.history.max);
+  ASSERT_EQ(0, hist_data.history.count);
+  ASSERT_EQ(1, hist_data.last_snapshot.max);
+  ASSERT_EQ(1, hist_data.last_snapshot.count);
+  ASSERT_LT(snapshot_end, hist_data.snapshot_end);
+  ASSERT_EQ(hist_data, hist_data2);
+
+  snapshot_end = hist_data.snapshot_end;
+
+  // Taking another snapshot should move the prior snapshot into history
+  handler.snapshot(component_name);
+  hist_data = handler.get(component_name).at(hist_name);
+  hist_data2 = handler.get(component_name, hist_name);
+  ASSERT_EQ(1, hist_data.history.max);
+  ASSERT_EQ(0, hist_data.last_snapshot.max);
+  ASSERT_LT(snapshot_end, hist_data.snapshot_end);
+  ASSERT_EQ(hist_data, hist_data2);
+
+  ASSERT_ANY_THROW(handler.get("bad_replica"));
+  ASSERT_ANY_THROW(handler.get("test_replica", "bad_histogram"));
+}

--- a/diagnostics/test/main.cpp
+++ b/diagnostics/test/main.cpp
@@ -12,14 +12,22 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#include <chrono>
+#include <random>
+#include <thread>
 #include <unistd.h>
 
 #include "diagnostics.h"
 #include "diagnostics_server.h"
 
+using namespace std::chrono_literals;
+
 using namespace concord::diagnostics;
 
 static constexpr uint16_t PORT = 6888;
+
+// 5 Minutes
+static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60 * 5;
 
 int main() {
   Registrar registrar;
@@ -30,13 +38,41 @@ int main() {
   registrar.status.registerHandler(handler1);
   registrar.status.registerHandler(handler2);
 
+  auto recorder1 = std::make_shared<Recorder>(1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  auto recorder2 = std::make_shared<Recorder>(1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  auto recorder3 = std::make_shared<Recorder>(1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  auto recorder4 = std::make_shared<Recorder>(1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+
+  registrar.perf.registerComponent("component1", {{"histogram1", recorder1}, {"histogram2", recorder2}});
+  registrar.perf.registerComponent("component2", {{"histogram3", recorder3}, {"histogram4", recorder4}});
+
   concord::diagnostics::Server diagnostics_server;
   diagnostics_server.start(registrar, INADDR_LOOPBACK, PORT);
 
-  // Keep the diagnostics_server alive indefinitely
-  while (true) {
-    sleep(1);
-  }
+  // Periodically update histograms
+  auto thread1 = std::thread([&recorder1, &recorder2]() mutable {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> distrib(1, 1000000);
+    while (true) {
+      std::this_thread::sleep_for(50ms);
+      recorder1->record(distrib(gen));
+      recorder2->record(distrib(gen));
+    }
+  });
+  auto thread2 = std::thread([&recorder3, &recorder4]() mutable {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> distrib(1, 1000000);
+    while (true) {
+      std::this_thread::sleep_for(50ms);
+      recorder3->record(distrib(gen));
+      recorder4->record(distrib(gen));
+    }
+  });
+
+  thread1.join();
+  thread2.join();
 
   return 0;
 }

--- a/diagnostics/test/main.cpp
+++ b/diagnostics/test/main.cpp
@@ -27,8 +27,8 @@ int main() {
   StatusHandler handler1("handler1", "handler 1 description", []() { return "handler1 called"; });
   StatusHandler handler2("handler2", "handler 2 description", []() { return "handler2 called"; });
 
-  registrar.registerStatusHandler(handler1);
-  registrar.registerStatusHandler(handler2);
+  registrar.status.registerHandler(handler1);
+  registrar.status.registerHandler(handler2);
 
   concord::diagnostics::Server diagnostics_server;
   diagnostics_server.start(registrar, INADDR_LOOPBACK, PORT);

--- a/tests/simpleTest/persistency_test.cpp
+++ b/tests/simpleTest/persistency_test.cpp
@@ -50,7 +50,7 @@ class PersistencyTest : public testing::Test {
   }
 
   void create_and_run_replica(ReplicaParams rp, ISimpleTestReplicaBehavior *behv) {
-    concord::diagnostics::RegistrarSingleton::getInstance().clearStatusHandlers();
+    concord::diagnostics::RegistrarSingleton::getInstance().status.clear();
     rp.keysFilePrefix = "private_replica_";
     auto replica = std::shared_ptr<SimpleTestReplica>(SimpleTestReplica::create_replica(behv, rp, nullptr));
     replicas.push_back(replica);


### PR DESCRIPTION
Support for histograms was added to the diagnostics library. Histograms are based on the [C Implementation](https://github.com/HdrHistogram/HdrHistogram_c/) of [HdrHistogram](http://hdrhistogram.org/).

This PR consists of 2 logical commits. The first commit is a refactoring of the diagnostics status code. The second is support for histograms. Please read and review the commits independently.

A follow up commit, in a separate PR, will register components and histograms for the concord-bft codebase.

As a side note, I just noticed that there are no units in the histogram output. Each histogram registration should likely include units. I will add that. I just wanted to get this out ASAP for review.