### PR TITLE
Cosmetic changes

### DIFF
--- a/bftengine/include/bftengine/CryptoManager.hpp
+++ b/bftengine/include/bftengine/CryptoManager.hpp
@@ -22,8 +22,8 @@ namespace bftEngine {
 
 class CryptoManager : public IKeyExchanger, public IMultiSigKeyGenerator {
  public:
-  static CryptoManager& instance(const ReplicaConfig* config = nullptr, Cryptosystem* cryptoSys = nullptr) {
-    static CryptoManager cm_(config, cryptoSys);
+  static CryptoManager& instance(Cryptosystem* cryptoSys = nullptr) {
+    static CryptoManager cm_(cryptoSys);
     return cm_;
   }
 
@@ -52,8 +52,10 @@ class CryptoManager : public IKeyExchanger, public IMultiSigKeyGenerator {
   }
 
  private:
-  CryptoManager(const ReplicaConfig* config, Cryptosystem* cryptoSys)
-      : f_{config->fVal}, c_{config->cVal}, numSigners_{config->numReplicas} {
+  CryptoManager(Cryptosystem* cryptoSys)
+      : f_{ReplicaConfig::instance().getfVal()},
+        c_{ReplicaConfig::instance().getcVal()},
+        numSigners_{ReplicaConfig::instance().getnumReplicas()} {
     multiSigCryptoSystem_.reset(cryptoSys);
     init();
   }

--- a/bftengine/src/bftengine/KeyManager.h
+++ b/bftengine/src/bftengine/KeyManager.h
@@ -113,14 +113,14 @@ class KeyManager {
     bool keyExchangeOnStart{false};
   };
 
-  static KeyManager& get(InitData* id = nullptr) {
+  static KeyManager& instance(InitData* id = nullptr) {
     static KeyManager km{id};
     return km;
   }
 
   static void start(InitData* id) {
-    get(id);
-    get().initMetrics(id->a, id->interval);
+    instance(id);
+    instance().initMetrics(id->a, id->interval);
   }
 
  private:

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -165,7 +165,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
 
   if (ReplicaConfig::instance().getkeyExchangeOnStart()) {
     // If Multi sig keys haven't been replaced for all replicas and it's not a key ex msg then don't accept the msg.
-    if (!KeyManager::get().keysExchanged && !(flags & KEY_EXCHANGE_FLAG)) {
+    if (!KeyManager::instance().keysExchanged && !(flags & KEY_EXCHANGE_FLAG)) {
       LOG_INFO(KEY_EX_LOG, "Didn't complete yet, dropping msg");
       delete m;
       return;
@@ -822,7 +822,7 @@ void ReplicaImp::tryToAskForMissingInfo() {
   for (SeqNum i = minSeqNum; i <= lastRelatedSeqNum; i++) {
     if (!recentViewChange) {
       // during exchange we need missing data to be performed in slow path
-      auto exchanging = (!KeyManager::get().keysExchanged && ReplicaConfig::instance().getkeyExchangeOnStart());
+      auto exchanging = (!KeyManager::instance().keysExchanged && ReplicaConfig::instance().getkeyExchangeOnStart());
       tryToSendReqMissingDataMsg(i, exchanging);
     } else {
       if (isCurrentPrimary()) {
@@ -2589,7 +2589,7 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   clientsManager->loadInfoFromReservedPages();
 
   if (ReplicaConfig::instance().getkeyExchangeOnStart()) {
-    KeyManager::get().loadKeysFromReservedPages();
+    KeyManager::instance().loadKeysFromReservedPages();
   }
 
   if (newCheckpointSeqNum > lastStableSeqNum + kWorkWindowSize) {
@@ -3671,7 +3671,7 @@ void ReplicaImp::start() {
   // It must happen after the replica recovers requests in the main thread.
   msgsCommunicator_->startMsgsProcessing(config_.getreplicaId());
   if (ReplicaConfig::instance().getkeyExchangeOnStart()) {
-    KeyManager::get().sendInitialKey();
+    KeyManager::instance().sendInitialKey();
   }
 }
 
@@ -3888,7 +3888,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
       onSeqNumIsSuperStable(lastStableSeqNum);
     }
 
-    KeyManager::get().onCheckpoint(checkpointNum);
+    KeyManager::instance().onCheckpoint(checkpointNum);
   }
 
   if (ps_) ps_->endWriteTran();
@@ -4009,7 +4009,7 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
     if (requestMissingInfo && !ready) {
       LOG_INFO(GL, "Asking for missing information: " << KVLOG(nextExecutedSeqNum, curView, lastStableSeqNum));
       // during exchange we need missing data to be performed in slow path
-      auto exchanging = (!KeyManager::get().keysExchanged && ReplicaConfig::instance().getkeyExchangeOnStart());
+      auto exchanging = (!KeyManager::instance().keysExchanged && ReplicaConfig::instance().getkeyExchangeOnStart());
       tryToSendReqMissingDataMsg(nextExecutedSeqNum, exchanging);
     }
 

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -78,7 +78,7 @@ ReplicaLoader::ErrorCode loadConfig(shared_ptr<PersistentStorage> &p, LoadedRepl
                                              ld.repConfig.numReplicas);
   cryptoSys->loadKeys(ld.repConfig.thresholdPublicKey_, ld.repConfig.thresholdVerificationKeys_);
   cryptoSys->loadPrivateKey(ld.repConfig.replicaId + 1, ld.repConfig.thresholdPrivateKey_);
-  bftEngine::CryptoManager::instance(&ld.repConfig, cryptoSys);
+  bftEngine::CryptoManager::instance(cryptoSys);
 
   return Succ;
 }

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -11,7 +11,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue &requests,
     if (req.flags & KEY_EXCHANGE_FLAG) {
       KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(req.request, req.requestSize);
       LOG_DEBUG(GL, "BFT handler received KEY_EXCHANGE msg " << ke.toString());
-      auto resp = KeyManager::get().onKeyExchange(ke, req.executionSequenceNum);
+      auto resp = KeyManager::instance().onKeyExchange(ke, req.executionSequenceNum);
       if (resp.size() <= req.maxReplySize) {
         std::copy(resp.begin(), resp.end(), req.outReply);
         req.outActualReplySize = resp.size();

--- a/bftengine/tests/messages/helper.cpp
+++ b/bftengine/tests/messages/helper.cpp
@@ -90,7 +90,7 @@ bftEngine::ReplicaConfig& createReplicaConfig() {
   config.publicKeysOfReplicas.insert(IdToKeyPair(2, publicKeyValue3));
   config.publicKeysOfReplicas.insert(IdToKeyPair(3, publicKeyValue4));
 
-  bftEngine::CryptoManager::instance(&config, new TestCryptoSystem);
+  bftEngine::CryptoManager::instance(new TestCryptoSystem);
 
   return config;
 }

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -56,7 +56,7 @@ void TestCommConfig::GetReplicaConfig(uint16_t replica_id,
                                       bftEngine::ReplicaConfig* out_config) {
   std::string key_file_name = keyFilePrefix + std::to_string(replica_id);
   if (Cryptosystem* sys = inputReplicaKeyfileMultisig(key_file_name, *out_config); sys != nullptr)
-    bftEngine::CryptoManager::instance(out_config, sys);
+    bftEngine::CryptoManager::instance(sys);
 }
 
 std::unordered_map<NodeNum, NodeInfo> TestCommConfig::SetUpConfiguredNodes(bool is_replica,


### PR DESCRIPTION
- CryptoManager::instance() - don't receive ReplicaConfig as a parameter since it's a singleton.
- Rename KeyManager::get() -> KeyManager::instance() for consistency.