### PR TITLE
Send noops in fast path

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -445,8 +445,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void addTimers();
   void startConsensusProcess(PrePrepareMsg* pp, bool isInternalNoop);
   void startConsensusProcess(PrePrepareMsg* pp);
-  void sendInternalNoopPrePrepareMsg(CommitPath firstPath = CommitPath::SLOW);
-  void bringTheSystemToCheckpointBySendingNoopCommands(SeqNum seqNumToStopAt, CommitPath firstPath = CommitPath::SLOW);
+  void sendInternalNoopPrePrepareMsg(CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
+  void bringTheSystemToCheckpointBySendingNoopCommands(SeqNum seqNumToStopAt,
+                                                       CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
   bool isSeqNumToStopAt(SeqNum seq_num);
 
   // 5 years


### PR DESCRIPTION
Currently, we send Noops in a slow path (by default).
There is no real reason for this.
In this PR we change the default to fast path