### PR TITLE
Remove summary from merkle tree

### DIFF
--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -235,7 +235,6 @@ class DBAdapter : public IDbAdapter {
   // The latest ST temporary block ID. Not set if no ST temporary blocks are present in the system.
   std::optional<BlockId> latestSTTempBlockId_;
   sparse_merkle::Tree smTree_;
-  std::unique_ptr<concordMetrics::ISummary> commitSizeSummary_;
   const NonProvableKeySet nonProvableKeySet_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };


### PR DESCRIPTION
We recently got aware of the fact that using Prometheus summaries may drastically affect the performance.
In this PR we remove the only place we use a summary in concordbft