### PR TITLE
Wire the read interface to the categories implementation

### DIFF
--- a/kvbc/include/categorization/blockchain.h
+++ b/kvbc/include/categorization/blockchain.h
@@ -65,7 +65,7 @@ class Blockchain {
     return Block::deserialize(block_ser.value());
   }
 
-  std::optional<RawBlock> getRawBlock(const BlockId block_id, const CategoriesMap* categorires) const {
+  std::optional<RawBlock> getRawBlock(const BlockId block_id, const CategoriesMap& categorires) const {
     auto block = getBlock(block_id);
     if (!block) {
       return std::optional<RawBlock>{};

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -90,25 +90,25 @@ struct RawBlock {
   RawBlock() = default;
   RawBlock(const Block& block,
            const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
-           const CategoriesMap* categorires);
+           const CategoriesMap& categorires);
 
   BlockMerkleInput getUpdates(const std::string& category_id,
                               const BlockMerkleOutput& update_info,
                               const BlockId& block_id,
                               const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
-                              const CategoriesMap* categorires);
+                              const CategoriesMap& categorires);
 
   VersionedInput getUpdates(const std::string& category_id,
                             const VersionedOutput& update_info,
                             const BlockId& block_id,
                             const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
-                            const CategoriesMap* categorires);
+                            const CategoriesMap& categorires);
 
   ImmutableInput getUpdates(const std::string& category_id,
                             const ImmutableOutput& update_info,
                             const BlockId& block_id,
                             const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
-                            const CategoriesMap* categorires);
+                            const CategoriesMap& categorires);
 
   template <typename T>
   static RawBlock deserialize(const T& input) {

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -55,24 +55,28 @@ class KeyValueBlockchain {
   /////////////////////// Read interface ///////////////////////
 
   // Gets the value of a key by the exact blockVersion.
-  std::optional<Value> get(const std::string& cat_id, const std::string& key, BlockId block_id) const;
-  std::optional<Value> getLatest(const std::string& cat_id, const std::string& key) const;
+  std::optional<Value> get(const std::string& category_id, const std::string& key, BlockId block_id) const;
 
-  void multiGet(const std::string& cat_id,
+  std::optional<Value> getLatest(const std::string& category_id, const std::string& key) const;
+
+  void multiGet(const std::string& category_id,
                 const std::vector<std::string>& keys,
                 const std::vector<BlockId>& versions,
                 std::vector<std::optional<Value>>& values) const;
 
-  void multiGetLatest(const std::string& cat_id,
+  void multiGetLatest(const std::string& category_id,
                       const std::vector<std::string>& keys,
                       std::vector<std::optional<Value>>& values) const;
 
-  std::optional<BlockId> getLatestVersion(const std::string& cat_id, const std::string& key) const;
-  void multiGetLatestVersion(const std::string& cat_id,
-                             const std::vector<std::string>& keys,
-                             std::vector<std::optional<BlockId>>& versions) const;
+  std::optional<categorization::TaggedVersion> getLatestVersion(const std::string& category_id,
+                                                                const std::string& key) const;
 
-  CategoryInput getBlockData(BlockId block_id);
+  void multiGetLatestVersion(const std::string& category_id,
+                             const std::vector<std::string>& keys,
+                             std::vector<std::optional<categorization::TaggedVersion>>& versions) const;
+
+  // Get the updates that were used to create `block_id`.
+  Updates getBlockUpdates(BlockId block_id) const;
 
  private:
   BlockId addBlock(CategoryInput&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);
@@ -163,8 +167,7 @@ class KeyValueBlockchain {
   VersionedRawBlock last_raw_block_;
 
   // currently we are operating with single thread
-  // to keep resources low I don't use the hardware concurrency constructor, but set it to 2 threads.
-  util::ThreadPool thread_pool_{2};
+  util::ThreadPool thread_pool_{1};
 
  public:
   struct KeyValueBlockchain_tester {

--- a/kvbc/include/categorization/types.h
+++ b/kvbc/include/categorization/types.h
@@ -19,8 +19,8 @@
 
 namespace concord::kvbc::categorization {
 
-using CategoriesMap = std::map<
-    std::string,
-    std::variant<detail::ImmutableKeyValueCategory, detail::BlockMerkleCategory, detail::VersionedKeyValueCategory>>;
+using Category =
+    std::variant<detail::ImmutableKeyValueCategory, detail::BlockMerkleCategory, detail::VersionedKeyValueCategory>;
+using CategoriesMap = std::map<std::string, Category>;
 
 }  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -148,6 +148,7 @@ struct BlockMerkleUpdates {
 struct Updates {
   Updates() = default;
   Updates(CategoryInput&& updates) : category_updates_{std::move(updates)} {}
+  bool operator==(const Updates& other) { return category_updates_ == other.category_updates_; }
   void add(const std::string& category_id, BlockMerkleUpdates&& updates) {
     if (const auto [itr, inserted] = category_updates_.kv.try_emplace(category_id, std::move(updates.data_));
         !inserted) {

--- a/kvbc/test/categorization/blockchain_test.cpp
+++ b/kvbc/test/categorization/blockchain_test.cpp
@@ -159,7 +159,8 @@ TEST_F(categorized_kvbc, get_block) {
 
 TEST_F(categorized_kvbc, fail_get_raw) {
   detail::Blockchain block_chain{db};
-  auto rb = block_chain.getRawBlock(100, nullptr);
+  CategoriesMap cats;
+  auto rb = block_chain.getRawBlock(100, cats);
   ASSERT_FALSE(rb.has_value());
 }
 

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -104,7 +104,7 @@ TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
     detail::Buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
     auto block1_from_db = Block::deserialize(in);
 
-    categorization::RawBlock rw(block1_from_db, db, &tester.getCategories(block_chain));
+    categorization::RawBlock rw(block1_from_db, db, tester.getCategories(block_chain));
     auto variant = rw.data.updates.kv["merkle"];
     auto merkle_updates = std::get<BlockMerkleInput>(variant);
     // check reconstruction of original kv
@@ -122,7 +122,7 @@ TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
     detail::Buffer in{block2_db_val.value().begin(), block2_db_val.value().end()};
     auto block2_from_db = Block::deserialize(in);
 
-    categorization::RawBlock rw(block2_from_db, db, &tester.getCategories(block_chain));
+    categorization::RawBlock rw(block2_from_db, db, tester.getCategories(block_chain));
     auto variant = rw.data.updates.kv["merkle"];
     auto merkle_updates = std::get<BlockMerkleInput>(variant);
     // check reconstruction of original kv
@@ -196,7 +196,7 @@ TEST_F(categorized_kvbc, reconstruct_immutable_updates) {
     detail::Buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
     auto block1_from_db = Block::deserialize(in);
 
-    categorization::RawBlock rw(block1_from_db, db, &tester.getCategories(block_chain));
+    categorization::RawBlock rw(block1_from_db, db, tester.getCategories(block_chain));
     auto variant = rw.data.updates.kv["imm"];
     auto imm_updates = std::get<ImmutableInput>(variant);
     // check reconstruction of original kv
@@ -215,7 +215,7 @@ TEST_F(categorized_kvbc, reconstruct_immutable_updates) {
     detail::Buffer in{block2_db_val.value().begin(), block2_db_val.value().end()};
     auto block2_from_db = Block::deserialize(in);
 
-    categorization::RawBlock rw(block2_from_db, db, &tester.getCategories(block_chain));
+    categorization::RawBlock rw(block2_from_db, db, tester.getCategories(block_chain));
     auto variant = rw.data.updates.kv["imm"];
     auto imm_updates = std::get<ImmutableInput>(variant);
     // check reconstruction of original kv
@@ -259,7 +259,7 @@ TEST_F(categorized_kvbc, fail_reconstruct_immutable_updates) {
   cat.deleteBlock(out, wb);
   db->write(std::move(wb));
 
-  ASSERT_DEATH(categorization::RawBlock rw(block1_from_db, db, &tester.getCategories(block_chain)), "");
+  ASSERT_DEATH(categorization::RawBlock rw(block1_from_db, db, tester.getCategories(block_chain)), "");
 }
 
 TEST_F(categorized_kvbc, reconstruct_versioned_kv_updates) {
@@ -300,7 +300,7 @@ TEST_F(categorized_kvbc, reconstruct_versioned_kv_updates) {
     detail::Buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
     auto block1_from_db = Block::deserialize(in);
 
-    categorization::RawBlock rw(block1_from_db, db, &tester.getCategories(block_chain));
+    categorization::RawBlock rw(block1_from_db, db, tester.getCategories(block_chain));
     auto variant = rw.data.updates.kv["ver"];
     auto ver_updates = std::get<VersionedInput>(variant);
     // check reconstruction of original kv
@@ -319,7 +319,7 @@ TEST_F(categorized_kvbc, reconstruct_versioned_kv_updates) {
     detail::Buffer in{block1_db_val.value().begin(), block1_db_val.value().end()};
     auto block1_from_db = Block::deserialize(in);
 
-    categorization::RawBlock rw(block1_from_db, db, &tester.getCategories(block_chain));
+    categorization::RawBlock rw(block1_from_db, db, tester.getCategories(block_chain));
     auto variant = rw.data.updates.kv["ver"];
     auto ver_updates = std::get<VersionedInput>(variant);
     // check reconstruction of original kv


### PR DESCRIPTION
Most of the work done by the adapter is to delegate the calls to the corresponding category.
Most of the code in this PR is unit testing.