### PR TITLE
Destroy the blockchain when no blocks are left

### DIFF
--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -81,6 +81,9 @@ class BlockMerkleCategory {
   uint64_t getLatestTreeVersion() const;
   uint64_t getLastDeletedTreeVersion() const;
 
+  // Destroy the category by dropping all column families and the data inside.
+  static void destroy(std::shared_ptr<storage::rocksdb::NativeClient>& db);
+
  private:
   void multiGet(const std::vector<Buffer>& versioned_keys,
                 const std::vector<BlockId>& versions,

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -91,6 +91,9 @@ class ImmutableKeyValueCategory {
                                         const std::string &key,
                                         const ImmutableOutput &updates_info) const;
 
+  // Destroy the category by dropping all column families and the data inside.
+  static void destroy(std::shared_ptr<storage::rocksdb::NativeClient> &db, const std::string &category_id);
+
  private:
   std::string cf_;
   std::shared_ptr<storage::rocksdb::NativeClient> db_;

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -41,6 +41,9 @@ class KeyValueBlockchain {
   bool deleteBlock(const BlockId& blockId);
   void deleteLastReachableBlock();
 
+  // Used for testing only.
+  void deleteLastReachableBlockImpl(bool throw_on_destroy_failure);
+
   /////////////////////// Raw Blocks ///////////////////////
 
   // Adds raw block and tries to link the state transfer blockchain to the main blockchain
@@ -152,6 +155,16 @@ class KeyValueBlockchain {
                                         const std::string& category_id,
                                         ImmutableInput&& updates,
                                         concord::storage::rocksdb::NativeWriteBatch& write_batch);
+
+  ///////////////////// Destruction /////////////////////
+  // Destroy all data in the blockchain.
+
+  // Called when all blocks have been deleted as last reachable (during replica state sync). Calls std::terminate() on
+  // failure.
+  void destroy() noexcept;
+
+  // Implementation of destroy() that throws instead of terminating. Used for testing only.
+  void destroyThrow();
 
   /////////////////////// Members ///////////////////////
 

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -85,6 +85,9 @@ class VersionedKeyValueCategory {
   // Return std::nullopt if the key doesn't exist.
   std::optional<KeyValueProof> getProof(BlockId block_id, const std::string &key, const VersionedOutput &) const;
 
+  // Destroy the category by dropping all column families and the data inside.
+  static void destroy(std::shared_ptr<storage::rocksdb::NativeClient> &db, const std::string &category_id);
+
  private:
   void addDeletes(BlockId, std::vector<std::string> &&keys, VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
 

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -543,6 +543,16 @@ uint64_t BlockMerkleCategory::getLastDeletedTreeVersion() const {
   return last_deleted;
 }
 
+void BlockMerkleCategory::destroy(std::shared_ptr<storage::rocksdb::NativeClient>& db) {
+  db->dropColumnFamily(BLOCK_MERKLE_INTERNAL_NODES_CF);
+  db->dropColumnFamily(BLOCK_MERKLE_LEAF_NODES_CF);
+  db->dropColumnFamily(BLOCK_MERKLE_LATEST_KEY_VERSION_CF);
+  db->dropColumnFamily(BLOCK_MERKLE_KEYS_CF);
+  db->dropColumnFamily(BLOCK_MERKLE_STALE_CF);
+  db->dropColumnFamily(BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF);
+  db->dropColumnFamily(BLOCK_MERKLE_PRUNED_BLOCKS_CF);
+}
+
 void BlockMerkleCategory::deleteStaleBatch(uint64_t start, uint64_t end) {
   auto keys = std::vector<Buffer>{};
   keys.reserve(end - start);

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -279,4 +279,9 @@ std::optional<KeyValueProof> ImmutableKeyValueCategory::getProof(const std::stri
   return proof;
 }
 
+void ImmutableKeyValueCategory::destroy(std::shared_ptr<storage::rocksdb::NativeClient> &db,
+                                        const std::string &category_id) {
+  db->dropColumnFamily(category_id + IMMUTABLE_KV_CF_SUFFIX);
+}
+
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -414,4 +414,11 @@ std::optional<KeyValueProof> VersionedKeyValueCategory::getProof(BlockId block_i
   return proof;
 }
 
+void VersionedKeyValueCategory::destroy(std::shared_ptr<storage::rocksdb::NativeClient> &db,
+                                        const std::string &category_id) {
+  db->dropColumnFamily(category_id + VERSIONED_KV_VALUES_CF_SUFFIX);
+  db->dropColumnFamily(category_id + VERSIONED_KV_LATEST_VER_CF_SUFFIX);
+  db->dropColumnFamily(category_id + VERSIONED_KV_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF_SUFFIX);
+}
+
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/test/categorization/block_merkle_category_unit_test.cpp
+++ b/kvbc/test/categorization/block_merkle_category_unit_test.cpp
@@ -466,6 +466,35 @@ TEST_F(block_merkle_category, prune_many_nodes) {
   ASSERT_FALSE(cat.getLatestVersion(key1));
 }
 
+TEST_F(block_merkle_category, destroy) {
+  // Before.
+  {
+    const auto from_db_before = NativeClient::columnFamilies(db->path());
+    const auto from_client_before = db->columnFamilies();
+    ASSERT_EQ(from_db_before, from_client_before);
+    ASSERT_THAT(from_db_before,
+                ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(),
+                                                            BLOCK_MERKLE_INTERNAL_NODES_CF,
+                                                            BLOCK_MERKLE_LEAF_NODES_CF,
+                                                            BLOCK_MERKLE_LATEST_KEY_VERSION_CF,
+                                                            BLOCK_MERKLE_KEYS_CF,
+                                                            BLOCK_MERKLE_STALE_CF,
+                                                            BLOCK_MERKLE_ACTIVE_KEYS_FROM_PRUNED_BLOCKS_CF,
+                                                            BLOCK_MERKLE_PRUNED_BLOCKS_CF}));
+  }
+
+  // Destroy.
+  BlockMerkleCategory::destroy(db);
+
+  // After.
+  {
+    const auto from_db_after = NativeClient::columnFamilies(db->path());
+    const auto from_client_after = db->columnFamilies();
+    ASSERT_EQ(from_db_after, from_client_after);
+    ASSERT_THAT(from_db_after, ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily()}));
+  }
+}
+
 }  // namespace
 
 int main(int argc, char *argv[]) {

--- a/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
@@ -688,6 +688,27 @@ TEST_F(immutable_kv_category, multi_get) {
   ASSERT_EQ(values, expected);
 }
 
+TEST_F(immutable_kv_category, destroy) {
+  // Before.
+  {
+    const auto from_db_before = NativeClient::columnFamilies(db->path());
+    const auto from_client_before = db->columnFamilies();
+    ASSERT_EQ(from_db_before, from_client_before);
+    ASSERT_THAT(from_db_before, ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(), column_family}));
+  }
+
+  // Destroy.
+  ImmutableKeyValueCategory::destroy(db, category_id);
+
+  // After.
+  {
+    const auto from_db_after = NativeClient::columnFamilies(db->path());
+    const auto from_client_after = db->columnFamilies();
+    ASSERT_EQ(from_db_after, from_client_after);
+    ASSERT_THAT(from_db_after, ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily()}));
+  }
+}
+
 }  // namespace
 
 int main(int argc, char *argv[]) {

--- a/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
@@ -957,6 +957,29 @@ TEST_F(versioned_kv_category, delete_last_reachable_with_deletes) {
   }
 }
 
