### PR TITLE
WIP: Add deleteGenesisBlock for BlockMerkle category

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -129,12 +129,14 @@ Msg ImmutableDbVersion 4005 {
     uint64 block_id
 }
 
-# Merkle Tree Data
+# Block Merkle Tree Data
 
 Msg MerkleBlockValue 5000 {
     fixedlist uint8 32 root_hash
-    list KeyHash hashed_added_keys
-    list KeyHash hashed_deleted_keys
+
+    # Keys are only added to this list after initial block pruning, if they remain active.
+    # They would be redundant prior to pruning as the block contains the unhashed keys.
+    list KeyHash active_keys
 }
 
 Msg NibblePath 5001 {
@@ -170,6 +172,19 @@ Msg BatchedInternalNode 5006 {
     uint32 bitmask
     list BatchedInternalNodeChild children
 }
+
+# The version of a sparse merkle tree. This is different from a block_id.
+Msg TreeVersion 5007 {
+    uint64 version
+}
+
+# Containes serialized internal node keys and leaf keys that are safe to delete when a block
+# pointing to a given tree version is pruned.
+Msg StaleKeys 5008 {
+    list bytes internal_keys
+    list bytes leaf_keys
+}
+
 
 # Versioned category
 

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -59,7 +59,7 @@ struct Block {
 
   BlockId id() const { return data.block_id; }
 
-  static const detail::Buffer& serialize(const Block& block) { return detail::serialize(block.data); }
+  static const detail::Buffer& serialize(const Block& block) { return detail::serializeThreadLocal(block.data); }
 
   template <typename T>
   static Block deserialize(const T& input) {
@@ -72,7 +72,7 @@ struct Block {
   // Using CMF for big endian
   static const detail::Buffer& generateKey(const BlockId block_id) {
     BlockKey key{block_id};
-    return detail::serialize(key);
+    return detail::serializeThreadLocal(key);
   }
 
   BlockData data;
@@ -111,7 +111,7 @@ struct RawBlock {
     return output;
   }
 
-  static const detail::Buffer& serialize(const RawBlock& raw) { return detail::serialize(raw.data); }
+  static const detail::Buffer& serialize(const RawBlock& raw) { return detail::serializeThreadLocal(raw.data); }
 
   RawBlockData data;
 };

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -29,7 +29,8 @@ inline const auto CAT_ID_TYPE_CF = std::string{"cat_id_type"};
 
 inline const auto BLOCK_MERKLE_INTERNAL_NODES_CF = std::string{"block_merkle_internal_nodes"};
 inline const auto BLOCK_MERKLE_LEAF_NODES_CF = std::string{"block_merkle_leaf_nodes"};
-inline const auto BLOCK_MERKLE_LATEST_KEY_VERSION = std::string{"block_merkle_latest_key_version"};
+inline const auto BLOCK_MERKLE_LATEST_KEY_VERSION_CF = std::string{"block_merkle_latest_key_version"};
 inline const auto BLOCK_MERKLE_KEYS_CF = std::string{"block_merkle_keys"};
+inline const auto BLOCK_MERKLE_STALE_CF = std::string{"block_merkle_stale"};
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -43,7 +43,18 @@ inline VersionedKey versionedKey(const Hash &key_hash, BlockId block_id) {
 }
 
 template <typename T>
-const Buffer &serialize(const T &value) {
+const Buffer serialize(const T &value) {
+  auto buf = Buffer{};
+  serialize(buf, value);
+  return buf;
+}
+
+// should only be used when the returned serialized value is immediately used. Otherwise the
+// reference will be overwritten. It is unsafe to use the result of this function in an inline call
+// to batch.put() for example. It's only safe when a copy is made in which case there is no
+// advantage to using it.
+template <typename T>
+const Buffer &serializeThreadLocal(const T &value) {
   static thread_local auto buf = Buffer{};
   buf.clear();
   serialize(buf, value);

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -18,38 +18,37 @@
 #include "assertUtils.hpp"
 #include "kv_types.hpp"
 #include "sha_hash.hpp"
+#include <iostream>
 
 using concord::storage::rocksdb::NativeWriteBatch;
 using concordUtils::Sliver;
 
 namespace concord::kvbc::categorization::detail {
 
-MerkleBlockValue hashUpdate(const BlockMerkleInput& updates) {
+std::pair<MerkleBlockValue, std::vector<KeyHash>> hashUpdate(const BlockMerkleInput& updates) {
   MerkleBlockValue value;
-  value.hashed_added_keys.reserve(updates.kv.size());
-  value.hashed_deleted_keys.reserve(updates.deletes.size());
+  auto hashed_deleted_keys = std::vector<KeyHash>{};
 
   // root_hash = h((h(k1) || h(v1)) || ... || (h(kN) || h(vN) || h(dk1) || ... || h(dkN))
   auto root_hasher = Hasher{};
   root_hasher.init();
-  auto kv_hasher = Hasher{};
 
   // Hash all keys and values as part of the root hash
   for (const auto& [k, v] : updates.kv) {
-    auto key_hash = kv_hasher.digest(k.data(), k.size());
-    auto val_hash = kv_hasher.digest(v.data(), v.size());
-    value.hashed_added_keys.push_back(KeyHash{key_hash});
+    auto key_hash = hash(k);
+    auto val_hash = hash(v);
+    value.active_keys.push_back(KeyHash{key_hash});
     root_hasher.update(key_hash.data(), key_hash.size());
     root_hasher.update(val_hash.data(), val_hash.size());
   }
 
   for (const auto& k : updates.deletes) {
-    auto key_hash = kv_hasher.digest(k.data(), k.size());
-    value.hashed_deleted_keys.push_back(KeyHash{key_hash});
+    auto key_hash = hash(k);
+    hashed_deleted_keys.push_back(KeyHash{key_hash});
     root_hasher.update(key_hash.data(), key_hash.size());
   }
   value.root_hash = root_hasher.finish();
-  return value;
+  return std::make_pair(value, hashed_deleted_keys);
 }
 
 BlockMerkleOutput inputToOutput(const BlockMerkleInput& updates) {
@@ -82,6 +81,11 @@ BatchedInternalNodeKey toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey&&
 std::vector<uint8_t> rootKey(uint64_t version) {
   auto v = sparse_merkle::Version(version);
   return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(v)));
+}
+
+Sliver merkleKey(BlockId block_id) {
+  auto block_key = serialize(BlockKey{block_id});
+  return Sliver::copy((const char*)block_key.data(), block_key.size());
 }
 
 std::vector<uint8_t> serializeBatchedInternalNode(sparse_merkle::BatchedInternalNode&& node) {
@@ -147,36 +151,119 @@ std::vector<Buffer> versionedKeys(const std::vector<std::string>& keys, const st
   return versioned_keys;
 }
 
+void putKeys(NativeWriteBatch& batch,
+             uint64_t block_id,
+             std::vector<KeyHash>&& hashed_added_keys,
+             std::vector<KeyHash>&& hashed_deleted_keys,
+             BlockMerkleInput& updates) {
+  auto kv_it = updates.kv.begin();
+  for (auto key_it = hashed_added_keys.begin(); key_it != hashed_added_keys.end(); key_it++) {
+    // Write the versioned key/value pair used for direct key lookup
+    batch.put(BLOCK_MERKLE_KEYS_CF, serialize(VersionedKey{*key_it, block_id}), kv_it->second);
+
+    // Put the latest version of the key
+    batch.put(BLOCK_MERKLE_LATEST_KEY_VERSION_CF, key_it->value, serialize(LatestKeyVersion{block_id}));
+
+    kv_it++;
+  }
+
+  const bool deleted = true;
+  for (auto key_it = hashed_deleted_keys.begin(); key_it != hashed_deleted_keys.end(); key_it++) {
+    BlockId latest = TaggedVersion(deleted, block_id).encode();
+    batch.put(BLOCK_MERKLE_LATEST_KEY_VERSION_CF, key_it->value, serialize(LatestKeyVersion{latest}));
+  }
+}
+
+void putLatestTreeVersion(uint64_t tree_version, NativeWriteBatch& batch) {
+  batch.put(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0), rootKey(tree_version));
+}
+
+// Write serialized stale keys at the given *tree* version. These keys are safe to delete when the
+// tree version is pruned.
+void putStaleKeys(NativeWriteBatch& batch, sparse_merkle::StaleNodeIndexes&& stale_batch) {
+  auto stale = StaleKeys{};
+  for (auto&& key : stale_batch.internal_keys) {
+    stale.internal_keys.push_back(serialize(toBatchedInternalNodeKey(std::move(key))));
+  }
+  for (auto&& key : stale_batch.leaf_keys) {
+    stale.leaf_keys.push_back(serialize(leafKeyToVersionedKey(key)));
+  }
+  auto tree_version_key = serialize(TreeVersion{stale_batch.stale_since_version.value()});
+  batch.put(BLOCK_MERKLE_STALE_CF, tree_version_key, serialize(stale));
+}
+
+void putMerkleNodes(NativeWriteBatch& batch, sparse_merkle::UpdateBatch&& update_batch) {
+  for (const auto& [leaf_key, leaf_val] : update_batch.leaf_nodes) {
+    auto ser_key = serialize(leafKeyToVersionedKey(leaf_key));
+    batch.put(BLOCK_MERKLE_LEAF_NODES_CF, ser_key, leaf_val.value.string_view());
+  }
+  for (auto& [internal_key, internal_node] : update_batch.internal_nodes) {
+    auto ser_key = serialize(toBatchedInternalNodeKey(std::move(internal_key)));
+    batch.put(BLOCK_MERKLE_INTERNAL_NODES_CF, ser_key, serializeBatchedInternalNode(std::move(internal_node)));
+  }
+
+  // We always add a root key at version 0 with a value that points to the latest root.
+  auto tree_version = update_batch.stale.stale_since_version.value();
+  putLatestTreeVersion(tree_version, batch);
+
+  putStaleKeys(batch, std::move(update_batch.stale));
+}
+
+// Delete keys that can be safely pruned.
+// Return any active key hashes.
+std::vector<KeyHash> deleteInactiveKeys(BlockId block_id,
+                                        std::vector<Hash>&& hashed_keys,
+                                        const std::vector<std::optional<TaggedVersion>>& latest_versions,
+                                        NativeWriteBatch& batch) {
+  std::vector<KeyHash> active_keys;
+  for (auto i = 0u; i < hashed_keys.size(); i++) {
+    auto& tagged_version = latest_versions[i];
+    auto& hashed_key = hashed_keys[i];
+    ConcordAssert(tagged_version.has_value());
+    ConcordAssertLE(block_id, tagged_version->version);
+
+    if (block_id == tagged_version->version) {
+      if (tagged_version->deleted) {
+        // The latest version is a tombstone. We can delete the key and version.
+        auto versioned_key = serialize(VersionedKey{KeyHash{hashed_key}, block_id});
+        batch.del(BLOCK_MERKLE_KEYS_CF, versioned_key);
+        batch.del(BLOCK_MERKLE_LATEST_KEY_VERSION_CF, hashed_key);
+      } else {
+        active_keys.push_back(KeyHash{hashed_key});
+      }
+    } else {
+      // block_id < tagged_version->version
+      // The key has been overwritten. Delete it.
+      auto versioned_key = serialize(VersionedKey{KeyHash{hashed_key}, block_id});
+      batch.del(BLOCK_MERKLE_KEYS_CF, versioned_key);
+    }
+  }
+  return active_keys;
+}
+
 BlockMerkleCategory::BlockMerkleCategory(const std::shared_ptr<storage::rocksdb::NativeClient>& db) : db_{db} {
   createColumnFamilyIfNotExisting(BLOCK_MERKLE_INTERNAL_NODES_CF, *db);
   createColumnFamilyIfNotExisting(BLOCK_MERKLE_LEAF_NODES_CF, *db);
-  createColumnFamilyIfNotExisting(BLOCK_MERKLE_LATEST_KEY_VERSION, *db);
+  createColumnFamilyIfNotExisting(BLOCK_MERKLE_LATEST_KEY_VERSION_CF, *db);
   createColumnFamilyIfNotExisting(BLOCK_MERKLE_KEYS_CF, *db);
+  createColumnFamilyIfNotExisting(BLOCK_MERKLE_STALE_CF, *db);
   tree_ = sparse_merkle::Tree{std::make_shared<Reader>(*db_)};
 }
 
 BlockMerkleOutput BlockMerkleCategory::add(BlockId block_id, BlockMerkleInput&& updates, NativeWriteBatch& batch) {
-  auto merkle_value = hashUpdate(updates);
-  putKeys(
-      batch, block_id, std::move(merkle_value.hashed_added_keys), std::move(merkle_value.hashed_deleted_keys), updates);
+  auto [merkle_value, hashed_deleted_keys] = hashUpdate(updates);
+  putKeys(batch, block_id, std::move(merkle_value.active_keys), std::move(hashed_deleted_keys), updates);
 
   // We don't want to actually write the hashed keys for new blocks.
   // We only write the remaining active keys when the block is pruned.
-  merkle_value.hashed_added_keys.clear();
-  merkle_value.hashed_deleted_keys.clear();
+  merkle_value.active_keys.clear();
 
-  auto block_key = serialize(BlockKey{block_id});
-  auto merkle_key = Sliver::copy((const char*)block_key.data(), block_key.size());
-  auto ser_value = serialize(merkle_value);
-  auto ser_value_sliver = Sliver::copy((const char*)ser_value.data(), ser_value.size());
-  auto tree_update_batch = tree_.update(SetOfKeyValuePairs{{merkle_key, ser_value_sliver}});
-
-  auto tree_version = tree_update_batch.stale.stale_since_version.value();
-  putMerkleNodes(batch, std::move(tree_update_batch), tree_version);
+  auto tree_update_batch = updateTree(block_id, std::move(merkle_value));
+  putMerkleNodes(batch, std::move(tree_update_batch));
 
   auto output = inputToOutput(updates);
   output.root_hash = tree_.get_root_hash().dataArray();
-  output.state_root_version = tree_version;
+  output.state_root_version = tree_.get_version().value();
   return output;
 }
 
@@ -210,7 +297,7 @@ std::optional<TaggedVersion> BlockMerkleCategory::getLatestVersion(const std::st
 }
 
 std::optional<TaggedVersion> BlockMerkleCategory::getLatestVersion(const Hash& hashed_key) const {
-  const auto serialized = db_->getSlice(BLOCK_MERKLE_LATEST_KEY_VERSION, hashed_key);
+  const auto serialized = db_->getSlice(BLOCK_MERKLE_LATEST_KEY_VERSION_CF, hashed_key);
   if (!serialized) {
     return std::nullopt;
   }
@@ -261,7 +348,7 @@ void BlockMerkleCategory::multiGetLatestVersion(const std::vector<Hash>& hashed_
   auto slices = std::vector<::rocksdb::PinnableSlice>{};
   auto statuses = std::vector<::rocksdb::Status>{};
 
-  db_->multiGet(BLOCK_MERKLE_LATEST_KEY_VERSION, hashed_keys, slices, statuses);
+  db_->multiGet(BLOCK_MERKLE_LATEST_KEY_VERSION_CF, hashed_keys, slices, statuses);
   versions.clear();
   for (auto i = 0ull; i < slices.size(); ++i) {
     const auto& status = statuses[i];
@@ -318,45 +405,120 @@ void BlockMerkleCategory::multiGetLatest(const std::vector<std::string>& keys,
   ConcordAssertEQ(values.size(), keys.size());
 }
 
-void BlockMerkleCategory::putKeys(NativeWriteBatch& batch,
-                                  uint64_t block_id,
-                                  std::vector<KeyHash>&& hashed_added_keys,
-                                  std::vector<KeyHash>&& hashed_deleted_keys,
-                                  BlockMerkleInput& updates) {
-  auto kv_it = updates.kv.begin();
-  for (auto key_it = hashed_added_keys.begin(); key_it != hashed_added_keys.end(); key_it++) {
-    // Write the versioned key/value pair used for direct key lookup
-    batch.put(BLOCK_MERKLE_KEYS_CF, serialize(VersionedKey{*key_it, block_id}), kv_it->second);
-
-    // Put the latest version of the key
-    batch.put(BLOCK_MERKLE_LATEST_KEY_VERSION, key_it->value, serialize(LatestKeyVersion{block_id}));
-
-    kv_it++;
+void BlockMerkleCategory::deleteGenesisBlock(BlockId block_id, const BlockMerkleOutput& out, NativeWriteBatch& batch) {
+  auto [hashed_keys, latest_versions] = getLatestVersions(out);
+  auto active_keys = deleteInactiveKeys(block_id, std::move(hashed_keys), latest_versions, batch);
+  if (active_keys.empty()) {
+    auto update_batch = tree_.remove({merkleKey(block_id)});
+    putMerkleNodes(batch, std::move(update_batch));
+  } else {
+    rewriteMerkleBlock(block_id, std::move(active_keys), batch);
   }
-
-  const bool deleted = true;
-  for (auto key_it = hashed_deleted_keys.begin(); key_it != hashed_deleted_keys.end(); key_it++) {
-    BlockId latest = TaggedVersion(deleted, block_id).encode();
-    batch.put(BLOCK_MERKLE_LATEST_KEY_VERSION, key_it->value, serialize(LatestKeyVersion{latest}));
-  }
+  deleteStaleData(out.state_root_version, batch);
 }
 
-void BlockMerkleCategory::putMerkleNodes(NativeWriteBatch& batch,
-                                         sparse_merkle::UpdateBatch&& update_batch,
-                                         uint64_t tree_version) {
-  ConcordAssertEQ(1, update_batch.leaf_nodes.size());
-  const auto& [leaf_key, leaf_val] = update_batch.leaf_nodes[0];
-  auto ser_key = serialize(leafKeyToVersionedKey(leaf_key));
-  batch.put(BLOCK_MERKLE_LEAF_NODES_CF, ser_key, leaf_val.value.string_view());
-
-  for (auto& [internal_key, internal_node] : update_batch.internal_nodes) {
-    auto ser_key = serialize(toBatchedInternalNodeKey(std::move(internal_key)));
-    batch.put(BLOCK_MERKLE_INTERNAL_NODES_CF, ser_key, serializeBatchedInternalNode(std::move(internal_node)));
+std::pair<std::vector<Hash>, std::vector<std::optional<TaggedVersion>>> BlockMerkleCategory::getLatestVersions(
+    const BlockMerkleOutput& out) {
+  std::vector<Hash> hashed_keys;
+  hashed_keys.reserve(out.keys.size());
+  for (auto& [key, flag] : out.keys) {
+    hashed_keys.push_back(hash(key));
   }
 
-  // We always add a root key at version 0 with a value that points to the latest root.
-  batch.put(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0), rootKey(tree_version));
+  std::vector<std::optional<TaggedVersion>> latest_versions;
+  multiGetLatestVersion(hashed_keys, latest_versions);
+
+  return std::make_pair(hashed_keys, latest_versions);
 }
+
+void BlockMerkleCategory::putLastDeletedTreeVersion(uint64_t tree_version, NativeWriteBatch& batch) {
+  batch.put(BLOCK_MERKLE_STALE_CF, serialize(TreeVersion{0}), serialize(TreeVersion{tree_version}));
+}
+
+uint64_t BlockMerkleCategory::getLastDeletedTreeVersion() const {
+  // We store the last deleted tree version at stale index 0. This allows us to delete all stale
+  // data for versions last_deleted + 1 up until `tree_version`.
+  auto ser_last_deleted_version = db_->get(BLOCK_MERKLE_STALE_CF, serialize(TreeVersion{0}));
+  uint64_t last_deleted = 0;
+  if (ser_last_deleted_version.has_value()) {
+    auto last_deleted_version = TreeVersion{};
+    deserialize(*ser_last_deleted_version, last_deleted_version);
+    last_deleted = last_deleted_version.version;
+  }
+  return last_deleted;
+}
+
+void BlockMerkleCategory::deleteStaleData(uint64_t tree_version, NativeWriteBatch& batch) {
+  auto last_deleted = getLastDeletedTreeVersion();
+  ConcordAssertLT(last_deleted, tree_version);
+
+  // This is expensive. We may want to play with various multiget strategies, such as retrieve the
+  // indexes for every X tree versions. For now let's keep it simple and iterative.
+  //
+  // Note also that we don't want to prune millions of blocks at a time as this will generate *huge* write batches.
+  //
+  // A simple solution if we want offline pruning may be to add a special (empty) block for every 1000
+  // pruned blocks or so. This would limit the cost of each block prune, although would result in some small storage
+  // overhead. Another option is to lazily do the deletion in another thread. It doesn't have to be atomic.
+  //
+  // We may want to mix pruning in with normal workloads to balance it out.
+  //
+  // Note: There can be no stale indexes before version 1 of the tree.
+  for (auto i = last_deleted + 1; i <= tree_version; i++) {
+    auto ser_stale = db_->get(BLOCK_MERKLE_STALE_CF, serialize(TreeVersion{i}));
+    ConcordAssert(ser_stale.has_value());
+    auto stale = StaleKeys{};
+    deserialize(*ser_stale, stale);
+    for (auto& key : stale.internal_keys) {
+      batch.del(BLOCK_MERKLE_INTERNAL_NODES_CF, key);
+    }
+    for (auto& key : stale.leaf_keys) {
+      batch.del(BLOCK_MERKLE_LEAF_NODES_CF, key);
+    }
+    batch.del(BLOCK_MERKLE_STALE_CF, serialize(TreeVersion{i}));
+  }
+
+  putLastDeletedTreeVersion(tree_version, batch);
+}
+
+void BlockMerkleCategory::rewriteMerkleBlock(BlockId block_id,
+                                             std::vector<KeyHash>&& active_keys,
+                                             NativeWriteBatch& batch) {
+  auto hasher = Hasher{};
+  hasher.init();
+  MerkleBlockValue merkle_value;
+  for (auto& key : active_keys) {
+    auto versioned_key = serialize(VersionedKey{key, block_id});
+    auto value = db_->getSlice(BLOCK_MERKLE_KEYS_CF, versioned_key);
+    ConcordAssert(value.has_value());
+    auto val_hash = hash(*value);
+    hasher.update(key.value.data(), key.value.size());
+    hasher.update(val_hash.data(), val_hash.size());
+  }
+  merkle_value.active_keys = std::move(active_keys);
+  merkle_value.root_hash = hasher.finish();
+  auto update_batch = updateTree(block_id, std::move(merkle_value));
+  putMerkleNodes(batch, std::move(update_batch));
+}
+
+uint64_t BlockMerkleCategory::getLatestTreeVersion() const {
+  if (auto latest_root_key = db_->get(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0))) {
+    BatchedInternalNodeKey key{};
+    deserialize(*latest_root_key, key);
+    return key.version;
+  }
+  return 0;
+}
+
+sparse_merkle::UpdateBatch BlockMerkleCategory::updateTree(BlockId block_id, MerkleBlockValue&& value) {
+  auto ser_value = serialize(value);
+  auto ser_value_sliver = Sliver::copy((const char*)ser_value.data(), ser_value.size());
+  return tree_.update(SetOfKeyValuePairs{{merkleKey(block_id), ser_value_sliver}});
+}
+
+void BlockMerkleCategory::deleteLastReachableBlock(BlockId block_Id,
+                                                   const BlockMerkleOutput& out,
+                                                   NativeWriteBatch& batch) {}
 
 sparse_merkle::BatchedInternalNode BlockMerkleCategory::Reader::get_latest_root() const {
   if (auto latest_root_key = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0))) {


### PR DESCRIPTION
We delete keys when we prune a block and the version of the key is not
the latest version. If the key is the latest version we call it the
`active` key.

When all keys in a block are inactive we remove the block from the
merkle tree. Otherwise we write a new version of the block in the merkle
tree that contains all the active keys. This is necessary for proving
the still active keys.

When we update the merkle tree, we now save any stale keys so we can
delete them when they are no longer referenced. This is necessary for
the safety of the sparse merkle tree.

A serious safety issue was discovered in testing, due to the use of
thread local buffer references in `detail::serialize`. When a reference
to the buffer is used in a batch.put operation for both a key and a
value, the value overwrites the key. This also occurs in any put
operations with multiple key references. This is extremely dangerous
and can result in different keys being written if a temporary without a
reference is used in a serialized key vesion. For example, the
difference between `auto x = serialize(key)` and
`batch.put(serialize(key), serialize(val))` is significant. Therefore
the `serialize` wrapper was changed to always allocate a new buffer. The
old behavior is preserved when users opt into it knowingly with
`serialiizeThreadLocal`.

There are 2 problems with this code that must be resolved before merge

Problem 1:

 After we prune a block that contains active keys, those keys are not
 deleted. However, when we delete the keys or overwrite them in a new
 block addition after the block has been pruned, we overwrite the latest
 version. We do not, however, go back and see if we overwrote a key from
 a pruned block. This means that in the current code, the keys are never
 pruned, nor are the blocks pruned from the merkle tree. This is the
 cause of the test failure.

 If we overwote a key from an already pruned block, we must:
  1. Remove the key.
  2. Rewrite the block in the merkle tree by removing the key from the
  `active_keys` list, and updating the root hash. If this was the last
  active key, we must delete the block from the merkle tree.

 There are two strategies we can use for this:
  1. On any overwritten (or deleted) active key, we can immediately do
  the two steps above inline with the add block code. This has the
  drawback of possibly requiring multiple block rewrites for a single
  addition, thus slowing down the hotpath. It has the advantage of
  immediately freeing unused space, and not requiring storing anymore
  metadata.
  2. We add an extra field to the `MerkleBlockValue` for the newly added
  block that contains the keys from deleted blocks that were
  overwritten. Then when we prune the newly added block we also go back
  and cleanup the stale data.

 I prefer strategy 2, as it requires less work on the hot path, and it
 keeps the addBlock code simple.

Problem 2:

 When we prune a block, we create new tree versions, but do not create
 corresponding blocks for those tree versions. These tree versions have
 corresponding stale keys that must be deleted when blocks generated
 after the tree version are created (with a new tree version). The code
 currently does this correctly as shown by the unit tests.

 The problem arises when many blocks are pruned before a block is added.
 This is a typical case when pruning is performed during a maintenance
 window. In this case, when the first newly added block is pruned the
 next time, all the stale keys must be removed from the last pruning.
 This is fine from a computational sense, as enough time should be
 allocated to do the pruning. The problem is that we currently add all
 these keys to a single writeBatch so the main category code can
 atomically delete them. This means that a write batch can have millions
 of entries!. Luckily, this is completely unnecessary, and we
 can just delete these nodes in a non-atomic manner as they are unused
 by the time the current block is being pruned. All blocks that would
 have referenced them (in between the two pruning sessions) have already
 been pruned since we prune blocks in ascending order.

 There are a few strategies we can use, but a simple proposal is to just
 do the deletes inline via the db before returning from the call to
 `deleteGenesisBlock`. Direct deletes performed in batches with
 batched multigets for N stale versions, will be an efficient way to
 delete, since RocksDB works best with a single writer anyway. Then the
 batch we return only contains the actual updates for the block and not
 the intermediate tree versions and their stale keys.