### PR TITLE
Better error logging for S3 client

### DIFF
--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -112,7 +112,7 @@ Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
     _outValue = Sliver::copy(reinterpret_cast<const char*>(cbData.data), cbData.readLength);
     return Status::OK();
   } else {
-    LOG_ERROR(logger_, "get status: " << S3_get_status_name(cbData.status));
+    LOG_ERROR(logger_, "get status: " << S3_get_status_name(cbData.status) << " (" << cbData.errorMessage << ")");
     if (cbData.status == S3Status::S3StatusHttpErrorNotFound || cbData.status == S3Status::S3StatusErrorNoSuchBucket ||
         cbData.status == S3Status::S3StatusErrorNoSuchKey)
       return Status::NotFound("Status: " + std::string(S3_get_status_name(cbData.status)) +
@@ -152,7 +152,7 @@ Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
     metrics_.metrics_component.UpdateAggregator();
     return Status::OK();
   } else {
-    LOG_ERROR(logger_, "put status: " << cbData.status);
+    LOG_ERROR(logger_, "put status: " << S3_get_status_name(cbData.status) << " (" << cbData.errorMessage << ")");
     if (cbData.status == S3Status::S3StatusHttpErrorNotFound || cbData.status == S3Status::S3StatusErrorNoSuchBucket)
       return Status::NotFound("Status: " + to_string(cbData.status) + "msg: " + cbData.errorMessage);
 


### PR DESCRIPTION
Use S3_get_status_name() function to convert the error code of get and
put operation to a meaningful error. Additionally print the errorMessage
for the error code received.

Add additional error message received from s3 library on client error:
When the S3 client encounters an error an error code and optionally an
error message is returned. This patch adds the error message in the logs
for easier debugging.
Additionally put status error code is converted to meaningful string
from the enum (similar to get status).