### PR TITLE
Add multi-send method to TLS layer to avoid excess copies in bft client

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -11,6 +11,9 @@ jobs:
                 - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
             ci_build_type:
                 - "-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle"
+            comm_type:
+                - "-DBUILD_COMM_TCP_PLAIN=FALSE -DBUILD_COMM_TCP_TLS=FALSE" #udp
+                - "-DBUILD_COMM_TCP_PLAIN=FALSE -DBUILD_COMM_TCP_TLS=TRUE" #tls
     steps:
         - name: Checkout
           uses: actions/checkout@v2
@@ -23,8 +26,7 @@ jobs:
                             CONCORD_BFT_CMAKE_FLAGS=\"\
                             ${{ matrix.ci_build_type }} \
                             -DBUILD_TESTING=ON \
-                            -DBUILD_COMM_TCP_PLAIN=FALSE \
-                            -DBUILD_COMM_TCP_TLS=FALSE \
+                            ${{ matrix.comm_type }} \
                             -DCMAKE_CXX_FLAGS_RELEASE=-O3 -g \
                             -DUSE_LOG4CPP=TRUE \
                             -DBUILD_ROCKSDB_STORAGE=TRUE \

--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -71,9 +71,6 @@ class Client {
   // Return a Reply on quorum, or std::nullopt on timeout.
   std::optional<Reply> wait();
 
-  // Send a Msg to all destinations in the configured quorum.
-  void sendToGroup(const MatchConfig& config, const Msg& msg);
-
   // Extract a matcher configurations from operational configurations
   //
   // Throws BftClientException on error.

--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -113,12 +113,12 @@ class FakeCommunication : public bft::communication::ICommunication {
   bool isRunning() const override { return true; }
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override { return ConnectionStatus{}; }
 
-  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t>&& msg) override {
+  int send(NodeNum destNode, std::vector<uint8_t>&& msg) override {
     runner_.send(MsgFromClient{ReplicaId{(uint16_t)destNode}, std::move(msg)});
     return 0;
   }
 
-  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
     for (auto& d : dests) {
       // This is a class used for unit testing, so a copy is passed for simplicity
       runner_.send(MsgFromClient{ReplicaId{(uint16_t)d}, msg});  // a copy is made here!

--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -113,9 +113,17 @@ class FakeCommunication : public bft::communication::ICommunication {
   bool isRunning() const override { return true; }
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override { return ConnectionStatus{}; }
 
-  int sendAsyncMessage(NodeNum dest, const char* const msg, size_t len) override {
-    runner_.send(MsgFromClient{ReplicaId{(uint16_t)dest}, Msg(msg, msg + len)});
+  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t>&& msg) override {
+    runner_.send(MsgFromClient{ReplicaId{(uint16_t)destNode}, std::move(msg)});
     return 0;
+  }
+
+  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
+    for (auto& d : dests) {
+      // This is a class used for unit testing, so a copy is passed for simplicity
+      runner_.send(MsgFromClient{ReplicaId{(uint16_t)d}, msg});  // a copy is made here!
+    }
+    return std::set<NodeNum>();
   }
 
   void setReceiver(NodeNum id, IReceiver* receiver) override { receiver_ = receiver; }

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -87,13 +87,13 @@ Reply Client::send(const MatchConfig& match_config,
   while (std::chrono::steady_clock::now() < end) {
     bft::client::Msg msg(orig_msg);  // create copy here due to the loop
     if (primary_ && !read_only) {
-      communication_->sendAsyncMessage(primary_.value().val, std::move(msg));
+      communication_->send(primary_.value().val, std::move(msg));
     } else {
       std::set<bft::communication::NodeNum> dests;
       for (const auto& d : match_config.quorum.destinations) {
         dests.emplace(d.val);
       }
-      communication_->multiSendMessage(dests, std::move(msg));
+      communication_->send(dests, std::move(msg));
     }
 
     if (auto reply = wait()) {

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -50,7 +50,7 @@ void MsgsCommunicator::stopMsgsProcessing() {
 }
 
 int MsgsCommunicator::sendAsyncMessage(NodeNum destNode, char* message, size_t messageLength) {
-  return communication_->sendAsyncMessage(destNode, message, messageLength);
+  return communication_->sendAsyncMessage(destNode, std::vector<uint8_t>(message, message + messageLength));
 }
 
 uint32_t MsgsCommunicator::numOfConnectedReplicas(uint32_t clusterSize) {

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -50,7 +50,7 @@ void MsgsCommunicator::stopMsgsProcessing() {
 }
 
 int MsgsCommunicator::sendAsyncMessage(NodeNum destNode, char* message, size_t messageLength) {
-  return communication_->sendAsyncMessage(destNode, std::vector<uint8_t>(message, message + messageLength));
+  return communication_->send(destNode, std::vector<uint8_t>(message, message + messageLength));
 }
 
 uint32_t MsgsCommunicator::numOfConnectedReplicas(uint32_t clusterSize) {

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -442,10 +442,10 @@ void SimpleClientImp::sendPendingRequest() {
 
   std::vector<uint8_t> msg(pendingRequest_->body(), pendingRequest_->body() + pendingRequest_->size());
   if (sendToAll) {
-    communication_->multiSendMessage(std::set<NodeNum>(replicas_.begin(), replicas_.end()), std::move(msg));
+    communication_->send(std::set<NodeNum>(replicas_.begin(), replicas_.end()), std::move(msg));
   } else {
     pm_->Delay<concord::performance::SlowdownPhase::BftClientBeforeSendPrimary>();
-    communication_->sendAsyncMessage(knownPrimaryReplica_, std::move(msg));
+    communication_->send(knownPrimaryReplica_, std::move(msg));
     // TODO(GG): handle errors (print and/or ....)
   }
 }

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -440,15 +440,12 @@ void SimpleClientImp::sendPendingRequest() {
     // TODO(GG): print ....
   }
 
+  std::vector<uint8_t> msg(pendingRequest_->body(), pendingRequest_->body() + pendingRequest_->size());
   if (sendToAll) {
-    for (uint16_t r : replicas_) {
-      // int stat =
-      communication_->sendAsyncMessage(r, pendingRequest_->body(), pendingRequest_->size());
-      // TODO(GG): handle errors (print and/or ....)
-    }
+    communication_->multiSendMessage(std::set<NodeNum>(replicas_.begin(), replicas_.end()), std::move(msg));
   } else {
     pm_->Delay<concord::performance::SlowdownPhase::BftClientBeforeSendPrimary>();
-    communication_->sendAsyncMessage(knownPrimaryReplica_, pendingRequest_->body(), pendingRequest_->size());
+    communication_->sendAsyncMessage(knownPrimaryReplica_, std::move(msg));
     // TODO(GG): handle errors (print and/or ....)
   }
 }

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -135,8 +135,8 @@ class PlainUDPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) override;
-  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
+  int send(NodeNum destNode, std::vector<uint8_t> &&msg) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
@@ -161,8 +161,8 @@ class PlainTCPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) override;
-  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
+  int send(NodeNum destNode, std::vector<uint8_t> &&msg) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
@@ -185,8 +185,8 @@ class TlsTCPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) override;
-  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
+  int send(NodeNum destNode, std::vector<uint8_t> &&msg) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -135,7 +135,8 @@ class PlainUDPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) override;
+  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) override;
+  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
@@ -160,7 +161,8 @@ class PlainTCPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) override;
+  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) override;
+  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
@@ -183,7 +185,8 @@ class TlsTCPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) override;
+  int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) override;
+  std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -13,6 +13,8 @@
 #pragma once
 
 #include <cstdint>
