### PR TITLE
Disallow deleting the only block as last reachable

### DIFF
--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -14,6 +14,8 @@
 #include "categorization/kv_blockchain.h"
 #include "bcstatetransfer/SimpleBCStateTransfer.hpp"
 
+#include <stdexcept>
+
 namespace concord::kvbc::categorization {
 
 using ::bftEngine::bcst::computeBlockDigest;
@@ -292,8 +294,10 @@ void KeyValueBlockchain::deleteGenesisBlock() {
 // 4 - increment the genesis block id.
 void KeyValueBlockchain::deleteLastReachableBlock() {
   const auto last_id = block_chain_.getLastReachableBlockId();
-  if (last_id == 0) {
-    throw std::runtime_error{"Blockchain empty, cannot delete last reachable block"};
+  if (last_id == detail::Blockchain::INVALID_BLOCK_ID) {
+    throw std::logic_error{"Blockchain empty, cannot delete last reachable block"};
+  } else if (last_id == block_chain_.getGenesisBlockId()) {
+    throw std::logic_error{"Cannot delete only block as a last reachable one"};
   }
 
   auto write_batch = native_client_->getBatch();

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -308,18 +308,23 @@ TEST_F(categorized_kvbc, delete_block) {
     ASSERT_THROW(block_chain.deleteBlock(2), std::logic_error);
   }
 
-  // call delete last block directly
-  block_chain.deleteLastReachableBlock();
-  ASSERT_EQ(block_chain.getLastReachableBlockId(), 0);
-  ASSERT_EQ(block_chain.getGenesisBlockId(), 0);
+  // Cannot delete the only block as last reachable.
+  ASSERT_THROW(block_chain.deleteLastReachableBlock(), std::logic_error);
 
-  ASSERT_FALSE(block_chain.getLatestVersion("versioned", "ver_key2"));
-  ASSERT_FALSE(block_chain.getLatest("versioned", "ver_key2"));
-  ASSERT_FALSE(block_chain.get("versioned", "ver_key2", 2));
+  ASSERT_EQ(block_chain.getLastReachableBlockId(), 2);
+  ASSERT_EQ(block_chain.getGenesisBlockId(), 2);
 
-  ASSERT_FALSE(block_chain.getLatestVersion("immutable", "immutable_key2"));
-  ASSERT_FALSE(block_chain.getLatest("immutable", "immutable_key2"));
-  ASSERT_FALSE(block_chain.get("immutable", "immutable_key2", 2));
+  ASSERT_TRUE(block_chain.getLatestVersion("merkle", "merkle_key2"));
+  ASSERT_TRUE(block_chain.getLatest("merkle", "merkle_key2"));
+  ASSERT_TRUE(block_chain.get("merkle", "merkle_key2", 2));
+
+  ASSERT_TRUE(block_chain.getLatestVersion("versioned", "ver_key2"));
+  ASSERT_TRUE(block_chain.getLatest("versioned", "ver_key2"));
+  ASSERT_TRUE(block_chain.get("versioned", "ver_key2", 2));
+
+  ASSERT_TRUE(block_chain.getLatestVersion("immutable", "immutable_key2"));
+  ASSERT_TRUE(block_chain.getLatest("immutable", "immutable_key2"));
+  ASSERT_TRUE(block_chain.get("immutable", "immutable_key2", 2));
 
   // Block 1 has been deleted as genesis, expect its versioned and merkle data to still be there. Immutable data should
   // be deleted.
@@ -358,9 +363,6 @@ TEST_F(categorized_kvbc, delete_block) {
     ASSERT_FALSE(block_chain.getLatest("immutable", "immutable_key1"));
     ASSERT_FALSE(block_chain.get("immutable", "immutable_key1", 1));
   }
-
-  // Block chain is empty
-  ASSERT_THROW(block_chain.deleteLastReachableBlock(), std::runtime_error);
 }
 
 TEST_F(categorized_kvbc, get_last_and_genesis_block) {


### PR DESCRIPTION
If we allow deletion of the only block as last reachable during replica
state sync, the replica will try to fetch all blocks from 1 to N, but
will always fail if some have been pruned (since we start pruning from
block 1).

The behavior in this PR assumes:
 * the last executed sequence number in the blockchain and the BFT
   metadata last executed sequence number differ by at most 1
 * when pruning, we will always leave at least 2 blocks in the
   blockchain

A corner case is if replica state sync needs to run when only one block
has been added. Will be handled in a separate commit or ignored as
an unlikely single startup event.

A final note is that deleting the only block as genesis (during pruning)
is also not allowed.

This PR is not compatible with https://github.com/vmware/concord-bft/pull/1172 - need to pick one of the two
or devise another strategy.