### PR TITLE
Fix bug in sending noops after wedge

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -423,7 +423,13 @@ void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp, bool isInternalNoop) {
 }
 
 void ReplicaImp::sendInternalNoopPrePrepareMsg(CommitPath firstPath) {
-  if (!checkSendPrePrepareMsgPrerequisites()) return;
+  if (primaryLastUsedSeqNum + 1 > lastStableSeqNum + kWorkWindowSize) {
+    LOG_INFO(GL,
+             "Will not send noop PrePrepare since next sequence number ["
+                 << primaryLastUsedSeqNum + 1 << "] exceeds window threshold [" << lastStableSeqNum + kWorkWindowSize
+                 << "]");
+    return;
+  }
   PrePrepareMsg *pp = new PrePrepareMsg(
       config_.replicaId, curView, (primaryLastUsedSeqNum + 1), firstPath, sizeof(ClientRequestMsgHeader));
   ClientRequestMsg emptyClientRequest(config_.replicaId);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -424,10 +424,10 @@ void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp, bool isInternalNoop) {
 
 void ReplicaImp::sendInternalNoopPrePrepareMsg(CommitPath firstPath) {
   if (primaryLastUsedSeqNum + 1 > lastStableSeqNum + kWorkWindowSize) {
-    LOG_INFO(GL,
-             "Will not send noop PrePrepare since next sequence number ["
-                 << primaryLastUsedSeqNum + 1 << "] exceeds window threshold [" << lastStableSeqNum + kWorkWindowSize
-                 << "]");
+    LOG_DEBUG(CNSUS,
+              "Will not send noop PrePrepare since next sequence number ["
+                  << primaryLastUsedSeqNum + 1 << "] exceeds window threshold [" << lastStableSeqNum + kWorkWindowSize
+                  << "]");
     return;
   }
   PrePrepareMsg *pp = new PrePrepareMsg(

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -423,6 +423,7 @@ void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp, bool isInternalNoop) {
 }
 
 void ReplicaImp::sendInternalNoopPrePrepareMsg(CommitPath firstPath) {
+  if (!checkSendPrePrepareMsgPrerequisites()) return;
   PrePrepareMsg *pp = new PrePrepareMsg(
       config_.replicaId, curView, (primaryLastUsedSeqNum + 1), firstPath, sizeof(ClientRequestMsgHeader));
   ClientRequestMsg emptyClientRequest(config_.replicaId);


### PR DESCRIPTION
We observed an error in which during the sending of noops commands we crash because a requested sequence number is out of the mainLog window:

```
|FATAL|0|concord.bft|message-processing||301|SequenceWithActiveWindow.hpp:60|ItemType &bftEngine::impl::SequenceWithActiveWindow<300, 1, long, bftEngine::impl::SeqNumInfo, bftEngine::impl::SeqNumInfo>::get(NumbersType) [WindowSize = 300, Resolution = 1, NumbersType = long, ItemType = bftEngine::impl::SeqNumInfo, ItemFuncs = bftEngine::impl::SeqNumInfo]| Assert: expression 'insideActiveWindow(n)' is false in function get (/concord/submodules/concord-bft/bftengine/src/bftengine/SequenceWithActiveWindow.hpp 60)|{"primary":"0"}|
```
This may happen due to the fact that we try to bring the system to the next next checkpoint in parallel. By thus we may exceed the working window.

To fix the issue we added a condition that checks if it is safe to send a new pre prepare message, before sending a noop command