### PR TITLE
Implement the SharedKeyValueCategory::add() method

### DIFF
--- a/cmake/FindCMFC.cmake
+++ b/cmake/FindCMFC.cmake
@@ -19,7 +19,7 @@ function(CMF_GENERATE_CPP CPP_HEADER CPP_IMPL CPP_NAMESPACE)
            --output ${FIL}
            --language cpp
            --namespace ${CPP_NAMESPACE}
-      DEPENDS ${CMF_COMPILER}
+      DEPENDS ${FIL} ${CMF_COMPILER} ${CMAKE_SOURCE_DIR}/messages/compiler/cpp/serialize.cpp
       COMMENT "CMFC: Generate C++ code for ${FIL}"
       VERBATIM
     )

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -20,6 +20,10 @@ add_library(kvbc  src/ClientImp.cpp
                   src/sparse_merkle/walker.cpp
 )
 
+if (BUILD_ROCKSDB_STORAGE)
+    target_sources(kvbc PRIVATE src/categorization/shared_kv_category.cpp)
+endif (BUILD_ROCKSDB_STORAGE)
+
 target_link_libraries(kvbc PUBLIC corebft )
 target_link_libraries(kvbc PUBLIC categorized_kvbc_msgs)
 

--- a/kvbc/benchmark/CMakeLists.txt
+++ b/kvbc/benchmark/CMakeLists.txt
@@ -12,4 +12,12 @@ if(benchmark_FOUND)
         corebft
         kvbc
     )
+
+    add_executable(categorization_benchmark categorization_benchmark.cpp )
+    target_link_libraries(categorization_benchmark PUBLIC
+        benchmark
+        util
+        corebft
+        kvbc
+    )
 endif()

