### PR TITLE
Add deleteGenesisBlock for BlockMerkle category

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -139,12 +139,10 @@ Msg ImmutableDbVersion 4007 {
     uint64 block_id
 }
 
-# Merkle Tree Data
+# Block Merkle Tree Data
 
 Msg MerkleBlockValue 5000 {
     fixedlist uint8 32 root_hash
-    list KeyHash hashed_added_keys
-    list KeyHash hashed_deleted_keys
 }
 
 Msg NibblePath 5001 {
@@ -179,4 +177,26 @@ Msg BatchedInternalNode 5006 {
     # Contains a 1 where a child node is present, 0 otherwise
     uint32 bitmask
     list BatchedInternalNodeChild children
+}
+
+# The version of a sparse merkle tree. This is different from a block_id.
+Msg TreeVersion 5007 {
+    uint64 version
+}
+
+Msg BlockVersion 5008 {
+    uint64 version
+}
+
+# Contains serialized internal node keys and leaf keys that are safe to delete when a block
+# pointing to a given tree version is pruned.
+Msg StaleKeys 5009 {
+    list bytes internal_keys
+    list bytes leaf_keys
+}
+
+# Keys are only added to this list after initial block pruning.
+# This list gets updated when the block that has overwritten these active keys gets pruned.
+Msg PrunedBlock 5010 {
+    list KeyHash active_keys
 }

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -60,7 +60,7 @@ struct Block {
 
   BlockId id() const { return data.block_id; }
 
-  static const detail::Buffer& serialize(const Block& block) { return detail::serialize(block.data); }
+  static const detail::Buffer& serialize(const Block& block) { return detail::serializeThreadLocal(block.data); }
 
   template <typename T>
   static Block deserialize(const T& input) {
@@ -73,7 +73,7 @@ struct Block {
   // Using CMF for big endian
   static const detail::Buffer& generateKey(const BlockId block_id) {
     BlockKey key{block_id};
-    return detail::serialize(key);
+    return detail::serializeThreadLocal(key);
   }
 
   BlockData data;
@@ -117,7 +117,7 @@ struct RawBlock {
     return output;
   }
 
-  static const detail::Buffer& serialize(const RawBlock& raw) { return detail::serialize(raw.data); }
+  static const detail::Buffer& serialize(const RawBlock& raw) { return detail::serializeThreadLocal(raw.data); }
 
   RawBlockData data;
 };

--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -29,7 +29,10 @@ inline const auto CAT_ID_TYPE_CF = std::string{"cat_id_type"};
 
 inline const auto BLOCK_MERKLE_INTERNAL_NODES_CF = std::string{"block_merkle_internal_nodes"};
 inline const auto BLOCK_MERKLE_LEAF_NODES_CF = std::string{"block_merkle_leaf_nodes"};
-inline const auto BLOCK_MERKLE_LATEST_KEY_VERSION = std::string{"block_merkle_latest_key_version"};
+inline const auto BLOCK_MERKLE_LATEST_KEY_VERSION_CF = std::string{"block_merkle_latest_key_version"};
 inline const auto BLOCK_MERKLE_KEYS_CF = std::string{"block_merkle_keys"};
+inline const auto BLOCK_MERKLE_STALE_CF = std::string{"block_merkle_stale"};
+inline const auto BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF = std::string{"block_merkle_active_from_pruned"};
+inline const auto BLOCK_MERKLE_PRUNED_BLOCKS_CF = std::string{"block_merkle_pruned"};
 
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -43,7 +43,18 @@ inline VersionedKey versionedKey(const Hash &key_hash, BlockId block_id) {
 }
 
 template <typename T>
-const Buffer &serialize(const T &value) {
+const Buffer serialize(const T &value) {
+  auto buf = Buffer{};
+  serialize(buf, value);
+  return buf;
+}
+
+// should only be used when the returned serialized value is immediately used. Otherwise the
+// reference will be overwritten. It is unsafe to use the result of this function in an inline call
+// to batch.put() for example. It's only safe when a copy is made in which case there is no
+// advantage to using it.
+template <typename T>
+const Buffer &serializeThreadLocal(const T &value) {
   static thread_local auto buf = Buffer{};
   buf.clear();
   serialize(buf, value);

--- a/kvbc/test/categorization/block_merkle_category_unit_test.cpp
+++ b/kvbc/test/categorization/block_merkle_category_unit_test.cpp
@@ -18,6 +18,7 @@
 #include "kv_types.hpp"
 #include "rocksdb/native_client.h"
 #include "storage/test/storage_test_common.h"
+#include "categorization/column_families.h"
 
 #include <memory>
 #include <optional>
@@ -64,11 +65,11 @@ class block_merkle_category : public Test {
   std::string val3 = "val3"s;
   std::string val4 = "val4"s;
   std::string val5 = "val5"s;
-  Hash hashed_key1 = Hasher{}.digest(key1.data(), key1.size());
-  Hash hashed_key2 = Hasher{}.digest(key2.data(), key2.size());
-  Hash hashed_key3 = Hasher{}.digest(key3.data(), key3.size());
-  Hash hashed_key4 = Hasher{}.digest(key4.data(), key4.size());
-  Hash hashed_key5 = Hasher{}.digest(key5.data(), key5.size());
+  Hash hashed_key1 = hash(key1);
+  Hash hashed_key2 = hash(key2);
+  Hash hashed_key3 = hash(key3);
+  Hash hashed_key4 = hash(key4);
+  Hash hashed_key5 = hash(key5);
 };
 
 TEST_F(block_merkle_category, empty_updates) {
@@ -76,8 +77,8 @@ TEST_F(block_merkle_category, empty_updates) {
   auto batch = db->getBatch();
   const auto output = cat.add(1, std::move(update), batch);
 
-  // A new root index, an internal node, and a leaf node are created.
-  ASSERT_EQ(batch.count(), 3);
+  // A new root index, an internal node, a leaf node, and stale index node are created.
+  ASSERT_EQ(batch.count(), 4);
 }
 
 TEST_F(block_merkle_category, put_and_get) {
@@ -86,9 +87,9 @@ TEST_F(block_merkle_category, put_and_get) {
   auto block_id = 1u;
   const auto output = cat.add(block_id, std::move(update), batch);
 
-  // A new root index, an internal node, and a leaf node are created.
+  // A new root index, an internal node, a leaf node, and stale index node are created.
   // Additionally, a key and its value are written.
-  ASSERT_EQ(batch.count(), 5);
+  ASSERT_EQ(batch.count(), 6);
   ASSERT_EQ(1, output.state_root_version);
   ASSERT_EQ(false, output.keys.find(key1)->second.deleted);
 
@@ -255,6 +256,214 @@ TEST_F(block_merkle_category, updates_with_deleted_keys) {
   ASSERT_EQ(expected_v3, tagged_versions[2]);
   ASSERT_EQ(expected_v4, tagged_versions[3]);
   ASSERT_EQ(expected_v5, tagged_versions[4]);
+}
+
+TEST_F(block_merkle_category, stale_node_creation_and_deletion) {
+  // Create the first block and read its stale keys
+  auto update = BlockMerkleInput{{{key1, val1}, {key2, val2}, {key3, val3}, {key4, val4}, {key5, val5}}};
+  const auto block_out1 = add(1, std::move(update));
+  auto ser_stale = db->get(BLOCK_MERKLE_STALE_CF, serialize(TreeVersion{1}));
+  auto stale = StaleKeys{};
+  deserialize(*ser_stale, stale);
+
+  // There's no stale keys on the first block creation, since nothing existed before the first block.
+  ASSERT_EQ(0, stale.internal_keys.size());
+  ASSERT_EQ(0, stale.leaf_keys.size());
+
+  // Create the second block and read its stale keys
+  const auto block_out2 = add(2, BlockMerkleInput{{{key2, "new_val"s}}, {{key3, key5}}});
+  ser_stale = db->get(BLOCK_MERKLE_STALE_CF, serialize(TreeVersion{2}));
+  stale = StaleKeys{};
+  deserialize(*ser_stale, stale);
+
+  // Adding a new block adds stale internal keys, but no stale leaf keys, as blocks aren't deleted.
+  ASSERT_LT(0, stale.internal_keys.size());
+  ASSERT_EQ(0, stale.leaf_keys.size());
+
+  // There have been no pruned blocks yet.
+  ASSERT_EQ(0, cat.getLastDeletedTreeVersion());
+  ASSERT_EQ(2, cat.getLatestTreeVersion());
+
+  // Pruning the first block causes key2, key3, and key5 from version 1 to be deleted.
+  // Keys 1 and 4 are still active at version 1 and so remain in the database.
+
+  // No tree nodes will get deleted though, as none are stale.
+  auto batch = db->getBatch();
+  cat.deleteGenesisBlock(1, block_out1, batch);
+  db->write(std::move(batch));
+  ASSERT_FALSE(cat.get(key2, 1));
+  ASSERT_FALSE(cat.get(key3, 1));
+  ASSERT_FALSE(cat.get(key5, 1));
+  ASSERT_TRUE(cat.get(key1, 1));
+  ASSERT_TRUE(cat.get(key4, 1));
+  ASSERT_EQ(1, cat.getLastDeletedTreeVersion());
+
+  // A new tree version gets created as a result of the block deletion.
+  ASSERT_EQ(3, cat.getLatestTreeVersion());
+
+  // There are stale leaf keys as of block deletion
+  ser_stale = db->get(BLOCK_MERKLE_STALE_CF, serialize(TreeVersion{3}));
+  stale = StaleKeys{};
+  deserialize(*ser_stale, stale);
+  ASSERT_LT(0, stale.internal_keys.size());
+  ASSERT_LT(0, stale.leaf_keys.size());
+
+  // Deleting Block2 causes there to still be active keys.
+  batch = db->getBatch();
+  cat.deleteGenesisBlock(2, block_out2, batch);
+  db->write(std::move(batch));
+  ASSERT_TRUE(cat.getLatest(key1));
+  ASSERT_TRUE(cat.getLatest(key2));
+  ASSERT_FALSE(cat.getLatest(key3));
+  ASSERT_TRUE(cat.getLatest(key4));
+  ASSERT_FALSE(cat.getLatest(key5));
+  ASSERT_EQ(2, cat.getLastDeletedTreeVersion());
+
+  // A new tree version gets created as a result of the block deletion.
+  ASSERT_EQ(4, cat.getLatestTreeVersion());
+
+  // Let's delete the last remaining keys, with a new block addition.
+  const auto block_out3 = add(3, BlockMerkleInput{{}, {{key1, key2, key4}}});
+  ASSERT_FALSE(cat.getLatest(key1));
+  ASSERT_FALSE(cat.getLatest(key2));
+  ASSERT_FALSE(cat.getLatest(key3));
+  ASSERT_FALSE(cat.getLatest(key4));
+  ASSERT_FALSE(cat.getLatest(key5));
+  ASSERT_EQ(2, cat.getLastDeletedTreeVersion());
+  ASSERT_EQ(5, cat.getLatestTreeVersion());
+
+  // We still see tombstones for keys 1, 2, 3
+  ASSERT_TRUE(cat.getLatestVersion(key1)->deleted);
+  ASSERT_TRUE(cat.getLatestVersion(key2)->deleted);
+  ASSERT_TRUE(cat.getLatestVersion(key4)->deleted);
+
+  // We can still access those keys at their old versions
+  auto expected1 = MerkleValue{{1, val1}};
+  auto expected2 = MerkleValue{{2, "new_val"s}};
+  auto expected4 = MerkleValue{{1, val4}};
+  ASSERT_EQ(expected1, asMerkle(*cat.get(key1, 1)));
+  ASSERT_EQ(expected2, asMerkle(*cat.get(key2, 2)));
+  ASSERT_EQ(expected4, asMerkle(*cat.get(key4, 1)));
+
+  // There exist pruned block indexes for block 1 and 2
+  // This is because there are still active keys for those blocks.
+  ASSERT_TRUE(db->get(BLOCK_MERKLE_PRUNED_BLOCKS_CF, serialize(BlockVersion{1})));
+  ASSERT_TRUE(db->get(BLOCK_MERKLE_PRUNED_BLOCKS_CF, serialize(BlockVersion{2})));
+
+  // There exist active key indexes only for the given active keys from pruned blocks
+  ASSERT_TRUE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key1})));
+  ASSERT_TRUE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key2})));
+  ASSERT_TRUE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key4})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key3})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key5})));
+
+  // Deleting block 3 triggers all tree versions up to 5 to be removed
+  batch = db->getBatch();
+  cat.deleteGenesisBlock(3, block_out3, batch);
+  db->write(std::move(batch));
+  ASSERT_EQ(5, cat.getLastDeletedTreeVersion());
+  ASSERT_EQ(6, cat.getLatestTreeVersion());
+
+  // There are no more latest versions for any keys.
+  ASSERT_FALSE(cat.getLatestVersion(key1));
+  ASSERT_FALSE(cat.getLatestVersion(key2));
+  ASSERT_FALSE(cat.getLatestVersion(key3));
+  ASSERT_FALSE(cat.getLatestVersion(key4));
+  ASSERT_FALSE(cat.getLatestVersion(key5));
+
+  // We can no longer retrieve keys 1, 2, 4 at their old versions
+  ASSERT_FALSE(cat.get(key1, 1));
+  ASSERT_FALSE(cat.get(key2, 2));
+  ASSERT_FALSE(cat.get(key4, 1));
+
+  // All pruned block indexes have been cleaned up. There are no active keys for any pruned blocks.
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_PRUNED_BLOCKS_CF, serialize(BlockVersion{1})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_PRUNED_BLOCKS_CF, serialize(BlockVersion{2})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_PRUNED_BLOCKS_CF, serialize(BlockVersion{3})));
+
+  // All key indexes have been removed.
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key1})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key2})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key4})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key3})));
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key5})));
+}
+
+// Prune several nodes in a row. Then add some new blocks. Then prune the rest of the nodes. Make
+// sure all the intermediate tree versions get garbage collected.
+TEST_F(block_merkle_category, prune_many_nodes) {
+  // Put 1001 blocks, overwriting key1 with an indentical value each time. The value doesn't matter
+  // for this test.
+  // Note that `out` is zero-indexed, while blocks are one-indexed.
+  std::vector<BlockMerkleOutput> out;
+  for (auto i = 1u; i <= 1001; i++) {
+    auto update = BlockMerkleInput{{{key1, val1}}};
+    out.push_back(add(i, std::move(update)));
+  }
+  ASSERT_EQ(1001, cat.getLatestTreeVersion());
+  ASSERT_EQ(0, cat.getLastDeletedTreeVersion());
+
+  // We can get key1 at any version.
+  for (auto i = 1u; i <= 1001; i++) {
+    ASSERT_TRUE(cat.get(key1, i));
+  }
+
+  // Prune the first 500 blocks. This will create at least another 500 deleted tree versions after the last initial tree
+  // version/block_id.
+  for (auto i = 1u; i <= 500; i++) {
+    auto batch = db->getBatch();
+    cat.deleteGenesisBlock(i, out[i - 1], batch);
+    db->write(std::move(batch));
+  }
+  auto tree_version_after_first_500_deletes = cat.getLatestTreeVersion();
+  ASSERT_LE(1501, tree_version_after_first_500_deletes);
+  ASSERT_EQ(500, cat.getLastDeletedTreeVersion());
+
+  // We can only get key1 at blocks 501 on. The key is overwritten in every version and we have
+  // pruned blocks with stale versions. Because there are no active keys in the first 500 pruned
+  // blocks, they don't generate pruned indexes.
+  for (auto i = 1u; i <= 500; i++) {
+    ASSERT_FALSE(cat.get(key1, i));
+    ASSERT_FALSE(db->get(BLOCK_MERKLE_PRUNED_BLOCKS_CF, serialize(BlockVersion{i})));
+  }
+  for (auto i = 501u; i <= 1001; i++) {
+    ASSERT_TRUE(cat.get(key1, i));
+  }
+
+  // Add another block that deletes key1.
+  auto last_out = add(1002, BlockMerkleInput{{}, {key1}});
+  ASSERT_EQ(tree_version_after_first_500_deletes + 1, cat.getLatestTreeVersion());
+
+  // Prune up to block 1001.
+  for (auto i = 501u; i <= 1001; i++) {
+    auto batch = db->getBatch();
+    cat.deleteGenesisBlock(i, out[i - 1], batch);
+    db->write(std::move(batch));
+  }
+
+  ASSERT_EQ(1001, cat.getLastDeletedTreeVersion());
+
+  // Now prune block 1002. This will prune all tree versions created from the first 500 prunes in addition to the
+  // version created by block 1002.
+  auto batch = db->getBatch();
+  cat.deleteGenesisBlock(1002, last_out, batch);
+  db->write(std::move(batch));
+
+  // We deleted the intermediate versions from the first 500 prunes, plus the version from the latest block.
+  ASSERT_EQ(tree_version_after_first_500_deletes + 1, cat.getLastDeletedTreeVersion());
+
+  // There are still new versions created from pruned blocks 501-1002;
+  ASSERT_GT(cat.getLatestTreeVersion(), cat.getLastDeletedTreeVersion());
+
+  // There should be no pruned block indexes, and no keys available at any version
+  for (auto i = 1u; i <= 1002; i++) {
+    ASSERT_FALSE(db->get(BLOCK_MERKLE_PRUNED_BLOCKS_CF, serialize(BlockVersion{i})));
+    // We can't retreive key1 at any version
+    ASSERT_FALSE(cat.get(key1, i));
+  }
+  ASSERT_FALSE(db->get(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF, serialize(KeyHash{hashed_key1})));
+  ASSERT_FALSE(cat.getLatest(key1));
+  ASSERT_FALSE(cat.getLatestVersion(key1));
 }
 
 }  // namespace


