### PR TITLE
Add has keys request

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeMsg.hpp
+++ b/bftengine/include/bftengine/KeyExchangeMsg.hpp
@@ -1,0 +1,52 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include "Serializable.h"
+
+struct KeyExchangeMsg : public concord::serialize::SerializableFactory<KeyExchangeMsg> {
+  constexpr static uint8_t EXCHANGE{0};
+  constexpr static uint8_t HAS_KEYS{1};
+  constexpr static std::string_view hasKeysTrueReply{"true"};
+  constexpr static std::string_view hasKeysFalseReply{"false"};
+  uint8_t op{EXCHANGE};
+  std::string key;
+  std::string signature;
+  uint16_t repID;
+
+  std::string toString() const {
+    std::stringstream ss;
+    ss << "key [" << key << "] signature [" << signature << "] replica id [" << repID << "]";
+    return ss.str();
+  }
+  static KeyExchangeMsg deserializeMsg(const char* serializedMsg, const int& size) {
+    std::stringstream ss;
+    KeyExchangeMsg ke;
+    ss.write(serializedMsg, std::streamsize(size));
+    deserialize(ss, ke);
+    return ke;
+  }
+
+ protected:
+  const std::string getVersion() const override { return "1"; }
+  void serializeDataMembers(std::ostream& outStream) const override {
+    serialize(outStream, op);
+    serialize(outStream, key);
+    serialize(outStream, signature);
+    serialize(outStream, repID);
+  }
+  void deserializeDataMembers(std::istream& inStream) override {
+    deserialize(inStream, op);
+    deserialize(inStream, key);
+    deserialize(inStream, signature);
+    deserialize(inStream, repID);
+  }
+};

--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -74,6 +74,12 @@ std::string KeyManager::generateCid() {
 // Key exchange msg for replica has been recieved:
 // update the replica public key store.
 std::string KeyManager::onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn) {
+  if (kemsg.op == KeyExchangeMsg::HAS_KEYS) {
+    LOG_INFO(KEY_EX_LOG, "Has key query arrived, returning " << std::boolalpha << keysExchanged << std::noboolalpha);
+    if (!keysExchanged) return std::string(KeyExchangeMsg::hasKeysFalseReply);
+    return std::string(KeyExchangeMsg::hasKeysTrueReply);
+  }
+
   LOG_INFO(KEY_EX_LOG, "Recieved onKeyExchange " << kemsg.toString() << " seq num " << sn);
   if (!keysExchanged) {
     onInitialKeyExchange(kemsg, sn);

--- a/bftengine/src/bftengine/KeyStore.cpp
+++ b/bftengine/src/bftengine/KeyStore.cpp
@@ -15,36 +15,6 @@
 
 namespace bftEngine::impl {
 
-////////////////////////////// KEY EXCHANGE MSG//////////////////////////////
-
-const std::string KeyExchangeMsg::getVersion() const { return "1"; }
-
-KeyExchangeMsg KeyExchangeMsg::deserializeMsg(const char* serializedMsg, const int& size) {
-  std::stringstream ss;
-  KeyExchangeMsg ke;
-  ss.write(serializedMsg, std::streamsize(size));
-  deserialize(ss, ke);
-  return ke;
-}
-
-void KeyExchangeMsg::serializeDataMembers(std::ostream& outStream) const {
-  serialize(outStream, key);
-  serialize(outStream, signature);
-  serialize(outStream, repID);
-}
-
-void KeyExchangeMsg::deserializeDataMembers(std::istream& inStream) {
-  deserialize(inStream, key);
-  deserialize(inStream, signature);
-  deserialize(inStream, repID);
-}
-
-std::string KeyExchangeMsg::toString() const {
-  std::stringstream ss;
-  ss << "key [" << key << "] signature [" << signature << "] replica id [" << repID << "]";
-  return ss.str();
-}
-
 ///////////////////////////REPLICA KEY STORE//////////////////////////////////
 
 bool ReplicaKeyStore::push(const KeyExchangeMsg& kem, const uint64_t& sn) {

--- a/bftengine/src/bftengine/KeyStore.h
+++ b/bftengine/src/bftengine/KeyStore.h
@@ -14,22 +14,8 @@
 #include "deque"
 #include "IReservedPages.hpp"
 #include "ReservedPages.hpp"
-
+#include "KeyExchangeMsg.hpp"
 namespace bftEngine::impl {
-
-struct KeyExchangeMsg : public concord::serialize::SerializableFactory<KeyExchangeMsg> {
-  std::string key;
-  std::string signature;
-  uint16_t repID;
-
-  std::string toString() const;
-  static KeyExchangeMsg deserializeMsg(const char* serStr, const int& size);
-
- protected:
-  const std::string getVersion() const;
-  void serializeDataMembers(std::ostream& outStream) const;
-  void deserializeDataMembers(std::istream& inStream);
-};
 
 // A replica's key store.
 // A queue with limit on its size.

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3468,7 +3468,7 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
     TimeRecorder scoped_timer(*histograms_.executeReadOnlyRequest);
     error = bftRequestsHandler_.execute(clientId,
                                         lastExecutedSeqNum,
-                                        READ_ONLY_FLAG,
+                                        request->flags(),
                                         request->requestLength(),
                                         request->requestBuf(),
                                         reply.maxReplyLength(),

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -26,6 +26,9 @@ int RequestHandler::execute(uint16_t clientId,
       outActualReplySize = 0;
     }
     return 0;
+  } else if (flags & READ_ONLY_FLAG) {
+    // Backward compatible with read only flag prior BC-5126
+    flags = READ_ONLY_FLAG;
   }
 
   return userRequestsHandler_->execute(clientId,


### PR DESCRIPTION
In order for BFT clients to know when the cluster has performed the initial key exchange and it's ready to accept requests


