### PR TITLE
bcstatetransfer_tests: Remove local database when test ends

### DIFF
--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -50,17 +50,20 @@ Config TestConfig() {
 // Test fixture for blockchain state transfer tests
 class BcStTest : public ::testing::Test {
  protected:
+  const std::string BCST_DB = "./bcst_db";
+
   void SetUp() override {
     // uncomment if needed
     //    logging::Logger::getInstance("serializable").setLogLevel(TRACE_LOG_LEVEL);
     //    logging::Logger::getInstance("concord.bft.st.dbdatastore").setLogLevel(TRACE_LOG_LEVEL);
     //    logging::Logger::getInstance("rocksdb").setLogLevel(TRACE_LOG_LEVEL);
 
+    DeleteBcStateTransferDbfolder();
     config_ = TestConfig();
     auto* db_key_comparator = new concord::kvbc::v1DirectKeyValue::DBKeyComparator();
 #ifdef USE_ROCKSDB
     concord::storage::IDBClient::ptr dbc(
-        new concord::storage::rocksdb::Client("./bcst_db", std::make_unique<KeyComparator>(db_key_comparator)));
+        new concord::storage::rocksdb::Client(BCST_DB, std::make_unique<KeyComparator>(db_key_comparator)));
     dbc->init();
     auto* datastore = new DBDataStore(
         dbc, config_.sizeOfReservedPage, std::make_shared<concord::storage::v1DirectKeyValue::STKeyManipulator>());
@@ -81,6 +84,14 @@ class BcStTest : public ::testing::Test {
     // Must stop running before destruction
     st_->stopRunning();
     delete st_;
+    DeleteBcStateTransferDbfolder();
+  }
+
+  void DeleteBcStateTransferDbfolder() {
+    std::string cmd = string("rm -rf ") + BCST_DB;
+    if (system(cmd.c_str())) {
+      ASSERT_TRUE(false);
+    }
   }
 
   Config config_;


### PR DESCRIPTION
When trying to run this test more than once (native Linux or the same
docker container), It always fails.

Resolution: When the test ends, on Teardown, remove the whole folder
`./bcst_db`.