### PR TITLE
State Transfer tweaks: (#992)

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -676,7 +676,7 @@ void ReplicaImp::tryToAskForMissingInfo() {
   SeqNum maxSeqNum = 0;
 
   if (!recentViewChange) {
-    const int16_t searchWindow = 4;  // TODO(GG): TBD - read from configuration
+    const int16_t searchWindow = 32;  // TODO(GG): TBD - read from configuration
     minSeqNum = lastExecutedSeqNum + 1;
     maxSeqNum = std::min(minSeqNum + searchWindow - 1, lastStableSeqNum + kWorkWindowSize);
   } else {
@@ -1470,6 +1470,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
   LOG_INFO(
       GL,
       "Received checkpoint message from node. " << KVLOG(msgSenderId, msgSeqNum, msg->size(), msgIsStable, msgDigest));
+  LOG_INFO(GL, "My " << KVLOG(lastStableSeqNum, lastExecutedSeqNum));
   auto span = concordUtils::startChildSpanFromContext(msg->spanContext<std::remove_pointer<decltype(msg)>::type>(),
                                                       "bft_handle_checkpoint_msg");
 
@@ -1503,6 +1504,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
   if (msgIsStable && msgSeqNum > lastExecutedSeqNum) {
     auto pos = tableOfStableCheckpoints.find(msgSenderId);
     if (pos == tableOfStableCheckpoints.end() || pos->second->seqNumber() <= msgSeqNum) {
+      // <= to allow repeating checkpoint message since state transfer may not kick in when we are inside active window
       if (pos != tableOfStableCheckpoints.end()) delete pos->second;
       CheckpointMsg *x = new CheckpointMsg(msgSenderId, msgSeqNum, msgDigest, msgIsStable);
       tableOfStableCheckpoints[msgSenderId] = x;
@@ -1527,6 +1529,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
         LOG_DEBUG(GL, KVLOG(numRelevant, numRelevantAboveWindow));
 
         if (numRelevantAboveWindow >= config_.getfVal() + 1) {
+          LOG_INFO(GL, "Number of stable checkpoints above window: " << numRelevantAboveWindow);
           askForStateTransfer = true;
         } else if (numRelevant >= config_.getfVal() + 1) {
           Time timeOfLastCommit = MinTime;
@@ -1534,6 +1537,10 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
             timeOfLastCommit = mainLog->get(lastExecutedSeqNum).lastUpdateTimeOfCommitMsgs();
           if ((getMonotonicTime() - timeOfLastCommit) >
               (milliseconds(timeToWaitBeforeStartingStateTransferInMainWindowMilli))) {
+            LOG_INFO(GL,
+                     "Number of stable checkpoints in current window: "
+                         << numRelevant
+                         << " time since last execution: " << (getMonotonicTime() - timeOfLastCommit).count() << " ms");
             askForStateTransfer = true;
           }
         }
@@ -1543,7 +1550,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
 
   if (askForStateTransfer && !stateTransfer->isCollectingState()) {
     LOG_INFO(GL, "Call to startCollectingState()");
-
+    clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout
     stateTransfer->startCollectingState();
   } else if (msgSeqNum > lastStableSeqNum + kWorkWindowSize) {
     onReportAboutAdvancedReplica(msgSenderId, msgSeqNum);
@@ -2427,8 +2434,8 @@ void ReplicaImp::onTransferringCompleteImp(SeqNum newStateCheckpoint) {
   }
 
   if (askAnotherStateTransfer) {
-    LOG_INFO(GL, "Call to startCollectingState()");
-
+    LOG_INFO(GL, "Call to another startCollectingState()");
+    clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout
     stateTransfer->startCollectingState();
   }
 }

--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -104,7 +104,7 @@ constexpr bool dynamicCollectorForExecutionProofs = false;  // if false, then th
 // State Transfer
 ///////////////////////////////////////////////////////////////////////////////
 
-constexpr int timeToWaitBeforeStartingStateTransferInMainWindowMilli = 2000;  // TODO(GG): move to configuration??
+constexpr int timeToWaitBeforeStartingStateTransferInMainWindowMilli = 5000;  // TODO(GG): move to configuration??
 
 ///////////////////////////////////////////////////////////////////////////////
 // Debug and Tuning of ControllerWithSimpleHistory


### PR DESCRIPTION
1. Make max chunk size equal to max block size if using TCP;
2. Increase timeout since last executed from 2s to 5s to let replica to catch up using request missing data first.
3. Clear all pending requests before call to startCollecting state to avoid entering to a new view on request timeout.
4. Increase search window for sequences in tryToAskForMissingInfo() from 4 to 32 for more aggressive catching up using request for missing data.

Cherry-pick commit