### PR TITLE
[Block accumulation] Remove single request execute method

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -65,7 +65,8 @@ class IRequestsHandler {
     uint8_t flags = 0;
     uint32_t requestSize = 0;
     const char *request;
-    std::string outReply;
+    uint32_t maxReplySize = 0;
+    char *outReply;
     uint64_t requestSequenceNum = executionSequenceNum;
     uint32_t outActualReplySize = 0;
     uint32_t outReplicaSpecificInfoSize = 0;

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -59,17 +59,6 @@ class ControlHandlers {
 
 class IRequestsHandler {
  public:
-  virtual int execute(uint16_t clientId,
-                      uint64_t sequenceNum,
-                      uint8_t flags,
-                      uint32_t requestSize,
-                      const char *request,
-                      uint32_t maxReplySize,
-                      char *outReply,
-                      uint32_t &outActualReplySize,
-                      uint32_t &outReplicaSpecificInfoSize,
-                      concordUtils::SpanWrapper &parent_span) = 0;
-
   struct ExecutionRequest {
     uint16_t clientId = 0;
     uint64_t executionSequenceNum = 0;

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -63,7 +63,8 @@ class IRequestsHandler {
     uint16_t clientId = 0;
     uint64_t executionSequenceNum = 0;
     uint8_t flags = 0;
-    std::string request;
+    uint32_t requestSize = 0;
+    const char *request;
     std::string outReply;
     uint64_t requestSequenceNum = executionSequenceNum;
     uint32_t outActualReplySize = 0;

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -9,7 +9,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue &requests,
                              concordUtils::SpanWrapper &parent_span) {
   for (auto &req : requests) {
     if (req.flags & KEY_EXCHANGE_FLAG) {
-      KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(req.request.c_str(), req.request.size());
+      KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(req.request, req.requestSize);
       LOG_DEBUG(GL, "BFT handler received KEY_EXCHANGE msg " << ke.toString());
       auto resp = KeyManager::get().onKeyExchange(ke, req.executionSequenceNum);
       if (resp.size() <= req.outReply.size()) {

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -12,8 +12,8 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue &requests,
       KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(req.request, req.requestSize);
       LOG_DEBUG(GL, "BFT handler received KEY_EXCHANGE msg " << ke.toString());
       auto resp = KeyManager::get().onKeyExchange(ke, req.executionSequenceNum);
-      if (resp.size() <= req.outReply.size()) {
-        std::copy(resp.begin(), resp.end(), req.outReply.data());
+      if (resp.size() <= req.maxReplySize) {
+        std::copy(resp.begin(), resp.end(), req.outReply);
         req.outActualReplySize = resp.size();
       } else {
         LOG_ERROR(GL, "KEY_EXCHANGE response is too large, response " << resp);

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -4,45 +4,6 @@
 
 namespace bftEngine {
 
-int RequestHandler::execute(uint16_t clientId,
-                            uint64_t sequenceNum,
-                            uint8_t flags,
-                            uint32_t requestSize,
-                            const char *request,
-                            uint32_t maxReplySize,
-                            char *outReply,
-                            uint32_t &outActualReplySize,
-                            uint32_t &outReplicaSpecificInfoSize,
-                            concordUtils::SpanWrapper &parent_span) {
-  if (flags & KEY_EXCHANGE_FLAG) {
-    KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(request, requestSize);
-    LOG_DEBUG(GL, "BFT handler received KEY_EXCHANGE msg " << ke.toString());
-    auto resp = KeyManager::get().onKeyExchange(ke, sequenceNum);
-    if (resp.size() <= maxReplySize) {
-      std::copy(resp.begin(), resp.end(), outReply);
-      outActualReplySize = resp.size();
-    } else {
-      LOG_ERROR(GL, "KEY_EXCHANGE response is too large, response " << resp);
-      outActualReplySize = 0;
-    }
-    return 0;
-  } else if (flags & READ_ONLY_FLAG) {
-    // Backward compatible with read only flag prior BC-5126
-    flags = READ_ONLY_FLAG;
-  }
-
-  return userRequestsHandler_->execute(clientId,
-                                       sequenceNum,
-                                       flags,
-                                       requestSize,
-                                       request,
-                                       maxReplySize,
-                                       outReply,
-                                       outActualReplySize,
-                                       outReplicaSpecificInfoSize,
-                                       parent_span);
-}
-
 void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue &requests,
                              const std::string &batchCid,
                              concordUtils::SpanWrapper &parent_span) {

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -7,16 +7,6 @@ namespace bftEngine {
 class RequestHandler : public IRequestsHandler {
  public:
   RequestHandler(IRequestsHandler *userHdlr) : userRequestsHandler_(userHdlr) {}
-  virtual int execute(uint16_t clientId,
-                      uint64_t sequenceNum,
-                      uint8_t flags,
-                      uint32_t requestSize,
-                      const char *request,
-                      uint32_t maxReplySize,
-                      char *outReply,
-                      uint32_t &outActualReplySize,
-                      uint32_t &outReplicaSpecificInfoSize,
-                      concordUtils::SpanWrapper &parent_span) override;
 
   virtual void execute(ExecutionRequestsQueue &requests,
                        const std::string &batchCid,

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -717,13 +717,14 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
                                                     (char *)getPreProcessResultBuffer(clientId)});
   requestsHandler_.execute(accumulatedRequests, cid, span);
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
-  auto status = request.outExecutionStatus;
+  const auto status = request.outExecutionStatus;
+  const auto resultLen = request.outActualReplySize;
   LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqSeqNum));
-  if (status != 0 || !request.outActualReplySize) {
-    LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqSeqNum, status, request.outActualReplySize));
+  if (status != 0 || !resultLen) {
+    LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqSeqNum, status, resultLen));
     ConcordAssert(false);
   }
-  return request.outActualReplySize;
+  return resultLen;
 }
 
 ReqId PreProcessor::getOngoingReqIdForClient(uint16_t clientId) {

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -702,28 +702,23 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
                                               char *reqBuf,
                                               const concordUtils::SpanContext &span_context) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.launchReqPreProcessing);
-  uint32_t resultLen = 0;
   // Unused for now. Replica Specific Info not currently supported in pre-execution.
-  uint32_t replicaSpecificInfoLen = 0;
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
   SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqSeqNum));
-  auto status = requestsHandler_.execute(clientId,
-                                         reqSeqNum,
-                                         PRE_PROCESS_FLAG,
-                                         reqLength,
-                                         reqBuf,
-                                         maxPreExecResultSize_,
-                                         (char *)getPreProcessResultBuffer(clientId),
-                                         resultLen,
-                                         replicaSpecificInfoLen,
-                                         span);
+  bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
+  accumulatedRequests.push_back(bftEngine::IRequestsHandler::ExecutionRequest{
+      clientId, reqSeqNum, PRE_PROCESS_FLAG, std::string(reqBuf, reqLength), std::string(maxPreExecResultSize_, 0)});
+  requestsHandler_.execute(accumulatedRequests, cid, span);
+  auto request = accumulatedRequests.back();
+  memcpy((char *)getPreProcessResultBuffer(clientId), request.outReply.c_str(), request.outActualReplySize);
+  auto status = request.outExecutionStatus;
   LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqSeqNum));
-  if (status != 0 || !resultLen) {
-    LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqSeqNum, status, resultLen));
+  if (status != 0 || !request.outActualReplySize) {
+    LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqSeqNum, status, request.outActualReplySize));
     ConcordAssert(false);
   }
