### PR TITLE
Add a flag to direct_kv_db_adapter which controls if KVs should be saved with the raw block or not

### DIFF
--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -124,7 +124,8 @@ class DBAdapter : public IDbAdapter {
  public:
   DBAdapter(std::shared_ptr<storage::IDBClient> dataStore,
             std::unique_ptr<IDataKeyGenerator> keyGen = std::make_unique<RocksKeyGenerator>(),
-            bool use_mdt = false);
+            bool use_mdt = false,
+            bool save_kv_pairs_separately = true);
 
   // Adds a block from a set of key/value pairs and a block ID. Includes:
   // - adding the key/value pairs in separate keys
@@ -182,6 +183,7 @@ class DBAdapter : public IDbAdapter {
   bool mdt_ = false;  // whether we explicitly store blockchain metadata
   BlockId lastBlockId_ = 0;
   BlockId lastReachableBlockId_ = 0;
+  bool saveKvPairsSeparately_;
 };
 
 }  // namespace concord::kvbc::v1DirectKeyValue

--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -83,7 +83,8 @@ IStorageFactory::DatabaseSet S3StorageFactory::newDatabaseSet() const {
   ret.dataDBClient->init();
 
   auto dataKeyGenerator = std::make_unique<S3KeyGenerator>(s3Conf_.pathPrefix);
-  ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient, std::move(dataKeyGenerator), true);
+  ret.dbAdapter = std::make_unique<DBAdapter>(
+      ret.dataDBClient, std::move(dataKeyGenerator), true /* use_mdt */, false /* save_kv_pairs_separately */);
 
   return ret;
 }


### PR DESCRIPTION
Besides the raw block itself direct_kv_db adapter saves also all KV pairs from the block in the database. This feature doesn't play well with S3 (which shares the adapter code), because there is a limitation for the size of the keys written to the object store (around 250 for minio and 1024 for AWS S3).  For this reason additional flag is added to the adapter constructor which controls whether to save the KV pairs AND the raw block or only the raw block.
