### PR TITLE
Implement Performance manager and Slowdown framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ option(BUILD_ROCKSDB_STORAGE "Enable building of RocksDB storage library" FALSE)
 # Build S3 Object Store support.
 option(USE_S3_OBJECT_STORE "Enable S3 Object Store" FALSE)
 
+# Build Slowdown framework
+option(BUILD_SLOWDOWN "Build Slowdown framework" FALSE)
+
 set(COMM_MODULES 0)
 if(BUILD_COMM_TCP_PLAIN)
     math(EXPR COMM_MODULES "${COMM_MODULES}+1")
@@ -116,6 +119,7 @@ add_subdirectory(logging)
 add_subdirectory(util)
 add_subdirectory(threshsign)
 add_subdirectory(communication)
+add_subdirectory(performance)
 add_subdirectory(bftengine)
 add_subdirectory(tools)
 add_subdirectory(kvbc)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ CONCORD_BFT_CMAKE_FLAGS:= \
 			-DUSE_OPENTRACING=ON \
 			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
 			-DOMIT_TEST_OUTPUT=OFF \
-			-DKEEP_APOLLO_LOGS=TRUE
+			-DKEEP_APOLLO_LOGS=TRUE \
+			-DBUILD_SLOWDOWN=FALSE
 
 # The consistency parameter makes sense only at MacOS.
 # It is ignored at all other platforms.

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -83,6 +83,8 @@ target_include_directories(bftheaders INTERFACE include)
 
 find_package(cryptopp REQUIRED)
 
+get_property(perf_include GLOBAL PROPERTY PERF_MANAGER_INCLUDE_DIR)
+
 target_compile_options(corebft PUBLIC "-Wno-extra-semi" "-Wno-undefined-var-template") # TODO tmp cryptopp
 target_include_directories(corebft PUBLIC include/)
 target_include_directories(corebft PUBLIC include/bftengine)
@@ -93,6 +95,7 @@ target_include_directories(corebft PRIVATE src/bftengine)
 target_include_directories(corebft PRIVATE src/preprocessor)
 target_include_directories(corebft PRIVATE util/include)
 target_include_directories(corebft PUBLIC ${CRYPTOPP_INCLUDE_DIRS})
+target_include_directories(corebft PUBLIC ${perf_include}/performance/include)
 target_link_libraries(corebft PUBLIC
   threshsign
   Threads::Threads
@@ -100,19 +103,28 @@ target_link_libraries(corebft PUBLIC
   concordbft_storage
   preprocessor
   bftcommunication
-  diagnostics
-)
+  diagnostics)
+
 
 target_include_directories(bftclient PUBLIC include/bftengine)
 target_include_directories(bftclient PUBLIC src/bftengine)
 target_include_directories(bftclient PUBLIC src/preprocessor)
+target_include_directories(bftclient PUBLIC ${perf_include})
 target_link_libraries(bftclient PUBLIC bftcommunication)
 
 target_include_directories(bftclient_shared PUBLIC include/bftengine)
 target_include_directories(bftclient_shared PUBLIC src/bftengine)
 target_include_directories(bftclient_shared PUBLIC src/preprocessor)
 target_include_directories(bftclient_shared PUBLIC ${CRYPTOPP_INCLUDE_DIRS})
+target_include_directories(bftclient_shared PUBLIC ${perf_include})
+
 target_link_libraries(bftclient_shared PUBLIC bftcommunication_shared ${CRYPTOPP_SHARED_LIBRARY})
 install (TARGETS bftclient_shared DESTINATION lib${LIB_SUFFIX})
 
 install(DIRECTORY include/bftengine DESTINATION include)
+
+if(BUILD_SLOWDOWN)
+    target_compile_definitions(bftclient PUBLIC USE_SLOWDOWN)
+    target_compile_definitions(corebft PUBLIC USE_SLOWDOWN)
+    target_compile_definitions(bftclient_shared PUBLIC USE_SLOWDOWN)
+endif()

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -24,6 +24,7 @@
 #include "Metrics.hpp"
 #include "ReplicaConfig.hpp"
 #include "ControlStateManager.hpp"
+#include "../../../performance/include/PerformanceManager.hpp"
 
 namespace bftEngine {
 
@@ -92,13 +93,17 @@ class IReplica {
                                       IRequestsHandler *,
                                       IStateTransfer *,
                                       bft::communication::ICommunication *,
-                                      MetadataStorage *);
+                                      MetadataStorage *,
+                                      std::shared_ptr<concord::performance::PerformanceManager> sdm =
+                                          std::make_shared<concord::performance::PerformanceManager>());
   static IReplicaPtr createNewReplica(const ReplicaConfig &,
                                       IRequestsHandler *,
                                       IStateTransfer *,
                                       bft::communication::ICommunication *,
                                       MetadataStorage *,
-                                      bool &erasedMetadata);
+                                      bool &erasedMetadata,
+                                      std::shared_ptr<concord::performance::PerformanceManager> sdm =
+                                          std::make_shared<concord::performance::PerformanceManager>());
 
   static IReplicaPtr createNewRoReplica(const ReplicaConfig &, IStateTransfer *, bft::communication::ICommunication *);
 

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -20,6 +20,7 @@
 
 #include "Metrics.hpp"
 #include "communication/ICommunication.hpp"
+#include "PerformanceManager.hpp"
 
 namespace bftEngine {
 struct SimpleClientParams {
@@ -48,10 +49,13 @@ enum OperationResult : int8_t { SUCCESS, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL };
 
 class SimpleClient {
  public:
-  explicit SimpleClient(uint16_t clientId)
+  explicit SimpleClient(uint16_t clientId,
+                        const std::shared_ptr<concord::performance::PerformanceManager>& pm =
+                            std::make_shared<concord::performance::PerformanceManager>())
       : metrics_{"clientMetrics_" + std::to_string(clientId), std::make_shared<concordMetrics::Aggregator>()},
         client_metrics_{{metrics_.RegisterCounter("retransmissions")},
-                        {metrics_.RegisterGauge("retransmissionTimer", 0)}} {
+                        {metrics_.RegisterGauge("retransmissionTimer", 0)}},
+        pm_{pm} {
     metrics_.Register();
   }
   static const uint64_t INFINITE_TIMEOUT = UINT64_MAX;
@@ -59,13 +63,17 @@ class SimpleClient {
   static SimpleClient* createSimpleClient(bft::communication::ICommunication* communication,
                                           uint16_t clientId,
                                           uint16_t fVal,
-                                          uint16_t cVal);
+                                          uint16_t cVal,
+                                          const std::shared_ptr<concord::performance::PerformanceManager>& pm =
+                                              std::make_shared<concord::performance::PerformanceManager>());
 
   static SimpleClient* createSimpleClient(bft::communication::ICommunication* communication,
                                           uint16_t clientId,
                                           uint16_t fVal,
                                           uint16_t cVal,
-                                          SimpleClientParams p);
+                                          SimpleClientParams p,
+                                          const std::shared_ptr<concord::performance::PerformanceManager>& pm =
+                                              std::make_shared<concord::performance::PerformanceManager>());
 
   virtual ~SimpleClient();
 
@@ -91,6 +99,7 @@ class SimpleClient {
     concordMetrics::CounterHandle retransmissions;
     concordMetrics::GaugeHandle retransmissionTimer;
   } client_metrics_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };
 
 // This class is mainly for testing and SimpleClient applications.

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1053,6 +1053,7 @@ void ReplicaImp::onMessage<FullCommitProofMsg>(FullCommitProofMsg *msg) {
 
       auto execution_span = concordUtils::startChildSpan("bft_execute_committed_reqs", span);
       metric_total_committed_sn_.Get().Inc();
+      pm_->Delay<concord::performance::SlowdownPhase::ConsensusFullCommitMsgProcess>();
       executeNextCommittedRequests(execution_span, msgSeqNum, askForMissingInfoAboutCommittedItems);
       return;
     } else if (pps.hasFullProof()) {
@@ -3122,7 +3123,8 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
                        shared_ptr<MsgsCommunicator> msgsCommunicator,
                        shared_ptr<PersistentStorage> persistentStorage,
                        shared_ptr<MsgHandlersRegistrator> msgHandlers,
-                       concordUtil::Timers &timers)
+                       concordUtil::Timers &timers,
+                       shared_ptr<concord::performance::PerformanceManager> &pm)
     : ReplicaImp(false,
                  ld.repConfig,
                  requestsHandler,
@@ -3132,7 +3134,8 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
                  ld.viewsManager,
                  msgsCommunicator,
                  msgHandlers,
-                 timers) {
+                 timers,
+                 pm) {
   ConcordAssertNE(persistentStorage, nullptr);
 
   ps_ = persistentStorage;
@@ -3382,9 +3385,19 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
                        shared_ptr<MsgsCommunicator> msgsCommunicator,
                        shared_ptr<PersistentStorage> persistentStorage,
                        shared_ptr<MsgHandlersRegistrator> msgHandlers,
-                       concordUtil::Timers &timers)
-    : ReplicaImp(
-          true, config, requestsHandler, stateTrans, nullptr, nullptr, nullptr, msgsCommunicator, msgHandlers, timers) {
+                       concordUtil::Timers &timers,
+                       shared_ptr<concord::performance::PerformanceManager> &pm)
+    : ReplicaImp(true,
+                 config,
+                 requestsHandler,
+                 stateTrans,
+                 nullptr,
+                 nullptr,
+                 nullptr,
+                 msgsCommunicator,
+                 msgHandlers,
+                 timers,
+                 pm) {
   if (persistentStorage != nullptr) {
     ps_ = persistentStorage;
   }
@@ -3403,7 +3416,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
                        ViewsManager *viewsMgr,
                        shared_ptr<MsgsCommunicator> msgsCommunicator,
                        shared_ptr<MsgHandlersRegistrator> msgHandlers,
-                       concordUtil::Timers &timers)
+                       concordUtil::Timers &timers,
+                       shared_ptr<concord::performance::PerformanceManager> &pm)
     : ReplicaForStateTransfer(config, stateTrans, msgsCommunicator, msgHandlers, firstTime, timers),
       viewChangeProtocolEnabled{config.viewChangeProtocolEnabled},
       autoPrimaryRotationEnabled{config.autoPrimaryRotationEnabled},
