### PR TITLE
SKVBC startup deterministic check

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -1129,7 +1129,7 @@ class BftTestNetwork:
             total_pre_exec_requests_executed = 0
             with trio.fail_after(5):
                 while pre_proc_req < num_requests or \
-                        total_pre_exec_requests_executed != num_requests:
+                        total_pre_exec_requests_executed < num_requests:
                     key1 = ["preProcessor", "Counters", "preProcReqSentForFurtherProcessing"]
                     pre_proc_req = await self.metrics.get(replica_id, *key1) - self.initial_preexec_sent
                     key2 = ["replica", "Counters", "totalPreExecRequestsExecuted"]


### PR DESCRIPTION
Currently, we don't have a deterministic way to know whether the blockchain can process requests (are at least n-f replicas started, did key exchange complete, are their thread pools ready to process requests?). We use hardcoded timeouts, e.g. in the pre-execution tests, before starting the actual test.

To make tests more robust and deterministic, this PR introduces `wait_for_liveness()` method in `SimpleKVBCProtocol` and `SkvbcTracker` and replaces the non-deterministic timeout waits with deterministic checks.