### PR TITLE
[Apollo] Reduce pre-processor log level for SKVBC replicas

### DIFF
--- a/tests/simpleKVBC/scripts/logging.properties
+++ b/tests/simpleKVBC/scripts/logging.properties
@@ -23,7 +23,7 @@ log4cplus.appender.R.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%
 
 
 log4cplus.rootLogger=INFO, STDOUT, R
-log4cplus.logger.concord.preprocessor=DEBUG
+log4cplus.logger.concord.preprocessor=INFO
 
 
 


### PR DESCRIPTION
This went in by mistake, following some local Apollo pre-execution test investigations... It may be why we are observing "disk space" issues in GitHub Actions.