@@ -3414,6 +3428,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       timeOfLastViewEntrance{getMonotonicTime()},  // TODO(GG): TBD
       timeOfLastAgreedView{getMonotonicTime()},    // TODO(GG): TBD
       complainedReplicas(config),
+      pm_{pm},
       metric_view_{metrics_.RegisterGauge("view", curView)},
       metric_last_stable_seq_num_{metrics_.RegisterGauge("lastStableSeqNum", lastStableSeqNum)},
       metric_last_executed_seq_num_{metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)},
@@ -3831,7 +3846,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
     auto dur = controller->durationSincePrePrepare(lastExecutedSeqNum + 1);
     if (dur > 0) {
       // Primary
-      LOG_DEBUG(CNSUS, "Consensus reached, duration [" << dur << "ms]");
+      LOG_DEBUG(CNSUS, "Consensus reached, sleep_duration_ms [" << dur << "ms]");
 
     } else {
       LOG_DEBUG(CNSUS, "Consensus reached");

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -37,6 +37,7 @@
 #include "RequestsBatchingLogic.hpp"
 #include "ReplicaStatusHandlers.hpp"
 #include "ReplicasAskedToLeaveViewInfo.hpp"
+#include "PerformanceManager.hpp"
 
 namespace bftEngine::impl {
 
@@ -167,6 +168,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   ReplicasAskedToLeaveViewInfo complainedReplicas;
 
+  shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
+
   //******** METRICS ************************************
   GaugeHandle metric_view_;
   GaugeHandle metric_last_stable_seq_num_;
@@ -235,7 +238,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
              shared_ptr<MsgsCommunicator> msgsCommunicator,
              shared_ptr<PersistentStorage> persistentStorage,
              shared_ptr<MsgHandlersRegistrator> msgHandlers,
-             concordUtil::Timers& timers);
+             concordUtil::Timers& timers,
+             shared_ptr<concord::performance::PerformanceManager>& pm);
 
   ReplicaImp(const LoadedReplicaData&,
              IRequestsHandler* requestsHandler,
@@ -243,7 +247,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
              shared_ptr<MsgsCommunicator> msgsCommunicator,
              shared_ptr<PersistentStorage> persistentStorage,
              shared_ptr<MsgHandlersRegistrator> msgHandlers,
-             concordUtil::Timers& timers);
+             concordUtil::Timers& timers,
+             shared_ptr<concord::performance::PerformanceManager>& pm);
 
   virtual ~ReplicaImp();
 
@@ -290,7 +295,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
              ViewsManager*,
              shared_ptr<MsgsCommunicator>,
              shared_ptr<MsgHandlersRegistrator>,
-             concordUtil::Timers& timers);
+             concordUtil::Timers& timers,
+             shared_ptr<concord::performance::PerformanceManager>& pm);
 
   void registerMsgHandlers();
 

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -14,6 +14,8 @@
 #include <mutex>
 #include <cmath>
 #include <condition_variable>
+#include <memory>
+#include <SimpleClient.hpp>
 
 #include "ClientMsgs.hpp"
 #include "OpenTracing.hpp"
@@ -35,8 +37,12 @@ namespace bftEngine {
 namespace impl {
 class SimpleClientImp : public SimpleClient, public IReceiver {
  public:
-  SimpleClientImp(
-      ICommunication* communication, uint16_t clientId, uint16_t fVal, uint16_t cVal, SimpleClientParams& p);
+  SimpleClientImp(ICommunication* communication,
+                  uint16_t clientId,
+                  uint16_t fVal,
+                  uint16_t cVal,
+                  SimpleClientParams& p,
+                  const std::shared_ptr<concord::performance::PerformanceManager>& pm);
   ~SimpleClientImp() override;
 
   OperationResult sendRequest(uint8_t flags,
@@ -105,6 +111,7 @@ class SimpleClientImp : public SimpleClient, public IReceiver {
   uint16_t clientSendsRequestToAllReplicasFirstThresh_;
   uint16_t clientSendsRequestToAllReplicasPeriodThresh_;
   uint16_t clientPeriodicResetThresh_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 
   logging::Logger logger_ = logging::getLogger("concord.bft.client");
 };
@@ -159,9 +166,13 @@ static std::set<ReplicaId> generateSetOfReplicas_helpFunc(const int16_t numberOf
   return retVal;
 }
 
-SimpleClientImp::SimpleClientImp(
-    ICommunication* communication, uint16_t clientId, uint16_t fVal, uint16_t cVal, SimpleClientParams& p)
-    : SimpleClient(clientId),
+SimpleClientImp::SimpleClientImp(ICommunication* communication,
+                                 uint16_t clientId,
+                                 uint16_t fVal,
+                                 uint16_t cVal,
+                                 SimpleClientParams& p,
+                                 const std::shared_ptr<concord::performance::PerformanceManager>& pm)
+    : SimpleClient(clientId, pm),
       clientId_{clientId},
       numberOfReplicas_(3 * fVal + 2 * cVal + 1),
       numberOfRequiredReplicas_(2 * fVal + cVal + 1),
@@ -180,7 +191,8 @@ SimpleClientImp::SimpleClientImp(
                                     p.clientSendsRequestToAllReplicasPeriodThresh),
       clientSendsRequestToAllReplicasFirstThresh_{p.clientSendsRequestToAllReplicasFirstThresh},
       clientSendsRequestToAllReplicasPeriodThresh_{p.clientSendsRequestToAllReplicasPeriodThresh},
-      clientPeriodicResetThresh_{p.clientPeriodicResetThresh} {
+      clientPeriodicResetThresh_{p.clientPeriodicResetThresh},
+      pm_{pm} {
   ConcordAssert(fVal_ >= 1);
 
   pendingRequest_ = nullptr;
@@ -435,7 +447,7 @@ void SimpleClientImp::sendPendingRequest() {
       // TODO(GG): handle errors (print and/or ....)
     }
   } else {
-    // int stat =
+    pm_->Delay<concord::performance::SlowdownPhase::BftClientBeforeSendPrimary>();
     communication_->sendAsyncMessage(knownPrimaryReplica_, pendingRequest_->body(), pendingRequest_->size());
     // TODO(GG): handle errors (print and/or ....)
   }
@@ -492,17 +504,22 @@ uint64_t SeqNumberGeneratorForClientRequestsImp::generateUniqueSequenceNumberFor
 
 }  // namespace impl
 
-SimpleClient* SimpleClient::createSimpleClient(
-    ICommunication* communication, uint16_t clientId, uint16_t fVal, uint16_t cVal, SimpleClientParams p) {
-  return new impl::SimpleClientImp(communication, clientId, fVal, cVal, p);
+SimpleClient* SimpleClient::createSimpleClient(ICommunication* communication,
+                                               uint16_t clientId,
+                                               uint16_t fVal,
+                                               uint16_t cVal,
+                                               SimpleClientParams p,
+                                               const std::shared_ptr<concord::performance::PerformanceManager>& pm) {
+  return new impl::SimpleClientImp(communication, clientId, fVal, cVal, p, pm);
 }
 
 SimpleClient* SimpleClient::createSimpleClient(ICommunication* communication,
                                                uint16_t clientId,
                                                uint16_t fVal,
-                                               uint16_t cVal) {
+                                               uint16_t cVal,
+                                               const std::shared_ptr<concord::performance::PerformanceManager>& pm) {
   SimpleClientParams p;
-  return SimpleClient::createSimpleClient(communication, clientId, fVal, cVal, p);
+  return SimpleClient::createSimpleClient(communication, clientId, fVal, cVal, p, pm);
 }
 
 SimpleClient::~SimpleClient() = default;

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -24,7 +24,13 @@ target_include_directories(preprocessor PUBLIC ${OPENSSL_INCLUDE_DIR})
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/include)
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/include/bftengine)
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/src/bftengine)
+get_property(perf_include GLOBAL PROPERTY PERF_MANAGER_INCLUDE_DIR)
+target_include_directories(preprocessor PUBLIC ${perf_include})
 target_link_libraries(preprocessor PUBLIC diagnostics)
+
+if(BUILD_SLOWDOWN)
+    target_compile_definitions(preprocessor PUBLIC USE_SLOWDOWN)
+endif()
 
 target_link_libraries(preprocessor PUBLIC util)
 target_link_libraries(preprocessor PUBLIC threshsign)

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -35,7 +35,8 @@ void PreProcessor::addNewPreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunic
                                       shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
                                       bftEngine::IRequestsHandler &requestsHandler,
                                       InternalReplicaApi &replica,
-                                      concordUtil::Timers &timers) {
+                                      concordUtil::Timers &timers,
+                                      shared_ptr<concord::performance::PerformanceManager> &pm) {
   if (ReplicaConfig::instance().getnumOfExternalClients() + ReplicaConfig::instance().getnumOfClientProxies() <= 0) {
     LOG_ERROR(logger(), "Wrong configuration: a number of clients could not be zero!");
     return;
@@ -43,7 +44,7 @@ void PreProcessor::addNewPreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunic
 
   if (ReplicaConfig::instance().getpreExecutionFeatureEnabled())
     preProcessors_.push_back(make_unique<PreProcessor>(
-        msgsCommunicator, incomingMsgsStorage, msgHandlersRegistrator, requestsHandler, replica, timers));
+        msgsCommunicator, incomingMsgsStorage, msgHandlersRegistrator, requestsHandler, replica, timers, pm));
 }
 
 void PreProcessor::setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
