### PR TITLE
Implement deleteLastReachable for the BlockMerkleCategory

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -129,13 +129,25 @@ Msg Deleted 4005 {
     bool value
 }
 
-Msg ImmutableDbValue 4006 {
+# Used for efficiently *writing* a DbValue to RocksDB
+# Values may be large and we want avoid having to copy the string into a vector during serialization.
+# If we just serialize the header we can pass both as slices to RocksDB to prevent an extra copy.
+# On reads we retrieve a DbValue.
+#
+# This takes advantage of the fact that CMF serializes string size as a uint32. If that ever
+# changes we must change this as well.
+Msg DbValueHeader 4006 {
+    bool deleted
+    uint32 value_size
+}
+
+Msg ImmutableDbValue 4007 {
     uint64 block_id
     string data
 }
 
 # Used to deserialize the version only from an ImmutableDbValue.
-Msg ImmutableDbVersion 4007 {
+Msg ImmutableDbVersion 4008 {
     uint64 block_id
 }
 

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -277,10 +277,10 @@ void KeyValueBlockchain::deleteGenesisBlock() {
   block_chain_.setGenesisBlockId(genesis_id + 1);
 }
 
-// 1 - Get last id block form DB.
-// 2 - iterate over the update_info and calls the corresponding deleteLastReachableBlock
-// 3 - perform the delete
-// 4 - increment the genesis block id.
+// 1 - Get last id block from DB.
+// 2 - Iterate over the update_info and calls the corresponding deleteLastReachableBlock
+// 3 - Perform the delete
+// 4 - Increment the genesis block id.
 void KeyValueBlockchain::deleteLastReachableBlock() {
   auto last_id = block_chain_.getLastReachableBlockId();
   if (last_id == 0) return;
@@ -296,7 +296,7 @@ void KeyValueBlockchain::deleteLastReachableBlock() {
   block_chain_.deleteBlock(last_id, write_batch);
 
   // Iterate over groups and call corresponding deleteGenesisBlock,
-  // Each group is responsible to fill its deltetes to the batch
+  // Each group is responsible to put its deletes into the batch
   for (auto&& [category_id, update_info] : block.value().data.categories_updates_info) {
     std::visit(
         [&last_id, category_id = category_id, &write_batch, this](const auto& update_info) {

--- a/storage/include/rocksdb/native_write_batch.ipp
+++ b/storage/include/rocksdb/native_write_batch.ipp
@@ -13,8 +13,9 @@
 
 #pragma once
 
-#include "details.h"
 #ifdef USE_ROCKSDB
+
+#include "details.h"
 
 namespace concord::storage::rocksdb {
 


### PR DESCRIPTION
This is required for sync between concord-bft metadata and the
application data in the `BlockMerkleCategory` on startup after a crash.

All tree nodes and stale indexes are removed for the block being
removed. Additionally all keys and version indexes are removed. The code
to do this latter part is based on code for the
`VersionedKeyValueCategory` by @dartdart26.

One important thing to keep in mind is around writing `DbValue` CMF
data. We write it as a `DbValueHeader` and the raw value passed in by
the caller as two separate slices, rather than forcing an extra copy
during serialization. We can do this using the RocksDB API enhancements
added in #1166. When we read out the value it comes back as one
serialized `DbValue`.

I also added fixes for the review comments made in #1143 and cleaned up
some comments.