### PR TITLE
Fix call to finishAddingRequests for the prePrepare message

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -389,6 +389,8 @@ PrePrepareMsg *ReplicaImp::buildPrePrepareMessage() {
     delete prePrepareMsg;
     return nullptr;
   }
+
+  prePrepareMsg->finishAddingRequests();
   LOG_DEBUG(GL, "Consensus batch size" << KVLOG(prePrepareMsg->numberOfRequests()));
   return prePrepareMsg;
 }

--- a/bftengine/src/bftengine/RequestsBatchingLogic.cpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.cpp
@@ -68,14 +68,6 @@ PrePrepareMsg *RequestsBatchingLogic::batchRequests() {
       LOG_ERROR(GL, "Unsupported batching policy" << KVLOG(batchingPolicy_));
       return nullptr;
   }
-
-  if (prePrepareMsg) {
-    if (prePrepareMsg->numberOfRequests() == 0) {
-      LOG_WARN(GL, "No client requests added to the PrePrepare message");
-      return nullptr;
-    }
-    prePrepareMsg->finishAddingRequests();
-  }
   return prePrepareMsg;
 }
 


### PR DESCRIPTION
The finishAddingRequests function should be called for all PrePrepare messages - batched or not.