### PR TITLE
Initial implementation of a Byzantine replica

### DIFF
--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -126,22 +126,26 @@ class ReplicaImp : public IReplica,
     }
   };
 
- private:
+  /**
+   * (Byzantine replica work) The following attributes shouldn't be "relaxed" from private to protected, if there was a
+   * small refactoring to expose them to potential subclasses.
+   */
+ protected:
   logging::Logger logger;
   RepStatus m_currentRepStatus;
-
-  std::unique_ptr<IDbAdapter> m_bcDbAdapter;
-  std::shared_ptr<storage::IDBClient> m_metadataDBClient;
   bft::communication::ICommunication *m_ptrComm = nullptr;
   const bftEngine::ReplicaConfig &replicaConfig_;
   bftEngine::IReplica::IReplicaPtr m_replicaPtr = nullptr;
-  ICommandsHandler *m_cmdHandler = nullptr;
   bftEngine::IStateTransfer *m_stateTransfer = nullptr;
-  concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
-  std::unique_ptr<ReplicaStateSync> replicaStateSync_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
   std::shared_ptr<bftEngine::ControlStateManager> controlStateManager_;
+  ICommandsHandler *m_cmdHandler = nullptr;
+  concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
+  std::unique_ptr<IDbAdapter> m_bcDbAdapter;
+  std::shared_ptr<storage::IDBClient> m_metadataDBClient;
+  std::unique_ptr<ReplicaStateSync> replicaStateSync_;
 
+ private:
   // 5 Minutes
   static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60 * 5;
   // 1 second

--- a/tests/apollo/test_skvbc_byzantine.py
+++ b/tests/apollo/test_skvbc_byzantine.py
@@ -1,0 +1,101 @@
+# Concord
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os.path
+import random
+import unittest
+from os import environ
+
+from util import blinking_replica
+from util import eliot_logging as log
+from util import skvbc as kvbc
+from util.bft import KEY_FILE_PREFIX, with_trio
+from util.bft import with_bft_network
+
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "10000"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "ByzantineReplica", "byzantine_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-v", viewChangeTimeoutMilli,
+            "-e", str(True),
+            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
+                    in set(["true", "on"])
+                 else "",
+            "-t", os.environ.get('STORAGE_TYPE')]
+
+
+class SkvbcByzantineTest(unittest.TestCase):
+
+    __test__ = False  # so that PyTest ignores this test scenario
+    
+    @with_trio
+    @with_bft_network(start_replica_cmd)
+    async def test_get_block_data(self, bft_network, exchange_keys=True):
+        """
+        Ensure that we can put a block and use the GetBlockData API request to
+        retrieve its KV pairs.
+        """
+
+        if exchange_keys:
+            await bft_network.do_key_exchange()
+
+        log.log_message("**** after exchange keys milestone")
+
+        bft_network.start_all_replicas()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        client = bft_network.random_client()
+        last_block = skvbc.parse_reply(await client.read(skvbc.get_last_block_req()))
+
+        # Perform an unconditional KV put.
+        # Ensure keys aren't identical
+        kv = [(skvbc.keys[0], skvbc.random_value()),
+              (skvbc.keys[1], skvbc.random_value())]
+
+        reply = await client.write(skvbc.write_req([], kv, 0))
+        reply = skvbc.parse_reply(reply)
+        self.assertTrue(reply.success)
+        self.assertEqual(last_block + 1, reply.last_block_id)
+
+        last_block = reply.last_block_id
+
+        # Get the kvpairs in the last written block
+        data = await client.read(skvbc.get_block_data_req(last_block))
+        kv2 = skvbc.parse_reply(data)
+        self.assertDictEqual(kv2, dict(kv))
+
+        # Write another block with the same keys but (probabilistically)
+        # different data
+        kv3 = [(skvbc.keys[0], skvbc.random_value()),
+               (skvbc.keys[1], skvbc.random_value())]
+        reply = await client.write(skvbc.write_req([], kv3, 0))
+        reply = skvbc.parse_reply(reply)
+        self.assertTrue(reply.success)
+        self.assertEqual(last_block + 1, reply.last_block_id)
+
+        # Get the kvpairs in the previously written block
+        data = await client.read(skvbc.get_block_data_req(last_block))
+        kv2 = skvbc.parse_reply(data)
+        self.assertDictEqual(kv2, dict(kv))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/simpleKVBC/ByzantineReplica/.gitignore
+++ b/tests/simpleKVBC/ByzantineReplica/.gitignore
@@ -1,0 +1,3 @@
+/Debug/
+ByzantineReplica
+*.o

