### PR TITLE
Fix for crash during View Change.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -280,14 +280,13 @@ void ReplicaImp::onMessage<ReplicaAsksToLeaveViewMsg>(ReplicaAsksToLeaveViewMsg 
 }
 
 bool ReplicaImp::checkSendPrePrepareMsgPrerequisites() {
-  if (!isCurrentPrimary()) {
-    LOG_WARN(GL, "Calling checkSendPrePrepareMsgPrerequisites in non primary replica!");
-    return false;
-  }
+  ConcordAssert(isCurrentPrimary());
+
   if (!currentViewIsActive()) {
     LOG_INFO(GL, "View " << getCurrentView() << " is not active yet. Won't send PrePrepareMsg-s.");
     return false;
   }
+
   if (isSeqNumToStopAt(lastExecutedSeqNum)) {
     LOG_INFO(GL,
              "Not sending PrePrepareMsg because system is stopped at checkpoint pending control state operation "

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -280,15 +280,20 @@ void ReplicaImp::onMessage<ReplicaAsksToLeaveViewMsg>(ReplicaAsksToLeaveViewMsg 
 }
 
 bool ReplicaImp::checkSendPrePrepareMsgPrerequisites() {
+  if (!isCurrentPrimary()) {
+    LOG_WARN(GL, "Calling checkSendPrePrepareMsgPrerequisites in non primary replica!");
+    return false;
+  }
+  if (!currentViewIsActive()) {
+    LOG_INFO(GL, "View " << getCurrentView() << " is not active yet. Won't send PrePrepareMsg-s.");
+    return false;
+  }
   if (isSeqNumToStopAt(lastExecutedSeqNum)) {
     LOG_INFO(GL,
              "Not sending PrePrepareMsg because system is stopped at checkpoint pending control state operation "
              "(upgrade, etc...)");
     return false;
   }
-
-  ConcordAssert(isCurrentPrimary());
-  ConcordAssert(currentViewIsActive());
 
   if (primaryLastUsedSeqNum + 1 > lastStableSeqNum + kWorkWindowSize) {
     LOG_INFO(GL,

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -280,7 +280,10 @@ void ReplicaImp::onMessage<ReplicaAsksToLeaveViewMsg>(ReplicaAsksToLeaveViewMsg 
 }
 
 bool ReplicaImp::checkSendPrePrepareMsgPrerequisites() {
-  ConcordAssert(isCurrentPrimary());
+  if (!isCurrentPrimary()) {
+    LOG_WARN(GL, "Called in a non-primary replica; won't send PrePrepareMsgs!");
+    return false;
+  }
 
   if (!currentViewIsActive()) {
     LOG_INFO(GL, "View " << getCurrentView() << " is not active yet. Won't send PrePrepareMsg-s.");


### PR DESCRIPTION
We had situations where the Primary was asserting in the check
whether it can send PrePrepares. If the preconditions for sending
PrePrepares are not met we can return false and not take any action.