### PR TITLE
Add implementation for each subclass of MessageBase to be created from MessageBase.

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -33,7 +33,8 @@ enum MsgFlag : uint8_t {
   READ_ONLY_FLAG = 0x1,
   PRE_PROCESS_FLAG = 0x2,
   HAS_PRE_PROCESSED_FLAG = 0x4,
-  KEY_EXCHANGE_FLAG = 0x8
+  KEY_EXCHANGE_FLAG = 0x8,
+  EMPTY_CLIENT_FLAG = 0x16
 };
 
 // The ControlHandlers is a group of method that enables the userRequestHandler to perform infrastructure

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -34,7 +34,7 @@ enum MsgFlag : uint8_t {
   PRE_PROCESS_FLAG = 0x2,
   HAS_PRE_PROCESSED_FLAG = 0x4,
   KEY_EXCHANGE_FLAG = 0x8,
-  EMPTY_CLIENT_FLAG = 0x16
+  EMPTY_CLIENT_FLAG = 0x10
 };
 
 // The ControlHandlers is a group of method that enables the userRequestHandler to perform infrastructure

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -35,7 +35,14 @@ struct SimpleClientParams {
 };
 
 // Possible values for 'flags' parameter
-enum ClientMsgFlag : uint8_t { EMPTY_FLAGS_REQ = 0x0, READ_ONLY_REQ = 0x1, PRE_PROCESS_REQ = 0x2 };
+enum ClientMsgFlag : uint8_t {
+  EMPTY_FLAGS_REQ = 0x0,
+  READ_ONLY_REQ = 0x1,
+  PRE_PROCESS_REQ = 0x2,
+  HAS_PRE_PROCESSED_REQ = 0x4,
+  KEY_EXCHANGE_REQ = 0x8,
+  EMPTY_CLIENT_REQ = 0x16
+};
 
 enum OperationResult : int8_t { SUCCESS, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL };
 

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -41,7 +41,7 @@ enum ClientMsgFlag : uint8_t {
   PRE_PROCESS_REQ = 0x2,
   HAS_PRE_PROCESSED_REQ = 0x4,
   KEY_EXCHANGE_REQ = 0x8,
-  EMPTY_CLIENT_REQ = 0x16
+  EMPTY_CLIENT_REQ = 0x10
 };
 
 enum OperationResult : int8_t { SUCCESS, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL };

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -125,10 +125,12 @@ void ReplicaImp::registerMsgHandlers() {
 
 template <typename T>
 void ReplicaImp::messageHandler(MessageBase *msg) {
-  if (validateMessage(msg) && !isCollectingState())
-    onMessage<T>(static_cast<T *>(msg));
+  T *trueTypeObj = new T(msg);
+  delete msg;
+  if (validateMessage(trueTypeObj) && !isCollectingState())
+    onMessage<T>(trueTypeObj);
   else
-    delete msg;
+    delete trueTypeObj;
 }
 
 template <class T>

--- a/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
@@ -26,6 +26,8 @@ class AskForCheckpointMsg : public MessageBase {
     memcpy(position, spanContext.data().data(), spanContext.data().size());
   }
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(AskForCheckpointMsg)
+
   AskForCheckpointMsg* clone() { return new AskForCheckpointMsg(*this); }
 
   void validate(const ReplicasInfo& repInfo) const override {

--- a/bftengine/src/bftengine/messages/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.hpp
@@ -25,6 +25,8 @@ class CheckpointMsg : public MessageBase {
                 bool stateIsStable,
                 const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(CheckpointMsg)
+
   SeqNum seqNumber() const { return b()->seqNum; }
 
   Digest& digestOfState() const { return b()->stateDigest; }

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -53,6 +53,11 @@ ClientRequestMsg::ClientRequestMsg(NodeIdType sender,
   memcpy(position, cid.data(), cid.size());
 }
 
+ClientRequestMsg::ClientRequestMsg(NodeIdType sender)
+    : MessageBase(sender, MsgCode::ClientRequest, 0, (sizeof(ClientRequestMsgHeader))) {
+  msgBody()->flags &= EMPTY_CLIENT_REQ;
+}
+
 ClientRequestMsg::ClientRequestMsg(ClientRequestMsgHeader* body)
     : MessageBase(getSender(body), (MessageBase::Header*)body, compRequestMsgSize(body), false) {}
 

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -38,6 +38,8 @@ class ClientRequestMsg : public MessageBase {
                    const std::string& cid = "",
                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  ClientRequestMsg(NodeIdType sender);
+
   BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(ClientRequestMsg)
 
   ClientRequestMsg(ClientRequestMsgHeader* body);

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -38,6 +38,8 @@ class ClientRequestMsg : public MessageBase {
                    const std::string& cid = "",
                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(ClientRequestMsg)
+
   ClientRequestMsg(ClientRequestMsgHeader* body);
 
   uint16_t clientProxyId() const { return msgBody()->idOfClientProxy; }

--- a/bftengine/src/bftengine/messages/FullCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/messages/FullCommitProofMsg.hpp
@@ -26,6 +26,8 @@ class FullCommitProofMsg : public MessageBase {
                      uint16_t commitProofSigLength,
                      const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(FullCommitProofMsg)
+
   ViewNum viewNumber() const { return b()->viewNum; }
 
   SeqNum seqNumber() const { return b()->seqNum; }

--- a/bftengine/src/bftengine/messages/MessageBase.cpp
+++ b/bftengine/src/bftengine/messages/MessageBase.cpp
@@ -14,6 +14,7 @@
 #include "MessageBase.hpp"
 #include "assertUtils.hpp"
 #include "ReplicaConfig.hpp"
+#include "Logger.hpp"
 
 #ifdef DEBUG_MEMORY_MSG
 #include <set>
@@ -105,6 +106,10 @@ MessageBase::MessageBase(NodeIdType sender, MessageBase::Header *body, MsgSize s
 #ifdef DEBUG_MEMORY_MSG
   liveMessagesDebug.insert(this);
 #endif
+}
+
+void MessageBase::validate(const ReplicasInfo &) const {
+  LOG_WARN(GL, "Calling MessageBase::validate on a message of type " << type());
 }
 
 void MessageBase::setMsgSize(MsgSize size) {

--- a/bftengine/src/bftengine/messages/MessageBase.hpp
+++ b/bftengine/src/bftengine/messages/MessageBase.hpp
@@ -48,7 +48,7 @@ class MessageBase {
 
   virtual ~MessageBase();
 
-  virtual void validate(const ReplicasInfo &) const {}
+  virtual void validate(const ReplicasInfo &) const;
 
   bool equals(const MessageBase &other) const;
 
@@ -114,6 +114,17 @@ class MessageBase {
   };
 #pragma pack(pop)
 };
+
+// Every subclass of MessageBase has to use this macro to generate a constructor for creation from MessageBase.
+// During deserialization we first place the raw char array that we receive with the actual message into the msgBody_
+// of a MessageBase object to be able to get the msgType. Later during dispatch we need to create an object of the
+// actual message type from the MessageBase object holding the msgBody_ of the actual message.
+#define BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(TrueTypeName)                                                     \
+  TrueTypeName(MessageBase *msgBase)                                                                                \
+      : MessageBase(                                                                                                \
+            msgBase->senderId(), reinterpret_cast<MessageBase::Header *>(msgBase->body()), msgBase->size(), true) { \
+    msgBase->releaseOwnership();                                                                                    \
+  }
 
 template <typename MessageT>
 size_t sizeOfHeader() {

--- a/bftengine/src/bftengine/messages/NewViewMsg.hpp
+++ b/bftengine/src/bftengine/messages/NewViewMsg.hpp
@@ -24,6 +24,8 @@ class NewViewMsg : public MessageBase {
              ViewNum newView,
              const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(NewViewMsg)
+
   void addElement(ReplicaId replicaId, Digest& viewChangeDigest);
 
   ViewNum newView() const { return b()->newViewNum; }

--- a/bftengine/src/bftengine/messages/PartialCommitProofMsg.hpp
+++ b/bftengine/src/bftengine/messages/PartialCommitProofMsg.hpp
@@ -30,6 +30,8 @@ class PartialCommitProofMsg : public MessageBase {
                         std::shared_ptr<IThresholdSigner> thresholdSigner,
                         const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(PartialCommitProofMsg)
+
   ViewNum viewNumber() const { return b()->viewNum; }
 
   SeqNum seqNumber() const { return b()->seqNum; }

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -68,6 +68,8 @@ class PrePrepareMsg : public MessageBase {
                 const concordUtils::SpanContext& spanContext,
                 size_t size);
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(PrePrepareMsg)
+
   uint32_t remainingSizeForRequests() const;
 
   void addRequest(const char* pRequest, uint32_t requestSize);

--- a/bftengine/src/bftengine/messages/ReplicaStatusMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReplicaStatusMsg.hpp
@@ -28,6 +28,8 @@ class ReplicaStatusMsg : public MessageBase {
                    bool listOfMissingPrePrepareMsgForViewChange,
                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(ReplicaStatusMsg)
+
   ViewNum getViewNumber() const;
 
   SeqNum getLastStableSeqNum() const;

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
@@ -24,6 +24,8 @@ class ReqMissingDataMsg : public MessageBase {
                     SeqNum s,
                     const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(ReqMissingDataMsg)
+
   ViewNum viewNumber() const { return b()->viewNum; }
 
   SeqNum seqNumber() const { return b()->seqNum; }

--- a/bftengine/src/bftengine/messages/SignedShareMsgs.hpp
+++ b/bftengine/src/bftengine/messages/SignedShareMsgs.hpp
@@ -66,6 +66,8 @@ class SignedShareBase : public MessageBase {
 
   SignedShareBase(ReplicaId sender, int16_t type, const concordUtils::SpanContext& spanContext, size_t msgSize);
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(SignedShareBase)
+
   Header* b() const { return (Header*)msgBody_; }
 };
 
@@ -84,6 +86,9 @@ class PreparePartialMsg : public SignedShareBase {
                                    Digest& ppDigest,
                                    std::shared_ptr<IThresholdSigner> thresholdSigner,
                                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
+
+  PreparePartialMsg(MessageBase* msgBase) : SignedShareBase(msgBase) {}
+
   void validate(const ReplicasInfo&) const override;
 };
 
@@ -105,6 +110,9 @@ class PrepareFullMsg : public SignedShareBase {
                                 const char* sig,
                                 uint16_t sigLen,
                                 const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
+
+  PrepareFullMsg(MessageBase* msgBase) : SignedShareBase(msgBase) {}
+
   void validate(const ReplicasInfo&) const override;
 };
 
@@ -128,6 +136,9 @@ class CommitPartialMsg : public SignedShareBase {
                                   Digest& ppDoubleDigest,
                                   std::shared_ptr<IThresholdSigner> thresholdSigner,
                                   const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
+
+  CommitPartialMsg(MessageBase* msgBase) : SignedShareBase(msgBase) {}
+
   void validate(const ReplicasInfo&) const override;
 };
 
@@ -149,6 +160,9 @@ class CommitFullMsg : public SignedShareBase {
                                const char* sig,
                                uint16_t sigLen,
                                const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
+
+  CommitFullMsg(MessageBase* msgBase) : SignedShareBase(msgBase) {}
+
   void validate(const ReplicasInfo&) const override;
 };
 

--- a/bftengine/src/bftengine/messages/SimpleAckMsg.hpp
+++ b/bftengine/src/bftengine/messages/SimpleAckMsg.hpp
@@ -24,6 +24,8 @@ class SimpleAckMsg : public MessageBase {
  public:
   SimpleAckMsg(SeqNum s, ViewNum v, ReplicaId senderId, uint64_t ackData);
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(SimpleAckMsg)
+
   ViewNum viewNumber() const { return b()->viewNum; }
 
   SeqNum seqNumber() const { return b()->seqNum; }

--- a/bftengine/src/bftengine/messages/StartSlowCommitMsg.hpp
+++ b/bftengine/src/bftengine/messages/StartSlowCommitMsg.hpp
@@ -26,6 +26,8 @@ class StartSlowCommitMsg : public MessageBase {
                      SeqNum s,
                      const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(StartSlowCommitMsg)
+
   ViewNum viewNumber() const { return b()->viewNum; }
 
   SeqNum seqNumber() const { return b()->seqNum; }

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
@@ -44,6 +44,8 @@ class ViewChangeMsg : public MessageBase {
                 SeqNum lastStableSeq,
                 const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(ViewChangeMsg)
+
   void setNewViewNumber(ViewNum newView);
 
   uint16_t idOfGeneratedReplica() const {


### PR DESCRIPTION
Fixes BC-4800.
This is needed during deserialization (constructing the messages from the
raw char array which is holding a packed struct). In this case we incorporate a larger
msgBody_ into a MessageBase object, having the header required for MessageBase in the beginning.
We need to later create the concrete object in order to call the accessor methods and
the virtual validate method for the complete msgBody_ (holding the header of the MessageBase
followed by the header of the concrete message followed by the payload).