### PR TITLE
Add atomics metrics

### DIFF
--- a/storage/include/rocksdb/native_client.h
+++ b/storage/include/rocksdb/native_client.h
@@ -406,7 +406,6 @@ void NativeClient::put(const std::string &cFamily, const KeySpan &key, const Val
   auto s =
       client_->dbInstance_->Put(::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), toSlice(key), toSlice(value));
   throwOnError("put() failed"sv, std::move(s));
-  client_->storage_metrics_.tryToUpdateMetrics();
 }
 
 template <typename KeySpan>
@@ -417,7 +416,6 @@ std::optional<std::string> NativeClient::get(const std::string &cFamily, const K
     return std::nullopt;
   }
   throwOnError("get() failed"sv, std::move(s));
-  client_->storage_metrics_.tryToUpdateMetrics();
   return value;
 }
 
@@ -425,7 +423,6 @@ template <typename KeySpan>
 void NativeClient::del(const std::string &cFamily, const KeySpan &key) {
   auto s = client_->dbInstance_->Delete(::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), toSlice(key));
   throwOnError("del() failed"sv, std::move(s));
-  client_->storage_metrics_.tryToUpdateMetrics();
 }
 
 template <typename KeySpan, typename ValueSpan>
@@ -478,7 +475,6 @@ inline std::vector<Iterator> NativeClient::getIterators(const std::vector<std::s
 inline void NativeClient::write(WriteBatch &&b) {
   auto s = client_->dbInstance_->Write(::rocksdb::WriteOptions{}, &b.batch_);
   throwOnError("write(batch) failed"sv, std::move(s));
-  client_->storage_metrics_.tryToUpdateMetrics();
 }
 
 inline std::unordered_set<std::string> NativeClient::columnFamilies(const std::string &path) {

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -29,6 +29,8 @@ class InMemoryStorageMetrics {
   concordMetrics::AtomicCounterHandle total_written_bytes_;
 
  private:
+  // update_metrics_ has to be the last declared member due to some synchronization issue. If you have to put something
+  // after it, then explicit release it on the destructor
   std::unique_ptr<concord::util::PeriodicCall> update_metrics_ = nullptr;
 
  public:
@@ -63,6 +65,8 @@ class RocksDbStorageMetrics {
 
   std::shared_ptr<::rocksdb::SstFileManager> sstFm;
   std::shared_ptr<::rocksdb::Statistics> statistics;
+  // update_metrics_ has to be the last declared member due to some synchronization issue. If you have to put something
+  // after it, then explicit release it on the destructor
   std::unique_ptr<concord::util::PeriodicCall> update_metrics_ = nullptr;
 
  public:
@@ -92,7 +96,6 @@ class RocksDbStorageMetrics {
                                ::rocksdb::Tickers::COMPACT_WRITE_BYTES,
                                ::rocksdb::Tickers::FLUSH_WRITE_BYTES,
                                ::rocksdb::Tickers::STALL_MICROS}) {}
-
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
     rocksdb_comp_.SetAggregator(aggregator);
   }

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -93,7 +93,7 @@ class RocksDbStorageMetrics {
                                ::rocksdb::Tickers::COMPACT_WRITE_BYTES,
                                ::rocksdb::Tickers::FLUSH_WRITE_BYTES,
                                ::rocksdb::Tickers::STALL_MICROS}) {}
-  ~RocksDbStorageMetrics() { update_metrics_.reset();}
+  ~RocksDbStorageMetrics() { update_metrics_.reset(); }
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
     rocksdb_comp_.SetAggregator(aggregator);
   }

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -39,9 +39,8 @@ class InMemoryStorageMetrics {
         keys_writes_(metrics_.RegisterAtomicCounter("storage_inmemory_total_written_keys")),
         total_written_bytes_(metrics_.RegisterAtomicCounter("storage_inmemory_total_written_bytes")) {
     metrics_.Register();
-    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([&]() { updateMetrics(); }, 1000);
+    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 1000);
   }
