### PR TITLE
Key-view file handling improvements (cherry pick from 0.8)

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3539,7 +3539,9 @@ void ReplicaImp::start() {
 
   // requires the init of state transfer
   std::shared_ptr<ISecureStore> sec(
-      new KeyManager::FileSecureStore(ReplicaConfig::instance().getkeyViewFilePath(), config_.getreplicaId()));
+      new KeyManager::FileSecureStore(ReplicaConfig::instance().getkeyViewFilePath(), config_.replicaId));
+  std::shared_ptr<ISecureStore> backupsec(
+      new KeyManager::FileSecureStore(ReplicaConfig::instance().getkeyViewFilePath(), config_.replicaId, "_backed"));
   KeyManager::InitData id{};
   id.cl = internalBFTClient_;
   id.id = config_.getreplicaId();
@@ -3549,6 +3551,7 @@ void ReplicaImp::start() {
   id.kg = &CryptoManager::instance();
   id.ke = &CryptoManager::instance();
   id.sec = sec;
+  id.backupSec = backupsec;
   id.timers = &timers_;
   id.a = aggregator_;
   id.interval = std::chrono::seconds(config_.getmetricsDumpIntervalSeconds());

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -663,7 +663,7 @@ TEST(ClusterKeyStore, clean_first_load_save_keys_rotate_and_reload) {
 }
 TEST(PrivateKeys, ser_der) {
   std::shared_ptr<ISecureStore> dls(new DummyLoaderSaver());
-  KeyManager::KeysView keys{dls, 4};
+  KeyManager::KeysView keys{dls, nullptr, 4};
   keys.data.generatedPrivateKey = "publish";
   keys.data.outstandingPrivateKey = "outstandingPrivateKey";
   keys.data.privateKey = "privateKey";
@@ -672,7 +672,7 @@ TEST(PrivateKeys, ser_der) {
   concord::serialize::Serializable::serialize(ss, keys.data);
   auto strMsg = ss.str();
 
-  KeyManager::KeysView keys2{dls, 4};
+  KeyManager::KeysView keys2{dls, nullptr, 4};
 
   ss.write(strMsg.c_str(), std::streamsize(strMsg.size()));
   concord::serialize::Serializable::deserialize(ss, keys2.data);
@@ -684,7 +684,7 @@ TEST(PrivateKeys, ser_der) {
 
 TEST(PrivateKeys, SaveLoad) {
   std::shared_ptr<ISecureStore> dls(new DummyLoaderSaver());
-  KeyManager::KeysView keys{dls, 4};
+  KeyManager::KeysView keys{dls, nullptr, 4};
   keys.data.generatedPrivateKey = "publish";
   keys.data.outstandingPrivateKey = "outstandingPrivateKey";
   keys.data.privateKey = "privateKey";


### PR DESCRIPTION
- writing to the key view file only when a real update occurs.

- store a backup 