### PR TITLE
Patch for v0.8

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -290,7 +290,7 @@ void ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
   ConcordAssert(isCurrentPrimary());
   ConcordAssert(currentViewIsActive());
 
-  if (lastStableSeqNum != nOutOfnCheckpoint &&
+  if (lastStableSeqNum > nOutOfnCheckpoint &&
       (getMonotonicTime() - timeOfLastStableSeqNum < milliseconds(waitForLateReplicasToCatchupTimeoutMilli))) {
     LOG_INFO(GL,
              "Will not send PrePrepare because we want to give a chance for late replicas to catchup"

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3778,6 +3778,7 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
 
   while (lastExecutedSeqNum < lastStableSeqNum + kWorkWindowSize) {
     SeqNum nextExecutedSeqNum = lastExecutedSeqNum + 1;
+    SCOPED_MDC_SEQ_NUM(std::to_string(nextExecutedSeqNum));
     SeqNumInfo &seqNumInfo = mainLog->get(nextExecutedSeqNum);
 
     PrePrepareMsg *prePrepareMsg = seqNumInfo.getPrePrepareMsg();

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -91,6 +91,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // the latest stable SeqNum known to this replica
   SeqNum lastStableSeqNum = 0;
+  SeqNum nOutOfnCheckpoint = 0;
 
   //
   SeqNum strictLowerBoundOfSeqNums = 0;
@@ -143,7 +144,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   Time timeOfLastStateSynch;    // last time the replica received a new state (via the state transfer mechanism)
   Time timeOfLastViewEntrance;  // last time the replica entered to a new view
   Time timeOfLastExecution;     // last time that some client request has been executed
-
+  Time timeOfLastStableSeqNum;  // last time we reached to a stable checkpoint
   // latest view number v such that the replica received 2f+2c+1 ViewChangeMsg messages
   // with view >= v
   ViewNum lastAgreedView = 0;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -163,6 +163,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   bool enableRetransmitSuperStableCheckpoint_ = false;
   int viewChangeTimerMilli = 0;
   int autoPrimaryRotationTimerMilli = 0;
+  int minTimeForWaitingToReplicasToCatchup = 1000;
+  int waitForLateReplicasToCatchupTimeoutMilli = 1000;
+  int timeToAddToLateReplicasTimeoutOnRFMD = 50;
+  int maxTimeForWaitToLateReplicasTimeout = 4000;
 
   shared_ptr<PersistentStorage> ps_;
 

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
@@ -38,6 +38,19 @@ class ReqMissingDataMsg : public MessageBase {
   bool getSlowPathHasStarted() const { return b()->flags.bits.slowPathHasStarted != 0; }
 
   uint16_t getFlags() const { return b()->flags.flags; }
+  std::string getFlagsAsBits() const {
+    std::string ret;
+    b()->flags.bits.slowPathHasStarted ? ret += "1" : ret += "0";
+    b()->flags.bits.fullCommitIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.fullPrepareIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.fullCommitProofIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.partialCommitIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.partialPrepareIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.partialProofIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.prePrepareIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.reserved ? ret += "1" : ret += "0";
+    return ret;
+  };
 
   void resetFlags();
 


### PR DESCRIPTION
This PR contains several patches that should help to avoid endless state transfer.

* Once the primary gets to a stable checkpoint, it takes the current time. It will send the next PrePrepare only if either at least one seconds has passed from that time or if it gets to an n/n checkpoint. This should help late replicas to catch up and thus avoiding from endless state transfer.

* Make all replicas involving in answering to missing PrePrepare request