### PR TITLE
Add cid to the earliestPendingRequest info

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -43,6 +43,7 @@ ClientsManager::ClientsManager(ReplicaId myId,
 
     indexToClientInfo_[idx].currentPendingRequest = 0;
     indexToClientInfo_[idx].timeOfCurrentPendingRequest = MinTime;
+    indexToClientInfo_[idx].cid = std::string();
 
     indexToClientInfo_[idx].lastSeqNumberOfReply = 0;
     indexToClientInfo_[idx].latestReplyTime = MinTime;
@@ -75,6 +76,7 @@ void ClientsManager::initInternalClientInfo(const int& numReplicas) {
     clientIdToIndex_.insert(std::pair<NodeIdType, uint16_t>(++currClId, ++currIdx));
     indexToClientInfo_[currIdx].currentPendingRequest = 0;
     indexToClientInfo_[currIdx].timeOfCurrentPendingRequest = MinTime;
+    indexToClientInfo_[currIdx].cid = std::string();
 
     indexToClientInfo_[currIdx].lastSeqNumberOfReply = 0;
     indexToClientInfo_[currIdx].latestReplyTime = MinTime;
@@ -131,6 +133,7 @@ void ClientsManager::loadInfoFromReservedPages() {
     if (ci.currentPendingRequest != 0 && (ci.currentPendingRequest <= replyHeader->reqSeqNum)) {
       ci.currentPendingRequest = 0;
       ci.timeOfCurrentPendingRequest = MinTime;
+      ci.cid = std::string();
     }
   }
 }
@@ -279,13 +282,14 @@ bool ClientsManager::isPendingOrLate(NodeIdType clientId, ReqId reqSeqNum) const
 }
 */
 
