### PR TITLE
Use gauge for last_saved_block_id S3 metric

### DIFF
--- a/bftengine/tests/s3/metrics_test.cpp
+++ b/bftengine/tests/s3/metrics_test.cpp
@@ -16,18 +16,18 @@ TEST(metrics_test, updateLastSavedBlockId) {
   // Create a data key - it should increase the metric
   auto dataKey = keygen->dataKey(concord::kvbc::Key{keyName}, blockId);
   m.updateLastSavedBlockId(dataKey.toString());
-  ASSERT_EQ(m.getLastSavedBlockId(), "1");
+  ASSERT_EQ(m.getLastSavedBlockId(), 1);
 
   // Create metadata key - it should NOT increase the metric
   auto mdtKey = keygen->mdtKey(Key{keyName});
   m.updateLastSavedBlockId(mdtKey.toString());
-  ASSERT_EQ(m.getLastSavedBlockId(), "1");
+  ASSERT_EQ(m.getLastSavedBlockId(), 1);
 
   // Create block key - it should increase the metric
   blockId++;
   auto blockKey = keygen->blockKey(blockId);
   m.updateLastSavedBlockId(blockKey.toString());
-  ASSERT_EQ(m.getLastSavedBlockId(), "2");
+  ASSERT_EQ(m.getLastSavedBlockId(), 2);
 }
 
 }  // namespace

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -10,6 +10,7 @@ find_library(LIBS3 s3)
 target_compile_definitions(concordbft_storage PUBLIC USE_S3_OBJECT_STORE=1)
 target_sources(concordbft_storage PRIVATE src/s3/client.cpp)
 target_link_libraries(concordbft_storage PRIVATE ${LIBS3})
+target_include_directories(concordbft_storage PRIVATE ${CMAKE_SOURCE_DIR}/kvbc/include/)
 endif(USE_S3_OBJECT_STORE)
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -206,8 +206,8 @@ class Client : public concord::storage::IDBClient {
   }
 
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override {
-    metrics_.metrics_component_.SetAggregator(aggregator);
-    metrics_.metrics_component_.UpdateAggregator();
+    metrics_.metrics_component.SetAggregator(aggregator);
+    metrics_.metrics_component.UpdateAggregator();
   }
 
   ///////////////////////// protected /////////////////////////////

