### PR TITLE
Improve pre-execution logs & try to fix request state cleanup after a view change

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -133,7 +133,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
     preProcessResultBuffers_.push_back(Sliver(new char[maxPreExecResultSize_], maxPreExecResultSize_));
   }
   uint64_t numOfThreads = myReplica.getReplicaConfig().preExecConcurrencyLevel;
-  if (!numOfThreads) numOfThreads = min((uint16_t)thread::hardware_concurrency(), numOfClients_);
+  if (!numOfThreads) numOfThreads = numOfClients_;
   threadPool_.start(numOfThreads);
   LOG_INFO(logger(),
            KVLOG(firstClientId, numOfClients_, maxPreExecResultSize_, preExecReqStatusCheckPeriodMilli_, numOfThreads));
@@ -190,8 +190,12 @@ void PreProcessor::onRequestsStatusCheckTimer() {
         preProcessorMetrics_.preProcPossiblePrimaryFaultDetected.Get().Inc();
         // The request could expire do to failed primary replica, let ReplicaImp to address that
         // TBD YS: This causes a request to retry in case the primary is OK. Consider passing a kind of NOOP message.
+        const auto &clientId = clientEntry.first;
+        const auto &reqSeqNum = clientReqStatePtr->getReqSeqNum();
+        const auto &cid = clientReqStatePtr->getReqCid();
+        LOG_INFO(logger(), "Let replica to handle request" << KVLOG(reqSeqNum, cid, clientId));
         incomingMsgsStorage_->pushExternalMsg(clientReqStatePtr->buildClientRequestMsg(true));
-        releaseClientPreProcessRequest(clientEntry.second, clientEntry.first, CANCEL);
+        releaseClientPreProcessRequest(clientEntry.second, clientId, CANCEL);
       } else if (myReplica_.isCurrentPrimary() && clientReqStatePtr->definePreProcessingConsensusResult() == CONTINUE)
         resendPreProcessRequest(clientReqStatePtr);
     }
@@ -200,6 +204,7 @@ void PreProcessor::onRequestsStatusCheckTimer() {
 
 bool PreProcessor::checkClientMsgCorrectness(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
                                              ReqId reqSeqNum) const {
+  SCOPED_MDC_CID(clientReqMsg->getCid());
   if (myReplica_.isCollectingState()) {
     LOG_INFO(logger(),
              "ClientPreProcessRequestMsg"
@@ -279,9 +284,11 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
     const auto &clientEntry = ongoingRequests_[clientId];
     lock_guard<mutex> lock(clientEntry->mutex);
     if (clientEntry->reqProcessingStatePtr) {
-      const ReqId &ongoingReqSeqNum = clientEntry->reqProcessingStatePtr->getReqSeqNum();
+      const auto &ongoingReqSeqNum = clientEntry->reqProcessingStatePtr->getReqSeqNum();
+      const auto &ongoingCid = clientEntry->reqProcessingStatePtr->getReqCid();
       LOG_DEBUG(logger(),
-                KVLOG(reqSeqNum, clientId, senderId) << " is ignored:" << KVLOG(ongoingReqSeqNum) << " is in progress");
+                KVLOG(reqSeqNum, clientId, senderId)
+                    << " is ignored:" << KVLOG(ongoingReqSeqNum, ongoingCid) << " is in progress");
       preProcessorMetrics_.preProcReqIgnored.Get().Inc();
       return;
     }
@@ -324,7 +331,12 @@ void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
   const NodeIdType &clientId = preProcessReqMsg->clientId();
   LOG_DEBUG(logger(), "Received PreProcessRequestMsg" << KVLOG(reqSeqNum, senderId, clientId));
 
-  if (myReplica_.isCurrentPrimary()) return;
+  if (myReplica_.isCurrentPrimary()) {
+    LOG_WARN(logger(),
+             "Received PreProcessRequestMsg; ignore as current replica is the primary"
+                 << KVLOG(reqSeqNum, senderId, clientId));
+    return;
+  }
 
   if (!myReplica_.currentViewIsActive()) {
     LOG_INFO(logger(), "PreProcessRequestMsg is ignored because current view is inactive," << KVLOG(reqSeqNum));
@@ -379,7 +391,10 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
       return;
     }
     clientEntry->reqProcessingStatePtr->handlePreProcessReplyMsg(preProcessReplyMsg);
-    if (status == STATUS_REJECT) return;
+    if (status == STATUS_REJECT) {
+      LOG_DEBUG(logger(), "Received PreProcessReplyMsg with STATUS_REJECT" << KVLOG(reqSeqNum, senderId, clientId));
+      return;
+    }
     result = clientEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
     if (result == CONTINUE) resendPreProcessRequest(clientEntry->reqProcessingStatePtr);
   }
@@ -424,7 +439,7 @@ void PreProcessor::cancelPreProcessing(NodeIdType clientId) {
       reqSeqNum = clientEntry->reqProcessingStatePtr->getReqSeqNum();
       SCOPED_MDC_CID(clientEntry->reqProcessingStatePtr->getReqCid());
       releaseClientPreProcessRequest(clientEntry, clientId, CANCEL);
-      LOG_WARN(logger(), "Pre-processing consensus not reached - abort request" << KVLOG(reqSeqNum, clientId));
+      LOG_WARN(logger(), "Pre-processing consensus not reached - cancel request" << KVLOG(reqSeqNum, clientId));
     }
   }
 }
