### PR TITLE
Fix for stuck inactive View after State Transfer.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2648,6 +2648,11 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
     LOG_INFO(GL, "Call to another startCollectingState()");
     clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout
     stateTransfer->startCollectingState();
+  } else {
+    if (!currentViewIsActive()) {
+      LOG_INFO(GL, "tryToEnterView after State Transfer finished ...");
+      tryToEnterView();
+    }
   }
 }
 


### PR DESCRIPTION
The fix covers the situation we get when we are 1 Checkpoint
(currently 150 SeqNo-s) behind our peers and our View is also behind.
In this case it happens that we receive all necessary View Change messages
and the New View message from the Primary, and being behind we are unable to
activate the View and therefore we initiate State Transfer to get up to date.
After State Transfer completes there is nothing to trigger us trying to
activate the View again, because we previously gathered all, so now after ST
completes we check if our View is inactive and try to enter it.