### PR TITLE
State Transfer tweaks:

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -106,8 +106,10 @@ struct Config {
   bool pedanticChecks = false;
   bool isReadOnly = false;
 
+  uint32_t maxBlockSize = 30 * 1024 * 1024;  // 30MB
+
 #if defined USE_COMM_PLAIN_TCP || defined USE_COMM_TLS_TCP
-  uint32_t maxChunkSize = 16384;
+  uint32_t maxChunkSize = maxBlockSize;
   uint16_t maxNumberOfChunksInBatch = 8;
 #else
   // maxChunkSize * maxNumberOfChunksInBatch should not exceed 64KB as UDP message size is limited to 64KB.
@@ -115,7 +117,6 @@ struct Config {
   uint16_t maxNumberOfChunksInBatch = 32;
 #endif
 
-  uint32_t maxBlockSize = 30 * 1024 * 1024;                      // 30MB
   uint32_t maxPendingDataFromSourceReplica = 256 * 1024 * 1024;  // Maximal internal buffer size for all ST data
   uint32_t maxNumOfReservedPages = 2048;
   uint32_t sizeOfReservedPage = 4096;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -673,7 +673,7 @@ void ReplicaImp::tryToAskForMissingInfo() {
   SeqNum maxSeqNum = 0;
 
   if (!recentViewChange) {
-    const int16_t searchWindow = 4;  // TODO(GG): TBD - read from configuration
+    const int16_t searchWindow = 32;  // TODO(GG): TBD - read from configuration
     minSeqNum = lastExecutedSeqNum + 1;
     maxSeqNum = std::min(minSeqNum + searchWindow - 1, lastStableSeqNum + kWorkWindowSize);
   } else {
@@ -1463,6 +1463,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
   LOG_INFO(
       GL,
       "Received checkpoint message from node. " << KVLOG(msgSenderId, msgSeqNum, msg->size(), msgIsStable, msgDigest));
+  LOG_INFO(GL, "My " << KVLOG(lastStableSeqNum, lastExecutedSeqNum));
   auto span = concordUtils::startChildSpanFromContext(msg->spanContext<std::remove_pointer<decltype(msg)>::type>(),
                                                       "bft_handle_checkpoint_msg");
 
@@ -1495,7 +1496,8 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
 
   if (msgIsStable && msgSeqNum > lastExecutedSeqNum) {
     auto pos = tableOfStableCheckpoints.find(msgSenderId);
-    if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() < msgSeqNum) {
+    if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() <= msgSeqNum) {
+      // <= to allow repeating checkpoint message since state transfer may not kick in when we are inside active window
       if (pos != tableOfStableCheckpoints.end()) delete pos->second;
       CheckpointMsg *x = new CheckpointMsg(msgSenderId, msgSeqNum, msgDigest, msgIsStable);
       tableOfStableCheckpoints[msgSenderId] = x;
@@ -1518,9 +1520,8 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
         }
         ConcordAssertEQ(numRelevant, tableOfStableCheckpoints.size());
 
-        LOG_DEBUG(GL, KVLOG(numRelevant, numRelevantAboveWindow));
-
         if (numRelevantAboveWindow >= config_.fVal + 1) {
+          LOG_INFO(GL, "Number of stable checkpoints above window: " << numRelevantAboveWindow);
           askForStateTransfer = true;
         } else if (numRelevant >= config_.fVal + 1) {
           Time timeOfLastCommit = MinTime;
@@ -1529,6 +1530,10 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
 
           if ((getMonotonicTime() - timeOfLastCommit) >
               (milliseconds(timeToWaitBeforeStartingStateTransferInMainWindowMilli))) {
+            LOG_INFO(GL,
+                     "Number of stable checkpoints in current window: "
+                         << numRelevant
+                         << " time since last execution: " << (getMonotonicTime() - timeOfLastCommit).count() << " ms");
             askForStateTransfer = true;
           }
         }
@@ -1538,7 +1543,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
 
   if (askForStateTransfer) {
     LOG_INFO(GL, "Call to startCollectingState()");
-
+    clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout
     stateTransfer->startCollectingState();
   } else if (msgSeqNum > lastStableSeqNum + kWorkWindowSize) {
     onReportAboutAdvancedReplica(msgSenderId, msgSeqNum);
@@ -2415,8 +2420,8 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
   }
 
   if (askAnotherStateTransfer) {
-    LOG_INFO(GL, "Call to startCollectingState()");
-
+    LOG_INFO(GL, "Call to another startCollectingState()");
+    clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout
     stateTransfer->startCollectingState();
   }
 }

--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -104,7 +104,7 @@ constexpr bool dynamicCollectorForExecutionProofs = false;  // if false, then th
 // State Transfer
 ///////////////////////////////////////////////////////////////////////////////
 
-constexpr int timeToWaitBeforeStartingStateTransferInMainWindowMilli = 2000;  // TODO(GG): move to configuration??
+constexpr int timeToWaitBeforeStartingStateTransferInMainWindowMilli = 5000;  // TODO(GG): move to configuration??
 
 ///////////////////////////////////////////////////////////////////////////////
 // Debug and Tuning of ControllerWithSimpleHistory


### PR DESCRIPTION
1. Make max chunk size equal to max block size if using TCP;
2. If inside active window try first to catch up using request for missing data;
3. Clear all pending requests before call to startCollecting state to avoid entering to a new view on request timeout.