### PR TITLE
WIP: Modifications for TesterReplica and TesterClient for RO replica performance tests

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1845,6 +1845,7 @@ bool BCStateTran::getNextFullBlock(uint64_t requiredBlock,
     ConcordAssertEQ(msg->totalNumberOfChunksInBlock, totalNumberOfChunks);
     ConcordAssertEQ(currentChunk + 1, msg->chunkNumber);
     ConcordAssertLE(currentPos + msg->dataSize, maxSize);
+    ConcordAssertGE(totalSizeOfPendingItemDataMsgs, (*it)->dataSize);
 
     memcpy(outBlock + currentPos, msg->data, msg->dataSize);
     currentChunk = msg->chunkNumber;

--- a/tests/config/test_parameters.hpp
+++ b/tests/config/test_parameters.hpp
@@ -22,6 +22,8 @@ struct ClientParams {
   uint16_t numOfSlow = 0;
   std::string configFileName;
   bool measurePerformance = false;
+  uint64_t sleepInterval = 100;  // On how many executed operations to make a sleep
+  uint64_t sleepDuration = 1;    // How much time to sleep (in ms)
 
   uint16_t get_numOfReplicas() { return (uint16_t)(3 * numOfFaulty + 2 * numOfSlow + 1); }
 };

--- a/tests/simpleKVBC/CMakeLists.txt
+++ b/tests/simpleKVBC/CMakeLists.txt
@@ -3,3 +3,7 @@ add_subdirectory(TesterReplica)
 add_custom_target(copy_blockchain_scripts2 ALL COMMENT "Copying scripts abcd")
 add_custom_command(TARGET copy_blockchain_scripts2
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/scripts ${CMAKE_CURRENT_BINARY_DIR}/scripts)
+
+add_custom_target(copy_ror_perf_test ALL COMMENT "Copying ror_perf_test")
+add_custom_command(TARGET copy_ror_perf_test
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/ror_perf_test ${CMAKE_CURRENT_BINARY_DIR}/ror_perf_test)

--- a/tests/simpleKVBC/TesterReplica/CMakeLists.txt
+++ b/tests/simpleKVBC/TesterReplica/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 3.2)
 project(skvbc_replica VERSION 0.1.0.0 LANGUAGES CXX)
 
 add_executable(skvbc_replica main.cpp
+							 FakeS3.cpp
         					 internalCommandsHandler.cpp
         					 setup.cpp
        						 ../simpleKVBTestsBuilder.cpp 

--- a/tests/simpleKVBC/TesterReplica/FakeS3.cpp
+++ b/tests/simpleKVBC/TesterReplica/FakeS3.cpp
@@ -1,0 +1,14 @@
+#include "FakeS3.hpp"
+
+using namespace concord::test::ror_perf;
+
+concordUtils::Status FakeS3::getValue(const concordUtils::Sliver& key, concordUtils::Sliver& result) const {
+  std::scoped_lock l(metadata_mut_);
+  auto res = data_.find(key);
+  if (res == data_.end()) {
+    return concordUtils::Status::NotFound("");
+  }
+
+  result = res->second;
+  return concordUtils::Status::OK();
+}

--- a/tests/simpleKVBC/TesterReplica/FakeS3.hpp
+++ b/tests/simpleKVBC/TesterReplica/FakeS3.hpp
@@ -1,0 +1,93 @@
+#include <exception>
+#include <thread>
+
+#include "storage/db_interface.h"
+
+namespace concord::test::ror_perf {
+class FakeS3 : public concord::storage::IDBClient {
+ public:
+  FakeS3(std::chrono::milliseconds opDelay) : delay{opDelay} {}
+
+  void init(bool readOnly = false) override {}
+  concordUtils::Status get(const concordUtils::Sliver& _key, OUT concordUtils::Sliver& _outValue) const override {
+    std::this_thread::sleep_for(delay);
+    return getValue(_key.toString(), _outValue);
+  }
+
+  concordUtils::Status get(const concordUtils::Sliver& _key,
+                           OUT char*& buf,
+                           uint32_t bufSize,
+                           OUT uint32_t& _size) const override {
+    throw std::runtime_error("get2");
+    return concordUtils::Status::IllegalOperation("");
+  }
+  concordUtils::Status has(const concordUtils::Sliver& _key) const override {
+    std::this_thread::sleep_for(delay);
+    std::scoped_lock l(metadata_mut_);
+    if (data_.find(_key) != data_.end()) {
+      return concordUtils::Status::OK();
+    } else {
+      return concordUtils::Status::NotFound("");
+    }
+    // throw std::runtime_error("has");
+  }
+  concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override {
+    std::this_thread::sleep_for(delay);
+    std::scoped_lock l(metadata_mut_);
+    data_.insert_or_assign(_key, _value);
+    return concordUtils::Status::OK();
+  }
+  concordUtils::Status del(const concordUtils::Sliver& _key) override {
+    throw std::runtime_error("del");
+    return concordUtils::Status::IllegalOperation("");
+  }
+  concordUtils::Status multiGet(const concord::storage::KeysVector& _keysVec,
+                                OUT concord::storage::ValuesVector& _valuesVec) override {
+    throw std::runtime_error("multiGet");
+    return concordUtils::Status::IllegalOperation("");
+  }
+  concordUtils::Status multiPut(const concord::storage::SetOfKeyValuePairs& _keyValueMap) override {
+    std::this_thread::sleep_for(delay * _keyValueMap.size());
+    std::scoped_lock l(metadata_mut_);
+    data_.insert(_keyValueMap.begin(), _keyValueMap.end());
+    return concordUtils::Status::OK();
+  }
+  concordUtils::Status multiDel(const concord::storage::KeysVector& _keysVec) override {
+    throw std::runtime_error("multidel");
+    return concordUtils::Status::IllegalOperation("");
+  }
+  concordUtils::Status rangeDel(const concordUtils::Sliver& _beginKey, const concordUtils::Sliver& _endKey) override {
+    throw std::runtime_error("rangedel");
+    return concordUtils::Status::IllegalOperation("");
+  }
+  bool isNew() override {
+    throw std::runtime_error("isNew");
+    return false;
+  }
+
+  // the caller is responsible for transaction object lifetime
+  // possible options: ITransaction::Guard or std::shared_ptr
+  concord::storage::ITransaction* beginTransaction() override {
+    throw std::runtime_error("beginTransaction");
+    return nullptr;
+  }
+
+  void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override {}
+
+  IDBClientIterator* getIterator() const override {
+    throw std::runtime_error("getiterator");
+    return nullptr;
+  }
+  concordUtils::Status freeIterator(IDBClientIterator* _iter) const override {
+    throw std::runtime_error("freeIterator");
+    return concordUtils::Status::IllegalOperation("");
+  }
+
+ private:
+  std::unordered_map<concordUtils::Sliver, concordUtils::Sliver> data_;
+  mutable std::mutex metadata_mut_;
+  std::chrono::milliseconds delay;
+
+  concordUtils::Status getValue(const concordUtils::Sliver& key, concordUtils::Sliver& result) const;
+};
+}  // namespace concord::test::ror_perf

--- a/tests/simpleKVBC/TesterReplica/FakeS3StorageFactory.hpp
+++ b/tests/simpleKVBC/TesterReplica/FakeS3StorageFactory.hpp
@@ -1,0 +1,52 @@
+#include "FakeS3.hpp"
+#include "direct_kv_db_adapter.h"
+#include "direct_kv_storage_factory.h"
+#include "object_store/object_store_client.hpp"
+#include "rocksdb/client.h"
+#include "rocksdb/key_comparator.h"
+#include "storage_factory_interface.h"
+
+namespace concord::test::ror_perf {
+
+class StorageFactory : public concord::kvbc::IStorageFactory {
+ public:
+  StorageFactory(std::string dbPath, const std::chrono::milliseconds s3OpDuration)
+      : dbPath_{dbPath}, s3Config_{}, s3Factory_{dbPath_, s3Config_}, s3OpDuration_{s3OpDuration} {}
+
+  // This method is 90% copy-paste of S3StorageFactory::newDatabaseSet()
+  // Don't try to call s3Factory_.newDatabaseSet() and to overwrite values.
+  // S3 client is initialised on creation.
+  IStorageFactory::DatabaseSet newDatabaseSet() const override {
+    auto ret = IStorageFactory::DatabaseSet{};
+    ret.metadataDBClient = std::make_shared<concord::storage::rocksdb::Client>(
+        dbPath_,
+        std::make_unique<concord::storage::rocksdb::KeyComparator>(
+            new concord::kvbc::v1DirectKeyValue::DBKeyComparator{}));
+    ret.metadataDBClient->init();
+    ret.dataDBClient = std::make_shared<concord::storage::ObjectStoreClient>(new FakeS3{s3OpDuration_});
+    ret.dataDBClient->init();
+
+    auto dataKeyGenerator = std::make_unique<concord::kvbc::v1DirectKeyValue::S3KeyGenerator>(s3Config_.pathPrefix);
+    ret.dbAdapter = std::make_unique<concord::kvbc::v1DirectKeyValue::DBAdapter>(
+        ret.dataDBClient, std::move(dataKeyGenerator), true);
+
+    return ret;
+  }
+
+  std::unique_ptr<storage::IMetadataKeyManipulator> newMetadataKeyManipulator() const override {
+    return s3Factory_.newMetadataKeyManipulator();
+  }
+
+  std::unique_ptr<storage::ISTKeyManipulator> newSTKeyManipulator() const override {
+    return s3Factory_.newSTKeyManipulator();
+  }
+
+  ~StorageFactory() {}
+
+ private:
+  const std::string dbPath_;
+  concord::storage::s3::StoreConfig s3Config_;
+  concord::kvbc::v1DirectKeyValue::S3StorageFactory s3Factory_;
+  std::chrono::milliseconds s3OpDuration_;  // how much time should it take to write a single KV pair
+};
+}  // namespace concord::test::ror_perf

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -248,6 +248,7 @@ concord::storage::s3::StoreConfig TestSetup::ParseS3Config(const std::string& s3
   config.protocol = get_config_value("s3-protocol");
   config.url = get_config_value("s3-url");
   config.secretKey = get_config_value("s3-secret-key");
+  config.maxWaitTime = std::stoi(get_config_value("s3-max-wait-time"));
   try {
     // TesterReplica is used for Apollo tests. Each test is executed against new blockchain, so we need brand new
     // bucket for the RO replica. To achieve this we use a hack - set the prefix to a uniqe value so each RO replica

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -30,7 +30,10 @@
 #include "config/config_file_parser.hpp"
 #include "direct_kv_storage_factory.h"
 #include "merkle_tree_storage_factory.h"
+
+#ifdef USE_S3_OBJECT_STORE
 #include "FakeS3StorageFactory.hpp"
+#endif
 
 namespace concord::kvbc {
 

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -54,7 +54,9 @@ class TestSetup {
             bool usePersistentStorage,
             std::string s3ConfigFile,
             StorageType storageType,
-            std::string logPropsFile)
+            std::string logPropsFile,
+            bool rorPerfMode,
+            std::chrono::milliseconds s3OpDelay)
       : replicaConfig_(config),
         communication_(std::move(comm)),
         logger_(logger),
@@ -62,7 +64,9 @@ class TestSetup {
         usePersistentStorage_(usePersistentStorage),
         s3ConfigFile_(s3ConfigFile),
         storageType_(storageType),
-        logPropsFile_(logPropsFile) {}
+        logPropsFile_(logPropsFile),
+        rorPerfMode_{rorPerfMode},
+        s3OpDelay_{s3OpDelay} {}
   TestSetup() = delete;
 #ifdef USE_S3_OBJECT_STORE
   concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
@@ -76,6 +80,8 @@ class TestSetup {
   std::string s3ConfigFile_;
   StorageType storageType_;
   std::string logPropsFile_;
+  bool rorPerfMode_;
+  std::chrono::milliseconds s3OpDelay_;  // applicable only in ROR performance mode
 };
 
 }  // namespace concord::kvbc

--- a/tests/simpleKVBC/basicRandomTestsRunner.hpp
+++ b/tests/simpleKVBC/basicRandomTestsRunner.hpp
@@ -21,12 +21,16 @@ namespace BasicRandomTests {
 
 class BasicRandomTestsRunner {
  public:
-  BasicRandomTestsRunner(logging::Logger &logger, concord::kvbc::IClient &client, size_t numOfOperations);
+  BasicRandomTestsRunner(logging::Logger &logger,
+                         concord::kvbc::IClient &client,
+                         size_t numOfOperations,
+                         uint32_t sleepInterval,
+                         std::chrono::milliseconds sleepDuration);
   ~BasicRandomTestsRunner() { delete testsBuilder_; }
   void run();
 
  private:
-  static void sleep(int ops);
+  void sleep(int ops);
   bool isReplyCorrect(RequestType requestType,
                       const SimpleReply *expectedReply,
                       const char *reply,
@@ -38,6 +42,8 @@ class BasicRandomTestsRunner {
   concord::kvbc::IClient &client_;
   const size_t numOfOperations_;
   TestsBuilder *testsBuilder_;
+  uint32_t sleepInterval_;
+  std::chrono::milliseconds sleepDuration_;
 };
 
 }  // namespace BasicRandomTests

--- a/tests/simpleKVBC/ror_perf_test/dump_stats.py
+++ b/tests/simpleKVBC/ror_perf_test/dump_stats.py
@@ -2,8 +2,10 @@ import socket
 import json
 import struct
 import time
+import glob
 
 ENDPOINTS = [("rep", "localhost", 4710, "lastStableSeqNum"), ("ror", "localhost", 4718, "lastExecutedSeqNum")]
+S3_DATA_DIR = "./s3-data/blockchain/"
 MESSAGE = b'\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 HEADER_FMT = "<BQ"
 HEADER_SIZE = struct.calcsize(HEADER_FMT)
@@ -20,6 +22,8 @@ while True:
         for component in data['Components']:
             if component['Name'] == "replica":
                 print("%d: %s: %s: %s" % (cnt, e[0], e[3], component["Gauges"][e[3]]))
+
+    print("%d: blocks on s3: %d" % (cnt, len(glob.glob(S3_DATA_DIR + '*/*'))))
     time.sleep(1)
     cnt = cnt+1
     print("\n")

--- a/tests/simpleKVBC/ror_perf_test/dump_stats.py
+++ b/tests/simpleKVBC/ror_perf_test/dump_stats.py
@@ -1,0 +1,25 @@
+import socket
+import json
+import struct
+import time
+
+ENDPOINTS = [("rep", "localhost", 4710, "lastStableSeqNum"), ("ror", "localhost", 4718, "lastExecutedSeqNum")]
+MESSAGE = b'\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+HEADER_FMT = "<BQ"
+HEADER_SIZE = struct.calcsize(HEADER_FMT)
+
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+cnt = 1
+while True:
+    for e in ENDPOINTS:
+        sock.sendto(MESSAGE, (e[1], e[2]))
+        resp, addr = sock.recvfrom(4096) # buffer size is 1024 bytes
+        data = json.loads(resp[HEADER_SIZE:])
+
+        for component in data['Components']:
+            if component['Name'] == "replica":
+                print("%d: %s: %s: %s" % (cnt, e[0], e[3], component["Gauges"][e[3]]))
+    time.sleep(1)
+    cnt = cnt+1
+    print("\n")

--- a/tests/simpleKVBC/ror_perf_test/logging-ror.properties
+++ b/tests/simpleKVBC/ror_perf_test/logging-ror.properties
@@ -24,3 +24,4 @@ log4cplus.appender.R.layout.ConversionPattern=%d{%Y-%m-%dT%H:%M:%S,%qZ}|%-5p|%X{
 
 log4cplus.rootLogger=OFF, STDOUT, R
 log4cplus.logger.concord.preprocessor=OFF
+log4cplus.logger.concord.bft = DEBUG

--- a/tests/simpleKVBC/ror_perf_test/logging.properties
+++ b/tests/simpleKVBC/ror_perf_test/logging.properties
@@ -1,0 +1,26 @@
+# Internal Logger Configuration
+
+# log.state-transfer:DEBUG
+#log.skvbc.replicaImp:DEBUG
+# log.concord:INFO
+
+
+# Log4cplus configuration
+
+#log4cplus.configDebug=true
+
+log4cplus.appender.STDOUT=log4cplus::ConsoleAppender
+log4cplus.appender.STDOUT.ImmediateFlush=true
+log4cplus.appender.STDOUT.layout=log4cplus::PatternLayout
+log4cplus.appender.STDOUT.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%-5p|%c|%X{thread}|%X{pri}|%X{cid}|%X{sn}|%X{path}|%M|%m%n
+
+log4cplus.appender.R=log4cplus::RollingFileAppender
+log4cplus.appender.R.File=concord.log
+log4cplus.appender.R.MaxFileSize=10MB
+log4cplus.appender.R.MaxBackupIndex=10
+log4cplus.appender.R.layout=log4cplus::PatternLayout
+log4cplus.appender.R.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%-5p|%c|%X{thread}|%X{pri}|%X{cid}|%X{sn}|%X{path}|%M|%m%n
+
+
+log4cplus.rootLogger=OFF, STDOUT, R
+log4cplus.logger.concord.preprocessor=OFF

--- a/tests/simpleKVBC/ror_perf_test/ror_perf_test.sh
+++ b/tests/simpleKVBC/ror_perf_test/ror_perf_test.sh
@@ -2,8 +2,11 @@
 
 cleanup() {
   killall -q skvbc_replica || true
+  killall -q skvbc_client || true
+  killall -q minio || true
   rm -rf simpleKVBTests_DB_*
   rm -rf ro_config_*
+  rm -rf s3-data/blockchain
 }
 
 trap 'cleanup' SIGINT
@@ -17,18 +20,24 @@ cleanup
 ../TesterReplica/skvbc_replica -k ror_perf_ -i 2 -l logging.properties &
 ../TesterReplica/skvbc_replica -k ror_perf_ -i 3 -l logging.properties &
 
+mkdir -p s3-data/blockchain
+MINIO_ACCESS_KEY="concordbft" MINIO_SECRET_KEY="concordbft" ~/minio server ./s3-data &
+
 echo "Sleeping for 5 seconds"
 sleep 5
-# The params below generate checkpoint on around each 10secs on dev machine (2020 mbp)
-# The client generates 200 keys per request (hardcoded value).
-time ../TesterClient/skvbc_client -f 1 -c 0 -p 40000 -i 5 -s 1 -d 20 > client.log &
 
 # (check this document for explanation: https://confluence.eng.vmware.com/display/BLOC/ROR+%28Object+Store%29+performance+analysis)
 # s3-op-delay sets delay per key. Client generates 200 keys per request => 20/200 = 0.1ms delay per req
-../TesterReplica/skvbc_replica -k ror_perf_ -i 4 -p --s3-config-file test_s3_config.txt --ror-performance --s3-op-delay 10 -l logging.properties &
+../TesterReplica/skvbc_replica -k ror_perf_ -i 4 -p --s3-config-file test_s3_config.txt -l logging-ror.properties > ./ror.log 2>&1 &
 
 sleep 3
-python3 dump_stats.py 
+python3 dump_stats.py &
+
+while true; do
+# The params below generate checkpoint on around each 10secs on dev machine (2020 mbp)
+# The client generates 200 keys per request (hardcoded value).
+../TesterClient/skvbc_client -f 1 -c 0 -p 40000 -i 5 -s 1 -d 10 > client.log 
+done
 
 echo "Finished!"
 cleanup

--- a/tests/simpleKVBC/ror_perf_test/ror_perf_test.sh
+++ b/tests/simpleKVBC/ror_perf_test/ror_perf_test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+cleanup() {
+  killall -q skvbc_replica || true
+  rm -rf simpleKVBTests_DB_*
+  rm -rf ro_config_*
+}
+
+trap 'cleanup' SIGINT
+
+cleanup
+
+../../../tools/GenerateConcordKeys -f 1 -n 4 -r 1 -o ror_perf_
+
+../TesterReplica/skvbc_replica -k ror_perf_ -i 0 -l logging.properties &
+../TesterReplica/skvbc_replica -k ror_perf_ -i 1 -l logging.properties &
+../TesterReplica/skvbc_replica -k ror_perf_ -i 2 -l logging.properties &
+../TesterReplica/skvbc_replica -k ror_perf_ -i 3 -l logging.properties &
+
+echo "Sleeping for 5 seconds"
+sleep 5
+# The params below generate checkpoint on around each 10secs on dev machine (2020 mbp)
+# The client generates 200 keys per request (hardcoded value).
+time ../TesterClient/skvbc_client -f 1 -c 0 -p 40000 -i 5 -s 1 -d 20 > client.log &
+
+# (check this document for explanation: https://confluence.eng.vmware.com/display/BLOC/ROR+%28Object+Store%29+performance+analysis)
+# s3-op-delay sets delay per key. Client generates 200 keys per request => 20/200 = 0.1ms delay per req
+../TesterReplica/skvbc_replica -k ror_perf_ -i 4 -p --s3-config-file test_s3_config.txt --ror-performance --s3-op-delay 10 -l logging.properties &
+
+sleep 3
+python3 dump_stats.py 
+
+echo "Finished!"
+cleanup
+

--- a/tests/simpleKVBC/ror_perf_test/test_s3_config.txt
+++ b/tests/simpleKVBC/ror_perf_test/test_s3_config.txt
@@ -1,0 +1,7 @@
+# test configuration for S3-compatible storage
+s3-bucket-name: blockchain
+s3-access-key: concordbft
+s3-protocol: HTTP
+s3-url: 127.0.0.1:9000
+s3-secret-key: concordbft
+s3-max-wait-time: 1000


### PR DESCRIPTION
Adds configurable performance penalties to TesterClient.
Adds FakeS3 implementation and FakeS3StorageFactory for TesterReplica. FakeS3 emulates S3 storage but saves the data in-memory in unordered_map.
Adds convenience script which starts the RO replica performance test.

Please check the commit messages for further details about each change.