### PR TITLE
Conversion from RocksDB IDBClient to NativeClient

### DIFF
--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -29,7 +29,7 @@ struct Block {
 };
 class KeyValueBlockchain {
  public:
-  KeyValueBlockchain() : native_client_(NativeClient::newClient("/tmp", false)) {}
+  KeyValueBlockchain() : native_client_(NativeClient::newClient("/tmp", false, NativeClient::DefaultOptions{})) {}
   // 1) Defines a new block
   // 2) calls per cateogry with its updates
   // 3) inserts the updates KV to the DB updates set per column family

--- a/storage/include/storage/test/storage_test_common.h
+++ b/storage/include/storage/test/storage_test_common.h
@@ -79,7 +79,26 @@ struct TestRocksDb {
 
   static std::shared_ptr<::concord::storage::rocksdb::NativeClient> createNative(std::size_t dbId = defaultDbId) {
     const auto readOnly = false;
-    return ::concord::storage::rocksdb::NativeClient::newClient(rocksDbPath(dbId), readOnly);
+    return ::concord::storage::rocksdb::NativeClient::newClient(
+        rocksDbPath(dbId), readOnly, ::concord::storage::rocksdb::NativeClient::DefaultOptions{});
+  }
+
+  static std::shared_ptr<::concord::storage::rocksdb::NativeClient> createNative(
+      const ::concord::storage::rocksdb::NativeClient::DefaultOptions &opts, std::size_t dbId = defaultDbId) {
+    const auto readOnly = false;
+    return ::concord::storage::rocksdb::NativeClient::newClient(rocksDbPath(dbId), readOnly, opts);
+  }
+
+  static std::shared_ptr<::concord::storage::rocksdb::NativeClient> createNative(
+      const ::concord::storage::rocksdb::NativeClient::ExistingOptions &opts, std::size_t dbId = defaultDbId) {
+    const auto readOnly = false;
+    return ::concord::storage::rocksdb::NativeClient::newClient(rocksDbPath(dbId), readOnly, opts);
+  }
+
+  static std::shared_ptr<::concord::storage::rocksdb::NativeClient> createNative(
+      const ::concord::storage::rocksdb::NativeClient::UserOptions &opts, std::size_t dbId = defaultDbId) {
+    const auto readOnly = false;
+    return ::concord::storage::rocksdb::NativeClient::newClient(rocksDbPath(dbId), readOnly, opts);
   }
 
   static void cleanup(std::size_t dbId = defaultDbId) { ::cleanup(dbId); }


### PR DESCRIPTION
Provide conversions from an IDBClient that points to rocksdb::Client to
NativeClient and vice versa.

Add support for user-supplied RocksDB options in NativeClient. Moreover,
support creating a NativeClient with default options and with the
existing (persisted) options. In effect, NativeClient::newClient() can
be called with:
 * UserOptions
 * DefaultOptions
 * ExistingOptions

Move column family handles from NativeClient to rocksdb::Client.
Rationale is that since we now support conversions between them, we want
rocksdb::Client to be able to open a DB with column families inside of
it. Without that change, it wouldn't be possible, because RocksDB
requires that all column families are specified when opening the DB.

Extract optimizations in rocksdb::Client into its own method and
support an ability to turn them on/off. Additionally, apply these
optimizations **after** having loaded the existing configuration from a
file.

Add a guard against multiple initializations in in ::rocksdb::Client.

Add tests to verify that conversions and options persistence work as
expected.