### PR TITLE
Github Actions: Fix The operation was canceled

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,6 +20,13 @@ jobs:
                 - "-DUSE_S3_OBJECT_STORE=ON"
                 - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
+        - name: Cleanup pre-installed tools
+          run: |
+            # This is a fix for https://github.com/actions/virtual-environments/issues/1918
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf /opt/ghc
+            sudo rm -rf "/usr/local/share/boost"
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         - name: Checkout
           uses: actions/checkout@v2
         - name: Create artifact directory

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ CONCORD_BFT_CORE_DIR:=${CONCORD_BFT_TARGET_SOURCE_PATH}/${CONCORD_BFT_BUILD_DIR}
 CONCORD_BFT_ADDITIONAL_RUN_PARAMS:=
 
 BASIC_RUN_PARAMS:=-it --init --rm --privileged=true \
+					  --memory-swap -1 \
 					  --cap-add NET_ADMIN --cap-add=SYS_PTRACE --ulimit core=-1 \
 					  --name="${CONCORD_BFT_DOCKER_CONTAINER}" \
 					  --workdir=${CONCORD_BFT_TARGET_SOURCE_PATH} \


### PR DESCRIPTION
Reason:
Some jobs randomly fail with the error: The operation was canceled.

Fix:
* Run the following in the beginning of the job:
```
sudo rm -rf /usr/share/dotnet
sudo rm -rf /opt/ghc
sudo rm -rf "/usr/local/share/boost"
sudo rm -rf "$AGENT_TOOLSDIRECTORY"
```
* Use memory swap limits for docker run:
```
--memory-swap -1
```

For more details, please see:
https://github.com/actions/virtual-environments/issues/1918