### PR TITLE
Fix reconfiguration bug

### DIFF
--- a/bftengine/src/bftengine/PathDetector.hpp
+++ b/bftengine/src/bftengine/PathDetector.hpp
@@ -18,7 +18,7 @@
 #include "SeqNumInfo.hpp"
 #include <memory>
 
-typedef SequenceWithActiveWindow<5 * kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
+typedef SequenceWithActiveWindow<2 * kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
 
 class PathDetector : public IPathDetector {
   std::shared_ptr<WindowOfSeqNumInfo> windowOfSeqNums_;

--- a/bftengine/src/bftengine/PathDetector.hpp
+++ b/bftengine/src/bftengine/PathDetector.hpp
@@ -18,7 +18,7 @@
 #include "SeqNumInfo.hpp"
 #include <memory>
 
-typedef SequenceWithActiveWindow<2 * kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
+typedef SequenceWithActiveWindow<5 * kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
 
 class PathDetector : public IPathDetector {
   std::shared_ptr<WindowOfSeqNumInfo> windowOfSeqNums_;

--- a/bftengine/src/bftengine/PathDetector.hpp
+++ b/bftengine/src/bftengine/PathDetector.hpp
@@ -18,7 +18,7 @@
 #include "SeqNumInfo.hpp"
 #include <memory>
 
-typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
+typedef SequenceWithActiveWindow<2 * kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
 
 class PathDetector : public IPathDetector {
   std::shared_ptr<WindowOfSeqNumInfo> windowOfSeqNums_;

--- a/bftengine/src/bftengine/PathDetector.hpp
+++ b/bftengine/src/bftengine/PathDetector.hpp
@@ -18,7 +18,7 @@
 #include "SeqNumInfo.hpp"
 #include <memory>
 
-typedef SequenceWithActiveWindow<2 * kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
+typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
 
 class PathDetector : public IPathDetector {
   std::shared_ptr<WindowOfSeqNumInfo> windowOfSeqNums_;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1500,9 +1500,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
       if (pos != tableOfStableCheckpoints.end()) delete pos->second;
       CheckpointMsg *x = new CheckpointMsg(msgSenderId, msgSeqNum, msgDigest, msgIsStable);
       tableOfStableCheckpoints[msgSenderId] = x;
-      LOG_INFO(GL,
-               "Added stable Checkpoint message to tableOfStableCheckpoints: " << KVLOG(
-                   msgSenderId, tableOfStableCheckpoints.size()));
+      LOG_INFO(GL, "Added stable Checkpoint message to tableOfStableCheckpoints: " << KVLOG(msgSenderId));
 
       if ((uint16_t)tableOfStableCheckpoints.size() >= config_.fVal + 1) {
         uint16_t numRelevant = 0;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1494,13 +1494,15 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
   if (msgIsStable && msgSeqNum > lastExecutedSeqNum) {
     auto pos = tableOfStableCheckpoints.find(msgSenderId);
     if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() < msgSeqNum ||
-        (pos->second->seqNumber() == msgSeqNum
-         && mainLog->insideActiveWindow(lastExecutedSeqNum)
-         && (getMonotonicTime() - mainLog->get(lastExecutedSeqNum).lastUpdateTimeOfCommitMsgs() > milliseconds(timeToWaitBeforeStartingStateTransferInMainWindowMilli)))) {
+        (pos->second->seqNumber() == msgSeqNum && mainLog->insideActiveWindow(lastExecutedSeqNum) &&
+         (getMonotonicTime() - mainLog->get(lastExecutedSeqNum).lastUpdateTimeOfCommitMsgs() >
+          milliseconds(timeToWaitBeforeStartingStateTransferInMainWindowMilli)))) {
       if (pos != tableOfStableCheckpoints.end()) delete pos->second;
       CheckpointMsg *x = new CheckpointMsg(msgSenderId, msgSeqNum, msgDigest, msgIsStable);
       tableOfStableCheckpoints[msgSenderId] = x;
-      LOG_INFO(GL, "Added stable Checkpoint message to tableOfStableCheckpoints: " << KVLOG(msgSenderId, tableOfStableCheckpoints.size()));
+      LOG_INFO(GL,
+               "Added stable Checkpoint message to tableOfStableCheckpoints: " << KVLOG(
+                   msgSenderId, tableOfStableCheckpoints.size()));
 
       if ((uint16_t)tableOfStableCheckpoints.size() >= config_.fVal + 1) {
         uint16_t numRelevant = 0;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1768,7 +1768,6 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
       for (SeqNum i = beginRange; i <= endRange; i = i + checkpointWindowSize) {
         CheckpointMsg *checkMsg = checkpointsLog->get(i).selfCheckpointMsg();
         if (checkMsg != nullptr) {
-          LOG_INFO(GL, " *** sends checkpoint *** " << KVLOG(i, msgSenderId));
           sendAndIncrementMetric(checkMsg, msgSenderId, metric_sent_checkpoint_msg_due_to_status_);
         }
       }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1493,7 +1493,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
 
   if (msgIsStable && msgSeqNum > lastExecutedSeqNum) {
     auto pos = tableOfStableCheckpoints.find(msgSenderId);
-    if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() < msgSeqNum) {
+    if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() <= msgSeqNum) {
       if (pos != tableOfStableCheckpoints.end()) delete pos->second;
       CheckpointMsg *x = new CheckpointMsg(msgSenderId, msgSeqNum, msgDigest, msgIsStable);
       tableOfStableCheckpoints[msgSenderId] = x;
@@ -1532,7 +1532,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
     }
   }
 
-  if (askForStateTransfer) {
+  if (askForStateTransfer && !stateTransfer->isCollectingState()) {
     LOG_INFO(GL, "Call to startCollectingState()");
 
     stateTransfer->startCollectingState();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2454,10 +2454,7 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     metric_primary_last_used_seq_num_.Get().Set(primaryLastUsedSeqNum);
     if (ps_) ps_->setPrimaryLastUsedSeqNum(primaryLastUsedSeqNum);
   }
-
-  if (lastStableSeqNum % kWorkWindowSize == 0) {
-    mainLog->advanceActiveWindow(lastStableSeqNum + 1);
-  }
+  mainLog->advanceActiveWindow(lastStableSeqNum + 1);
   // Basically, once a checkpoint become stable, we advance the checkpoints log window to it.
   // Alas, by doing so, we does not leave time for a checkpoint to try and become super stable.
   // For that we added another cell to the checkpoints log such that the "oldest" cell contains the checkpoint is

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1493,7 +1493,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
 
   if (msgIsStable && msgSeqNum > lastExecutedSeqNum) {
     auto pos = tableOfStableCheckpoints.find(msgSenderId);
-    if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() <= msgSeqNum) {
+    if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() < msgSeqNum) {
       if (pos != tableOfStableCheckpoints.end()) delete pos->second;
       CheckpointMsg *x = new CheckpointMsg(msgSenderId, msgSeqNum, msgDigest, msgIsStable);
       tableOfStableCheckpoints[msgSenderId] = x;
@@ -1532,7 +1532,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
     }
   }
 
-  if (askForStateTransfer && !stateTransfer->isCollectingState()) {
+  if (askForStateTransfer) {
     LOG_INFO(GL, "Call to startCollectingState()");
 
     stateTransfer->startCollectingState();

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -155,10 +155,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concordUtil::Timers::Handle infoReqTimer_;
   concordUtil::Timers::Handle statusReportTimer_;
   concordUtil::Timers::Handle viewChangeTimer_;
-  concordUtil::Timers::Handle superStableCheckpointRetransmitTimer_;
 
-  int timeoutOfSuperStableCheckpointTimerMs_ = 1000;
-  bool enableRetransmitSuperStableCheckpoint_ = false;
   int viewChangeTimerMilli = 0;
   int autoPrimaryRotationTimerMilli = 0;
 

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -47,7 +47,6 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcReconfigurationTest(unittest.TestCase):
 
-    @unittest.skip("Unstable due to BC-4663")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command(self, bft_network):
@@ -110,7 +109,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
 
-    @unittest.skip("Unstable due to BC-4663")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command_and_specific_replica_info(self, bft_network):
@@ -190,7 +188,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         await self.validate_state_consistency(skvbc, key, val)
         await skvbc.write_known_kv()
 
-    @unittest.skip("Unstable due to BC-4663")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_remove_nodes(self, bft_network):


### PR DESCRIPTION
Once we stop processing new requests (for example, due to wedge command) the following scenario may happen:

n-f replicas are getting to a stable checkpoint and advance the mainLog (https://github.com/vmware/concord-bft/blob/master/bftengine/src/bftengine/ReplicaImp.cpp#L2460)
The f remaining replicas are trying to get updated by sending reqMissingInfo messages
Yet, the first n-f replicas reject their messages due to the following condition: https://github.com/vmware/concord-bft/blob/master/bftengine/src/bftengine/ReplicaImp.cpp#L2649
Following No. 3, the f late replicas can only get updated using state transfer, but due to the fact that the system does not produce new checkpoints they cannot get to the following conditions: https://github.com/vmware/concord-bft/blob/master/bftengine/src/bftengine/ReplicaImp.cpp#L1537
The late f replicas never get to a n/n checkpoint and the test fails
Our solution is to enable re-adding stable checkpoints to the checkpoint table https://github.com/vmware/concord-bft/blob/master/bftengine/src/bftengine/ReplicaImp.cpp#L1496. This should not harm performance (in the worst case we will have a dozen of replicas, and lopping over the table won't make any effect)
From reading the logs, it seems that with this change, the late f replicas eventually initiate the state transfer (a thing that did not happen without this change) end eventually they reach to a n/n checkpoint

EDIT:
After discussing with @guyg8 I have removed the retransmitting solution #800 and use the existing status messages mechanism.

To test the stability of reconfiguration I've run some the reconfiguration test for hundreds of times on my local machine without any failure.
In addition, I have triggered the CI tests several times and it passed in all of them.

Note:
We won't merge this change before OCT cut release.