@@ -71,7 +72,8 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
                            shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
                            IRequestsHandler &requestsHandler,
                            const InternalReplicaApi &myReplica,
-                           concordUtil::Timers &timers)
+                           concordUtil::Timers &timers,
+                           shared_ptr<concord::performance::PerformanceManager> &pm)
     : msgsCommunicator_(msgsCommunicator),
       incomingMsgsStorage_(incomingMsgsStorage),
       msgHandlersRegistrator_(msgHandlersRegistrator),
@@ -99,7 +101,8 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       preExecReqStatusCheckPeriodMilli_(myReplica_.getReplicaConfig().preExecReqStatusCheckTimerMillisec),
       timers_{timers},
       preExecuteDuration_{histograms_.totalPreExecutionDuration},
-      lastViewNum_(myReplica.getCurrentView()) {
+      lastViewNum_(myReplica.getCurrentView()),
+      pm_{pm} {
   registerMsgHandlers();
   metricsComponent_.Register();
   sigManager_ = make_shared<SigManager>(myReplicaId_,
@@ -784,11 +787,14 @@ void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr
   }
   SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(), "Request pre-processed" << KVLOG(isPrimary, reqSeqNum, clientId));
-  if (isPrimary)
+  if (isPrimary) {
+    pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecNonPrimary>();
     handlePreProcessedReqByPrimary(preProcessReqMsg, clientId, actualResultBufLen);
-  else
+  } else {
+    pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecPrimary>();
     handlePreProcessedReqByNonPrimary(
         clientId, reqSeqNum, preProcessReqMsg->reqRetryId(), actualResultBufLen, preProcessReqMsg->getCid());
+  }
 }
 
 //**************** Class AsyncPreProcessJob ****************//

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -788,10 +788,10 @@ void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr
   SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(), "Request pre-processed" << KVLOG(isPrimary, reqSeqNum, clientId));
   if (isPrimary) {
-    pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecNonPrimary>();
+    pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecPrimary>();
     handlePreProcessedReqByPrimary(preProcessReqMsg, clientId, actualResultBufLen);
   } else {
-    pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecPrimary>();
+    pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecNonPrimary>();
     handlePreProcessedReqByNonPrimary(
         clientId, reqSeqNum, preProcessReqMsg->reqRetryId(), actualResultBufLen, preProcessReqMsg->getCid());
   }

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -26,6 +26,7 @@
 #include "InternalReplicaApi.hpp"
 #include "PreProcessorRecorder.hpp"
 #include "diagnostics.h"
+#include "PerformanceManager.hpp"
 
 #include <mutex>
 
@@ -57,7 +58,8 @@ class PreProcessor {
                std::shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
                bftEngine::IRequestsHandler &requestsHandler,
                const InternalReplicaApi &replica,
-               concordUtil::Timers &timers);
+               concordUtil::Timers &timers,
+               std::shared_ptr<concord::performance::PerformanceManager> &sdm);
 
   ~PreProcessor();
 
@@ -66,7 +68,8 @@ class PreProcessor {
                                  std::shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
                                  bftEngine::IRequestsHandler &requestsHandler,
                                  InternalReplicaApi &myReplica,
-                                 concordUtil::Timers &timers);
+                                 concordUtil::Timers &timers,
+                                 std::shared_ptr<concord::performance::PerformanceManager> &pm);
 
   static void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
@@ -183,6 +186,7 @@ class PreProcessor {
   PreProcessorRecorder histograms_;
   concord::diagnostics::AsyncTimeRecorderMap<std::string> preExecuteDuration_;
   ViewNum lastViewNum_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };
 
 //**************** Class AsyncPreProcessJob ****************//

--- a/bftengine/src/preprocessor/tests/CMakeLists.txt
+++ b/bftengine/src/preprocessor/tests/CMakeLists.txt
@@ -11,3 +11,7 @@ target_link_libraries(preprocessor_test PUBLIC
     bftcommunication
     preprocessor
     corebft)
+
+if(BUILD_SLOWDOWN)
+    target_compile_definitions(preprocessor_test PUBLIC USE_SLOWDOWN)
+endif()

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -431,7 +431,8 @@ TEST(requestPreprocessingState_test, requestTimedOut) {
   bftEngine::impl::ReplicasInfo replicasInfo(replicaConfig, false, false);
   DummyReplica replica(replicasInfo);
   concordUtil::Timers timers;
-  PreProcessor preProcessor(msgsCommunicator, msgsStorage, msgHandlersRegPtr, requestsHandler, replica, timers);
+  auto sdm = make_shared<concord::performance::PerformanceManager>();
+  PreProcessor preProcessor(msgsCommunicator, msgsStorage, msgHandlersRegPtr, requestsHandler, replica, timers, sdm);
 
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
@@ -451,7 +452,8 @@ TEST(requestPreprocessingState_test, primaryCrashDetected) {
   replica.setPrimary(false);
   concordUtil::Timers timers;
   replicaConfig.preExecReqStatusCheckTimerMillisec = preExecReqStatusCheckTimerMillisec;
-  PreProcessor preProcessor(msgsCommunicator, msgsStorage, msgHandlersRegPtr, requestsHandler, replica, timers);
+  auto sdm = make_shared<concord::performance::PerformanceManager>();
+  PreProcessor preProcessor(msgsCommunicator, msgsStorage, msgHandlersRegPtr, requestsHandler, replica, timers, sdm);
 
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
@@ -474,7 +476,8 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
   replicaConfig.replicaId = replica_1;
 
   concordUtil::Timers timers;
-  PreProcessor preProcessor(msgsCommunicator, msgsStorage, msgHandlersRegPtr, requestsHandler, replica, timers);
+  auto sdm = make_shared<concord::performance::PerformanceManager>();
+  PreProcessor preProcessor(msgsCommunicator, msgsStorage, msgHandlersRegPtr, requestsHandler, replica, timers, sdm);
 
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);

--- a/kvbc/include/KVBCInterfaces.h
+++ b/kvbc/include/KVBCInterfaces.h
@@ -122,6 +122,7 @@ class ICommandsHandler : public bftEngine::IRequestsHandler {
                const std::string& batchCid,
                concordUtils::SpanWrapper& parent_span) override = 0;
   virtual void setControlStateManager(std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) = 0;
+  virtual void setPerformanceManager(std::shared_ptr<concord::performance::PerformanceManager> perfManager) = 0;
   ~ICommandsHandler() override = default;
 };
 

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -80,7 +80,8 @@ class ReplicaImp : public IReplica,
   ReplicaImp(bft::communication::ICommunication *comm,
              const bftEngine::ReplicaConfig &config,
              std::unique_ptr<IStorageFactory> storageFactory,
-             std::shared_ptr<concordMetrics::Aggregator> aggregator);
+             std::shared_ptr<concordMetrics::Aggregator> aggregator,
+             const std::shared_ptr<concord::performance::PerformanceManager> &pm);
 
   void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 
