### PR TITLE
Suggestion for categories update API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CONCORD_BFT_DOCKER_CONTAINER:=concord-bft
 CONCORD_BFT_DOCKERFILE:=Dockerfile
 CONCORD_BFT_BUILD_DIR:=build
 CONCORD_BFT_TARGET_SOURCE_PATH:=/concord-bft
+CONCORD_BFT_CMF_PATHS:=/concord-bft/build/*/cmf
 CONCORD_BFT_CONTAINER_SHELL:=/bin/bash
 CONCORD_BFT_CONTAINER_CC:=clang
 CONCORD_BFT_CONTAINER_CXX:=clang++
@@ -111,6 +112,7 @@ tidy-check: ## Run clang-tidy
 		cd ${CONCORD_BFT_BUILD_DIR} && \
 		CC=${CONCORD_BFT_CONTAINER_CC} CXX=${CONCORD_BFT_CONTAINER_CXX} \
 		cmake ${CONCORD_BFT_CMAKE_FLAGS} .. && \
+		make -C ${CONCORD_BFT_CMF_PATHS} &> /dev/null && \
 		run-clang-tidy-10 &> clang-tidy-report.txt && \
 		../scripts/check-forbidden-usage.sh .." \
 		&& (echo "\nClang-tidy finished successfully.") \

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(kvbc  src/ClientImp.cpp
 )
 
 target_link_libraries(kvbc PUBLIC corebft )
+target_link_libraries(kvbc PUBLIC categorized_kvbc_msgs)
+
 
 target_include_directories(kvbc PUBLIC include util)
 
@@ -33,3 +35,6 @@ endif()
 
 add_subdirectory(benchmark)
 add_subdirectory(tools)
+find_package(CMFC REQUIRED)
+add_subdirectory(cmf)
+

--- a/kvbc/cmf/CMakeLists.txt
+++ b/kvbc/cmf/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmf_generate_cpp(header cpp concord::kvbc::categorization categorized_kvbc_msgs.cmf)
+add_library(categorized_kvbc_msgs ${cpp})
+set_target_properties(categorized_kvbc_msgs PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(categorized_kvbc_msgs PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -1,0 +1,60 @@
+# Updates
+
+Msg MerkleUpdatesData 1 {
+    map string string kv
+    list string deletes
+}
+
+Msg ValueWithExpirationData 2{
+    string value
+    optional int64 expire_at
+    bool stale_on_update
+}
+
+Msg KeyValueUpdatesData 3{
+    map string ValueWithExpirationData kv
+    list string deletes
+    bool calculate_hash
+}
+
+Msg SharedValueData 4{
+    string value
+    list string categories_ids
+}
+
+Msg SharedUpdatesData 5{
+    map string SharedValueData kv
+    bool calculate_hash
+}
+
+
+# Updates info
+
+Msg MerkleKeyFlag 6{
+    bool deleted
+}
+
+Msg MerkleUpdatesInfo 7{
+    map string MerkleKeyFlag keys
+    fixedlist uint8 32 hash
+    uint64 version
+}
+
+Msg KVKeyFlag 8{
+    bool deleted
+    bool stale_on_update
+}
+
+Msg KeyValueUpdatesInfo 9{
+    map string KVKeyFlag keys
+    optional fixedlist uint8 32 hash
+}
+
+Msg SharedKeyData 10 {
+    list string categories
+}
+
+Msg SharedKeyValueUpdatesInfo 11{
+    map string SharedKeyData keys
+    optional fixedlist uint8 32 hash
+}

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -1,0 +1,79 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "updates.h"
+#include "rocksdb/native_client.h"
+#include <memory>
+
+#include "kv_types.hpp"
+
+using namespace concord::storage::rocksdb;
+
+namespace concord::kvbc::categorization {
+
+struct Block {
+  void add(const std::string& category_id, std::variant<MerkleUpdatesInfo, KeyValueUpdatesInfo> updates_info) {}
+  void add(SharedKeyValueUpdatesInfo updates_info) {}
+};
+class KeyValueBlockchain {
+ public:
+  KeyValueBlockchain() : native_client_(NativeClient::newClient("/tmp", false)) {}
+  // 1) Defines a new block
+  // 2) calls per cateogry with its updates
+  // 3) inserts the updates KV to the DB updates set per column family
+  // 4) add the category block data into the new block
+  BlockId addBlock(Updates& updates) {
+    // Use new client batch and column families
+    auto write_batch = native_client_->getBatch();
+    // const auto addedBlockId = getLastReachableBlockId() + 1;
+    // auto parentBlockDigestFuture = computeParentBlockDigest(blockId);
+    Block new_block;
+    // Per category updates
+    for (auto& [category_id, update] : updates.getCategoryUpdate()) {
+      // https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding
+      std::visit(
+          [&new_block, category_id = category_id, write_batch, this](auto& update) {
+            auto block_updates = handleCategoryUpdates(category_id, update, write_batch);
+            new_block.add(category_id, block_updates);
+          },
+          update);
+    }
+    if (updates.getSharedUpdates().has_value()) {
+      auto block_updates = handleCategoryUpdates(updates.getSharedUpdates().value(), write_batch);
+      new_block.add(block_updates);
+    }
+    return BlockId{8};
+    // newBlock.parentDigest = parentBlockDigestFuture.get();
+    // // E.L blocks in new column Family
+    // write_batch.put("blocks",DBKeyManipulator::genBlockDbKey(blockId),serizilize(newBlock));
+    // native_client_->write(write_batch);
+  }
+
+ private:
+  std::variant<MerkleUpdatesInfo, KeyValueUpdatesInfo> handleCategoryUpdates(
+      const std::string& category_id,
+      std::variant<MerkleUpdatesData, KeyValueUpdatesData> updates_info,
+      const WriteBatch& write_batch) {
+    return MerkleUpdatesInfo{};
+  }
+
+  SharedKeyValueUpdatesInfo handleCategoryUpdates(SharedUpdatesData& updates_info, const WriteBatch& write_batch) {
+    return SharedKeyValueUpdatesInfo{};
+  }
+
+  std::shared_ptr<NativeClient> native_client_;
+};
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -1,0 +1,180 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "assertUtils.hpp"
+#include "kv_types.hpp"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+#include <ctime>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <variant>
+
+// Categorized key-value updates for KVBC blocks. Every category supports different properties and functionalities.
+// Note1: Empty category IDs are invalid and not supported.
+// Note2: Using the same category ID for different category types is an error.
+namespace concord::kvbc::categorization {
+
+// Shared updates across multiple categories.
+// Persists key-values directly in the underlying key-value store. All key-values are marked stale during the update
+// itself. Explicit deletes are not supported.
+struct SharedKeyValueUpdates {
+  SharedKeyValueUpdates() = default;
+  SharedKeyValueUpdates(SharedKeyValueUpdates&& other) = default;
+  SharedKeyValueUpdates& operator=(SharedKeyValueUpdates&& other) = default;
+
+  // Do not allow copy
+  SharedKeyValueUpdates(SharedKeyValueUpdates& other) = delete;
+  SharedKeyValueUpdates& operator=(SharedKeyValueUpdates& other) = delete;
+
+  struct SharedValue {
+    SharedValue(std::string&& val, std::set<std::string>&& cat_ids) {
+      data_.value = std::move(val);
+      for (auto it = cat_ids.begin(); it != cat_ids.end();) {
+        data_.categories_ids.emplace_back(cat_ids.extract(it++).value());
+      }
+    }
+
+   private:
+    SharedValueData data_;
+    friend struct SharedKeyValueUpdates;
+  };
+
+  void addUpdate(std::string&& key, SharedValue&& val) { data_.kv.emplace(std::move(key), std::move(val.data_)); }
+
+ private:
+  SharedUpdatesData data_;
+  friend struct Updates;
+};
+
+// Updates for a key-value category.
+// Persists key-values directly in the underlying key-value store.
+// Controls whether a hash of the updated key-values is calculated for this update
+struct KeyValueUpdates {
+  KeyValueUpdates() = default;
+  KeyValueUpdates(KeyValueUpdates&& other) = default;
+  KeyValueUpdates& operator=(KeyValueUpdates&& other) = default;
+
+  // Do not allow copy
+  KeyValueUpdates(KeyValueUpdates& other) = delete;
+  KeyValueUpdates& operator=(KeyValueUpdates& other) = delete;
+  struct Value {
+    std::string data;
+
+    // If set, the expiry time will be persisted and available on lookups.
+    // An implementation might optionally choose to automatically mark the key-value stale at or after the `expire_at`
+    // time. If not done automatically, the application needs to manage the lifetime of the key.
+    std::optional<std::time_t> expire_at;
+
+    // Mark the key-value stale during the update itself.
+    bool stale_on_update{false};
+  };
+
+  void addUpdate(std::string&& key, Value&& val) {
+    data_.kv.emplace(std::move(key), ValueWithExpirationData{std::move(val.data), val.expire_at, val.stale_on_update});
+  }
+
+  // Set a value with no expiration and that is not stale on update
+  void addUpdate(std::string&& key, std::string&& val) {
+    data_.kv.emplace(std::move(key), ValueWithExpirationData{std::move(val), 0, false});
+  }
+
+  void addDelete(std::string&& key) {
+    if (const auto [itr, inserted] = unique_deletes_.insert(key); !inserted) {
+      *itr;  // disable unused variable
+      // Log warn
+      return;
+    }
+    data_.deletes.emplace_back(std::move(key));
+  }
+
+  void calculateHash(const bool hash) { data_.calculate_hash = hash; }
+
+ private:
+  KeyValueUpdatesData data_;
+  std::set<std::string> unique_deletes_;
+  friend struct Updates;
+};
+
+// Updates for a merkle tree category.
+// Persists key-values in a merkle tree that is constructed on top of the underlying key-value store.
+struct MerkleUpdates {
+  MerkleUpdates() = default;
+  MerkleUpdates(MerkleUpdates&& other) = default;
+  MerkleUpdates& operator=(MerkleUpdates&& other) = default;
+
+  // Do not allow copy
+  MerkleUpdates(MerkleUpdates& other) = delete;
+  MerkleUpdates& operator=(MerkleUpdates& other) = delete;
+
+  void addUpdate(std::string&& key, std::string&& val) { data_.kv.emplace(std::move(key), std::move(val)); }
+
+  void addDelete(std::string&& key) {
+    if (const auto [itr, inserted] = unique_deletes_.insert(key); !inserted) {
+      *itr;  // disable unused variable
+      // Log warn
+      return;
+    }
+    data_.deletes.emplace_back(std::move(key));
+  }
+
+  const MerkleUpdatesData& getData() { return data_; }
+
+ private:
+  MerkleUpdatesData data_;
+  std::set<std::string> unique_deletes_;
+  friend struct Updates;
+};
+
+// Updates contains a list of updates for different categories.
+// Note: Only a single `SharedKeyValueUpdates` is supported per block.
+struct Updates {
+  void addMerkleUpdate(std::string category_id, MerkleUpdates&& updates) {
+    if (const auto [itr, inserted] = category_updates_.insert({category_id, std::move(updates.data_)}); inserted) {
+      *itr;  // disable unused variable
+      throw std::logic_error{std::string("Only one update for category is allowed. type: Merkle, category: ") +
+                             category_id};
+    }
+  }
+
+  void addKeyValueUpdates(std::string category_id, KeyValueUpdates&& updates) {
+    if (const auto [itr, inserted] = category_updates_.insert({category_id, std::move(updates.data_)}); inserted) {
+      *itr;  // disable unused variable
+      throw std::logic_error{std::string("Only one update for category is allowed. type: KVHash, category: ") +
+                             category_id};
+    }
+  }
+
+  void addSharedKeyValueUpdates(std::string category_id, SharedKeyValueUpdates&& updates) {
+    if (shared_update_.has_value()) {
+      throw std::logic_error{std::string("Only one update for category is allowed. type: Shared KV, category: ") +
+                             category_id};
+    }
+    shared_update_.emplace(std::move(updates.data_));
+  }
+
+  std::map<std::string, std::variant<MerkleUpdatesData, KeyValueUpdatesData>>& getCategoryUpdate() {
+    return category_updates_;
+  }
+
+  std::optional<SharedUpdatesData>& getSharedUpdates() { return shared_update_; }
+
+ private:
+  std::optional<SharedUpdatesData> shared_update_;
+  std::map<std::string, std::variant<MerkleUpdatesData, KeyValueUpdatesData>> category_updates_;
+};
+}  // namespace concord::kvbc::categorization

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -34,6 +34,18 @@ target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
     stdc++fs
 )
 
+add_executable(categorized_updates_unit_test
+    categorization/updates_test.cpp )
+add_test(categorized_updates_unit_test categorized_updates_unit_test)
+target_link_libraries(categorized_updates_unit_test PUBLIC
+    GTest::Main
+    GTest::GTest
+    util
+    corebft
+    kvbc
+    stdc++fs
+)
+
 add_executable(sparse_merkle_storage_serialization_unit_test
     sparse_merkle_storage/serialization_unit_test.cpp )
 add_test(sparse_merkle_storage_serialization_unit_test sparse_merkle_storage_serialization_unit_test)

--- a/kvbc/test/categorization/updates_test.cpp
+++ b/kvbc/test/categorization/updates_test.cpp
@@ -1,0 +1,37 @@
+// Copyright 2018 VMware, all rights reserved
+/**
+ * The following test suite tests ordering of KeyValuePairs
+ */
+
+#include "gtest/gtest.h"
+#include "categorization/updates.h"
+#include "categorization/kv_blockchain.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace concord::kvbc::categorization;
+using namespace concord::kvbc;
+
+namespace {
+
+TEST(categorized_updates, merkle_update) {
+  std::string key{"key"};
+  std::string val{"val"};
+  MerkleUpdates mu;
+  mu.addUpdate(std::move(key), std::move(val));
+  ASSERT_TRUE(mu.getData().kv.size() == 1);
+}
+
+TEST(categorized_updates, add_block) {
+  KeyValueBlockchain block_chain;
+  Updates updates;
+  ASSERT_TRUE(block_chain.addBlock(updates) == (BlockId)8);
+}
+
+}  // end namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/messages/compiler/cpp/serialize.cpp
+++ b/messages/compiler/cpp/serialize.cpp
@@ -13,6 +13,12 @@
 
 namespace cmf {
 
+inline void cmfAssert(bool expr) {
+  if (expr != true) {
+    std::terminate();
+  }
+}
+
 class DeserializeError : public std::runtime_error {
  public:
   DeserializeError(const std::string& error) : std::runtime_error(("DeserializeError: " + error).c_str()) {}
@@ -83,7 +89,7 @@ void deserialize(uint8_t*& start, const uint8_t* end, T& t) {
  * Strings are preceded by a uint32_t length
  ******************************************************************************/
 static inline void serialize(std::vector<uint8_t>& output, const std::string& s) {
-  assert(s.size() <= 0xFFFFFFFF);
+  cmfAssert(s.size() <= 0xFFFFFFFF);
   uint32_t length = s.size() & 0xFFFFFFFF;
   serialize(output, length);
   std::copy(s.begin(), s.end(), std::back_inserter(output));
@@ -133,7 +139,7 @@ void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t);
  ******************************************************************************/
 template <typename T>
 void serialize(std::vector<uint8_t>& output, const std::vector<T>& v) {
-  assert(v.size() <= 0xFFFFFFFF);
+  cmfAssert(v.size() <= 0xFFFFFFFF);
   uint32_t length = v.size() & 0xFFFFFFFF;
   serialize(output, length);
   for (auto& it : v) {
@@ -206,7 +212,7 @@ void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair) {
  ******************************************************************************/
 template <typename K, typename V>
 void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m) {
-  assert(m.size() <= 0xFFFFFFFF);
+  cmfAssert(m.size() <= 0xFFFFFFFF);
   uint32_t size = m.size() & 0xFFFFFFFF;
   serialize(output, size);
   for (auto& it : m) {


### PR DESCRIPTION
Defining structs for category updates  e.g. ```MerkleUpdates``` and a ```concord::kvbc::categorization::Updates``` struct
which aggregates the categorized updates .

The ```concord::kvbc::categorization::Updates``` struct is used by a client in order to perform categorized KV updates
against the storage layer.

The Update API uses _rvalue_ references for the public calls, this is done in order to explicitly say that we are going to move 
the content from the client to the storage and minimize copy and allocation as much as possible.

The data itself is being structured using CMF (thanks @andrewjstone) and is encapsulated as private members of those structs.

An ```addBlock(const Updates& updates)``` method was added to start "feeling" the flow and usage of the suggested interface. 