--- a/tests/simpleKVBC/ByzantineReplica/ByzantineReplicaImp.cpp
+++ b/tests/simpleKVBC/ByzantineReplica/ByzantineReplicaImp.cpp
@@ -1,0 +1,326 @@
+// Concord
+//
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "bftengine/DebugPersistentStorage.hpp"
+#include "bftengine/MsgHandlersRegistrator.hpp"
+#include "bftengine/IncomingMsgsStorageImp.hpp"
+#include "bftengine/IStateTransfer.hpp"
+#include "bftengine/MsgReceiver.hpp"
+#include "bftengine/Replica.hpp"
+#include "bftengine/PersistentStorageImp.hpp"
+#include "bftengine/ReplicaLoader.hpp"
+#include "preprocessor/PreProcessor.hpp"
+#include "ReplicaImp.hpp"
+#include "ReplicaImp.h"
+
+#include "ByzantineReplicaImp.hpp"
+
+using namespace bftEngine;
+using namespace bftEngine::impl;
+using namespace preprocessor;
+using bft::communication::ICommunication;
+using concord::kvbc::IStorageFactory;
+
+namespace bftEngine::impl {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+/**
+ * Private state duplicated from BFTEngine.cpp.
+ */
+
+bool cryptoInitialized = false;
+std::mutex mutexForCryptoInitialization;
+}  // namespace
+
+namespace byzantine {
+
+/**
+ * Local copy of BFTEngine.cpp's ReplicaInternal private class. If that was accessible or reusable somehow, this
+ * definition here shouldn't be needed.
+ */
+
+class ReplicaInternal : public IReplica {
+  friend class IReplica;
+
+ public:
+  bool isRunning() const override;
+
+  int64_t getLastExecutedSequenceNum() const override { return replica_->getLastExecutedSequenceNum(); }
+
+  void start() override;
+
+  void stop() override;
+
+  void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) override;
+
+  void restartForDebug(uint32_t delayMillis) override;
+
+  void setControlStateManager(std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) override {
+    replica_->setControlStateManager(controlStateManager);
+  }
+
+ public:
+  std::unique_ptr<ReplicaBase> replica_;
+  std::condition_variable debugWait_;
+  std::mutex debugWaitLock_;
+};
+
+bool ReplicaInternal::isRunning() const { return replica_->isRunning(); }
+
+void ReplicaInternal::start() {
+  replica_->start();
+  preprocessor::PreProcessor::setAggregator(replica_->getAggregator());
+}
+
+void ReplicaInternal::stop() {
+  unique_lock<std::mutex> lk(debugWaitLock_);
+  if (replica_->isRunning()) {
+    replica_->stop();
+  }
+
+  debugWait_.notify_all();
+}
+
+void ReplicaInternal::SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) { replica_->SetAggregator(a); }
+
+void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
+  {
+    unique_lock<std::mutex> lk(debugWaitLock_);
+    replica_->stop();
+    if (delayMillis > 0) {
+      std::cv_status res = debugWait_.wait_for(lk, std::chrono::milliseconds(delayMillis));
+      if (std::cv_status::no_timeout == res)  // stop() was called
+        return;
+    }
+  }
+
+  if (!replica_->isReadOnly()) {
+    ReplicaImp *replicaImp = dynamic_cast<ReplicaImp *>(replica_.get());
+
+    shared_ptr<PersistentStorage> persistentStorage(replicaImp->getPersistentStorage());
+    ReplicaLoader::ErrorCode loadErrCode;
+    LoadedReplicaData ld = ReplicaLoader::loadReplica(persistentStorage, loadErrCode);
+    ConcordAssert(loadErrCode == ReplicaLoader::ErrorCode::Success);
+
+    replica_.reset(new concord::kvbc::test::ByzantineBftEngineReplicaImp(ld,
+                                                                         replicaImp->getRequestsHandler(),
+                                                                         replicaImp->getStateTransfer(),
+                                                                         replicaImp->getMsgsCommunicator(),
+                                                                         persistentStorage,
+                                                                         replicaImp->getMsgHandlersRegistrator(),
+                                                                         replicaImp->timers()));
+
+  } else {
+    //  TODO [TK] rep.reset(new ReadOnlyReplicaImp());
+  }
+  replica_->start();
+}
+}  // namespace byzantine
+}  // namespace bftEngine::impl
+
+namespace concord::kvbc::test {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Byzantine replica extending bftEngine::impl::ReplicaImp
+ *
+ * These default constructors could do more than just calling the parent class constructor. If the Byzantine behavior is
+ * not injected via the constructor arguments (e.g. custom MsgsCommunicator and/or MsgHandlersRegistrator), the
+ * constructors can inject the Byzantine components here by themselves.
+ */
+
+ByzantineBftEngineReplicaImp::ByzantineBftEngineReplicaImp(const ReplicaConfig &config,
+                                                           IRequestsHandler *requestsHandler,
+                                                           IStateTransfer *stateTrans,
+                                                           shared_ptr<MsgsCommunicator> msgsCommunicator,
+                                                           shared_ptr<PersistentStorage> persistentStorage,
+                                                           shared_ptr<MsgHandlersRegistrator> msgHandlers,
+                                                           concordUtil::Timers &timers)
+    : bftEngine::impl::ReplicaImp(
+          config, requestsHandler, stateTrans, msgsCommunicator, persistentStorage, msgHandlers, timers) {
+  LOG_DEBUG(GL, "ByzantineBftEngineReplicaImp constructor!");
+}
+
+ByzantineBftEngineReplicaImp::ByzantineBftEngineReplicaImp(const LoadedReplicaData &ld,
+                                                           IRequestsHandler *requestsHandler,
+                                                           IStateTransfer *stateTrans,
+                                                           shared_ptr<MsgsCommunicator> msgsCommunicator,
+                                                           shared_ptr<PersistentStorage> persistentStorage,
+                                                           shared_ptr<MsgHandlersRegistrator> msgHandlers,
+                                                           concordUtil::Timers &timers)
+    : bftEngine::impl::ReplicaImp(
+          ld, requestsHandler, stateTrans, msgsCommunicator, persistentStorage, msgHandlers, timers) {
+  LOG_DEBUG(GL, "ByzantineBftEngineReplicaImp constructor!");
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Byzantine replica extending concord::kvbc::ReplicaImp
+ *
+ * With an extra refactoring of the original concord::kvbc::ReplicaImp implementation, many of the code duplicated here
+ * shouldn't be required.
+ */
+
+ByzantineKvbcReplicaImp::ByzantineKvbcReplicaImp(ICommunication *comm,
+                                                 const bftEngine::ReplicaConfig &replicaConfig,
+                                                 std::unique_ptr<IStorageFactory> storageFactory,
+                                                 std::shared_ptr<concordMetrics::Aggregator> aggregator)
+    : concord::kvbc::ReplicaImp(comm, replicaConfig, std::move(storageFactory), aggregator) {
+  LOG_DEBUG(GL, "ByzantineKvbcReplicaImp constructor!");
+}
+
+/**
+ * Custom implementation to invoke the createReplicaAndSyncState function.
+ */
+Status ByzantineKvbcReplicaImp::start() {
+  LOG_INFO(logger, "ByzantineKvbcReplicaImp::Start() id = " << replicaConfig_.replicaId);
+
+  if (m_currentRepStatus != RepStatus::Idle) {
+    return Status::IllegalOperation("todo");
+  }
+
+  m_currentRepStatus = RepStatus::Starting;
+
+  if (replicaConfig_.isReadOnly) {
+    LOG_INFO(logger, "ReadOnly mode");
+    m_replicaPtr = bftEngine::IReplica::createNewRoReplica(replicaConfig_, m_stateTransfer, m_ptrComm);
+  } else {
+    createReplicaAndSyncState();
+  }
+  concord::kvbc::ReplicaImp::m_replicaPtr->setControlStateManager(controlStateManager_);
+  m_replicaPtr->SetAggregator(aggregator_);
+  m_replicaPtr->start();
+  m_currentRepStatus = RepStatus::Running;
+
+  /// TODO(IG, GG)
+  /// add return value to start/stop
+
+  return Status::OK();
+}
+
+/**
+ * Custom implementation to invoke the createNewReplica function.
+ */
+void ByzantineKvbcReplicaImp::createReplicaAndSyncState() {
+  bool isNewStorage = m_metadataStorage->isNewStorage();
+  bool erasedMetaData;
+  m_replicaPtr = concord::kvbc::test::createNewReplica(
+      replicaConfig_, m_cmdHandler, m_stateTransfer, m_ptrComm, m_metadataStorage, erasedMetaData);
+  if (erasedMetaData) isNewStorage = true;
+  LOG_INFO(logger, "ByzantineKvbcReplicaImp::createReplicaAndSyncState: isNewStorage= " << isNewStorage);
+  if (!isNewStorage && !m_stateTransfer->isCollectingState()) {
+    uint64_t removedBlocksNum = replicaStateSync_->execute(
+        logger, *m_bcDbAdapter, getLastReachableBlockNum(), m_replicaPtr->getLastExecutedSequenceNum());
+    LOG_INFO(logger,
+             "ByzantineKvbcReplicaImp::createReplicaAndSyncState: removedBlocksNum = "
+                 << removedBlocksNum << ", new m_lastBlock = " << getLastBlockNum()
+                 << ", new m_lastReachableBlock = " << getLastReachableBlockNum());
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Custom implementation to inject the ByzantineBftEngineReplicaImp instance.
+ */
+bftEngine::IReplica::IReplicaPtr createNewReplica(const ReplicaConfig &replicaConfig,
+                                                  IRequestsHandler *requestsHandler,
+                                                  IStateTransfer *stateTransfer,
+                                                  bft::communication::ICommunication *communication,
+                                                  MetadataStorage *metadataStorage,
+                                                  bool &erasedMetadata) {
+  erasedMetadata = false;
+  {
+    std::lock_guard<std::mutex> lock(mutexForCryptoInitialization);
+    if (!cryptoInitialized) {
+      cryptoInitialized = true;
+      CryptographyWrapper::init();
+    }
+  }
+
+  shared_ptr<PersistentStorage> persistentStoragePtr;
+  uint16_t numOfObjects = 0;
+  bool isNewStorage = true;
+
+  if (replicaConfig.debugPersistentStorageEnabled)
+    if (metadataStorage == nullptr)
+      persistentStoragePtr.reset(new DebugPersistentStorage(replicaConfig.fVal, replicaConfig.cVal));
+
+  // Testing/real metadataStorage passed.
+  if (metadataStorage != nullptr) {
+    persistentStoragePtr.reset(new PersistentStorageImp(replicaConfig.fVal, replicaConfig.cVal));
+    unique_ptr<MetadataStorage> metadataStoragePtr(metadataStorage);
+    auto objectDescriptors =
+        ((PersistentStorageImp *)persistentStoragePtr.get())->getDefaultMetadataObjectDescriptors(numOfObjects);
+    isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);
+    bool erasedMetaData;
+    ((PersistentStorageImp *)persistentStoragePtr.get())->init(move(metadataStoragePtr), erasedMetaData);
+    if (erasedMetaData) {
+      isNewStorage = true;
+      erasedMetadata = true;
+    }
+  }
+  auto replicaInternal = std::make_unique<bftEngine::impl::byzantine::ReplicaInternal>();
+  shared_ptr<MsgHandlersRegistrator> msgHandlersPtr(new MsgHandlersRegistrator());
+  auto incomingMsgsStorageImpPtr =
+      std::make_unique<IncomingMsgsStorageImp>(msgHandlersPtr, timersResolution, replicaConfig.replicaId);
+  auto &timers = incomingMsgsStorageImpPtr->timers();
+  shared_ptr<IncomingMsgsStorage> incomingMsgsStoragePtr{std::move(incomingMsgsStorageImpPtr)};
+
+  /**
+   * A custom implementation for MsgsCommunicator and/or MsgReceiver could be used here to inject different Byzantine
+   * behavior regardging incoming and outgoing messages.
+   */
+
+  shared_ptr<bft::communication::IReceiver> msgReceiverPtr(new MsgReceiver(incomingMsgsStoragePtr));
+  shared_ptr<MsgsCommunicator> msgsCommunicatorPtr(
+      new MsgsCommunicator(communication, incomingMsgsStoragePtr, msgReceiverPtr));
+
+  if (isNewStorage) {
+    replicaInternal->replica_.reset(new ByzantineBftEngineReplicaImp(replicaConfig,
+                                                                     requestsHandler,
+                                                                     stateTransfer,
+                                                                     msgsCommunicatorPtr,
+                                                                     persistentStoragePtr,
+                                                                     msgHandlersPtr,
+                                                                     timers));
+  } else {
+    ReplicaLoader::ErrorCode loadErrCode;
+    auto loadedReplicaData = ReplicaLoader::loadReplica(persistentStoragePtr, loadErrCode);
+    if (loadErrCode != ReplicaLoader::ErrorCode::Success) {
+      LOG_ERROR(GL, "Unable to load replica state from storage. Error " << (uint32_t)loadErrCode);
+      return nullptr;
+    }
+    // TODO(GG): compare ld.repConfig and replicaConfig
+    replicaInternal->replica_.reset(new ByzantineBftEngineReplicaImp(loadedReplicaData,
+                                                                     requestsHandler,
+                                                                     stateTransfer,
+                                                                     msgsCommunicatorPtr,
+                                                                     persistentStoragePtr,
+                                                                     msgHandlersPtr,
+                                                                     timers));
+  }
+  PreProcessor::addNewPreProcessor(msgsCommunicatorPtr,
+                                   incomingMsgsStoragePtr,
+                                   msgHandlersPtr,
+                                   *requestsHandler,
+                                   *dynamic_cast<InternalReplicaApi *>(replicaInternal->replica_.get()),
+                                   timers);
+  return replicaInternal;
+}
+};  // namespace concord::kvbc::test

--- a/tests/simpleKVBC/ByzantineReplica/ByzantineReplicaImp.hpp
+++ b/tests/simpleKVBC/ByzantineReplica/ByzantineReplicaImp.hpp
@@ -1,0 +1,64 @@
+// Concord
+//
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "bftengine/IStateTransfer.hpp"
+#include "bftengine/Replica.hpp"
+#include "ReplicaImp.hpp"
+#include "ReplicaImp.h"
+
+using namespace bftEngine;
+using namespace bftEngine::impl;
+using bft::communication::ICommunication;
+using concord::kvbc::IStorageFactory;
+
+namespace concord::kvbc::test {
+
+bftEngine::IReplica::IReplicaPtr createNewReplica(const ReplicaConfig &replicaConfig,
+                                                  IRequestsHandler *requestsHandler,
+                                                  IStateTransfer *stateTransfer,
+                                                  bft::communication::ICommunication *communication,
+                                                  MetadataStorage *metadataStorage,
+                                                  bool &erasedMetadata);
+
+class ByzantineBftEngineReplicaImp : public bftEngine::impl::ReplicaImp {
+ public:
+  ByzantineBftEngineReplicaImp(const ReplicaConfig &config,
+                               IRequestsHandler *requestsHandler,
+                               IStateTransfer *stateTrans,
+                               shared_ptr<MsgsCommunicator> msgsCommunicator,
+                               shared_ptr<PersistentStorage> persistentStorage,
+                               shared_ptr<MsgHandlersRegistrator> msgHandlers,
+                               concordUtil::Timers &timers);
+
+  ByzantineBftEngineReplicaImp(const LoadedReplicaData &ld,
+                               IRequestsHandler *requestsHandler,
+                               IStateTransfer *stateTrans,
+                               shared_ptr<MsgsCommunicator> msgsCommunicator,
+                               shared_ptr<PersistentStorage> persistentStorage,
+                               shared_ptr<MsgHandlersRegistrator> msgHandlers,
+                               concordUtil::Timers &timers);
+};
+
+class ByzantineKvbcReplicaImp : public concord::kvbc::ReplicaImp {
+ public:
+  ByzantineKvbcReplicaImp(ICommunication *comm,
+                          const bftEngine::ReplicaConfig &replicaConfig,
+                          std::unique_ptr<IStorageFactory> storageFactory,
+                          std::shared_ptr<concordMetrics::Aggregator> aggregator);
+
+  Status start() override;
+
+ private:
+  void createReplicaAndSyncState();
+};
+};  // namespace concord::kvbc::test

--- a/tests/simpleKVBC/ByzantineReplica/CMakeLists.txt
+++ b/tests/simpleKVBC/ByzantineReplica/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required (VERSION 3.2)
+project(byzantine_replica VERSION 0.1.0.0 LANGUAGES CXX)
+
+add_executable(byzantine_replica ByzantineReplicaImp.cpp
+								 main.cpp
+								 internalCommandsHandler.cpp
+								 setup.cpp
+   								 ../simpleKVBTestsBuilder.cpp
+       							 ${concord_bft_tools_SOURCE_DIR}/KeyfileIOUtils.cpp)
+
+if(${USE_COMM_PLAIN_TCP})
+	target_compile_definitions(byzantine_replica PUBLIC USE_COMM_PLAIN_TCP)
+endif()
+
+if(${USE_COMM_TLS_TCP})
+	target_compile_definitions(byzantine_replica PUBLIC USE_COMM_TLS_TCP)
+endif()
+
+if(BUILD_ROCKSDB_STORAGE)
+	target_compile_definitions(byzantine_replica PUBLIC "USE_ROCKSDB=1")
+endif()
+
+target_link_libraries(byzantine_replica PUBLIC kvbc corebft threshsign util test_config_lib )
+
+target_include_directories(byzantine_replica PUBLIC ..)
+target_include_directories(byzantine_replica PUBLIC ../..)
+target_include_directories(byzantine_replica PUBLIC ${libkvbc_SOURCE_DIR}/include)
+target_include_directories(byzantine_replica PUBLIC ${CMAKE_SOURCE_DIR}/bftengine/src)

--- a/tests/simpleKVBC/ByzantineReplica/README.md
+++ b/tests/simpleKVBC/ByzantineReplica/README.md
@@ -1,0 +1,20 @@
+This folder contains the initial implementation of a so-called Byzantine testing extension for the Apollo framework. The idea is to provide a series of extension points within the regular replica logic to allow the injection of certain Byzantine behavior.
+
+From the implementation point of view:
+
+```
+- main.cpp
+- ByzantineReplicaImp.hpp
+- ByzantineReplicaImp.cpp
+```
+Those contain the main interfaces and classes to start a Byzantine replica with the proper settings in the Apollo tests context and to extend the default replica logic in order to add different Byzantine behavior.
+
+```
+- setup.hpp
+- setup.cpp
+- internalCommandsHandler.hpp
+- internalCommandsHandler.cpp
+```
+Those contain helper interfaces and clases for replica initialization purposes in the Apollo tests context. They are actually pretty similar to the ones within the `../TesterReplica` folder, and with a bit of refactoring they could be shared and reused.
+
+At tests level, the `test_skvbc_byzantine.py` file contains a simple test that makes use of a Byzantine replica instance.

--- a/tests/simpleKVBC/ByzantineReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/ByzantineReplica/internalCommandsHandler.cpp
@@ -1,0 +1,360 @@
+// Concord
+//
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "internalCommandsHandler.hpp"
+#include "OpenTracing.hpp"
+#include "assertUtils.hpp"
+#include "sliver.hpp"
+#include "kv_types.hpp"
+#include "block_metadata.hpp"
+#include <unistd.h>
+#include <algorithm>
+
+using namespace BasicRandomTests;
+using namespace bftEngine;
+
+using concordUtils::Status;
+using concordUtils::Sliver;
+using concord::kvbc::BlockId;
+using concord::kvbc::KeyValuePair;
+using concord::storage::SetOfKeyValuePairs;
+
+const uint64_t LONG_EXEC_CMD_TIME_IN_SEC = 11;
+
+void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequestsQueue &requests,
+                                      const std::string &batchCid,
+                                      concordUtils::SpanWrapper &parent_span) {
+  for (auto &req : requests) {
+    // ReplicaSpecificInfo is not currently used in the TesterReplica
+    if (req.outExecutionStatus != 1) continue;
+    req.outReplicaSpecificInfoSize = 0;
+    int res;
+    if (req.requestSize < sizeof(SimpleRequest)) {
+      LOG_ERROR(m_logger,
+                "The message is too small: requestSize is " << req.requestSize << ", required size is "
+                                                            << sizeof(SimpleRequest));
+      req.outExecutionStatus = -1;
+      continue;
+    }
+    bool readOnly = req.flags & MsgFlag::READ_ONLY_FLAG;
+    if (readOnly) {
+      res = executeReadOnlyCommand(req.requestSize,
+                                   req.request,
+                                   req.maxReplySize,
+                                   req.outReply,
+                                   req.outActualReplySize,
+                                   req.outReplicaSpecificInfoSize);
+    } else {
+      res = executeWriteCommand(req.requestSize,
+                                req.request,
+                                req.executionSequenceNum,
+                                req.flags,
+                                req.maxReplySize,
+                                req.outReply,
+                                req.outActualReplySize);
+    }
+    if (!res) LOG_ERROR(m_logger, "Command execution failed!");
+    req.outExecutionStatus = res ? 0 : -1;
+  }
+}
+
+void InternalCommandsHandler::addMetadataKeyValue(SetOfKeyValuePairs &updates, uint64_t sequenceNum) const {
+  Sliver metadataKey = m_blockMetadata->getKey();
+  Sliver metadataValue = m_blockMetadata->serialize(sequenceNum);
+  updates.insert(KeyValuePair(metadataKey, metadataValue));
+}
+
+Sliver InternalCommandsHandler::buildSliverFromStaticBuf(char *buf) {
+  char *newBuf = new char[KV_LEN];
+  memcpy(newBuf, buf, KV_LEN);
+  return Sliver(newBuf, KV_LEN);
+}
+
+bool InternalCommandsHandler::verifyWriteCommand(uint32_t requestSize,
+                                                 const SimpleCondWriteRequest &request,
+                                                 size_t maxReplySize,
+                                                 uint32_t &outReplySize) const {
+  if (requestSize < sizeof(SimpleCondWriteRequest)) {
+    LOG_ERROR(m_logger,
+              "The message is too small: requestSize is " << requestSize << ", required size is "
+                                                          << sizeof(SimpleCondWriteRequest));
+    return false;
+  }
+  if (requestSize < sizeof(request)) {
+    LOG_ERROR(m_logger,
+              "The message is too small: requestSize is " << requestSize << ", required size is " << sizeof(request));
+    return false;
+  }
+  if (maxReplySize < outReplySize) {
+    LOG_ERROR(m_logger, "replySize is too big: replySize=" << outReplySize << ", maxReplySize=" << maxReplySize);
+    return false;
+  }
+  return true;
+}
+
+bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
+                                                  const char *request,
+                                                  uint64_t sequenceNum,
+                                                  uint8_t flags,
+                                                  size_t maxReplySize,
+                                                  char *outReply,
+                                                  uint32_t &outReplySize) {
+  auto *writeReq = (SimpleCondWriteRequest *)request;
+  LOG_INFO(m_logger,
+           "Execute WRITE command:"
+               << " type=" << writeReq->header.type << " seqNum=" << sequenceNum
+               << " numOfWrites=" << writeReq->numOfWrites << " numOfKeysInReadSet=" << writeReq->numOfKeysInReadSet
+               << " readVersion=" << writeReq->readVersion
+               << " READ_ONLY_FLAG=" << ((flags & MsgFlag::READ_ONLY_FLAG) != 0 ? "true" : "false")
+               << " PRE_PROCESS_FLAG=" << ((flags & MsgFlag::PRE_PROCESS_FLAG) != 0 ? "true" : "false")
+               << " HAS_PRE_PROCESSED_FLAG=" << ((flags & MsgFlag::HAS_PRE_PROCESSED_FLAG) != 0 ? "true" : "false"));
+
+  if (writeReq->header.type == WEDGE) {
+    LOG_INFO(m_logger, "A wedge command has been called" << KVLOG(sequenceNum));
+    controlStateManager_->setStopAtNextCheckpoint(sequenceNum);
+  }
+  if (writeReq->header.type == ADD_REMOVE_NODE) {
+    LOG_INFO(m_logger, "An add_remove_node command has been called" << KVLOG(sequenceNum));
+    controlStateManager_->setStopAtNextCheckpoint(sequenceNum);
+    controlStateManager_->setEraseMetadataFlag(sequenceNum);
+  }
+
+  if (!(flags & MsgFlag::HAS_PRE_PROCESSED_FLAG)) {
+    bool result = verifyWriteCommand(requestSize, *writeReq, maxReplySize, outReplySize);
+    if (!result) ConcordAssert(0);
+    if (flags & MsgFlag::PRE_PROCESS_FLAG) {
+      if (writeReq->header.type == LONG_EXEC_COND_WRITE) sleep(LONG_EXEC_CMD_TIME_IN_SEC);
+      outReplySize = requestSize;
+      memcpy(outReply, request, requestSize);
+      return result;
+    }
+  }
+
+  SimpleKey *readSetArray = writeReq->readSetArray();
+  BlockId currBlock = m_storage->getLastBlock();
+
+  // Look for conflicts
+  bool hasConflict = false;
+  for (size_t i = 0; !hasConflict && i < writeReq->numOfKeysInReadSet; i++) {
+    m_storage->mayHaveConflictBetween(
+        buildSliverFromStaticBuf(readSetArray[i].key), writeReq->readVersion + 1, currBlock, hasConflict);
+  }
+
+  if (!hasConflict) {
+    SimpleKV *keyValArray = writeReq->keyValueArray();
+    SetOfKeyValuePairs updates;
+    for (size_t i = 0; i < writeReq->numOfWrites; i++) {
+      KeyValuePair keyValue(buildSliverFromStaticBuf(keyValArray[i].simpleKey.key),
+                            buildSliverFromStaticBuf(keyValArray[i].simpleValue.value));
+      updates.insert(keyValue);
+    }
+    addMetadataKeyValue(updates, sequenceNum);
+    BlockId newBlockId = 0;
+    Status addSuccess = m_blocksAppender->addBlock(updates, newBlockId);
+    ConcordAssert(addSuccess.isOK());
+    ConcordAssert(newBlockId == currBlock + 1);
+  }
+
+  ConcordAssert(sizeof(SimpleReply_ConditionalWrite) <= maxReplySize);
+  auto *reply = (SimpleReply_ConditionalWrite *)outReply;
+  reply->header.type = COND_WRITE;
+  reply->success = (!hasConflict);
+  if (!hasConflict)
+    reply->latestBlock = currBlock + 1;
+  else
+    reply->latestBlock = currBlock;
+
+  outReplySize = sizeof(SimpleReply_ConditionalWrite);
+  ++m_writesCounter;
+  LOG_INFO(
+      m_logger,
+      "ConditionalWrite message handled; writesCounter=" << m_writesCounter << " currBlock=" << reply->latestBlock);
+  return true;
+}
+
+bool InternalCommandsHandler::executeGetBlockDataCommand(
+    uint32_t requestSize, const char *request, size_t maxReplySize, char *outReply, uint32_t &outReplySize) {
+  auto *req = (SimpleGetBlockDataRequest *)request;
+  LOG_INFO(m_logger, "Execute GET_BLOCK_DATA command: type=" << req->h.type << ", BlockId=" << req->block_id);
+
+  auto minRequestSize = std::max(sizeof(SimpleGetBlockDataRequest), req->size());
+  if (requestSize < minRequestSize) {
+    LOG_ERROR(m_logger,
+              "The message is too small: requestSize=" << requestSize << ", minRequestSize=" << minRequestSize);
+    return false;
+  }
+
+  auto block_id = req->block_id;
+  SetOfKeyValuePairs outBlockData;
+  if (!m_storage->getBlockData(block_id, outBlockData).isOK()) {
+    LOG_ERROR(m_logger, "GetBlockData: Failed to retrieve block %" << block_id);
+    return false;
+  }
+
+  // Each block contains a single metadata key holding the sequence number
+  const int numMetadataKeys = 1;
+  auto numOfElements = outBlockData.size() - numMetadataKeys;
+  size_t replySize = SimpleReply_Read::getSize(numOfElements);
+  LOG_INFO(m_logger, "NUM OF ELEMENTS IN BLOCK = " << numOfElements);
+  if (maxReplySize < replySize) {
+    LOG_ERROR(m_logger, "replySize is too big: replySize=" << replySize << ", maxReplySize=" << maxReplySize);
+    return false;
+  }
+
+  SimpleReply_Read *pReply = (SimpleReply_Read *)(outReply);
+  outReplySize = replySize;
+  memset(pReply, 0, replySize);
+  pReply->header.type = READ;
+  pReply->numOfItems = numOfElements;
+
+  const Sliver metadataKey = m_blockMetadata->getKey();
+
+  auto i = 0;
+  for (const auto &kv : outBlockData) {
+    if (kv.first != metadataKey) {
+      memcpy(pReply->items[i].simpleKey.key, kv.first.data(), KV_LEN);
+      memcpy(pReply->items[i].simpleValue.value, kv.second.data(), KV_LEN);
+      ++i;
+    }
+  }
+  return true;
+}
+
+bool InternalCommandsHandler::executeReadCommand(
+    uint32_t requestSize, const char *request, size_t maxReplySize, char *outReply, uint32_t &outReplySize) {
+  auto *readReq = (SimpleReadRequest *)request;
+  LOG_INFO(m_logger,
+           "Execute READ command: type=" << readReq->header.type << ", numberOfKeysToRead="
+                                         << readReq->numberOfKeysToRead << ", readVersion=" << readReq->readVersion);
+
+  auto minRequestSize = std::max(sizeof(SimpleReadRequest), readReq->getSize());
+  if (requestSize < minRequestSize) {
+    LOG_ERROR(m_logger,
+              "The message is too small: requestSize=" << requestSize << ", minRequestSize=" << minRequestSize);
+    return false;
+  }
+
+  size_t numOfItems = readReq->numberOfKeysToRead;
+  size_t replySize = SimpleReply_Read::getSize(numOfItems);
+
+  if (maxReplySize < replySize) {
+    LOG_ERROR(m_logger, "replySize is too big: replySize=" << replySize << ", maxReplySize=" << maxReplySize);
+    return false;
+  }
+
+  auto *reply = (SimpleReply_Read *)(outReply);
+  outReplySize = replySize;
+  reply->header.type = READ;
+  reply->numOfItems = numOfItems;
+
+  SimpleKey *readKeys = readReq->keys;
+  SimpleKV *replyItems = reply->items;
+  for (size_t i = 0; i < numOfItems; i++) {
+    memcpy(replyItems->simpleKey.key, readKeys->key, KV_LEN);
+    Sliver value;
+    BlockId outBlock = 0;
+    if (!m_storage->get(readReq->readVersion, buildSliverFromStaticBuf(readKeys->key), value, outBlock).isOK()) {
+      LOG_ERROR(m_logger, "Read: Failed to get keys for readVersion = %" << readReq->readVersion);
+      return false;
+    }
+
+    if (value.length() > 0)
+      memcpy(replyItems->simpleValue.value, value.data(), KV_LEN);
+    else
+      memset(replyItems->simpleValue.value, 0, KV_LEN);
+    ++readKeys;
+    ++replyItems;
+  }
+  ++m_readsCounter;
+  LOG_INFO(m_logger, "READ message handled; readsCounter=" << m_readsCounter);
+  return true;
+}
+
+bool InternalCommandsHandler::executeHaveYouStoppedReadCommand(uint32_t requestSize,
+                                                               const char *request,
+                                                               size_t maxReplySize,
+                                                               char *outReply,
+                                                               uint32_t &outReplySize,
+                                                               uint32_t &specificReplicaInfoSize) {
+  auto *readReq = (SimpleHaveYouStoppedRequest *)request;
+  LOG_INFO(m_logger, "Execute HaveYouStopped command: type=" << readReq->header.type);
+
+  specificReplicaInfoSize = sizeof(int64_t);
+  outReplySize = sizeof(SimpleReply);
+  outReplySize += specificReplicaInfoSize;
+  if (maxReplySize < outReplySize) {
+    LOG_ERROR(m_logger, "The message is too small: requestSize=" << requestSize << ", minRequestSize=" << outReplySize);
+    return false;
+  }
+  auto *reply = (SimpleReply_HaveYouStopped *)(outReply);
+  reply->header.type = WEDGE;
+  reply->stopped = controlHandlers_->haveYouStopped(readReq->n_of_n_stop);
+  LOG_INFO(m_logger, "HaveYouStopped message handled");
+  return true;
+}
+
+bool InternalCommandsHandler::executeGetLastBlockCommand(uint32_t requestSize,
+                                                         size_t maxReplySize,
+                                                         char *outReply,
+                                                         uint32_t &outReplySize) {
+  LOG_INFO(m_logger, "GET LAST BLOCK!!!");
+
+  if (requestSize < sizeof(SimpleGetLastBlockRequest)) {
+    LOG_ERROR(m_logger,
+              "The message is too small: requestSize is " << requestSize << ", required size is "
+                                                          << sizeof(SimpleGetLastBlockRequest));
+    return false;
+  }
+
+  outReplySize = sizeof(SimpleReply_GetLastBlock);
+  if (maxReplySize < outReplySize) {
+    LOG_ERROR(m_logger, "maxReplySize is too small: replySize=" << outReplySize << ", maxReplySize=" << maxReplySize);
+    return false;
+  }
+
+  auto *reply = (SimpleReply_GetLastBlock *)(outReply);
+  reply->header.type = GET_LAST_BLOCK;
+  reply->latestBlock = m_storage->getLastBlock();
+  ++m_getLastBlockCounter;
+  LOG_INFO(m_logger,
+           "GetLastBlock message handled; getLastBlockCounter=" << m_getLastBlockCounter
+                                                                << ", latestBlock=" << reply->latestBlock);
+  return true;
+}
+
+bool InternalCommandsHandler::executeReadOnlyCommand(uint32_t requestSize,
+                                                     const char *request,
+                                                     size_t maxReplySize,
+                                                     char *outReply,
+                                                     uint32_t &outReplySize,
+                                                     uint32_t &specificReplicaInfoOutReplySize) {
+  auto *requestHeader = (SimpleRequest *)request;
+  if (requestHeader->type == READ) {
+    return executeReadCommand(requestSize, request, maxReplySize, outReply, outReplySize);
+  } else if (requestHeader->type == GET_LAST_BLOCK) {
+    return executeGetLastBlockCommand(requestSize, maxReplySize, outReply, outReplySize);
+  } else if (requestHeader->type == GET_BLOCK_DATA) {
+    return executeGetBlockDataCommand(requestSize, request, maxReplySize, outReply, outReplySize);
+  } else if (requestHeader->type == WEDGE) {
+    return executeHaveYouStoppedReadCommand(
+        requestSize, request, maxReplySize, outReply, outReplySize, specificReplicaInfoOutReplySize);
+  } else {
+    outReplySize = 0;
+    LOG_ERROR(m_logger, "Illegal message received: requestHeader->type=" << requestHeader->type);
+    return false;
+  }
+}
+void InternalCommandsHandler::setControlStateManager(
+    std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) {
+  controlStateManager_ = controlStateManager;
+}

