### PR TITLE
Reserved Pages usage

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -43,6 +43,7 @@ class ControlStatePage : public concord::serialize::SerializableFactory<ControlS
 
 static constexpr uint32_t ControlHandlerStateManagerReservedPagesIndex = 1;
 static constexpr uint32_t ControlHandlerStateManagerNumOfReservedPages = 1;
+
 class ControlStateManager : public ResPagesClient<ControlStateManager,
                                                   ControlHandlerStateManagerReservedPagesIndex,
                                                   ControlHandlerStateManagerNumOfReservedPages> {
@@ -57,7 +58,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
 
   void setPruningProcess(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
   bool getPruningProcessStatus() const { return onPruningProcess_; }
-  ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages);
+  ControlStateManager(IReservedPages* reserved_pages);
   ControlStateManager& operator=(const ControlStateManager&) = delete;
   ControlStateManager(const ControlStateManager&) = delete;
   ~ControlStateManager() {}
@@ -66,8 +67,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   void enable() { enabled_ = true; }
 
  private:
-  IStateTransfer* state_transfer_;
-  const uint32_t sizeOfReservedPage_;
+  IReservedPages* reserved_pages_;
   std::string scratchPage_;
   bool enabled_ = true;
   ControlStatePage page_;

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -32,13 +32,13 @@ void ControlStateManager::setStopAtNextCheckpoint(int64_t currentSeqNum) {
   page_.seq_num_to_stop_at_ = seq_num_to_stop_at;
   concord::serialize::Serializable::serialize(outStream, page_);
   auto data = outStream.str();
-  state_transfer_->saveReservedPage(resPageOffset(), data.size(), data.data());
+  reserved_pages_->saveReservedPage(resPageOffset(), data.size(), data.data());
 }
 
 std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
   if (!enabled_) return {};
   if (page_.seq_num_to_stop_at_ != 0) return page_.seq_num_to_stop_at_;
-  if (!state_transfer_->loadReservedPage(resPageOffset(), sizeOfReservedPage_, scratchPage_.data())) {
+  if (!reserved_pages_->loadReservedPage(resPageOffset(), reserved_pages_->sizeOfReservedPage(), scratchPage_.data())) {
     return {};
   }
   std::istringstream inStream;
@@ -52,9 +52,8 @@ std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
   return page_.seq_num_to_stop_at_;
 }
 
-ControlStateManager::ControlStateManager(IStateTransfer* state_transfer, uint32_t sizeOfReservedPages)
-    : state_transfer_{state_transfer}, sizeOfReservedPage_{sizeOfReservedPages} {
-  scratchPage_.resize(sizeOfReservedPage_);
+ControlStateManager::ControlStateManager(IReservedPages* reserved_pages) : reserved_pages_{reserved_pages} {
+  scratchPage_.resize(reserved_pages_->sizeOfReservedPage());
 }
 
 void ControlStateManager::setEraseMetadataFlag(int64_t currentSeqNum) {
@@ -65,13 +64,13 @@ void ControlStateManager::setEraseMetadataFlag(int64_t currentSeqNum) {
   page_.erase_metadata_at_seq_num_ = seq_num_to_erase_at;
   concord::serialize::Serializable::serialize(outStream, page_);
   auto data = outStream.str();
-  state_transfer_->saveReservedPage(resPageOffset(), data.size(), data.data());
+  reserved_pages_->saveReservedPage(resPageOffset(), data.size(), data.data());
 }
 
 std::optional<int64_t> ControlStateManager::getEraseMetadataFlag() {
   if (!enabled_) return {};
   if (page_.erase_metadata_at_seq_num_ != 0) return page_.erase_metadata_at_seq_num_;
-  if (!state_transfer_->loadReservedPage(resPageOffset(), sizeOfReservedPage_, scratchPage_.data())) {
+  if (!reserved_pages_->loadReservedPage(resPageOffset(), reserved_pages_->sizeOfReservedPage(), scratchPage_.data())) {
     return {};
   }
   std::istringstream inStream;
@@ -90,7 +89,7 @@ void ControlStateManager::clearCheckpointToStopAt() {
   std::ostringstream outStream;
   concord::serialize::Serializable::serialize(outStream, tmpPage);
   auto data = outStream.str();
-  state_transfer_->saveReservedPage(resPageOffset(), data.size(), data.data());
+  reserved_pages_->saveReservedPage(resPageOffset(), data.size(), data.data());
 }
 
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -23,7 +23,7 @@ KeyManager::KeyManager(InitData* id)
     : repID_(id->id),
       clusterSize_(id->clusterSize),
       client_(id->cl),
-      keyStore_{id->clusterSize, *id->reservedPages, id->sizeOfReservedPage},
+      keyStore_{id->clusterSize, id->reservedPages, id->sizeOfReservedPage},
       multiSigKeyHdlr_(id->kg),
       keysView_(id->sec, id->backupSec, id->clusterSize),
       keyExchangeOnStart_(id->keyExchangeOnStart),

--- a/bftengine/src/bftengine/KeyStore.h
+++ b/bftengine/src/bftengine/KeyStore.h
@@ -64,7 +64,7 @@ class ReplicaKeyStore : public concord::serialize::SerializableFactory<ReplicaKe
 // Responsible on reserved pages operations.
 class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, 2> {
  public:
-  ClusterKeyStore(const uint32_t& clusterSize, IReservedPages& reservedPages, const uint32_t& sizeOfReservedPage);
+  ClusterKeyStore(const uint32_t& clusterSize, IReservedPages* reservedPages, const uint32_t& sizeOfReservedPage);
   bool push(const KeyExchangeMsg& kem, const uint64_t& sn);
   // iterate on all replcias
   std::vector<uint16_t> rotate(const uint64_t& chknum);
@@ -81,7 +81,7 @@ class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, 2> {
 
  private:
   std::vector<ReplicaKeyStore> clusterKeys_;
-  IReservedPages& reservedPages_;
+  IReservedPages* reservedPages_;
   std::string buffer_;
 };
 }  // namespace bftEngine::impl

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -262,7 +262,7 @@ TEST(ReplicaKeyStore, rotate) {
 
 TEST(ClusterKeyStore, push) {
   ReservedPagesMock rpm(7, true);
-  ClusterKeyStore cks{7, rpm, 4094};
+  ClusterKeyStore cks{7, &rpm, 4094};
   {
     KeyExchangeMsg kem;
     kem.key = "a";
@@ -305,7 +305,7 @@ TEST(ClusterKeyStore, push) {
 
 TEST(ClusterKeyStore, rotate) {
   ReservedPagesMock rpm(7, true);
-  ClusterKeyStore cks{7, rpm, 4094};
+  ClusterKeyStore cks{7, &rpm, 4094};
 
   KeyExchangeMsg kem;
   kem.key = "a";
@@ -553,7 +553,7 @@ TEST(KeyManager, endToEnd) {
 
 TEST(ClusterKeyStore, dirty_first_load) {
   ReservedPagesMock rpm(4, false);
-  ClusterKeyStore cks{4, rpm, 4094};
+  ClusterKeyStore cks{4, &rpm, 4094};
 
   for (int i = 0; i < 4; i++) {
     ASSERT_EQ(cks.numKeys(i), 0);
@@ -562,7 +562,7 @@ TEST(ClusterKeyStore, dirty_first_load) {
 
 TEST(ClusterKeyStore, dirty_first_load_save_keys_and_reload) {
   ReservedPagesMock rpm(4, false);
-  ClusterKeyStore cks{4, rpm, 4094};
+  ClusterKeyStore cks{4, &rpm, 4094};
 
   KeyExchangeMsg kem;
   kem.key = "a";
@@ -594,7 +594,7 @@ TEST(ClusterKeyStore, dirty_first_load_save_keys_and_reload) {
   kem5.repID = 0;
   cks.push(kem5, 2);
 
-  ClusterKeyStore reloadCks{4, rpm, 4094};
+  ClusterKeyStore reloadCks{4, &rpm, 4094};
   for (int i = 0; i < 4; i++) {
     if (i == 0) {
       ASSERT_EQ(reloadCks.numKeys(i), 2);
@@ -606,7 +606,7 @@ TEST(ClusterKeyStore, dirty_first_load_save_keys_and_reload) {
 
 TEST(ClusterKeyStore, clean_first_load_save_keys_rotate_and_reload) {
   ReservedPagesMock rpm(4, false);
-  ClusterKeyStore cks{4, rpm, 4094};
+  ClusterKeyStore cks{4, &rpm, 4094};
 
   KeyExchangeMsg kem;
   kem.key = "a";
@@ -646,7 +646,7 @@ TEST(ClusterKeyStore, clean_first_load_save_keys_rotate_and_reload) {
 
   cks.rotate(2);
 
-  ClusterKeyStore reloadCks{4, rpm, 4094};
+  ClusterKeyStore reloadCks{4, &rpm, 4094};
   ASSERT_EQ(reloadCks.exchangedReplicas.size(), 4);
   for (int i = 0; i < 4; i++) {
     if (i == 0) {

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -253,8 +253,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
 
-  controlStateManager_ =
-      std::make_shared<bftEngine::ControlStateManager>(m_stateTransfer, replicaConfig_.getsizeOfReservedPage());
+  controlStateManager_ = std::make_shared<bftEngine::ControlStateManager>(m_stateTransfer);
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -181,7 +181,7 @@ class SimpleTestReplica {
 
   void start() {
     replica->start();
-    control_state_manager_ = std::make_shared<ControlStateManager>(inMemoryST_, inMemoryST_->numberOfReservedPages());
+    control_state_manager_ = std::make_shared<ControlStateManager>(inMemoryST_);
     control_state_manager_->disable();
     replica->setControlStateManager(control_state_manager_);
   }


### PR DESCRIPTION
- ControlStateManager to work with IReservedPages* interface, instead of IStateTransfer*.
- KeyStore use IReservedPages* instead of IReservedPages& for uniformity and ability to seamlessly replace it by a shared_ptr.