### PR TITLE
fix small bug in request missing info mechanism

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2575,7 +2575,7 @@ void ReplicaImp::tryToSendReqMissingDataMsg(SeqNum seqNumber, bool slowPathOnly,
 
     if ((t < lastInfoRequest)) t = lastInfoRequest;
 
-    if (t == MinTime && (t < curTime)) {
+    if (t != MinTime && (t < curTime)) {
       auto diffMilli = duration_cast<milliseconds>(curTime - t);
       if (diffMilli.count() < dynamicUpperLimitOfRounds->upperLimit() / 4)  // TODO(GG): config
         return;


### PR DESCRIPTION
Before sending a request for missing info, a replica checks if not enough time passed for the sequence number from (a) the last time a request for missing info was sent or (b) the last time we got data from the primary for this sequence number.

Alas, in the current code we check if the time == MinTime which means that we don't actually check this condition (and hence sending unnecessary requests)