### PR TITLE
Save Apollo logs when running natively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ if (NOT DEFINED USE_LOG4CPP)
   option(USE_LOG4CPP "Enable LOG4CPP" FALSE)
 endif()
 
-# Default KEEP_APOLLO_LOGS to FALSE
-option(KEEP_APOLLO_LOGS "Retains logs from replicas in separate folder for each test in /tmp/apollo " FALSE)
+# Default KEEP_APOLLO_LOGS to TRUE
+option(KEEP_APOLLO_LOGS "Retains logs from replicas in separate folder for each test in build/tests/apollo/logs " TRUE)
 
 # Default BUILD_COMM_TCP_PLAIN to FALSE
 option(BUILD_COMM_TCP_PLAIN "Enable TCP communication" FALSE)

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -211,11 +211,6 @@ class BftTestNetwork:
         builddir = os.path.abspath("../../build")
         toolsdir = os.path.join(builddir, "tools")
         testdir = tempfile.mkdtemp()
-        if os.environ.get('KEEP_APOLLO_LOGS', "").lower() in ["true", "on"]:
-            try:
-                os.mkdir("/tmp/apollo")
-            except FileExistsError:
-                pass
         bft_network = cls(
             is_existing=False,
             origdir=os.getcwd(),


### PR DESCRIPTION
I turned on the 'KEEP_APOLLO_LOGS' flag so that a developer who builds natively would have the same logs as in the CI and the dockerized build.

*Removed the code which opens the old logs directory.