### PR TITLE
Kvbcbench concurrent reads

### DIFF
--- a/kvbc/benchmark/kvbcbench/input.h
+++ b/kvbc/benchmark/kvbcbench/input.h
@@ -1,0 +1,108 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+//
+
+#pragma once
+
+#include <vector>
+#include <boost/program_options/variables_map.hpp>
+
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+namespace concord::kvbc::bench {
+
+namespace po = boost::program_options;
+using categorization::BlockMerkleInput;
+using ReadKeys = std::vector<std::string>;
+
+struct InputData {
+  std::vector<BlockMerkleInput> block_merkle_input;
+  ReadKeys block_merkle_read_keys;
+};
+
+InputData createBlockInput(const po::variables_map& config) {
+  auto total_blocks = config["total-blocks"].as<size_t>();
+  auto key_size = config["block-merkle-key-size"].as<size_t>();
+  auto value_size = config["block-merkle-value-size"].as<size_t>();
+  auto batch_size = config["batch-size"].as<size_t>();
+  auto num_adds = config["num-block-merkle-keys-add"].as<size_t>() * batch_size;
+  auto num_deletes = config["num-block-merkle-keys-delete"].as<size_t>() * batch_size;
+  auto max_memory_for_kv = config["max-memory-for-kv-gen"].as<size_t>();
+  auto max_read_keys = config["max-total-block-merkle-read-keys"].as<size_t>();
+
+  const auto block_size = (key_size + value_size) * num_adds + key_size * num_deletes;
+  const size_t num_blocks = std::min(max_memory_for_kv / block_size, total_blocks);
+  auto blocks = std::vector<BlockMerkleInput>{};
+  blocks.reserve(num_blocks);
+
+  // Run generation in parallel
+  auto num_cpus = std::thread::hardware_concurrency();
+  std::cout << "Generating blocks in parallel across " << num_cpus << " cpus" << std::endl;
+  auto blocks_per_thread = num_blocks / num_cpus;
+
+  // Each thread fills in their subset of keys in a pre-allocated vector. There is no race here, and
+  // no need for locks as the buffer segments in each thread are disjoint.
+  auto total_read_keys = std::min(num_adds * num_blocks, max_read_keys);
+  auto read_keys_per_thread = total_read_keys / num_cpus;
+  auto read_keys = ReadKeys(total_read_keys);
+
+  auto gen = [&](size_t thread_id) -> std::vector<categorization::BlockMerkleInput> {
+    static thread_local std::mt19937 generator;
+    auto distribution = std::uniform_int_distribution<unsigned short>(0, 255);
+    auto rand_char = [&]() -> uint8_t { return static_cast<uint8_t>(distribution(generator)); };
+    size_t read_key_start = thread_id * read_keys_per_thread;
+    size_t read_key_end = read_key_start + read_keys_per_thread;
+    auto output = std::vector<BlockMerkleInput>{};
+    output.reserve(blocks_per_thread);
+    for (auto j = 0u; j < blocks_per_thread; j++) {
+      auto input = BlockMerkleInput{};
+      for (auto i = 0u; i < num_adds; i++) {
+        auto key = std::string{};
+        auto val = std::string{};
+        key.reserve(key_size);
+        val.reserve(value_size);
+        generate_n(std::back_inserter(key), key_size, rand_char);
+        generate_n(std::back_inserter(val), value_size, rand_char);
+        if (read_key_start != read_key_end) {
+          read_keys[read_key_start] = key;
+          read_key_start++;
+        }
+        input.kv.emplace(key, val);
+      }
+
+      for (auto i = 0u; i < num_deletes; i++) {
+        auto key = std::string{};
+        key.reserve(key_size);
+        generate_n(std::back_inserter(key), key_size, rand_char);
+        input.deletes.push_back(key);
+      }
+      output.push_back(input);
+    }
+    return output;
+  };
+
+  auto output_futures = std::vector<std::future<std::vector<categorization::BlockMerkleInput>>>{};
+  output_futures.reserve(num_cpus);
+
+  // Launch random key-value generation in parallel
+  for (auto i = 0u; i < num_cpus; i++) {
+    output_futures.push_back(std::async(std::launch::async, gen, i));
+  }
+  // Merge the results
+  for (auto i = 0u; i < num_cpus; i++) {
+    auto batch = output_futures[i].get();
+    blocks.insert(blocks.end(), batch.begin(), batch.end());
+  }
+  return InputData{blocks, read_keys};
+}
+
+}  // namespace concord::kvbc::bench

