### PR TITLE
[Apollo] Reproduce BC-4982 outside of long-running tests

### DIFF
--- a/tests/simpleKVBC/scripts/logging.properties
+++ b/tests/simpleKVBC/scripts/logging.properties
@@ -23,6 +23,7 @@ log4cplus.appender.R.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%
 
 
 log4cplus.rootLogger=INFO, STDOUT, R
+log4cplus.logger.concord.preprocessor=DEBUG
 
 
 


### PR DESCRIPTION
1) Select two clients - one that runs "long" and one that runs "short" requests
2) Set the timeout of the long client to LONG_REQ_TIMEOUT_MILLI
3) Concurrently:
  3.1) Run a long executing request via the "long" client
  3.2) Trigger a view change during the long execution
4) Run a short write using the "short" client (succeeds)
5) Run a short write using the "long" client (fails because the long client is not freed in the pre-processor)