--- a/tests/simpleKVBC/ByzantineReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/ByzantineReplica/internalCommandsHandler.hpp
@@ -1,0 +1,112 @@
+// Concord
+//
+// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "Logger.hpp"
+#include "OpenTracing.hpp"
+#include "sliver.hpp"
+#include "simpleKVBTestsBuilder.hpp"
+#include "db_interfaces.h"
+#include "block_metadata.hpp"
+#include "KVBCInterfaces.h"
+#include <memory>
+#include "ControlStateManager.hpp"
+#include <chrono>
+#include <thread>
+
+class InternalControlHandlers : public bftEngine::ControlHandlers {
+  bool stoppedOnSuperStableCheckpoint = false;
+  bool stoppedOnStableCheckpoint = false;
+
+ public:
+  void onSuperStableCheckpoint() override { stoppedOnSuperStableCheckpoint = true; }
+  void onStableCheckpoint() override { stoppedOnStableCheckpoint = true; }
+  bool onPruningProcess() override { return false; }
+
+  virtual ~InternalControlHandlers(){};
+  bool haveYouStopped(uint64_t n_of_n) {
+    return n_of_n == 1 ? stoppedOnSuperStableCheckpoint : stoppedOnStableCheckpoint;
+  }
+};
+class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
+ public:
+  InternalCommandsHandler(concord::kvbc::ILocalKeyValueStorageReadOnly *storage,
+                          concord::kvbc::IBlocksAppender *blocksAppender,
+                          concord::kvbc::IBlockMetadata *blockMetadata,
+                          logging::Logger &logger)
+      : m_storage(storage),
+        m_blocksAppender(blocksAppender),
+        m_blockMetadata(blockMetadata),
+        m_logger(logger),
+        controlHandlers_(std::make_shared<InternalControlHandlers>()) {}
+
+  virtual void execute(ExecutionRequestsQueue &requests,
+                       const std::string &batchCid,
+                       concordUtils::SpanWrapper &parent_span) override;
+
+  void setControlStateManager(std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) override;
+
+ private:
+  bool executeWriteCommand(uint32_t requestSize,
+                           const char *request,
+                           uint64_t sequenceNum,
+                           uint8_t flags,
+                           size_t maxReplySize,
+                           char *outReply,
+                           uint32_t &outReplySize);
+
+  bool executeReadOnlyCommand(uint32_t requestSize,
+                              const char *request,
+                              size_t maxReplySize,
+                              char *outReply,
+                              uint32_t &outReplySize,
+                              uint32_t &specificReplicaInfoOutReplySize);
+
+  bool verifyWriteCommand(uint32_t requestSize,
+                          const BasicRandomTests::SimpleCondWriteRequest &request,
+                          size_t maxReplySize,
+                          uint32_t &outReplySize) const;
+
+  bool executeReadCommand(
+      uint32_t requestSize, const char *request, size_t maxReplySize, char *outReply, uint32_t &outReplySize);
+
+  bool executeGetBlockDataCommand(
+      uint32_t requestSize, const char *request, size_t maxReplySize, char *outReply, uint32_t &outReplySize);
+
+  bool executeHaveYouStoppedReadCommand(uint32_t requestSize,
+                                        const char *request,
+                                        size_t maxReplySize,
+                                        char *outReply,
+                                        uint32_t &outReplySize,
+                                        uint32_t &specificReplicaInfoSize);
+  bool executeGetLastBlockCommand(uint32_t requestSize, size_t maxReplySize, char *outReply, uint32_t &outReplySize);
+
+  void addMetadataKeyValue(concord::storage::SetOfKeyValuePairs &updates, uint64_t sequenceNum) const;
+
+  std::shared_ptr<bftEngine::ControlHandlers> getControlHandlers() override { return controlHandlers_; }
+
+ private:
+  static concordUtils::Sliver buildSliverFromStaticBuf(char *buf);
+
+ private:
+  concord::kvbc::ILocalKeyValueStorageReadOnly *m_storage;
+  concord::kvbc::IBlocksAppender *m_blocksAppender;
+  concord::kvbc::IBlockMetadata *m_blockMetadata;
+  logging::Logger &m_logger;
+  size_t m_readsCounter = 0;
+  size_t m_writesCounter = 0;
+  size_t m_getLastBlockCounter = 0;
+  std::shared_ptr<bftEngine::ControlStateManager> controlStateManager_;
+  std::shared_ptr<InternalControlHandlers> controlHandlers_;
+};

