### PR TITLE
Add histograms for merkle based storage

### DIFF
--- a/kvbc/include/sparse_merkle/histograms.h
+++ b/kvbc/include/sparse_merkle/histograms.h
@@ -11,6 +11,8 @@
 // terms and conditions of the sub-component's license, as noted in the
 // LICENSE file.
 
+#pragma once
+
 #include "diagnostics.h"
 #include "sparse_merkle/base_types.h"
 
@@ -124,6 +126,6 @@ struct Recorders {
   std::shared_ptr<Recorder> dba_hashed_parent_block_size = std::make_shared<Recorder>(1, MAX_VAL_SIZE, 3, Unit::BYTES);
 };
 
-static Recorders histograms;
+inline const Recorders histograms;
 
 }  // namespace concord::kvbc::sparse_merkle::detail

--- a/kvbc/include/sparse_merkle/histograms.h
+++ b/kvbc/include/sparse_merkle/histograms.h
@@ -1,0 +1,129 @@
+
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "diagnostics.h"
+#include "sparse_merkle/base_types.h"
+
+namespace concord::kvbc::sparse_merkle::detail {
+
+struct Recorders {
+  static constexpr int64_t MAX_NS = 1000 * 1000 * 1000;       // 1s
+  static constexpr int64_t MAX_VAL_SIZE = 1024 * 1024 * 100;  // 100MB
+
+  using Recorder = concord::diagnostics::Recorder;
+  using Unit = concord::diagnostics::Unit;
+
+  Recorders() {
+    auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+    registrar.perf.registerComponent("sparse_merkle",
+                                     {{"update", update},
+                                      {"insert_key", insert_key},
+                                      {"remove_key", remove_key},
+                                      {"num_update_keys", num_updated_keys},
+                                      {"num_deleted_keys", num_deleted_keys},
+                                      {"key_size", key_size},
+                                      {"val_size", val_size},
+                                      {"hash_val", hash_val},
+                                      {"num_batch_internal_nodes", num_batch_internal_nodes},
+                                      {"num_batch_leaf_nodes", num_batch_leaf_nodes},
+                                      {"num_stale_internal_keys", num_stale_internal_keys},
+                                      {"num_stale_leaf_keys", num_stale_leaf_keys},
+                                      {"insert_depth", insert_depth},
+                                      {"remove_depth", remove_depth},
+
+                                      {"internal_node_update_hashes", internal_node_update_hashes},
+                                      {"internal_node_insert", internal_node_insert},
+                                      {"internal_node_remove", internal_node_remove},
+
+                                      {"dba_batch_to_db_updates", dba_batch_to_db_updates},
+                                      {"dba_get_value", dba_get_value},
+                                      {"dba_get_genesis_block_id", dba_get_genesis_block_id},
+                                      {"dba_get_last_reachable_block_id", dba_get_last_reachable_block_id},
+                                      {"dba_get_latest_block_id", dba_get_latest_block_id},
+                                      {"dba_create_block_node", dba_create_block_node},
+                                      {"dba_get_raw_block", dba_get_raw_block},
+                                      {"dba_last_reachable_block_db_updates", dba_last_reachable_block_db_updates},
+                                      {"dba_size_of_updates", dba_size_of_updates},
+                                      {"dba_get_internal", dba_get_internal},
+                                      {"dba_serialize_internal", dba_serialize_internal},
+                                      {"dba_serialize_leaf", dba_serialize_leaf},
+                                      {"dba_deserialize_internal", dba_deserialize_internal},
+                                      {"dba_deserialize_block", dba_deserialize_block},
+                                      {"dba_deserialize_leaf", dba_deserialize_leaf},
+                                      {"dba_link_st_chain", dba_link_st_chain},
+                                      {"dba_num_blocks_for_st_link", dba_num_blocks_for_st_link},
+                                      {"dba_add_raw_block", dba_add_raw_block},
+                                      {"dba_delete_block", dba_delete_block},
+                                      {"dba_get_leaf_key_val_at_most_version", dba_get_leaf_key_val_at_most_version},
+                                      {"dba_delete_keys_for_block", dba_delete_keys_for_block},
+                                      {"dba_has_block", dba_has_block},
+                                      {"dba_keys_for_version", dba_keys_for_version},
+                                      {"dba_hash_parent_block", dba_hash_parent_block},
+                                      {"dba_hashed_parent_block_size", dba_hashed_parent_block_size}});
+  }
+
+  // Used in tree.cpp
+  std::shared_ptr<Recorder> update = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> insert_key = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> remove_key = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> num_updated_keys = std::make_shared<Recorder>(1, 1000, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> num_deleted_keys = std::make_shared<Recorder>(1, 1000, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> key_size = std::make_shared<Recorder>(1, 2048, 3, Unit::BYTES);
+  std::shared_ptr<Recorder> val_size = std::make_shared<Recorder>(1, MAX_VAL_SIZE, 3, Unit::BYTES);
+  std::shared_ptr<Recorder> hash_val = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> num_batch_internal_nodes = std::make_shared<Recorder>(1, 1000, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> num_batch_leaf_nodes = std::make_shared<Recorder>(1, 1000, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> num_stale_internal_keys = std::make_shared<Recorder>(1, 1000, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> num_stale_leaf_keys = std::make_shared<Recorder>(1, 1000, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> insert_depth = std::make_shared<Recorder>(1, Hash::MAX_NIBBLES, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> remove_depth = std::make_shared<Recorder>(1, Hash::MAX_NIBBLES, 3, Unit::COUNT);
+
+  // Used in internal_node.cpp
+  std::shared_ptr<Recorder> internal_node_update_hashes = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> internal_node_insert = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> internal_node_remove = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+
+  // Used in merkle_tree_db_adapter.cpp
+  std::shared_ptr<Recorder> dba_batch_to_db_updates = std::make_shared<Recorder>(1, MAX_NS * 5, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_get_value = std::make_shared<Recorder>(1, MAX_NS * 5, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_get_genesis_block_id = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_get_last_reachable_block_id =
+      std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_get_latest_block_id = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_create_block_node = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_get_raw_block = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_last_reachable_block_db_updates =
+      std::make_shared<Recorder>(1, MAX_NS * 5, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_size_of_updates = std::make_shared<Recorder>(1, MAX_VAL_SIZE, 3, Unit::BYTES);
+  std::shared_ptr<Recorder> dba_get_internal = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_serialize_internal = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_serialize_leaf = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_deserialize_internal = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_deserialize_block = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_deserialize_leaf = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_link_st_chain = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_num_blocks_for_st_link = std::make_shared<Recorder>(1, 1000000, 3, Unit::COUNT);
+  std::shared_ptr<Recorder> dba_add_raw_block = std::make_shared<Recorder>(1, MAX_NS * 10, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_delete_block = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_get_leaf_key_val_at_most_version =
+      std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_delete_keys_for_block = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_has_block = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_keys_for_version = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_hash_parent_block = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
+  std::shared_ptr<Recorder> dba_hashed_parent_block_size = std::make_shared<Recorder>(1, MAX_VAL_SIZE, 3, Unit::BYTES);
+};
+
+static Recorders histograms;
+
+}  // namespace concord::kvbc::sparse_merkle::detail

--- a/kvbc/src/sparse_merkle/internal_node.cpp
+++ b/kvbc/src/sparse_merkle/internal_node.cpp
@@ -11,15 +11,20 @@
 // LICENSE file.
 
 #include "sparse_merkle/internal_node.h"
+#include "sparse_merkle/histograms.h"
 
 #include <iostream>
 using namespace std;
+using namespace concord::diagnostics;
 
 namespace concord {
 namespace kvbc {
 namespace sparse_merkle {
 
+using namespace detail;
+
 void BatchedInternalNode::updateHashes(size_t index, Version version) {
+  TimeRecorder scoped_timer(*histograms.internal_node_update_hashes);
   ConcordAssert(index > 0);
   auto hasher = Hasher();
 
@@ -53,6 +58,7 @@ void BatchedInternalNode::updateHashes(size_t index, Version version) {
 BatchedInternalNode::InsertResult BatchedInternalNode::insert(const LeafChild& child,
                                                               size_t depth,
                                                               Version current_version) {
+  TimeRecorder scoped_timer(*histograms.internal_node_insert);
   // The index into the children_ array
   size_t index = 0;
   Nibble child_key = child.key.hash().getNibble(depth);
@@ -187,6 +193,7 @@ BatchedInternalNode::InsertResult BatchedInternalNode::insertTwoLeafChildren(
 }
 
 BatchedInternalNode::RemoveResult BatchedInternalNode::remove(const Hash& key, size_t depth, Version new_version) {
+  TimeRecorder scoped_timer(*histograms.internal_node_remove);
   // The index into the children_ array
   size_t index = 0;
 

--- a/kvbc/src/sparse_merkle/tree.cpp
+++ b/kvbc/src/sparse_merkle/tree.cpp
@@ -120,7 +120,7 @@ void remove(Walker& walker, const Hash& key_hash) {
   }
 }
 
-void updateBatchHistograms(const UpdateBatch& batch) {
+static void updateBatchHistograms(const UpdateBatch& batch) {
   histograms.num_batch_internal_nodes->record(batch.internal_nodes.size());
   histograms.num_batch_leaf_nodes->record(batch.leaf_nodes.size());
   histograms.num_stale_internal_keys->record(batch.stale.internal_keys.size());

--- a/kvbc/src/sparse_merkle/tree.cpp
+++ b/kvbc/src/sparse_merkle/tree.cpp
@@ -10,6 +10,7 @@
 // terms and conditions of the sub-component's license, as noted in the
 // LICENSE file.
 
+#include "sparse_merkle/histograms.h"
 #include "sparse_merkle/tree.h"
 #include "sparse_merkle/walker.h"
 
@@ -17,11 +18,13 @@
 using namespace std;
 
 using namespace concordUtils;
+using namespace concord::diagnostics;
 
 namespace concord::kvbc::sparse_merkle {
 using namespace detail;
 
 void insertComplete(Walker& walker, const BatchedInternalNode::InsertComplete& result) {
+  histograms.insert_depth->record(walker.depth());
   walker.ascendToRoot(result.stale_leaf);
 }
 
@@ -45,6 +48,7 @@ void handleCollision(Walker& walker, const LeafChild& stored_child, const LeafCh
 // responses and walk the tree as appropriate to get to the correct node, where
 // the insert will succeed.
 void insert(Walker& walker, const LeafChild& child) {
+  TimeRecorder scoped_timer(*histograms.insert_key);
   while (true) {
     ConcordAssert(walker.depth() < Hash::MAX_NIBBLES);
 
@@ -89,12 +93,14 @@ void removeBatchedInternalNode(Walker& walker, const std::optional<LeafChild>& p
 }
 
 void remove(Walker& walker, const Hash& key_hash) {
+  TimeRecorder scoped_timer(*histograms.remove_key);
   while (true) {
     ConcordAssert(walker.depth() < Hash::MAX_NIBBLES);
 
     auto result = walker.currentNode().remove(key_hash, walker.depth(), walker.version());
 
     if (auto rv = std::get_if<BatchedInternalNode::RemoveComplete>(&result)) {
+      histograms.remove_depth->record(walker.depth());
       auto stale = LeafKey(key_hash, rv->version);
       return walker.ascendToRoot(stale);
     }
@@ -114,8 +120,18 @@ void remove(Walker& walker, const Hash& key_hash) {
   }
 }
 
+void updateBatchHistograms(const UpdateBatch& batch) {
+  histograms.num_batch_internal_nodes->record(batch.internal_nodes.size());
+  histograms.num_batch_leaf_nodes->record(batch.leaf_nodes.size());
+  histograms.num_stale_internal_keys->record(batch.stale.internal_keys.size());
+  histograms.num_stale_leaf_keys->record(batch.stale.leaf_keys.size());
+}
+
 UpdateBatch Tree::update(const concord::kvbc::SetOfKeyValuePairs& updates,
                          const concord::kvbc::KeysVector& deleted_keys) {
+  histograms.num_updated_keys->record(updates.size());
+  histograms.num_deleted_keys->record(deleted_keys.size());
+  TimeRecorder scoped_timer(*histograms.update);
   reset();
   UpdateCache cache(root_, db_reader_);
   return update_impl(updates, deleted_keys, cache);
@@ -145,7 +161,13 @@ UpdateBatch Tree::update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
   }
 
   for (auto&& [key, val] : updates) {
-    auto leaf_hash = hasher.hash(val.data(), val.length());
+    histograms.key_size->record(key.length());
+    histograms.val_size->record(val.length());
+    Hash leaf_hash;
+    {
+      TimeRecorder scoped_timer(*histograms.hash_val);
+      leaf_hash = hasher.hash(val.data(), val.length());
+    }
     LeafNode leaf_node{val};
     LeafKey leaf_key{hasher.hash(key.data(), key.length()), version};
     LeafChild child{leaf_hash, leaf_key};
@@ -160,6 +182,7 @@ UpdateBatch Tree::update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
   for (auto& it : cache.internalNodes()) {
     batch.internal_nodes.emplace_back(InternalNodeKey(version, it.first), it.second);
   }
+  updateBatchHistograms(batch);
 
   // Set the root after updates so that it is reflected to users in get_root_hash() and get_version() .
   root_ = cache.getRoot();


### PR DESCRIPTION
Add many histograms to cover sparse merkle code as well as DBAdapter
code for the sparse merkle tree based storage backend.

Since computing of parent block hashes happens in another thread using
std::async, we need to use atomic updates for the related histograms.
The diagnostics Recorder and TimeRecorder classes were enhanced to
support atomic update using the underlying HdrHistogram support.