### PR TITLE
Explicitly set the last executed seqnum for ReadOnlyReplica

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -107,6 +107,7 @@ class IReplica {
   virtual bool isRunning() const = 0;
 
   virtual int64_t getLastExecutedSequenceNum() const = 0;
+  virtual void setLastExecutedSequenceNum(const SeqNum &) = 0;
 
   virtual void start() = 0;
 

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -40,6 +40,7 @@ class ReplicaInternal : public IReplica {
   bool isRunning() const override;
 
   int64_t getLastExecutedSequenceNum() const override { return replica_->getLastExecutedSequenceNum(); }
+  void setLastExecutedSequenceNum(const SeqNum &seqNum) override { replica_->setLastExecutedSequenceNum(seqNum); }
 
   void start() override;
 

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -70,6 +70,7 @@ class ReplicaBase {
   virtual void start();
   virtual void stop();
   SeqNum getLastExecutedSequenceNum() const { return lastExecutedSeqNum; }
+  void setLastExecutedSequenceNum(const SeqNum& seqNum) { lastExecutedSeqNum = seqNum; }
   virtual bool isRunning() const;
 
   auto& timers() { return timers_; }

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -47,6 +47,9 @@ Status ReplicaImp::start() {
   if (replicaConfig_.isReadOnly) {
     LOG_INFO(logger, "ReadOnly mode");
     m_replicaPtr = bftEngine::IReplica::createNewRoReplica(replicaConfig_, m_stateTransfer, m_ptrComm);
+    // explicitly set the last executed seqnum from the last reachable block for proper State Transfer functioning
+    // when regular replicas are restored from a backup, earlier than the last reachable block
+    m_replicaPtr->setLastExecutedSequenceNum(m_bcDbAdapter->getLastReachableBlockId() * checkpointWindowSize);
   } else {
     createReplicaAndSyncState();
   }


### PR DESCRIPTION
 from the last reachable block for proper State Transfer functioning
when regular replicas are restored from a backup, earlier than the last reachable block.