### PR TITLE
Define the update interface for key categorization

### DIFF
--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -1,0 +1,74 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "kv_types.hpp"
+#include "sparse_merkle/base_types.h"
+
+#include <optional>
+#include <set>
+#include <unordered_map>
+#include <variant>
+
+namespace concord::kvbc::categorization::detail {
+
+struct MerkleUpdateInfo {
+  struct KeyFlags {
+    bool deleted{false};
+  };
+
+  std::unordered_map<Key, KeyFlags> keys;
+  std::array<std::uint8_t, 32> hash;
+  sparse_merkle::Version version;
+  std::string category_id;
+
+  template <typename T>
+  bool operator<(const T &other) const {
+    return category_id < other.category_id;
+  }
+};
+
+struct KeyValueUpdateInfo {
+  struct KeyFlags {
+    bool deleted{false};
+
+    // Applicable to non-deleted keys only.
+    bool stale_on_update{false};
+  };
+
+  std::unordered_map<Key, KeyFlags> keys;
+  std::optional<std::array<std::uint8_t, 32>> hash;
+  std::string category_id;
+
+  template <typename T>
+  bool operator<(const T &other) const {
+    return category_id < other.category_id;
+  }
+};
+
+struct CategorizedKeyValueUpdateInfo {
+  std::set<Key> keys;
+  std::optional<std::array<std::uint8_t, 32>> hash;
+  std::string category_id;
+
+  template <typename T>
+  bool operator<(const T &other) const {
+    return category_id < other.category_id;
+  }
+};
+
+// Represents updates returned by categories and consumbed by the blockchain (for use in blocks).
+using CategoryUpdateInfos = std::set<std::variant<MerkleUpdateInfo, KeyValueUpdateInfo, CategorizedKeyValueUpdateInfo>>;
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -23,7 +23,7 @@
 
 namespace concord::kvbc::categorization::detail {
 
-struct MerkleUpdateInfo {
+struct MerkleUpdatesInfo {
   struct KeyFlags {
     bool deleted{false};
   };
@@ -39,7 +39,7 @@ struct MerkleUpdateInfo {
   }
 };
 
-struct KeyValueUpdateInfo {
+struct KeyValueUpdatesInfo {
   struct KeyFlags {
     bool deleted{false};
 
@@ -57,7 +57,7 @@ struct KeyValueUpdateInfo {
   }
 };
 
-struct CategorizedKeyValueUpdateInfo {
+struct ShareddKeyValueUpdatesInfo {
   std::set<Key> keys;
   std::optional<std::array<std::uint8_t, 32>> hash;
   std::string category_id;
@@ -69,6 +69,6 @@ struct CategorizedKeyValueUpdateInfo {
 };
 
 // Represents updates returned by categories and consumbed by the blockchain (for use in blocks).
-using CategoryUpdateInfos = std::set<std::variant<MerkleUpdateInfo, KeyValueUpdateInfo, CategorizedKeyValueUpdateInfo>>;
+using CategoryUpdatesInfo = std::set<std::variant<MerkleUpdateInfos, KeyValueUpdateInfos, ShareddKeyValueUpdatesInfo>>;
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -1,0 +1,27 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "updates.h"
+
+#include "kv_types.hpp"
+
+namespace concord::kvbc::categorization {
+
+class KeyValueBlockchain {
+ public:
+  BlockId addBlock(const CategorizedUpdates&);
+};
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -30,7 +30,7 @@ namespace concord::kvbc::categorization {
 
 // Updates for multiple categories.
 // Persists key-values directly in the underlying key-value store. All key-values are marked stale during the update
-// itself. Explicit removals are not supported.
+// itself. Explicit deletes are not supported.
 struct CategorizedKeyValueUpdate {
   struct CategorizedValue {
     Value value;
@@ -59,24 +59,6 @@ struct CategorizedKeyValueUpdate {
   }
 };
 
-// Updates for a merkle tree category.
-// Persists key-values in a merkle tree that is constructed on top of the underlying key-value store.
-struct MerkleUpdate {
-  MerkleUpdate(const std::string &category_id) : category_id{category_id} { ConcordAssert(!category_id.empty()); }
-
-  OrderedSetOfKeyValuePairs updates;
-  OrderedKeysSet removals;
-
-  const std::string category_id;
-
-  bool operator<(const CategorizedKeyValueUpdate &) const { return false; }
-
-  template <typename T>
-  bool operator<(const T &other) const {
-    return category_id < other.category_id;
-  }
-};
-
 // Updates for a key-value category.
 // Persists key-values directly in the underlying key-value store.
 struct KeyValueUpdate {
@@ -94,12 +76,30 @@ struct KeyValueUpdate {
     bool stale_on_update{false};
   };
   std::map<Key, ValueData> updates;
-  OrderedKeysSet removals;
+  OrderedKeysSet deletes;
 
   const std::string category_id;
 
   // Controls whether a hash of the updated key-values is calculated for this update.
   bool calculate_hash{false};
+
+  bool operator<(const CategorizedKeyValueUpdate &) const { return false; }
+
+  template <typename T>
+  bool operator<(const T &other) const {
+    return category_id < other.category_id;
+  }
+};
+
+// Updates for a merkle tree category.
+// Persists key-values in a merkle tree that is constructed on top of the underlying key-value store.
+struct MerkleUpdate {
+  MerkleUpdate(const std::string &category_id) : category_id{category_id} { ConcordAssert(!category_id.empty()); }
+
+  OrderedSetOfKeyValuePairs updates;
+  OrderedKeysSet deletes;
+
+  const std::string category_id;
 
   bool operator<(const CategorizedKeyValueUpdate &) const { return false; }
 

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -1,0 +1,116 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "assertUtils.hpp"
+#include "kv_types.hpp"
+
+#include <ctime>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <variant>
+
+// Categorized key-value updates for KVBC blocks. Every category supports different properties and functionalities.
+// Note1: Empty category IDs are invalid and not supported.
+// Note2: Using the same category ID for different category types is an error.
+namespace concord::kvbc::categorization {
+
+// Updates for multiple categories.
+// Persists key-values directly in the underlying key-value store. All key-values are marked stale during the update
+// itself. Explicit removals are not supported.
+struct CategorizedKeyValueUpdate {
+  struct CategorizedValue {
+    Value value;
+
+    // Persist the key-value into this set of categories.
+    std::set<std::string> category_ids;
+  };
+  std::map<Key, CategorizedValue> updates;
+
+  // Controls whether a hash of the key-values is calculated per category for this update.
+  bool calculate_hash{true};
+
+  // All key-values are marked stale during the update itself. Cannot be turned off for this category.
+  static constexpr bool stale_on_update{true};
+
+  bool operator<(const CategorizedKeyValueUpdate &) const {
+    // Implies that a single categorized update per block is supported.
+    return false;
+  }
+
+  template <typename T>
+  bool operator<(const T &) const {
+    // Since empty category IDs are not supported, use the empty one to designate a categorized update. Implies that the
+    // categorized update is always `less` than other types and that a single categorized update per block is supported.
+    return true;
+  }
+};
+
+// Updates for a merkle tree category.
+// Persists key-values in a merkle tree that is constructed on top of the underlying key-value store.
+struct MerkleUpdate {
+  MerkleUpdate(const std::string &category_id) : category_id{category_id} { ConcordAssert(!category_id.empty()); }
+
+  OrderedSetOfKeyValuePairs updates;
+  OrderedKeysSet removals;
+
+  const std::string category_id;
+
+  bool operator<(const CategorizedKeyValueUpdate &) const { return false; }
+
+  template <typename T>
+  bool operator<(const T &other) const {
+    return category_id < other.category_id;
+  }
+};
+
+// Updates for a key-value category.
+// Persists key-values directly in the underlying key-value store.
+struct KeyValueUpdate {
+  KeyValueUpdate(const std::string &category_id) : category_id{category_id} { ConcordAssert(!category_id.empty()); }
+
+  struct ValueData {
+    Value value;
+
+    // If set, the expiry time will be persisted and available on lookups.
+    // An implementation might optionally choose to automatically mark the key-value stale at or after the `expire_at`
+    // time. If not done automatically, the application needs to manage the lifetime of the key.
+    std::optional<std::time_t> expire_at;
+
+    // Mark the key-value stale during the update itself.
+    bool stale_on_update{false};
+  };
+  std::map<Key, ValueData> updates;
+  OrderedKeysSet removals;
+
+  const std::string category_id;
+
+  // Controls whether a hash of the updated key-values is calculated for this update.
+  bool calculate_hash{false};
+
+  bool operator<(const CategorizedKeyValueUpdate &) const { return false; }
+
+  template <typename T>
+  bool operator<(const T &other) const {
+    return category_id < other.category_id;
+  }
+};
+
+// A block update is a list of updates for different categories.
+// Note: Only a single `CategorizedKeyValueUpdate` is supported per block.
+using CategorizedUpdates = std::set<std::variant<MerkleUpdate, KeyValueUpdate, CategorizedKeyValueUpdate>>;
+
+}  // namespace concord::kvbc::categorization


### PR DESCRIPTION
Key categorization allows users of the Key-Value Blockchain to select
different key categories for their keys. Every key category type has its
own properties and supports a specific set of functionalities. Having
the ability to put keys into different categories enables optimal
storage and performance, based on the requirements users have for
lifetime, lookup and provability.

Aims at:
 * ability to have different properties and functionalities per category
 * support multiple categories of the same type
 * ability to extend key categorization with new category types