### PR TITLE
Support Pruning for non-provable keys

### DIFF
--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -58,7 +58,8 @@ class DBAdapter : public IDbAdapter {
   // mechanism. The constructor throws if an error occurs.
   // Note1: The passed DB client must be initialized beforehand.
   // Note2: The 'linkTempSTChain' parameter turns of chain linking and is used for testing/tooling purposes.
-  // Note3: The key provided via 'non_provable_key_set' parameter will be stored outside of the Merkle Tree.
+  // Note3: The key provided via 'nonProvableKeySet' parameter will be stored outside of the Merkle Tree,
+  // the keys must have the same size!
   // Note4: Non-provable keys cannot be deleted for now.
   DBAdapter(const std::shared_ptr<concord::storage::IDBClient> &db,
             bool linkTempSTChain = true,
@@ -182,9 +183,11 @@ class DBAdapter : public IDbAdapter {
 
   block::detail::Node getBlockNode(BlockId blockId) const;
 
-  KeysVector staleIndexKeysForVersion(const sparse_merkle::Version &version) const;
+  KeysVector staleIndexNonProvableKeysForBlock(BlockId blockId) const;
 
-  KeysVector internalKeysForVersion(const sparse_merkle::Version &version) const;
+  KeysVector staleIndexProvableKeysForVersion(const sparse_merkle::Version &version) const;
+
+  KeysVector internalProvableKeysForVersion(const sparse_merkle::Version &version) const;
 
   KeysVector lastReachableBlockKeyDeletes(BlockId blockId) const;
 
@@ -203,6 +206,8 @@ class DBAdapter : public IDbAdapter {
 
   // Return std::nullopt if no temporary ST blocks are present.
   std::optional<BlockId> loadLatestTempSTBlockId() const;
+
+  std::optional<std::pair<Value, BlockId>> getValueForNonProvableKey(const Key &key, const BlockId &blockVersion) const;
 
   class Reader : public sparse_merkle::IDBReader {
    public:

--- a/kvbc/include/merkle_tree_key_manipulator.h
+++ b/kvbc/include/merkle_tree_key_manipulator.h
@@ -26,12 +26,13 @@ namespace concord::kvbc::v2MerkleTree::detail {
 class DBKeyManipulator {
  public:
   static Key genBlockDbKey(BlockId version);
-  static Key genNonProvableBlockDbKey(BlockId block_id, const Key &key);
+  static Key genNonProvableDbKey(BlockId block_id, const Key &key);
   static Key genDataDbKey(const sparse_merkle::LeafKey &key);
   static Key genDataDbKey(const Key &key, const sparse_merkle::Version &version);
   static Key genInternalDbKey(const sparse_merkle::InternalNodeKey &key);
   static Key genStaleDbKey(const sparse_merkle::InternalNodeKey &key, const sparse_merkle::Version &staleSinceVersion);
   static Key genStaleDbKey(const sparse_merkle::LeafKey &key, const sparse_merkle::Version &staleSinceVersion);
+  static Key genNonProvableStaleDbKey(const Key &key, BlockId staleSinceBlock);
   // Version-only stale keys do not exist in the DB. They are used as a placeholder for searching through the stale
   // index. Rationale is that they are a lower bound of all stale keys for a specific version due to lexicographical
   // ordering, the fact that the version comes first and that real stale keys are longer and always follow version-only
@@ -53,10 +54,16 @@ class DBKeyManipulator {
   static sparse_merkle::Hash extractHashFromLeafKey(const Key &key);
 
   // Extract the stale since version from a stale node index key.
-  static sparse_merkle::Version extractVersionFromStaleKey(const Key &key);
+  static sparse_merkle::Version extractVersionFromProvableStaleKey(const Key &key);
+
+  // Extract the stale since block id from a stale node index key.
+  static BlockId extractBlockIdFromNonProvableStaleKey(const Key &key);
 
   // Extract the actual key from the stale node index key.
-  static Key extractKeyFromStaleKey(const Key &key);
+  static Key extractKeyFromProvableStaleKey(const Key &key);
+
+  // Extract the actual key from the non-provable stale key.
+  static Key extractKeyFromNonProvableStaleKey(const Key &key);
 
   // Extract the version of an internal key.
   static sparse_merkle::Version extractVersionFromInternalKey(const Key &key);


### PR DESCRIPTION
This commit adds the possibility to mark non-provable keys as
NonProvableStale in case a given key already exists.

Changes:
* The method `addBlock` checks if input non-provable keys already exist
and mark them as stale.
* `DBAdapter::lastReachableBlockKeyDeletes` and `DBAdapter::genesisBlockKeyDeletes` are udpated to support
the cleanup of non-provable keys.
* Added method `DBAdapter::staleIndexKeysForBlock` to look for stale
indices.
* Unit tests.

Additional information:
The non-provable stale keys are stored in the DB in the following way:
```
|EDBKeyType::Key|EKeySubtype::NonProvableStale|Stale since version(block id)|Actual NonProvable key|