### PR TITLE
test_state_transfer wouldn't fail correctly for f>1

### DIFF
--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -54,9 +54,9 @@ class SkvbcTest(unittest.TestCase):
         Test that state transfer starts and completes.
 
         Stop one node, add a bunch of data to the rest of the cluster, restart
-        the node and verify state transfer works as expected. In a 4 node
-        cluster with f=1 we should be able to stop a different node after state
-        transfer completes and still operate correctly.
+        the node and verify state transfer works as expected. We should be able
+        to stop a different set of f nodes after state transfer completes and
+        still operate correctly.
         """
         if exchange_keys:
             await bft_network.do_key_exchange()
@@ -75,9 +75,7 @@ class SkvbcTest(unittest.TestCase):
         await bft_network.wait_for_state_transfer_to_start()
         await bft_network.wait_for_state_transfer_to_stop(0, stale_node)
         await skvbc.assert_successful_put_get(self)
-        random_replica = random.choice(
-            bft_network.all_replicas(without={0, stale_node}))
-        bft_network.stop_replica(random_replica)
+        await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get(self)
 
     @with_trio

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -282,8 +282,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
         await bft_network.wait_for_state_transfer_to_stop(current_primary, isolated_node)
 
         await skvbc.assert_successful_put_get(self)
-        bft_network.stop_replicas(
-            bft_network.random_set_of_replicas(f, without={current_primary, isolated_node}))
+        await bft_network.force_quorum_including_replica(isolated_node)
         # After stopping f other replicas we execute another request and if the isolated_node
         # fails to process it for any reason we won't have consensus. Thus we'll know it's
         # recovered correctly.

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -157,7 +157,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
         await bft_network.wait_for_state_transfer_to_stop(up_to_date_node,
                                                           stale_node)
 
-        bft_network.force_quorum_including_replica(stale_node)
+        await bft_network.force_quorum_including_replica(stale_node)
 
         # Retrieve the value we put first to ensure state transfer worked
         # when the log went away
@@ -206,7 +206,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
         bft_network.start_replica(stale_node)
         await bft_network.wait_for_state_transfer_to_stop(0, stale_node)
 
-        bft_network.force_quorum_including_replica(stale_node)
+        await bft_network.force_quorum_including_replica(stale_node)
 
         # Retrieve the value we put first to ensure state transfer worked
         # when the log went away
@@ -281,7 +281,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
             unstable_replicas=unstable_replicas
         )
 
-        bft_network.force_quorum_including_replica(stale_node)
+        await bft_network.force_quorum_including_replica(stale_node)
 
         # Retrieve the value we put first to ensure state transfer worked
         # when the log went away
@@ -422,7 +422,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
                 trigger_view_change=trigger_view_change
             )
 
-        bft_network.force_quorum_including_replica(stale_replica)
+        await bft_network.force_quorum_including_replica(stale_replica)
 
         kvpairs = await tracker.read_and_track_known_kv(known_key, client)
         self.assertDictEqual(dict(known_kv), kvpairs)


### PR DESCRIPTION
Due to only stopping one node the test would always succeed irrespective of stale_node working correctly or not when f>1