### PR TITLE
Add sequence number to key exchange logs

### DIFF
--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -75,6 +75,7 @@ std::string KeyManager::generateCid() {
 // Key exchange msg for replica has been recieved:
 // update the replica public key store.
 std::string KeyManager::onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn) {
+  SCOPED_MDC_SEQ_NUM(std::to_string(sn));
   if (kemsg.op == KeyExchangeMsg::HAS_KEYS) {
     LOG_INFO(KEY_EX_LOG, "Has key query arrived, returning " << std::boolalpha << keysExchanged << std::noboolalpha);
     if (!keysExchanged && keyExchangeOnStart_) return std::string(KeyExchangeMsg::hasKeysFalseReply);
@@ -100,6 +101,7 @@ std::string KeyManager::onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn)
 
 // Once the set contains all replicas the crypto system is being updated and the gate is open.
 void KeyManager::onInitialKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn) {
+  SCOPED_MDC_SEQ_NUM(std::to_string(sn));
   // For some reason we recieved a key for a replica that already exchanged it's key.
   if (keyStore_.exchangedReplicas.find(kemsg.repID) != keyStore_.exchangedReplicas.end()) {
     LOG_DEBUG(KEY_EX_LOG, "Replica [" << kemsg.repID << "] already exchanged initial key");

--- a/bftengine/src/bftengine/KeyStore.cpp
+++ b/bftengine/src/bftengine/KeyStore.cpp
@@ -18,6 +18,7 @@ namespace bftEngine::impl {
 ///////////////////////////REPLICA KEY STORE//////////////////////////////////
 
 bool ReplicaKeyStore::push(const KeyExchangeMsg& kem, const uint64_t& sn) {
+  SCOPED_MDC_SEQ_NUM(std::to_string(sn));
   if (keys_.size() >= numOfKeysLimit_) {
     LOG_ERROR(KEY_EX_LOG, "Keys limit for replica exceeds, limit " << numOfKeysLimit_);
     return false;
@@ -74,6 +75,7 @@ bool ReplicaKeyStore::rotate(const uint64_t& chknum) {
   }
   // if somehow rotation wasn't performed on desired checkpoint.
   ConcordAssertLT(seqNumsSinceKeyExchangeMsg, checkPointsForRotation_ * seqNumsPerChkPoint_);
+  SCOPED_MDC_SEQ_NUM(std::to_string(keys_[1].seqnum));
   LOG_DEBUG(KEY_EX_LOG,
             "Key rotation for replica " << keys_[1].msg.repID << " recieved on seqnum " << keys_[1].seqnum
                                         << " rotated on " << chekPointSeqNum);
@@ -166,6 +168,7 @@ void ClusterKeyStore::saveReplicaKeyStoreToReserevedPages(const uint16_t& repID)
 }
 
 bool ClusterKeyStore::push(const KeyExchangeMsg& kem, const uint64_t& sn) {
+  SCOPED_MDC_SEQ_NUM(std::to_string(sn));
   if (kem.repID >= clusterKeys_.size()) {
     LOG_ERROR(KEY_EX_LOG, "Replica id is out of range " << kem.repID);
     return false;


### PR DESCRIPTION
The motivation is to be able to causally order key-exchange events by sequence number