### PR TITLE
fix(build): Misc fixes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,8 +25,7 @@ jobs:
           run: mkdir -p ${{ github.workspace }}/artifact
         - name: Configure core dump location
           run: |
-            echo '/cores/core.%e.%p' | sudo tee /proc/sys/kernel/core_pattern
-            mkdir -p ${{ github.workspace }}/artifact/cores/
+            echo "/concord-bft/build/cores/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
             # Uncomment this is you want to login into the running session.
             # Please note that the build will block on this step.
             # Refer to https://github.com/marketplace/actions/debugging-with-tmate
@@ -54,10 +53,10 @@ jobs:
         - name: Prepare artifacts
           if: failure()
           run: |
-            sudo chown -R $USER:$GROUP ${PWD}/build
+            sudo chown -R ${USER}:${GROUP} ${PWD}/build
             mv ${PWD}/build ${{ github.workspace }}/artifact/
-            ls -lh ${{ github.workspace }}/artifact/cores
-            sudo chown -R $USER:$GROUP ${{ github.workspace }}/artifact/
+            du -h ${{ github.workspace }}/artifact
+            sudo df -h
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
           if: failure()


### PR DESCRIPTION
Core dumps have to be located in build/cores directory.

Changes:
* Added `--init` flag to docker to handle signals correctly
* Cleaned the Makefile
* Removed the mounted `cores` directory in the Makefile
* Added creation of cores dir to `make test` and `make single-test`
    The location of the core files is defined by the variable `CONCORD_BFT_CORE_DIR` which is `build/cores` by default.
    In order to change it, run the following `make test CONCORD_BFT_CORE_DIR=<path>`.
    Please note that the path has to be accessible from the container(can be an additional mount point set via `CONCORD_BFT_ADDITIONAL_RUN_PARAMS`)
    and core pattern has to point to the directory.
* Changed the path to the core directory in the CI
* Cleaned the github action
* Print total disk space usage in case of failure
* Print disk usage of the build dir in case of failure