### PR TITLE
Move initial key-exchange to infra

### DIFF
--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -49,7 +49,7 @@ class SkvbcFastPathTest(unittest.TestCase):
         self.evaluation_period_seq_num = 64
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_fast_path_only(self, bft_network, tracker,exchange_keys=True):
         """
@@ -61,8 +61,6 @@ class SkvbcFastPathTest(unittest.TestCase):
 
         Finally the decorator verifies the KV execution.
         """
-        if exchange_keys:
-            await bft_network.do_key_exchange()
 
         bft_network.start_all_replicas()
 
@@ -70,7 +68,7 @@ class SkvbcFastPathTest(unittest.TestCase):
             run_ops=lambda: tracker.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_fast_to_slow_path_transition(self, bft_network, tracker):
         """
@@ -87,7 +85,6 @@ class SkvbcFastPathTest(unittest.TestCase):
 
         Finally the decorator verifies the KV execution.
         """
-        await bft_network.do_key_exchange()
         bft_network.start_all_replicas()
 
         await bft_network.wait_for_fast_path_to_be_prevalent(
@@ -103,7 +100,7 @@ class SkvbcFastPathTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd,
                       num_clients=4,
-                      selected_configs=lambda n, f, c: c >= 1 and n >= 6)
+                      selected_configs=lambda n, f, c: c >= 1 and n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_fast_path_resilience_to_crashes(self, bft_network, tracker):
         """
@@ -117,7 +114,6 @@ class SkvbcFastPathTest(unittest.TestCase):
 
         Finally the decorator verifies the KV execution.
         """
-        await bft_network.do_key_exchange()
 
         bft_network.start_all_replicas()
         unstable_replicas = bft_network.all_replicas(without={0})

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -53,7 +53,7 @@ class SkvbcChaosTest(unittest.TestCase):
     __test__ = False  # so that PyTest ignores this test scenario
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
     @verify_linearizability()
     async def test_healthy(self, bft_network, tracker,exchange_keys=True):
         """
@@ -61,8 +61,6 @@ class SkvbcChaosTest(unittest.TestCase):
         linearizability. The system is healthy and stable and no faults are
         intentionally generated.
         """
-        if exchange_keys:
-            await bft_network.do_key_exchange()
         num_ops = 500
 
         self.skvbc = kvbc.SimpleKVBCProtocol(bft_network)
@@ -71,7 +69,7 @@ class SkvbcChaosTest(unittest.TestCase):
         await tracker.run_concurrent_ops(num_ops)
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
     @verify_linearizability()
     async def test_wreak_havoc(self, bft_network, tracker):
         """
@@ -79,7 +77,6 @@ class SkvbcChaosTest(unittest.TestCase):
         linearizability. In this test we generate faults periodically and verify
         linearizability at the end of the run.
         """
-        await bft_network.do_key_exchange()
         num_ops = 500
 
         self.skvbc = kvbc.SimpleKVBCProtocol(bft_network)

--- a/tests/apollo/test_skvbc_multi_sig.py
+++ b/tests/apollo/test_skvbc_multi_sig.py
@@ -74,6 +74,7 @@ class SkvbcMultiSig(unittest.TestCase):
         
        
     @with_trio
+    @unittest.skip("BC-5047")
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)   
     async def test_rough_initial_key_exchange(self, bft_network):
         """

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -54,7 +54,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd,
-                      selected_configs=lambda n, f, c: c == 0 and n >= 6)
+                      selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_persistent_slow_path(self, bft_network, tracker):
         """
@@ -68,7 +68,6 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
         Finally, we check if a these entries were executed and readable.
         """
-        await bft_network.do_key_exchange()
 
         bft_network.start_all_replicas()
 
@@ -81,7 +80,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd,
-                      num_clients=4, selected_configs=lambda n, f, c: n >= 6)
+                      num_clients=4, selected_configs=lambda n, f, c: n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_slow_to_fast_path_transition(self, bft_network, tracker,exchange_keys=True):
         """
@@ -101,8 +100,6 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
         Finally we check if a known K/V has been executed and readable.
         """
-        if exchange_keys:
-            await bft_network.do_key_exchange()
 
         run_ops = lambda: tracker.run_concurrent_ops(num_ops=20, write_weight=1)
 
@@ -119,7 +116,7 @@ class SkvbcSlowPathTest(unittest.TestCase):
         await bft_network.wait_for_fast_path_to_be_prevalent(run_ops=run_ops, threshold=20)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_slow_path_view_change(self, bft_network, tracker):
         """
