### PR TITLE
[Apollo] Fix flaky checkpoint test

### DIFF
--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -56,15 +56,11 @@ class SkvbcCheckpointTest(unittest.TestCase):
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
 
-        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
             num_of_checkpoints_to_add=1,
             verify_checkpoint_persistency=False
         )
-        checkpoint_after = await bft_network.wait_for_checkpoint(replica_id=0)
-
-        self.assertEqual(checkpoint_after, 1 + checkpoint_before)
 
     @with_trio
     @with_bft_network(start_replica_cmd)


### PR DESCRIPTION
As per the analysis by @robem and @shgandhi:
_The test checks whether we are able to create a checkpoint or not. It clearly succeeds however, the test expected that we would have created CP 1 instead of 2. This might be a flaky test due to we are reading "before checkpoint" twice. Once from replica 0 and internally (lib function) from a random replica. If for whatever reason, those replicas are not in sync then it would explain the difference._
...
_We read the `before checkpoint` twice, that is most likely causing this. To avoid the flakiness, we can do away with the assertion check in this specific test, because the call to `fill_and_wait_for_checkpoint` essentially does the same thing._