### PR TITLE
Apollo test replica misses 2 view changes

### DIFF
--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -51,6 +51,75 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
+    #@unittest.skip("Disabled due to BC-6816")
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_constant_load
+    async def test_missed_two_view_changes(self, bft_network, skvbc, constant_load):
+        """
+        The purpose of this test is to verify that if a Replica's View is behind the peers by more than 1
+        it manages to catch up properly and to join and participate in the View its peers are working in.
+        1) Start all replicas and store the current View they are in.
+        2) Stop Replica 2 which we will later bring back
+        3) Isolate Replica 0 and verify View Change happens
+        4) Isolate Replica 1 and verify View Change happens. This time we are going to go to View = 3,
+           because we previously stopped Replica 2.
+        5) Start Replica 2.
+        6) Verify Fast Path of execution is restored.
+        """
+
+        late_replica = 2
+        connected_replica = 3  # This Replica will always be connected to the peers during the test.
+        num_req = 10
+
+        async def write_req():
+            for _ in range(num_req):
+                await skvbc.write_known_kv()
+
+        bft_network.start_all_replicas()
+        await write_req()
+
+        current_view = await bft_network.wait_for_view(
+            replica_id=0,
+            err_msg="Make sure view is stable after all replicas are started."
+        )
+
+        bft_network.stop_replica(late_replica)
+
+        for isolated_replica in [0, 1]:
+            with net.ReplicaSubsetTwoWayIsolatingAdversary(bft_network, {isolated_replica}) as adversary:
+                adversary.interfere()
+                try:
+                    client = bft_network.random_client()
+                    client.primary = None
+                    for _ in range(5):
+                        msg = skvbc.write_req(
+                            [], [(skvbc.random_key(), skvbc.random_value())], 0)
+                        await client.write(msg)
+                except:
+                    pass
+
+                await trio.sleep(seconds=30)
+
+            view = await bft_network.wait_for_view(
+                replica_id=connected_replica,
+                expected=lambda v: v > current_view,
+                err_msg=f"Make sure current View is higher than {current_view}"
+            )
+            current_view = view
+
+        bft_network.start_replica(late_replica)
+
+        # Make sure the current view is stable
+        await bft_network.wait_for_view(
+            replica_id=0,
+            expected=lambda v: v == current_view,
+            err_msg="Make sure view is stable after all Replicas are connected."
+        )
+
+        await bft_network.wait_for_fast_path_to_be_prevalent(
+            run_ops=lambda: write_req(), threshold=num_req)
+
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -51,7 +51,8 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    #@unittest.skip("Disabled due to BC-6816")
+    # @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @unittest.skip("Disabled due to BC-6816")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load


### PR DESCRIPTION
Added new View Change Apollo test.
In this test we set things up to get a Replica 2 Views behind
its peers and verify it correctly manages to enter the View
and participate in quorum for execution and the system reaches
Fast Path.