### PR TITLE
Proper handling for empty prefix in S3KeyGenerator

### DIFF
--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -76,7 +76,7 @@ class RocksKeyGenerator : public IDataKeyGenerator, storage::v1DirectKeyValue::D
  */
 class S3KeyGenerator : public IDataKeyGenerator {
  public:
-  S3KeyGenerator(const std::string &prefix = "") : prefix_(prefix + std::string("/")) {}
+  S3KeyGenerator(const std::string &prefix = "") : prefix_(prefix.size() ? prefix + std::string("/") : "") {}
   Key blockKey(const BlockId &) const override;
   Key dataKey(const Key &, const BlockId &) const override;
   Key mdtKey(const Key &key) const override;

--- a/kvbc/test/s3_storage_factory_test.cpp
+++ b/kvbc/test/s3_storage_factory_test.cpp
@@ -33,3 +33,21 @@ TEST(s3, key_generation) {
   auto mdtKey = keygen->mdtKey(concord::kvbc::Key{keyName});
   ASSERT_EQ(mdtKey.toString(), pathPrefix + std::string{"/metadata/"} + keyName);
 }
+
+TEST(s3, empty_prefix_keygen) {
+  // Path can't contain two slashes, so we have to handle empty prefix correctly
+  const auto keyName{"test_key"};
+  const auto keyHex{"746573745f6b6579"};  // hex representation of the key
+  const auto blockId = concord::kvbc::BlockId{1};
+  const auto delim = std::string{"/"};
+  auto keygen = std::make_unique<concord::kvbc::v1DirectKeyValue::S3KeyGenerator>("");
+
+  auto blockKey = keygen->blockKey(blockId);
+  ASSERT_EQ(blockKey.toString(), std::to_string(blockId) + std::string{"/raw_block"});
+
+  auto dataKey = keygen->dataKey(concord::kvbc::Key{keyName}, blockId);
+  ASSERT_EQ(dataKey.toString(), std::to_string(blockId) + delim + keyHex);
+
+  auto mdtKey = keygen->mdtKey(concord::kvbc::Key{keyName});
+  ASSERT_EQ(mdtKey.toString(), std::string{"metadata/"} + keyName);
+}


### PR DESCRIPTION
The key for the object store can't contain two slashes. However if empty
prefix is set, the generated key is something like '//1/rawblock'.

This patch adds proper handling for empty prefix.