### PR TITLE
Fix metrics preProcInFlyRequests num

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -303,9 +303,10 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
           move(clientPreProcessReqMsg), preProcessRequestMsg, ++(clientEntry->reqRetryId));
   }
 
-  if (myReplica_.isCurrentPrimary() && registerSucceeded)
+  if (myReplica_.isCurrentPrimary() && registerSucceeded) {
     preProcessorMetrics_.preProcInFlyRequestsNum.Get().Inc();  // Increase this metric on the primary replica
-  return handleClientPreProcessRequestByPrimary(preProcessRequestMsg);
+    return handleClientPreProcessRequestByPrimary(preProcessRequestMsg);
+  }
 
   LOG_DEBUG(logger(),
             "ClientPreProcessRequestMsg" << KVLOG(reqSeqNum, clientId, senderId)
@@ -356,10 +357,11 @@ void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
     }
     registerSucceeded = registerRequest(ClientPreProcessReqMsgUniquePtr(), preProcessReqMsg);
   }
-  if (registerSucceeded)
+  if (registerSucceeded) {
     preProcessorMetrics_.preProcInFlyRequestsNum.Get().Inc();  // Increase the metric on non-primary replica
-  // Pre-process the request, calculate a hash of the result and send a reply back
-  launchAsyncReqPreProcessingJob(preProcessReqMsg, false, false);
+    // Pre-process the request, calculate a hash of the result and send a reply back
+    launchAsyncReqPreProcessingJob(preProcessReqMsg, false, false);
+  }
 }
 
 // Primary replica handling


### PR DESCRIPTION
It turns out that a non-primary replica may update this metric twice - once if it gets a client request, and when it gets the preProcess request from primary.

We fix it such that each replica will update the metric only once