### PR TITLE
Added new View Change Apollo test.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2646,6 +2646,11 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
     LOG_INFO(GL, "Call to another startCollectingState()");
     clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout
     stateTransfer->startCollectingState();
+  } else {
+    if (!currentViewIsActive()) {
+      LOG_INFO(GL, "tryToEnterView after State Transfer finished ...");
+      tryToEnterView();
+    }
   }
 }
 

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -69,6 +69,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
         """
 
         late_replica = 2
+        connected_replica = 3  # This Replica will always be connected to the peers during the test.
         num_req = 10
 
         async def write_req():
@@ -85,7 +86,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
         bft_network.stop_replica(late_replica)
 
-        for isolated_replica in [0, 1]:
+        for isolated_replica, views_to_advance in [(0, 1), (1, 2)]:
             with net.ReplicaSubsetTwoWayIsolatingAdversary(bft_network, {isolated_replica}) as adversary:
                 adversary.interfere()
                 try:
@@ -98,15 +99,22 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
                 except:
                     pass
 
-                await trio.sleep(seconds=30)
+                # Wait for View Change initiation to happen
+                with trio.fail_after(60):
+                    while True:
+                        view_of_connected_replica = await self._get_gauge(connected_replica, bft_network, "currentActiveView")
+                        if view_of_connected_replica == current_view + views_to_advance:
+                            break
+                        await trio.sleep(0.2)
 
             view = await bft_network.wait_for_view(
-                replica_id=3,
+                replica_id=connected_replica,
                 expected=lambda v: v > current_view,
                 err_msg=f"Make sure current View is higher than {current_view}"
             )
             current_view = view
 
+        constant_load.cancel()
         bft_network.start_replica(late_replica)
 
         # Make sure the current view is stable

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -54,6 +54,65 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
+    async def test_missed_two_view_changes(self, bft_network, skvbc, constant_load):
+        """
+        The purpose of this test is to verify that if a Replica's View is behind the peers by more than 1
+        it manages to catch up properly and to join and participate in the View its peers are working in.
+        """
+
+        late_replica = 2
+        num_req = 10
+
+        async def write_req():
+            for _ in range(num_req):
+                await skvbc.write_known_kv()
+
+        bft_network.start_all_replicas()
+        await write_req()
+
+        current_view = await bft_network.wait_for_view(
+            replica_id=0,
+            err_msg="Make sure view is stable after all replicas are started."
+        )
+
+        bft_network.stop_replica(late_replica)
+
+        for isolated_replica in [0, 1]:
+            with net.ReplicaSubsetTwoWayIsolatingAdversary(bft_network, {isolated_replica}) as adversary:
+                adversary.interfere()
+                try:
+                    client = bft_network.random_client()
+                    client.primary = None
+                    for _ in range(5):
+                        msg = skvbc.write_req(
+                            [], [(skvbc.random_key(), skvbc.random_value())], 0)
+                        await client.write(msg)
+                except:
+                    pass
+
+                await trio.sleep(seconds=30)
+
+            view = await bft_network.wait_for_view(
+                replica_id=3,
+                expected=lambda v: v > current_view,
+                err_msg=f"Make sure current View is higher than {current_view}"
+            )
+            current_view = view
+
+        bft_network.start_replica(late_replica)
+
+        # Make sure the current view is stable
+        current_view = await bft_network.wait_for_view(
+            replica_id=0,
+            err_msg="Make sure view is stable after all Replicas are connected."
+        )
+
+        await bft_network.wait_for_fast_path_to_be_prevalent(
+            run_ops=lambda: write_req(), threshold=num_req)
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_constant_load
     async def test_delayed_replicas_start_up(self, bft_network, skvbc, constant_load):
         """
         The goal is to make sure that if replicas are started in a random

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -59,6 +59,13 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
         """
         The purpose of this test is to verify that if a Replica's View is behind the peers by more than 1
         it manages to catch up properly and to join and participate in the View its peers are working in.
+        1) Start all replicas and store the current View they are in.
+        2) Stop Replica 2 which we will later bring back
+        3) Isolate Replica 0 and verify View Change happens
+        4) Isolate Replica 1 and verify View Change happens. This time we are going to go to View = 3,
+           because we previously stopped Replica 2.
+        5) Start Replica 2.
+        6) Verify Fast Path of execution is restored.
         """
 
         late_replica = 2

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -51,6 +51,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
+    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
@@ -102,8 +103,9 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
         bft_network.start_replica(late_replica)
 
         # Make sure the current view is stable
-        current_view = await bft_network.wait_for_view(
+        await bft_network.wait_for_view(
             replica_id=0,
+            expected=lambda v: v == current_view,
             err_msg="Make sure view is stable after all Replicas are connected."
         )
 


### PR DESCRIPTION
In this test we set things up to get a Replica 2 Views behind
its peers and verify it correctly manages to enter the View
and participate in quorum for execution and the system reaches
Fast Path. This test fails if we don't do a tryToEnterView() after
State Transfer.