### PR TITLE
Enhance concord-ctl with pre-execution status

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -35,6 +35,7 @@ set(corebft_source_files
     src/bftengine/MsgReceiver.cpp
     src/bftengine/DbMetadataStorage.cpp
     src/bftengine/RequestsBatchingLogic.cpp
+    src/bftengine/ReplicaStatusHandlers.cpp
     src/bcstatetransfer/BCStateTran.cpp
     src/bcstatetransfer/InMemoryDataStore.cpp
     src/bcstatetransfer/STDigest.cpp

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -58,27 +58,6 @@ using namespace concord::diagnostics;
 
 namespace bftEngine::impl {
 
-void ReplicaImp::registerStatusHandlers() {
-  auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-  auto &msgQueue = getIncomingMsgsStorage();
-
-  auto make_handler_callback = [&msgQueue](const string &name, const string &description) {
-    return concord::diagnostics::StatusHandler(name, description, [&msgQueue, name]() {
-      GetStatus get_status{name, std::promise<std::string>()};
-      auto result = get_status.output.get_future();
-      // Send a GetStatus InternalMessage to ReplicaImp, then wait for the result to be published.
-      msgQueue.pushInternalMsg(std::move(get_status));
-      return result.get();
-    });
-  };
-
-  auto replica_handler = make_handler_callback("replica", "Internal state of the concord-bft replica");
-  auto state_transfer_handler = make_handler_callback("state-transfer", "Status of blockchain state transfer");
-
-  registrar.status.registerHandler(replica_handler);
-  registrar.status.registerHandler(state_transfer_handler);
-}
-
 void ReplicaImp::registerMsgHandlers() {
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint, bind(&ReplicaImp::messageHandler<CheckpointMsg>, this, _1));
 
@@ -1056,6 +1035,11 @@ void ReplicaImp::onInternalMsg(GetStatus &status) const {
   if (status.key == "state-transfer") {
     return status.output.set_value(stateTransfer->getStatus());
   }
+
+  if (status.key == "pre-execution") {
+    return status.output.set_value(replStatusHandlers_.preExecutionStatus(getAggregator()));
+  }
+
   // We must always return something to unblock the future.
   return status.output.set_value("** - Invalid Key - **");
 }
@@ -3213,7 +3197,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_total_fastPath_{metrics_.RegisterCounter("totalFastPaths")},
       metric_total_slowPath_requests_{metrics_.RegisterCounter("totalSlowPathRequests")},
       metric_total_fastPath_requests_{metrics_.RegisterCounter("totalFastPathRequests")},
-      reqBatchingLogic_(*this, config_, metrics_) {
+      reqBatchingLogic_(*this, config_, metrics_),
+      replStatusHandlers_(*this) {
   ConcordAssertLT(config_.replicaId, config_.numReplicas);
   // TODO(GG): more asserts on params !!!!!!!!!!!
 
@@ -3221,7 +3206,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   ConcordAssert(firstTime || ((sigMgr != nullptr) && (replicasInfo != nullptr) && (viewsMgr != nullptr)));
 
   registerMsgHandlers();
-  registerStatusHandlers();
+  replStatusHandlers_.registerStatusHandlers();
 
   // Register metrics component with the default aggregator.
   metrics_.Register();

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -35,6 +35,7 @@
 #include "diagnostics.h"
 #include "performance_handler.h"
 #include "RequestsBatchingLogic.hpp"
+#include "ReplicaStatusHandlers.hpp"
 
 namespace bftEngine::impl {
 
@@ -279,7 +280,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
              shared_ptr<MsgHandlersRegistrator>,
              concordUtil::Timers& timers);
 
-  void registerStatusHandlers();
   void registerMsgHandlers();
 
   template <typename T>
@@ -303,7 +303,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // Generate diagnostics status replies
   std::string getReplicaState() const;
-
   template <typename T>
   void onMessage(T* msg);
 
@@ -450,6 +449,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   Recorders histograms_;
   batchingLogic::RequestsBatchingLogic reqBatchingLogic_;
+  ReplicaStatusHandlers replStatusHandlers_;
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
+++ b/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
@@ -1,0 +1,80 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "ReplicaStatusHandlers.hpp"
+#include "diagnostics.h"
+#include "json_output.hpp"
+
+#include <string>
+
+#define getName(var) #var
+
+using namespace std;
+using concordUtils::toPair;
+
+namespace bftEngine::impl {
+
+ReplicaStatusHandlers::ReplicaStatusHandlers(InternalReplicaApi &replica) : replica_(replica) {}
+
+void ReplicaStatusHandlers::registerStatusHandlers() const {
+  auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+  auto &msgQueue = replica_.getIncomingMsgsStorage();
+
+  auto make_handler_callback = [&msgQueue](const string &name, const string &description) {
+    return concord::diagnostics::StatusHandler(name, description, [&msgQueue, name]() {
+      GetStatus get_status{name, std::promise<std::string>()};
+      auto result = get_status.output.get_future();
+      // Send a GetStatus InternalMessage to ReplicaImp, then wait for the result to be published.
+      msgQueue.pushInternalMsg(std::move(get_status));
+      return result.get();
+    });
+  };
+
+  auto replica_handler = make_handler_callback("replica", "Internal state of the concord-bft replica");
+  auto state_transfer_handler = make_handler_callback("state-transfer", "Status of blockchain state transfer");
+  auto preexecution_handler = make_handler_callback("pre-execution", "Status of pre-execution");
+
+  registrar.status.registerHandler(replica_handler);
+  registrar.status.registerHandler(state_transfer_handler);
+  registrar.status.registerHandler(preexecution_handler);
+}
+
+std::string ReplicaStatusHandlers::preExecutionStatus(std::shared_ptr<concordMetrics::Aggregator> aggregator) const {
+  const auto &curView = replica_.getCurrentView();
+  const auto &primaryId = replica_.getReplicasInfo().primaryOfView(curView);
+  std::ostringstream oss;
+  std::unordered_map<std::string, std::string> result, nested_data;
+  result.insert(toPair("Replica ID", std::to_string(replica_.getReplicasInfo().myId())));
+  result.insert(toPair("Primary", std::to_string(primaryId)));
+  const auto numOfClients =
+      replica_.getReplicaConfig().numOfExternalClients + replica_.getReplicaConfig().numOfClientProxies;
+  result.insert(toPair("numOfClients", std::to_string(numOfClients)));
+
+  result.insert(
+      toPair(getName(preProcReqReceived), aggregator->GetCounter("preProcessor", "preProcReqReceived").Get()));
+  result.insert(toPair(getName(preProcReqInvalid), aggregator->GetCounter("preProcessor", "preProcReqInvalid").Get()));
+  result.insert(toPair(getName(preProcReqIgnored), aggregator->GetCounter("preProcessor", "preProcReqIgnored").Get()));
+  result.insert(toPair(getName(preProcConsensusNotReached),
+                       aggregator->GetCounter("preProcessor", "preProcConsensusNotReached").Get()));
+  result.insert(toPair(getName(preProcessRequestTimedout),
+                       aggregator->GetCounter("preProcessor", "preProcessRequestTimedout").Get()));
+  result.insert(toPair(getName(preProcReqSentForFurtherProcessing),
+                       aggregator->GetCounter("preProcessor", "preProcReqSentForFurtherProcessing").Get()));
+  result.insert(toPair(getName(preProcPossiblePrimaryFaultDetected),
+                       aggregator->GetCounter("preProcessor", "preProcPossiblePrimaryFaultDetected").Get()));
+  result.insert(
+      toPair(getName(preProcInFlyRequestsNum), aggregator->GetGauge("preProcessor", "PreProcInFlyRequestsNum").Get()));
+
+  oss << concordUtils::kContainerToJson(result);
+  return oss.str();
+}
+
+}  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaStatusHandlers.hpp
+++ b/bftengine/src/bftengine/ReplicaStatusHandlers.hpp
@@ -1,0 +1,34 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "ReplicaConfig.hpp"
+#include "InternalReplicaApi.hpp"
+#include "Metrics.hpp"
+
+namespace bftEngine::impl {
+
+class ReplicaStatusHandlers {
+ public:
+  ReplicaStatusHandlers(InternalReplicaApi &replica);
+  virtual ~ReplicaStatusHandlers() = default;
+
+  void registerStatusHandlers() const;
+
+  // Generate diagnostics status replies
+  std::string preExecutionStatus(std::shared_ptr<concordMetrics::Aggregator> aggregator) const;
+
+ private:
+  InternalReplicaApi &replica_;
+};
+
+}  // namespace bftEngine::impl

--- a/util/include/json_output.hpp
+++ b/util/include/json_output.hpp
@@ -23,7 +23,7 @@
 namespace concordUtils {
 
 template <typename KVContainer, typename Encoder>
-std::string kvContainerToJson(const KVContainer &kv, const Encoder &enc) {
+inline std::string kvContainerToJson(const KVContainer &kv, const Encoder &enc) {
   auto out = std::string{"{\n"};
   for (const auto &[key, value] : kv) {
     out += ("  \"" + enc(key) + "\": \"" + enc(value) + "\",\n");
@@ -35,7 +35,7 @@ std::string kvContainerToJson(const KVContainer &kv, const Encoder &enc) {
   return out;
 }
 
-std::string kContainerToJson(const std::unordered_map<std::string, std::string> &kv) {
+inline std::string kContainerToJson(const std::unordered_map<std::string, std::string> &kv) {
   auto out = std::string{"{\n"};
   for (const auto &[key, value] : kv) {
     out += ("  \"" + key + "\": " + value + ",\n");
@@ -64,15 +64,15 @@ inline std::string toJson(const std::string &key, const std::string &value) {
 }
 
 template <typename T>
-std::string toJson(const std::string &key, const T &value) {
+inline std::string toJson(const std::string &key, const T &value) {
   return toJson(key, std::to_string(value));
 }
 template <typename T>
-std::pair<std::string, std::string> toPair(const std::string &key, const T &value) {
+inline std::pair<std::string, std::string> toPair(const std::string &key, const T &value) {
   return std::make_pair(key, std::to_string(value));
 }
 
-std::pair<std::string, std::string> toPair(const std::string &key, const std::string &value) {
+inline std::pair<std::string, std::string> toPair(const std::string &key, const std::string &value) {
   return std::make_pair(key, value);
 }
 


### PR DESCRIPTION
Make pre-execution metrics available through concord-ctl
Example output:
root@a4832145a294:/concord# ./concord-ctl status get pre-execution
{
  "preProcInFlyRequestsNum": 0,
  "preProcReqSentForFurtherProcessing": 154,
  "preProcConsensusNotReached": 0,
  "preProcessRequestTimedout": 0,
  "Primary": 0,
  "Replica ID": 0,
  "numOfClients": 31,
  "preProcReqIgnored": 56,
  "preProcReqReceived": 210,
  "preProcPossiblePrimaryFaultDetected": 0,
  "preProcReqInvalid": 0
}