+TEST_F(versioned_kv_category, destroy) {
+  // Before.
+  {
+    const auto from_db_before = NativeClient::columnFamilies(db->path());
+    const auto from_client_before = db->columnFamilies();
+    ASSERT_EQ(from_db_before, from_client_before);
+    ASSERT_THAT(
+        from_db_before,
+        ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily(), values_cf, latest_ver_cf, active_cf_}));
+  }
+
+  // Destroy.
+  VersionedKeyValueCategory::destroy(db, category_id);
+
+  // After.
+  {
+    const auto from_db_after = NativeClient::columnFamilies(db->path());
+    const auto from_client_after = db->columnFamilies();
+    ASSERT_EQ(from_db_after, from_client_after);
+    ASSERT_THAT(from_db_after, ContainerEq(std::unordered_set<std::string>{db->defaultColumnFamily()}));
+  }
+}
+
 }  // namespace
 
 int main(int argc, char *argv[]) {

--- a/storage/include/storage/db_types.h
+++ b/storage/include/storage/db_types.h
@@ -14,8 +14,13 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace concord::storage {
+
+// Do not use BLOCKCHAIN_DESTRUCTION_INITIATED's value for any other key types in the default column family.
+const auto BLOCKCHAIN_DESTRUCTION_INITIATED = std::uint8_t{127};
+const auto BLOCKCHAIN_DESTRUCTION_INITIATED_KEY = std::string{{BLOCKCHAIN_DESTRUCTION_INITIATED}};
 
 // DB key types are an implementation detail. External users should not rely on it.
 namespace v1DirectKeyValue::detail {


### PR DESCRIPTION
Destroy the blockchain by dropping all category-related column families
and re-creating KeyValueBlockchain-related ones (effectively deleting
all data inside) when one block is left and it is deleted as a last
reachable one. This is a scenario that can happen during replica state
sync.

A note on above is that active keys from pruned blocks will also be
deleted, meaning that all data in the blockchain is destroyed.

Rationale for above behaviors is that we cannot allow any data leftovers
in case we have deleted all blocks in the blockchain as last reachable
(during replica state sync). Moreover, there might be active keys from
pruned blocks and since the blockchain will start again from block 1,
we don't want any keys at the same block IDs from the previous
blockchain in the new one.

Introduce a special BLOCKCHAIN_DESTRUCTION_INITIATED_KEY key in the
default column family that is used as a flag to denote a destruction
operation has started. Remove the key once done. That is useful if there
is an error during destruction itself - we want to continue the process
on the next startup. Additionally, we never drop the default column
family.

Related to above, provide two modes for handling failures during
destroy:
 * call std::terminate() - used for production
 * throw an exception - used for testing only, due to the fact that
   GTest's ASSERT_DEATH is implemented via fork() and that has
   implications on RocksDB that prevent us from using the
   std::terminate() version (DB updates in the child process are not
   seen in the parent)

Add unit tests to verify the behavior.