### PR TITLE
Do not run S3 Apollo tests if S3 is not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ option(BUILD_COMM_TCP_TLS "Enable TCP TLS communication" FALSE)
 # This requires the rocksdb dependencies to be installed, so defaults to FALSE
 option(BUILD_ROCKSDB_STORAGE "Enable building of RocksDB storage library" FALSE)
 
+# Build S3 Object Store support.
+option(USE_S3_OBJECT_STORE "Enable S3 Object Store" FALSE)
+
 set(COMM_MODULES 0)
 if(BUILD_COMM_TCP_PLAIN)
     math(EXPR COMM_MODULES "${COMM_MODULES}+1")

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -95,8 +95,10 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
             "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_persistence_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-    add_test(NAME skvbc_ro_replica_tests_${STORAGE_TYPE} COMMAND sh -c
-            "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    if (USE_S3_OBJECT_STORE)
+      add_test(NAME skvbc_ro_replica_tests_${STORAGE_TYPE} COMMAND sh -c
+              "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
+              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
   endif()
 endforeach()

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -99,11 +99,7 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
                                                     close_fds=True)
 
     @classmethod
-    def setUpClass(cls):
-        if not os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):
-            log.log_message(message_type="CONCORD_BFT_MINIO_BINARY_PATH is not set. Running in RocksDB mode.")
-            return
-        
+    def setUpClass(cls):        
         log.log_message(message_type="CONCORD_BFT_MINIO_BINARY_PATH is set. Running in S3 mode.")
 
         # We need a temp dir for data and binaries - this is cls.dest_dir


### PR DESCRIPTION
Do not add the skvbc_ro_replica_tests if USE_S3_OBJECT_STORE is not set.
Consequently, remove the check for whether S3 is used in
skvbc_ro_replica_tests (as they won't run at all if not used).

Add USE_S3_OBJECT_STORE as a CMake option.