### PR TITLE
BC-4947: Disabling unstable pre-execution test

### DIFF
--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -299,6 +299,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
             last_block = await tracker.get_last_block_id(read_client)
             assert last_block > start_block
 
+    @unittest.skip("Unstable due to BC-4947")
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)


### PR DESCRIPTION
This test runs pre-execution commands while dropping a small amount of UDP packets. This failure has lower priority, given we are going to move to a TLS setup in the near future.