### PR TITLE
Introduce the VersionedKeyValueCategory

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library(kvbc  src/ClientImp.cpp
 
 if (BUILD_ROCKSDB_STORAGE)
     target_sources(kvbc PRIVATE src/categorization/immutable_kv_category.cpp
-                                src/categorization/kv_blockchain.cpp
+                                src/categorization/versioned_kv_category.cpp
+                                src/categorization/kv_blockchain.cpp 
                                 src/categorization/blocks.cpp
                                 src/categorization/blockchain.cpp
                                 src/categorization/block_merkle_category.cpp)

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -5,14 +5,13 @@ Msg BlockMerkleInput 1 {
     list string deletes
 }
 
-Msg ValueWithExpirationData 2 {
-    string value
-    optional int64 expire_at
+Msg ValueWithFlags 2 {
+    string data
     bool stale_on_update
 }
 
-Msg KeyValueInput 3 {
-    map string ValueWithExpirationData kv
+Msg VersionedInput 3 {
+    map string ValueWithFlags kv
     list string deletes
     bool calculate_root_hash
 }
@@ -31,7 +30,7 @@ Msg ImmutableInput 5 {
 Msg CategoryInput 6 {
     map string oneof{
         BlockMerkleInput
-        KeyValueInput
+        VersionedInput
         ImmutableInput
     } kv
 }
@@ -48,14 +47,13 @@ Msg BlockMerkleOutput 1001 {
     uint64 state_root_version
 }
 
-Msg KVKeyFlag 1002 {
-
+Msg VersionedKeyFlags 1002 {
     bool deleted
     bool stale_on_update
 }
 
-Msg KeyValueOutput 1003 {
-    map string KVKeyFlag keys
+Msg VersionedOutput 1003 {
+    map string VersionedKeyFlags keys
     optional fixedlist uint8 32 root_hash
 }
 
@@ -76,11 +74,10 @@ Msg BlockData 2001 {
     fixedlist uint8 32 parent_digest
     map string oneof{
         BlockMerkleOutput
-        KeyValueOutput
+        VersionedOutput
         ImmutableOutput
     } categories_updates_info
 }
-
 
 Msg RawBlockData 2005 {
     fixedlist uint8 32 parent_digest
@@ -98,22 +95,37 @@ Msg BenchmarkMessage 3000 {
 
 # DB Key-Values
 
-Msg KeyHash 4000 {
+# An index to the latest version of a key.
+# The high-bit being set indicates whether or not the last update was a delete, i.e. a tombstone.
+Msg LatestKeyVersion 4000 {
+    uint64 block_id
+}
+
+Msg KeyHash 4001 {
     fixedlist uint8 32 value
 }
 
-Msg VersionedKey 4001 {
+Msg VersionedKey 4002 {
+    # Exploit big-endian integer serialization to order different versions
+    # of the key by version.
     KeyHash key_hash
     uint64 version
 }
 
-Msg ImmutableDbValue 4002 {
+Msg VersionedRawKey 4003 {
+    # Exploit CMF string and big-endian integer serialization to order keys
+    # by size, key and version.
+    string value
+    uint64 version
+}
+
+Msg ImmutableDbValue 4004 {
     uint64 block_id
     string data
 }
 
 # Used to deserialize the version only from an ImmutableDbValue.
-Msg ImmutableDbVersion 4003 {
+Msg ImmutableDbVersion 4005 {
     uint64 block_id
 }
 
@@ -159,9 +171,19 @@ Msg BatchedInternalNode 5006 {
     list BatchedInternalNodeChild children
 }
 
-# An index to the latest version of a key.
-#
-# The high-bit being set indicates whether or not the last update was a delete, i.e. a tombstone.
-Msg LatestKeyVersion 5009 {
-    uint64 block_id
+# Versioned category
+
+Msg Tombstone 6000 {
+    bool dummy
+}
+
+Msg DbValue 6001 {
+    string data
+}
+
+Msg VersionedDbValue 6002 {
+    oneof {
+        Tombstone
+        DbValue
+    } data
 }

--- a/kvbc/include/categorization/blockchain.h
+++ b/kvbc/include/categorization/blockchain.h
@@ -22,6 +22,7 @@ class Blockchain {
  public:
   static constexpr auto MAX_BLOCK_ID = std::numeric_limits<BlockId>::max();
   static constexpr auto INITIAL_GENESIS_BLOCK_ID = BlockId{1};
+  static constexpr auto INVALID_BLOCK_ID = BlockId{0};
 
   Blockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client);
 

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -45,7 +45,7 @@ struct Block {
     data.categories_updates_info.emplace(category_id, std::move(updates_info));
   }
 
-  void add(const std::string& category_id, KeyValueOutput&& updates_info) {
+  void add(const std::string& category_id, VersionedOutput&& updates_info) {
     data.categories_updates_info.emplace(category_id, std::move(updates_info));
   }
 
@@ -94,10 +94,10 @@ struct RawBlock {
                               const BlockId& block_id,
                               const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
-  KeyValueInput getUpdates(const std::string& category_id,
-                           const KeyValueOutput& update_info,
-                           const BlockId& block_id,
-                           const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+  VersionedInput getUpdates(const std::string& category_id,
+                            const VersionedOutput& update_info,
+                            const BlockId& block_id,
+                            const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
 
   ImmutableInput getUpdates(const std::string& category_id,
                             const ImmutableOutput& update_info,

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -19,6 +19,9 @@ namespace concord::kvbc::categorization::detail {
 
 inline const auto IMMUTABLE_KV_CF_SUFFIX = std::string{"_immutable"};
 
+inline const auto VERSIONED_KV_VALUES_CF_SUFFIX = std::string{"_ver_values"};
+inline const auto VERSIONED_KV_LATEST_VER_CF_SUFFIX = std::string{"_ver_latest"};
+
 inline const auto BLOCKS_CF = std::string{"blocks"};
 inline const auto ST_CHAIN_CF = std::string{"st_chain"};
 

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -38,6 +38,10 @@ inline VersionedKey versionedKey(const std::string &key, BlockId block_id) {
   return VersionedKey{KeyHash{detail::hash(key)}, block_id};
 }
 
+inline VersionedKey versionedKey(const Hash &key_hash, BlockId block_id) {
+  return VersionedKey{KeyHash{key_hash}, block_id};
+}
+
 template <typename T>
 const Buffer &serialize(const T &value) {
   static thread_local auto buf = Buffer{};

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -19,9 +19,6 @@
 #include "base_types.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
 
-#include <rocksdb/slice.h>
-#include <rocksdb/status.h>
-
 #include <memory>
 #include <optional>
 #include <string>
@@ -40,6 +37,8 @@ namespace concord::kvbc::categorization::detail {
 // is defined as:
 //   root_hash = h(h(k1) || h(v1) || h(k2) || h(v2) || ... || h(kn) || h(vn))
 // A proof for some key per tag is just the hashes of all the other keys and values with the same tag.
+//
+// There is an option to turn off proofs (root hash calculation) per block.
 class ImmutableKeyValueCategory {
  public:
   ImmutableKeyValueCategory() = default;  // for testing only

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -110,7 +110,7 @@ class KeyValueBlockchain {
 
   void deleteGenesisBlock(BlockId block_id,
                           const std::string& category_id,
-                          const KeyValueOutput& updates_info,
+                          const VersionedOutput& updates_info,
                           storage::rocksdb::NativeWriteBatch&);
 
   void deleteGenesisBlock(BlockId block_id,
@@ -125,7 +125,7 @@ class KeyValueBlockchain {
 
   void deleteLastReachableBlock(BlockId block_id,
                                 const std::string& category_id,
-                                const KeyValueOutput& updates_info,
+                                const VersionedOutput& updates_info,
                                 storage::rocksdb::NativeWriteBatch&);
 
   void deleteLastReachableBlock(BlockId block_id,
@@ -142,11 +142,11 @@ class KeyValueBlockchain {
                                           concord::storage::rocksdb::NativeWriteBatch& write_batch,
                                           categorization::RawBlock& raw_block);
 
-  KeyValueOutput handleCategoryUpdates(BlockId block_id,
-                                       const std::string& category_id,
-                                       KeyValueInput&& updates,
-                                       concord::storage::rocksdb::NativeWriteBatch& write_batch,
-                                       categorization::RawBlock& raw_block);
+  VersionedOutput handleCategoryUpdates(BlockId block_id,
+                                        const std::string& category_id,
+                                        VersionedInput&& updates,
+                                        concord::storage::rocksdb::NativeWriteBatch& write_batch,
+                                        categorization::RawBlock& raw_block);
   ImmutableOutput handleCategoryUpdates(BlockId block_id,
                                         const std::string& category_id,
                                         ImmutableInput&& updates,

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -1,0 +1,115 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+
+#include "base_types.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace concord::kvbc::categorization::detail {
+
+// VersionedKeyValueCategory stores versioned keys directly in RocksDB. Explicit key deletions and marking
+// keys stale immediately on update are supported.
+//
+// Keys are stored as is, without being hashed.
+//
+// Proofs for keys in a block are supported in the form of a root hash that is defined as:
+//   root_hash = h(h(k1) || h(v1) || h(k2) || h(v2) || ... || h(kn) || h(vn))
+// A proof for some key in a block is just the hashes of all the other keys and values in the block.
+//
+// There is an option to turn off proofs (root hash calculation) per block.
+class VersionedKeyValueCategory {
+ public:
+  VersionedKeyValueCategory() = default;  // for testing only
+  VersionedKeyValueCategory(const std::string &category_id, const std::shared_ptr<storage::rocksdb::NativeClient> &);
+
+  VersionedOutput add(BlockId, VersionedInput &&, storage::rocksdb::NativeWriteBatch &);
+
+  // Delete the given block ID as a genesis one.
+  // Precondition: The given block ID must be the genesis one.
+  void deleteGenesisBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
+
+  // Delete the given block ID as a last reachable one.
+  // Precondition: The given block ID must be the last reachable one.
+  void deleteLastReachableBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
+
+  // Get the value of a versioned key in `block_id`.
+  // Return std::nullopt if `key` doesn't exist in `block_id`.
+  std::optional<Value> get(const std::string &key, BlockId block_id) const;
+
+  // Get the latest value of `key`.
+  // Return std::nullopt if the key doesn't exist.
+  std::optional<Value> getLatest(const std::string &key) const;
+
+  // Get values for keys at specific versions.
+  // `keys` and `versions` must be the same size.
+  // If a key is missing at the specified version, std::nullopt is returned for it.
+  void multiGet(const std::vector<std::string> &keys,
+                const std::vector<BlockId> &versions,
+                std::vector<std::optional<Value>> &values) const;
+
+  // Get the latest values of a list of keys.
+  // If a key is missing, std::nullopt is returned for it.
+  void multiGetLatest(const std::vector<std::string> &keys, std::vector<std::optional<Value>> &values) const;
+
+  // Get the latest version of `key`.
+  // Return std::nullopt if the key doesn't exist.
+  std::optional<BlockId> getLatestVersion(const std::string &key) const;
+
+  // Get the latest versions of the given keys.
+  // If a key is missing, std::nullopt is returned for its version.
+  void multiGetLatestVersion(const std::vector<std::string> &keys, std::vector<std::optional<BlockId>> &versions) const;
+
+  // Get the value of `key` and a proof for it at `block_id`.
+  // Return std::nullopt if the key doesn't exist.
+  std::optional<KeyValueProof> getProof(BlockId block_id, const std::string &key, const VersionedOutput &) const;
+
+ private:
+  void addDeletes(BlockId, std::vector<std::string> &&keys, VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
+
+  void addUpdates(BlockId,
+                  bool calculate_root_hash,
+                  std::map<std::string, ValueWithFlags> &&,
+                  VersionedOutput &,
+                  storage::rocksdb::NativeWriteBatch &);
+
+  void updateLatestKeyVersion(const std::string &key, BlockId version, storage::rocksdb::NativeWriteBatch &);
+
+  void putValue(const VersionedRawKey &, const VersionedDbValue &, storage::rocksdb::NativeWriteBatch &);
+
+  void addKeyToUpdateInfo(std::string &&key, bool deleted, bool stale_on_update, VersionedOutput &);
+
+ private:
+  std::string values_cf_;
+  std::string latest_ver_cf_;
+  std::shared_ptr<storage::rocksdb::NativeClient> db_;
+};
+
+inline const VersionedValue &asVersioned(const Value &v) { return std::get<VersionedValue>(v); }
+inline VersionedValue &asVersioned(Value &v) { return std::get<VersionedValue>(v); }
+
+// Optional overloads assume the optional contains a value.
+inline const VersionedValue &asVersioned(const std::optional<Value> &v) { return asVersioned(*v); }
+inline VersionedValue &asVersioned(std::optional<Value> &v) { return asVersioned(*v); }
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/src/categorization/blocks.cpp
+++ b/kvbc/src/categorization/blocks.cpp
@@ -71,12 +71,12 @@ BlockMerkleInput RawBlock::getUpdates(const std::string& category_id,
   return data;
 }
 
-// KeyValueUpdatesData updates reconstruction
-KeyValueInput RawBlock::getUpdates(const std::string& category_id,
-                                   const KeyValueOutput& update_info,
-                                   const BlockId& block_id,
-                                   const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
-  KeyValueInput data;
+// VersionedInput reconstruction
+VersionedInput RawBlock::getUpdates(const std::string& category_id,
+                                    const VersionedOutput& update_info,
+                                    const BlockId& block_id,
+                                    const std::shared_ptr<storage::rocksdb::NativeClient>& native_client) {
+  VersionedInput data;
 
   return data;
 }

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -17,6 +17,9 @@
 #include "categorization/column_families.h"
 #include "categorization/details.h"
 
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
+
 #include <algorithm>
 #include <map>
 #include <stdexcept>

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -362,7 +362,7 @@ void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
 
 void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
-                                            const KeyValueOutput& updates_info,
+                                            const VersionedOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch&) {}
 
 void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
@@ -377,7 +377,7 @@ void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
 
 void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
                                                   const std::string& category_id,
-                                                  const KeyValueOutput& updates_info,
+                                                  const VersionedOutput& updates_info,
                                                   storage::rocksdb::NativeWriteBatch&) {}
 
 void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
@@ -429,20 +429,20 @@ BlockMerkleOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
   return mui;
 }
 
-KeyValueOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
-                                                         const std::string& category_id,
-                                                         KeyValueInput&& updates,
-                                                         concord::storage::rocksdb::NativeWriteBatch& write_batch,
-                                                         categorization::RawBlock& raw_block) {
-  KeyValueOutput kvui;
+VersionedOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
+                                                          const std::string& category_id,
+                                                          VersionedInput&& updates,
+                                                          concord::storage::rocksdb::NativeWriteBatch& write_batch,
+                                                          categorization::RawBlock& raw_block) {
+  VersionedOutput out;
   for (auto& [k, v] : updates.kv) {
     (void)v;
-    kvui.keys[k] = KVKeyFlag{false, v.stale_on_update};
+    out.keys[k] = VersionedKeyFlags{false, v.stale_on_update};
   }
   for (auto& k : updates.deletes) {
-    kvui.keys[k] = KVKeyFlag{true, false};
+    out.keys[k] = VersionedKeyFlags{true, false};
   }
-  return kvui;
+  return out;
 }
 
 ImmutableOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -1,0 +1,347 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "categorization/versioned_kv_category.h"
+
+#include "assertUtils.hpp"
+#include "categorization/blockchain.h"
+#include "categorization/column_families.h"
+#include "categorization/details.h"
+
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
+
+#include <utility>
+#include <variant>
+
+namespace concord::kvbc::categorization::detail {
+
+using namespace std::literals;
+
+template <typename Span>
+std::optional<std::string> value(const Span &ser) {
+  auto db_value = VersionedDbValue{};
+  deserialize(ser, db_value);
+  if (!std::holds_alternative<DbValue>(db_value.data)) {
+    return std::nullopt;
+  }
+  return std::get<DbValue>(std::move(db_value.data)).data;
+}
+
+template <typename Span>
+BlockId latestVersion(const Span &ser) {
+  auto latest_version = LatestKeyVersion{};
+  deserialize(ser, latest_version);
+  return latest_version.block_id;
+}
+
+VersionedKeyValueCategory::VersionedKeyValueCategory(const std::string &category_id,
+                                                     const std::shared_ptr<storage::rocksdb::NativeClient> &db)
+    : values_cf_{category_id + VERSIONED_KV_VALUES_CF_SUFFIX},
+      latest_ver_cf_{category_id + VERSIONED_KV_LATEST_VER_CF_SUFFIX},
+      db_{db} {
+  createColumnFamilyIfNotExisting(values_cf_, *db_);
+  createColumnFamilyIfNotExisting(latest_ver_cf_, *db_);
+}
+
+VersionedOutput VersionedKeyValueCategory::add(BlockId block_id,
+                                               VersionedInput &&in,
+                                               storage::rocksdb::NativeWriteBatch &batch) {
+  auto out = VersionedOutput{};
+  addDeletes(block_id, std::move(in.deletes), out, batch);
+  addUpdates(block_id, in.calculate_root_hash, std::move(in.kv), out, batch);
+  return out;
+}
+
+void VersionedKeyValueCategory::addDeletes(BlockId block_id,
+                                           std::vector<std::string> &&keys,
+                                           VersionedOutput &out,
+                                           storage::rocksdb::NativeWriteBatch &batch) {
+  const auto deleted = true;
+  const auto stale_on_update = false;
+  for (auto &&key : keys) {
+    auto versioned_key = VersionedRawKey{std::move(key), block_id};
+
+    updateLatestKeyVersion(versioned_key.value, block_id, batch);
+
+    putValue(versioned_key, VersionedDbValue{Tombstone{}}, batch);
+
+    addKeyToUpdateInfo(std::move(versioned_key.value), deleted, stale_on_update, out);
+  }
+}
+
+void updateRootHash(const std::string &key, const std::string &value, Hasher &hasher) {
+  const auto key_hash = hash(key);
+  const auto value_hash = hash(value);
+  hasher.update(key_hash.data(), key_hash.size());
+  hasher.update(value_hash.data(), value_hash.size());
+}
+
+void VersionedKeyValueCategory::addUpdates(BlockId block_id,
+                                           bool calculate_root_hash,
+                                           std::map<std::string, ValueWithFlags> &&updates,
+                                           VersionedOutput &out,
+                                           storage::rocksdb::NativeWriteBatch &batch) {
+  if (updates.empty()) {
+    return;
+  }
+
+  auto hasher = Hasher{};
+  hasher.init();
+  const auto deleted = false;
+  for (auto it = updates.begin(); it != updates.end();) {
+    // Save the iterator as extract() invalidates it.
+    auto extracted_it = it;
+    ++it;
+    auto node = updates.extract(extracted_it);
+    auto &key = node.key();
+    auto &value = node.mapped();
+
+    if (calculate_root_hash) {
+      updateRootHash(key, value.data, hasher);
+    }
+
+    auto versioned_key = VersionedRawKey{std::move(key), block_id};
+
+    updateLatestKeyVersion(versioned_key.value, block_id, batch);
+
+    putValue(versioned_key, VersionedDbValue{DbValue{std::move(value.data)}}, batch);
+
+    addKeyToUpdateInfo(std::move(versioned_key.value), deleted, value.stale_on_update, out);
+  }
+
+  if (calculate_root_hash) {
+    out.root_hash = hasher.finish();
+  }
+}
+
+void VersionedKeyValueCategory::updateLatestKeyVersion(const std::string &key,
+                                                       BlockId version,
+                                                       storage::rocksdb::NativeWriteBatch &batch) {
+  batch.put(latest_ver_cf_, key, serialize(LatestKeyVersion{version}));
+}
+
+void VersionedKeyValueCategory::putValue(const VersionedRawKey &key,
+                                         const VersionedDbValue &value,
+                                         storage::rocksdb::NativeWriteBatch &batch) {
+  batch.put(values_cf_, serialize(key), serialize(value));
+}
+
+void VersionedKeyValueCategory::addKeyToUpdateInfo(std::string &&key,
+                                                   bool deleted,
+                                                   bool stale_on_update,
+                                                   VersionedOutput &out) {
+  out.keys.emplace(std::move(key), VersionedKeyFlags{deleted, stale_on_update});
+}
+
+void VersionedKeyValueCategory::deleteGenesisBlock(BlockId block_id,
+                                                   const VersionedOutput &out,
+                                                   storage::rocksdb::NativeWriteBatch &batch) {
+  for (const auto &[key, flags] : out.keys) {
+    const auto latest_version = getLatestVersion(key);
+    ConcordAssert(latest_version.has_value());
+    if (flags.stale_on_update) {
+      // This key is marked stale-on-update and, therefore, we can remove its value at `block_id`.
+      batch.del(values_cf_, serialize(VersionedRawKey{key, block_id}));
+
+      // If there are no new versions of a key that was marked as stale-on-update at `block_id`, remove the versions
+      // index too.
+      if (*latest_version == block_id) {
+        batch.del(latest_ver_cf_, key);
+      }
+    } else if (*latest_version > block_id) {
+      // If this key is stale as of `block_id` (meaning it has a newer version), we can remove its value at `block_id`.
+      batch.del(values_cf_, serialize(VersionedRawKey{key, block_id}));
+    }
+  }
+}
+
+void VersionedKeyValueCategory::deleteLastReachableBlock(BlockId block_id,
+                                                         const VersionedOutput &out,
+                                                         storage::rocksdb::NativeWriteBatch &batch) {
+  for (const auto &[key, _] : out.keys) {
+    (void)_;
+    const auto versioned_key = serialize(VersionedRawKey{key, block_id});
+
+    // Find the previous version of the key and set it as a last version. Exploit the fact that CMF
+    // serializes strings prefixed by their length (in big-endian). Therefore, VersionedRawKeys will be ordered by key
+    // size, key and version. If not found, then this is the only version of the key and we can remove the latest
+    // version index too.
+    auto iter = db_->getIterator(values_cf_);
+    iter.seekAtMost(versioned_key);
+    ConcordAssert(iter);
+    iter.prev();
+    if (iter) {
+      auto prev_key = VersionedRawKey{};
+      deserialize(iter.keyView(), prev_key);
+      if (prev_key.value == key) {
+        updateLatestKeyVersion(key, prev_key.version, batch);
+      } else {
+        // This is the only version of the key - remove the latest version index too.
+        batch.del(latest_ver_cf_, key);
+      }
+    } else {
+      // No previous keys means this is the only version of the key - remove the latest version index too.
+      batch.del(latest_ver_cf_, key);
+    }
+
+    // Remove the value for the key at `block_id`.
+    batch.del(values_cf_, versioned_key);
+  }
+}
+
+std::optional<Value> VersionedKeyValueCategory::get(const std::string &key, BlockId block_id) const {
+  const auto ser = db_->getSlice(values_cf_, serialize(VersionedRawKey{key, block_id}));
+  if (!ser) {
+    return std::nullopt;
+  }
+  auto v = value(*ser);
+  if (!v) {
+    return std::nullopt;
+  }
+  return VersionedValue{{block_id, *std::move(v)}};
+}
+
+std::optional<Value> VersionedKeyValueCategory::getLatest(const std::string &key) const {
+  const auto latest_version = getLatestVersion(key);
+  if (!latest_version) {
+    return std::nullopt;
+  }
+  return get(key, *latest_version);
+}
+
+void VersionedKeyValueCategory::multiGet(const std::vector<std::string> &keys,
+                                         const std::vector<BlockId> &versions,
+                                         std::vector<std::optional<Value>> &values) const {
+  ConcordAssertEQ(keys.size(), versions.size());
+
+  auto slices = std::vector<::rocksdb::PinnableSlice>{};
+  auto statuses = std::vector<::rocksdb::Status>{};
+  auto versioned_keys = std::vector<std::vector<std::uint8_t>>{};
+  versioned_keys.reserve(keys.size());
+
+  for (auto i = 0ull; i < keys.size(); ++i) {
+    versioned_keys.push_back(serialize(VersionedRawKey{keys[i], versions[i]}));
+  }
+
+  db_->multiGet(values_cf_, versioned_keys, slices, statuses);
+
+  values.clear();
+  for (auto i = 0ull; i < slices.size(); ++i) {
+    const auto &status = statuses[i];
+    const auto &slice = slices[i];
+    const auto version = versions[i];
+    if (status.ok()) {
+      auto v = value(slice);
+      if (v) {
+        values.push_back(VersionedValue{{version, *std::move(v)}});
+      } else {
+        values.push_back(std::nullopt);
+      }
+    } else if (status.IsNotFound()) {
+      values.push_back(std::nullopt);
+    } else {
+      throw std::runtime_error{"VersionedKeyValueCategory multiGet() failure: " + status.ToString()};
+    }
+  }
+}
+
+void VersionedKeyValueCategory::multiGetLatest(const std::vector<std::string> &keys,
+                                               std::vector<std::optional<Value>> &values) const {
+  auto versions = std::vector<BlockId>{};
+  versions.reserve(keys.size());
+  auto slices = std::vector<::rocksdb::PinnableSlice>{};
+  auto statuses = std::vector<::rocksdb::Status>{};
+  db_->multiGet(latest_ver_cf_, keys, slices, statuses);
+  for (auto i = 0ull; i < slices.size(); ++i) {
+    const auto &status = statuses[i];
+    const auto &slice = slices[i];
+    if (status.ok()) {
+      versions.push_back(latestVersion(slice));
+    } else if (status.IsNotFound()) {
+      versions.push_back(Blockchain::INVALID_BLOCK_ID);
+    } else {
+      throw std::runtime_error{"VersionedKeyValueCategory multiGetLatest() failure: " + status.ToString()};
+    }
+  }
+  multiGet(keys, versions, values);
+}
+
+std::optional<BlockId> VersionedKeyValueCategory::getLatestVersion(const std::string &key) const {
+  const auto ser = db_->getSlice(latest_ver_cf_, key);
+  if (!ser) {
+    return std::nullopt;
+  }
+  return latestVersion(*ser);
+}
+
+void VersionedKeyValueCategory::multiGetLatestVersion(const std::vector<std::string> &keys,
+                                                      std::vector<std::optional<BlockId>> &versions) const {
+  auto slices = std::vector<::rocksdb::PinnableSlice>{};
+  auto statuses = std::vector<::rocksdb::Status>{};
+  db_->multiGet(latest_ver_cf_, keys, slices, statuses);
+  for (auto i = 0ull; i < slices.size(); ++i) {
+    const auto &status = statuses[i];
+    const auto &slice = slices[i];
+    if (status.ok()) {
+      versions.push_back(latestVersion(slice));
+    } else if (status.IsNotFound()) {
+      versions.push_back(std::nullopt);
+    } else {
+      throw std::runtime_error{"VersionedKeyValueCategory multiGetLatestVersion() failure: " + status.ToString()};
+    }
+  }
+}
+
+std::optional<KeyValueProof> VersionedKeyValueCategory::getProof(BlockId block_id,
+                                                                 const std::string &key,
+                                                                 const VersionedOutput &out) const {
+  // If the key is not part of this block, return a null proof.
+  auto key_it = out.keys.find(key);
+  if (key_it == out.keys.cend()) {
+    return std::nullopt;
+  }
+
+  auto value = get(key, block_id);
+  if (!value) {
+    return std::nullopt;
+  }
+  auto &ver_value = asVersioned(value);
+
+  auto proof = KeyValueProof{};
+  proof.block_id = ver_value.block_id;
+  proof.key = key;
+  proof.value = std::move(ver_value.data);
+
+  auto i = std::size_t{0};
+  for (const auto &[update_key, _] : out.keys) {
+    (void)_;
+    if (update_key == key) {
+      proof.key_value_index = i;
+      continue;
+    }
+
+    const auto update_value = get(update_key, block_id);
+    ConcordAssert(update_value.has_value());
+
+    proof.ordered_complement_kv_hashes.push_back(hash(update_key));
+    proof.ordered_complement_kv_hashes.push_back(hash(asVersioned(update_value).data));
+
+    // Increment by 2 as we push 2 hashes - one of the key and one of the value.
+    i += 2;
+  }
+
+  return proof;
+}
+
+}  // namespace concord::kvbc::categorization::detail

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -200,4 +200,15 @@ if (BUILD_ROCKSDB_STORAGE)
         kvbc
         stdc++fs
     )
+
+    add_executable(versioned_kv_category_unit_test categorization/versioned_kv_category_unit_test.cpp )
+    add_test(versioned_kv_category_unit_test versioned_kv_category_unit_test)
+    target_link_libraries(versioned_kv_category_unit_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        corebft
+        kvbc
+        stdc++fs
+    )
 endif (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -53,20 +53,20 @@ TEST_F(categorized_kvbc, serialization_and_desirialization_of_block) {
     pHash[i] = (uint8_t)(rd() % 255);
   }
   Block block{8};
-  KeyValueOutput kvui;
-  kvui.keys["key1"] = {false, false};
-  kvui.keys["key2"] = {true, false};
-  block.add("KeyValueOutput", std::move(kvui));
+  VersionedOutput out;
+  out.keys["key1"] = {false, false};
+  out.keys["key2"] = {true, false};
+  block.add("VersionedOutput", std::move(out));
   block.setParentHash(pHash);
   auto ser = Block::serialize(block);
   auto des_block = Block::deserialize(ser);
 
   // Test the deserialized Block
   ASSERT_TRUE(des_block.id() == 8);
-  auto variant = des_block.data.categories_updates_info["KeyValueOutput"];
-  KeyValueOutput kv_updates_info = std::get<KeyValueOutput>(variant);
-  ASSERT_TRUE(kv_updates_info.keys.size() == 2);
-  ASSERT_TRUE(kv_updates_info.keys["key2"].deleted == true);
+  auto variant = des_block.data.categories_updates_info["VersionedOutput"];
+  VersionedOutput ver_out = std::get<VersionedOutput>(variant);
+  ASSERT_TRUE(ver_out.keys.size() == 2);
+  ASSERT_TRUE(ver_out.keys["key2"].deleted == true);
   ASSERT_EQ(des_block.data.parent_digest, block.data.parent_digest);
 }
 

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -58,10 +58,10 @@ TEST_F(categorized_kvbc, add_blocks) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key1", "key_val1");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key1", "ver_val1");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("versioned", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
   }
   // Add block2
@@ -72,10 +72,10 @@ TEST_F(categorized_kvbc, add_blocks) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key2", "key_val2");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key2", "ver_val2");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("versioned", std::move(ver_updates));
 
     ImmutableUpdates immutable_updates;
     immutable_updates.addUpdate("immutable_key2", {"immutable_val2", {"1", "2"}});
@@ -93,9 +93,9 @@ TEST_F(categorized_kvbc, add_blocks) {
     auto merkle_variant = block1_from_db.data.categories_updates_info["merkle"];
     auto merkle_update_info1 = std::get<BlockMerkleOutput>(merkle_variant);
     ASSERT_EQ(merkle_update_info1.keys["merkle_deleted"].deleted, true);
-    auto kv_hash_variant = block1_from_db.data.categories_updates_info["kv_hash"];
-    auto kv_hash_update_info1 = std::get<KeyValueOutput>(kv_hash_variant);
-    ASSERT_EQ(kv_hash_update_info1.keys["kv_deleted"].deleted, true);
+    auto ver_variant = block1_from_db.data.categories_updates_info["versioned"];
+    auto ver_out1 = std::get<VersionedOutput>(ver_variant);
+    ASSERT_EQ(ver_out1.keys["ver_deleted"].deleted, true);
   }
   // get block 2 from DB and test it
   {
@@ -122,10 +122,10 @@ TEST_F(categorized_kvbc, delete_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key1", "key_val1");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key1", "ver_val1");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("kv_hash", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
   }
   // Can't delete only block
@@ -139,10 +139,10 @@ TEST_F(categorized_kvbc, delete_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key2", "key_val2");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key2", "ver_val2");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("versioned", std::move(ver_updates));
 
     ImmutableUpdates immutable_updates;
     immutable_updates.addUpdate("immutable_key2", {"immutable_val2", {"1", "2"}});
@@ -158,10 +158,10 @@ TEST_F(categorized_kvbc, delete_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key3", "key_val3");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key3", "ver_val3");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("versioned", std::move(ver_updates));
 
     ImmutableUpdates immutable_updates;
     immutable_updates.addUpdate("immutable_key3", {"immutable_val3", {"1", "2"}});
@@ -190,10 +190,10 @@ TEST_F(categorized_kvbc, delete_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key4", "key_val4");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key4", "ver_val4");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("versioned", std::move(ver_updates));
 
     ImmutableUpdates immutable_updates;
     immutable_updates.addUpdate("immutable_key4", {"immutable_val4", {"1", "2"}});
@@ -238,10 +238,10 @@ TEST_F(categorized_kvbc, get_last_and_genesis_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key1", "key_val1");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key1", "key_val1");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("ver", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
   }
   // Add block2
@@ -252,10 +252,10 @@ TEST_F(categorized_kvbc, get_last_and_genesis_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key2", "key_val2");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key2", "key_val2");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("ver", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)2);
   }
   ASSERT_TRUE(block_chain_imp.loadLastReachableBlockId().has_value());
@@ -276,10 +276,10 @@ TEST_F(categorized_kvbc, add_raw_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key1", "key_val1");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key1", "key_val1");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("kv_hash", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
     ASSERT_EQ(block_chain.getGenesisBlockId(), 1);
   }
@@ -291,10 +291,10 @@ TEST_F(categorized_kvbc, add_raw_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key2", "key_val2");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key2", "key_val2");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("ver", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)2);
     ASSERT_EQ(block_chain.getLastReachableBlockId(), 2);
   }
@@ -351,10 +351,10 @@ TEST_F(categorized_kvbc, get_raw_block) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key1", "key_val1");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key1", "key_val1");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("kv_hash", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
     ASSERT_EQ(block_chain.getGenesisBlockId(), 1);
   }
@@ -402,10 +402,10 @@ TEST_F(categorized_kvbc, link_state_transfer_chain) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key1", "key_val1");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key1", "key_val1");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("ver", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
     ASSERT_EQ(block_chain.getGenesisBlockId(), 1);
   }
@@ -417,10 +417,10 @@ TEST_F(categorized_kvbc, link_state_transfer_chain) {
     merkle_updates.addDelete("merkle_deleted");
     updates.add("merkle", std::move(merkle_updates));
 
-    KeyValueUpdates keyval_updates;
-    keyval_updates.addUpdate("kv_key2", "key_val2");
-    keyval_updates.addDelete("kv_deleted");
-    updates.add("kv_hash", std::move(keyval_updates));
+    VersionedUpdates ver_updates;
+    ver_updates.addUpdate("ver_key2", "key_val2");
+    ver_updates.addDelete("ver_deleted");
+    updates.add("kv_hash", std::move(ver_updates));
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)2);
     ASSERT_EQ(block_chain.getLastReachableBlockId(), 2);
     ASSERT_EQ(block_chain_imp.loadLastReachableBlockId().value(), 2);

--- a/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
@@ -1,0 +1,625 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "categorization/base_types.h"
+#include "categorization/column_families.h"
+#include "categorization/details.h"
+#include "categorization/versioned_kv_category.h"
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "storage/test/storage_test_common.h"
+
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace {
+
+using namespace ::testing;
+using namespace concord::storage::rocksdb;
+using namespace concord::kvbc;
+using namespace concord::kvbc::categorization;
+using namespace concord::kvbc::categorization::detail;
+using namespace std::literals;
+
+class versioned_kv_category : public Test {
+  void SetUp() override {
+    cleanup();
+    db = TestRocksDb::createNative();
+    cat = VersionedKeyValueCategory{category_id, db};
+  }
+  void TearDown() override { cleanup(); }
+
+ protected:
+  auto add(BlockId block_id, VersionedInput &&in) {
+    auto update_batch = db->getBatch();
+    auto out = cat.add(block_id, std::move(in), update_batch);
+    db->write(std::move(update_batch));
+    return out;
+  }
+
+ protected:
+  const std::string category_id{"cat"};
+  const std::string values_cf{category_id + VERSIONED_KV_VALUES_CF_SUFFIX};
+  const std::string latest_ver_cf{category_id + VERSIONED_KV_LATEST_VER_CF_SUFFIX};
+  std::shared_ptr<NativeClient> db;
+
+  VersionedKeyValueCategory cat;
+};
+
+TEST_F(versioned_kv_category, create_column_families_on_construction) {
+  ASSERT_THAT(db->columnFamilies(),
+              ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(), values_cf, latest_ver_cf}));
+}
+
+TEST_F(versioned_kv_category, empty_updates) {
+  // Calculate root hash = false.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = false;
+    auto batch = db->getBatch();
+    const auto out = cat.add(1, std::move(in), batch);
+    ASSERT_EQ(batch.count(), 0);
+    ASSERT_FALSE(out.root_hash);
+    ASSERT_TRUE(out.keys.empty());
+  }
+
+  // Calculate root hash = true.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    auto batch = db->getBatch();
+    const auto out = cat.add(1, std::move(in), batch);
+    ASSERT_EQ(batch.count(), 0);
+    ASSERT_FALSE(out.root_hash);
+    ASSERT_TRUE(out.keys.empty());
+  }
+}
+
+TEST_F(versioned_kv_category, calculate_root_hash_toggle) {
+  const auto stale_on_update = false;
+
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["k"] = ValueWithFlags{"v", stale_on_update};
+    const auto out = add(1, std::move(in));
+    ASSERT_TRUE(out.root_hash);
+  }
+
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = false;
+    in.kv["k"] = ValueWithFlags{"v", stale_on_update};
+    const auto out = add(1, std::move(in));
+    ASSERT_FALSE(out.root_hash);
+  }
+}
+
+TEST_F(versioned_kv_category, non_existent_key) { ASSERT_FALSE(cat.getLatest("non-existent"s)); }
+
+TEST_F(versioned_kv_category, get_and_get_latest) {
+  const auto stale_on_update = false;
+
+  // Update key "k" with "v1" at block 1.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["k"] = ValueWithFlags{"v1", stale_on_update};
+    add(1, std::move(in));
+  }
+
+  // Update key "k" with "v3" at block 3.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["k"] = ValueWithFlags{"v3", stale_on_update};
+    add(3, std::move(in));
+  }
+
+  // Get key "k" at block 1.
+  {
+    const auto value = cat.get("k", 1);
+    ASSERT_TRUE(value);
+    ASSERT_EQ(asVersioned(value).block_id, 1);
+    ASSERT_EQ(asVersioned(value).data, "v1");
+  }
+
+  // Get key "k" at the non-existent versions.
+  {
+    ASSERT_FALSE(cat.get("k", 2));
+    ASSERT_FALSE(cat.get("k", 4));
+  }
+
+  // Get key "k" at block 3.
+  {
+    const auto value = cat.get("k", 3);
+    ASSERT_TRUE(value);
+    ASSERT_EQ(asVersioned(value).block_id, 3);
+    ASSERT_EQ(asVersioned(value).data, "v3");
+  }
+
+  // Get the latest value of key "k".
+  {
+    const auto value = cat.getLatest("k");
+    ASSERT_TRUE(value);
+    ASSERT_EQ(asVersioned(value).block_id, 3);
+    ASSERT_EQ(asVersioned(value).data, "v3");
+  }
+}
+
+TEST_F(versioned_kv_category, multi_get_and_multi_get_latest) {
+  const auto stale_on_update = false;
+
+  // Update keys "ka" and "kb" with "va1" and "vb1" at block 1.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va1", stale_on_update};
+    in.kv["kb"] = ValueWithFlags{"vb1", stale_on_update};
+    add(1, std::move(in));
+  }
+
+  // Update keys "ka" and "kb" with "va3" and "vb3" at block 3.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va3", stale_on_update};
+    in.kv["kb"] = ValueWithFlags{"vb3", stale_on_update};
+    add(3, std::move(in));
+  }
+
+  // Get keys "ka" and "kb" at block 1.
+  {
+    auto values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGet({"ka", "kb", "non-existent"}, {1, 1, 1}, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{
+        VersionedValue{{1, "va1"}}, VersionedValue{{1, "vb1"}}, std::nullopt};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Get keys "ka" and "kb" at block 3.
+  {
+    auto values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGet({"non-existent1", "ka", "non-existent2", "kb", "non-existent3"}, {3, 3, 3, 3, 3}, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{
+        std::nullopt, VersionedValue{{3, "va3"}}, std::nullopt, VersionedValue{{3, "vb3"}}, std::nullopt};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Get keys at non-existent versions.
+  {
+    auto values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGet({"ka", "kb", "ka"}, {2, 4, 1}, values);
+    const auto expected =
+        std::vector<std::optional<categorization::Value>>{std::nullopt, std::nullopt, VersionedValue{{1, "va1"}}};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Get the latest values of keys.
+  {
+    auto values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGetLatest({"ka", "kb", "non-existent"}, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{
+        VersionedValue{{3, "va3"}}, VersionedValue{{3, "vb3"}}, std::nullopt};
+    ASSERT_EQ(values, expected);
+  }
+}
+
+TEST_F(versioned_kv_category, get_latest_ver_and_multi_get_latest_ver) {
+  const auto stale_on_update = false;
+
+  // Update keys "ka" and "kb" with "va1" and "vb1" at block 1.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va1", stale_on_update};
+    in.kv["kb"] = ValueWithFlags{"vb1", stale_on_update};
+    add(1, std::move(in));
+  }
+
+  // Update keys "ka" and "kb" with "va3" and "vb3" at block 3.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va3", stale_on_update};
+    in.kv["kb"] = ValueWithFlags{"vb3", stale_on_update};
+    add(3, std::move(in));
+  }
+
+  // Get latest version of existing keys.
+  {
+    const auto ka_ver = cat.getLatestVersion("ka");
+    ASSERT_TRUE(ka_ver);
+    ASSERT_EQ(*ka_ver, 3);
+
+    const auto kb_ver = cat.getLatestVersion("kb");
+    ASSERT_TRUE(kb_ver);
+    ASSERT_EQ(*kb_ver, 3);
+  }
+
+  // Get latest version of a non-existent key.
+  {
+    const auto ver = cat.getLatestVersion("non-existent");
+    ASSERT_FALSE(ver);
+  }
+
+  // Get multiple latest versions.
+  {
+    auto versions = std::vector<std::optional<BlockId>>{};
+    cat.multiGetLatestVersion({"ka", "non-existent", "kb"}, versions);
+    const auto expected = std::vector<std::optional<BlockId>>{3, std::nullopt, 3};
+    ASSERT_EQ(versions, expected);
+  }
+}
+
+TEST_F(versioned_kv_category, get_proof) {
+  const auto stale_on_update = false;
+  const auto block1 = 1;
+  const auto block2 = 2;
+  const auto invalid_block = 3;
+
+  // Add block1 with provable keys.
+  auto in = VersionedInput{};
+  in.calculate_root_hash = true;
+  in.kv["k1"] = ValueWithFlags{"v1", stale_on_update};
+  in.kv["k2"] = ValueWithFlags{"v2", stale_on_update};
+  in.kv["k3"] = ValueWithFlags{"v3", stale_on_update};
+  const auto out = add(block1, std::move(in));
+
+  // Insert a block2 after block1 in order to ensure we are providing proofs for the correct block ID.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["k1"] = ValueWithFlags{"dummyv1", stale_on_update};
+    in.kv["k2"] = ValueWithFlags{"dummyv2", stale_on_update};
+    in.kv["k3"] = ValueWithFlags{"dummyv2", stale_on_update};
+    add(block2, std::move(in));
+  }
+
+  // h("k1") = 89a6df64f1536985fcb7326c0e56f03762b581b2253cf9fadc695c8dbb740a96
+  // h("v1") = 9c209c84e360d17dd267fc53a46db30009b9f39ce2b905fa29fbd5fd4c44ea17
+  // h("k2") = 189284195f920d885bc46edf2d6c2c56194d3333448eda64ddd726c901b59c28
+  // h("v2") = 86a74b56a4ca89e2a292dc3995a15149a2843b038965d0feabd3d20a663f759f
+  // h("k3") = d2cd0fe12ce97350e7d136d40707373305040a5c5a72b5aded93ecd104548244
+  // h("v3") = ef1ceacbca55ac4c6d196f5aa52e9c712574d3f42810309e74dfa697861ecf88
+  // root_hash = h(h("k1") || h("v1") || h("k2") || h("v2") || h("k3") || h("v3")) =
+  //           = acc07312b86daec7d0b8b53bd67e49d7c5c1677bf174904962a836eb9db4a8cf
+
+  // First key.
+  {
+    const auto proof = cat.getProof(block1, "k1", out);
+    ASSERT_TRUE(proof);
+    ASSERT_EQ(proof->block_id, block1);
+    ASSERT_EQ(proof->key, "k1");
+    ASSERT_EQ(proof->value, "v1");
+    ASSERT_EQ(proof->key_value_index, 0);  // indexing starts at 0
+    ASSERT_THAT(proof->calculateRootHash(),
+                ContainerEq(Hash{0xac, 0xc0, 0x73, 0x12, 0xb8, 0x6d, 0xae, 0xc7, 0xd0, 0xb8, 0xb5,
+                                 0x3b, 0xd6, 0x7e, 0x49, 0xd7, 0xc5, 0xc1, 0x67, 0x7b, 0xf1, 0x74,
+                                 0x90, 0x49, 0x62, 0xa8, 0x36, 0xeb, 0x9d, 0xb4, 0xa8, 0xcf}));
+  }
+
+  // Middle key.
+  {
+    const auto proof = cat.getProof(block1, "k2", out);
+    ASSERT_TRUE(proof);
+    ASSERT_EQ(proof->block_id, block1);
+    ASSERT_EQ(proof->key, "k2");
+    ASSERT_EQ(proof->value, "v2");
+    ASSERT_EQ(proof->key_value_index, 2);  // indexing starts at 0
+    ASSERT_THAT(proof->calculateRootHash(),
+                ContainerEq(Hash{0xac, 0xc0, 0x73, 0x12, 0xb8, 0x6d, 0xae, 0xc7, 0xd0, 0xb8, 0xb5,
+                                 0x3b, 0xd6, 0x7e, 0x49, 0xd7, 0xc5, 0xc1, 0x67, 0x7b, 0xf1, 0x74,
+                                 0x90, 0x49, 0x62, 0xa8, 0x36, 0xeb, 0x9d, 0xb4, 0xa8, 0xcf}));
+  }
+
+  // Last key.
+  {
+    const auto proof = cat.getProof(block1, "k3", out);
+    ASSERT_TRUE(proof);
+    ASSERT_EQ(proof->block_id, block1);
+    ASSERT_EQ(proof->key, "k3");
+    ASSERT_EQ(proof->value, "v3");
+    ASSERT_EQ(proof->key_value_index, 4);  // indexing starts at 0
+    ASSERT_THAT(proof->calculateRootHash(),
+                ContainerEq(Hash{0xac, 0xc0, 0x73, 0x12, 0xb8, 0x6d, 0xae, 0xc7, 0xd0, 0xb8, 0xb5,
+                                 0x3b, 0xd6, 0x7e, 0x49, 0xd7, 0xc5, 0xc1, 0x67, 0x7b, 0xf1, 0x74,
+                                 0x90, 0x49, 0x62, 0xa8, 0x36, 0xeb, 0x9d, 0xb4, 0xa8, 0xcf}));
+  }
+
+  // Invalid block ID.
+  {
+    ASSERT_FALSE(cat.getProof(invalid_block, "k1", out));
+    ASSERT_FALSE(cat.getProof(invalid_block, "k2", out));
+    ASSERT_FALSE(cat.getProof(invalid_block, "k3", out));
+  }
+
+  // Non-existing key.
+  { ASSERT_FALSE(cat.getProof(block1, "non-existing", out)); }
+}
+
+TEST_F(versioned_kv_category, delete_key) {
+  const auto stale_on_update = false;
+
+  // Update key "k" to "v1" in block 1.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["k"] = ValueWithFlags{"v1", stale_on_update};
+    add(1, std::move(in));
+  }
+
+  // Delete key "k" in block 2.
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.deletes.push_back("k");
+    const auto out = add(2, std::move(in));
+    ASSERT_EQ(out.keys.size(), 1);
+    ASSERT_EQ(out.keys.cbegin()->first, "k");
+    ASSERT_TRUE(out.keys.cbegin()->second.deleted);
+  }
+
+  // Key "k" is still available at block 1 via get().
+  {
+    const auto value = cat.get("k", 1);
+    ASSERT_TRUE(value);
+    ASSERT_EQ(asVersioned(value).block_id, 1);
+    ASSERT_EQ(asVersioned(value).data, "v1");
+  }
+
+  // Key "k" is still available at block 1 via multiGet().
+  {
+    auto values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGet({"k"}, {1}, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{VersionedValue{{1, "v1"}}};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Key "k" is no longer available for blocks >= 2 via get().
+  {
+    ASSERT_FALSE(cat.get("k", 2));
+    ASSERT_FALSE(cat.get("k", 3));
+  }
+
+  // Key "k" is no longer available for blocks >= 2 via multiGet().
+  {
+    auto values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGet({"k", "k"}, {2, 3}, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{std::nullopt, std::nullopt};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Key "k" has no latest value via getLatest().
+  { ASSERT_FALSE(cat.getLatest("k")); }
+
+  {
+    // Key "k" has no latest value via multiGetLatest().
+    auto values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGetLatest({"k"}, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{std::nullopt};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Key "k" has a latest version of 2 via getLatestVersion() - the version it was deleted at.
+  {
+    const auto latest_version = cat.getLatestVersion("k");
+    ASSERT_TRUE(latest_version);
+    ASSERT_EQ(*latest_version, 2);
+  }
+
+  // Key "k" has a latest version of 2 via multiGetLatestVersion() - the version it was deleted at.
+  {
+    auto latest_versions = std::vector<std::optional<BlockId>>{};
+    cat.multiGetLatestVersion({"k"}, latest_versions);
+    const auto expected = std::vector<std::optional<BlockId>>{2};
+    ASSERT_EQ(latest_versions, expected);
+  }
+}
+
+TEST_F(versioned_kv_category, propagate_stale_on_update) {
+  {
+    const auto stale_on_update = false;
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["k"] = ValueWithFlags{"v1", stale_on_update};
+    const auto out = add(1, std::move(in));
+
+    ASSERT_FALSE(out.keys.cbegin()->second.stale_on_update);
+  }
+
+  {
+    const auto stale_on_update = true;
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["k"] = ValueWithFlags{"v2", stale_on_update};
+    const auto out = add(2, std::move(in));
+
+    ASSERT_TRUE(out.keys.cbegin()->second.stale_on_update);
+  }
+}
+
+TEST_F(versioned_kv_category, delete_genesis) {
+  const auto mark_stale_on_update = true;
+  const auto non_stale_on_update = false;
+
+  // Add keys "ka", "kb", "kc" and "kd" in block 1. Mark "kc" as stale-on-update.
+  auto out1 = VersionedOutput{};
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va1", non_stale_on_update};
+    in.kv["kb"] = ValueWithFlags{"vb1", non_stale_on_update};
+    in.kv["kc"] = ValueWithFlags{"vc1", mark_stale_on_update};
+    in.kv["kd"] = ValueWithFlags{"vd1", mark_stale_on_update};
+    out1 = add(1, std::move(in));
+  }
+
+  // Update key "ka" and "kd" in block 2 (making them stale).
+  auto out5 = VersionedOutput{};
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va5", non_stale_on_update};
+    in.kv["kd"] = ValueWithFlags{"vd5", non_stale_on_update};
+    out5 = add(5, std::move(in));
+  }
+
+  // Delete genesis block 1.
+  {
+    auto batch = db->getBatch();
+    cat.deleteGenesisBlock(1, out1, batch);
+    db->write(std::move(batch));
+  }
+
+  // Lookups in block 1.
+  {
+    ASSERT_FALSE(cat.get("ka", 1));
+    ASSERT_FALSE(cat.get("kc", 1));
+    ASSERT_FALSE(cat.get("kd", 1));
+
+    const auto value = cat.get("kb", 1);
+    ASSERT_TRUE(value);
+    ASSERT_EQ(asVersioned(value).block_id, 1);
+    ASSERT_EQ(asVersioned(value).data, "vb1");
+  }
+
+  // Make sure we have a latest version for "ka".
+  {
+    const auto latest_version = cat.getLatestVersion("ka");
+    ASSERT_TRUE(latest_version);
+    ASSERT_EQ(*latest_version, 5);
+
+    const auto value = cat.getLatest("ka");
+    ASSERT_EQ(asVersioned(value).block_id, 5);
+    ASSERT_EQ(asVersioned(value).data, "va5");
+
+    auto latest_versions = std::vector<std::optional<BlockId>>{};
+    cat.multiGetLatestVersion({"ka"}, latest_versions);
+    const auto expected_versions = std::vector<std::optional<BlockId>>{5};
+    ASSERT_EQ(latest_versions, expected_versions);
+
+    auto latest_values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGetLatest({"ka"}, latest_values);
+    const auto expected_values = std::vector<std::optional<categorization::Value>>{VersionedValue{{5, "va5"}}};
+    ASSERT_EQ(latest_values, expected_values);
+  }
+
+  // Make sure we have a latest version for "kd".
+  {
+    const auto latest_version = cat.getLatestVersion("kd");
+    ASSERT_TRUE(latest_version);
+    ASSERT_EQ(*latest_version, 5);
+
+    const auto value = cat.getLatest("kd");
+    ASSERT_EQ(asVersioned(value).block_id, 5);
+    ASSERT_EQ(asVersioned(value).data, "vd5");
+
+    auto latest_versions = std::vector<std::optional<BlockId>>{};
+    cat.multiGetLatestVersion({"kd"}, latest_versions);
+    const auto expected_versions = std::vector<std::optional<BlockId>>{5};
+    ASSERT_EQ(latest_versions, expected_versions);
+
+    auto latest_values = std::vector<std::optional<categorization::Value>>{};
+    cat.multiGetLatest({"kd"}, latest_values);
+    const auto expected_values = std::vector<std::optional<categorization::Value>>{VersionedValue{{5, "vd5"}}};
+    ASSERT_EQ(latest_values, expected_values);
+  }
+
+  // Make sure there is no "kc" as it is stale-on-update and there is no subsequent version.
+  {
+    ASSERT_FALSE(cat.get("kc", 1));
+    ASSERT_FALSE(cat.getLatest("kc"));
+    ASSERT_FALSE(cat.getLatestVersion("kc"));
+  }
+}
+
+TEST_F(versioned_kv_category, delete_last_reachable) {
+  const auto stale_on_update = false;
+
+  // Add key "ka" in block 1.
+  auto out1 = VersionedOutput{};
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va1", stale_on_update};
+    out1 = add(1, std::move(in));
+  }
+
+  // Update key "ka" in block 2 (making it stale). Add a new key "kab" in block 5.
+  auto out5 = VersionedOutput{};
+  {
+    auto in = VersionedInput{};
+    in.calculate_root_hash = true;
+    in.kv["ka"] = ValueWithFlags{"va5", stale_on_update};
+    in.kv["kab"] = ValueWithFlags{"vab5", stale_on_update};
+    out5 = add(5, std::move(in));
+  }
+
+  // Delete last reachable block 5.
+  {
+    auto batch = db->getBatch();
+    cat.deleteLastReachableBlock(5, out5, batch);
+    db->write(std::move(batch));
+  }
+
+  // Make sure the latest version of "ka" is 1.
+  {
+    const auto latest_version = cat.getLatestVersion("ka");
+    ASSERT_TRUE(latest_version);
+    ASSERT_EQ(*latest_version, 1);
+
+    const auto value = cat.getLatest("ka");
+    ASSERT_EQ(asVersioned(value).block_id, 1);
+    ASSERT_EQ(asVersioned(value).data, "va1");
+  }
+
+  // Make sure there's no trace of "kab".
+  {
+    ASSERT_FALSE(cat.get("kab", 5));
+    ASSERT_FALSE(cat.getLatest("kab"));
+    ASSERT_FALSE(cat.getLatestVersion("kab"));
+  }
+
+  // Delete last reachable block 1.
+  {
+    auto batch = db->getBatch();
+    cat.deleteLastReachableBlock(1, out1, batch);
+    db->write(std::move(batch));
+  }
+
+  // Make sure the are no keys left.
+  {
+    auto values_iter = db->getIterator(values_cf);
+    values_iter.first();
+    ASSERT_FALSE(values_iter);
+
+    auto latest_ver_iter = db->getIterator(latest_ver_cf);
+    latest_ver_iter.first();
+    ASSERT_FALSE(latest_ver_iter);
+  }
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  ::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The VersionedKeyValueCategory stores versioned keys directly in RocksDB.
It has the following features:
 * Keys are versioned by block ID
 * A separate index (in a separate column family) that holds a key's
   latest version is implemented
 * Keys are stored as is, without being hashed
 * Lookups for specific key versions and a key's latest version are
   supported
 * Supports multi-key lookups
 * Explicit key deletions are supported
 * Ability to mark a key stale immediately on update is supported
 * KeyValueProofs per block are supported
 * An option to turn off proofs (root hash calculation) per block is
   supported

Add an unit test to verify the behavior of the category.