### PR TITLE
tests for mini batching in preexecution

### DIFF
--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -66,6 +66,10 @@ foreach(STORAGE_TYPE ${STORAGE_TYPES})
           "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_preexecution_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+  add_test(NAME skvbc_batch_preexecution_tests_${STORAGE_TYPE} COMMAND sh -c
+          "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_batch_preexecution_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_batch_preexecution ${TEST_OUTPUT}"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
   add_test(NAME skvbc_network_partitioning_tests_${STORAGE_TYPE} COMMAND sh -c
           "env ${APOLLO_TEST_ENV} STORAGE_TYPE=${STORAGE_TYPE} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_network_partitioning_tests_${STORAGE_TYPE} python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -1,0 +1,255 @@
+# Concord
+#
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os.path
+import unittest
+import trio
+import random
+
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load
+from util.skvbc_history_tracker import verify_linearizability
+from util import skvbc as kvbc
+
+import util.bft_network_partitioning as net
+import util.eliot_logging as log
+
+SKVBC_INIT_GRACE_TIME = 2
+BATCH_SIZE = 4
+NUM_OF_SEQ_WRITES = 25
+NUM_OF_PARALLEL_WRITES = 100
+MAX_CONCURRENCY = 10
+SHORT_REQ_TIMEOUT_MILLI = 3000
+LONG_REQ_TIMEOUT_MILLI = 15000
+
+def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+    The replica is started with a short view change timeout and with RocksDB
+    persistence enabled (-p).
+    Note each arguments is an element in a list.
+    """
+
+    status_timer_milli = "500"
+
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", status_timer_milli,
+            "-v", view_change_timeout_milli,
+            "-p",
+            "-t", os.environ.get('STORAGE_TYPE')
+            ]
+
+def start_replica_cmd_with_vc_timeout(vc_timeout):
+    def wrapper(*args, **kwargs):
+        return start_replica_cmd(*args, **kwargs, view_change_timeout_milli=vc_timeout)
+    return wrapper
+
+
+class SkvbcBatchPreExecutionTest(unittest.TestCase):
+
+    __test__ = False  # so that PyTest ignores this test scenario
+
+    async def send_single_batch_write_with_pre_execution_and_kv(self, skvbc, client, batch_size, long_exec=False):
+        msg_batch = []
+        batch_seq_nums = []
+        for i in range(batch_size):
+            readset = set()
+            writeset = self.writeset(skvbc, 2)
+            msg_batch.append(skvbc.write_req(readset, writeset, 0, long_exec))
+            seq_num = client.req_seq_num.next()
+            batch_seq_nums.append(seq_num)
+        replies = await client.write_batch(msg_batch, batch_seq_nums)
+        for seq_num, reply_msg in replies.items():
+            self.assertTrue(skvbc.parse_reply(reply_msg.get_common_data()).success)
+
+    def writeset(self, skvbc, max_size, keys=None):
+        writeset_keys = skvbc.random_keys(random.randint(0, max_size)) if keys is None else keys
+        writeset_values = skvbc.random_values(len(writeset_keys))
+        return list(zip(writeset_keys, writeset_values))
+
+    @unittest.skip("for future use")
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
+    async def test_sequential_pre_process_requests(self, bft_network, tracker):
+        """
+        Use a random client to launch one batch pre-process request at a time and ensure that created blocks are as expected.
+        """
+        bft_network.start_all_replicas()
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
+
+        for i in range(NUM_OF_SEQ_WRITES):
+            client = bft_network.random_client()
+            await tracker.send_tracked_write_batch(client, 2, BATCH_SIZE)
+
+        await bft_network.assert_successful_pre_executions_count(0, NUM_OF_SEQ_WRITES * BATCH_SIZE)
+
+    @unittest.skip("for future use")
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
+    async def test_concurrent_pre_process_requests(self, bft_network, tracker):
+        """
+        Launch concurrent requests from different clients in parallel. Ensure that created blocks are as expected.
+        """
+        bft_network.start_all_replicas()
+        await trio.sleep(SKVBC_INIT_GRACE_TIME) 
+
+        clients = bft_network.random_clients(MAX_CONCURRENCY)
+        num_of_requests = NUM_OF_PARALLEL_WRITES
+        wr = await tracker.run_concurrent_batch_ops(num_of_requests, BATCH_SIZE)
+        self.assertTrue(wr >= num_of_requests)
+
+        await bft_network.assert_successful_pre_executions_count(0, wr * BATCH_SIZE)
+
+    @unittest.skip("for future use")
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
+    async def test_long_time_executed_pre_process_request(self, bft_network, tracker):
+        """
+        Launch pre-process request with a long-time execution and ensure that created blocks are as expected
+        and no view-change was triggered.
+        """
+        bft_network.start_all_replicas()
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
+
+        client = bft_network.random_client()
+        client.config = client.config._replace(
+            req_timeout_milli=LONG_REQ_TIMEOUT_MILLI,
+            retry_timeout_milli=1000
+        )
+
+        await tracker.send_tracked_write_batch(client, 2, BATCH_SIZE, long_exec=True)
+
+        last_block = await tracker.get_last_block_id(client)
+        self.assertEqual(last_block, BATCH_SIZE)
+
+        await bft_network.assert_successful_pre_executions_count(0, BATCH_SIZE)
+
+        with trio.move_on_after(seconds=1):
+            await tracker.send_indefinite_tracked_ops(write_weight=1)
+
+        initial_primary = 0
+        with trio.move_on_after(seconds=15):
+            while True:
+                await bft_network.wait_for_view(replica_id=initial_primary,
+                                                expected=lambda v: v == initial_primary,
+                                                err_msg="Make sure the view did not change.")
+                await trio.sleep(seconds=5)
+
+    @unittest.skip("for future use")
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_constant_load
+    async def test_long_request_with_constant_load(self, bft_network, skvbc, constant_load):
+        """
+        In this test we make sure a long-running request executes
+        concurrently with a constant system load in the background.
+        """
+        bft_network.start_all_replicas()
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
+
+        client = bft_network.random_client()
+        client.config = client.config._replace(
+            req_timeout_milli=LONG_REQ_TIMEOUT_MILLI,
+            retry_timeout_milli=1000
+        )
+
+        await self.send_single_batch_write_with_pre_execution_and_kv(
+            skvbc, client, BATCH_SIZE, long_exec=True)
+
+        # Wait for some background "constant load" requests to execute
+        await trio.sleep(seconds=5)
+
+        await bft_network.assert_successful_pre_executions_count(0, BATCH_SIZE)
+
+        # Let's just check no view change occurred in the meantime
+        initial_primary = 0
+        await bft_network.wait_for_view(replica_id=initial_primary,
+                                        expected=lambda v: v == initial_primary,
+                                        err_msg="Make sure the view did not change.")
+
+    @unittest.skip("for future use")
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
+    async def test_view_change(self, bft_network, tracker):
+        """
+        Crash the primary replica and verify that the system triggers a view change and moves to a new view.
+        """
+        bft_network.start_all_replicas()
+
+        await trio.sleep(5)
+
+        clients = bft_network.clients.values()
+        client = random.choice(list(clients))
+
+        await tracker.send_tracked_write_batch(client, 2, BATCH_SIZE)
+
+        await bft_network.assert_successful_pre_executions_count(0, BATCH_SIZE)
+
+        initial_primary = 0
+        await bft_network.wait_for_view(replica_id=initial_primary,
+                                        expected=lambda v: v == initial_primary,
+                                        err_msg="Make sure we are in the initial view before crashing the primary.")
+
+        last_block = await tracker.get_last_block_id(client)
+        bft_network.stop_replica(initial_primary)
+
+        try:
+            with trio.move_on_after(seconds=1):
+                await tracker.send_indefinite_tracked_batch_writes(BATCH_SIZE)
+
+        except trio.TooSlowError:
+            pass
+        finally:
+            expected_next_primary = 1
+            await bft_network.wait_for_view(replica_id=random.choice(bft_network.all_replicas(without={0})),
+                                            expected=lambda v: v == expected_next_primary,
+                                            err_msg="Make sure view change has been triggered.")
+            await tracker.send_tracked_write_batch(client, 2, BATCH_SIZE)
+
+    @unittest.skip("for future use")
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
+    async def test_parallel_tx_after_f_nonprimary_crash(self, bft_network, tracker):
+        '''
+        Crash f nonprimary replicas and submit X parallel write submissions.
+        Block processing of the network should be unaffected with f-count interruption.
+        Final block length should match submitted transactions count exactly.
+        '''
+        bft_network.start_all_replicas()
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
+
+        read_client = bft_network.random_client()
+        submit_clients = bft_network.random_clients(MAX_CONCURRENCY)
+        num_of_requests = 10 * len(submit_clients) # each client will send 10 tx
+        nonprimaries = bft_network.all_replicas(without={0}) # primary index is 0
+        crash_targets = random.sample(nonprimaries, bft_network.config.f) # pick random f to crash
+        bft_network.stop_replicas(crash_targets) # crash chosen nonprimary replicas
+
+        wr = await tracker.run_concurrent_batch_ops(num_of_requests, BATCH_SIZE)
+        final_block_count = await tracker.get_last_block_id(read_client)
+        print(f"final_block_count {final_block_count}")
+
+        log.log_message(message_type=f"Randomly picked replica indexes {crash_targets} (nonprimary) to be stopped.")
+        log.log_message(message_type=f"Total of {num_of_requests} write pre-exec tx, "
+              f"concurrently submitted through {len(submit_clients)} clients.")
+        log.log_message(message_type=f"Finished at block {final_block_count}.")
+        self.assertTrue(wr >= num_of_requests)
+
+        await bft_network.assert_successful_pre_executions_count(0, wr * BATCH_SIZE)

--- a/tests/apollo/util/skvbc_history_tracker.py
+++ b/tests/apollo/util/skvbc_history_tracker.py
@@ -848,6 +848,32 @@ class SkvbcTracker:
         msg = kvbc.SimpleKVBCProtocol.get_last_block_req()
         return kvbc.SimpleKVBCProtocol.parse_reply(await client.read(msg))
 
+    async def send_tracked_write_batch(self, client, max_set_size, batch_size, read_version = None, long_exec = False):
+        msg_batch = []
+        batch_seq_nums = []
+        client_id = client.client_id
+        if read_version is None:
+            read_version = self.read_block_id()
+        for i in range(batch_size):
+            max_read_set_size = 0 if self.no_conflicts else max_set_size
+            readset = self.readset(0, max_read_set_size)
+            writeset = self.writeset(max_set_size)
+            msg_batch.append(self.skvbc.write_req(readset, writeset, read_version, long_exec))
+            seq_num = client.req_seq_num.next()
+            batch_seq_nums.append(seq_num)
+            self.send_write(client_id, seq_num, readset, dict(writeset), read_version)
+        
+        with log.start_action(action_type="send_tracked_kv_set_batch"):
+            try:
+                replies = await client.write_batch(msg_batch, batch_seq_nums)
+                self.status.record_client_reply(client_id)
+                for seq_num, reply_msg in replies.items():
+                    reply = self.skvbc.parse_reply(reply_msg.get_common_data())
+                    self.handle_write_reply(client_id, seq_num, reply)
+            except trio.TooSlowError:
+                self.status.record_client_timeout(client_id)
+                return
+
     async def send_tracked_write(self, client, max_set_size, long_exec=False):
         max_read_set_size = 0 if self.no_conflicts else max_set_size
         readset = self.readset(0, max_read_set_size)
@@ -898,6 +924,22 @@ class SkvbcTracker:
         writeset_values = self.skvbc.random_values(len(writeset_keys))
         return list(zip(writeset_keys, writeset_values))
 
+    async def run_concurrent_batch_ops(self, num_ops, batch_size):
+        with log.start_action(action_type="run_concurrent_batch_ops"):
+            max_concurrency = len(self.bft_network.clients) // 2
+            max_size = len(self.skvbc.keys) // 2
+            sent = 0
+            write_count = 0
+            clients = self.bft_network.random_clients(max_concurrency)
+            with log.start_action(action_type="send_concurrent_ops"):
+                while sent < num_ops:
+                    async with trio.open_nursery() as nursery:
+                        for client in clients:
+                            nursery.start_soon(self.send_tracked_write_batch, client, max_size, batch_size)
+                            write_count += 1
+                    sent += len(clients)
+            return write_count
+
     async def run_concurrent_ops(self, num_ops, write_weight=.70):
         with log.start_action(action_type="run_concurrent_ops"):
             max_concurrency = len(self.bft_network.clients) // 2
@@ -938,6 +980,17 @@ class SkvbcTracker:
                             read_count += 1
                 sent += len(clients)
         return read_count, write_count
+
+    async def send_indefinite_tracked_batch_writes(self, batch_size, time_interval=.01):
+        max_size = len(self.skvbc.keys) // 2
+        while True:
+            client = self.bft_network.random_client()
+            async with trio.open_nursery() as nursery:
+                try:
+                    nursery.start_soon(self.send_tracked_write_batch, client, max_size, batch_size)
+                except:
+                    pass
+                await trio.sleep(time_interval)
 
     async def send_indefinite_tracked_ops(self, write_weight=.70, time_interval=.01):
         max_size = len(self.skvbc.keys) // 2

--- a/util/pyclient/replica_specific_info.py
+++ b/util/pyclient/replica_specific_info.py
@@ -34,6 +34,9 @@ class MsgWithReplicaSpecificInfo:
     def get_common_reply(self):
         return self.common_header, self.common_data
 
+    def get_common_data(self):
+        return self.common_data
+
     def get_rsi_data(self):
         return self.rsi_data
 
@@ -50,6 +53,7 @@ class MsgWithReplicaSpecificInfo:
 class RepliesManager:
     def __init__(self):
         self.replies = dict()
+        self.seq_nums = dict()
 
     def add_reply(self, rsi_message):
         """
@@ -59,10 +63,16 @@ class RepliesManager:
         per-replica in a dictionary.
         """
         key = rsi_message.get_matched_reply_key()
+        self.seq_nums[rsi_message.common_header.req_seq_num] = key
         if key not in self.replies.keys():
             self.replies[key] = dict()
-        self.replies[key][rsi_message.get_sender_id()] = rsi_message.get_rsi_data()
+        self.replies[key][rsi_message.get_sender_id()] = rsi_message
         return len(self.replies[key])
+
+    def set_seq_nums(self, seq_nums):
+        self.seq_nums = dict()
+        for s in seq_nums:
+            self.seq_nums[s] = None
 
     def pop(self, matched_reply_key):
         return self.replies.pop(matched_reply_key)
@@ -78,8 +88,28 @@ class RepliesManager:
     def get_rsi_replies(self, matched_reply_key):
         if matched_reply_key not in self.replies.keys():
             return dict()
-        return self.replies[matched_reply_key]
+        rsi_replies = dict()
+        for k,v in self.replies[matched_reply_key].items():
+            rsi_replies[k] = v.get_rsi_data()
+        return rsi_replies
+
+    def get_all_replies(self):
+        replies = dict()
+        for seq_num, key in self.seq_nums.items():
+            replies[seq_num] = next(iter(self.replies[key].values()))
+        return replies
 
     def clear_replies(self):
         self.replies = dict()
 
+    def expects_seq_num(self, seq_num):
+        return seq_num in self.seq_nums.keys()
+
+    def has_quorum_on_all(self, required_replies):
+        has_quorum = True
+        for seq_num, key in self.seq_nums.items():
+            if key is None:
+                has_quorum = False
+            elif self.num_matching_replies(key) < required_replies:
+                has_quorum = False
+        return has_quorum

--- a/util/pyclient/test_msgs.py
+++ b/util/pyclient/test_msgs.py
@@ -71,8 +71,8 @@ class TestRepliesManager(unittest.TestCase):
         self.assertEqual(common_key.header.primary_id, 0)
         self.assertEqual(common_key.header.req_seq_num, 1)
         self.assertEqual(common_key.data, b'hello')
-        self.assertEqual(b'1', rsi_replies[0])
-        self.assertTrue(b'0', rsi_replies[1])
+        self.assertEqual(b'1', rsi_replies[0].get_rsi_data())
+        self.assertTrue(b'0', rsi_replies[1].get_rsi_data())
 
     def test_add_message_with_two_seq_num_to_manager(self):
         replies_manager = rsi.RepliesManager()


### PR DESCRIPTION
Updated the python client to work with batch requests. Updated history tracker to work with batch requests. New tests still disabled until the functionality becomes available.

The batch message consists of one or more regular messages. The replicas respond to each of these as if it was a separate message send on it's own. For this reason in order to determine when the whole batch is done RepliesManager will now expect a list of seq_nums to get a quorum of replies instead of individual messages. It will store full reply messages of these instead of just rsi_data, so after quorum is reached they are available to be returned by the client.