### PR TITLE
Add delete block to the categorized DB adapter

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -21,7 +21,10 @@ add_library(kvbc  src/ClientImp.cpp
 )
 
 if (BUILD_ROCKSDB_STORAGE)
-    target_sources(kvbc PRIVATE src/categorization/shared_kv_category.cpp)
+    target_sources(kvbc PRIVATE src/categorization/shared_kv_category.cpp 
+                                src/categorization/kv_blockchain.cpp 
+                                src/categorization/blocks.cpp
+                                src/categorization/blockchain.cpp)
 endif (BUILD_ROCKSDB_STORAGE)
 
 target_link_libraries(kvbc PUBLIC corebft )

--- a/kvbc/include/categorization/blockchain.h
+++ b/kvbc/include/categorization/blockchain.h
@@ -1,0 +1,119 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "blocks.h"
+
+namespace concord::kvbc::categorization::detail {
+
+// This class exposes an API for interaction with the blockchain and the state transfer blockchain.
+class Blockchain {
+ public:
+  static constexpr auto MAX_BLOCK_ID = std::numeric_limits<BlockId>::max();
+  static constexpr auto INITIAL_GENESIS_BLOCK_ID = BlockId{1};
+
+  Blockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client);
+
+  /////////////////////// Last/genesis block IDs operations ///////////////////////
+  // Last reachable
+  std::optional<BlockId> loadLastReachableBlockId();
+  void setLastReachableBlockId(const BlockId id) { last_reachable_block_id_ = id; }
+  BlockId getLastReachableBlockId() const { return last_reachable_block_id_; }
+
+  // Genesis
+  std::optional<BlockId> loadGenesisBlockId();
+  void setGenesisBlockId(const BlockId id) { genesis_block_id_ = id; }
+  BlockId getGenesisBlockId() const { return genesis_block_id_; }
+
+  // both
+  void setAddedBlockId(const BlockId last) {
+    setLastReachableBlockId(last);
+    // We don't allow deletion of the genesis block if it is the only one left in the system. We do allow deleting it as
+    // last reachable, though, to support replica state sync. Therefore, if we couldn't load the genesis block ID on
+    // startup, it means there are no blocks in storage and we are now adding the first one. Make sure we set the
+    // genesis block ID cache to reflect that.
+    if (genesis_block_id_ == 0) {
+      genesis_block_id_ = INITIAL_GENESIS_BLOCK_ID;
+    }
+  }
+
+  void addBlock(const Block& new_block, storage::rocksdb::NativeWriteBatch& wb) {
+    wb.put(detail::BLOCKS_CF, Block::generateKey(new_block.id()), Block::serialize(new_block));
+  }
+
+  void deleteBlock(const BlockId id, storage::rocksdb::NativeWriteBatch& wb) {
+    wb.del(detail::BLOCKS_CF, Block::generateKey(id));
+  }
+
+  std::optional<Block> getBlock(const BlockId block_id) {
+    auto block_ser = native_client_->get(detail::BLOCKS_CF, Block::generateKey(block_id));
+    if (!block_ser) {
+      return std::optional<Block>{};
+    }
+    return Block::deserialize(*block_ser);
+  }
+
+  /////////////////////// State transfer Block chain ///////////////////////
+  class StateTransfer {
+   public:
+    StateTransfer(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client)
+        : native_client_{native_client} {
+      loadLastBlockId();
+    }
+
+    void deleteBlock(const BlockId id, storage::rocksdb::NativeWriteBatch& wb) {
+      auto db_key = Block::generateKey(id);
+      wb.del(detail::ST_CHAIN_CF, db_key);
+      // If we deleted the latest block reset it
+      if (*latestSTTempBlockId_ == id) {
+        // E.L log
+        latestSTTempBlockId_.reset();
+      }
+      return;
+    }
+
+    void loadLastBlockId() {
+      auto itr = native_client_->getIterator(detail::ST_CHAIN_CF);
+      auto max_db_key = Block::generateKey(MAX_BLOCK_ID);
+      itr.seekAtMost(max_db_key);
+      if (!itr) {
+        latestSTTempBlockId_.reset();
+        return;
+      }
+      BlockKey key{};
+      detail::deserialize(itr.keyView(), key);
+      latestSTTempBlockId_ = key.block_id;
+    }
+
+    std::optional<BlockId> getLastBlockId() const { return latestSTTempBlockId_; }
+
+   private:
+    std::optional<BlockId> latestSTTempBlockId_;
+    std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
+  };
+
+  BlockId getLatestBlockId(const Blockchain::StateTransfer& st_chain) const {
+    if (st_chain.getLastBlockId().has_value()) {
+      return st_chain.getLastBlockId().value();
+    }
+    return getLastReachableBlockId();
+  }
+
+ private:
+  BlockId last_reachable_block_id_{0};
+  BlockId genesis_block_id_{0};
+  std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
+};
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -21,6 +21,7 @@
 #include "merkle_tree_key_manipulator.h"
 #include "merkle_tree_db_adapter.h"
 #include "sliver.hpp"
