### PR TITLE
bft_client: catch OverflowError on TLS stream.receive_some()

### DIFF
--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -411,8 +411,11 @@ class TcpTlsClient(BftClient):
                 out_data += data
                 return True
         except (trio.BrokenResourceError, trio.ClosedResourceError):
+            # We got EOF or an exception - close the stream
             pass
-        # We got EOF or an exception - close the stream
+        except OverflowError:
+            # The size of the payload is too big, something is wrong. Close the stream and restart.
+            pass
         if dest_addr in self.ssl_streams:
             self.establish_ssl_stream_parklot[dest_addr].unpark()
         return False


### PR DESCRIPTION
Due to an exception:
"OverflowError: signed integer is greater than maximum".

I've found out that if something is wrong with payload size (too big),
client code is not resilient to an uncaught exception.
The trio documentation does not mention any limit.
The ssl.py module supports up to 2^31. That means, we gave a very very
large number.

Resolution: Catch exception, and unpark internal re-connect task to
close the stream and re-connect.