### PR TITLE
Fix active keys from pruned blocks in versioned cat

### DIFF
--- a/kvbc/include/categorization/column_families.h
+++ b/kvbc/include/categorization/column_families.h
@@ -17,16 +17,20 @@
 
 namespace concord::kvbc::categorization::detail {
 
-inline const auto IMMUTABLE_KV_CF_SUFFIX = std::string{"_immutable"};
-
-inline const auto VERSIONED_KV_VALUES_CF_SUFFIX = std::string{"_ver_values"};
-inline const auto VERSIONED_KV_LATEST_VER_CF_SUFFIX = std::string{"_ver_latest"};
-
+// Blockchain
 inline const auto BLOCKS_CF = std::string{"blocks"};
 inline const auto ST_CHAIN_CF = std::string{"st_chain"};
-
 inline const auto CAT_ID_TYPE_CF = std::string{"cat_id_type"};
 
+// ImmutableKeyValueCategory
+inline const auto IMMUTABLE_KV_CF_SUFFIX = std::string{"_immutable"};
+
+// VersionedKeyValueCategory
+inline const auto VERSIONED_KV_VALUES_CF_SUFFIX = std::string{"_ver_values"};
+inline const auto VERSIONED_KV_LATEST_VER_CF_SUFFIX = std::string{"_ver_latest"};
+inline const auto VERSIONED_KV_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF_SUFFIX = std::string{"_ver_active"};
+
+// BlockMerkleCategory
 inline const auto BLOCK_MERKLE_INTERNAL_NODES_CF = std::string{"block_merkle_internal_nodes"};
 inline const auto BLOCK_MERKLE_LEAF_NODES_CF = std::string{"block_merkle_leaf_nodes"};
 inline const auto BLOCK_MERKLE_LATEST_KEY_VERSION_CF = std::string{"block_merkle_latest_key_version"};

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace concord::kvbc::categorization::detail {
@@ -99,9 +100,13 @@ class VersionedKeyValueCategory {
 
   void addKeyToUpdateInfo(std::string &&key, bool deleted, bool stale_on_update, VersionedOutput &);
 
+  std::unordered_map<BlockId, std::vector<std::string>> activeKeysFromPrunedBlocks(
+      const std::map<std::string, VersionedKeyFlags> &kv) const;
+
  private:
   std::string values_cf_;
   std::string latest_ver_cf_;
+  std::string active_cf_;
   std::shared_ptr<storage::rocksdb::NativeClient> db_;
 };
 

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -96,7 +96,7 @@ ImmutableOutput ImmutableKeyValueCategory::add(BlockId block_id,
     }
 
     // Persist the key-value.
-    batch.put(cf_, key, serialize(ImmutableDbValue{block_id, std::move(value.data)}));
+    batch.put(cf_, key, serializeThreadLocal(ImmutableDbValue{block_id, std::move(value.data)}));
 
     // Move the key and the tags to the update info and (optionally) update hashes per tag.
     auto &key_tags = update_info.tagged_keys.emplace(std::move(key), std::vector<std::string>{}).first->second;


### PR DESCRIPTION
Delete active keys from pruned blocks in the VersionedKeyValueCategory.
Introduce an `active keys` column family that contains a mapping from
key to pruned block ID.

When deleting (pruning) genesis block 1, if a key `K` in block 1 remains
active, insert it into the `active keys` column family with an active
block version of 1.

If a future block 2 overwrites `K` and is itself pruned, query the
`active keys` column family and delete the active key at block version 1
from the `values` column family. If `K` from block 2 is itself active,
update key `K` in the `active keys` column family with an active block
version of 2. If `K` is no longer active, delete it from the `active
keys` column family.

Add unit tests to verify that behavior.

Use serializeThreadLocal() in places that are safe to do so.

Idea borrowed from: https://github.com/vmware/concord-bft/pull/1143
Thanks to @andrewjstone!