### PR TITLE
Reduce merkle tree serialization allocation count

### DIFF
--- a/kvbc/include/merkle_tree_serialization.h
+++ b/kvbc/include/merkle_tree_serialization.h
@@ -168,7 +168,7 @@ inline std::string serializeImp(const sparse_merkle::BatchedInternalNode &intNod
 
   auto mask = BatchedInternalMaskType{0};
 
-  // We assume the largest batched internal node contains with 15 internal and 16 leaf children. We then factor in the
+  // We assume the largest batched internal node contains 15 internal and 16 leaf children. We then factor in the
   // mask that indicates which child is set and the single-byte child type bytes serialized for every child.
   auto out = std::string{};
   out.reserve((sparse_merkle::InternalChild::SIZE_IN_BYTES * 15) + (sparse_merkle::LeafChild::SIZE_IN_BYTES * 16) +


### PR DESCRIPTION
Use an output parameter instead of std::string concatenation when
serializing merkle tree internals. That has the effect of reducing the
count of memory allocations. Special attention is given to serialization
of BatchedInternalNodes as it was creating a big number of temporary
strings that were large enough to trigger allocations (without
taking advantage of small string optimizations).

Add a benchmark for BatchedInternalNodes. Change constants for block
count and key/value count and sizes in order to better reflect real uses
cases.

```
Before:
-------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations
-------------------------------------------------------------------------
serializeBatchedInternalNode         3229 ns         3229 ns       212506
```

```
After:
-------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations
-------------------------------------------------------------------------
serializeBatchedInternalNode          680 ns          680 ns       818500
```

Thanks to @andrewjstone for observing and measuring.