### PR TITLE
This change makes not necessary to make ReplicaAsksToLeaveViewMsg-s p…

### DIFF
--- a/bftengine/src/bftengine/messages/ReplicaAsksToLeaveViewMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReplicaAsksToLeaveViewMsg.cpp
@@ -50,7 +50,7 @@ ReplicaAsksToLeaveViewMsg* ReplicaAsksToLeaveViewMsg::create(ReplicaId senderId,
 
 void ReplicaAsksToLeaveViewMsg::validate(const ReplicasInfo& repInfo) const {
   auto totalSize = sizeof(Header) + spanContextSize();
-  if (size() < totalSize || !repInfo.isIdOfReplica(idOfGeneratedReplica()) || idOfGeneratedReplica() == repInfo.myId())
+  if (size() < totalSize || !repInfo.isIdOfReplica(idOfGeneratedReplica()))
     throw std::runtime_error(__PRETTY_FUNCTION__ + std::string(": basic validations"));
 
   uint16_t sigLen = ViewsManager::sigManager_->getSigLength(idOfGeneratedReplica());


### PR DESCRIPTION
…ersistent.

During recover we recover either in an Active View, or the first Inactive View we have reached.
In other words in the cases we have multiple View Changes we can reach inconsistent Complaint/View scenario.
An example is as follows:

1. We have a setup of Replicas with F=3 and all are up and executing Client requests in view 0, thus view 0 is Active.
2. We crash Replica 0, 1 and 2.
3. View Change is initiated and happens multiple times, because now the next 2 expected Primaries (1 and 2)
   are also down and no View gets activated during this process.
4. We chose a Replica, for example Replica 6 and restart it right before it manages to activate View 3,
   the View that the View Change process will reach, because Replicas 1 and 2 are down.
5. After the restart, Replica 6 will recover in View 1.

The described scenario does not allow us to persist the Complaints (ReplicaAsksToLeaveViewMsg-s) because we might
reach a situation after restarting a Replica where it is in a lower View than the last stored Complaint it has generated.

We have a solution though which does not involve persistent Storage.
Currently the Replicas reject ReplicaAsksToLeaveViewMsg that has been generated from itself,
even if it is properly signed. This was the initial cause for the necessity of persistence.
If we accept Complaints generated from ourself that carry the correct signature we do not have
to persist them. Once a Replica is restarted and recovers in a lower View than it was previously
it will catch up by receiving View Change messages from peers and if it has generated a ReplicaAsksToLeaveViewMsg
for this higher View, the peers will have stored it (in RAM) and send it to the restarted Replica.

Final note: Complaints (with the proper signatures) backing up a ViewChangeMsg will be persisted inside the ViewChangeMsg itself.