### PR TITLE
Support TaggedVersion in ImmutableKeyValueCategory

### DIFF
--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -79,11 +79,12 @@ class ImmutableKeyValueCategory {
 
   // Get the version of an immutable key.
   // Return std::nullopt if the key doesn't exist.
-  std::optional<BlockId> getLatestVersion(const std::string &key) const;
+  std::optional<TaggedVersion> getLatestVersion(const std::string &key) const;
 
   // Get the latest versions of the given keys.
   // If a key is missing, std::nullopt is returned for its version.
-  void multiGetLatestVersion(const std::vector<std::string> &keys, std::vector<std::optional<BlockId>> &versions) const;
+  void multiGetLatestVersion(const std::vector<std::string> &keys,
+                             std::vector<std::optional<TaggedVersion>> &versions) const;
 
   // Get the value of a key and a proof for it in `tag`.
   // Return std::nullopt if the key doesn't exist.

--- a/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
@@ -55,6 +55,7 @@ class immutable_kv_category : public Test {
   }
 
  protected:
+  const bool key_deleted{false};
   const std::string category_id{"cat"};
   const std::string column_family{category_id + IMMUTABLE_KV_CF_SUFFIX};
   std::shared_ptr<NativeClient> db;
@@ -633,7 +634,8 @@ TEST_F(immutable_kv_category, get_latest_version) {
   {
     const auto version = cat.getLatestVersion("k");
     ASSERT_TRUE(version);
-    ASSERT_EQ(*version, block_id);
+    const auto expected = TaggedVersion{key_deleted, block_id};
+    ASSERT_EQ(*version, expected);
   }
 
   ASSERT_FALSE(cat.getLatestVersion("non-existent"));
@@ -655,9 +657,10 @@ TEST_F(immutable_kv_category, multi_get_latest_version) {
   }
 
   const auto keys = std::vector<std::string>{"k1", "k2", "k3"};
-  auto versions = std::vector<std::optional<BlockId>>{};
+  auto versions = std::vector<std::optional<TaggedVersion>>{};
   cat.multiGetLatestVersion(keys, versions);
-  const auto expected = std::vector<std::optional<BlockId>>{1, 2, std::nullopt};
+  const auto expected = std::vector<std::optional<TaggedVersion>>{
+      TaggedVersion{key_deleted, 1}, TaggedVersion{key_deleted, 2}, std::nullopt};
   ASSERT_EQ(versions, expected);
 }
 


### PR DESCRIPTION
Add support for TaggedVersion in ImmutableKeyValueCategory in order to
unify the interface across different categories. Always return
`deleted = false` for keys in the ImmutableKeyValueCategory.