### PR TITLE
Serialization enhancements:

### DIFF
--- a/bftengine/tests/controllerWithSimpleHistory/ControllerWithSimpleHistory_test.cpp
+++ b/bftengine/tests/controllerWithSimpleHistory/ControllerWithSimpleHistory_test.cpp
@@ -304,9 +304,6 @@ class ThreshSigMock : public IThresholdSigner {
 
   virtual const IShareSecretKey &getShareSecretKey() { return is; };
   virtual const IShareVerificationKey &getShareVerificationKey() const { return isv; };
-  const std::string getVersion() const { return "v"; }
-  void serializeDataMembers(std::ostream &) const {}
-  void deserializeDataMembers(std::istream &) {}
   const IShareSecretKey &getShareSecretKey() const { return is; }
 };
 

--- a/bftengine/tests/messages/helper.hpp
+++ b/bftengine/tests/messages/helper.hpp
@@ -32,8 +32,7 @@ class IShareVerificationKeyDummy : public IShareVerificationKey {
   std::string toString() const override { return "IShareVerificationKeyDummy"; }
 };
 
-class IThresholdSignerDummy : public IThresholdSigner,
-                              public concord::serialize::SerializableFactory<IThresholdSignerDummy> {
+class IThresholdSignerDummy : public IThresholdSigner {
  public:
   int requiredLengthForSignedData() const override { return 2048; }
   void signData(const char *hash, int hashLen, char *outSig, int outSigLen) override {
@@ -42,9 +41,6 @@ class IThresholdSignerDummy : public IThresholdSigner,
 
   const IShareSecretKey &getShareSecretKey() const override { return shareSecretKey; }
   const IShareVerificationKey &getShareVerificationKey() const override { return shareVerifyKey; }
-  const std::string getVersion() const override { return "1"; }
-  void serializeDataMembers(std::ostream &outStream) const override {}
-  void deserializeDataMembers(std::istream &outStream) override {}
   IShareSecretKeyDummy shareSecretKey;
   IShareVerificationKeyDummy shareVerifyKey;
 };
@@ -58,8 +54,7 @@ class IThresholdAccumulatorDummy : public IThresholdAccumulator {
   void getFullSignedData(char *outThreshSig, int threshSigLen) override {}
 };
 
-class IThresholdVerifierDummy : public IThresholdVerifier,
-                                public concord::serialize::SerializableFactory<IThresholdVerifierDummy> {
+class IThresholdVerifierDummy : public IThresholdVerifier {
  public:
   IThresholdAccumulator *newAccumulator(bool withShareVerification) const override {
     return new IThresholdAccumulatorDummy;
@@ -69,9 +64,6 @@ class IThresholdVerifierDummy : public IThresholdVerifier,
   const IPublicKey &getPublicKey() const override { return shareVerifyKey; }
   const IShareVerificationKey &getShareVerificationKey(ShareID signer) const override { return shareVerifyKey; }
 
-  const std::string getVersion() const override { return "1"; }
-  void serializeDataMembers(std::ostream &outStream) const override {}
-  void deserializeDataMembers(std::istream &outStream) override {}
   IShareVerificationKeyDummy shareVerifyKey;
 };
 

--- a/bftengine/tests/testViewChange/testViewChange.cpp
+++ b/bftengine/tests/testViewChange/testViewChange.cpp
@@ -101,9 +101,6 @@ class DummySigner : public IThresholdSigner {
   virtual const IShareSecretKey& getShareSecretKey() const override { return dummyShareSecretKey_; }
   virtual const IShareVerificationKey& getShareVerificationKey() const override { return dummyShareVerificationKey_; }
 
-  virtual const std::string getVersion() const override { return std::string("123"); }
-  virtual void serializeDataMembers(std::ostream&) const override {}
-  virtual void deserializeDataMembers(std::istream&) override {}
 } dummySigner_;
 
 class DummyVerifier : public IThresholdVerifier {
@@ -121,9 +118,6 @@ class DummyVerifier : public IThresholdVerifier {
   virtual const IShareVerificationKey& getShareVerificationKey(ShareID signer) const override {
     return dummyShareVerificationKey_;
   }
-  virtual const std::string getVersion() const override { return std::string("123"); }
-  virtual void serializeDataMembers(std::ostream&) const override {}
-  virtual void deserializeDataMembers(std::istream&) override {}
 };
 
 void setUpConfiguration_4() {

--- a/threshsign/include/threshsign/IThresholdSigner.h
+++ b/threshsign/include/threshsign/IThresholdSigner.h
@@ -16,8 +16,9 @@
 #include "ISecretKey.h"
 #include "IPublicKey.h"
 
-class IThresholdSigner : public virtual concord::serialize::Serializable {
+class IThresholdSigner {
  public:
+  virtual ~IThresholdSigner() = default;
   virtual int requiredLengthForSignedData() const = 0;
   virtual void signData(const char *hash, int hashLen, char *outSig, int outSigLen) = 0;
 

--- a/threshsign/include/threshsign/IThresholdVerifier.h
+++ b/threshsign/include/threshsign/IThresholdVerifier.h
@@ -20,9 +20,9 @@
 #include "ThresholdSignaturesTypes.h"
 #include "IThresholdAccumulator.h"
 
-class IThresholdVerifier : public virtual concord::serialize::Serializable {
+class IThresholdVerifier {
  public:
-  ~IThresholdVerifier() override = default;
+  virtual ~IThresholdVerifier() = default;
 
  public:
   virtual IThresholdAccumulator *newAccumulator(bool withShareVerification) const = 0;

--- a/util/include/type_traits.h
+++ b/util/include/type_traits.h
@@ -15,6 +15,8 @@
 #include <vector>
 #include <type_traits>
 #include <deque>
+#include <map>
+#include <unordered_map>
 
 namespace concord {
 
@@ -27,13 +29,43 @@ struct is_set : std::false_type {};
 template <typename T>
 struct is_set<std::set<T>> : std::true_type {};
 template <typename T>
+inline constexpr bool is_set_v = is_set<T>::value;
+
+template <typename T>
 struct is_vector : std::false_type {};
 template <typename T>
 struct is_vector<std::vector<T>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_vector_v = is_vector<T>::value;
+
 template <typename T>
 struct is_deque : std::false_type {};
 template <typename T>
 struct is_deque<std::deque<T>> : std::true_type {};
+template <typename T>
+inline constexpr bool is_deque_v = is_deque<T>::value;
+
+template <typename T, typename U = void>
+struct is_pair : std::false_type {};
+template <typename T>
+struct is_pair<T, std::void_t<typename T::first_type, typename T::second_type>> : std::true_type {};
+template <typename T>
+inline constexpr bool is_pair_v = is_pair<T>::value;
+
+// https://stackoverflow.com/questions/35293470/checking-if-a-type-is-a-map
+// std::map, std::unordered_map
+template <typename T, typename U = void>
+struct is_map : std::false_type {};
+
+template <typename T>
+struct is_map<T,
+              std::void_t<typename T::key_type,
+                          typename T::mapped_type,
+                          decltype(std::declval<T&>()[std::declval<const typename T::key_type&>()])>> : std::true_type {
+};
+template <typename T>
+inline constexpr bool is_map_v = is_map<T>::value;
 
 template <class T, T v>
 struct std_container {
@@ -41,10 +73,11 @@ struct std_container {
   constexpr T operator()() const noexcept { return value; }
 };
 template <class T>
-struct is_std_container : std_container<bool, is_set<T>::value || is_vector<T>::value || is_deque<T>::value> {};
+struct is_std_container
+    : std_container<bool, is_set<T>::value || is_vector<T>::value || is_deque<T>::value || is_map<T>::value> {};
 
-template <class T, T v>
-constexpr const T std_container<T, v>::value;
+template <class T>
+inline constexpr bool is_std_container_v = is_std_container<T>::value;
 
 // Taken from https://stackoverflow.com/a/22759544
 template <typename S, typename T>

--- a/util/test/serializable_test.cpp
+++ b/util/test/serializable_test.cpp
@@ -100,6 +100,30 @@ TEST(serializable, VectorInt) {
   ASSERT_TRUE(s == s_out);
 }
 
+TEST(serializable, Map) {
+  std::stringstream sstream;
+  std::map<std::string, int> s_out, s{{"k0", 0}, {"k1", 1}, {"k2", 2}, {"k3", 3}, {"k4", 4}, {"k5", 5}};
+  Serializable::serialize(sstream, s);
+  Serializable::deserialize(sstream, s_out);
+  ASSERT_TRUE(s == s_out);
+}
+
+TEST(serializable, MapConstString) {
+  std::stringstream sstream;
+  std::map<const std::string, int> s_out, s{{"k0", 0}, {"k1", 1}, {"k2", 2}, {"k3", 3}, {"k4", 4}, {"k5", 5}};
+  Serializable::serialize(sstream, s);
+  Serializable::deserialize(sstream, s_out);
+  ASSERT_TRUE(s == s_out);
+}
+
+TEST(serializable, UnorderedMap) {
+  std::stringstream sstream;
+  std::unordered_map<std::string, int> s_out, s{{"k0", 0}, {"k1", 1}, {"k2", 2}, {"k3", 3}, {"k4", 4}, {"k5", 5}};
+  Serializable::serialize(sstream, s);
+  Serializable::deserialize(sstream, s_out);
+  ASSERT_TRUE(s == s_out);
+}
+
 TEST(serializable, VectorSerializable) {
   std::vector<TestSerializable> s, s_out;
   for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
- add support for std::map, std::unordered_map
- add support for const std::string
- add syntactic sugar to type_traits as acceptible since c++17 (e.g. is_vector_v)
- minor cleanup for several serializable classes, which are not serialized anymore.