+#include "column_families.h"
 
 namespace concord::kvbc::categorization {
 
@@ -53,30 +54,23 @@ struct Block {
   void setParentHash(const BlockDigest& parent_hash) {
     std::copy(parent_hash.begin(), parent_hash.end(), data.parent_digest.begin());
   }
-  inline BlockId id() const { return data.block_id; }
 
-  static const detail::Buffer& serialize(const Block& block) {
-    static thread_local detail::Buffer output;
-    output.clear();
-    concord::kvbc::categorization::serialize(output, block.data);
-    return output;
-  }
+  BlockId id() const { return data.block_id; }
 
-  static Block deserialize(const detail::Buffer& input) {
+  static const detail::Buffer& serialize(const Block& block) { return detail::serialize(block.data); }
+
+  template <typename T>
+  static Block deserialize(const T& input) {
     Block output;
-    concord::kvbc::categorization::deserialize(input, output.data);
+    detail::deserialize(input, output.data);
     return output;
   }
 
   // Generate block key from block ID
   // Using CMF for big endian
   static const detail::Buffer& generateKey(const BlockId block_id) {
-    static thread_local detail::Buffer output;
-    output.clear();
     BlockKey key{block_id};
-    // think about optimization
-    concord::kvbc::categorization::serialize(output, key);
-    return output;
+    return detail::serialize(key);
   }
 
   BlockData data;
@@ -84,85 +78,13 @@ struct Block {
 
 //////////////////////////////////// RAW BLOCKS//////////////////////////////////////
 
-// Reconstructs the updates data as recieved from the user
-// This set methods are overloaded in order to construct the appropriate updates
-
-// Merkle updates reconstruction
-RawBlockMerkleUpdates getRawUpdates(const std::string& category_id,
-                                    const MerkleUpdatesInfo& update_info,
-                                    const BlockId& block_id,
-                                    const storage::rocksdb::NativeClient* native_client) {
-  // For old serialization
-  using namespace concord::kvbc::v2MerkleTree;
-  RawBlockMerkleUpdates data;
-  // Copy state hash (std::copy?)
-  data.root_hash = update_info.root_hash;
-  // Iterate over the keys:
-  // if deleted, add to the deleted set.
-  // else generate a db key, serialize it and
-  // get the value from the corresponding column family
-  for (auto& [key, flag] : update_info.keys) {
-    if (flag.deleted) {
-      data.updates.deletes.push_back(key);
-      continue;
-    }
-    // E.L see how we can optimize the sliver temporary allocation
-    auto db_key =
-        v2MerkleTree::detail::DBKeyManipulator::genDataDbKey(Key(std::string(key)), update_info.state_root_version);
-    auto val = native_client->get(category_id, db_key);
-    if (!val.has_value()) {
-      throw std::logic_error("Couldn't find value for key");
-    }
-    // E.L serializtion of the Merkle to CMF will be in later phase
-    auto dbLeafVal = v2MerkleTree::detail::deserialize<v2MerkleTree::detail::DatabaseLeafValue>(
-        concordUtils::Sliver{std::move(val.value())});
-    ConcordAssert(dbLeafVal.addedInBlockId == block_id);
-
-    data.updates.kv[key] = dbLeafVal.leafNode.value.toString();
-  }
-
-  return data;
-}
-
-// KeyValueUpdatesData updates reconstruction
-RawBlockKeyValueUpdates getRawUpdates(const std::string& category_id,
-                                      const KeyValueUpdatesInfo& update_info,
-                                      const BlockId& block_id,
-                                      const storage::rocksdb::NativeClient* native_client) {
-  RawBlockKeyValueUpdates data;
-  return data;
-}
-
-// shared updates reconstruction
-RawBlockSharedUpdates getRawSharedUpdates(const SharedKeyValueUpdatesInfo& update_info,
-                                          const BlockId& block_id,
-                                          const storage::rocksdb::NativeClient* native_client) {
-  RawBlockSharedUpdates data;
-  return data;
-}
-
 // Raw block is the unit which we can transfer and reconstruct a block in a remote replica.
 // It contains all the relevant updates as recieved from the client in the initial call to storage.
 // It also contains:
 // - parent digest
 // - state hash per category (if exists) E.L check why do we pass it.
 struct RawBlock {
-  RawBlock(const Block& block, const storage::rocksdb::NativeClient* native_client) {
-    // parent digest (std::copy?)
-    data.parent_digest = block.data.parent_digest;
-    // recontruct updates of categories
-    for (auto& [cat_id, update_info] : block.data.categories_updates_info) {
-      std::visit(
-          [category_id = cat_id, &block, this, &native_client](const auto& update_info) {
-            auto category_updates = getRawUpdates(category_id, update_info, block.id(), native_client);
-            data.category_updates.emplace(category_id, std::move(category_updates));
-          },
-          update_info);
-    }
-    if (block.data.shared_updates_info.has_value()) {
-      data.shared_update = getRawSharedUpdates(block.data.shared_updates_info.value(), block.id(), native_client);
-    }
-  }
+  RawBlock(const Block& block, const storage::rocksdb::NativeClient& native_client);
 
   static const detail::Buffer& serialize(const RawBlockData& data) {
     static thread_local detail::Buffer out;
@@ -170,6 +92,20 @@ struct RawBlock {
     concord::kvbc::categorization::serialize(out, data);
     return out;
   }
+
+  RawBlockKeyValueUpdates getRawUpdates(const std::string& category_id,
+                                        const KeyValueUpdatesInfo& update_info,
+                                        const BlockId& block_id,
+                                        const storage::rocksdb::NativeClient& native_client);
+
+  RawBlockMerkleUpdates getRawUpdates(const std::string& category_id,
+                                      const MerkleUpdatesInfo& update_info,
+                                      const BlockId& block_id,
+                                      const storage::rocksdb::NativeClient& native_client);
+
+  RawBlockSharedUpdates getRawSharedUpdates(const SharedKeyValueUpdatesInfo& update_info,
+                                            const BlockId& block_id,
+                                            const storage::rocksdb::NativeClient& native_client);
 
   RawBlockData data;
 };

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -21,5 +21,6 @@ inline const auto SHARED_KV_DATA_CF = std::string{"shared_kv_data"};
 inline const auto SHARED_KV_KEY_VERSIONS_CF = std::string{"shared_kv_key_versions"};
 
 inline const auto BLOCKS_CF = std::string{"blocks"};
+inline const auto ST_CHAIN_CF = std::string{"st_chain"};
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -17,6 +17,7 @@
 #include "rocksdb/native_client.h"
 #include <memory>
 #include "blocks.h"
+#include "blockchain.h"
 
 #include "kv_types.hpp"
 
@@ -24,88 +25,73 @@ namespace concord::kvbc::categorization {
 
 class KeyValueBlockchain {
  public:
-  KeyValueBlockchain()
-      : native_client_(concord::storage::rocksdb::NativeClient::newClient(
-            "/tmp", false, concord::storage::rocksdb::NativeClient::DefaultOptions{})) {}
   KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client)
-      : native_client_(native_client) {}
-  // 1) Defines a new block
-  // 2) calls per cateogry with its updates
-  // 3) inserts the updates KV to the DB updates set per column family
-  // 4) add the category block data into the new block
-  BlockId addBlock(Updates&& updates) {
-    // Use new client batch and column families
-    auto write_batch = native_client_->getBatch();
-    Block new_block{getLastReachableBlockId() + 1};
-    // auto parentBlockDigestFuture = computeParentBlockDigest(new_block.ID( ));
-    // Per category updates
-    for (auto&& [category_id, update] : updates.category_updates_) {
-      // https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding
-      std::visit(
-          [&new_block, category_id = category_id, &write_batch, this](auto& update) {
-            auto block_updates = handleCategoryUpdates(new_block.id(), category_id, std::move(update), write_batch);
-            new_block.add(category_id, std::move(block_updates));
-          },
-          update);
-    }
-    if (updates.shared_update_.has_value()) {
-      auto block_updates =
-          handleCategoryUpdates(new_block.id(), std::move(updates.shared_update_.value()), write_batch);
-      new_block.add(std::move(block_updates));
-    }
-    // newBlock.parentDigest = parentBlockDigestFuture.get();
-    // // E.L blocks in new column Family
-    write_batch.put(detail::BLOCKS_CF, Block::generateKey(new_block.id()), Block::serialize(new_block));
-    native_client_->write(std::move(write_batch));
-    return lastReachableBlockId_ = new_block.id();
-  }
+      : native_client_{native_client}, block_chain_{native_client_}, state_transfer_block_chain_{native_client_} {}
+
+  /////////////////////// Add Block ///////////////////////
+
+  BlockId addBlock(Updates&& updates);
+
+  /////////////////////// Delete block ///////////////////////
+
+  bool deleteBlock(const BlockId& blockId);
+  void deleteLastReachableBlock();
+
+  /////////////////////// Info ///////////////////////
+  inline BlockId getGenesisBlockId() { return block_chain_.getGenesisBlockId(); }
+  inline BlockId getLastReachableBlockId() { return block_chain_.getLastReachableBlockId(); }
 
  private:
+  void deleteStateTransferBlock(const BlockId block_id);
+  void deleteGenesisBlock();
+
+  // Delete per category
+  void deleteGenesisBlock(BlockId block_id,
+                          const SharedKeyValueUpdatesInfo& updates_info,
+                          storage::rocksdb::NativeWriteBatch&);
+
+  void deleteGenesisBlock(BlockId block_id,
+                          const std::string& category_id,
+                          const KeyValueUpdatesInfo& updates_info,
+                          storage::rocksdb::NativeWriteBatch&);
+
+  void deleteGenesisBlock(BlockId block_id,
+                          const std::string& category_id,
+                          const MerkleUpdatesInfo& updates_info,
+                          storage::rocksdb::NativeWriteBatch&);
+
+  void deleteLastReachableBlock(BlockId block_id,
+                                const SharedKeyValueUpdatesInfo& updates_info,
+                                storage::rocksdb::NativeWriteBatch&);
+
+  void deleteLastReachableBlock(BlockId block_id,
+                                const std::string& category_id,
+                                const KeyValueUpdatesInfo& updates_info,
+                                storage::rocksdb::NativeWriteBatch&);
+
+  void deleteLastReachableBlock(BlockId block_id,
+                                const std::string& category_id,
+                                const MerkleUpdatesInfo& updates_info,
+                                storage::rocksdb::NativeWriteBatch&);
+
+  // Update per category
   MerkleUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                           const std::string& category_id,
                                           MerkleUpdatesData&& updates,
-                                          concord::storage::rocksdb::NativeWriteBatch& write_batch) {
-    MerkleUpdatesInfo mui;
-    for (auto& [k, v] : updates.kv) {
-      (void)v;
-      mui.keys[k] = MerkleKeyFlag{false};
-    }
-    for (auto& k : updates.deletes) {
-      mui.keys[k] = MerkleKeyFlag{true};
-    }
-    return mui;
-  }
+                                          concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
   KeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                             const std::string& category_id,
                                             KeyValueUpdatesData&& updates,
-                                            concord::storage::rocksdb::NativeWriteBatch& write_batch) {
-    KeyValueUpdatesInfo kvui;
-    for (auto& [k, v] : updates.kv) {
-      (void)v;
-      kvui.keys[k] = KVKeyFlag{false, v.stale_on_update};
-    }
-    for (auto& k : updates.deletes) {
-      kvui.keys[k] = KVKeyFlag{true, false};
-    }
-    return kvui;
-  }
-
+                                            concord::storage::rocksdb::NativeWriteBatch& write_batch);
   SharedKeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                                   SharedKeyValueUpdatesData&& updates,
-                                                  concord::storage::rocksdb::NativeWriteBatch& write_batch) {
-    SharedKeyValueUpdatesInfo skvui;
-    for (auto& [k, v] : updates.kv) {
-      (void)v;
-      skvui.keys[k] = SharedKeyData{v.category_ids};
-    }
-    return skvui;
-  }
+                                                  concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
-  BlockId getLastReachableBlockId() { return lastReachableBlockId_; }
   // Members
   std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
-  BlockId lastReachableBlockId_{0};
+  detail::Blockchain block_chain_;
+  detail::Blockchain::StateTransfer state_transfer_block_chain_;
 };
 
 }  // namespace concord::kvbc::categorization

