### PR TITLE
take execution in account on vc

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2773,12 +2773,17 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
         duration_cast<milliseconds>(currTime - timeOfEarliestPendingRequest).count();
     const uint64_t timeFromLastExecution = duration_cast<milliseconds>(currTime - timeOfLastExecution).count();
 
+    if (timeFromEarliestPendingRequest > 0.5 * viewChangeTimeout) {
+      LOG_WARN(VC_LOG,
+               "Time from earliest pending request is larger than half of the viewchange timeout"
+                   << KVLOG(timeFromEarliestPendingRequest, viewChangeTimeout));
+    }
     if (timeFromLastExecution <= viewChangeTimeout && timeFromEarliestPendingRequest > viewChangeTimeout) {
       // If the replica is progressing, but yet client messages are timed out, it means that the replica is busy with
       // other requests, thus we double the viewchange timeout to reduce the possibility of unnecessary viewchange.
       LOG_INFO(VC_LOG,
                "time from eraliest pending request is greater than viewChangeTimeout but time from last execution is "
-               "not. This may indicate that the replcia is struggling to execute requests amd there is no need to "
+               "not. This may indicate that the replcia is struggling to execute requests and there is no need to "
                "trigger a viewchange. Doubling the viewChangeTimeout"
                    << KVLOG(viewChangeTimeout, timeFromEarliestPendingRequest, timeFromLastExecution));
       viewChangeTimeout = viewChangeTimeout * 2;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -142,6 +142,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   Time lastTimeThisReplicaSentStatusReportMsgToAllPeerReplicas = MinTime;
   Time timeOfLastStateSynch;    // last time the replica received a new state (via the state transfer mechanism)
   Time timeOfLastViewEntrance;  // last time the replica entered to a new view
+  Time timeOfLastExecution;     // last time that some client request has been executed
 
   // latest view number v such that the replica received 2f+2c+1 ViewChangeMsg messages
   // with view >= v


### PR DESCRIPTION
In order to stabilize the viewchange action, we want to take in account the replica progression that is not related to the earliest client request timeout. 

For that, we have added another check in the viewchange timer such that if the time from the last execution is less than the viewchange timeout while the time from the earliest pending client request is larger, we double the view change timeout.