### PR TITLE
Diagnostics: Add support for histogram timers

### DIFF
--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
@@ -16,6 +16,8 @@
 #include "IncomingMsgsStorage.hpp"
 #include "MsgHandlersRegistrator.hpp"
 #include "Timers.hpp"
+#include "diagnostics.h"
+#include "performance_handler.h"
 
 #include <queue>
 #include <atomic>
@@ -78,6 +80,26 @@ class IncomingMsgsStorageImp : public IncomingMsgsStorage {
   std::promise<void> signalStarted_;
   std::atomic<bool> stopped_ = false;
   concordUtil::Timers timers_;
+
+  // 5 seconds
+  static constexpr int64_t MAX_VALUE_NANOSECONDS = 1000 * 1000 * 1000 * 5l;
+  using Recorder = concord::diagnostics::Recorder;
+  struct Recorders {
+    Recorders() {
+      auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+      registrar.perf.registerComponent("incomingMsgsStorageImp",
+                                       {{"externalQueueLenAtSwap", externalQueueLenAtSwap},
+                                        {"internalQueueLenAtSwap", internalQueueLenAtSwap},
+                                        {"getMsgForProcessing", getMsgForProcessing}});
+    }
+    std::shared_ptr<Recorder> externalQueueLenAtSwap =
+        std::make_shared<Recorder>(1, 10000, 3, concord::diagnostics::Unit::COUNT);
+    std::shared_ptr<Recorder> internalQueueLenAtSwap =
+        std::make_shared<Recorder>(1, 10000, 3, concord::diagnostics::Unit::COUNT);
+    std::shared_ptr<Recorder> getMsgForProcessing =
+        std::make_shared<Recorder>(1, MAX_VALUE_NANOSECONDS, 3, concord::diagnostics::Unit::NANOSECONDS);
+  };
+  Recorders histograms_;
 };
 
 }  // namespace bftEngine::impl

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -25,6 +25,7 @@
 
 using bft::communication::ICommunication;
 using bftEngine::SimpleBlockchainStateTransfer::StateTransferDigest;
+using namespace concord::diagnostics;
 
 using concord::storage::DBMetadataStorage;
 
@@ -105,6 +106,7 @@ Status ReplicaImp::get(const Sliver &key, Sliver &outValue) const {
   // TODO(GG): check legality of operation (the method should be invoked from
   // the replica's internal thread)
 
+  TimeRecorder scoped_timer(*histograms_.get_value);
   BlockId dummy;
   return getInternal(getLastBlockNum(), key, outValue, dummy);
 }
@@ -113,6 +115,7 @@ Status ReplicaImp::get(BlockId readVersion, const Sliver &key, Sliver &outValue,
   // TODO(GG): check legality of operation (the method should be invoked from
   // the replica's internal thread)
 
+  TimeRecorder scoped_timer(*histograms_.get_block);
   return getInternal(readVersion, key, outValue, outBlock);
 }
 
@@ -121,6 +124,7 @@ Status ReplicaImp::getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockDat
   // the replica's internal thread)
 
   try {
+    TimeRecorder scoped_timer(*histograms_.get_block_data);
     Sliver block = getBlockInternal(blockId);
     outBlockData = m_bcDbAdapter->getBlockData(block);
   } catch (const NotFoundException &e) {
@@ -135,6 +139,7 @@ Status ReplicaImp::mayHaveConflictBetween(const Sliver &key, BlockId fromBlock, 
   // TODO(GG): add assert or print warning if fromBlock==0 (all keys have a
   // conflict in block 0)
 
+  TimeRecorder scoped_timer(*histograms_.may_have_conflict_between);
   // we conservatively assume that we have a conflict
   outRes = true;
 
@@ -157,6 +162,7 @@ Status ReplicaImp::addBlock(const SetOfKeyValuePairs &updates,
   // TODO(GG): what do we want to do with several identical keys in the same
   // block?
 
+  TimeRecorder scoped_timer(*histograms_.add_block);
   return addBlockInternal(updates, outBlockId);
 }
 


### PR DESCRIPTION
Use the new timers in kvbc, IncomingMsgsStorage and bftEngine::ReplicaImp.