### PR TITLE
[Apollo] Wait more for source replica replacement during ST

### DIFF
--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -313,7 +313,8 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
             await bft_network.wait_for_state_transfer_to_stop(
                 up_to_date_node=primary,
-                stale_node=stale
+                stale_node=stale,
+                stop_on_stable_seq_num=True
             )
 
             log.log_message(message_type=f'State transfer completed, despite initial source '
@@ -325,7 +326,8 @@ class SkvbcPersistenceTest(unittest.TestCase):
                   "if state transfer has already completed...")
             await bft_network.wait_for_state_transfer_to_stop(
                 up_to_date_node=primary,
-                stale_node=stale
+                stale_node=stale,
+                stop_on_stable_seq_num=True
             )
             log.log_message(message_type="State transfer completed before we had a chance "
                   "to stop the source replica.")
@@ -527,7 +529,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
 
         log.log_message(message_type=f'Restarting stale replica until '
               f'it fetches from {unstable_replicas}...')
-        with trio.move_on_after(10):  # seconds
+        with trio.move_on_after(seconds=30):
             while True:
                 bft_network.start_replica(stale)
                 source_replica_id = await bft_network.wait_for_fetching_state(

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -649,9 +649,9 @@ class BftTestNetwork:
         Returns the current source replica for state transfer.
         """
         with log.start_action(action_type="wait_for_fetching_state"):
-            with trio.fail_after(10): # seconds
+            with trio.fail_after(seconds=30):
                 while True:
-                    with trio.move_on_after(.5): # seconds
+                    with trio.move_on_after(seconds=.5): # seconds
                         is_fetching = await self.is_fetching(replica_id)
                         source_replica_id = await self.source_replica(replica_id)
                         if is_fetching:


### PR DESCRIPTION
In a recent PR, the source replica replacement timeout was increased to 15s:
https://github.com/vmware/concord-bft/pull/950

This seems to cause an occasional failure of the Apollo test which covers this path. In this PR we increase the time Apollo waits for the ST source replica to be replaced.