### PR TITLE
Coverity - 86318 Argument cannot be negative

### DIFF
--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -164,6 +164,11 @@ class PlainUDPCommunication::PlainUdpImpl {
     // Initialize socket.
     udpSockFd = socket(AF_INET, SOCK_DGRAM, 0);
 
+    if (udpSockFd < 0) {
+      LOG_FATAL(_logger, "Failed to initialize socket, error: " << strerror(errno));
+      std::terminate();
+    }
+
     // Name the socket.
     sAddr.sin_family = AF_INET;
     sAddr.sin_addr.s_addr = htonl(INADDR_ANY);


### PR DESCRIPTION
Validate the socket value, and return -1 if the socket couldn't be open.