### PR TITLE
Logging Enhancements to Replica

### DIFF
--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -68,8 +68,9 @@ void ReplicaBase::sendRaw(MessageBase* m, NodeIdType dest) {
   if (config_.debugStatisticsEnabled) DebugStatistics::onSendExMessage(m->type());
 
   LOG_TRACE(GL, "sending msg type: " << m->type() << " dest: " << dest);
-  if (msgsCommunicator_->sendAsyncMessage(dest, m->body(), m->size()))
-    LOG_ERROR(GL, "sendAsyncMessage failed for message type: " << m->type());
+  if (msgsCommunicator_->sendAsyncMessage(dest, m->body(), m->size())) {
+    LOG_ERROR(GL, "sendAsyncMessage failed: " << KVLOG(m->type(), dest));
+  }
 }
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3512,6 +3512,10 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
         NodeIdType clientId = req.clientProxyId();
 
         const bool validClient = isValidClient(clientId);
+        const bool validNoop = ((clientId == currentPrimary()) && (req.requestLength() == 0));
+        if (validNoop) {
+          continue;
+        }
         if (!validClient) {
           LOG_WARN(GL, "The client is not valid. " << KVLOG(clientId));
           continue;


### PR DESCRIPTION
* Only log warning about invalid client when the request is not a noop
from the primary. These noops are used during wedge commands.
* Add destination to sendAsyncMessage failed messages for easier
debugging.