@@ -140,6 +141,7 @@ class ReplicaImp : public IReplica,
   concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
   std::unique_ptr<ReplicaStateSync> replicaStateSync_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_;
   std::shared_ptr<bftEngine::ControlStateManager> controlStateManager_;
 
   // 5 Minutes

--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -10,6 +10,7 @@
 #include "Logger.hpp"
 #include "storage/db_interface.h"
 #include "storage/direct_kv_key_manipulator.h"
+#include "PerformanceManager.hpp"
 
 #include <memory>
 
@@ -125,7 +126,9 @@ class DBAdapter : public IDbAdapter {
   DBAdapter(std::shared_ptr<storage::IDBClient> dataStore,
             std::unique_ptr<IDataKeyGenerator> keyGen = std::make_unique<RocksKeyGenerator>(),
             bool use_mdt = false,
-            bool save_kv_pairs_separately = true);
+            bool save_kv_pairs_separately = true,
+            const std::shared_ptr<concord::performance::PerformanceManager> &pm_ =
+                std::make_shared<concord::performance::PerformanceManager>());
 
   // Adds a block from a set of key/value pairs and a block ID. Includes:
   // - adding the key/value pairs in separate keys
@@ -184,6 +187,7 @@ class DBAdapter : public IDbAdapter {
   BlockId lastBlockId_ = 0;
   BlockId lastReachableBlockId_ = 0;
   bool saveKvPairsSeparately_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };
 
 }  // namespace concord::kvbc::v1DirectKeyValue

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -22,6 +22,7 @@
 #include "sparse_merkle/tree.h"
 #include "storage/db_interface.h"
 #include "Statistics.hpp"
+#include "PerformanceManager.hpp"
 
 #include <future>
 #include <memory>
@@ -63,7 +64,9 @@ class DBAdapter : public IDbAdapter {
   // Note4: Non-provable keys cannot be deleted for now.
   DBAdapter(const std::shared_ptr<concord::storage::IDBClient> &db,
             bool linkTempSTChain = true,
-            const NonProvableKeySet &nonProvableKeySet = NonProvableKeySet{});
+            const NonProvableKeySet &nonProvableKeySet = NonProvableKeySet{},
+            const std::shared_ptr<concord::performance::PerformanceManager> &pm_ =
+                std::make_shared<concord::performance::PerformanceManager>());
 
   // Make the adapter non-copyable.
   DBAdapter(const DBAdapter &) = delete;
