### PR TITLE
Make test stable to include in CI.

### DIFF
--- a/tests/apollo/test_skvbc_backup_restore.py
+++ b/tests/apollo/test_skvbc_backup_restore.py
@@ -112,7 +112,7 @@ class SkvbcBackupRestoreTest(unittest.TestCase):
     @with_bft_network(start_replica_cmd_with_vc_timeout("20000"),
                       selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
-    async def test_checkpoint_propagation_after_restarting_all_replicas_under_load(self, bft_network, skvbc, nursery):
+    async def test_checkpoint_propagation_after_restarting_all_replicas_under_load(self, bft_network, skvbc, constant_load):
         """
         Here we trigger a checkpoint, restart all replicas in a random order with 10s delay in-between,
         both while stopping and starting. We verify checkpoint persisted upon restart and then trigger
@@ -192,7 +192,7 @@ class SkvbcBackupRestoreTest(unittest.TestCase):
     @with_bft_network(start_replica_cmd_with_vc_timeout("20000"), selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
     async def test_checkpoint_propagation_after_restarting_majority_replicas_under_load(self, bft_network, skvbc,
-                                                                                        nursery):
+                                                                                        constant_load):
         """
         Here we trigger a checkpoint, restart all replicas in a random order with a delay in-between,
         both while stopping and starting. We verify checkpoint persisted upon restart and then trigger

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -51,9 +51,8 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    @unittest.skip("Unstable because of BC-5164")
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_with_vc_timeout("6500"), selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
     async def test_delayed_replicas_start_up(self, bft_network, skvbc, nursery):
         """

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -54,7 +54,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd_with_vc_timeout("6500"), selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
-    async def test_delayed_replicas_start_up(self, bft_network, skvbc, nursery):
+    async def test_delayed_replicas_start_up(self, bft_network, skvbc, constant_load):
         """
         The goal is to make sure that if replicas are started in a random
         order, with delays in-between, and with constant load (request sent every 1s),
@@ -117,7 +117,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
             # Stop sending requests, and make sure the restarted replica
             # is up-and-running and participates in consensus
-            nursery.cancel_scope.cancel()
+            constant_load.cancel()
 
             key = ['replica', 'Gauges', 'lastExecutedSeqNum']
             last_executed_seq_num = await bft_network.metrics.get(current_primary, *key)
@@ -140,7 +140,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
     @with_bft_network(start_replica_cmd_with_vc_timeout("20000"),
                       selected_configs=lambda n, f, c: f >= 2)
     @with_constant_load
-    async def test_f_staggered_replicas_requesting_vc(self, bft_network, skvbc, nursery):
+    async def test_f_staggered_replicas_requesting_vc(self, bft_network, skvbc, constant_load):
         """
         The goal of this test is to verify correct behaviour in the situation where
         a subset of F replicas not big enough to reach quorum for execution starts early,
@@ -228,7 +228,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
     @with_bft_network(start_replica_cmd_with_vc_timeout("20000"),
                       selected_configs=lambda n, f, c: f >= 2)
     @with_constant_load
-    async def test_f_minus_one_staggered_replicas_requesting_vc(self, bft_network, skvbc, nursery):
+    async def test_f_minus_one_staggered_replicas_requesting_vc(self, bft_network, skvbc, constant_load):
         """
         In this test we check that if f-1 replicas have started to run and initiated viewchange, then the system is
         still able to make progress. To make sure the system still have 2f+1 active replicas, we wait for the early
@@ -310,7 +310,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
     @with_bft_network(start_replica_cmd_with_vc_timeout("20000"),
                       selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
-    async def stuck_view_change_bug_recreation(self, bft_network, skvbc, nursery):
+    async def stuck_view_change_bug_recreation(self, bft_network, skvbc, constant_load):
         """
         Test inspired by failure of a subset of replicas to enter a New View after View Change
         due to insufficient ViewChange messages and previous no resend of ViewChange messages

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -240,7 +240,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
-    async def test_long_request_with_constant_load(self, bft_network, skvbc, nursery):
+    async def test_long_request_with_constant_load(self, bft_network, skvbc, constant_load):
         """
         In this test we make sure a long-running request executes
         concurrently with a constant system load in the background.
@@ -343,7 +343,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd)
     @with_constant_load
-    async def test_pre_execution_with_added_constant_load(self, bft_network, skvbc, nursery):
+    async def test_pre_execution_with_added_constant_load(self, bft_network, skvbc, constant_load):
         """
         Run a batch of concurrent pre-execution requests, while
         sending a constant "time service like" load on the normal execution path.


### PR DESCRIPTION
Because the View Change timer is set to tick with a precision of 1/2
of the View Change Timeout, we usually get it to timeout later
than the specified period. In order to make the test pass consistently
we need to start the Replicas with a delay of at least 3/2 of the
View Change period.