--- a/tests/simpleKVBC/ByzantineReplica/main.cpp
+++ b/tests/simpleKVBC/ByzantineReplica/main.cpp
@@ -1,0 +1,94 @@
+// Concord
+//
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "setup.hpp"
+#include "ReplicaImp.h"
+#include "internalCommandsHandler.hpp"
+#include "replica_state_sync_imp.hpp"
+#include "block_metadata.hpp"
+#include "SimpleBCStateTransfer.hpp"
+#include "assertUtils.hpp"
+#include <csignal>
+
+#include "ByzantineReplicaImp.hpp"
+
+#ifdef USE_ROCKSDB
+#include "rocksdb/client.h"
+#include "rocksdb/key_comparator.h"
+#endif
+
+#include <memory>
+
+namespace concord::kvbc::test {
+
+std::atomic_bool timeToExit = false;
+
+void run_replica(int argc, char** argv) {
+  const auto setup = TestSetup::ParseArgs(argc, argv);
+  logging::initLogger(setup->getLogPropertiesFile());
+  auto logger = setup->GetLogger();
+  MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(setup->GetReplicaConfig().replicaId));
+  MDC_PUT(MDC_THREAD_KEY, "main");
+
+  std::shared_ptr<ByzantineKvbcReplicaImp> replica =
+      std::make_shared<ByzantineKvbcReplicaImp>(setup->GetCommunication(),
+                                                setup->GetReplicaConfig(),
+                                                setup->GetStorageFactory(),
+                                                setup->GetMetricsServer().GetAggregator());
+
+  auto* blockMetadata = new BlockMetadata(*replica);
+
+  if (!setup->GetReplicaConfig().isReadOnly) replica->setReplicaStateSync(new ReplicaStateSyncImp(blockMetadata));
+
+  InternalCommandsHandler* cmdHandler =
+      new InternalCommandsHandler(replica.get(), replica.get(), blockMetadata, logger);
+  replica->set_command_handler(cmdHandler);
+  replica->start();
+
+  // Start metrics server after creation of the replica so that we ensure
+  // registration of metrics from the replica with the aggregator and don't
+  // return empty metrics from the metrics server.
+  setup->GetMetricsServer().Start();
+  while (replica->isRunning()) {
+    if (timeToExit) {
+      setup->GetMetricsServer().Stop();
+      replica->stop();
+    } else {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+  }
+}
+}  // namespace concord::kvbc::test
+
+using namespace std;
+
+namespace {
+static void signal_handler(int signal_num) {
+  LOG_INFO(GL, "Program received signal " << signal_num);
+  concord::kvbc::test::timeToExit = true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  signal(SIGINT, signal_handler);
+  signal(SIGTERM, signal_handler);
+
+  LOG_INFO(GL, "Starting Byzantine replica... ");
+  try {
+    concord::kvbc::test::run_replica(argc, argv);
+  } catch (const std::exception& e) {
+    LOG_FATAL(GL, "exception: " << e.what());
+  }
+  return 0;
+}

--- a/tests/simpleKVBC/ByzantineReplica/setup.cpp
+++ b/tests/simpleKVBC/ByzantineReplica/setup.cpp
@@ -1,0 +1,280 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <thread>
+#include <sys/param.h>
+#include <string>
+#include <cstring>
+#include <getopt.h>
+#include <unistd.h>
+#include <tuple>
+#include <chrono>
+
+#include "Logger.hpp"
+#include "setup.hpp"
+#include "communication/CommFactory.hpp"
+#include "config/test_comm_config.hpp"
+#include "commonKVBTests.hpp"
+#include "memorydb/client.h"
+#include "string.hpp"
+#include "config/config_file_parser.hpp"
+#include "direct_kv_storage_factory.h"
+#include "merkle_tree_storage_factory.h"
+
+namespace concord::kvbc {
+
+std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
+  try {
+    // used to get info from parsing the key file
+    bftEngine::ReplicaConfig& replicaConfig = bftEngine::ReplicaConfig::instance();
+    replicaConfig.numOfClientProxies = 100;
+    replicaConfig.numOfExternalClients = 30;
+    replicaConfig.concurrencyLevel = 1;
+    replicaConfig.debugStatisticsEnabled = true;
+    replicaConfig.viewChangeTimerMillisec = 45 * 1000;
+    replicaConfig.statusReportTimerMillisec = 10 * 1000;
+    replicaConfig.preExecutionFeatureEnabled = true;
+    replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
+    PersistencyMode persistMode = PersistencyMode::Off;
+    std::string keysFilePrefix;
+    std::string commConfigFile;
+    std::string s3ConfigFile;
+    std::string certRootPath = "certs";
+    std::string logPropsFile = "logging.properties";
+    // Set StorageType::V1DirectKeyValue as the default storage type.
+    auto storageType = StorageType::V1DirectKeyValue;
+
+    static struct option longOptions[] = {{"replica-id", required_argument, 0, 'i'},
+                                          {"key-file-prefix", required_argument, 0, 'k'},
+                                          {"network-config-file", required_argument, 0, 'n'},
+                                          {"status-report-timeout", required_argument, 0, 's'},
+                                          {"view-change-timeout", required_argument, 0, 'v'},
+                                          {"auto-primary-rotation-timeout", required_argument, 0, 'a'},
+                                          {"s3-config-file", required_argument, 0, '3'},
+                                          {"persistence-mode", no_argument, 0, 'p'},
+                                          {"storage-type", required_argument, 0, 't'},
+                                          {"log-props-file", required_argument, 0, 'l'},
+                                          {"key-exchange-on-start", required_argument, 0, 'e'},
+                                          {"cert-root-path", required_argument, 0, 'c'},
+                                          {"consensus-batching-policy", required_argument, 0, 'b'},
+                                          {"consensus-batching-max-reqs-size", required_argument, 0, 'm'},
+                                          {"consensus-batching-max-req-num", required_argument, 0, 'q'},
+                                          {"consensus-batching-flush-period", required_argument, 0, 'z'},
+                                          {"consensus-concurrency-level", required_argument, 0, 'y'},
+                                          {0, 0, 0, 0}};
+
+    int o = 0;
+    int optionIndex = 0;
+    LOG_INFO(GL, "Command line options:");
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:l:c:e:b:m:q:y:z:", longOptions, &optionIndex)) != -1) {
+      switch (o) {
+        case 'i': {
+          replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
+        } break;
+        case 'k': {
+          if (optarg[0] == '-') throw std::runtime_error("invalid argument for --key-file-prefix");
+          keysFilePrefix = optarg;
+        } break;
+        case 'n': {
+          if (optarg[0] == '-') throw std::runtime_error("invalid argument for --network-config-file");
+          commConfigFile = optarg;
+        } break;
+        case 's': {
+          replicaConfig.statusReportTimerMillisec = concord::util::to<std::uint16_t>(std::string(optarg));
+        } break;
+        case 'v': {
+          replicaConfig.viewChangeTimerMillisec = concord::util::to<std::uint16_t>(std::string(optarg));
+          replicaConfig.viewChangeProtocolEnabled = true;
+        } break;
+        case 'a': {
+          replicaConfig.autoPrimaryRotationTimerMillisec = concord::util::to<std::uint16_t>(std::string(optarg));
+          replicaConfig.autoPrimaryRotationEnabled = true;
+        } break;
+        case '3': {
+          if (optarg[0] == '-') throw std::runtime_error("invalid argument for --s3-config-file");
+          s3ConfigFile = optarg;
+        } break;
+        case 'e': {
+          replicaConfig.keyExchangeOnStart = true;
+        } break;
+        case 'y': {
+          const auto concurrencyLevel = concord::util::to<std::uint16_t>(std::string(optarg));
+          if (concurrencyLevel < 1 || concurrencyLevel > 30)
+            throw std::runtime_error{"invalid argument for --consensus-concurrency-level"};
+          replicaConfig.concurrencyLevel = concurrencyLevel;
+        } break;
+        // We can only toggle persistence on or off. It defaults to InMemory unless -p flag is provided.
+        case 'p': {
+          persistMode = PersistencyMode::RocksDB;
+        } break;
+        case 't': {
+          if (optarg == std::string{"v1direct"}) {
+            storageType = StorageType::V1DirectKeyValue;
+          } else if (optarg == std::string{"v2merkle"}) {
+            storageType = StorageType::V2MerkleTree;
+          } else {
+            throw std::runtime_error{"invalid argument for --storage-type"};
+          }
+        } break;
+        case 'l': {
+          logPropsFile = optarg;
+          break;
+        }
+        case 'c': {
+          certRootPath = optarg;
+          break;
+        }
+        case 'b': {
+          auto policy = concord::util::to<std::uint32_t>(std::string(optarg));
+          if (policy < bftEngine::BATCH_SELF_ADJUSTED || policy > bftEngine::BATCH_BY_REQ_NUM)
+            throw std::runtime_error{"invalid argument for --consensus-batching-policy"};
+          replicaConfig.batchingPolicy = policy;
+          break;
+        }
+        case 'm': {
+          replicaConfig.maxBatchSizeInBytes = concord::util::to<std::uint32_t>(std::string(optarg));
+          break;
+        }
+        case 'q': {
+          replicaConfig.maxNumOfRequestsInBatch = concord::util::to<std::uint32_t>(std::string(optarg));
+          break;
+        }
+        case 'z': {
+          const auto batchFlushPeriod = concord::util::to<std::uint32_t>(std::string(optarg));
+          if (!batchFlushPeriod) throw std::runtime_error{"invalid argument for --consensus-batching-flush-period"};
+          replicaConfig.batchFlushPeriod = batchFlushPeriod;
+          break;
+        }
+        case '?': {
+          throw std::runtime_error("invalid arguments");
+        } break;
+
+        default:
+          break;
+      }
+    }
+
+    if (keysFilePrefix.empty()) throw std::runtime_error("missing --key-file-prefix");
+
+    logging::Logger logger = logging::getLogger("skvbctest.replica");
+
+    TestCommConfig testCommConfig(logger);
+    testCommConfig.GetReplicaConfig(replicaConfig.replicaId, keysFilePrefix, &replicaConfig);
+    uint16_t numOfReplicas = (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1);
+
+#ifdef USE_COMM_PLAIN_TCP
+    bft::communication::PlainTcpConfig conf = testCommConfig.GetTCPConfig(
+        true, replicaConfig.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, commConfigFile);
+#elif USE_COMM_TLS_TCP
+    bft::communication::TlsTcpConfig conf = testCommConfig.GetTlsTCPConfig(
+        true, replicaConfig.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, commConfigFile, certRootPath);
+#else
+    bft::communication::PlainUdpConfig conf = testCommConfig.GetUDPConfig(
+        true, replicaConfig.replicaId, replicaConfig.numOfClientProxies, numOfReplicas, commConfigFile);
+#endif
+
+    std::unique_ptr<bft::communication::ICommunication> comm(bft::communication::CommFactory::create(conf));
+
+    uint16_t metricsPort = conf.listenPort + 1000;
+
+    LOG_INFO(logger, "\nReplica Configuration: \n" << replicaConfig);
+
+    return std::unique_ptr<TestSetup>(new TestSetup{replicaConfig,
+                                                    std::move(comm),
+                                                    logger,
+                                                    metricsPort,
+                                                    persistMode == PersistencyMode::RocksDB,
+                                                    s3ConfigFile,
+                                                    storageType,
+                                                    logPropsFile});
+
+  } catch (const std::exception& e) {
+    LOG_FATAL(GL, "failed to parse command line arguments: " << e.what());
+    throw;
+  }
+}
+
+std::unique_ptr<IStorageFactory> TestSetup::GetInMemStorageFactory() const {
+  if (storageType_ == StorageType::V1DirectKeyValue) {
+    return std::make_unique<v1DirectKeyValue::MemoryDBStorageFactory>();
+  } else if (storageType_ == StorageType::V2MerkleTree) {
+    return std::make_unique<v2MerkleTree::MemoryDBStorageFactory>();
+  }
+  throw std::runtime_error{"Invalid storage type"};
+}
+
+#ifdef USE_S3_OBJECT_STORE
+concord::storage::s3::StoreConfig TestSetup::ParseS3Config(const std::string& s3ConfigFile) {
+  ConfigFileParser parser(logger_, s3ConfigFile);
+  if (!parser.Parse()) throw std::runtime_error("failed to parse" + s3ConfigFile);
+
+  auto get_config_value = [&s3ConfigFile, &parser](const std::string& key) {
+    std::vector<std::string> v = parser.GetValues(key);
+    if (v.size()) {
+      return v[0];
+    } else {
+      throw std::runtime_error("failed to parse " + s3ConfigFile + ": " + key + " is not set.");
+    }
+  };
+
+  concord::storage::s3::StoreConfig config;
+  config.bucketName = get_config_value("s3-bucket-name");
+  config.accessKey = get_config_value("s3-access-key");
+  config.protocol = get_config_value("s3-protocol");
+  config.url = get_config_value("s3-url");
+  config.secretKey = get_config_value("s3-secret-key");
+  try {
+    // TesterReplica is used for Apollo tests. Each test is executed against new blockchain, so we need brand new
+    // bucket for the RO replica. To achieve this we use a hack - set the prefix to a uniqe value so each RO replica
+    // writes in the same bucket but in different directory.
+    // So if s3-path-prefix is NOT SET it is initialised to a unique value based on current time.
+    config.pathPrefix = get_config_value("s3-path-prefix");
+  } catch (std::runtime_error& e) {
+    config.pathPrefix = std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+  }
+
+  LOG_INFO(logger_,
+           "\nS3 Configuration:"
+               << "\nbucket:\t\t" << config.bucketName << "\nprotocol:\t" << config.protocol << "\nurl:\t\t"
+               << config.url);
+  return config;
+}
+#endif
+
+std::unique_ptr<IStorageFactory> TestSetup::GetStorageFactory() {
+#ifndef USE_ROCKSDB
+  return GetInMemStorageFactory();
+#else
+
+  if (!UsePersistentStorage()) return GetInMemStorageFactory();
+
+  std::stringstream dbPath;
+  dbPath << BasicRandomTests::DB_FILE_PREFIX << GetReplicaConfig().replicaId;
+
+#ifdef USE_S3_OBJECT_STORE
+  if (GetReplicaConfig().isReadOnly) {
+    if (s3ConfigFile_.empty()) throw std::runtime_error("--s3-config-file must be provided");
+    const auto s3Config = ParseS3Config(s3ConfigFile_);
+    return std::make_unique<v1DirectKeyValue::S3StorageFactory>(dbPath.str(), s3Config);
+  }
+#endif
+  if (storageType_ == StorageType::V1DirectKeyValue) {
+    return std::make_unique<v1DirectKeyValue::RocksDBStorageFactory>(dbPath.str());
+  } else if (storageType_ == StorageType::V2MerkleTree) {
+    return std::make_unique<v2MerkleTree::RocksDBStorageFactory>(dbPath.str());
+  }
+  throw std::runtime_error{"Invalid storage type"};
+#endif
+}
+
+}  // namespace concord::kvbc

