### PR TITLE
Test ReplicaAsksToLeaveView by isolating a replica 

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2442,6 +2442,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
   controller->onNewView(curView, primaryLastUsedSeqNum);
   metric_current_active_view_.Get().Set(curView);
   complainedReplicas.clear();
+  metric_sent_replica_asks_to_leave_view_msg_.Get().Set(0);
 }
 
 void ReplicaImp::sendCheckpointIfNeeded() {
@@ -2952,6 +2953,7 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
           config_.getreplicaId(), curView, ReplicaAsksToLeaveViewMsg::Reason::ClientRequestTimeout));
       sendToAllOtherReplicas(askToLeaveView.get());
       complainedReplicas.store(std::move(askToLeaveView));
+      metric_sent_replica_asks_to_leave_view_msg_.Get().Inc();
 
       tryToGotoNextView();
       return;
@@ -3346,6 +3348,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_concurrency_level_{metrics_.RegisterGauge("concurrencyLevel", config_.getconcurrencyLevel())},
       metric_primary_last_used_seq_num_{metrics_.RegisterGauge("primaryLastUsedSeqNum", primaryLastUsedSeqNum)},
       metric_on_call_back_of_super_stable_cp_{metrics_.RegisterGauge("OnCallBackOfSuperStableCP", 0)},
+      metric_sent_replica_asks_to_leave_view_msg_{metrics_.RegisterGauge("sentReplicaAsksToLeaveViewMsg", 0)},
       metric_first_commit_path_{metrics_.RegisterStatus(
           "firstCommitPath", CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath))},
       metric_slow_path_count_{metrics_.RegisterCounter("slowPathCount", 0)},

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -181,6 +181,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   GaugeHandle metric_concurrency_level_;
   GaugeHandle metric_primary_last_used_seq_num_;
   GaugeHandle metric_on_call_back_of_super_stable_cp_;
+  GaugeHandle metric_sent_replica_asks_to_leave_view_msg_;
 
   // The first commit path being attempted for a new request.
   StatusHandle metric_first_commit_path_;

--- a/tests/apollo/util/bft_network_partitioning.py
+++ b/tests/apollo/util/bft_network_partitioning.py
@@ -266,3 +266,22 @@ class ReplicaSubsetOneWayIsolatingAdversary(NetworkPartitioningAdversary):
                 if ir != r:
                     self._drop_packets_between(ir, r)
 
+class ReplicaSubsetTwoWayIsolatingAdversary(NetworkPartitioningAdversary):
+    """
+    Adversary that isolates all messages except client requests
+    to a subset of replicas. The Replicas in the subset will not
+    be able to send or receive messages from other replicas.
+    """
+
+    def __init__(self, bft_network, replicas_to_isolate):
+        assert len(replicas_to_isolate) < bft_network.config.n
+        self.replicas_to_isolate = replicas_to_isolate
+        super(ReplicaSubsetTwoWayIsolatingAdversary, self).__init__(bft_network)
+
+    def interfere(self):
+        for ir in self.replicas_to_isolate:
+            for r in self.bft_network.all_replicas():
+                if ir != r:
+                    self._drop_packets_between(ir, r)
+                    self._drop_packets_between(r, ir)
+


### PR DESCRIPTION
Test makes sure that a single isolated replica will ask for a view change, but it doesn't occur:
        1) Start all replicas
        2) Isolate a single replica for long enough to trigger a ReplicaAsksToLeaveViewMsg
        3) Let the replica rejoin the consensus
        4) Make sure a view change does not happen and the isolated replica
        rejoins the fast path in the existing view