### PR DESCRIPTION
We delete keys when we prune a block and the version of the key is not
the latest version. If the key is the latest version we call it the
`active` key.

When all keys in a block are inactive we remove the block from the
merkle tree. Otherwise we write a new version of the block in the merkle
tree, as well as metadata indexes that contain the active keys by block
id (`PrunedBlock` msg), and the pruned block version by hashed key. This
metadata is necessary for proving the still active keys as well as
allowing garbage collection of prior active keys and
block-rewriting/deletion in the merkle tree to be postponed until prune
operations. Essentially, we make `add` faster at the cost of
`deleteGenesisBlock` and some small storage overhead. This work is
performed in the `writePrunedBlock` and `rewriteAlreadyPrunedBlocks`
methods.

When we update the merkle tree, we now save any stale keys so we can
delete them when they are no longer referenced. This is necessary for
the safety of the sparse copy-on-write merkle tree. Nodes in un-pruned
tree versions must be able to retrieve data from nodes that may have
been generated in blocks that were already pruned. We keep these nodes
available until the last referencing tree version gets pruned.

During pruning, new tree versions are created and nodes are marked
stale. These nodes are created because the merkle tree is modified by
either inserting an updated version of a block id and hash for a pruned
block with active keys, or the pruned block has no active keys, in which
case it is removed from the tree. These tree versions are not tied to
any block, since we don't create new blocks when we prune a block.
However, the stale nodes that get generated as a result of deleting
blocks must be garbage collected at some point. After pruning, when a
new block is added, it will be at a version greater than those stale
nodes. When this new block is eventually pruned, all prior stale
versions are finally deleted from the database. This work is performed
by the `deleteStaleData` method and tested in `prune_many_nodes`.

In order to make the deletion of stale nodes as a result of pruning many
blocks in a row before adding a new block efficient, we do it in atomic
batches in the `deleteStaleBatch` method. These batches are deleted
directly and not returned as one giant batch to the caller because:
 1. The stale keys do not need to all be deleted in one atomic batch.
 2. There can be upwards of a million versions to delete for large,
 uninterrupted pruning sessions done during maintenance windows.

A serious safety issue was discovered in testing, due to the use of
thread local buffer references in `detail::serialize`. When a reference
to the buffer is used in a `batch.put` operation for both a key and a
value of the same type, the value overwrites the key. This also occurs
in any put operations with multiple key references. This is extremely
dangerous and can result in different keys being written if a temporary
without a reference is used in a serialized key vesion. For example, the
difference between `auto x = serialize(key)` and
`batch.put(serialize(key), serialize(val))` is significant. Therefore
the `serialize` wrapper was changed to always allocate a new buffer. The
old behavior is preserved when users opt into it knowingly with
`serialiizeThreadLocal`.