### PR TITLE
New kv_blockchain_db_editor tool for db access.

### DIFF
--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -125,7 +125,19 @@ add_test(sparse_merkle_db_editor_test sparse_merkle_db_editor_test)
 target_link_libraries(sparse_merkle_db_editor_test PUBLIC
     GTest::Main
     GTest::GTest
-    lib_sparse_merkle_db_editor
+    lib_db_editor
+    util
+    kvbc
+    stdc++fs
+)
+
+add_executable(kv_blockchain_db_editor_test sparse_merkle_storage/kv_blockchain_db_editor_test.cpp )
+add_test(kv_blockchain_db_editor_test kv_blockchain_db_editor_test)
+
+target_link_libraries(kv_blockchain_db_editor_test PUBLIC
+    GTest::Main
+    GTest::GTest
+    lib_db_editor
     util
     kvbc
     stdc++fs

--- a/kvbc/test/sparse_merkle_storage/db_editor_tests_base.h
+++ b/kvbc/test/sparse_merkle_storage/db_editor_tests_base.h
@@ -1,0 +1,103 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "endianness.hpp"
+#include "kvbc_storage_test_common.h"
+#include "kv_types.hpp"
+#include "merkle_tree_db_adapter.h"
+#include "PersistentStorageImp.hpp"
+#include "sliver.hpp"
+#include "storage/db_types.h"
+#include "storage/merkle_tree_key_manipulator.h"
+
+namespace {
+
+using namespace concord::kvbc::v2MerkleTree;
+using concord::kvbc::BlockId;
+using concord::kvbc::INITIAL_GENESIS_BLOCK_ID;
+using concord::kvbc::SetOfKeyValuePairs;
+using concordUtils::toBigEndianStringBuffer;
+using concordUtils::Sliver;
+
+using testing::EndsWith;
+using testing::HasSubstr;
+using testing::InitGoogleTest;
+using testing::Not;
+using testing::StartsWith;
+using testing::Test;
+
+using namespace std::string_literals;
+
+class DbEditorTestsBase : public Test {
+ public:
+  virtual void SetUp() override {
+    CleanDbs();
+    CreateBlockchain(main_path_db_id_, num_blocks_);
+  }
+
+  virtual void TearDown() override { CleanDbs(); }
+
+  virtual void CleanDbs() {
+    TestRocksDb::cleanup(main_path_db_id_);
+    TestRocksDb::cleanup(other_path_db_id_);
+    TestRocksDb::cleanup(non_existent_path_db_id_);
+    TestRocksDb::cleanup(empty_path_db_id_);
+  }
+
+  virtual void CreateBlockchain(std::size_t db_id,
+                                BlockId blocks,
+                                std::optional<BlockId> mismatch_at = std::nullopt) = 0;
+
+  virtual void DeleteBlocksUntil(std::size_t db_id, BlockId until_block_id) = 0;
+
+  Sliver getSliver(unsigned value) { return toBigEndianStringBuffer(value); }
+
+  SetOfKeyValuePairs generateMetadataAndStateTransfer() {
+    // Create a full range of metadata objects
+    constexpr auto num_metadata_object_ids = MAX_METADATA_PARAMS_NUM - INITIALIZED_FLAG;
+    auto updates = SetOfKeyValuePairs{};
+    concord::storage::v2MerkleTree::MetadataKeyManipulator manipulator;
+    for (concord::storage::ObjectId i = INITIALIZED_FLAG; i < num_metadata_object_ids; ++i) {
+      updates[manipulator.generateMetadataKey(i)] = getSliver(i);
+    }
+
+    concord::storage::v2MerkleTree::STKeyManipulator st_manipulator;
+    updates[st_manipulator.generateStateTransferKey(1)] = std::string{"val"};
+    updates[st_manipulator.generateSTPendingPageKey(1)] = std::string{"val"};
+    updates[st_manipulator.generateSTCheckpointDescriptorKey(1)] = std::string{"val"};
+    updates[st_manipulator.generateSTReservedPageDynamicKey(1, 1)] = std::string{"val"};
+    return updates;
+  }
+
+ protected:
+  static constexpr std::size_t main_path_db_id_{defaultDbId};
+  static constexpr std::size_t other_path_db_id_{main_path_db_id_ + 1};
+  static constexpr std::size_t non_existent_path_db_id_{other_path_db_id_ + 1};
+  static constexpr std::size_t empty_path_db_id_{non_existent_path_db_id_ + 1};
+  static constexpr unsigned kv_multiplier_{10};
+  static constexpr BlockId empty_block_id_{10};
+  static constexpr BlockId num_blocks_{10};
+  static constexpr BlockId more_num_blocks_{16};
+  static constexpr BlockId first_mismatch_block_id_{7};
+  static constexpr unsigned num_keys_{3};
+
+  std::stringstream out_;
+  std::stringstream err_;
+};
+
+}  // namespace

--- a/kvbc/tools/CMakeLists.txt
+++ b/kvbc/tools/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_subdirectory(sparse_merkle_db)
+add_subdirectory(db_editor)

--- a/kvbc/tools/db_editor/CMakeLists.txt
+++ b/kvbc/tools/db_editor/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(lib_db_editor INTERFACE)
+target_link_libraries(lib_db_editor INTERFACE)
+target_include_directories(lib_db_editor INTERFACE include)
+
+if(BUILD_ROCKSDB_STORAGE)
+add_executable(sparse_merkle_db_editor src/sparse_merkle_db_editor.cpp)
+target_link_libraries(sparse_merkle_db_editor PUBLIC lib_db_editor util kvbc stdc++fs)
+add_executable(kv_blockchain_db_editor src/kv_blockchain_db_editor.cpp)
+target_link_libraries(kv_blockchain_db_editor PUBLIC lib_db_editor util kvbc stdc++fs)
+endif()

--- a/kvbc/tools/db_editor/include/db_editor_common.hpp
+++ b/kvbc/tools/db_editor/include/db_editor_common.hpp
@@ -1,0 +1,84 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "json_output.hpp"
+
+#include "merkle_tree_block.h"
+#include "storage/db_types.h"
+#include "rocksdb/client.h"
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing filesystem support"
+#endif
+
+namespace concord::kvbc::tools::db_editor {
+
+using namespace std::string_literals;
+using concordUtils::toJson;
+
+template <typename Tag>
+struct Arguments {
+  std::vector<std::string> values;
+};
+
+struct CommandLineArgumentsTag {};
+struct CommandArgumentsTag {};
+
+using CommandArguments = Arguments<CommandArgumentsTag>;
+using CommandLineArguments = Arguments<CommandArgumentsTag>;
+
+inline auto toBlockId(const std::string &s) {
+  if (s.find_first_not_of("0123456789") != std::string::npos) {
+    throw std::invalid_argument{"Invalid BLOCK-ID: " + s};
+  }
+  return kvbc::BlockId{std::stoull(s, nullptr)};
+}
+
+inline std::shared_ptr<storage::IDBClient> getDBClient(const std::string &path, bool read_only = false) {
+  if (!fs::exists(path) || !fs::is_directory(path)) {
+    throw std::invalid_argument{"RocksDB directory path doesn't exist at " + path};
+  }
+
+  std::shared_ptr<storage::IDBClient> db{std::make_shared<storage::rocksdb::Client>(path)};
+  db->init(read_only);
+
+  return db;
+}
+
+inline constexpr auto kMinCmdLineArguments = 3ull;
+
+inline CommandLineArguments command_line_arguments(int argc, char *argv[]) {
+  auto cmd_line_args = CommandLineArguments{};
+  for (auto i = 0; i < argc; ++i) {
+    cmd_line_args.values.push_back(argv[i]);
+  }
+  return cmd_line_args;
+}
+
+inline CommandArguments command_arguments(const CommandLineArguments &cmd_line_args) {
+  auto cmd_args = CommandArguments{};
+  for (auto i = kMinCmdLineArguments; i < cmd_line_args.values.size(); ++i) {
+    cmd_args.values.push_back(cmd_line_args.values[i]);
+  }
+  return cmd_args;
+}
+
+}  // namespace concord::kvbc::tools::db_editor

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -1,0 +1,512 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "db_editor_common.hpp"
+#include "categorization/kv_blockchain.h"
+
+namespace concord::kvbc::tools::db_editor {
+
+using namespace categorization;
+
+inline const auto kToolName = "kv_blockchain_db_editor"s;
+inline KeyValueBlockchain getAdapter(const std::string &path, const bool read_only = false) {
+  auto db = getDBClient(path, read_only);
+
+  // Make sure we don't link the temporary ST chain as we don't want to change the DB in any way.
+  const auto link_temp_st_chain = false;
+  return KeyValueBlockchain{concord::storage::rocksdb::NativeClient::fromIDBClient(db), link_temp_st_chain};
+}
+
+inline BlockId getLatestBlockId(const KeyValueBlockchain &adapter) {
+  auto blockId = adapter.getLastStatetransferBlockId();
+  return blockId ? *blockId : adapter.getLastReachableBlockId();
+}
+
+inline const std::map<CATEGORY_TYPE, std::string> cat_type_str = {
+    std::make_pair(CATEGORY_TYPE::block_merkle, "block_merkle"),
+    std::make_pair(CATEGORY_TYPE::immutable, "immutable"),
+    std::make_pair(CATEGORY_TYPE::versioned_kv, "versioned_kv")};
+
+inline const std::string getCategoryType(const std::variant<BlockMerkleInput, VersionedInput, ImmutableInput> &c) {
+  return std::visit(
+      [](auto &&arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, BlockMerkleInput>) {
+          return cat_type_str.at(CATEGORY_TYPE::block_merkle);
+        } else if constexpr (std::is_same_v<T, VersionedInput>) {
+          return cat_type_str.at(CATEGORY_TYPE::versioned_kv);
+        } else if constexpr (std::is_same_v<T, ImmutableInput>) {
+          return cat_type_str.at(CATEGORY_TYPE::immutable);
+        }
+      },
+      c);
+}
+
+struct GetGenesisBlockID {
+  const bool read_only = true;
+  std::string description() const {
+    return "getGenesisBlockID\n"
+           "  Returns the genesis block ID.";
+  }
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &) const {
+    return toJson("genesisBlockID", adapter.getGenesisBlockId());
+  }
+};
+
+struct GetLastReachableBlockID {
+  const bool read_only = true;
+  std::string description() const {
+    return "getLastReachableBlockID\n"
+           "  Returns the last reachable block ID.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &) const {
+    return toJson("lastReachableBlockID", adapter.getLastReachableBlockId());
+  }
+};
+
+struct GetLastStateTransferBlockID {
+  const bool read_only = true;
+  std::string description() const {
+    return "getLastStateTransferBlockID\n"
+           " Returns the last state transfer block ID. If there is no state transfer returns n/a.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &) const {
+    auto blockId = adapter.getLastStatetransferBlockId();
+    return toJson("lastStateTransferBlockID", blockId ? std::to_string(*blockId) : "n/a"s);
+  }
+};
+
+struct GetLastBlockID {
+  const bool read_only = true;
+  std::string description() const {
+    return "getLastBlockID\n"
+           " Returns the last block ID. Either reachable or state transfer.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &) const {
+    return toJson("lastBlockID", getLatestBlockId(adapter));
+  }
+};
+
+struct GetRawBlock {
+  const bool read_only = true;
+  std::string description() const {
+    return "getRawBlock BLOCK-ID\n"
+           "  Returns a serialized raw block (encoded in hex).";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
+    if (args.values.empty()) {
+      throw std::invalid_argument{"Missing BLOCK-ID argument"};
+    }
+    const auto &blockId = args.values.front();
+    const auto raw_block = adapter.getRawBlock(toBlockId(blockId));
+    if (!raw_block) {
+      throw NotFoundException{"Couldn't find a block by ID = "s + blockId};
+    }
+    return toJson("rawBlock", concordUtils::vectorToHex(categorization::RawBlock::serialize(*raw_block)));
+  }
+};
+
+struct GetRawBlockRange {
+  const bool read_only = true;
+  std::string description() const {
+    return "getRawBlockRange BLOCK-ID-START BLOCK-ID-END\n"
+           "  Returns a list of serialized raw blocks (encoded in hex) in the [BLOCK-ID-START, BLOCK-ID-END) range.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
+    if (args.values.size() < 2) {
+      throw std::invalid_argument{"Missing or invalid block range"};
+    }
+    const auto end = toBlockId(args.values[1]);
+    if (end == 0) {
+      throw std::invalid_argument{"Invalid BLOCK-ID-END value"};
+    }
+    const auto first = toBlockId(args.values[0]);
+    const auto last = std::min(end - 1, getLatestBlockId(adapter));
+    if (first > last) {
+      throw std::invalid_argument{"Invalid block range"};
+    }
+    auto raw_blocks = std::vector<std::pair<std::string, std::string>>{};
+    for (auto i = first; i <= last; ++i) {
+      const auto raw_block = adapter.getRawBlock(i);
+      if (!raw_block) {
+        throw NotFoundException{"Couldn't find a block by ID = " + std::to_string(i)};
+      }
+      raw_blocks.emplace_back("rawBlock" + std::to_string(i),
+                              concordUtils::vectorToHex(categorization::RawBlock::serialize(*raw_block)));
+    }
+    return toJson(raw_blocks);
+  }
+};
+
+struct GetBlockInfo {
+  const bool read_only = true;
+  std::string description() const {
+    return "getBlockInfo BLOCK-ID\n"
+           "  Returns information about the requested block (excluding its key-values).";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
+    if (args.values.empty()) {
+      throw std::invalid_argument{"Missing BLOCK-ID argument"};
+    }
+    auto blockId = toBlockId(args.values.front());
+    const auto parent_digest = adapter.parentDigest(blockId);
+    const auto updates = adapter.getBlockUpdates(blockId);
+    if (!updates) {
+      throw NotFoundException{"Couldn't find a block by ID = " + std::to_string(blockId)};
+    }
+    ConcordAssert(parent_digest.has_value());
+    auto catUpdates = updates->categoryUpdates();
+    size_t keyValueTotalCount = 0;
+    std::stringstream out;
+    out << "{" << std::endl;
+    out << "  \"parentBlockDigest\": \"" << concordUtils::bufferToHex(parent_digest->data(), parent_digest->size())
+        << "\"," << std::endl;
+    out << "  \"categoriesCount\": \"" << std::to_string(catUpdates.kv.size()) << "\"," << std::endl;
+    out << "  \"categories\": {" << std::endl;
+
+    for (auto it = catUpdates.kv.begin(); it != catUpdates.kv.end(); ++it) {
+      const auto &s = std::visit([](auto &&arg) { return arg.kv.size(); }, it->second);
+      keyValueTotalCount += s;
+
+      out << "    \"" << it->first << "\": {" << std::endl;
+      out << "      \"keyValueCount\": \"" << std::to_string(s) << "\"," << std::endl;
+      out << "      \"type\": \"" << getCategoryType(it->second) << "\"" << std::endl;
+      out << "    }";
+      if (std::next(it) != catUpdates.kv.end()) out << ",";
+      out << std::endl;
+    }
+    out << "  }," << std::endl;
+
+    out << "  \"keyValueTotalCount\": \"" << std::to_string(keyValueTotalCount) << "\"" << std::endl;
+    out << "}" << std::endl;
+
+    return out.str();
+  }
+};
+
+inline std::map<std::string, std::string> getKVStr(
+    const std::variant<BlockMerkleInput, VersionedInput, ImmutableInput> &val) {
+  std::map<std::string, std::string> kvout;
+  std::visit(
+      [&kvout](auto &&arg) {
+        for (auto const &c : arg.kv) {
+          using T = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<T, BlockMerkleInput>) {
+            kvout[concordUtils::bufferToHex(c.first.data(), c.first.size())] =
+                concordUtils::bufferToHex(c.second.data(), c.second.size());
+          } else if constexpr (std::is_same_v<T, VersionedInput>) {
+            kvout[concordUtils::bufferToHex(c.first.data(), c.first.size())] =
+                concordUtils::bufferToHex(c.second.data.data(), c.second.data.size());
+          } else if constexpr (std::is_same_v<T, ImmutableInput>) {
+            kvout[concordUtils::bufferToHex(c.first.data(), c.first.size())] =
+                concordUtils::bufferToHex(c.second.data.data(), c.second.data.size());
+          }
+        }
+      },
+      val);
+
+  return kvout;
+}
+
+struct GetBlockKeyValues {
+  const bool read_only = true;
+  std::string description() const {
+    return "getBlockKeyValues BLOCK-ID [CATEGORY]\n"
+           "  Returns the block's key-values. If a CATEGORY is passed only those keys/values are listed.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
+    if (args.values.empty()) {
+      throw std::invalid_argument{"Missing BLOCK-ID argument"};
+    }
+
+    auto blockId = toBlockId(args.values.front());
+    const auto updates = adapter.getBlockUpdates(blockId);
+    if (!updates) {
+      throw NotFoundException{"Couldn't find a block by ID = " + std::to_string(blockId)};
+    }
+
+    std::stringstream out;
+    out << "{" << std::endl;
+
+    if (args.values.size() >= 2) {
+      auto requested_category = args.values[1];
+      auto kvs = updates->categoryUpdates(requested_category);
+      if (!kvs) {
+        throw NotFoundException{"Couldn't find category = " + requested_category};
+      }
+      out << "\"" << requested_category << "\": " << toJson(getKVStr(kvs->get())) << std::endl;
+    } else {
+      auto catUpdates = updates->categoryUpdates();
+
+      for (auto it = catUpdates.kv.begin(); it != catUpdates.kv.end(); ++it) {
+        out << "\"" << it->first << "\": " << toJson(getKVStr(it->second));
+        if (std::next(it) != catUpdates.kv.end()) out << ",";
+        out << std::endl;
+      }
+    }
+
+    out << "}";
+
+    return out.str();
+  }
+};
+
+struct GetCategories {
+  const bool read_only = true;
+  std::string description() const {
+    return "getCategories [BLOCK-VERSION]\n"
+           "  Returns all categories. If a BLOCK-VERSION is passed only categories in that block are listed.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
+    std::map<std::string, std::string> out;
+
+    if (args.values.size() >= 1) {
+      auto requested_block_version = toBlockId(args.values[0]);
+      const auto updates = adapter.getBlockUpdates(requested_block_version);
+      if (!updates) {
+        throw NotFoundException{"Couldn't find a block by ID = " + std::to_string(requested_block_version)};
+      }
+      auto catUpdates = updates->categoryUpdates();
+      for (auto const &c : catUpdates.kv) {
+        out[c.first] = getCategoryType(c.second);
+      }
+    } else {
+      auto categories = adapter.blockchainCategories();
+      for (auto const &c : categories) {
+        out[c.first] = cat_type_str.at(c.second);
+      }
+    }
+
+    return toJson(out);
+  }
+};
+
+struct GetValue {
+  const bool read_only = true;
+  std::string description() const {
+    return "getValue CATEGORY HEX-KEY [BLOCK-VERSION]\n"
+           "  Gets a value by category, a hex-encoded key and (optionally) a block version.\n"
+           "  If no BLOCK-VERSION is passed, the value for the latest one will be returned\n"
+           "  (if existing). If the key doesn't exist at BLOCK-VERSION, it will not be returned.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
+    if (args.values.size() < 2) {
+      throw std::invalid_argument{"Missing CATEGORY and HEX-KEY arguments"};
+    }
+    const auto &category = args.values[0];
+    const auto key = concordUtils::hexToSliver(args.values[1]).toString();
+    std::optional<categorization::Value> val;
+    if (args.values.size() >= 3) {
+      auto requested_block_version = toBlockId(args.values[2]);
+      val = adapter.get(category, key, requested_block_version);
+    } else {
+      val = adapter.getLatest(category, key);
+    }
+    if (!val) throw NotFoundException{"Couldn't find a value"};
+
+    auto strval = std::visit([](auto &&arg) { return arg.data; }, *val);
+    return toJson("value", concordUtils::bufferToHex(strval.data(), strval.size()));
+  }
+};
+
+struct CompareTo {
+  const bool read_only = true;
+  std::string description() const {
+    return "compareTo PATH-TO-OTHER-DB\n"
+           "  Compares the passed DB at PATH-TO-DB to the one in PATH-TO-OTHER-DB.\n"
+           "  Returns the ID of the first mismatching block, if such exists, in the overlapping \n"
+           "  range found in the two databases. If there is no overlapping range in the \n"
+           "  databases, no comparison is made.";
+  }
+
+  std::string execute(const KeyValueBlockchain &main_adapter, const CommandArguments &args) const {
+    if (args.values.empty()) {
+      throw std::invalid_argument{"Missing PATH-TO-OTHER-DB argument"};
+    }
+
+    const auto read_only = true;
+    const auto other_adapter = getAdapter(args.values.front(), read_only);
+
+    const auto main_genesis = main_adapter.getGenesisBlockId();
+    const auto other_genesis = other_adapter.getGenesisBlockId();
+    const auto compared_range_first_block_id = std::max(main_genesis, other_genesis);
+
+    const auto main_last_reachable = main_adapter.getLastReachableBlockId();
+    const auto other_last_reachable = other_adapter.getLastReachableBlockId();
+    const auto compared_range_last_block_id = std::min(main_last_reachable, other_last_reachable);
+
+    auto result = std::map<std::string, std::string>{
+        std::make_pair("mainGenesisBlockId", std::to_string(main_genesis)),
+        std::make_pair("otherGenesisBlockId", std::to_string(other_genesis)),
+        std::make_pair("mainLastReachableBlockId", std::to_string(main_last_reachable)),
+        std::make_pair("otherLastReachableBlockId", std::to_string(other_last_reachable))};
+
+    if (compared_range_first_block_id > compared_range_last_block_id) {
+      result["result"] = "no-overlap";
+      return toJson(result);
+    }
+
+    result["comparedRangeFirstBlockId"] = std::to_string(compared_range_first_block_id);
+    result["comparedRangeLastBlockId"] = std::to_string(compared_range_last_block_id);
+
+    const auto mismatch =
+        firstMismatch(compared_range_first_block_id, compared_range_last_block_id, main_adapter, other_adapter);
+    if (mismatch) {
+      result["result"] = "mismatch";
+      result["firstMismatchingBlockId"] = std::to_string(*mismatch);
+    } else {
+      result["result"] = "equivalent";
+    }
+
+    return toJson(result);
+  }
+
+ private:
+  static std::optional<BlockId> firstMismatch(BlockId left,
+                                              BlockId right,
+                                              const KeyValueBlockchain &adapter1,
+                                              const KeyValueBlockchain &adapter2) {
+    ConcordAssertGT(left, 0);
+    ConcordAssertGE(right, left);
+    auto mismatch = std::optional<BlockId>{};
+    // Exploit the blockchain property - if a block is different, try to search for earlier differences to the left.
+    // Otherwise, go right.
+    while (left <= right) {
+      auto current = (right - left) / 2 + left;
+      const auto raw1 = adapter1.getRawBlock(current);
+      const auto raw2 = adapter2.getRawBlock(current);
+      if (raw1 != raw2) {
+        mismatch = current;
+        right = current - 1;
+      } else {
+        left = current + 1;
+      }
+    }
+    return mismatch;
+  }
+};
+
+struct RemoveMetadata {
+  const bool read_only = false;
+  std::string description() const {
+    return "removeMetadata\n"
+           "  Removes metadata and state transfer data from RocksDB.";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &) const {
+    using storage::v2MerkleTree::detail::EDBKeyType;
+
+    static_assert(static_cast<uint8_t>(EDBKeyType::BFT) + 1 == static_cast<uint8_t>(EDBKeyType::Key),
+                  "Key has to be after BFT, if not please review this functionality");
+
+    const concordUtils::Sliver begin{std::string{static_cast<char>(EDBKeyType::BFT)}};
+    const concordUtils::Sliver end{std::string{static_cast<char>(EDBKeyType::Key)}};
+
+    const auto status = adapter.db()->asIDBClient()->rangeDel(begin, end);
+    if (!status.isOK()) {
+      throw std::runtime_error{"Failed to delete metadata and state transfer data: " + status.toString()};
+    }
+    return toJson(std::string{"result"}, std::string{"true"});
+  }
+};
+
+using Command = std::variant<GetGenesisBlockID,
+                             GetLastReachableBlockID,
+                             GetLastStateTransferBlockID,
+                             GetLastBlockID,
+                             GetRawBlock,
+                             GetRawBlockRange,
+                             GetBlockInfo,
+                             GetBlockKeyValues,
+                             GetCategories,
+                             GetValue,
+                             CompareTo,
+                             RemoveMetadata>;
+inline const auto commands_map = std::map<std::string, Command>{
+    std::make_pair("getGenesisBlockID", GetGenesisBlockID{}),
+    std::make_pair("getLastReachableBlockID", GetLastReachableBlockID{}),
+    std::make_pair("getLastStateTransferBlockID", GetLastStateTransferBlockID{}),
+    std::make_pair("getLastBlockID", GetLastBlockID{}),
+    std::make_pair("getRawBlock", GetRawBlock{}),
+    std::make_pair("getRawBlockRange", GetRawBlockRange{}),
+    std::make_pair("getBlockInfo", GetBlockInfo{}),
+    std::make_pair("getBlockKeyValues", GetBlockKeyValues{}),
+    std::make_pair("getCategories", GetCategories{}),
+    std::make_pair("getValue", GetValue{}),
+    std::make_pair("compareTo", CompareTo{}),
+    std::make_pair("removeMetadata", RemoveMetadata{}),
+};
+
+inline std::string usage() {
+  auto ret = "Usage: " + kToolName + " PATH-TO-DB COMMAND [ARGUMENTS]...\n\n";
+  ret += "Supported commands:\n\n";
+
+  for (const auto &kv : commands_map) {
+    ret += std::visit([](const auto &command) { return command.description(); }, kv.second);
+    ret += "\n\n";
+  }
+
+  ret += "Note:\n";
+  ret += "The DB Editor is configured to use the following non-provable keys:\n";
+  ret += "0x20, 0x22\n\n";
+
+  ret += "Examples:\n";
+  ret += "  " + kToolName + " /rocksdb-path getGenesisBlockID\n";
+  ret += "  " + kToolName + " /rocksdb-path getRawBlock 42\n";
+  ret += "  " + kToolName + " /rocksdb-path getValue merkle 0x0a0b0c\n";
+  ret += "  " + kToolName + " /rocksdb-path getValue versioned 0x0a0b0c 42\n";
+
+  return ret;
+}
+
+inline int run(const CommandLineArguments &cmd_line_args, std::ostream &out, std::ostream &err) {
+  // Make sure the output is clean
+  logging::Logger::getRoot().setLogLevel(log4cplus::WARN_LOG_LEVEL);
+
+  if (cmd_line_args.values.size() < kMinCmdLineArguments) {
+    err << usage();
+    return EXIT_FAILURE;
+  }
+
+  auto cmd_it = commands_map.find(cmd_line_args.values[2]);
+  if (cmd_it == std::cend(commands_map)) {
+    err << usage();
+    return EXIT_FAILURE;
+  }
+
+  try {
+    auto read_only = std::visit([](const auto &command) { return command.read_only; }, cmd_it->second);
+    auto adapter = getAdapter(cmd_line_args.values[1], read_only);
+    const auto output =
+        std::visit([&](const auto &command) { return command.execute(adapter, command_arguments(cmd_line_args)); },
+                   cmd_it->second);
+    out << output << std::endl;
+  } catch (const std::exception &e) {
+    err << "Failed to execute command [" << cmd_it->first << "], reason: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+}  // namespace concord::kvbc::tools::db_editor

--- a/kvbc/tools/db_editor/src/kv_blockchain_db_editor.cpp
+++ b/kvbc/tools/db_editor/src/kv_blockchain_db_editor.cpp
@@ -1,0 +1,20 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kv_blockchain_db_editor.hpp"
+
+#include <iostream>
+
+using namespace concord::kvbc::tools::db_editor;
+
+int main(int argc, char *argv[]) { return run(command_line_arguments(argc, argv), std::cout, std::cerr); }

--- a/kvbc/tools/db_editor/src/sparse_merkle_db_editor.cpp
+++ b/kvbc/tools/db_editor/src/sparse_merkle_db_editor.cpp
@@ -15,6 +15,6 @@
 
 #include <iostream>
 
-using namespace concord::kvbc::tools::sparse_merkle_db;
+using namespace concord::kvbc::tools::db_editor;
 
 int main(int argc, char *argv[]) { return run(command_line_arguments(argc, argv), std::cout, std::cerr); }

--- a/kvbc/tools/sparse_merkle_db/CMakeLists.txt
+++ b/kvbc/tools/sparse_merkle_db/CMakeLists.txt
@@ -1,8 +1,0 @@
-add_library(lib_sparse_merkle_db_editor INTERFACE)
-target_link_libraries(lib_sparse_merkle_db_editor INTERFACE)
-target_include_directories(lib_sparse_merkle_db_editor INTERFACE include)
-
-if(BUILD_ROCKSDB_STORAGE)
-add_executable(sparse_merkle_db_editor src/sparse_merkle_db_editor.cpp)
-target_link_libraries(sparse_merkle_db_editor PUBLIC lib_sparse_merkle_db_editor util kvbc stdc++fs)
-endif()

--- a/util/include/hex_tools.h
+++ b/util/include/hex_tools.h
@@ -34,4 +34,7 @@ std::string bufferToHex(const std::uint8_t *data, size_t size);
 // Converts a sliver into a hex string.
 std::string sliverToHex(const Sliver &sliver);
 
+// Converts a byte vector into a hex string
+std::string vectorToHex(const std::vector<std::uint8_t> &data);
+
 }  // namespace concordUtils

--- a/util/src/hex_tools.cpp
+++ b/util/src/hex_tools.cpp
@@ -64,4 +64,6 @@ std::string bufferToHex(const std::uint8_t *data, size_t size) {
 
 std::string sliverToHex(const Sliver &sliver) { return bufferToHex(sliver.data(), sliver.length()); }
 
+std::string vectorToHex(const std::vector<std::uint8_t> &data) { return bufferToHex(data.data(), data.size()); }
+
 }  // namespace concordUtils


### PR DESCRIPTION
New **kv_blockchain_db_editor** tool similar to sparse_merkle_db_editor will allow for inspecting KeyValueBlockchains with categories.

```
Usage: kv_blockchain_db_editor PATH-TO-DB COMMAND [ARGUMENTS]...

Supported commands:

compareTo PATH-TO-OTHER-DB
  Compares the passed DB at PATH-TO-DB to the one in PATH-TO-OTHER-DB.
  Returns the ID of the first mismatching block, if such exists, in the overlapping 
  range found in the two databases. If there is no overlapping range in the 
  databases, no comparison is made.

getBlockInfo BLOCK-ID
  Returns information about the requested block (excluding its key-values).

getBlockKeyValues BLOCK-ID [CATEGORY]
  Returns the block's key-values. If a CATEGORY is passed only those keys/values are listed.

getCategories [BLOCK-VERSION]
  Returns all categories. If a BLOCK-VERSION is passed only categories in that block are listed.

getGenesisBlockID
  Returns the genesis block ID.

getLastBlockID
 Returns the last block ID. Either reachable or state transfer.

getLastReachableBlockID
  Returns the last reachable block ID.

getLastStateTransferBlockID
 Returns the last state transfer block ID. If there is no state transfer returns n/a.

getRawBlock BLOCK-ID
  Returns a serialized raw block (encoded in hex).

getRawBlockRange BLOCK-ID-START BLOCK-ID-END
  Returns a list of serialized raw blocks (encoded in hex) in the [BLOCK-ID-START, BLOCK-ID-END) range.

getValue CATEGORY HEX-KEY [BLOCK-VERSION]
  Gets a value by category, a hex-encoded key and (optionally) a block version.
  If no BLOCK-VERSION is passed, the value for the latest one will be returned
  (if existing). If the key doesn't exist at BLOCK-VERSION, it will not be returned.

removeMetadata
  Removes metadata and state transfer data from RocksDB.

Note:
The DB Editor is configured to use the following non-provable keys:
0x20, 0x22

Examples:
  kv_blockchain_db_editor /rocksdb-path getGenesisBlockID
  kv_blockchain_db_editor /rocksdb-path getRawBlock 42
  kv_blockchain_db_editor /rocksdb-path getValue merkle 0x0a0b0c
  kv_blockchain_db_editor /rocksdb-path getValue versioned 0x0a0b0c 42
```

Specific differences with the other tool are the new getCategories command, and the category parameter on getValue and getBlockKeyValues. When getBlockKeyValues is called without a category the output is the key/values for all categories one after the other.

Example output:
```
./kv_blockchain_db_editor ~/temp/kv getCategories
{
  "merkle": "block_merkle",
  "versioned": "versioned_kv"
}

./kv_blockchain_db_editor ~/temp/kv getBlockKeyValues 2
{
"merkle": {
  "0x0000000a": "0x00000014",
  "0x00000014": "0x00000028",
  "0x0000001e": "0x0000003c"
},
"versioned": {
  "0x766b65793130": "0x7676616c3230",
  "0x766b65793230": "0x7676616c3430",
  "0x766b65793330": "0x7676616c3630"
}
}

./kv_blockchain_db_editor ~/temp/kv/ getBlockInfo 1
{
  "parentBlockDigest": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "categoriesCount": "3",
  "categories": {
    "immutable": {
      "keyValueCount": "1",
      "type": "immutable"
    },
    "merkle": {
      "keyValueCount": "3",
      "type": "block_merkle"
    },
    "versioned": {
      "keyValueCount": "3",
      "type": "versioned_kv"
    }
  },
  "keyValueTotalCount": "7"
}

```