### PR TITLE
Remove pending requests after the sequence number commit (instead of …

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4019,12 +4019,13 @@ void ReplicaImp::tryToRemovePendingRequestsForSeqNum(SeqNum seqNum) {
   SeqNumInfo &seqNumInfo = mainLog->get(seqNum);
   PrePrepareMsg *prePrepareMsg = seqNumInfo.getPrePrepareMsg();
   if (prePrepareMsg == nullptr) return;
-  LOG_DEBUG(GL, "clear pending requests" << KVLOG(seqNum));
+  LOG_INFO(GL, "clear pending requests" << KVLOG(seqNum));
 
   RequestsIterator reqIter(prePrepareMsg);
   char *requestBody = nullptr;
   while (reqIter.getAndGoToNext(requestBody)) {
     ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
+    if (!clientsManager->isValidClient(req.clientProxyId())) continue;
     auto clientId = req.clientProxyId();
     LOG_DEBUG(GL, "removing pending requests for client" << KVLOG(clientId));
     clientsManager->removePendingRequestOfClient(clientId);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -365,6 +365,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   void tryToAskForMissingInfo();
 
+  void tryToRemovePendingRequestsForSeqNum(SeqNum seqNum);
+
   void sendPreparePartial(SeqNumInfo&);
 
   void sendCommitPartial(SeqNum);  // TODO(GG): the argument should be a ref to SeqNumInfo


### PR DESCRIPTION
…execution)

The execution is a detemenistic part in the protocol that is not depended on other replicas data. Thus it make sense not to take the execution time in account for complaining the primary.
In this PR we remove the pending request after the commit instead of after the execution.
We expect this change to stablize VC and prevent unnecessary VCs