-  ~InMemoryStorageMetrics() { update_metrics_.release(); }
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) { metrics_.SetAggregator(aggregator); }
   void updateMetrics() { metrics_.UpdateAggregator(); }
 };
@@ -98,12 +97,11 @@ class RocksDbStorageMetrics {
     rocksdb_comp_.SetAggregator(aggregator);
   }
 
-  ~RocksDbStorageMetrics() { update_metrics_.release(); }
   void setMetricsDataSources(std::shared_ptr<::rocksdb::SstFileManager> sourceSstFm,
                              std::shared_ptr<::rocksdb::Statistics> sourceStatistics) {
     sstFm = sourceSstFm;
     statistics = sourceStatistics;
-    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([&]() { updateMetrics(); }, 1000);
+    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 1000);
   }
 
   void updateMetrics() {

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -21,14 +21,15 @@ namespace storage {
  * Recall that the in memory db is quite simple and therefor it has only few relevant metrics to collect.
  */
 class InMemoryStorageMetrics {
-  std::unique_ptr<concord::util::PeriodicCall> update_metrics_;
-
  public:
   concordMetrics::Component metrics_;
   concordMetrics::AtomicCounterHandle keys_reads_;
   concordMetrics::AtomicCounterHandle total_read_bytes_;
   concordMetrics::AtomicCounterHandle keys_writes_;
   concordMetrics::AtomicCounterHandle total_written_bytes_;
+
+ private:
+  std::unique_ptr<concord::util::PeriodicCall> update_metrics_ = nullptr;
 
  public:
   InMemoryStorageMetrics()
@@ -56,13 +57,13 @@ class InMemoryStorageMetrics {
  * operation) the overhead of that approach is negligible.
  */
 class RocksDbStorageMetrics {
-  std::unique_ptr<concord::util::PeriodicCall> update_metrics_;
   concordMetrics::Component rocksdb_comp_;
   std::unordered_map<::rocksdb::Tickers, concordMetrics::AtomicGaugeHandle> active_tickers_;
   concordMetrics::AtomicGaugeHandle total_db_disk_size_;
 
   std::shared_ptr<::rocksdb::SstFileManager> sstFm;
   std::shared_ptr<::rocksdb::Statistics> statistics;
+  std::unique_ptr<concord::util::PeriodicCall> update_metrics_ = nullptr;
 
  public:
   RocksDbStorageMetrics(const std::vector<::rocksdb::Tickers>& tickers)

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -41,6 +41,7 @@ class InMemoryStorageMetrics {
     metrics_.Register();
     update_metrics_ = std::make_unique<concord::util::PeriodicCall>([&]() { updateMetrics(); }, 1000);
   }
+  ~InMemoryStorageMetrics() { update_metrics_.release(); }
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) { metrics_.SetAggregator(aggregator); }
   void updateMetrics() { metrics_.UpdateAggregator(); }
 };
@@ -97,6 +98,7 @@ class RocksDbStorageMetrics {
     rocksdb_comp_.SetAggregator(aggregator);
   }
 
+  ~RocksDbStorageMetrics() { update_metrics_.release(); }
   void setMetricsDataSources(std::shared_ptr<::rocksdb::SstFileManager> sourceSstFm,
                              std::shared_ptr<::rocksdb::Statistics> sourceStatistics) {
     sstFm = sourceSstFm;

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -26,17 +26,17 @@ class InMemoryStorageMetrics {
 
  public:
   concordMetrics::Component metrics_;
-  concordMetrics::CounterHandle keys_reads_;
-  concordMetrics::CounterHandle total_read_bytes_;
-  concordMetrics::CounterHandle keys_writes_;
-  concordMetrics::CounterHandle total_written_bytes_;
+  concordMetrics::AtomicCounterHandle keys_reads_;
+  concordMetrics::AtomicCounterHandle total_read_bytes_;
+  concordMetrics::AtomicCounterHandle keys_writes_;
+  concordMetrics::AtomicCounterHandle total_written_bytes_;
 
   InMemoryStorageMetrics()
       : metrics_("storage_inmemory", std::make_shared<concordMetrics::Aggregator>()),
-        keys_reads_(metrics_.RegisterCounter("storage_inmemory_total_read_keys")),
-        total_read_bytes_(metrics_.RegisterCounter("storage_inmemory_total_read_bytes")),
-        keys_writes_(metrics_.RegisterCounter("storage_inmemory_total_written_keys")),
-        total_written_bytes_(metrics_.RegisterCounter("storage_inmemory_total_written_bytes")) {
+        keys_reads_(metrics_.RegisterAtomicCounter("storage_inmemory_total_read_keys")),
+        total_read_bytes_(metrics_.RegisterAtomicCounter("storage_inmemory_total_read_bytes")),
+        keys_writes_(metrics_.RegisterAtomicCounter("storage_inmemory_total_written_keys")),
+        total_written_bytes_(metrics_.RegisterAtomicCounter("storage_inmemory_total_written_bytes")) {
     metrics_.Register();
   }
 
@@ -64,8 +64,8 @@ class InMemoryStorageMetrics {
  */
 class RocksDbStorageMetrics {
   concordMetrics::Component rocksdb_comp_;
-  std::unordered_map<::rocksdb::Tickers, concordMetrics::GaugeHandle> active_tickers_;
-  concordMetrics::GaugeHandle total_db_disk_size_;
+  std::unordered_map<::rocksdb::Tickers, concordMetrics::AtomicGaugeHandle> active_tickers_;
+  concordMetrics::AtomicGaugeHandle total_db_disk_size_;
 
   std::shared_ptr<::rocksdb::SstFileManager> sstFm;
   std::shared_ptr<::rocksdb::Statistics> statistics;
@@ -76,12 +76,12 @@ class RocksDbStorageMetrics {
  public:
   RocksDbStorageMetrics(const std::vector<::rocksdb::Tickers>& tickers)
       : rocksdb_comp_("storage_rocksdb", std::make_shared<concordMetrics::Aggregator>()),
-        total_db_disk_size_(rocksdb_comp_.RegisterGauge("storage_rocksdb_total_db_disk_size", 0)) {
+        total_db_disk_size_(rocksdb_comp_.RegisterAtomicGauge("storage_rocksdb_total_db_disk_size", 0)) {
     for (const auto& pair : ::rocksdb::TickersNameMap) {
       if (std::find(tickers.begin(), tickers.end(), pair.first) != tickers.end()) {
         auto metric_suffix = pair.second;
         std::replace(metric_suffix.begin(), metric_suffix.end(), '.', '_');
-        active_tickers_.emplace(pair.first, rocksdb_comp_.RegisterGauge("storage_" + metric_suffix, 0));
+        active_tickers_.emplace(pair.first, rocksdb_comp_.RegisterAtomicGauge("storage_" + metric_suffix, 0));
       }
     }
     rocksdb_comp_.Register();

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -39,7 +39,7 @@ class InMemoryStorageMetrics {
         keys_writes_(metrics_.RegisterAtomicCounter("storage_inmemory_total_written_keys")),
         total_written_bytes_(metrics_.RegisterAtomicCounter("storage_inmemory_total_written_bytes")) {
     metrics_.Register();
-    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 1000);
+    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 100);
   }
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) { metrics_.SetAggregator(aggregator); }
   void updateMetrics() { metrics_.UpdateAggregator(); }
@@ -101,7 +101,7 @@ class RocksDbStorageMetrics {
                              std::shared_ptr<::rocksdb::Statistics> sourceStatistics) {
     sstFm = sourceSstFm;
     statistics = sourceStatistics;
-    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 1000);
+    update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 100);
   }
 
   void updateMetrics() {

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -29,8 +29,6 @@ class InMemoryStorageMetrics {
   concordMetrics::AtomicCounterHandle total_written_bytes_;
 
  private:
-  // update_metrics_ has to be the last declared member due to some synchronization issue. If you have to put something
-  // after it, then explicit release it on the destructor
   std::unique_ptr<concord::util::PeriodicCall> update_metrics_ = nullptr;
 
  public:
@@ -43,6 +41,7 @@ class InMemoryStorageMetrics {
     metrics_.Register();
     update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 100);
   }
+  ~InMemoryStorageMetrics() { update_metrics_.release(); }
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) { metrics_.SetAggregator(aggregator); }
   void updateMetrics() { metrics_.UpdateAggregator(); }
 };
@@ -65,8 +64,6 @@ class RocksDbStorageMetrics {
 
   std::shared_ptr<::rocksdb::SstFileManager> sstFm;
   std::shared_ptr<::rocksdb::Statistics> statistics;
-  // update_metrics_ has to be the last declared member due to some synchronization issue. If you have to put something
-  // after it, then explicit release it on the destructor
   std::unique_ptr<concord::util::PeriodicCall> update_metrics_ = nullptr;
 
  public:
@@ -96,6 +93,7 @@ class RocksDbStorageMetrics {
                                ::rocksdb::Tickers::COMPACT_WRITE_BYTES,
                                ::rocksdb::Tickers::FLUSH_WRITE_BYTES,
                                ::rocksdb::Tickers::STALL_MICROS}) {}
+  ~RocksDbStorageMetrics() { update_metrics_.release(); }
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
     rocksdb_comp_.SetAggregator(aggregator);
   }

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -136,6 +136,7 @@ class RocksDbStorageMetrics : public StorageMetrics {
   }
 
   void updateMetrics() override {
+    if (!sstFm || !statistics) return;
     for (auto& pair : active_tickers_) {
       pair.second.Get().Set(statistics->getTickerCount(pair.first));
     }

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -24,21 +24,18 @@ class StorageMetricsUpdator {
   StorageMetrics& storage_metrics_;
   std::thread t;
   std::chrono::milliseconds metrics_update_interval_ = std::chrono::milliseconds(100);  // TODO: read from configuration
-  std::atomic_bool active = true;
+  std::atomic_bool active = false;
 
  public:
   StorageMetricsUpdator(StorageMetrics& storage_metrics) : storage_metrics_(storage_metrics) {}
 
-  ~StorageMetricsUpdator() {
-    active = false;
-    t.join();
-  }
-
   void close() {
+    if (!active) return;
     active = false;
     t.join();
   }
   void start() {
+    active = true;
     t = std::thread([&] {
       while (active) {
         storage_metrics_.updateMetrics();

--- a/storage/include/storage/storage_metrics.h
+++ b/storage/include/storage/storage_metrics.h
@@ -41,7 +41,7 @@ class InMemoryStorageMetrics {
     metrics_.Register();
     update_metrics_ = std::make_unique<concord::util::PeriodicCall>([this]() { updateMetrics(); }, 100);
   }
-  ~InMemoryStorageMetrics() { update_metrics_.release(); }
+  ~InMemoryStorageMetrics() { update_metrics_.reset(); }
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) { metrics_.SetAggregator(aggregator); }
   void updateMetrics() { metrics_.UpdateAggregator(); }
 };
@@ -93,7 +93,7 @@ class RocksDbStorageMetrics {
                                ::rocksdb::Tickers::COMPACT_WRITE_BYTES,
                                ::rocksdb::Tickers::FLUSH_WRITE_BYTES,
                                ::rocksdb::Tickers::STALL_MICROS}) {}
-  ~RocksDbStorageMetrics() { update_metrics_.release(); }
+  ~RocksDbStorageMetrics() { update_metrics_.reset();}
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
     rocksdb_comp_.SetAggregator(aggregator);
   }

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -43,7 +43,6 @@ Status Client::get(const Sliver &_key, OUT Sliver &_outValue) const {
   }
   storage_metrics_.keys_reads_.Get().Inc();
   storage_metrics_.total_read_bytes_.Get().Inc(_outValue.length());
-  storage_metrics_.tryToUpdateMetrics();
   return Status::OK();
 }
 
@@ -104,7 +103,6 @@ Status Client::put(const Sliver &_key, const Sliver &_value) {
   map_.insert_or_assign(_key, _value.clone());
   storage_metrics_.keys_writes_.Get().Inc();
   storage_metrics_.total_written_bytes_.Get().Inc(_key.length() + _value.length());
-  storage_metrics_.tryToUpdateMetrics();
   return Status::OK();
 }
 

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -206,7 +206,6 @@ Status Client::get(const Sliver &_key, OUT std::string &_value) const {
     LOG_DEBUG(logger(), "Failed to get key " << _key << " due to " << s.ToString());
     return Status::GeneralError("Failed to read key");
   }
-  storage_metrics_.tryToUpdateMetrics();
   return Status::OK();
 }
 
@@ -325,7 +324,6 @@ Status Client::put(const Sliver &_key, const Sliver &_value) {
     LOG_ERROR(logger(), "Failed to put key " << _key << ", value " << _value);
     return Status::GeneralError("Failed to put key");
   }
-  storage_metrics_.tryToUpdateMetrics();
   return Status::OK();
 }
 
@@ -348,7 +346,6 @@ Status Client::del(const Sliver &_key) {
     LOG_ERROR(logger(), "Failed to delete key " << _key);
     return Status::GeneralError("Failed to delete key");
   }
-  storage_metrics_.tryToUpdateMetrics();
   return Status::OK();
 }
 
@@ -367,7 +364,6 @@ Status Client::multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec
     }
     _valuesVec.push_back(Sliver(std::move(values[i])));
   }
