### PR TITLE
Re-enable rapidcheck property tests

### DIFF
--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -44,31 +44,29 @@ target_link_libraries(sparse_merkle_storage_serialization_unit_test PUBLIC
     kvbc
 )
 
-if(RAPIDCHECK_FOUND)
+if(rapidcheck_FOUND)
 add_executable(sparse_merkle_storage_db_adapter_property_test
     sparse_merkle_storage/db_adapter_property_test.cpp )
 add_test(sparse_merkle_storage_db_adapter_property_test sparse_merkle_storage_db_adapter_property_test)
 # Decrease both the input size and test count from the default value of 100 to 50 in order to speed up this test.
 set_property(TEST sparse_merkle_storage_db_adapter_property_test PROPERTY ENVIRONMENT RC_PARAMS=max_size=50\ max_success=50)
-target_include_directories(sparse_merkle_storage_db_adapter_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
 target_link_libraries(sparse_merkle_storage_db_adapter_property_test PUBLIC
     GTest::Main
     GTest::GTest
-    ${RAPIDCHECK_LIBRARIES}
-        util
-        corebft
-        kvbc
-        stdc++fs
-    )
+    rapidcheck
+    util
+    corebft
+    kvbc
+    stdc++fs
+)
 
 add_executable(sparse_merkle_internal_node_property_test sparse_merkle/internal_node_property_tests.cpp
 )
 add_test(sparse_merkle_internal_node_property_test sparse_merkle_internal_node_property_test)
-target_include_directories(sparse_merkle_internal_node_property_test PRIVATE ${RAPIDCHECK_INCLUDE_DIRS})
 target_link_libraries(sparse_merkle_internal_node_property_test PUBLIC
     GTest::Main
     GTest::GTest
-    ${RAPIDCHECK_LIBRARIES}
+    rapidcheck
     util
     kvbc
     OpenSSL::Crypto

--- a/kvbc/test/sparse_merkle/internal_node_property_tests.cpp
+++ b/kvbc/test/sparse_merkle/internal_node_property_tests.cpp
@@ -13,8 +13,8 @@
 #include <algorithm>
 
 #include "gtest/gtest.h"
-#include "rapidcheck/rapidcheck.h"
-#include "rapidcheck/extras/gtest.h"
+#include <rapidcheck.h>
+#include <rapidcheck/gtest.h>
 
 #include "sparse_merkle/internal_node.h"
 #include "sliver.hpp"
@@ -70,12 +70,13 @@ rc::Gen<std::vector<Nibble>> genUniqueNibbles() {
 // Return a generator for the depth of a BatchedInternalNode in a tree
 rc::Gen<size_t> genDepth() { return rc::gen::inRange<size_t>(0ul, Hash::MAX_NIBBLES); }
 
-rc::Gen<std::vector<LeafChild>> genLeafChildrenWithSameVersion(rc::Gen<std::vector<LeafChild>> childGen) {
+rc::Gen<std::vector<LeafChild>> genLeafChildrenWithSameVersion(const rc::Gen<std::vector<LeafChild>>& childGen) {
   return rc::gen::apply(
-      [](Version version, std::vector<LeafChild> children) {
+      [](Version version, const std::vector<LeafChild>& children) {
         std::vector<LeafChild> output;
+        output.reserve(children.size());
         for (const auto& child : children) {
-          output.emplace_back(LeafChild(child.hash, LeafKey(child.key.hash(), version)));
+          output.push_back(LeafChild(child.hash, LeafKey(child.key.hash(), version)));
         }
         return output;
       },
@@ -101,7 +102,7 @@ rc::Gen<std::tuple<std::vector<Hash>, size_t>> genHashesWithUniqueNibblesAtGener
 }
 
 rc::Gen<std::tuple<std::vector<LeafChild>, size_t>> genKeysWithMatchingPrefixesUpToDepth(
-    rc::Gen<std::vector<LeafChild>> childGen) {
+    const rc::Gen<std::vector<LeafChild>>& childGen) {
   return rc::gen::apply(
       [](auto children, size_t depth) {
         for (auto& child : children) {

--- a/kvbc/test/sparse_merkle_storage/db_adapter_property_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_property_test.cpp
@@ -1,8 +1,8 @@
 // Copyright 2020 VMware, all rights reserved
 
 #include "gtest/gtest.h"
-#include "rapidcheck/rapidcheck.h"
-#include "rapidcheck/extras/gtest.h"
+#include <rapidcheck.h>
+#include <rapidcheck/gtest.h>
 
 #include "storage_test_common.h"
 
@@ -93,7 +93,10 @@ struct IDbAdapterTest {
 
 template <typename Database, bool multiVersionedKeys = false>
 struct DbAdapterTest : public IDbAdapterTest {
-  std::shared_ptr<IDBClient> db() const override { return Database::create(); }
+  std::shared_ptr<IDBClient> db() const override {
+    Database::cleanup();
+    return Database::create();
+  }
   std::string type() const override {
     return Database::type() + (enforceMultiVersionedKeys() ? "_enforcedMultiVerKey" : "_noMultiVerKeyEnforced");
   }


### PR DESCRIPTION
Fix the way we use CMake to find the rapidcheck library. Installing it
via `make install` is different than the previous Conan method and that
has led to the tests not compiling and not running.

Call Database::cleanup() explicitly in the db_adapter_property_test in
order to start with a fresh DB on every input.