### PR TITLE
Diagnostics: Prevent out of bound memory access

### DIFF
--- a/diagnostics/include/diagnostics_server.h
+++ b/diagnostics/include/diagnostics_server.h
@@ -69,7 +69,7 @@ inline std::string readline(int sock) {
       throw std::runtime_error("Request exceeded max size: " + std::to_string(MAX_INPUT_SIZE));
     }
 
-    rv = read(sock, &buf + count, buf.size() - count);
+    rv = read(sock, buf.data() + count, buf.size() - count);
     if (rv <= 0) {
       throw std::runtime_error("read failed: " + errnoString(rv));
     }


### PR DESCRIPTION
It is not safe to take the address of a `std::array` using `&` and then
do pointer arithmetic with that address. The problem is that the
calculations may end out of bounds because the pointer appears to advances by a
pointer size and not a multiple of the size of the template
argument of the array. This is probably undefined behavior since
std::array doesn't provide a `&` operator.

The proper way to do this is to use the `.data()`
member function to get a properly typed address.