### PR TITLE
Storage Categorization: Add BlockMerkle category

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -5,26 +5,27 @@ add_library(kvbc  src/ClientImp.cpp
     src/ReplicaImp.cpp
     src/replica_state_sync_imp.cpp
     src/block_metadata.cpp
-                  src/direct_kv_db_adapter.cpp
-                  src/merkle_tree_db_adapter.cpp
-                  src/merkle_tree_key_manipulator.cpp
-                  src/direct_kv_block.cpp
-                  src/merkle_tree_block.cpp
-                  src/direct_kv_storage_factory.cpp
-                  src/merkle_tree_storage_factory.cpp
-                  src/sparse_merkle/base_types.cpp
-                  src/sparse_merkle/keys.cpp
-                  src/sparse_merkle/internal_node.cpp
-                  src/sparse_merkle/tree.cpp
-                  src/sparse_merkle/update_cache.cpp
-                  src/sparse_merkle/walker.cpp
+    src/direct_kv_db_adapter.cpp
+    src/merkle_tree_db_adapter.cpp
+    src/merkle_tree_key_manipulator.cpp
+    src/direct_kv_block.cpp
+    src/merkle_tree_block.cpp
+    src/direct_kv_storage_factory.cpp
+    src/merkle_tree_storage_factory.cpp
+    src/sparse_merkle/base_types.cpp
+    src/sparse_merkle/keys.cpp
+    src/sparse_merkle/internal_node.cpp
+    src/sparse_merkle/tree.cpp
+    src/sparse_merkle/update_cache.cpp
+    src/sparse_merkle/walker.cpp
 )
 
 if (BUILD_ROCKSDB_STORAGE)
-    target_sources(kvbc PRIVATE src/categorization/immutable_kv_category.cpp 
-                                src/categorization/kv_blockchain.cpp 
+    target_sources(kvbc PRIVATE src/categorization/immutable_kv_category.cpp
+                                src/categorization/kv_blockchain.cpp
                                 src/categorization/blocks.cpp
-                                src/categorization/blockchain.cpp)
+                                src/categorization/blockchain.cpp
+                                src/categorization/block_merkle_category.cpp)
 endif (BUILD_ROCKSDB_STORAGE)
 
 target_link_libraries(kvbc PUBLIC corebft )
@@ -44,4 +45,3 @@ add_subdirectory(benchmark)
 add_subdirectory(tools)
 find_package(CMFC REQUIRED)
 add_subdirectory(cmf)
-

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -1,6 +1,6 @@
-# Updates
+# Input for category `add`
 