@@ -137,7 +134,6 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
         We make sure the second batch of requests have been processed via the slow path.
         """
-        await bft_network.do_key_exchange()
         bft_network.start_all_replicas()
 
         num_ops = 5

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -49,7 +49,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
     __test__ = False  # so that PyTest ignores this test scenario
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
     async def test_request_block_not_written_primary_down(self, bft_network):
         """
         The goal of this test is to validate that a block wasn't written,
@@ -61,7 +61,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
         4) Verify the BFT network eventually transitions to the next view.
         5) Validate that there is no new block written.
         """
-        await bft_network.do_key_exchange()
 
         bft_network.start_all_replicas()
 
@@ -106,7 +105,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
     @verify_linearizability()
     async def test_single_vc_only_primary_down(self, bft_network, tracker,exchange_keys=True):
         """
@@ -119,8 +118,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
         4) Verify the BFT network eventually transitions to the next view.
         5) Perform a "read-your-writes" check in the new view
         """
-        if exchange_keys:
-            await bft_network.do_key_exchange()
 
         await self._single_vc_with_consecutive_failed_replicas(
             bft_network,
@@ -129,7 +126,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         )
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
     @verify_linearizability()
     async def test_single_vc_with_f_replicas_down(self, bft_network, tracker):
         """
@@ -142,7 +139,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
         4) Verify the BFT network eventually transitions to the next view.
         5) Perform a "read-your-writes" check in the new view
         """
-        await bft_network.do_key_exchange()
         bft_network.start_all_replicas()
 
         n = bft_network.config.n
@@ -179,7 +175,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         await tracker.run_concurrent_ops(10)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2, rotate_keys=True)
     @verify_linearizability()
     async def test_crashed_replica_catch_up_after_view_change(self, bft_network, tracker):
         """
@@ -198,7 +194,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
         two simultaneously crashed replicas (the primary and the non-primary that is
         missing the view change).
         """
-        await bft_network.do_key_exchange()
 
         bft_network.start_all_replicas()
 
@@ -245,7 +240,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
         )
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2, rotate_keys=True)
     @verify_linearizability()
     async def test_restart_replica_after_view_change(self, bft_network, tracker):
         """
@@ -258,7 +253,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
         6) Send a batch of concurrent reads/writes
         7) Make sure the restarted replica is alive and that it works in the new view
         """
-        await bft_network.do_key_exchange()
         bft_network.start_all_replicas()
         initial_primary = 0
 
@@ -377,7 +371,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd,
-                      selected_configs = lambda n,f,c : f >= 2)
+                      selected_configs = lambda n,f,c : f >= 2, rotate_keys=True)
     @verify_linearizability()
     async def test_single_vc_current_and_next_primaries_down(self, bft_network, tracker):
         """
@@ -393,7 +387,6 @@ class SkvbcViewChangeTest(unittest.TestCase):
         5) Perform a "read-your-writes" check in the new view.
         6) We have to filter only configurations which support more than 2 faulty replicas.
         """
-        await bft_network.do_key_exchange()
 		
         await self._single_vc_with_consecutive_failed_replicas(
             bft_network,

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -114,7 +114,7 @@ def with_constant_load(async_fn):
                 nursery.cancel_scope.cancel()
     return wrapper
 
-def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None, num_ro_replicas=0):
+def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None, num_ro_replicas=0, rotate_keys=False):
     """
     Runs the decorated async function for all selected BFT configs
     start_replica_cmd is a callback which is used to start a replica. It should have the following
@@ -154,6 +154,8 @@ def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None,
                                                                      + "_f=" + str(bft_config['f']) \
                                                                      + "_c=" + str(bft_config['c'])
                         with log.start_task(action_type=f"{bft_network.current_test}_num_clients={config.num_clients}"):
+                            if rotate_keys:
+                                await bft_network.do_key_exchange()
                             await async_fn(*args, **kwargs, bft_network=bft_network)
         return wrapper
 


### PR DESCRIPTION
- do_key_exchange() is done as part of the with_bft_network decorator. by default it won't be done, unless one passes ```rotate_keys=True```

- ```test_rough_initial_key_exchange``` is marked as skip. 