### PR TITLE
[Apollo] Skipping unstable test

### DIFF
--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -51,6 +51,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
+    @unittest.skip("Unstable because of BC-5164")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load


### PR DESCRIPTION
The `test_delayed_replicas_start_up` has started failing recently (although intermittently). I'm disabling it for now, to avoid having frequent failed runs. Still, we need to investigate how recent changes could have caused this (I've logged BC-5164 for this purpose).