### PR TITLE
BCStateTran: Add a periodic status log while in GettingMissingBlocks

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -158,7 +158,6 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
       // same order as defined in the header file.
       metrics_{
           metrics_component_.RegisterStatus("fetching_state", stateName(FetchingState::NotFetching)),
-          metrics_component_.RegisterStatus("pedantic_checks_enabled", config_.pedanticChecks ? "true" : "false"),
           metrics_component_.RegisterStatus("preferred_replicas", ""),
 
           metrics_component_.RegisterGauge("current_source_replica", NO_REPLICA),

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -156,61 +156,68 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
 
       // We must make sure that we actually initialize all these metrics in the
       // same order as defined in the header file.
-      metrics_{
-          metrics_component_.RegisterStatus("fetching_state", stateName(FetchingState::NotFetching)),
-          metrics_component_.RegisterStatus("preferred_replicas", ""),
+      metrics_{metrics_component_.RegisterStatus("fetching_state", stateName(FetchingState::NotFetching)),
+               metrics_component_.RegisterStatus("preferred_replicas", ""),
 
-          metrics_component_.RegisterGauge("current_source_replica", NO_REPLICA),
-          metrics_component_.RegisterGauge("checkpoint_being_fetched", 0),
-          metrics_component_.RegisterGauge("last_stored_checkpoint", 0),
-          metrics_component_.RegisterGauge("number_of_reserved_pages", 0),
-          metrics_component_.RegisterGauge("size_of_reserved_page", config_.sizeOfReservedPage),
-          metrics_component_.RegisterGauge("last_msg_seq_num", lastMsgSeqNum_),
-          metrics_component_.RegisterGauge("next_required_block_", nextRequiredBlock_),
-          metrics_component_.RegisterGauge("num_pending_item_data_msgs_", pendingItemDataMsgs.size()),
-          metrics_component_.RegisterGauge("total_size_of_pending_item_data_msgs", totalSizeOfPendingItemDataMsgs),
-          metrics_component_.RegisterGauge("last_block_", 0),
-          metrics_component_.RegisterGauge("last_reachable_block", 0),
+               metrics_component_.RegisterGauge("current_source_replica", NO_REPLICA),
+               metrics_component_.RegisterGauge("checkpoint_being_fetched", 0),
+               metrics_component_.RegisterGauge("last_stored_checkpoint", 0),
+               metrics_component_.RegisterGauge("number_of_reserved_pages", 0),
+               metrics_component_.RegisterGauge("size_of_reserved_page", config_.sizeOfReservedPage),
+               metrics_component_.RegisterGauge("last_msg_seq_num", lastMsgSeqNum_),
+               metrics_component_.RegisterGauge("next_required_block_", nextRequiredBlock_),
+               metrics_component_.RegisterGauge("num_pending_item_data_msgs_", pendingItemDataMsgs.size()),
+               metrics_component_.RegisterGauge("total_size_of_pending_item_data_msgs", totalSizeOfPendingItemDataMsgs),
+               metrics_component_.RegisterGauge("last_block_", 0),
+               metrics_component_.RegisterGauge("last_reachable_block", 0),
 
-          metrics_component_.RegisterCounter("sent_ask_for_checkpoint_summaries_msg"),
-          metrics_component_.RegisterCounter("sent_checkpoint_summary_msg"),
-          metrics_component_.RegisterCounter("sent_fetch_blocks_msg"),
-          metrics_component_.RegisterCounter("sent_fetch_res_pages_msg"),
-          metrics_component_.RegisterCounter("sent_reject_fetch_msg"),
-          metrics_component_.RegisterCounter("sent_item_data_msg"),
+               metrics_component_.RegisterCounter("sent_ask_for_checkpoint_summaries_msg"),
+               metrics_component_.RegisterCounter("sent_checkpoint_summary_msg"),
+               metrics_component_.RegisterCounter("sent_fetch_blocks_msg"),
+               metrics_component_.RegisterCounter("sent_fetch_res_pages_msg"),
+               metrics_component_.RegisterCounter("sent_reject_fetch_msg"),
+               metrics_component_.RegisterCounter("sent_item_data_msg"),
 
-          metrics_component_.RegisterCounter("received_ask_for_checkpoint_summaries_msg"),
-          metrics_component_.RegisterCounter("received_checkpoint_summary_msg"),
-          metrics_component_.RegisterCounter("received_fetch_blocks_msg"),
-          metrics_component_.RegisterCounter("received_fetch_res_pages_msg"),
-          metrics_component_.RegisterCounter("received_reject_fetching_msg"),
-          metrics_component_.RegisterCounter("received_item_data_msg"),
-          metrics_component_.RegisterCounter("received_illegal_msg_"),
+               metrics_component_.RegisterCounter("received_ask_for_checkpoint_summaries_msg"),
+               metrics_component_.RegisterCounter("received_checkpoint_summary_msg"),
+               metrics_component_.RegisterCounter("received_fetch_blocks_msg"),
+               metrics_component_.RegisterCounter("received_fetch_res_pages_msg"),
+               metrics_component_.RegisterCounter("received_reject_fetching_msg"),
+               metrics_component_.RegisterCounter("received_item_data_msg"),
+               metrics_component_.RegisterCounter("received_illegal_msg_"),
 
-          metrics_component_.RegisterCounter("invalid_ask_for_checkpoint_summaries_msg"),
-          metrics_component_.RegisterCounter("irrelevant_ask_for_checkpoint_summaries_msg"),
-          metrics_component_.RegisterCounter("invalid_checkpoint_summary_msg"),
-          metrics_component_.RegisterCounter("irrelevant_checkpoint_summary_msg"),
-          metrics_component_.RegisterCounter("invalid_fetch_blocks_msg"),
-          metrics_component_.RegisterCounter("irrelevant_fetch_blocks_msg"),
-          metrics_component_.RegisterCounter("invalid_fetch_res_pages_msg"),
-          metrics_component_.RegisterCounter("irrelevant_fetch_res_pages_msg"),
-          metrics_component_.RegisterCounter("invalid_reject_fetching_msg"),
-          metrics_component_.RegisterCounter("irrelevant_reject_fetching_msg"),
-          metrics_component_.RegisterCounter("invalid_item_data_msg"),
-          metrics_component_.RegisterCounter("irrelevant_item_data_msg"),
+               metrics_component_.RegisterCounter("invalid_ask_for_checkpoint_summaries_msg"),
+               metrics_component_.RegisterCounter("irrelevant_ask_for_checkpoint_summaries_msg"),
+               metrics_component_.RegisterCounter("invalid_checkpoint_summary_msg"),
+               metrics_component_.RegisterCounter("irrelevant_checkpoint_summary_msg"),
+               metrics_component_.RegisterCounter("invalid_fetch_blocks_msg"),
+               metrics_component_.RegisterCounter("irrelevant_fetch_blocks_msg"),
+               metrics_component_.RegisterCounter("invalid_fetch_res_pages_msg"),
+               metrics_component_.RegisterCounter("irrelevant_fetch_res_pages_msg"),
+               metrics_component_.RegisterCounter("invalid_reject_fetching_msg"),
+               metrics_component_.RegisterCounter("irrelevant_reject_fetching_msg"),
+               metrics_component_.RegisterCounter("invalid_item_data_msg"),
+               metrics_component_.RegisterCounter("irrelevant_item_data_msg"),
 
-          metrics_component_.RegisterCounter("create_checkpoint"),
-          metrics_component_.RegisterCounter("mark_checkpoint_as_stable"),
-          metrics_component_.RegisterCounter("load_reserved_page"),
-          metrics_component_.RegisterCounter("load_reserved_page_from_pending"),
-          metrics_component_.RegisterCounter("load_reserved_page_from_checkpoint"),
-          metrics_component_.RegisterCounter("save_reserved_page"),
-          metrics_component_.RegisterCounter("zero_reserved_page"),
-          metrics_component_.RegisterCounter("start_collecting_state"),
-          metrics_component_.RegisterCounter("on_timer"),
-          metrics_component_.RegisterCounter("on_transferring_complete"),
-      },
+               metrics_component_.RegisterCounter("create_checkpoint"),
+               metrics_component_.RegisterCounter("mark_checkpoint_as_stable"),
+               metrics_component_.RegisterCounter("load_reserved_page"),
+               metrics_component_.RegisterCounter("load_reserved_page_from_pending"),
+               metrics_component_.RegisterCounter("load_reserved_page_from_checkpoint"),
+               metrics_component_.RegisterCounter("save_reserved_page"),
+               metrics_component_.RegisterCounter("zero_reserved_page"),
+               metrics_component_.RegisterCounter("start_collecting_state"),
+               metrics_component_.RegisterCounter("on_timer"),
+               metrics_component_.RegisterCounter("on_transferring_complete"),
+
+               metrics_component_.RegisterGauge("overall_blocks_collected", 0),
+               metrics_component_.RegisterGauge("overall_blocks_throughtput", 0),
+               metrics_component_.RegisterGauge("overall_bytes_collected", 0),
+               metrics_component_.RegisterGauge("overall_bytes_throughtput", 0),
+               metrics_component_.RegisterGauge("prev_win_blocks_collected", 0),
+               metrics_component_.RegisterGauge("prev_win_blocks_throughtput", 0),
+               metrics_component_.RegisterGauge("prev_win_bytes_collected", 0),
+               metrics_component_.RegisterGauge("prev_win_bytes_throughtput", 0)},
       blocks_collected_(get_missing_blocks_summary_window_size),
       bytes_collected_(get_missing_blocks_summary_window_size),
       first_collected_block_num_({}) {
@@ -601,6 +608,15 @@ void BCStateTran::startCollectingStats() {
   blocks_collected_.start();
   bytes_collected_.start();
   first_collected_block_num_ = {};
+
+  metrics_.overall_blocks_collected_.Get().Set(0ull);
+  metrics_.overall_blocks_throughtput_.Get().Set(0ull);
+  metrics_.overall_bytes_collected_.Get().Set(0ull);
+  metrics_.overall_bytes_throughtput_.Get().Set(0ull);
+  metrics_.prev_win_blocks_collected_.Get().Set(0ull);
+  metrics_.prev_win_blocks_throughtput_.Get().Set(0ull);
+  metrics_.prev_win_bytes_collected_.Get().Set(0ull);
+  metrics_.prev_win_bytes_throughtput_.Get().Set(0ull);
 }
 
 void BCStateTran::startCollectingState() {
@@ -1944,7 +1960,30 @@ void BCStateTran::EnterGettingCheckpointSummariesState() {
   sendAskForCheckpointSummariesMsg();
 }
 
-void BCStateTran::logGettingMissingBlocksSummary(const uint64_t firstRequiredBlock) {
+void BCStateTran::reportCollectingStatus(const uint64_t firstRequiredBlock, const uint32_t actualBlockSize) {
+  metrics_.overall_blocks_collected_.Get().Inc();
+  metrics_.overall_bytes_collected_.Get().Set(metrics_.overall_bytes_collected_.Get().Get() + actualBlockSize);
+
+  bytes_collected_.report(actualBlockSize);
+  if (blocks_collected_.report()) {
+    auto overall_block_results = blocks_collected_.getOverallResults();
+    auto overall_bytes_results = bytes_collected_.getOverallResults();
+    auto prev_win_block_results = blocks_collected_.getPrevWinResults();
+    auto prev_win_bytes_results = bytes_collected_.getPrevWinResults();
+
+    metrics_.overall_blocks_throughtput_.Get().Set(overall_block_results.throughput_);
+    metrics_.overall_bytes_throughtput_.Get().Set(overall_bytes_results.throughput_);
+
+    metrics_.prev_win_blocks_collected_.Get().Set(prev_win_block_results.num_processed_items_);
+    metrics_.prev_win_blocks_throughtput_.Get().Set(prev_win_block_results.throughput_);
+    metrics_.prev_win_bytes_collected_.Get().Set(prev_win_bytes_results.num_processed_items_);
+    metrics_.prev_win_bytes_throughtput_.Get().Set(prev_win_bytes_results.throughput_);
+
+    logCollectingStatus(firstRequiredBlock);
+  }
+}
+
+void BCStateTran::logCollectingStatus(const uint64_t firstRequiredBlock) {
   std::ostringstream oss;
   const DataStore::CheckpointDesc fetched_cp = psd_->getCheckpointBeingFetched();
   auto blocks_overall_r = blocks_collected_.getOverallResults();
@@ -2099,8 +2138,7 @@ void BCStateTran::processData() {
       ConcordAssert(as_->putBlock(nextRequiredBlock_, buffer_, actualBlockSize));
 
       const uint64_t firstRequiredBlock = g.txn()->getFirstRequiredBlock();
-      bytes_collected_.report(actualBlockSize);
-      if (blocks_collected_.report()) logGettingMissingBlocksSummary(firstRequiredBlock);
+      reportCollectingStatus(firstRequiredBlock, actualBlockSize);
       memset(buffer_, 0, actualBlockSize);
 
       if (firstRequiredBlock < nextRequiredBlock_) {

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <array>
 #include <cstdint>
+#include <optional>
 
 #include "Logger.hpp"
 #include "SimpleBCStateTransfer.hpp"
@@ -34,6 +35,8 @@
 #include "SourceSelector.hpp"
 #include "callback_registry.hpp"
 #include "Handoff.hpp"
+#include "SysConsts.hpp"
+#include "throughput.hpp"
 
 using std::set;
 using std::map;
@@ -41,6 +44,7 @@ using std::string;
 using concordMetrics::StatusHandle;
 using concordMetrics::GaugeHandle;
 using concordMetrics::CounterHandle;
+using concord::util::Throughput;
 
 namespace bftEngine::bcst::impl {
 
@@ -407,6 +411,19 @@ class BCStateTran : public IStateTransfer {
   mutable Metrics metrics_;
 
   concord::util::CallbackRegistry<uint64_t> on_transferring_complete_cb_registry_;
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Internal Statistics
+  ///////////////////////////////////////////////////////////////////////////
+ protected:
+  static constexpr uint32_t get_missing_blocks_summary_window_size = checkpointWindowSize;
+  Throughput blocks_collected_;
+  Throughput bytes_collected_;
+  std::optional<uint64_t> first_collected_block_num_;
+
+  // used to print periodic summary of recent checkpoints, and collected date while in state GettingMissingBlocks
+  void logGettingMissingBlocksSummary(const uint64_t firstRequiredBlock);
+  void startCollectingStats();
 };
 
 }  // namespace bftEngine::bcst::impl

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -406,6 +406,15 @@ class BCStateTran : public IStateTransfer {
     CounterHandle on_timer_;
 
     CounterHandle on_transferring_complete_;
+
+    GaugeHandle overall_blocks_collected_;
+    GaugeHandle overall_blocks_throughtput_;
+    GaugeHandle overall_bytes_collected_;
+    GaugeHandle overall_bytes_throughtput_;
+    GaugeHandle prev_win_blocks_collected_;
+    GaugeHandle prev_win_blocks_throughtput_;
+    GaugeHandle prev_win_bytes_collected_;
+    GaugeHandle prev_win_bytes_throughtput_;
   };
 
   mutable Metrics metrics_;
@@ -422,7 +431,8 @@ class BCStateTran : public IStateTransfer {
   std::optional<uint64_t> first_collected_block_num_;
 
   // used to print periodic summary of recent checkpoints, and collected date while in state GettingMissingBlocks
-  void logGettingMissingBlocksSummary(const uint64_t firstRequiredBlock);
+  void logCollectingStatus(const uint64_t firstRequiredBlock);
+  void reportCollectingStatus(const uint64_t firstRequiredBlock, const uint32_t actualBlockSize);
   void startCollectingStats();
 };
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -348,7 +348,6 @@ class BCStateTran : public IStateTransfer {
   concordMetrics::Component metrics_component_;
   struct Metrics {
     StatusHandle fetching_state_;
-    StatusHandle pedantic_checks_enabled_;
     StatusHandle preferred_replicas_;
 
     GaugeHandle current_source_replica_;

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -9,7 +9,8 @@ set(util_source_files
     src/status.cpp
     src/sliver.cpp
     src/hex_tools.cpp
-    src/OpenTracing.cpp)
+    src/OpenTracing.cpp
+    src/throughput.cpp)
 
 add_library(util STATIC
     ${util_source_files}

--- a/util/include/throughput.hpp
+++ b/util/include/throughput.hpp
@@ -1,0 +1,87 @@
+// Concord
+//
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <stdint.h>
+#include <chrono>
+
+#include "assertUtils.hpp"
+
+namespace concord::util {
+/**
+ * A Throughput object is used to calculate the number of items processed in a time unit.
+ * After construction, it must be started by calling start(). In order to get meaningful statistics, user should
+ * report periodically to the object on the processing progress by calling report().
+ *
+ * If the user supplies a window_size > 0:
+ * 1) User may call all member functions prefixed with getPrevWin*.
+ * 2) Last window throughput is calculated and saved.
+ * 3) Overall and last window calculations are based on the window's end time.
+ * 4) report() returns true when the window's end reached.
+ *
+ * To get overall and/or last window statistics, the user has 2 options:
+ * 1) If window_size > 0, it should waits until report() returns true and then it may call getOverallResults()
+ * and/or getPrevWinResults().
+ * 2) If window_size is 0, user can call at any time for getOverallResults(). Calling report() to continue collecting
+ * statistics is still possible after.
+ */
+class Throughput {
+ public:
+  Throughput(uint32_t window_size = 0ul) : num_reports_per_window_(window_size) {}
+  Throughput() = delete;
+
+  // Reset all statistics and record starting time
+  void start();
+
+  // Report amount of items processed since last report.
+  // If window_size > 0: returns true if reached the end of a summary window, and started a new window
+  bool report(uint64_t items_processed = 1);
+
+  struct Results {
+    uint64_t elapsed_time_ms_;
+    uint64_t throughput_ = 0ull;  // items per sec
+    uint64_t num_processed_items_ = 0ull;
+  };
+
+  // Get overall Results: total number of items processed, and throughput from time elapsed_time_ms_
+  const Results& getOverallResults();
+
+  // Get previous window's results. Can be called only if report() returned true.
+  const Results& getPrevWinResults() const;
+
+  // Get previous window's index. Can be called only if report() returned true.
+  uint64_t getPrevWinIndex() const;
+
+ protected:
+  class Stats {
+    std::chrono::time_point<std::chrono::steady_clock> start_time_;
+
+   public:
+    Results results_;
+
+    void reset();
+    void calcThroughput();
+  };
+
+  const uint32_t num_reports_per_window_;
+  bool started_ = false;
+  bool prev_win_calculated_ = false;
+  Stats overall_stats_;
+  Stats current_window_stats_;
+  Stats previous_window_stats_;
+  uint64_t previous_window_index_;
+  uint64_t reports_counter_ = 0;
+};  // class Throughput
+
+}  // namespace concord::util

--- a/util/src/throughput.cpp
+++ b/util/src/throughput.cpp
@@ -1,0 +1,88 @@
+// Concord
+//
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "throughput.hpp"
+
+namespace concord::util {
+//////////////////////////////////////////////////////////////////////////////
+// Throughput member functions
+//////////////////////////////////////////////////////////////////////////////
+void Throughput::start() {
+  started_ = true;
+  overall_stats_.reset();
+  if (num_reports_per_window_ > 0ul) {
+    current_window_stats_.reset();
+  }
+}
+
+bool Throughput::report(uint64_t items_processed) {
+  ConcordAssert(started_);
+
+  ++reports_counter_;
+  overall_stats_.results_.num_processed_items_ += items_processed;
+
+  if (num_reports_per_window_ > 0ul) {
+    current_window_stats_.results_.num_processed_items_ += items_processed;
+    if ((reports_counter_ % num_reports_per_window_) == 0ul) {
+      // Calculate throughput every num_reports_per_window_ reports
+      previous_window_stats_ = current_window_stats_;
+      previous_window_index_ = (reports_counter_ - 1) / num_reports_per_window_;
+      current_window_stats_.reset();
+      previous_window_stats_.calcThroughput();
+      overall_stats_.calcThroughput();
+      prev_win_calculated_ = true;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const Throughput::Results& Throughput::getOverallResults() {
+  if (!prev_win_calculated_) {
+    ConcordAssert(started_);
+    overall_stats_.calcThroughput();
+  }
+
+  return overall_stats_.results_;
+}
+
+const Throughput::Results& Throughput::getPrevWinResults() const {
+  ConcordAssert(prev_win_calculated_);
+
+  return previous_window_stats_.results_;
+}
+
+uint64_t Throughput::getPrevWinIndex() const {
+  ConcordAssert(prev_win_calculated_);
+
+  return previous_window_index_;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Throughput::Stats member functions
+//////////////////////////////////////////////////////////////////////////////
+
+void Throughput::Stats::reset() {
+  results_.num_processed_items_ = 0ull;
+  results_.throughput_ = 0ull;
+  start_time_ = std::chrono::steady_clock::now();
+}
+
+void Throughput::Stats::calcThroughput() {
+  auto duration = std::chrono::steady_clock::now() - start_time_;
+  results_.elapsed_time_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+  results_.throughput_ = static_cast<uint64_t>((1000 * results_.num_processed_items_) / results_.elapsed_time_ms_);
+}
+
+}  // namespace concord::util


### PR DESCRIPTION
State Transfer Improvements:
1) util: Introduce a new class Throughput - we will first use it in BCStateTran, but it is for general use.
2) BCStateTran: Remove unneeded metric
3) BCStateTran: Add a periodic status log while in GettingMissingBlocks.
4) BCStateTran: Add throughput, blocks, and bytes to metrics report
