### PR TITLE
Calculate client reply buffer id with RO replicas

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -107,7 +107,7 @@ class PreProcessor {
                                     uint64_t reqRetryId,
                                     const std::string &cid,
                                     const std::string &ongoingCid);
-  uint16_t getClientReplyBufferId(uint16_t clientId) const { return clientId - numOfReplicas_; }
+  uint16_t getClientReplyBufferId(uint16_t clientId) const { return clientId - numOfReplicas_ - numOfRoReplicas_; }
   const char *getPreProcessResultBuffer(uint16_t clientId) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,


### PR DESCRIPTION
When initiating Preprocessor we initiate an array of ongoing requests.
This array is being initiated according to the client id’s, but we detected a bug since we didn’t calculate the RO replicas.
Since the RO replicas ID’s are right after the regular replicas and before the clients we need to calculate them also.
I’ve added a member variable for the number of RO replicas and use this variable in all the places that calculate/uses the number of replicas.