### PR TITLE
Integrate replica asks to leave view msg in replica status msg

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2919,7 +2919,7 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
   }
 
   if (currentViewIsActive()) {
-    if (isCurrentPrimary()) return;
+    if (isCurrentPrimary() || complainedReplicas.getComplaintFromReplica(config_.replicaId) != nullptr) return;
 
     const Time timeOfEarliestPendingRequest = clientsManager->timeOfEarliestPendingRequest();
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2037,6 +2037,18 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
     tryToSendStatusReport();
   }
 
+  /////////////////////////////////////////////////////////////////////////
+  // msgSenderId's View is active and we have complaints for this View
+  /////////////////////////////////////////////////////////////////////////
+
+  if (msg->currentViewIsActive()) {
+    for (const auto &i : complainedReplicas.getAllMsgs()) {
+      if (!msg->hasComplaintFromReplica(i.first) && msg->getViewNumber() == i.second->viewNumber()) {
+        sendAndIncrementMetric(i.second.get(), msgSenderId, metric_sent_replica_asks_to_leave_view_msg_due_to_status_);
+      }
+    }
+  }
+
   delete msg;
 }
 
@@ -2077,6 +2089,11 @@ void ReplicaImp::tryToSendStatusReport(bool onTimer) {
                        listOfMissingVCMsg,
                        listOfMissingPPMsg);
 
