### PR TITLE
Github Actions: Debug messages for "No space left on device" issue

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,9 @@ jobs:
             #- name: Setup tmate session
             #  uses: mxschmitt/action-tmate@v2
         - name: Build and test
-          run: >
+          run: |
+              script -q -e -c "make pull"
+              sudo df -h
               script -q -e -c "make build \
                               ${{ matrix.compiler}} \
                               CONCORD_BFT_CMAKE_FLAGS=\"\


### PR DESCRIPTION
Sometimes jobs fail due to "No space left on device" error.
In order to monitor the disk usage, `sudo df -h` is executed right after
pulling the docker image.

In case it happens again, I'll open an issue in Github Actions repo.