### PR TITLE
Add histograms for checkpoint and state transfer duration

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1683,6 +1683,7 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
 
   if (askForStateTransfer && !stateTransfer->isCollectingState()) {
     LOG_INFO(GL, "Call to startCollectingState()");
+    time_in_state_transfer_.start();
     clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout
     stateTransfer->startCollectingState();
   } else if (msgSeqNum > lastStableSeqNum + kWorkWindowSize) {
@@ -2508,7 +2509,7 @@ void ReplicaImp::sendCheckpointIfNeeded() {
 
 void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   TimeRecorder scoped_timer(*histograms_.onTransferringCompleteImp);
-
+  time_in_state_transfer_.end();
   LOG_INFO(GL, KVLOG(newStateCheckpoint));
 
   if (ps_) {
@@ -2617,6 +2618,7 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
   ConcordAssertEQ(newStableSeqNum % checkpointWindowSize, 0);
 
   if (newStableSeqNum <= lastStableSeqNum) return;
+  checkpoint_times_.end(newStableSeqNum);
   TimeRecorder scoped_timer(*histograms_.onSeqNumIsStable);
 
   LOG_INFO(GL,
@@ -3414,7 +3416,9 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_total_fastPath_requests_{metrics_.RegisterCounter("totalFastPathRequests")},
       metric_total_preexec_requests_executed_{metrics_.RegisterCounter("totalPreExecRequestsExecuted")},
       consensus_times_(histograms_.consensus),
+      checkpoint_times_(histograms_.checkpoint_creation_to_stable),
       time_in_active_view_(histograms_.timeInActiveView),
+      time_in_state_transfer_(histograms_.timeInStateTransfer),
       reqBatchingLogic_(*this, config_, metrics_, timers),
       replStatusHandlers_(*this) {
   ConcordAssertLT(config_.getreplicaId(), config_.getnumReplicas());
@@ -3775,6 +3779,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {
     checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;
     stateTransfer->createCheckpointOfCurrentState(checkpointNum);
+    checkpoint_times_.start(checkpointNum);
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3779,7 +3779,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {
     checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;
     stateTransfer->createCheckpointOfCurrentState(checkpointNum);
-    checkpoint_times_.start(checkpointNum);
+    checkpoint_times_.start(lastExecutedSeqNum);
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -464,6 +464,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                         {"onTransferringCompleteImp", onTransferringCompleteImp},
                                         {"consensus", consensus},
                                         {"timeInActiveView", timeInActiveView},
+                                        {"timeInStateTransfer", timeInStateTransfer},
                                         {"checkpointFromCreationToStable", checkpoint_creation_to_stable}});
     }
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -463,7 +463,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                         {"onSeqNumIsStable", onSeqNumIsStable},
                                         {"onTransferringCompleteImp", onTransferringCompleteImp},
                                         {"consensus", consensus},
-                                        {"timeInActiveView", timeInActiveView}});
+                                        {"timeInActiveView", timeInActiveView},
+                                        {"checkpointFromCreationToStable", checkpoint_creation_to_stable}});
     }
 
     std::shared_ptr<Recorder> send =
@@ -490,6 +491,12 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
     std::shared_ptr<Recorder> timeInActiveView =
         std::make_shared<Recorder>(1, MAX_VALUE_SECONDS, 3, concord::diagnostics::Unit::SECONDS);
+
+    std::shared_ptr<Recorder> timeInStateTransfer =
+        std::make_shared<Recorder>(1, MAX_VALUE_SECONDS, 3, concord::diagnostics::Unit::SECONDS);
+
+    std::shared_ptr<Recorder> checkpoint_creation_to_stable =
+        std::make_shared<Recorder>(1, MAX_VALUE_SECONDS, 3, concord::diagnostics::Unit::SECONDS);
   };
 
   Recorders histograms_;
@@ -497,9 +504,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // Used to measure the time for each consensus slot to go from pre-prepare to commit at the primary.
   // Time is recorded in histograms_.consensus
   concord::diagnostics::AsyncTimeRecorderMap<SeqNum> consensus_times_;
+  concord::diagnostics::AsyncTimeRecorderMap<SeqNum> checkpoint_times_;
 
   concord::diagnostics::AsyncTimeRecorder<false> time_in_active_view_;
-
+  concord::diagnostics::AsyncTimeRecorder<false> time_in_state_transfer_;
   batchingLogic::RequestsBatchingLogic reqBatchingLogic_;
   ReplicaStatusHandlers replStatusHandlers_;
 };


### PR DESCRIPTION
Add multiple histograms:
1. To measure the time that passes between a creation of a checkpoint to the time it became stable
2. To measure the time that state transfer takes from starting to its end