### PR TITLE
Wire categories to the addBlock operation

### DIFF
--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -41,12 +41,12 @@ class BlockMerkleCategory {
 
   // Return the value of `key` at `block_id`.
   // Return std::nullopt if the key doesn't exist at `block_id`.
-  std::optional<MerkleValue> get(const std::string& key, BlockId block_id) const;
-  std::optional<MerkleValue> get(const Hash& hashed_key, BlockId block_id) const;
+  std::optional<Value> get(const std::string& key, BlockId block_id) const;
+  std::optional<Value> get(const Hash& hashed_key, BlockId block_id) const;
 
   // Return the value of `key` at its most recent block version.
   // Return std::nullopt if the key doesn't exist.
-  std::optional<MerkleValue> getLatest(const std::string& key) const;
+  std::optional<Value> getLatest(const std::string& key) const;
 
   // Returns the latest *block* version of a key.
   // Returns std::nullopt if the key doesn't exist.
@@ -58,11 +58,11 @@ class BlockMerkleCategory {
   // If a key is missing at the specified version, std::nullopt is returned for it.
   void multiGet(const std::vector<std::string>& keys,
                 const std::vector<BlockId>& versions,
-                std::vector<std::optional<MerkleValue>>& values) const;
+                std::vector<std::optional<Value>>& values) const;
 
   // Get the latest values of a list of keys.
   // If a key is missing, std::nullopt is returned for it.
-  void multiGetLatest(const std::vector<std::string>& keys, std::vector<std::optional<MerkleValue>>& values) const;
+  void multiGetLatest(const std::vector<std::string>& keys, std::vector<std::optional<Value>>& values) const;
 
   // Get the latest versions of the given keys.
   // If a key is missing, std::nullopt is returned for its version.
@@ -73,7 +73,7 @@ class BlockMerkleCategory {
  private:
   void multiGet(const std::vector<Buffer>& versioned_keys,
                 const std::vector<BlockId>& versions,
-                std::vector<std::optional<MerkleValue>>& values) const;
+                std::vector<std::optional<Value>>& values) const;
 
   void putKeys(storage::rocksdb::NativeWriteBatch& batch,
                uint64_t block_id,
@@ -110,6 +110,9 @@ class BlockMerkleCategory {
   logging::Logger logger_;
   sparse_merkle::Tree tree_;
 };
+
+inline const MerkleValue& asMerkle(const Value& v) { return std::get<MerkleValue>(v); }
+inline MerkleValue& asMerkle(Value& v) { return std::get<MerkleValue>(v); }
 
 }  // namespace concord::kvbc::categorization::detail
 

--- a/kvbc/include/categorization/blockchain.h
+++ b/kvbc/include/categorization/blockchain.h
@@ -65,12 +65,12 @@ class Blockchain {
     return Block::deserialize(block_ser.value());
   }
 
-  std::optional<RawBlock> getRawBlock(const BlockId block_id) const {
+  std::optional<RawBlock> getRawBlock(const BlockId block_id, const CategoriesMap* categorires) const {
     auto block = getBlock(block_id);
     if (!block) {
       return std::optional<RawBlock>{};
     }
-    return RawBlock(block.value(), native_client_);
+    return RawBlock(block.value(), native_client_, categorires);
   }
 
   /////////////////////// State transfer Block chain ///////////////////////

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -22,6 +22,7 @@
 #include "merkle_tree_db_adapter.h"
 #include "sliver.hpp"
 #include "column_families.h"
+#include "categorization/types.h"
 
 namespace concord::kvbc::categorization {
 
@@ -87,22 +88,27 @@ struct Block {
 // - state hash per category (if exists) E.L check why do we pass it.
 struct RawBlock {
   RawBlock() = default;
-  RawBlock(const Block& block, const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+  RawBlock(const Block& block,
+           const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
+           const CategoriesMap* categorires);
 
   BlockMerkleInput getUpdates(const std::string& category_id,
                               const BlockMerkleOutput& update_info,
                               const BlockId& block_id,
-                              const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+                              const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
+                              const CategoriesMap* categorires);
 
   VersionedInput getUpdates(const std::string& category_id,
                             const VersionedOutput& update_info,
                             const BlockId& block_id,
-                            const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+                            const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
+                            const CategoriesMap* categorires);
 
   ImmutableInput getUpdates(const std::string& category_id,
                             const ImmutableOutput& update_info,
                             const BlockId& block_id,
-                            const std::shared_ptr<storage::rocksdb::NativeClient>& native_client);
+                            const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
+                            const CategoriesMap* categorires);
 
   template <typename T>
   static RawBlock deserialize(const T& input) {

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -27,7 +27,7 @@ namespace concord::kvbc::categorization::detail {
 
 using Buffer = std::vector<std::uint8_t>;
 
-enum class CATEGORY_TYPE : char { merkle = 0, immutable = 1, kv_hash = 2, end_of_types };
+enum class CATEGORY_TYPE : char { block_merkle = 0, immutable = 1, versioned_kv = 2, end_of_types };
 
 template <typename Span>
 Hash hash(const Span &span) {

--- a/kvbc/include/categorization/types.h
+++ b/kvbc/include/categorization/types.h
@@ -1,0 +1,26 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "categorization/immutable_kv_category.h"
+#include "categorization/block_merkle_category.h"
+#include "categorization/versioned_kv_category.h"
+
+namespace concord::kvbc::categorization {
+
+using CategoriesMap = std::map<
+    std::string,
+    std::variant<detail::ImmutableKeyValueCategory, detail::BlockMerkleCategory, detail::VersionedKeyValueCategory>>;
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -61,6 +61,8 @@ struct ImmutableUpdates {
 
   void addUpdate(std::string&& key, ImmutableValue&& val) { data_.kv.emplace(std::move(key), std::move(val.update_)); }
 
+  void calculateRootHash(const bool hash) { data_.calculate_root_hash = hash; }
+
  private:
   ImmutableInput data_;
   friend struct Updates;

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -180,11 +180,11 @@ BlockMerkleOutput BlockMerkleCategory::add(BlockId block_id, BlockMerkleInput&& 
   return output;
 }
 
-std::optional<MerkleValue> BlockMerkleCategory::get(const std::string& key, BlockId block_id) const {
+std::optional<Value> BlockMerkleCategory::get(const std::string& key, BlockId block_id) const {
   return get(hash(key), block_id);
 }
 
-std::optional<MerkleValue> BlockMerkleCategory::get(const Hash& hashed_key, BlockId block_id) const {
+std::optional<Value> BlockMerkleCategory::get(const Hash& hashed_key, BlockId block_id) const {
   auto key = VersionedKey{KeyHash{hashed_key}, block_id};
   if (auto val = db_->get(BLOCK_MERKLE_KEYS_CF, serialize(key))) {
     auto rv = MerkleValue{};
@@ -195,7 +195,7 @@ std::optional<MerkleValue> BlockMerkleCategory::get(const Hash& hashed_key, Bloc
   return std::nullopt;
 }
 
-std::optional<MerkleValue> BlockMerkleCategory::getLatest(const std::string& key) const {
+std::optional<Value> BlockMerkleCategory::getLatest(const std::string& key) const {
   auto hashed_key = hash(key);
   if (auto latest = getLatestVersion(hashed_key)) {
     if (!latest->deleted) {
@@ -221,7 +221,7 @@ std::optional<TaggedVersion> BlockMerkleCategory::getLatestVersion(const Hash& h
 
 void BlockMerkleCategory::multiGet(const std::vector<std::string>& keys,
                                    const std::vector<BlockId>& versions,
-                                   std::vector<std::optional<MerkleValue>>& values) const {
+                                   std::vector<std::optional<Value>>& values) const {
   ConcordAssertEQ(keys.size(), versions.size());
   auto versioned_keys = versionedKeys(keys, versions);
   multiGet(versioned_keys, versions, values);
@@ -229,7 +229,7 @@ void BlockMerkleCategory::multiGet(const std::vector<std::string>& keys,
 
 void BlockMerkleCategory::multiGet(const std::vector<Buffer>& versioned_keys,
                                    const std::vector<BlockId>& versions,
-                                   std::vector<std::optional<MerkleValue>>& values) const {
+                                   std::vector<std::optional<Value>>& values) const {
   auto slices = std::vector<::rocksdb::PinnableSlice>{};
   auto statuses = std::vector<::rocksdb::Status>{};
 
@@ -279,7 +279,7 @@ void BlockMerkleCategory::multiGetLatestVersion(const std::vector<Hash>& hashed_
 }
 
 void BlockMerkleCategory::multiGetLatest(const std::vector<std::string>& keys,
-                                         std::vector<std::optional<MerkleValue>>& values) const {
+                                         std::vector<std::optional<Value>>& values) const {
   auto hashed_keys = hashedKeys(keys);
   std::vector<std::optional<TaggedVersion>> versions;
   multiGetLatestVersion(hashed_keys, versions);
@@ -302,7 +302,7 @@ void BlockMerkleCategory::multiGetLatest(const std::vector<std::string>& keys,
   }
 
   // Retrieve only the keys that have latest versions
-  auto retrieved_values = std::vector<std::optional<MerkleValue>>{};
+  auto retrieved_values = std::vector<std::optional<Value>>{};
   multiGet(versioned_keys, found_versions, retrieved_values);
 
   // Merge any keys that didn't have latest versions along with the retrieved keys.

--- a/kvbc/test/categorization/blockchain_test.cpp
+++ b/kvbc/test/categorization/blockchain_test.cpp
@@ -159,7 +159,7 @@ TEST_F(categorized_kvbc, get_block) {
 
 TEST_F(categorized_kvbc, fail_get_raw) {
   detail::Blockchain block_chain{db};
-  auto rb = block_chain.getRawBlock(100);
+  auto rb = block_chain.getRawBlock(100, nullptr);
   ASSERT_FALSE(rb.has_value());
 }
 


### PR DESCRIPTION
Wire the ```ImmutableKeyValueCategory, VersionedKeyValueCategory, BlockMerkleCategory``` 
add(BlockId block_id, category update, storage::rocksdb::NativeWriteBatch&) method to the adapter upon
adding a new block.

Now that those methods actually write to storage, the  ```raw block``` can be reconstructed
from a block, by reconstructing the updates from the block struct.

Changing the ```BlockMerkleCategory``` to return a ```Value``` variant instead of the category specific 
```MerkleValue```.

