### PR TITLE
Cache lastReachable/latest/genesis block IDs

### DIFF
--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -50,6 +50,7 @@ namespace concord::kvbc::v2MerkleTree {
 class DBAdapter : public IDbAdapter {
  public:
   using NonProvableKeySet = std::unordered_set<Key>;
+
   // Unless explicitly turned off, the constructor will try to link the blockchain with any blocks in the temporary
   // state transfer chain. This is done so that the DBAdapter will operate correctly in case a crash or an abnormal
   // shutdown has occurred prior to startup (construction). Only a single DBAdapter instance should operate on a
@@ -192,7 +193,16 @@ class DBAdapter : public IDbAdapter {
   std::optional<std::pair<Key, Value>> getLeafKeyValAtMostVersion(const Key &key,
                                                                   const sparse_merkle::Version &version) const;
 
+  void deleteGenesisBlock();
+
   void deleteKeysForBlock(const KeysVector &keys, BlockId blockId) const;
+
+  BlockId loadGenesisBlockId() const;
+
+  BlockId loadLastReachableBlockId() const;
+
+  // Return std::nullopt if no temporary ST blocks are present.
+  std::optional<BlockId> loadLatestTempSTBlockId() const;
 
   class Reader : public sparse_merkle::IDBReader {
    public:
@@ -212,6 +222,10 @@ class DBAdapter : public IDbAdapter {
 
   logging::Logger logger_;
   std::shared_ptr<storage::IDBClient> db_;
+  BlockId genesisBlockId_{0};
+  BlockId lastReachableBlockId_{0};
+  // The latest ST temporary block ID. Not set if no ST temporary blocks are present in the system.
+  std::optional<BlockId> latestSTTempBlockId_;
   sparse_merkle::Tree smTree_;
   std::unique_ptr<concordMetrics::ISummary> commitSizeSummary_;
   const NonProvableKeySet nonProvableKeySet_;

--- a/kvbc/include/sparse_merkle/histograms.h
+++ b/kvbc/include/sparse_merkle/histograms.h
@@ -49,9 +49,6 @@ struct Recorders {
 
                                       {"dba_batch_to_db_updates", dba_batch_to_db_updates},
                                       {"dba_get_value", dba_get_value},
-                                      {"dba_get_genesis_block_id", dba_get_genesis_block_id},
-                                      {"dba_get_last_reachable_block_id", dba_get_last_reachable_block_id},
-                                      {"dba_get_latest_block_id", dba_get_latest_block_id},
                                       {"dba_create_block_node", dba_create_block_node},
                                       {"dba_get_raw_block", dba_get_raw_block},
                                       {"dba_last_reachable_block_db_updates", dba_last_reachable_block_db_updates},
@@ -98,10 +95,6 @@ struct Recorders {
   // Used in merkle_tree_db_adapter.cpp
   std::shared_ptr<Recorder> dba_batch_to_db_updates = std::make_shared<Recorder>(1, MAX_NS * 5, 3, Unit::NANOSECONDS);
   std::shared_ptr<Recorder> dba_get_value = std::make_shared<Recorder>(1, MAX_NS * 5, 3, Unit::NANOSECONDS);
-  std::shared_ptr<Recorder> dba_get_genesis_block_id = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
-  std::shared_ptr<Recorder> dba_get_last_reachable_block_id =
-      std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
-  std::shared_ptr<Recorder> dba_get_latest_block_id = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
   std::shared_ptr<Recorder> dba_create_block_node = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
   std::shared_ptr<Recorder> dba_get_raw_block = std::make_shared<Recorder>(1, MAX_NS, 3, Unit::NANOSECONDS);
   std::shared_ptr<Recorder> dba_last_reachable_block_db_updates =


### PR DESCRIPTION
Analisys by @andrewjstone has shown that RocksDB iterator seeks for
lastReachable/latest/genesis block IDs are expensive. Therefore, since
there is an option to cache them in memory, provide that in this PR.

Remove the related histograms as these methods should be called very
rarely given caching.

Change existing unit tests and add ones in order to verify caching
doesn't change behavior.

In addition, since support for non-provable keys is still not ready,
remove the seek for non-provable keys in getRawBlock() and the
corresponding unit test. Future commits will provide full support for
non-provable keys. Until then, non-provable functionality will not work.