### PR TITLE
[Apollo] Accelerate tests by skipping n=4

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -62,9 +62,9 @@ def interesting_configs(selected=None):
     if selected is None:
         selected=lambda *config: True
 
-    bft_configs = [{'n': 4, 'f': 1, 'c': 0, 'num_clients': 30},
-                   {'n': 6, 'f': 1, 'c': 1, 'num_clients': 30},
+    bft_configs = [{'n': 6, 'f': 1, 'c': 1, 'num_clients': 30},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': 30},
+                   # {'n': 4, 'f': 1, 'c': 0, 'num_clients': 30},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': 30}
                    # {'n': 12, 'f': 3, 'c': 1, 'num_clients': 30}
                    ]


### PR DESCRIPTION
We are approaching test execution maximum durations on both Travis (50min) and GA (1h). In order to accelerate CI jobs, I suggest to skip testing BFT networks with n=4 replicas.

The following configurations remain active, and cover all main flows, including having more than one collector (c > 0):
* n=6 (f=1, c=1)
* n=7 (f=2, c=0)

PS: in terms of risk mitigation, the n=4 case is tested as part of product CI where we run Apollo tests against a 4-replica Concord/SKVBC setup.