@@ -234,6 +237,7 @@ class DBAdapter : public IDbAdapter {
   sparse_merkle::Tree smTree_;
   std::unique_ptr<concordMetrics::ISummary> commitSizeSummary_;
   const NonProvableKeySet nonProvableKeySet_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };
 
 namespace detail {
@@ -267,6 +271,8 @@ struct DatabaseLeafValue {
 
   // The block ID this value was deleted in. Not set if this value has not been deleted.
   std::optional<BlockIdType> deletedInBlockId;
+
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };
 
 inline bool operator==(const DatabaseLeafValue &lhs, const DatabaseLeafValue &rhs) {

--- a/kvbc/include/merkle_tree_storage_factory.h
+++ b/kvbc/include/merkle_tree_storage_factory.h
@@ -14,6 +14,7 @@
 
 #include "storage_factory_interface.h"
 #include "kv_types.hpp"
+#include "PerformanceManager.hpp"
 
 #include <optional>
 #include <string>
@@ -26,7 +27,9 @@ class RocksDBStorageFactory : public IStorageFactory {
  public:
   RocksDBStorageFactory(
       const std::string& dbPath,
-      const std::unordered_set<concord::kvbc::Key>& nonProvableKeySet = std::unordered_set<concord::kvbc::Key>{});
+      const std::unordered_set<concord::kvbc::Key>& nonProvableKeySet = std::unordered_set<concord::kvbc::Key>{},
+      const std::shared_ptr<concord::performance::PerformanceManager>& pm =
+          std::make_shared<concord::performance::PerformanceManager>());
 
  public:
   DatabaseSet newDatabaseSet() const override;
@@ -36,6 +39,7 @@ class RocksDBStorageFactory : public IStorageFactory {
  private:
   const std::string dbPath_;
   const std::unordered_set<concord::kvbc::Key> nonProvableKeySet_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };
 #endif
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -197,12 +197,14 @@ void ReplicaImp::set_command_handler(ICommandsHandler *handler) {
 ReplicaImp::ReplicaImp(ICommunication *comm,
                        const bftEngine::ReplicaConfig &replicaConfig,
                        std::unique_ptr<IStorageFactory> storageFactory,
-                       std::shared_ptr<concordMetrics::Aggregator> aggregator)
+                       std::shared_ptr<concordMetrics::Aggregator> aggregator,
+                       const std::shared_ptr<concord::performance::PerformanceManager> &pm)
     : logger(logging::getLogger("skvbc.replicaImp")),
       m_currentRepStatus(RepStatus::Idle),
       m_ptrComm(comm),
       replicaConfig_(replicaConfig),
-      aggregator_(aggregator) {
+      aggregator_(aggregator),
+      pm_{pm} {
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {
     replicaConfig_.replicaId,

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -266,8 +266,9 @@ ReplicaImp::~ReplicaImp() {
 }
 
 Status ReplicaImp::addBlockInternal(const SetOfKeyValuePairs &updates, BlockId &outBlockId) {
-  outBlockId = m_bcDbAdapter->addBlock(updates);
-
+  auto data = updates;
+  pm_->Delay<concord::performance::SlowdownPhase::StorageBeforeKVBC>(data);
+  outBlockId = m_bcDbAdapter->addBlock(data);
   return Status::OK();
 }
 

--- a/kvbc/src/merkle_tree_storage_factory.cpp
+++ b/kvbc/src/merkle_tree_storage_factory.cpp
@@ -18,18 +18,18 @@
 #include "rocksdb/client.h"
 
 namespace concord::kvbc::v2MerkleTree {
-
 #ifdef USE_ROCKSDB
 RocksDBStorageFactory::RocksDBStorageFactory(const std::string& dbPath,
-                                             const std::unordered_set<concord::kvbc::Key>& nonProvableKeySet)
-    : dbPath_{dbPath}, nonProvableKeySet_{nonProvableKeySet} {}
+                                             const std::unordered_set<concord::kvbc::Key>& nonProvableKeySet,
+                                             const std::shared_ptr<concord::performance::PerformanceManager>& pm)
+    : dbPath_{dbPath}, nonProvableKeySet_{nonProvableKeySet}, pm_{pm} {}
 
 IStorageFactory::DatabaseSet RocksDBStorageFactory::newDatabaseSet() const {
   auto ret = IStorageFactory::DatabaseSet{};
   ret.dataDBClient = std::make_shared<storage::rocksdb::Client>(dbPath_);
   ret.dataDBClient->init();
   ret.metadataDBClient = ret.dataDBClient;
-  ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient, true, nonProvableKeySet_);
+  ret.dbAdapter = std::make_unique<DBAdapter>(ret.dataDBClient, true, nonProvableKeySet_, pm_);
   return ret;
 }
 

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+if(BUILD_SLOWDOWN)
+    add_subdirectory(test)
+endif()
+
+set_property(GLOBAL PROPERTY PERF_MANAGER_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/performance/README.MD
+++ b/performance/README.MD
@@ -1,0 +1,23 @@
+# PerformanceManager class
+
+This class is a high level injector over the concord-bft code to perform various performance related operations.
+It's instance can be injected to various modules via constructors, which is default pattern in Concord-bft for dependencies injection.
+
+## SlowdownManager
+
+As the name suggests, this class is responsible for implementing slowdown methods. Sometimes in order to figure out performance bottleneck it makes sense to slow down some components and to evaluate overall system impact.
+
+This class implements `Delay<T>` method, which can be called from various modules.
+
+The `slowdown_config_reference.yaml` file can be used as a reference configuration file. Currently 5 modules are supported, each of them has it's own phases.
+This is not a generic mechanism to handle slowdown configuration, but an example of how application can do it.
+
+This file should be managed and parse by the application that uses concord-bft. Class' ctor expects configuration object to be passed from the calling application.
+
+### Policies
+Policy defines how the slowdown is reached. We support Sleep, BusyWait and AddKeys policies, each of them can be used in appropriate place in the code. Sleep and BusyWait are trivial and the AddKeys can be used for storage related tasks and to create additional work by adding dummy keys to the write set.
+
+## Build
+The class depends on `USE_SLOWDOWN` preprocessor definition, which in turn is set by setting `BUILD_SLOWDOWN` option in the main `CMakeLists.txt` file.
+The expectation is that the up level application will set this build flag. 
+

--- a/performance/include/Helper.hpp
+++ b/performance/include/Helper.hpp
@@ -1,0 +1,25 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+struct xorshift64_state {
+  uint64_t a;
+};
+
+inline uint64_t xorshift64(struct xorshift64_state *state) {
+  uint64_t x = state->a;
+  x ^= x << 13;
+  x ^= x >> 7;
+  x ^= x << 17;
+  return state->a = x;
+}

--- a/performance/include/PerformanceManager.hpp
+++ b/performance/include/PerformanceManager.hpp
@@ -22,7 +22,6 @@ class PerformanceManager {
   explicit PerformanceManager(std::shared_ptr<SlowdownConfiguration> &config) {
     slowdownManager_ = std::make_shared<SlowdownManager>(config);
   }
-
 #ifdef USE_SLOWDOWN
   // slow down methods
   template <SlowdownPhase T>

--- a/performance/include/PerformanceManager.hpp
+++ b/performance/include/PerformanceManager.hpp
@@ -1,0 +1,56 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include "SlowdownManager.hpp"
+
+namespace concord::performance {
+
+class PerformanceManager {
+ public:
+  PerformanceManager() = default;
+  explicit PerformanceManager(std::shared_ptr<SlowdownConfiguration> &config) {
+    slowdownManager_ = std::make_shared<SlowdownManager>(config);
+  }
+
+#ifdef USE_SLOWDOWN
+  // slow down methods
+  template <SlowdownPhase T>
+  SlowDownResult Delay(concord::kvbc::SetOfKeyValuePairs &kvpairs) {
+    if (slowdownManager_) return slowdownManager_->Delay<T>(kvpairs);
+    return SlowDownResult{};
+  }
+
+  template <SlowdownPhase T>
+  SlowDownResult Delay() {
+    if (slowdownManager_) return slowdownManager_->Delay<T>();
+    return SlowDownResult{};
+  }
+#else
+  // slow down methods
+  template <SlowdownPhase T>
+  void Delay(concord::kvbc::SetOfKeyValuePairs &kvpairs) {
+    if (slowdownManager_) slowdownManager_->Delay<T>(kvpairs);
+  }
+
+  template <SlowdownPhase T>
+  void Delay() {
+    if (slowdownManager_) slowdownManager_->Delay<T>();
+  }
+#endif
+
+ private:
+  std::shared_ptr<SlowdownManager> slowdownManager_ = nullptr;
+};
+
+}  // namespace concord::performance

--- a/performance/include/SlowdownManager.hpp
+++ b/performance/include/SlowdownManager.hpp
@@ -1,0 +1,372 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+#include <iostream>
+#include "Helper.hpp"
+#include "../../kvbc/include/kv_types.hpp"
+#include "../../util/include/sliver.hpp"
+
+namespace concord::performance {
+
+enum class SlowdownPhase : uint16_t {
+  None,
+  BftClientBeforeSendPrimary,
+  PreProcessorAfterPreexecPrimary,
+  PreProcessorAfterPreexecNonPrimary,
+  ConsensusFullCommitMsgProcess,
+  PostExecBeforeConflictResolution,
+  PostExecAfterConflictResolution,
+  StorageBeforeMerkleTree,
+  StorageBeforeDbWrite
+};
+
+enum class SlowdownPolicyType { BusyWait, AddKeys, Sleep };
+
+struct SlowDownResult {
+  SlowdownPhase phase = SlowdownPhase::None;
+  uint totalKeyCount = 0;
+  uint totalValueSize = 0;
+  uint totalWaitDuration = 0;
+  uint totalSleepDuration = 0;
+
+  friend std::ostream &operator<<(std::ostream &os, const SlowDownResult &r);
+};
+
+inline std::ostream &operator<<(std::ostream &os, const SlowDownResult &r) {
+  os << "phase: " << (uint)r.phase << ", totalWaitDuration: " << r.totalWaitDuration
+     << ", totalSleepDuration: " << r.totalSleepDuration << ", totalKeyCount: " << r.totalKeyCount
+     << ",totalValueSize: " << r.totalValueSize;
+  return os;
+}
+
+struct SlowdownPolicyConfig {
+  SlowdownPolicyType type;
+  virtual uint16_t GetSleepDuration() { return 0; }
+  virtual uint16_t GetBusyWaitTime() { return 0; }
+  virtual uint16_t GetItemCount() { return 0; }
+  virtual uint16_t GetKeySize() { return 0; }
+  virtual uint16_t GetValueSize() { return 0; }
+  virtual ~SlowdownPolicyConfig() = default;
+
+  explicit SlowdownPolicyConfig(SlowdownPolicyType t) : type{t} {}
+};
+using SlowdownConfiguration = std::unordered_map<SlowdownPhase, std::vector<std::shared_ptr<SlowdownPolicyConfig>>>;
+
+struct SleepPolicyConfig : public SlowdownPolicyConfig {
+  uint16_t sleep_duration_ms;
+
+  uint16_t GetSleepDuration() override { return sleep_duration_ms; }
+
+  explicit SleepPolicyConfig(uint16_t dur) : SlowdownPolicyConfig(SlowdownPolicyType::Sleep) {
+    sleep_duration_ms = dur;
+  }
+  SleepPolicyConfig() = delete;
+  virtual ~SleepPolicyConfig() = default;
+};
+
+struct BusyWaitPolicyConfig : public SleepPolicyConfig {
+  uint16_t wait_duration_ms;
+  uint16_t GetBusyWaitTime() override { return wait_duration_ms; }
+
+  BusyWaitPolicyConfig() = delete;
+  virtual ~BusyWaitPolicyConfig() = default;
+
+  BusyWaitPolicyConfig(uint16_t waitDurMs, uint16_t sleepDurMs)
+      : SleepPolicyConfig(sleepDurMs), wait_duration_ms{waitDurMs} {
+    type = SlowdownPolicyType::BusyWait;
+  }
+};
+
+struct AddKeysPolicyConfig : SlowdownPolicyConfig {
+  uint16_t key_count;
+  uint16_t key_size;
+  uint16_t value_size;
+
+  AddKeysPolicyConfig(uint16_t keys, uint16_t ksize, uint16_t vsize)
+      : SlowdownPolicyConfig(SlowdownPolicyType::AddKeys), key_count{keys}, key_size{ksize}, value_size{vsize} {}
+
+  AddKeysPolicyConfig() = delete;
+  virtual ~AddKeysPolicyConfig() = default;
+
+  uint16_t GetItemCount() override { return key_count; }
+  uint16_t GetKeySize() override { return key_size; }
+  uint16_t GetValueSize() override { return value_size; }
+};
+
+#ifdef USE_SLOWDOWN
+
+template <SlowdownPhase e>
+struct phase_tag {};
+typedef phase_tag<SlowdownPhase::BftClientBeforeSendPrimary> bftclient_before_send_primary;
+typedef phase_tag<SlowdownPhase::PreProcessorAfterPreexecPrimary> pre_processor_aferpe_primary;
+typedef phase_tag<SlowdownPhase::PreProcessorAfterPreexecNonPrimary> pre_processor_aferpe_nonprimary;
+typedef phase_tag<SlowdownPhase::ConsensusFullCommitMsgProcess> cons_process_fullcommit_msg;
+typedef phase_tag<SlowdownPhase::StorageBeforeMerkleTree> storage_before_merkle_tree;
+typedef phase_tag<SlowdownPhase::StorageBeforeDbWrite> storage_before_db_write;
+typedef phase_tag<SlowdownPhase::PostExecAfterConflictResolution> post_exec_after_conflict_det;
+typedef phase_tag<SlowdownPhase::PostExecBeforeConflictResolution> post_exec_before_conflict_det;
+
+class BasePolicy {
+ public:
+  BasePolicy() = default;
+  virtual void Slowdown(SlowDownResult &outRes) {}
+  virtual void Slowdown(concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &outRes) {}
+  virtual ~BasePolicy() = default;
+};
+
+class BusyWaitPolicy : public BasePolicy {
+ public:
+  explicit BusyWaitPolicy(SlowdownPolicyConfig *c)
+      : sleepTime_{c->GetSleepDuration()}, waitTime_{c->GetBusyWaitTime()} {}
+
+  void Slowdown(SlowDownResult &outRes) override {
+    if (waitTime_ == 0) return;
+    auto s = std::chrono::steady_clock::now();
+    while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - s).count() <
+           waitTime_)
+      std::this_thread::sleep_for(std::chrono::milliseconds(sleepTime_));
+    outRes.totalSleepDuration += sleepTime_;
+    outRes.totalWaitDuration += waitTime_;
+  }
+
+  void Slowdown(concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &outRes) override { Slowdown(outRes); }
+
+  virtual ~BusyWaitPolicy() = default;
+
+ private:
+  uint sleepTime_;
+  uint waitTime_;
+};
+
+class SleepPolicy : public BasePolicy {
+ public:
+  explicit SleepPolicy(SlowdownPolicyConfig *c) : sleepDuration_{c->GetSleepDuration()} {}
+
+  void Slowdown(SlowDownResult &outRes) override {
+    if (sleepDuration_ == 0) return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleepDuration_));
+    outRes.totalSleepDuration += sleepDuration_;
+  }
+
+  void Slowdown(concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &outRes) override { Slowdown(outRes); }
+
+  virtual ~SleepPolicy() = default;
+
+ private:
+  uint sleepDuration_;
+};
+
+class AddKeysPolicy : public BasePolicy {
+ public:
+  explicit AddKeysPolicy(SlowdownPolicyConfig *c) : keyCount_{c->GetItemCount()} {
+    prgState_.a = std::chrono::steady_clock::now().time_since_epoch().count();
+    data_.reserve(keyCount_ * 10);
+    for (uint i = 0; i < keyCount_ * 10; ++i) {
+      std::vector<uint64_t> key;
+      uint size = 0;
+      while (size < c->GetKeySize()) {
+        auto t = xorshift64(&prgState_);
+        key.push_back(t);
+        size += sizeof(uint64_t);
+      }
+
+      size = 0;
+      std::vector<uint64_t> value;
+      while (size < c->GetValueSize()) {
+        auto t = xorshift64(&prgState_);
+        value.push_back(t);
+        size += sizeof(uint64_t);
+      }
+      totalValueSize_ += size;
+
+      auto *key_data = new uint64_t[key.size()];
+      std::copy(key.begin(), key.end(), key_data);
+      auto *value_data = new uint64_t[value.size()];
+      std::copy(value.begin(), value.end(), value_data);
+
+      concordUtils::Sliver k{(const char *)key_data, key.size() * sizeof(uint64_t)};
+      concordUtils::Sliver v{(const char *)value_data, value.size() * sizeof(uint64_t)};
+      data_.emplace_back(k, v);
+    }
+  }
+
+  void Slowdown(concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &outRes) override {
+    for (uint i = 0; i < keyCount_;) {
+      auto ind = std::rand() % data_.size();
+      auto key = data_[ind].first;
+      if (set.find(key) != set.end()) continue;
+      ++i;
+      set[key] = data_[ind].second;
+      outRes.totalValueSize += data_[ind].second.size();
+    }
+
+    outRes.totalKeyCount += keyCount_;
+  }
+
+  virtual ~AddKeysPolicy() = default;
+
+ private:
+  uint keyCount_ = 0;
+  uint totalValueSize_ = 0;
+  std::vector<concord::kvbc::KeyValuePair> data_;
+  xorshift64_state prgState_{};
+};
+
+class SlowdownManager {
+ private:
+  std::vector<std::shared_ptr<BasePolicy>> GetPolicies(const SlowdownPhase &phase, SlowDownResult &outRes) {
+    auto it = config_.find(phase);
+    if (config_.end() == it) {
+      outRes.phase = SlowdownPhase::None;
+      return std::vector<std::shared_ptr<BasePolicy>>();
+    }
+    outRes.phase = phase;
+    return it->second;
+  }
+
+  void DelayInternal(SlowdownPhase phase, SlowDownResult &res) {
+    auto policies = GetPolicies(phase, res);
+    for (auto &policy : policies) policy->Slowdown(res);
+  }
+
+  void DelayInternal(SlowdownPhase phase, concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &res) {
+    auto policies = GetPolicies(phase, res);
+    for (auto &policy : policies) policy->Slowdown(set, res);
+  }
+
+  void DelayImp(bftclient_before_send_primary, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::BftClientBeforeSendPrimary, res);
+  }
+
+  void DelayImp(pre_processor_aferpe_primary, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::PreProcessorAfterPreexecPrimary, res);
+  }
+
+  void DelayImp(pre_processor_aferpe_nonprimary, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::PreProcessorAfterPreexecNonPrimary, res);
+  }
+
+  void DelayImp(cons_process_fullcommit_msg, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::ConsensusFullCommitMsgProcess, res);
+  }
+
+  void DelayImp(storage_before_merkle_tree, concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::StorageBeforeMerkleTree, set, res);
+  }
+
+  void DelayImp(storage_before_merkle_tree, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::StorageBeforeMerkleTree, res);
+  }
+
+  void DelayImp(storage_before_db_write, concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::StorageBeforeDbWrite, set, res);
+  }
+
+  void DelayImp(storage_before_db_write, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::StorageBeforeDbWrite, res);
+  }
+
+  void DelayImp(post_exec_before_conflict_det, concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::PostExecBeforeConflictResolution, set, res);
+  }
+
+  void DelayImp(post_exec_before_conflict_det, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::PostExecBeforeConflictResolution, res);
+  }
+
+  void DelayImp(post_exec_after_conflict_det, concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::PostExecAfterConflictResolution, set, res);
+  }
+
+  void DelayImp(post_exec_after_conflict_det, SlowDownResult &res) {
+    DelayInternal(SlowdownPhase::PostExecAfterConflictResolution, res);
+  }
+
+ public:
+  explicit SlowdownManager(std::shared_ptr<SlowdownConfiguration> &config) {
+    using namespace std;
+    if (!config) return;
+    for (auto &it : *config) {
+      vector<shared_ptr<BasePolicy>> policies;
+      for (auto &p : it.second) {
+        switch (p->type) {
+          case SlowdownPolicyType::Sleep:
+            policies.push_back(make_shared<SleepPolicy>(p.get()));
+            break;
+          case SlowdownPolicyType::BusyWait:
+            policies.push_back(make_shared<BusyWaitPolicy>(p.get()));
+            break;
+          case SlowdownPolicyType::AddKeys:
+            policies.push_back(make_shared<AddKeysPolicy>(p.get()));
+            break;
+          default:
+            throw runtime_error("unsupported policy");
+        }
+      }
+      config_[it.first] = policies;
+    }
+  }
+
+  SlowdownManager() = default;
+
+  template <SlowdownPhase T>
+  SlowDownResult Delay(concord::kvbc::SetOfKeyValuePairs &set) {
+    SlowDownResult res;
+    auto t = phase_tag<T>();
+    DelayImp(t, set, res);
+    return res;
+  }
+
+  template <SlowdownPhase T>
+  SlowDownResult Delay() {
+    SlowDownResult res;
+    auto t = phase_tag<T>();
+    DelayImp(t, res);
+    return res;
+  }
+
+  ~SlowdownManager() = default;
+
+ private:
+  std::unordered_map<SlowdownPhase, std::vector<std::shared_ptr<BasePolicy>>> config_;
+};
+
+#else
+
+class SlowdownManager {
+ public:
+  SlowdownManager() {}
+
+  SlowdownManager(std::shared_ptr<SlowdownConfiguration> &config) {}
+
+  template <SlowdownPhase T>
+  SlowDownResult Delay(concord::kvbc::SetOfKeyValuePairs &set) {
+    return SlowDownResult();
+  }
+
+  template <SlowdownPhase T>
+  SlowDownResult Delay() {
+    return SlowDownResult();
+  }
+
+  ~SlowdownManager() {}
+};
+
+#endif
+
+}  // namespace concord::performance