-  storage_metrics_.tryToUpdateMetrics();
   return Status::OK();
 }
 
@@ -396,7 +392,6 @@ Status Client::multiPut(const SetOfKeyValuePairs &keyValueMap) {
   }
   Status status = launchBatchJob(batch);
   if (status.isOK()) LOG_DEBUG(logger(), "Successfully put all entries to the database");
-  storage_metrics_.tryToUpdateMetrics();
   return status;
 }
 
@@ -408,7 +403,6 @@ Status Client::multiDel(const KeysVector &_keysVec) {
   }
   Status status = launchBatchJob(batch);
   if (status.isOK()) LOG_DEBUG(logger(), "Successfully deleted entries");
-  storage_metrics_.tryToUpdateMetrics();
   return status;
 }
 
@@ -427,7 +421,6 @@ Status Client::rangeDel(const Sliver &_beginKey, const Sliver &_endKey) {
     return Status::GeneralError("Failed to delete range");
   }
   LOG_TRACE(logger(), "RocksDB successful range delete, begin=" << _beginKey << ", end=" << _endKey);
-  storage_metrics_.tryToUpdateMetrics();
   return Status::OK();
 }
 

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <stdint.h>
 #include <map>
 #include <vector>
@@ -30,6 +31,8 @@ class Values;
 class Gauge;
 class Status;
 class Counter;
