### PR TITLE
Support TaggedVersion in VersionedKeyValueCategory

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -119,13 +119,23 @@ Msg VersionedRawKey 4003 {
     uint64 version
 }
 
-Msg ImmutableDbValue 4004 {
+Msg DbValue 4004 {
+    bool deleted
+    string data
+}
+
+# Used to deserialize the deleted flag only from a DbValue.
+Msg Deleted 4005 {
+    bool value
+}
+
+Msg ImmutableDbValue 4006 {
     uint64 block_id
     string data
 }
 
 # Used to deserialize the version only from an ImmutableDbValue.
-Msg ImmutableDbVersion 4005 {
+Msg ImmutableDbVersion 4007 {
     uint64 block_id
 }
 
@@ -169,21 +179,4 @@ Msg BatchedInternalNode 5006 {
     # Contains a 1 where a child node is present, 0 otherwise
     uint32 bitmask
     list BatchedInternalNodeChild children
-}
-
-# Versioned category
-
-Msg Tombstone 6000 {
-    bool dummy
-}
-
-Msg DbValue 6001 {
-    string data
-}
-
-Msg VersionedDbValue 6002 {
-    oneof {
-        Tombstone
-        DbValue
-    } data
 }

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -23,7 +23,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <variant>
 #include <vector>
 
 namespace concord::kvbc::categorization::detail {
@@ -74,11 +73,12 @@ class VersionedKeyValueCategory {
 
   // Get the latest version of `key`.
   // Return std::nullopt if the key doesn't exist.
-  std::optional<BlockId> getLatestVersion(const std::string &key) const;
+  std::optional<TaggedVersion> getLatestVersion(const std::string &key) const;
 
   // Get the latest versions of the given keys.
   // If a key is missing, std::nullopt is returned for its version.
-  void multiGetLatestVersion(const std::vector<std::string> &keys, std::vector<std::optional<BlockId>> &versions) const;
+  void multiGetLatestVersion(const std::vector<std::string> &keys,
+                             std::vector<std::optional<TaggedVersion>> &versions) const;
 
   // Get the value of `key` and a proof for it at `block_id`.
   // Return std::nullopt if the key doesn't exist.
@@ -93,9 +93,9 @@ class VersionedKeyValueCategory {
                   VersionedOutput &,
                   storage::rocksdb::NativeWriteBatch &);
 
-  void updateLatestKeyVersion(const std::string &key, BlockId version, storage::rocksdb::NativeWriteBatch &);
+  void updateLatestKeyVersion(const std::string &key, TaggedVersion version, storage::rocksdb::NativeWriteBatch &);
 
-  void putValue(const VersionedRawKey &, const VersionedDbValue &, storage::rocksdb::NativeWriteBatch &);
+  void putValue(const VersionedRawKey &, const DbValue &, storage::rocksdb::NativeWriteBatch &);
 
   void addKeyToUpdateInfo(std::string &&key, bool deleted, bool stale_on_update, VersionedOutput &);
 


### PR DESCRIPTION
Unify categories by supporting TaggedVersion in
VersionedKeyValueCategory.

Optimize tombstone values by not using a variant type. Instead, use a
simple flag to designate a value is a tombstone. The value of a
tombstone is the empty buffer. Rationale is that the variant adds an
overhead of 4 bytes for its type.

Handle deleted keys in deleteLastReachableBlock() by preserving the
deleted flag when seeking back to a previously deleted key version.

Optimize multiGetLatest() by not including deleted (or not found) keys
in the values column family lookup. Implementation is borrowed from the
BlockMerkleCategory.

Add unit tests to verify the new behavior.