### PR TITLE
Support block deletion in KeyValueBlockchain

### DIFF
--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -97,8 +97,8 @@ class KeyValueBlockchain {
                              const detail::CATEGORY_TYPE type,
                              concord::storage::rocksdb::NativeWriteBatch& write_batch);
 
-  const std::variant<detail::ImmutableKeyValueCategory, detail::BlockMerkleCategory, detail::VersionedKeyValueCategory>&
-  getCategory(const std::string& cat_id) const;
+  const Category& getCategory(const std::string& cat_id) const;
+  Category& getCategory(const std::string& cat_id);
 
   /////////////////////// deletes ///////////////////////
 

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -192,11 +192,12 @@ TEST_F(categorized_kvbc, delete_block) {
     ver_updates.addUpdate("ver_key1", "ver_val1");
     ver_updates.addDelete("ver_deleted");
     updates.add("versioned", std::move(ver_updates));
-    ASSERT_EQ(block_chain.addBlock(std::move(updates)), (BlockId)1);
 
     ImmutableUpdates immutable_updates;
     immutable_updates.addUpdate("immutable_key1", {"immutable_val1", {"1", "2"}});
     updates.add("immutable", std::move(immutable_updates));
+
+    ASSERT_EQ(block_chain.addBlock(std::move(updates)), 1);
   }
   // Can't delete only block
   ASSERT_THROW(block_chain.deleteBlock(1), std::logic_error);


### PR DESCRIPTION
Delegate block deletion calls to the respective category in
KeyValueBlockchain.

Implement KeyValueBlockchain::getCategory() with a single std::map
lookup.

If there are no blocks in the blockchain, throw an exception instead of
silently returning.

Fix genesis and last reachable cache variables handling when the last
remaining block in the blockchain is being deleted as a last reachable
one. In that case, set both to 0 instead of decrementing them.

Add unit tests for above behaviors.