+  if (viewIsActive) {
+    for (const auto &i : complainedReplicas.getAllMsgs()) {
+      msg.setComplaintFromReplica(i.first);
+    }
+  }
   if (listOfPPInActiveWindow) {
     const SeqNum start = lastStableSeqNum + 1;
     const SeqNum end = lastStableSeqNum + kWorkWindowSize;
@@ -3342,6 +3359,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_sent_viewchange_msg_due_to_status_{metrics_.RegisterCounter("sentViewChangeMsgDueToTimer")},
       metric_sent_newview_msg_due_to_status_{metrics_.RegisterCounter("sentNewviewMsgDueToCounter")},
       metric_sent_preprepare_msg_due_to_status_{metrics_.RegisterCounter("sentPreprepareMsgDueToStatus")},
+      metric_sent_replica_asks_to_leave_view_msg_due_to_status_{
+          metrics_.RegisterCounter("sentReplicaAsksToLeaveViewMsgDueToStatus")},
       metric_sent_preprepare_msg_due_to_reqMissingData_{
           metrics_.RegisterCounter("sentPreprepareMsgDueToReqMissingData")},
       metric_sent_startSlowPath_msg_due_to_reqMissingData_{

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -208,6 +208,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_sent_viewchange_msg_due_to_status_;
   CounterHandle metric_sent_newview_msg_due_to_status_;
   CounterHandle metric_sent_preprepare_msg_due_to_status_;
+  CounterHandle metric_sent_replica_asks_to_leave_view_msg_due_to_status_;
   CounterHandle metric_sent_preprepare_msg_due_to_reqMissingData_;
   CounterHandle metric_sent_startSlowPath_msg_due_to_reqMissingData_;
   CounterHandle metric_sent_partialCommitProof_msg_due_to_reqMissingData_;

--- a/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
@@ -15,6 +15,7 @@
 
 namespace bftEngine {
 namespace impl {
+namespace {
 static uint8_t powersOf2[] = {
     0x1,
     0x2,
@@ -26,18 +27,26 @@ static uint8_t powersOf2[] = {
     0x80,
 };
 
+static const int kWorkWindowBitMaskSize = (kWorkWindowSize + 7) / 8;
+static const int maxNumberOfReplicasBitMaskSize = (MaxNumberOfReplicas + 7) / 8;
+
+}  // namespace
+
 // TODO(GG): here we assume that replica Ids are between 0 and MaxNumberOfReplicas-1 (should be changed to support
 // dynamic reconfiguration)
 
-MsgSize ReplicaStatusMsg::calcSizeOfReplicaStatusMsg(bool listOfPrePrepareMsgsInActiveWindow,
+MsgSize ReplicaStatusMsg::calcSizeOfReplicaStatusMsg(bool viewIsActive,
+                                                     bool listOfPrePrepareMsgsInActiveWindow,
                                                      bool listOfMissingViewChangeMsgForViewChange,
                                                      bool listOfMissingPrePrepareMsgForViewChange) {
-  if (listOfPrePrepareMsgsInActiveWindow)
-    return sizeof(ReplicaStatusMsg::Header) + (kWorkWindowSize + 7) / 8;
+  if (listOfPrePrepareMsgsInActiveWindow && viewIsActive)
+    return sizeof(ReplicaStatusMsg::Header) + kWorkWindowBitMaskSize + maxNumberOfReplicasBitMaskSize;
+  else if (viewIsActive)
+    return sizeof(ReplicaStatusMsg::Header) + maxNumberOfReplicasBitMaskSize;
   else if (listOfMissingViewChangeMsgForViewChange)
-    return sizeof(ReplicaStatusMsg::Header) + (MaxNumberOfReplicas + 7) / 8;
+    return sizeof(ReplicaStatusMsg::Header) + maxNumberOfReplicasBitMaskSize;
   else if (listOfMissingPrePrepareMsgForViewChange)
-    return sizeof(ReplicaStatusMsg::Header) + (kWorkWindowSize + 7) / 8;
+    return sizeof(ReplicaStatusMsg::Header) + kWorkWindowBitMaskSize;
   else
     return sizeof(ReplicaStatusMsg::Header);
 }
@@ -55,7 +64,8 @@ ReplicaStatusMsg::ReplicaStatusMsg(ReplicaId senderId,
     : MessageBase(senderId,
                   MsgCode::ReplicaStatus,
                   spanContext.data().size(),
-                  calcSizeOfReplicaStatusMsg(listOfPPInActiveWindow, listOfMissingVCForVC, listOfMissingPPForVC)) {
+                  calcSizeOfReplicaStatusMsg(
+                      viewIsActive, listOfPPInActiveWindow, listOfMissingVCForVC, listOfMissingPPForVC)) {
   ConcordAssert(lastExecutedSeqNum >= lastStableSeqNum);
   ConcordAssert(lastStableSeqNum % checkpointWindowSize == 0);
   ConcordAssert(!viewIsActive || hasNewChangeMsg);         // viewIsActive --> hasNewChangeMsg
@@ -105,8 +115,9 @@ void ReplicaStatusMsg::validate(const ReplicasInfo& repInfo) const {
       !(!viewIsActive || !listOfMissingPPForVC) ||   // if NOT (viewIsActive --> !listOfMissingPPForVC)
       !(viewIsActive || !listOfPPInActiveWindow) ||  // if NOT (!viewIsActive --> !listOfPPInActiveWindow)
       (((listOfPPInActiveWindow ? 1 : 0) + (listOfMissingVCForVC ? 1 : 0) + (listOfMissingPPForVC ? 1 : 0)) >= 2) ||
-      size() != calcSizeOfReplicaStatusMsg(listOfPPInActiveWindow, listOfMissingVCForVC, listOfMissingPPForVC) +
-                    spanContextSize())
+      size() !=
+          calcSizeOfReplicaStatusMsg(viewIsActive, listOfPPInActiveWindow, listOfMissingVCForVC, listOfMissingPPForVC) +
+              spanContextSize())
     throw std::runtime_error(__PRETTY_FUNCTION__ + std::string(": advanced"));
 }
 
@@ -190,6 +201,38 @@ void ReplicaStatusMsg::setMissingPrePrepareMsgForViewChange(SeqNum seqNum) {
   size_t byteIndex = index / 8;
   size_t bitIndex = index % 8;
   uint8_t* p = (uint8_t*)body() + payloadShift();
+  p[byteIndex] = p[byteIndex] | powersOf2[bitIndex];
+}
+
+bool ReplicaStatusMsg::hasComplaintFromReplica(ReplicaId replicaId) const {
+  ConcordAssert(currentViewIsActive());
+  ConcordAssert(replicaId < MaxNumberOfReplicas);
+
+  auto shift = payloadShift();
+  if (hasListOfPrePrepareMsgsInActiveWindow()) {
+    shift += kWorkWindowBitMaskSize;
+  }
+
+  size_t index = replicaId;
+  size_t byteIndex = index / 8;
+  size_t bitIndex = index % 8;
+  uint8_t* p = (uint8_t*)body() + shift;
+  return ((p[byteIndex] & powersOf2[bitIndex]) != 0);
+}
+
+void ReplicaStatusMsg::setComplaintFromReplica(ReplicaId replicaId) {
+  ConcordAssert(currentViewIsActive());
+  ConcordAssert(replicaId < MaxNumberOfReplicas);
+
+  auto shift = payloadShift();
+  if (hasListOfPrePrepareMsgsInActiveWindow()) {
+    shift += kWorkWindowBitMaskSize;
+  }
+
+  size_t index = replicaId;
+  size_t byteIndex = index / 8;
+  size_t bitIndex = index % 8;
+  uint8_t* p = (uint8_t*)body() + shift;
   p[byteIndex] = p[byteIndex] | powersOf2[bitIndex];
 }
 

--- a/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReplicaStatusMsg.cpp
@@ -16,7 +16,7 @@
 namespace bftEngine {
 namespace impl {
 namespace {
-static uint8_t powersOf2[] = {
+constexpr uint8_t powersOf2[] = {
     0x1,
     0x2,
     0x4,
@@ -27,8 +27,8 @@ static uint8_t powersOf2[] = {
     0x80,
 };
 
-static const int kWorkWindowBitMaskSize = (kWorkWindowSize + 7) / 8;
-static const int maxNumberOfReplicasBitMaskSize = (MaxNumberOfReplicas + 7) / 8;
+constexpr int kWorkWindowBitMaskSize = (kWorkWindowSize + 7) / 8;
+constexpr int maxNumberOfReplicasBitMaskSize = (MaxNumberOfReplicas + 7) / 8;
 
 }  // namespace
 

--- a/bftengine/src/bftengine/messages/ReplicaStatusMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReplicaStatusMsg.hpp
@@ -52,11 +52,15 @@ class ReplicaStatusMsg : public MessageBase {
 
   bool isMissingPrePrepareMsgForViewChange(SeqNum seqNum) const;
 
+  bool hasComplaintFromReplica(ReplicaId replicaId) const;
+
   void setPrePrepareInActiveWindow(SeqNum seqNum) const;
 
   void setMissingViewChangeMsgForViewChange(ReplicaId replicaId);
 
   void setMissingPrePrepareMsgForViewChange(SeqNum seqNum);
+
+  void setComplaintFromReplica(ReplicaId replicaId);
 
   void validate(const ReplicasInfo&) const override;
 
@@ -82,7 +86,8 @@ class ReplicaStatusMsg : public MessageBase {
 #pragma pack(pop)
   static_assert(sizeof(Header) == (6 + 8 + 8 + 8 + 1), "Header is 31B");
 
-  static MsgSize calcSizeOfReplicaStatusMsg(bool listOfPrePrepareMsgsInActiveWindow,
+  static MsgSize calcSizeOfReplicaStatusMsg(bool viewIsActive,
+                                            bool listOfPrePrepareMsgsInActiveWindow,
                                             bool listOfMissingViewChangeMsgForViewChange,
                                             bool listOfMissingPrePrepareMsgForViewChange);
 

--- a/bftengine/tests/messages/ReplicaStatusMsg_test.cpp
+++ b/bftengine/tests/messages/ReplicaStatusMsg_test.cpp
@@ -59,6 +59,15 @@ TEST(ReplicaStatusMsg, viewActiveNoLists) {
   EXPECT_EQ(msg.hasListOfMissingViewChangeMsgForViewChange(), listOfMissingViewChangeMsgForViewChange);
   EXPECT_EQ(msg.hasListOfMissingPrePrepareMsgForViewChange(), listOfMissingPrePrepareMsgForViewChange);
 
+  for (auto& id : replicaInfo.idsOfPeerReplicas()) {
+    EXPECT_FALSE(msg.hasComplaintFromReplica(id));
+    msg.setComplaintFromReplica(id);
+    EXPECT_TRUE(msg.hasComplaintFromReplica(id));
+  }
+  for (auto& id : replicaInfo.idsOfPeerReplicas()) {
+    EXPECT_TRUE(msg.hasComplaintFromReplica(id));
+  }
+
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   /* the next methods crash the app with an assert ¯\_(ツ)_/¯
   EXPECT_FALSE(msg.isPrePrepareInActiveWindow(151));
@@ -101,6 +110,15 @@ TEST(ReplicaStatusMsg, haslistOfPrePrepareMsgsInActiveWindow) {
   EXPECT_EQ(msg.hasListOfMissingViewChangeMsgForViewChange(), listOfMissingViewChangeMsgForViewChange);
   EXPECT_EQ(msg.hasListOfMissingPrePrepareMsgForViewChange(), listOfMissingPrePrepareMsgForViewChange);
 
+  for (auto& id : replicaInfo.idsOfPeerReplicas()) {
+    EXPECT_FALSE(msg.hasComplaintFromReplica(id));
+    msg.setComplaintFromReplica(id);
+    EXPECT_TRUE(msg.hasComplaintFromReplica(id));
+  }
+  for (auto& id : replicaInfo.idsOfPeerReplicas()) {
+    EXPECT_TRUE(msg.hasComplaintFromReplica(id));
+  }
+
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   EXPECT_FALSE(msg.isPrePrepareInActiveWindow(151));
   msg.setPrePrepareInActiveWindow(151);
@@ -109,6 +127,10 @@ TEST(ReplicaStatusMsg, haslistOfPrePrepareMsgsInActiveWindow) {
   EXPECT_FALSE(msg.isPrePrepareInActiveWindow(152));
   msg.setPrePrepareInActiveWindow(152);
   EXPECT_TRUE(msg.isPrePrepareInActiveWindow(152));
+
+  for (auto& id : replicaInfo.idsOfPeerReplicas()) {
+    EXPECT_TRUE(msg.hasComplaintFromReplica(id));
+  }
 
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   /* the next methods crash the app with an assert ¯\_(ツ)_/¯


### PR DESCRIPTION
During Status Reports Replicas indicate from which peers they have complaints for the View they are in.
By doing so peers are able to send them the complaints (ReplicaAsksToLeaveViewMSg-s) they are missing.
Resending of the complaint is disabled, because it can be resend during Status Reports.