### PR TITLE
Use metrics for preexecution tests

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3352,6 +3352,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_total_fastPath_{metrics_.RegisterCounter("totalFastPaths")},
       metric_total_slowPath_requests_{metrics_.RegisterCounter("totalSlowPathRequests")},
       metric_total_fastPath_requests_{metrics_.RegisterCounter("totalFastPathRequests")},
+      metric_total_preexec_requests_executed_{metrics_.RegisterCounter("totalPreExecRequestsExecuted")},
       reqBatchingLogic_(*this, config_, metrics_, timers),
       replStatusHandlers_(*this) {
   ConcordAssertLT(config_.getreplicaId(), config_.getnumReplicas());
@@ -3741,6 +3742,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
         const auto requestSeqNum = req.requestSeqNum();
         LOG_WARN(CNSUS, "Request execution failed: " << KVLOG(clientId, requestSeqNum));
       } else {
+        if (req.flags() & HAS_PRE_PROCESSED_FLAG) metric_total_preexec_requests_executed_.Get().Inc();
         ClientReplyMsg *replyMsg = clientsManager->allocateNewReplyMsgAndWriteToStorage(
             clientId, req.requestSeqNum(), currentPrimary(), replyBuffer, actualReplyLength);
         replyMsg->setReplicaSpecificInfoLength(actualReplicaSpecificInfoLength);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -218,6 +218,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_total_fastPath_;
   CounterHandle metric_total_slowPath_requests_;
   CounterHandle metric_total_fastPath_requests_;
+  CounterHandle metric_total_preexec_requests_executed_;
   //*****************************************************
  public:
   ReplicaImp(const ReplicaConfig&,

--- a/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
+++ b/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
@@ -70,6 +70,8 @@ std::string ReplicaStatusHandlers::preExecutionStatus(std::shared_ptr<concordMet
                        aggregator->GetCounter("preProcessor", "preProcReqSentForFurtherProcessing").Get()));
   result.insert(toPair(getName(preProcPossiblePrimaryFaultDetected),
                        aggregator->GetCounter("preProcessor", "preProcPossiblePrimaryFaultDetected").Get()));
+  result.insert(toPair(getName(preProcReqForwardedByNonPrimaryNotIgnored),
+                       aggregator->GetCounter("preProcessor", "preProcReqForwardedByNonPrimaryNotIgnored").Get()));
   result.insert(
       toPair(getName(preProcInFlyRequestsNum), aggregator->GetGauge("preProcessor", "PreProcInFlyRequestsNum").Get()));
 

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -171,9 +171,11 @@ class PreProcessor {
     concordMetrics::CounterHandle preProcessRequestTimedout;
     concordMetrics::CounterHandle preProcReqSentForFurtherProcessing;
     concordMetrics::CounterHandle preProcPossiblePrimaryFaultDetected;
+    concordMetrics::CounterHandle preProcReqForwardedByNonPrimaryNotIgnored;
     concordMetrics::GaugeHandle preProcInFlyRequestsNum;
   } preProcessorMetrics_;
   concordUtil::Timers::Handle requestsStatusCheckTimer_;
+  concordUtil::Timers::Handle metricsTimer_;
   const uint64_t preExecReqStatusCheckPeriodMilli_;
   concordUtil::Timers &timers_;
 


### PR DESCRIPTION
Add new metric to count write requests that come from pre-execution. Use that as well as the preProcReqSentForFurtherProcessing metric in tests.