### PR TITLE
Cherry-pick some S3 client fixes in v0.9.x

### DIFF
--- a/bftengine/tests/s3/metrics_test.cpp
+++ b/bftengine/tests/s3/metrics_test.cpp
@@ -16,18 +16,18 @@ TEST(metrics_test, updateLastSavedBlockId) {
   // Create a data key - it should increase the metric
   auto dataKey = keygen->dataKey(concord::kvbc::Key{keyName}, blockId);
   m.updateLastSavedBlockId(dataKey.toString());
-  ASSERT_EQ(m.getLastSavedBlockId(), "1");
+  ASSERT_EQ(m.getLastSavedBlockId(), 1);
 
   // Create metadata key - it should NOT increase the metric
   auto mdtKey = keygen->mdtKey(Key{keyName});
   m.updateLastSavedBlockId(mdtKey.toString());
-  ASSERT_EQ(m.getLastSavedBlockId(), "1");
+  ASSERT_EQ(m.getLastSavedBlockId(), 1);
 
   // Create block key - it should increase the metric
   blockId++;
   auto blockKey = keygen->blockKey(blockId);
   m.updateLastSavedBlockId(blockKey.toString());
-  ASSERT_EQ(m.getLastSavedBlockId(), "2");
+  ASSERT_EQ(m.getLastSavedBlockId(), 2);
 }
 
 }  // namespace

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -10,7 +10,6 @@ find_library(LIBS3 s3)
 target_compile_definitions(concordbft_storage PUBLIC USE_S3_OBJECT_STORE=1)
 target_sources(concordbft_storage PRIVATE src/s3/client.cpp)
 target_link_libraries(concordbft_storage PRIVATE ${LIBS3})
-target_include_directories(concordbft_storage PRIVATE ${CMAKE_SOURCE_DIR}/kvbc/include/)
 endif(USE_S3_OBJECT_STORE)
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -10,6 +10,7 @@ find_library(LIBS3 s3)
 target_compile_definitions(concordbft_storage PUBLIC USE_S3_OBJECT_STORE=1)
 target_sources(concordbft_storage PRIVATE src/s3/client.cpp)
 target_link_libraries(concordbft_storage PRIVATE ${LIBS3})
+target_include_directories(concordbft_storage PRIVATE ${CMAKE_SOURCE_DIR}/kvbc/include/)
 endif(USE_S3_OBJECT_STORE)
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -206,8 +206,8 @@ class Client : public concord::storage::IDBClient {
   }
 
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) override {
-    metrics_.metrics_component_.SetAggregator(aggregator);
-    metrics_.metrics_component_.UpdateAggregator();
+    metrics_.metrics_component.SetAggregator(aggregator);
+    metrics_.metrics_component.UpdateAggregator();
   }
 
   ///////////////////////// protected /////////////////////////////

--- a/storage/include/s3/metrics.hpp
+++ b/storage/include/s3/metrics.hpp
@@ -2,7 +2,6 @@
 
 #include "Metrics.hpp"
 #include "sliver.hpp"
-#include "kv_types.hpp"
 #include "Logger.hpp"
 namespace concord::storage::s3 {
 
@@ -56,7 +55,7 @@ class Metrics {
     last_saved_block_id_.Get().Set(lastSavedBlockVal);
   }
 
-  kvbc::BlockId getLastSavedBlockId() { return last_saved_block_id_.Get().Get(); }
+  uint64_t getLastSavedBlockId() { return last_saved_block_id_.Get().Get(); }
 
   concordMetrics::Component metrics_component;
 

--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -133,10 +133,10 @@ Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
   string s = string(_key.data());
   S3_put_object(&context_, string(_key.data()).c_str(), _value.length(), NULL, NULL, &putObjectHandler, &cbData);
   if (cbData.status == S3Status::S3StatusOK) {
-    metrics_.numKeysTransferred.Get().Inc();
-    metrics_.bytesTransferred.Get().Inc(_key.length() + _value.length());
+    metrics_.num_keys_transferred.Get().Inc();
+    metrics_.bytes_transferred.Get().Inc(_key.length() + _value.length());
     metrics_.updateLastSavedBlockId(_key);
-    metrics_.metrics_component_.UpdateAggregator();
+    metrics_.metrics_component.UpdateAggregator();
     return Status::OK();
   } else {
     LOG_ERROR(logger_, "put status: " << cbData.status);


### PR DESCRIPTION
Fixes being cherry-picked:
- last_saved_block_id is gauge instead of status
- proper handling for S3 protocol parameter

Please check the cherry-picked commit messages for details.