### PR TITLE
Handle non-atomic RocksDB column family creation

### DIFF
--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -125,6 +125,7 @@ class Client : public concord::storage::IDBClient {
   concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob);
   concordUtils::Status get(const concordUtils::Sliver& _key, std::string& _value) const;
   bool keyIsBefore(const concordUtils::Sliver& _lhs, const concordUtils::Sliver& _rhs) const;
+  bool columnFamilyIsEmpty(::rocksdb::ColumnFamilyHandle*) const;
 
   // Column family unique pointers that are managed solely by Client. This allows us to use a raw
   // pointer in CfDeleter as we know the column family unique pointer will not be moved out of Client.

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -254,18 +254,18 @@ void Client::initDB(bool readOnly, const std::optional<Options> &userOptions, bo
     if (columnFamilyIsEmpty(cf_iter->second.get())) {
       const auto s = dbInstance_->DropColumnFamily(cf_iter->second.get());
       if (!s.ok()) {
-        const auto msg = "Failed to drop incompletely created RocksDB column family: " + s.ToString();
+        const auto msg =
+            "Failed to drop incompletely created RocksDB column family [" + cf + "], reason: " + s.ToString();
         LOG_ERROR(logger(), msg);
         throw std::runtime_error{msg};
       }
       cf_handles_.erase(cf_iter);
-      LOG_WARN(logger(), "Dropped incompletely created and empty RocksDB column family: " << cf);
+      LOG_WARN(logger(), "Dropped incompletely created and empty RocksDB column family [" << cf << ']');
     } else {
-      LOG_WARN(
-          logger(),
-          "Column family ["
-              << cf
-              << "] was not completely created and user-provided options are not persisted, using default options");
+      const auto msg = "RocksDB column family [" + cf +
+                       "] has no persisted options, yet there is data inside - cannot continue with unknown options";
+      LOG_ERROR(logger(), msg);
+      throw std::runtime_error{msg};
     }
   }
 


### PR DESCRIPTION
RocksDB creates column families in 2 non-atomic steps:
 1. Create the column family in the DB.
 2. Create the column family in the options file by persisting the
    options provided by the user.

Reference:
https://github.com/facebook/rocksdb/blob/v6.8.1/db/db_impl/db_impl.cc#L2187

If the process is stopped between these steps, there could be a mismatch
between them. That could lead to:
 1. The DB open process failing due to missing column families in the
    call to Open() as the cf_descs variable that contains column family
    names and options is loaded from the options file.
 2. Losing the column family options the user provided.

In order to solve it, track incompletely created column families (i.e.
ones that have mismatching information about them in the DB and the
options file). If such a family is empty (i.e. has no keys inside), drop
it so that user code can re-create it. If not empty, warn and continue
the DB open process.

The test causing the issue to show up is `test_skvbc_persistence.py`
when used with key categorization.