### PR TITLE
Add metrics to storage

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -29,7 +29,7 @@ if (BUILD_ROCKSDB_STORAGE)
                                 src/categorization/block_merkle_category.cpp)
 
 endif (BUILD_ROCKSDB_STORAGE)
-target_link_libraries(kvbc PUBLIC corebft )
+target_link_libraries(kvbc PUBLIC corebft util)
 target_link_libraries(kvbc PUBLIC categorized_kvbc_msgs)
 
 

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -24,6 +24,7 @@
 #include "kv_types.hpp"
 #include "categorization/types.h"
 #include "thread_pool.hpp"
+#include "Metrics.hpp"
 
 namespace concord::kvbc::categorization {
 
@@ -178,6 +179,12 @@ class KeyValueBlockchain {
 
   // currently we are operating with single thread
   util::ThreadPool thread_pool_{1};
+
+  // metrics
+  std::shared_ptr<concordMetrics::Aggregator> aggregator_;
+  concordMetrics::Component metrics_;
+  concordMetrics::CounterHandle num_of_deleted_blocks_;
+  concordMetrics::CounterHandle num_of_deleted_keys_;
 
  public:
   struct KeyValueBlockchain_tester {

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -182,7 +182,7 @@ class KeyValueBlockchain {
 
   // metrics
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
-  concordMetrics::Component metrics_;
+  concordMetrics::Component delete_metrics_comp_;
   concordMetrics::CounterHandle versioned_num_of_deletes_keys_;
   concordMetrics::CounterHandle immuteable_num_of_deleted_keys_;
   concordMetrics::CounterHandle merkle_num_of_deleted_keys_;
@@ -205,7 +205,7 @@ class KeyValueBlockchain {
 
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
     aggregator_ = aggregator;
-    metrics_.UpdateAggregator();
+    delete_metrics_comp_.UpdateAggregator();
   }
   friend struct KeyValueBlockchain_tester;
 };

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -201,6 +201,11 @@ class KeyValueBlockchain {
 
     const VersionedRawBlock& getLastRawBlocked(KeyValueBlockchain& kvbc) { return kvbc.last_raw_block_; }
   };  // namespace concord::kvbc::categorization
+
+  void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
+    aggregator_ = aggregator;
+    metrics_.UpdateAggregator();
+  }
   friend struct KeyValueBlockchain_tester;
 };
 

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -183,8 +183,9 @@ class KeyValueBlockchain {
   // metrics
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
   concordMetrics::Component metrics_;
-  concordMetrics::CounterHandle num_of_deleted_blocks_;
-  concordMetrics::CounterHandle num_of_deleted_keys_;
+  concordMetrics::CounterHandle versioned_num_of_deletes_keys_;
+  concordMetrics::CounterHandle immuteable_num_of_deleted_keys_;
+  concordMetrics::CounterHandle merkle_num_of_deleted_keys_;
 
  public:
   struct KeyValueBlockchain_tester {

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -184,7 +184,7 @@ class KeyValueBlockchain {
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
   concordMetrics::Component delete_metrics_comp_;
   concordMetrics::CounterHandle versioned_num_of_deletes_keys_;
-  concordMetrics::CounterHandle immuteable_num_of_deleted_keys_;
+  concordMetrics::CounterHandle immutable_num_of_deleted_keys_;
   concordMetrics::CounterHandle merkle_num_of_deleted_keys_;
 
  public:

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -234,6 +234,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   if (!replicaConfig.isReadOnly) {
     const auto linkStChain = true;
     m_kvBlockchain.emplace(storage::rocksdb::NativeClient::fromIDBClient(m_dbSet.dataDBClient), linkStChain);
+    m_kvBlockchain->setAggregator(aggregator);
   }
   m_dbSet.dataDBClient->setAggregator(aggregator);
   m_dbSet.metadataDBClient->setAggregator(aggregator);

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -33,7 +33,7 @@ KeyValueBlockchain::KeyValueBlockchain(const std::shared_ptr<concord::storage::r
       delete_metrics_comp_{
           concordMetrics::Component("kv_blockchain_deletes", std::make_shared<concordMetrics::Aggregator>())},
       versioned_num_of_deletes_keys_{delete_metrics_comp_.RegisterCounter("numOfVersionedKeysDeleted")},
-      immuteable_num_of_deleted_keys_{delete_metrics_comp_.RegisterCounter("numOfImmutableKeysDeleted")},
+      immutable_num_of_deleted_keys_{delete_metrics_comp_.RegisterCounter("numOfImmutableKeysDeleted")},
       merkle_num_of_deleted_keys_{delete_metrics_comp_.RegisterCounter("numOfMerkleKeysDeleted")} {
   if (detail::createColumnFamilyIfNotExisting(detail::CAT_ID_TYPE_CF, *native_client_.get())) {
     LOG_INFO(CAT_BLOCK_LOG, "Created [" << detail::CAT_ID_TYPE_CF << "] column family for the category types");
@@ -384,7 +384,7 @@ void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const ImmutableOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch& batch) {
-  immuteable_num_of_deleted_keys_.Get().Inc(updates_info.tagged_keys.size());
+  immutable_num_of_deleted_keys_.Get().Inc(updates_info.tagged_keys.size());
   std::get<detail::ImmutableKeyValueCategory>(getCategory(category_id))
       .deleteGenesisBlock(block_id, updates_info, batch);
 }
@@ -410,7 +410,7 @@ void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
                                                   const std::string& category_id,
                                                   const ImmutableOutput& updates_info,
                                                   storage::rocksdb::NativeWriteBatch& batch) {
-  immuteable_num_of_deleted_keys_.Get().Inc(updates_info.tagged_keys.size());
+  immutable_num_of_deleted_keys_.Get().Inc(updates_info.tagged_keys.size());
   std::get<detail::ImmutableKeyValueCategory>(getCategory(category_id))
       .deleteLastReachableBlock(block_id, updates_info, batch);
 }

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -27,7 +27,12 @@ void nullopts(std::vector<std::optional<T>>& vec, std::size_t count) {
 
 KeyValueBlockchain::KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client,
                                        bool link_st_chain)
-    : native_client_{native_client}, block_chain_{native_client_}, state_transfer_block_chain_{native_client_} {
+    : native_client_{native_client},
+      block_chain_{native_client_},
+      state_transfer_block_chain_{native_client_},
+      metrics_{concordMetrics::Component("kv_blockchain", std::make_shared<concordMetrics::Aggregator>())},
+      num_of_deleted_blocks_{metrics_.RegisterCounter("numOfDeletedBlocks")},
+      num_of_deleted_keys_{metrics_.RegisterCounter("numOfDeletedkeys")} {
   if (detail::createColumnFamilyIfNotExisting(detail::CAT_ID_TYPE_CF, *native_client_.get())) {
     LOG_INFO(CAT_BLOCK_LOG, "Created [" << detail::CAT_ID_TYPE_CF << "] column family for the category types");
   }
@@ -271,9 +276,11 @@ bool KeyValueBlockchain::deleteBlock(const BlockId& block_id) {
     throw std::logic_error{"Deleting the only block in the system is not supported"};
   } else if (block_id == last_reachable_block_id) {
     deleteLastReachableBlock();
+    num_of_deleted_blocks_.Get().Inc();
     return true;
   } else if (block_id == genesis_block_id) {
     deleteGenesisBlock();
+    num_of_deleted_blocks_.Get().Inc();
     return true;
   } else {
     throw std::invalid_argument{"Cannot delete blocks in the middle of the blockchain"};
@@ -373,6 +380,7 @@ void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const ImmutableOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch& batch) {
+  num_of_deleted_keys_.Get().Inc(updates_info.tagged_keys.size());
   std::get<detail::ImmutableKeyValueCategory>(getCategory(category_id))
       .deleteGenesisBlock(block_id, updates_info, batch);
 }
@@ -381,6 +389,7 @@ void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const VersionedOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch& batch) {
+  num_of_deleted_keys_.Get().Inc(updates_info.keys.size());
   std::get<detail::VersionedKeyValueCategory>(getCategory(category_id))
       .deleteGenesisBlock(block_id, updates_info, batch);
 }
@@ -389,6 +398,7 @@ void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const BlockMerkleOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch& batch) {
+  num_of_deleted_keys_.Get().Inc(updates_info.keys.size());
   std::get<detail::BlockMerkleCategory>(getCategory(category_id)).deleteGenesisBlock(block_id, updates_info, batch);
 }
 
@@ -396,6 +406,7 @@ void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
                                                   const std::string& category_id,
                                                   const ImmutableOutput& updates_info,
                                                   storage::rocksdb::NativeWriteBatch& batch) {
+  num_of_deleted_keys_.Get().Inc(updates_info.tagged_keys.size());
   std::get<detail::ImmutableKeyValueCategory>(getCategory(category_id))
       .deleteLastReachableBlock(block_id, updates_info, batch);
 }
@@ -404,6 +415,7 @@ void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
                                                   const std::string& category_id,
                                                   const VersionedOutput& updates_info,
                                                   storage::rocksdb::NativeWriteBatch& batch) {
+  num_of_deleted_keys_.Get().Inc(updates_info.keys.size());
   std::get<detail::VersionedKeyValueCategory>(getCategory(category_id))
       .deleteLastReachableBlock(block_id, updates_info, batch);
 }
@@ -412,6 +424,7 @@ void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,
                                                   const std::string& category_id,
                                                   const BlockMerkleOutput& updates_info,
                                                   storage::rocksdb::NativeWriteBatch& batch) {
+  num_of_deleted_keys_.Get().Inc(updates_info.keys.size());
   std::get<detail::BlockMerkleCategory>(getCategory(category_id))
       .deleteLastReachableBlock(block_id, updates_info, batch);
 }

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -44,6 +44,7 @@ KeyValueBlockchain::KeyValueBlockchain(const std::shared_ptr<concord::storage::r
   // is getValue() that returns keys from the blockchain only and ignores keys in the temporary state
   // transfer chain.
   linkSTChainFrom(getLastReachableBlockId() + 1);
+  metrics_.Register();
 }
 
 void KeyValueBlockchain::instantiateCategories() {
@@ -351,7 +352,7 @@ void KeyValueBlockchain::deleteLastReachableBlock() {
 
   block_chain_.deleteBlock(last_id, write_batch);
 
-  // Iterate over groups and call corresponding deleteGenesisBlock,
+  // Iterate over groups and call corresponding deleteLastReachableBlock,
   // Each group is responsible to put its deletes into the batch
   for (auto&& [category_id, update_info] : block.value().data.categories_updates_info) {
     std::visit(


### PR DESCRIPTION
In this PR we add metrics to the new storage.
We started by adding to simple metrics:
1 . number of deleted keys per category