### PR TITLE
TlsTCPCommunication: Degrade log message

### DIFF
--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -1307,7 +1307,7 @@ class TlsTCPCommunication::TlsTcpImpl : public std::enable_shared_from_this<TlsT
     lock_guard<mutex> lock(_connectionsGuard);
     const auto &conn = _connections.find(destNode);
     if (conn != _connections.end()) {
-      LOG_INFO(_logger, "Connection found from " << _selfId << " to " << destNode);
+      LOG_DEBUG(_logger, "Connection found from " << _selfId << " to " << destNode);
       if (conn->second->isAuthenticated()) {
         return ConnectionStatus::Connected;
       } else {


### PR DESCRIPTION
This function is called frequently and the common case is that we already have
a connection with that node. If we don't then there are two other log messages
and one will be printed for sure. Meaning, I don't think we loose any
information at runtime by degrading this message to DEBUG.