### PR TITLE
Remove the C++ serialization lib as CMF dependency

### DIFF
--- a/cmake/FindCMFC.cmake
+++ b/cmake/FindCMFC.cmake
@@ -19,7 +19,7 @@ function(CMF_GENERATE_CPP CPP_HEADER CPP_IMPL CPP_NAMESPACE)
            --output ${FIL}
            --language cpp
            --namespace ${CPP_NAMESPACE}
-      DEPENDS ${FIL} ${CMF_COMPILER} ${CMAKE_SOURCE_DIR}/messages/compiler/cpp/serialize.cpp
+      DEPENDS ${FIL} ${CMF_COMPILER}
       COMMENT "CMFC: Generate C++ code for ${FIL}"
       VERBATIM
     )


### PR DESCRIPTION
Using Concord-BFT as a submodule is problematic when using a path that
is relative to CMAKE_SOURCE_DIR . Will fix in a future commit.