### PR TITLE
Fix genesis and last ID cache in v2Merkle adapter

### DIFF
--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -651,14 +651,15 @@ void DBAdapter::deleteLastReachableBlock() {
 
   deleteKeysForBlock(lastReachableBlockKeyDeletes(lastReachableBlockId_), lastReachableBlockId_);
 
-  // Since we allow deletion of the only block left as last reachable (due to replica state sync), reflect that in the
-  // genesis block ID cache.
+  // Since we allow deletion of the only block left as last reachable (due to replica state sync), set both genesis and
+  // last reachable cache variables to 0. Otherise, only decrement the last reachable block ID cache.
   if (lastReachableBlockId_ == genesisBlockId_) {
-    --genesisBlockId_;
+    genesisBlockId_ = 0;
+    lastReachableBlockId_ = 0;
+  } else {
+    // Decrement the last reachable block ID cache.
+    --lastReachableBlockId_;
   }
-
-  // Decrement the last reachable block ID cache.
-  --lastReachableBlockId_;
 }
 
 void DBAdapter::deleteGenesisBlock() {


### PR DESCRIPTION
Fix genesis and last reachable cache variables handling when the last
remaining block in the blockchain is being deleted as a last reachable
one. In that case, set both to 0 instead of decrementing them.

Add an unit test to verify the behavior.