### PR TITLE
Fix CMF fixedlist composition

### DIFF
--- a/messages/compiler/cpp/serialize.cpp
+++ b/messages/compiler/cpp/serialize.cpp
@@ -114,6 +114,12 @@ void serialize(std::vector<uint8_t>& output, const std::vector<T>& v);
 template <typename T>
 void deserialize(const uint8_t*& start, const uint8_t* end, std::vector<T>& v);
 
+// Fixed Lists
+template <typename T, std::size_t N>
+void serialize(std::vector<uint8_t>& output, const std::array<T, N>& v);
+template <typename T, std::size_t N>
+void deserialize(const uint8_t*& start, const uint8_t* end, std::array<T, N>& v);
+
 // KVPairs
 template <typename K, typename V>
 void serialize(std::vector<uint8_t>& output, const std::pair<K, V>& kvpair);

--- a/messages/compiler/cpp/test_cppgen.py
+++ b/messages/compiler/cpp/test_cppgen.py
@@ -150,16 +150,17 @@ class InstanceVisitor(Visitor):
     def list_end(self):
         self.instance += "}"
 
-    # Initialize all std::array elements with the same value, i.e. `instance{value,}`. See `map`
-    # for more information about the limitations.
+    # Initialize the first std::array element with a random value only, i.e. `instance{value}`.
+    # Other values are default-initialized to 0. See `map` for more information about the
+    # limitations.
     def fixedlist_start(self):
-        pass
+        self.instance += "{"
 
     def fixedlist_type_end(self):
         pass
 
     def fixedlist_end(self, size):
-        pass
+        self.instance += "}"
 
     # Map instances are tricky to generate. Uniform initialization of maps is done by lists of
     # std::pairs, which themselves are represented as initializer lists. For this reason, we

--- a/messages/example.cmf
+++ b/messages/example.cmf
@@ -69,6 +69,10 @@ Msg FixedTransactionList 15 {
     fixedlist Transaction 2 transactions2
 }
 
+Msg ComposedFixedList 16 {
+    list fixedlist uint8 32 hashes
+}
+
 ######
 # Uncomment each message to induce various parse errors
 ######


### PR DESCRIPTION
Add missing (de)serialize forward declarations for the `fixedlist` type
(i.e. std::array). This was preventing `fixedlist` composition with
other types, i.e. std::vector<std::array<>>.

Fix a comment about std::array initialization in the cppgen test - be
explicit and say we only initialize the first std::array element with a
random value.