+#include <set>
+#include <vector>
 
 namespace bft::communication {
 
@@ -25,7 +27,7 @@ class IReceiver {
   // Invoked when a new message is received
   // Notice that the memory pointed by message may be freed immediately
   // after the execution of this method.
-  virtual void onNewMessage(NodeNum sourceNode, const char *const message, size_t messageLength) = 0;
+  virtual void onNewMessage(NodeNum sourceNode, const char* const message, size_t messageLength) = 0;
 
   // Invoked when the known status of a connection is changed.
   // For each NodeNum, this method will never be concurrently
@@ -53,9 +55,11 @@ class ICommunication {
   // Sends a message on the underlying communication layer to a given
   // destination node. Asynchronous (non-blocking) method.
   // Returns 0 on success.
-  virtual int sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) = 0;
+  virtual int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t>&& msg) = 0;
 
-  virtual void setReceiver(NodeNum receiverNum, IReceiver *receiver) = 0;
+  virtual std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t>&& msg) = 0;
+
+  virtual void setReceiver(NodeNum receiverNum, IReceiver* receiver) = 0;
 
   virtual ~ICommunication() = default;
 };

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -54,10 +54,16 @@ class ICommunication {
 
   // Sends a message on the underlying communication layer to a given
   // destination node. Asynchronous (non-blocking) method.
+  // The function takes ownership of the buffer provided.
   // Returns 0 on success.
-  virtual int sendAsyncMessage(NodeNum destNode, std::vector<uint8_t>&& msg) = 0;
+  virtual int send(NodeNum destNode, std::vector<uint8_t>&& msg) = 0;
 
-  virtual std::set<NodeNum> multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t>&& msg) = 0;
+  // Sends a message to all nodes in dests set.
+  // The function takes ownership of the buffer provided.
+  // The return value is a set<NodeNum>.
+  //    On success the set is empty.
+  //    On failure it contains the NodeNum-s of the destinations for which the message sending has failed.
+  virtual std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg) = 0;
 
   virtual void setReceiver(NodeNum receiverNum, IReceiver* receiver) = 0;
 

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -207,7 +207,7 @@ void AsyncTlsConnection::dispose(bool close_connection) {
 }
 
 void AsyncTlsConnection::write() {
-  if (disposed_ || write_msg_.has_value()) return;
+  if (disposed_ || write_msg_) return;
 
   write_msg_ = write_queue_->pop();
   if (!write_msg_) return;
@@ -241,7 +241,7 @@ void AsyncTlsConnection::write() {
                              write_timer_.cancel(_ec);
 
                              tlsTcpImpl_.histograms_.sent_msg_size->record(write_msg_->msg.size());
-                             write_msg_ = std::nullopt;
+                             write_msg_ = nullptr;
                              write();
                            });
   startWriteTimer();

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -21,8 +21,6 @@
 #include "TlsTcpImpl.h"
 #include "TlsDiagnostics.h"
 