--- a/kvbc/benchmark/categorization_benchmark.cpp
+++ b/kvbc/benchmark/categorization_benchmark.cpp
@@ -1,0 +1,78 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+//
+
+#include <benchmark/benchmark.h>
+
+#include "categorization/base_types.h"
+#include "categorization/details.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+#include <cstddef>
+
+namespace {
+
+using namespace concord::kvbc::categorization;
+using namespace concord::kvbc::categorization::detail;
+
+template <typename T>
+Buffer serializeAlloc(const T &data) {
+  auto out = Buffer{};
+  serialize(out, data);
+  return out;
+}
+
+template <typename T>
+const Buffer &serializeTls(const T &data) {
+  static thread_local auto out = Buffer{};
+  out.clear();
+  serialize(out, data);
+  return out;
+}
+
+BenchmarkMessage message(std::size_t range) {
+  auto msg = BenchmarkMessage{};
+  auto str = std::string(range, 'a');
+  msg.str = str;
+  msg.map["k1"] = str;
+  msg.map["k2"] = str;
+  msg.map["k3"] = str;
+  msg.map[str] = str;
+  return msg;
+}
+
+void serializeAlloc(benchmark::State &state) {
+  const auto msg = message(state.range(0));
+  for (auto _ : state) {
+    const auto out = serializeAlloc(msg);
+    benchmark::DoNotOptimize(out);
+  }
+}
+
+void serializeTls(benchmark::State &state) {
+  const auto msg = message(state.range(0));
+  for (auto _ : state) {
+    const auto &out = serializeTls(msg);
+    benchmark::DoNotOptimize(out);
+  }
+}
+
+}  // namespace
+
+const auto range_multiplier = 2;
+const auto serialize_size_start = 8;
+const auto serialize_size_end = 4096;
+
+BENCHMARK(serializeAlloc)->RangeMultiplier(range_multiplier)->Range(serialize_size_start, serialize_size_end);
+BENCHMARK(serializeTls)->RangeMultiplier(range_multiplier)->Range(serialize_size_start, serialize_size_end);
+
+BENCHMARK_MAIN();

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -102,11 +102,7 @@ Msg RawBlockData 2005 {
 
 # Misc
 
-Msg Version 3000 {
-    uint64 value
-}
-
-Msg BenchmarkMessage 3001 {
+Msg BenchmarkMessage 3000 {
     string str
     fixedlist uint8 32 hash
     map string string map
@@ -123,17 +119,9 @@ Msg VersionedKey 4001 {
     uint64 version
 }
 
-Msg SharedDbValuePointer 4002 {
-    string category_id
+# Persisted as a value in for keys in the index column family.
+# Contains a per category sorted list of versions for the key.
+Msg KeyVersionsPerCategory 4002 {
+    map string list uint64 data
 }
 
-Msg SharedDbValueData 4003 {
-    string data
-}
-
-Msg SharedDbValue 4004 {
-    oneof {
-        SharedDbValueData
-        SharedDbValuePointer
-    } data
-}

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -14,26 +14,24 @@ Msg ValueWithExpirationData 2 {
 Msg KeyValueUpdatesData 3 {
     map string ValueWithExpirationData kv
     list string deletes
-    bool calculate_hash
+    bool calculate_root_hash
 }
 
 Msg SharedValueData 4 {
     string value
-    list string categories_ids
+    list string category_ids
 }
 
 Msg SharedKeyValueUpdatesData 5 {
     map string SharedValueData kv
-    bool calculate_hash
+    bool calculate_root_hash
 }
-
 
 # Updates info
 
 Msg MerkleKeyFlag 1000 {
     bool deleted
 }
-
 
 Msg MerkleUpdatesInfo 1001 {
     map string MerkleKeyFlag keys
@@ -42,6 +40,7 @@ Msg MerkleUpdatesInfo 1001 {
 }
 
 Msg KVKeyFlag 1002 {
+
     bool deleted
     bool stale_on_update
 }
@@ -57,7 +56,7 @@ Msg SharedKeyData 1004 {
 
 Msg SharedKeyValueUpdatesInfo 1005 {
     map string SharedKeyData keys
-    optional fixedlist uint8 32 root_hash
+    optional map string fixedlist uint8 32 category_root_hashes
 }
 
 # Blocks
@@ -101,10 +100,40 @@ Msg RawBlockData 2005 {
     optional RawBlockSharedUpdates shared_update
 }
 
+# Misc
 
-# keys
+Msg Version 3000 {
+    uint64 value
+}
 
-Msg DbKey 3000 {
-    fixedlist uint8 32 hashed_key
+Msg BenchmarkMessage 3001 {
+    string str
+    fixedlist uint8 32 hash
+    map string string map
+}
+
+# DB Key-Values
+
+Msg KeyHash 4000 {
+    fixedlist uint8 32 value
+}
+
+Msg VersionedKey 4001 {
+    KeyHash key_hash
     uint64 version
+}
+
+Msg SharedDbValuePointer 4002 {
+    string category_id
+}
+
+Msg SharedDbValueData 4003 {
+    string data
+}
+
+Msg SharedDbValue 4004 {
+    oneof {
+        SharedDbValueData
+        SharedDbValuePointer
+    } data
 }

--- a/kvbc/include/categorization/base_types.h
+++ b/kvbc/include/categorization/base_types.h
@@ -1,0 +1,69 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "kv_types.hpp"
+#include "sha_hash.hpp"
+
+#include <cstddef>
+#include <ctime>
+#include <optional>
+#include <string>
+
+namespace concord::kvbc::categorization {
+
+struct Value {
+  std::string data;
+  BlockId block_id{0};
+  std::optional<std::time_t> expire_at;
+};
+
+using Hasher = concord::util::SHA3_256;
+using Hash = Hasher::Digest;
+
+struct KeyValueProof {
+  std::string key;
+  Value value;
+
+  // The index at which the key-value hash is to be combined with the complement ones.
+  std::size_t key_value_index{0};
+
+  // Ordeded hashes of the other key-values in the category.
+  std::vector<Hash> ordered_complement_kv_hashes;
+
+  Hash calculateRootHash() const {
+    auto hasher = Hasher{};
+    const auto key_hash = hasher.digest(key.data(), key.size());
+    const auto value_hash = hasher.digest(value.data.data(), value.data.size());
+
+    // root_hash = h((h(k1) || h(v1)) || (h(k2) || h(v2)) || ... || (h(k3) || h(v3)))
+    hasher.init();
+    if (ordered_complement_kv_hashes.empty()) {
+      hasher.update(key_hash.data(), key_hash.size());
+      hasher.update(value_hash.data(), value_hash.size());
+    } else {
+      for (auto i = 0ul; i < ordered_complement_kv_hashes.size(); ++i) {
+        if (i == key_value_index) {
+          hasher.update(key_hash.data(), key_hash.size());
+          hasher.update(value_hash.data(), value_hash.size());
+        }
+        const auto &hash_i = ordered_complement_kv_hashes[i];
+        hasher.update(hash_i.data(), hash_i.size());
+      }
+    }
+    return hasher.finish();
+  }
+};
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -1,3 +1,18 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
 #include "updates.h"
 #include <utility>
 #include <block_digest.h>
@@ -15,7 +30,6 @@ namespace concord::kvbc::categorization {
 // - Categories' updates_info where update info is essentially a list of keys, metadata on the keys and a hash of the
 // category state.
 struct Block {
-  static const std::string CATEGORY_ID;
   Block() {
     data.block_id = 0;
     data.parent_digest.fill(0);
@@ -67,8 +81,6 @@ struct Block {
 
   BlockData data;
 };
-
-const std::string Block::CATEGORY_ID{"__blocks__"};
 
 //////////////////////////////////// RAW BLOCKS//////////////////////////////////////
 

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -4,6 +4,7 @@
 #include "details.h"
 #include "merkle_tree_serialization.h"
 #include "merkle_tree_key_manipulator.h"
+#include "merkle_tree_db_adapter.h"
 #include "sliver.hpp"
 
 namespace concord::kvbc::categorization {
@@ -40,14 +41,14 @@ struct Block {
   }
   inline BlockId id() const { return data.block_id; }
 
-  static const serialization::buffer& serialize(const Block& block) {
-    static thread_local serialization::buffer output;
+  static const detail::Buffer& serialize(const Block& block) {
+    static thread_local detail::Buffer output;
     output.clear();
     concord::kvbc::categorization::serialize(output, block.data);
     return output;
   }
 
-  static Block deserialize(const serialization::buffer& input) {
+  static Block deserialize(const detail::Buffer& input) {
     Block output;
     concord::kvbc::categorization::deserialize(input, output.data);
     return output;
@@ -55,8 +56,8 @@ struct Block {
 
   // Generate block key from block ID
   // Using CMF for big endian
-  static const serialization::buffer& generateKey(const BlockId block_id) {
-    static thread_local serialization::buffer output;
+  static const detail::Buffer& generateKey(const BlockId block_id) {
+    static thread_local detail::Buffer output;
     output.clear();
     BlockKey key{block_id};
     // think about optimization
@@ -101,8 +102,8 @@ RawBlockMerkleUpdates getRawUpdates(const std::string& category_id,
       throw std::logic_error("Couldn't find value for key");
     }
     // E.L serializtion of the Merkle to CMF will be in later phase
-    auto dbLeafVal =
-        v2MerkleTree::detail::deserialize<detail::DatabaseLeafValue>(concordUtils::Sliver{std::move(val.value())});
+    auto dbLeafVal = v2MerkleTree::detail::deserialize<v2MerkleTree::detail::DatabaseLeafValue>(
+        concordUtils::Sliver{std::move(val.value())});
     ConcordAssert(dbLeafVal.addedInBlockId == block_id);
 
     data.updates.kv[key] = dbLeafVal.leafNode.value.toString();
@@ -151,8 +152,8 @@ struct RawBlock {
     }
   }
 
-  static const serialization::buffer& serialize(const RawBlockData& data) {
-    static thread_local serialization::buffer out;
+  static const detail::Buffer& serialize(const RawBlockData& data) {
+    static thread_local detail::Buffer out;
     out.clear();
     concord::kvbc::categorization::serialize(out, data);
     return out;

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -17,8 +17,8 @@
 
 namespace concord::kvbc::categorization::detail {
 
-inline const auto SHARED_KV_DATA_CF_SUFFIX = std::string{"_skvdata"};
-inline const auto SHARED_KV_LATEST_KEY_VER_CF_SUFFIX = std::string{"_skvlatest"};
+inline const auto SHARED_KV_DATA_CF = std::string{"shared_kv_data"};
+inline const auto SHARED_KV_KEY_VERSIONS_CF = std::string{"shared_kv_key_versions"};
 
 inline const auto BLOCKS_CF = std::string{"blocks"};
 

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -1,0 +1,25 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+
+namespace concord::kvbc::categorization::detail {
+
+inline const auto SHARED_KV_DATA_CF_SUFFIX = std::string{"_skvdata"};
+inline const auto SHARED_KV_LATEST_KEY_VER_CF_SUFFIX = std::string{"_skvlatest"};
+
+inline const auto BLOCKS_CF = std::string{"blocks"};
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -15,9 +15,11 @@
 
 #include "base_types.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
+#include "rocksdb/native_client.h"
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -64,6 +66,12 @@ template <typename Span,
 void deserialize(const Span &in, T &out) {
   auto begin = in.data();
   deserialize(begin, begin + in.size(), out);
+}
+
+inline void createColumnFamilyIfNotExisting(const std::string &cf, storage::rocksdb::NativeClient &db) {
+  if (!db.hasColumnFamily(cf)) {
+    db.createColumnFamily(cf);
+  }
 }
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -1,30 +1,69 @@
-#include <vector>
-#include <string>
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "base_types.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
-#include "kv_types.hpp"
-#include "sparse_merkle/base_types.h"
-#include "evp_hash.hpp"
 
-namespace concord::kvbc::categorization {
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
 
-namespace serialization {
-using buffer = std::vector<uint8_t>;
-}  // namespace serialization
+namespace concord::kvbc::categorization::detail {
 
-namespace hash {
-using HashType = concord::util::SHA3_256;
-using digest = HashType::Digest;
-digest sha3_256(const void* buf, size_t size) { return HashType{}.digest(buf, size); }
-}  // namespace hash
+using Buffer = std::vector<std::uint8_t>;
 
-// DB key is a CMF stuct of hashed key and the version.
-// On serialization it will be hashed_key || version(big endian)
-DbKey genDbKey(const std::string& key, const BlockId& version) {
-  DbKey db_key;
-  auto hash_arr = hash::sha3_256(key.data(), key.length());
-  db_key.hashed_key = hash_arr;
-  db_key.version = version;
-  return db_key;
+template <typename Span>
+Hash hash(const Span &span) {
+  return Hasher{}.digest(span.data(), span.size());
 }
 
-}  // namespace concord::kvbc::categorization
+inline VersionedKey versionedKey(const std::string &key, BlockId block_id) {
+  return VersionedKey{KeyHash{detail::hash(key)}, block_id};
+}
+
+template <typename T>
+const Buffer &serialize(const T &value) {
+  static thread_local auto buf = Buffer{};
+  buf.clear();
+  serialize(buf, value);
+  return buf;
+}
+
+template <typename Span,
+          typename T,
+          std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
+                               std::is_pointer_v<decltype(std::declval<Span>().data())> &&
+                               std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
+                                                     const char (*)[]>,
+                           int> = 0>
+void deserialize(const Span &in, T &out) {
+  auto begin = reinterpret_cast<const std::uint8_t *>(in.data());
+  deserialize(begin, begin + in.size(), out);
+}
+
+template <typename Span,
+          typename T,
+          std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
+                               std::is_pointer_v<decltype(std::declval<Span>().data())> &&
+                               std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
+                                                     const std::uint8_t (*)[]>,
+                           int> = 0>
+void deserialize(const Span &in, T &out) {
+  auto begin = in.data();
+  deserialize(begin, begin + in.size(), out);
+}
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -42,13 +42,14 @@ class KeyValueBlockchain {
       // https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding
       std::visit(
           [&new_block, category_id = category_id, &write_batch, this](auto& update) {
-            auto block_updates = handleCategoryUpdates(category_id, std::move(update), write_batch);
+            auto block_updates = handleCategoryUpdates(new_block.id(), category_id, std::move(update), write_batch);
             new_block.add(category_id, std::move(block_updates));
           },
           update);
     }
     if (updates.shared_update_.has_value()) {
-      auto block_updates = handleCategoryUpdates(std::move(updates.shared_update_.value()), write_batch);
+      auto block_updates =
+          handleCategoryUpdates(new_block.id(), std::move(updates.shared_update_.value()), write_batch);
       new_block.add(std::move(block_updates));
     }
     // newBlock.parentDigest = parentBlockDigestFuture.get();
@@ -59,7 +60,8 @@ class KeyValueBlockchain {
   }
 
  private:
-  MerkleUpdatesInfo handleCategoryUpdates(const std::string& category_id,
+  MerkleUpdatesInfo handleCategoryUpdates(BlockId block_id,
+                                          const std::string& category_id,
                                           MerkleUpdatesData&& updates,
                                           WriteBatch& write_batch) {
     MerkleUpdatesInfo mui;
@@ -73,7 +75,8 @@ class KeyValueBlockchain {
     return mui;
   }
 
-  KeyValueUpdatesInfo handleCategoryUpdates(const std::string& category_id,
+  KeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
+                                            const std::string& category_id,
                                             KeyValueUpdatesData&& updates,
                                             WriteBatch& write_batch) {
     KeyValueUpdatesInfo kvui;
@@ -87,11 +90,13 @@ class KeyValueBlockchain {
     return kvui;
   }
 
-  SharedKeyValueUpdatesInfo handleCategoryUpdates(SharedKeyValueUpdatesData&& updates, WriteBatch& write_batch) {
+  SharedKeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
+                                                  SharedKeyValueUpdatesData&& updates,
+                                                  WriteBatch& write_batch) {
     SharedKeyValueUpdatesInfo skvui;
     for (auto& [k, v] : updates.kv) {
       (void)v;
-      skvui.keys[k] = SharedKeyData{v.categories_ids};
+      skvui.keys[k] = SharedKeyData{v.category_ids};
     }
     return skvui;
   }

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -54,7 +54,7 @@ class KeyValueBlockchain {
     }
     // newBlock.parentDigest = parentBlockDigestFuture.get();
     // // E.L blocks in new column Family
-    write_batch.put(Block::CATEGORY_ID, Block::generateKey(new_block.id()), Block::serialize(new_block));
+    write_batch.put(detail::BLOCKS_CF, Block::generateKey(new_block.id()), Block::serialize(new_block));
     native_client_->write(std::move(write_batch));
     return lastReachableBlockId_ = new_block.id();
   }

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -20,14 +20,15 @@
 
 #include "kv_types.hpp"
 
-using namespace concord::storage::rocksdb;
-
 namespace concord::kvbc::categorization {
 
 class KeyValueBlockchain {
  public:
-  KeyValueBlockchain() : native_client_(NativeClient::newClient("/tmp", false, NativeClient::DefaultOptions{})) {}
-  KeyValueBlockchain(const std::shared_ptr<NativeClient>& native_client) : native_client_(native_client) {}
+  KeyValueBlockchain()
+      : native_client_(concord::storage::rocksdb::NativeClient::newClient(
+            "/tmp", false, concord::storage::rocksdb::NativeClient::DefaultOptions{})) {}
+  KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client)
+      : native_client_(native_client) {}
   // 1) Defines a new block
   // 2) calls per cateogry with its updates
   // 3) inserts the updates KV to the DB updates set per column family
@@ -63,7 +64,7 @@ class KeyValueBlockchain {
   MerkleUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                           const std::string& category_id,
                                           MerkleUpdatesData&& updates,
-                                          WriteBatch& write_batch) {
+                                          concord::storage::rocksdb::NativeWriteBatch& write_batch) {
     MerkleUpdatesInfo mui;
     for (auto& [k, v] : updates.kv) {
       (void)v;
@@ -78,7 +79,7 @@ class KeyValueBlockchain {
   KeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                             const std::string& category_id,
                                             KeyValueUpdatesData&& updates,
-                                            WriteBatch& write_batch) {
+                                            concord::storage::rocksdb::NativeWriteBatch& write_batch) {
     KeyValueUpdatesInfo kvui;
     for (auto& [k, v] : updates.kv) {
       (void)v;
@@ -92,7 +93,7 @@ class KeyValueBlockchain {
 
   SharedKeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                                   SharedKeyValueUpdatesData&& updates,
-                                                  WriteBatch& write_batch) {
+                                                  concord::storage::rocksdb::NativeWriteBatch& write_batch) {
     SharedKeyValueUpdatesInfo skvui;
     for (auto& [k, v] : updates.kv) {
       (void)v;
@@ -103,7 +104,7 @@ class KeyValueBlockchain {
 
   BlockId getLastReachableBlockId() { return lastReachableBlockId_; }
   // Members
-  std::shared_ptr<NativeClient> native_client_;
+  std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
   BlockId lastReachableBlockId_{0};
 };
 

--- a/kvbc/include/categorization/shared_kv_category.h
+++ b/kvbc/include/categorization/shared_kv_category.h
@@ -44,21 +44,23 @@ class SharedKeyValueCategory {
   SharedKeyValueCategory(const std::shared_ptr<storage::rocksdb::NativeClient> &);
 
   // Add the given block updates and return the information that needs to be persisted in the block.
-  SharedKeyValueUpdatesInfo add(BlockId block_id, SharedKeyValueUpdatesData &&update, storage::rocksdb::WriteBatch &);
+  SharedKeyValueUpdatesInfo add(BlockId block_id,
+                                SharedKeyValueUpdatesData &&update,
+                                storage::rocksdb::NativeWriteBatch &);
 
   // Delete the genesis block.
   // `updates_info` must be the updates for `block_id`.
   // Precondition: `block_id` is the current genesis block ID.
   void deleteGenesisBlock(BlockId block_id,
                           const SharedKeyValueUpdatesInfo &updates_info,
-                          storage::rocksdb::WriteBatch &);
+                          storage::rocksdb::NativeWriteBatch &);
 
   // Delete the last reachable block.
   // `updates_info` must be the updates for `block_id`.
   // Precondition: `block_id` is the current last reachable block ID.
   void deleteLastReachableBlock(BlockId block_id,
                                 const SharedKeyValueUpdatesInfo &updates_info,
-                                storage::rocksdb::WriteBatch &);
+                                storage::rocksdb::NativeWriteBatch &);
 
   // Get the value of a key in `category_id` with a block version up to `max_block_id`.
   // Return std::nullopt if the key doesn't exist in any earlier blocks than `max_block_id`.

--- a/kvbc/include/categorization/shared_kv_category.h
+++ b/kvbc/include/categorization/shared_kv_category.h
@@ -27,7 +27,10 @@ namespace concord::kvbc::categorization::detail {
 // The shared key-value category persists key-values across multiple categories. A category is implemented as a pair of
 // RocksDB column families:
 //  * `data` column family - contains versioned key-values for the given category
-//  * `latest version` column family - contains the latest version of a key for the given category
+//  * `latest version` column family - contains the latest version of a key for the given category. The rationale behind
+//    storing the latest version of a key is to support latest version key lookup without using RocksdDB iterators.
+//    Instead, we can use two point lookups - one to get the latest version and one to get the actual value. This is
+//    done for performance reasons.
 //
 // If a key-value is part of multiple categories in a single block update, the value will be physically stored once only
 // in one of the categories and other categories will contain a key with a `pointer` to the value.

--- a/kvbc/include/categorization/shared_kv_category.h
+++ b/kvbc/include/categorization/shared_kv_category.h
@@ -1,0 +1,89 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+
+#include "base_types.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+#include <memory>
+#include <string>
+
+namespace concord::kvbc::categorization::detail {
+
+// The shared key-value category persists key-values across multiple categories. A category is implemented as a pair of
+// RocksDB column families:
+//  * `data` column family - contains versioned key-values for the given category
+//  * `latest version` column family - contains the latest version of a key for the given category
+//
+// If a key-value is part of multiple categories in a single block update, the value will be physically stored once only
+// in one of the categories and other categories will contain a key with a `pointer` to the value.
+//
+// Key-values in the shared category are automatically made stale on addition.
+//
+// Key-value proofs per category and per block are supported in the form of a root hash that describes the block
+// updates.
+class SharedKeyValueCategory {
+ public:
+  SharedKeyValueCategory(const std::shared_ptr<storage::rocksdb::NativeClient> &);
+
+  // Add the given block updates and return the information that needs to be persisted in the block.
+  SharedKeyValueUpdatesInfo add(BlockId block_id, SharedKeyValueUpdatesData &&update, storage::rocksdb::WriteBatch &);
+
+  // Delete the genesis block.
+  // `updates_info` must be the updates for `block_id`.
+  // Precondition: `block_id` is the current genesis block ID.
+  void deleteGenesisBlock(BlockId block_id,
+                          const SharedKeyValueUpdatesInfo &updates_info,
+                          storage::rocksdb::WriteBatch &);
+
+  // Delete the last reachable block.
+  // `updates_info` must be the updates for `block_id`.
+  // Precondition: `block_id` is the current last reachable block ID.
+  void deleteLastReachableBlock(BlockId block_id,
+                                const SharedKeyValueUpdatesInfo &updates_info,
+                                storage::rocksdb::WriteBatch &);
+
+  // Get the value of a key in `category_id` with a block version up to `max_block_id`.
+  // Return std::nullopt if the key doesn't exist in any earlier blocks than `max_block_id`.
+  std::optional<Value> getValueUpToBlock(const std::string &category_id,
+                                         const std::string &key,
+                                         BlockId max_block_id) const;
+
+  // Get the value of a key in `category_id` at `block_id`.
+  // Return std::nullopt if the key doesn't exist at `block_id`.
+  std::optional<Value> getValueAtBlock(const std::string &category_id, const std::string &key, BlockId block_id) const;
+
+  // Get the latest value of a key in `category_id`.
+  // Return std::nullopt if the key doesn't exist.
+  std::optional<Value> getLatestValue(const std::string &category_id, const std::string &key) const;
+
+  // Get the value of a key and a proof for it in `category_id` at the given `block_id`.
+  // `updates_info` must be the updates for `block_id`.
+  // Return std::nullopt if the key doesn't exist at `block_id`.
+  std::optional<KeyValueProof> getValueProofAtBlock(const std::string &category_id,
+                                                    const std::string &key,
+                                                    BlockId block_id,
+                                                    const SharedKeyValueUpdatesInfo &updates_info) const;
+
+ private:
+  void createColumnFamilyIfNotExisting(const std::string &category_id) const;
+
+ private:
+  const std::shared_ptr<storage::rocksdb::NativeClient> db_;
+};
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -45,7 +45,10 @@ struct SharedKeyValueUpdates {
     SharedValue(std::string&& val, std::set<std::string>&& cat_ids) {
       data_.value = std::move(val);
       for (auto it = cat_ids.begin(); it != cat_ids.end();) {
-        data_.categories_ids.emplace_back(cat_ids.extract(it++).value());
+        // Save the iterator as extract() invalidates it.
+        auto extracted_it = it;
+        ++it;
+        data_.category_ids.emplace_back(cat_ids.extract(extracted_it).value());
       }
     }
 
@@ -102,7 +105,7 @@ struct KeyValueUpdates {
     data_.deletes.emplace_back(std::move(key));
   }
 
-  void calculateHash(const bool hash) { data_.calculate_hash = hash; }
+  void calculateRootHash(const bool hash) { data_.calculate_root_hash = hash; }
 
  private:
   KeyValueUpdatesData data_;

--- a/kvbc/src/categorization/shared_kv_category.cpp
+++ b/kvbc/src/categorization/shared_kv_category.cpp
@@ -17,35 +17,14 @@
 #include "categorization/column_families.h"
 #include "categorization/details.h"
 
-#include <algorithm>
 #include <map>
 #include <stdexcept>
+#include <string_view>
 #include <utility>
 
 using namespace std::literals;
 
 namespace concord::kvbc::categorization::detail {
-
-const Buffer &version(BlockId block_id) {
-  static thread_local auto buf = Buffer{};
-  buf.clear();
-  serialize(buf, Version{block_id});
-  return buf;
-}
-
-const Buffer &sharedValuePointer(const std::string &category_id) {
-  static thread_local auto buf = Buffer{};
-  buf.clear();
-  serialize(buf, SharedDbValue{SharedDbValuePointer{category_id}});
-  return buf;
-}
-
-const Buffer &sharedValueData(std::string &&data) {
-  static thread_local auto buf = Buffer{};
-  buf.clear();
-  serialize(buf, SharedDbValue{SharedDbValueData{std::move(data)}});
-  return buf;
-}
 
 // root_hash = h((h(k1) || h(v1)) || (h(k2) || h(v2)) || ... || (h(k3) || h(v3)))
 void updateCategoryHash(const std::string &category_id,
@@ -60,11 +39,18 @@ void updateCategoryHash(const std::string &category_id,
   it->second.update(value_hash.data(), value_hash.size());
 }
 
-std::string dataCf(const std::string &category_id) { return category_id + SHARED_KV_DATA_CF_SUFFIX; }
+void finishCategoryHashes(std::map<std::string, Hasher> &category_hashers, SharedKeyValueUpdatesInfo &update_info) {
+  auto category_hashes = std::map<std::string, Hash>{};
+  for (auto &[category_id, hasher] : category_hashers) {
+    category_hashes[category_id] = hasher.finish();
+  }
+  update_info.category_root_hashes = std::move(category_hashes);
+}
 
-std::string latestVersionCf(const std::string &category_id) { return category_id + SHARED_KV_LATEST_KEY_VER_CF_SUFFIX; }
-
-SharedKeyValueCategory::SharedKeyValueCategory(const std::shared_ptr<storage::rocksdb::NativeClient> &db) : db_{db} {}
+SharedKeyValueCategory::SharedKeyValueCategory(const std::shared_ptr<storage::rocksdb::NativeClient> &db) : db_{db} {
+  createColumnFamilyIfNotExisting(SHARED_KV_DATA_CF, *db_);
+  createColumnFamilyIfNotExisting(SHARED_KV_KEY_VERSIONS_CF, *db_);
+}
 
 SharedKeyValueUpdatesInfo SharedKeyValueCategory::add(BlockId block_id,
                                                       SharedKeyValueUpdatesData &&update,
@@ -88,55 +74,49 @@ SharedKeyValueUpdatesInfo SharedKeyValueCategory::add(BlockId block_id,
     }
 
     const auto versioned_key = versionedKey(key, block_id);
-
-    auto [key_it, inserted_key] = update_info.keys.emplace(std::move(key), SharedKeyData{});
-    // Make sure we've inserted the key for the first time.
-    ConcordAssert(inserted_key);
-    auto &key_data = key_it->second;
-
+    auto &key_data = update_info.keys.emplace(std::move(key), SharedKeyData{}).first->second;
+    auto key_versions = versionsForKey(versioned_key.key_hash.value);
     const auto value_hash = hash(shared_value.value);
-    auto first_category = std::optional<std::string>{std::nullopt};
-    for (auto &&category_id : shared_value.category_ids) {
-      const auto data_cf = dataCf(category_id);
-      const auto latest_version_cf = latestVersionCf(category_id);
-      createColumnFamilyIfNotExisting(data_cf);
-      createColumnFamilyIfNotExisting(latest_version_cf);
 
+    for (auto &&category_id : shared_value.category_ids) {
       if (update.calculate_root_hash) {
         updateCategoryHash(category_id, versioned_key.key_hash.value, value_hash, category_hashers);
       }
 
-      // Versioned key-value.
-      if (!first_category) {
-        batch.put(data_cf, serialize(versioned_key), sharedValueData(std::move(shared_value.value)));
-        first_category = category_id;
-      } else {
-        batch.put(data_cf, serialize(versioned_key), sharedValuePointer(*first_category));
-      }
+      // The value is persisted into the data column family.
+      batch.put(SHARED_KV_DATA_CF, serialize(versioned_key), shared_value.value);
 
-      // Latest version of a key.
-      batch.put(latest_version_cf, serialize(versioned_key.key_hash), version(block_id));
+      // Append the block ID to the key versions (per category).
+      {
+        auto &versions_for_cat = key_versions.data[category_id];
+        if (!versions_for_cat.empty()) {
+          ConcordAssertGT(block_id, versions_for_cat.back());
+        }
+        versions_for_cat.push_back(block_id);
+      }
 
       // Accumulate category IDs for keys in the update info.
       key_data.categories.push_back(std::move(category_id));
     }
+
+    // Persist the key versions.
+    batch.put(SHARED_KV_KEY_VERSIONS_CF, versioned_key.key_hash.value, serialize(key_versions));
   }
 
   // Finish hash calculation per category.
   if (update.calculate_root_hash) {
-    auto category_hashes = std::map<std::string, Hash>{};
-    for (auto &[category_id, hasher] : category_hashers) {
-      category_hashes[category_id] = hasher.finish();
-    }
-    update_info.category_root_hashes = std::move(category_hashes);
+    finishCategoryHashes(category_hashers, update_info);
   }
   return update_info;
 }
 
-void SharedKeyValueCategory::createColumnFamilyIfNotExisting(const std::string &cf) const {
-  if (!db_->hasColumnFamily(cf)) {
-    db_->createColumnFamily(cf);
+KeyVersionsPerCategory SharedKeyValueCategory::versionsForKey(const Hash &key_hash) const {
+  auto key_versions = KeyVersionsPerCategory{};
+  const auto key_versions_db_value = db_->get(SHARED_KV_KEY_VERSIONS_CF, key_hash);
+  if (key_versions_db_value) {
+    deserialize(*key_versions_db_value, key_versions);
   }
+  return key_versions;
 }
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/src/categorization/shared_kv_category.cpp
+++ b/kvbc/src/categorization/shared_kv_category.cpp
@@ -131,7 +131,7 @@ SharedKeyValueUpdatesInfo SharedKeyValueCategory::add(BlockId block_id,
     update_info.category_root_hashes = std::move(category_hashes);
   }
   return update_info;
-}  // namespace concord::kvbc::categorization::detail
+}
 
 void SharedKeyValueCategory::createColumnFamilyIfNotExisting(const std::string &cf) const {
   if (!db_->hasColumnFamily(cf)) {

--- a/kvbc/src/categorization/shared_kv_category.cpp
+++ b/kvbc/src/categorization/shared_kv_category.cpp
@@ -68,7 +68,7 @@ SharedKeyValueCategory::SharedKeyValueCategory(const std::shared_ptr<storage::ro
 
 SharedKeyValueUpdatesInfo SharedKeyValueCategory::add(BlockId block_id,
                                                       SharedKeyValueUpdatesData &&update,
-                                                      storage::rocksdb::WriteBatch &batch) {
+                                                      storage::rocksdb::NativeWriteBatch &batch) {
   if (update.kv.empty()) {
     throw std::invalid_argument{"Empty shared key-value updates"};
   }

--- a/kvbc/src/categorization/shared_kv_category.cpp
+++ b/kvbc/src/categorization/shared_kv_category.cpp
@@ -1,0 +1,142 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "categorization/shared_kv_category.h"
+
+#include "assertUtils.hpp"
+#include "categorization/column_families.h"
+#include "categorization/details.h"
+
+#include <algorithm>
+#include <map>
+#include <stdexcept>
+#include <utility>
+
+using namespace std::literals;
+
+namespace concord::kvbc::categorization::detail {
+
+const Buffer &version(BlockId block_id) {
+  static thread_local auto buf = Buffer{};
+  buf.clear();
+  serialize(buf, Version{block_id});
+  return buf;
+}
+
+const Buffer &sharedValuePointer(const std::string &category_id) {
+  static thread_local auto buf = Buffer{};
+  buf.clear();
+  serialize(buf, SharedDbValue{SharedDbValuePointer{category_id}});
+  return buf;
+}
+
+const Buffer &sharedValueData(std::string &&data) {
+  static thread_local auto buf = Buffer{};
+  buf.clear();
+  serialize(buf, SharedDbValue{SharedDbValueData{std::move(data)}});
+  return buf;
+}
+
+// root_hash = h((h(k1) || h(v1)) || (h(k2) || h(v2)) || ... || (h(k3) || h(v3)))
+void updateCategoryHash(const std::string &category_id,
+                        const Hash &key_hash,
+                        const Hash &value_hash,
+                        std::map<std::string, Hasher> &category_hashers) {
+  auto [it, inserted] = category_hashers.emplace(category_id, Hasher{});
+  if (inserted) {
+    it->second.init();
+  }
+  it->second.update(key_hash.data(), key_hash.size());
+  it->second.update(value_hash.data(), value_hash.size());
+}
+
+std::string dataCf(const std::string &category_id) { return category_id + SHARED_KV_DATA_CF_SUFFIX; }
+
+std::string latestVersionCf(const std::string &category_id) { return category_id + SHARED_KV_LATEST_KEY_VER_CF_SUFFIX; }
+
+SharedKeyValueCategory::SharedKeyValueCategory(const std::shared_ptr<storage::rocksdb::NativeClient> &db) : db_{db} {}
+
+SharedKeyValueUpdatesInfo SharedKeyValueCategory::add(BlockId block_id,
+                                                      SharedKeyValueUpdatesData &&update,
+                                                      storage::rocksdb::WriteBatch &batch) {
+  if (update.kv.empty()) {
+    throw std::invalid_argument{"Empty shared key-value updates"};
+  }
+
+  auto update_info = SharedKeyValueUpdatesInfo{};
+  auto category_hashers = std::map<std::string, Hasher>{};
+
+  for (auto it = update.kv.begin(); it != update.kv.end();) {
+    // Save the iterator as extract() invalidates it.
+    auto extracted_it = it;
+    ++it;
+    auto node = update.kv.extract(extracted_it);
+    auto &key = node.key();
+    auto &shared_value = node.mapped();
+    if (shared_value.category_ids.empty()) {
+      throw std::invalid_argument{"Empty category ID set for a shared key-value update"};
+    }
+
+    const auto versioned_key = versionedKey(key, block_id);
+
+    auto [key_it, inserted_key] = update_info.keys.emplace(std::move(key), SharedKeyData{});
+    // Make sure we've inserted the key for the first time.
+    ConcordAssert(inserted_key);
+    auto &key_data = key_it->second;
+
+    const auto value_hash = hash(shared_value.value);
+    auto first_category = std::optional<std::string>{std::nullopt};
+    for (auto &&category_id : shared_value.category_ids) {
+      const auto data_cf = dataCf(category_id);
+      const auto latest_version_cf = latestVersionCf(category_id);
+      createColumnFamilyIfNotExisting(data_cf);
+      createColumnFamilyIfNotExisting(latest_version_cf);
+
+      if (update.calculate_root_hash) {
+        updateCategoryHash(category_id, versioned_key.key_hash.value, value_hash, category_hashers);
+      }
+
+      // Versioned key-value.
+      if (!first_category) {
+        batch.put(data_cf, serialize(versioned_key), sharedValueData(std::move(shared_value.value)));
+        first_category = category_id;
+      } else {
+        batch.put(data_cf, serialize(versioned_key), sharedValuePointer(*first_category));
+      }
+
+      // Latest version of a key.
+      batch.put(latest_version_cf, serialize(versioned_key.key_hash), version(block_id));
+
+      // Accumulate category IDs for keys in the update info.
+      key_data.categories.push_back(std::move(category_id));
+    }
+  }
+
+  // Finish hash calculation per category.
+  if (update.calculate_root_hash) {
+    auto category_hashes = std::map<std::string, Hash>{};
+    for (auto &[category_id, hasher] : category_hashers) {
+      category_hashes[category_id] = hasher.finish();
+    }
+    update_info.category_root_hashes = std::move(category_hashes);
+  }
+  return update_info;
+}  // namespace concord::kvbc::categorization::detail
+
+void SharedKeyValueCategory::createColumnFamilyIfNotExisting(const std::string &cf) const {
+  if (!db_->hasColumnFamily(cf)) {
+    db_->createColumnFamily(cf);
+  }
+}
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -34,18 +34,6 @@ target_link_libraries(sparse_merkle_storage_db_adapter_unit_test PUBLIC
     stdc++fs
 )
 
-add_executable(categorized_updates_unit_test
-    categorization/updates_test.cpp )
-add_test(categorized_updates_unit_test categorized_updates_unit_test)
-target_link_libraries(categorized_updates_unit_test PUBLIC
-    GTest::Main
-    GTest::GTest
-    util
-    corebft
-    kvbc
-    stdc++fs
-)
-
 add_executable(sparse_merkle_storage_serialization_unit_test
     sparse_merkle_storage/serialization_unit_test.cpp )
 add_test(sparse_merkle_storage_serialization_unit_test sparse_merkle_storage_serialization_unit_test)
@@ -155,3 +143,28 @@ target_link_libraries(s3_storage_factory_test PUBLIC
     kvbc
 )
 endif(USE_S3_OBJECT_STORE)
+
+if (BUILD_ROCKSDB_STORAGE)
+    add_executable(categorized_updates_unit_test
+        categorization/updates_test.cpp )
+    add_test(categorized_updates_unit_test categorized_updates_unit_test)
+    target_link_libraries(categorized_updates_unit_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        corebft
+        kvbc
+        stdc++fs
+    )
+
+    add_executable(shared_kv_category_unit_test categorization/shared_kv_category_unit_test.cpp )
+    add_test(shared_kv_category_unit_test shared_kv_category_unit_test)
+    target_link_libraries(shared_kv_category_unit_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        corebft
+        kvbc
+        stdc++fs
+    )
+endif (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/test/categorization/shared_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/shared_kv_category_unit_test.cpp
@@ -1,0 +1,274 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "categorization/column_families.h"
+#include "categorization/details.h"
+#include "categorization/shared_kv_category.h"
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "storage/test/storage_test_common.h"
+
+#include <memory>
+#include <utility>
+#include <variant>
+
+namespace {
+
+using namespace ::testing;
+using namespace concord::storage::rocksdb;
+using namespace concord::kvbc;
+using namespace concord::kvbc::categorization;
+using namespace concord::kvbc::categorization::detail;
+using namespace std::literals;
+
+class shared_kv_category_test : public Test {
+  void SetUp() override {
+    cleanup();
+    db = TestRocksDb::createNative();
+  }
+  void TearDown() override { cleanup(); }
+
+ protected:
+  void assertKvData(const std::string &category_id,
+                    const std::string &key,
+                    const std::string &value,
+                    BlockId block_id) {
+    const auto db_value = db->get(category_id + SHARED_KV_DATA_CF_SUFFIX, serialize(versionedKey(key, block_id)));
+    ASSERT_TRUE(db_value);
+    auto shared_db_value = SharedDbValue{};
+    deserialize(*db_value, shared_db_value);
+    ASSERT_TRUE(std::holds_alternative<SharedDbValueData>(shared_db_value.data));
+    ASSERT_EQ(std::get<SharedDbValueData>(shared_db_value.data).data, value);
+  }
+
+  void assertKvPointer(const std::string &category_id,
+                       const std::string &key,
+                       const std::string &pointed_category_id,
+                       BlockId block_id) {
+    const auto db_value = db->get(category_id + SHARED_KV_DATA_CF_SUFFIX, serialize(versionedKey(key, block_id)));
+    ASSERT_TRUE(db_value);
+    auto shared_db_value = SharedDbValue{};
+    deserialize(*db_value, shared_db_value);
+    ASSERT_TRUE(std::holds_alternative<SharedDbValuePointer>(shared_db_value.data));
+    ASSERT_EQ(std::get<SharedDbValuePointer>(shared_db_value.data).category_id, pointed_category_id);
+  }
+
+  void assertLatestKeyVersion(const std::string &category_id, const std::string &key, BlockId block_id) {
+    const auto db_value = db->get(category_id + SHARED_KV_LATEST_KEY_VER_CF_SUFFIX, serialize(KeyHash{hash(key)}));
+    ASSERT_TRUE(db_value);
+    auto block_version = Version{};
+    deserialize(*db_value, block_version);
+    ASSERT_EQ(block_version.value, block_id);
+  }
+
+ protected:
+  std::shared_ptr<NativeClient> db;
+};
+
+TEST_F(shared_kv_category_test, empty_updates) {
+  auto update = SharedKeyValueUpdatesData{};
+  update.calculate_root_hash = true;
+  auto batch = db->getBatch();
+  auto cat = SharedKeyValueCategory{db};
+  ASSERT_THROW(cat.add(1, std::move(update), batch), std::invalid_argument);
+}
+
+TEST_F(shared_kv_category_test, key_without_categories) {
+  auto update = SharedKeyValueUpdatesData{};
+  update.calculate_root_hash = true;
+  update.kv["k1"] = SharedValueData{"v1", {"c1"}};
+  update.kv["k2"] = SharedValueData{"v2", {}};
+  auto batch = db->getBatch();
+  auto cat = SharedKeyValueCategory{db};
+  ASSERT_THROW(cat.add(1, std::move(update), batch), std::invalid_argument);
+}
+
+TEST_F(shared_kv_category_test, create_column_families_on_add) {
+  auto update = SharedKeyValueUpdatesData{};
+  update.calculate_root_hash = true;
+  update.kv["k1"] = SharedValueData{"v1", {"c1"}};
+  update.kv["k2"] = SharedValueData{"v2", {"c2"}};
+  update.kv["k3"] = SharedValueData{"v3", {"c3", "c4"}};
+
+  const auto block_id = 1;
+  auto batch = db->getBatch();
+  auto cat = SharedKeyValueCategory{db};
+  const auto update_info = cat.add(block_id, std::move(update), batch);
+  db->write(std::move(batch));
+
+  ASSERT_THAT(db->columnFamilies(),
+              ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(),
+                                                          "c1" + SHARED_KV_DATA_CF_SUFFIX,
+                                                          "c2" + SHARED_KV_DATA_CF_SUFFIX,
+                                                          "c3" + SHARED_KV_DATA_CF_SUFFIX,
+                                                          "c4" + SHARED_KV_DATA_CF_SUFFIX,
+                                                          "c1" + SHARED_KV_LATEST_KEY_VER_CF_SUFFIX,
+                                                          "c2" + SHARED_KV_LATEST_KEY_VER_CF_SUFFIX,
+                                                          "c3" + SHARED_KV_LATEST_KEY_VER_CF_SUFFIX,
+                                                          "c4" + SHARED_KV_LATEST_KEY_VER_CF_SUFFIX}));
+}
+
+TEST_F(shared_kv_category_test, calculate_root_hash_toggle) {
+  auto batch = db->getBatch();
+  auto cat = SharedKeyValueCategory{db};
+
+  {
+    auto update = SharedKeyValueUpdatesData{};
+    update.calculate_root_hash = true;
+    update.kv["k1"] = SharedValueData{"v1", {"c1"}};
+    const auto update_info = cat.add(1, std::move(update), batch);
+    ASSERT_TRUE(update_info.category_root_hashes);
+  }
+
+  {
+    auto update = SharedKeyValueUpdatesData{};
+    update.calculate_root_hash = false;
+    update.kv["k1"] = SharedValueData{"v1", {"c1"}};
+    const auto update_info = cat.add(1, std::move(update), batch);
+    ASSERT_FALSE(update_info.category_root_hashes);
+  }
+}
+
+TEST_F(shared_kv_category_test, add_one_key_per_category) {
+  auto update = SharedKeyValueUpdatesData{};
+  update.calculate_root_hash = true;
+  update.kv["k1"] = SharedValueData{"v1", {"c1"}};
+  update.kv["k2"] = SharedValueData{"v2", {"c2"}};
+
+  const auto block_id = 1;
+  auto batch = db->getBatch();
+  auto cat = SharedKeyValueCategory{db};
+  const auto update_info = cat.add(block_id, std::move(update), batch);
+  db->write(std::move(batch));
+
+  ASSERT_THAT(update_info.keys,
+              ContainerEq(std::map<std::string, SharedKeyData>{std::make_pair("k1"s, SharedKeyData{{"c1"}}),
+                                                               std::make_pair("k2"s, SharedKeyData{{"c2"}})}));
+  ASSERT_TRUE(update_info.category_root_hashes);
+
+  // h("k1") = 89a6df64f1536985fcb7326c0e56f03762b581b2253cf9fadc695c8dbb740a96
+  // h("v1") = 9c209c84e360d17dd267fc53a46db30009b9f39ce2b905fa29fbd5fd4c44ea17
+  // root_hash = h(h("k1") || h("v1")) = db58ae726159bc3ef4487002a2169b64c4e968f3ea4938da8a62520aa59d9ddb
+  {
+    auto it = update_info.category_root_hashes->find("c1");
+    ASSERT_NE(it, update_info.category_root_hashes->cend());
+    ASSERT_THAT(it->second, ContainerEq(Hash{0xdb, 0x58, 0xae, 0x72, 0x61, 0x59, 0xbc, 0x3e, 0xf4, 0x48, 0x70,
+                                             0x02, 0xa2, 0x16, 0x9b, 0x64, 0xc4, 0xe9, 0x68, 0xf3, 0xea, 0x49,
+                                             0x38, 0xda, 0x8a, 0x62, 0x52, 0x0a, 0xa5, 0x9d, 0x9d, 0xdb}));
+  }
+
+  // h("k2") = 189284195f920d885bc46edf2d6c2c56194d3333448eda64ddd726c901b59c28
+  // h("v2") = 86a74b56a4ca89e2a292dc3995a15149a2843b038965d0feabd3d20a663f759f
+  // root_hash = h(h("k2") || h("v2")) = 3c38959dcca140355bc0be13c1ab09aba5c4a74672138639fa1136906b69af02
+  {
+    auto it = update_info.category_root_hashes->find("c2");
+    ASSERT_NE(it, update_info.category_root_hashes->cend());
+    ASSERT_THAT(it->second, ContainerEq(Hash{0x3c, 0x38, 0x95, 0x9d, 0xcc, 0xa1, 0x40, 0x35, 0x5b, 0xc0, 0xbe,
+                                             0x13, 0xc1, 0xab, 0x09, 0xab, 0xa5, 0xc4, 0xa7, 0x46, 0x72, 0x13,
+                                             0x86, 0x39, 0xfa, 0x11, 0x36, 0x90, 0x6b, 0x69, 0xaf, 0x02}));
+  }
+
+  assertKvData("c1", "k1", "v1", block_id);
+  assertKvData("c2", "k2", "v2", block_id);
+  assertLatestKeyVersion("c1", "k1", block_id);
+  assertLatestKeyVersion("c2", "k2", block_id);
+}
+
+TEST_F(shared_kv_category_test, add_key_in_two_categories) {
+  auto update = SharedKeyValueUpdatesData{};
+  update.calculate_root_hash = true;
+  update.kv["k1"] = SharedValueData{"v1", {"c1", "c2"}};
+
+  const auto block_id = 2;
+  auto batch = db->getBatch();
+  auto cat = SharedKeyValueCategory{db};
+  const auto update_info = cat.add(block_id, std::move(update), batch);
+  db->write(std::move(batch));
+
+  ASSERT_THAT(update_info.keys,
+              ContainerEq(std::map<std::string, SharedKeyData>{std::make_pair("k1"s, SharedKeyData{{"c1", "c2"}})}));
+
+  ASSERT_TRUE(update_info.category_root_hashes);
+
+  // h("k1") = 89a6df64f1536985fcb7326c0e56f03762b581b2253cf9fadc695c8dbb740a96
+  // h("v1") = 9c209c84e360d17dd267fc53a46db30009b9f39ce2b905fa29fbd5fd4c44ea17
+  // root_hash = h(h("k1") || h("v1")) = db58ae726159bc3ef4487002a2169b64c4e968f3ea4938da8a62520aa59d9ddb
+  {
+    auto it = update_info.category_root_hashes->find("c1");
+    ASSERT_NE(it, update_info.category_root_hashes->cend());
+    ASSERT_THAT(it->second, ContainerEq(Hash{0xdb, 0x58, 0xae, 0x72, 0x61, 0x59, 0xbc, 0x3e, 0xf4, 0x48, 0x70,
+                                             0x02, 0xa2, 0x16, 0x9b, 0x64, 0xc4, 0xe9, 0x68, 0xf3, 0xea, 0x49,
+                                             0x38, 0xda, 0x8a, 0x62, 0x52, 0x0a, 0xa5, 0x9d, 0x9d, 0xdb}));
+  }
+
+  {
+    auto it = update_info.category_root_hashes->find("c2");
+    ASSERT_NE(it, update_info.category_root_hashes->cend());
+    ASSERT_THAT(it->second, ContainerEq(Hash{0xdb, 0x58, 0xae, 0x72, 0x61, 0x59, 0xbc, 0x3e, 0xf4, 0x48, 0x70,
+                                             0x02, 0xa2, 0x16, 0x9b, 0x64, 0xc4, 0xe9, 0x68, 0xf3, 0xea, 0x49,
+                                             0x38, 0xda, 0x8a, 0x62, 0x52, 0x0a, 0xa5, 0x9d, 0x9d, 0xdb}));
+  }
+
+  assertKvData("c1", "k1", "v1", block_id);
+  assertKvPointer("c2", "k1", "c1", block_id);
+  assertLatestKeyVersion("c1", "k1", block_id);
+  assertLatestKeyVersion("c2", "k1", block_id);
+}
+
+TEST_F(shared_kv_category_test, add_two_keys_in_one_category) {
+  auto update = SharedKeyValueUpdatesData{};
+  update.calculate_root_hash = true;
+  update.kv["k1"] = SharedValueData{"v1", {"c1"}};
+  update.kv["k2"] = SharedValueData{"v2", {"c1"}};
+
+  const auto block_id = 1;
+  auto batch = db->getBatch();
+  auto cat = SharedKeyValueCategory{db};
+  const auto update_info = cat.add(block_id, std::move(update), batch);
+  db->write(std::move(batch));
+
+  ASSERT_THAT(update_info.keys,
+              ContainerEq(std::map<std::string, SharedKeyData>{std::make_pair("k1"s, SharedKeyData{{"c1"}}),
+                                                               std::make_pair("k2"s, SharedKeyData{{"c1"}})}));
+
+  ASSERT_TRUE(update_info.category_root_hashes);
+
+  // h("k1") = 89a6df64f1536985fcb7326c0e56f03762b581b2253cf9fadc695c8dbb740a96
+  // h("v1") = 9c209c84e360d17dd267fc53a46db30009b9f39ce2b905fa29fbd5fd4c44ea17
+  // h("k2") = 189284195f920d885bc46edf2d6c2c56194d3333448eda64ddd726c901b59c28
+  // h("v2") = 86a74b56a4ca89e2a292dc3995a15149a2843b038965d0feabd3d20a663f759f
+  // root_hash = h(h("k1") || h("v1") || h("k2") || h("v2")) =
+  //           = 57ddbd4f1dcab48ea5a6429091549b3f811e0bbe3d14d1f6a1f129cf1acfdb86
+  {
+    auto it = update_info.category_root_hashes->find("c1");
+    ASSERT_NE(it, update_info.category_root_hashes->cend());
+    ASSERT_THAT(it->second, ContainerEq(Hash{0x57, 0xdd, 0xbd, 0x4f, 0x1d, 0xca, 0xb4, 0x8e, 0xa5, 0xa6, 0x42,
+                                             0x90, 0x91, 0x54, 0x9b, 0x3f, 0x81, 0x1e, 0x0b, 0xbe, 0x3d, 0x14,
+                                             0xd1, 0xf6, 0xa1, 0xf1, 0x29, 0xcf, 0x1a, 0xcf, 0xdb, 0x86}));
+  }
+
+  assertKvData("c1", "k1", "v1", block_id);
+  assertKvData("c1", "k2", "v2", block_id);
+  assertLatestKeyVersion("c1", "k1", block_id);
+  assertLatestKeyVersion("c1", "k2", block_id);
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  ::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/kvbc/test/categorization/updates_test.cpp
+++ b/kvbc/test/categorization/updates_test.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gtest/gtest.h"
+#include "categorization/column_families.h"
 #include "categorization/updates.h"
 #include "categorization/kv_blockchain.h"
 #include <iostream>
@@ -26,6 +27,7 @@
 #include "storage/test/storage_test_common.h"
 
 using namespace concord::kvbc::categorization;
+using namespace concord::kvbc::categorization::detail;
 using namespace concord::kvbc;
 
 namespace {
@@ -50,7 +52,7 @@ TEST_F(categorized_kvbc, merkle_update) {
 }
 
 TEST_F(categorized_kvbc, add_blocks) {
-  db->createColumnFamily(Block::CATEGORY_ID);
+  db->createColumnFamily(BLOCKS_CF);
   KeyValueBlockchain block_chain{db};
   // Add block1
   {
@@ -87,7 +89,7 @@ TEST_F(categorized_kvbc, add_blocks) {
   // get block 1 from DB and test it
   {
     const detail::Buffer& block_db_key = Block::generateKey(1);
-    auto block1_db_val = db->get(Block::CATEGORY_ID, block_db_key);
+    auto block1_db_val = db->get(BLOCKS_CF, block_db_key);
     ASSERT_TRUE(block1_db_val.has_value());
     // E.L need to add support for strings in cmf
     detail::Buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
@@ -103,7 +105,7 @@ TEST_F(categorized_kvbc, add_blocks) {
   // get block 2 from DB and test it
   {
     const detail::Buffer& block_db_key = Block::generateKey(2);
-    auto block2_db_val = db->get(Block::CATEGORY_ID, block_db_key);
+    auto block2_db_val = db->get(BLOCKS_CF, block_db_key);
     ASSERT_TRUE(block2_db_val.has_value());
     // E.L need to add support for strings in cmf
     detail::Buffer in{block2_db_val.value().begin(), block2_db_val.value().end()};

--- a/kvbc/test/categorization/updates_test.cpp
+++ b/kvbc/test/categorization/updates_test.cpp
@@ -26,6 +26,7 @@
 #include <random>
 #include "storage/test/storage_test_common.h"
 
+using concord::storage::rocksdb::NativeClient;
 using namespace concord::kvbc::categorization;
 using namespace concord::kvbc::categorization::detail;
 using namespace concord::kvbc;

--- a/kvbc/test/categorization/updates_test.cpp
+++ b/kvbc/test/categorization/updates_test.cpp
@@ -1,4 +1,16 @@
-// Copyright 2018 VMware, all rights reserved
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
 /**
  * The following test suite tests ordering of KeyValuePairs
  */
@@ -8,6 +20,7 @@
 #include "categorization/kv_blockchain.h"
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 #include <random>
 #include "storage/test/storage_test_common.h"
@@ -73,11 +86,11 @@ TEST_F(categorized_kvbc, add_blocks) {
   }
   // get block 1 from DB and test it
   {
-    const serialization::buffer& block_db_key = Block::generateKey(1);
+    const detail::Buffer& block_db_key = Block::generateKey(1);
     auto block1_db_val = db->get(Block::CATEGORY_ID, block_db_key);
     ASSERT_TRUE(block1_db_val.has_value());
     // E.L need to add support for strings in cmf
-    serialization::buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
+    detail::Buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
     auto block1_from_db = Block::deserialize(in);
     auto merkle_variant = block1_from_db.data.categories_updates_info["merkle"];
     auto merkle_update_info1 = std::get<MerkleUpdatesInfo>(merkle_variant);
@@ -89,11 +102,11 @@ TEST_F(categorized_kvbc, add_blocks) {
   }
   // get block 2 from DB and test it
   {
-    const serialization::buffer& block_db_key = Block::generateKey(2);
+    const detail::Buffer& block_db_key = Block::generateKey(2);
     auto block2_db_val = db->get(Block::CATEGORY_ID, block_db_key);
     ASSERT_TRUE(block2_db_val.has_value());
     // E.L need to add support for strings in cmf
-    serialization::buffer in{block2_db_val.value().begin(), block2_db_val.value().end()};
+    detail::Buffer in{block2_db_val.value().begin(), block2_db_val.value().end()};
     auto block2_from_db = Block::deserialize(in);
     ASSERT_TRUE(block2_from_db.data.shared_updates_info.has_value());
     std::vector<std::string> v{"1", "2"};

--- a/messages/compiler/cpp/cpp_visitor.py
+++ b/messages/compiler/cpp/cpp_visitor.py
@@ -32,7 +32,7 @@ def serialize_start(name):
     return serialize_fn.format(name=name) + " {\n"
 
 
-deserialize_fn = "void deserialize(uint8_t*& input, const uint8_t* end, {name}& t)"
+deserialize_fn = "void deserialize(const uint8_t*& input, const uint8_t* end, {name}& t)"
 
 
 def deserialize_declaration(name):
@@ -52,7 +52,7 @@ def deserialize_byte_buffer_declaration(name):
 
 def deserialize_byte_buffer(name):
     return deserialize_byte_buffer_fn.format(name=name) + f""" {{
-    auto* begin = const_cast<uint8_t*>(input.data());
+    auto begin = input.data();
     deserialize(begin, begin + input.size(), t);
 }}
 """
@@ -90,7 +90,7 @@ def variant_serialize(variant):
 }"""
 
 
-variant_deserialize_fn = "void deserialize(uint8_t*& start, const uint8_t* end, {variant}& val)"
+variant_deserialize_fn = "void deserialize(const uint8_t*& start, const uint8_t* end, {variant}& val)"
 
 
 def variant_deserialize_declaration(variant):

--- a/messages/compiler/cpp/serialize.cpp
+++ b/messages/compiler/cpp/serialize.cpp
@@ -58,7 +58,7 @@ void serialize(std::vector<uint8_t>& output, const T& t) {
 }
 
 template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-void deserialize(uint8_t*& start, const uint8_t* end, T& t) {
+void deserialize(const uint8_t*& start, const uint8_t* end, T& t) {
   if constexpr (std::is_same_v<T, bool>) {
     if (start + 1 > end) {
       throw NoDataLeftError();
@@ -95,7 +95,7 @@ static inline void serialize(std::vector<uint8_t>& output, const std::string& s)
   std::copy(s.begin(), s.end(), std::back_inserter(output));
 }
 
-static inline void deserialize(uint8_t*& start, const uint8_t* end, std::string& s) {
+static inline void deserialize(const uint8_t*& start, const uint8_t* end, std::string& s) {
   uint32_t length;
   deserialize(start, end, length);
   if (start + length > end) {
@@ -112,25 +112,25 @@ static inline void deserialize(uint8_t*& start, const uint8_t* end, std::string&
 template <typename T>
 void serialize(std::vector<uint8_t>& output, const std::vector<T>& v);
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::vector<T>& v);
+void deserialize(const uint8_t*& start, const uint8_t* end, std::vector<T>& v);
 
 // KVPairs
 template <typename K, typename V>
 void serialize(std::vector<uint8_t>& output, const std::pair<K, V>& kvpair);
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair);
+void deserialize(const uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair);
 
 // Maps
 template <typename K, typename V>
 void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m);
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::map<K, V>& m);
+void deserialize(const uint8_t*& start, const uint8_t* end, std::map<K, V>& m);
 
 // Optionals
 template <typename T>
 void serialize(std::vector<uint8_t>& output, const std::optional<T>& t);
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t);
+void deserialize(const uint8_t*& start, const uint8_t* end, std::optional<T>& t);
 
 /******************************************************************************
  * Lists are modeled as std::vectors
@@ -148,7 +148,7 @@ void serialize(std::vector<uint8_t>& output, const std::vector<T>& v) {
 }
 
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::vector<T>& v) {
+void deserialize(const uint8_t*& start, const uint8_t* end, std::vector<T>& v) {
   uint32_t length;
   deserialize(start, end, length);
   if constexpr (std::is_integral_v<T> && sizeof(T) == 1) {
@@ -175,7 +175,7 @@ void serialize(std::vector<uint8_t>& output, const std::array<T, N>& a) {
 }
 
 template <typename T, std::size_t N>
-void deserialize(uint8_t*& start, const uint8_t* end, std::array<T, N>& a) {
+void deserialize(const uint8_t*& start, const uint8_t* end, std::array<T, N>& a) {
   if constexpr (std::is_integral_v<T> && sizeof(T) == 1) {
     // Optimized for bytes
     if (start + a.size() > end) {
@@ -200,7 +200,7 @@ void serialize(std::vector<uint8_t>& output, const std::pair<K, V>& kvpair) {
 }
 
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair) {
+void deserialize(const uint8_t*& start, const uint8_t* end, std::pair<K, V>& kvpair) {
   deserialize(start, end, kvpair.first);
   deserialize(start, end, kvpair.second);
 }
@@ -221,7 +221,7 @@ void serialize(std::vector<uint8_t>& output, const std::map<K, V>& m) {
 }
 
 template <typename K, typename V>
-void deserialize(uint8_t*& start, const uint8_t* end, std::map<K, V>& m) {
+void deserialize(const uint8_t*& start, const uint8_t* end, std::map<K, V>& m) {
   uint32_t size;
   deserialize(start, end, size);
   for (auto i = 0u; i < size; i++) {
@@ -245,7 +245,7 @@ void serialize(std::vector<uint8_t>& output, const std::optional<T>& t) {
 }
 
 template <typename T>
-void deserialize(uint8_t*& start, const uint8_t* end, std::optional<T>& t) {
+void deserialize(const uint8_t*& start, const uint8_t* end, std::optional<T>& t) {
   bool has_value;
   deserialize(start, end, has_value);
   if (has_value) {

--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -27,6 +27,7 @@ FILES_TO_FORMAT=$(find ${ABS_CONCORD_PATH} \
     -iname "*.cc" -o \
     -iname "*.cpp" -o \
     -iname "*.h" -o \
+    -iname "*.ipp" -o \
     -iname "*.hpp" \) \
   -a -not -path "${ABS_CONCORD_PATH}/deps/*" \
   -a -not -path "${ABS_CONCORD_PATH}/build/*")

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -104,6 +104,11 @@ class Client : public concord::storage::IDBClient {
     storage_metrics_.setAggregator(aggregator);
   }
 
+  static logging::Logger& logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.storage.rocksdb");
+    return logger_;
+  }
+
  private:
   struct Options {
     ::rocksdb::Options db_options;
@@ -120,10 +125,6 @@ class Client : public concord::storage::IDBClient {
   concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob);
   concordUtils::Status get(const concordUtils::Sliver& _key, std::string& _value) const;
   bool keyIsBefore(const concordUtils::Sliver& _lhs, const concordUtils::Sliver& _rhs) const;
-  static logging::Logger& logger() {
-    static logging::Logger logger_ = logging::getLogger("concord.storage.rocksdb");
-    return logger_;
-  }
 
   // Column family unique pointers that are managed solely by Client. This allows us to use a raw
   // pointer in CfDeleter as we know the column family unique pointer will not be moved out of Client.

--- a/storage/include/rocksdb/details.h
+++ b/storage/include/rocksdb/details.h
@@ -1,0 +1,73 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#ifdef USE_ROCKSDB
+
+#include "client.h"
+#include "rocksdb_exception.h"
+
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace concord::storage::rocksdb::detail {
+
+using namespace std::string_view_literals;
+
+// Make sure we only allow types that have data() and size() members. That excludes raw pointers without corresponding
+// size.
+template <typename Span,
+          std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
+                               std::is_pointer_v<decltype(std::declval<Span>().data())> &&
+                               std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
+                                                     const char (*)[]>,
+                           int> = 0>
+::rocksdb::Slice toSlice(const Span &span) noexcept {
+  return ::rocksdb::Slice{span.data(), span.size()};
+}
+
+template <typename Span,
+          std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
+                               std::is_pointer_v<decltype(std::declval<Span>().data())> &&
+                               std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
+                                                     const std::uint8_t (*)[]>,
+                           int> = 0>
+::rocksdb::Slice toSlice(const Span &span) noexcept {
+  return ::rocksdb::Slice{reinterpret_cast<const char *>(span.data()), span.size()};
+}
+
+inline void throwOnError(std::string_view msg1, std::string_view msg2, ::rocksdb::Status &&s) {
+  if (!s.ok()) {
+    auto rocksdbMsg = std::string{"RocksDB: "};
+    rocksdbMsg.append(msg1);
+    if (!msg2.empty()) {
+      rocksdbMsg.append(": ");
+      rocksdbMsg.append(msg2);
+    }
+    LOG_ERROR(Client::logger(), rocksdbMsg << ", status = " << s.ToString());
+    throw RocksDBException{rocksdbMsg, std::move(s)};
+  }
+}
+
+inline void throwOnError(std::string_view msg, ::rocksdb::Status &&s) { return throwOnError(msg, ""sv, std::move(s)); }
+
+}  // namespace concord::storage::rocksdb::detail
+
+#endif  // USE_ROCKSDB

--- a/storage/include/rocksdb/native_client.h
+++ b/storage/include/rocksdb/native_client.h
@@ -116,9 +116,9 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
   // Return the column families in the DB pointed to by `path`.
   static std::unordered_set<std::string> columnFamilies(const std::string &path);
 
-  // Client instance column management. Methods below only operate on column families this client is ware of. The actual
-  // column families on-disk can be different if this client is in read-only mode as another read-write client might
-  // have modified them. Return the column families this client is aware of.
+  // Client instance column management. Methods below only operate on column families this client is aware of. The
+  // actual column families on-disk can be different if this client is in read-only mode as another read-write client
+  // might have modified them. Return the column families this client is aware of.
   std::unordered_set<std::string> columnFamilies() const;
   // Checks if the client has a column family.
   bool hasColumnFamily(const std::string cFamily) const;

--- a/storage/include/rocksdb/native_client.h
+++ b/storage/include/rocksdb/native_client.h
@@ -15,30 +15,20 @@
 
 #ifdef USE_ROCKSDB
 
-#include "assertUtils.hpp"
-#include "client.h"
-#include "storage/db_interface.h"
+#include "details.h"
+#include "native_iterator.h"
+#include "native_write_batch.h"
+#include "rocksdb_exception.h"
 
-#include <rocksdb/env.h>
-#include <rocksdb/slice.h>
-#include <rocksdb/status.h>
+#include "client.h"
+
 #include <rocksdb/utilities/options_util.h>
 #include <rocksdb/utilities/transaction_db.h>
-#include <rocksdb/write_batch.h>
 
-#include <algorithm>
-#include <cstdint>
-#include <exception>
-#include <map>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 #include <string>
-#include <string_view>
-#include <typeinfo>
-#include <type_traits>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 // Wrapper around the RocksDB library that aims at improving:
@@ -53,96 +43,6 @@
 // Note1: All methods on all classes throw on errors.
 // Note2: All methods without a column family parameter work with the default column family.
 namespace concord::storage::rocksdb {
-
-using namespace std::string_view_literals;
-
-struct RocksDBException : std::runtime_error {
-  RocksDBException(const std::string &what, ::rocksdb::Status &&s) : std::runtime_error{what}, status{std::move(s)} {}
-  const ::rocksdb::Status status;
-};
-
-class NativeClient;
-
-class WriteBatch {
- public:
-  WriteBatch(const std::shared_ptr<const NativeClient> &) noexcept;
-
-  template <typename KeySpan, typename ValueSpan>
-  void put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value);
-  template <typename KeySpan, typename ValueSpan>
-  void put(const KeySpan &key, const ValueSpan &value);
-
-  // Deleting a key that doesn't exist is not an error.
-  template <typename KeySpan>
-  void del(const std::string &cFamily, const KeySpan &key);
-  template <typename KeySpan>
-  void del(const KeySpan &key);
-
-  // Remove the DB entries in the range [beginKey, endKey).
-  template <typename BeginSpan, typename EndSpan>
-  void delRange(const std::string &cFamily, const BeginSpan &beginKey, const EndSpan &endKey);
-  template <typename BeginSpan, typename EndSpan>
-  void delRange(const BeginSpan &beginKey, const EndSpan &endKey);
-
- private:
-  std::shared_ptr<const NativeClient> client_;
-  ::rocksdb::WriteBatch batch_;
-  friend class NativeClient;
-};
-
-// Put a container of key-value pair spans.
-template <typename Container>
-void putInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont);
-template <typename Container>
-void putInBatch(WriteBatch &batch, const Container &cont);
-
-// Delete a container of key spans.
-template <typename Container>
-void delInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont);
-template <typename Container>
-void delInBatch(WriteBatch &batch, const Container &cont);
-
-class Iterator {
- public:
-  // Returns true if the iterator points to a key-value pair and false otherwise. Initially, an iterator doesn't point
-  // to anything. A false return from this method is not an error - it might mean there are no more keys or a key wasn't
-  // found.
-  operator bool() const;
-
-  // Methods that move the iterator.
-  // Precondition: the iterator points to a key-value pair.
-  void first();
-  void last();
-  void next();
-  void prev();
-
-  // Seek for a key that is at or past target.
-  template <typename KeySpan>
-  void seekAtLeast(const KeySpan &target);
-
-  // Seek for a key that is at or before target.
-  template <typename KeySpan>
-  void seekAtMost(const KeySpan &target);
-
-  // Copy the key and value from the iterator.
-  // Precondition: the iterator points to a key-value pair.
-  std::string key() const;
-  std::string value() const;
-
-  // A view into the key and value inside the iterator. The return value is valid until the iterator is modified.
-  // Precondition: the iterator points to a key-value pair.
-  std::string_view keyView() const;
-  std::string_view valueView() const;
-
- private:
-  Iterator(std::unique_ptr<::rocksdb::Iterator> iter) noexcept;
-  static std::string sliceToString(const ::rocksdb::Slice &);
-  static std::string_view sliceToStringView(const ::rocksdb::Slice &);
-
- private:
-  std::unique_ptr<::rocksdb::Iterator> iter_;
-  friend class NativeClient;
-};
 
 class NativeClient : public std::enable_shared_from_this<NativeClient> {
  public:
@@ -191,20 +91,20 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
   void del(const KeySpan &key);
 
   // Batching interface.
-  WriteBatch getBatch() const;
-  void write(WriteBatch &&);
+  NativeWriteBatch getBatch() const;
+  void write(NativeWriteBatch &&);
 
   // Iterator interface.
   // Iterators initially don't point to a key value, i.e. they convert to false.
   // Important note - RocksDB requires that iterators are destroyed before the DB client that created them.
   //
   // Get an iterator into the default column family.
-  Iterator getIterator() const;
+  NativeIterator getIterator() const;
   // Get an iterator into a column family
-  Iterator getIterator(const std::string &cFamily) const;
+  NativeIterator getIterator(const std::string &cFamily) const;
   // Get iterators from a consistent database state across multiple column families. The order of the returned iterators
   // match the families input.
-  std::vector<Iterator> getIterators(const std::vector<std::string> &cFamilies) const;
+  std::vector<NativeIterator> getIterators(const std::vector<std::string> &cFamilies) const;
 
   ::rocksdb::Options options() const;
 
@@ -241,33 +141,6 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
   NativeClient &operator=(const NativeClient &) = delete;
   NativeClient &operator=(NativeClient &&) = delete;
 
-  // Make sure we only allow types that have data() and size() members. That excludes raw pointers without corresponding
-  // size.
-  template <
-      typename Span,
-      std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
-                           std::is_pointer_v<decltype(std::declval<Span>().data())> &&
-                           std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
-                                                 const char (*)[]>,
-                       int> = 0>
-  static ::rocksdb::Slice toSlice(const Span &span) noexcept {
-    return ::rocksdb::Slice{span.data(), span.size()};
-  }
-
-  template <
-      typename Span,
-      std::enable_if_t<std::is_convertible_v<decltype(std::declval<Span>().size()), std::size_t> &&
-                           std::is_pointer_v<decltype(std::declval<Span>().data())> &&
-                           std::is_convertible_v<std::remove_pointer_t<decltype(std::declval<Span>().data())> (*)[],
-                                                 const std::uint8_t (*)[]>,
-                       int> = 0>
-  static ::rocksdb::Slice toSlice(const Span &span) noexcept {
-    return ::rocksdb::Slice{reinterpret_cast<const char *>(span.data()), span.size()};
-  }
-
-  static void throwOnError(std::string_view msg1, std::string_view msg2, ::rocksdb::Status &&);
-  static void throwOnError(std::string_view msg, ::rocksdb::Status &&);
-
   ::rocksdb::ColumnFamilyHandle *defaultColumnFamilyHandle() const;
   ::rocksdb::ColumnFamilyHandle *columnFamilyHandle(const std::string &cFamily) const;
   Client::CfUniquePtr createColumnFamilyHandle(const std::string &cFamily,
@@ -276,367 +149,12 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
  private:
   std::shared_ptr<Client> client_;
   static const bool applyOptimizationsOnDefaultOpts_ = false;
-  friend class WriteBatch;
-  friend class Iterator;
+  friend class NativeWriteBatch;
 };
-
-inline WriteBatch::WriteBatch(const std::shared_ptr<const NativeClient> &client) noexcept : client_{client} {}
-
-template <typename KeySpan, typename ValueSpan>
-void WriteBatch::put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value) {
-  auto s = batch_.Put(client_->columnFamilyHandle(cFamily), NativeClient::toSlice(key), NativeClient::toSlice(value));
-  NativeClient::throwOnError("batch put failed"sv, std::move(s));
-}
-
-template <typename KeySpan, typename ValueSpan>
-void WriteBatch::put(const KeySpan &key, const ValueSpan &value) {
-  put(NativeClient::defaultColumnFamily(), key, value);
-}
-
-template <typename KeySpan>
-void WriteBatch::del(const std::string &cFamily, const KeySpan &key) {
-  auto s = batch_.Delete(client_->columnFamilyHandle(cFamily), NativeClient::toSlice(key));
-  NativeClient::throwOnError("batch del failed"sv, std::move(s));
-}
-
-template <typename KeySpan>
-void WriteBatch::del(const KeySpan &key) {
-  del(NativeClient::defaultColumnFamily(), key);
-}
-
-template <typename BeginSpan, typename EndSpan>
-void WriteBatch::delRange(const std::string &cFamily, const BeginSpan &beginKey, const EndSpan &endKey) {
-  auto s = batch_.DeleteRange(
-      client_->columnFamilyHandle(cFamily), NativeClient::toSlice(beginKey), NativeClient::toSlice(endKey));
-  NativeClient::throwOnError("delRange failed", std::move(s));
-}
-
-template <typename BeginSpan, typename EndSpan>
-void WriteBatch::delRange(const BeginSpan &beginKey, const EndSpan &endKey) {
-  delRange(client_->defaultColumnFamily(), beginKey, endKey);
-}
-
-template <typename Container>
-void putInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont) {
-  for (const auto &[key, value] : cont) {
-    batch.put(cFamily, key, value);
-  }
-}
-
-template <typename Container>
-void putInBatch(WriteBatch &batch, const Container &cont) {
-  putInBatch(batch, NativeClient::defaultColumnFamily(), cont);
-}
-
-template <typename Container>
-void delInBatch(WriteBatch &batch, const std::string &cFamily, const Container &cont) {
-  for (const auto &key : cont) {
-    batch.del(cFamily, key);
-  }
-}
-
-template <typename Container>
-void delInBatch(WriteBatch &batch, const Container &cont) {
-  delInBatch(batch, NativeClient::defaultColumnFamily(), cont);
-}
-
-inline Iterator::Iterator(std::unique_ptr<::rocksdb::Iterator> iter) noexcept : iter_{std::move(iter)} {}
-
-inline std::string Iterator::sliceToString(const ::rocksdb::Slice &s) { return std::string{s.data(), s.size()}; }
-
-inline std::string_view Iterator::sliceToStringView(const ::rocksdb::Slice &s) {
-  return std::string_view{s.data(), s.size()};
-}
-
-inline Iterator::operator bool() const { return iter_->Valid(); }
-
-inline void Iterator::first() {
-  iter_->SeekToFirst();
-  NativeClient::throwOnError("iterator first failed"sv, iter_->status());
-}
-
-inline void Iterator::last() {
-  iter_->SeekToLast();
-  NativeClient::throwOnError("iterator last failed"sv, iter_->status());
-}
-
-inline void Iterator::next() {
-  if (!iter_->Valid()) {
-    NativeClient::throwOnError("next on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
-  }
-  iter_->Next();
-  auto s = iter_->status();
-  NativeClient::throwOnError("iterator next failed"sv, iter_->status());
-}
-
-inline void Iterator::prev() {
-  if (!iter_->Valid()) {
-    NativeClient::throwOnError("prev on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
-  }
-  iter_->Prev();
-  auto s = iter_->status();
-  NativeClient::throwOnError("iterator prev failed"sv, iter_->status());
-}
-
-template <typename KeySpan>
-void Iterator::seekAtLeast(const KeySpan &target) {
-  iter_->Seek(NativeClient::toSlice(target));
-  NativeClient::throwOnError("iterator seekAtLeast failed"sv, iter_->status());
-}
-
-template <typename KeySpan>
-void Iterator::seekAtMost(const KeySpan &target) {
-  iter_->SeekForPrev(NativeClient::toSlice(target));
-  NativeClient::throwOnError("iterator seekAtMost failed"sv, iter_->status());
-}
-
-inline std::string Iterator::key() const {
-  if (!iter_->Valid()) {
-    NativeClient::throwOnError("key on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
-  }
-  return sliceToString(iter_->key());
-}
-
-inline std::string Iterator::value() const {
-  if (!iter_->Valid()) {
-    NativeClient::throwOnError("value on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
-  }
-  return sliceToString(iter_->value());
-}
-
-inline std::string_view Iterator::keyView() const {
-  if (!iter_->Valid()) {
-    NativeClient::throwOnError("keyView on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
-  }
-  return sliceToStringView(iter_->key());
-}
-
-inline std::string_view Iterator::valueView() const {
-  if (!iter_->Valid()) {
-    NativeClient::throwOnError("valueView on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
-  }
-  return sliceToStringView(iter_->value());
-}
-
-inline std::shared_ptr<NativeClient> NativeClient::newClient(const std::string &path,
-                                                             bool readOnly,
-                                                             const DefaultOptions &opts) {
-  return std::shared_ptr<NativeClient>{new NativeClient{path, readOnly, opts}};
-}
-
-inline std::shared_ptr<NativeClient> NativeClient::newClient(const std::string &path,
-                                                             bool readOnly,
-                                                             const ExistingOptions &opts) {
-  return std::shared_ptr<NativeClient>{new NativeClient{path, readOnly, opts}};
-}
-
-inline std::shared_ptr<NativeClient> NativeClient::newClient(const std::string &path,
-                                                             bool readOnly,
-                                                             const UserOptions &opts) {
-  return std::shared_ptr<NativeClient>{new NativeClient{path, readOnly, opts}};
-}
-
-inline std::shared_ptr<NativeClient> NativeClient::fromIDBClient(const std::shared_ptr<IDBClient> &idb) {
-  auto rocksDbClient = std::dynamic_pointer_cast<Client>(idb);
-  if (!rocksDbClient) {
-    throw std::bad_cast{};
-  }
-  return std::shared_ptr<NativeClient>(new NativeClient{rocksDbClient});
-}
-
-inline NativeClient::NativeClient(const std::string &path, bool readOnly, const DefaultOptions &)
-    : client_{std::make_shared<Client>(path)} {
-  auto options = Client::Options{};
-  options.db_options.create_if_missing = true;
-  client_->initDB(readOnly, options, applyOptimizationsOnDefaultOpts_);
-}
-
-inline NativeClient::NativeClient(const std::string &path, bool readOnly, const ExistingOptions &)
-    : client_{std::make_shared<Client>(path)} {
-  client_->initDB(readOnly, std::nullopt, applyOptimizationsOnDefaultOpts_);
-}
-
-inline NativeClient::NativeClient(const std::string &path, bool readOnly, const UserOptions &userOpts)
-    : client_{std::make_shared<Client>(path)} {
-  auto options = Client::Options{userOpts.dbOptions, userOpts.txnOptions};
-  options.db_options.create_if_missing = true;
-  client_->initDB(readOnly, options, applyOptimizationsOnDefaultOpts_);
-}
-
-inline NativeClient::NativeClient(const std::shared_ptr<Client> &client) : client_{client} {}
-
-inline std::shared_ptr<IDBClient> NativeClient::asIDBClient() const { return client_; }
-
-template <typename KeySpan, typename ValueSpan>
-void NativeClient::put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value) {
-  auto s =
-      client_->dbInstance_->Put(::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), toSlice(key), toSlice(value));
-  throwOnError("put() failed"sv, std::move(s));
-}
-
-template <typename KeySpan>
-std::optional<std::string> NativeClient::get(const std::string &cFamily, const KeySpan &key) const {
-  auto value = std::string{};
-  auto s = client_->dbInstance_->Get(::rocksdb::ReadOptions{}, columnFamilyHandle(cFamily), toSlice(key), &value);
-  if (s.IsNotFound()) {
-    return std::nullopt;
-  }
-  throwOnError("get() failed"sv, std::move(s));
-  return value;
-}
-
-template <typename KeySpan>
-void NativeClient::del(const std::string &cFamily, const KeySpan &key) {
-  auto s = client_->dbInstance_->Delete(::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), toSlice(key));
-  throwOnError("del() failed"sv, std::move(s));
-}
-
-template <typename KeySpan, typename ValueSpan>
-void NativeClient::put(const KeySpan &key, const ValueSpan &value) {
-  put(defaultColumnFamily(), key, value);
-}
-
-template <typename KeySpan>
-std::optional<std::string> NativeClient::get(const KeySpan &key) const {
-  return get(defaultColumnFamily(), key);
-}
-
-template <typename KeySpan>
-void NativeClient::del(const KeySpan &key) {
-  del(defaultColumnFamily(), key);
-}
-
-inline WriteBatch NativeClient::getBatch() const { return WriteBatch{shared_from_this()}; }
-
-inline Iterator NativeClient::getIterator() const {
-  return std::unique_ptr<::rocksdb::Iterator>{client_->dbInstance_->NewIterator(::rocksdb::ReadOptions{})};
-}
-
-inline Iterator NativeClient::getIterator(const std::string &cFamily) const {
-  return std::unique_ptr<::rocksdb::Iterator>{
-      client_->dbInstance_->NewIterator(::rocksdb::ReadOptions{}, columnFamilyHandle(cFamily))};
-}
-
-inline std::vector<Iterator> NativeClient::getIterators(const std::vector<std::string> &cFamilies) const {
-  auto cfHandles = std::vector<::rocksdb::ColumnFamilyHandle *>{};
-  for (const auto &cf : cFamilies) {
-    cfHandles.push_back(columnFamilyHandle(cf));
-  }
-
-  auto rawPtrIterators = std::vector<::rocksdb::Iterator *>{};
-  auto status = client_->dbInstance_->NewIterators(::rocksdb::ReadOptions{}, cfHandles, &rawPtrIterators);
-
-  // Wrap RocksDB iterators in unique pointers so that they are freed, irrespective of the returned status.
-  // Note: NewIterators()'s interface is bad and the caller doesn't have enough info by just looking at it. One has to
-  // look into the RocksDB implementation to see that no iterators will be returned if the status is not OK. That,
-  // however, might change, but the interface will stay the same...
-  auto ret = std::vector<Iterator>{};
-  for (auto iter : rawPtrIterators) {
-    ret.push_back(std::unique_ptr<::rocksdb::Iterator>{iter});
-  }
-  throwOnError("get multiple iterators failed"sv, std::move(status));
-  return ret;
-}
-
-inline void NativeClient::write(WriteBatch &&b) {
-  auto s = client_->dbInstance_->Write(::rocksdb::WriteOptions{}, &b.batch_);
-  throwOnError("write(batch) failed"sv, std::move(s));
-}
-
-inline std::unordered_set<std::string> NativeClient::columnFamilies(const std::string &path) {
-  auto families = std::vector<std::string>{};
-  auto status = ::rocksdb::DB::ListColumnFamilies(::rocksdb::DBOptions{}, path, &families);
-  throwOnError("list column families failed"sv, std::move(status));
-  auto ret = std::unordered_set<std::string>{};
-  for (auto &f : families) {
-    ret.emplace(std::move(f));
-  }
-  return ret;
-}
-
-inline std::string NativeClient::defaultColumnFamily() { return ::rocksdb::kDefaultColumnFamilyName; }
-
-inline std::unordered_set<std::string> NativeClient::columnFamilies() const {
-  auto ret = std::unordered_set<std::string>{};
-  for (const auto &cFamilyToHandle : client_->cf_handles_) {
-    ret.insert(cFamilyToHandle.first);
-  }
-  return ret;
-}
-
-inline bool NativeClient::hasColumnFamily(const std::string cFamily) const {
-  return (client_->cf_handles_.find(cFamily) != client_->cf_handles_.cend());
-}
-
-inline void NativeClient::createColumnFamily(const std::string &cFamily,
-                                             const ::rocksdb::ColumnFamilyOptions &options) {
-  auto handle = createColumnFamilyHandle(cFamily, options);
-  client_->cf_handles_[cFamily] = std::move(handle);
-}
-
-inline ::rocksdb::ColumnFamilyOptions NativeClient::columnFamilyOptions(const std::string &cFamily) const {
-  auto family = columnFamilyHandle(cFamily);
-  auto descriptor = ::rocksdb::ColumnFamilyDescriptor{};
-  auto s = family->GetDescriptor(&descriptor);
-  throwOnError("getting column family options failed"sv, std::move(s));
-  return descriptor.options;
-}
-
-inline void NativeClient::dropColumnFamily(const std::string &cFamily) {
-  auto it = client_->cf_handles_.find(cFamily);
-  if (it == client_->cf_handles_.cend()) {
-    return;
-  }
-  auto s = client_->dbInstance_->DropColumnFamily(it->second.get());
-  throwOnError("failed to drop column family"sv, cFamily, std::move(s));
-  // std::map::erase(iterator) cannot throw.
-  client_->cf_handles_.erase(it);
-}
-
-inline ::rocksdb::Options NativeClient::options() const { return client_->dbInstance_->GetOptions(); }
-
-inline void NativeClient::throwOnError(std::string_view msg1, std::string_view msg2, ::rocksdb::Status &&s) {
-  if (!s.ok()) {
-    auto rocksdbMsg = std::string{"RocksDB: "};
-    rocksdbMsg.append(msg1);
-    if (!msg2.empty()) {
-      rocksdbMsg.append(": ");
-      rocksdbMsg.append(msg2);
-    }
-    LOG_ERROR(Client::logger(), rocksdbMsg << ", status = " << s.ToString());
-    throw RocksDBException{rocksdbMsg, std::move(s)};
-  }
-}
-
-inline void NativeClient::throwOnError(std::string_view msg, ::rocksdb::Status &&s) {
-  return throwOnError(msg, ""sv, std::move(s));
-}
-
-inline ::rocksdb::ColumnFamilyHandle *NativeClient::defaultColumnFamilyHandle() const {
-  return client_->dbInstance_->DefaultColumnFamily();
-}
-
-inline ::rocksdb::ColumnFamilyHandle *NativeClient::columnFamilyHandle(const std::string &cFamily) const {
-  auto it = client_->cf_handles_.find(cFamily);
-  if (it == client_->cf_handles_.cend()) {
-    throwOnError("no such column family"sv, cFamily, ::rocksdb::Status::ColumnFamilyDropped());
-  }
-  return it->second.get();
-}
-
-inline Client::CfUniquePtr NativeClient::createColumnFamilyHandle(const std::string &cFamily,
-                                                                  const ::rocksdb::ColumnFamilyOptions &options) {
-  ::rocksdb::ColumnFamilyHandle *cf{nullptr};
-  auto s = client_->dbInstance_->CreateColumnFamily(options, cFamily, &cf);
-  // Make sure we delete any returned column family handle, irrespective of the returned status.
-  // Note: CreateColumnFamily()'s interface is bad and the caller doesn't have enough info by just looking at it. One
-  // has to look into the RocksDB implementation to see that a nullptr handle will be returned if the status is not OK.
-  // That, however, might change, but the interface will stay the same...
-  auto ret = Client::CfUniquePtr{cf, Client::CfDeleter{client_.get()}};
-  throwOnError("cannot create column family handle"sv, cFamily, std::move(s));
-  return ret;
-}
 
 }  // namespace concord::storage::rocksdb
 
-#endif
+#include "native_write_batch.ipp"
+#include "native_client.ipp"
+
+#endif  // USE_ROCKSDB

--- a/storage/include/rocksdb/native_client.ipp
+++ b/storage/include/rocksdb/native_client.ipp
@@ -1,0 +1,240 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#ifdef USE_ROCKSDB
+
+#include "client.h"
+#include "details.h"
+
+#include <rocksdb/options.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace concord::storage::rocksdb {
+
+using namespace std::string_view_literals;
+
+inline std::shared_ptr<NativeClient> NativeClient::newClient(const std::string &path,
+                                                             bool readOnly,
+                                                             const DefaultOptions &opts) {
+  return std::shared_ptr<NativeClient>{new NativeClient{path, readOnly, opts}};
+}
+
+inline std::shared_ptr<NativeClient> NativeClient::newClient(const std::string &path,
+                                                             bool readOnly,
+                                                             const ExistingOptions &opts) {
+  return std::shared_ptr<NativeClient>{new NativeClient{path, readOnly, opts}};
+}
+
+inline std::shared_ptr<NativeClient> NativeClient::newClient(const std::string &path,
+                                                             bool readOnly,
+                                                             const UserOptions &opts) {
+  return std::shared_ptr<NativeClient>{new NativeClient{path, readOnly, opts}};
+}
+
+inline std::shared_ptr<NativeClient> NativeClient::fromIDBClient(const std::shared_ptr<IDBClient> &idb) {
+  auto rocksDbClient = std::dynamic_pointer_cast<Client>(idb);
+  if (!rocksDbClient) {
+    throw std::bad_cast{};
+  }
+  return std::shared_ptr<NativeClient>(new NativeClient{rocksDbClient});
+}
+
+inline NativeClient::NativeClient(const std::string &path, bool readOnly, const DefaultOptions &)
+    : client_{std::make_shared<Client>(path)} {
+  auto options = Client::Options{};
+  options.db_options.create_if_missing = true;
+  client_->initDB(readOnly, options, applyOptimizationsOnDefaultOpts_);
+}
+
+inline NativeClient::NativeClient(const std::string &path, bool readOnly, const ExistingOptions &)
+    : client_{std::make_shared<Client>(path)} {
+  client_->initDB(readOnly, std::nullopt, applyOptimizationsOnDefaultOpts_);
+}
+
+inline NativeClient::NativeClient(const std::string &path, bool readOnly, const UserOptions &userOpts)
+    : client_{std::make_shared<Client>(path)} {
+  auto options = Client::Options{userOpts.dbOptions, userOpts.txnOptions};
+  options.db_options.create_if_missing = true;
+  client_->initDB(readOnly, options, applyOptimizationsOnDefaultOpts_);
+}
+
+inline NativeClient::NativeClient(const std::shared_ptr<Client> &client) : client_{client} {}
+
+inline std::shared_ptr<IDBClient> NativeClient::asIDBClient() const { return client_; }
+
+template <typename KeySpan, typename ValueSpan>
+void NativeClient::put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value) {
+  auto s = client_->dbInstance_->Put(
+      ::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), detail::toSlice(key), detail::toSlice(value));
+  detail::throwOnError("put() failed"sv, std::move(s));
+}
+
+template <typename KeySpan>
+std::optional<std::string> NativeClient::get(const std::string &cFamily, const KeySpan &key) const {
+  auto value = std::string{};
+  auto s =
+      client_->dbInstance_->Get(::rocksdb::ReadOptions{}, columnFamilyHandle(cFamily), detail::toSlice(key), &value);
+  if (s.IsNotFound()) {
+    return std::nullopt;
+  }
+  detail::throwOnError("get() failed"sv, std::move(s));
+  return value;
+}
+
+template <typename KeySpan>
+void NativeClient::del(const std::string &cFamily, const KeySpan &key) {
+  auto s = client_->dbInstance_->Delete(::rocksdb::WriteOptions{}, columnFamilyHandle(cFamily), detail::toSlice(key));
+  detail::throwOnError("del() failed"sv, std::move(s));
+}
+
+template <typename KeySpan, typename ValueSpan>
+void NativeClient::put(const KeySpan &key, const ValueSpan &value) {
+  put(defaultColumnFamily(), key, value);
+}
+
+template <typename KeySpan>
+std::optional<std::string> NativeClient::get(const KeySpan &key) const {
+  return get(defaultColumnFamily(), key);
+}
+
+template <typename KeySpan>
+void NativeClient::del(const KeySpan &key) {
+  del(defaultColumnFamily(), key);
+}
+
+inline NativeWriteBatch NativeClient::getBatch() const { return NativeWriteBatch{shared_from_this()}; }
+
+inline NativeIterator NativeClient::getIterator() const {
+  return std::unique_ptr<::rocksdb::Iterator>{client_->dbInstance_->NewIterator(::rocksdb::ReadOptions{})};
+}
+
+inline NativeIterator NativeClient::getIterator(const std::string &cFamily) const {
+  return std::unique_ptr<::rocksdb::Iterator>{
+      client_->dbInstance_->NewIterator(::rocksdb::ReadOptions{}, columnFamilyHandle(cFamily))};
+}
+
+inline std::vector<NativeIterator> NativeClient::getIterators(const std::vector<std::string> &cFamilies) const {
+  auto cfHandles = std::vector<::rocksdb::ColumnFamilyHandle *>{};
+  for (const auto &cf : cFamilies) {
+    cfHandles.push_back(columnFamilyHandle(cf));
+  }
+
+  auto rawPtrIterators = std::vector<::rocksdb::Iterator *>{};
+  auto status = client_->dbInstance_->NewIterators(::rocksdb::ReadOptions{}, cfHandles, &rawPtrIterators);
+
+  // Wrap RocksDB iterators in unique pointers so that they are freed, irrespective of the returned status.
+  // Note: NewIterators()'s interface is bad and the caller doesn't have enough info by just looking at it. One has to
+  // look into the RocksDB implementation to see that no iterators will be returned if the status is not OK. That,
+  // however, might change, but the interface will stay the same...
+  auto ret = std::vector<NativeIterator>{};
+  for (auto iter : rawPtrIterators) {
+    ret.push_back(std::unique_ptr<::rocksdb::Iterator>{iter});
+  }
+  detail::throwOnError("get multiple iterators failed"sv, std::move(status));
+  return ret;
+}
+
+inline void NativeClient::write(NativeWriteBatch &&b) {
+  auto s = client_->dbInstance_->Write(::rocksdb::WriteOptions{}, &b.batch_);
+  detail::throwOnError("write(batch) failed"sv, std::move(s));
+}
+
+inline std::unordered_set<std::string> NativeClient::columnFamilies(const std::string &path) {
+  auto families = std::vector<std::string>{};
+  auto status = ::rocksdb::DB::ListColumnFamilies(::rocksdb::DBOptions{}, path, &families);
+  detail::throwOnError("list column families failed"sv, std::move(status));
+  auto ret = std::unordered_set<std::string>{};
+  for (auto &f : families) {
+    ret.emplace(std::move(f));
+  }
+  return ret;
+}
+
+inline std::string NativeClient::defaultColumnFamily() { return ::rocksdb::kDefaultColumnFamilyName; }
+
+inline std::unordered_set<std::string> NativeClient::columnFamilies() const {
+  auto ret = std::unordered_set<std::string>{};
+  for (const auto &cFamilyToHandle : client_->cf_handles_) {
+    ret.insert(cFamilyToHandle.first);
+  }
+  return ret;
+}
+
+inline bool NativeClient::hasColumnFamily(const std::string cFamily) const {
+  return (client_->cf_handles_.find(cFamily) != client_->cf_handles_.cend());
+}
+
+inline void NativeClient::createColumnFamily(const std::string &cFamily,
+                                             const ::rocksdb::ColumnFamilyOptions &options) {
+  auto handle = createColumnFamilyHandle(cFamily, options);
+  client_->cf_handles_[cFamily] = std::move(handle);
+}
+
+inline ::rocksdb::ColumnFamilyOptions NativeClient::columnFamilyOptions(const std::string &cFamily) const {
+  auto family = columnFamilyHandle(cFamily);
+  auto descriptor = ::rocksdb::ColumnFamilyDescriptor{};
+  auto s = family->GetDescriptor(&descriptor);
+  detail::throwOnError("getting column family options failed"sv, std::move(s));
+  return descriptor.options;
+}
+
+inline void NativeClient::dropColumnFamily(const std::string &cFamily) {
+  auto it = client_->cf_handles_.find(cFamily);
+  if (it == client_->cf_handles_.cend()) {
+    return;
+  }
+  auto s = client_->dbInstance_->DropColumnFamily(it->second.get());
+  detail::throwOnError("failed to drop column family"sv, cFamily, std::move(s));
+  // std::map::erase(iterator) cannot throw.
+  client_->cf_handles_.erase(it);
+}
+
+inline ::rocksdb::Options NativeClient::options() const { return client_->dbInstance_->GetOptions(); }
+
+inline ::rocksdb::ColumnFamilyHandle *NativeClient::defaultColumnFamilyHandle() const {
+  return client_->dbInstance_->DefaultColumnFamily();
+}
+
+inline ::rocksdb::ColumnFamilyHandle *NativeClient::columnFamilyHandle(const std::string &cFamily) const {
+  auto it = client_->cf_handles_.find(cFamily);
+  if (it == client_->cf_handles_.cend()) {
+    detail::throwOnError("no such column family"sv, cFamily, ::rocksdb::Status::ColumnFamilyDropped());
+  }
+  return it->second.get();
+}
+
+inline Client::CfUniquePtr NativeClient::createColumnFamilyHandle(const std::string &cFamily,
+                                                                  const ::rocksdb::ColumnFamilyOptions &options) {
+  ::rocksdb::ColumnFamilyHandle *cf{nullptr};
+  auto s = client_->dbInstance_->CreateColumnFamily(options, cFamily, &cf);
+  // Make sure we delete any returned column family handle, irrespective of the returned status.
+  // Note: CreateColumnFamily()'s interface is bad and the caller doesn't have enough info by just looking at it. One
+  // has to look into the RocksDB implementation to see that a nullptr handle will be returned if the status is not OK.
+  // That, however, might change, but the interface will stay the same...
+  auto ret = Client::CfUniquePtr{cf, Client::CfDeleter{client_.get()}};
+  detail::throwOnError("cannot create column family handle"sv, cFamily, std::move(s));
+  return ret;
+}
+
+}  // namespace concord::storage::rocksdb
+
+#endif  // USE_ROCKSDB

--- a/storage/include/rocksdb/native_iterator.h
+++ b/storage/include/rocksdb/native_iterator.h
@@ -1,0 +1,154 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#ifdef USE_ROCKSDB
+
+#include "details.h"
+
+#include <rocksdb/iterator.h>
+#include <rocksdb/slice.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace concord::storage::rocksdb {
+
+using namespace std::string_view_literals;
+
+// For use with NativeClient. See native_client.h .
+class NativeIterator {
+ public:
+  // Returns true if the iterator points to a key-value pair and false otherwise. Initially, an iterator doesn't point
+  // to anything. A false return from this method is not an error - it might mean there are no more keys or a key wasn't
+  // found.
+  operator bool() const;
+
+  // Methods that move the iterator.
+  // Precondition: the iterator points to a key-value pair.
+  void first();
+  void last();
+  void next();
+  void prev();
+
+  // Seek for a key that is at or past target.
+  template <typename KeySpan>
+  void seekAtLeast(const KeySpan &target);
+
+  // Seek for a key that is at or before target.
+  template <typename KeySpan>
+  void seekAtMost(const KeySpan &target);
+
+  // Copy the key and value from the iterator.
+  // Precondition: the iterator points to a key-value pair.
+  std::string key() const;
+  std::string value() const;
+
+  // A view into the key and value inside the iterator. The return value is valid until the iterator is modified.
+  // Precondition: the iterator points to a key-value pair.
+  std::string_view keyView() const;
+  std::string_view valueView() const;
+
+ private:
+  NativeIterator(std::unique_ptr<::rocksdb::Iterator> iter) noexcept;
+  static std::string sliceToString(const ::rocksdb::Slice &);
+  static std::string_view sliceToStringView(const ::rocksdb::Slice &);
+
+ private:
+  std::unique_ptr<::rocksdb::Iterator> iter_;
+  friend class NativeClient;
+};
+
+inline NativeIterator::NativeIterator(std::unique_ptr<::rocksdb::Iterator> iter) noexcept : iter_{std::move(iter)} {}
+
+inline std::string NativeIterator::sliceToString(const ::rocksdb::Slice &s) { return std::string{s.data(), s.size()}; }
+
+inline std::string_view NativeIterator::sliceToStringView(const ::rocksdb::Slice &s) {
+  return std::string_view{s.data(), s.size()};
+}
+
+inline NativeIterator::operator bool() const { return iter_->Valid(); }
+
+inline void NativeIterator::first() {
+  iter_->SeekToFirst();
+  detail::throwOnError("iterator first failed"sv, iter_->status());
+}
+
+inline void NativeIterator::last() {
+  iter_->SeekToLast();
+  detail::throwOnError("iterator last failed"sv, iter_->status());
+}
+
+inline void NativeIterator::next() {
+  if (!iter_->Valid()) {
+    detail::throwOnError("next on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  iter_->Next();
+  auto s = iter_->status();
+  detail::throwOnError("iterator next failed"sv, iter_->status());
+}
+
+inline void NativeIterator::prev() {
+  if (!iter_->Valid()) {
+    detail::throwOnError("prev on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  iter_->Prev();
+  auto s = iter_->status();
+  detail::throwOnError("iterator prev failed"sv, iter_->status());
+}
+
+template <typename KeySpan>
+void NativeIterator::seekAtLeast(const KeySpan &target) {
+  iter_->Seek(detail::toSlice(target));
+  detail::throwOnError("iterator seekAtLeast failed"sv, iter_->status());
+}
+
+template <typename KeySpan>
+void NativeIterator::seekAtMost(const KeySpan &target) {
+  iter_->SeekForPrev(detail::toSlice(target));
+  detail::throwOnError("iterator seekAtMost failed"sv, iter_->status());
+}
+
+inline std::string NativeIterator::key() const {
+  if (!iter_->Valid()) {
+    detail::throwOnError("key on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToString(iter_->key());
+}
+
+inline std::string NativeIterator::value() const {
+  if (!iter_->Valid()) {
+    detail::throwOnError("value on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToString(iter_->value());
+}
+
+inline std::string_view NativeIterator::keyView() const {
+  if (!iter_->Valid()) {
+    detail::throwOnError("keyView on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToStringView(iter_->key());
+}
+
+inline std::string_view NativeIterator::valueView() const {
+  if (!iter_->Valid()) {
+    detail::throwOnError("valueView on invalid iterator"sv, ::rocksdb::Status::InvalidArgument());
+  }
+  return sliceToStringView(iter_->value());
+}
+
+}  // namespace concord::storage::rocksdb
+
+#endif  // USE_ROCKSDB

--- a/storage/include/rocksdb/native_write_batch.h
+++ b/storage/include/rocksdb/native_write_batch.h
@@ -17,6 +17,7 @@
 
 #include <rocksdb/write_batch.h>
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -45,6 +46,8 @@ class NativeWriteBatch {
   void delRange(const std::string &cFamily, const BeginSpan &beginKey, const EndSpan &endKey);
   template <typename BeginSpan, typename EndSpan>
   void delRange(const BeginSpan &beginKey, const EndSpan &endKey);
+
+  std::size_t size() const;
 
  private:
   std::shared_ptr<const NativeClient> client_;

--- a/storage/include/rocksdb/native_write_batch.h
+++ b/storage/include/rocksdb/native_write_batch.h
@@ -1,0 +1,69 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#ifdef USE_ROCKSDB
+
+#include <rocksdb/write_batch.h>
+
+#include <memory>
+#include <string>
+
+namespace concord::storage::rocksdb {
+
+class NativeClient;
+
+// For use with NativeClient. See native_client.h .
+class NativeWriteBatch {
+ public:
+  NativeWriteBatch(const std::shared_ptr<const NativeClient> &) noexcept;
+
+  template <typename KeySpan, typename ValueSpan>
+  void put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value);
+  template <typename KeySpan, typename ValueSpan>
+  void put(const KeySpan &key, const ValueSpan &value);
+
+  // Deleting a key that doesn't exist is not an error.
+  template <typename KeySpan>
+  void del(const std::string &cFamily, const KeySpan &key);
+  template <typename KeySpan>
+  void del(const KeySpan &key);
+
+  // Remove the DB entries in the range [beginKey, endKey).
+  template <typename BeginSpan, typename EndSpan>
+  void delRange(const std::string &cFamily, const BeginSpan &beginKey, const EndSpan &endKey);
+  template <typename BeginSpan, typename EndSpan>
+  void delRange(const BeginSpan &beginKey, const EndSpan &endKey);
+
+ private:
+  std::shared_ptr<const NativeClient> client_;
+  ::rocksdb::WriteBatch batch_;
+  friend class NativeClient;
+};
+
+// Put a container of key-value pair spans.
+template <typename Container>
+void putInBatch(NativeWriteBatch &batch, const std::string &cFamily, const Container &cont);
+template <typename Container>
+void putInBatch(NativeWriteBatch &batch, const Container &cont);
+
+// Delete a container of key spans.
+template <typename Container>
+void delInBatch(NativeWriteBatch &batch, const std::string &cFamily, const Container &cont);
+template <typename Container>
+void delInBatch(NativeWriteBatch &batch, const Container &cont);
+
+}  // namespace concord::storage::rocksdb
+
+#endif  // USE_ROCKSDB

--- a/storage/include/rocksdb/native_write_batch.ipp
+++ b/storage/include/rocksdb/native_write_batch.ipp
@@ -53,6 +53,8 @@ void NativeWriteBatch::delRange(const BeginSpan &beginKey, const EndSpan &endKey
   delRange(client_->defaultColumnFamily(), beginKey, endKey);
 }
 
+inline std::size_t NativeWriteBatch::size() const { return batch_.GetDataSize(); }
+
 template <typename Container>
 void putInBatch(NativeWriteBatch &batch, const std::string &cFamily, const Container &cont) {
   for (const auto &[key, value] : cont) {

--- a/storage/include/rocksdb/native_write_batch.ipp
+++ b/storage/include/rocksdb/native_write_batch.ipp
@@ -1,0 +1,82 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#ifdef USE_ROCKSDB
+
+namespace concord::storage::rocksdb {
+
+inline NativeWriteBatch::NativeWriteBatch(const std::shared_ptr<const NativeClient> &client) noexcept
+    : client_{client} {}
+
+template <typename KeySpan, typename ValueSpan>
+void NativeWriteBatch::put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value) {
+  auto s = batch_.Put(client_->columnFamilyHandle(cFamily), detail::toSlice(key), detail::toSlice(value));
+  detail::throwOnError("batch put failed"sv, std::move(s));
+}
+
+template <typename KeySpan, typename ValueSpan>
+void NativeWriteBatch::put(const KeySpan &key, const ValueSpan &value) {
+  put(NativeClient::defaultColumnFamily(), key, value);
+}
+
+template <typename KeySpan>
+void NativeWriteBatch::del(const std::string &cFamily, const KeySpan &key) {
+  auto s = batch_.Delete(client_->columnFamilyHandle(cFamily), detail::toSlice(key));
+  detail::throwOnError("batch del failed"sv, std::move(s));
+}
+
+template <typename KeySpan>
+void NativeWriteBatch::del(const KeySpan &key) {
+  del(NativeClient::defaultColumnFamily(), key);
+}
+
+template <typename BeginSpan, typename EndSpan>
+void NativeWriteBatch::delRange(const std::string &cFamily, const BeginSpan &beginKey, const EndSpan &endKey) {
+  auto s = batch_.DeleteRange(client_->columnFamilyHandle(cFamily), detail::toSlice(beginKey), detail::toSlice(endKey));
+  detail::throwOnError("delRange failed", std::move(s));
+}
+
+template <typename BeginSpan, typename EndSpan>
+void NativeWriteBatch::delRange(const BeginSpan &beginKey, const EndSpan &endKey) {
+  delRange(client_->defaultColumnFamily(), beginKey, endKey);
+}
+
+template <typename Container>
+void putInBatch(NativeWriteBatch &batch, const std::string &cFamily, const Container &cont) {
+  for (const auto &[key, value] : cont) {
+    batch.put(cFamily, key, value);
+  }
+}
+
+template <typename Container>
+void putInBatch(NativeWriteBatch &batch, const Container &cont) {
+  putInBatch(batch, NativeClient::defaultColumnFamily(), cont);
+}
+
+template <typename Container>
+void delInBatch(NativeWriteBatch &batch, const std::string &cFamily, const Container &cont) {
+  for (const auto &key : cont) {
+    batch.del(cFamily, key);
+  }
+}
+
+template <typename Container>
+void delInBatch(NativeWriteBatch &batch, const Container &cont) {
+  delInBatch(batch, NativeClient::defaultColumnFamily(), cont);
+}
+
+}  // namespace concord::storage::rocksdb
+
+#endif  // USE_ROCKSDB

--- a/storage/include/rocksdb/rocksdb_exception.h
+++ b/storage/include/rocksdb/rocksdb_exception.h
@@ -1,0 +1,31 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#ifdef USE_ROCKSDB
+
+#include <rocksdb/status.h>
+
+#include <stdexcept>
+
+namespace concord::storage::rocksdb {
+
+struct RocksDBException : std::runtime_error {
+  RocksDBException(const std::string &what, ::rocksdb::Status &&s) : std::runtime_error{what}, status{std::move(s)} {}
+  const ::rocksdb::Status status;
+};
+
+}  // namespace concord::storage::rocksdb
+
+#endif  // USE_ROCKSDB

--- a/storage/test/native_rocksdb_client_test.cpp
+++ b/storage/test/native_rocksdb_client_test.cpp
@@ -1,3 +1,16 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
@@ -17,7 +30,7 @@ using namespace concord::storage::rocksdb;
 using namespace ::testing;
 using namespace std::literals;
 
-class native_rocksdb_test : public ::testing::Test {
+class native_rocksdb_test : public Test {
   void SetUp() override {
     cleanup();
     db = TestRocksDb::createNative();

--- a/util/include/evp_hash.hpp
+++ b/util/include/evp_hash.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <array>
+#include <utility>
 
 #include <openssl/evp.h>
 
@@ -32,11 +33,22 @@ class EVPHash {
 
   EVPHash() noexcept : ctx_(EVP_MD_CTX_new()) { ConcordAssert(ctx_ != nullptr); }
 
-  ~EVPHash() noexcept { EVP_MD_CTX_destroy(ctx_); }
+  ~EVPHash() noexcept {
+    if (ctx_) {
+      EVP_MD_CTX_destroy(ctx_);
+    }
+  }
 
-  // Be explicit about move ops being noexcept.
-  EVPHash(EVPHash&&) noexcept = default;
-  EVPHash& operator=(EVPHash&&) noexcept = default;
+  EVPHash(EVPHash&& other) noexcept {
+    ctx_ = other.ctx_;
+    updating_ = other.updating_;
+    other.ctx_ = nullptr;
+  };
+
+  EVPHash& operator=(EVPHash&& other) noexcept {
+    *this = EVPHash{std::move(other)};
+    return *this;
+  }
 
   // Don't allow copying.
   EVPHash(const EVPHash&) = delete;


### PR DESCRIPTION
Introduce the shared key-value category that persists key-values across
multiple categories. If a key-value is part of multiple categories in a
single block update, the value will be physically stored once only in
one of the categories and other categories will contain a key with a
`pointer` to the value. Additionally, support key-value proofs per
category and per block.

Add a unit test to verify the SharedKeyValueCategory::add() method.

Fix EVPHash's move ctor and assignment operator.

Re-generate code on changes to CMF files or to CMF's C++ serialization
library. Accept non-const reference to pointer to const (i.e. const
std::uint8_t*&) in deserialization methods in order to be able to
consume const containers and avoid const_cast.

Add a benchmark to evaluate any performance gains of using
`thread_local` buffers for serialization. Usage is still TBD.

Make sure categorization and RocksDB NativeClient (and tests) are built
only when RocksDB is being used.

Optimize column family lookups via a cache in NativeClient in order to
support dynamic column family creation.

Remaining SharedKeyValueCategory functionality will be provided in
separate commits.