### PR TITLE
Stateless docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,15 @@ CONCORD_BFT_CTEST_TIMEOUT:=3000 # Default value is 1500 sec. It takes 2500 to ru
 CONCORD_BFT_USER_GROUP:=--user `id -u`:`id -g`
 
 CONCORD_BFT_ADDITIONAL_RUN_PARAMS:=
-CONCORD_BFT_ADDITIONAL_RUN_COMMANDS:=
+
+BASIC_RUN_PARAMS:=--rm --privileged=true \
+					  --cap-add NET_ADMIN --cap-add=SYS_PTRACE --ulimit core=-1 \
+					  --name="${CONCORD_BFT_DOCKER_CONTAINER}" \
+					  --workdir=${CONCORD_BFT_TARGET_SOURCE_PATH} \
+					  --mount type=bind,source=${CURDIR},target=/cores \
+					  --mount type=bind,source=${CURDIR},target=${CONCORD_BFT_TARGET_SOURCE_PATH}${CONCORD_BFT_CONTAINER_MOUNT_CONSISTENCY} \
+					  ${CONCORD_BFT_ADDITIONAL_RUN_PARAMS} \
+					  ${CONCORD_BFT_DOCKER_REPO}${CONCORD_BFT_DOCKER_IMAGE}:${CONCORD_BFT_DOCKER_IMAGE_VERSION}
 
 .DEFAULT_GOAL:=build
 
@@ -38,66 +46,30 @@ CONCORD_BFT_ADDITIONAL_RUN_COMMANDS:=
 # or adding custom targets. The include directive is ignored if MakefileCustom file does not exist.
 -include MakefileCustom
 
-IF_CONTAINER_RUNS=$(shell docker container inspect -f '{{.State.Running}}' ${CONCORD_BFT_DOCKER_CONTAINER})
+IF_CONTAINER_RUNS=$(shell docker container inspect -f '{{.State.Running}}' ${CONCORD_BFT_DOCKER_CONTAINER} 2>/dev/null)
 
 .PHONY: help
 help: ## The Makefile helps to build Concord-BFT in a docker container
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-	# Basic HOW-TO:
-	# make                    # Build Concord-BFT sources
-	# make test               # Run tests
-	# make remove-c           # Remove existing container
-	# make build-docker-image # Build docker image locally
-
 .PHONY: pull
 pull: ## Pull image from remote
 	docker pull ${CONCORD_BFT_DOCKER_REPO}${CONCORD_BFT_DOCKER_IMAGE}:${CONCORD_BFT_DOCKER_IMAGE_VERSION}
 
-.PHONY: run-c
-run-c: ## Run container in background
-	docker run -d --rm --privileged=true \
-			  --cap-add NET_ADMIN --cap-add=SYS_PTRACE --ulimit core=-1 \
-			  --name="${CONCORD_BFT_DOCKER_CONTAINER}" \
-			  --workdir=${CONCORD_BFT_TARGET_SOURCE_PATH} \
-			  --mount type=bind,source=${CURDIR},target=/cores \
-			  --mount type=bind,source=${CURDIR},target=${CONCORD_BFT_TARGET_SOURCE_PATH}${CONCORD_BFT_CONTAINER_MOUNT_CONSISTENCY} \
-			  ${CONCORD_BFT_ADDITIONAL_RUN_PARAMS} \
-			  ${CONCORD_BFT_DOCKER_REPO}${CONCORD_BFT_DOCKER_IMAGE}:${CONCORD_BFT_DOCKER_IMAGE_VERSION} \
-			  ${CONCORD_BFT_CONTAINER_SHELL} -c \
-			  "${CONCORD_BFT_ADDITIONAL_RUN_COMMANDS} \
-			  /usr/bin/tail -f /dev/null"
-	@echo
-	@echo "The container \"${CONCORD_BFT_DOCKER_CONTAINER}\" with the build environment is started as daemon."
-	@echo "Run \"make stop-c\" to stop or \"make remove-c\" to delete."
-
 .PHONY: login
-login: ## Login to the container
+login: ## Login to the container. Note: if the container is already running, login into existing one
 	@if [ "${IF_CONTAINER_RUNS}" != "true" ]; then \
-		make run-c; \
+		docker run -it ${BASIC_RUN_PARAMS} \
+			${CONCORD_BFT_CONTAINER_SHELL};exit 0; \
+	else \
+		docker exec -it ${CONCORD_BFT_DOCKER_CONTAINER} \
+			${CONCORD_BFT_CONTAINER_SHELL};exit 0; \
 	fi
-	docker exec -it ${CONCORD_BFT_DOCKER_CONTAINER} \
-		${CONCORD_BFT_CONTAINER_SHELL};exit 0
-
-.PHONY: stop-c
-stop-c: ## Stop the container
-	docker container stop ${CONCORD_BFT_DOCKER_CONTAINER}
-	@echo
-	@echo "The container \"${CONCORD_BFT_DOCKER_CONTAINER}\" is successfully stopped."
-
-.PHONY: remove-c
-remove-c: ## Remove the container
-	docker container rm -f ${CONCORD_BFT_DOCKER_CONTAINER}
-	@echo
-	@echo "The container \"${CONCORD_BFT_DOCKER_CONTAINER}\" is successfully removed."
 
 .PHONY: build
