### PR TITLE
Wrap RocksDB for safety and column family support

### DIFF
--- a/kvbc/test/sparse_merkle_storage/db_adapter_property_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_property_test.cpp
@@ -4,7 +4,7 @@
 #include <rapidcheck.h>
 #include <rapidcheck/gtest.h>
 
-#include "storage_test_common.h"
+#include "kvbc_storage_test_common.h"
 
 #include "kv_types.hpp"
 #include "merkle_tree_block.h"

--- a/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -4,7 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "storage_test_common.h"
+#include "kvbc_storage_test_common.h"
 
 #include "block_digest.h"
 #include "merkle_tree_block.h"

--- a/kvbc/test/sparse_merkle_storage/kvbc_storage_test_common.h
+++ b/kvbc/test/sparse_merkle_storage/kvbc_storage_test_common.h
@@ -1,0 +1,39 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "storage/test/storage_test_common.h"
+
+#include "block_digest.h"
+#include "kv_types.hpp"
+#include "sparse_merkle/base_types.h"
+
+inline ::concord::kvbc::BlockDigest blockDigest(concord::kvbc::BlockId blockId, const concordUtils::Sliver &block) {
+  return ::bftEngine::bcst::computeBlockDigest(blockId, block.data(), block.length());
+}
+
+inline auto getHash(const std::string &str) {
+  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
+  return hasher.hash(str.data(), str.size());
+}
+
+inline auto getHash(const concordUtils::Sliver &sliver) {
+  auto hasher = ::concord::kvbc::sparse_merkle::Hasher{};
+  return hasher.hash(sliver.data(), sliver.length());
+}
+
+inline auto getBlockDigest(const std::string &data) { return getHash(data).dataArray(); }
+
+inline const auto defaultBlockId = ::concord::kvbc::BlockId{42};
+inline const auto maxNumKeys = 16u;

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-#include "storage_test_common.h"
+#include "kvbc_storage_test_common.h"
 
 #include "endianness.hpp"
 #include "kv_types.hpp"

--- a/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/sparse_merkle_db_editor_test.cpp
@@ -16,12 +16,12 @@
 
 #include "db_adapter_interface.h"
 #include "endianness.hpp"
+#include "kvbc_storage_test_common.h"
 #include "kv_types.hpp"
 #include "merkle_tree_db_adapter.h"
 #include "PersistentStorageImp.hpp"
 #include "sliver.hpp"
 #include "sparse_merkle_db_editor.hpp"
-#include "storage_test_common.h"
 #include "storage/db_types.h"
 #include "storage/merkle_tree_key_manipulator.h"
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -26,4 +26,7 @@ if (BUILD_ROCKSDB_STORAGE)
   target_compile_definitions(concordbft_storage PUBLIC USE_ROCKSDB=1 __BASE=1 SPARSE_STATE=1)
   target_include_directories(concordbft_storage PUBLIC ${ROCKSDB_INCLUDE_DIR})
   target_link_libraries(concordbft_storage PRIVATE ${ROCKSDB} ${LIBBZ2} ${LIBLZ4} ${LIBZSTD} ${LIBZ} ${LIBSNAPPY} ${CMAKE_DL_LIBS})
+
 endif(BUILD_ROCKSDB_STORAGE)
+
+add_subdirectory(test)

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -115,6 +115,8 @@ class Client : public concord::storage::IDBClient {
 
   // Metrics
   mutable RocksDbStorageMetrics storage_metrics_;
+
+  friend class NativeClient;
 };
 
 ::rocksdb::Slice toRocksdbSlice(const concordUtils::Sliver& _s);

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -19,10 +19,14 @@
 
 #ifdef USE_ROCKSDB
 #include "Logger.hpp"
+#include <rocksdb/db.h>
 #include <rocksdb/utilities/transaction_db.h>
 #include <rocksdb/sst_file_manager.h>
 #include "storage/db_interface.h"
 #include "storage/storage_metrics.h"
