### PR TITLE
Check if the MetricsServer thread is joinable before join

### DIFF
--- a/util/src/MetricsServer.cpp
+++ b/util/src/MetricsServer.cpp
@@ -67,7 +67,7 @@ void Server::Stop() {
   close(sock_);
 
   // Wait for the recvLoop thread to stop
-  thread_.join();
+  if (thread_.joinable()) thread_.join();
 }
 
 void Server::RecvLoop() {


### PR DESCRIPTION
The Stop() function of the MetricsServer calls join() on the processing
thread however there are cases when the thread is not joinable.

This causes std::terminate() to be called and breaks the cleanup process
of concord-bft library.