### PR TITLE
Limit rocksdb max_open_files to 50. (#962)

### DIFF
--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -113,6 +113,7 @@ void Client::init(bool readOnly) {
   options.level0_slowdown_writes_trigger = 48;
   options.level0_stop_writes_trigger = 56;
   options.bytes_per_sync = 1024 * 2048;
+  options.max_open_files = 50;
 
   table_options.block_size = 4 * 4096;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));


### PR DESCRIPTION
This is initial value, we need to experiment
and do performance tests to determine the most
suitable value.