### PR TITLE
Add unique identity to the PreProcess messages to match between requests and replies including client retries

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -35,6 +35,7 @@ struct ClientRequestState {
   // A list of requests passed a pre-processing consensus used for a non-determinism detection at later stage.
   static const uint8_t reqProcessingHistoryHeight = 30;
   std::deque<RequestProcessingStateUniquePtr> reqProcessingHistory;
+  uint64_t reqRetryId = 1;
 };
 
 typedef std::shared_ptr<ClientRequestState> ClientRequestStateSharedPtr;
@@ -81,7 +82,8 @@ class PreProcessor {
   void onMessage(T *msg);
 
   bool registerReplicaDependentRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
-                                       PreProcessRequestMsgSharedPtr &preProcessRequestMsg);
+                                       PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
+                                       uint64_t reqRetryId);
   bool registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
                        PreProcessRequestMsgSharedPtr preProcessRequestMsg);
   void releaseClientPreProcessRequestSafe(uint16_t clientId, PreProcessingResult result);
@@ -100,6 +102,7 @@ class PreProcessor {
                                     NodeIdType senderId,
                                     SeqNum reqSeqNum,
                                     SeqNum ongoingReqSeqNum,
+                                    uint64_t reqRetryId,
                                     const std::string &cid,
                                     const std::string &ongoingCid);
   uint16_t getClientReplyBufferId(uint16_t clientId) const { return clientId - numOfReplicas_; }
@@ -114,10 +117,8 @@ class PreProcessor {
                                   char *reqBuf,
                                   const concordUtils::SpanContext &span_context);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg, bool isPrimary, bool isRetry);
-  void handlePreProcessedReqByNonPrimary(uint16_t clientId,
-                                         ReqId reqSeqNum,
-                                         uint32_t resBufLen,
-                                         const std::string &cid);
+  void handlePreProcessedReqByNonPrimary(
+      uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId, uint32_t resBufLen, const std::string &cid);
   void handlePreProcessedReqByPrimary(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       uint16_t clientId,
                                       uint32_t resultBufLen);

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -46,11 +46,12 @@ class RequestProcessingState {
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut() const;
+  const uint64_t reqRetryId() const { return reqRetryId_; }
   uint64_t getReqTimeoutMilli() const {
     return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->requestTimeoutMilli() : 0;
   }
   std::string getReqCid() const { return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->getCid() : ""; }
-  void detectNonDeterministicPreProcessing(const uint8_t* newHash, NodeIdType newSenderId) const;
+  void detectNonDeterministicPreProcessing(const uint8_t* newHash, NodeIdType newSenderId, uint64_t reqRetryId) const;
   void releaseResources();
   ReplicaIdsList getRejectedReplicasList() { return rejectedReplicaIds_; }
   void resetRejectedReplicasList() { rejectedReplicaIds_.clear(); }
@@ -68,7 +69,8 @@ class RequestProcessingState {
   }
   auto calculateMaxNbrOfEqualHashes(uint16_t& maxNumOfEqualHashes) const;
   void detectNonDeterministicPreProcessing(const concord::util::SHA3_256::Digest& newHash,
-                                           NodeIdType newSenderId) const;
+                                           NodeIdType newSenderId,
+                                           uint64_t reqRetryId) const;
 
  private:
   static uint16_t numOfRequiredEqualReplies_;
@@ -91,6 +93,7 @@ class RequestProcessingState {
   std::map<concord::util::SHA3_256::Digest, int> preProcessingResultHashes_;
   bool retrying_ = false;
   bool preprocessingRightNow_ = false;
+  uint64_t reqRetryId_ = 0;
 };
 
 typedef std::unique_ptr<RequestProcessingState> RequestProcessingStateUniquePtr;

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -24,13 +24,15 @@ class PreProcessReplyMsg : public MessageBase {
   PreProcessReplyMsg(bftEngine::impl::SigManagerSharedPtr sigManager,
                      NodeIdType senderId,
                      uint16_t clientId,
-                     uint64_t reqSeqNum);
+                     uint64_t reqSeqNum,
+                     uint64_t reqRetryId);
 
   void setupMsgBody(const char* buf, uint32_t bufLen, const std::string& cid, ReplyStatus status);
 
   void validate(const bftEngine::impl::ReplicasInfo&) const override;
   const uint16_t clientId() const { return msgBody()->clientId; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
+  const uint64_t reqRetryId() const { return msgBody()->reqRetryId; }
   const uint32_t replyLength() const { return msgBody()->replyLength; }
   const uint8_t* resultsHash() const { return msgBody()->resultsHash; }
   const uint8_t status() const { return msgBody()->status; }
@@ -47,6 +49,7 @@ class PreProcessReplyMsg : public MessageBase {
     uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES];
     uint32_t replyLength;
     uint32_t cidLength;
+    uint64_t reqRetryId;
   };
 // The pre-executed results' hash signature resides in the message body
 #pragma pack(pop)
