### PR TITLE
skvbc_history_tracker: fix bug in send_indefinite_tracked_ops()

### DIFF
--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -947,7 +947,7 @@ class SkvbcTracker:
                     if random.random() < write_weight:
                         nursery.start_soon(self.send_tracked_write, client, max_size)
                     else:
-                        nursery.start_soon(self.send_tracked_write, client, max_size)
+                        nursery.start_soon(self.send_tracked_read, client, max_size)
                 except:
                     pass
                 await trio.sleep(time_interval)


### PR DESCRIPTION
The modified block of code is intended to have a sequence of
random reads and writes. But before change we got 100% writes since in
both cases we called self.send_tracked_write().