+class AtomicCounter;
+class AtomicGauge;
 typedef struct metric_ Metric;
 
 // An aggregator maintains metrics for multiple components. Components
@@ -104,6 +107,40 @@ class Counter {
   uint64_t val_;
 };
 
+class AtomicCounter {
+ public:
+  explicit AtomicCounter(const uint64_t val) : val_(val) {}
+  AtomicCounter(const AtomicCounter& counter) { val_.store((unsigned long)counter.val_); }
+  AtomicCounter& operator=(const AtomicCounter& counter) {
+    val_.store((unsigned long)counter.val_);
+    return *this;
+  }
+  // Increment the counter and return the value after incrementing.
+  uint64_t Inc(uint64_t val = 1) { return val_ += val; }
+  uint64_t Get() { return (unsigned long)val_; }
+
+ private:
+  std::atomic_uint64_t val_;
+};
+
+class AtomicGauge {
+ public:
+  explicit AtomicGauge(const uint64_t val) : val_(val) {}
+  AtomicGauge(const AtomicGauge& gauge) { val_.store((unsigned long)gauge.val_); }
+  AtomicGauge& operator=(const AtomicGauge& gauge) {
+    val_.store((unsigned long)gauge.val_);
+    return *this;
+  }
+  // Increment the counter and return the value after incrementing.
+  void Inc() { ++val_; }
+  void Dec() { --val_; }
+  void Set(const uint64_t val) { val_ = val; }
+  uint64_t Get() { return (unsigned long)val_; }
+
+ private:
+  std::atomic_uint64_t val_;
+};
+
 // A generic struct that may represent a counter or a gauge
 // the motivation is to eliminate that need to know the exact
 // metric name before getting it from the aggregator
