### PR TITLE
Improve concord logs

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2831,12 +2831,18 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
       }
     }
 
-    if (msg->getPrePrepareIsMissing()) {
-      PrePrepareMsg *pp = seqNumInfo.getSelfPrePrepareMsg();
-      if (pp != nullptr) {
-        LOG_DEBUG(GL, "sending PrePrepare message as a response of RFMD" << KVLOG(msgSender, msgSeqNum));
-        sendAndIncrementMetric(pp, msgSender, metric_sent_preprepare_msg_due_to_reqMissingData_);
+    if (msg->getFullCommitIsMissing()) {
+      CommitFullMsg *c = seqNumInfo.getValidCommitFullMsg();
+      if (c != nullptr) {
+        LOG_DEBUG(GL, "sending FullCommit message as a response of RFMD" << KVLOG(msgSender, msgSeqNum));
+        sendAndIncrementMetric(c, msgSender, metric_sent_commitFull_msg_due_to_reqMissingData_);
       }
+    }
+
+    if (msg->getFullCommitProofIsMissing() && seqNumInfo.partialProofs().hasFullProof()) {
+      FullCommitProofMsg *fcp = seqNumInfo.partialProofs().getFullProof();
+      LOG_DEBUG(GL, "sending FullCommitProof message as a response of RFMD" << KVLOG(msgSender, msgSeqNum));
+      sendAndIncrementMetric(fcp, msgSender, metric_sent_fullCommitProof_msg_due_to_reqMissingData_);
     }
 
     if (msg->getPartialProofIsMissing()) {
@@ -2873,20 +2879,6 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
         LOG_DEBUG(GL, "sending PartialCommit message as a response of RFMD" << KVLOG(msgSender, msgSeqNum));
         sendAndIncrementMetric(c, msgSender, metric_sent_commitPartial_msg_due_to_reqMissingData_);
       }
-    }
-
-    if (msg->getFullCommitIsMissing()) {
-      CommitFullMsg *c = seqNumInfo.getValidCommitFullMsg();
-      if (c != nullptr) {
-        LOG_DEBUG(GL, "sending FullCommit message as a response of RFMD" << KVLOG(msgSender, msgSeqNum));
-        sendAndIncrementMetric(c, msgSender, metric_sent_commitFull_msg_due_to_reqMissingData_);
-      }
-    }
-
-    if (msg->getFullCommitProofIsMissing() && seqNumInfo.partialProofs().hasFullProof()) {
-      FullCommitProofMsg *fcp = seqNumInfo.partialProofs().getFullProof();
-      LOG_DEBUG(GL, "sending FullCommitProof message as a response of RFMD" << KVLOG(msgSender, msgSeqNum));
-      sendAndIncrementMetric(fcp, msgSender, metric_sent_fullCommitProof_msg_due_to_reqMissingData_);
     }
   } else {
     LOG_INFO(GL,

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
@@ -14,6 +14,10 @@
 #include "MessageBase.hpp"
 #include "OpenTracing.hpp"
 
+#include <iostream>
+#include <sstream>
+#include <bitset>
+
 namespace bftEngine {
 namespace impl {
 
@@ -41,17 +45,9 @@ class ReqMissingDataMsg : public MessageBase {
 
   uint16_t getFlags() const { return b()->flags.flags; }
   std::string getFlagsAsBits() const {
-    std::string ret;
-    b()->flags.bits.slowPathHasStarted ? ret += "1" : ret += "0";
-    b()->flags.bits.fullCommitIsMissing ? ret += "1" : ret += "0";
-    b()->flags.bits.fullPrepareIsMissing ? ret += "1" : ret += "0";
-    b()->flags.bits.fullCommitProofIsMissing ? ret += "1" : ret += "0";
-    b()->flags.bits.partialCommitIsMissing ? ret += "1" : ret += "0";
-    b()->flags.bits.partialPrepareIsMissing ? ret += "1" : ret += "0";
-    b()->flags.bits.partialProofIsMissing ? ret += "1" : ret += "0";
-    b()->flags.bits.prePrepareIsMissing ? ret += "1" : ret += "0";
-    b()->flags.bits.reserved ? ret += "1" : ret += "0";
-    return ret;
+    std::stringstream sst;
+    sst << std::bitset<9>(b()->flags.flags);
+    return sst.str();
   };
 
   void resetFlags();

--- a/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReqMissingDataMsg.hpp
@@ -40,6 +40,19 @@ class ReqMissingDataMsg : public MessageBase {
   bool getSlowPathHasStarted() const { return b()->flags.bits.slowPathHasStarted != 0; }
 
   uint16_t getFlags() const { return b()->flags.flags; }
+  std::string getFlagsAsBits() const {
+    std::string ret;
+    b()->flags.bits.slowPathHasStarted ? ret += "1" : ret += "0";
+    b()->flags.bits.fullCommitIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.fullPrepareIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.fullCommitProofIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.partialCommitIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.partialPrepareIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.partialProofIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.prePrepareIsMissing ? ret += "1" : ret += "0";
+    b()->flags.bits.reserved ? ret += "1" : ret += "0";
+    return ret;
+  };
 
   void resetFlags();
 


### PR DESCRIPTION
In this PR we present some log improvements as well as changing the order of answering to RFMD.

The benefit from changing the order is that the requester replica has a higher probability to handle first the PrePrepare and commit messages and thus to avoid handling unnecessary messages.