### PR TITLE
Fix a race  with pending requests cleanup

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -73,7 +73,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
   // void removeEarlierOrEqualPendingRequests(NodeIdType clientId, ReqId reqSeqNum);
 
   void removePendingRequestOfClient(NodeIdType clientId);
-
+  void removePendingForExecutionRequestOfClient(NodeIdType clientId);
   void clearAllPendingRequests();
 
   Time infoOfEarliestPendingRequest(std::string& cid) const;
@@ -110,7 +110,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
     ReqId currentPendingRequest;
     Time timeOfCurrentPendingRequest;
     std::string cid;
-
+    bool waitsForExecution;
     // replies
     ReqId lastSeqNumberOfReply;
     Time latestReplyTime;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4019,6 +4019,8 @@ void ReplicaImp::executeRequestsAndSendResponses(PrePrepareMsg *ppMsg,
       free(req.outReply);
       send(replyMsg.get(), req.clientId);
     }
+    if (clientsManager->isValidClient(req.clientId))
+      clientsManager->removePendingForExecutionRequestOfClient(req.clientId);
   }
 }
 


### PR DESCRIPTION
@HristoStaykov found the following race:
1. We now clean pending requests after committing
2. Yet, we decide to ignore client requests based on these pending requests
The result is that we may accept client requests while we still executing their previous request, allowing the client to resubmit a request.

In this PR we fix this problem by adding a flag of `waitsForExecution` in the client info.
This flag is set once we get the client message and cleared only after the execution (similar to what we did before the latest change in the pending request)