### PR TITLE
[Block accumulation] Add ExecutionRequest struct & adjust RequestsHandler interface

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -70,18 +70,20 @@ class IRequestsHandler {
                       concordUtils::SpanWrapper &parent_span) = 0;
 
   struct ExecutionRequest {
-    uint16_t clientId;
+    uint16_t clientId = 0;
     uint64_t executionSequenceNum = 0;
-    uint8_t flags;
+    uint8_t flags = 0;
     std::string request;
     std::string outReply;
-    uint32_t outActualReplySize;
-    uint32_t outReplicaSpecificInfoSize;
-    int outExecutionStatus;
     uint64_t requestSequenceNum = executionSequenceNum;
+    uint32_t outActualReplySize = 0;
+    uint32_t outReplicaSpecificInfoSize = 0;
+    int outExecutionStatus = 1;
   };
 
-  virtual void execute(std::deque<ExecutionRequest> &requests,
+  typedef std::deque<ExecutionRequest> ExecutionRequestsQueue;
+
+  virtual void execute(ExecutionRequestsQueue &requests,
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) = 0;
 

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -69,6 +69,20 @@ class IRequestsHandler {
                       uint32_t &outReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &parent_span) = 0;
 
+  struct ExecutionRequest {
+    uint16_t clientId;
+    uint64_t sequenceNum;
+    uint8_t flags;
+    uint32_t requestSize;
+    const char *request;
+    uint32_t maxReplySize;
+    char *outReply;
+    uint32_t &outActualReplySize;
+    uint32_t &outReplicaSpecificInfoSize;
+    int &outExecutionStatus;
+    concordUtils::SpanWrapper &parent_span;
+  };
+
   virtual void onFinishExecutingReadWriteRequests() {}
   virtual ~IRequestsHandler() {}
 

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -81,7 +81,7 @@ class IRequestsHandler {
     uint64_t requestSequenceNum = executionSequenceNum;
   };
 
-  virtual void execute(std::deque<ExecutionRequest> &requestList,
+  virtual void execute(std::deque<ExecutionRequest> &requests,
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) = 0;
 

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -71,17 +71,19 @@ class IRequestsHandler {
 
   struct ExecutionRequest {
     uint16_t clientId;
-    uint64_t sequenceNum;
+    uint64_t executionSequenceNum = 0;
     uint8_t flags;
-    uint32_t requestSize;
-    const char *request;
-    uint32_t maxReplySize;
-    char *outReply;
-    uint32_t &outActualReplySize;
-    uint32_t &outReplicaSpecificInfoSize;
-    int &outExecutionStatus;
-    concordUtils::SpanWrapper &parent_span;
+    std::string request;
+    std::string outReply;
+    uint32_t outActualReplySize;
+    uint32_t outReplicaSpecificInfoSize;
+    int outExecutionStatus;
+    uint64_t requestSequenceNum = executionSequenceNum;
   };
+
+  virtual void execute(std::deque<ExecutionRequest> &requestList,
+                       const std::string &batchCid,
+                       concordUtils::SpanWrapper &parent_span) = 0;
 
   virtual void onFinishExecutingReadWriteRequests() {}
   virtual ~IRequestsHandler() {}

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -367,9 +367,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                       PrePrepareMsg* pp,
                                       bool recoverFromErrorInRequestsExecution = false);
 
-  void executeRequestsAndSendResponses(IRequestsHandler::ExecutionRequestsQueue& accumulatedRequests,
-                                       const std::string& batchCid,
-                                       concordUtils::SpanWrapper& span);
+  void executeRequestsAndSendResponses(PrePrepareMsg* pp, Bitmap& requestSet, concordUtils::SpanWrapper& span);
 
   void onSeqNumIsStable(
       SeqNum newStableSeqNum,

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -367,6 +367,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                       PrePrepareMsg* pp,
                                       bool recoverFromErrorInRequestsExecution = false);
 
+  void executeRequestsAndSendResponses(IRequestsHandler::ExecutionRequestsQueue& accumulatedRequests,
+                                       const std::string& batchCid,
+                                       concordUtils::SpanWrapper& span);
+
   void onSeqNumIsStable(
       SeqNum newStableSeqNum,
       bool hasStateInformation = true,  // true IFF we have checkpoint Or digest in the state transfer

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -43,10 +43,10 @@ int RequestHandler::execute(uint16_t clientId,
                                        parent_span);
 }
 
-void RequestHandler::execute(std::deque<IRequestsHandler::ExecutionRequest> &requestList,
+void RequestHandler::execute(std::deque<IRequestsHandler::ExecutionRequest> &requests,
                              const std::string &batchCid,
                              concordUtils::SpanWrapper &parent_span) {
-  for (auto it = requestList.begin(); it != requestList.end(); ++it) {
+  for (auto it = requests.begin(); it != requests.end(); ++it) {
     if (it->flags & KEY_EXCHANGE_FLAG) {
       KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(it->request.c_str(), it->request.size());
       LOG_DEBUG(GL, "BFT handler received KEY_EXCHANGE msg " << ke.toString());
@@ -64,7 +64,7 @@ void RequestHandler::execute(std::deque<IRequestsHandler::ExecutionRequest> &req
       it->flags = READ_ONLY_FLAG;
     }
   }
-  return userRequestsHandler_->execute(requestList, batchCid, parent_span);
+  return userRequestsHandler_->execute(requests, batchCid, parent_span);
 }
 
 void RequestHandler::onFinishExecutingReadWriteRequests() {

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -17,6 +17,11 @@ class RequestHandler : public IRequestsHandler {
                       uint32_t &outActualReplySize,
                       uint32_t &outReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &parent_span) override;
+
+  virtual void execute(std::deque<ExecutionRequest> &requestList,
+                       const std::string &batchCid,
+                       concordUtils::SpanWrapper &parent_span) override;
+
   virtual void onFinishExecutingReadWriteRequests() override;
 
   virtual std::shared_ptr<ControlHandlers> getControlHandlers() override;

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -18,7 +18,7 @@ class RequestHandler : public IRequestsHandler {
                       uint32_t &outReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &parent_span) override;
 
-  virtual void execute(std::deque<ExecutionRequest> &requestList,
+  virtual void execute(std::deque<ExecutionRequest> &requests,
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) override;
 

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -18,7 +18,7 @@ class RequestHandler : public IRequestsHandler {
                       uint32_t &outReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &parent_span) override;
 
-  virtual void execute(std::deque<ExecutionRequest> &requests,
+  virtual void execute(ExecutionRequestsQueue &requests,
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) override;
 

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -71,6 +71,15 @@ class DummyRequestsHandler : public IRequestsHandler {
     return 0;
   }
 
+  void execute(std::deque<ExecutionRequest>& requestList,
+               const std::string& batchCid,
+               concordUtils::SpanWrapper& parent_span) override {
+    for (auto it = requestList.begin(); it != requestList.end(); ++it) {
+      it->outActualReplySize = 256;
+      it->outExecutionStatus = 0;
+    }
+  }
+
   std::shared_ptr<ControlHandlers> getControlHandlers() override { return nullptr; }
 };
 

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -72,12 +72,12 @@ class DummyRequestsHandler : public IRequestsHandler {
     return 0;
   }
 
-  void execute(std::deque<ExecutionRequest>& requests,
+  void execute(ExecutionRequestsQueue& requests,
                const std::string& batchCid,
                concordUtils::SpanWrapper& parent_span) override {
-    for (auto it = requests.begin(); it != requests.end(); ++it) {
-      it->outActualReplySize = 256;
-      it->outExecutionStatus = 0;
+    for (auto& req : requests) {
+      req.outActualReplySize = 256;
+      req.outExecutionStatus = 0;
     }
   }
 

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -72,10 +72,10 @@ class DummyRequestsHandler : public IRequestsHandler {
     return 0;
   }
 
-  void execute(std::deque<ExecutionRequest>& requestList,
+  void execute(std::deque<ExecutionRequest>& requests,
                const std::string& batchCid,
                concordUtils::SpanWrapper& parent_span) override {
-    for (auto it = requestList.begin(); it != requestList.end(); ++it) {
+    for (auto it = requests.begin(); it != requests.end(); ++it) {
       it->outActualReplySize = 256;
       it->outExecutionStatus = 0;
     }

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -128,6 +128,9 @@ class ICommandsHandler : public bftEngine::IRequestsHandler {
               uint32_t& outActualReplySize,
               uint32_t& outActualReplicaSpecificInfoSize,
               concordUtils::SpanWrapper& span) override = 0;
+  void execute(std::deque<ExecutionRequest>& requestList,
+               const std::string& batchCid,
+               concordUtils::SpanWrapper& parent_span) override = 0;
   virtual void setControlStateManager(std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) = 0;
   ~ICommandsHandler() override = default;
 };

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -128,7 +128,7 @@ class ICommandsHandler : public bftEngine::IRequestsHandler {
               uint32_t& outActualReplySize,
               uint32_t& outActualReplicaSpecificInfoSize,
               concordUtils::SpanWrapper& span) override = 0;
-  void execute(std::deque<ExecutionRequest>& requestList,
+  void execute(ExecutionRequestsQueue& requestList,
                const std::string& batchCid,
                concordUtils::SpanWrapper& parent_span) override = 0;
   virtual void setControlStateManager(std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) = 0;

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -61,10 +61,10 @@ int InternalCommandsHandler::execute(uint16_t clientId,
   return res ? 0 : -1;
 }
 
-void InternalCommandsHandler::execute(std::deque<InternalCommandsHandler::ExecutionRequest> &requestList,
+void InternalCommandsHandler::execute(std::deque<InternalCommandsHandler::ExecutionRequest> &requests,
                                       const std::string &batchCid,
                                       concordUtils::SpanWrapper &parent_span) {
-  for (auto it = requestList.begin(); it != requestList.end(); ++it) {
+  for (auto it = requests.begin(); it != requests.end(); ++it) {
     // ReplicaSpecificInfo is not currently used in the TesterReplica
     if (it->outExecutionStatus != 1) continue;
     it->outReplicaSpecificInfoSize = 0;

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -61,6 +61,42 @@ int InternalCommandsHandler::execute(uint16_t clientId,
   return res ? 0 : -1;
 }
 
+void InternalCommandsHandler::execute(std::deque<InternalCommandsHandler::ExecutionRequest> &requestList,
+                                      const std::string &batchCid,
+                                      concordUtils::SpanWrapper &parent_span) {
+  for (auto it = requestList.begin(); it != requestList.end(); ++it) {
+    // ReplicaSpecificInfo is not currently used in the TesterReplica
+    if (it->outExecutionStatus != 1) continue;
+    it->outReplicaSpecificInfoSize = 0;
+    int res;
+    if (it->request.size() < sizeof(SimpleRequest)) {
+      LOG_ERROR(m_logger,
+                "The message is too small: requestSize is " << it->request.size() << ", required size is "
+                                                            << sizeof(SimpleRequest));
+      it->outExecutionStatus = -1;
+    }
+    bool readOnly = it->flags & MsgFlag::READ_ONLY_FLAG;
+    if (readOnly) {
+      res = executeReadOnlyCommand(it->request.size(),
+                                   it->request.c_str(),
+                                   it->outReply.size(),
+                                   it->outReply.data(),
+                                   it->outActualReplySize,
+                                   it->outReplicaSpecificInfoSize);
+    } else {
+      res = executeWriteCommand(it->request.size(),
+                                it->request.c_str(),
+                                it->executionSequenceNum,
+                                it->flags,
+                                it->outReply.size(),
+                                it->outReply.data(),
+                                it->outActualReplySize);
+    }
+    if (!res) LOG_ERROR(m_logger, "Command execution failed!");
+    it->outExecutionStatus = res ? 0 : -1;
+  }
+}
+
 void InternalCommandsHandler::addMetadataKeyValue(SetOfKeyValuePairs &updates, uint64_t sequenceNum) const {
   Sliver metadataKey = m_blockMetadata->getKey();
   Sliver metadataValue = m_blockMetadata->serialize(sequenceNum);

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -61,7 +61,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                       uint32_t &outActualReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &span) override;
 
-  virtual void execute(std::deque<ExecutionRequest> &requests,
+  virtual void execute(ExecutionRequestsQueue &requests,
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) override;
 

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -61,7 +61,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                       uint32_t &outActualReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &span) override;
 
-  virtual void execute(std::deque<ExecutionRequest> &requestList,
+  virtual void execute(std::deque<ExecutionRequest> &requests,
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) override;
 

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -61,6 +61,10 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                       uint32_t &outActualReplicaSpecificInfoSize,
                       concordUtils::SpanWrapper &span) override;
 
+  virtual void execute(std::deque<ExecutionRequest> &requestList,
+                       const std::string &batchCid,
+                       concordUtils::SpanWrapper &parent_span) override;
+
   void setControlStateManager(std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) override;
 
  private:

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -129,10 +129,10 @@ class SimpleAppState : public IRequestsHandler {
     }
     return 0;
   }
-  void execute(std::deque<ExecutionRequest> &requestList,
+  void execute(std::deque<ExecutionRequest> &requests,
                const std::string &batchCid,
                concordUtils::SpanWrapper &parent_span) override {
-    for (auto it = requestList.begin(); it != requestList.end(); ++it) {
+    for (auto it = requests.begin(); it != requests.end(); ++it) {
       // Not currently used
       it->outReplicaSpecificInfoSize = 0;
 


### PR DESCRIPTION
We made this change to introduce the ExecutionRequest struct in the IRequestsHandler interface as part of our work on block accumulation.
This struct includes all the fields that need to be passed to execute() and another field for the execution result.
each request that is represented by this structure will be added to a list when block accumulation is active.