@@ -56,7 +59,7 @@ class PreProcessReplyMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
-  void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum);
+  void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId);
   Header* msgBody() const { return ((Header*)msgBody_); }
 
  private:

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -23,6 +23,7 @@ class PreProcessRequestMsg : public MessageBase {
   PreProcessRequestMsg(NodeIdType senderId,
                        uint16_t clientId,
                        uint64_t reqSeqNum,
+                       uint64_t reqRetryId,
                        uint32_t reqLength,
                        const char* request,
                        const std::string& cid,
@@ -33,6 +34,7 @@ class PreProcessRequestMsg : public MessageBase {
   const uint32_t requestLength() const { return msgBody()->requestLength; }
   const uint16_t clientId() const { return msgBody()->clientId; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
+  const uint64_t reqRetryId() const { return msgBody()->reqRetryId; }
   std::string getCid() const;
 
  protected:
@@ -46,6 +48,7 @@ class PreProcessRequestMsg : public MessageBase {
     NodeIdType senderId;
     uint32_t requestLength;
     uint32_t cidLength;
+    uint64_t reqRetryId;
   };
 #pragma pack(pop)
 
@@ -54,7 +57,7 @@ class PreProcessRequestMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
-  void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint32_t reqLength);
+  void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId, uint32_t reqLength);
 
  private:
   Header* msgBody() const { return ((Header*)msgBody_); }

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -50,6 +50,8 @@ const NodeIdType replica_2 = 2;
 const NodeIdType replica_3 = 3;
 const NodeIdType replica_4 = 4;
 
+uint64_t reqRetryId = 20;
+
 ReplicaConfig& replicaConfig = ReplicaConfig::instance();
 char buf[bufLen];
 SigManagerSharedPtr sigManager_[numOfReplicas_4];
@@ -321,7 +323,8 @@ void setUpCommunication() {
 }
 
 PreProcessReplyMsgSharedPtr preProcessNonPrimary(NodeIdType replicaId, const bftEngine::impl::ReplicasInfo& repInfo) {
-  auto preProcessReplyMsg = make_shared<PreProcessReplyMsg>(sigManager_[replicaId], replicaId, clientId, reqSeqNum);
+  auto preProcessReplyMsg =
+      make_shared<PreProcessReplyMsg>(sigManager_[replicaId], replicaId, clientId, reqSeqNum, reqRetryId);
   preProcessReplyMsg->setupMsgBody(buf, bufLen, "", STATUS_GOOD);
   preProcessReplyMsg->validate(repInfo);
   return preProcessReplyMsg;
@@ -474,7 +477,7 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId) == reqSeqNum);
 
   auto* preProcessReqMsg =
-      new PreProcessRequestMsg(replica.currentPrimary(), clientId, reqSeqNum, bufLen, buf, cid, span);
+      new PreProcessRequestMsg(replica.currentPrimary(), clientId, reqSeqNum, reqRetryId, bufLen, buf, cid, span);
   msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::PreProcessRequest);
   msgHandlerCallback(preProcessReqMsg);
   usleep(reqWaitTimeoutMilli * 1000 / 2);  // Wait for the pre-execution completion


### PR DESCRIPTION
This PR provides a way to match between a PreProcess request and corresponding replies including client retries when both - cid and reqSeqNum are the same. New fields are added to the PreProcessRequest/PreProcessReply messages. They are set to the same number for a request and all its replies. The retry message gets a different value. This approach allows reporting about non-determinism in the correct way and not to mix old replies with a retried request.