### PR TITLE
Clear wedge point before shutdown

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -53,6 +53,8 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   void setEraseMetadataFlag(int64_t currentSeqNum);
   std::optional<int64_t> getEraseMetadataFlag();
 
+  void clearCheckpointToStopAt();
+
   ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages);
   ControlStateManager& operator=(const ControlStateManager&) = delete;
   ControlStateManager(const ControlStateManager&) = delete;

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -84,5 +84,13 @@ std::optional<int64_t> ControlStateManager::getEraseMetadataFlag() {
   }
   return page_.erase_metadata_at_seq_num_;
 }
+void ControlStateManager::clearCheckpointToStopAt() {
+  ControlStatePage tmpPage = page_;
+  tmpPage.seq_num_to_stop_at_ = 0;
+  std::ostringstream outStream;
+  concord::serialize::Serializable::serialize(outStream, tmpPage);
+  auto data = outStream.str();
+  state_transfer_->saveReservedPage(resPageOffset(), data.size(), data.data());
+}
 
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -183,10 +183,12 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   GaugeHandle metric_primary_last_used_seq_num_;
   GaugeHandle metric_on_call_back_of_super_stable_cp_;
   GaugeHandle metric_sent_replica_asks_to_leave_view_msg_;
+  GaugeHandle metric_bft_batch_size_;
 
   // The first commit path being attempted for a new request.
   StatusHandle metric_first_commit_path_;
 
+  CounterHandle metric_total_committed_sn_;
   CounterHandle metric_slow_path_count_;
   CounterHandle metric_received_internal_msgs_;
   CounterHandle metric_received_client_requests_;


### PR DESCRIPTION
In wedge, we save the wedge point on the reserved pages in order to transfer it using ST. 
That means, that once the replicas recover, they try to read the reserved page again and thus try to wedge again. Hence we need a mechanism for safely clear the wedge point on a replica recovery.

As the data is saved in the RP, we have to clear the data in a point where we know that no replica is running a ST, and that no ST can be initiated in the meanwhile.
Thus, we clear the wedge point once we reached to an n/n checkpoint in this wedge point.
If we reached to an n/n checkpoint it means that all replicas have done with ST (if there was any) and all replicas are going to stop processing new requests (which means that there won't be another ST until we restart the replicas).

*******
In addition in this PR we added two metrics that help us to analyze performance.