-  return resultLen;
+  return request.outActualReplySize;
 }
 
 ReqId PreProcessor::getOngoingReqIdForClient(uint16_t clientId) {

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -707,11 +707,16 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqSeqNum));
   bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
-  accumulatedRequests.push_back(bftEngine::IRequestsHandler::ExecutionRequest{
-      clientId, reqSeqNum, PRE_PROCESS_FLAG, reqLength, reqBuf, std::string(maxPreExecResultSize_, 0)});
+  accumulatedRequests.push_back(
+      bftEngine::IRequestsHandler::ExecutionRequest{clientId,
+                                                    reqSeqNum,
+                                                    PRE_PROCESS_FLAG,
+                                                    reqLength,
+                                                    reqBuf,
+                                                    maxPreExecResultSize_,
+                                                    (char *)getPreProcessResultBuffer(clientId)});
   requestsHandler_.execute(accumulatedRequests, cid, span);
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
-  memcpy((char *)getPreProcessResultBuffer(clientId), request.outReply.c_str(), request.outActualReplySize);
   auto status = request.outExecutionStatus;
   LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqSeqNum));
   if (status != 0 || !request.outActualReplySize) {

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -708,9 +708,9 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqSeqNum));
   bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
   accumulatedRequests.push_back(bftEngine::IRequestsHandler::ExecutionRequest{
-      clientId, reqSeqNum, PRE_PROCESS_FLAG, std::string(reqBuf, reqLength), std::string(maxPreExecResultSize_, 0)});
+      clientId, reqSeqNum, PRE_PROCESS_FLAG, reqLength, reqBuf, std::string(maxPreExecResultSize_, 0)});
   requestsHandler_.execute(accumulatedRequests, cid, span);
