### PR TITLE
Prolong the maxmimum source replica selection timeout from 5s to 15s

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -123,7 +123,7 @@ struct Config {
   uint32_t refreshTimerMilli = 300;                               // ms
   uint32_t checkpointSummariesRetransmissionTimeoutMilli = 2500;  // ms
   uint32_t maxAcceptableMsgDelayMilli = 60000;                    // 1 minute
-  uint32_t sourceReplicaReplacementTimeoutMilli = 5000;           // 5 seconds
+  uint32_t sourceReplicaReplacementTimeoutMilli = 15000;          // 15 seconds
   uint32_t fetchRetransmissionTimeoutMilli = 250;                 // ms
   std::chrono::seconds metricsDumpIntervalSeconds;                // sec
 };


### PR DESCRIPTION
to deal with larger blocks.