--- a/tests/simpleKVBC/ByzantineReplica/setup.hpp
+++ b/tests/simpleKVBC/ByzantineReplica/setup.hpp
@@ -1,0 +1,81 @@
+// Concord
+//
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include "ReplicaConfig.hpp"
+#include "communication/ICommunication.hpp"
+#include "Logger.hpp"
+#include "MetricsServer.hpp"
+#include "config/test_parameters.hpp"
+#include "storage_factory_interface.h"
+
+#ifdef USE_S3_OBJECT_STORE
+#include "s3/client.hpp"
+#endif
+
+namespace concord::kvbc {
+
+class TestSetup {
+ public:
+  static std::unique_ptr<TestSetup> ParseArgs(int argc, char** argv);
+
+  std::unique_ptr<IStorageFactory> GetStorageFactory();
+
+  const bftEngine::ReplicaConfig& GetReplicaConfig() const { return replicaConfig_; }
+  bft::communication::ICommunication* GetCommunication() const { return communication_.get(); }
+  concordMetrics::Server& GetMetricsServer() { return metricsServer_; }
+  logging::Logger GetLogger() { return logger_; }
+  const bool UsePersistentStorage() const { return usePersistentStorage_; }
+  std::string getLogPropertiesFile() { return logPropsFile_; }
+
+ private:
+  enum class StorageType {
+    V1DirectKeyValue,
+    V2MerkleTree,
+  };
+
+  TestSetup(const bftEngine::ReplicaConfig& config,
+            std::unique_ptr<bft::communication::ICommunication> comm,
+            logging::Logger logger,
+            uint16_t metricsPort,
+            bool usePersistentStorage,
+            const std::string& s3ConfigFile,
+            StorageType storageType,
+            const std::string& logPropsFile)
+      : replicaConfig_(config),
+        communication_(std::move(comm)),
+        logger_(logger),
+        metricsServer_(metricsPort),
+        usePersistentStorage_(usePersistentStorage),
+        s3ConfigFile_(s3ConfigFile),
+        storageType_(storageType),
+        logPropsFile_(logPropsFile) {}
+  TestSetup() = delete;
+#ifdef USE_S3_OBJECT_STORE
+  concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
+#endif
+  std::unique_ptr<IStorageFactory> GetInMemStorageFactory() const;
+  const bftEngine::ReplicaConfig& replicaConfig_;
+  std::unique_ptr<bft::communication::ICommunication> communication_;
+  logging::Logger logger_;
+  concordMetrics::Server metricsServer_;
+  bool usePersistentStorage_;
+  std::string s3ConfigFile_;
+  StorageType storageType_;
+  std::string logPropsFile_;
+};
+
+}  // namespace concord::kvbc

