### PR TITLE
create_tls_certs.sh: extend user certificate generation options

### DIFF
--- a/scripts/linux/create_tls_certs.sh
+++ b/scripts/linux/create_tls_certs.sh
@@ -1,38 +1,54 @@
 #!/usr/bin/env bash
-# creates simple self signed certificates to use with TCP TLS module
-# by default, it will create "certs" folder in the current folder
+# Creates simple self-signed certificates to use with TCP/TLS module
+# by default, the script:
+# 1) Creates "certs" folder in the current folder
+# 2) Starts from node ID 0
+#
+# Examples usage:
+# 1) To create 10 certificates folders with node IDs 0 to 9 in "./certs:
+# > ./create_tls_certs.sh 10
+#
+# 2) To create 15 certificates folders with node IDs 0 to 14 in "/tmp/abc/:
+# > ./create_tls_certs.sh 15 /tmp/abc
+#
+# 3) To create 30 certificates folders with node IDs 5 to 34 in "/tmp/fldkdsZ/:
+# > ./create_tls_certs.sh 30 /tmp/fldkdsZ 5
 
 if [ "$#" -eq 0 ] || [ -z "$1" ]; then
-   echo "usage: create_certs.sh {num of replicas} {optional - output folder}"
+   echo "usage: create_tls_certs.sh {num of replicas} {optional - output folder} {optional - start node ID}"
    exit 1
 fi
 
 dir=$2
-if [ -z $dir ]; then
+if [ -z "$dir" ]; then
    dir="certs"
 fi
 
-i=0
-while [ $i -lt $1 ]; do
-   echo "processing replica $i"
+start_node_id=$3
+if [ -z "$start_node_id" ]; then
+   start_node_id=0
+fi
+
+i=$start_node_id
+last_node_id=$((i + $1 - 1))
+while [ $i -le $last_node_id ]; do
+   echo "processing replica $i/$last_node_id"
    clientDir=$dir/$i/client
    serverDir=$dir/$i/server
 
    mkdir -p $clientDir
    mkdir -p $serverDir
 
-   openssl ecparam -name secp384r1 -genkey -noout -out \
-$serverDir/pk.pem
-   openssl ecparam -name secp384r1 -genkey -noout -out \
-$clientDir/pk.pem
+   openssl ecparam -name secp384r1 -genkey -noout -out $serverDir/pk.pem
+   openssl ecparam -name secp384r1 -genkey -noout -out $clientDir/pk.pem
 
    openssl req -new -key $serverDir/pk.pem -nodes -days 365 -x509 \
--subj "/C=NA/ST=NA/L=NA/O=NA/OU="$i"/CN=node"$i"ser" -out $serverDir/server.cert
+        -subj "/C=NA/ST=NA/L=NA/O=NA/OU=${i}/CN=node${i}ser" -out $serverDir/server.cert
 
    openssl req -new -key $clientDir/pk.pem -nodes -days 365 -x509 \
--subj "/C=NA/ST=NA/L=NA/O=NA/OU="$i"/CN=node"$i"cli" -out $clientDir/client.cert
+        -subj "/C=NA/ST=NA/L=NA/O=NA/OU=${i}/CN=node${i}cli" -out $clientDir/client.cert
 
-   let i=i+1
+   (( i=i+1 ))
 done
 
 exit 0


### PR DESCRIPTION
Here we modify this script to give the user more control over how
certificates are generated:
1) new optional input - 'output folder'. If not given, we keep ./certs
as default.
2) new optional input - 'start node ID'. If not given, we keep 0 as the
start node id.

Both of these capabilities are needed for testing purposes (To support Apollo TLS communication tests).
Additional remarks:
1) We also made some "cosmetic" changes in the script.
2) The lines starting with 'openssl req ' has some bug, double quotes
inside double quotes are not allowed in bash.
3) Keep the positional and optional input convention for now. Examples
are given above.

Issue: BC-4932