### PR TITLE
[Apollo/GHA] Fix unstable pre-execution test

### DIFF
--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -125,6 +125,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         and no view-change was triggered.
         """
         bft_network.start_all_replicas()
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
 
         client = bft_network.random_client()
         client.config = client.config._replace(


### PR DESCRIPTION
As for other pre-execution tests, here too, we need to wait for the pre-execution thread pools on replicas to be ready for request processing.

Note: this failure is seen on GHA, not in Travis. It's a step towards stabilizing GHA jobs and ultimately dropping Travis altogether.