### PR TITLE
Support put of multiple slices to RocksDB WriteBatch

### DIFF
--- a/storage/include/rocksdb/native_write_batch.h
+++ b/storage/include/rocksdb/native_write_batch.h
@@ -35,6 +35,12 @@ class NativeWriteBatch {
   template <typename KeySpan, typename ValueSpan>
   void put(const KeySpan &key, const ValueSpan &value);
 
+  // Multi-value put used to eliminate excess copying.
+  template <typename KeySpan, size_t N>
+  void put(const std::string &cFamily, const KeySpan &key, const std::array<::rocksdb::Slice, N> &value);
+  template <typename KeySpan, size_t N>
+  void put(const KeySpan &key, const std::array<::rocksdb::Slice, N> &value);
+
   // Deleting a key that doesn't exist is not an error.
   template <typename KeySpan>
   void del(const std::string &cFamily, const KeySpan &key);

--- a/storage/test/native_rocksdb_client_test.cpp
+++ b/storage/test/native_rocksdb_client_test.cpp
@@ -307,6 +307,19 @@ TEST_F(native_rocksdb_test, put_in_batch_in_2_families) {
   }
 }
 
+TEST_F(native_rocksdb_test, put_in_batch_multiple_slice_value) {
+  const auto cf1 = "cf1"s;
+  const auto cf2 = "cf2"s;
+  db->createColumnFamily(cf1);
+  auto batch = db->getBatch();
+  std::array<::rocksdb::Slice, 2> val{detail::toSlice(value1), detail::toSlice(value2)};
+  batch.put(cf1, key1, val);
+  db->write(std::move(batch));
+
+  // We should have written the concatenation of value1 and value2 to key1
+  ASSERT_EQ(value1 + value2, db->get(cf1, key1).value());
+}
+
 TEST_F(native_rocksdb_test, del_non_existent_key_in_batch_is_not_an_error) {
   auto batch = db->getBatch();
   batch.del(key);


### PR DESCRIPTION
RocksDB supports writing multiple slices as a key or value to remove the
need to copy into a single buffer. This is most useful for us when we
want to write large values wrapped in a CMF type. In this case we can
serialize the header and not have to serialize the value at all thus
saving time.