-using concord::diagnostics::TimeRecorder;
-
 namespace bft::communication {
 
 void AsyncTlsConnection::readMsgSizeHeader(std::optional<size_t> bytes_already_read) {
@@ -134,7 +132,7 @@ void AsyncTlsConnection::readMsg() {
                read_timer_.cancel(_ec);
                tlsTcpImpl_.histograms_.received_msg_size->record(bytes_transferred);
                {
-                 TimeRecorder scoped_timer(*tlsTcpImpl_.histograms_.read_enqueue_time);
+                 concord::diagnostics::TimeRecorder scoped_timer(*tlsTcpImpl_.histograms_.read_enqueue_time);
                  receiver_->onNewMessage(peer_id_.value(), read_msg_.data(), bytes_transferred);
                }
                if (tlsTcpImpl_.config_.statusCallback && tlsTcpImpl_.isReplica(peer_id_.value())) {
@@ -384,7 +382,7 @@ bool AsyncTlsConnection::verifyCertificateServer(bool preverified, boost::asio::
 
 std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* receivedCert,
                                                               std::string connectionType,
-                                                              std::string subject,
+                                                              const std::string& subject,
                                                               std::optional<NodeNum> expectedPeerId) {
   // First, perform a basic sanity test, in order to eliminate a disk read if the certificate is
   // unknown.

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -27,8 +27,6 @@
 
 namespace bft::communication {
 
-class TlsTcpImpl;
-
 typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> SSL_SOCKET;
 
 class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnection> {
@@ -146,7 +144,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Return true along with the actual node id if verification succeeds, (false, 0) if not.
   std::pair<bool, NodeNum> checkCertificate(X509* cert,
                                             std::string connectionType,
-                                            std::string subject,
+                                            const std::string& subject,
                                             std::optional<NodeNum> expected_peer_id);
 
   logging::Logger logger_;

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -180,7 +180,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   std::vector<char> read_msg_;
 
   // Message being currently written.
-  std::optional<OutgoingMsg> write_msg_;
+  std::shared_ptr<OutgoingMsg> write_msg_;
 
   WriteQueue* write_queue_ = nullptr;
 };

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -399,12 +399,12 @@ ConnectionStatus PlainUDPCommunication::getCurrentConnectionStatus(NodeNum node)
   return _ptrImpl->getCurrentConnectionStatus(node);
 }
 
-int PlainUDPCommunication::sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) {
+int PlainUDPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg) {
   auto m = std::make_shared<std::vector<uint8_t>>(std::move(msg));
   return _ptrImpl->sendAsyncMessage(destNode, m);
 }
 
-std::set<NodeNum> PlainUDPCommunication::multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
+std::set<NodeNum> PlainUDPCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
   std::set<NodeNum> failed_nodes;
   auto m = std::make_shared<std::vector<uint8_t>>(std::move(msg));
   for (auto &d : dests) {

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -238,11 +238,11 @@ class PlainUDPCommunication::PlainUdpImpl {
     return ConnectionStatus::Disconnected;
   }
 
-  int sendAsyncMessage(const NodeNum &destNode, const char *const message, const size_t &messageLength) {
-    int error = 0;
+  int sendAsyncMessage(const NodeNum &destNode, std::shared_ptr<std::vector<uint8_t>> msg) {
+    ssize_t error = 0;
 
-    if (messageLength > MAX_UDP_PAYLOAD_SIZE) {
-      LOG_ERROR(_logger, "Error, exceeded UDP payload size limit, message length: " << std::to_string(messageLength));
+    if (msg->size() > MAX_UDP_PAYLOAD_SIZE) {
+      LOG_ERROR(_logger, "Error, exceeded UDP payload size limit, message length: " << std::to_string(msg->size()));
       return -1;
     }
 
@@ -251,25 +251,24 @@ class PlainUDPCommunication::PlainUdpImpl {
     const Addr *to = &nodes2addresses[destNode];
 
     ConcordAssert((to != NULL) && "The destination endpoint does not exist!");
-    ConcordAssert((messageLength > 0) && "The message length must be positive!");
-    ConcordAssert((message != NULL) && "No message provided!");
+    ConcordAssert((msg->size() > 0) && "The message length must be positive!");
 
     LOG_DEBUG(_logger,
-              " Sending " << messageLength << " bytes to " << destNode << " (" << inet_ntoa(to->sin_addr) << ":"
+              " Sending " << msg->size() << " bytes to " << destNode << " (" << inet_ntoa(to->sin_addr) << ":"
                           << ntohs(to->sin_port));
 
-    error = sendto(udpSockFd, message, messageLength, 0, (struct sockaddr *)to, sizeof(Addr));
+    error = sendto(udpSockFd, msg->data(), msg->size(), 0, (struct sockaddr *)to, sizeof(Addr));
 
     if (error < 0) {
       /** -1 return value means underlying socket error. */
       LOG_INFO(_logger, "Error while sending: " << concordUtils::errnoString(errno));
-    } else if (error < (int)messageLength) {
+    } else if (error < (ssize_t)msg->size()) {
       /** Mesage was partially sent. Unclear why this would happen, perhaps
        * due to oversized messages (?). */
       LOG_INFO(_logger, "Sent %d out of %d bytes!");
     }
 
-    if (error == (ssize_t)messageLength) {
+    if (error == (ssize_t)msg->size()) {
       if (statusCallback) {
         PeerConnectivityStatus pcs{};
         pcs.peerId = selfId;
@@ -400,8 +399,20 @@ ConnectionStatus PlainUDPCommunication::getCurrentConnectionStatus(NodeNum node)
   return _ptrImpl->getCurrentConnectionStatus(node);
 }
 
-int PlainUDPCommunication::sendAsyncMessage(NodeNum destNode, const char *const message, size_t messageLength) {
-  return _ptrImpl->sendAsyncMessage(destNode, message, messageLength);
+int PlainUDPCommunication::sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) {
+  auto m = std::make_shared<std::vector<uint8_t>>(std::move(msg));
+  return _ptrImpl->sendAsyncMessage(destNode, m);
+}
+
+std::set<NodeNum> PlainUDPCommunication::multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
+  std::set<NodeNum> failed_nodes;
+  auto m = std::make_shared<std::vector<uint8_t>>(std::move(msg));
+  for (auto &d : dests) {
+    if (_ptrImpl->sendAsyncMessage(d, m) != 0) {
+      failed_nodes.insert(d);
+    }
+  }
+  return failed_nodes;
 }
 
 void PlainUDPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {

--- a/communication/src/TlsDiagnostics.h
+++ b/communication/src/TlsDiagnostics.h
@@ -105,7 +105,7 @@ struct Recorders {
   using Recorder = concord::diagnostics::Recorder;
   using Unit = concord::diagnostics::Unit;
 
-  Recorders(std::string selfId, int64_t max_msg_size, int64_t max_queue_size_in_bytes)
+  Recorders(const std::string& selfId, int64_t max_msg_size, int64_t max_queue_size_in_bytes)
       : write_queue_size_in_bytes(
             MAKE_SHARED_RECORDER("write_queue_size_in_bytes", 1, max_queue_size_in_bytes, 3, Unit::BYTES)),
         sent_msg_size(MAKE_SHARED_RECORDER("sent_msg_size", 1, max_msg_size, 3, Unit::BYTES)),

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -39,12 +39,12 @@ ConnectionStatus TlsTCPCommunication::getCurrentConnectionStatus(const NodeNum n
   return impl_->getCurrentConnectionStatus(node);
 }
 
-int TlsTCPCommunication::sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) {
+int TlsTCPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg) {
   auto omsg = std::make_shared<OutgoingMsg>(std::move(msg));
   return impl_->sendAsyncMessage(destNode, omsg);
 }
 
-std::set<NodeNum> TlsTCPCommunication::multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
+std::set<NodeNum> TlsTCPCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
   std::set<NodeNum> failed_nodes;
   auto omsg = std::make_shared<OutgoingMsg>(std::move(msg));
   for (auto &d : dests) {

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -39,10 +39,20 @@ ConnectionStatus TlsTCPCommunication::getCurrentConnectionStatus(const NodeNum n
   return impl_->getCurrentConnectionStatus(node);
 }
 
-int TlsTCPCommunication::sendAsyncMessage(const NodeNum destNode,
-                                          const char *const message,
-                                          const size_t messageLength) {
-  return impl_->sendAsyncMessage(destNode, message, messageLength);
+int TlsTCPCommunication::sendAsyncMessage(NodeNum destNode, std::vector<uint8_t> &&msg) {
+  auto omsg = std::make_shared<OutgoingMsg>(std::move(msg));
+  return impl_->sendAsyncMessage(destNode, omsg);
+}
+
+std::set<NodeNum> TlsTCPCommunication::multiSendMessage(const std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
+  std::set<NodeNum> failed_nodes;
+  auto omsg = std::make_shared<OutgoingMsg>(std::move(msg));
+  for (auto &d : dests) {
+    if (impl_->sendAsyncMessage(d, omsg) != 0) {
+      failed_nodes.insert(d);
+    }
+  }
+  return failed_nodes;
 }
 
 void TlsTCPCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {

--- a/communication/src/TlsTcpImpl.cpp
+++ b/communication/src/TlsTcpImpl.cpp
@@ -133,7 +133,8 @@ void TlsTCPCommunication::TlsTcpImpl::setReceiver(NodeNum _, IReceiver* receiver
   receiver_ = receiver;
 }
 
-int TlsTCPCommunication::TlsTcpImpl::sendAsyncMessage(const NodeNum destination, std::shared_ptr<OutgoingMsg>& msg) {
+int TlsTCPCommunication::TlsTcpImpl::sendAsyncMessage(const NodeNum destination,
+                                                      const std::shared_ptr<OutgoingMsg>& msg) {
   auto max_size = config_.bufferLength - AsyncTlsConnection::MSG_HEADER_SIZE;
   if (msg->payload_size() > max_size) {
     status_->total_messages_dropped++;

--- a/communication/src/TlsTcpImpl.cpp
+++ b/communication/src/TlsTcpImpl.cpp
@@ -15,8 +15,6 @@
 #include "assertUtils.hpp"
 #include "TlsTcpImpl.h"
 
-using concord::diagnostics::TimeRecorder;
-
 namespace bft::communication {
 
 int TlsTCPCommunication::TlsTcpImpl::Start() {
@@ -225,7 +223,7 @@ void TlsTCPCommunication::TlsTcpImpl::onConnectionAuthenticated(std::shared_ptr<
   // discard it. In this case it was likely that connecting end of the connection thinks there is
   // something wrong. This is a vector for a denial of service attack on the accepting side. We can
   // track the number of connections from the node and mark it malicious if necessary.
-  TimeRecorder scoped_timer(*histograms_.on_connection_authenticated);
+  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.on_connection_authenticated);
   auto& queue = write_queues_.at(conn->getPeerId().value());
   {
     std::lock_guard<std::mutex> lock(connections_guard_);
@@ -333,7 +331,7 @@ void TlsTCPCommunication::TlsTcpImpl::resolve(NodeNum i) {
   });
 }
 
-void TlsTCPCommunication::TlsTcpImpl::connect(NodeNum i, boost::asio::ip::tcp::endpoint endpoint) {
+void TlsTCPCommunication::TlsTcpImpl::connect(NodeNum i, const boost::asio::ip::tcp::endpoint& endpoint) {
   auto [it, inserted] = connecting_.emplace(i, boost::asio::ip::tcp::socket(io_service_));
   ConcordAssert(inserted);
   status_->num_connecting = connecting_.size();

--- a/communication/src/TlsTcpImpl.h
+++ b/communication/src/TlsTcpImpl.h
@@ -125,7 +125,7 @@ class TlsTCPCommunication::TlsTcpImpl {
         "tls" + std::to_string(config.selfId), "TlsTcpImpl status", [this]() { return status_->status(); });
     registrar.status.registerHandler(handler);
     write_queues_.reserve(config_.nodes.size() - 1);
-    for (const auto node : config_.nodes) {
+    for (const auto &node : config_.nodes) {
       if (node.first != config_.selfId) {
         NodeNum id = node.first;
         write_queues_.try_emplace(id, id, histograms_);
@@ -168,7 +168,7 @@ class TlsTCPCommunication::TlsTcpImpl {
   // Replicas only connect to replicas with smaller node ids.
   // This method is called at startup and also on a periodic timer tick.
   void connect();
-  void connect(NodeNum, boost::asio::ip::tcp::endpoint);
+  void connect(NodeNum, const boost::asio::ip::tcp::endpoint &);
 
   // Start a steady_timer in order to trigger needed `connect` operations.
   void startConnectTimer();

--- a/communication/src/TlsTcpImpl.h
+++ b/communication/src/TlsTcpImpl.h
@@ -142,7 +142,7 @@ class TlsTCPCommunication::TlsTcpImpl {
   bool isRunning() const;
   ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const;
   void setReceiver(NodeNum nodeId, IReceiver *receiver);
-  int sendAsyncMessage(const NodeNum destination, const char *const msg, const size_t msg_len);
+  int sendAsyncMessage(const NodeNum destination, std::shared_ptr<OutgoingMsg> &msg);
   int getMaxMessageSize();
 
  private:

--- a/communication/src/TlsTcpImpl.h
+++ b/communication/src/TlsTcpImpl.h
@@ -142,7 +142,7 @@ class TlsTCPCommunication::TlsTcpImpl {
   bool isRunning() const;
   ConnectionStatus getCurrentConnectionStatus(const NodeNum node) const;
   void setReceiver(NodeNum nodeId, IReceiver *receiver);
-  int sendAsyncMessage(const NodeNum destination, std::shared_ptr<OutgoingMsg> &msg);
+  int sendAsyncMessage(const NodeNum destination, const std::shared_ptr<OutgoingMsg> &msg);
   int getMaxMessageSize();
 
  private:

--- a/performance/test/slowdown_test.cpp
+++ b/performance/test/slowdown_test.cpp
@@ -47,7 +47,7 @@ class MockComm : public bft::communication::ICommunication {
     return 0;
   }
 
-  std::set<NodeNum> send(const std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
     (void)dests;
     (void)msg;
     return {};

--- a/performance/test/slowdown_test.cpp
+++ b/performance/test/slowdown_test.cpp
@@ -41,11 +41,16 @@ class MockComm : public bft::communication::ICommunication {
 
   bool isRunning() const override { return true; }
 
-  int sendAsyncMessage(NodeNum destNode, const char* const message, size_t messageLength) override {
+  int send(NodeNum destNode, std::vector<uint8_t>&& msg) override {
     (void)destNode;
-    (void)message;
-    (void)messageLength;
+    (void)msg;
     return 0;
+  }
+
+  std::set<NodeNum> send(const std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
+    (void)dests;
+    (void)msg;
+    return {};
   }
 
   void setReceiver(NodeNum receiverNum, IReceiver* receiver) override {


### PR DESCRIPTION
This patch modifies ICommunication interface for two main reasons:
- Avoid unnecessary memory copying when the bft client sends messages
to all replicas. In the current implementation the message is copied for
each replica instance.
- Remove unnecessary use of raw pointers in the code.

How this is achieved:

Add new method to ICommunication - multiSendMessage(). It receives a raw
message buffer in form of std::vector<uint8_t> and takes ownership of
it. Internally the vector is converted to shared_ptr and it is shared
between all TLS connections. This approach avoids copying the same
message multiple times.

sendAsyncMessage() from ICommunication also accepts rvalue ref to
std::vector<uint8_t>. For consistency it is internally converted to
shared_ptr.

These changes lead to some additional modifications:
1. struct OutgoingMsg accepts vector instead of raw pointer. A copy of
the vector is made, because each message consists of LEN + PAYLOAD. To
construct the correct message structure a new chunk of memory needs to
be allocated.

2. The implementation of TlsTCPCommunication is changed. Now OutgoingMsg
is created from the raw buffer passed by the upper layer. This OutgoingMsg
is passed to the implementation. The benefit is that memory for the
message is allocated only once.

3. WriteQueue works with shared_ptr<OutgoingMsg> instead of OutgoingMsg
directly. Additionally OutgoingMsg is not created in the WriteQueue
anymore. The message is created in TlsTcpImpl send functions.

4. Add implementations for sendAsyncMessage and multiSendMessage to
PlainUDPCommunication and FakeCommunication.