### PR TITLE
BlockMerkle category improvements

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -161,10 +161,7 @@ Msg BatchedInternalNode 5006 {
 
 # An index to the latest version of a key.
 #
-# A sentinel of 0 is used to mark the key as deleted. We don't need tombstones as we never rewrite
-# the same key after it has been deleted. The use of a sentinel is to optimize the size and
-# serialization performance of this index.
-
+# The high-bit being set indicates whether or not the last update was a delete, i.e. a tombstone.
 Msg LatestKeyVersion 5009 {
     uint64 block_id
 }

--- a/kvbc/include/sparse_merkle/base_types.h
+++ b/kvbc/include/sparse_merkle/base_types.h
@@ -330,7 +330,7 @@ class NibblePath {
   const std::vector<uint8_t>& data() const { return path_; }
 
   // Allow moving the data out of the path.
-  std::vector<uint8_t> move_data() { return path_; }
+  std::vector<uint8_t> move_data() { return std::move(path_); }
 
  private:
   size_t num_nibbles_;

--- a/kvbc/include/sparse_merkle/tree.h
+++ b/kvbc/include/sparse_merkle/tree.h
@@ -42,7 +42,7 @@ namespace sparse_merkle {
 // can be written to the DB atomically.
 class Tree {
  public:
-  Tree() {}
+  Tree() = default;
   explicit Tree(std::shared_ptr<IDBReader> db_reader) : db_reader_(db_reader) { reset(); }
 
   const Hash& get_root_hash() const { return root_.hash(); }


### PR DESCRIPTION
Indexes for the latest version of keys now utilize the high order bit to
indicate whether the last write was a delete. This translates to an
API change that returns a `TaggedVersion` for latest version retrievals.
This is useful for pre-execution conflict detection.

Other fixes include:
 * Properly move the internal data from a NibblePath
 * Reuse the hash function in details.h rather than calling
 Hasher.digest directly.
 * Not writing added and deleted keys to the merkle value on initial
 block creation.
 * Using the root hash of the block tree rather than just the root hash
 of the block for output to category `add`.
 * Removing unnecessary reserve calls to vectors for multiGet calls.
 * Adding a test to ensure the new key delete/tombstone behavior works