-build: ## Build Concord-BFT source. Note: this command is mostly for developers
-	@if [ "${IF_CONTAINER_RUNS}" != "true" ]; then \
-		make run-c; \
-	fi
-	docker exec -it ${CONCORD_BFT_USER_GROUP} ${CONCORD_BFT_DOCKER_CONTAINER} \
+build: ## Build Concord-BFT source. Note: this is the default target
+	docker run -it ${CONCORD_BFT_USER_GROUP} ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"mkdir -p ${CONCORD_BFT_TARGET_SOURCE_PATH}/${CONCORD_BFT_BUILD_DIR} && \
 		cd ${CONCORD_BFT_BUILD_DIR} && \
@@ -109,11 +81,8 @@ build: ## Build Concord-BFT source. Note: this command is mostly for developers
 	@echo "Build finished. The binaries are in ${CURDIR}/${CONCORD_BFT_BUILD_DIR}"
 
 .PHONY: format
-format: ## Format Concord-BFT source
-	@if [ "${IF_CONTAINER_RUNS}" != "true" ]; then \
-		make run-c; \
-	fi
-	docker exec -it ${CONCORD_BFT_USER_GROUP} ${CONCORD_BFT_DOCKER_CONTAINER} \
+format: ## Format Concord-BFT source with clang-format
+	docker run -it ${CONCORD_BFT_USER_GROUP} ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"mkdir -p ${CONCORD_BFT_TARGET_SOURCE_PATH}/${CONCORD_BFT_BUILD_DIR} && \
 		cd ${CONCORD_BFT_BUILD_DIR} && \
@@ -124,11 +93,8 @@ format: ## Format Concord-BFT source
 	@echo "Format finished."
 
 .PHONY: tidy-check
-tidy-check: ## Runs clang-tidy
-	@if [ "${IF_CONTAINER_RUNS}" != "true" ]; then \
-		make run-c; \
-	fi
-	docker exec -it ${CONCORD_BFT_USER_GROUP} ${CONCORD_BFT_DOCKER_CONTAINER} \
+tidy-check: ## Run clang-tidy
+	docker run -it ${CONCORD_BFT_USER_GROUP} ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"mkdir -p ${CONCORD_BFT_TARGET_SOURCE_PATH}/${CONCORD_BFT_BUILD_DIR} && \
 		cd ${CONCORD_BFT_BUILD_DIR} && \
@@ -143,35 +109,26 @@ tidy-check: ## Runs clang-tidy
 
 .PHONY: test
 test: ## Run all tests
-	@if [ "${IF_CONTAINER_RUNS}" != "true" ]; then \
-		make run-c; \
-	fi
-	docker exec -it ${CONCORD_BFT_DOCKER_CONTAINER} \
+	docker run -it ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"cd ${CONCORD_BFT_BUILD_DIR} && \
 		ctest --timeout ${CONCORD_BFT_CTEST_TIMEOUT} --output-on-failure"
 
 .PHONY: single-test
-single-test: ## Run single test `make single-test TEST_NAME=<test name>`
-	@if [ "${IF_CONTAINER_RUNS}" != "true" ]; then \
-		make run-c; \
-	fi
-	docker exec -it ${CONCORD_BFT_DOCKER_CONTAINER} \
+single-test: ## Run a single test `make single-test TEST_NAME=<test name>`
+	docker run -it ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"cd ${CONCORD_BFT_BUILD_DIR} && \
 		ctest -V -R ${TEST_NAME} --timeout ${CONCORD_BFT_CTEST_TIMEOUT} --output-on-failure"
 
 .PHONY: clean
 clean: ## Clean Concord-BFT build directory
-	@if [ "${IF_CONTAINER_RUNS}" != "true" ]; then \
-		make run-c; \
-	fi
-	docker exec -it ${CONCORD_BFT_DOCKER_CONTAINER} \
+	docker run -it ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"rm -rf ${CONCORD_BFT_BUILD_DIR}"
 
 .PHONY: build-docker-image
-build-docker-image: ## Re-build the container without caching
+build-docker-image: ## Build the image. Note: without caching
 	docker build --rm --no-cache=true -t ${CONCORD_BFT_DOCKER_IMAGE}:latest \
 		-f ./${CONCORD_BFT_DOCKERFILE} .
 	@echo


### PR DESCRIPTION
Rationale:
Avoid restarting the docker container manually on every update of the image or switch between release branches.

Solution:
Since there is no intermediate state of the build docker container except the `build` directory, we can
make the docker build stateless. As a result, the update of docker image would be easier: no need to restart the
container after the rebase or to make sure that you’re using the latest image because `docker run` would download the
latest automatically.

Changes:
* Every command launches a docker container: replaced all the `exec` commands with `run`
* `make login` launches a new container only if it does not exist, otherwise it enters the existing
* Forwared the error output of `docker container inspect` to `/dev/null`
* Removed `run-c`, `stop-c`, and `remove-c` targets

Usage:
* Once the commit is merged, need to run `docker kill concord-bft`
to allow launching it.
* All the rest is exactly the same