-void ClientsManager::addPendingRequest(NodeIdType clientId, ReqId reqSeqNum) {
+void ClientsManager::addPendingRequest(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid) {
   uint16_t idx = clientIdToIndex_.at(clientId);
   ClientInfo& c = indexToClientInfo_.at(idx);
   ConcordAssert(reqSeqNum > c.lastSeqNumberOfReply && reqSeqNum > c.currentPendingRequest);
 
   c.currentPendingRequest = reqSeqNum;
   c.timeOfCurrentPendingRequest = getMonotonicTime();
+  c.cid = cid;
 }
 
 /*
@@ -336,6 +340,7 @@ void ClientsManager::removePendingRequestOfClient(NodeIdType clientId) {
   if (c.currentPendingRequest != 0) {
     c.currentPendingRequest = 0;
     c.timeOfCurrentPendingRequest = MinTime;
+    c.cid = std::string();
   }
 }
 
@@ -343,13 +348,15 @@ void ClientsManager::clearAllPendingRequests() {
   for (ClientInfo& c : indexToClientInfo_) {
     c.currentPendingRequest = 0;
     c.timeOfCurrentPendingRequest = MinTime;
+    c.cid = std::string();
   }
 
   ConcordAssert(indexToClientInfo_[0].currentPendingRequest == 0);  // TODO(GG): debug
 }
 
 // iterate over all clients and choose the earliest pending request.
-Time ClientsManager::timeOfEarliestPendingRequest() const  // TODO(GG): naive implementation - consider to optimize
+ClientsManager::ClientInfo ClientsManager::infoOfEarliestPendingRequest()
+    const  // TODO(GG): naive implementation - consider to optimize
 {
   Time t = MaxTime;
   ClientInfo earliestClientWithPendingRequest = indexToClientInfo_.at(0);
@@ -363,7 +370,7 @@ Time ClientsManager::timeOfEarliestPendingRequest() const  // TODO(GG): naive im
 
   LOG_INFO(GL, "Earliest pending client request: " << KVLOG(earliestClientWithPendingRequest.currentPendingRequest));
 
-  return t;
+  return earliestClientWithPendingRequest;
 }
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -355,8 +355,8 @@ void ClientsManager::clearAllPendingRequests() {
 }
 
 // iterate over all clients and choose the earliest pending request.
-ClientsManager::ClientInfo ClientsManager::infoOfEarliestPendingRequest()
-    const  // TODO(GG): naive implementation - consider to optimize
+Time ClientsManager::infoOfEarliestPendingRequest(
+    std::string& cid) const  // TODO(GG): naive implementation - consider to optimize
 {
   Time t = MaxTime;
   ClientInfo earliestClientWithPendingRequest = indexToClientInfo_.at(0);
@@ -369,8 +369,8 @@ ClientsManager::ClientInfo ClientsManager::infoOfEarliestPendingRequest()
   }
 
   LOG_INFO(GL, "Earliest pending client request: " << KVLOG(earliestClientWithPendingRequest.currentPendingRequest));
-
-  return earliestClientWithPendingRequest;
+  cid = earliestClientWithPendingRequest.cid;
+  return t;
 }
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -27,7 +27,6 @@ class ClientRequestMsg;
 
 class ClientsManager : public ResPagesClient<ClientsManager, 0> {
  public:
-  struct ClientInfo;
   ClientsManager(ReplicaId myId,
                  std::set<NodeIdType>& clientsSet,
                  uint32_t sizeOfReservedPage,
@@ -77,7 +76,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   void clearAllPendingRequests();
 
-  ClientInfo infoOfEarliestPendingRequest() const;
+  Time infoOfEarliestPendingRequest(std::string& cid) const;
 
   // Internal Clients
   void initInternalClientInfo(const int& numReplicas);
@@ -106,7 +105,6 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   std::map<NodeIdType, uint16_t> clientIdToIndex_;
 
- public:
   struct ClientInfo {
     // requests
     ReqId currentPendingRequest;

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -27,6 +27,7 @@ class ClientRequestMsg;
 
 class ClientsManager : public ResPagesClient<ClientsManager, 0> {
  public:
+  struct ClientInfo;
   ClientsManager(ReplicaId myId,
                  std::set<NodeIdType>& clientsSet,
                  uint32_t sizeOfReservedPage,
@@ -64,7 +65,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   // bool isPendingOrLate(NodeIdType clientId, ReqId reqSeqNum) const ;
 
-  void addPendingRequest(NodeIdType clientId, ReqId reqSeqNum);
+  void addPendingRequest(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid);
 
   // void removePendingRequest(NodeIdType clientId, ReqId reqSeqNum);
 
@@ -76,7 +77,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   void clearAllPendingRequests();
 
-  Time timeOfEarliestPendingRequest() const;
+  ClientInfo infoOfEarliestPendingRequest() const;
 
   // Internal Clients
   void initInternalClientInfo(const int& numReplicas);
@@ -105,10 +106,12 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   std::map<NodeIdType, uint16_t> clientIdToIndex_;
 
+ public:
   struct ClientInfo {
     // requests
     ReqId currentPendingRequest;
     Time timeOfCurrentPendingRequest;
+    std::string cid;
 
     // replies
     ReqId lastSeqNumberOfReply;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -234,7 +234,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
       }
     } else {  // not the current primary
       if (clientsManager->noPendingAndRequestCanBecomePending(clientId, reqSeqNum)) {
-        clientsManager->addPendingRequest(clientId, reqSeqNum);
+        clientsManager->addPendingRequest(clientId, reqSeqNum, m->getCid());
 
         // TODO(GG): add a mechanism that retransmits (otherwise we may start unnecessary view-change)
         send(m, currentPrimary());
@@ -401,7 +401,8 @@ ClientRequestMsg *ReplicaImp::addRequestToPrePrepareMessage(ClientRequestMsg *&n
     if (clientsManager->noPendingAndRequestCanBecomePending(nextRequest->clientProxyId(),
                                                             nextRequest->requestSeqNum())) {
       prePrepareMsg.addRequest(nextRequest->body(), nextRequest->size());
-      clientsManager->addPendingRequest(nextRequest->clientProxyId(), nextRequest->requestSeqNum());
+      clientsManager->addPendingRequest(
+          nextRequest->clientProxyId(), nextRequest->requestSeqNum(), nextRequest->getCid());
     }
     primaryCombinedReqSize -= nextRequest->size();
   } else if (nextRequest->size() > maxStorageForRequests) {  // The message is too big
@@ -3004,7 +3005,9 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
   if (currentViewIsActive()) {
     if (isCurrentPrimary() || complainedReplicas.getComplaintFromReplica(config_.replicaId) != nullptr) return;
 
-    const Time timeOfEarliestPendingRequest = clientsManager->timeOfEarliestPendingRequest();
+    const auto earliestPendingRequestInfo = clientsManager->infoOfEarliestPendingRequest();
+    const Time timeOfEarliestPendingRequest = earliestPendingRequestInfo.timeOfCurrentPendingRequest;
+    const auto &cidOfEarliestPendingRequest = earliestPendingRequestInfo.cid;
 
     const bool hasPendingRequest = (timeOfEarliestPendingRequest != MaxTime);
 
@@ -3015,9 +3018,10 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
     const uint64_t diffMilli3 = duration_cast<milliseconds>(currTime - timeOfEarliestPendingRequest).count();
 
     if ((diffMilli1 > viewChangeTimeout) && (diffMilli2 > viewChangeTimeout) && (diffMilli3 > viewChangeTimeout)) {
-      LOG_INFO(
-          VC_LOG,
-          "Ask to leave view=" << curView << " (" << diffMilli3 << " ms after the earliest pending client request).");
+      LOG_INFO(VC_LOG,
+               "Ask to leave view=" << curView << " (" << diffMilli3
+                                    << " ms after the earliest pending client request)."
+                                    << KVLOG(cidOfEarliestPendingRequest));
 
       std::unique_ptr<ReplicaAsksToLeaveViewMsg> askToLeaveView(ReplicaAsksToLeaveViewMsg::create(
           config_.getreplicaId(), curView, ReplicaAsksToLeaveViewMsg::Reason::ClientRequestTimeout));

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3005,9 +3005,8 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
   if (currentViewIsActive()) {
     if (isCurrentPrimary() || complainedReplicas.getComplaintFromReplica(config_.replicaId) != nullptr) return;
 
-    const auto earliestPendingRequestInfo = clientsManager->infoOfEarliestPendingRequest();
-    const Time timeOfEarliestPendingRequest = earliestPendingRequestInfo.timeOfCurrentPendingRequest;
-    const auto &cidOfEarliestPendingRequest = earliestPendingRequestInfo.cid;
+    std::string cidOfEarliestPendingRequest = std::string();
+    const Time timeOfEarliestPendingRequest = clientsManager->infoOfEarliestPendingRequest(cidOfEarliestPendingRequest);
 
     const bool hasPendingRequest = (timeOfEarliestPendingRequest != MaxTime);
 


### PR DESCRIPTION
To help us debug viewchanges we would like to know which client request was timed out.
For that, we added a cid filed to the ClientInfo. Every time we take the earllest pendin grequest, we also take its cid. In addition, we log this cid if we decided on a view change.