### PR TITLE
ROReplica backup/restore

### DIFF
--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -77,7 +77,7 @@ class IStateTransfer : public IReservedPages {
 // (methods can be invoked by any thread)
 class IReplicaForStateTransfer {
  public:
-  virtual void onTransferringComplete(int64_t checkpointNumberOfNewState) = 0;
+  virtual void onTransferringComplete(uint64_t checkpointNumberOfNewState) = 0;
 
   // The following methods can be used to simplify the state transfer
   // implementations. (A state transfer module may not need to use them).

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -108,10 +108,7 @@ class IReplica {
                                       MetadataStorage *,
                                       bool &erasedMetadata);
 
-  static IReplicaPtr createNewRoReplica(const ReplicaConfig &,
-                                        IStateTransfer *,
-                                        bft::communication::ICommunication *,
-                                        MetadataStorage *);
+  static IReplicaPtr createNewRoReplica(const ReplicaConfig &, IStateTransfer *, bft::communication::ICommunication *);
 
   virtual ~IReplica() = default;
 

--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -25,7 +25,6 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
   ReadOnlyReplica(const ReplicaConfig&,
                   IStateTransfer*,
                   std::shared_ptr<MsgsCommunicator>,
-                  std::shared_ptr<PersistentStorage>,
                   std::shared_ptr<MsgHandlersRegistrator>,
                   concordUtil::Timers& timers);
 
@@ -36,7 +35,7 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
  protected:
   void sendAskForCheckpointMsg();
 
-  void onTransferringCompleteImp(int64_t newStateCheckpoint) override;
+  void onTransferringCompleteImp(uint64_t newStateCheckpoint) override;
   void onReportAboutInvalidMessage(MessageBase* msg, const char* reason) override;
 
   template <typename T>
@@ -51,7 +50,6 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
   void onMessage(T*);
 
  protected:
-  std::shared_ptr<PersistentStorage> ps_;
   // last known stable checkpoint of each peer replica.
   // We sometimes delete checkpoints before lastExecutedSeqNum
   std::map<ReplicaId, CheckpointMsg*> tableOfStableCheckpoints;

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -108,7 +108,6 @@ class ReplicaBase {
   std::shared_ptr<MsgsCommunicator> msgsCommunicator_;
   std::shared_ptr<MsgHandlersRegistrator> msgHandlers_;
 
-  // TODO [TK] move to ReplicaImpl
   // last SeqNum executed  by this replica (or its affect was transferred to this replica)
   SeqNum lastExecutedSeqNum = 0;
 

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -89,10 +89,10 @@ void ReplicaForStateTransfer::sendStateTransferMessage(char *m, uint32_t size, u
   delete p;
 }
 
-void ReplicaForStateTransfer::onTransferringComplete(int64_t checkpointNumberOfNewState) {
+void ReplicaForStateTransfer::onTransferringComplete(uint64_t checkpointNumberOfNewState) {
   // TODO(GG): if this method is invoked by an external thread, then send an "internal message" to the commands
   // processing thread
-  onTransferringCompleteImp(checkpointNumberOfNewState * checkpointWindowSize);
+  onTransferringCompleteImp(checkpointNumberOfNewState);
 }
 
 void ReplicaForStateTransfer::changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) {

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -33,7 +33,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   // IReplicaForStateTransfer
   void freeStateTransferMsg(char* m) override;
   void sendStateTransferMessage(char* m, uint32_t size, uint16_t replicaId) override;
-  void onTransferringComplete(int64_t checkpointNumberOfNewState) override;
+  void onTransferringComplete(uint64_t checkpointNumberOfNewState) override;
   void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) override;
 
   bool isCollectingState() const { return stateTransfer->isCollectingState(); }
@@ -42,7 +42,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   void stop() override;
 
  protected:
-  virtual void onTransferringCompleteImp(int64_t checkpointNumberOfNewState) = 0;
+  virtual void onTransferringCompleteImp(uint64_t checkpointNumberOfNewState) = 0;
 
   template <typename T>
   void messageHandler(MessageBase* msg) {

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -376,7 +376,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   );
 
   void onSeqNumIsSuperStable(SeqNum superStableSeqNum);
-  void onTransferringCompleteImp(SeqNum) override;
+  void onTransferringCompleteImp(uint64_t) override;
 
   template <typename T>
   bool relevantMsgForActiveView(const T* msg);

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -123,7 +123,7 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
     // IReplicaForStateTransfer methods
     ////////////////////////////////////////////////////////////////////////
 
-    void onTransferringComplete(int64_t checkpointNumberOfNewState) override {
+    void onTransferringComplete(uint64_t checkpointNumberOfNewState) override {
       stObject->onComplete(checkpointNumberOfNewState);
 
       realInterface_->onTransferringComplete(checkpointNumberOfNewState);

--- a/bftengine/tests/bcstatetransfer/test_replica.hpp
+++ b/bftengine/tests/bcstatetransfer/test_replica.hpp
@@ -36,7 +36,7 @@ class TestReplica : public IReplicaForStateTransfer {
   ///////////////////////////////////////////////////////////////////////////
   // IReplicaForStateTransfer methods
   ///////////////////////////////////////////////////////////////////////////
-  void onTransferringComplete(int64_t checkpointNumberOfNewState) override{};
+  void onTransferringComplete(uint64_t checkpointNumberOfNewState) override{};
 
   void freeStateTransferMsg(char* m) override {
     char* p = (m - sizeof(bftEngine::impl::MessageBase::Header));

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -46,8 +46,7 @@ Status ReplicaImp::start() {
 
   if (replicaConfig_.isReadOnly) {
     LOG_INFO(logger, "ReadOnly mode");
-    m_replicaPtr =
-        bftEngine::IReplica::createNewRoReplica(replicaConfig_, m_stateTransfer, m_ptrComm, m_metadataStorage);
+    m_replicaPtr = bftEngine::IReplica::createNewRoReplica(replicaConfig_, m_stateTransfer, m_ptrComm);
   } else {
     createReplicaAndSyncState();
   }


### PR DESCRIPTION
First steps not to save the ROReplica state in rocksDB:
- don't use bft PersistentStorage in ROReplica (was used for saving lastExecutedSeqNum) as not necessary;
- make naming order with sequence numbers and checkpoints in a confusing otherwise onTransferringComplete()