### PR TITLE
Block accumulation memory leak fix

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -23,9 +23,9 @@
 
 namespace bftEngine {
 struct SimpleClientParams {
-  uint64_t clientInitialRetryTimeoutMilli = 150;
-  uint64_t clientMinRetryTimeoutMilli = 50;
-  uint64_t clientMaxRetryTimeoutMilli = 1000;
+  uint16_t clientInitialRetryTimeoutMilli = 150;
+  uint16_t clientMinRetryTimeoutMilli = 50;
+  uint16_t clientMaxRetryTimeoutMilli = 1000;
   uint16_t numberOfStandardDeviationsToTolerate = 2;
   uint16_t samplesPerEvaluation = 32;
   uint16_t samplesUntilReset = 1000;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3955,6 +3955,7 @@ void ReplicaImp::executeRequestsAndSendResponses(PrePrepareMsg *ppMsg,
       std::unique_ptr<ClientReplyMsg> replyMsg{clientsManager->allocateNewReplyMsgAndWriteToStorage(
           req.clientId, req.requestSequenceNum, currentPrimary(), req.outReply, req.outActualReplySize)};
       replyMsg->setReplicaSpecificInfoLength(req.outReplicaSpecificInfoSize);
+      free(req.outReply);
       send(replyMsg.get(), req.clientId);
     }
     clientsManager->removePendingRequestOfClient(req.clientId);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3471,11 +3471,11 @@ ReplicaImp::ReplicaImp(bool firstTime,
   metrics_.Register();
 
   if (firstTime) {
-    sigManager =
-        new SigManager(config_.getreplicaId(),
-                       config_.getnumReplicas() + config_.getnumOfClientProxies() + config_.getnumOfExternalClients(),
-                       config_.getreplicaPrivateKey(),
-                       config_.publicKeysOfReplicas);
+    sigManager = new SigManager(config_.getreplicaId(),
+                                config_.getnumReplicas() + config_.getnumRoReplicas() +
+                                    config_.getnumOfClientProxies() + config_.getnumOfExternalClients(),
+                                config_.getreplicaPrivateKey(),
+                                config_.publicKeysOfReplicas);
     repsInfo = new ReplicasInfo(config_, dynamicCollectorForPartialProofs, dynamicCollectorForExecutionProofs);
     viewsManager =
         new ViewsManager(repsInfo, sigManager, CryptoManager::instance().thresholdVerifierForSlowPathCommit());
@@ -3488,9 +3488,9 @@ ReplicaImp::ReplicaImp(bool firstTime,
   }
 
   std::set<NodeIdType> clientsSet;
-  const auto numOfEntities =
-      config_.getnumReplicas() + config_.getnumOfClientProxies() + config_.getnumOfExternalClients();
-  for (uint16_t i = config_.getnumReplicas(); i < numOfEntities; i++) clientsSet.insert(i);
+  const auto numOfEntities = config_.getnumReplicas() + config_.getnumRoReplicas() + config_.getnumOfClientProxies() +
+                             config_.getnumOfExternalClients();
+  for (uint16_t i = config_.getnumReplicas() + config_.getnumRoReplicas(); i < numOfEntities; i++) clientsSet.insert(i);
   clientsManager = new ClientsManager(config_.getreplicaId(),
                                       clientsSet,
                                       ReplicaConfig::instance().getsizeOfReservedPage(),


### PR DESCRIPTION
This MR fixing 3 issues:

1. Memory leak - I allocated memory for responses for each request but forgot to release the memory once I copied it to the reply message.
2. RO replica id's - inserted RO replica id when calculating the clients set inside the constructor of the replica imp.
3. Parameters sizing - fixed simple client parameters sizing we got from the configuration manager as uint16_t so we need to adhere to that size.