--- a/performance/include/SlowdownManager.hpp
+++ b/performance/include/SlowdownManager.hpp
@@ -31,7 +31,7 @@ enum class SlowdownPhase : uint16_t {
   ConsensusFullCommitMsgProcess,
   PostExecBeforeConflictResolution,
   PostExecAfterConflictResolution,
-  StorageBeforeMerkleTree,
+  StorageBeforeKVBC,
   StorageBeforeDbWrite
 };
 
@@ -116,7 +116,7 @@ typedef phase_tag<SlowdownPhase::BftClientBeforeSendPrimary> bftclient_before_se
 typedef phase_tag<SlowdownPhase::PreProcessorAfterPreexecPrimary> pre_processor_aferpe_primary;
 typedef phase_tag<SlowdownPhase::PreProcessorAfterPreexecNonPrimary> pre_processor_aferpe_nonprimary;
 typedef phase_tag<SlowdownPhase::ConsensusFullCommitMsgProcess> cons_process_fullcommit_msg;
-typedef phase_tag<SlowdownPhase::StorageBeforeMerkleTree> storage_before_merkle_tree;
+typedef phase_tag<SlowdownPhase::StorageBeforeKVBC> storage_before_merkle_tree;
 typedef phase_tag<SlowdownPhase::StorageBeforeDbWrite> storage_before_db_write;
 typedef phase_tag<SlowdownPhase::PostExecAfterConflictResolution> post_exec_after_conflict_det;
 typedef phase_tag<SlowdownPhase::PostExecBeforeConflictResolution> post_exec_before_conflict_det;
