### PR TITLE
Add pruning status to controlManager and controlHandlers

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -55,6 +55,8 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
 
   void clearCheckpointToStopAt();
 
+  void setPruningProcessOn(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
+  bool getPruningProcessStatus() { return onPruningProcess_; }
   ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages);
   ControlStateManager& operator=(const ControlStateManager&) = delete;
   ControlStateManager(const ControlStateManager&) = delete;
@@ -69,5 +71,6 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   std::string scratchPage_;
   bool enabled_ = true;
   ControlStatePage page_;
+  bool onPruningProcess_ = false;
 };
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -55,7 +55,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
 
   void clearCheckpointToStopAt();
 
-  void setPruningProcessOn(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
+  void setPruningProcess(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
   bool getPruningProcessStatus() { return onPruningProcess_; }
   ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages);
   ControlStateManager& operator=(const ControlStateManager&) = delete;

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -56,7 +56,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   void clearCheckpointToStopAt();
 
   void setPruningProcess(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
-  bool getPruningProcessStatus() { return onPruningProcess_; }
+  bool getPruningProcessStatus() const { return onPruningProcess_; }
   ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages);
   ControlStateManager& operator=(const ControlStateManager&) = delete;
   ControlStateManager(const ControlStateManager&) = delete;

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -53,6 +53,7 @@ class ControlHandlers {
  public:
   virtual void onSuperStableCheckpoint() = 0;
   virtual void onStableCheckpoint() = 0;
+  virtual void onPruningProcess() = 0;
   virtual ~ControlHandlers() {}
 };
 

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -53,7 +53,7 @@ class ControlHandlers {
  public:
   virtual void onSuperStableCheckpoint() = 0;
   virtual void onStableCheckpoint() = 0;
-  virtual void onPruningProcess() = 0;
+  virtual bool onPruningProcess() = 0;
   virtual ~ControlHandlers() {}
 };
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -550,6 +550,7 @@ bool ReplicaImp::isSeqNumToStopAt(SeqNum seq_num) {
   // There might be a race condition between the time the replica starts to the time the controlStateManager is
   // initiated.
   if (!controlStateManager_) return false;
+  if (controlStateManager_->getPruningProcessStatus()) return true;
   if (seqNumToStopAt_ > 0 && seq_num == seqNumToStopAt_) return true;
   if (seqNumToStopAt_ > 0 && seq_num > seqNumToStopAt_) return false;
   auto seq_num_to_stop_at = controlStateManager_->getCheckpointToStopAt();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -195,6 +195,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
     LOG_INFO(GL,
              "Ignoring ClientRequest because system is stopped at checkpoint pending control state operation (upgrade, "
              "etc...)");
+    delete m;
     return;
   }
 
@@ -224,6 +225,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         requestsQueueOfPrimary.push(m);
         primaryCombinedReqSize += m->size();
         tryToSendPrePrepareMsg(true);
+        delete m;
         return;
       } else {
         LOG_INFO(GL,

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -225,7 +225,6 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         requestsQueueOfPrimary.push(m);
         primaryCombinedReqSize += m->size();
         tryToSendPrePrepareMsg(true);
-        delete m;
         return;
       } else {
         LOG_INFO(GL,

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -32,6 +32,7 @@ class InternalControlHandlers : public bftEngine::ControlHandlers {
  public:
   void onSuperStableCheckpoint() override { stoppedOnSuperStableCheckpoint = true; }
   void onStableCheckpoint() override { stoppedOnStableCheckpoint = true; }
+  bool onPruningProcess() override { return false; }
 
   virtual ~InternalControlHandlers(){};
   bool haveYouStopped(uint64_t n_of_n) {


### PR DESCRIPTION
In order to enable async pruning, we want to have the ability to signal the bft layer that we are in the middle of pruning.
For that, we added the necessary logic.
Once the command handler initiates pruning it marks in the controlMnager that pruning is on the fly. From this point until pruning is done, the replicas will answer only read requests (the same way we do with wedge).

Notice, that in case of a crash, the same mechanism that returns pruning will set the pruning indicator to true (in the command handler layer)