### PR TITLE
Multiple tests expect RocksDB to be available

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd concord-bft
 sudo ./install_deps.sh # Installs all dependencies and 3rd parties
 mkdir build
 cd build
-cmake ..
+cmake -DBUILD_ROCKSDB_STORAGE=TRUE ..
 make
 sudo make test
 ```


### PR DESCRIPTION
Bring native build in line with docker build to use persistency.