### PR TITLE
Modify tests config to accept command line TLS certificate root path

### DIFF
--- a/tests/config/itest_comm_config.hpp
+++ b/tests/config/itest_comm_config.hpp
@@ -51,7 +51,8 @@ class ITestCommConfig {
                                                            uint16_t id,
                                                            uint16_t& num_of_clients,
                                                            uint16_t& num_of_replicas,
-                                                           const std::string& config_file_name) = 0;
+                                                           const std::string& config_file_name,
+                                                           const std::string& cert_root_path) = 0;
 
  protected:
   logging::Logger& logger_;

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -173,7 +173,8 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
                                              uint16_t id,
                                              uint16_t& num_of_clients,
                                              uint16_t& num_of_replicas,
-                                             const std::string& config_file_name) {
+                                             const std::string& config_file_name,
+                                             const std::string& cert_root_path) {
   string ip;
   uint16_t port;
 
@@ -181,7 +182,13 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
       SetUpNodes(is_replica, id, ip, port, num_of_clients, num_of_replicas, config_file_name);
 
   // need to move the default cipher suite to the config file
-  TlsTcpConfig retVal(
-      default_listen_ip_, port, buf_length_, nodes, num_of_replicas - 1, id, "certs", "ECDHE-ECDSA-AES256-GCM-SHA384");
+  TlsTcpConfig retVal(default_listen_ip_,
+                      port,
+                      buf_length_,
+                      nodes,
+                      num_of_replicas - 1,
+                      id,
+                      cert_root_path,
+                      "ECDHE-ECDSA-AES256-GCM-SHA384");
   return retVal;
 }

--- a/tests/config/test_comm_config.hpp
+++ b/tests/config/test_comm_config.hpp
@@ -40,7 +40,8 @@ class TestCommConfig : public ITestCommConfig {
                                                    uint16_t id,
                                                    uint16_t& num_of_clients,
                                                    uint16_t& num_of_replicas,
-                                                   const std::string& config_file_name) override;
+                                                   const std::string& config_file_name,
+                                                   const std::string& cert_root_path = "certs") override;
 
  private:
   std::unordered_map<bft::communication::NodeNum, bft::communication::NodeInfo> SetUpConfiguredNodes(

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -49,6 +49,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::string keysFilePrefix;
     std::string commConfigFile;
     std::string s3ConfigFile;
+    std::string certRootPath = "certs";
     std::string logPropsFile = "logging.properties";
     // Set StorageType::V1DirectKeyValue as the default storage type.
     auto storageType = StorageType::V1DirectKeyValue;
@@ -64,12 +65,13 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"storage-type", required_argument, 0, 't'},
                                           {"log-props-file", required_argument, 0, 'l'},
                                           {"key-exchange-on-start", required_argument, 0, 'e'},
+                                          {"cert-root-path", required_argument, 0, 'c'},
                                           {0, 0, 0, 0}};
 
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
-    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:l:e:", longOptions, &optionIndex)) != -1) {
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:l:c:e:", longOptions, &optionIndex)) != -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -118,6 +120,10 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           logPropsFile = optarg;
           break;
         }
+        case 'c': {
+          certRootPath = optarg;
+          break;
+        }
         case '?': {
           throw std::runtime_error("invalid arguments");
         } break;
@@ -140,7 +146,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         true, replicaConfig.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, commConfigFile);
 #elif USE_COMM_TLS_TCP
     bft::communication::TlsTcpConfig conf = testCommConfig.GetTlsTCPConfig(
-        true, replicaConfig.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, commConfigFile);
+        true, replicaConfig.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, commConfigFile, certRootPath);
 #else
     bft::communication::PlainUdpConfig conf = testCommConfig.GetUDPConfig(
         true, replicaConfig.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, commConfigFile);


### PR DESCRIPTION
Until now the only option for a simpleKVBC TesterReplica,
was to look for its TLS certificates in the current working folder under
"certs". Apollo tests run under some random folder under /tmp, and
the certificate is generated into this folder. To save time, we would
like to allow the user to point into this folder
and override the default case. We add an option -c / --cert-root-path.
This is only optional, if not given, a replica will look under ./certs.
This option should be used only when a replica supports TCP/TLS
communication, else it is ignored.