### PR TITLE
Incorporate proof in vc msgs

### DIFF
--- a/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
@@ -231,7 +231,7 @@ bool ViewChangeMsg::checkComplaints(uint16_t sigSize) const {
     remainingBytes -= sizeof(MsgSize);
     currLoc += sizeof(MsgSize);
 
-    if (*complaintSize <= sizeof(MessageBase::Header)) {
+    if (*complaintSize <= sizeOfHeader<ReplicaAsksToLeaveViewMsg>()) {
       return false;
     }
 

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.cpp
@@ -365,13 +365,9 @@ bool ViewChangeMsg::ComplaintsIterator::getCurrent(char*& pComplaint, MsgSize& s
   if (end()) return false;
 
   size = *(MsgSize*)(msg->body() + currLoc);
-
   const uint32_t remainingbytes = (endLoc - currLoc) - sizeof(MsgSize);
-
   ConcordAssert(remainingbytes >= size);  // Validate method must make sure we never accept such message
-
   pComplaint = (char*)malloc(size);
-
   memcpy(pComplaint, msg->body() + currLoc + sizeof(MsgSize), size);
 
   return true;
@@ -381,11 +377,8 @@ void ViewChangeMsg::ComplaintsIterator::gotoNext() {
   if (end()) return;
 
   const uint32_t size = *(MsgSize*)(msg->body() + currLoc);
-
   const uint32_t remainingbytes = (endLoc - currLoc) - sizeof(MsgSize);
-
   ConcordAssert(remainingbytes >= size);  // Validate method must make sure we never accept such message
-
   currLoc += sizeof(MsgSize) + size;
 
   nextComplaintNum++;

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
@@ -16,6 +16,7 @@
 #include "OpenTracing.hpp"
 #include "ReplicasInfo.hpp"
 #include "ReplicaConfig.hpp"
+#include "ReplicaAsksToLeaveViewMsg.hpp"
 
 namespace bftEngine {
 namespace impl {
@@ -59,6 +60,10 @@ class ViewChangeMsg : public MessageBase {
 
   uint16_t numberOfElements() const { return b()->numberOfElements; }
 
+  uint16_t numberOfComplaints() const { return b()->numberOfComplaints; }
+
+  uint32_t sizeOfAllComplaints() const { return b()->sizeOfAllComplaints; }
+
   void getMsgDigest(Digest& outDigest) const;
 
   void addElement(SeqNum seqNum,
@@ -68,6 +73,8 @@ class ViewChangeMsg : public MessageBase {
                   ViewNum certificateView,
                   uint16_t certificateSigLength,
                   const char* certificateSig);
+
+  void addComplaint(const ReplicaAsksToLeaveViewMsg* const complaint);
 
   void finalizeMessage();
 
@@ -95,6 +102,26 @@ class ViewChangeMsg : public MessageBase {
     uint16_t nextElementNum;  // used for debug
   };
 
+  class ComplaintsIterator {
+   public:
+    // this ctor assumes that m is a legal ViewChangeMsg message (as defined by checkComplaints() )
+    ComplaintsIterator(const ViewChangeMsg* const m);
+
+    bool getCurrent(char*& pComplaint, MsgSize& size);
+
+    bool end();
+
+    void gotoNext();
+
+    bool getAndGoToNext(char*& pComplaint, MsgSize& size);
+
+   protected:
+    const ViewChangeMsg* const msg;
+    uint32_t endLoc;
+    uint32_t currLoc;
+    uint16_t nextComplaintNum;  // used for debug
+  };
+
  protected:
   template <typename MessageT>
   friend size_t sizeOfHeader();
@@ -105,17 +132,22 @@ class ViewChangeMsg : public MessageBase {
     ReplicaId genReplicaId;  // the replica that originally generated this message
     ViewNum newView;         // the new view
     SeqNum lastStable;
+    uint16_t numberOfComplaints;
+    uint32_t sizeOfAllComplaints;
     uint16_t numberOfElements;
     uint32_t locationAfterLast;  // if(numberOfElements > 0) then it holds the location after the last element
                                  // followed by a sequence of Element
                                  // followed by a signature (by genReplicaId)
+                                 // followed by quorum of complaints from different Replicas
   };
 #pragma pack(pop)
-  static_assert(sizeof(Header) == (6 + 2 + 8 + 8 + 2 + 4), "Header is 30B");
+  static_assert(sizeof(Header) == (6 + 2 + 8 + 8 + 2 + 4 + 2 + 4), "Header is 36B");
 
   Header* b() const { return ((Header*)msgBody_); }
 
   bool checkElements(uint16_t sigSize) const;
+
+  bool checkComplaints(uint16_t sigSize) const;
 };
 
 template <>

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
@@ -145,6 +145,8 @@ class ViewChangeMsg : public MessageBase {
 
   Header* b() const { return ((Header*)msgBody_); }
 
+  uint32_t getBodySize() const;
+
   bool checkElements(uint16_t sigSize) const;
 
   bool checkComplaints(uint16_t sigSize) const;

--- a/bftengine/tests/messages/ViewChangeMsg_test.cpp
+++ b/bftengine/tests/messages/ViewChangeMsg_test.cpp
@@ -28,7 +28,7 @@ using namespace bftEngine::impl;
 ReplicaConfig& config = createReplicaConfig();
 const char rawSpanContext[] = {"span_\0context"};
 
-void ViewChangeMsgTests(bool bAddElements, bool bAddComplaints, const std::string spanContext = "") {
+void ViewChangeMsgTests(bool bAddElements, bool bAddComplaints, const std::string& spanContext = "") {
   ReplicaId senderId = 1u;
   ViewNum viewNum = 2u;
   SeqNum seqNum = 3u;

--- a/bftengine/tests/messages/ViewChangeMsg_test.cpp
+++ b/bftengine/tests/messages/ViewChangeMsg_test.cpp
@@ -25,13 +25,13 @@
 using namespace bftEngine;
 using namespace bftEngine::impl;
 
-TEST(ViewChangeMsg, base_methods) {
-  ReplicaConfig& config = createReplicaConfig();
+ReplicaConfig& config = createReplicaConfig();
+const char rawSpanContext[] = {"span_\0context"};
+
+void ViewChangeMsgTests(bool bAddElements, bool bAddComplaints, const std::string spanContext = "") {
   ReplicaId senderId = 1u;
   ViewNum viewNum = 2u;
   SeqNum seqNum = 3u;
-  const char rawSpanContext[] = {"span_\0context"};
-  const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
   ReplicasInfo replicaInfo(config, true, true);
   SigManager sigManager(config.replicaId,
                         config.numReplicas + config.numOfClientProxies,
@@ -50,55 +50,58 @@ TEST(ViewChangeMsg, base_methods) {
 
   typedef std::tuple<SeqNum, Digest, ViewNum, bool, ViewNum, size_t, char*> InputTuple;
   std::vector<InputTuple> inputData;
-  Digest digest1(1);
-  auto originalViewNum1 = viewNum;
-  auto viewNum1 = ++viewNum;
-  char certificate1[DIGEST_SIZE] = {1};
-  auto seqNum1 = ++seqNum;
-  inputData.push_back(
-      std::make_tuple(seqNum1, digest1, viewNum1, true, originalViewNum1, sizeof(certificate1), certificate1));
-  msg.addElement(seqNum1, digest1, viewNum1, true, originalViewNum1, sizeof(certificate1), certificate1);
-  Digest digest2(2);
-  auto originalViewNum2 = viewNum;
-  auto viewNum2 = ++viewNum;
-  char certificate2[DIGEST_SIZE] = {2};
-  auto seqNum2 = ++seqNum;
-  inputData.push_back(
-      std::make_tuple(seqNum2, digest2, viewNum2, true, originalViewNum2, sizeof(certificate2), certificate2));
-  msg.addElement(seqNum2, digest2, viewNum2, true, originalViewNum2, sizeof(certificate2), certificate2);
-  EXPECT_EQ(msg.numberOfElements(), 2);
-
+  if (bAddElements) {
+    Digest digest1(1);
+    auto originalViewNum1 = viewNum;
+    auto viewNum1 = ++viewNum;
+    char certificate1[DIGEST_SIZE] = {1};
+    auto seqNum1 = ++seqNum;
+    inputData.push_back(
+        std::make_tuple(seqNum1, digest1, viewNum1, true, originalViewNum1, sizeof(certificate1), certificate1));
+    msg.addElement(seqNum1, digest1, viewNum1, true, originalViewNum1, sizeof(certificate1), certificate1);
+    Digest digest2(2);
+    auto originalViewNum2 = viewNum;
+    auto viewNum2 = ++viewNum;
+    char certificate2[DIGEST_SIZE] = {2};
+    auto seqNum2 = ++seqNum;
+    inputData.push_back(
+        std::make_tuple(seqNum2, digest2, viewNum2, true, originalViewNum2, sizeof(certificate2), certificate2));
+    msg.addElement(seqNum2, digest2, viewNum2, true, originalViewNum2, sizeof(certificate2), certificate2);
+    EXPECT_EQ(msg.numberOfElements(), 2);
+  }
   msg.setNewViewNumber(++viewNum);
 
-  /////////////////////////////////////////////////////////////////////////////////////////////////////
   uint32_t totalSizeOfComplaints = 0;
   uint32_t numberOfComplaints = 0;
-  for (ReplicaId sender = 1; sender < 4; sender++) {
-    std::unique_ptr<ReplicaAsksToLeaveViewMsg> msg_complaint(
-        ReplicaAsksToLeaveViewMsg::create(sender,
-                                          viewNum,
-                                          ReplicaAsksToLeaveViewMsg::Reason::ClientRequestTimeout,
-                                          concordUtils::SpanContext{spanContext}));
-    EXPECT_EQ(msg_complaint->idOfGeneratedReplica(), sender);
-    EXPECT_EQ(msg_complaint->viewNumber(), viewNum);
-    EXPECT_EQ(msg_complaint->reason(), ReplicaAsksToLeaveViewMsg::Reason::ClientRequestTimeout);
+  if (bAddComplaints) {
+    for (ReplicaId sender = 1; sender < 4; sender++) {
+      std::unique_ptr<ReplicaAsksToLeaveViewMsg> msg_complaint(
+          ReplicaAsksToLeaveViewMsg::create(sender,
+                                            viewNum,
+                                            ReplicaAsksToLeaveViewMsg::Reason::ClientRequestTimeout,
+                                            concordUtils::SpanContext{spanContext}));
+      EXPECT_EQ(msg_complaint->idOfGeneratedReplica(), sender);
+      EXPECT_EQ(msg_complaint->viewNumber(), viewNum);
+      EXPECT_EQ(msg_complaint->reason(), ReplicaAsksToLeaveViewMsg::Reason::ClientRequestTimeout);
 
-    testMessageBaseMethods(*msg_complaint.get(), MsgCode::ReplicaAsksToLeaveView, sender, spanContext);
+      testMessageBaseMethods(*msg_complaint.get(), MsgCode::ReplicaAsksToLeaveView, sender, spanContext);
 
-    EXPECT_NO_THROW(msg_complaint->validate(replicaInfo));
+      EXPECT_NO_THROW(msg_complaint->validate(replicaInfo));
 
-    msg.addComplaint(msg_complaint.get());
+      msg.addComplaint(msg_complaint.get());
 
-    totalSizeOfComplaints += sizeof(decltype(msg_complaint->size()));
-    totalSizeOfComplaints += msg_complaint->size();
-    numberOfComplaints++;
+      totalSizeOfComplaints += sizeof(decltype(msg_complaint->size()));
+      totalSizeOfComplaints += msg_complaint->size();
+      numberOfComplaints++;
+    }
+    EXPECT_EQ(msg.numberOfComplaints(), numberOfComplaints);
+    EXPECT_EQ(msg.sizeOfAllComplaints(), totalSizeOfComplaints);
   }
-  EXPECT_EQ(msg.numberOfComplaints(), numberOfComplaints);
-  EXPECT_EQ(msg.sizeOfAllComplaints(), totalSizeOfComplaints);
-  /////////////////////////////////////////////////////////////////////////////////////////////////////
 
   msg.finalizeMessage();
-  EXPECT_EQ(msg.numberOfElements(), 2);
+  EXPECT_EQ(msg.numberOfElements(), bAddElements ? 2 : 0);
+  EXPECT_EQ(msg.numberOfComplaints(), numberOfComplaints);
+  EXPECT_EQ(msg.sizeOfAllComplaints(), totalSizeOfComplaints);
   EXPECT_NO_THROW(msg.validate(replicaInfo));
 
   {
@@ -117,52 +120,70 @@ TEST(ViewChangeMsg, base_methods) {
 
   testMessageBaseMethods(msg, MsgCode::ViewChange, senderId, spanContext);
 
-  {
-    ViewChangeMsg::ElementsIterator iter(&msg);
-    for (size_t i = 0; !iter.end(); ++i) {
-      ViewChangeMsg::Element* currentElement = nullptr;
-      iter.getCurrent(currentElement);
-      ViewChangeMsg::Element* element = nullptr;
-      EXPECT_TRUE(iter.getAndGoToNext(element));
-      EXPECT_EQ(element, currentElement);
-      EXPECT_EQ(element->hasPreparedCertificate, true);
-      EXPECT_EQ(element->originView, std::get<2>(inputData[i]));
-      EXPECT_EQ(element->hasPreparedCertificate, std::get<3>(inputData[i]));
-      EXPECT_EQ(element->prePrepareDigest, std::get<1>(inputData[i]));
-      EXPECT_EQ(element->seqNum, std::get<0>(inputData[i]));
+  if (bAddElements) {
+    {
+      ViewChangeMsg::ElementsIterator iter(&msg);
+      for (size_t i = 0; !iter.end(); ++i) {
+        ViewChangeMsg::Element* currentElement = nullptr;
+        iter.getCurrent(currentElement);
+        ViewChangeMsg::Element* element = nullptr;
+        EXPECT_TRUE(iter.getAndGoToNext(element));
+        EXPECT_EQ(element, currentElement);
+        EXPECT_EQ(element->hasPreparedCertificate, true);
+        EXPECT_EQ(element->originView, std::get<2>(inputData[i]));
+        EXPECT_EQ(element->hasPreparedCertificate, std::get<3>(inputData[i]));
+        EXPECT_EQ(element->prePrepareDigest, std::get<1>(inputData[i]));
+        EXPECT_EQ(element->seqNum, std::get<0>(inputData[i]));
+      }
     }
-  }
-  {
-    ViewChangeMsg::ElementsIterator iter(&msg);
-    size_t i = 0;
-    for (; !iter.end(); ++i) {
-      iter.gotoNext();
+    {
+      ViewChangeMsg::ElementsIterator iter(&msg);
+      size_t i = 0;
+      for (; !iter.end(); ++i) {
+        iter.gotoNext();
+      }
+      EXPECT_EQ(i, msg.numberOfElements());
     }
-    EXPECT_EQ(i, msg.numberOfElements());
-  }
-  {
-    ViewChangeMsg::ElementsIterator iter(&msg);
-    ViewChangeMsg::Element* element = nullptr;
-    iter.getCurrent(element);
-  }
-  {
-    ViewChangeMsg::ElementsIterator iter(&msg);
-    for (const auto& t : inputData) {
-      EXPECT_TRUE(iter.goToAtLeast(std::get<0>(t)));
+    {
+      ViewChangeMsg::ElementsIterator iter(&msg);
       ViewChangeMsg::Element* element = nullptr;
       iter.getCurrent(element);
-      EXPECT_EQ(element->hasPreparedCertificate, true);
-      EXPECT_EQ(element->originView, std::get<2>(t));
-      EXPECT_EQ(element->hasPreparedCertificate, std::get<3>(t));
-      EXPECT_EQ(element->prePrepareDigest, std::get<1>(t));
-      EXPECT_EQ(element->seqNum, std::get<0>(t));
+    }
+    {
+      ViewChangeMsg::ElementsIterator iter(&msg);
+      for (const auto& t : inputData) {
+        EXPECT_TRUE(iter.goToAtLeast(std::get<0>(t)));
+        ViewChangeMsg::Element* element = nullptr;
+        iter.getCurrent(element);
+        EXPECT_EQ(element->hasPreparedCertificate, true);
+        EXPECT_EQ(element->originView, std::get<2>(t));
+        EXPECT_EQ(element->hasPreparedCertificate, std::get<3>(t));
+        EXPECT_EQ(element->prePrepareDigest, std::get<1>(t));
+        EXPECT_EQ(element->seqNum, std::get<0>(t));
+      }
+    }
+    {
+      ViewChangeMsg::ElementsIterator iter(&msg);
+      EXPECT_FALSE(iter.goToAtLeast(0xFFFF));
     }
   }
-  {
-    ViewChangeMsg::ElementsIterator iter(&msg);
-    EXPECT_FALSE(iter.goToAtLeast(0xFFFF));
-  }
 }
+
+TEST(ViewChangeMsg, base_methods_no_span) { ViewChangeMsgTests(false, false); }
+
+TEST(ViewChangeMsg, add_elements_no_span) { ViewChangeMsgTests(true, false); }
+
+TEST(ViewChangeMsg, add_complaints_no_span) { ViewChangeMsgTests(false, true); }
+
+TEST(ViewChangeMsg, add_elements_and_complaints_no_span) { ViewChangeMsgTests(true, true); }
+
+TEST(ViewChangeMsg, base_methods_with_span) { ViewChangeMsgTests(false, false, rawSpanContext); }
+
+TEST(ViewChangeMsg, add_elements_with_span) { ViewChangeMsgTests(true, false, rawSpanContext); }
+
+TEST(ViewChangeMsg, add_complaints_with_span) { ViewChangeMsgTests(false, true, rawSpanContext); }
+
+TEST(ViewChangeMsg, add_elements_and_complaints_with_span) { ViewChangeMsgTests(true, true, rawSpanContext); }
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
The purpose of this change is to incorporate the quorum of Complaints in the View Change message. 
This way once a Replica receives such View Change message, even if it has not yet received all the necessary
complaints from peers it will be able to verify that it also has to leave the current View.
1. Added list of Complaints to ViewChangeMsg.
2. Added check method for Complaints list.
3. Added ComplaintsIterator to iterate over packed list of Complaints.
4. Added list of Complaints to unit test for ViewChangeMsg.