-Msg MerkleUpdatesData 1 {
+Msg BlockMerkleInput 1 {
     map string string kv
     list string deletes
 }
@@ -11,7 +11,7 @@ Msg ValueWithExpirationData 2 {
     bool stale_on_update
 }
 
-Msg KeyValueUpdatesData 3 {
+Msg KeyValueInput 3 {
     map string ValueWithExpirationData kv
     list string deletes
     bool calculate_root_hash
@@ -22,27 +22,27 @@ Msg ImmutableValueUpdate 4 {
     list string tags
 }
 
-Msg ImmutableUpdatesData 5 {
+Msg ImmutableInput 5 {
     # key -> value, [tag1, tag2...]
     map string ImmutableValueUpdate kv
     bool calculate_root_hash
 }
 
-Msg CategoryUpdatesData 6 {
+Msg CategoryInput 6 {
     map string oneof{
-        MerkleUpdatesData
-        KeyValueUpdatesData
-        ImmutableUpdatesData
+        BlockMerkleInput
+        KeyValueInput
+        ImmutableInput
     } kv
 }
 
-# Updates info
+# Output for category `add`
 
 Msg MerkleKeyFlag 1000 {
     bool deleted
 }
 
-Msg MerkleUpdatesInfo 1001 {
+Msg BlockMerkleOutput 1001 {
     map string MerkleKeyFlag keys
     fixedlist uint8 32 root_hash
     uint64 state_root_version
@@ -54,12 +54,12 @@ Msg KVKeyFlag 1002 {
     bool stale_on_update
 }
 
-Msg KeyValueUpdatesInfo 1003 {
+Msg KeyValueOutput 1003 {
     map string KVKeyFlag keys
     optional fixedlist uint8 32 root_hash
 }
 
-Msg ImmutableUpdatesInfo 1004 {
+Msg ImmutableOutput 1004 {
     # key -> [tag1, tag2...]
     map string list string tagged_keys
     optional map string fixedlist uint8 32 tag_root_hashes
@@ -75,16 +75,16 @@ Msg BlockData 2001 {
     uint64 block_id
     fixedlist uint8 32 parent_digest
     map string oneof{
-        MerkleUpdatesInfo
-        KeyValueUpdatesInfo
-        ImmutableUpdatesInfo
+        BlockMerkleOutput
+        KeyValueOutput
+        ImmutableOutput
     } categories_updates_info
 }
 
 
 Msg RawBlockData 2005 {
     fixedlist uint8 32 parent_digest
-    CategoryUpdatesData updates
+    CategoryInput updates
     map string optional fixedlist uint8 32 category_root_hash
 }
 
@@ -114,5 +114,57 @@ Msg ImmutableDbValue 4002 {
 
 # Used to deserialize the version only from an ImmutableDbValue.
 Msg ImmutableDbVersion 4003 {
+    uint64 block_id
+}
+
+# Merkle Tree Data
+
+Msg MerkleBlockValue 5000 {
+    fixedlist uint8 32 root_hash
+    list KeyHash hashed_added_keys
+    list KeyHash hashed_deleted_keys
+}
+
+Msg NibblePath 5001 {
+    uint8 length
+    list uint8 data
+}
+
+Msg BatchedInternalNodeKey 5002 {
+    # The version of this key is the *tree* version, not block version
+    uint64 version
+    NibblePath path
+}
+
+Msg LeafChild 5003 {
+    fixedlist uint8 32 hash
+    VersionedKey key
+}
+
+Msg InternalChild 5004 {
+    fixedlist uint8 32 hash
+    uint64 version
+}
+
+Msg BatchedInternalNodeChild 5005 {
+    oneof {
+        LeafChild
+        InternalChild
+    } child
+}
+
+Msg BatchedInternalNode 5006 {
+    # Contains a 1 where a child node is present, 0 otherwise
+    uint32 bitmask
+    list BatchedInternalNodeChild children
+}
+
+# An index to the latest version of a key.
+#
+# A sentinel of 0 is used to mark the key as deleted. We don't need tombstones as we never rewrite
+# the same key after it has been deleted. The use of a sentinel is to optimize the size and
+# serialization performance of this index.
+
+Msg LatestKeyVersion 5009 {
     uint64 block_id
 }

--- a/kvbc/include/categorization/base_types.h
+++ b/kvbc/include/categorization/base_types.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -39,6 +39,10 @@ inline bool operator==(const BasicValue &lhs, const BasicValue &rhs) {
 struct MerkleValue : BasicValue {};
 struct ImmutableValue : BasicValue {};
 struct VersionedValue : BasicValue {};
+
+inline bool operator==(const MerkleValue &lhs, const MerkleValue &rhs) {
+  return (lhs.block_id == rhs.block_id && lhs.data == rhs.data);
+}
 
 using Value = std::variant<MerkleValue, ImmutableValue, VersionedValue>;
 

--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -1,0 +1,116 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#ifdef USE_ROCKSDB
+
+#include "Logger.hpp"
+#include "rocksdb/native_client.h"
+#include "sparse_merkle/tree.h"
+
+#include "base_types.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "details.h"
+
+namespace concord::kvbc::categorization::detail {
+
+// This category puts only block relevant information into the sparse merkle tree. This drastically
+// reduces the storage load and merkle tree overhead, but still allows the same proof guarantees.
+// The `key` going into the merkle tree is the block version, while the value consists of:
+//     * The root hash of the merkle provable keys and values for the block
+//     * The hash of each provable key in the block.
+//
+// The latter is necessary for maintaining proof guarantees after a block is pruned.
+class BlockMerkleCategory {
+ public:
+  BlockMerkleCategory() = default;  // Gtest usage only
+  BlockMerkleCategory(const std::shared_ptr<storage::rocksdb::NativeClient>&);
+
+  // Add the given block updates and return the information that needs to be persisted in the block.
+  BlockMerkleOutput add(BlockId block_id, BlockMerkleInput&& update, storage::rocksdb::NativeWriteBatch&);
+
+  // Return the value of `key` at `block_id`.
+  // Return std::nullopt if the key doesn't exist at `block_id`.
+  std::optional<MerkleValue> get(const std::string& key, BlockId block_id) const;
+  std::optional<MerkleValue> get(const Hash& hashed_key, BlockId block_id) const;
+
+  // Return the value of `key` at its most recent block version.
+  // Return std::nullopt if the key doesn't exist.
+  std::optional<MerkleValue> getLatest(const std::string& key) const;
+
+  // Returns the latest *block* version of a key.
+  // Returns std::nullopt if the key doesn't exist.
+  std::optional<BlockId> getLatestVersion(const std::string& key) const;
+  std::optional<BlockId> getLatestVersion(const Hash& key) const;
+
+  // Get values for keys at specific versions.
+  // `keys` and `versions` must be the same size.
+  // If a key is missing at the specified version, std::nullopt is returned for it.
+  void multiGet(const std::vector<std::string>& keys,
+                const std::vector<BlockId>& versions,
+                std::vector<std::optional<MerkleValue>>& values) const;
+
+  // Get the latest values of a list of keys.
+  // If a key is missing, std::nullopt is returned for it.
+  void multiGetLatest(const std::vector<std::string>& keys, std::vector<std::optional<MerkleValue>>& values) const;
+
+  // Get the latest versions of the given keys.
+  // If a key is missing, std::nullopt is returned for its version.
+  void multiGetLatestVersion(const std::vector<std::string>& keys, std::vector<std::optional<BlockId>>& versions) const;
+  void multiGetLatestVersion(const std::vector<Hash>& keys, std::vector<std::optional<BlockId>>& versions) const;
+
+ private:
+  void multiGet(const std::vector<Buffer>& versioned_keys,
+                const std::vector<BlockId>& versions,
+                std::vector<std::optional<MerkleValue>>& values) const;
+
+  void putKeys(storage::rocksdb::NativeWriteBatch& batch,
+               uint64_t block_id,
+               const std::vector<KeyHash>& hashed_added_keys,
+               const std::vector<KeyHash>& hashed_deleted_keys,
+               BlockMerkleInput& updates);
+
+  void putMerkleNodes(storage::rocksdb::NativeWriteBatch& batch,
+                      sparse_merkle::UpdateBatch&& update_batch,
+                      uint64_t tree_version);
+
+ private:
+  class Reader : public sparse_merkle::IDBReader {
+   public:
+    Reader(const storage::rocksdb::NativeClient& db) : db_{db} {}
+
+    // Return the latest root node in the system.
+    sparse_merkle::BatchedInternalNode get_latest_root() const override;
+
+    // Retrieve a BatchedInternalNode given an InternalNodeKey.
+    //
+    // Throws a std::out_of_range exception if the internal node does not exist.
+    sparse_merkle::BatchedInternalNode get_internal(const sparse_merkle::InternalNodeKey&) const override;
+
+   private:
+    // The lifetime of this reference is shorter than the lifetime of the tree which is shorter than
+    // the lifetime of the category.
+    const storage::rocksdb::NativeClient& db_;
+  };
+
+ private:
+  std::shared_ptr<storage::rocksdb::NativeClient> db_;
+
+  logging::Logger logger_;
+  sparse_merkle::Tree tree_;
+};
+
+}  // namespace concord::kvbc::categorization::detail
+
+#endif

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -41,15 +41,15 @@ struct Block {
     data.parent_digest.fill(0);
   }
 
-  void add(const std::string& category_id, MerkleUpdatesInfo&& updates_info) {
+  void add(const std::string& category_id, BlockMerkleOutput&& updates_info) {
     data.categories_updates_info.emplace(category_id, std::move(updates_info));
   }
 
-  void add(const std::string& category_id, KeyValueUpdatesInfo&& updates_info) {
+  void add(const std::string& category_id, KeyValueOutput&& updates_info) {
     data.categories_updates_info.emplace(category_id, std::move(updates_info));
   }
 
-  void add(const std::string& category_id, ImmutableUpdatesInfo&& updates_info) {
+  void add(const std::string& category_id, ImmutableOutput&& updates_info) {
     data.categories_updates_info.emplace(category_id, std::move(updates_info));
   }
 
@@ -89,20 +89,20 @@ struct RawBlock {
   RawBlock() = default;
   RawBlock(const Block& block, const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
-  MerkleUpdatesData getUpdates(const std::string& category_id,
-                               const MerkleUpdatesInfo& update_info,
-                               const BlockId& block_id,
-                               const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+  BlockMerkleInput getUpdates(const std::string& category_id,
+                              const BlockMerkleOutput& update_info,
+                              const BlockId& block_id,
+                              const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
-  KeyValueUpdatesData getUpdates(const std::string& category_id,
-                                 const KeyValueUpdatesInfo& update_info,
-                                 const BlockId& block_id,
-                                 const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+  KeyValueInput getUpdates(const std::string& category_id,
+                           const KeyValueOutput& update_info,
+                           const BlockId& block_id,
+                           const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
-  ImmutableUpdatesData getUpdates(const std::string& category_id,
-                                  const ImmutableUpdatesInfo& update_info,
-                                  const BlockId& block_id,
-                                  const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+  ImmutableInput getUpdates(const std::string& category_id,
+                            const ImmutableOutput& update_info,
+                            const BlockId& block_id,
+                            const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
   template <typename T>
   static RawBlock deserialize(const T& input) {

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -23,5 +23,10 @@ inline const auto BLOCKS_CF = std::string{"blocks"};
 inline const auto ST_CHAIN_CF = std::string{"st_chain"};
 
 inline const auto CAT_ID_TYPE_CF = std::string{"cat_id_type"};
+
+inline const auto BLOCK_MERKLE_INTERNAL_NODES_CF = std::string{"block_merkle_internal_nodes"};
+inline const auto BLOCK_MERKLE_LEAF_NODES_CF = std::string{"block_merkle_leaf_nodes"};
+inline const auto BLOCK_MERKLE_LATEST_KEY_VERSION = std::string{"block_merkle_latest_key_version"};
+inline const auto BLOCK_MERKLE_KEYS_CF = std::string{"block_merkle_keys"};
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -47,16 +47,16 @@ class ImmutableKeyValueCategory {
 
   // Add the given block updates and return the information that needs to be persisted in the block.
   // Adding keys that already exist in this category is undefined behavior.
-  ImmutableUpdatesInfo add(BlockId, ImmutableUpdatesData &&, storage::rocksdb::NativeWriteBatch &);
+  ImmutableOutput add(BlockId, ImmutableInput &&, storage::rocksdb::NativeWriteBatch &);
 
   // Delete the genesis block. Implemented by directly calling deleteBlock().
-  void deleteGenesisBlock(BlockId, const ImmutableUpdatesInfo &, storage::rocksdb::NativeWriteBatch &);
+  void deleteGenesisBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);
 
   // Delete the last reachable block. Implemented by directly calling deleteBlock().
-  void deleteLastReachableBlock(BlockId, const ImmutableUpdatesInfo &, storage::rocksdb::NativeWriteBatch &);
+  void deleteLastReachableBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);
 
   // Deletes the keys for the passed updates info.
-  void deleteBlock(const ImmutableUpdatesInfo &, storage::rocksdb::NativeWriteBatch &);
+  void deleteBlock(const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);
 
   // Get the value of an immutable key in `block_id`.
   // Return std::nullopt if `key` doesn't exist in `block_id`.
@@ -89,7 +89,7 @@ class ImmutableKeyValueCategory {
   // Return std::nullopt if the key doesn't exist.
   std::optional<KeyValueProof> getProof(const std::string &tag,
                                         const std::string &key,
-                                        const ImmutableUpdatesInfo &updates_info) const;
+                                        const ImmutableOutput &updates_info) const;
 
  private:
   std::string cf_;

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -25,7 +25,7 @@
 namespace concord::kvbc::categorization {
 
 // Temp forward declearations
-struct MerkleCategory {};
+struct BlockMerkleCategory {};
 struct KVHashCategory {};
 
 class KeyValueBlockchain {
@@ -73,10 +73,10 @@ class KeyValueBlockchain {
                              const std::vector<std::string>& keys,
                              std::vector<std::optional<BlockId>>& versions) const;
 
-  CategoryUpdatesData getBlockData(BlockId block_id);
+  CategoryInput getBlockData(BlockId block_id);
 
  private:
-  BlockId addBlock(CategoryUpdatesData&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);
+  BlockId addBlock(CategoryInput&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
   // tries to link the state transfer chain to the main blockchain
   void linkSTChainFrom(BlockId block_id);
@@ -94,7 +94,7 @@ class KeyValueBlockchain {
                              const detail::CATEGORY_TYPE type,
                              concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
-  const std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>& getCategory(
+  const std::variant<detail::ImmutableKeyValueCategory, BlockMerkleCategory, KVHashCategory>& getCategory(
       const std::string& cat_id) const;
 
   /////////////////////// deletes ///////////////////////
@@ -105,58 +105,59 @@ class KeyValueBlockchain {
   // Delete per category
   void deleteGenesisBlock(BlockId block_id,
                           const std::string& category_id,
-                          const ImmutableUpdatesInfo& updates_info,
+                          const ImmutableOutput& updates_info,
                           storage::rocksdb::NativeWriteBatch&);
 
   void deleteGenesisBlock(BlockId block_id,
                           const std::string& category_id,
-                          const KeyValueUpdatesInfo& updates_info,
+                          const KeyValueOutput& updates_info,
                           storage::rocksdb::NativeWriteBatch&);
 
   void deleteGenesisBlock(BlockId block_id,
                           const std::string& category_id,
-                          const MerkleUpdatesInfo& updates_info,
+                          const BlockMerkleOutput& updates_info,
                           storage::rocksdb::NativeWriteBatch&);
 
   void deleteLastReachableBlock(BlockId block_id,
                                 const std::string& category_id,
-                                const ImmutableUpdatesInfo& updates_info,
+                                const ImmutableOutput& updates_info,
                                 storage::rocksdb::NativeWriteBatch&);
 
   void deleteLastReachableBlock(BlockId block_id,
                                 const std::string& category_id,
-                                const KeyValueUpdatesInfo& updates_info,
+                                const KeyValueOutput& updates_info,
                                 storage::rocksdb::NativeWriteBatch&);
 
   void deleteLastReachableBlock(BlockId block_id,
                                 const std::string& category_id,
-                                const MerkleUpdatesInfo& updates_info,
+                                const BlockMerkleOutput& updates_info,
                                 storage::rocksdb::NativeWriteBatch&);
 
   /////////////////////// Updates ///////////////////////
 
   // Update per category
-  MerkleUpdatesInfo handleCategoryUpdates(BlockId block_id,
+  BlockMerkleOutput handleCategoryUpdates(BlockId block_id,
                                           const std::string& category_id,
-                                          MerkleUpdatesData&& updates,
+                                          BlockMerkleInput&& updates,
                                           concord::storage::rocksdb::NativeWriteBatch& write_batch,
                                           categorization::RawBlock& raw_block);
 
-  KeyValueUpdatesInfo handleCategoryUpdates(BlockId block_id,
-                                            const std::string& category_id,
-                                            KeyValueUpdatesData&& updates,
-                                            concord::storage::rocksdb::NativeWriteBatch& write_batch,
-                                            categorization::RawBlock& raw_block);
-  ImmutableUpdatesInfo handleCategoryUpdates(BlockId block_id,
-                                             const std::string& category_id,
-                                             ImmutableUpdatesData&& updates,
-                                             concord::storage::rocksdb::NativeWriteBatch& write_batch,
-                                             categorization::RawBlock& raw_block);
+  KeyValueOutput handleCategoryUpdates(BlockId block_id,
+                                       const std::string& category_id,
+                                       KeyValueInput&& updates,
+                                       concord::storage::rocksdb::NativeWriteBatch& write_batch,
+                                       categorization::RawBlock& raw_block);
+  ImmutableOutput handleCategoryUpdates(BlockId block_id,
+                                        const std::string& category_id,
+                                        ImmutableInput&& updates,
+                                        concord::storage::rocksdb::NativeWriteBatch& write_batch,
+                                        categorization::RawBlock& raw_block);
 
   /////////////////////// Members ///////////////////////
 
   std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
-  std::map<std::string, std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>> categorires_;
+  std::map<std::string, std::variant<detail::ImmutableKeyValueCategory, BlockMerkleCategory, KVHashCategory>>
+      categorires_;
   std::map<std::string, detail::CATEGORY_TYPE> categorires_types_;
   detail::Blockchain block_chain_;
   detail::Blockchain::StateTransfer state_transfer_block_chain_;
@@ -169,11 +170,11 @@ class KeyValueBlockchain {
  public:
   struct KeyValueBlockchain_tester {
     void instantiateCategories(KeyValueBlockchain& kvbc) { kvbc.instantiateCategories(); }
-    const std::map<std::string, std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>>&
+    const std::map<std::string, std::variant<detail::ImmutableKeyValueCategory, BlockMerkleCategory, KVHashCategory>>&
     getCategories(KeyValueBlockchain& kvbc) {
       return kvbc.categorires_;
     }
-    const std::variant<detail::ImmutableKeyValueCategory, MerkleCategory, KVHashCategory>& getCategory(
+    const std::variant<detail::ImmutableKeyValueCategory, BlockMerkleCategory, KVHashCategory>& getCategory(
         const std::string& cat_id, KeyValueBlockchain& kvbc) const {
       return kvbc.getCategory(cat_id);
     }

--- a/kvbc/include/sparse_merkle/base_types.h
+++ b/kvbc/include/sparse_merkle/base_types.h
@@ -329,6 +329,9 @@ class NibblePath {
   // Return the internal representation of the path.
   const std::vector<uint8_t>& data() const { return path_; }
 
+  // Allow moving the data out of the path.
+  std::vector<uint8_t> move_data() { return path_; }
+
  private:
   size_t num_nibbles_;
   std::vector<uint8_t> path_;

--- a/kvbc/include/sparse_merkle/keys.h
+++ b/kvbc/include/sparse_merkle/keys.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0 License.
@@ -49,6 +49,7 @@ class InternalNodeKey {
   Version version() const { return version_; }
 
   const NibblePath& path() const { return path_; }
+  NibblePath& path() { return path_; }
 
  private:
   Version version_;

--- a/kvbc/include/sparse_merkle/tree.h
+++ b/kvbc/include/sparse_merkle/tree.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0 License.
@@ -9,6 +9,8 @@
 // notices and license terms. Your use of these subcomponents is subject to the
 // terms and conditions of the sub-component's license, as noted in the
 // LICENSE file.
+
+#pragma once
 
 #include <vector>
 #include <cstddef>
@@ -40,6 +42,7 @@ namespace sparse_merkle {
 // can be written to the DB atomically.
 class Tree {
  public:
+  Tree() {}
   explicit Tree(std::shared_ptr<IDBReader> db_reader) : db_reader_(db_reader) { reset(); }
 
   const Hash& get_root_hash() const { return root_.hash(); }

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -1,0 +1,398 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "categorization/block_merkle_category.h"
+#include "categorization/column_families.h"
+#include "categorization/details.h"
+
+#include "assertUtils.hpp"
+#include "kv_types.hpp"
+#include "sha_hash.hpp"
+
+using concord::storage::rocksdb::NativeWriteBatch;
+using concordUtils::Sliver;
+
+namespace concord::kvbc::categorization::detail {
+
+MerkleBlockValue hashUpdate(const BlockMerkleInput& updates) {
+  MerkleBlockValue value;
+  value.hashed_added_keys.reserve(updates.kv.size());
+  value.hashed_deleted_keys.reserve(updates.deletes.size());
+
+  // root_hash = h((h(k1) || h(v1)) || ... || (h(kN) || h(vN) || h(dk1) || ... || h(dkN))
+  auto root_hasher = Hasher{};
+  root_hasher.init();
+  auto kv_hasher = Hasher{};
+
+  // Hash all keys and values as part of the root hash
+  for (const auto& [k, v] : updates.kv) {
+    auto key_hash = kv_hasher.digest(k.data(), k.size());
+    auto val_hash = kv_hasher.digest(v.data(), v.size());
+    value.hashed_added_keys.push_back(KeyHash{key_hash});
+    root_hasher.update(key_hash.data(), key_hash.size());
+    root_hasher.update(val_hash.data(), val_hash.size());
+  }
+
+  for (const auto& k : updates.deletes) {
+    auto key_hash = kv_hasher.digest(k.data(), k.size());
+    value.hashed_deleted_keys.push_back(KeyHash{key_hash});
+    root_hasher.update(key_hash.data(), key_hash.size());
+  }
+  value.root_hash = root_hasher.finish();
+  return value;
+}
+
+BlockMerkleOutput inputToOutput(const BlockMerkleInput& updates) {
+  BlockMerkleOutput output{};
+  for (const auto& kv : updates.kv) {
+    output.keys.emplace(kv.first, MerkleKeyFlag{false});
+  }
+  for (const auto& key : updates.deletes) {
+    output.keys.emplace(key, MerkleKeyFlag{true});
+  }
+  return output;
+}
+
+VersionedKey leafKeyToVersionedKey(const sparse_merkle::LeafKey& leaf_key) {
+  return VersionedKey{KeyHash{leaf_key.hash().dataArray()}, leaf_key.version().value()};
+}
+
+// If we change the interface of IDBReader to accept r-values we can get rid of this function in
+// favor of the one immediately below it.
+BatchedInternalNodeKey toBatchedInternalNodeKey(const sparse_merkle::InternalNodeKey& key) {
+  auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().data()};
+  return BatchedInternalNodeKey{key.version().value(), std::move(path)};
+}
+
+BatchedInternalNodeKey toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey&& key) {
+  auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().move_data()};
+  return BatchedInternalNodeKey{key.version().value(), std::move(path)};
+}
+
+std::vector<uint8_t> rootKey(uint64_t version) {
+  auto v = sparse_merkle::Version(version);
+  return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(v)));
+}
+
+std::vector<uint8_t> serializeBatchedInternalNode(sparse_merkle::BatchedInternalNode&& node) {
+  BatchedInternalNode cmf_node{};
+  cmf_node.bitmask = 0;
+  const auto& children = node.children();
+  for (auto i = 0u; i < children.size(); ++i) {
+    const auto& child = children[i];
+    if (child) {
+      cmf_node.bitmask |= (1 << i);
+      if (auto leaf_child = std::get_if<sparse_merkle::LeafChild>(&child.value())) {
+        cmf_node.children.push_back(
+            BatchedInternalNodeChild{LeafChild{leaf_child->hash.dataArray(), leafKeyToVersionedKey(leaf_child->key)}});
+      } else {
+        auto internal_child = std::get<sparse_merkle::InternalChild>(child.value());
+        cmf_node.children.push_back(
+            BatchedInternalNodeChild{InternalChild{internal_child.hash.dataArray(), internal_child.version.value()}});
+      }
+    }
+  }
+  return serialize(cmf_node);
+}
+
+sparse_merkle::BatchedInternalNode deserializeBatchedInternalNode(const std::string& buf) {
+  BatchedInternalNode cmf_node{};
+  deserialize(buf, cmf_node);
+  sparse_merkle::BatchedInternalNode::Children children;
+  size_t child_index = 0;
+  for (auto i = 0u; i < sparse_merkle::BatchedInternalNode::MAX_CHILDREN; ++i) {
+    if (cmf_node.bitmask & (1 << i)) {
+      const auto& child = cmf_node.children[child_index].child;
+      ++child_index;
+      if (auto leaf_child = std::get_if<LeafChild>(&child)) {
+        auto sm_hash = sparse_merkle::Hash(leaf_child->hash);
+        auto sm_key =
+            sparse_merkle::LeafKey(sparse_merkle::Hash(leaf_child->key.key_hash.value), leaf_child->key.version);
+        children[i] = sparse_merkle::LeafChild(sm_hash, sm_key);
+      } else {
+        auto internal_child = std::get<InternalChild>(child);
+        auto sm_hash = sparse_merkle::Hash(internal_child.hash);
+        children[i] = sparse_merkle::InternalChild{sm_hash, internal_child.version};
+      }
+    }
+  }
+  return sparse_merkle::BatchedInternalNode(children);
+}
+
+std::vector<Hash> hashedKeys(const std::vector<std::string>& keys) {
+  std::vector<Hash> hashed_keys;
+  hashed_keys.reserve(keys.size());
+  std::transform(keys.begin(), keys.end(), std::back_inserter(hashed_keys), [](auto& key) {
+    return Hasher{}.digest(key.data(), key.size());
+  });
+  return hashed_keys;
+}
+
+std::vector<Buffer> versionedKeys(const std::vector<std::string>& keys, const std::vector<BlockId>& versions) {
+  auto versioned_keys = std::vector<Buffer>{};
+  versioned_keys.reserve(keys.size());
+  std::transform(
+      keys.begin(), keys.end(), versions.begin(), std::back_inserter(versioned_keys), [](auto& key, auto version) {
+        auto key_hash = KeyHash{Hasher{}.digest(key.data(), key.size())};
+        return serialize(VersionedKey{key_hash, version});
+      });
+  return versioned_keys;
+}
+
+BlockMerkleCategory::BlockMerkleCategory(const std::shared_ptr<storage::rocksdb::NativeClient>& db) : db_{db} {
+  createColumnFamilyIfNotExisting(BLOCK_MERKLE_INTERNAL_NODES_CF, *db);
+  createColumnFamilyIfNotExisting(BLOCK_MERKLE_LEAF_NODES_CF, *db);
+  createColumnFamilyIfNotExisting(BLOCK_MERKLE_LATEST_KEY_VERSION, *db);
+  createColumnFamilyIfNotExisting(BLOCK_MERKLE_KEYS_CF, *db);
+  tree_ = sparse_merkle::Tree{std::make_shared<Reader>(*db_)};
+}
+
+BlockMerkleOutput BlockMerkleCategory::add(BlockId block_id, BlockMerkleInput&& updates, NativeWriteBatch& batch) {
+  auto merkle_value = hashUpdate(updates);
+  auto root_hash = merkle_value.root_hash;
+  putKeys(batch, block_id, merkle_value.hashed_added_keys, merkle_value.hashed_deleted_keys, updates);
+
+  auto block_key = serialize(BlockKey{block_id});
+  auto merkle_key = Sliver::copy((const char*)block_key.data(), block_key.size());
+  auto ser_value = serialize(merkle_value);
+  auto ser_value_sliver = Sliver::copy((const char*)ser_value.data(), ser_value.size());
+  auto tree_update_batch = tree_.update(SetOfKeyValuePairs{{merkle_key, ser_value_sliver}});
+
+  auto tree_version = tree_update_batch.stale.stale_since_version.value();
+  putMerkleNodes(batch, std::move(tree_update_batch), tree_version);
+
+  auto output = inputToOutput(updates);
+  output.root_hash = root_hash;
+  output.state_root_version = tree_version;
+  return output;
+}
+
+std::optional<MerkleValue> BlockMerkleCategory::get(const std::string& key, BlockId block_id) const {
+  auto hasher = Hasher{};
+  auto hashed_key = hasher.digest(key.data(), key.size());
+  return get(hashed_key, block_id);
+}
+
+std::optional<MerkleValue> BlockMerkleCategory::get(const Hash& hashed_key, BlockId block_id) const {
+  auto key = VersionedKey{KeyHash{hashed_key}, block_id};
+  if (auto val = db_->get(BLOCK_MERKLE_KEYS_CF, serialize(key))) {
+    auto rv = MerkleValue{};
+    rv.data = std::move(*val);
+    rv.block_id = block_id;
+    return rv;
+  }
+  return std::nullopt;
+}
+
+std::optional<MerkleValue> BlockMerkleCategory::getLatest(const std::string& key) const {
+  auto hasher = Hasher{};
+  auto hashed_key = hasher.digest(key.data(), key.size());
+  if (auto block_id = getLatestVersion(hashed_key)) {
+    return get(hashed_key, *block_id);
+  }
+  return std::nullopt;
+}
+
+std::optional<BlockId> BlockMerkleCategory::getLatestVersion(const std::string& key) const {
+  auto hasher = Hasher{};
+  auto hashed_key = hasher.digest(key.data(), key.size());
+  return getLatestVersion(hashed_key);
+}
+
+std::optional<BlockId> BlockMerkleCategory::getLatestVersion(const Hash& hashed_key) const {
+  const auto serialized = db_->getSlice(BLOCK_MERKLE_LATEST_KEY_VERSION, hashed_key);
+  if (!serialized) {
+    return std::nullopt;
+  }
+  auto version = LatestKeyVersion{};
+  deserialize(*serialized, version);
+  if (version.block_id == 0) {
+    // 0 is a tombstone sentinel
+    return std::nullopt;
+  }
+  return version.block_id;
+}
+
+void BlockMerkleCategory::multiGet(const std::vector<std::string>& keys,
+                                   const std::vector<BlockId>& versions,
+                                   std::vector<std::optional<MerkleValue>>& values) const {
+  ConcordAssertEQ(keys.size(), versions.size());
+  auto versioned_keys = versionedKeys(keys, versions);
+  multiGet(versioned_keys, versions, values);
+}
+
+void BlockMerkleCategory::multiGet(const std::vector<Buffer>& versioned_keys,
+                                   const std::vector<BlockId>& versions,
+                                   std::vector<std::optional<MerkleValue>>& values) const {
+  auto slices = std::vector<::rocksdb::PinnableSlice>{};
+  slices.reserve(versioned_keys.size());
+  auto statuses = std::vector<::rocksdb::Status>{};
+  statuses.reserve(versioned_keys.size());
+
+  db_->multiGet(BLOCK_MERKLE_KEYS_CF, versioned_keys, slices, statuses);
+
+  values.clear();
+  for (auto i = 0ull; i < slices.size(); ++i) {
+    const auto& status = statuses[i];
+    const auto& slice = slices[i];
+    const auto version = versions[i];
+    if (status.ok()) {
+      values.push_back(MerkleValue{{version, slice.ToString()}});
+    } else if (status.IsNotFound()) {
+      values.push_back(std::nullopt);
+    } else {
+      throw std::runtime_error{"BlockMerkleCategory multiGet() failure: " + status.ToString()};
+    }
+  }
+}
+
+void BlockMerkleCategory::multiGetLatestVersion(const std::vector<std::string>& keys,
+                                                std::vector<std::optional<BlockId>>& versions) const {
+  auto hashed_keys = hashedKeys(keys);
+  multiGetLatestVersion(hashed_keys, versions);
+}
+
+void BlockMerkleCategory::multiGetLatestVersion(const std::vector<Hash>& hashed_keys,
+                                                std::vector<std::optional<BlockId>>& versions) const {
+  auto slices = std::vector<::rocksdb::PinnableSlice>{};
+  slices.reserve(hashed_keys.size());
+  auto statuses = std::vector<::rocksdb::Status>{};
+  statuses.reserve(hashed_keys.size());
+
+  db_->multiGet(BLOCK_MERKLE_LATEST_KEY_VERSION, hashed_keys, slices, statuses);
+  versions.clear();
+  for (auto i = 0ull; i < slices.size(); ++i) {
+    const auto& status = statuses[i];
+    const auto& slice = slices[i];
+    if (status.ok()) {
+      auto version = LatestKeyVersion{};
+      deserialize(slice, version);
+      if (version.block_id == 0) {
+        // 0 is a tombstone sentinel
+        versions.push_back(std::nullopt);
+      } else {
+        versions.push_back(version.block_id);
+      }
+    } else if (status.IsNotFound()) {
+      versions.push_back(std::nullopt);
+    } else {
+      throw std::runtime_error{"BlockMerkleCategory multiGet() failure: " + status.ToString()};
+    }
+  }
+}
+
+void BlockMerkleCategory::multiGetLatest(const std::vector<std::string>& keys,
+                                         std::vector<std::optional<MerkleValue>>& values) const {
+  auto hashed_keys = hashedKeys(keys);
+  std::vector<std::optional<BlockId>> versions;
+  versions.reserve(keys.size());
+  multiGetLatestVersion(hashed_keys, versions);
+
+  // Generate the set of versioned keys for all keys that have latest versions
+  auto versioned_keys = std::vector<Buffer>{};
+  auto found_versions = std::vector<BlockId>{};
+  for (auto i = 0u; i < hashed_keys.size(); i++) {
+    if (versions[i]) {
+      found_versions.push_back(*versions[i]);
+      versioned_keys.push_back(serialize(VersionedKey{KeyHash{hashed_keys[i]}, *versions[i]}));
+    }
+  }
+
+  values.clear();
+  // Optimize for all keys existing (having latest versions)
+  if (versioned_keys.size() == hashed_keys.size()) {
+    return multiGet(versioned_keys, found_versions, values);
+  }
+
+  // Retrieve only the keys that have latest versions
+  auto retrieved_values = std::vector<std::optional<MerkleValue>>{};
+  retrieved_values.reserve(versioned_keys.size());
+  multiGet(versioned_keys, found_versions, retrieved_values);
+
+  // Merge any keys that didn't have latest versions along with the retrieved keys.
+  auto value_index = 0u;
+  for (auto& version : versions) {
+    if (version) {
+      values.push_back(retrieved_values[value_index]);
+      ++value_index;
+    } else {
+      values.push_back(std::nullopt);
+    }
+  }
+  ConcordAssertEQ(values.size(), keys.size());
+}
+
+void BlockMerkleCategory::putKeys(NativeWriteBatch& batch,
+                                  uint64_t block_id,
+                                  const std::vector<KeyHash>& hashed_added_keys,
+                                  const std::vector<KeyHash>& hashed_deleted_keys,
+                                  BlockMerkleInput& updates) {
+  auto kv_it = updates.kv.begin();
+  for (auto key_it = hashed_added_keys.begin(); key_it != hashed_added_keys.end(); key_it++) {
+    // Write the versioned key/value pair used for direct key lookup
+    batch.put(BLOCK_MERKLE_KEYS_CF, serialize(VersionedKey{*key_it, block_id}), kv_it->second);
+
+    // Put the latest version of the key
+    batch.put(BLOCK_MERKLE_LATEST_KEY_VERSION, key_it->value, serialize(LatestKeyVersion{block_id}));
+
+    kv_it++;
+  }
+
+  for (auto key_it = hashed_deleted_keys.begin(); key_it != hashed_deleted_keys.end(); key_it++) {
+    // Add the new tombstone to the key versions. We use 0 here to avoid the serialization overhead of a
+    // variant/optional.
+    batch.put(BLOCK_MERKLE_LATEST_KEY_VERSION, key_it->value, serialize(LatestKeyVersion{0}));
+  }
+}
+
+void BlockMerkleCategory::putMerkleNodes(NativeWriteBatch& batch,
+                                         sparse_merkle::UpdateBatch&& update_batch,
+                                         uint64_t tree_version) {
+  for (const auto& [leaf_key, leaf_val] : update_batch.leaf_nodes) {
+    auto ser_key = serialize(leafKeyToVersionedKey(leaf_key));
+    batch.put(BLOCK_MERKLE_LEAF_NODES_CF, ser_key, leaf_val.value.string_view());
+  }
+
+  for (auto& [internal_key, internal_node] : update_batch.internal_nodes) {
+    auto ser_key = serialize(toBatchedInternalNodeKey(std::move(internal_key)));
+    batch.put(BLOCK_MERKLE_INTERNAL_NODES_CF, ser_key, serializeBatchedInternalNode(std::move(internal_node)));
+  }
+
+  // We always add a root key at version 0 with a value that points to the latest root.
+  batch.put(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0), rootKey(tree_version));
+}
+
+sparse_merkle::BatchedInternalNode BlockMerkleCategory::Reader::get_latest_root() const {
+  if (auto latest_root_key = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0))) {
+    if (auto serialized = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, *latest_root_key)) {
+      return deserializeBatchedInternalNode(*serialized);
+    }
+    // TODO: LOG THIS
+    // The merkle tree should never ask for a version that doesn't exist.
+    std::terminate();
+  }
+  return sparse_merkle::BatchedInternalNode{};
+}
+
+sparse_merkle::BatchedInternalNode BlockMerkleCategory::Reader::get_internal(
+    const sparse_merkle::InternalNodeKey& key) const {
+  auto ser_key = serialize(toBatchedInternalNodeKey(key));
+  if (auto serialized = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, ser_key)) {
+    return deserializeBatchedInternalNode(*serialized);
+  }
+  // TODO: LOG THIS
+  // The merkle tree should never ask for a version that doesn't exist.
+  std::terminate();
+}
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/src/categorization/blocks.cpp
+++ b/kvbc/src/categorization/blocks.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -37,13 +37,13 @@ RawBlock::RawBlock(const Block& block, const std::shared_ptr<storage::rocksdb::N
 // This set methods are overloaded in order to construct the appropriate updates
 
 // Merkle updates reconstruction
-MerkleUpdatesData RawBlock::getUpdates(const std::string& category_id,
-                                       const MerkleUpdatesInfo& update_info,
-                                       const BlockId& block_id,
-                                       const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
+BlockMerkleInput RawBlock::getUpdates(const std::string& category_id,
+                                      const BlockMerkleOutput& update_info,
+                                      const BlockId& block_id,
+                                      const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
   // For old serialization
   using namespace concord::kvbc::v2MerkleTree;
-  MerkleUpdatesData data;
+  BlockMerkleInput data;
   // Iterate over the keys:
   // if deleted, add to the deleted set.
   // else generate a db key, serialize it and
@@ -72,11 +72,11 @@ MerkleUpdatesData RawBlock::getUpdates(const std::string& category_id,
 }
 
 // KeyValueUpdatesData updates reconstruction
-KeyValueUpdatesData RawBlock::getUpdates(const std::string& category_id,
-                                         const KeyValueUpdatesInfo& update_info,
-                                         const BlockId& block_id,
-                                         const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
-  KeyValueUpdatesData data;
+KeyValueInput RawBlock::getUpdates(const std::string& category_id,
+                                   const KeyValueOutput& update_info,
+                                   const BlockId& block_id,
+                                   const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
+  KeyValueInput data;
 
   return data;
 }
@@ -85,11 +85,11 @@ KeyValueUpdatesData RawBlock::getUpdates(const std::string& category_id,
 // Iterate over the keys from the update info.
 // get the value of a key from the DB by performing get on the category.
 // assemble a ImmutableValueUpdate from value and tags.
-ImmutableUpdatesData RawBlock::getUpdates(const std::string& category_id,
-                                          const ImmutableUpdatesInfo& update_info,
-                                          const BlockId& block_id,
-                                          const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
-  ImmutableUpdatesData data;
+ImmutableInput RawBlock::getUpdates(const std::string& category_id,
+                                    const ImmutableOutput& update_info,
+                                    const BlockId& block_id,
+                                    const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
+  ImmutableInput data;
   detail::ImmutableKeyValueCategory imm{category_id, native_client};
   for (const auto& [key, tags] : update_info.tagged_keys) {
     auto val = imm.get(key, block_id);

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -190,4 +190,14 @@ if (BUILD_ROCKSDB_STORAGE)
         kvbc
         stdc++fs
     )
+
+    add_executable(block_merkle_category_unit_test categorization/block_merkle_category_unit_test.cpp )
+    add_test(block_merkle_category_unit_test block_merkle_category_unit_test)
+    target_link_libraries(block_merkle_category_unit_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        kvbc
+        stdc++fs
+    )
 endif (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/test/categorization/block_merkle_category_unit_test.cpp
+++ b/kvbc/test/categorization/block_merkle_category_unit_test.cpp
@@ -1,0 +1,209 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "categorization/block_merkle_category.h"
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "storage/test/storage_test_common.h"
+
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace {
+
+using namespace ::testing;
+using namespace concord::storage::rocksdb;
+using namespace concord::kvbc;
+using namespace concord::kvbc::categorization;
+using namespace concord::kvbc::categorization::detail;
+using namespace std::literals;
+
+class block_merkle_category : public Test {
+  void SetUp() override {
+    cleanup();
+    db = TestRocksDb::createNative();
+    cat = BlockMerkleCategory{db};
+  }
+  void TearDown() override { cleanup(); }
+
+ protected:
+  auto add(BlockId block_id, BlockMerkleInput &&update) {
+    auto batch = db->getBatch();
+    auto output = cat.add(block_id, std::move(update), batch);
+    db->write(std::move(batch));
+    return output;
+  }
+
+ protected:
+  std::shared_ptr<NativeClient> db;
+  BlockMerkleCategory cat;
+  std::string key1 = "key1"s;
+  std::string key2 = "key2"s;
+  std::string key3 = "key3"s;
+  std::string key4 = "key4"s;
+  std::string val1 = "val1"s;
+  std::string val2 = "val2"s;
+  std::string val3 = "val3"s;
+  std::string val4 = "val4"s;
+  Hash hashed_key1 = Hasher{}.digest(key1.data(), key1.size());
+  Hash hashed_key2 = Hasher{}.digest(key2.data(), key2.size());
+  Hash hashed_key3 = Hasher{}.digest(key3.data(), key3.size());
+  Hash hashed_key4 = Hasher{}.digest(key4.data(), key4.size());
+};
+
+TEST_F(block_merkle_category, empty_updates) {
+  auto update = BlockMerkleInput{};
+  auto batch = db->getBatch();
+  const auto output = cat.add(1, std::move(update), batch);
+
+  // A new root index, an internal node, and a leaf node are created.
+  ASSERT_EQ(batch.count(), 3);
+}
+
+TEST_F(block_merkle_category, put_and_get) {
+  auto update = BlockMerkleInput{{{key1, val1}}};
+  auto batch = db->getBatch();
+  auto block_id = 1u;
+  const auto output = cat.add(block_id, std::move(update), batch);
+
+  // A new root index, an internal node, and a leaf node are created.
+  // Additionally, a key and its value are written.
+  ASSERT_EQ(batch.count(), 5);
+  ASSERT_EQ(1, output.state_root_version);
+  ASSERT_EQ(false, output.keys.find(key1)->second.deleted);
+
+  db->write(std::move(batch));
+
+  auto expected = MerkleValue{{block_id, val1}};
+
+  // Get by key works
+  ASSERT_EQ(expected, cat.getLatest(key1).value());
+  // Get by specific block works
+  ASSERT_EQ(expected, cat.get(key1, 1));
+
+  // Get by hash works
+  ASSERT_EQ(expected, cat.get(hashed_key1, block_id).value());
+
+  // Getting the latest version by key and hash works
+  ASSERT_EQ(block_id, cat.getLatestVersion(key1));
+  ASSERT_EQ(block_id, cat.getLatestVersion(hashed_key1));
+
+  // Getting the key at the wrong block fails
+  ASSERT_EQ(false, cat.get(key1, block_id + 1).has_value());
+  ASSERT_EQ(false, cat.get(hashed_key1, block_id + 1).has_value());
+
+  // Trying to get non-existant keys returns std::nullopt
+  ASSERT_EQ(false, cat.getLatest(key2).has_value());
+  ASSERT_EQ(false, cat.get(key2, block_id).has_value());
+  ASSERT_EQ(false, cat.get(hashed_key2, block_id).has_value());
+}
+
+TEST_F(block_merkle_category, multiget) {
+  auto update = BlockMerkleInput{{{key1, val1}, {key2, val2}, {key3, val3}}};
+  BlockId block_id = 1;
+  const auto output = add(block_id, std::move(update));
+
+  // We can get all keys individually
+  ASSERT_EQ(val1, cat.getLatest(key1).value().data);
+  ASSERT_EQ(val2, cat.getLatest(key2).value().data);
+  ASSERT_EQ(val3, cat.getLatest(key3).value().data);
+
+  // We can get all 3 with a multiget
+  auto keys = std::vector<std::string>{key1, key2, key3};
+  auto versions = std::vector<BlockId>{1u, 1u, 1u};
+  auto values = std::vector<std::optional<MerkleValue>>{};
+  cat.multiGet(keys, versions, values);
+  ASSERT_EQ(keys.size(), values.size());
+  ASSERT_EQ((MerkleValue{{block_id, val1}}), *values[0]);
+  ASSERT_EQ((MerkleValue{{block_id, val2}}), *values[1]);
+  ASSERT_EQ((MerkleValue{{block_id, val3}}), *values[2]);
+
+  // Retrieving a key with the non-existant version causes a nullopt for that key only
+  versions[1] = 2u;
+  cat.multiGet(keys, versions, values);
+  ASSERT_EQ(keys.size(), values.size());
+  ASSERT_EQ((MerkleValue{{block_id, val1}}), *values[0]);
+  ASSERT_EQ(false, values[1].has_value());
+  ASSERT_EQ((MerkleValue{{block_id, val3}}), *values[2]);
+
+  // Retrieving a non-existant key causes a nullopt for that key only
+  keys.push_back("key4");
+  versions.push_back(1u);
+  cat.multiGet(keys, versions, values);
+  ASSERT_EQ(keys.size(), values.size());
+  ASSERT_EQ((MerkleValue{{block_id, val1}}), *values[0]);
+  ASSERT_EQ(false, values[1].has_value());
+  ASSERT_EQ((MerkleValue{{block_id, val3}}), *values[2]);
+  ASSERT_EQ(false, values[3].has_value());
+
+  // Get latest versions
+  auto out_versions = std::vector<std::optional<BlockId>>{};
+  cat.multiGetLatestVersion(keys, out_versions);
+  ASSERT_EQ(1, *out_versions[0]);
+  ASSERT_EQ(1, out_versions[1].has_value());
+  ASSERT_EQ(1, *out_versions[2]);
+  ASSERT_EQ(false, out_versions[3].has_value());
+
+  // Get latest values
+  cat.multiGetLatest(keys, values);
+  ASSERT_EQ((MerkleValue{{block_id, val1}}), *values[0]);
+  ASSERT_EQ((MerkleValue{{block_id, val2}}), *values[1]);
+  ASSERT_EQ((MerkleValue{{block_id, val3}}), *values[2]);
+  ASSERT_EQ(false, values[3].has_value());
+}
+
+TEST_F(block_merkle_category, overwrite) {
+  auto update = BlockMerkleInput{{{key1, val1}, {key2, val2}, {key3, val3}}};
+  auto _ = add(1, std::move(update));
+
+  // Overwrite key 2 and add key4
+  _ = add(2, BlockMerkleInput{{{key2, "new_val"s}, {key4, val4}}});
+  auto expected1 = MerkleValue{{1, val1}};
+  auto expected2 = MerkleValue{{2, "new_val"s}};
+  auto expected3 = MerkleValue{{1, val3}};
+  auto expected4 = MerkleValue{{2, val4}};
+  ASSERT_EQ(expected1, *cat.getLatest(key1));
+  ASSERT_EQ(expected2, *cat.getLatest(key2));
+  ASSERT_EQ(expected3, *cat.getLatest(key3));
+  ASSERT_EQ(expected4, *cat.getLatest(key4));
+
+  auto keys = std::vector<std::string>{key1, key2, key3, key4};
+  auto values = std::vector<std::optional<MerkleValue>>{};
+  cat.multiGetLatest(keys, values);
+  ASSERT_EQ(expected1, *values[0]);
+  ASSERT_EQ(expected2, *values[1]);
+  ASSERT_EQ(expected3, *values[2]);
+  ASSERT_EQ(expected4, *values[3]);
+
+  // Multiget will find the old value of key2 at 1, but not key4 since it was written at block 2
+  const auto versions = std::vector<BlockId>{1u, 1u, 1u, 1u};
+  cat.multiGet(keys, versions, values);
+  ASSERT_EQ(expected1, *values[0]);
+  ASSERT_EQ((MerkleValue{{1, val2}}), *values[1]);
+  ASSERT_EQ(expected3, *values[2]);
+  ASSERT_EQ(false, values[3].has_value());
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  ::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/kvbc/test/categorization/blockchain_test.cpp
+++ b/kvbc/test/categorization/blockchain_test.cpp
@@ -137,7 +137,7 @@ TEST_F(categorized_kvbc, get_block) {
     auto key = std::string("key");
 
     uint64_t state_root_version = 886;
-    MerkleUpdatesInfo mui;
+    BlockMerkleOutput mui;
     mui.keys[key] = MerkleKeyFlag{true};
     mui.root_hash = pHash;
     mui.state_root_version = state_root_version;
@@ -153,7 +153,7 @@ TEST_F(categorized_kvbc, get_block) {
     auto block_from_db = block_chain.getBlock(888);
     ASSERT_TRUE(block_from_db.has_value());
     auto merkle_variant = (*block_from_db).data.categories_updates_info["merkle"];
-    ASSERT_TRUE(std::get<MerkleUpdatesInfo>(merkle_variant).keys[key].deleted);
+    ASSERT_TRUE(std::get<BlockMerkleOutput>(merkle_variant).keys[key].deleted);
   }
 }
 

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -53,18 +53,18 @@ TEST_F(categorized_kvbc, serialization_and_desirialization_of_block) {
     pHash[i] = (uint8_t)(rd() % 255);
   }
   Block block{8};
-  KeyValueUpdatesInfo kvui;
+  KeyValueOutput kvui;
   kvui.keys["key1"] = {false, false};
   kvui.keys["key2"] = {true, false};
-  block.add("KeyValueUpdatesInfo", std::move(kvui));
+  block.add("KeyValueOutput", std::move(kvui));
   block.setParentHash(pHash);
   auto ser = Block::serialize(block);
   auto des_block = Block::deserialize(ser);
 
   // Test the deserialized Block
   ASSERT_TRUE(des_block.id() == 8);
-  auto variant = des_block.data.categories_updates_info["KeyValueUpdatesInfo"];
-  KeyValueUpdatesInfo kv_updates_info = std::get<KeyValueUpdatesInfo>(variant);
+  auto variant = des_block.data.categories_updates_info["KeyValueOutput"];
+  KeyValueOutput kv_updates_info = std::get<KeyValueOutput>(variant);
   ASSERT_TRUE(kv_updates_info.keys.size() == 2);
   ASSERT_TRUE(kv_updates_info.keys["key2"].deleted == true);
   ASSERT_EQ(des_block.data.parent_digest, block.data.parent_digest);
@@ -82,7 +82,7 @@ TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
   auto value = std::string("val");
 
   uint64_t state_root_version = 886;
-  MerkleUpdatesInfo mui;
+  BlockMerkleOutput mui;
   mui.keys[key] = MerkleKeyFlag{false};
   mui.root_hash = pHash;
   mui.state_root_version = state_root_version;
@@ -102,7 +102,7 @@ TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
   categorization::RawBlock rw(block, db);
   ASSERT_EQ(rw.data.parent_digest, block.data.parent_digest);
   auto variant = rw.data.updates.kv[cf];
-  auto merkle_updates = std::get<MerkleUpdatesData>(variant);
+  auto merkle_updates = std::get<BlockMerkleInput>(variant);
   // check reconstruction of original kv
   ASSERT_EQ(merkle_updates.kv[key], value);
 }
@@ -119,7 +119,7 @@ TEST_F(categorized_kvbc, fail_reconstruct_merkle_updates) {
   auto value = std::string("val");
 
   uint64_t state_root_version = 886;
-  MerkleUpdatesInfo mui;
+  BlockMerkleOutput mui;
   mui.keys[key] = MerkleKeyFlag{false};
   mui.root_hash = pHash;
   mui.state_root_version = state_root_version;

--- a/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
@@ -47,7 +47,7 @@ class immutable_kv_category : public Test {
   void TearDown() override { cleanup(); }
 
  protected:
-  auto add(BlockId block_id, ImmutableUpdatesData &&update) {
+  auto add(BlockId block_id, ImmutableInput &&update) {
     auto update_batch = db->getBatch();
     auto update_info = cat.add(block_id, std::move(update), update_batch);
     db->write(std::move(update_batch));
@@ -71,7 +71,7 @@ TEST_F(immutable_kv_category, create_column_family_on_construction) {
 TEST_F(immutable_kv_category, empty_updates) {
   // Calculate root hash = false.
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = false;
     auto batch = db->getBatch();
     const auto update_info = cat.add(1, std::move(update), batch);
@@ -82,7 +82,7 @@ TEST_F(immutable_kv_category, empty_updates) {
 
   // Calculate root hash = true.
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     auto batch = db->getBatch();
     const auto update_info = cat.add(1, std::move(update), batch);
@@ -96,7 +96,7 @@ TEST_F(immutable_kv_category, calculate_root_hash_toggle) {
   auto batch = db->getBatch();
 
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     update.kv["k"] = ImmutableValueUpdate{"v", {"t"}};
     const auto update_info = cat.add(1, std::move(update), batch);
@@ -104,7 +104,7 @@ TEST_F(immutable_kv_category, calculate_root_hash_toggle) {
   }
 
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = false;
     update.kv["k"] = ImmutableValueUpdate{"v", {"t"}};
     const auto update_info = cat.add(1, std::move(update), batch);
@@ -116,7 +116,7 @@ TEST_F(immutable_kv_category, non_existent_key) { ASSERT_FALSE(cat.getLatest("no
 
 TEST_F(immutable_kv_category, key_without_tags) {
   const auto block_id = 42;
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t2"}};
@@ -151,7 +151,7 @@ TEST_F(immutable_kv_category, key_without_tags) {
 }
 
 TEST_F(immutable_kv_category, one_tag_per_key) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t1"}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t2"}};
@@ -203,7 +203,7 @@ TEST_F(immutable_kv_category, one_tag_per_key) {
 }
 
 TEST_F(immutable_kv_category, two_tags_per_key) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t1", "t2"}};
 
@@ -244,7 +244,7 @@ TEST_F(immutable_kv_category, two_tags_per_key) {
 }
 
 TEST_F(immutable_kv_category, one_and_two_keys_per_tag) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t1", "t2"}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t1"}};
@@ -300,7 +300,7 @@ TEST_F(immutable_kv_category, one_and_two_keys_per_tag) {
 }
 
 TEST_F(immutable_kv_category, two_keys_per_tag) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t"}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t"}};
@@ -344,7 +344,7 @@ TEST_F(immutable_kv_category, two_keys_per_tag) {
 }
 
 TEST_F(immutable_kv_category, get_proof_multiple_keys) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t"}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t"}};
@@ -406,7 +406,7 @@ TEST_F(immutable_kv_category, get_proof_multiple_keys) {
 }
 
 TEST_F(immutable_kv_category, get_proof_multiple_tags) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t1", "t2"}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t1", "t2"}};
@@ -501,7 +501,7 @@ TEST_F(immutable_kv_category, get_proof_multiple_tags) {
 }
 
 TEST_F(immutable_kv_category, get_proof_single_key) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t"}};
 
@@ -527,7 +527,7 @@ TEST_F(immutable_kv_category, get_proof_single_key) {
 }
 
 TEST_F(immutable_kv_category, get_proof_key_not_tagged) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t1"}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t1"}};
@@ -541,7 +541,7 @@ TEST_F(immutable_kv_category, get_proof_key_not_tagged) {
 }
 
 TEST_F(immutable_kv_category, get_proof_non_existent_key) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k"] = ImmutableValueUpdate{"v", {"t"}};
 
@@ -552,7 +552,7 @@ TEST_F(immutable_kv_category, get_proof_non_existent_key) {
 }
 
 TEST_F(immutable_kv_category, delete_block) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k1"] = ImmutableValueUpdate{"v1", {"t"}};
   update.kv["k2"] = ImmutableValueUpdate{"v2", {"t"}};
@@ -573,7 +573,7 @@ TEST_F(immutable_kv_category, delete_block) {
 }
 
 TEST_F(immutable_kv_category, get_methods) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k"] = ImmutableValueUpdate{"v", {"t"}};
 
@@ -601,14 +601,14 @@ TEST_F(immutable_kv_category, get_methods) {
 }
 TEST_F(immutable_kv_category, multi_get_latest) {
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     update.kv["k1"] = ImmutableValueUpdate{"v1", {"t"}};
     add(1, std::move(update));
   }
 
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     update.kv["k2"] = ImmutableValueUpdate{"v2", {"t"}};
     add(2, std::move(update));
@@ -623,7 +623,7 @@ TEST_F(immutable_kv_category, multi_get_latest) {
 }
 
 TEST_F(immutable_kv_category, get_latest_version) {
-  auto update = ImmutableUpdatesData{};
+  auto update = ImmutableInput{};
   update.calculate_root_hash = true;
   update.kv["k"] = ImmutableValueUpdate{"v", {"t"}};
 
@@ -641,14 +641,14 @@ TEST_F(immutable_kv_category, get_latest_version) {
 
 TEST_F(immutable_kv_category, multi_get_latest_version) {
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     update.kv["k1"] = ImmutableValueUpdate{"v1", {"t"}};
     add(1, std::move(update));
   }
 
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     update.kv["k2"] = ImmutableValueUpdate{"v2", {"t"}};
     add(2, std::move(update));
@@ -663,14 +663,14 @@ TEST_F(immutable_kv_category, multi_get_latest_version) {
 
 TEST_F(immutable_kv_category, multi_get) {
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     update.kv["k1"] = ImmutableValueUpdate{"v1", {"t"}};
     add(1, std::move(update));
   }
 
   {
-    auto update = ImmutableUpdatesData{};
+    auto update = ImmutableInput{};
     update.calculate_root_hash = true;
     update.kv["k2"] = ImmutableValueUpdate{"v2", {"t"}};
     add(2, std::move(update));

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -43,7 +43,7 @@ class categorized_kvbc : public ::testing::Test {
 TEST_F(categorized_kvbc, merkle_update) {
   std::string key{"key"};
   std::string val{"val"};
-  MerkleUpdates mu;
+  BlockMerkleUpdates mu;
   mu.addUpdate(std::move(key), std::move(val));
   ASSERT_TRUE(mu.getData().kv.size() == 1);
 }
@@ -53,7 +53,7 @@ TEST_F(categorized_kvbc, add_blocks) {
   // Add block1
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key1", "merkle_value1");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -67,7 +67,7 @@ TEST_F(categorized_kvbc, add_blocks) {
   // Add block2
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key2", "merkle_value2");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -91,10 +91,10 @@ TEST_F(categorized_kvbc, add_blocks) {
     detail::Buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
     auto block1_from_db = Block::deserialize(in);
     auto merkle_variant = block1_from_db.data.categories_updates_info["merkle"];
-    auto merkle_update_info1 = std::get<MerkleUpdatesInfo>(merkle_variant);
+    auto merkle_update_info1 = std::get<BlockMerkleOutput>(merkle_variant);
     ASSERT_EQ(merkle_update_info1.keys["merkle_deleted"].deleted, true);
     auto kv_hash_variant = block1_from_db.data.categories_updates_info["kv_hash"];
-    auto kv_hash_update_info1 = std::get<KeyValueUpdatesInfo>(kv_hash_variant);
+    auto kv_hash_update_info1 = std::get<KeyValueOutput>(kv_hash_variant);
     ASSERT_EQ(kv_hash_update_info1.keys["kv_deleted"].deleted, true);
   }
   // get block 2 from DB and test it
@@ -107,7 +107,7 @@ TEST_F(categorized_kvbc, add_blocks) {
     auto block2_from_db = Block::deserialize(in);
     const auto expected_tags = std::vector<std::string>{"1", "2"};
     auto immutable_variant = block2_from_db.data.categories_updates_info["immutable"];
-    auto immutable_update_info2 = std::get<ImmutableUpdatesInfo>(immutable_variant);
+    auto immutable_update_info2 = std::get<ImmutableOutput>(immutable_variant);
     ASSERT_EQ(immutable_update_info2.tagged_keys["immutable_key2"], expected_tags);
   }
 }
@@ -117,7 +117,7 @@ TEST_F(categorized_kvbc, delete_block) {
   // Add block1
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key1", "merkle_value1");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -134,7 +134,7 @@ TEST_F(categorized_kvbc, delete_block) {
   // Add block2
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key2", "merkle_value2");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -153,7 +153,7 @@ TEST_F(categorized_kvbc, delete_block) {
   // Add block3
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key3", "merkle_value3");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -185,7 +185,7 @@ TEST_F(categorized_kvbc, delete_block) {
   // Add block4
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key4", "merkle_value4");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -233,7 +233,7 @@ TEST_F(categorized_kvbc, get_last_and_genesis_block) {
   // Add block1
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key1", "merkle_value1");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -247,7 +247,7 @@ TEST_F(categorized_kvbc, get_last_and_genesis_block) {
   // Add block2
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key2", "merkle_value2");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -271,7 +271,7 @@ TEST_F(categorized_kvbc, add_raw_block) {
   // Add block1
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key1", "merkle_value1");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -286,7 +286,7 @@ TEST_F(categorized_kvbc, add_raw_block) {
   // Add block2
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key2", "merkle_value2");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -346,7 +346,7 @@ TEST_F(categorized_kvbc, get_raw_block) {
   // Add block1
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key1", "merkle_value1");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -361,7 +361,7 @@ TEST_F(categorized_kvbc, get_raw_block) {
 
   {
     categorization::RawBlock rb;
-    MerkleUpdatesData merkle_updates;
+    BlockMerkleInput merkle_updates;
     merkle_updates.kv["merkle_key3"] = "merkle_value3";
     merkle_updates.deletes.push_back("merkle_deleted3");
     rb.data.updates.kv["merkle"] = merkle_updates;
@@ -375,13 +375,14 @@ TEST_F(categorized_kvbc, get_raw_block) {
 
   {
     auto rb = block_chain.getRawBlock(5);
-    ASSERT_EQ(std::get<MerkleUpdatesData>(rb.data.updates.kv["merkle"]).kv["merkle_key3"], "merkle_value3");
+    ASSERT_EQ(std::get<BlockMerkleInput>(rb.data.updates.kv["merkle"]).kv["merkle_key3"], "merkle_value3");
   }
 
   // E.L not yet possible
   // {
   //   auto rb = block_chain.getRawBlock(1);
-  //   ASSERT_EQ(std::get<MerkleUpdatesData>(rb.data.category_updates["merkle"]).kv["merkle_key1"], "merkle_value1");
+  //   ASSERT_EQ(std::get<BlockMerkleInput>(rb.data.category_updates["merkle"]).kv["merkle_key1"],
+  //   "merkle_value1");
   // }
 
   { ASSERT_THROW(block_chain.getRawBlock(0), std::runtime_error); }
@@ -396,7 +397,7 @@ TEST_F(categorized_kvbc, link_state_transfer_chain) {
   // Add block1
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key1", "merkle_value1");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -411,7 +412,7 @@ TEST_F(categorized_kvbc, link_state_transfer_chain) {
   // Add block2
   {
     Updates updates;
-    MerkleUpdates merkle_updates;
+    BlockMerkleUpdates merkle_updates;
     merkle_updates.addUpdate("merkle_key2", "merkle_value2");
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
@@ -464,7 +465,7 @@ TEST_F(categorized_kvbc, link_state_transfer_chain) {
   // Link the chains
   {
     categorization::RawBlock rb;
-    MerkleUpdatesData merkle_updates;
+    BlockMerkleInput merkle_updates;
     merkle_updates.kv["merkle_key3"] = "merkle_value3";
     merkle_updates.deletes.push_back("merkle_deleted3");
     rb.data.updates.kv["merkle"] = merkle_updates;
@@ -500,18 +501,18 @@ TEST_F(categorized_kvbc, instantiation_of_categories) {
   auto cats = tester.getCategories(block_chain);
   ASSERT_EQ(cats.count("merkle"), 1);
   ASSERT_THROW(std::get<KVHashCategory>(cats["merkle"]), std::bad_variant_access);
-  ASSERT_NO_THROW(std::get<MerkleCategory>(cats["merkle"]));
+  ASSERT_NO_THROW(std::get<BlockMerkleCategory>(cats["merkle"]));
 
   ASSERT_EQ(cats.count("merkle2"), 1);
   ASSERT_THROW(std::get<KVHashCategory>(cats["merkle2"]), std::bad_variant_access);
-  ASSERT_NO_THROW(std::get<MerkleCategory>(cats["merkle2"]));
+  ASSERT_NO_THROW(std::get<BlockMerkleCategory>(cats["merkle2"]));
 
   ASSERT_EQ(cats.count("imm"), 1);
   ASSERT_THROW(std::get<KVHashCategory>(cats["imm"]), std::bad_variant_access);
   ASSERT_NO_THROW(std::get<detail::ImmutableKeyValueCategory>(cats["imm"]));
 
   ASSERT_EQ(cats.count("kvhash"), 1);
-  ASSERT_THROW(std::get<MerkleCategory>(cats["kvhash"]), std::bad_variant_access);
+  ASSERT_THROW(std::get<BlockMerkleCategory>(cats["kvhash"]), std::bad_variant_access);
   ASSERT_NO_THROW(std::get<KVHashCategory>(cats["kvhash"]));
 }
 
@@ -541,7 +542,7 @@ TEST_F(categorized_kvbc, get_category) {
   db->write(std::move(wb));
   KeyValueBlockchain block_chain{db, true};
   KeyValueBlockchain::KeyValueBlockchain_tester tester;
-  ASSERT_NO_THROW(std::get<MerkleCategory>(tester.getCategory("merkle", block_chain)));
+  ASSERT_NO_THROW(std::get<BlockMerkleCategory>(tester.getCategory("merkle", block_chain)));
 }
 
 // E.L temporary imp till categories are wired
@@ -561,7 +562,7 @@ TEST_F(categorized_kvbc, get_block_data) {
   auto value = std::string("val");
 
   uint64_t state_root_version = 886;
-  MerkleUpdatesInfo mui;
+  BlockMerkleOutput mui;
   mui.keys[key] = MerkleKeyFlag{false};
   mui.root_hash = pHash;
   mui.state_root_version = state_root_version;
@@ -592,7 +593,7 @@ TEST_F(categorized_kvbc, get_block_data) {
   ASSERT_THROW(block_chain.getBlockData(887), std::runtime_error);
   auto updates = block_chain.getBlockData(888);
   auto variant = updates.kv[cf];
-  auto merkle_updates = std::get<MerkleUpdatesData>(variant);
+  auto merkle_updates = std::get<BlockMerkleInput>(variant);
   // check reconstruction of original kv
   ASSERT_EQ(merkle_updates.kv[key], value);
 }
@@ -629,8 +630,8 @@ TEST_F(categorized_kvbc, compare_raw_blocks) {
   ASSERT_EQ(last_raw.first, 1);
   ASSERT_TRUE(last_raw.second.has_value());
   auto raw_from_api = block_chain.getRawBlock(1);
-  auto last_raw_imm_data = std::get<ImmutableUpdatesData>(last_raw.second.value().data.updates.kv["imm"]);
-  auto raw_from_api_imm_data = std::get<ImmutableUpdatesData>(raw_from_api.data.updates.kv["imm"]);
+  auto last_raw_imm_data = std::get<ImmutableInput>(last_raw.second.value().data.updates.kv["imm"]);
+  auto raw_from_api_imm_data = std::get<ImmutableInput>(raw_from_api.data.updates.kv["imm"]);
   std::vector<std::string> vec{"0", "1"};
   ASSERT_EQ(last_raw_imm_data.kv["key"].data, "val");
   ASSERT_EQ(last_raw_imm_data.kv["key"].tags, vec);


### PR DESCRIPTION
The block merkle category operates by only storing a single key in the
sparse merkle tree per block. The key is the block id, and the value is
the hash of the concatenation of the hashes of all the keys and values
(including deleted keys), that were updated in the merkle tree for the
given block.

Direct lookup is enabled by versioned key lookup on hashed values.
Values can be looked up directly if the block id is known for the value,
or the latest value can be retrieved. MultiGet is also supported. In
order to avoid the computational overhead of RocksDB seeks, point
lookups of the latest value are done by maintaining an index for the
latst block id of each key in a separate column family.

Unit tests were added that mainly verify the behavior required by direct
gets and puts.

A follow up commit will add support for deletes and pruning behavior.
Unit tests will be added for this behavior, and to cover the block
merkle nodes and hashes appropriately.

Lastly, category type suffixes were changed from *UpdatesData* and
*UpdatesInfo* to *Input* and *Output*, respectively.