--- a/kvbc/src/categorization/blockchain.cpp
+++ b/kvbc/src/categorization/blockchain.cpp
@@ -1,0 +1,56 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "categorization/blockchain.h"
+
+namespace concord::kvbc::categorization::detail {
+
+Blockchain::Blockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client)
+    : native_client_{native_client} {
+  auto last_reachable_block_id = loadLastReachableBlockId();
+  if (last_reachable_block_id) {
+    last_reachable_block_id_ = last_reachable_block_id.value();
+  }
+  auto genesis_blockId = loadGenesisBlockId();
+  if (genesis_blockId) {
+    genesis_block_id_ = genesis_blockId.value();
+  }
+}
+
+/////////////////////// Last and genesis block IDs operations ///////////////////////
+
+// Last reachable
+std::optional<BlockId> Blockchain::loadLastReachableBlockId() {
+  auto itr = native_client_->getIterator(detail::BLOCKS_CF);
+  itr.seekAtMost(Block::generateKey(MAX_BLOCK_ID));
+  if (!itr) {
+    return std::optional<BlockId>{};
+  }
+  BlockKey key{};
+  detail::deserialize(itr.keyView(), key);
+  return key.block_id;
+}
+
+// Genesis
+std::optional<BlockId> Blockchain::loadGenesisBlockId() {
+  auto itr = native_client_->getIterator(detail::BLOCKS_CF);
+  itr.seekAtLeast(Block::generateKey(INITIAL_GENESIS_BLOCK_ID));
+  if (!itr) {
+    return std::optional<BlockId>{};
+  }
+  BlockKey key{};
+  detail::deserialize(itr.keyView(), key);
+  return key.block_id;
+}
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/src/categorization/blocks.cpp
+++ b/kvbc/src/categorization/blocks.cpp
@@ -1,0 +1,95 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "categorization/blocks.h"
+
+namespace concord::kvbc::categorization {
+
+//////////////////////////////////// RAW BLOCKS//////////////////////////////////////
+
+// the constructor converts the input block i.e. the update_infos into a raw block
+RawBlock::RawBlock(const Block& block, const storage::rocksdb::NativeClient& native_client) {
+  // parent digest (std::copy?)
+  data.parent_digest = block.data.parent_digest;
+  // recontruct updates of categories
+  for (auto& [cat_id, update_info] : block.data.categories_updates_info) {
+    std::visit(
+        [category_id = cat_id, &block, this, &native_client](const auto& update_info) {
+          auto category_updates = getRawUpdates(category_id, update_info, block.id(), native_client);
+          data.category_updates.emplace(category_id, std::move(category_updates));
+        },
+        update_info);
+  }
+  if (block.data.shared_updates_info.has_value()) {
+    data.shared_update = getRawSharedUpdates(block.data.shared_updates_info.value(), block.id(), native_client);
+  }
+}
+
+// Reconstructs the updates data as recieved from the user
+// This set methods are overloaded in order to construct the appropriate updates
+
+// Merkle updates reconstruction
+RawBlockMerkleUpdates RawBlock::getRawUpdates(const std::string& category_id,
+                                              const MerkleUpdatesInfo& update_info,
+                                              const BlockId& block_id,
+                                              const storage::rocksdb::NativeClient& native_client) {
+  // For old serialization
+  using namespace concord::kvbc::v2MerkleTree;
+  RawBlockMerkleUpdates data;
+  // Copy state hash (std::copy?)
+  data.root_hash = update_info.root_hash;
+  // Iterate over the keys:
+  // if deleted, add to the deleted set.
+  // else generate a db key, serialize it and
+  // get the value from the corresponding column family
+  for (auto& [key, flag] : update_info.keys) {
+    if (flag.deleted) {
+      data.updates.deletes.push_back(key);
+      continue;
+    }
+    // E.L see how we can optimize the sliver temporary allocation
+    auto db_key =
+        v2MerkleTree::detail::DBKeyManipulator::genDataDbKey(Key(std::string(key)), update_info.state_root_version);
+    auto val = native_client.get(category_id, db_key);
+    if (!val.has_value()) {
+      throw std::logic_error("Couldn't find value for key");
+    }
+    // E.L serializtion of the Merkle to CMF will be in later phase
+    auto dbLeafVal = v2MerkleTree::detail::deserialize<v2MerkleTree::detail::DatabaseLeafValue>(
+        concordUtils::Sliver{std::move(val.value())});
+    ConcordAssert(dbLeafVal.addedInBlockId == block_id);
+
+    data.updates.kv[key] = dbLeafVal.leafNode.value.toString();
+  }
+
+  return data;
+}
+
+// KeyValueUpdatesData updates reconstruction
+RawBlockKeyValueUpdates RawBlock::getRawUpdates(const std::string& category_id,
+                                                const KeyValueUpdatesInfo& update_info,
+                                                const BlockId& block_id,
+                                                const storage::rocksdb::NativeClient& native_client) {
+  RawBlockKeyValueUpdates data;
+  return data;
+}
+
+// shared updates reconstruction
+RawBlockSharedUpdates RawBlock::getRawSharedUpdates(const SharedKeyValueUpdatesInfo& update_info,
+                                                    const BlockId& block_id,
+                                                    const storage::rocksdb::NativeClient& native_client) {
+  RawBlockSharedUpdates data;
+  return data;
+}
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -1,0 +1,248 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "categorization/kv_blockchain.h"
+
+namespace concord::kvbc::categorization {
+
+// 1) Defines a new block
+// 2) calls per cateogry with its updates
+// 3) inserts the updates KV to the DB updates set per column family
+// 4) add the category block data into the new block
+BlockId KeyValueBlockchain::addBlock(Updates&& updates) {
+  // Use new client batch and column families
+  auto write_batch = native_client_->getBatch();
+  Block new_block{block_chain_.getLastReachableBlockId() + 1};
+  // auto parentBlockDigestFuture = computeParentBlockDigest(new_block.ID( ));
+  // Per category updates
+  for (auto&& [category_id, update] : updates.category_updates_) {
+    // https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding
+    std::visit(
+        [&new_block, category_id = category_id, &write_batch, this](auto& update) {
+          auto block_updates = handleCategoryUpdates(new_block.id(), category_id, std::move(update), write_batch);
+          new_block.add(category_id, std::move(block_updates));
+        },
+        update);
+  }
+  if (updates.shared_update_.has_value()) {
+    auto block_updates = handleCategoryUpdates(new_block.id(), std::move(updates.shared_update_.value()), write_batch);
+    new_block.add(std::move(block_updates));
+  }
+  // newBlock.parentDigest = parentBlockDigestFuture.get();
+  block_chain_.addBlock(new_block, write_batch);
+  write_batch.put(detail::BLOCKS_CF, Block::generateKey(new_block.id()), Block::serialize(new_block));
+  native_client_->write(std::move(write_batch));
+  block_chain_.setAddedBlockId(new_block.id());
+  return new_block.id();
+}
+
+/////////////////////// Delete block ///////////////////////
+bool KeyValueBlockchain::deleteBlock(const BlockId& block_id) {
+  // Deleting blocks that don't exist is not an error.
+  if (block_id == 0 || block_id < block_chain_.getGenesisBlockId()) {
+    // E.L log
+    return false;
+  }
+
+  // If block id is bigger than what we have
+  const auto latest_block_id = block_chain_.getLatestBlockId(state_transfer_block_chain_);
+  if (latest_block_id == 0 || block_id > latest_block_id) {
+    return false;
+  }
+
+  const auto last_reachable_block_id = block_chain_.getLastReachableBlockId();
+
+  // Block id belongs to the ST chain
+  if (block_id > last_reachable_block_id) {
+    deleteStateTransferBlock(block_id);
+    return true;
+  }
+
+  const auto genesis_block_id = block_chain_.getGenesisBlockId();
+  if (block_id == last_reachable_block_id && block_id == genesis_block_id) {
+    throw std::logic_error{"Deleting the only block in the system is not supported"};
+  } else if (block_id == last_reachable_block_id) {
+    deleteLastReachableBlock();
+    return true;
+  } else if (block_id == genesis_block_id) {
+    deleteGenesisBlock();
+    return true;
+  } else {
+    throw std::invalid_argument{"Cannot delete blocks in the middle of the blockchain"};
+  }
+}
+
+void KeyValueBlockchain::deleteStateTransferBlock(const BlockId block_id) {
+  auto write_batch = native_client_->getBatch();
+  state_transfer_block_chain_.deleteBlock(block_id, write_batch);
+  native_client_->write(std::move(write_batch));
+  if (!state_transfer_block_chain_.getLastBlockId()) {
+    state_transfer_block_chain_.loadLastBlockId();
+  }
+}
+
+// 1 - Get genesis block form DB.
+// 2 - iterate over the update_info and calls the corresponding deleteGenesisBlock
+// 3 - perform the delete
+// 4 - increment the genesis block id.
+void KeyValueBlockchain::deleteGenesisBlock() {
+  // We assume there are blocks in the system.
+  auto genesis_id = block_chain_.getGenesisBlockId();
+  ConcordAssertGE(genesis_id, INITIAL_GENESIS_BLOCK_ID);
+  // And we assume this is not the only block in the blockchain. That excludes ST temporary blocks as they are not yet
+  // part of the blockchain.
+  ConcordAssertNE(genesis_id, block_chain_.getLastReachableBlockId());
+  auto write_batch = native_client_->getBatch();
+
+  // Get block node from storage
+  auto block = block_chain_.getBlock(genesis_id);
+  if (!block) {
+    const auto msg = "Failed to get block node for block ID = " + std::to_string(genesis_id);
+    throw std::runtime_error{msg};
+  }
+
+  block_chain_.deleteBlock(genesis_id, write_batch);
+
+  // Iterate over groups and call corresponding deleteGenesisBlock,
+  // Each group is responsible to fill its deltetes to the batch
+  for (auto&& [category_id, update_info] : (*block).data.categories_updates_info) {
+    std::visit([&genesis_id, category_id = category_id, &write_batch, this](
+                   const auto& update_info) { deleteGenesisBlock(genesis_id, category_id, update_info, write_batch); },
+               update_info);
+  }
+  if ((*block).data.shared_updates_info.has_value()) {
+    deleteGenesisBlock(genesis_id, (*block).data.shared_updates_info.value(), write_batch);
+  }
+
+  native_client_->write(std::move(write_batch));
+  // Increment the genesis block ID cache.
+  block_chain_.setGenesisBlockId(genesis_id + 1);
+}
+
+// 1 - Get last id block form DB.
+// 2 - iterate over the update_info and calls the corresponding deleteLastReachableBlock
+// 3 - perform the delete
+// 4 - increment the genesis block id.
+void KeyValueBlockchain::deleteLastReachableBlock() {
+  auto last_id = block_chain_.getLastReachableBlockId();
+  if (last_id == 0) return;
+
+  auto write_batch = native_client_->getBatch();
+  // Get block node from storage
+  auto block = block_chain_.getBlock(last_id);
+  if (!block) {
+    const auto msg = "Failed to get block node for block ID = " + std::to_string(last_id);
+    throw std::runtime_error{msg};
+  }
+
+  block_chain_.deleteBlock(last_id, write_batch);
+
+  // Iterate over groups and call corresponding deleteGenesisBlock,
+  // Each group is responsible to fill its deltetes to the batch
+  for (auto&& [category_id, update_info] : (*block).data.categories_updates_info) {
+    std::visit(
+        [&last_id, category_id = category_id, &write_batch, this](const auto& update_info) {
+          deleteLastReachableBlock(last_id, category_id, update_info, write_batch);
+        },
+        update_info);
+  }
+  if ((*block).data.shared_updates_info.has_value()) {
+    deleteLastReachableBlock(last_id, (*block).data.shared_updates_info.value(), write_batch);
+  }
+
+  native_client_->write(std::move(write_batch));
+
+  // Since we allow deletion of the only block left as last reachable (due to replica state sync), reflect that in the
+  // genesis block ID cache.
+  auto genesis_id = block_chain_.getGenesisBlockId();
+  if (last_id == genesis_id) {
+    block_chain_.setGenesisBlockId(genesis_id - 1);
+  }
+
+  // Decrement the last reachable block ID cache.
+  block_chain_.setLastReachableBlockId(last_id - 1);
+}
+
+// Deletes per category
+void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
+                                            const SharedKeyValueUpdatesInfo& updates_info,
+                                            storage::rocksdb::NativeWriteBatch&) {}
+
+void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
+                                            const std::string& category_id,
+                                            const KeyValueUpdatesInfo& updates_info,
+                                            storage::rocksdb::NativeWriteBatch&) {}
+
+void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
+                                            const std::string& category_id,
+                                            const MerkleUpdatesInfo& updates_info,
+                                            storage::rocksdb::NativeWriteBatch&) {}
+
+void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
+                                                  const SharedKeyValueUpdatesInfo& updates_info,
+                                                  storage::rocksdb::NativeWriteBatch&) {}
+
+void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
+                                                  const std::string& category_id,
+                                                  const KeyValueUpdatesInfo& updates_info,
+                                                  storage::rocksdb::NativeWriteBatch&) {}
+
+void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
+                                                  const std::string& category_id,
+                                                  const MerkleUpdatesInfo& updates_info,
+                                                  storage::rocksdb::NativeWriteBatch&) {}
+
+// Updates per category
+
+MerkleUpdatesInfo KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
+                                                            const std::string& category_id,
+                                                            MerkleUpdatesData&& updates,
+                                                            concord::storage::rocksdb::NativeWriteBatch& write_batch) {
+  MerkleUpdatesInfo mui;
+  for (auto& [k, v] : updates.kv) {
+    (void)v;
+    mui.keys[k] = MerkleKeyFlag{false};
+  }
+  for (auto& k : updates.deletes) {
+    mui.keys[k] = MerkleKeyFlag{true};
+  }
+  return mui;
+}
+
+KeyValueUpdatesInfo KeyValueBlockchain::handleCategoryUpdates(
+    BlockId block_id,
+    const std::string& category_id,
+    KeyValueUpdatesData&& updates,
+    concord::storage::rocksdb::NativeWriteBatch& write_batch) {
+  KeyValueUpdatesInfo kvui;
+  for (auto& [k, v] : updates.kv) {
+    (void)v;
+    kvui.keys[k] = KVKeyFlag{false, v.stale_on_update};
+  }
+  for (auto& k : updates.deletes) {
+    kvui.keys[k] = KVKeyFlag{true, false};
+  }
+  return kvui;
+}
+
+SharedKeyValueUpdatesInfo KeyValueBlockchain::handleCategoryUpdates(
+    BlockId block_id, SharedKeyValueUpdatesData&& updates, concord::storage::rocksdb::NativeWriteBatch& write_batch) {
+  SharedKeyValueUpdatesInfo skvui;
+  for (auto& [k, v] : updates.kv) {
+    (void)v;
+    skvui.keys[k] = SharedKeyData{v.category_ids};
+  }
+  return skvui;
+}
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -145,10 +145,22 @@ target_link_libraries(s3_storage_factory_test PUBLIC
 endif(USE_S3_OBJECT_STORE)
 
 if (BUILD_ROCKSDB_STORAGE)
-    add_executable(categorized_updates_unit_test
-        categorization/updates_test.cpp )
-    add_test(categorized_updates_unit_test categorized_updates_unit_test)
-    target_link_libraries(categorized_updates_unit_test PUBLIC
+    add_executable(categorized_kv_blockchain_unit_test
+        categorization/kv_blockchain_test.cpp )
+    add_test(categorized_kv_blockchain_unit_test categorized_kv_blockchain_unit_test)
+    target_link_libraries(categorized_kv_blockchain_unit_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        corebft
+        kvbc
+        stdc++fs
+    )
+
+    add_executable(categorized_blocks_unit_test
+        categorization/blocks_test.cpp )
+    add_test(categorized_blocks_unit_test categorized_blocks_unit_test)
+    target_link_libraries(categorized_blocks_unit_test PUBLIC
         GTest::Main
         GTest::GTest
         util

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -1,0 +1,162 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+/**
+ * The following test suite tests ordering of KeyValuePairs
+ */
+
+#include "gtest/gtest.h"
+#include "categorization/column_families.h"
+#include "categorization/updates.h"
+#include "categorization/kv_blockchain.h"
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+#include <random>
+#include "storage/test/storage_test_common.h"
+
+using concord::storage::rocksdb::NativeClient;
+using namespace concord::kvbc::categorization;
+using namespace concord::kvbc::categorization::detail;
+using namespace concord::kvbc;
+
+namespace {
+
+class categorized_kvbc : public ::testing::Test {
+  void SetUp() override {
+    cleanup();
+    db = TestRocksDb::createNative();
+    db->createColumnFamily(BLOCKS_CF);
+    db->createColumnFamily(ST_CHAIN_CF);
+  }
+  void TearDown() override { cleanup(); }
+
+ protected:
+  std::shared_ptr<NativeClient> db;
+};
+
+TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
+  BlockDigest pHash;
+  std::random_device rd;
+  for (int i = 0; i < (int)pHash.size(); i++) {
+    pHash[i] = (uint8_t)(rd() % 255);
+  }
+
+  auto cf = std::string("merkle");
+  auto key = std::string("key");
+  auto value = std::string("val");
+
+  uint64_t state_root_version = 886;
+  MerkleUpdatesInfo mui;
+  mui.keys[key] = MerkleKeyFlag{false};
+  mui.root_hash = pHash;
+  mui.state_root_version = state_root_version;
+
+  Block block{888};
+  block.add(cf, std::move(mui));
+  block.setParentHash(pHash);
+
+  db->createColumnFamily(cf);
+  auto db_key = v2MerkleTree::detail::DBKeyManipulator::genDataDbKey(std::string(key), state_root_version);
+  auto db_val = v2MerkleTree::detail::serialize(
+      v2MerkleTree::detail::DatabaseLeafValue{block.id(), sparse_merkle::LeafNode{std::string(value)}});
+  db->put(cf, db_key, db_val);
+  auto db_get_val = db->get(cf, db_key);
+  ASSERT_EQ(db_get_val.value(), db_val);
+
+  categorization::RawBlock rw(block, *db.get());
+  ASSERT_EQ(rw.data.parent_digest, block.data.parent_digest);
+  auto variant = rw.data.category_updates[cf];
+  auto raw_merkle_updates = std::get<RawBlockMerkleUpdates>(variant);
+  // check reconstruction of original kv
+  ASSERT_EQ(raw_merkle_updates.updates.kv[key], value);
+}
+
+TEST_F(categorized_kvbc, serialization_and_desirialization_of_block) {
+  BlockDigest pHash;
+  std::random_device rd;
+  for (int i = 0; i < (int)pHash.size(); i++) {
+    pHash[i] = (uint8_t)(rd() % 255);
+  }
+  Block block{8};
+  KeyValueUpdatesInfo kvui;
+  kvui.keys["key1"] = {false, false};
+  kvui.keys["key2"] = {true, false};
+  block.add("KeyValueUpdatesInfo", std::move(kvui));
+  block.setParentHash(pHash);
+  auto ser = Block::serialize(block);
+  auto des_block = Block::deserialize(ser);
+
+  // Test the deserialized Block
+  ASSERT_TRUE(des_block.id() == 8);
+  auto variant = des_block.data.categories_updates_info["KeyValueUpdatesInfo"];
+  KeyValueUpdatesInfo kv_updates_info = std::get<KeyValueUpdatesInfo>(variant);
+  ASSERT_TRUE(kv_updates_info.keys.size() == 2);
+  ASSERT_TRUE(kv_updates_info.keys["key2"].deleted == true);
+  ASSERT_EQ(des_block.data.parent_digest, block.data.parent_digest);
+}
+
+TEST_F(categorized_kvbc, fail_to_get_last_or_genesis_block) {
+  detail::Blockchain block_chain{db};
+  ASSERT_FALSE(block_chain.loadLastReachableBlockId().has_value());
+  ASSERT_FALSE(block_chain.loadGenesisBlockId().has_value());
+}
+
+TEST_F(categorized_kvbc, get_last_and_genesis_block) {
+  KeyValueBlockchain block_chain{db};
+  detail::Blockchain block_chain_imp{db};
+  // Add block1
+  {
+    Updates updates;
+    MerkleUpdates merkle_updates;
+    merkle_updates.addUpdate("merkle_key1", "merkle_value1");
+    merkle_updates.addDelete("merkle_deleted");
+    updates.add("merkle", std::move(merkle_updates));
+
+    KeyValueUpdates keyval_updates;
+    keyval_updates.addUpdate("kv_key1", "key_val1");
+    keyval_updates.addDelete("kv_deleted");
+    updates.add("kv_hash", std::move(keyval_updates));
+    ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
+  }
+  // Add block2
+  {
+    Updates updates;
+    MerkleUpdates merkle_updates;
+    merkle_updates.addUpdate("merkle_key2", "merkle_value2");
+    merkle_updates.addDelete("merkle_deleted");
+    updates.add("merkle", std::move(merkle_updates));
+
+    KeyValueUpdates keyval_updates;
+    keyval_updates.addUpdate("kv_key2", "key_val2");
+    keyval_updates.addDelete("kv_deleted");
+    updates.add("kv_hash", std::move(keyval_updates));
+
+    SharedKeyValueUpdates shared_updates;
+    shared_updates.addUpdate("shared_key2", {"shared_Val2", {"1", "2"}});
+    updates.add(std::move(shared_updates));
+    ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)2);
+  }
+  ASSERT_TRUE(block_chain_imp.loadLastReachableBlockId().has_value());
+  ASSERT_EQ(block_chain_imp.loadLastReachableBlockId().value(), 2);
+  ASSERT_TRUE(block_chain_imp.loadGenesisBlockId().has_value());
+  ASSERT_EQ(block_chain_imp.loadGenesisBlockId().value(), 1);
+}
+
+}  // end namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Support delete block via a similar mechanism used for the add block i.e. std::visit and per-category delete.
Support for delete genesis and last reachable.

The logic was mostly migrated from the Merkle DB adapter and was adopted to support categorization.

Under the block file, a ```BlockChain``` class was added, in order to encapsulate the interaction with the blockchain itself.
This class also defines a ```StateTransfer``` inner class for interaction with the state-transfer chain.

Files were divided into smaller grains and into cpp files as well.

