### PR TITLE
Adding categorized block and raw block structs

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -5,24 +5,24 @@ Msg MerkleUpdatesData 1 {
     list string deletes
 }
 
-Msg ValueWithExpirationData 2{
+Msg ValueWithExpirationData 2 {
     string value
     optional int64 expire_at
     bool stale_on_update
 }
 
-Msg KeyValueUpdatesData 3{
+Msg KeyValueUpdatesData 3 {
     map string ValueWithExpirationData kv
     list string deletes
     bool calculate_hash
 }
 
-Msg SharedValueData 4{
+Msg SharedValueData 4 {
     string value
     list string categories_ids
 }
 
-Msg SharedUpdatesData 5{
+Msg SharedKeyValueUpdatesData 5 {
     map string SharedValueData kv
     bool calculate_hash
 }
@@ -30,31 +30,81 @@ Msg SharedUpdatesData 5{
 
 # Updates info
 
-Msg MerkleKeyFlag 6{
+Msg MerkleKeyFlag 1000 {
     bool deleted
 }
 
-Msg MerkleUpdatesInfo 7{
+
+Msg MerkleUpdatesInfo 1001 {
     map string MerkleKeyFlag keys
-    fixedlist uint8 32 hash
-    uint64 version
+    fixedlist uint8 32 root_hash
+    uint64 state_root_version
 }
 
-Msg KVKeyFlag 8{
+Msg KVKeyFlag 1002 {
     bool deleted
     bool stale_on_update
 }
 
-Msg KeyValueUpdatesInfo 9{
+Msg KeyValueUpdatesInfo 1003 {
     map string KVKeyFlag keys
-    optional fixedlist uint8 32 hash
+    optional fixedlist uint8 32 root_hash
 }
 
-Msg SharedKeyData 10 {
+Msg SharedKeyData 1004 {
     list string categories
 }
 
-Msg SharedKeyValueUpdatesInfo 11{
+Msg SharedKeyValueUpdatesInfo 1005 {
     map string SharedKeyData keys
-    optional fixedlist uint8 32 hash
+    optional fixedlist uint8 32 root_hash
+}
+
+# Blocks
+
+Msg BlockKey 2000 {
+    uint64 block_id
+}
+
+Msg BlockData 2001 {
+    uint64 block_id
+    fixedlist uint8 32 parent_digest
+    optional SharedKeyValueUpdatesInfo shared_updates_info
+    map string oneof{
+        MerkleUpdatesInfo
+        KeyValueUpdatesInfo
+    } categories_updates_info
+}
+
+Msg RawBlockMerkleUpdates 2002 {
+    MerkleUpdatesData updates
+    fixedlist uint8 32 root_hash
+}
+
+Msg RawBlockKeyValueUpdates 2003 {
+    KeyValueUpdatesData updates
+    optional fixedlist uint8 32 root_hash
+}
+
+Msg RawBlockSharedUpdates 2004 {
+    SharedKeyValueUpdatesData updates
+    optional fixedlist uint8 32 root_hash
+}
+
+Msg RawBlockData 2005 {
+    fixedlist uint8 32 parent_digest
+    map string oneof{
+        RawBlockMerkleUpdates
+        RawBlockKeyValueUpdates
+    } category_updates
+
+    optional RawBlockSharedUpdates shared_update
+}
+
+
+# keys
+
+Msg DbKey 3000 {
+    fixedlist uint8 32 hashed_key
+    uint64 version
 }

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -1,0 +1,164 @@
+#include "updates.h"
+#include <utility>
+#include <block_digest.h>
+#include "details.h"
+#include "merkle_tree_serialization.h"
+#include "merkle_tree_key_manipulator.h"
+#include "sliver.hpp"
+
+namespace concord::kvbc::categorization {
+
+// Block is composed out of:
+// - BlockID
+// - Parent digest
+// - Categories' updates_info where update info is essentially a list of keys, metadata on the keys and a hash of the
+// category state.
+struct Block {
+  static const std::string CATEGORY_ID;
+  Block() {
+    data.block_id = 0;
+    data.parent_digest.fill(0);
+  }
+
+  Block(const BlockId block_id) {
+    data.block_id = block_id;
+    data.parent_digest.fill(0);
+  }
+
+  void add(const std::string& category_id, MerkleUpdatesInfo&& updates_info) {
+    data.categories_updates_info.emplace(category_id, std::move(updates_info));
+  }
+
+  void add(const std::string& category_id, KeyValueUpdatesInfo&& updates_info) {
+    data.categories_updates_info.emplace(category_id, std::move(updates_info));
+  }
+
+  void add(SharedKeyValueUpdatesInfo&& updates_info) { data.shared_updates_info = std::move(updates_info); }
+
+  void setParentHash(const BlockDigest& parent_hash) {
+    std::copy(parent_hash.begin(), parent_hash.end(), data.parent_digest.begin());
+  }
+  inline BlockId id() const { return data.block_id; }
+
+  static const serialization::buffer& serialize(const Block& block) {
+    static thread_local serialization::buffer output;
+    output.clear();
+    concord::kvbc::categorization::serialize(output, block.data);
+    return output;
+  }
+
+  static Block deserialize(const serialization::buffer& input) {
+    Block output;
+    concord::kvbc::categorization::deserialize(input, output.data);
+    return output;
+  }
+
+  // Generate block key from block ID
+  // Using CMF for big endian
+  static const serialization::buffer& generateKey(const BlockId block_id) {
+    static thread_local serialization::buffer output;
+    output.clear();
+    BlockKey key{block_id};
+    // think about optimization
+    concord::kvbc::categorization::serialize(output, key);
+    return output;
+  }
+
+  BlockData data;
+};
+
+const std::string Block::CATEGORY_ID{"__blocks__"};
+
+//////////////////////////////////// RAW BLOCKS//////////////////////////////////////
+
+// Reconstructs the updates data as recieved from the user
+// This set methods are overloaded in order to construct the appropriate updates
+
+// Merkle updates reconstruction
+RawBlockMerkleUpdates getRawUpdates(const std::string& category_id,
+                                    const MerkleUpdatesInfo& update_info,
+                                    const BlockId& block_id,
+                                    const storage::rocksdb::NativeClient* native_client) {
+  // For old serialization
+  using namespace concord::kvbc::v2MerkleTree;
+  RawBlockMerkleUpdates data;
+  // Copy state hash (std::copy?)
+  data.root_hash = update_info.root_hash;
+  // Iterate over the keys:
+  // if deleted, add to the deleted set.
+  // else generate a db key, serialize it and
+  // get the value from the corresponding column family
+  for (auto& [key, flag] : update_info.keys) {
+    if (flag.deleted) {
+      data.updates.deletes.push_back(key);
+      continue;
+    }
+    // E.L see how we can optimize the sliver temporary allocation
+    auto db_key =
+        v2MerkleTree::detail::DBKeyManipulator::genDataDbKey(Key(std::string(key)), update_info.state_root_version);
+    auto val = native_client->get(category_id, db_key);
+    if (!val.has_value()) {
+      throw std::logic_error("Couldn't find value for key");
+    }
+    // E.L serializtion of the Merkle to CMF will be in later phase
+    auto dbLeafVal =
+        v2MerkleTree::detail::deserialize<detail::DatabaseLeafValue>(concordUtils::Sliver{std::move(val.value())});
+    ConcordAssert(dbLeafVal.addedInBlockId == block_id);
+
+    data.updates.kv[key] = dbLeafVal.leafNode.value.toString();
+  }
+
+  return data;
+}
+
+// KeyValueUpdatesData updates reconstruction
+RawBlockKeyValueUpdates getRawUpdates(const std::string& category_id,
+                                      const KeyValueUpdatesInfo& update_info,
+                                      const BlockId& block_id,
+                                      const storage::rocksdb::NativeClient* native_client) {
+  RawBlockKeyValueUpdates data;
+  return data;
+}
+
+// shared updates reconstruction
+RawBlockSharedUpdates getRawSharedUpdates(const SharedKeyValueUpdatesInfo& update_info,
+                                          const BlockId& block_id,
+                                          const storage::rocksdb::NativeClient* native_client) {
+  RawBlockSharedUpdates data;
+  return data;
+}
+
+// Raw block is the unit which we can transfer and reconstruct a block in a remote replica.
+// It contains all the relevant updates as recieved from the client in the initial call to storage.
+// It also contains:
+// - parent digest
+// - state hash per category (if exists) E.L check why do we pass it.
+struct RawBlock {
+  RawBlock(const Block& block, const storage::rocksdb::NativeClient* native_client) {
+    // parent digest (std::copy?)
+    data.parent_digest = block.data.parent_digest;
+    // recontruct updates of categories
+    for (auto& [cat_id, update_info] : block.data.categories_updates_info) {
+      std::visit(
+          [category_id = cat_id, &block, this, &native_client](const auto& update_info) {
+            auto category_updates = getRawUpdates(category_id, update_info, block.id(), native_client);
+            data.category_updates.emplace(category_id, std::move(category_updates));
+          },
+          update_info);
+    }
+    if (block.data.shared_updates_info.has_value()) {
+      data.shared_update = getRawSharedUpdates(block.data.shared_updates_info.value(), block.id(), native_client);
+    }
+  }
+
+  static const serialization::buffer& serialize(const RawBlockData& data) {
+    static thread_local serialization::buffer out;
+    out.clear();
+    concord::kvbc::categorization::serialize(out, data);
+    return out;
+  }
+
+  RawBlockData data;
+};
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -1,0 +1,30 @@
+#include <vector>
+#include <string>
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "kv_types.hpp"
+#include "sparse_merkle/base_types.h"
+#include "evp_hash.hpp"
+
+namespace concord::kvbc::categorization {
+
+namespace serialization {
+using buffer = std::vector<uint8_t>;
+}  // namespace serialization
+
+namespace hash {
+using HashType = concord::util::SHA3_256;
+using digest = HashType::Digest;
+digest sha3_256(const void* buf, size_t size) { return HashType{}.digest(buf, size); }
+}  // namespace hash
+
+// DB key is a CMF stuct of hashed key and the version.
+// On serialization it will be hashed_key || version(big endian)
+DbKey genDbKey(const std::string& key, const BlockId& version) {
+  DbKey db_key;
+  auto hash_arr = hash::sha3_256(key.data(), key.length());
+  db_key.hashed_key = hash_arr;
+  db_key.version = version;
+  return db_key;
+}
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/test/categorization/updates_test.cpp
+++ b/kvbc/test/categorization/updates_test.cpp
@@ -9,13 +9,26 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <random>
+#include "storage/test/storage_test_common.h"
 
 using namespace concord::kvbc::categorization;
 using namespace concord::kvbc;
 
 namespace {
 
-TEST(categorized_updates, merkle_update) {
+class categorized_kvbc : public ::testing::Test {
+  void SetUp() override {
+    cleanup();
+    db = TestRocksDb::createNative();
+  }
+  void TearDown() override { cleanup(); }
+
+ protected:
+  std::shared_ptr<NativeClient> db;
+};
+
+TEST_F(categorized_kvbc, merkle_update) {
   std::string key{"key"};
   std::string val{"val"};
   MerkleUpdates mu;
@@ -23,10 +36,130 @@ TEST(categorized_updates, merkle_update) {
   ASSERT_TRUE(mu.getData().kv.size() == 1);
 }
 
-TEST(categorized_updates, add_block) {
-  KeyValueBlockchain block_chain;
-  Updates updates;
-  ASSERT_TRUE(block_chain.addBlock(updates) == (BlockId)8);
+TEST_F(categorized_kvbc, add_blocks) {
+  db->createColumnFamily(Block::CATEGORY_ID);
+  KeyValueBlockchain block_chain{db};
+  // Add block1
+  {
+    Updates updates;
+    MerkleUpdates merkle_updates;
+    merkle_updates.addUpdate("merkle_key1", "merkle_value1");
+    merkle_updates.addDelete("merkle_deleted");
+    updates.add("merkle", std::move(merkle_updates));
+
+    KeyValueUpdates keyval_updates;
+    keyval_updates.addUpdate("kv_key1", "key_val1");
+    keyval_updates.addDelete("kv_deleted");
+    updates.add("kv_hash", std::move(keyval_updates));
+    ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
+  }
+  // Add block2
+  {
+    Updates updates;
+    MerkleUpdates merkle_updates;
+    merkle_updates.addUpdate("merkle_key2", "merkle_value2");
+    merkle_updates.addDelete("merkle_deleted");
+    updates.add("merkle", std::move(merkle_updates));
+
+    KeyValueUpdates keyval_updates;
+    keyval_updates.addUpdate("kv_key2", "key_val2");
+    keyval_updates.addDelete("kv_deleted");
+    updates.add("kv_hash", std::move(keyval_updates));
+
+    SharedKeyValueUpdates shared_updates;
+    shared_updates.addUpdate("shared_key2", {"shared_Val2", {"1", "2"}});
+    updates.add(std::move(shared_updates));
+    ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)2);
+  }
+  // get block 1 from DB and test it
+  {
+    const serialization::buffer& block_db_key = Block::generateKey(1);
+    auto block1_db_val = db->get(Block::CATEGORY_ID, block_db_key);
+    ASSERT_TRUE(block1_db_val.has_value());
+    // E.L need to add support for strings in cmf
+    serialization::buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
+    auto block1_from_db = Block::deserialize(in);
+    auto merkle_variant = block1_from_db.data.categories_updates_info["merkle"];
+    auto merkle_update_info1 = std::get<MerkleUpdatesInfo>(merkle_variant);
+    ASSERT_EQ(merkle_update_info1.keys["merkle_deleted"].deleted, true);
+    auto kv_hash_variant = block1_from_db.data.categories_updates_info["kv_hash"];
+    auto kv_hash_update_info1 = std::get<KeyValueUpdatesInfo>(kv_hash_variant);
+    ASSERT_EQ(kv_hash_update_info1.keys["kv_deleted"].deleted, true);
+    ASSERT_FALSE(block1_from_db.data.shared_updates_info.has_value());
+  }
+  // get block 2 from DB and test it
+  {
+    const serialization::buffer& block_db_key = Block::generateKey(2);
+    auto block2_db_val = db->get(Block::CATEGORY_ID, block_db_key);
+    ASSERT_TRUE(block2_db_val.has_value());
+    // E.L need to add support for strings in cmf
+    serialization::buffer in{block2_db_val.value().begin(), block2_db_val.value().end()};
+    auto block2_from_db = Block::deserialize(in);
+    ASSERT_TRUE(block2_from_db.data.shared_updates_info.has_value());
+    std::vector<std::string> v{"1", "2"};
+    ASSERT_EQ(block2_from_db.data.shared_updates_info.value().keys["shared_key2"].categories, v);
+  }
+}
+
+TEST_F(categorized_kvbc, serialization_and_desirialization_of_block) {
+  BlockDigest pHash;
+  std::random_device rd;
+  for (int i = 0; i < (int)pHash.size(); i++) {
+    pHash[i] = (uint8_t)(rd() % 255);
+  }
+  Block block{8};
+  KeyValueUpdatesInfo kvui;
+  kvui.keys["key1"] = {false, false};
+  kvui.keys["key2"] = {true, false};
+  block.add("KeyValueUpdatesInfo", std::move(kvui));
+  block.setParentHash(pHash);
+  auto ser = Block::serialize(block);
+  auto des_block = Block::deserialize(ser);
+
+  // Test the deserialized Block
+  ASSERT_TRUE(des_block.id() == 8);
+  auto variant = des_block.data.categories_updates_info["KeyValueUpdatesInfo"];
+  KeyValueUpdatesInfo kv_updates_info = std::get<KeyValueUpdatesInfo>(variant);
+  ASSERT_TRUE(kv_updates_info.keys.size() == 2);
+  ASSERT_TRUE(kv_updates_info.keys["key2"].deleted == true);
+  ASSERT_EQ(des_block.data.parent_digest, block.data.parent_digest);
+}
+
+TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
+  BlockDigest pHash;
+  std::random_device rd;
+  for (int i = 0; i < (int)pHash.size(); i++) {
+    pHash[i] = (uint8_t)(rd() % 255);
+  }
+
+  auto cf = std::string("merkle");
+  auto key = std::string("key");
+  auto value = std::string("val");
+
+  uint64_t state_root_version = 886;
+  MerkleUpdatesInfo mui;
+  mui.keys[key] = MerkleKeyFlag{false};
+  mui.root_hash = pHash;
+  mui.state_root_version = state_root_version;
+
+  Block block{888};
+  block.add(cf, std::move(mui));
+  block.setParentHash(pHash);
+
+  db->createColumnFamily(cf);
+  auto db_key = v2MerkleTree::detail::DBKeyManipulator::genDataDbKey(std::string(key), state_root_version);
+  auto db_val = v2MerkleTree::detail::serialize(
+      v2MerkleTree::detail::DatabaseLeafValue{block.id(), sparse_merkle::LeafNode{std::string(value)}});
+  db->put(cf, db_key, db_val);
+  auto db_get_val = db->get(cf, db_key);
+  ASSERT_EQ(db_get_val.value(), db_val);
+
+  concord::kvbc::categorization::RawBlock rw(block, db.get());
+  ASSERT_EQ(rw.data.parent_digest, block.data.parent_digest);
+  auto variant = rw.data.category_updates[cf];
+  auto raw_merkle_updates = std::get<RawBlockMerkleUpdates>(variant);
+  // check reconstruction of original kv
+  ASSERT_EQ(raw_merkle_updates.updates.kv[key], value);
 }
 
 }  // end namespace

--- a/storage/include/rocksdb/native_client.h
+++ b/storage/include/rocksdb/native_client.h
@@ -237,6 +237,17 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
     return ::rocksdb::Slice{span.data(), span.size()};
   }
 
+  template <
+      typename Span,
+      std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
+                           std::is_pointer_v<decltype(std::declval<Span>().data())> &&
+                           std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
+                                                 const uint8_t (*)[]>,
+                       int> = 0>
+  static ::rocksdb::Slice toSlice(const Span &span) noexcept {
+    return ::rocksdb::Slice{reinterpret_cast<const char *>(span.data()), span.size()};
+  }
+
   static void throwOnError(std::string_view msg1, std::string_view msg2, ::rocksdb::Status &&);
   static void throwOnError(std::string_view msg, ::rocksdb::Status &&);
 


### PR DESCRIPTION
Block contains data per category, about keys that were added at this block.
In addition, it contains the parent digest and the block ID.

Each category is responsible to handle the block struct its ```update_info``` as the result of an update operation.

Rawblock is a unit, which we can transfer and reconstruct a block in a remote replica.
It contains all the relevant updates as received from the client in the initial call to storage.

RawBlock can be constructed from a ```Block``` struct.

In addition, this PR adds support to ```unsigned char``` in RocksDB NativeClient.
Refactoring to the updates and kv_blockchain API.
Unit tests.