+
+#include <optional>
+#include <vector>
 
 namespace concord {
 namespace storage {
@@ -97,6 +101,10 @@ class Client : public concord::storage::IDBClient {
   }
 
  private:
+  // If initCFamilies is true, return a vector of column family handles. A default column family handle is always
+  // returned. If initCFamilies is set to false, no column family initialization is attempted and std::nullopt is
+  // returned. It is up to callers to destroy the returned handles. Throws on errors.
+  std::optional<std::vector<::rocksdb::ColumnFamilyHandle*>> initDB(bool readOnly, bool initCFamilies);
   concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob);
   concordUtils::Status get(const concordUtils::Sliver& _key, std::string& _value) const;
   bool keyIsBefore(const concordUtils::Sliver& _lhs, const concordUtils::Sliver& _rhs) const;

--- a/storage/include/rocksdb/native_client.h
+++ b/storage/include/rocksdb/native_client.h
@@ -1,0 +1,542 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "client.h"
+#include "storage/db_interface.h"
+
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
+#include <rocksdb/write_batch.h>
+
+#include <exception>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+// Wrapper around the RocksDB library that aims at improving:
+//  * memory management
+//  * error reporting - done via exceptions instead of status codes
+//
+// The Span template parameters to methods allow conversion from any type that has data() and size()
+// members. The data() member should return a char pointer. That includes std::string, std::string_view,
+// std::vector<char>, std::span<char>, Sliver, etc. Raw pointers without size are not supported.
+//
+// Note1: All methods on all classes throw on errors.
+// Note2: All methods without a column family parameter work with the default column family.
+namespace concord::storage::rocksdb {
+
+using namespace std::string_view_literals;
+
+struct RocksDBException : std::runtime_error {
+  RocksDBException(const std::string &what, ::rocksdb::Status &&s) : std::runtime_error{what}, status{std::move(s)} {}
+  const ::rocksdb::Status status;
+};
+
+class NativeClient;
+
+class WriteBatch {
+ public:
+  WriteBatch(const std::shared_ptr<const NativeClient> &);
+
+  template <typename KeySpan, typename ValueSpan>
+  void put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value);
+  template <typename KeySpan, typename ValueSpan>
+  void put(const KeySpan &key, const ValueSpan &value);
+
+  // Deleting a key that doesn't exist is not an error.
+  template <typename KeySpan>
+  void del(const std::string &cFamily, const KeySpan &key);
+  template <typename KeySpan>
+  void del(const KeySpan &key);
+
+  // Remove the DB entries in the range [beginKey, endKey).
+  template <typename BeginSpan, typename EndSpan>
+  void delRange(const std::string &cFamily, const BeginSpan &beginKey, const EndSpan &endKey);
+  template <typename BeginSpan, typename EndSpan>
+  void delRange(const BeginSpan &beginKey, const EndSpan &endKey);
+
+ private:
+  std::shared_ptr<const NativeClient> client_;
+  ::rocksdb::WriteBatch batch_;
+  friend class NativeClient;
+};
+
+// Put a container of key-value pair spans.
+template <typename Container>
+void putInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont);
+template <typename Container>
+void putInBatch(WriteBatch &batch, const Container &cont);
+
+// Delete a container of key spans.
+template <typename Container>
+void delInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont);
+template <typename Container>
+void delInBatch(WriteBatch &batch, const Container &cont);
+
+class Iterator {
+ public:
+  // Returns true if the iterator points to a key-value pair and false otherwise. Initially, an iterator doesn't point
+  // to anything. A false return from this method is not an error - it might mean there are no more keys or a key wasn't
+  // found.
+  operator bool() const;
+
+  // Methods that move the iterator.
+  // Precondition: the iterator points to a key-value pair.
+  void first();
+  void last();
+  void next();
+  void prev();
+
+  // Seek for a key that is at or past target.
+  template <typename KeySpan>
+  void seekAtLeast(const KeySpan &target);
+
+  // Seek for a key that is at or before target.
+  template <typename KeySpan>
+  void seekAtMost(const KeySpan &target);
+
+  // Copy the key and value from the iterator.
+  // Precondition: the iterator points to a key-value pair.
+  std::string key() const;
+  std::string value() const;
+
+  // A view into the key and value inside the iterator. The return value is valid until the iterator is modified.
+  // Precondition: the iterator points to a key-value pair.
+  std::string_view keyView() const;
+  std::string_view valueView() const;
+
+ private:
+  Iterator(std::unique_ptr<::rocksdb::Iterator> iter);
+  static std::string sliceToString(const ::rocksdb::Slice &);
+  static std::string_view sliceToStringView(const ::rocksdb::Slice &);
+
+ private:
+  std::unique_ptr<::rocksdb::Iterator> iter_;
+  friend class NativeClient;
+};
+
+class NativeClient : public std::enable_shared_from_this<NativeClient> {
+ public:
+  static std::shared_ptr<NativeClient> newClient(const std::string &path, bool readOnly);
+
+  // Use this native client through the IDBClient interface.
+  std::shared_ptr<IDBClient> asIDBClient() const;
+
+  // Column family single key read-write interface.
+  template <typename KeySpan, typename ValueSpan>
+  void put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value);
+  // Returns nullopt if the key is not found.
+  template <typename KeySpan>
+  std::optional<std::string> get(const std::string &cFamily, const KeySpan &key) const;
+  // Deleting a key that doesn't exist is not an error.
+  template <typename KeySpan>
+  void del(const std::string &cFamily, const KeySpan &key);
+
+  // Single key read-write interface for the default column family.
+  template <typename KeySpan, typename ValueSpan>
+  void put(const KeySpan &key, const ValueSpan &value);
+  // Returns nullopt if the key is not found.
+  template <typename KeySpan>
+  std::optional<std::string> get(const KeySpan &key) const;
+  // Deleting a key that doesn't exist is not an error.
+  template <typename KeySpan>
+  void del(const KeySpan &key);
+
+  // Batching interface.
+  WriteBatch getBatch() const;
+  void write(WriteBatch &&);
+
+  // Iterator interface.
+  // Iterators initially don't point to a key value, i.e. they convert to false.
+  // Important note - RocksDB requires that iterators are destroyed before the DB client that created them.
+  //
+  // Get an iterator into the default column family.
+  Iterator getIterator() const;
+  // Get an iterator into a column family
+  Iterator getIterator(const std::string &cFamily) const;
+  // Get iterators from a consistent database state across multiple column families. The order of the returned iterators
+  // match the families input.
+  std::vector<Iterator> getIterators(const std::vector<std::string> &cFamilies) const;
+
+  // Column family management.
+  static std::string defaultColumnFamily();
+  static std::unordered_set<std::string> columnFamilies(const std::string &path);
+  std::unordered_set<std::string> columnFamilies() const;
+  // If is not an error if it already exists.
+  void createColumnFamily(const std::string &cFamily);
+  // Drops a column family and its data. It is not an error if the column family doesn't exist.
+  void dropColumnFamily(const std::string &cFamily);
+
+ private:
+  NativeClient(const std::string &path, bool readOnly);
+
+  // Make sure we only allow types that have data() and size() members. That excludes raw pointers without corresponding
+  // size.
+  template <
+      typename Span,
+      std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
+                           std::is_pointer_v<decltype(std::declval<Span>().data())> &&
+                           std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
+                                                 const char (*)[]>,
+                       int> = 0>
+  static ::rocksdb::Slice toSlice(const Span &span) noexcept {
+    return ::rocksdb::Slice{span.data(), span.size()};
+  }
+
+  static void throwOnError(std::string_view msg1, std::string_view msg2, ::rocksdb::Status &&);
+  static void throwOnError(std::string_view msg, ::rocksdb::Status &&);
+
+  // For use in column family unique pointers that are managed solely by NativeClient. This allows us to use a raw
+  // pointer in CfDeleter as we know the column family unique pointer will not be moved out of NativeClient.
+  struct CfDeleter {
+    void operator()(::rocksdb::ColumnFamilyHandle *h) const noexcept {
+      if (!client_->dbInstance_->DestroyColumnFamilyHandle(h).ok()) {
+        std::terminate();
+      }
+    }
+    Client *client_{nullptr};
+  };
+
+  using CfUniquePtr = std::unique_ptr<::rocksdb::ColumnFamilyHandle, CfDeleter>;
+
+  ::rocksdb::ColumnFamilyHandle *defaultColumnFamilyHandle() const;
+  ::rocksdb::ColumnFamilyHandle *columnFamilyHandle(const std::string &cFamily) const;
+  CfUniquePtr createColumnFamilyHandle(const std::string &cFamily);
+
+ private:
+  std::string path_;
+  // Keep cf_handles_ after the client_ as column family handles need to be deleted before deleting the client. See
+  // CfDeleter.
+  std::shared_ptr<Client> client_;
+  std::map<std::string, CfUniquePtr> cf_handles_;
+  friend class WriteBatch;
+  friend class Iterator;
+};
+
+inline WriteBatch::WriteBatch(const std::shared_ptr<const NativeClient> &client) : client_{client} {}
+
+template <typename KeySpan, typename ValueSpan>
+void WriteBatch::put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value) {
+  auto s = batch_.Put(client_->columnFamilyHandle(cFamily), NativeClient::toSlice(key), NativeClient::toSlice(value));
+  NativeClient::throwOnError("batch put failed"sv, std::move(s));
+}
+
+template <typename KeySpan, typename ValueSpan>
+void WriteBatch::put(const KeySpan &key, const ValueSpan &value) {
+  return put(NativeClient::defaultColumnFamily(), key, value);
+}
+
+template <typename KeySpan>
+void WriteBatch::del(const std::string &cFamily, const KeySpan &key) {
+  auto s = batch_.Delete(client_->columnFamilyHandle(cFamily), NativeClient::toSlice(key));
+  NativeClient::throwOnError("batch del failed"sv, std::move(s));
+}
+
+template <typename KeySpan>
+void WriteBatch::del(const KeySpan &key) {
+  return del(NativeClient::defaultColumnFamily(), key);
+}
+
+template <typename BeginSpan, typename EndSpan>
+void WriteBatch::delRange(const std::string &cFamily, const BeginSpan &beginKey, const EndSpan &endKey) {
+  auto s = batch_.DeleteRange(
+      client_->columnFamilyHandle(cFamily), NativeClient::toSlice(beginKey), NativeClient::toSlice(endKey));
+  NativeClient::throwOnError("delRange failed", std::move(s));
+}
+
+template <typename BeginSpan, typename EndSpan>
+void WriteBatch::delRange(const BeginSpan &beginKey, const EndSpan &endKey) {
+  return delRange(client_->defaultColumnFamily(), beginKey, endKey);
+}
+
+template <typename Container>
+void putInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont) {
+  for (auto &[key, value] : cont) {
+    batch.put(cFamily, key, value);
+  }
+}
+
+template <typename Container>
+void putInBatch(WriteBatch &batch, const Container &cont) {
+  return putInBatch(batch, NativeClient::defaultColumnFamily(), cont);
+}
+
+template <typename Container>
+void delInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont) {
+  for (auto &key : cont) {
+    batch.del(cFamily, key);
+  }
+}
+
+template <typename Container>
+void delInBatch(WriteBatch &batch, const Container &cont) {
+  return delInBatch(batch, NativeClient::defaultColumnFamily(), cont);
+}
+
+inline Iterator::Iterator(std::unique_ptr<::rocksdb::Iterator> iter) : iter_{std::move(iter)} {}
+
+inline std::string Iterator::sliceToString(const ::rocksdb::Slice &s) { return std::string{s.data(), s.size()}; }
+
+inline std::string_view Iterator::sliceToStringView(const ::rocksdb::Slice &s) {
+  return std::string_view{s.data(), s.size()};
+}
+
+inline Iterator::operator bool() const { return iter_->Valid(); }
+
+inline void Iterator::first() {
+  iter_->SeekToFirst();
+  NativeClient::throwOnError("iterator first failed"sv, iter_->status());
+}
+
+inline void Iterator::last() {
+  iter_->SeekToLast();
+  NativeClient::throwOnError("iterator last failed"sv, iter_->status());
+}
+
+inline void Iterator::next() {
+  if (!iter_->Valid()) {
+    NativeClient::throwOnError("next on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  iter_->Next();
+  auto s = iter_->status();
+  NativeClient::throwOnError("iterator next failed"sv, iter_->status());
+}
+
+inline void Iterator::prev() {
+  if (!iter_->Valid()) {
+    NativeClient::throwOnError("prev on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  iter_->Prev();
+  auto s = iter_->status();
+  NativeClient::throwOnError("iterator prev failed"sv, iter_->status());
+}
+
+template <typename KeySpan>
+void Iterator::seekAtLeast(const KeySpan &target) {
+  iter_->Seek(NativeClient::toSlice(target));
+  NativeClient::throwOnError("iterator seekAtLeast failed"sv, iter_->status());
+}
+
+template <typename KeySpan>
+void Iterator::seekAtMost(const KeySpan &target) {
+  iter_->SeekForPrev(NativeClient::toSlice(target));
+  NativeClient::throwOnError("iterator seekAtMost failed"sv, iter_->status());
+}
+
+inline std::string Iterator::key() const {
+  if (!iter_->Valid()) {
+    NativeClient::throwOnError("key on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToString(iter_->key());
+}
+
+inline std::string Iterator::value() const {
+  if (!iter_->Valid()) {
+    NativeClient::throwOnError("value on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToString(iter_->value());
+}
+
+inline std::string_view Iterator::keyView() const {
+  if (!iter_->Valid()) {
+    NativeClient::throwOnError("keyView on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToStringView(iter_->key());
+}
+
+inline std::string_view Iterator::valueView() const {
+  if (!iter_->Valid()) {
+    NativeClient::throwOnError("valueView on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToStringView(iter_->value());
+}
+
+inline std::shared_ptr<NativeClient> NativeClient::newClient(const std::string &path, bool readOnly) {
+  return std::shared_ptr<NativeClient>{new NativeClient{path, readOnly}};
+}
+
+inline NativeClient::NativeClient(const std::string &path, bool readOnly)
+    : path_{path}, client_{std::make_shared<Client>(path)} {
+  client_->init(readOnly);
+
+  const auto families = NativeClient::columnFamilies(path);
+  for (auto &f : families) {
+    if (defaultColumnFamily() != f) {
+      cf_handles_.emplace(f, createColumnFamilyHandle(f));
+    }
+  }
+}
+
+inline std::shared_ptr<IDBClient> NativeClient::asIDBClient() const { return client_; }
+
+template <typename KeySpan, typename ValueSpan>
+void NativeClient::put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value) {
+  auto s =
+      client_->dbInstance_->Put(::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), toSlice(key), toSlice(value));
+  throwOnError("put() failed"sv, std::move(s));
+  client_->storage_metrics_.tryToUpdateMetrics();
+}
+
+template <typename KeySpan>
+std::optional<std::string> NativeClient::get(const std::string &cFamily, const KeySpan &key) const {
+  auto value = std::string{};
+  auto s = client_->dbInstance_->Get(::rocksdb::ReadOptions{}, columnFamilyHandle(cFamily), toSlice(key), &value);
+  if (s.IsNotFound()) {
+    return std::nullopt;
+  }
+  throwOnError("get() failed"sv, std::move(s));
+  client_->storage_metrics_.tryToUpdateMetrics();
+  return value;
+}
+
+template <typename KeySpan>
+void NativeClient::del(const std::string &cFamily, const KeySpan &key) {
+  auto s = client_->dbInstance_->Delete(::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), toSlice(key));
+  throwOnError("del() failed"sv, std::move(s));
+  client_->storage_metrics_.tryToUpdateMetrics();
+}
+
+template <typename KeySpan, typename ValueSpan>
+void NativeClient::put(const KeySpan &key, const ValueSpan &value) {
+  return put(defaultColumnFamily(), key, value);
+}
+
+template <typename KeySpan>
+std::optional<std::string> NativeClient::get(const KeySpan &key) const {
+  return get(defaultColumnFamily(), key);
+}
+
+template <typename KeySpan>
+void NativeClient::del(const KeySpan &key) {
+  return del(defaultColumnFamily(), key);
+}
+
+inline WriteBatch NativeClient::getBatch() const { return WriteBatch{shared_from_this()}; }
+
+inline Iterator NativeClient::getIterator() const {
+  return std::unique_ptr<::rocksdb::Iterator>{client_->dbInstance_->NewIterator(::rocksdb::ReadOptions{})};
+}
+
+inline Iterator NativeClient::getIterator(const std::string &cFamily) const {
+  return std::unique_ptr<::rocksdb::Iterator>{
+      client_->dbInstance_->NewIterator(::rocksdb::ReadOptions{}, columnFamilyHandle(cFamily))};
+}
+
+inline std::vector<Iterator> NativeClient::getIterators(const std::vector<std::string> &cFamilies) const {
+  auto cfHandles = std::vector<::rocksdb::ColumnFamilyHandle *>{};
+  for (auto &cf : cFamilies) {
+    cfHandles.push_back(columnFamilyHandle(cf));
+  }
+  auto rawPtrIterators = std::vector<::rocksdb::Iterator *>{};
+  auto uniquePtrIterators = std::vector<std::unique_ptr<::rocksdb::Iterator>>{};
+  auto status = client_->dbInstance_->NewIterators(::rocksdb::ReadOptions{}, cfHandles, &rawPtrIterators);
+  // Are we supposed to delete the iterators if error is returned...
+  for (auto iter : rawPtrIterators) {
+    uniquePtrIterators.push_back(std::unique_ptr<::rocksdb::Iterator>{iter});
+  }
+  throwOnError("get multiple iterators failed"sv, std::move(status));
+  auto ret = std::vector<Iterator>{};
+  for (auto &iter : uniquePtrIterators) {
+    ret.push_back(std::move(iter));
+  }
+  return ret;
+}
+
+inline void NativeClient::write(WriteBatch &&b) {
+  auto s = client_->dbInstance_->Write(::rocksdb::WriteOptions{}, &b.batch_);
+  throwOnError("write(batch) failed"sv, std::move(s));
+  client_->storage_metrics_.tryToUpdateMetrics();
+}
+
+inline std::unordered_set<std::string> NativeClient::columnFamilies(const std::string &path) {
+  auto families = std::vector<std::string>{};
+  auto status = ::rocksdb::DB::ListColumnFamilies(::rocksdb::DBOptions{}, path, &families);
+  throwOnError("list column families failed"sv, std::move(status));
+  auto ret = std::unordered_set<std::string>{};
+  for (auto &f : families) {
+    ret.emplace(std::move(f));
+  }
+  return ret;
+}
+
+inline std::string NativeClient::defaultColumnFamily() { return ::rocksdb::kDefaultColumnFamilyName; }
+
+inline std::unordered_set<std::string> NativeClient::columnFamilies() const { return columnFamilies(path_); }
+
+inline void NativeClient::createColumnFamily(const std::string &cFamily) {
+  if (cf_handles_.find(cFamily) != cf_handles_.cend()) {
+    return;
+  }
+  cf_handles_.emplace(cFamily, createColumnFamilyHandle(cFamily));
+}
+
+inline void NativeClient::dropColumnFamily(const std::string &cFamily) {
+  auto it = cf_handles_.find(cFamily);
+  if (it == cf_handles_.cend()) {
+    return;
+  }
+  auto s = client_->dbInstance_->DropColumnFamily(it->second.get());
+  throwOnError("failed to drop column family"sv, cFamily, std::move(s));
+  // std::map::erase(iterator) cannot throw.
+  cf_handles_.erase(it);
+}
+
+inline void NativeClient::throwOnError(std::string_view msg1, std::string_view msg2, ::rocksdb::Status &&s) {
+  if (!s.ok()) {
+    auto rocksdbMsg = std::string{"RocksDB: "};
+    rocksdbMsg.append(msg1);
+    rocksdbMsg.append(": ");
+    rocksdbMsg.append(msg2);
+    LOG_ERROR(Client::logger(), rocksdbMsg << ", status = " << s.ToString());
+    throw RocksDBException{rocksdbMsg, std::move(s)};
+  }
+}
+
+inline void NativeClient::throwOnError(std::string_view msg, ::rocksdb::Status &&s) {
+  return throwOnError(msg, ""sv, std::move(s));
+}
+
+inline ::rocksdb::ColumnFamilyHandle *NativeClient::defaultColumnFamilyHandle() const {
+  return client_->dbInstance_->DefaultColumnFamily();
+}
+
+inline ::rocksdb::ColumnFamilyHandle *NativeClient::columnFamilyHandle(const std::string &cFamily) const {
+  if (defaultColumnFamily() == cFamily) {
+    return defaultColumnFamilyHandle();
+  }
+  auto it = cf_handles_.find(cFamily);
+  if (it == cf_handles_.cend()) {
+    throwOnError("no such column family"sv, cFamily, ::rocksdb::Status::ColumnFamilyDropped());
+  }
+  return it->second.get();
+}
+
+inline NativeClient::CfUniquePtr NativeClient::createColumnFamilyHandle(const std::string &cFamily) {
+  ::rocksdb::ColumnFamilyHandle *cf{nullptr};
+  auto s = client_->dbInstance_->CreateColumnFamily(::rocksdb::ColumnFamilyOptions{}, cFamily, &cf);
+  // Are we supposed to delete the handle if error is returned...
+  auto ret = CfUniquePtr{cf, CfDeleter{client_.get()}};
+  throwOnError("cannot create column family handle"sv, cFamily, std::move(s));
+  return ret;
+}
+
+}  // namespace concord::storage::rocksdb

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(GTest REQUIRED)
+
+if (BUILD_ROCKSDB_STORAGE)
+    add_executable(native_rocksdb_client_test native_rocksdb_client_test.cpp )
+    add_test(native_rocksdb_client_test native_rocksdb_client_test)
+
+    target_link_libraries(native_rocksdb_client_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        concordbft_storage
+        util
+        stdc++fs
+    )
+endif(BUILD_ROCKSDB_STORAGE)

--- a/storage/test/native_rocksdb_client_test.cpp
+++ b/storage/test/native_rocksdb_client_test.cpp
@@ -1,0 +1,621 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "storage/db_interface.h"
+#include "rocksdb/native_client.h"
+#include "sliver.hpp"
+#include "storage/test/storage_test_common.h"
+
+#include <string_view>
+#include <utility>
+
+namespace {
+
+using namespace concord::storage;
+using namespace concord::storage::rocksdb;
+using namespace ::testing;
+using namespace std::literals;
+
+class native_rocksdb_test : public ::testing::Test {
+  void SetUp() override {
+    cleanup();
+    db = TestRocksDb::createNative();
+  }
+  void TearDown() override { cleanup(); }
+
+ protected:
+  std::shared_ptr<NativeClient> db;
+  const std::string key{"key"};
+  const std::string value{"value"};
+  const std::string key1{"key1"};
+  const std::string value1{"value1"};
+  const std::string key2{"key2"};
+  const std::string value2{"value2"};
+  const std::string key3{"key3"};
+  const std::string value3{"value3"};
+
+  template <typename T>
+  static Sliver toSliver(const T &v) {
+    return Sliver::copy(v.data(), v.size());
+  }
+};
+
+TEST_F(native_rocksdb_test, empty_db_has_default_family_only) {
+  const auto families = db->columnFamilies();
+  ASSERT_EQ(families.size(), 1);
+  ASSERT_EQ(*families.begin(), NativeClient::defaultColumnFamily());
+}
+
+TEST_F(native_rocksdb_test, create_families) {
+  db->createColumnFamily("cf1");
+  db->createColumnFamily("cf2");
+  db->createColumnFamily("cf3");
+  ASSERT_THAT(db->columnFamilies(),
+              ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(), "cf1", "cf2", "cf3"}));
+}
+
+TEST_F(native_rocksdb_test, creating_a_family_twice_is_not_an_error) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  ASSERT_NO_THROW(db->createColumnFamily(cf));
+  ASSERT_THAT(db->columnFamilies(), ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(), "cf"}));
+}
+
+TEST_F(native_rocksdb_test, drop_family_and_list) {
+  db->createColumnFamily("cf1");
+  db->createColumnFamily("cf2");
+  db->dropColumnFamily("cf2");
+  ASSERT_THAT(db->columnFamilies(), ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(), "cf1"}));
+}
+
+TEST_F(native_rocksdb_test, dropping_a_family_twice_is_not_an_error) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->dropColumnFamily(cf);
+  ASSERT_NO_THROW(db->dropColumnFamily(cf));
+  ASSERT_THAT(db->columnFamilies(), ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily()}));
+}
+
+TEST_F(native_rocksdb_test, single_key_api_throws_on_non_existent_family) {
+  const auto cf = "cf"s;
+  ASSERT_THROW(db->get(cf, key), RocksDBException);
+  ASSERT_THROW(db->put(cf, key, value), RocksDBException);
+  ASSERT_THROW(db->del(cf, key), RocksDBException);
+}
+
+TEST_F(native_rocksdb_test, put_in_default_family) {
+  db->put(key, value);
+
+  // Ensure key is in the default family via the non-family interface.
+  {
+    const auto dbValue = db->get(key);
+    ASSERT_TRUE(dbValue.has_value());
+    ASSERT_EQ(*dbValue, value);
+  }
+
+  // Ensure key is in the default family via the family interface.
+  {
+    const auto dbValue = db->get(db->defaultColumnFamily(), key);
+    ASSERT_TRUE(dbValue.has_value());
+    ASSERT_EQ(*dbValue, value);
+  }
+}
+
+TEST_F(native_rocksdb_test, put_with_different_key_and_value_types) {
+  db->put("key"sv, "value"s);
+  const auto dbValue = db->get("key"s);
+  ASSERT_TRUE(dbValue.has_value());
+  ASSERT_EQ(*dbValue, "value");
+}
+
+TEST_F(native_rocksdb_test, del_from_default_family) {
+  db->put(key, value);
+  db->del(key);
+  ASSERT_FALSE(db->get(key).has_value());
+}
+
+TEST_F(native_rocksdb_test, put_in_created_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key, value);
+  const auto dbValue = db->get(cf, key);
+  ASSERT_TRUE(dbValue.has_value());
+  ASSERT_EQ(*dbValue, value);
+  // Ensure the key is not the default family.
+  ASSERT_FALSE(db->get(key).has_value());
+}
+
+TEST_F(native_rocksdb_test, del_from_created_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  // Put in both the default and the created one.
+  db->put(key, value);
+  db->put(cf, key, value);
+  db->del(cf, key);
+  const auto defaultValue = db->get(key);
+  ASSERT_TRUE(defaultValue.has_value());
+  ASSERT_EQ(*defaultValue, value);
+  ASSERT_FALSE(db->get(cf, key).has_value());
+}
+
+TEST_F(native_rocksdb_test, del_non_existent_key_is_not_an_error) { ASSERT_NO_THROW(db->del(key)); }
+
+TEST_F(native_rocksdb_test, drop_family_and_get) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key, value);
+  db->dropColumnFamily(cf);
+  ASSERT_THROW(db->get(cf, key), RocksDBException);
+}
+
+TEST_F(native_rocksdb_test, drop_family_then_create_and_ensure_empty) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key, value);
+  db->dropColumnFamily(cf);
+  db->createColumnFamily(cf);
+  ASSERT_FALSE(db->get(cf, key).has_value());
+}
+
+TEST_F(native_rocksdb_test, put_in_batch_in_default_family) {
+  auto batch = db->getBatch();
+  batch.put(key1, value1);
+  batch.put(key2, value2);
+  db->write(std::move(batch));
+  const auto dbValue1 = db->get(key1);
+  const auto dbValue2 = db->get(key2);
+  ASSERT_TRUE(dbValue1.has_value());
+  ASSERT_EQ(*dbValue1, value1);
+  ASSERT_TRUE(dbValue2.has_value());
+  ASSERT_EQ(*dbValue2, value2);
+}
+
+TEST_F(native_rocksdb_test, put_in_batch_in_2_families) {
+  const auto cf1 = "cf1"s;
+  const auto cf2 = "cf2"s;
+  db->createColumnFamily(cf1);
+  db->createColumnFamily(cf2);
+  auto batch = db->getBatch();
+  db->put(cf1, key1, value1);
+  db->put(cf1, key2, value2);
+  db->put(cf2, key2, value2);
+  db->put(cf2, key3, value3);
+  db->write(std::move(batch));
+
+  // cf1
+  {
+    const auto dbValue1 = db->get(cf1, key1);
+    const auto dbValue2 = db->get(cf1, key2);
+    ASSERT_TRUE(dbValue1.has_value());
+    ASSERT_EQ(*dbValue1, value1);
+    ASSERT_TRUE(dbValue2.has_value());
+    ASSERT_EQ(*dbValue2, value2);
+  }
+
+  // cf2
+  {
+    const auto dbValue2 = db->get(cf2, key2);
+    const auto dbValue3 = db->get(cf2, key3);
+    ASSERT_TRUE(dbValue2.has_value());
+    ASSERT_EQ(*dbValue2, value2);
+    ASSERT_TRUE(dbValue3.has_value());
+    ASSERT_EQ(*dbValue3, value3);
+  }
+}
+
+TEST_F(native_rocksdb_test, del_non_existent_key_in_batch_is_not_an_error) {
+  auto batch = db->getBatch();
+  batch.del(key);
+  ASSERT_NO_THROW(db->write(std::move(batch)));
+}
+
+TEST_F(native_rocksdb_test, multiple_deletes_for_same_key_in_batch) {
+  db->put(key, value);
+  auto batch = db->getBatch();
+  batch.del(key);
+  batch.del(key);
+  ASSERT_NO_THROW(db->write(std::move(batch)));
+  ASSERT_FALSE(db->get(key).has_value());
+}
+
+TEST_F(native_rocksdb_test, batch_operations_honor_order) {
+  // put -> delete
+  {
+    auto batch = db->getBatch();
+    batch.put(key, value);
+    batch.del(key);
+    db->write(std::move(batch));
+    ASSERT_FALSE(db->get(key).has_value());
+  }
+
+  // put -> delete -> put
+  {
+    auto batch = db->getBatch();
+    batch.put(key, value);
+    batch.del(key);
+    batch.put(key, value2);
+    db->write(std::move(batch));
+    const auto dbValue = db->get(key);
+    ASSERT_TRUE(dbValue.has_value());
+    ASSERT_EQ(*dbValue, value2);
+  }
+}
+
+TEST_F(native_rocksdb_test, put_container_in_batch_in_default_family) {
+  const auto kvSet = SetOfKeyValuePairs{std::make_pair(toSliver(key1), toSliver(value1)),
+                                        std::make_pair(toSliver(key2), toSliver(value2))};
+  auto batch = db->getBatch();
+  putInBatch(batch, kvSet);
+  db->write(std::move(batch));
+  const auto dbValue1 = db->get(key1);
+  ASSERT_TRUE(dbValue1.has_value());
+  ASSERT_EQ(*dbValue1, value1);
+  const auto dbValue2 = db->get(key2);
+  ASSERT_TRUE(dbValue2.has_value());
+  ASSERT_EQ(*dbValue2, value2);
+}
+
+TEST_F(native_rocksdb_test, put_container_in_batch_in_a_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  const auto kvSet = SetOfKeyValuePairs{std::make_pair(toSliver(key1), toSliver(value1)),
+                                        std::make_pair(toSliver(key2), toSliver(value2))};
+  auto batch = db->getBatch();
+  putInBatch(batch, cf, kvSet);
+  db->write(std::move(batch));
+  const auto dbValue1 = db->get(cf, key1);
+  ASSERT_TRUE(dbValue1.has_value());
+  ASSERT_EQ(*dbValue1, value1);
+  const auto dbValue2 = db->get(cf, key2);
+  ASSERT_TRUE(dbValue2.has_value());
+  ASSERT_EQ(*dbValue2, value2);
+}
+
+TEST_F(native_rocksdb_test, del_container_in_batch_in_default_family) {
+  db->put(key1, value1);
+  db->put(key2, value2);
+  const auto kvVec = KeysVector{toSliver(key1), toSliver(key2)};
+  auto batch = db->getBatch();
+  delInBatch(batch, kvVec);
+  db->write(std::move(batch));
+  ASSERT_FALSE(db->get(key1).has_value());
+  ASSERT_FALSE(db->get(key2).has_value());
+}
+
+TEST_F(native_rocksdb_test, del_container_in_batch_in_a_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key1, value1);
+  db->put(cf, key2, value2);
+  const auto kvVec = KeysVector{toSliver(key1), toSliver(key2)};
+  auto batch = db->getBatch();
+  delInBatch(batch, cf, kvVec);
+  db->write(std::move(batch));
+  ASSERT_FALSE(db->get(cf, key1).has_value());
+  ASSERT_FALSE(db->get(cf, key2).has_value());
+}
+
+TEST_F(native_rocksdb_test, batch_del_range_in_default_family) {
+  db->put(key1, value1);
+  db->put(key2, value2);
+  db->put(key3, value3);
+  auto batch = db->getBatch();
+  batch.delRange(key1, key3);
+  db->write(std::move(batch));
+  ASSERT_FALSE(db->get(key1).has_value());
+  ASSERT_FALSE(db->get(key2).has_value());
+  const auto dbValue3 = db->get(key3);
+  ASSERT_TRUE(dbValue3.has_value());
+  ASSERT_EQ(*dbValue3, value3);
+}
+
+TEST_F(native_rocksdb_test, batch_del_range_in_a_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key1, value1);
+  db->put(cf, key2, value2);
+  db->put(cf, key3, value3);
+  auto batch = db->getBatch();
+  batch.delRange(cf, key1, key3);
+  db->write(std::move(batch));
+  ASSERT_FALSE(db->get(cf, key1).has_value());
+  ASSERT_FALSE(db->get(cf, key2).has_value());
+  const auto dbValue3 = db->get(cf, key3);
+  ASSERT_TRUE(dbValue3.has_value());
+  ASSERT_EQ(*dbValue3, value3);
+}
+
+TEST_F(native_rocksdb_test, batch_del_invalid_range_in_default_family) {
+  db->put(key1, value1);
+  db->put(key2, value2);
+  auto batch = db->getBatch();
+  batch.delRange(key3, key1);
+  db->write(std::move(batch));
+  const auto dbValue1 = db->get(key1);
+  ASSERT_TRUE(dbValue1.has_value());
+  ASSERT_EQ(*dbValue1, value1);
+  const auto dbValue2 = db->get(key2);
+  ASSERT_TRUE(dbValue2.has_value());
+  ASSERT_EQ(*dbValue2, value2);
+}
+
+TEST_F(native_rocksdb_test, batch_del_invalid_range_in_a_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key1, value1);
+  db->put(cf, key2, value2);
+  auto batch = db->getBatch();
+  batch.delRange(cf, key3, key1);
+  db->write(std::move(batch));
+  const auto dbValue1 = db->get(cf, key1);
+  ASSERT_TRUE(dbValue1.has_value());
+  ASSERT_EQ(*dbValue1, value1);
+  const auto dbValue2 = db->get(cf, key2);
+  ASSERT_TRUE(dbValue2.has_value());
+  ASSERT_EQ(*dbValue2, value2);
+}
+
+TEST_F(native_rocksdb_test, batch_for_non_existent_family_throws) {
+  const auto cf = "cf"s;
+
+  {
+    auto batch = db->getBatch();
+    ASSERT_THROW(batch.put(cf, key, value), RocksDBException);
+    ASSERT_THROW(batch.del(cf, key), RocksDBException);
+    ASSERT_THROW(batch.delRange(cf, key1, key2), RocksDBException);
+  }
+}
+
+TEST_F(native_rocksdb_test, iterator_is_invalid_on_creation) {
+  {
+    auto it = db->getIterator();
+    ASSERT_FALSE(it);
+  }
+
+  const auto cf1 = "cf1"s;
+  {
+    db->createColumnFamily(cf1);
+    auto it = db->getIterator(cf1);
+    ASSERT_FALSE(it);
+  }
+
+  const auto cf2 = "cf2"s;
+  {
+    db->createColumnFamily(cf2);
+    auto iters = db->getIterators({cf1, cf2});
+    ASSERT_EQ(iters.size(), 2);
+    ASSERT_FALSE(iters[0]);
+    ASSERT_FALSE(iters[1]);
+  }
+}
+
+TEST_F(native_rocksdb_test, iterator_get_throws_for_non_existent_column_families) {
+  const auto cf1 = "cf1"s;
+  const auto cf2 = "cf2"s;
+
+  ASSERT_THROW(db->getIterator(cf1), RocksDBException);
+  ASSERT_THROW(db->getIterators({cf1, cf2}), RocksDBException);
+}
+
+TEST_F(native_rocksdb_test, iterate_all_keys_in_default_family) {
+  db->put(key1, value1);
+  db->put(key2, value2);
+  auto it = db->getIterator();
+  it.first();
+  ASSERT_EQ(it.keyView(), key1);
+  ASSERT_EQ(it.valueView(), value1);
+  it.next();
+  ASSERT_EQ(it.keyView(), key2);
+  ASSERT_EQ(it.valueView(), value2);
+}
+
+TEST_F(native_rocksdb_test, iterate_all_keys_in_a_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key1, value1);
+  db->put(cf, key2, value2);
+  auto it = db->getIterator(cf);
+  it.first();
+  ASSERT_EQ(it.keyView(), key1);
+  ASSERT_EQ(it.valueView(), value1);
+  it.next();
+  ASSERT_EQ(it.keyView(), key2);
+  ASSERT_EQ(it.valueView(), value2);
+}
+
+TEST_F(native_rocksdb_test, iterator_going_past_last_is_invalid) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(key1, value1);
+  db->put(cf, key2, value2);
+
+  {
+    auto it = db->getIterator();
+    it.first();
+    ASSERT_NO_THROW(it.next());
+    ASSERT_FALSE(it);
+  }
+
+  {
+    auto it = db->getIterator(cf);
+    it.first();
+    ASSERT_NO_THROW(it.next());
+    ASSERT_FALSE(it);
+  }
+}
+
+TEST_F(native_rocksdb_test, iterator_going_before_first_is_invalid) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(key1, value1);
+  db->put(cf, key2, value2);
+
+  {
+    auto it = db->getIterator();
+    it.first();
+    ASSERT_NO_THROW(it.prev());
+    ASSERT_FALSE(it);
+  }
+
+  {
+    auto it = db->getIterator(cf);
+    it.first();
+    ASSERT_NO_THROW(it.prev());
+    ASSERT_FALSE(it);
+  }
+}
+
+TEST_F(native_rocksdb_test, iterator_key_values_and_views_are_equal) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(key1, value1);
+  db->put(cf, key2, value2);
+
+  {
+    auto it = db->getIterator();
+    it.first();
+    ASSERT_EQ(it.key(), key1);
+    ASSERT_EQ(it.value(), value1);
+    ASSERT_EQ(it.key(), it.keyView());
+    ASSERT_EQ(it.value(), it.valueView());
+  }
+
+  {
+    auto it = db->getIterator(cf);
+    it.first();
+    ASSERT_EQ(it.key(), key2);
+    ASSERT_EQ(it.value(), value2);
+    ASSERT_EQ(it.key(), it.keyView());
+    ASSERT_EQ(it.value(), it.valueView());
+  }
+}
+
+TEST_F(native_rocksdb_test, iterator_seek_at_least_in_default_family) {
+  db->put(key1, value1);
+  db->put(key3, value3);
+  auto it = db->getIterator();
+  it.seekAtLeast(key2);
+  ASSERT_TRUE(it);
+  ASSERT_EQ(it.key(), key3);
+  ASSERT_EQ(it.value(), value3);
+}
+
+TEST_F(native_rocksdb_test, iterator_seek_at_least_in_a_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key1, value1);
+  db->put(cf, key3, value3);
+  auto it = db->getIterator(cf);
+  it.seekAtLeast(key2);
+  ASSERT_TRUE(it);
+  ASSERT_EQ(it.key(), key3);
+  ASSERT_EQ(it.value(), value3);
+}
+
+TEST_F(native_rocksdb_test, iterator_seek_at_most_in_default_family) {
+  db->put(key1, value1);
+  db->put(key3, value3);
+  auto it = db->getIterator();
+  it.seekAtMost(key2);
+  ASSERT_TRUE(it);
+  ASSERT_EQ(it.key(), key1);
+  ASSERT_EQ(it.value(), value1);
+}
+
+TEST_F(native_rocksdb_test, iterator_seek_at_most_in_a_family) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(cf, key1, value1);
+  db->put(cf, key3, value3);
+  auto it = db->getIterator(cf);
+  it.seekAtMost(key2);
+  ASSERT_TRUE(it);
+  ASSERT_EQ(it.key(), key1);
+  ASSERT_EQ(it.value(), value1);
+}
+
+TEST_F(native_rocksdb_test, iterator_seek_success_after_unsuccessful_seeks) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+  db->put(key2, value);
+  db->put(cf, key2, value);
+
+  {
+    auto it = db->getIterator();
+    it.seekAtLeast(key3);
+    ASSERT_FALSE(it);
+
+    it.seekAtMost(key1);
+    ASSERT_FALSE(it);
+
+    it.seekAtLeast(key2);
+    ASSERT_TRUE(it);
+  }
+
+  {
+    auto it = db->getIterator(cf);
+    it.seekAtLeast(key3);
+    ASSERT_FALSE(it);
+
+    it.seekAtMost(key1);
+    ASSERT_FALSE(it);
+
+    it.seekAtLeast(key2);
+    ASSERT_TRUE(it);
+  }
+}
+
+TEST_F(native_rocksdb_test, iterator_key_value_prev_next_throw_when_invalid) {
+  const auto cf = "cf"s;
+  db->createColumnFamily(cf);
+
+  {
+    auto it = db->getIterator();
+    ASSERT_FALSE(it);
+    ASSERT_THROW(it.key(), RocksDBException);
+    ASSERT_THROW(it.value(), RocksDBException);
+    ASSERT_THROW(it.keyView(), RocksDBException);
+    ASSERT_THROW(it.valueView(), RocksDBException);
+    ASSERT_THROW(it.prev(), RocksDBException);
+    ASSERT_THROW(it.next(), RocksDBException);
+  }
+
+  {
+    auto it = db->getIterator(cf);
+    ASSERT_FALSE(it);
+    ASSERT_THROW(it.key(), RocksDBException);
+    ASSERT_THROW(it.value(), RocksDBException);
+    ASSERT_THROW(it.keyView(), RocksDBException);
+    ASSERT_THROW(it.valueView(), RocksDBException);
+    ASSERT_THROW(it.prev(), RocksDBException);
+    ASSERT_THROW(it.next(), RocksDBException);
+  }
+}
+
+TEST_F(native_rocksdb_test, get_iterators) {
+  const auto cf1 = "cf1"s;
+  const auto cf2 = "cf2"s;
+  db->createColumnFamily(cf1);
+  db->createColumnFamily(cf2);
+  db->put(cf1, key1, value1);
+  db->put(cf2, key2, value2);
+
+  auto iters = db->getIterators({cf1, cf2});
+
+  iters[0].seekAtLeast(key1);
+  ASSERT_TRUE(iters[0]);
+  ASSERT_EQ(iters[0].key(), key1);
+  ASSERT_EQ(iters[0].value(), value1);
+
+  iters[1].seekAtLeast(key2);
+  ASSERT_TRUE(iters[1]);
+  ASSERT_EQ(iters[1].key(), key2);
+  ASSERT_EQ(iters[1].value(), value2);
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  ::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/util/include/sliver.hpp
+++ b/util/include/sliver.hpp
@@ -50,6 +50,7 @@ class Sliver {
 
   bool empty() const;
   size_t length() const;
+  size_t size() const;
   const char* data() const;
   std::string_view string_view() const;
 

--- a/util/src/sliver.cpp
+++ b/util/src/sliver.cpp
@@ -114,6 +114,8 @@ bool Sliver::empty() const { return (length_ == 0); }
 
 size_t Sliver::length() const { return length_; }
 
+size_t Sliver::size() const { return length(); }
+
 std::string_view Sliver::string_view() const { return std::string_view(data(), length_); }
 
 std::ostream& Sliver::operator<<(std::ostream& s) const { return hexPrint(s, data(), length()); }


### PR DESCRIPTION
Wrap the RocksDB client library for:
 * improved memory management - use value semantics instead of raw
   pointers
 * improved error reporting - done via exceptions instead of status
   codes
 * introduce support for column families

Support the following RocksDB features:
 * single-key put/get/del interfaces
 * write batches
 * column families
 * iterators

More features can be added in the future, based on demand.

No dependency on Sliver is required. Instead, use templates that support
any container or span via the data() and size() method pair.

Interoperability with the existing IDBClient interface is perserved via
the asIDBClient() method.

Add a size() method to Sliver so that it behaves like a contiguous
memory container, i.e. having data() and size() members (similar to
std::vector, std::string, etc.).

Move storage_test_common.h from kvbc to storage for reuse. Provide unit
tests for the newly-introduced wrappers.