### PR TITLE
Histograms: Remove allocation in AsyncTimeRecorder

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -441,6 +441,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void bringTheSystemToCheckpointBySendingNoopCommands(SeqNum seqNumToStopAt, CommitPath firstPath = CommitPath::SLOW);
   bool isSeqNumToStopAt(SeqNum seq_num);
 
+  // 5 years
+  static constexpr int64_t MAX_VALUE_SECONDS = 60 * 60 * 24 * 365 * 5;
   // 5 Minutes
   static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60 * 5l;
   // 60 seconds
@@ -458,7 +460,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                         {"requestsQueueOfPrimarySize", requestsQueueOfPrimarySize},
                                         {"onSeqNumIsStable", onSeqNumIsStable},
                                         {"onTransferringCompleteImp", onTransferringCompleteImp},
-                                        {"consensus", consensus}});
+                                        {"consensus", consensus},
+                                        {"timeInActiveView", timeInActiveView}});
     }
 
     std::shared_ptr<Recorder> send =
@@ -482,6 +485,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
     // Only updated by the primary
     std::shared_ptr<Recorder> consensus =
         std::make_shared<Recorder>(1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+
+    std::shared_ptr<Recorder> timeInActiveView =
+        std::make_shared<Recorder>(1, MAX_VALUE_SECONDS, 3, concord::diagnostics::Unit::SECONDS);
   };
 
   Recorders histograms_;
@@ -489,6 +495,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // Used to measure the time for each consensus slot to go from pre-prepare to commit at the primary.
   // Time is recorded in histograms_.consensus
   concord::diagnostics::AsyncTimeRecorderMap<SeqNum> consensus_times_;
+
+  concord::diagnostics::AsyncTimeRecorder<false> time_in_active_view_;
 
   batchingLogic::RequestsBatchingLogic reqBatchingLogic_;
   ReplicaStatusHandlers replStatusHandlers_;

--- a/diagnostics/include/performance_handler.h
+++ b/diagnostics/include/performance_handler.h
@@ -183,17 +183,19 @@ class AsyncTimeRecorder {
   void start() {
     // If a timer was already started, it will record if start is called again before end.
     // This behavior can be prevented by explicitly calling clear().
-    timer_.reset(new TimeRecorder<IsAtomic>(*recorder_));
+    timer_.emplace(*recorder_);
   }
   void end() { timer_.reset(); }
   void clear() {
-    timer_->doNotRecord();
-    timer_.reset();
+    if (timer_) {
+      timer_->doNotRecord();
+      timer_.reset();
+    }
   }
 
  private:
   std::shared_ptr<Recorder> recorder_;
-  std::unique_ptr<TimeRecorder<IsAtomic>> timer_;
+  std::optional<TimeRecorder<IsAtomic>> timer_;
 };
 
 struct Histogram {


### PR DESCRIPTION
This allocation is completely unnecessary and goes against the rule of
making measurement as cheap as possible to encourage its use.

An example was also added for using the AsyncTimeRecorder.