### PR TITLE
Calculate client set id's with RO replicas

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -23,9 +23,9 @@
 
 namespace bftEngine {
 struct SimpleClientParams {
-  uint64_t clientInitialRetryTimeoutMilli = 150;
-  uint64_t clientMinRetryTimeoutMilli = 50;
-  uint64_t clientMaxRetryTimeoutMilli = 1000;
+  uint16_t clientInitialRetryTimeoutMilli = 150;
+  uint16_t clientMinRetryTimeoutMilli = 50;
+  uint16_t clientMaxRetryTimeoutMilli = 1000;
   uint16_t numberOfStandardDeviationsToTolerate = 2;
   uint16_t samplesPerEvaluation = 32;
   uint16_t samplesUntilReset = 1000;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3430,11 +3430,11 @@ ReplicaImp::ReplicaImp(bool firstTime,
   metrics_.Register();
 
   if (firstTime) {
-    sigManager =
-        new SigManager(config_.getreplicaId(),
-                       config_.getnumReplicas() + config_.getnumOfClientProxies() + config_.getnumOfExternalClients(),
-                       config_.getreplicaPrivateKey(),
-                       config_.publicKeysOfReplicas);
+    sigManager = new SigManager(config_.getreplicaId(),
+                                config_.getnumReplicas() + config_.getnumRoReplicas() +
+                                    config_.getnumOfClientProxies() + config_.getnumOfExternalClients(),
+                                config_.getreplicaPrivateKey(),
+                                config_.publicKeysOfReplicas);
     repsInfo = new ReplicasInfo(config_, dynamicCollectorForPartialProofs, dynamicCollectorForExecutionProofs);
     viewsManager =
         new ViewsManager(repsInfo, sigManager, CryptoManager::instance().thresholdVerifierForSlowPathCommit());
@@ -3447,9 +3447,9 @@ ReplicaImp::ReplicaImp(bool firstTime,
   }
 
   std::set<NodeIdType> clientsSet;
-  const auto numOfEntities =
-      config_.getnumReplicas() + config_.getnumOfClientProxies() + config_.getnumOfExternalClients();
-  for (uint16_t i = config_.getnumReplicas(); i < numOfEntities; i++) clientsSet.insert(i);
+  const auto numOfEntities = config_.getnumReplicas() + config_.getnumRoReplicas() + config_.getnumOfClientProxies() +
+                             config_.getnumOfExternalClients();
+  for (uint16_t i = config_.getnumReplicas() + config_.getnumRoReplicas(); i < numOfEntities; i++) clientsSet.insert(i);
   clientsManager = new ClientsManager(config_.getreplicaId(),
                                       clientsSet,
                                       ReplicaConfig::instance().getsizeOfReservedPage(),


### PR DESCRIPTION
This PR is fixing 2 issues:

RO replica id's - inserted RO replica id when calculating the clients set inside the constructor of the replica imp.
Parameters sizing - fixed simple client parameters sizing we got from the configuration manager as uint16_t so we need to adhere to that size.