### PR TITLE
Enhance apollo logging and prevent busy waits

### DIFF
--- a/tests/apollo/util/skvbc_exceptions.py
+++ b/tests/apollo/util/skvbc_exceptions.py
@@ -17,6 +17,11 @@ class Error(Exception):
 class BadReplyError(Exception):
     """An invalid reply was returned from the client"""
     pass
+
+class ReadTimeoutError(Exception):
+    """A read was expected to succeed but timed out instead"""
+    pass
+
 ##
 ## Exceptions for skvbc_linearizability
 ##

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -21,7 +21,8 @@ from util.skvbc_exceptions import(
     StaleReadError,
     NoConflictError,
     InvalidReadError,
-    PhantomBlockError
+    PhantomBlockError,
+    ReadTimeoutError
 )
 
 MAX_LOOKBACK=10
@@ -1031,6 +1032,8 @@ class SkvbcTracker:
         #reply = await client.write(self.write_req([], kv, 0))
         #reply = self.parse_reply(reply)
         reply = await self.write_and_track_known_kv(kv, client)
+        if not reply:
+            raise ReadTimeoutError
         assert reply.success
         assert last_block + 1 == reply.last_block_id
 


### PR DESCRIPTION
More details in the form of KV pairs were added to eliot actions and
logs in bft.py. This makes the data reported in eliot-tree much more
useful.

Additionally, in many cases we are spinning in a tight loop when a
condition is not met in an await. The expectation was tha the timeout
given in `trio.move_on_after` would prevent this, but it only ensures
that an await call will give up after that time. If the call succeeds
but the condition is not met we immediately loop again. This not only
causes 100% cpu usage, but also adds unnecessary data to the logs making
them harder to parse for eliot-tree. Every time we are about to execute
a tight loop we put a short `trio.sleep` call instead to allow the
coroutine to yield, and give time for the condition to become true.

Lastly, a bug was fixed such that when a call to
`write_and_track_known_kv` is made and the reply is checked, we take
into consideration the fact that the call may have timed out. We don't
want to throw an exception from the tracker, because in many cases we
just want the tracker to log the timeout. However, if we do need to
check the result, we can now raise a `ReadTimeoutError` rather than
getting an error when trying to access a the `success` field on a `None`
value.