### PR TITLE
Move KeyManager's Empty String from Loader Error to Warning

### DIFF
--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -322,7 +322,7 @@ bool KeyManager::KeysView::load() {
   }
   auto str = secStore->load();
   if (str.empty()) {
-    LOG_ERROR(KEY_EX_LOG, "Got empty string from loader");
+    LOG_WARN(KEY_EX_LOG, "Got empty string from loader. This is expected on startup");
     return false;
   }
   std::stringstream ss;

--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -322,7 +322,7 @@ bool KeyManager::KeysView::load() {
   }
   auto str = secStore->load();
   if (str.empty()) {
-    LOG_WARN(KEY_EX_LOG, "Got empty string from loader. This is expected on startup");
+    LOG_WARN(KEY_EX_LOG, "Got empty string from loader. This is expected on first startup with an empty database");
     return false;
   }
   std::stringstream ss;


### PR DESCRIPTION
Moving the error to warning as it happens every time during startup