-  auto request = accumulatedRequests.back();
+  const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
   memcpy((char *)getPreProcessResultBuffer(clientId), request.outReply.c_str(), request.outActualReplySize);
   auto status = request.outExecutionStatus;
   LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqSeqNum));

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -58,20 +58,6 @@ char buf[bufLen];
 SigManagerSharedPtr sigManager_[numOfReplicas_4];
 
 class DummyRequestsHandler : public IRequestsHandler {
-  int execute(uint16_t,
-              uint64_t,
-              uint8_t,
-              uint32_t,
-              const char*,
-              uint32_t,
-              char*,
-              uint32_t& outActualReplySize,
-              uint32_t&,
-              concordUtils::SpanWrapper&) override {
-    outActualReplySize = 256;
-    return 0;
-  }
-
   void execute(ExecutionRequestsQueue& requests,
                const std::string& batchCid,
                concordUtils::SpanWrapper& parent_span) override {

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -118,16 +118,6 @@ class IReplica {
 
 class ICommandsHandler : public bftEngine::IRequestsHandler {
  public:
-  int execute(uint16_t clientId,
-              uint64_t sequenceNum,
-              uint8_t flags,
-              uint32_t requestSize,
-              const char* request,
-              uint32_t maxReplySize,
-              char* outReply,
-              uint32_t& outActualReplySize,
-              uint32_t& outActualReplicaSpecificInfoSize,
-              concordUtils::SpanWrapper& span) override = 0;
   void execute(ExecutionRequestsQueue& requestList,
                const std::string& batchCid,
                concordUtils::SpanWrapper& parent_span) override = 0;

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -50,8 +50,8 @@ void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequests
     if (readOnly) {
       res = executeReadOnlyCommand(req.requestSize,
                                    req.request,
-                                   req.outReply.size(),
-                                   req.outReply.data(),
+                                   req.maxReplySize,
+                                   req.outReply,
                                    req.outActualReplySize,
                                    req.outReplicaSpecificInfoSize);
     } else {
@@ -59,8 +59,8 @@ void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequests
                                 req.request,
                                 req.executionSequenceNum,
                                 req.flags,
-                                req.outReply.size(),
-                                req.outReply.data(),
+                                req.maxReplySize,
+                                req.outReply,
                                 req.outActualReplySize);
     }
     if (!res) LOG_ERROR(m_logger, "Command execution failed!");

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -39,24 +39,24 @@ void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequests
     if (req.outExecutionStatus != 1) continue;
     req.outReplicaSpecificInfoSize = 0;
     int res;
-    if (req.request.size() < sizeof(SimpleRequest)) {
+    if (req.requestSize < sizeof(SimpleRequest)) {
       LOG_ERROR(m_logger,
-                "The message is too small: requestSize is " << req.request.size() << ", required size is "
+                "The message is too small: requestSize is " << req.requestSize << ", required size is "
                                                             << sizeof(SimpleRequest));
       req.outExecutionStatus = -1;
       continue;
     }
     bool readOnly = req.flags & MsgFlag::READ_ONLY_FLAG;
     if (readOnly) {
-      res = executeReadOnlyCommand(req.request.size(),
-                                   req.request.c_str(),
+      res = executeReadOnlyCommand(req.requestSize,
+                                   req.request,
                                    req.outReply.size(),
                                    req.outReply.data(),
                                    req.outActualReplySize,
                                    req.outReplicaSpecificInfoSize);
     } else {
-      res = executeWriteCommand(req.request.size(),
-                                req.request.c_str(),
+      res = executeWriteCommand(req.requestSize,
+                                req.request,
                                 req.executionSequenceNum,
                                 req.flags,
                                 req.outReply.size(),

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -31,36 +31,6 @@ using concord::storage::SetOfKeyValuePairs;
 
 const uint64_t LONG_EXEC_CMD_TIME_IN_SEC = 11;
 
-int InternalCommandsHandler::execute(uint16_t clientId,
-                                     uint64_t sequenceNum,
-                                     uint8_t flags,
-                                     uint32_t requestSize,
-                                     const char *request,
-                                     uint32_t maxReplySize,
-                                     char *outReply,
-                                     uint32_t &outActualReplySize,
-                                     uint32_t &outActualReplicaSpecificInfoSize,
-                                     concordUtils::SpanWrapper &span) {
-  // ReplicaSpecificInfo is not currently used in the TesterReplica
-  outActualReplicaSpecificInfoSize = 0;
-  int res;
-  if (requestSize < sizeof(SimpleRequest)) {
-    LOG_ERROR(
-        m_logger,
-        "The message is too small: requestSize is " << requestSize << ", required size is " << sizeof(SimpleRequest));
-    return -1;
-  }
-  bool readOnly = flags & MsgFlag::READ_ONLY_FLAG;
-  if (readOnly) {
-    res = executeReadOnlyCommand(
-        requestSize, request, maxReplySize, outReply, outActualReplySize, outActualReplicaSpecificInfoSize);
-  } else {
-    res = executeWriteCommand(requestSize, request, sequenceNum, flags, maxReplySize, outReply, outActualReplySize);
-  }
-  if (!res) LOG_ERROR(m_logger, "Command execution failed!");
-  return res ? 0 : -1;
-}
-
 void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequestsQueue &requests,
                                       const std::string &batchCid,
                                       concordUtils::SpanWrapper &parent_span) {
@@ -74,6 +44,7 @@ void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequests
                 "The message is too small: requestSize is " << req.request.size() << ", required size is "
                                                             << sizeof(SimpleRequest));
       req.outExecutionStatus = -1;
+      continue;
     }
     bool readOnly = req.flags & MsgFlag::READ_ONLY_FLAG;
     if (readOnly) {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -51,17 +51,6 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
         m_logger(logger),
         controlHandlers_(std::make_shared<InternalControlHandlers>()) {}
 
-  virtual int execute(uint16_t clientId,
-                      uint64_t sequenceNum,
-                      uint8_t flags,
-                      uint32_t requestSize,
-                      const char *request,
-                      uint32_t maxReplySize,
-                      char *outReply,
-                      uint32_t &outActualReplySize,
-                      uint32_t &outActualReplicaSpecificInfoSize,
-                      concordUtils::SpanWrapper &span) override;
-
   virtual void execute(ExecutionRequestsQueue &requests,
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) override;

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -74,62 +74,6 @@ class SimpleAppState : public IRequestsHandler {
   ~SimpleAppState() { delete[] statePtr; }
 
   // Handler for the upcall from Concord-BFT.
-  int execute(uint16_t clientId,
-              uint64_t sequenceNum,
-              uint8_t flags,
-              uint32_t requestSize,
-              const char *request,
-              uint32_t maxReplySize,
-              char *outReply,
-              uint32_t &outActualReplySize,
-              uint32_t &outActualReplicaSpecificInfoSize,
-              concordUtils::SpanWrapper &span) override {
-    // Not currently used
-    outActualReplicaSpecificInfoSize = 0;
-
-    bool readOnly = flags & READ_ONLY_FLAG;
-    if (readOnly) {
-      // Our read-only request includes only a type, no argument.
-      test_assert_replica(requestSize == sizeof(uint64_t), "requestSize =! " << sizeof(uint64_t));
-
-      // We only support the READ operation in read-only mode.
-      test_assert_replica(*reinterpret_cast<const uint64_t *>(request) == READ_VAL_REQ,
-                          "request is NOT " << READ_VAL_REQ);
-
-      // Copy the latest register value to the reply buffer.
-      test_assert_replica(maxReplySize >= sizeof(uint64_t), "maxReplySize < " << sizeof(uint64_t));
-      uint64_t *pRet = reinterpret_cast<uint64_t *>(outReply);
-      auto lastValue = get_last_state_value(clientId);
-      *pRet = lastValue;
-      outActualReplySize = sizeof(uint64_t);
-    } else {
-      // Our read-write request includes one eight-byte argument, in addition to
-      // the request type.
-      test_assert_replica(requestSize == 2 * sizeof(uint64_t), "requestSize != " << 2 * sizeof(uint64_t));
-
-      // We only support the WRITE operation in read-write mode.
-      const uint64_t *pReqId = reinterpret_cast<const uint64_t *>(request);
-      test_assert_replica(*pReqId == SET_VAL_REQ, "*preqId != " << SET_VAL_REQ);
-
-      // The value to write is the second eight bytes of the request.
-      const uint64_t *pReqVal = (pReqId + 1);
-
-      // Modify the register state.
-      set_last_state_value(clientId, *pReqVal);
-      // Count the number of times we've modified it.
-      auto stateNum = get_last_state_num(clientId);
-      set_last_state_num(clientId, stateNum + 1);
-
-      // Reply with the number of times we've modified the register.
-      test_assert_replica(maxReplySize >= sizeof(uint64_t), "maxReplySize < " << sizeof(uint64_t));
-      uint64_t *pRet = reinterpret_cast<uint64_t *>(outReply);
-      *pRet = stateNum;
-      outActualReplySize = sizeof(uint64_t);
-
-      st->markUpdate(statePtr, sizeof(State) * numOfClients);
-    }
-    return 0;
-  }
   void execute(ExecutionRequestsQueue &requests,
                const std::string &batchCid,
                concordUtils::SpanWrapper &parent_span) override {

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -84,10 +84,10 @@ class SimpleAppState : public IRequestsHandler {
       bool readOnly = req.flags & READ_ONLY_FLAG;
       if (readOnly) {
         // Our read-only request includes only a type, no argument.
-        test_assert_replica(req.request.size() == sizeof(uint64_t), "requestSize =! " << sizeof(uint64_t));
+        test_assert_replica(req.requestSize == sizeof(uint64_t), "requestSize =! " << sizeof(uint64_t));
 
         // We only support the READ operation in read-only mode.
-        test_assert_replica(*reinterpret_cast<const uint64_t *>(req.request.c_str()) == READ_VAL_REQ,
+        test_assert_replica(*reinterpret_cast<const uint64_t *>(req.request) == READ_VAL_REQ,
                             "request is NOT " << READ_VAL_REQ);
 
         // Copy the latest register value to the reply buffer.
@@ -99,10 +99,10 @@ class SimpleAppState : public IRequestsHandler {
       } else {
         // Our read-write request includes one eight-byte argument, in addition to
         // the request type.
-        test_assert_replica(req.request.size() == 2 * sizeof(uint64_t), "requestSize != " << 2 * sizeof(uint64_t));
+        test_assert_replica(req.requestSize == 2 * sizeof(uint64_t), "requestSize != " << 2 * sizeof(uint64_t));
 
         // We only support the WRITE operation in read-write mode.
-        const uint64_t *pReqId = reinterpret_cast<const uint64_t *>(req.request.c_str());
+        const uint64_t *pReqId = reinterpret_cast<const uint64_t *>(req.request);
         test_assert_replica(*pReqId == SET_VAL_REQ, "*preqId != " << SET_VAL_REQ);
 
         // The value to write is the second eight bytes of the request.

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -91,8 +91,8 @@ class SimpleAppState : public IRequestsHandler {
                             "request is NOT " << READ_VAL_REQ);
 
         // Copy the latest register value to the reply buffer.
-        test_assert_replica(req.outReply.size() >= sizeof(uint64_t), "maxReplySize < " << sizeof(uint64_t));
-        uint64_t *pRet = const_cast<uint64_t *>(reinterpret_cast<const uint64_t *>(req.outReply.c_str()));
+        test_assert_replica(req.maxReplySize >= sizeof(uint64_t), "maxReplySize < " << sizeof(uint64_t));
+        uint64_t *pRet = const_cast<uint64_t *>(reinterpret_cast<const uint64_t *>(req.outReply));
         auto lastValue = get_last_state_value(req.clientId);
         *pRet = lastValue;
         req.outActualReplySize = sizeof(uint64_t);
@@ -115,8 +115,8 @@ class SimpleAppState : public IRequestsHandler {
         set_last_state_num(req.clientId, stateNum + 1);
 
         // Reply with the number of times we've modified the register.
-        test_assert_replica(req.outReply.size() >= sizeof(uint64_t), "maxReplySize < " << sizeof(uint64_t));
-        uint64_t *pRet = const_cast<uint64_t *>(reinterpret_cast<const uint64_t *>(req.outReply.c_str()));
+        test_assert_replica(req.maxReplySize >= sizeof(uint64_t), "maxReplySize < " << sizeof(uint64_t));
+        uint64_t *pRet = const_cast<uint64_t *>(reinterpret_cast<const uint64_t *>(req.outReply));
         *pRet = stateNum;
         req.outActualReplySize = sizeof(uint64_t);
 


### PR DESCRIPTION
In the current MR, I have removed the old execute method which gets all the parameters one by one, and replaced it with the one which takes a list of ExecutionRequest.