### PR TITLE
clear control state manager data on startup

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -53,7 +53,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   void setEraseMetadataFlag(int64_t currentSeqNum);
   std::optional<int64_t> getEraseMetadataFlag();
 
-  ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages);
+  ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages, bool disabled = false);
   ControlStateManager& operator=(const ControlStateManager&) = delete;
   ControlStateManager(const ControlStateManager&) = delete;
   ~ControlStateManager() {}

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -22,7 +22,7 @@ namespace bftEngine {
 
 class ControlStatePage : public concord::serialize::SerializableFactory<ControlStatePage> {
  public:
-  int64_t seq_num_to_stop_at_ = -1;
+  int64_t seq_num_to_stop_at_ = 0;
   int64_t erase_metadata_at_seq_num_ = 0;
   ControlStatePage() {
     static_assert(sizeof(ControlStatePage) < 4096, "The page exceeds the maximal size of reserved page");

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -22,7 +22,7 @@ namespace bftEngine {
 
 class ControlStatePage : public concord::serialize::SerializableFactory<ControlStatePage> {
  public:
-  int64_t seq_num_to_stop_at_ = 0;
+  int64_t seq_num_to_stop_at_ = -1;
   int64_t erase_metadata_at_seq_num_ = 0;
   ControlStatePage() {
     static_assert(sizeof(ControlStatePage) < 4096, "The page exceeds the maximal size of reserved page");
@@ -60,6 +60,8 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
 
   void disable() { enabled_ = false; }
   void enable() { enabled_ = true; }
+
+  void clearControlStateManagerData();
 
  private:
   IStateTransfer* state_transfer_;

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -13,6 +13,7 @@
 
 #include "ControlStateManager.hpp"
 #include "Logger.hpp"
+#include "../../include/bftengine/ControlStateManager.hpp"
 namespace bftEngine {
 
 /*
@@ -85,4 +86,13 @@ std::optional<int64_t> ControlStateManager::getEraseMetadataFlag() {
   return page_.erase_metadata_at_seq_num_;
 }
 
+void bftEngine::ControlStateManager::clearControlStateManagerData() {
+  if (!enabled_) return;
+  page_.seq_num_to_stop_at_ = 0;
+  page_.erase_metadata_at_seq_num_ = 0;
+  std::ostringstream outStream;
+  concord::serialize::Serializable::serialize(outStream, page_);
+  auto data = outStream.str();
+  state_transfer_->saveReservedPage(resPageOffset(), data.size(), data.data());
+}
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -53,8 +53,8 @@ std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
   return page_.seq_num_to_stop_at_;
 }
 
-ControlStateManager::ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages)
-    : state_transfer_{state_transfer}, sizeOfReservedPage_{sizeOfReservedPages} {
+ControlStateManager::ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages, bool disabled)
+    : state_transfer_{state_transfer}, sizeOfReservedPage_{sizeOfReservedPages}, enabled_{!disabled} {
   scratchPage_.resize(sizeOfReservedPage_);
 }
 

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -88,6 +88,7 @@ std::optional<int64_t> ControlStateManager::getEraseMetadataFlag() {
 
 void bftEngine::ControlStateManager::clearControlStateManagerData() {
   if (!enabled_) return;
+  if (state_transfer_->isCollectingState()) return;
   page_.seq_num_to_stop_at_ = 0;
   page_.erase_metadata_at_seq_num_ = 0;
   std::ostringstream outStream;

--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -49,6 +49,9 @@ void ReplicaBase::start() {
       LOG_INFO(GL, "-- ReplicaBase metrics dump--" + metrics_.ToJson());
     }
   });
+  // On startup we clean the controlStateManagerData. If the replica has been wedged before, we want to clean the
+  // wedge point such that the replica will be able to continue running.
+  controlStateManager_->clearControlStateManagerData();
   msgsCommunicator_->startCommunication(config_.replicaId);
 }
 

--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -51,7 +51,9 @@ void ReplicaBase::start() {
   });
   // On startup we clean the controlStateManagerData. If the replica has been wedged before, we want to clean the
   // wedge point such that the replica will be able to continue running.
-  controlStateManager_->clearControlStateManagerData();
+  if (controlStateManager_) {
+    controlStateManager_->clearControlStateManagerData();
+  }
   msgsCommunicator_->startCommunication(config_.replicaId);
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3549,7 +3549,6 @@ void ReplicaImp::addTimers() {
 void ReplicaImp::start() {
   LOG_INFO(GL, "Running ReplicaImp");
   ReplicaForStateTransfer::start();
-
   // requires the init of state transfer
   std::shared_ptr<ISecureStore> sec(
       new KeyManager::FileSecureStore(ReplicaConfig::instance().getkeyViewFilePath(), config_.replicaId));

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -235,10 +235,9 @@ class SimpleTestReplica {
   uint16_t get_replica_id() { return replicaConfig.replicaId; }
 
   void start() {
-    replica->start();
-    control_state_manager_ = std::make_shared<ControlStateManager>(inMemoryST_, inMemoryST_->numberOfReservedPages());
-    control_state_manager_->disable();
+    control_state_manager_ = std::make_shared<ControlStateManager>(inMemoryST_, 0, true);
     replica->setControlStateManager(control_state_manager_);
+    replica->start();
   }
 
   void stop() {


### PR DESCRIPTION
After successful wedge, the instruction to a wedge is still in the reserved pages. Thus, when the replica starts again it will try to wedge again.
For that, we clear all the controlStateManager data on startup.

Notice, that if a replica has crashed after wedge command and before the actual shutdown, this may cause to instability.