### PR TITLE
Support non-provable keys

### DIFF
--- a/kvbc/include/merkle_tree_key_manipulator.h
+++ b/kvbc/include/merkle_tree_key_manipulator.h
@@ -26,6 +26,7 @@ namespace concord::kvbc::v2MerkleTree::detail {
 class DBKeyManipulator {
  public:
   static Key genBlockDbKey(BlockId version);
+  static Key genNonProvableBlockDbKey(BlockId block_id, const Key &key);
   static Key genDataDbKey(const sparse_merkle::LeafKey &key);
   static Key genDataDbKey(const Key &key, const sparse_merkle::Version &version);
   static Key genInternalDbKey(const sparse_merkle::InternalNodeKey &key);
@@ -38,6 +39,12 @@ class DBKeyManipulator {
   static Key genStaleDbKey(const sparse_merkle::Version &staleSinceVersion);
 
   static Key generateSTTempBlockKey(BlockId blockId);
+
+  // Extract the block ID from a EDBKeyType::Key and EKeySubtype::NonProvable key.
+  static BlockId extractBlockIdFromNonProvableKey(const Key &key);
+
+  // Extract the key from a EDBKeyType::Key and EKeySubtype::NonProvable key.
+  static Key extractKeyFromNonProvableKey(const Key &key);
 
   // Extract the block ID from a EDBKeyType::Block key or from a EKeySubtype::Leaf key.
   static BlockId extractBlockIdFromKey(const Key &key);

--- a/storage/include/storage/db_types.h
+++ b/storage/include/storage/db_types.h
@@ -50,9 +50,18 @@ enum class EDBKeyType : std::uint8_t {
 // containing actual application data.
 enum class EKeySubtype : std::uint8_t {
   Internal,
-  Stale,
+  ProvableStale,
   Leaf,
+  NonProvableStale,
+  NonProvable,
 };
+
+// To enforce the order of keys
+static_assert(static_cast<std::uint8_t>(EKeySubtype::Internal) == 0u);
+static_assert(static_cast<std::uint8_t>(EKeySubtype::ProvableStale) == 1u);
+static_assert(static_cast<std::uint8_t>(EKeySubtype::Leaf) == 2u);
+static_assert(static_cast<std::uint8_t>(EKeySubtype::NonProvableStale) == 3u);
+static_assert(static_cast<std::uint8_t>(EKeySubtype::NonProvable) == 4u);
 
 // BFT subtypes.
 enum class EBFTSubtype : std::uint8_t {


### PR DESCRIPTION
Reason:
Some keys don't need proof. By saving the non-provable keys outside of the Merkle Tree,
Concord-BFT can save a significant amount of disk space. In some scenarios up to 10 times.

Changes:
* Merkle Tree DB Adapter is initialized with a set of non-provable keys.
* If the updates passed to the method `addBlock` contain the non-provable keys,
    the key-values are stored outside of the Merkle Tree.
* The method `addBlock` throws an exception if the "deletes" set
    contains a non-provable key.
* The non-provable keys are stored in the following way:
    `|EKeyType::Key |EKeySubtype::NonProvable|Block ID|Key1 |  = Value1`
* A block with non-provable keys will look like:
    ```
    |EDBKeyType::Block |Block ID                               |  = Block Node
    |EKeyType::Key     |EKeySubtype::NonProvable|Block ID|Key1 |  = Value1
    |EKeyType::Key     |EKeySubtype::NonProvable|Block ID|Key2 |  = Value2
    ```
* The method `getValue` checks if a given key is non-provable.
    If so, it looks up according to the scheme above, if it fails to find,
    the regular search is done.

Note:
Non-provable keys will not be pruned as of this commit and that a subsequent one will do it.