### PR TITLE
Revert "Limit rocksdb max_open_files to 50. (#962)"

### DIFF
--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -113,7 +113,6 @@ void Client::init(bool readOnly) {
   options.level0_slowdown_writes_trigger = 48;
   options.level0_stop_writes_trigger = 56;
   options.bytes_per_sync = 1024 * 2048;
-  options.max_open_files = 50;
 
   table_options.block_size = 4 * 4096;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));


### PR DESCRIPTION
This reverts commit c553de2f3b44a88601c0a8be68288167693bd4b3.

Due to observed performance degradation in master this limit will be removed or further fine tuned.