### PR TITLE
Added additional storage to keep information for Sequence Numbers

### DIFF
--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -65,6 +65,8 @@ class CheckpointInfo {
   static void free(CheckpointInfo& i);
 
   static void reset(CheckpointInfo& i);
+
+  static void acquire(CheckpointInfo& to, CheckpointInfo& from) {}
 };
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
+++ b/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
@@ -38,6 +38,17 @@ class CollectorOfThresholdSignatures {
  public:
   CollectorOfThresholdSignatures(void* cnt) { this->context = cnt; }
 
+  void acquire(CollectorOfThresholdSignatures* rhs) {
+    replicasInfo = rhs->replicasInfo;
+    rhs->replicasInfo.clear();
+
+    combinedValidSignatureMsg = rhs->combinedValidSignatureMsg;
+    rhs->combinedValidSignatureMsg = nullptr;
+
+    candidateCombinedSignatureMsg = rhs->candidateCombinedSignatureMsg;
+    rhs->candidateCombinedSignatureMsg = nullptr;
+  }
+
   ~CollectorOfThresholdSignatures() { resetAndFree(); }
 
   bool addMsgWithPartialSignature(PART* partialSigMsg, ReplicaId repId) {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2651,8 +2651,8 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
   const ReplicaId msgSender = msg->senderId();
   SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   LOG_INFO(GL, "Received ReqMissingDataMsg. " << KVLOG(msgSender, msg->getFlags()));
-  if ((currentViewIsActive()) && mainLog->IsPressentInHistory(msgSeqNum)) {
-    SeqNumInfo &seqNumInfo = mainLog->getFromHistory(msgSeqNum);
+  if ((currentViewIsActive()) && (mainLog->insideActiveWindow(msgSeqNum) || mainLog->isPressentInHistory(msgSeqNum))) {
+    SeqNumInfo &seqNumInfo = mainLog->getFromActiveWindowOrHistory(msgSeqNum);
 
     if (config_.replicaId == currentPrimary()) {
       PrePrepareMsg *pp = seqNumInfo.getSelfPrePrepareMsg();

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -104,7 +104,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]
-  typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo> WindowOfSeqNumInfo;
+  typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo, 1> WindowOfSeqNumInfo;
   std::shared_ptr<WindowOfSeqNumInfo> mainLog;
 
   // bounded log used to store information about checkpoints in the range [lastStableSeqNum,lastStableSeqNum +

--- a/bftengine/src/bftengine/SeqNumInfo.cpp
+++ b/bftengine/src/bftengine/SeqNumInfo.cpp
@@ -39,6 +39,15 @@ SeqNumInfo::~SeqNumInfo() {
   delete partialProofsSet;
 }
 
+void SeqNumInfo::acquire(SeqNumInfo& rhs) {
+  prePrepareMsg = rhs.prePrepareMsg;
+  rhs.prePrepareMsg = nullptr;
+
+  prepareSigCollector->acquire(rhs.prepareSigCollector);
+  commitMsgsCollector->acquire(rhs.commitMsgsCollector);
+  partialProofsSet->acquire(rhs.partialProofsSet);
+}
+
 void SeqNumInfo::resetAndFree() {
   delete prePrepareMsg;
   prePrepareMsg = nullptr;

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -35,6 +35,8 @@ class SeqNumInfo {
   SeqNumInfo();
   ~SeqNumInfo();
 
+  void acquire(SeqNumInfo& rhs);
+
   void resetAndFree();  // TODO(GG): name
   void getAndReset(PrePrepareMsg*& outPrePrepare, PrepareFullMsg*& outCombinedValidSignatureMsg);
 
@@ -192,6 +194,8 @@ class SeqNumInfo {
   static void free(SeqNumInfo& i) { i.resetAndFree(); }
 
   static void reset(SeqNumInfo& i) { i.resetAndFree(); }
+
+  static void acquire(SeqNumInfo& to, SeqNumInfo& from) { to.acquire(from); }
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
+++ b/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
@@ -21,7 +21,65 @@
 namespace bftEngine {
 namespace impl {
 
-template <uint16_t WindowSize, uint16_t Resolution, typename NumbersType, typename ItemType, typename ItemFuncs>
+template <uint16_t Resolution, typename NumbersType, typename ItemType, typename ItemFuncs>
+class InactiveStorage {
+ public:
+  InactiveStorage(uint16_t maxSize, void *initData) {
+    if (maxSize > 0) {
+      filled = false;
+      inactiveSavedSeqs.resize(maxSize);
+      elementsInInactiveWindow = currentPosOfInactiveWindow = 0;
+      for (uint16_t i = 0; i < maxSize; i++) {
+        ItemFuncs::init(inactiveSavedSeqs[i], initData);
+        ItemFuncs::reset(inactiveSavedSeqs[i]);
+      }
+    }
+  }
+
+  ~InactiveStorage() {
+    for (uint16_t i = 0; i < inactiveSavedSeqs.size(); i++) ItemFuncs::free(inactiveSavedSeqs[i]);
+  }
+
+  void add(ItemType &item) {
+    ConcordAssertGT(inactiveSavedSeqs.size(), 0);
+    ItemFuncs::reset(inactiveSavedSeqs[currentPosOfInactiveWindow]);
+    ItemFuncs::acquire(inactiveSavedSeqs[currentPosOfInactiveWindow], item);
+    currentPosOfInactiveWindow = (currentPosOfInactiveWindow + 1) % inactiveSavedSeqs.size();
+    if (filled || ++elementsInInactiveWindow > inactiveSavedSeqs.size()) {
+      filled = true;
+      beginningOfInactiveWindow += Resolution;
+    }
+  }
+
+  ItemType &get(NumbersType n) {
+    ConcordAssert(n % Resolution == 0);
+    ConcordAssertGT(inactiveSavedSeqs.size(), 0);
+    auto index = (currentPosOfInactiveWindow + (n - beginningOfInactiveWindow) / Resolution) % inactiveSavedSeqs.size();
+    LOG_DEBUG(GL,
+              "Actual get from Inactive Window"
+                  << KVLOG(index, currentPosOfInactiveWindow, n, beginningOfInactiveWindow, inactiveSavedSeqs.size()));
+    return inactiveSavedSeqs[index];
+  }
+
+  const NumbersType &getBeginningOfInactiveWindow() const {
+    ConcordAssertGT(inactiveSavedSeqs.size(), 0);
+    return beginningOfInactiveWindow;
+  }
+
+ private:
+  std::vector<ItemType> inactiveSavedSeqs;
+  size_t currentPosOfInactiveWindow;
+  size_t elementsInInactiveWindow;
+  bool filled;
+  NumbersType beginningOfInactiveWindow;
+};
+
+template <uint16_t WindowSize,
+          uint16_t Resolution,
+          typename NumbersType,
+          typename ItemType,
+          typename ItemFuncs,
+          uint16_t WindowHistory = 0>
 class SequenceWithActiveWindow {
   static_assert(WindowSize >= 8, "");
   static_assert(WindowSize < UINT16_MAX, "");
@@ -34,9 +92,11 @@ class SequenceWithActiveWindow {
 
   NumbersType beginningOfActiveWindow;
   ItemType activeWindow[numItems];
+  InactiveStorage<Resolution, NumbersType, ItemType, ItemFuncs> inactiveStorage;
 
  public:
-  SequenceWithActiveWindow(NumbersType windowFirst, void *initData) {
+  SequenceWithActiveWindow(NumbersType windowFirst, void *initData)
+      : inactiveStorage(WindowHistory * numItems, initData) {
     ConcordAssert(windowFirst % Resolution == 0);
 
     beginningOfActiveWindow = windowFirst;
@@ -55,12 +115,27 @@ class SequenceWithActiveWindow {
     return ((n >= beginningOfActiveWindow) && (n < (beginningOfActiveWindow + WindowSize)));
   }
 
+  bool IsPressentInHistory(NumbersType n) const {
+    return ((n >= inactiveStorage.getBeginningOfInactiveWindow()) && (n < (beginningOfActiveWindow + WindowSize)));
+  }
+
   ItemType &get(NumbersType n) {
     ConcordAssert(n % Resolution == 0);
     ConcordAssert(insideActiveWindow(n));
 
     uint16_t i = ((n / Resolution) % numItems);
     return activeWindow[i];
+  }
+
+  ItemType &getFromHistory(NumbersType n) {
+    if (insideActiveWindow(n)) {
+      return get(n);
+    } else {
+      LOG_DEBUG(GL,
+                "Getting info from Inactive Window for SeqNo="
+                    << n << KVLOG(beginningOfActiveWindow, inactiveStorage.getBeginningOfInactiveWindow()));
+      return inactiveStorage.get(n);
+    }
   }
 
   std::pair<NumbersType, NumbersType> currentActiveWindow() const {
@@ -86,6 +161,11 @@ class SequenceWithActiveWindow {
 
     if (newFirstIndexOfActiveWindow - beginningOfActiveWindow >= WindowSize) {
       resetAll(newFirstIndexOfActiveWindow);
+      if (WindowHistory > 0) {
+        for (NumbersType n = 0; n > newFirstIndexOfActiveWindow - beginningOfActiveWindow; n++) {
+          inactiveStorage.add(activeWindow[0]);  // clear necessary elements from inactiveStorage to stay in sync
+        }
+      }
       return;
     }
 
@@ -101,6 +181,10 @@ class SequenceWithActiveWindow {
 
     uint16_t debugNumOfReset = 0;
     for (uint16_t i = inactiveBegin; i != activeBegin; (i = ((i + 1) % numItems))) {
+      if (WindowHistory > 0) {
+        inactiveStorage.add(activeWindow[i]);
+      }
+
       ItemFuncs::reset(activeWindow[i]);
       debugNumOfReset++;
     }

--- a/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
+++ b/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
@@ -115,8 +115,9 @@ class SequenceWithActiveWindow {
     return ((n >= beginningOfActiveWindow) && (n < (beginningOfActiveWindow + WindowSize)));
   }
 
-  bool IsPressentInHistory(NumbersType n) const {
-    return ((n >= inactiveStorage.getBeginningOfInactiveWindow()) && (n < (beginningOfActiveWindow + WindowSize)));
+  bool isPressentInHistory(NumbersType n) const {
+    auto BeginningOfInactiveWindow = inactiveStorage.getBeginningOfInactiveWindow();
+    return ((n >= BeginningOfInactiveWindow) && (n < (BeginningOfInactiveWindow + (WindowHistory * WindowSize))));
   }
 
   ItemType &get(NumbersType n) {
@@ -128,13 +129,19 @@ class SequenceWithActiveWindow {
   }
 
   ItemType &getFromHistory(NumbersType n) {
+    ConcordAssert(isPressentInHistory(n));
+    LOG_DEBUG(GL,
+              "Getting info from Inactive Window for SeqNo="
+                  << n << KVLOG(beginningOfActiveWindow, inactiveStorage.getBeginningOfInactiveWindow()));
+    return inactiveStorage.get(n);
+  }
+
+  ItemType &getFromActiveWindowOrHistory(NumbersType n) {
+    ConcordAssert(insideActiveWindow(n) || isPressentInHistory(n));
     if (insideActiveWindow(n)) {
       return get(n);
     } else {
-      LOG_DEBUG(GL,
-                "Getting info from Inactive Window for SeqNo="
-                    << n << KVLOG(beginningOfActiveWindow, inactiveStorage.getBeginningOfInactiveWindow()));
-      return inactiveStorage.get(n);
+      return getFromHistory(n);
     }
   }
 

--- a/bftengine/src/bftengine/messages/PartialProofsSet.cpp
+++ b/bftengine/src/bftengine/messages/PartialProofsSet.cpp
@@ -42,6 +42,16 @@ PartialProofsSet::PartialProofsSet(InternalReplicaApi* const rep)
 
 PartialProofsSet::~PartialProofsSet() { resetAndFree(); }
 
+void PartialProofsSet::acquire(PartialProofsSet* rhs) {
+  fullCommitProof = rhs->fullCommitProof;
+  rhs->fullCommitProof = nullptr;
+  selfPartialCommitProof = rhs->selfPartialCommitProof;
+  rhs->selfPartialCommitProof = nullptr;
+  participatingReplicasInFast = rhs->participatingReplicasInFast;
+  participatingReplicasInOptimisticFast = rhs->participatingReplicasInOptimisticFast;
+  expectedDigest = rhs->expectedDigest;
+}
+
 void PartialProofsSet::resetAndFree() {
   seqNumber = 0;
   if (fullCommitProof) delete fullCommitProof;

--- a/bftengine/src/bftengine/messages/PartialProofsSet.hpp
+++ b/bftengine/src/bftengine/messages/PartialProofsSet.hpp
@@ -35,6 +35,8 @@ class PartialProofsSet {
   PartialProofsSet(InternalReplicaApi* const rep);
   ~PartialProofsSet();
 
+  void acquire(PartialProofsSet* rhs);
+
   void addSelfMsgAndPPDigest(PartialCommitProofMsg* m, Digest& digest);
 
   void setTimeOfSelfPartialProof(const Time& t);


### PR DESCRIPTION
for up to N previous working windows. This is an optimisation to
help in the situation where a Replica is catching up and is being
slightly behind the others. If in this case the other Replicas
agree on a stable Checkpoint further than the sequence ID the
behind Replica is requesting, currently we will have to wait for
State Transfer to start to be able to catch up. By keeping the
information for the sequence numbers from the previous Working
Window, the behind Replica will be able to catch up by means of
ReqMissingDataMsg messages.