--- a/tests/simpleKVBC/CMakeLists.txt
+++ b/tests/simpleKVBC/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(TesterClient)
 add_subdirectory(TesterReplica)
+add_subdirectory(ByzantineReplica)
 add_custom_target(copy_blockchain_scripts2 ALL COMMENT "Copying scripts abcd")
 add_custom_command(TARGET copy_blockchain_scripts2
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/scripts ${CMAKE_CURRENT_BINARY_DIR}/scripts)


### PR DESCRIPTION
The idea of this change is to propose an initial implementation of a Byzantine replica, or in
other words, an extension of a regular replica where it's possible to inject different
Byzantine behavior by extending the default logic.

What this change proposes tries to achieve is basically:
- Create an extension of bftengine::ReplicaImp to expose some interesting methods that can be
overridden in order to inject some Byzantine behavior.
- Create an extension of kvbc::ReplicaImp to override some methods in order to instantiate the
new ByzantineBftEngineReplicaImp.
- Add an initial test case that makes use of the Byzantine classes.

See the README file and the comments inside the ByzantineReplicaImp.cpp for some more details.

Small disclaimer: I'm not sure whether this set of changes could or should be merged "as it is"
or not, probably not :) But with the proper feedback, addressing the comments and perhaps
splitting the changes in different reviews if needed, it could be a good enough starting point.