@@ -447,6 +462,7 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId) {
                                                        reqProcessingStatePtr->getPrimaryPreProcessedResult(),
                                                        reqProcessingStatePtr->getReqTimeoutMilli(),
                                                        cid);
+      LOG_DEBUG(logger(), "Pass pre-processed request to the replica" << KVLOG(cid, reqSeqNum, clientId));
       incomingMsgsStorage_->pushExternalMsg(move(clientRequestMsg));
       preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
       releaseClientPreProcessRequest(clientEntry, clientId, COMPLETE);
@@ -527,6 +543,7 @@ void PreProcessor::releaseClientPreProcessRequest(const ClientRequestStateShared
       givenReq->releaseResources();
       clientEntry->reqProcessingHistory.push_back(move(givenReq));
     } else {  // No consensus reached => release request
+      SCOPED_MDC_CID(givenReq->getReqCid());
       LOG_INFO(logger(), KVLOG(requestSeqNum, clientId) << " no consensus reached, request released");
       givenReq.reset();
     }
@@ -564,6 +581,7 @@ void PreProcessor::handleClientPreProcessRequestByPrimary(PreProcessRequestMsgSh
   const auto &reqSeqNum = preProcessRequestMsg->reqSeqNum();
   const auto &clientId = preProcessRequestMsg->clientId();
   const auto &senderId = preProcessRequestMsg->senderId();
+  SCOPED_MDC_CID(preProcessRequestMsg->getCid());
   LOG_DEBUG(logger(), "Start request processing by a primary replica" << KVLOG(reqSeqNum, clientId, senderId));
   sendPreProcessRequestToAllReplicas(preProcessRequestMsg);
   // Pre-process the request and calculate a hash of the result
@@ -578,11 +596,13 @@ void PreProcessor::handleClientPreProcessRequestByNonPrimary(ClientPreProcessReq
   const auto &senderId = clientReqMsg->senderId();
   const auto &reqTimeoutMilli = clientReqMsg->requestTimeoutMilli();
   // Save parameters required for a message sending before being moved to registerRequest
-  const auto &msgBody = clientReqMsg->body();
-  const auto &msgType = clientReqMsg->type();
-  const auto &msgSize = clientReqMsg->size();
+  const auto msgBody = clientReqMsg->body();
+  const auto msgType = clientReqMsg->type();
+  const auto msgSize = clientReqMsg->size();
+  const auto cid = clientReqMsg->getCid();
   // Register a client request message with an empty PreProcessRequestMsg to allow follow up.
   if (registerRequest(move(clientReqMsg), PreProcessRequestMsgSharedPtr())) {
+    SCOPED_MDC_CID(cid);
     LOG_DEBUG(
         logger(),
         "Start request processing by a non-primary replica" << KVLOG(reqSeqNum, clientId, senderId, reqTimeoutMilli));
@@ -697,16 +717,15 @@ void PreProcessor::handlePreProcessedReqByNonPrimary(uint16_t clientId,
   releaseClientPreProcessRequestSafe(clientId, COMPLETE);
   sendMsg(replyMsg->body(), myReplica_.currentPrimary(), replyMsg->type(), replyMsg->size());
   SCOPED_MDC_CID(cid);
-  LOG_DEBUG(
-      logger(),
-      "Sent PreProcessReplyMsg with" << KVLOG(reqSeqNum) << " to the primary replica: " << myReplica_.currentPrimary());
+  LOG_DEBUG(logger(),
+            "Sent PreProcessReplyMsg with" << KVLOG(reqSeqNum, replyMsg->status())
+                                           << " to the primary replica: " << myReplica_.currentPrimary());
 }
 
 void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                              bool isPrimary,
                                              bool isRetry) {
   const string cid = preProcessReqMsg->getCid();
-  SCOPED_MDC_CID(cid);
   const uint16_t &clientId = preProcessReqMsg->clientId();
   const SeqNum &reqSeqNum = preProcessReqMsg->reqSeqNum();
   const auto &span_context = preProcessReqMsg->spanContext<PreProcessRequestMsgSharedPtr::element_type>();
@@ -716,6 +735,8 @@ void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr
     handlePreProcessedReqPrimaryRetry(clientId);
     return;
   }
+  SCOPED_MDC_CID(cid);
+  LOG_DEBUG(logger(), "Request pre-processed" << KVLOG(isPrimary, reqSeqNum, clientId));
   if (isPrimary)
     handlePreProcessedReqByPrimary(preProcessReqMsg, clientId, actualResultBufLen);
   else

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -37,6 +37,8 @@ struct ClientRequestState {
   std::deque<RequestProcessingStateUniquePtr> reqProcessingHistory;
 };
 
+typedef enum { UNKNOWN_ROLE, PRIMARY, NON_PRIMARY } ReplicaState;
+
 typedef std::shared_ptr<ClientRequestState> ClientRequestStateSharedPtr;
 typedef std::unordered_map<uint16_t, ClientRequestStateSharedPtr> OngoingReqMap;  // clientId -> ClientRequestState map
 
@@ -133,6 +135,7 @@ class PreProcessor {
   void addTimers();
   void cancelTimers();
   void onRequestsStatusCheckTimer();
+  void handlePossibleReplicaRoleChange();
 
   static logging::Logger &logger() {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
@@ -173,6 +176,9 @@ class PreProcessor {
   concordUtil::Timers::Handle requestsStatusCheckTimer_;
   const uint64_t preExecReqStatusCheckPeriodMilli_;
   concordUtil::Timers &timers_;
+  ReplicaState lastReplicaRole_;
+  ReplicaRoleTransition replicaRoleTransition_;
+  std::mutex replicaStateMutex_;
 };
 
 //**************** Class AsyncPreProcessJob ****************//

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -42,6 +42,7 @@ RequestProcessingState::RequestProcessingState(uint16_t numOfReplicas,
       entryTime_(getMonotonicTimeMilli()),
       clientPreProcessReqMsg_(move(clientReqMsg)),
       preProcessRequestMsg_(preProcessRequestMsg) {
+  SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(), "Created RequestProcessingState with" << KVLOG(reqSeqNum, numOfReplicas_));
 }
 
@@ -119,6 +120,7 @@ bool RequestProcessingState::isReqTimedOut(bool isPrimary) const {
   if (!clientPreProcessReqMsg_) return false;
 
   SCOPED_MDC_CID(cid_);
+  LOG_DEBUG(logger(), KVLOG(isPrimary, primaryPreProcessResultLen_, clientPreProcessReqMsg_->getCid()));
   if (!isPrimary || primaryPreProcessResultLen_ != 0) {
     // On the primary: check request timeout once an asynchronous pre-execution completed (to not abort the execution
     // thread)

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -116,12 +116,14 @@ auto RequestProcessingState::calculateMaxNbrOfEqualHashes(uint16_t &maxNumOfEqua
   return itOfChosenHash;
 }
 
-bool RequestProcessingState::isReqTimedOut(bool isPrimary) const {
+bool RequestProcessingState::isPrimaryPreprocessingCompleted() const { return primaryPreProcessResultLen_ != 0; }
+
+bool RequestProcessingState::isReqTimedOut(bool isPrimary, ReplicaRoleTransition replicaRoleTransition) const {
   if (!clientPreProcessReqMsg_) return false;
 
   SCOPED_MDC_CID(cid_);
-  LOG_DEBUG(logger(), KVLOG(isPrimary, primaryPreProcessResultLen_, clientPreProcessReqMsg_->getCid()));
-  if (!isPrimary || primaryPreProcessResultLen_ != 0) {
+  LOG_DEBUG(logger(), KVLOG(isPrimary, replicaRoleTransition, isPrimaryPreprocessingCompleted()));
+  if (!isPrimary || replicaRoleTransition == BECAME_PRIMARY || isPrimaryPreprocessingCompleted()) {
     // On the primary: check request timeout once an asynchronous pre-execution completed (to not abort the execution
     // thread)
     auto reqProcessingTime = getMonotonicTimeMilli() - entryTime_;

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -22,6 +22,7 @@ namespace preprocessor {
 
 // This class collects and stores data relevant to the processing of one specific client request by all replicas.
 
+typedef enum { UNKNOWN, BECAME_PRIMARY, BECAME_NON_PRIMARY } ReplicaRoleTransition;
 typedef enum { NONE, CONTINUE, COMPLETE, CANCEL, RETRY_PRIMARY } PreProcessingResult;
 typedef std::vector<ReplicaId> ReplicaIdsList;
 
@@ -45,7 +46,7 @@ class RequestProcessingState {
   PreProcessingResult definePreProcessingConsensusResult();
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
-  bool isReqTimedOut(bool isPrimary) const;
+  bool isReqTimedOut(bool isPrimary, ReplicaRoleTransition replicaRoleTransition) const;
   uint64_t getReqTimeoutMilli() const {
     return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->requestTimeoutMilli() : 0;
   }
@@ -68,6 +69,7 @@ class RequestProcessingState {
   auto calculateMaxNbrOfEqualHashes(uint16_t& maxNumOfEqualHashes) const;
   void detectNonDeterministicPreProcessing(const concord::util::SHA3_256::Digest& newHash,
                                            NodeIdType newSenderId) const;
+  bool isPrimaryPreprocessingCompleted() const;
 
  private:
   static uint16_t numOfRequiredEqualReplies_;


### PR DESCRIPTION
- Fix a lack of a request state cleanup after a view change
- Improve pre-execution log
- Set a number of pre-execution threads to (numOfExternalClients + numOfClientProxies)