### PR TITLE
Enhance logging of sent and received messages

### DIFF
--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -66,10 +66,12 @@ bool ReplicaBase::isRunning() const { return msgsCommunicator_->isMsgsProcessing
 
 void ReplicaBase::sendRaw(MessageBase* m, NodeIdType dest) {
   if (config_.debugStatisticsEnabled) DebugStatistics::onSendExMessage(m->type());
+  MsgCode::Type type = static_cast<MsgCode::Type>(m->type());
 
-  LOG_TRACE(GL, "sending msg type: " << m->type() << " dest: " << dest);
-  if (msgsCommunicator_->sendAsyncMessage(dest, m->body(), m->size()))
-    LOG_ERROR(GL, "sendAsyncMessage failed for message type: " << m->type());
+  LOG_DEBUG(MSGS, "sending msg type: " << type << ", dest: " << dest);
+  if (msgsCommunicator_->sendAsyncMessage(dest, m->body(), m->size())) {
+    LOG_ERROR(MSGS, "sendAsyncMessage failed: " << KVLOG(type, dest));
+  }
 }
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -155,7 +155,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
 
   SCOPED_MDC_PRIMARY(std::to_string(currentPrimary()));
   SCOPED_MDC_CID(m->getCid());
-  LOG_DEBUG(GL, KVLOG(clientId, reqSeqNum, senderId) << " flags: " << std::bitset<8>(flags));
+  LOG_DEBUG(MSGS, KVLOG(clientId, reqSeqNum, senderId) << " flags: " << std::bitset<8>(flags));
 
   const auto &span_context = m->spanContext<std::remove_pointer<decltype(m)>::type>();
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_client_request");
@@ -508,7 +508,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
 
   SCOPED_MDC_PRIMARY(std::to_string(currentPrimary()));
   SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
-  LOG_DEBUG(GL, KVLOG(msg->senderId(), msg->size()));
+  LOG_DEBUG(MSGS, KVLOG(msg->senderId(), msg->size()));
   auto span = concordUtils::startChildSpanFromContext(msg->spanContext<std::remove_pointer<decltype(msg)>::type>(),
                                                       "handle_bft_preprepare");
   span.setTag("rid", config_.replicaId);
@@ -800,7 +800,7 @@ void ReplicaImp::sendPreparePartial(SeqNumInfo &seqNumInfo) {
 
     ConcordAssertNE(pp, nullptr);
 
-    LOG_DEBUG(GL, "Sending PreparePartialMsg. " << KVLOG(pp->seqNumber()));
+    LOG_DEBUG(MSGS, "Sending PreparePartialMsg. " << KVLOG(pp->seqNumber()));
 
     const auto &span_context = pp->spanContext<std::remove_pointer<decltype(pp)>::type>();
     PreparePartialMsg *p = PreparePartialMsg::create(curView,
@@ -862,7 +862,7 @@ void ReplicaImp::onMessage<PartialCommitProofMsg>(PartialCommitProofMsg *msg) {
   ConcordAssert(repsInfo->isIdOfPeerReplica(msgSender));
   ConcordAssert(repsInfo->isCollectorForPartialProofs(msgView, msgSeqNum));
 
-  LOG_DEBUG(GL, KVLOG(msgSender, msg->size()));
+  LOG_DEBUG(MSGS, KVLOG(msgSender, msg->size()));
 
   auto span = concordUtils::startChildSpanFromContext(msg->spanContext<std::remove_pointer<decltype(msg)>::type>(),
                                                       "bft_handle_partial_commit_proof_msg");
@@ -1075,7 +1075,7 @@ void ReplicaImp::onMessage<PreparePartialMsg>(PreparePartialMsg *msg) {
 
     sendAckIfNeeded(msg, msgSender, msgSeqNum);
 
-    LOG_DEBUG(GL, "Received relevant PreparePartialMsg." << KVLOG(msgSender));
+    LOG_DEBUG(MSGS, "Received relevant PreparePartialMsg." << KVLOG(msgSender));
 
     controller->onMessage(msg);
 
@@ -1099,7 +1099,7 @@ void ReplicaImp::onMessage<PreparePartialMsg>(PreparePartialMsg *msg) {
   }
 
   if (!msgAdded) {
-    LOG_DEBUG(GL,
+    LOG_DEBUG(MSGS,
               "Node " << config_.replicaId << " ignored the PreparePartialMsg from node " << msgSender << " (seqNumber "
                       << msgSeqNum << ")");
     delete msg;
@@ -1125,7 +1125,7 @@ void ReplicaImp::onMessage<CommitPartialMsg>(CommitPartialMsg *msg) {
 
     sendAckIfNeeded(msg, msgSender, msgSeqNum);
 
-    LOG_DEBUG(GL, "Received CommitPartialMsg from node " << msgSender);
+    LOG_DEBUG(MSGS, "Received CommitPartialMsg from node " << msgSender);
 
     SeqNumInfo &seqNumInfo = mainLog->get(msgSeqNum);
 
@@ -1163,7 +1163,7 @@ void ReplicaImp::onMessage<PrepareFullMsg>(PrepareFullMsg *msg) {
   if (relevantMsgForActiveView(msg)) {
     sendAckIfNeeded(msg, msgSender, msgSeqNum);
 
-    LOG_DEBUG(GL, "received PrepareFullMsg");
+    LOG_DEBUG(MSGS, "received PrepareFullMsg");
 
     SeqNumInfo &seqNumInfo = mainLog->get(msgSeqNum);
 
@@ -1185,7 +1185,7 @@ void ReplicaImp::onMessage<PrepareFullMsg>(PrepareFullMsg *msg) {
   }
 
   if (!msgAdded) {
-    LOG_DEBUG(GL, "Ignored PrepareFullMsg." << KVLOG(msgSender));
+    LOG_DEBUG(MSGS, "Ignored PrepareFullMsg." << KVLOG(msgSender));
     delete msg;
   }
 }
@@ -1204,7 +1204,7 @@ void ReplicaImp::onMessage<CommitFullMsg>(CommitFullMsg *msg) {
   if (relevantMsgForActiveView(msg)) {
     sendAckIfNeeded(msg, msgSender, msgSeqNum);
 
-    LOG_DEBUG(GL, "Received CommitFullMsg" << KVLOG(msgSender));
+    LOG_DEBUG(MSGS, "Received CommitFullMsg" << KVLOG(msgSender));
 
     SeqNumInfo &seqNumInfo = mainLog->get(msgSeqNum);
 
@@ -1224,7 +1224,7 @@ void ReplicaImp::onMessage<CommitFullMsg>(CommitFullMsg *msg) {
   }
 
   if (!msgAdded) {
-    LOG_DEBUG(GL,
+    LOG_DEBUG(MSGS,
               "Node " << config_.replicaId << " ignored the CommitFullMsg from node " << msgSender << " (seqNumber "
                       << msgSeqNum << ")");
     delete msg;
@@ -1629,7 +1629,7 @@ void ReplicaImp::onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqN
         PrePrepareMsg *msgToSend = seqNumInfo.getSelfPrePrepareMsg();
         ConcordAssertNE(msgToSend, nullptr);
         sendRetransmittableMsgToReplica(msgToSend, s.replicaId, s.msgSeqNum);
-        LOG_DEBUG(GL,
+        LOG_DEBUG(MSGS,
                   "Replica " << myId << " retransmits to replica " << s.replicaId << " PrePrepareMsg with seqNumber "
                              << s.msgSeqNum);
       } break;
@@ -1638,7 +1638,7 @@ void ReplicaImp::onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqN
         PartialCommitProofMsg *msgToSend = seqNumInfo.partialProofs().getSelfPartialCommitProof();
         ConcordAssertNE(msgToSend, nullptr);
         sendRetransmittableMsgToReplica(msgToSend, s.replicaId, s.msgSeqNum);
-        LOG_DEBUG(GL,
+        LOG_DEBUG(MSGS,
                   "Replica " << myId << " retransmits to replica " << s.replicaId
                              << " PartialCommitProofMsg with seqNumber " << s.msgSeqNum);
       } break;
@@ -1648,7 +1648,7 @@ void ReplicaImp::onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqN
         StartSlowCommitMsg *msgToSend = new StartSlowCommitMsg(myId, curView, s.msgSeqNum);
         sendRetransmittableMsgToReplica(msgToSend, s.replicaId, s.msgSeqNum);
         delete msgToSend;
-        LOG_DEBUG(GL,
+        LOG_DEBUG(MSGS,
                   "Replica " << myId << " retransmits to replica " << s.replicaId
                              << " StartSlowCommitMsg with seqNumber " << s.msgSeqNum);
       } break;
@@ -1657,7 +1657,7 @@ void ReplicaImp::onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqN
         PreparePartialMsg *msgToSend = seqNumInfo.getSelfPreparePartialMsg();
         ConcordAssertNE(msgToSend, nullptr);
         sendRetransmittableMsgToReplica(msgToSend, s.replicaId, s.msgSeqNum);
-        LOG_DEBUG(GL,
+        LOG_DEBUG(MSGS,
                   "Replica " << myId << " retransmits to replica " << s.replicaId
                              << " PreparePartialMsg with seqNumber " << s.msgSeqNum);
       } break;
@@ -1666,7 +1666,7 @@ void ReplicaImp::onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqN
         PrepareFullMsg *msgToSend = seqNumInfo.getValidPrepareFullMsg();
         ConcordAssertNE(msgToSend, nullptr);
         sendRetransmittableMsgToReplica(msgToSend, s.replicaId, s.msgSeqNum);
-        LOG_DEBUG(GL,
+        LOG_DEBUG(MSGS,
                   "Replica " << myId << " retransmits to replica " << s.replicaId << " PrepareFullMsg with seqNumber "
                              << s.msgSeqNum);
       } break;
@@ -1676,7 +1676,7 @@ void ReplicaImp::onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqN
         CommitPartialMsg *msgToSend = seqNumInfo.getSelfCommitPartialMsg();
         ConcordAssertNE(msgToSend, nullptr);
         sendRetransmittableMsgToReplica(msgToSend, s.replicaId, s.msgSeqNum);
-        LOG_DEBUG(GL,
+        LOG_DEBUG(MSGS,
                   "Replica " << myId << " retransmits to replica " << s.replicaId << " CommitPartialMsg with seqNumber "
                              << s.msgSeqNum);
       } break;
@@ -1709,7 +1709,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
   const ViewNum msgViewNum = msg->getViewNumber();
   ConcordAssertEQ(msgLastStable % checkpointWindowSize, 0);
 
-  LOG_DEBUG(GL, KVLOG(msgSenderId));
+  LOG_DEBUG(MSGS, KVLOG(msgSenderId));
 
   /////////////////////////////////////////////////////////////////////////
   // Checkpoints
@@ -2813,7 +2813,7 @@ void ReplicaImp::onMessage<SimpleAckMsg>(SimpleAckMsg *msg) {
   SCOPED_MDC_SEQ_NUM(std::to_string(msg->seqNumber()));
   uint16_t relatedMsgType = (uint16_t)msg->ackData();  // TODO(GG): does this make sense ?
   if (retransmissionsLogicEnabled) {
-    LOG_DEBUG(GL, KVLOG(msg->senderId(), relatedMsgType));
+    LOG_DEBUG(MSGS, KVLOG(msg->senderId(), relatedMsgType));
     retransmissionsManager->onAck(msg->senderId(), msg->seqNumber(), relatedMsgType);
   } else {
     LOG_WARN(GL, "Received Ack, but retransmissions not enabled. " << KVLOG(msg->senderId(), relatedMsgType));
@@ -3619,7 +3619,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
   // TODO(GG): Explain what happens in recovery mode
   //////////////////////////////////////////////////////////////////////
 
-  LOG_DEBUG(GL, "Finalized execution. " << KVLOG(lastExecutedSeqNum + 1, curView, lastStableSeqNum));
+  LOG_DEBUG(CNSUS, "Finalized execution. " << KVLOG(lastExecutedSeqNum + 1, curView, lastStableSeqNum));
 
   if (ps_) {
     ps_->beginWriteTran();

--- a/bftengine/src/bftengine/messages/MsgCode.hpp
+++ b/bftengine/src/bftengine/messages/MsgCode.hpp
@@ -12,12 +12,13 @@
 #pragma once
 
 #include <cstdint>
+#include <sstream>
 
 namespace bftEngine::impl {
 
 class MsgCode {
  public:
-  enum : uint16_t {
+  enum Type : uint16_t {
     None = 0,
 
     PrePrepare = 100,
@@ -49,5 +50,88 @@ class MsgCode {
 
   };
 };
+
+inline std::ostream& operator<<(std::ostream& os, const MsgCode::Type& c) {
+  switch (c) {
+    case MsgCode::None:
+      os << "None";
+      break;
+    case MsgCode::PrePrepare:
+      os << "PrePrepare";
+      break;
+    case MsgCode::PreparePartial:
+      os << "PreparePartial";
+      break;
+    case MsgCode::PrepareFull:
+      os << "PrepareFull";
+      break;
+    case MsgCode::CommitPartial:
+      os << "CommitPartial";
+      break;
+    case MsgCode::CommitFull:
+      os << "CommitFull";
+      break;
+    case MsgCode::StartSlowCommit:
+      os << "StartSlowCommit";
+      break;
+    case MsgCode::PartialCommitProof:
+      os << "PartialCommitProof";
+      break;
+    case MsgCode::FullCommitProof:
+      os << "FullCommitProof";
+      break;
+    case MsgCode::PartialExecProof:
+      os << "PartialExecProof";
+      break;
+    case MsgCode::FullExecProof:
+      os << "FullExecProof";
+      break;
+    case MsgCode::SimpleAck:
+      os << "SimpleAck";
+      break;
+    case MsgCode::ViewChange:
+      os << "ViewChange";
+      break;
+    case MsgCode::NewView:
+      os << "NewView";
+      break;
+    case MsgCode::Checkpoint:
+      os << "Checkpoint";
+      break;
+    case MsgCode::AskForCheckpoint:
+      os << "AskForCheckpoint";
+      break;
+    case MsgCode::ReplicaStatus:
+      os << "ReplicaStatus";
+      break;
+    case MsgCode::ReqMissingData:
+      os << "ReqMissingData";
+      break;
+    case MsgCode::StateTransfer:
+      os << "StateTransfer";
+      break;
+    case MsgCode::ReplicaAsksToLeaveView:
+      os << "ReplicaAsksToLeaveView";
+      break;
+    case MsgCode::ClientPreProcessRequest:
+      os << "ClientPreProcessRequest";
+      break;
+    case MsgCode::PreProcessRequest:
+      os << "PreProcessRequest";
+      break;
+    case MsgCode::PreProcessReply:
+      os << "PreProcessReply";
+      break;
+    case MsgCode::ClientRequest:
+      os << "ClientRequest";
+      break;
+    case MsgCode::ClientReply:
+      os << "ClientReply";
+      break;
+    default:
+      os << "UNKNOWN";
+  }
+  return os;
+}
 
 }  // namespace bftEngine::impl

--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -32,6 +32,7 @@ extern logging::Logger BLS_LOG;
 extern logging::Logger KEY_EX_LOG;
 extern logging::Logger VC_LOG;
 extern logging::Logger STLogger;
+extern logging::Logger MSGS;
 
 namespace logging {
 

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -29,3 +29,4 @@ logging::Logger BLS_LOG = logging::getLogger("concord.bft.threshsign.bls");
 logging::Logger KEY_EX_LOG = logging::getLogger("concord.bft.key-exchange");
 logging::Logger VC_LOG = logging::getLogger("concord.bft.viewchange");
 logging::Logger STLogger = logging::getLogger("concord.bft.st");
+logging::Logger MSGS = logging::getLogger("concord.bft.msgs");


### PR DESCRIPTION
A new logger, `MSGS`, was introduced so that debug messages for messages
sent and received by ReplicaImp and ReplicaBase could be turned on
independently. Both of those files were modified to use the new logger
instead of the global logger, `GL`.

Additionally, the name of the MsgCode is now printed instead of the
number. This makes following the logs much easier.