### PR TITLE
Add flag to disable has keys request if feature is disabled

### DIFF
--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -26,6 +26,7 @@ KeyManager::KeyManager(InitData* id)
       keyStore_{id->clusterSize, *id->reservedPages, id->sizeOfReservedPage},
       multiSigKeyHdlr_(id->kg),
       keysView_(id->sec, id->backupSec, id->clusterSize),
+      keyExchangeOnStart_(id->keyExchangeOnStart),
       timers_(*(id->timers)) {
   registryToExchange_.push_back(id->ke);
   if (keyStore_.exchangedReplicas.size() == 0) {
@@ -76,7 +77,7 @@ std::string KeyManager::generateCid() {
 std::string KeyManager::onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn) {
   if (kemsg.op == KeyExchangeMsg::HAS_KEYS) {
     LOG_INFO(KEY_EX_LOG, "Has key query arrived, returning " << std::boolalpha << keysExchanged << std::noboolalpha);
-    if (!keysExchanged) return std::string(KeyExchangeMsg::hasKeysFalseReply);
+    if (!keysExchanged && keyExchangeOnStart_) return std::string(KeyExchangeMsg::hasKeysFalseReply);
     return std::string(KeyExchangeMsg::hasKeysTrueReply);
   }
 

--- a/bftengine/src/bftengine/KeyManager.h
+++ b/bftengine/src/bftengine/KeyManager.h
@@ -110,6 +110,7 @@ class KeyManager {
     concordUtil::Timers* timers{nullptr};
     std::shared_ptr<concordMetrics::Aggregator> a;
     std::chrono::seconds interval;
+    bool keyExchangeOnStart{false};
   };
 
   static KeyManager& get(InitData* id = nullptr) {
@@ -136,6 +137,7 @@ class KeyManager {
 
   IMultiSigKeyGenerator* multiSigKeyHdlr_{nullptr};
   KeysView keysView_;
+  bool keyExchangeOnStart_{};
 
   void onInitialKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn);
   void notifyRegistry(bool save);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3568,6 +3568,7 @@ void ReplicaImp::start() {
   id.timers = &timers_;
   id.a = aggregator_;
   id.interval = std::chrono::seconds(config_.getmetricsDumpIntervalSeconds());
+  id.keyExchangeOnStart = ReplicaConfig::instance().getkeyExchangeOnStart();
 
   KeyManager::start(&id);
   if (!firstTime_ || config_.getdebugPersistentStorageEnabled()) clientsManager->loadInfoFromReservedPages();


### PR DESCRIPTION
Has-key request is made in order to synch the key exchange of the BFT library with its client. 
When the feature is `off` this request should return ```true``` by defult.