@@ -273,11 +273,11 @@ class SlowdownManager {
   }
 
   void DelayImp(storage_before_merkle_tree, concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &res) {
-    DelayInternal(SlowdownPhase::StorageBeforeMerkleTree, set, res);
+    DelayInternal(SlowdownPhase::StorageBeforeKVBC, set, res);
   }
 
   void DelayImp(storage_before_merkle_tree, SlowDownResult &res) {
-    DelayInternal(SlowdownPhase::StorageBeforeMerkleTree, res);
+    DelayInternal(SlowdownPhase::StorageBeforeKVBC, res);
   }
 
   void DelayImp(storage_before_db_write, concord::kvbc::SetOfKeyValuePairs &set, SlowDownResult &res) {

--- a/performance/include/SlowdownManager.hpp
+++ b/performance/include/SlowdownManager.hpp
@@ -173,7 +173,8 @@ class SleepPolicy : public BasePolicy {
 
 class AddKeysPolicy : public BasePolicy {
  public:
-  explicit AddKeysPolicy(SlowdownPolicyConfig *c) : keyCount_{c->GetItemCount()}, keySize_{c->GetKeySize()}, valueSize_{c->GetValueSize()} {
+  explicit AddKeysPolicy(SlowdownPolicyConfig *c)
+      : keyCount_{c->GetItemCount()}, keySize_{c->GetKeySize()}, valueSize_{c->GetValueSize()} {
     prgState_.a = std::chrono::steady_clock::now().time_since_epoch().count();
     data_.reserve(keyCount_ * 10);
     for (uint i = 0; i < keyCount_ * 10; ++i) {
@@ -198,7 +199,7 @@ class AddKeysPolicy : public BasePolicy {
       std::copy(key.begin(), key.end(), key_data);
       concordUtils::Sliver k{(const char *)key_data, key.size() * sizeof(uint64_t)};
 
-      if(valueSize_ > 0) {
+      if (valueSize_ > 0) {
         auto *value_data = new uint64_t[value.size()];
         std::copy(value.begin(), value.end(), value_data);
         concordUtils::Sliver v{(const char *)value_data, value.size() * sizeof(uint64_t)};

--- a/performance/slowdown_config_reference.yaml
+++ b/performance/slowdown_config_reference.yaml
@@ -1,0 +1,61 @@
+bftclient:
+  - phase: before-send
+    id: 1
+    policies:
+      - id: 0
+        duration: 0
+        sleep-time: 0
+      - id: 3
+        duration: 0
+
+preprocessor:
+  - phase: after-preexec-primary
+    id: 2
+    policies:
+      - id: 0
+        duration: 0
+        sleep-time: 0
+  - phase: after-preexec-nonprimary
+    id: 3
+    policies:
+      - id: 3
+        duration: 0
+
+consensus:
+  - phase: on-fullcommitproof
+    id: 4
+    policies:
+      - id: 0
+        duration: 0
+        sleep-time: 0
+
+# will be removed, implemented here for the simplicity
+post_execution:
+  - phase: before-contention
+    id: 5
+    policies:
+      - id: 2
+        count: 0
+        key-size: 0
+        value-size: 0
+  - phase: after-contention
+    id: 6
+    policies:
+      - id: 0
+        duration: 0
+        sleep-time: 0
+
+storage:
+  - phase: before-merkle
+    id: 7
+    policies:
+      - id: 2
+        count: 0
+        key-size: 0
+        value-size: 0
+  - phase: before-dbwrite
+    id: 8
+    policies:
+      - id: 0
+        duration: 0
+        sleep-time: 0

--- a/performance/test/CMakeLists.txt
+++ b/performance/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+find_package(GTest REQUIRED)
+add_executable(slowdown_test slowdown_test.cpp )
+target_include_directories(slowdown_test PUBLIC ${CMAKE_SOURCE_DIR}/performance/include)
+target_compile_definitions(slowdown_test PUBLIC USE_SLOWDOWN)
+target_link_libraries(slowdown_test GTest::Main kvbc util)
+add_test(slowdown_test slowdown_test)

--- a/performance/test/slowdown_test.cpp
+++ b/performance/test/slowdown_test.cpp
@@ -1,0 +1,82 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <thread>
+#include <chrono>
+
+#include "PerformanceManager.hpp"
+
+namespace {
+
+using namespace concord::performance;
+
+TEST(slowdown_test, empty_configuration) {
+  PerformanceManager pm;
+  SlowDownResult res = pm.Delay<SlowdownPhase::PreProcessorAfterPreexecPrimary>();
+  assert(res.phase == SlowdownPhase::None);
+  assert(res.totalWaitDuration == 0);
+  assert(res.totalSleepDuration == 0);
+  assert(res.totalKeyCount == 0);
+  assert(res.totalValueSize == 0);
+}
+
+TEST(slowdown_test, simple_configuration) {
+  auto sm = std::make_shared<SlowdownConfiguration>();
+  BusyWaitPolicyConfig bp(100, 30);
+  SleepPolicyConfig sp(40);
+  std::vector<std::shared_ptr<SlowdownPolicyConfig>> policies;
+  policies.push_back(std::make_shared<BusyWaitPolicyConfig>(bp));
+  policies.push_back(std::make_shared<SleepPolicyConfig>(sp));
+  (*sm)[SlowdownPhase::BftClientBeforeSendPrimary] = policies;
+  PerformanceManager pm(sm);
+  SlowDownResult res = pm.Delay<SlowdownPhase::BftClientBeforeSendPrimary>();
+  assert(res.phase == SlowdownPhase::BftClientBeforeSendPrimary);
+  assert(res.totalWaitDuration == bp.wait_duration_ms);
+  assert(res.totalSleepDuration == bp.sleep_duration_ms + sp.sleep_duration_ms);
+  assert(res.totalKeyCount == 0);
+  assert(res.totalValueSize == 0);
+}
+
+TEST(slowdown_test, hybrid_configuration) {
+  auto sm = std::make_shared<SlowdownConfiguration>();
+  BusyWaitPolicyConfig bp(100, 30);
+  SleepPolicyConfig sp(40);
+  AddKeysPolicyConfig ap(10, 200, 3000);
+  std::vector<std::shared_ptr<SlowdownPolicyConfig>> policies;
+  policies.push_back(std::make_shared<BusyWaitPolicyConfig>(bp));
+  policies.push_back(std::make_shared<SleepPolicyConfig>(sp));
+  policies.push_back(std::make_shared<AddKeysPolicyConfig>(ap));
+  (*sm)[SlowdownPhase::StorageBeforeDbWrite] = policies;
+  PerformanceManager pm(sm);
+  concord::kvbc::SetOfKeyValuePairs set;
+  SlowDownResult res = pm.Delay<SlowdownPhase::StorageBeforeDbWrite>(set);
+  assert(res.phase == SlowdownPhase::StorageBeforeDbWrite);
+  assert(res.totalWaitDuration == bp.wait_duration_ms);
+  assert(res.totalSleepDuration == bp.sleep_duration_ms + sp.sleep_duration_ms);
+  assert(res.totalKeyCount == 10);
+  assert(set.size() == 10);
+  assert(res.totalValueSize >= 10 * 3000);
+}
+
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/performance/test/slowdown_test.cpp
+++ b/performance/test/slowdown_test.cpp
@@ -29,11 +29,11 @@ using namespace concord::performance;
 TEST(slowdown_test, empty_configuration) {
   PerformanceManager pm;
   SlowDownResult res = pm.Delay<SlowdownPhase::PreProcessorAfterPreexecPrimary>();
-  assert(res.phase == SlowdownPhase::None);
-  assert(res.totalWaitDuration == 0);
-  assert(res.totalSleepDuration == 0);
-  assert(res.totalKeyCount == 0);
-  assert(res.totalValueSize == 0);
+  EXPECT_EQ(res.phase, SlowdownPhase::None);
+  EXPECT_EQ(res.totalWaitDuration, 0);
+  EXPECT_EQ(res.totalSleepDuration, 0);
+  EXPECT_EQ(res.totalKeyCount, 0);
+  EXPECT_EQ(res.totalValueSize, 0);
 }
 
 TEST(slowdown_test, simple_configuration) {
@@ -46,11 +46,11 @@ TEST(slowdown_test, simple_configuration) {
   (*sm)[SlowdownPhase::BftClientBeforeSendPrimary] = policies;
   PerformanceManager pm(sm);
   SlowDownResult res = pm.Delay<SlowdownPhase::BftClientBeforeSendPrimary>();
-  assert(res.phase == SlowdownPhase::BftClientBeforeSendPrimary);
-  assert(res.totalWaitDuration == bp.wait_duration_ms);
-  assert(res.totalSleepDuration == bp.sleep_duration_ms + sp.sleep_duration_ms);
-  assert(res.totalKeyCount == 0);
-  assert(res.totalValueSize == 0);
+  EXPECT_EQ(res.phase, SlowdownPhase::BftClientBeforeSendPrimary);
+  EXPECT_EQ(res.totalWaitDuration, bp.wait_duration_ms);
+  EXPECT_EQ(res.totalSleepDuration, bp.sleep_duration_ms + sp.sleep_duration_ms);
+  EXPECT_EQ(res.totalKeyCount, 0);
+  EXPECT_EQ(res.totalValueSize, 0);
 }
 
 TEST(slowdown_test, hybrid_configuration) {
@@ -66,12 +66,12 @@ TEST(slowdown_test, hybrid_configuration) {
   PerformanceManager pm(sm);
   concord::kvbc::SetOfKeyValuePairs set;
   SlowDownResult res = pm.Delay<SlowdownPhase::StorageBeforeDbWrite>(set);
-  assert(res.phase == SlowdownPhase::StorageBeforeDbWrite);
-  assert(res.totalWaitDuration == bp.wait_duration_ms);
-  assert(res.totalSleepDuration == bp.sleep_duration_ms + sp.sleep_duration_ms);
-  assert(res.totalKeyCount == 10);
-  assert(set.size() == 10);
-  assert(res.totalValueSize >= 10 * 3000);
+  EXPECT_EQ(res.phase, SlowdownPhase::StorageBeforeDbWrite);
+  EXPECT_EQ(res.totalWaitDuration, bp.wait_duration_ms);
+  EXPECT_EQ(res.totalSleepDuration, bp.sleep_duration_ms + sp.sleep_duration_ms);
+  EXPECT_EQ(res.totalKeyCount, 10);
+  EXPECT_EQ(set.size(), 10);
+  EXPECT_GE(res.totalValueSize, 10 * 3000);
 }
 
 }  // anonymous namespace

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -358,3 +358,7 @@ void InternalCommandsHandler::setControlStateManager(
     std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) {
   controlStateManager_ = controlStateManager;
 }
+
+void InternalCommandsHandler::setPerformanceManager(std::shared_ptr<concord::performance::PerformanceManager> perfManager) {
+   perfManager_ = perfManager;
+}

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -359,6 +359,7 @@ void InternalCommandsHandler::setControlStateManager(
   controlStateManager_ = controlStateManager;
 }
 
-void InternalCommandsHandler::setPerformanceManager(std::shared_ptr<concord::performance::PerformanceManager> perfManager) {
-   perfManager_ = perfManager;
+void InternalCommandsHandler::setPerformanceManager(
+    std::shared_ptr<concord::performance::PerformanceManager> perfManager) {
+  perfManager_ = perfManager;
 }

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -57,6 +57,8 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
 
   void setControlStateManager(std::shared_ptr<bftEngine::ControlStateManager> controlStateManager) override;
 
+  void setPerformanceManager(std::shared_ptr<concord::performance::PerformanceManager> perfManager) override;
+
  private:
   bool executeWriteCommand(uint32_t requestSize,
                            const char *request,
@@ -109,4 +111,5 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
   size_t m_getLastBlockCounter = 0;
   std::shared_ptr<bftEngine::ControlStateManager> controlStateManager_;
   std::shared_ptr<InternalControlHandlers> controlHandlers_;
+  std::shared_ptr<concord::performance::PerformanceManager> perfManager_;
 };

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -41,7 +41,8 @@ void run_replica(int argc, char** argv) {
   std::shared_ptr<ReplicaImp> replica = std::make_shared<ReplicaImp>(setup->GetCommunication(),
                                                                      setup->GetReplicaConfig(),
                                                                      setup->GetStorageFactory(),
-                                                                     setup->GetMetricsServer().GetAggregator());
+                                                                     setup->GetMetricsServer().GetAggregator(),
+                                                                     setup->GetPerformanceManager());
 
   auto* blockMetadata = new BlockMetadata(*replica);
 

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -21,6 +21,7 @@
 #include "MetricsServer.hpp"
 #include "config/test_parameters.hpp"
 #include "storage_factory_interface.h"
+#include "PerformanceManager.hpp"
 
 #ifdef USE_S3_OBJECT_STORE
 #include "s3/client.hpp"
@@ -40,6 +41,7 @@ class TestSetup {
   logging::Logger GetLogger() { return logger_; }
   const bool UsePersistentStorage() const { return usePersistentStorage_; }
   std::string getLogPropertiesFile() { return logPropsFile_; }
+  std::shared_ptr<concord::performance::PerformanceManager> GetPerformanceManager() { return pm_; }
 
  private:
   enum class StorageType {
@@ -62,7 +64,8 @@ class TestSetup {
         usePersistentStorage_(usePersistentStorage),
         s3ConfigFile_(s3ConfigFile),
         storageType_(storageType),
-        logPropsFile_(logPropsFile) {}
+        logPropsFile_(logPropsFile),
+        pm_{std::make_shared<concord::performance::PerformanceManager>()} {}
   TestSetup() = delete;
 #ifdef USE_S3_OBJECT_STORE
   concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
@@ -76,6 +79,7 @@ class TestSetup {
   std::string s3ConfigFile_;
   StorageType storageType_;
   std::string logPropsFile_;
+  std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
This PR introduces optional Performance framework component to be used with concord-bft.
Currently only one submodule, the Slowdown, is implemented, which can be used to introduce "synthetic" slowdowns in various modules to evaluate possible performance impact.
The framework is implemented as header files, and is controlled by BUILD_SLOWDOWN build flag. By default, the flag is not set, and al public methods related to slowdown, are implemented as empty functions, which probably will be wiped out by compiler.
The initializition of the slowdown component is assumed to be done by the up level application.