### PR TITLE
ECS S3 doesn't support batch operations there's a problem storing met…

### DIFF
--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -77,9 +77,9 @@ std::unique_ptr<storage::ISTKeyManipulator> MemoryDBStorageFactory::newSTKeyMani
 #if defined(USE_S3_OBJECT_STORE)
 IStorageFactory::DatabaseSet S3StorageFactory::newDatabaseSet() const {
   auto ret = IStorageFactory::DatabaseSet{};
-
-  ret.metadataDBClient = std::make_shared<storage::s3::Client>(s3Conf_);
-  ret.dataDBClient = ret.metadataDBClient;
+  const auto comparator = storage::memorydb::KeyComparator{new DBKeyComparator{}};
+  ret.metadataDBClient = std::make_shared<storage::memorydb::Client>(comparator);
+  ret.dataDBClient = std::make_shared<storage::s3::Client>(s3Conf_);
   ret.dataDBClient->init();
 
   auto dataKeyGenerator = std::make_unique<S3KeyGenerator>(s3Conf_.pathPrefix);


### PR DESCRIPTION
…adata as an atomic transaction which may lead to inconsistencies in State Transfer metadata if RO Replica stops ungracefully.

Since Reserved Pages are not currently used by a RO Replica for Object Store Replication, State Transfer persistence is only a optimization and can be omitted.
The only drawback can be a repeaded transfer of at most 150 blocks in case of such a crash, which we can tolerate.