### PR TITLE
Integrate the categorized KVBC interfaces

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -70,8 +70,8 @@ Msg BlockKey 2000 {
 }
 
 Msg BlockData 2001 {
-    uint64 block_id
     fixedlist uint8 32 parent_digest
+    uint64 block_id
     map string oneof{
         BlockMerkleOutput
         VersionedOutput
@@ -83,6 +83,11 @@ Msg RawBlockData 2005 {
     fixedlist uint8 32 parent_digest
     CategoryInput updates
     map string optional fixedlist uint8 32 category_root_hash
+}
+
+# Used to deserialize the parent_digest only from RawBlockData and BlockData.
+Msg ParentDigest 2006 {
+    fixedlist uint8 32 value
 }
 
 # Misc

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -100,11 +100,11 @@ class IReplica {
 
   // Used to read from storage, only when a replica is Idle. Useful for
   // initialization and maintenance.
-  virtual const concord::kvbc::ILocalKeyValueStorageReadOnly& getReadOnlyStorage() = 0;
+  virtual const concord::kvbc::IReader& getReadOnlyStorage() const = 0;
 
   // Used to append blocks to storage, only when a replica is Idle. Useful
   // for initialization and maintenance.
-  virtual Status addBlockToIdleReplica(const concord::kvbc::SetOfKeyValuePairs& updates) = 0;
+  virtual concord::kvbc::BlockId addBlockToIdleReplica(concord::kvbc::categorization::Updates&& updates) = 0;
 
   /// TODO(IG) the following methods are probably temp solution,
   /// need to split interfaces implementations to differrent modules

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -80,7 +80,7 @@ class ReplicaImp : public IReplica,
                              const std::vector<std::string> &keys,
                              std::vector<std::optional<categorization::TaggedVersion>> &versions) const override;
 
-  categorization::Updates getBlockUpdates(BlockId block_id) const override;
+  std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const override;
 
   // Get the current genesis block ID in the system.
   BlockId getGenesisBlockId() const override;

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -35,10 +35,7 @@ class ReplicaImp : public IReplica,
                    public IBlocksDeleter,
                    public IReader,
                    public IBlockAdder,
-                   public bftEngine::bcst::IAppState,
-                   // Deprecated interfaces follow. Will be removed after integration.
-                   public IBlocksAppender,
-                   public ILocalKeyValueStorageReadOnly {
+                   public bftEngine::bcst::IAppState {
  public:
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IReplica implementation
@@ -92,29 +89,6 @@ class ReplicaImp : public IReplica,
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IBlockAdder
   BlockId add(categorization::Updates &&) override;
-  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  // Deprecated: ILocalKeyValueStorageReadOnly implementation
-  Status get(const Sliver &key, Sliver &outValue) const override { return Status::GeneralError(""); }
-  Status get(BlockId readVersion, const Sliver &key, Sliver &outValue, BlockId &outBlock) const override {
-    return Status::GeneralError("");
-  }
-  BlockId getGenesisBlock() const override { return 0; }
-  BlockId getLastBlock() const override { return 0; }
-  Status getBlockData(BlockId blockId, concord::storage::SetOfKeyValuePairs &outBlockData) const override {
-    return Status::GeneralError("");
-  }
-  Status mayHaveConflictBetween(const Sliver &key, BlockId fromBlock, BlockId toBlock, bool &outRes) const override {
-    return Status::GeneralError("");
-  }
-  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  // Deprecated: IBlocksAppender implementation
-  Status addBlock(const concord::storage::SetOfKeyValuePairs &updates,
-                  BlockId &outBlockId,
-                  const concordUtils::SpanWrapper &parent_span) override {
-    return Status::GeneralError("");
-  }
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/kvbc/include/categorization/base_types.h
+++ b/kvbc/include/categorization/base_types.h
@@ -115,4 +115,6 @@ inline bool operator==(const TaggedVersion &lhs, const TaggedVersion &rhs) {
   return (lhs.deleted == rhs.deleted && lhs.version == rhs.version);
 }
 
+enum class CATEGORY_TYPE : char { block_merkle = 0, immutable = 1, versioned_kv = 2, end_of_types };
+
 }  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/blockchain.h
+++ b/kvbc/include/categorization/blockchain.h
@@ -73,6 +73,20 @@ class Blockchain {
     return RawBlock(block.value(), native_client_, categorires);
   }
 
+  std::optional<Hash> parentDigest(BlockId block_id) const {
+    const auto block_ser = native_client_->getSlice(detail::BLOCKS_CF, Block::generateKey(block_id));
+    if (!block_ser) {
+      return std::nullopt;
+    }
+    auto digest = ParentDigest{};
+    deserialize(*block_ser, digest);
+    return digest.value;
+  }
+
+  bool hasBlock(BlockId block_id) const {
+    return native_client_->getSlice(detail::BLOCKS_CF, Block::generateKey(block_id)).has_value();
+  }
+
   /////////////////////// State transfer Block chain ///////////////////////
   class StateTransfer {
    public:
@@ -126,6 +140,20 @@ class Blockchain {
         return std::optional<RawBlock>{};
       }
       return RawBlock::deserialize(raw_block_ser.value());
+    }
+
+    std::optional<Hash> parentDigest(BlockId block_id) const {
+      const auto raw_block_ser = native_client_->getSlice(detail::ST_CHAIN_CF, Block::generateKey(block_id));
+      if (!raw_block_ser) {
+        return std::nullopt;
+      }
+      auto digest = ParentDigest{};
+      deserialize(*raw_block_ser, digest);
+      return digest.value;
+    }
+
+    bool hasBlock(BlockId block_id) const {
+      return native_client_->getSlice(detail::ST_CHAIN_CF, Block::generateKey(block_id)).has_value();
     }
 
     void updateLastId(const BlockId id) {

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -122,4 +122,7 @@ struct RawBlock {
   RawBlockData data;
 };
 
+inline bool operator==(const RawBlock& l, const RawBlock& r) { return l.data == r.data; }
+inline bool operator!=(const RawBlock& l, const RawBlock& r) { return !(l == r); }
+
 }  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -27,8 +27,6 @@ namespace concord::kvbc::categorization::detail {
 
 using Buffer = std::vector<std::uint8_t>;
 
-enum class CATEGORY_TYPE : char { block_merkle = 0, immutable = 1, versioned_kv = 2, end_of_types };
-
 template <typename Span>
 Hash hash(const Span &span) {
   return Hasher{}.digest(span.data(), span.size());

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -84,6 +84,9 @@ class KeyValueBlockchain {
   // Get a map from category ID -> type for all known categories in the blockchain.
   const std::map<std::string, CATEGORY_TYPE>& blockchainCategories() const { return categorires_types_; }
 
+  std::shared_ptr<concord::storage::rocksdb::NativeClient> db() { return native_client_; }
+  std::shared_ptr<const concord::storage::rocksdb::NativeClient> db() const { return native_client_; }
+
  private:
   BlockId addBlock(CategoryInput&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);
 

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -45,7 +45,7 @@ class KeyValueBlockchain {
 
   // Adds raw block and tries to link the state transfer blockchain to the main blockchain
   void addRawBlock(const RawBlock& block, const BlockId& block_id);
-  RawBlock getRawBlock(const BlockId& block_id) const;
+  std::optional<RawBlock> getRawBlock(const BlockId& block_id) const;
 
   /////////////////////// Info ///////////////////////
   BlockId getGenesisBlockId() const { return block_chain_.getGenesisBlockId(); }
@@ -79,7 +79,7 @@ class KeyValueBlockchain {
                              std::vector<std::optional<categorization::TaggedVersion>>& versions) const;
 
   // Get the updates that were used to create `block_id`.
-  Updates getBlockUpdates(BlockId block_id) const;
+  std::optional<Updates> getBlockUpdates(BlockId block_id) const;
 
  private:
   BlockId addBlock(CategoryInput&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -100,7 +100,6 @@ class KeyValueBlockchain {
                              const detail::CATEGORY_TYPE type,
                              concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
-
   const Category& getCategory(const std::string& cat_id) const;
   Category& getCategory(const std::string& cat_id);
   bool hasCategory(const std::string& cat_id) const;

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -44,13 +44,16 @@ class KeyValueBlockchain {
   /////////////////////// Raw Blocks ///////////////////////
 
   // Adds raw block and tries to link the state transfer blockchain to the main blockchain
-  void addRawBlock(RawBlock& block, const BlockId& block_id);
+  void addRawBlock(const RawBlock& block, const BlockId& block_id);
   RawBlock getRawBlock(const BlockId& block_id) const;
 
   /////////////////////// Info ///////////////////////
-  BlockId getGenesisBlockId() { return block_chain_.getGenesisBlockId(); }
+  BlockId getGenesisBlockId() const { return block_chain_.getGenesisBlockId(); }
   BlockId getLastReachableBlockId() const { return block_chain_.getLastReachableBlockId(); }
   std::optional<BlockId> getLastStatetransferBlockId() const { return state_transfer_block_chain_.getLastBlockId(); }
+
+  std::optional<Hash> parentDigest(BlockId block_id) const;
+  bool hasBlock(BlockId block_id) const;
 
   /////////////////////// Read interface ///////////////////////
 
@@ -97,8 +100,10 @@ class KeyValueBlockchain {
                              const detail::CATEGORY_TYPE type,
                              concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
+
   const Category& getCategory(const std::string& cat_id) const;
   Category& getCategory(const std::string& cat_id);
+  bool hasCategory(const std::string& cat_id) const;
 
   /////////////////////// deletes ///////////////////////
 

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -81,6 +81,9 @@ class KeyValueBlockchain {
   // Get the updates that were used to create `block_id`.
   std::optional<Updates> getBlockUpdates(BlockId block_id) const;
 
+  // Get a map from category ID -> type for all known categories in the blockchain.
+  const std::map<std::string, CATEGORY_TYPE>& blockchainCategories() const { return categorires_types_; }
+
  private:
   BlockId addBlock(CategoryInput&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
@@ -97,7 +100,7 @@ class KeyValueBlockchain {
   void instantiateCategories();
   // insert a new category into the categories column family and instantiate it.
   bool insertCategoryMapping(const std::string& cat_id,
-                             const detail::CATEGORY_TYPE type,
+                             const CATEGORY_TYPE type,
                              concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
   const Category& getCategory(const std::string& cat_id) const;
@@ -161,7 +164,7 @@ class KeyValueBlockchain {
 
   std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
   CategoriesMap categorires_;
-  std::map<std::string, detail::CATEGORY_TYPE> categorires_types_;
+  std::map<std::string, CATEGORY_TYPE> categorires_types_;
   detail::Blockchain block_chain_;
   detail::Blockchain::StateTransfer state_transfer_block_chain_;
 

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -205,6 +205,8 @@ struct Updates {
     return it->second;
   }
 
+  const CategoryInput& categoryUpdates() const { return category_updates_; }
+
   // Appends a key-value of an `Update` type to already existing key-values for that category.
   // Precondition: The given `category_id` is of the same type as the passed updates.
   // Returns true on success or false if the given `category_id` doesn't exist.

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -18,6 +18,7 @@
 #include "categorized_kvbc_msgs.cmf.hpp"
 
 #include <ctime>
+#include <functional>
 #include <map>
 #include <optional>
 #include <set>
@@ -191,6 +192,15 @@ struct Updates {
       throw std::logic_error{std::string("Only one update for category is allowed. type: Immutable, category: ") +
                              category_id};
     }
+  }
+
+  std::optional<std::reference_wrapper<const std::variant<BlockMerkleInput, VersionedInput, ImmutableInput>>>
+  categoryUpdates(const std::string& category_id) const {
+    auto it = category_updates_.kv.find(category_id);
+    if (it == category_updates_.kv.cend()) {
+      return std::nullopt;
+    }
+    return it->second;
   }
 
   std::size_t size() const { return block_merkle_size + versioned_kv_size + immutable_size; }

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -218,8 +218,8 @@ struct Updates {
   std::size_t immutable_size{};
 
  private:
-  std::optional<std::reference_wrapper<std::variant<BlockMerkleInput, VersionedInput, ImmutableInput>>> categoryUpdates(
-      const std::string& category_id) {
+  std::optional<std::reference_wrapper<std::variant<BlockMerkleInput, VersionedInput, ImmutableInput>>>
+  mutableCategoryUpdates(const std::string& category_id) {
     auto it = category_updates_.kv.find(category_id);
     if (it == category_updates_.kv.end()) {
       return std::nullopt;
@@ -239,7 +239,7 @@ template <>
 inline bool Updates::appendKeyValue<ImmutableUpdates>(const std::string& category_id,
                                                       std::string&& key,
                                                       ImmutableUpdates::ValueType&& val) {
-  auto updates = categoryUpdates(category_id);
+  auto updates = mutableCategoryUpdates(category_id);
   if (!updates) {
     return false;
   }
@@ -252,7 +252,7 @@ template <>
 inline bool Updates::appendKeyValue<VersionedUpdates>(const std::string& category_id,
                                                       std::string&& key,
                                                       VersionedUpdates::ValueType&& val) {
-  auto updates = categoryUpdates(category_id);
+  auto updates = mutableCategoryUpdates(category_id);
   if (!updates) {
     return false;
   }
@@ -266,7 +266,7 @@ template <>
 inline bool Updates::appendKeyValue<BlockMerkleUpdates>(const std::string& category_id,
                                                         std::string&& key,
                                                         BlockMerkleUpdates::ValueType&& val) {
-  auto updates = categoryUpdates(category_id);
+  auto updates = mutableCategoryUpdates(category_id);
   if (!updates) {
     return false;
   }

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -60,9 +60,7 @@ struct ImmutableUpdates {
     friend struct ImmutableUpdates;
   };
 
-  void addUpdate(std::string&& key, ImmutableValue&& val, bool allow_update = false) {
-    data_.kv[std::move(key)] = std::move(val.update_);
-  }
+  void addUpdate(std::string&& key, ImmutableValue&& val) { data_.kv[std::move(key)] = std::move(val.update_); }
 
   void calculateRootHash(const bool hash) { data_.calculate_root_hash = hash; }
 
@@ -94,12 +92,12 @@ struct VersionedUpdates {
     bool stale_on_update{false};
   };
 
-  void addUpdate(std::string&& key, Value&& val, bool allow_update = false) {
+  void addUpdate(std::string&& key, Value&& val) {
     data_.kv[std::move(key)] = ValueWithFlags{std::move(val.data), val.stale_on_update};
   }
 
   // Set a value with no flags set
-  void addUpdate(std::string&& key, std::string&& val, bool allow_update = false) {
+  void addUpdate(std::string&& key, std::string&& val) {
     data_.kv[std::move(key)] = ValueWithFlags{std::move(val), false};
   }
 
@@ -136,9 +134,7 @@ struct BlockMerkleUpdates {
   BlockMerkleUpdates(BlockMerkleUpdates& other) = delete;
   BlockMerkleUpdates& operator=(BlockMerkleUpdates& other) = delete;
 
-  void addUpdate(std::string&& key, std::string&& val, bool allow_update = false) {
-    data_.kv[std::move(key)] = std::move(val);
-  }
+  void addUpdate(std::string&& key, std::string&& val) { data_.kv[std::move(key)] = std::move(val); }
 
   void addDelete(std::string&& key) {
     if (const auto [itr, inserted] = unique_deletes_.insert(key); !inserted) {

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -163,7 +163,6 @@ struct BlockMerkleUpdates {
 struct Updates {
   Updates() = default;
   Updates(CategoryInput&& updates) : category_updates_{std::move(updates)} {}
-  bool operator==(const Updates& other) { return category_updates_ == other.category_updates_; }
   void add(const std::string& category_id, BlockMerkleUpdates&& updates) {
     block_merkle_size += updates.size();
     if (const auto [itr, inserted] = category_updates_.kv.try_emplace(category_id, std::move(updates.data_));
@@ -210,8 +209,11 @@ struct Updates {
   std::size_t immutable_size{};
 
  private:
+  friend bool operator==(const Updates&, const Updates&);
   friend class KeyValueBlockchain;
   CategoryInput category_updates_;
 };
+
+inline bool operator==(const Updates& l, const Updates& r) { return l.category_updates_ == r.category_updates_; }
 
 }  // namespace concord::kvbc::categorization

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -74,7 +74,8 @@ class IReader {
                                      std::vector<std::optional<categorization::TaggedVersion>> &versions) const = 0;
 
   // Get the updates that were used to create `block_id`.
-  virtual categorization::Updates getBlockUpdates(BlockId block_id) const = 0;
+  // Return std::nullopt if this block doesn't exist.
+  virtual std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const = 0;
 
   // Get the current genesis block ID in the system.
   virtual BlockId getGenesisBlockId() const = 0;

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -101,34 +101,4 @@ class IBlocksDeleter {
   virtual ~IBlocksDeleter() = default;
 };
 
-// Deprecated interfaces. Will be removed after integration.
-class ILocalKeyValueStorageReadOnly {
- public:
-  // convenience where readVersion==latest, and block is not needed?
-  virtual concordUtils::Status get(const Key &key, Value &outValue) const = 0;
-  virtual concordUtils::Status get(BlockId readVersion, const Key &key, Value &outValue, BlockId &outBlock) const = 0;
-
-  // Returns the genesis block ID. If the blockchain is empty, 0 is returned.
-  // Throws on errors.
-  virtual BlockId getGenesisBlock() const = 0;
-  virtual BlockId getLastBlock() const = 0;
-  virtual concordUtils::Status getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockData) const = 0;
-  // TODO(GG): explain motivation
-  virtual concordUtils::Status mayHaveConflictBetween(const Key &key,
-                                                      BlockId fromBlock,
-                                                      BlockId toBlock,
-                                                      bool &outRes) const = 0;
-
-  virtual ~ILocalKeyValueStorageReadOnly() = default;
-};
-
-class IBlocksAppender {
- public:
-  virtual concordUtils::Status addBlock(const SetOfKeyValuePairs &updates,
-                                        BlockId &outBlockId,
-                                        const concordUtils::SpanWrapper &parent_span = concordUtils::SpanWrapper{}) = 0;
-
-  virtual ~IBlocksAppender() = default;
-};
-
 }  // namespace concord::kvbc

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -14,49 +14,16 @@
 #include <vector>
 
 namespace concord::kvbc {
-/**
- *
- */
-class ILocalKeyValueStorageReadOnly {
- public:
-  // convenience where readVersion==latest, and block is not needed?
-  virtual concordUtils::Status get(const Key &key, Value &outValue) const = 0;
-  virtual concordUtils::Status get(BlockId readVersion, const Key &key, Value &outValue, BlockId &outBlock) const = 0;
 
-  // Returns the genesis block ID. If the blockchain is empty, 0 is returned.
-  // Throws on errors.
-  virtual BlockId getGenesisBlock() const = 0;
-  virtual BlockId getLastBlock() const = 0;
-  virtual concordUtils::Status getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockData) const = 0;
-  // TODO(GG): explain motivation
-  virtual concordUtils::Status mayHaveConflictBetween(const Key &key,
-                                                      BlockId fromBlock,
-                                                      BlockId toBlock,
-                                                      bool &outRes) const = 0;
-
-  virtual ~ILocalKeyValueStorageReadOnly() = default;
-};
-
-/**
- *
- */
-class IBlocksAppender {
- public:
-  virtual concordUtils::Status addBlock(const SetOfKeyValuePairs &updates,
-                                        BlockId &outBlockId,
-                                        const concordUtils::SpanWrapper &parent_span = concordUtils::SpanWrapper{}) = 0;
-
-  virtual ~IBlocksAppender() = default;
-};
-
-// Categorized interfaces follow. Non-categorized interfaces will be deprecated after full integration of categorized
-// ones.
+// Concord and Concord-BFT internal category that is used for various kinds of metadata.
+// The type of the internal category is VersionedKeyValueCategory.
+inline const auto kConcordInternalCategoryId = "concord_internal";
 
 // Add blocks to the key-value blockchain.
 class IBlockAdder {
  public:
   // Add a block from the given categorized updates and return its ID.
-  virtual BlockId add(categorization::Updates &&, const concordUtils::SpanWrapper &parent_span) = 0;
+  virtual BlockId add(categorization::Updates &&) = 0;
 
   virtual ~IBlockAdder() = default;
 };
@@ -65,6 +32,9 @@ class IBlockAdder {
 //
 // Output vector parameters to multi* calls can contain more values than requested. This is an optimization, in order to
 // reduce memory allocations. Users are encouraged to reuse a single vector instance.
+//
+// If the given category doesn't exist, all get* calls will return std::nullopt. In case of multiGet* calls, the
+// returned vectors will be filled with std::nullopts.
 class IReader {
  public:
   // Get the value of a key in `category_id` at `block_id`.
@@ -84,13 +54,13 @@ class IReader {
   virtual void multiGet(const std::string &category_id,
                         const std::vector<std::string> &keys,
                         const std::vector<BlockId> &versions,
-                        std::vector<std::optional<Value>> &values) const = 0;
+                        std::vector<std::optional<categorization::Value>> &values) const = 0;
 
   // Get the latest values of a list of keys in `category_id`.
   // If a key is missing or is deleted, then std::nullopt is returned for it.
   virtual void multiGetLatest(const std::string &category_id,
                               const std::vector<std::string> &keys,
-                              std::vector<std::optional<Value>> &values) const = 0;
+                              std::vector<std::optional<categorization::Value>> &values) const = 0;
 
   // Get the latest version of `key` in `category_id`.
   // Return std::nullopt if the key doesn't exist or is deleted.
@@ -101,7 +71,7 @@ class IReader {
   // If a key is missing, then std::nullopt is returned for its version.
   virtual void multiGetLatestVersion(const std::string &category_id,
                                      const std::vector<std::string> &keys,
-                                     std::vector<std::optional<categorization::TaggedVersion>> &versions) const;
+                                     std::vector<std::optional<categorization::TaggedVersion>> &versions) const = 0;
 
   // Get the updates that were used to create `block_id`.
   virtual categorization::Updates getBlockUpdates(BlockId block_id) const = 0;
@@ -128,6 +98,36 @@ class IBlocksDeleter {
   virtual BlockId deleteBlocksUntil(BlockId until) = 0;
 
   virtual ~IBlocksDeleter() = default;
+};
+
+// Deprecated interfaces. Will be removed after integration.
+class ILocalKeyValueStorageReadOnly {
+ public:
+  // convenience where readVersion==latest, and block is not needed?
+  virtual concordUtils::Status get(const Key &key, Value &outValue) const = 0;
+  virtual concordUtils::Status get(BlockId readVersion, const Key &key, Value &outValue, BlockId &outBlock) const = 0;
+
+  // Returns the genesis block ID. If the blockchain is empty, 0 is returned.
+  // Throws on errors.
+  virtual BlockId getGenesisBlock() const = 0;
+  virtual BlockId getLastBlock() const = 0;
+  virtual concordUtils::Status getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockData) const = 0;
+  // TODO(GG): explain motivation
+  virtual concordUtils::Status mayHaveConflictBetween(const Key &key,
+                                                      BlockId fromBlock,
+                                                      BlockId toBlock,
+                                                      bool &outRes) const = 0;
+
+  virtual ~ILocalKeyValueStorageReadOnly() = default;
+};
+
+class IBlocksAppender {
+ public:
+  virtual concordUtils::Status addBlock(const SetOfKeyValuePairs &updates,
+                                        BlockId &outBlockId,
+                                        const concordUtils::SpanWrapper &parent_span = concordUtils::SpanWrapper{}) = 0;
+
+  virtual ~IBlocksAppender() = default;
 };
 
 }  // namespace concord::kvbc

--- a/kvbc/include/replica_state_sync.h
+++ b/kvbc/include/replica_state_sync.h
@@ -19,6 +19,8 @@
 #include "Logger.hpp"
 #include "db_adapter_interface.h"
 
+#include "categorization/kv_blockchain.h"
+
 namespace concord::kvbc {
 
 class IBlockMetadata;
@@ -29,7 +31,7 @@ class ReplicaStateSync {
 
   // Synchronizes replica state and returns a number of deleted blocks.
   virtual uint64_t execute(logging::Logger& logger,
-                           IDbAdapter& bcDBAdapter,
+                           categorization::KeyValueBlockchain& blockchain,
                            BlockId lastReachableBlockId,
                            uint64_t lastExecutedSeqNum) = 0;
 };

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -26,7 +26,7 @@ class ReplicaStateSyncImp : public ReplicaStateSync {
   ~ReplicaStateSyncImp() override = default;
 
   uint64_t execute(logging::Logger& logger,
-                   IDbAdapter& bcDBAdapter,
+                   categorization::KeyValueBlockchain& blockchain,
                    BlockId lastReachableBlockId,
                    uint64_t lastExecutedSeqNum) override;
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -162,7 +162,7 @@ void ReplicaImp::multiGetLatestVersion(const std::string &category_id,
   return m_kvBlockchain->multiGetLatestVersion(category_id, keys, versions);
 }
 
-categorization::Updates ReplicaImp::getBlockUpdates(BlockId block_id) const {
+std::optional<categorization::Updates> ReplicaImp::getBlockUpdates(BlockId block_id) const {
   return m_kvBlockchain->getBlockUpdates(block_id);
 }
 
@@ -335,7 +335,10 @@ bool ReplicaImp::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSi
     return getBlockFromObjectStore(blockId, outBlock, outBlockSize);
   }
   const auto rawBlock = m_kvBlockchain->getRawBlock(blockId);
-  const auto &ser = categorization::RawBlock::serialize(rawBlock);
+  if (!rawBlock) {
+    throw NotFoundException{"Raw block not found: " + std::to_string(blockId)};
+  }
+  const auto &ser = categorization::RawBlock::serialize(*rawBlock);
   *outBlockSize = ser.size();
   std::memcpy(outBlock, ser.data(), *outBlockSize);
   return true;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <exception>
+#include <string_view>
 #include <utility>
 #include "assertUtils.hpp"
 #include "communication/CommDefs.hpp"
@@ -22,6 +23,7 @@
 #include "replica_state_sync.h"
 #include "sliver.hpp"
 #include "bftengine/DbMetadataStorage.hpp"
+#include "rocksdb/native_client.h"
 
 using bft::communication::ICommunication;
 using bftEngine::bcst::StateTransferDigest;
@@ -67,9 +69,9 @@ void ReplicaImp::createReplicaAndSyncState() {
       replicaConfig_, m_cmdHandler, m_stateTransfer, m_ptrComm, m_metadataStorage, erasedMetaData, pm_);
   if (erasedMetaData) isNewStorage = true;
   LOG_INFO(logger, "createReplicaAndSyncState: isNewStorage= " << isNewStorage);
-  if (!isNewStorage && !m_stateTransfer->isCollectingState()) {
+  if (!replicaConfig_.isReadOnly && !isNewStorage && !m_stateTransfer->isCollectingState()) {
     uint64_t removedBlocksNum = replicaStateSync_->execute(
-        logger, *m_bcDbAdapter, getLastReachableBlockNum(), m_replicaPtr->getLastExecutedSequenceNum());
+        logger, *m_kvBlockchain, getLastReachableBlockNum(), m_replicaPtr->getLastExecutedSequenceNum());
     LOG_INFO(logger,
              "createReplicaAndSyncState: removedBlocksNum = "
                  << removedBlocksNum << ", new m_lastBlock = " << getLastBlockNum()
@@ -89,103 +91,89 @@ Status ReplicaImp::stop() {
 
 ReplicaImp::RepStatus ReplicaImp::getReplicaStatus() const { return m_currentRepStatus; }
 
-const ILocalKeyValueStorageReadOnly &ReplicaImp::getReadOnlyStorage() { return *this; }
+const IReader &ReplicaImp::getReadOnlyStorage() const { return *this; }
 
-Status ReplicaImp::addBlockToIdleReplica(const SetOfKeyValuePairs &updates) {
+BlockId ReplicaImp::addBlockToIdleReplica(categorization::Updates &&updates) {
   if (getReplicaStatus() != IReplica::RepStatus::Idle) {
-    return Status::IllegalOperation("");
+    throw std::logic_error{"addBlockToIdleReplica() called on a non-idle replica"};
   }
 
-  BlockId d;
-  return addBlockInternal(updates, d);
-}
-
-Status ReplicaImp::get(const Sliver &key, Sliver &outValue) const {
-  // TODO(GG): check legality of operation (the method should be invoked from
-  // the replica's internal thread)
-
-  TimeRecorder scoped_timer(*histograms_.get_value);
-  BlockId dummy;
-  return getInternal(getLastBlockNum(), key, outValue, dummy);
-}
-
-Status ReplicaImp::get(BlockId readVersion, const Sliver &key, Sliver &outValue, BlockId &outBlock) const {
-  // TODO(GG): check legality of operation (the method should be invoked from
-  // the replica's internal thread)
-
-  TimeRecorder scoped_timer(*histograms_.get_block);
-  return getInternal(readVersion, key, outValue, outBlock);
-}
-
-Status ReplicaImp::getBlockData(BlockId blockId, SetOfKeyValuePairs &outBlockData) const {
-  // TODO(GG): check legality of operation (the method should be invoked from
-  // the replica's internal thread)
-
-  try {
-    TimeRecorder scoped_timer(*histograms_.get_block_data);
-    Sliver block = getBlockInternal(blockId);
-    outBlockData = m_bcDbAdapter->getBlockData(block);
-  } catch (const NotFoundException &e) {
-    LOG_ERROR(logger, e.what());
-    return Status::NotFound("todo");
-  }
-
-  return Status::OK();
-}
-
-Status ReplicaImp::mayHaveConflictBetween(const Sliver &key, BlockId fromBlock, BlockId toBlock, bool &outRes) const {
-  // TODO(GG): add assert or print warning if fromBlock==0 (all keys have a
-  // conflict in block 0)
-
-  TimeRecorder scoped_timer(*histograms_.may_have_conflict_between);
-  // we conservatively assume that we have a conflict
-  outRes = true;
-
-  Sliver dummy;
-  BlockId block = 0;
-  Status s = getInternal(toBlock, key, dummy, block);
-  if (s.isOK() && block < fromBlock) {
-    outRes = false;
-  }
-
-  return s;
-}
-
-Status ReplicaImp::addBlock(const SetOfKeyValuePairs &updates,
-                            BlockId &outBlockId,
-                            const concordUtils::SpanWrapper & /*parent_span*/) {
-  // TODO(GG): check legality of operation (the method should be invoked from
-  // the replica's internal thread)
-
-  // TODO(GG): what do we want to do with several identical keys in the same
-  // block?
-
-  TimeRecorder scoped_timer(*histograms_.add_block);
-  return addBlockInternal(updates, outBlockId);
+  return m_kvBlockchain->addBlock(std::move(updates));
 }
 
 void ReplicaImp::deleteGenesisBlock() {
-  const auto genesisBlock = m_bcDbAdapter->getGenesisBlockId();
+  const auto genesisBlock = m_kvBlockchain->getGenesisBlockId();
   if (genesisBlock == 0) {
     throw std::logic_error{"Cannot delete the genesis block from an empty blockchain"};
   }
-  m_bcDbAdapter->deleteBlock(genesisBlock);
+  m_kvBlockchain->deleteBlock(genesisBlock);
 }
 
 BlockId ReplicaImp::deleteBlocksUntil(BlockId until) {
-  const auto genesisBlock = m_bcDbAdapter->getGenesisBlockId();
+  const auto genesisBlock = m_kvBlockchain->getGenesisBlockId();
   if (genesisBlock == 0) {
     throw std::logic_error{"Cannot delete a block range from an empty blockchain"};
   } else if (until <= genesisBlock) {
     throw std::invalid_argument{"Invalid 'until' value passed to deleteBlocksUntil()"};
   }
 
-  const auto lastBlock = getLastBlock();
-  const auto lastDeletedBlock = std::min(lastBlock, until - 1);
+  const auto lastReachableBlock = m_kvBlockchain->getLastReachableBlockId();
+  const auto lastDeletedBlock = std::min(lastReachableBlock, until - 1);
   for (auto i = genesisBlock; i <= lastDeletedBlock; ++i) {
-    m_bcDbAdapter->deleteBlock(i);
+    ConcordAssert(m_kvBlockchain->deleteBlock(i));
   }
   return lastDeletedBlock;
+}
+
+BlockId ReplicaImp::add(categorization::Updates &&updates) { return m_kvBlockchain->addBlock(std::move(updates)); }
+
+std::optional<categorization::Value> ReplicaImp::get(const std::string &category_id,
+                                                     const std::string &key,
+                                                     BlockId block_id) const {
+  return m_kvBlockchain->get(category_id, key, block_id);
+}
+
+std::optional<categorization::Value> ReplicaImp::getLatest(const std::string &category_id,
+                                                           const std::string &key) const {
+  return m_kvBlockchain->getLatest(category_id, key);
+}
+
+void ReplicaImp::multiGet(const std::string &category_id,
+                          const std::vector<std::string> &keys,
+                          const std::vector<BlockId> &versions,
+                          std::vector<std::optional<categorization::Value>> &values) const {
+  return m_kvBlockchain->multiGet(category_id, keys, versions, values);
+}
+
+void ReplicaImp::multiGetLatest(const std::string &category_id,
+                                const std::vector<std::string> &keys,
+                                std::vector<std::optional<categorization::Value>> &values) const {
+  return m_kvBlockchain->multiGetLatest(category_id, keys, values);
+}
+
+std::optional<categorization::TaggedVersion> ReplicaImp::getLatestVersion(const std::string &category_id,
+                                                                          const std::string &key) const {
+  return m_kvBlockchain->getLatestVersion(category_id, key);
+}
+
+void ReplicaImp::multiGetLatestVersion(const std::string &category_id,
+                                       const std::vector<std::string> &keys,
+                                       std::vector<std::optional<categorization::TaggedVersion>> &versions) const {
+  return m_kvBlockchain->multiGetLatestVersion(category_id, keys, versions);
+}
+
+categorization::Updates ReplicaImp::getBlockUpdates(BlockId block_id) const {
+  return m_kvBlockchain->getBlockUpdates(block_id);
+}
+
+BlockId ReplicaImp::getGenesisBlockId() const { return m_kvBlockchain->getGenesisBlockId(); }
+
+BlockId ReplicaImp::getLastBlockId() const {
+  const auto lastSt = m_kvBlockchain->getLastStatetransferBlockId();
+  if (lastSt) {
+    return *lastSt;
+  }
+  return m_kvBlockchain->getLastReachableBlockId();
 }
 
 void ReplicaImp::set_command_handler(ICommandsHandler *handler) { m_cmdHandler = handler; }
@@ -197,6 +185,9 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
                        const std::shared_ptr<concord::performance::PerformanceManager> &pm)
     : logger(logging::getLogger("skvbc.replicaImp")),
       m_currentRepStatus(RepStatus::Idle),
+      m_dbSet{storageFactory->newDatabaseSet()},
+      m_bcDbAdapter{std::move(m_dbSet.dbAdapter)},
+      m_metadataDBClient{m_dbSet.metadataDBClient},
       m_ptrComm(comm),
       replicaConfig_(replicaConfig),
       aggregator_(aggregator),
@@ -240,11 +231,12 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   }
 #endif
 
-  auto dbSet = storageFactory->newDatabaseSet();
-  m_bcDbAdapter = std::move(dbSet.dbAdapter);
-  dbSet.dataDBClient->setAggregator(aggregator);
-  dbSet.metadataDBClient->setAggregator(aggregator);
-  m_metadataDBClient = dbSet.metadataDBClient;
+  if (!replicaConfig.isReadOnly) {
+    const auto linkStChain = true;
+    m_kvBlockchain.emplace(storage::rocksdb::NativeClient::fromIDBClient(m_dbSet.dataDBClient), linkStChain);
+  }
+  m_dbSet.dataDBClient->setAggregator(aggregator);
+  m_dbSet.metadataDBClient->setAggregator(aggregator);
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
@@ -259,40 +251,38 @@ ReplicaImp::~ReplicaImp() {
   }
 }
 
-Status ReplicaImp::addBlockInternal(const SetOfKeyValuePairs &updates, BlockId &outBlockId) {
-  auto data = updates;
-  pm_->Delay<concord::performance::SlowdownPhase::StorageBeforeKVBC>(data);
-  outBlockId = m_bcDbAdapter->addBlock(data);
-  return Status::OK();
-}
-
-Status ReplicaImp::getInternal(BlockId readVersion, const Key &key, Sliver &outValue, BlockId &outBlock) const {
-  const auto clear = [&outValue, &outBlock]() {
-    outValue = Sliver{};
-    outBlock = 0;
-  };
-
-  try {
-    std::tie(outValue, outBlock) = m_bcDbAdapter->getValue(key, readVersion);
-  } catch (const NotFoundException &) {
-    clear();
-  } catch (const std::exception &e) {
-    clear();
-    return Status::GeneralError(std::string{"getInternal() failed to get value due to a DBAdapter error: "} + e.what());
-  } catch (...) {
-    clear();
-    return Status::GeneralError("getInternal() failed to get value due to an unknown DBAdapter error");
-  }
-
-  return Status::OK();
-}
-
 /*
  * This method can't return false by current insertBlockInternal impl.
  * It is used only by State Transfer to synchronize state between replicas.
  */
-bool ReplicaImp::putBlock(const uint64_t blockId, const char *block_data, const uint32_t blockSize) {
-  Sliver block = Sliver::copy(block_data, blockSize);
+bool ReplicaImp::putBlock(const uint64_t blockId, const char *blockData, const uint32_t blockSize) {
+  if (replicaConfig_.isReadOnly) {
+    return putBlockToObjectStore(blockId, blockData, blockSize);
+  }
+
+  auto view = std::string_view{blockData, blockSize};
+  const auto rawBlock = categorization::RawBlock::deserialize(view);
+  if (m_kvBlockchain->hasBlock(blockId)) {
+    const auto existingRawBlock = m_kvBlockchain->getRawBlock(blockId);
+    if (rawBlock != existingRawBlock) {
+      LOG_ERROR(logger,
+                "found existing (and different) block ID[" << blockId << "] when receiving from state transfer");
+
+      // TODO consider assert?
+      m_kvBlockchain->deleteBlock(blockId);
+      throw std::runtime_error(
+          __PRETTY_FUNCTION__ +
+          std::string("found existing (and different) block when receiving state transfer, block ID: ") +
+          std::to_string(blockId));
+    }
+  } else {
+    m_kvBlockchain->addRawBlock(rawBlock, blockId);
+  }
+  return true;
+}
+
+bool ReplicaImp::putBlockToObjectStore(const uint64_t blockId, const char *blockData, const uint32_t blockSize) {
+  Sliver block = Sliver::copy(blockData, blockSize);
 
   if (m_bcDbAdapter->hasBlock(blockId)) {
     // if we already have a block with the same ID
@@ -316,6 +306,24 @@ bool ReplicaImp::putBlock(const uint64_t blockId, const char *block_data, const 
   return true;
 }
 
+uint64_t ReplicaImp::getLastReachableBlockNum() const {
+  if (replicaConfig_.isReadOnly) {
+    return m_bcDbAdapter->getLastReachableBlockId();
+  }
+  return m_kvBlockchain->getLastReachableBlockId();
+}
+
+uint64_t ReplicaImp::getLastBlockNum() const {
+  if (replicaConfig_.isReadOnly) {
+    return m_bcDbAdapter->getLatestBlockId();
+  }
+  const auto last = m_kvBlockchain->getLastStatetransferBlockId();
+  if (last) {
+    return *last;
+  }
+  return m_kvBlockchain->getLastReachableBlockId();
+}
+
 RawBlock ReplicaImp::getBlockInternal(BlockId blockId) const { return m_bcDbAdapter->getRawBlock(blockId); }
 
 /*
@@ -323,6 +331,17 @@ RawBlock ReplicaImp::getBlockInternal(BlockId blockId) const { return m_bcDbAdap
  * The caller is the owner of the memory
  */
 bool ReplicaImp::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) {
+  if (replicaConfig_.isReadOnly) {
+    return getBlockFromObjectStore(blockId, outBlock, outBlockSize);
+  }
+  const auto rawBlock = m_kvBlockchain->getRawBlock(blockId);
+  const auto &ser = categorization::RawBlock::serialize(rawBlock);
+  *outBlockSize = ser.size();
+  std::memcpy(outBlock, ser.data(), *outBlockSize);
+  return true;
+}
+
+bool ReplicaImp::getBlockFromObjectStore(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) {
   try {
     RawBlock block = getBlockInternal(blockId);
     *outBlockSize = block.length();
@@ -334,17 +353,36 @@ bool ReplicaImp::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSi
   }
 }
 
-bool ReplicaImp::hasBlock(BlockId blockId) const { return m_bcDbAdapter->hasBlock(blockId); }
+bool ReplicaImp::hasBlock(BlockId blockId) const {
+  if (replicaConfig_.isReadOnly) {
+    return m_bcDbAdapter->hasBlock(blockId);
+  }
+  return m_kvBlockchain->hasBlock(blockId);
+}
 
 bool ReplicaImp::getPrevDigestFromBlock(BlockId blockId, StateTransferDigest *outPrevBlockDigest) {
+  if (replicaConfig_.isReadOnly) {
+    return getPrevDigestFromObjectStoreBlock(blockId, outPrevBlockDigest);
+  }
+  ConcordAssert(blockId > 0);
+  const auto parent_digest = m_kvBlockchain->parentDigest(blockId);
+  ConcordAssert(parent_digest.has_value());
+  static_assert(parent_digest->size() == BLOCK_DIGEST_SIZE);
+  static_assert(sizeof(StateTransferDigest) == BLOCK_DIGEST_SIZE);
+  std::memcpy(outPrevBlockDigest, parent_digest->data(), BLOCK_DIGEST_SIZE);
+  return true;
+}
+
+bool ReplicaImp::getPrevDigestFromObjectStoreBlock(uint64_t blockId,
+                                                   bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) {
   ConcordAssert(blockId > 0);
   try {
-    RawBlock result = getBlockInternal(blockId);
-    auto parentDigest = m_bcDbAdapter->getParentDigest(result);
+    const auto rawBlockSer = m_bcDbAdapter->getRawBlock(blockId);
+    const auto rawBlock = categorization::RawBlock::deserialize(rawBlockSer);
     ConcordAssert(outPrevBlockDigest != nullptr);
-    static_assert(parentDigest.size() == BLOCK_DIGEST_SIZE);
+    static_assert(rawBlock.data.parent_digest.size() == BLOCK_DIGEST_SIZE);
     static_assert(sizeof(StateTransferDigest) == BLOCK_DIGEST_SIZE);
-    memcpy(outPrevBlockDigest, parentDigest.data(), BLOCK_DIGEST_SIZE);
+    memcpy(outPrevBlockDigest, rawBlock.data.parent_digest.data(), BLOCK_DIGEST_SIZE);
     return true;
   } catch (const NotFoundException &e) {
     LOG_FATAL(logger, "Block not found for parent digest, ID: " << blockId << " " << e.what());

--- a/kvbc/src/block_metadata.cpp
+++ b/kvbc/src/block_metadata.cpp
@@ -5,27 +5,28 @@
 
 #include "block_metadata.hpp"
 
-using concordUtils::Status;
+#include "assertUtils.hpp"
+#include "endianness.hpp"
 
 namespace concord {
 namespace kvbc {
 
-Sliver BlockMetadata::serialize(uint64_t bft_sequence_num) const {
-  return Sliver::copy((char*)&bft_sequence_num, sizeof(uint64_t));
+std::string BlockMetadata::serialize(uint64_t bft_sequence_num) const {
+  return concordUtils::toBigEndianStringBuffer(bft_sequence_num);
 }
 
-uint64_t BlockMetadata::getLastBlockSequenceNum(const Sliver& key) const {
-  Sliver outValue;
-  Status status = storage_.get(key, outValue);
-  uint64_t sequenceNum = 0;
-  if (status.isOK() && outValue.length() > 0) {
-    sequenceNum = *(uint64_t*)outValue.data();
+uint64_t BlockMetadata::getLastBlockSequenceNum() const {
+  const auto value = storage_.getLatest(kConcordInternalCategoryId, IBlockMetadata::kBlockMetadataKeyStr);
+  auto sequenceNum = uint64_t{0};
+  if (value) {
+    const auto& data = std::get<categorization::VersionedValue>(*value).data;
+    ConcordAssertEQ(data.size(), sizeof(uint64_t));
+    sequenceNum = concordUtils::fromBigEndianBuffer<uint64_t>(data.data());
   } else {
-    LOG_WARN(
-        logger_,
-        "Unable to get block or has zero-length; status = " << status << ", outValue.length = " << outValue.length());
+    LOG_WARN(logger_, "Unable to get last block sequence number");
   }
-  LOG_INFO(logger_, "key = " << key << ", sequenceNum = " << sequenceNum);
+
+  LOG_INFO(logger_, "last block sequenceNum = " << sequenceNum);
   return sequenceNum;
 }
 

--- a/kvbc/src/categorization/blockchain.cpp
+++ b/kvbc/src/categorization/blockchain.cpp
@@ -29,7 +29,7 @@ Blockchain::Blockchain(const std::shared_ptr<concord::storage::rocksdb::NativeCl
   auto genesis_blockId = loadGenesisBlockId();
   if (genesis_blockId) {
     genesis_block_id_ = genesis_blockId.value();
-    LOG_INFO(CAT_BLOCK_LOG, "Genesis block as loaded from storage " << last_reachable_block_id_);
+    LOG_INFO(CAT_BLOCK_LOG, "Genesis block as loaded from storage " << genesis_block_id_);
   }
 }
 

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -20,6 +20,14 @@ namespace concord::kvbc::categorization {
 
 using ::bftEngine::bcst::computeBlockDigest;
 
+template <typename T>
+void nullopts(std::vector<std::optional<T>>& vec, std::size_t count) {
+  vec.clear();
+  for (auto i = 0ull; i < count; ++i) {
+    vec.push_back(std::nullopt);
+  }
+}
+
 KeyValueBlockchain::KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client,
                                        bool link_st_chain)
     : native_client_{native_client}, block_chain_{native_client_}, state_transfer_block_chain_{native_client_} {
@@ -161,9 +169,14 @@ Category& KeyValueBlockchain::getCategory(const std::string& cat_id) {
   return it->second;
 }
 
+bool KeyValueBlockchain::hasCategory(const std::string& cat_id) const { return (categorires_.count(cat_id) != 0); }
+
 std::optional<Value> KeyValueBlockchain::get(const std::string& category_id,
                                              const std::string& key,
                                              BlockId block_id) const {
+  if (!hasCategory(category_id)) {
+    return std::nullopt;
+  }
   std::optional<Value> ret;
   std::visit([&key, &block_id, &ret](const auto& category) { ret = category.get(key, block_id); },
              getCategory(category_id));
@@ -171,6 +184,9 @@ std::optional<Value> KeyValueBlockchain::get(const std::string& category_id,
 }
 
 std::optional<Value> KeyValueBlockchain::getLatest(const std::string& category_id, const std::string& key) const {
+  if (!hasCategory(category_id)) {
+    return std::nullopt;
+  }
   std::optional<Value> ret;
   std::visit([&key, &ret](const auto& category) { ret = category.getLatest(key); }, getCategory(category_id));
   return ret;
@@ -180,6 +196,10 @@ void KeyValueBlockchain::multiGet(const std::string& category_id,
                                   const std::vector<std::string>& keys,
                                   const std::vector<BlockId>& versions,
                                   std::vector<std::optional<Value>>& values) const {
+  if (!hasCategory(category_id)) {
+    nullopts(values, keys.size());
+    return;
+  }
   std::visit([&keys, &versions, &values](const auto& category) { category.multiGet(keys, versions, values); },
              getCategory(category_id));
 }
@@ -187,12 +207,19 @@ void KeyValueBlockchain::multiGet(const std::string& category_id,
 void KeyValueBlockchain::multiGetLatest(const std::string& category_id,
                                         const std::vector<std::string>& keys,
                                         std::vector<std::optional<Value>>& values) const {
+  if (!hasCategory(category_id)) {
+    nullopts(values, keys.size());
+    return;
+  }
   std::visit([&keys, &values](const auto& category) { category.multiGetLatest(keys, values); },
              getCategory(category_id));
 }
 
 std::optional<categorization::TaggedVersion> KeyValueBlockchain::getLatestVersion(const std::string& category_id,
                                                                                   const std::string& key) const {
+  if (!hasCategory(category_id)) {
+    return std::nullopt;
+  }
   std::optional<categorization::TaggedVersion> ret;
   std::visit([&key, &ret](const auto& category) { ret = category.getLatestVersion(key); }, getCategory(category_id));
   return ret;
@@ -202,6 +229,10 @@ void KeyValueBlockchain::multiGetLatestVersion(
     const std::string& category_id,
     const std::vector<std::string>& keys,
     std::vector<std::optional<categorization::TaggedVersion>>& versions) const {
+  if (!hasCategory(category_id)) {
+    nullopts(versions, keys.size());
+    return;
+  }
   std::visit([&keys, &versions](const auto& catagory) { catagory.multiGetLatestVersion(keys, versions); },
              getCategory(category_id));
 }
@@ -469,7 +500,7 @@ ImmutableOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
 }
 
 /////////////////////// state transfer blockchain ///////////////////////
-void KeyValueBlockchain::addRawBlock(RawBlock& block, const BlockId& block_id) {
+void KeyValueBlockchain::addRawBlock(const RawBlock& block, const BlockId& block_id) {
   const auto last_reachable_block = getLastReachableBlockId();
   if (block_id <= last_reachable_block) {
     const auto msg = "Cannot add an existing block ID " + std::to_string(block_id);
@@ -512,6 +543,22 @@ RawBlock KeyValueBlockchain::getRawBlock(const BlockId& block_id) const {
     throw std::runtime_error{"Failed to get block node ID = " + std::to_string(block_id)};
   }
   return raw_block.value();
+}
+
+std::optional<Hash> KeyValueBlockchain::parentDigest(BlockId block_id) const {
+  const auto last_reachable_block = getLastReachableBlockId();
+  if (block_id > last_reachable_block) {
+    return state_transfer_block_chain_.parentDigest(block_id);
+  }
+  return block_chain_.parentDigest(block_id);
+}
+
+bool KeyValueBlockchain::hasBlock(BlockId block_id) const {
+  const auto last_reachable_block = getLastReachableBlockId();
+  if (block_id > last_reachable_block) {
+    return state_transfer_block_chain_.hasBlock(block_id);
+  }
+  return block_chain_.hasBlock(block_id);
 }
 
 // tries to remove blocks form the state transfer chain to the blockchain

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -49,21 +49,21 @@ void KeyValueBlockchain::instantiateCategories() {
       LOG_FATAL(CAT_BLOCK_LOG, "Category type value of [" << itr.key() << "] is invalid (bigger than one).");
       ConcordAssertEQ(itr.valueView().size(), 1);
     }
-    auto cat_type = static_cast<detail::CATEGORY_TYPE>(itr.valueView()[0]);
+    auto cat_type = static_cast<CATEGORY_TYPE>(itr.valueView()[0]);
     switch (cat_type) {
-      case detail::CATEGORY_TYPE::block_merkle:
+      case CATEGORY_TYPE::block_merkle:
         categorires_.emplace(itr.key(), detail::BlockMerkleCategory{native_client_});
-        categorires_types_[itr.key()] = detail::CATEGORY_TYPE::block_merkle;
+        categorires_types_[itr.key()] = CATEGORY_TYPE::block_merkle;
         LOG_INFO(CAT_BLOCK_LOG, "Created category [" << itr.key() << "] as type BlockMerkleCategory");
         break;
-      case detail::CATEGORY_TYPE::immutable:
+      case CATEGORY_TYPE::immutable:
         categorires_.emplace(itr.key(), detail::ImmutableKeyValueCategory{itr.key(), native_client_});
-        categorires_types_[itr.key()] = detail::CATEGORY_TYPE::immutable;
+        categorires_types_[itr.key()] = CATEGORY_TYPE::immutable;
         LOG_INFO(CAT_BLOCK_LOG, "Created category [" << itr.key() << "] as type ImmutableKeyValueCategory");
         break;
-      case detail::CATEGORY_TYPE::versioned_kv:
+      case CATEGORY_TYPE::versioned_kv:
         categorires_.emplace(itr.key(), detail::VersionedKeyValueCategory{itr.key(), native_client_});
-        categorires_types_[itr.key()] = detail::CATEGORY_TYPE::versioned_kv;
+        categorires_types_[itr.key()] = CATEGORY_TYPE::versioned_kv;
         LOG_INFO(CAT_BLOCK_LOG, "Created category [" << itr.key() << "] as type VersionedKeyValueCategory");
         break;
       default:
@@ -419,7 +419,7 @@ void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
 // Updates per category
 
 bool KeyValueBlockchain::insertCategoryMapping(const std::string& cat_id,
-                                               const detail::CATEGORY_TYPE type,
+                                               const CATEGORY_TYPE type,
                                                concord::storage::rocksdb::NativeWriteBatch& write_batch) {
   // check if we know this category type already
   if (categorires_types_.count(cat_id) == 1) {
@@ -440,7 +440,7 @@ BlockMerkleOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
                                                             BlockMerkleInput&& updates,
                                                             concord::storage::rocksdb::NativeWriteBatch& write_batch) {
   // if true means that category is new and we should create an instance of it.
-  if (insertCategoryMapping(category_id, detail::CATEGORY_TYPE::block_merkle, write_batch)) {
+  if (insertCategoryMapping(category_id, CATEGORY_TYPE::block_merkle, write_batch)) {
     if (const auto [_, inserted] = categorires_.try_emplace(category_id, detail::BlockMerkleCategory{native_client_});
         !inserted) {
       (void)_;
@@ -462,7 +462,7 @@ VersionedOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
                                                           VersionedInput&& updates,
                                                           concord::storage::rocksdb::NativeWriteBatch& write_batch) {
   // if true means that category is new and we should create an instance of it.
-  if (insertCategoryMapping(category_id, detail::CATEGORY_TYPE::versioned_kv, write_batch)) {
+  if (insertCategoryMapping(category_id, CATEGORY_TYPE::versioned_kv, write_batch)) {
     if (const auto [_, inserted] =
             categorires_.try_emplace(category_id, detail::VersionedKeyValueCategory{category_id, native_client_});
         !inserted) {
@@ -485,7 +485,7 @@ ImmutableOutput KeyValueBlockchain::handleCategoryUpdates(BlockId block_id,
                                                           ImmutableInput&& updates,
                                                           concord::storage::rocksdb::NativeWriteBatch& write_batch) {
   // if true means that category is new and we should create an instance of it.
-  if (insertCategoryMapping(category_id, detail::CATEGORY_TYPE::immutable, write_batch)) {
+  if (insertCategoryMapping(category_id, CATEGORY_TYPE::immutable, write_batch)) {
     if (const auto [_, inserted] =
             categorires_.try_emplace(category_id, detail::ImmutableKeyValueCategory{category_id, native_client_});
         !inserted) {

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -402,7 +402,7 @@ BlockId DBAdapter::addBlock(const SetOfKeyValuePairs &kv) {
 
 void DBAdapter::addRawBlock(const RawBlock &block, const BlockId &blockId) {
   SetOfKeyValuePairs keys;
-  if (block.length() > 0) {
+  if (saveKvPairsSeparately_ && block.length() > 0) {
     keys = getBlockData(block);
   }
   if (Status s = addBlockAndUpdateMultiKey(keys, blockId, block); !s.isOK())

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -1539,7 +1539,7 @@ TEST_F(categorized_kvbc, updates_append_single_key_value_non_existent_category) 
   auto updates = Updates{};
 
   ASSERT_FALSE(updates.appendKeyValue<BlockMerkleUpdates>("non-existent", "k", "v"));
-  ASSERT_FALSE(updates.appendKeyValue<VersionedUpdates>("non-existent", "k", {{"v", false}}));
+  ASSERT_FALSE(updates.appendKeyValue<VersionedUpdates>("non-existent", "k", VersionedUpdates::Value{"v", false}));
   ASSERT_FALSE(updates.appendKeyValue<ImmutableUpdates>(
       "non-existent", "k", ImmutableUpdates::ImmutableValue{"v", {"t1", "t2"}}));
 

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -513,7 +513,8 @@ TEST_F(categorized_kvbc, get_raw_block) {
 
   {
     auto rb = block_chain.getRawBlock(5);
-    ASSERT_EQ(std::get<BlockMerkleInput>(rb.data.updates.kv["merkle"]).kv["merkle_key3"], "merkle_value3");
+    ASSERT_TRUE(rb);
+    ASSERT_EQ(std::get<BlockMerkleInput>(rb->data.updates.kv["merkle"]).kv["merkle_key3"], "merkle_value3");
   }
 
   // E.L not yet possible
@@ -714,7 +715,8 @@ TEST_F(categorized_kvbc, get_block_data) {
 
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
     auto reconstructed_updates = block_chain.getBlockUpdates(1);
-    ASSERT_TRUE(up_before_move == reconstructed_updates);
+    ASSERT_TRUE(reconstructed_updates);
+    ASSERT_EQ(up_before_move, *reconstructed_updates);
   }
   // Add block2
   {
@@ -746,7 +748,8 @@ TEST_F(categorized_kvbc, get_block_data) {
     auto up_before_move = updates;
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)2);
     auto reconstructed_updates = block_chain.getBlockUpdates(2);
-    ASSERT_TRUE(up_before_move == reconstructed_updates);
+    ASSERT_TRUE(reconstructed_updates);
+    ASSERT_EQ(up_before_move, *reconstructed_updates);
   }
 
   // try to get updates
@@ -786,8 +789,9 @@ TEST_F(categorized_kvbc, compare_raw_blocks) {
   ASSERT_EQ(last_raw.first, 1);
   ASSERT_TRUE(last_raw.second.has_value());
   auto raw_from_api = block_chain.getRawBlock(1);
+  ASSERT_TRUE(raw_from_api);
   auto last_raw_imm_data = std::get<ImmutableInput>(last_raw.second.value().updates.kv["imm"]);
-  auto raw_from_api_imm_data = std::get<ImmutableInput>(raw_from_api.data.updates.kv["imm"]);
+  auto raw_from_api_imm_data = std::get<ImmutableInput>(raw_from_api->data.updates.kv["imm"]);
   std::vector<std::string> vec{"0", "1"};
   ASSERT_EQ(last_raw_imm_data.kv["key"].data, "val");
   ASSERT_EQ(last_raw_imm_data.kv["key"].tags, vec);

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -507,8 +507,8 @@ TEST_F(categorized_kvbc, get_raw_block) {
     ASSERT_TRUE(block_chain.getLastStatetransferBlockId().has_value());
     ASSERT_EQ(block_chain.getLastStatetransferBlockId().value(), 5);
 
-    ASSERT_THROW(block_chain.getRawBlock(3), std::runtime_error);
-    ASSERT_THROW(block_chain.getRawBlock(6), std::runtime_error);
+    ASSERT_FALSE(block_chain.getRawBlock(3));
+    ASSERT_FALSE(block_chain.getRawBlock(6));
   }
 
   {
@@ -524,7 +524,7 @@ TEST_F(categorized_kvbc, get_raw_block) {
   //   "merkle_value1");
   // }
 
-  { ASSERT_THROW(block_chain.getRawBlock(0), std::runtime_error); }
+  { ASSERT_FALSE(block_chain.getRawBlock(0)); }
 }
 
 TEST_F(categorized_kvbc, link_state_transfer_chain) {
@@ -753,8 +753,8 @@ TEST_F(categorized_kvbc, get_block_data) {
   }
 
   // try to get updates
-  ASSERT_THROW(block_chain.getBlockUpdates(889), std::runtime_error);
-  ASSERT_THROW(block_chain.getBlockUpdates(887), std::runtime_error);
+  ASSERT_FALSE(block_chain.getBlockUpdates(889));
+  ASSERT_FALSE(block_chain.getBlockUpdates(887));
 }
 
 TEST_F(categorized_kvbc, validate_category_creation_on_add) {

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -822,7 +822,7 @@ TEST_F(categorized_kvbc, single_read_with_version) {
     ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
   }
 
-  ASSERT_THROW(block_chain.get("non_exist", "key", 1), std::runtime_error);
+  ASSERT_NO_THROW(block_chain.get("non_exist", "key", 1));
   ASSERT_FALSE(block_chain.get("merkle", "non_exist", 1).has_value());
   ASSERT_FALSE(block_chain.get("versioned", "non_exist", 1).has_value());
   ASSERT_FALSE(block_chain.get("immutable", "non_exist", 1).has_value());

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -624,17 +624,13 @@ TEST_F(categorized_kvbc, creation_of_category_type_cf) {
 TEST_F(categorized_kvbc, instantiation_of_categories) {
   auto wb = db->getBatch();
   db->createColumnFamily(detail::CAT_ID_TYPE_CF);
-  wb.put(detail::CAT_ID_TYPE_CF,
-         std::string("merkle"),
-         std::string(1, static_cast<char>(detail::CATEGORY_TYPE::block_merkle)));
-  wb.put(detail::CAT_ID_TYPE_CF,
-         std::string("merkle2"),
-         std::string(1, static_cast<char>(detail::CATEGORY_TYPE::block_merkle)));
+  wb.put(detail::CAT_ID_TYPE_CF, std::string("merkle"), std::string(1, static_cast<char>(CATEGORY_TYPE::block_merkle)));
   wb.put(
-      detail::CAT_ID_TYPE_CF, std::string("imm"), std::string(1, static_cast<char>(detail::CATEGORY_TYPE::immutable)));
+      detail::CAT_ID_TYPE_CF, std::string("merkle2"), std::string(1, static_cast<char>(CATEGORY_TYPE::block_merkle)));
+  wb.put(detail::CAT_ID_TYPE_CF, std::string("imm"), std::string(1, static_cast<char>(CATEGORY_TYPE::immutable)));
   wb.put(detail::CAT_ID_TYPE_CF,
          std::string("versioned_kv"),
-         std::string(1, static_cast<char>(detail::CATEGORY_TYPE::versioned_kv)));
+         std::string(1, static_cast<char>(CATEGORY_TYPE::versioned_kv)));
 
   db->write(std::move(wb));
 
@@ -661,9 +657,7 @@ TEST_F(categorized_kvbc, instantiation_of_categories) {
 TEST_F(categorized_kvbc, throw_on_non_exist_category_type) {
   KeyValueBlockchain block_chain{db, true};
   auto wb = db->getBatch();
-  wb.put(detail::CAT_ID_TYPE_CF,
-         std::string("merkle"),
-         std::string(1, static_cast<char>(detail::CATEGORY_TYPE::end_of_types)));
+  wb.put(detail::CAT_ID_TYPE_CF, std::string("merkle"), std::string(1, static_cast<char>(CATEGORY_TYPE::end_of_types)));
   db->write(std::move(wb));
 
   KeyValueBlockchain::KeyValueBlockchain_tester tester;
@@ -679,9 +673,7 @@ TEST_F(categorized_kvbc, throw_on_non_exist_category) {
 TEST_F(categorized_kvbc, get_category) {
   db->createColumnFamily(detail::CAT_ID_TYPE_CF);
   auto wb = db->getBatch();
-  wb.put(detail::CAT_ID_TYPE_CF,
-         std::string("merkle"),
-         std::string(1, static_cast<char>(detail::CATEGORY_TYPE::block_merkle)));
+  wb.put(detail::CAT_ID_TYPE_CF, std::string("merkle"), std::string(1, static_cast<char>(CATEGORY_TYPE::block_merkle)));
   db->write(std::move(wb));
   KeyValueBlockchain block_chain{db, true};
   KeyValueBlockchain::KeyValueBlockchain_tester tester;
@@ -773,7 +765,7 @@ TEST_F(categorized_kvbc, validate_category_creation_on_add) {
 
   auto type = db->get(detail::CAT_ID_TYPE_CF, std::string("imm"));
   ASSERT_TRUE(type.has_value());
-  ASSERT_EQ(static_cast<detail::CATEGORY_TYPE>((*type)[0]), detail::CATEGORY_TYPE::immutable);
+  ASSERT_EQ(static_cast<CATEGORY_TYPE>((*type)[0]), CATEGORY_TYPE::immutable);
 }
 
 TEST_F(categorized_kvbc, compare_raw_blocks) {

--- a/performance/test/slowdown_test.cpp
+++ b/performance/test/slowdown_test.cpp
@@ -169,38 +169,39 @@ TEST(slowdown_test, hybrid_configuration) {
   t1(data, 10, 'd');
 }
 
-TEST(slowdown_test, add_keys_configuration) {
-  using namespace concord::kvbc;
-  using namespace concord::kvbc::v2MerkleTree;
+// TODO: Provide an implementation for categorization.
+// TEST(slowdown_test, add_keys_configuration) {
+//   using namespace concord::kvbc;
+//   using namespace concord::kvbc::v2MerkleTree;
 
-  auto sm = std::make_shared<SlowdownConfiguration>();
-  AddKeysPolicyConfig ap(10, 200, 3000);
-  std::vector<std::shared_ptr<SlowdownPolicyConfig>> policies;
-  policies.push_back(std::make_shared<AddKeysPolicyConfig>(ap));
+//   auto sm = std::make_shared<SlowdownConfiguration>();
+//   AddKeysPolicyConfig ap(10, 200, 3000);
+//   std::vector<std::shared_ptr<SlowdownPolicyConfig>> policies;
+//   policies.push_back(std::make_shared<AddKeysPolicyConfig>(ap));
 
-  std::unique_ptr<IStorageFactory> f = std::make_unique<MemoryDBStorageFactory>();
-  auto comm = MockComm();
-  bftEngine::ReplicaConfig& rc = bftEngine::ReplicaConfig::instance();
-  rc.numReplicas = 4;
-  rc.fVal = 1;
-  rc.cVal = 0;
-  rc.numOfExternalClients = 1;
-  (*sm)[SlowdownPhase::StorageBeforeKVBC] = policies;
-  auto pm = std::make_shared<PerformanceManager>(sm);
+//   std::unique_ptr<IStorageFactory> f = std::make_unique<MemoryDBStorageFactory>();
+//   auto comm = MockComm();
+//   bftEngine::ReplicaConfig& rc = bftEngine::ReplicaConfig::instance();
+//   rc.numReplicas = 4;
+//   rc.fVal = 1;
+//   rc.cVal = 0;
+//   rc.numOfExternalClients = 1;
+//   (*sm)[SlowdownPhase::StorageBeforeKVBC] = policies;
+//   auto pm = std::make_shared<PerformanceManager>(sm);
 
-  ReplicaImp r(
-      dynamic_cast<ICommunication*>(&comm), rc, std::move(f), std::make_shared<concordMetrics::Aggregator>(), pm);
-  SetOfKeyValuePairs set;
-  set.insert({concordUtils::Sliver("key"), concordUtils::Sliver("value")});
-  set.insert({concordUtils::Sliver("key1"), concordUtils::Sliver("value2")});
-  set.insert({concordUtils::Sliver("key2"), concordUtils::Sliver("value2")});
-  auto size = set.size();
-  concordUtils::SpanWrapper s;
-  BlockId id;
-  r.addBlock(set, id, s);
-  EXPECT_EQ(id, 1);
-  EXPECT_EQ(set.size(), size);  // was not changed
-}
+//   ReplicaImp r(
+//       dynamic_cast<ICommunication*>(&comm), rc, std::move(f), std::make_shared<concordMetrics::Aggregator>(), pm);
+//   SetOfKeyValuePairs set;
+//   set.insert({concordUtils::Sliver("key"), concordUtils::Sliver("value")});
+//   set.insert({concordUtils::Sliver("key1"), concordUtils::Sliver("value2")});
+//   set.insert({concordUtils::Sliver("key2"), concordUtils::Sliver("value2")});
+//   auto size = set.size();
+//   concordUtils::SpanWrapper s;
+//   BlockId id;
+//   r.addBlock(set, id, s);
+//   EXPECT_EQ(id, 1);
+//   EXPECT_EQ(set.size(), size);  // was not changed
+// }
 
 }  // anonymous namespace
 

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} KEEP_APOLLO_LOGS=${KEEP_APOLLO_LOGS}")
 
-set(STORAGE_TYPES "v1direct" "v2merkle")
+set(STORAGE_TYPES "versioned_kv" "block_merkle")
 if (CI_TEST_STORAGE_TYPE)
   set(STORAGE_TYPES ${CI_TEST_STORAGE_TYPE})
 endif()
@@ -29,80 +29,78 @@ if (OMIT_TEST_OUTPUT)
     set(TEST_OUTPUT "2>&1 > /dev/null")
 endif()
 
-foreach(STORAGE_TYPE ${STORAGE_TYPES})
-  add_test(NAME skvbc_basic_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_basic_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc ${TEST_OUTPUT}"
+add_test(NAME skvbc_basic_tests COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_basic_tests python3 -m unittest test_skvbc ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_multi_sig COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_multi_sig python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_linearizability_tests COMMAND sudo sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_linearizability_tests python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME test_skvbc_history_tracker COMMAND sudo sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=test_skvbc_history_tracker python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_fast_path_tests COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_fast_path_tests python3 -m unittest test_skvbc_fast_path ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_slow_path_tests COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_slow_path_tests python3 -m unittest test_skvbc_slow_path ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_view_change_tests COMMAND sudo sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_view_change_tests python3 -m unittest test_skvbc_view_change ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_auto_view_change_tests COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_auto_view_change_tests python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_preexecution_tests COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_preexecution_tests python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_batch_preexecution_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_batch_preexecution_tests python3 -m unittest test_skvbc_batch_preexecution ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_test(NAME skvbc_multi_sig_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_multi_sig_${STORAGE_TYPE} python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
+add_test(NAME skvbc_network_partitioning_tests COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_network_partitioning_tests python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_checkpoints COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_checkpoints python3 -m unittest test_skvbc_checkpoints 2>&1 > /dev/null"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_chaotic_startup COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_chaotic_startup python3 -m unittest test_skvbc_chaotic_startup 2>&1 > /dev/null"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_backup_restore COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_reconfiguration COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_consensus_batching COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_consensus_batching python3 -m unittest test_skvbc_consensus_batching ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+if (BUILD_ROCKSDB_STORAGE)
+  add_test(NAME skvbc_persistence_tests COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_persistence_tests python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_test(NAME skvbc_linearizability_tests_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_linearizability_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME test_skvbc_history_tracker_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=test_skvbc_history_tracker_${STORAGE_TYPE} python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_fast_path_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_fast_path_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_fast_path ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_slow_path_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_slow_path_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_slow_path ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_view_change_tests_${STORAGE_TYPE} COMMAND sudo sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_view_change_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_view_change ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_auto_view_change_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_auto_view_change_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_preexecution_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_preexecution_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_batch_preexecution_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_batch_preexecution_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_batch_preexecution ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_network_partitioning_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_network_partitioning_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_checkpoints_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_checkpoints_${STORAGE_TYPE} python3 -m unittest test_skvbc_checkpoints 2>&1 > /dev/null"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_chaotic_startup_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_chaotic_startup_${STORAGE_TYPE} python3 -m unittest test_skvbc_chaotic_startup 2>&1 > /dev/null"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_backup_restore_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore_${STORAGE_TYPE} python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_reconfiguration_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration_${STORAGE_TYPE} python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  add_test(NAME skvbc_consensus_batching_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_consensus_batching_${STORAGE_TYPE} python3 -m unittest test_skvbc_consensus_batching ${TEST_OUTPUT}"
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-  if (BUILD_ROCKSDB_STORAGE)
-    add_test(NAME skvbc_persistence_tests_${STORAGE_TYPE} COMMAND sh -c
-            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_persistence_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
+  if (USE_S3_OBJECT_STORE)
+    add_test(NAME skvbc_ro_replica_tests COMMAND sh -c
+            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-    if (USE_S3_OBJECT_STORE)
-      add_test(NAME skvbc_ro_replica_tests_${STORAGE_TYPE} COMMAND sh -c
-              "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
-              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    endif()
   endif()
-endforeach()
+endif()

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -20,87 +20,82 @@ endif()
 
 set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} KEEP_APOLLO_LOGS=${KEEP_APOLLO_LOGS}")
 
-set(STORAGE_TYPES "versioned_kv" "block_merkle")
-if (CI_TEST_STORAGE_TYPE)
-  set(STORAGE_TYPES ${CI_TEST_STORAGE_TYPE})
-endif()
-
 if (OMIT_TEST_OUTPUT)
     set(TEST_OUTPUT "2>&1 > /dev/null")
 endif()
 
 add_test(NAME skvbc_basic_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_basic_tests python3 -m unittest test_skvbc ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_basic_tests python3 -m unittest test_skvbc ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_multi_sig COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_multi_sig python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_multi_sig python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_linearizability_tests COMMAND sudo sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_linearizability_tests python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_linearizability_tests python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME test_skvbc_history_tracker COMMAND sudo sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=test_skvbc_history_tracker python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=test_skvbc_history_tracker python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_fast_path_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_fast_path_tests python3 -m unittest test_skvbc_fast_path ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_fast_path_tests python3 -m unittest test_skvbc_fast_path ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_slow_path_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_slow_path_tests python3 -m unittest test_skvbc_slow_path ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_slow_path_tests python3 -m unittest test_skvbc_slow_path ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_view_change_tests COMMAND sudo sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_view_change_tests python3 -m unittest test_skvbc_view_change ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_view_change_tests python3 -m unittest test_skvbc_view_change ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_auto_view_change_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_auto_view_change_tests python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_auto_view_change_tests python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_preexecution_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_preexecution_tests python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_preexecution_tests python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_batch_preexecution_tests_${STORAGE_TYPE} COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_batch_preexecution_tests python3 -m unittest test_skvbc_batch_preexecution ${TEST_OUTPUT}"
+add_test(NAME skvbc_batch_preexecution_tests COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_batch_preexecution_tests python3 -m unittest test_skvbc_batch_preexecution ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_network_partitioning_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_network_partitioning_tests python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_network_partitioning_tests python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_checkpoints COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_checkpoints python3 -m unittest test_skvbc_checkpoints 2>&1 > /dev/null"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_checkpoints python3 -m unittest test_skvbc_checkpoints 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_chaotic_startup COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_chaotic_startup python3 -m unittest test_skvbc_chaotic_startup 2>&1 > /dev/null"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_chaotic_startup python3 -m unittest test_skvbc_chaotic_startup 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_backup_restore COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_reconfiguration COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_consensus_batching COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_consensus_batching python3 -m unittest test_skvbc_consensus_batching ${TEST_OUTPUT}"
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_consensus_batching python3 -m unittest test_skvbc_consensus_batching ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 if (BUILD_ROCKSDB_STORAGE)
   add_test(NAME skvbc_persistence_tests COMMAND sh -c
-          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_persistence_tests python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
+          "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_persistence_tests python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
   if (USE_S3_OBJECT_STORE)
     add_test(NAME skvbc_ro_replica_tests COMMAND sh -c
-            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
+            "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 endif()

--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -39,8 +39,8 @@ def start_replica_cmd(builddir, replica_id):
             "-e", str(True),
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 class SkvbcTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -36,10 +36,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-e", str(True),
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-e", str(True)
             ]
 
 

--- a/tests/apollo/test_skvbc_auto_view_change.py
+++ b/tests/apollo/test_skvbc_auto_view_change.py
@@ -34,10 +34,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-a", autoPrimaryRotationTimeoutMilli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-a", autoPrimaryRotationTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_auto_view_change.py
+++ b/tests/apollo/test_skvbc_auto_view_change.py
@@ -37,8 +37,8 @@ def start_replica_cmd(builddir, replica_id):
             "-a", autoPrimaryRotationTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 class SkvbcAutoViewChangeTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_backup_restore.py
+++ b/tests/apollo/test_skvbc_backup_restore.py
@@ -35,8 +35,8 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", view_change_timeout_milli,
-            "-p",
-            "-t", os.environ.get('STORAGE_TYPE')]
+            "-p"
+            ]
 
 
 def start_replica_cmd_with_vc_timeout(vc_timeout):

--- a/tests/apollo/test_skvbc_backup_restore.py
+++ b/tests/apollo/test_skvbc_backup_restore.py
@@ -24,8 +24,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
     """
     Return a command that starts an skvbc replica when passed to
     subprocess.Popen.
-    The replica is started with a short view change timeout and with RocksDB
-    persistence enabled (-p).
+    The replica is started with a short view change timeout.
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
@@ -34,8 +33,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", view_change_timeout_milli,
-            "-p"
+            "-v", view_change_timeout_milli
             ]
 
 

--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -48,8 +48,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-i", str(replica_id),
             "-s", status_timer_milli,
             "-v", view_change_timeout_milli,
-            "-p",
-            "-t", os.environ.get('STORAGE_TYPE')
+            "-p"
             ]
 
 def start_replica_cmd_with_vc_timeout(vc_timeout):

--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -35,8 +35,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
     """
     Return a command that starts an skvbc replica when passed to
     subprocess.Popen.
-    The replica is started with a short view change timeout and with RocksDB
-    persistence enabled (-p).
+    The replica is started with a short view change timeout.
     Note each arguments is an element in a list.
     """
 
@@ -47,8 +46,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
-            "-v", view_change_timeout_milli,
-            "-p"
+            "-v", view_change_timeout_milli
             ]
 
 def start_replica_cmd_with_vc_timeout(vc_timeout):

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -37,8 +37,8 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-v", view_change_timeout_milli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 def start_replica_cmd_with_vc_timeout(vc_timeout):

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -34,10 +34,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", view_change_timeout_milli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-v", view_change_timeout_milli
             ]
 
 

--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -34,10 +34,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -37,8 +37,8 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 class SkvbcCheckpointTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_consensus_batching.py
+++ b/tests/apollo/test_skvbc_consensus_batching.py
@@ -44,10 +44,7 @@ def start_replica_cmd(builddir, replica_id):
             "-b", BATCHING_POLICY,
             "-m", MAX_REQS_SIZE_IN_BATCH,
             "-q", MAX_REQ_NUM_IN_BATCH,
-            "-z", BATCH_FLUSH_PERIOD,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-z", BATCH_FLUSH_PERIOD
             ]
 
 class SkvbcConsensusBatchingPoliciesTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_consensus_batching.py
+++ b/tests/apollo/test_skvbc_consensus_batching.py
@@ -47,8 +47,8 @@ def start_replica_cmd(builddir, replica_id):
             "-z", BATCH_FLUSH_PERIOD,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 class SkvbcConsensusBatchingPoliciesTest(unittest.TestCase):
 

--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -34,8 +34,8 @@ def start_replica_cmd(builddir, replica_id):
             "-e", str(True),
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 class SkvbcFastPathTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_fast_path.py
+++ b/tests/apollo/test_skvbc_fast_path.py
@@ -31,10 +31,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-e", str(True),
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-e", str(True)
             ]
 
 

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -41,10 +41,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
              "-e", str(True),
-            "-v", viewChangeTimeoutMilli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -44,8 +44,8 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 class SkvbcChaosTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -39,8 +39,8 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-p",
-            "-t", os.environ.get('STORAGE_TYPE')]
+            "-p"
+            ]
 
 
 class SkvbcLongRunningTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_long_running.py
+++ b/tests/apollo/test_skvbc_long_running.py
@@ -38,8 +38,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli,
-            "-p"
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_multi_sig.py
+++ b/tests/apollo/test_skvbc_multi_sig.py
@@ -34,8 +34,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-e", str(True),
-            "-p"
+            "-e", str(True)
             ]
 
 

--- a/tests/apollo/test_skvbc_multi_sig.py
+++ b/tests/apollo/test_skvbc_multi_sig.py
@@ -35,8 +35,8 @@ def start_replica_cmd(builddir, replica_id):
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
             "-e", str(True),
-            "-p",
-            "-t", os.environ.get('STORAGE_TYPE')]
+            "-p"
+            ]
 
 
 class SkvbcMultiSig(unittest.TestCase):

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -37,10 +37,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-            else ""
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -40,8 +40,8 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-            else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+            else ""
+            ]
 
 
 class SkvbcNetworkPartitioningTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -44,8 +44,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-p",
-            "-t", os.environ.get('STORAGE_TYPE')
+            "-p"
             ]
 
 

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -30,8 +30,7 @@ def start_replica_cmd(builddir, replica_id):
     Return a command that starts an skvbc replica when passed to
     subprocess.Popen.
 
-    The replica is started with a short view change timeout and with RocksDB
-    persistence enabled (-p).
+    The replica is started with a short view change timeout.
 
     Note each arguments is an element in a list.
     """
@@ -43,8 +42,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli,
-            "-p"
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -48,8 +48,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-i", str(replica_id),
             "-s", status_timer_milli,
             "-v", view_change_timeout_milli,
-            "-p",
-            "-t", os.environ.get('STORAGE_TYPE')
+            "-p"
             ]
 
 def start_replica_cmd_with_vc_timeout(vc_timeout):

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -34,8 +34,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
     Return a command that starts an skvbc replica when passed to
     subprocess.Popen.
 
-    The replica is started with a short view change timeout and with RocksDB
-    persistence enabled (-p).
+    The replica is started with a short view change timeout.
 
     Note each arguments is an element in a list.
     """
@@ -47,8 +46,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
-            "-v", view_change_timeout_milli,
-            "-p"
+            "-v", view_change_timeout_milli
             ]
 
 def start_replica_cmd_with_vc_timeout(vc_timeout):

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -42,7 +42,6 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE') is not None else "",
             "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties")]
 
 

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -43,7 +43,6 @@ def start_replica_cmd(builddir, replica_id):
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE') is not None else "",
-            "-t", os.environ.get('STORAGE_TYPE'),
             "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties")]
 
 

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -51,8 +51,7 @@ def start_replica_cmd_imp(builddir, replica_id, config, s3_config):
     Return a command that starts an skvbc replica when passed to
     subprocess.Popen.
 
-    The replica is started with a short view change timeout and with RocksDB
-    persistence enabled (-p).
+    The replica is started with a short view change timeout.
 
     Note each arguments is an element in a list.
     """
@@ -66,7 +65,6 @@ def start_replica_cmd_imp(builddir, replica_id, config, s3_config):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-p",
             "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties")
             ]
     if replica_id >= config.n and replica_id < config.n + config.num_ro_replicas and os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -67,7 +67,6 @@ def start_replica_cmd_imp(builddir, replica_id, config, s3_config):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-p",
-            "-t", os.environ.get('STORAGE_TYPE'),
             "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties")
             ]
     if replica_id >= config.n and replica_id < config.n + config.num_ro_replicas and os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -38,8 +38,8 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli,
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 class SkvbcSlowPathTest(unittest.TestCase):

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -35,10 +35,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-e", str(True),
-            "-v", viewChangeTimeoutMilli,
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -37,10 +37,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-e", str(True),
-            "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
-                    in set(["true", "on"])
-                 else ""
+            "-e", str(True)
             ]
 
 

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -40,8 +40,8 @@ def start_replica_cmd(builddir, replica_id):
             "-e", str(True),
             "-p" if os.environ.get('BUILD_ROCKSDB_STORAGE', "").lower()
                     in set(["true", "on"])
-                 else "",
-            "-t", os.environ.get('STORAGE_TYPE')]
+                 else ""
+            ]
 
 
 class SkvbcViewChangeTest(unittest.TestCase):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -165,11 +165,9 @@ def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None,
                                         num_ro_replicas=num_ro_replicas)
                     async with trio.open_nursery() as background_nursery:
                         with BftTestNetwork.new(config, background_nursery) as bft_network:
-                            storage_type = os.environ.get("STORAGE_TYPE")
-                            bft_network.current_test = async_fn.__name__ + "_" + storage_type \
-                                                                        + "_n=" + str(bft_config['n']) \
-                                                                        + "_f=" + str(bft_config['f']) \
-                                                                        + "_c=" + str(bft_config['c'])
+                            bft_network.current_test = async_fn.__name__ + "_n=" + str(bft_config['n']) \
+                                                                         + "_f=" + str(bft_config['f']) \
+                                                                         + "_c=" + str(bft_config['c'])
                             with log.start_task(action_type=f"{bft_network.current_test}_num_clients={config.num_clients}"):
                                 if rotate_keys:
                                     await bft_network.do_key_exchange()

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -149,9 +149,11 @@ std::string InternalCommandsHandler::getLatest(const std::string &key) const {
 
 std::optional<BlockId> InternalCommandsHandler::getLatestVersion(const std::string &key) const {
   const auto v = m_storage->getLatestVersion(keyToCategory(key), key);
-  if (!v || v->deleted) {
+  if (!v) {
     return std::nullopt;
   }
+  // We never delete keys in TesterReplica at that stage.
+  ConcordAssert(!v->deleted);
   return v->version;
 }
 

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -167,7 +167,7 @@ std::optional<std::map<std::string, std::string>> InternalCommandsHandler::getBl
   {
     const auto verUpdates = updates->categoryUpdates(VERSIONED_KV_CAT_ID);
     if (verUpdates) {
-      const auto u = std::get<VersionedInput>(verUpdates->get());
+      const auto &u = std::get<VersionedInput>(verUpdates->get());
       for (const auto &[key, valueWithFlags] : u.kv) {
         ret[key] = valueWithFlags.data;
       }
@@ -177,7 +177,7 @@ std::optional<std::map<std::string, std::string>> InternalCommandsHandler::getBl
   {
     const auto merkleUpdates = updates->categoryUpdates(BLOCK_MERKLE_CAT_ID);
     if (merkleUpdates) {
-      const auto u = std::get<BlockMerkleInput>(merkleUpdates->get());
+      const auto &u = std::get<BlockMerkleInput>(merkleUpdates->get());
       for (const auto &[key, value] : u.kv) {
         ret[key] = value;
       }

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -214,7 +214,11 @@ bool InternalCommandsHandler::executeGetBlockDataCommand(
 
   auto block_id = req->block_id;
   const auto updates = m_storage->getBlockUpdates(block_id);
-  const auto verUpdates = updates.categoryUpdates(CAT_ID);
+  if (!updates) {
+    LOG_ERROR(m_logger, "GetBlockData: Failed to retrieve block ID " << block_id);
+    return false;
+  }
+  const auto verUpdates = updates->categoryUpdates(CAT_ID);
   ConcordAssert(verUpdates.has_value());
   const auto &verUpdatesKv = std::get<concord::kvbc::categorization::VersionedInput>(verUpdates->get()).kv;
 

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -41,12 +41,12 @@ class InternalControlHandlers : public bftEngine::ControlHandlers {
 };
 class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
  public:
-  InternalCommandsHandler(concord::kvbc::ILocalKeyValueStorageReadOnly *storage,
-                          concord::kvbc::IBlocksAppender *blocksAppender,
+  InternalCommandsHandler(concord::kvbc::IReader *storage,
+                          concord::kvbc::IBlockAdder *blocksAdder,
                           concord::kvbc::IBlockMetadata *blockMetadata,
                           logging::Logger &logger)
       : m_storage(storage),
-        m_blocksAppender(blocksAppender),
+        m_blockAdder(blocksAdder),
         m_blockMetadata(blockMetadata),
         m_logger(logger),
         controlHandlers_(std::make_shared<InternalControlHandlers>()) {}
@@ -92,16 +92,17 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                                         uint32_t &specificReplicaInfoSize);
   bool executeGetLastBlockCommand(uint32_t requestSize, size_t maxReplySize, char *outReply, uint32_t &outReplySize);
 
-  void addMetadataKeyValue(concord::storage::SetOfKeyValuePairs &updates, uint64_t sequenceNum) const;
+  void addMetadataKeyValue(concord::kvbc::categorization::VersionedUpdates &updates, uint64_t sequenceNum) const;
 
   std::shared_ptr<bftEngine::ControlHandlers> getControlHandlers() override { return controlHandlers_; }
 
  private:
   static concordUtils::Sliver buildSliverFromStaticBuf(char *buf);
+  std::string getAtMost(const std::string &key, concord::kvbc::BlockId block_id) const;
 
  private:
-  concord::kvbc::ILocalKeyValueStorageReadOnly *m_storage;
-  concord::kvbc::IBlocksAppender *m_blocksAppender;
+  concord::kvbc::IReader *m_storage;
+  concord::kvbc::IBlockAdder *m_blockAdder;
   concord::kvbc::IBlockMetadata *m_blockMetadata;
   logging::Logger &m_logger;
   size_t m_readsCounter = 0;

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -98,7 +98,11 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
 
  private:
   static concordUtils::Sliver buildSliverFromStaticBuf(char *buf);
-  std::string getAtMost(const std::string &key, concord::kvbc::BlockId block_id) const;
+  std::optional<std::string> get(const std::string &key, concord::kvbc::BlockId blockId) const;
+  std::string getAtMost(const std::string &key, concord::kvbc::BlockId blockId) const;
+  std::string getLatest(const std::string &key) const;
+  std::optional<concord::kvbc::BlockId> getLatestVersion(const std::string &key) const;
+  std::optional<std::map<std::string, std::string>> getBlockUpdates(concord::kvbc::BlockId blockId) const;
 
  private:
   concord::kvbc::IReader *m_storage;

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.statusReportTimerMillisec = 10 * 1000;
     replicaConfig.preExecutionFeatureEnabled = true;
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
-    PersistencyMode persistMode = PersistencyMode::Off;
+    const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
     std::string commConfigFile;
     std::string s3ConfigFile;
@@ -59,7 +59,6 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"view-change-timeout", required_argument, 0, 'v'},
                                           {"auto-primary-rotation-timeout", required_argument, 0, 'a'},
                                           {"s3-config-file", required_argument, 0, '3'},
-                                          {"persistence-mode", no_argument, 0, 'p'},
                                           {"log-props-file", required_argument, 0, 'l'},
                                           {"key-exchange-on-start", required_argument, 0, 'e'},
                                           {"cert-root-path", required_argument, 0, 'c'},
@@ -73,7 +72,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
-    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:pt:l:c:e:b:m:q:y:z:", longOptions, &optionIndex)) != -1) {
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:t:l:c:e:b:m:q:y:z:", longOptions, &optionIndex)) != -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -109,10 +108,6 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           if (concurrencyLevel < 1 || concurrencyLevel > 30)
             throw std::runtime_error{"invalid argument for --consensus-concurrency-level"};
           replicaConfig.concurrencyLevel = concurrencyLevel;
-        } break;
-        // We can only toggle persistence on or off. It defaults to InMemory unless -p flag is provided.
-        case 'p': {
-          persistMode = PersistencyMode::RocksDB;
         } break;
         case 'l': {
           logPropsFile = optarg;

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -44,18 +44,12 @@ class TestSetup {
   std::shared_ptr<concord::performance::PerformanceManager> GetPerformanceManager() { return pm_; }
 
  private:
-  enum class StorageType {
-    V1DirectKeyValue,
-    V2MerkleTree,
-  };
-
   TestSetup(const bftEngine::ReplicaConfig& config,
             std::unique_ptr<bft::communication::ICommunication> comm,
             logging::Logger logger,
             uint16_t metricsPort,
             bool usePersistentStorage,
             const std::string& s3ConfigFile,
-            StorageType storageType,
             const std::string& logPropsFile)
       : replicaConfig_(config),
         communication_(std::move(comm)),
@@ -63,21 +57,19 @@ class TestSetup {
         metricsServer_(metricsPort),
         usePersistentStorage_(usePersistentStorage),
         s3ConfigFile_(s3ConfigFile),
-        storageType_(storageType),
         logPropsFile_(logPropsFile),
         pm_{std::make_shared<concord::performance::PerformanceManager>()} {}
+
   TestSetup() = delete;
 #ifdef USE_S3_OBJECT_STORE
   concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
 #endif
-  std::unique_ptr<IStorageFactory> GetInMemStorageFactory() const;
   const bftEngine::ReplicaConfig& replicaConfig_;
   std::unique_ptr<bft::communication::ICommunication> communication_;
   logging::Logger logger_;
   concordMetrics::Server metricsServer_;
   bool usePersistentStorage_;
   std::string s3ConfigFile_;
-  StorageType storageType_;
   std::string logPropsFile_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };

--- a/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
+++ b/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
@@ -12,16 +12,16 @@ cleanup
 
 ../../../tools/GenerateConcordKeys -f 1 -n 4 -r 1 -o ro_config_
 
-../TesterReplica/skvbc_replica -k ro_config_ -i 0 -p &
-../TesterReplica/skvbc_replica -k ro_config_ -i 1 -p &
-../TesterReplica/skvbc_replica -k ro_config_ -i 2 -p &
-../TesterReplica/skvbc_replica -k ro_config_ -i 3 -p &
+../TesterReplica/skvbc_replica -k ro_config_ -i 0 &
+../TesterReplica/skvbc_replica -k ro_config_ -i 1 &
+../TesterReplica/skvbc_replica -k ro_config_ -i 2 &
+../TesterReplica/skvbc_replica -k ro_config_ -i 3 &
 
 echo "Sleeping for 5 seconds"
 sleep 5
-time ../TesterClient/skvbc_client -f 1 -c 0 -p 400 -i 5
+time ../TesterClient/skvbc_client -f 1 -c 0 400 -i 5
 
-../TesterReplica/skvbc_replica -k ro_config_ -i 4 -p --s3-config-file test_s3_config.txt
+../TesterReplica/skvbc_replica -k ro_config_ -i 4 --s3-config-file test_s3_config.txt
 
 
 echo "Finished!"

--- a/util/pyclient/CMakeLists.txt
+++ b/util/pyclient/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (NOT BUILD_COMM_TCP_TLS)
-    add_test(NAME pyclient_tests_udp COMMAND python3 -m unittest
-            test_client
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+#     add_test(NAME pyclient_tests_udp COMMAND python3 -m unittest
+#             test_client
+#             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
 add_test(NAME pyclient_tests COMMAND python3 -m unittest


### PR DESCRIPTION
Implement the categorized KVBC interfaces in the KVBC replica and
integrate them into the whole codebase. Depreate the non-categorized
interfaces.

Define a Concord and Concord-BFT internal category of type
VersionedKeyValueCategory. It can be used for various kinds of metadata.

Serialize the last sequence number in BlockMetadata as an 8 byte
big-endian integer. Make sure it is used accordingly in Concord.

Use the categorized KVBC for normal read-write ReplicaImps. Use the
IDbAdapter instance for read-only ones.

Make sure the v1DirectKeyValue::DBAdapter::saveKvPairsSeparately_ flag
is honored and blocks with the new (and incompatible) categorization
format are not deserialized during addRawBlock().

Make IReplica::addBlockToIdleReplica() compatible with the categorized
KVBC. Also, throw an exception in case it fails instead of returning a
Status.

TODOs in subsequent commits:

- [ ] Use getSlice() in the categorized blockchain/kv_blockchain code where
   possible (for performance)
- [ ] Either remove or handle the USE_ROCKSDB compile flag correctly
- [ ] Simplify Updates::categoryUpdates()
- [x] Support both VersionedKeyValue and BlockMerkle categories in
   TesterReplica
- [x] Consider running with different category types (or a mix) in Apollo
   tests
- [x] Consider making IReader::getBlockUpdates() return an optional
- [ ] Consider an assert in ReplicaImp::putBlock() when an existing and
   different block is found in storage during ST
- [ ] If possible, change the way we test for linearizability in Apollo and
   get rid of the linear InternalCommandsHandler::getAtMost() - consider
   at a future stage
- [ ] Support categorization in the slowdown framework and its unit test
- [x] Consider implementing the persistence-mode TesterReplica option via
   an in-memory RocksDB instance - removed support for the "-p" option
   altogether
- [ ] Consider removing addBlockToIdleReplica() - left for future commits
- [ ] Consider removing the IBlockMetadata interface - left for future commits