### PR TITLE
Using new metrics to provide fast/slow path testing

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -219,6 +219,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_total_finished_consensuses_;
   CounterHandle metric_total_slowPath_;
   CounterHandle metric_total_fastPath_;
+  CounterHandle metric_total_slowPath_requests_;
+  CounterHandle metric_total_fastPath_requests_;
   //*****************************************************
  public:
   ReplicaImp(const ReplicaConfig&,

--- a/tests/apollo/test_skvbc_auto_view_change.py
+++ b/tests/apollo/test_skvbc_auto_view_change.py
@@ -99,6 +99,7 @@ class SkvbcAutoViewChangeTest(unittest.TestCase):
 
         await tracker.tracked_read_your_writes()
 
+    @unittest.skip("Unstable because of BC-5101")
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability()

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -372,8 +372,8 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
         await tracker.tracked_read_your_writes()
 
-        await bft_network.wait_for_slow_path_to_be_prevalent(
-            replica_id=current_primary)
+        #check after test is fixed
+        await bft_network.assert_slow_path_prevalent()
 
     @with_trio
     @with_bft_network(start_replica_cmd,


### PR DESCRIPTION
New metrics that count requests rather than batches, so the client can ensure a certain number of requests that were sent were processed on the expected path.

Rewritten the wait_for methods to send requests as necessary and check the counts until the requested path is prevalent or a timeout.

Retained the assert_X_path_prevalent option for cases where the tests want to check if a predetermined series of events happened on the expected path similar to the previous functionality except they should be deterministic with an exact threshold of maximum number requests processed on the undesired path and minimum on the desired.

_wait_for_consensus_path_to_be_prevalent algorithm:
  read new metrics to set baseline number
  use the callback to send requests
  read the new metrics
  if there are any requests processed on the undesired path wait 5 seconds and send new requests
  if there are no undesired requests, but not enough requests on the desired path wait .5 seconds and read the metrics again. If the desired number(threshold input parameter) isn't reached within 15 seconds sends new requests.
  if neither failure mode happens i.e. we have enough desired path requests to clear the threshold and no undesired requests we succeed.