### PR TITLE
Apollo: Do not log a function using eliot

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -697,7 +697,7 @@ class BftTestNetwork:
         """
         Wait for the last agreed view to match the "expected" predicate
         """
-        with log.start_action(action_type="_wait_for_matching_agreed_view", replica=replica_id, expected=expected) as action:
+        with log.start_action(action_type="_wait_for_matching_agreed_view", replica=replica_id) as action:
             last_agreed_view = None
             with trio.fail_after(seconds=30):
                 while True:


### PR DESCRIPTION
This is not serializable and causes errors of the form:
```
├── eliot:destination_failure/10/3 2020-11-04 03:11:29Z
    │   │   ├── exception: builtins.TypeError
    │   │   ├── message: {"'replica'": '3', "'expected'": '<function SkvbcSlowPathTest.test_slow_path_view_change.<locals>.<l…
    │   │   └── reason: Object of type 'function' is not JSON serializable
```