### PR TITLE
Implement read interface and infra for category type mapping

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -28,6 +28,14 @@ Msg ImmutableUpdatesData 5 {
     bool calculate_root_hash
 }
 
+Msg CategoryUpdatesData 6 {
+    map string oneof{
+        MerkleUpdatesData
+        KeyValueUpdatesData
+        ImmutableUpdatesData
+    } kv
+}
+
 # Updates info
 
 Msg MerkleKeyFlag 1000 {
@@ -76,15 +84,8 @@ Msg BlockData 2001 {
 
 Msg RawBlockData 2005 {
     fixedlist uint8 32 parent_digest
-    
-    map string oneof{
-        MerkleUpdatesData
-        KeyValueUpdatesData
-	    ImmutableUpdatesData
-    } category_updates
-
+    CategoryUpdatesData updates
     map string optional fixedlist uint8 32 category_root_hash
-
 }
 
 # Misc

--- a/kvbc/include/categorization/blockchain.h
+++ b/kvbc/include/categorization/blockchain.h
@@ -69,7 +69,7 @@ class Blockchain {
     if (!block) {
       return std::optional<RawBlock>{};
     }
-    return RawBlock(block.value(), *native_client_.get());
+    return RawBlock(block.value(), native_client_);
   }
 
   /////////////////////// State transfer Block chain ///////////////////////
@@ -77,7 +77,14 @@ class Blockchain {
    public:
     StateTransfer(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client)
         : native_client_{native_client} {
+      if (detail::createColumnFamilyIfNotExisting(detail::ST_CHAIN_CF, *native_client_.get())) {
+        LOG_INFO(CAT_BLOCK_LOG,
+                 "Created [" << detail::ST_CHAIN_CF << "] column family for the state transfer blockchain");
+      }
       loadLastBlockId();
+      if (last_block_id_) {
+        LOG_INFO(CAT_BLOCK_LOG, "State transfer last block id: " << last_block_id_.value());
+      }
     }
 
     void deleteBlock(const BlockId id, storage::rocksdb::NativeWriteBatch& wb) {

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -87,22 +87,22 @@ struct Block {
 // - state hash per category (if exists) E.L check why do we pass it.
 struct RawBlock {
   RawBlock() = default;
-  RawBlock(const Block& block, const storage::rocksdb::NativeClient& native_client);
+  RawBlock(const Block& block, const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
   MerkleUpdatesData getUpdates(const std::string& category_id,
                                const MerkleUpdatesInfo& update_info,
                                const BlockId& block_id,
-                               const storage::rocksdb::NativeClient& native_client);
+                               const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
   KeyValueUpdatesData getUpdates(const std::string& category_id,
                                  const KeyValueUpdatesInfo& update_info,
                                  const BlockId& block_id,
-                                 const storage::rocksdb::NativeClient& native_client);
+                                 const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
   ImmutableUpdatesData getUpdates(const std::string& category_id,
                                   const ImmutableUpdatesInfo& update_info,
                                   const BlockId& block_id,
-                                  const storage::rocksdb::NativeClient& native_client);
+                                  const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
   template <typename T>
   static RawBlock deserialize(const T& input) {

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -22,4 +22,6 @@ inline const auto IMMUTABLE_KV_CF_SUFFIX = std::string{"_immutable"};
 inline const auto BLOCKS_CF = std::string{"blocks"};
 inline const auto ST_CHAIN_CF = std::string{"st_chain"};
 
+inline const auto CAT_ID_TYPE_CF = std::string{"cat_id_type"};
+
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -27,6 +27,8 @@ namespace concord::kvbc::categorization::detail {
 
 using Buffer = std::vector<std::uint8_t>;
 
+enum class CATEGORY_TYPE : char { merkle = 0, immutable = 1, kv_hash = 2, end_of_types };
+
 template <typename Span>
 Hash hash(const Span &span) {
   return Hasher{}.digest(span.data(), span.size());
@@ -68,10 +70,12 @@ void deserialize(const Span &in, T &out) {
   deserialize(begin, begin + in.size(), out);
 }
 
-inline void createColumnFamilyIfNotExisting(const std::string &cf, storage::rocksdb::NativeClient &db) {
+inline bool createColumnFamilyIfNotExisting(const std::string &cf, storage::rocksdb::NativeClient &db) {
   if (!db.hasColumnFamily(cf)) {
     db.createColumnFamily(cf);
+    return true;
   }
+  return false;
 }
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -18,16 +18,21 @@
 #include <memory>
 #include "blocks.h"
 #include "blockchain.h"
+#include "immutable_kv_category.h"
 
 #include "kv_types.hpp"
 
 namespace concord::kvbc::categorization {
 
-class KeyValueBlockchain {
- public:
-  KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client)
-      : native_client_{native_client}, block_chain_{native_client_}, state_transfer_block_chain_{native_client_} {}
+// Temp forward declearations
+struct MerkleCategory {};
+struct KVHashCategory {};
 
+class KeyValueBlockchain {
+  using VersionedRawBlock = std::pair<BlockId, std::optional<categorization::RawBlock>>;
+
+ public:
+  KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client, bool link_st_chain);
   /////////////////////// Add Block ///////////////////////
 
   BlockId addBlock(Updates&& updates);
@@ -48,13 +53,51 @@ class KeyValueBlockchain {
   BlockId getLastReachableBlockId() const { return block_chain_.getLastReachableBlockId(); }
   std::optional<BlockId> getLastStatetransferBlockId() const { return state_transfer_block_chain_.getLastBlockId(); }
 
- private:
-  BlockId addBlock(std::map<std::string, std::variant<MerkleUpdatesData, KeyValueUpdatesData, ImmutableUpdatesData>>&&
-                       category_updates,
-                   concord::storage::rocksdb::NativeWriteBatch& write_batch);
+  /////////////////////// Read interface ///////////////////////
 
+  // Gets the value of a key by the exact blockVersion.
+  std::optional<Value> get(const std::string& cat_id, const std::string& key, BlockId block_id) const;
+  std::optional<Value> getLatest(const std::string& cat_id, const std::string& key) const;
+
+  void multiGet(const std::string& cat_id,
+                const std::vector<std::string>& keys,
+                const std::vector<BlockId>& versions,
+                std::vector<std::optional<Value>>& values) const;
+
+  void multiGetLatest(const std::string& cat_id,
+                      const std::vector<std::string>& keys,
+                      std::vector<std::optional<Value>>& values) const;
+
+  std::optional<BlockId> getLatestVersion(const std::string& cat_id, const std::string& key) const;
+  void multiGetLatestVersion(const std::string& cat_id,
+                             const std::vector<std::string>& keys,
+                             std::vector<std::optional<BlockId>>& versions) const;
+
+  CategoryUpdatesData getBlockData(BlockId block_id);
+
+ private:
+  BlockId addBlock(CategoryUpdatesData&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);
+
+  // tries to link the state transfer chain to the main blockchain
   void linkSTChainFrom(BlockId block_id);
   void writeSTLinkTransaction(const BlockId block_id, RawBlock& block);
+
+  // computes the digest of a raw block which is the parent of block_id i.e. block_id - 1
+  std::future<BlockDigest> computeParentBlockDigest(const BlockId block_id, VersionedRawBlock&& cached_raw_block);
+
+  /////////////////////// Categories operations ///////////////////////
+
+  // iterate over the categories column family and instantiate the stored categories.
+  void instantiateCategories();
+  // insert a new category into the categories column family and instantiate it.
+  bool insertCategoryMapping(const std::string& cat_id,
+                             const detail::CATEGORY_TYPE type,
+                             concord::storage::rocksdb::NativeWriteBatch& write_batch);
+
+  const std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>& getCategory(
+      const std::string& cat_id) const;
+
+  /////////////////////// deletes ///////////////////////
 
   void deleteStateTransferBlock(const BlockId block_id);
   void deleteGenesisBlock();
@@ -90,25 +133,56 @@ class KeyValueBlockchain {
                                 const MerkleUpdatesInfo& updates_info,
                                 storage::rocksdb::NativeWriteBatch&);
 
+  /////////////////////// Updates ///////////////////////
+
   // Update per category
   MerkleUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                           const std::string& category_id,
                                           MerkleUpdatesData&& updates,
-                                          concord::storage::rocksdb::NativeWriteBatch& write_batch);
+                                          concord::storage::rocksdb::NativeWriteBatch& write_batch,
+                                          categorization::RawBlock& raw_block);
 
   KeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                             const std::string& category_id,
                                             KeyValueUpdatesData&& updates,
-                                            concord::storage::rocksdb::NativeWriteBatch& write_batch);
+                                            concord::storage::rocksdb::NativeWriteBatch& write_batch,
+                                            categorization::RawBlock& raw_block);
   ImmutableUpdatesInfo handleCategoryUpdates(BlockId block_id,
                                              const std::string& category_id,
                                              ImmutableUpdatesData&& updates,
-                                             concord::storage::rocksdb::NativeWriteBatch& write_batch);
+                                             concord::storage::rocksdb::NativeWriteBatch& write_batch,
+                                             categorization::RawBlock& raw_block);
 
-  // Members
+  /////////////////////// Members ///////////////////////
+
   std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
+  std::map<std::string, std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>> categorires_;
+  std::map<std::string, detail::CATEGORY_TYPE> categorires_types_;
   detail::Blockchain block_chain_;
   detail::Blockchain::StateTransfer state_transfer_block_chain_;
+
+  // Holds the last raw block of the last corresponding block that was added.
+  // Used to save construction of a raw block per addBlock method.
+  // E.L - compare this with getRawBlock to see they are equal
+  VersionedRawBlock last_raw_block_;
+
+ public:
+  struct KeyValueBlockchain_tester {
+    void instantiateCategories(KeyValueBlockchain& kvbc) { kvbc.instantiateCategories(); }
+    const std::map<std::string, std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>>&
+    getCategories(KeyValueBlockchain& kvbc) {
+      return kvbc.categorires_;
+    }
+    const std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>& getCategory(
+        const std::string& cat_id, KeyValueBlockchain& kvbc) const {
+      return kvbc.getCategory(cat_id);
+    }
+
+    detail::Blockchain& getBlockchain(KeyValueBlockchain& kvbc) { return kvbc.block_chain_; }
+
+    const VersionedRawBlock& getLastRawBlocked(KeyValueBlockchain& kvbc) { return kvbc.last_raw_block_; }
+  };
+  friend struct KeyValueBlockchain_tester;
 };
 
 }  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -150,8 +150,11 @@ struct MerkleUpdates {
 
 // Updates contains a list of updates for different categories.
 struct Updates {
+  Updates() = default;
+  Updates(CategoryUpdatesData&& updates) : category_updates_{std::move(updates)} {}
   void add(const std::string& category_id, MerkleUpdates&& updates) {
-    if (const auto [itr, inserted] = category_updates_.try_emplace(category_id, std::move(updates.data_)); !inserted) {
+    if (const auto [itr, inserted] = category_updates_.kv.try_emplace(category_id, std::move(updates.data_));
+        !inserted) {
       (void)itr;  // disable unused variable
       throw std::logic_error{std::string("Only one update for category is allowed. type: Merkle, category: ") +
                              category_id};
@@ -159,7 +162,8 @@ struct Updates {
   }
 
   void add(const std::string& category_id, KeyValueUpdates&& updates) {
-    if (const auto [itr, inserted] = category_updates_.try_emplace(category_id, std::move(updates.data_)); !inserted) {
+    if (const auto [itr, inserted] = category_updates_.kv.try_emplace(category_id, std::move(updates.data_));
+        !inserted) {
       (void)itr;  // disable unused variable
       throw std::logic_error{std::string("Only one update for category is allowed. type: KVHash, category: ") +
                              category_id};
@@ -167,7 +171,8 @@ struct Updates {
   }
 
   void add(const std::string& category_id, ImmutableUpdates&& updates) {
-    if (const auto [itr, inserted] = category_updates_.try_emplace(category_id, std::move(updates.data_)); !inserted) {
+    if (const auto [itr, inserted] = category_updates_.kv.try_emplace(category_id, std::move(updates.data_));
+        !inserted) {
       (void)itr;  // disable unused variable
       throw std::logic_error{std::string("Only one update for category is allowed. type: Immutable, category: ") +
                              category_id};
@@ -176,7 +181,7 @@ struct Updates {
 
  private:
   friend class KeyValueBlockchain;
-  std::map<std::string, std::variant<MerkleUpdatesData, KeyValueUpdatesData, ImmutableUpdatesData>> category_updates_;
+  CategoryUpdatesData category_updates_;
 };
 
 }  // namespace concord::kvbc::categorization

--- a/kvbc/src/categorization/blockchain.cpp
+++ b/kvbc/src/categorization/blockchain.cpp
@@ -12,18 +12,24 @@
 // file.
 
 #include "categorization/blockchain.h"
+#include "Logger.hpp"
 
 namespace concord::kvbc::categorization::detail {
 
 Blockchain::Blockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client)
     : native_client_{native_client} {
+  if (detail::createColumnFamilyIfNotExisting(detail::BLOCKS_CF, *native_client_.get())) {
+    LOG_INFO(CAT_BLOCK_LOG, "Created [" << detail::BLOCKS_CF << "] column family for the main blockchain");
+  }
   auto last_reachable_block_id = loadLastReachableBlockId();
   if (last_reachable_block_id) {
     last_reachable_block_id_ = last_reachable_block_id.value();
+    LOG_INFO(CAT_BLOCK_LOG, "Last reachable block as loaded from storage " << last_reachable_block_id_);
   }
   auto genesis_blockId = loadGenesisBlockId();
   if (genesis_blockId) {
     genesis_block_id_ = genesis_blockId.value();
+    LOG_INFO(CAT_BLOCK_LOG, "Genesis block as loaded from storage " << last_reachable_block_id_);
   }
 }
 

--- a/kvbc/test/categorization/blockchain_test.cpp
+++ b/kvbc/test/categorization/blockchain_test.cpp
@@ -33,14 +33,17 @@ class categorized_kvbc : public ::testing::Test {
   void SetUp() override {
     cleanup();
     db = TestRocksDb::createNative();
-    db->createColumnFamily(BLOCKS_CF);
-    db->createColumnFamily(ST_CHAIN_CF);
   }
   void TearDown() override { cleanup(); }
 
  protected:
   std::shared_ptr<NativeClient> db;
 };
+
+TEST_F(categorized_kvbc, creation_of_state_transfter_blockchain_cf) {
+  detail::Blockchain::StateTransfer st(db);
+  ASSERT_TRUE(db->hasColumnFamily(detail::ST_CHAIN_CF));
+}
 
 TEST_F(categorized_kvbc, last_reachable_block) {
   detail::Blockchain block_chain{db};

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -99,9 +99,9 @@ TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
   auto db_get_val = db->get(cf, db_key);
   ASSERT_EQ(db_get_val.value(), db_val);
 
-  categorization::RawBlock rw(block, *db.get());
+  categorization::RawBlock rw(block, db);
   ASSERT_EQ(rw.data.parent_digest, block.data.parent_digest);
-  auto variant = rw.data.category_updates[cf];
+  auto variant = rw.data.updates.kv[cf];
   auto merkle_updates = std::get<MerkleUpdatesData>(variant);
   // check reconstruction of original kv
   ASSERT_EQ(merkle_updates.kv[key], value);
@@ -130,7 +130,7 @@ TEST_F(categorized_kvbc, fail_reconstruct_merkle_updates) {
 
   db->createColumnFamily(cf);
 
-  ASSERT_THROW(categorization::RawBlock rw(block, *db.get()), std::logic_error);
+  ASSERT_THROW(categorization::RawBlock rw(block, db), std::runtime_error);
 }
 
 }  // end namespace

--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -30,6 +30,7 @@ extern logging::Logger CNSUS;
 extern logging::Logger THRESHSIGN_LOG;
 extern logging::Logger BLS_LOG;
 extern logging::Logger KEY_EX_LOG;
+extern logging::Logger CAT_BLOCK_LOG;
 extern logging::Logger VC_LOG;
 extern logging::Logger ST_SRC_LOG;
 extern logging::Logger ST_DST_LOG;

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -27,6 +27,7 @@ logging::Logger CNSUS = logging::getLogger("concord.bft.consensus");
 logging::Logger THRESHSIGN_LOG = logging::getLogger("concord.bft.threshsign");
 logging::Logger BLS_LOG = logging::getLogger("concord.bft.threshsign.bls");
 logging::Logger KEY_EX_LOG = logging::getLogger("concord.bft.key-exchange");
+logging::Logger CAT_BLOCK_LOG = logging::getLogger("concord.kvbc.categorized-blockchain");
 logging::Logger VC_LOG = logging::getLogger("concord.bft.viewchange");
 logging::Logger ST_DST_LOG = logging::getLogger("concord.bft.st.dst");
 logging::Logger ST_SRC_LOG = logging::getLogger("concord.bft.st.src");


### PR DESCRIPTION
- Prepare the infrastructure for the read interface, which will be wired when all categories will be implemented.
- Implement the mapping of categories to their corresponding type, and use it on Blockchain construction when loading the categories to memory.
-  Adding logger
- Optimization: creation of a raw block on add block, in order to use it for the next add block digest computation.
- ```RawBlock``` and ```Updates``` share the same CMF struct for seamless conversions.


