### PR TITLE
Add num of RO replicas to the preprocessor

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -81,6 +81,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       maxPreExecResultSize_(myReplica.getReplicaConfig().maxExternalMessageSize),
       idsOfPeerReplicas_(myReplica.getIdsOfPeerReplicas()),
       numOfReplicas_(myReplica.getReplicaConfig().numReplicas),
+      numOfRoReplicas_(myReplica.getReplicaConfig().numRoReplicas),
       numOfClients_(myReplica.getReplicaConfig().numOfExternalClients +
                     myReplica_.getReplicaConfig().numOfClientProxies),
       metricsComponent_{concordMetrics::Component("preProcessor", std::make_shared<concordMetrics::Aggregator>())},
@@ -100,10 +101,10 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   registerMsgHandlers();
   metricsComponent_.Register();
   sigManager_ = make_shared<SigManager>(myReplicaId_,
-                                        numOfReplicas_ + numOfClients_,
+                                        numOfReplicas_ + numOfRoReplicas_ + numOfClients_,
                                         myReplica.getReplicaConfig().replicaPrivateKey,
                                         myReplica.getReplicaConfig().publicKeysOfReplicas);
-  const uint16_t firstClientId = numOfReplicas_;
+  const uint16_t firstClientId = numOfReplicas_ + numOfRoReplicas_;
   for (auto i = 0; i < numOfClients_; i++) {
     // Placeholders for all clients
     ongoingRequests_[firstClientId + i] = make_shared<ClientRequestState>();
@@ -526,7 +527,7 @@ bool PreProcessor::registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
   const auto &clientEntry = ongoingRequests_[clientId];
   if (!clientEntry->reqProcessingStatePtr)
     clientEntry->reqProcessingStatePtr = make_unique<RequestProcessingState>(
-        numOfReplicas_, clientId, cid, reqSeqNum, move(clientReqMsg), preProcessRequestMsg);
+        numOfReplicas_ + numOfRoReplicas_, clientId, cid, reqSeqNum, move(clientReqMsg), preProcessRequestMsg);
   else if (!clientEntry->reqProcessingStatePtr->getPreProcessRequest())
     // The request was registered before as arrived directly from the client
     clientEntry->reqProcessingStatePtr->setPreProcessRequest(preProcessRequestMsg);

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -107,7 +107,7 @@ class PreProcessor {
                                     uint64_t reqRetryId,
                                     const std::string &cid,
                                     const std::string &ongoingCid);
-  uint16_t getClientReplyBufferId(uint16_t clientId) const { return clientId - numOfReplicas_; }
+  uint16_t getClientReplyBufferId(uint16_t clientId) const { return clientId - numOfReplicas_ - numOfRoReplicas_; }
   const char *getPreProcessResultBuffer(uint16_t clientId) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -156,6 +156,7 @@ class PreProcessor {
   const uint32_t maxPreExecResultSize_;
   const std::set<ReplicaId> &idsOfPeerReplicas_;
   const uint16_t numOfReplicas_;
+  const uint16_t numOfRoReplicas_;
   const uint16_t numOfClients_;
   util::SimpleThreadPool threadPool_;
   // One-time allocated buffers (one per client) for the pre-execution results storage


### PR DESCRIPTION
When initiating Preprocessor we initiate an array of ongoing requests.
This array is being initiated according to the client id’s, but we detected a bug since we didn’t calculate the RO replicas.
Since the RO replicas ID’s are right after the regular replicas and before the clients we need to calculate them also.
I’ve added a member variable for the number of RO replicas and use this variable in all the places that calculate/uses the number of replicas.