### PR TITLE
Add num of RO replicas to the preprocessor

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -156,6 +156,7 @@ class PreProcessor {
   const uint32_t maxPreExecResultSize_;
   const std::set<ReplicaId> &idsOfPeerReplicas_;
   const uint16_t numOfReplicas_;
+  const uint16_t numOfRoReplicas_;
   const uint16_t numOfClients_;
   util::SimpleThreadPool threadPool_;
   // One-time allocated buffers (one per client) for the pre-execution results storage


### PR DESCRIPTION
When initiating Preprocessor we initiate an array of ongoing requests.
This array is being initiated according to the client id’s, but we detected a bug since we didn’t calculate the RO replicas.
Since the RO replicas ID’s are right after the regular replicas and before the clients we need to calculate them also.
I’ve added a member variable for the number of RO replicas and use this variable in all the places that calculate/uses the number of replicas.