@@ -118,6 +155,8 @@ class Values {
   std::vector<Gauge> gauges_;
   std::vector<Status> statuses_;
   std::vector<Counter> counters_;
+  std::vector<AtomicCounter> atomic_counters_;
+  std::vector<AtomicGauge> atomic_gauges_;
 
   friend class Component;
   friend class Aggregator;
@@ -132,6 +171,8 @@ class Names {
   std::vector<std::string> gauge_names_;
   std::vector<std::string> status_names_;
   std::vector<std::string> counter_names_;
+  std::vector<std::string> atomic_counter_names_;
+  std::vector<std::string> atomic_gauge_names_;
 
   friend class Component;
   friend class Aggregator;
@@ -171,6 +212,10 @@ class Component {
   Handle<Status> RegisterStatus(const std::string& name, const std::string& val);
   Handle<Counter> RegisterCounter(const std::string& name, const uint64_t val);
   Handle<Counter> RegisterCounter(const std::string& name) { return RegisterCounter(name, 0); }
+  Handle<AtomicCounter> RegisterAtomicCounter(const std::string& name, const uint64_t val);
+  Handle<AtomicCounter> RegisterAtomicCounter(const std::string& name) { return RegisterAtomicCounter(name, 0); }
+  Handle<AtomicGauge> RegisterAtomicGauge(const std::string& name, const uint64_t val);
+
   std::list<Metric> CollectGauges();
   std::list<Metric> CollectCounters();
   std::list<Metric> CollectStatuses();
@@ -219,5 +264,7 @@ class Component {
 typedef concordMetrics::Component::Handle<concordMetrics::Gauge> GaugeHandle;
 typedef concordMetrics::Component::Handle<concordMetrics::Status> StatusHandle;
 typedef concordMetrics::Component::Handle<concordMetrics::Counter> CounterHandle;
+typedef concordMetrics::Component::Handle<concordMetrics::AtomicCounter> AtomicCounterHandle;
+typedef concordMetrics::Component::Handle<concordMetrics::AtomicGauge> AtomicGaugeHandle;
 
 }  // namespace concordMetrics

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -95,9 +95,9 @@ template <class T>
 class BasicCounter {
  public:
   explicit BasicCounter(const uint64_t val) : val_(val) {}
-  BasicCounter(const BasicCounter& counter) { val_ = (unsigned long)counter.val_; }
+  BasicCounter(const BasicCounter& counter) { val_ = (uint64_t)counter.val_; }
   BasicCounter& operator=(const BasicCounter& counter) {
-    val_ = (unsigned long)counter.val_;
+    val_ = (uint64_t)counter.val_;
     return *this;
   }
   uint64_t Inc(uint64_t val = 1) {

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -25,14 +25,14 @@
 
 namespace concordMetrics {
 template <class T>
-class basic_gauge;
+class BasicGauge;
 template <class T>
-class basic_counter;
+class BasicCounter;
 
-using Gauge = basic_gauge<uint64_t>;
-using Counter = basic_counter<uint64_t>;
-using AtomicGauge = basic_gauge<std::atomic_uint64_t>;
-using AtomicCounter = basic_counter<std::atomic_uint64_t>;
+using Gauge = BasicGauge<uint64_t>;
+using Counter = BasicCounter<uint64_t>;
+using AtomicGauge = BasicGauge<std::atomic_uint64_t>;
+using AtomicCounter = BasicCounter<std::atomic_uint64_t>;
 
 // Forward declarations since Aggregator requires these types.
 class Component;
@@ -74,11 +74,11 @@ class Aggregator {
 // A Gauge is a an integer value that shows the current value of something. It
 // can only be varied by directly setting and getting it.
 template <class T>
-class basic_gauge {
+class BasicGauge {
  public:
-  explicit basic_gauge(const uint64_t val) : val_(val) {}
-  basic_gauge(const basic_gauge& gauge) { val_ = (unsigned long)gauge.val_; }
-  basic_gauge& operator=(const basic_gauge& gauge) {
+  explicit BasicGauge(const uint64_t val) : val_(val) {}
+  BasicGauge(const BasicGauge& gauge) { val_ = (unsigned long)gauge.val_; }
+  BasicGauge& operator=(const BasicGauge& gauge) {
     val_ = (unsigned long)gauge.val_;
     return *this;
   }
@@ -92,11 +92,11 @@ class basic_gauge {
 };
 
 template <class T>
-class basic_counter {
+class BasicCounter {
  public:
-  explicit basic_counter(const uint64_t val) : val_(val) {}
-  basic_counter(const basic_counter& counter) { val_ = (unsigned long)counter.val_; }
-  basic_counter& operator=(const basic_counter& counter) {
+  explicit BasicCounter(const uint64_t val) : val_(val) {}
+  BasicCounter(const BasicCounter& counter) { val_ = (unsigned long)counter.val_; }
+  BasicCounter& operator=(const BasicCounter& counter) {
     val_ = (unsigned long)counter.val_;
     return *this;
   }

--- a/util/include/periodic_call.hpp
+++ b/util/include/periodic_call.hpp
@@ -28,8 +28,9 @@ class PeriodicCall {
       : intervalMilli_(intervalMilli), active_(true), fun_(fun) {
     t_ = std::thread([this] {
       while (active_) {
-        fun_();
         std::this_thread::sleep_for(std::chrono::milliseconds(intervalMilli_));
+        if (!active_) break;
+        fun_();
       }
     });
   }

--- a/util/include/periodic_call.hpp
+++ b/util/include/periodic_call.hpp
@@ -21,15 +21,15 @@ class PeriodicCall {
   std::thread t_;
   uint32_t intervalMilli_;
   std::atomic_bool active_ = false;
+  std::function<void()> fun_;
 
  public:
-  PeriodicCall(std::function<void()> fun, uint32_t intervalMilli = 100) {
-    intervalMilli_ = intervalMilli;
-    active_ = true;
-    t_ = std::thread([&] {
+  PeriodicCall(const std::function<void()>& fun, uint32_t intervalMilli = 100)
+      : intervalMilli_(intervalMilli), active_(true), fun_(fun) {
+    t_ = std::thread([this] {
       while (active_) {
+        fun_();
         std::this_thread::sleep_for(std::chrono::milliseconds(intervalMilli_));
-        fun();
       }
     });
   }

--- a/util/include/periodic_call.hpp
+++ b/util/include/periodic_call.hpp
@@ -1,0 +1,41 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license,
+// as noted in the LICENSE file.
+
+#pragma once
+
+#include <thread>
+#include <chrono>
+#include <functional>
+#include <atomic>
+namespace concord::util {
+class PeriodicCall {
+  std::thread t_;
+  uint32_t intervalMilli_;
+  std::atomic_bool active_ = false;
+
+ public:
+  PeriodicCall(std::function<void()> fun, uint32_t intervalMilli = 100) {
+    intervalMilli_ = intervalMilli;
+    active_ = true;
+    t_ = std::thread([&] {
+      while (active_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(intervalMilli_));
+        fun();
+      }
+    });
+  }
+  ~PeriodicCall() {
+    active_ = false;
+    t_.join();
+  }
+};
+}  // namespace concord::util


### PR DESCRIPTION
In this PR we add new sub metrics types:
* AtomicCounter
* AtomicGauge

These kinds of metrics are thread-safe even when multiple threads are updating the same component.
In addition, a higher level (such as concord) will see them as ordinary counters and gauges. 

Lastly, we changed the storage metrics to be atomic as they accessed from multiple threads (pre-execution and ordinary execution)