### PR TITLE
Check the complaints placed inside the View Change message for higher…

### DIFF
--- a/bftengine/src/bftengine/ReplicasAskedToLeaveViewInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasAskedToLeaveViewInfo.hpp
@@ -22,6 +22,14 @@ class ReplicasAskedToLeaveViewInfo {
  public:
   ReplicasAskedToLeaveViewInfo(const ReplicaConfig& config) : config_(config) {}
 
+  ReplicasAskedToLeaveViewInfo(ReplicasAskedToLeaveViewInfo&& rhs) : config_(rhs.config_), msgs(std::move(rhs.msgs)) {}
+
+  ReplicasAskedToLeaveViewInfo& operator=(ReplicasAskedToLeaveViewInfo&& rhs) {
+    msgs.clear();
+    msgs = std::move(rhs.msgs);
+    return *this;
+  }
+
   bool hasQuorumToLeaveView() const { return msgs.size() >= config_.fVal + 1U; }
 
   void store(std::unique_ptr<ReplicaAsksToLeaveViewMsg>&& msg) {


### PR DESCRIPTION
… View than the Replica's current.

This handles the case where we have a Replica behind more than 1 View from the others.
This is an improvement, the behind Replica can catch-up by the F+1 View Change messages that it will
receive from peers. We can though move to the agreed view earlier based on the F+1 signed Complaints.