### PR TITLE
Add a MultiGet operation to RocksDB NativeClient

### DIFF
--- a/storage/include/rocksdb/native_client.h
+++ b/storage/include/rocksdb/native_client.h
@@ -101,6 +101,23 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
   NativeWriteBatch getBatch() const;
   void write(NativeWriteBatch &&);
 
+  // MultiGet interface
+  //
+  // Return values in the same order of keys. All keys reside in the same column family. There
+  // aren't really any benefits to using multiget across column families, except consistency, which
+  // we do not require, since our keys are versioned or immutable in all cases.
+  //
+  // We don't use exceptions here, and stick to standard RocksDB status types because:
+  //   1. Each key has a distinct status.
+  //   2. Performance - We want to minimize allocation and copying.
+  //
+  // ContiguousStatusContainer must always contain type ::rocksdb::Status
+  template <typename KeySpan>
+  void multiGet(const std::string &cFamily,
+                const std::vector<KeySpan> &keys,
+                std::vector<::rocksdb::PinnableSlice> &values,
+                std::vector<::rocksdb::Status> &statuses) const;
+
   // Iterator interface.
   // Iterators initially don't point to a key value, i.e. they convert to false.
   // Important note - RocksDB requires that iterators are destroyed before the DB client that created them.


### PR DESCRIPTION
This is a thin wrapper around the optimized overload of the rocksdb
implementation for a single column family. It allows multiple parallel
io requests in a single thread via the use of io_uring on Linux.

The wrapper has 2 primary goals:
 * Maximum efficiency with a realistic key interface.
 * Safety - We don't want to allow passing in contiguous containers that
 are too small to receieve output data.

This implementation is not intended to be used directly by user code,
and should be wrapped by the appopriate storage code. We have the option
to either copy strings and return them from the PinnableSlices, or
return a wrapper type that allows zero copy. We could also return the
raw RocksDB type, but so far we have not made those public outside
storage layer code.