### PR TITLE
Fix batch requests retry issue

### DIFF
--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -202,7 +202,8 @@ class BftClient(ABC):
         try:
             with trio.fail_after(batch_size * self.config.req_timeout_milli / 1000):
                 self._reset_on_new_request(batch_seq_nums)
-                return await self._send_receive_loop(data, False, m_of_n_quorum, batch_size * self.config.req_timeout_milli / 1000)
+                return await self._send_receive_loop(data, False, m_of_n_quorum, 
+                    batch_size * self.config.retry_timeout_milli / 1000)
         except trio.TooSlowError:
             print(f"TooSlowError thrown from client_id {self.client_id}, for batch msg {cid} {batch_seq_nums}")
             raise trio.TooSlowError


### PR DESCRIPTION
Retry timeout was set to request timeout, so no retry was attempted in time. This breaks the view_change_test in the case where a client expects primary 0 which has been stopped. Also the view_change_test will now always require a retry instead of just when by chance the same client is used as for the first request. Enough time will be spent in send_indefinite_tracked_batch_writes for retries to be sent.