### PR TITLE
[WIP, Proposal] Support a client for partitioned DBs

### DIFF
--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -237,9 +237,9 @@ void DBDataStore::deserializeResPage(
  * [pageId, checkpoint] => <serialized page>
  */
 void DBDataStore::loadResPages() {
-  auto it(dbc_->getIteratorGuard());
+  auto it = dbc_->getIterator();
   for (auto keyValue = it->seekAtLeast(dynamicResPageKey(0, 0));  // start of dynamic keys space
-       !it->isEnd() && keyValue.first.string_view().find(keymanip_->getReservedPageKeyPrefix().string_view()) == 0;
+       it->valid() && keyValue.first.string_view().find(keymanip_->getReservedPageKeyPrefix().string_view()) == 0;
        keyValue = it->next()) {
     std::istringstream iss(
         std::string(reinterpret_cast<const char*>(keyValue.second.data()), keyValue.second.length()));

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -181,7 +181,7 @@ class DataStoreTransaction : public DataStore, public ITransaction {
   class Guard : public ITransaction::Guard {
    public:
     Guard(DataStoreTransaction* t) : ITransaction::Guard(t) {}
-    DataStoreTransaction* txn() { return static_cast<DataStoreTransaction*>(txn_); }
+    DataStoreTransaction* txn() { return static_cast<DataStoreTransaction*>(ITransaction::Guard::txn()); }
   };
 
   DataStoreTransaction(std::shared_ptr<DataStore> ds, ITransaction* txn)

--- a/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -4,7 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "storage_test_common.h"
+#include "kvbc_storage_test_common.h"
 
 #include "block_digest.h"
 #include "merkle_tree_block.h"
@@ -102,7 +102,7 @@ ValuesVector createReferenceBlockchain(const std::shared_ptr<IDBClient> &db,
 }
 
 bool hasStaleIndexKeysSince(const std::shared_ptr<IDBClient> &db, const Version &version) {
-  auto iter = db->getIteratorGuard();
+  auto iter = db->getIterator();
   const auto key = iter->seekAtLeast(DBKeyManipulator::genStaleDbKey(version)).first;
   if (!key.empty() && DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key &&
       DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Stale &&
@@ -113,7 +113,7 @@ bool hasStaleIndexKeysSince(const std::shared_ptr<IDBClient> &db, const Version 
 }
 
 bool hasInternalKeysForVersion(const std::shared_ptr<IDBClient> &db, const Version &version) {
-  auto iter = db->getIteratorGuard();
+  auto iter = db->getIterator();
   const auto key = iter->seekAtLeast(DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version))).first;
   if (!key.empty() && DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key &&
       DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Internal &&

--- a/kvbc/test/sparse_merkle_storage/kvbc_storage_test_common.h
+++ b/kvbc/test/sparse_merkle_storage/kvbc_storage_test_common.h
@@ -1,0 +1,38 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "storage/test/storage_test_common.h"
+
+#include "block_digest.h"
+#include "kv_types.hpp"
+#include "sparse_merkle/base_types.h"
+
+inline ::concord::kvbc::BlockDigest blockDigest(concord::kvbc::BlockId blockId, const concordUtils::Sliver &block) {
+  return ::bftEngine::bcst::computeBlockDigest(blockId, block.data(), block.length());
+}
+inline auto getHash(const std::string &str) {
+  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
+  return hasher.hash(str.data(), str.size());
+}
+
+inline auto getHash(const concordUtils::Sliver &sliver) {
+  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
+  return hasher.hash(sliver.data(), sliver.length());
+}
+
+inline auto getBlockDigest(const std::string &data) { return getHash(data).dataArray(); }
+
+inline const auto defaultBlockId = ::concord::kvbc::BlockId{42};
+inline const auto maxNumKeys = 16u;

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-#include "storage_test_common.h"
+#include "kvbc_storage_test_common.h"
 
 #include "endianness.hpp"
 #include "kv_types.hpp"

--- a/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
@@ -21,7 +21,7 @@
 #include "PersistentStorageImp.hpp"
 #include "sliver.hpp"
 #include "sparse_merkle_db_editor.hpp"
-#include "storage_test_common.h"
+#include "kvbc_storage_test_common.h"
 #include "storage/db_types.h"
 #include "storage/merkle_tree_key_manipulator.h"
 

--- a/kvbc/tools/sparse_merkle_db/include/sparse_merkle_db_editor.hpp
+++ b/kvbc/tools/sparse_merkle_db/include/sparse_merkle_db_editor.hpp
@@ -84,9 +84,9 @@ inline v2MerkleTree::DBAdapter getAdapter(const std::string &path, bool read_onl
   // empty one if it doesn't. Therefore, until the below-mentioned RocksDB issue is fixed, we just check if
   // the DB is empty, i.e. no keys are present.
   // https://github.com/facebook/rocksdb/issues/5029
-  auto iter = db->getIteratorGuard();
+  auto iter = db->getIterator();
   iter->first();
-  if (iter->isEnd()) {
+  if (!iter->valid()) {
     throw std::invalid_argument{"RocksDB database is empty at path " + path};
   }
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -27,3 +27,5 @@ if (BUILD_ROCKSDB_STORAGE)
   target_include_directories(concordbft_storage PUBLIC ${ROCKSDB_INCLUDE_DIR})
   target_link_libraries(concordbft_storage PRIVATE ${ROCKSDB} ${LIBBZ2} ${LIBLZ4} ${LIBZSTD} ${LIBZ} ${LIBSNAPPY} ${CMAKE_DL_LIBS})
 endif(BUILD_ROCKSDB_STORAGE)
+
+add_subdirectory(test)

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -87,9 +87,12 @@ class Client : public IPartitionedDBClient {
   std::unique_ptr<IDBClientIterator> getIterator() const override;
   virtual concordUtils::Status put(const Sliver &_key, const Sliver &_value) override;
   virtual concordUtils::Status del(const Sliver &_key) override;
-  concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) override;
+  concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) const override;
   concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap) override;
   concordUtils::Status multiDel(const KeysVector &_keysVec) override;
+  Status multiGet(const std::vector<PartitionedKey> &keys, ValuesVector &values) const override;
+  Status multiPut(const std::vector<PartitionedKeyValue> &keyValues) override;
+  Status multiDel(const std::vector<PartitionedKey> &keys) override;
   concordUtils::Status rangeDel(const Sliver &_beginKey, const Sliver &_endKey) override;
   bool isNew() override { return true; }
   ITransaction *beginTransaction() override;
@@ -109,7 +112,7 @@ class Client : public IPartitionedDBClient {
   Status has(const std::string &partition, const Sliver &key) const override;
   Status put(const std::string &partition, const Sliver &key, const Sliver &value) override;
   Status del(const std::string &partition, const Sliver &key) override;
-  Status multiGet(const std::string &partition, const KeysVector &keys, ValuesVector &values) override;
+  Status multiGet(const std::string &partition, const KeysVector &keys, ValuesVector &values) const override;
   Status multiPut(const std::string &partition, const SetOfKeyValuePairs &keyValues) override;
   Status multiDel(const std::string &partition, const KeysVector &keys) override;
   Status rangeDel(const std::string &partition, const Sliver &beginKey, const Sliver &endKey) override;

--- a/storage/include/object_store/object_store_client.hpp
+++ b/storage/include/object_store/object_store_client.hpp
@@ -44,11 +44,13 @@ class ObjectStoreClient : public IDBClient {
 
   bool isNew() override { return pImpl_->isNew(); }
 
-  IDBClient::IDBClientIterator* getIterator() const override { return pImpl_->getIterator(); }
-
-  Status freeIterator(IDBClientIterator* _iter) const override { return pImpl_->freeIterator(_iter); }
+  std::unique_ptr<IDBClient::IDBClientIterator> getIterator() const override { return pImpl_->getIterator(); }
 
   ITransaction* beginTransaction() override { return pImpl_->beginTransaction(); }
+
+  std::unique_ptr<ITransaction> startTransaction() override {
+    return std::unique_ptr<ITransaction>{beginTransaction()};
+  }
 
   Status has(const Sliver& key) const override { return pImpl_->has(key); }
 

--- a/storage/include/object_store/object_store_client.hpp
+++ b/storage/include/object_store/object_store_client.hpp
@@ -34,7 +34,7 @@ class ObjectStoreClient : public IDBClient {
 
   Status del(const Sliver& _key) override { return pImpl_->del(_key); }
 
-  Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) override {
+  Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) const override {
     return pImpl_->multiGet(_keysVec, _valuesVec);
   }
 

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -84,7 +84,7 @@ class Client : public concord::storage::IDBClient {
   std::unique_ptr<IDBClientIterator> getIterator() const override;
   concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override;
   concordUtils::Status del(const concordUtils::Sliver& _key) override;
-  concordUtils::Status multiGet(const KeysVector& _keysVec, ValuesVector& _valuesVec) override;
+  concordUtils::Status multiGet(const KeysVector& _keysVec, ValuesVector& _valuesVec) const override;
   concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override;
   concordUtils::Status multiDel(const KeysVector& _keysVec) override;
   concordUtils::Status rangeDel(const Sliver& _beginKey, const Sliver& _endKey) override;

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -45,8 +45,8 @@ class ClientIterator : public concord::storage::IDBClient::IDBClientIterator {
   KeyValuePair previous() override;
   KeyValuePair next() override;
   KeyValuePair getCurrent() override;
-  bool isEnd() override;
-  concordUtils::Status getStatus() override;
+  bool valid() const override;
+  concordUtils::Status getStatus() const override;
 
  private:
   logging::Logger logger;
@@ -81,8 +81,7 @@ class Client : public concord::storage::IDBClient {
                            uint32_t bufSize,
                            uint32_t& _realSize) const override;
   concordUtils::Status has(const Sliver& _key) const override;
-  IDBClientIterator* getIterator() const override;
-  concordUtils::Status freeIterator(IDBClientIterator* _iter) const override;
+  std::unique_ptr<IDBClientIterator> getIterator() const override;
   concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override;
   concordUtils::Status del(const concordUtils::Sliver& _key) override;
   concordUtils::Status multiGet(const KeysVector& _keysVec, ValuesVector& _valuesVec) override;
@@ -92,6 +91,7 @@ class Client : public concord::storage::IDBClient {
   ::rocksdb::Iterator* getNewRocksDbIterator() const;
   bool isNew() override;
   ITransaction* beginTransaction() override;
+  std::unique_ptr<ITransaction> startTransaction() override;
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override {
     storage_metrics_.setAggregator(aggregator);
   }

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -157,7 +157,7 @@ class Client : public concord::storage::IDBClient {
 
   concordUtils::Status del(const concordUtils::Sliver& key) override;
 
-  concordUtils::Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) override {
+  concordUtils::Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) const override {
     ConcordAssert(_keysVec.size() == _valuesVec.size());
 
     for (KeysVector::size_type i = 0; i < _keysVec.size(); ++i)

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -181,16 +181,16 @@ class Client : public concord::storage::IDBClient {
 
   bool isNew() override { throw std::logic_error("isNew()  Not implemented for S3 object store"); }
 
-  IDBClient::IDBClientIterator* getIterator() const override {
+  std::unique_ptr<IDBClient::IDBClientIterator> getIterator() const override {
     ConcordAssert("getIterator() Not implemented for ECS S3 object store" && false);
     throw std::logic_error("getIterator() Not implemented for ECS S3 object store");
   }
 
-  concordUtils::Status freeIterator(IDBClientIterator* _iter) const override {
-    throw std::logic_error("freeIterator() Not implemented for ECS S3 object store");
-  }
-
   ITransaction* beginTransaction() override { return new Transaction(this); }
+
+  std::unique_ptr<ITransaction> startTransaction() override {
+    return std::unique_ptr<ITransaction>{beginTransaction()};
+  }
 
   concordUtils::Status rangeDel(const Sliver& _beginKey, const Sliver& _endKey) override {
     throw std::logic_error("rangeDel()  Not implemented for S3 object store");

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -72,7 +72,7 @@ class IDBClient {
   virtual Status has(const Sliver& _key) const = 0;
   virtual Status put(const Sliver& _key, const Sliver& _value) = 0;
   virtual Status del(const Sliver& _key) = 0;
-  virtual Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) = 0;
+  virtual Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) const = 0;
   virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap) = 0;
   virtual Status multiDel(const KeysVector& _keysVec) = 0;
   // Delete keys in the [_beginKey, _endKey) range (_beginKey included and _endKey excluded). If an inavlid range has

--- a/storage/include/storage/partitioned_db_interface.h
+++ b/storage/include/storage/partitioned_db_interface.h
@@ -99,9 +99,21 @@ class IPartitionedDBClient : public IDBClient, public std::enable_shared_from_th
   virtual Status has(const std::string& partition, const Sliver& key) const = 0;
   virtual Status put(const std::string& partition, const Sliver& key, const Sliver& value) = 0;
   virtual Status del(const std::string& partition, const Sliver& key) = 0;
-  virtual Status multiGet(const std::string& partition, const KeysVector& keys, ValuesVector& values) = 0;
+  virtual Status multiGet(const std::string& partition, const KeysVector& keys, ValuesVector& values) const = 0;
   virtual Status multiPut(const std::string& partition, const SetOfKeyValuePairs& keyValues) = 0;
   virtual Status multiDel(const std::string& partition, const KeysVector& keys) = 0;
+  struct PartitionedKey {
+    std::string partition;
+    Sliver key;
+  };
+  struct PartitionedKeyValue {
+    std::string partition;
+    KeyValuePair keyValue;
+  };
+  virtual Status multiGet(const std::vector<PartitionedKey>& keys, ValuesVector& values) const = 0;
+  virtual Status multiPut(const std::vector<PartitionedKeyValue>& keyValues) = 0;
+  virtual Status multiDel(const std::vector<PartitionedKey>& keys) = 0;
+
   // A version of IDBClient::rangeDel() that works on a single partition. See IDBClient::rangeDel() for more
   // information.
   virtual Status rangeDel(const std::string& partition, const Sliver& beginKey, const Sliver& endKey) = 0;
@@ -162,7 +174,7 @@ class PartitionDBClient : public IDBClient {
   Status has(const Sliver& key) const override { return db_->has(partition_, key); }
   Status put(const Sliver& key, const Sliver& value) override { return db_->put(partition_, key, value); }
   Status del(const Sliver& key) override { return db_->del(partition_, key); }
-  Status multiGet(const KeysVector& keys, ValuesVector& values) override {
+  Status multiGet(const KeysVector& keys, ValuesVector& values) const override {
     return db_->multiGet(partition_, keys, values);
   }
   Status multiPut(const SetOfKeyValuePairs& keyValues) override { return db_->multiPut(partition_, keyValues); }

--- a/storage/include/storage/partitioned_db_interface.h
+++ b/storage/include/storage/partitioned_db_interface.h
@@ -1,0 +1,196 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "db_interface.h"
+
+#include <cstring>
+#include <memory>
+#include <set>
+#include <utility>
+
+namespace concord::storage {
+
+// A transaction in a partitioned DB. Introduces a DB `partition` notion while keeping the existing ITransaction
+// interface. Calling ITransaction methods on a IPartitionedTransaction instance is equivalent to using the default
+// partition for the client in use.
+//
+// See IPartitionedDBClient for more information.
+class IPartitionedTransaction : public ITransaction {
+ public:
+  using ITransaction::put;
+  using ITransaction::get;
+  using ITransaction::del;
+
+  IPartitionedTransaction(ITransaction::ID id) : ITransaction{id} {}
+
+  virtual void put(const std::string& partition, const Sliver& key, const Sliver& value) = 0;
+  virtual std::string get(const std::string& partition, const Sliver& key) = 0;
+  virtual void del(const std::string& partition, const Sliver& key) = 0;
+
+  virtual ~IPartitionedTransaction() = default;
+
+  // Takes ownership of the passed transaction. Commits the transaction when destructed.
+  class Guard {
+   public:
+    Guard(IPartitionedTransaction* txn) : txn_{txn}, guard_{txn} {}
+    Guard(std::unique_ptr<IPartitionedTransaction>&& txn) : txn_{txn.get()}, guard_{std::move(txn)} {}
+    Guard(const Guard&) = delete;
+    Guard& operator=(const Guard&) = delete;
+    Guard(Guard&&) = default;
+    Guard& operator=(Guard&&) = default;
+
+    IPartitionedTransaction* operator->() const noexcept { return txn_; }
+
+   private:
+    // The transaction is managed by guard_. Store the pointer with its real type here too, in order to avoid a
+    // dynamic_cast on every dereference in operator->().
+    IPartitionedTransaction* txn_{nullptr};
+
+    ITransaction::Guard guard_;
+  };
+};
+
+// A client to a partitioned DB. Introduces a DB `partition` notion while mimicking the existing IDBClient interface as
+// closely as possible.
+//
+// A `partition` can be thought of as a key namespace. Two or more partitions can contain the same key and its value can
+// be different across them. Partitions can be useful for logically grouping keys in a database. In addition, certain
+// implementations can provide optimizations as compared to using key prefixing.
+//
+// Finally, calling IDBClient methods on a IPartitionedDBClient instance is equivalent to using the default partition.
+// Default partition names can vary across implementations and users are required to accomodate that via the
+// getDetaultPartition() method.
+class IPartitionedDBClient : public IDBClient, public std::enable_shared_from_this<IPartitionedDBClient> {
+ public:
+  using IDBClient::get;
+  using IDBClient::has;
+  using IDBClient::put;
+  using IDBClient::del;
+  using IDBClient::multiGet;
+  using IDBClient::multiPut;
+  using IDBClient::multiDel;
+  using IDBClient::rangeDel;
+  using IDBClient::getIterator;
+
+  virtual std::string defaultPartition() const = 0;
+  virtual std::set<std::string> partitions() const = 0;
+  virtual bool hasPartition(const std::string& partition) const = 0;
+  // Adds a partition.
+  // Fails with Status::InvalidArgument if the partition already exists.
+  virtual Status addPartition(const std::string& partition) = 0;
+  // Drops a partition, destroying all key-values inside of it.
+  // Fails with Status::InvalidArgument if the partition doesn't exist.
+  // Fails with Status::IllegalOperation if the given partition is the default one as it cannot be deleted.
+  virtual Status dropPartition(const std::string& partition) = 0;
+
+  virtual Status get(const std::string& partition, const Sliver& key, Sliver& outValue) const = 0;
+  virtual Status has(const std::string& partition, const Sliver& key) const = 0;
+  virtual Status put(const std::string& partition, const Sliver& key, const Sliver& value) = 0;
+  virtual Status del(const std::string& partition, const Sliver& key) = 0;
+  virtual Status multiGet(const std::string& partition, const KeysVector& keys, ValuesVector& values) = 0;
+  virtual Status multiPut(const std::string& partition, const SetOfKeyValuePairs& keyValues) = 0;
+  virtual Status multiDel(const std::string& partition, const KeysVector& keys) = 0;
+  // A version of IDBClient::rangeDel() that works on a single partition. See IDBClient::rangeDel() for more
+  // information.
+  virtual Status rangeDel(const std::string& partition, const Sliver& beginKey, const Sliver& endKey) = 0;
+
+  // Get an iterator to the given partition. Returns a nullptr if the partition doesn't exist.
+  virtual std::unique_ptr<IDBClientIterator> getIterator(const std::string& partition) const = 0;
+
+  // Starts a partitioned transaction. Can be upgraded to an IPartitionedTransaction::Guard in order to commit
+  // automatically on destruction.
+  virtual std::unique_ptr<IPartitionedTransaction> startPartitionedTransaction() = 0;
+
+  // Get a IDBClient instance that works for the given partition. Returns a nullptr if the partition doesn't exist.
+  std::unique_ptr<IDBClient> getPartitionClient(const std::string& partition);
+
+  virtual ~IPartitionedDBClient() = default;
+};
+
+// A transaction that operates on a single partition that is potentially different than the default one. Allows usage of
+// partitions as IDBClient instances (see PartitionDBClient).
+class PartitionTransaction : public ITransaction {
+ public:
+  PartitionTransaction(const std::string& partition, std::unique_ptr<IPartitionedTransaction>&& txn)
+      : ITransaction{txn->getId()}, partition_{partition}, txn_{std::move(txn)} {}
+
+  void commit() override { return txn_->commit(); }
+  void rollback() override { return txn_->rollback(); }
+  void put(const Sliver& key, const Sliver& value) override { return txn_->put(partition_, key, value); }
+  std::string get(const Sliver& key) override { return txn_->get(partition_, key); }
+  void del(const Sliver& key) override { return txn_->del(partition_, key); }
+
+ private:
+  std::string partition_;
+  std::unique_ptr<IPartitionedTransaction> txn_;
+};
+
+// A client to a DB partition that behaves as a normal IDBClient. All operations are executed in the passed partition as
+// if it was the default one.
+class PartitionDBClient : public IDBClient {
+ public:
+  PartitionDBClient(const std::string& partition, const std::shared_ptr<IPartitionedDBClient>& db)
+      : partition_{partition}, db_{db} {}
+
+  void init(bool) override {}
+  Status get(const Sliver& key, Sliver& outValue) const override { return db_->get(partition_, key, outValue); }
+  Status get(const Sliver& key, char*& buf, uint32_t bufSize, uint32_t& size) const override {
+    auto outValue = Sliver{};
+    const auto s = get(key, outValue);
+    if (!s.isOK()) {
+      return s;
+    }
+    if (bufSize < outValue.length()) {
+      return Status::GeneralError("Key value is bigger than the output buffer");
+    }
+    size = outValue.length();
+    std::memcpy(buf, outValue.data(), size);
+    return Status::OK();
+  }
+  Status has(const Sliver& key) const override { return db_->has(partition_, key); }
+  Status put(const Sliver& key, const Sliver& value) override { return db_->put(partition_, key, value); }
+  Status del(const Sliver& key) override { return db_->del(partition_, key); }
+  Status multiGet(const KeysVector& keys, ValuesVector& values) override {
+    return db_->multiGet(partition_, keys, values);
+  }
+  Status multiPut(const SetOfKeyValuePairs& keyValues) override { return db_->multiPut(partition_, keyValues); }
+  Status multiDel(const KeysVector& keys) override { return db_->multiDel(partition_, keys); }
+  Status rangeDel(const Sliver& beginKey, const Sliver& endKey) override {
+    return db_->rangeDel(partition_, beginKey, endKey);
+  }
+  bool isNew() override { return db_->isNew(); }
+  ITransaction* beginTransaction() override {
+    return new PartitionTransaction{partition_, db_->startPartitionedTransaction()};
+  }
+  std::unique_ptr<ITransaction> startTransaction() override {
+    return std::unique_ptr<ITransaction>{beginTransaction()};
+  }
+  // TODO - should we overwrite the parent aggregator or just ignore this call?
+  void setAggregator(std::shared_ptr<concordMetrics::Aggregator>) override {}
+  std::unique_ptr<IDBClientIterator> getIterator() const override { return db_->getIterator(partition_); }
+
+ private:
+  std::string partition_;
+  std::shared_ptr<IPartitionedDBClient> db_;
+};
+
+inline std::unique_ptr<IDBClient> IPartitionedDBClient::getPartitionClient(const std::string& partition) {
+  if (!hasPartition(partition)) {
+    return nullptr;
+  }
+  return std::make_unique<PartitionDBClient>(partition, shared_from_this());
+}
+
+}  // namespace concord::storage

--- a/storage/include/storage/test/storage_test_common.h
+++ b/storage/include/storage/test/storage_test_common.h
@@ -1,15 +1,23 @@
-// Copyright 2020 VMware, all rights reserved
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
 
 #pragma once
 
 #include "gtest/gtest.h"
 
-#include "block_digest.h"
-#include "kv_types.hpp"
 #include "memorydb/client.h"
 #include "rocksdb/client.h"
 #include "sliver.hpp"
-#include "sparse_merkle/base_types.h"
 #include "storage/db_interface.h"
 
 #include <unistd.h>
@@ -33,7 +41,7 @@ namespace fs = std::experimental::filesystem;
 inline constexpr auto defaultDbId = std::size_t{0};
 
 #ifdef USE_ROCKSDB
-inline const auto rocksDbPathPrefix = std::string{"/tmp/sparse_merkle_storage_test_rocksdb"};
+inline const auto rocksDbPathPrefix = std::string{"/tmp/storage_test_rocksdb"};
 
 // Support multithreaded runs by appending the thread ID to the RocksDB path.
 inline std::string rocksDbPath(std::size_t dbId) {
@@ -47,15 +55,15 @@ inline void cleanup(std::size_t dbId = defaultDbId) { fs::remove_all(rocksDbPath
 inline void cleanup(std::size_t = defaultDbId) {}
 #endif
 
-inline ::concord::kvbc::BlockDigest blockDigest(concord::kvbc::BlockId blockId, const concordUtils::Sliver &block) {
-  return ::bftEngine::bcst::computeBlockDigest(blockId, block.data(), block.length());
-}
-
 struct TestMemoryDb {
-  static std::shared_ptr<concord::storage::IDBClient> create(std::size_t dbId = defaultDbId) {
+  static std::shared_ptr<concord::storage::IPartitionedDBClient> createPartitioned(std::size_t dbId = defaultDbId) {
     auto db = std::make_shared<concord::storage::memorydb::Client>();
     db->init();
     return db;
+  }
+
+  static std::shared_ptr<concord::storage::IDBClient> create(std::size_t dbId = defaultDbId) {
+    return createPartitioned(dbId);
   }
 
   static void cleanup(std::size_t = defaultDbId) {}
@@ -92,20 +100,7 @@ struct TypePrinter {
   }
 };
 
-inline auto getHash(const std::string &str) {
-  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
-  return hasher.hash(str.data(), str.size());
-}
-
-inline auto getHash(const concordUtils::Sliver &sliver) {
-  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
-  return hasher.hash(sliver.data(), sliver.length());
-}
-
-inline auto getBlockDigest(const std::string &data) { return getHash(data).dataArray(); }
 inline concordUtils::Sliver getSliverOfSize(std::size_t size, char content = 'a') { return std::string(size, content); }
 
-inline const auto defaultBlockId = ::concord::kvbc::BlockId{42};
 inline const auto defaultData = std::string{"defaultData"};
 inline const auto defaultSliver = concordUtils::Sliver::copy(defaultData.c_str(), defaultData.size());
-inline const auto maxNumKeys = 16u;

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -313,7 +313,7 @@ Status Client::del(const Sliver &_key) {
   return Status::OK();
 }
 
-Status Client::multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) {
+Status Client::multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) const {
   std::vector<std::string> values;
   std::vector<::rocksdb::Slice> keys;
   for (auto const &it : _keysVec) keys.push_back(toRocksdbSlice(it));

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(GTest REQUIRED)
+
+add_executable(db_partitions_test db_partitions_test.cpp)
+add_test(db_partitions_test db_partitions_test)
+target_link_libraries(db_partitions_test PUBLIC
+    GTest::Main
+    GTest::GTest
+    util
+    concordbft_storage
+    stdc++fs
+)

--- a/storage/test/db_partitions_test.cpp
+++ b/storage/test/db_partitions_test.cpp
@@ -1,0 +1,336 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+
+#include "status.hpp"
+#include "storage/test/storage_test_common.h"
+
+#include <iterator>
+#include <string>
+
+// NOTE: All tests assume lexicographical key ordering.
+namespace {
+
+using namespace concordUtils;
+using namespace concord::storage;
+
+template <typename T>
+struct partition_test : public testing::Test {
+  using Db = T;
+
+  void SetUp() override { Db::cleanup(); }
+  void TearDown() override { Db::cleanup(); }
+};
+
+using Types = testing::Types<TestMemoryDb>;
+TYPED_TEST_CASE(partition_test, Types, );
+
+TYPED_TEST(partition_test, has_default_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partitions = db->partitions();
+  ASSERT_EQ(partitions.size(), 1);
+  ASSERT_EQ(*std::cbegin(partitions), db->defaultPartition());
+}
+
+TYPED_TEST(partition_test, add_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition = db->defaultPartition() + "1";
+  ASSERT_EQ(db->addPartition(partition), Status::OK());
+  const auto partitions_after = db->partitions();
+  ASSERT_EQ(partitions_after.size(), 2);
+  ASSERT_NE(partitions_after.find(partition), std::cend(partitions_after));
+  ASSERT_NE(partitions_after.find(db->defaultPartition()), std::cend(partitions_after));
+}
+
+TYPED_TEST(partition_test, cannot_add_existing_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition = db->defaultPartition() + "1";
+  ASSERT_EQ(db->addPartition(partition), Status::OK());
+  ASSERT_EQ(db->addPartition(partition), Status::InvalidArgument(""));
+  // The default and the added one are present.
+  ASSERT_EQ(db->partitions().size(), 2);
+}
+
+TYPED_TEST(partition_test, drop_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition = db->defaultPartition() + "1";
+  ASSERT_EQ(db->addPartition(partition), Status::OK());
+  ASSERT_EQ(db->dropPartition(partition), Status::OK());
+  const auto partitions_after = db->partitions();
+  ASSERT_EQ(partitions_after.size(), 1);
+  ASSERT_EQ(partitions_after.find(partition), std::cend(partitions_after));
+  ASSERT_NE(partitions_after.find(db->defaultPartition()), std::cend(partitions_after));
+}
+
+TYPED_TEST(partition_test, cannot_drop_default_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  ASSERT_EQ(db->dropPartition(db->defaultPartition()), Status::IllegalOperation(""));
+  const auto partitions = db->partitions();
+  ASSERT_EQ(partitions.size(), 1);
+  ASSERT_NE(partitions.find(db->defaultPartition()), std::cend(partitions));
+}
+
+TYPED_TEST(partition_test, put_same_key_in_multiple_partitions) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition1 = db->defaultPartition() + "1";
+  const auto partition2 = db->defaultPartition() + "2";
+  ASSERT_EQ(db->addPartition(partition1), Status::OK());
+  ASSERT_EQ(db->addPartition(partition2), Status::OK());
+
+  const auto key = getSliverOfSize(2);
+  const auto value_in_default = getSliverOfSize(10, 'd');
+  const auto value_in_1 = getSliverOfSize(10, '1');
+  const auto value_in_2 = getSliverOfSize(10, '2');
+  ASSERT_EQ(db->put(db->defaultPartition(), key, value_in_default), Status::OK());
+  ASSERT_EQ(db->put(partition1, key, value_in_1), Status::OK());
+  ASSERT_EQ(db->put(partition2, key, value_in_2), Status::OK());
+
+  auto out = Sliver{};
+  ASSERT_EQ(db->has(db->defaultPartition(), key), Status::OK());
+  ASSERT_EQ(db->get(db->defaultPartition(), key, out), Status::OK());
+  ASSERT_EQ(out, value_in_default);
+  ASSERT_EQ(db->has(partition1, key), Status::OK());
+  ASSERT_EQ(db->get(partition1, key, out), Status::OK());
+  ASSERT_EQ(out, value_in_1);
+  ASSERT_EQ(db->has(partition2, key), Status::OK());
+  ASSERT_EQ(db->get(partition2, key, out), Status::OK());
+  ASSERT_EQ(out, value_in_2);
+}
+
+TYPED_TEST(partition_test, delete_key_in_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition1 = db->defaultPartition() + "1";
+  const auto partition2 = db->defaultPartition() + "2";
+  ASSERT_EQ(db->addPartition(partition1), Status::OK());
+  ASSERT_EQ(db->addPartition(partition2), Status::OK());
+
+  const auto key = getSliverOfSize(2);
+  const auto value_in_1 = getSliverOfSize(10, '1');
+  const auto value_in_2 = getSliverOfSize(10, '2');
+  ASSERT_EQ(db->put(partition1, key, value_in_1), Status::OK());
+  ASSERT_EQ(db->put(partition2, key, value_in_2), Status::OK());
+
+  auto out = Sliver{};
+  ASSERT_EQ(db->del(partition1, key), Status::OK());
+  ASSERT_EQ(db->get(partition1, key, out), Status::NotFound(""));
+  ASSERT_EQ(db->get(partition2, key, out), Status::OK());
+  ASSERT_EQ(out, value_in_2);
+}
+
+TYPED_TEST(partition_test, range_delete_in_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition1 = db->defaultPartition() + "1";
+  const auto partition2 = db->defaultPartition() + "2";
+  ASSERT_EQ(db->addPartition(partition1), Status::OK());
+  ASSERT_EQ(db->addPartition(partition2), Status::OK());
+
+  const auto a = getSliverOfSize(1, 'a');
+  const auto b = getSliverOfSize(1, 'b');
+  const auto c = getSliverOfSize(1, 'c');
+  const auto in_value = getSliverOfSize(2, 'v');
+
+  ASSERT_EQ(db->put(partition1, a, in_value), Status::OK());
+  ASSERT_EQ(db->put(partition1, b, in_value), Status::OK());
+  ASSERT_EQ(db->put(partition1, c, in_value), Status::OK());
+  ASSERT_EQ(db->put(partition2, a, in_value), Status::OK());
+  ASSERT_EQ(db->put(partition2, b, in_value), Status::OK());
+  ASSERT_EQ(db->put(partition2, c, in_value), Status::OK());
+
+  // Delete the [a, c) range in partition1.
+  ASSERT_EQ(db->rangeDel(partition1, a, c), Status::OK());
+  ASSERT_EQ(db->has(partition1, a), Status::NotFound(""));
+  ASSERT_EQ(db->has(partition1, b), Status::NotFound(""));
+  ASSERT_EQ(db->has(partition1, c), Status::OK());
+  ASSERT_EQ(db->has(partition2, a), Status::OK());
+  ASSERT_EQ(db->has(partition2, b), Status::OK());
+  ASSERT_EQ(db->has(partition2, c), Status::OK());
+}
+
+TYPED_TEST(partition_test, drop_partition_destroys_data_in_dropped_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition1 = db->defaultPartition() + "1";
+  const auto partition2 = db->defaultPartition() + "2";
+  ASSERT_EQ(db->addPartition(partition1), Status::OK());
+  ASSERT_EQ(db->addPartition(partition2), Status::OK());
+
+  const auto key = getSliverOfSize(2);
+  const auto value_in_1 = getSliverOfSize(10, '1');
+  const auto value_in_2 = getSliverOfSize(10, '2');
+  ASSERT_EQ(db->put(partition1, key, value_in_1), Status::OK());
+  ASSERT_EQ(db->put(partition2, key, value_in_2), Status::OK());
+
+  // Drop and add the partition.
+  ASSERT_EQ(db->dropPartition(partition1), Status::OK());
+  ASSERT_EQ(db->addPartition(partition1), Status::OK());
+
+  auto out = Sliver{};
+  ASSERT_EQ(db->get(partition1, key, out), Status::NotFound(""));
+  ASSERT_EQ(db->get(partition2, key, out), Status::OK());
+  ASSERT_EQ(out, value_in_2);
+}
+
+TYPED_TEST(partition_test, non_existing_partition_returns_invalid_argument) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition = db->defaultPartition() + "1";
+  const auto key = getSliverOfSize(1);
+  auto out_value = Sliver{};
+  const auto keys = KeysVector{key};
+  auto out_values = ValuesVector{};
+  const auto kvs = SetOfKeyValuePairs{std::make_pair(key, Sliver{})};
+
+  ASSERT_EQ(db->get(partition, key, out_value), Status::InvalidArgument(""));
+  ASSERT_EQ(db->has(partition, key), Status::InvalidArgument(""));
+  ASSERT_EQ(db->del(partition, key), Status::InvalidArgument(""));
+  // Test multi calls with empty and non-empty key vectors.
+  ASSERT_EQ(db->multiGet(partition, keys, out_values), Status::InvalidArgument(""));
+  ASSERT_EQ(db->multiGet(partition, KeysVector{}, out_values), Status::InvalidArgument(""));
+  ASSERT_EQ(db->multiPut(partition, kvs), Status::InvalidArgument(""));
+  ASSERT_EQ(db->multiPut(partition, SetOfKeyValuePairs{}), Status::InvalidArgument(""));
+  ASSERT_EQ(db->multiDel(partition, keys), Status::InvalidArgument(""));
+  ASSERT_EQ(db->multiDel(partition, KeysVector{}), Status::InvalidArgument(""));
+  ASSERT_EQ(db->rangeDel(partition, getSliverOfSize(1, 'a'), getSliverOfSize(1, 'b')), Status::InvalidArgument(""));
+  ASSERT_EQ(db->getIterator(partition), nullptr);
+  ASSERT_EQ(db->getPartitionClient(partition), nullptr);
+}
+
+TYPED_TEST(partition_test, iterate_a_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition = db->defaultPartition() + "1";
+  ASSERT_EQ(db->addPartition(partition), Status::OK());
+  const auto kva = std::make_pair(getSliverOfSize(1, 'a'), getSliverOfSize(2, 'x'));
+  const auto kvb = std::make_pair(getSliverOfSize(1, 'b'), getSliverOfSize(2, 'y'));
+  const auto kvc = std::make_pair(getSliverOfSize(1, 'c'), getSliverOfSize(2, 'z'));
+  const auto empty = std::make_pair(Sliver{}, Sliver{});
+  const auto kvs = SetOfKeyValuePairs{kva, kvb, kvc};
+  ASSERT_EQ(db->multiPut(partition, kvs), Status::OK());
+
+  auto iter = db->getIterator(partition);
+  ASSERT_NE(iter, nullptr);
+
+  // Iterate forward.
+  ASSERT_FALSE(iter->valid());
+
+  ASSERT_EQ(iter->first(), kva);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), kva);
+
+  ASSERT_EQ(iter->next(), kvb);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), kvb);
+  ;
+
+  ASSERT_EQ(iter->next(), kvc);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), kvc);
+
+  ASSERT_EQ(iter->next(), empty);
+  ASSERT_FALSE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), empty);
+
+  // Iterate backward.
+  ASSERT_EQ(iter->last(), kvc);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), kvc);
+
+  ASSERT_EQ(iter->previous(), kvb);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), kvb);
+
+  ASSERT_EQ(iter->previous(), kva);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), kva);
+
+  ASSERT_EQ(iter->previous(), empty);
+  ASSERT_FALSE(iter->valid());
+  ASSERT_EQ(iter->getCurrent(), empty);
+}
+
+TYPED_TEST(partition_test, seek_in_a_partition) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition = db->defaultPartition() + "1";
+  ASSERT_EQ(db->addPartition(partition), Status::OK());
+  const auto kva = std::make_pair(getSliverOfSize(1, 'a'), getSliverOfSize(2, 'x'));
+  const auto kvb = std::make_pair(getSliverOfSize(1, 'b'), getSliverOfSize(2, 'y'));
+  const auto kvc = std::make_pair(getSliverOfSize(1, 'c'), getSliverOfSize(2, 'y'));
+  const auto kvd = std::make_pair(getSliverOfSize(1, 'd'), getSliverOfSize(2, 'z'));
+  const auto empty = std::make_pair(Sliver{}, Sliver{});
+  const auto kvs = SetOfKeyValuePairs{kva, kvb, kvd};
+  ASSERT_EQ(db->multiPut(partition, kvs), Status::OK());
+
+  auto iter = db->getIterator(partition);
+  ASSERT_NE(iter, nullptr);
+
+  // [a, b, d] seekAtLeast(c) returns d
+  ASSERT_EQ(iter->seekAtLeast(kvc.first), kvd);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->next(), empty);
+  ASSERT_FALSE(iter->valid());
+
+  // [a, b, d] seekAtMost(c) returns b
+  ASSERT_EQ(iter->seekAtMost(kvc.first), kvb);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->next(), kvd);
+  ASSERT_TRUE(iter->valid());
+  ASSERT_EQ(iter->next(), empty);
+  ASSERT_FALSE(iter->valid());
+}
+
+TYPED_TEST(partition_test, iterator_first_and_last) {
+  using Db = typename TestFixture::Db;
+
+  auto db = Db::createPartitioned();
+  const auto partition = db->defaultPartition() + "1";
+  ASSERT_EQ(db->addPartition(partition), Status::OK());
+  const auto kva = std::make_pair(getSliverOfSize(1, 'a'), getSliverOfSize(2, 'x'));
+  const auto kvb = std::make_pair(getSliverOfSize(1, 'b'), getSliverOfSize(2, 'y'));
+  const auto kvs = SetOfKeyValuePairs{kva, kvb};
+  ASSERT_EQ(db->multiPut(partition, kvs), Status::OK());
+
+  auto iter = db->getIterator(partition);
+  ASSERT_NE(iter, nullptr);
+
+  ASSERT_EQ(iter->first(), kva);
+  ASSERT_EQ(iter->last(), kvb);
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Extend the IDBClient and ITransaction interfaces by providing support
for the notion of `partitions`. A `partition` can be thought of as a key
namespace. Two or more partitions can contain the same key and its value
can be different across them.

In terms of design, the IPartitionedDBClient and the
IPartitionedTransaction interfaces are introduced by extending the
IDBClient and the ITransaction interfaces, respectively. The new
interfaces just add another parameter to the key-value methods, namely
the `partition`. An attempt is made to not change the interfaces
significantly. Moreover, methods for partition management are supported,
i.e. looking up, adding, dropping.

In addition, introduce the PartitionDBClient and PartitionTransaction
classes that bridge partition-based interfaces to the existing IDBClient
one. That way, a partition can be used as drop-in replacement for
existing partition-unaware IDBClient implementations.

Remove the IDBClient::freeIterator() method and make the
IDBClient::getIterator() one return an std::unique_ptr. Remove the
corresponding Guard.

Introduce the IDBClient::startTransaction() method that is an alias to
the IDBClient::beginTransaction() method, but returning an
std::unique_ptr. Support upgrade from the std::unique_ptr to an
ITransaction::Guard in order to automatically commit the transaction.
Applies to IPartitionedTransaction too.

Rename IDBClientITerator::isEnd() to valid() and invert its meaning.
That allows for graceful handling of the case of calling previous() on
an iterator that points to the first element. Fix const-correcness for
the valid() and getStatus() methods.

Move common GTest storage code from `kvbc` to `storage`. Add the
`db_partitions` unit test.

This PR assumes that the underlying store can meaningfully support
partitions. For example, partitions map to column families when RocksDB
is used.

A sample implementation is provided in the existing `memorydb` client.

Finally, this PR is just a proposal and a placeholder for discussions.
Suggestions for changes or totally abandoning the idea are welcome. If
accepted, a RocksDB implementation will be added in a future commit.