--- a/kvbc/benchmark/kvbcbench/main.cpp
+++ b/kvbc/benchmark/kvbcbench/main.cpp
@@ -1,3 +1,16 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+//
+
 #include <chrono>
 #include <cstddef>
 #include <iostream>
@@ -22,6 +35,8 @@
 #include "rocksdb/native_client.h"
 #include "diagnostics.h"
 #include "diagnostics_server.h"
+#include "input.h"
+#include "pre_execution.h"
 
 using namespace std;
 namespace po = boost::program_options;
@@ -30,8 +45,6 @@ namespace concord::kvbc::bench {
 
 using categorization::BlockMerkleInput;
 using categorization::TaggedVersion;
-
-using ReadKeys = std::vector<std::string>;
 
 // Since we generate all keys up front we need to prevent explosive memory growth.
 //
@@ -81,7 +94,15 @@ po::variables_map parseArgs(int argc, char** argv) {
 
     ("max-memory-for-kv-gen",
     po::value<size_t>()->default_value(MAX_MEMORY_SIZE_FOR_KV_DEFAULT),
-    "Maximum amount of memory to allocate for random kv pairs during key-value generation");
+    "Maximum amount of memory to allocate for random kv pairs during key-value generation")
+
+    ("pre-execution-concurrency",
+    po::value<size_t>()->default_value(10),
+    "Amount of pre-execution tasks to run during block generation")
+
+    ("pre-execution-delay-ms",
+    po::value<size_t>()->default_value(50),
+    "Time it takes to run a pre-execution request.");
 
   // clang-format on
 
@@ -120,93 +141,28 @@ std::shared_ptr<rocksdb::Statistics> completeRocksdbConfiguration(
   return db_options.statistics;
 }
 
-std::pair<std::vector<categorization::BlockMerkleInput>, ReadKeys> createBlockInput(const po::variables_map& config) {
-  auto total_blocks = config["total-blocks"].as<size_t>();
-  auto key_size = config["block-merkle-key-size"].as<size_t>();
-  auto value_size = config["block-merkle-value-size"].as<size_t>();
-  auto batch_size = config["batch-size"].as<size_t>();
-  auto num_adds = config["num-block-merkle-keys-add"].as<size_t>() * batch_size;
-  auto num_deletes = config["num-block-merkle-keys-delete"].as<size_t>() * batch_size;
-  auto max_memory_for_kv = config["max-memory-for-kv-gen"].as<size_t>();
-  auto max_read_keys = config["max-total-block-merkle-read-keys"].as<size_t>();
+size_t numVersionsToRead(const po::variables_map& config, size_t num_read_keys) {
+  return std::min(config["num-block-merkle-read-keys-per-transaction"].as<size_t>(), num_read_keys);
+}
 
-  const auto block_size = (key_size + value_size) * num_adds + key_size * num_deletes;
-  const size_t num_blocks = std::min(max_memory_for_kv / block_size, total_blocks);
-  auto blocks = std::vector<BlockMerkleInput>{};
-  blocks.reserve(num_blocks);
-
-  // Run generation in parallel
-  auto num_cpus = std::thread::hardware_concurrency();
-  cout << "Generating blocks in parallel across " << num_cpus << " cpus" << endl;
-  auto blocks_per_thread = num_blocks / num_cpus;
-
-  // Each thread fills in their subset of keys in a pre-allocated vector. There is no race here, and
-  // no need for locks as the buffer segments in each thread are disjoint.
-  auto total_read_keys = std::min(num_adds * num_blocks, max_read_keys);
-  auto read_keys_per_thread = total_read_keys / num_cpus;
-  auto read_keys = ReadKeys(total_read_keys);
-
-  auto gen = [&](size_t thread_id) -> std::vector<categorization::BlockMerkleInput> {
-    static thread_local std::mt19937 generator;
-    auto distribution = std::uniform_int_distribution<unsigned short>(0, 255);
-    auto rand_char = [&]() -> uint8_t { return static_cast<uint8_t>(distribution(generator)); };
-    size_t read_key_start = thread_id * read_keys_per_thread;
-    size_t read_key_end = read_key_start + read_keys_per_thread;
-    auto output = std::vector<BlockMerkleInput>{};
-    output.reserve(blocks_per_thread);
-    for (auto j = 0u; j < blocks_per_thread; j++) {
-      auto input = BlockMerkleInput{};
-      for (auto i = 0u; i < num_adds; i++) {
-        auto key = std::string{};
-        auto val = std::string{};
-        key.reserve(key_size);
-        val.reserve(value_size);
-        generate_n(std::back_inserter(key), key_size, rand_char);
-        generate_n(std::back_inserter(val), value_size, rand_char);
-        if (read_key_start != read_key_end) {
-          read_keys[read_key_start] = key;
-          read_key_start++;
-        }
-        input.kv.emplace(key, val);
-      }
-
-      for (auto i = 0u; i < num_deletes; i++) {
-        auto key = std::string{};
-        key.reserve(key_size);
-        generate_n(std::back_inserter(key), key_size, rand_char);
-        input.deletes.push_back(key);
-      }
-      output.push_back(input);
-    }
-    return output;
-  };
-
-  auto output_futures = std::vector<std::future<std::vector<categorization::BlockMerkleInput>>>{};
-  output_futures.reserve(num_cpus);
-
-  // Launch random key-value generation in parallel
-  for (auto i = 0u; i < num_cpus; i++) {
-    output_futures.push_back(std::async(std::launch::async, gen, i));
-  }
-  // Merge the results
-  for (auto i = 0u; i < num_cpus; i++) {
-    auto batch = output_futures[i].get();
-    blocks.insert(blocks.end(), batch.begin(), batch.end());
-  }
-  return std::make_pair(blocks, read_keys);
+PreExecConfig preExecConfig(const po::variables_map& config, const ReadKeys& block_merkle_read_keys) {
+  auto pre_exec_config = PreExecConfig{};
+  pre_exec_config.concurrency = config["pre-execution-concurrency"].as<size_t>();
+  pre_exec_config.delay = std::chrono::milliseconds(config["pre-execution-delay-ms"].as<size_t>());
+  pre_exec_config.num_block_merkle_keys_to_read = numVersionsToRead(config, block_merkle_read_keys.size());
+  return pre_exec_config;
 }
 
 void addBlocks(const po::variables_map& config,
                std::shared_ptr<storage::rocksdb::NativeClient>& db,
+               categorization::detail::BlockMerkleCategory& cat,
                std::vector<BlockMerkleInput>& input,
                std::vector<string>& read_keys,
                std::shared_ptr<diagnostics::Recorder>& add_block_recorder,
                std::shared_ptr<diagnostics::Recorder>& conflict_detection_recorder) {
-  auto cat = categorization::detail::BlockMerkleCategory{db};
   auto total_blocks = config["total-blocks"].as<size_t>();
   auto max_memory_for_kv = config["max-memory-for-kv-gen"].as<size_t>();
-  auto num_versions_to_read =
-      std::min(config["num-block-merkle-read-keys-per-transaction"].as<size_t>(), read_keys.size());
+  auto num_versions_to_read = numVersionsToRead(config, read_keys.size());
 
   const auto input_blocks = input.size();
   if (total_blocks > input_blocks) {
@@ -263,7 +219,7 @@ int main(int argc, char** argv) {
 
     cout << "Starting Input Data Generation..." << endl;
     auto start = std::chrono::steady_clock::now();
-    auto [input, read_keys] = createBlockInput(config);
+    auto input = createBlockInput(config);
     auto end = std::chrono::steady_clock::now();
     cout << "Input Data Generation completed in " << chrono::duration_cast<chrono::seconds>(end - start).count()
          << " seconds." << endl;
@@ -274,13 +230,26 @@ int main(int argc, char** argv) {
     };
     auto opts = storage::rocksdb::NativeClient::UserOptions{"kvbcbench_rocksdb_opts.ini", completeInit};
     auto db = storage::rocksdb::NativeClient::newClient(config["rocksdb-path"].as<std::string>(), false, opts);
+    auto cat = kvbc::categorization::detail::BlockMerkleCategory{db};
+
+    auto pre_exec_config = preExecConfig(config, input.block_merkle_read_keys);
+    auto pre_exec_sim = PreExecutionSimulator(pre_exec_config, input.block_merkle_read_keys, cat);
+    pre_exec_sim.start();
 
     cout << "Starting to Add Blocks..." << endl;
     start = std::chrono::steady_clock::now();
-    addBlocks(config, db, input, read_keys, add_block_recorder, conflict_detection_recorder);
+    addBlocks(config,
+              db,
+              cat,
+              input.block_merkle_input,
+              input.block_merkle_read_keys,
+              add_block_recorder,
+              conflict_detection_recorder);
     end = std::chrono::steady_clock::now();
     auto add_block_duration = chrono::duration_cast<chrono::milliseconds>(end - start).count();
     cout << "Adding blocks completed in = " << add_block_duration / 1000.0 << " seconds" << endl << endl;
+
+    pre_exec_sim.stop();
 
     printHistograms();
 

--- a/kvbc/benchmark/kvbcbench/pre_execution.h
+++ b/kvbc/benchmark/kvbcbench/pre_execution.h
@@ -1,0 +1,80 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+//
+#pragma once
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include "categorization/block_merkle_category.h"
+#include "input.h"
+
+namespace concord::kvbc::bench {
+
+struct PreExecConfig {
+  size_t concurrency;
+  std::chrono::milliseconds delay;
+  size_t num_block_merkle_keys_to_read;
+};
+
+class PreExecutionSimulator {
+ public:
+  PreExecutionSimulator(const PreExecConfig& config,
+                        const ReadKeys& read_keys,
+                        categorization::detail::BlockMerkleCategory& cat)
+      : config_(config), read_keys_(read_keys), cat_(cat) {}
+
+  void start() {
+    std::cout << "Starting Simulated Pre-Execution Reads" << std::endl;
+    for (auto i = 0u; i < config_.concurrency; i++) {
+      threads_.emplace_back([this]() {
+        // Only alloacate the read_keys vector once
+        auto read_keys = std::vector<std::string>{};
+        read_keys.reserve(config_.num_block_merkle_keys_to_read);
+        auto values = std::vector<std::optional<categorization::Value>>{};
+        while (!stop_) {
+          read_keys.clear();
+          values.clear();
+          auto start = randomKeyIter();
+          std::copy(start, start + config_.num_block_merkle_keys_to_read, std::back_inserter(read_keys));
+          cat_.multiGetLatest(read_keys, values);
+          std::this_thread::sleep_for(config_.delay);
+        }
+      });
+    }
+  }
+
+  void stop() {
+    std::cout << "Stopping Simulated Pre-Execution Reads" << std::endl;
+    stop_ = true;
+    for (auto& thread : threads_) {
+      thread.join();
+    }
+  }
+
+ private:
+  std::vector<std::string>::const_iterator randomKeyIter() {
+    auto max_read_offset = read_keys_.size() - config_.num_block_merkle_keys_to_read;
+    return read_keys_.begin() + (rand() % max_read_offset);
+  }
+  std::atomic_bool stop_ = false;
+
+  std::vector<std::thread> threads_;
+
+  const PreExecConfig config_;
+  const ReadKeys& read_keys_;
+  // TODO: Replace this with kv_blockchain for more general reads
+  categorization::detail::BlockMerkleCategory& cat_;
+};
+
+}  // namespace concord::kvbc::bench


### PR DESCRIPTION
The second commit in this PR adds concurrent reads to `kvbcbench` to simulate read load on RocksDB during pre-execution.

Only the second commit should be reviewed, since the first commit is identical to #1196. 