--- a/storage/include/s3/metrics.hpp
+++ b/storage/include/s3/metrics.hpp
@@ -8,17 +8,17 @@ namespace concord::storage::s3 {
 class Metrics {
   public:
   Metrics()
-      : metrics_component_{concordMetrics::Component("s3", std::make_shared<concordMetrics::Aggregator>())},
-        numKeysTransferred{metrics_component_.RegisterCounter("keys_transferred")},
-        bytesTransferred{
-            metrics_component_.RegisterCounter("bytes_transferred"),
+      : metrics_component{concordMetrics::Component("s3", std::make_shared<concordMetrics::Aggregator>())},
+        num_keys_transferred{metrics_component.RegisterCounter("keys_transferred")},
+        bytes_transferred{
+            metrics_component.RegisterCounter("bytes_transferred"),
         },
-        lastSavedBlockId_{
-            metrics_component_.RegisterGauge("last_saved_block_id", 0),
+        last_saved_block_id_{
+            metrics_component.RegisterGauge("last_saved_block_id", 0),
         }
 
   {
-    metrics_component_.Register();
+    metrics_component.Register();
   }
 
   void updateLastSavedBlockId(const concordUtils::Sliver& key) {
@@ -49,22 +49,22 @@ class Metrics {
       LOG_ERROR(logger_, "Unexpected error occured while converting lastSavedBlockId (" << elems[elems.size() - 2] << ") to numeric value.");
       return;
     }
-    lastSavedBlockId_.Get().Set(lastSavedBlockVal);
+    last_saved_block_id_.Get().Set(lastSavedBlockVal);
   }
 
-  uint64_t getLastSavedBlockId() { return lastSavedBlockId_.Get().Get(); }
+  uint64_t getLastSavedBlockId() { return last_saved_block_id_.Get().Get(); }
 
-  concordMetrics::Component metrics_component_;
+  concordMetrics::Component metrics_component;
 
-  concordMetrics::CounterHandle numKeysTransferred;
-  concordMetrics::CounterHandle bytesTransferred;
+  concordMetrics::CounterHandle num_keys_transferred;
+  concordMetrics::CounterHandle bytes_transferred;
 
  private:
   // This function "guesses" if metadata or block is being updated.
   // In the latter case it updates the metric
   bool isBlockKey(std::string_view key) { return key.find("metadata") == std::string_view::npos; }
 
-  concordMetrics::GaugeHandle lastSavedBlockId_;
+  concordMetrics::GaugeHandle last_saved_block_id_;
 
   logging::Logger logger_ = logging::getLogger("concord.storage.s3.metrics");
 };

--- a/storage/include/s3/metrics.hpp
+++ b/storage/include/s3/metrics.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <Metrics.hpp>
-#include <sliver.hpp>
-
+#include "Metrics.hpp"
+#include "sliver.hpp"
+#include "Logger.hpp"
 namespace concord::storage::s3 {
 
-struct Metrics {
+class Metrics {
+  public:
   Metrics()
       : metrics_component_{concordMetrics::Component("s3", std::make_shared<concordMetrics::Aggregator>())},
         numKeysTransferred{metrics_component_.RegisterCounter("keys_transferred")},
@@ -13,7 +14,7 @@ struct Metrics {
             metrics_component_.RegisterCounter("bytes_transferred"),
         },
         lastSavedBlockId_{
-            metrics_component_.RegisterStatus("last_saved_block_id", "0"),
+            metrics_component_.RegisterGauge("last_saved_block_id", 0),
         }
 
   {
@@ -35,10 +36,23 @@ struct Metrics {
     // the format is: "PREFIX/BLOCK_ID/KEY", where PREFIX is optional
     if (elems.size() < 2) return;
 
-    lastSavedBlockId_.Get().Set(elems[elems.size() - 2]);
+    uint64_t lastSavedBlockVal = 0;
+    try {
+      lastSavedBlockVal = stoull(elems[elems.size() - 2]);
+    } catch(std::invalid_argument& e) {
+      LOG_ERROR(logger_, "Can't convert lastSavedBlockId (" << elems[elems.size() - 2] << ") to numeric value.");
+      return;
+    } catch(std::out_of_range& e) {
+      LOG_ERROR(logger_, "lastSavedBlockId value (" << elems[elems.size() - 2] << ") doesn't fit in unsigned 64bit integer.");
+      return;
+    } catch(std::exception& e) {
+      LOG_ERROR(logger_, "Unexpected error occured while converting lastSavedBlockId (" << elems[elems.size() - 2] << ") to numeric value.");
+      return;
+    }
+    lastSavedBlockId_.Get().Set(lastSavedBlockVal);
   }
 
-  std::string getLastSavedBlockId() { return lastSavedBlockId_.Get().Get(); }
+  uint64_t getLastSavedBlockId() { return lastSavedBlockId_.Get().Get(); }
 
   concordMetrics::Component metrics_component_;
 
@@ -50,6 +64,8 @@ struct Metrics {
   // In the latter case it updates the metric
   bool isBlockKey(std::string_view key) { return key.find("metadata") == std::string_view::npos; }
 
-  concordMetrics::StatusHandle lastSavedBlockId_;
+  concordMetrics::GaugeHandle lastSavedBlockId_;
+
+  logging::Logger logger_ = logging::getLogger("concord.storage.s3.metrics");
 };
 }  // namespace concord::storage::s3

--- a/storage/include/s3/metrics.hpp
+++ b/storage/include/s3/metrics.hpp
@@ -2,11 +2,12 @@
 
 #include "Metrics.hpp"
 #include "sliver.hpp"
+#include "kv_types.hpp"
 #include "Logger.hpp"
 namespace concord::storage::s3 {
 
 class Metrics {
-  public:
+ public:
   Metrics()
       : metrics_component{concordMetrics::Component("s3", std::make_shared<concordMetrics::Aggregator>())},
         num_keys_transferred{metrics_component.RegisterCounter("keys_transferred")},
@@ -39,20 +40,23 @@ class Metrics {
     uint64_t lastSavedBlockVal = 0;
     try {
       lastSavedBlockVal = stoull(elems[elems.size() - 2]);
-    } catch(std::invalid_argument& e) {
+    } catch (std::invalid_argument& e) {
       LOG_ERROR(logger_, "Can't convert lastSavedBlockId (" << elems[elems.size() - 2] << ") to numeric value.");
       return;
-    } catch(std::out_of_range& e) {
-      LOG_ERROR(logger_, "lastSavedBlockId value (" << elems[elems.size() - 2] << ") doesn't fit in unsigned 64bit integer.");
+    } catch (std::out_of_range& e) {
+      LOG_ERROR(logger_,
+                "lastSavedBlockId value (" << elems[elems.size() - 2] << ") doesn't fit in unsigned 64bit integer.");
       return;
-    } catch(std::exception& e) {
-      LOG_ERROR(logger_, "Unexpected error occured while converting lastSavedBlockId (" << elems[elems.size() - 2] << ") to numeric value.");
+    } catch (std::exception& e) {
+      LOG_ERROR(logger_,
+                "Unexpected error occured while converting lastSavedBlockId (" << elems[elems.size() - 2]
+                                                                               << ") to numeric value.");
       return;
     }
     last_saved_block_id_.Get().Set(lastSavedBlockVal);
   }
 
-  uint64_t getLastSavedBlockId() { return last_saved_block_id_.Get().Get(); }
+  kvbc::BlockId getLastSavedBlockId() { return last_saved_block_id_.Get().Get(); }
 
   concordMetrics::Component metrics_component;
 

--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -133,10 +133,10 @@ Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
   string s = string(_key.data());
   S3_put_object(&context_, string(_key.data()).c_str(), _value.length(), NULL, NULL, &putObjectHandler, &cbData);
   if (cbData.status == S3Status::S3StatusOK) {
-    metrics_.numKeysTransferred.Get().Inc();
-    metrics_.bytesTransferred.Get().Inc(_key.length() + _value.length());
+    metrics_.num_keys_transferred.Get().Inc();
+    metrics_.bytes_transferred.Get().Inc(_key.length() + _value.length());
     metrics_.updateLastSavedBlockId(_key);
-    metrics_.metrics_component_.UpdateAggregator();
+    metrics_.metrics_component.UpdateAggregator();
     return Status::OK();
   } else {
     LOG_ERROR(logger_, "put status: " << cbData.status);


### PR DESCRIPTION
Gauge is more suitable type for the metric as it represents a numeric
value.