### PR TITLE
Mini-batching feature

### DIFF
--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use
 // this product except in compliance with the Apache 2.0 License.
@@ -41,7 +41,7 @@ Msg makeClientMsg(const RequestConfig& config, Msg&& request, bool read_only, ui
   header->reqSeqNum = config.sequence_number;
   header->requestLength = request.size();
   header->timeoutMilli = config.timeout.count();
-  header->cid_length = config.correlation_id.size();
+  header->cidLength = config.correlation_id.size();
 
   auto* position = msg.data() + header_size;
 

--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -13,13 +13,23 @@
 
 #include <cstdint>
 
-#define REQUEST_MSG_TYPE (700)
-#define REPLY_MSG_TYPE (800)
 #define PRE_PROCESS_REQUEST_MSG_TYPE (500)
+#define REQUEST_MSG_TYPE (700)
+#define BATCH_REQUEST_MSG_TYPE (750)
+#define REPLY_MSG_TYPE (800)
 
 namespace bftEngine {
 
 #pragma pack(push, 1)
+
+struct ClientBatchRequestMsgHeader {
+  uint16_t msgType;  // always == BATCH_REQUEST_MSG_TYPE
+  uint32_t cidSize;
+  uint16_t clientId;
+  uint32_t numOfMessagesInBatch;
+  uint32_t dataSize;
+};
+
 struct ClientRequestMsgHeader {
   uint16_t msgType;  // always == REQUEST_MSG_TYPE
   uint32_t spanContextSize = 0u;
@@ -28,7 +38,7 @@ struct ClientRequestMsgHeader {
   uint64_t reqSeqNum;
   uint32_t requestLength;
   uint64_t timeoutMilli;
-  uint32_t cid_length = 0;
+  uint32_t cidLength = 0;
   // followed by the request (security information, such as signatures, should be part of the request)
 
   // TODO(GG): idOfClientProxy is not needed here

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -69,6 +69,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   CONFIG_PARAM(autoPrimaryRotationEnabled, bool, false, "if automatic primary rotation is enabled");
   CONFIG_PARAM(autoPrimaryRotationTimerMillisec, uint16_t, 0, "timeout for automatic primary rotation");
   CONFIG_PARAM(preExecutionFeatureEnabled, bool, false, "enables the pre-execution feature");
+  CONFIG_PARAM(clientMiniBatchingEnabled, bool, false, "enables the client-mini-batch feature");
+  CONFIG_PARAM(clientMiniBatchingMaxMsgsNbr, uint16_t, 10, "Maximum messages number in one mini-batch");
   CONFIG_PARAM(preExecReqStatusCheckTimerMillisec,
                uint64_t,
                5000,
@@ -163,6 +165,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, autoPrimaryRotationTimerMillisec);
 
     serialize(outStream, preExecutionFeatureEnabled);
+    serialize(outStream, clientMiniBatchingEnabled);
+    serialize(outStream, clientMiniBatchingMaxMsgsNbr);
     serialize(outStream, preExecReqStatusCheckTimerMillisec);
     serialize(outStream, preExecConcurrencyLevel);
     serialize(outStream, batchingPolicy);
@@ -210,6 +214,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, autoPrimaryRotationTimerMillisec);
 
     deserialize(inStream, preExecutionFeatureEnabled);
+    deserialize(inStream, clientMiniBatchingEnabled);
+    deserialize(inStream, clientMiniBatchingMaxMsgsNbr);
     deserialize(inStream, preExecReqStatusCheckTimerMillisec);
     deserialize(inStream, preExecConcurrencyLevel);
     deserialize(inStream, batchingPolicy);
@@ -290,7 +296,7 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.keyExchangeOnStart,
               rc.blockAccumulation);
   os << ", ";
-  os << KVLOG(rc.keyViewFilePath);
+  os << KVLOG(rc.clientMiniBatchingEnabled, rc.clientMiniBatchingMaxMsgsNbr, rc.keyViewFilePath);
 
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
 

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -112,7 +112,7 @@ void ClientsManager::loadInfoFromReservedPages() {
   }
 }
 
-bool ClientsManager::isReplySentToClientForRequest(NodeIdType clientId, ReqId reqSeqNum) {
+bool ClientsManager::hasReply(NodeIdType clientId, ReqId reqSeqNum) {
   uint16_t idx = clientIdToIndex_.at(clientId);
   const auto& repliesInfo = indexToClientInfo_.at(idx).repliesInfo;
   const auto& elem = repliesInfo.find(reqSeqNum);
@@ -214,7 +214,9 @@ ClientReplyMsg* ClientsManager::allocateReplyFromSavedOne(NodeIdType clientId,
   }
 
   if (r->reqSeqNum() != requestSeqNum) {
-    LOG_WARN(GL, "Reserved page contains reply for the different request: " << r->reqSeqNum() << " => ignore");
+    LOG_INFO(GL,
+             "The reserved page contains a reply for a different request, so the current request gets ignored"
+                 << KVLOG(r->reqSeqNum(), requestSeqNum));
     delete r;
     return nullptr;
   }
@@ -236,7 +238,7 @@ bool ClientsManager::canBecomePending(NodeIdType clientId, ReqId reqSeqNum) cons
   }
   const auto& reqIt = requestsInfo.find(reqSeqNum);
   if (reqIt != requestsInfo.end()) {
-    LOG_DEBUG(GL, "The request has been executing right now" << KVLOG(clientId, reqSeqNum));
+    LOG_DEBUG(GL, "The request is executing right now" << KVLOG(clientId, reqSeqNum));
     return false;
   }
   const auto& repliesInfo = indexToClientInfo_.at(idx).repliesInfo;

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -9,58 +9,45 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <string.h>
 #include "ClientsManager.hpp"
 #include "messages/ClientReplyMsg.hpp"
-#include "messages/ClientRequestMsg.hpp"
 #include "IStateTransfer.hpp"
 #include "assertUtils.hpp"
 #include "Logger.hpp"
 #include "ReplicaConfig.hpp"
 
-namespace bftEngine {
-namespace impl {
-// initialize:
-//* map of client id to indices.
-//* map indices to client info.
-//* Calculate reserved pages per client.
-ClientsManager::ClientsManager(ReplicaId myId,
-                               std::set<NodeIdType>& clientsSet,
-                               uint32_t sizeOfReservedPage,
-                               const uint32_t& maxReplysize)
-    : myId_(myId),
-      sizeOfReservedPage_(sizeOfReservedPage),
+namespace bftEngine::impl {
+// Initialize:
+// * map of client id to indices.
+// * Calculate reserved pages per client.
+ClientsManager::ClientsManager(std::set<NodeIdType>& clientsSet)
+    : myId_(ReplicaConfig::instance().replicaId),
+      sizeOfReservedPage_(ReplicaConfig::instance().getsizeOfReservedPage()),
       indexToClientInfo_(clientsSet.size()),
-      maxReplysize_(maxReplysize) {
+      maxReplySize_(ReplicaConfig::instance().getmaxReplyMessageSize()),
+      maxNumOfReqsPerClient_(ReplicaConfig::instance().clientMiniBatchingEnabled
+                                 ? ReplicaConfig::instance().clientMiniBatchingMaxMsgsNbr
+                                 : 1) {
   ConcordAssert(clientsSet.size() >= 1);
-
-  scratchPage_ = (char*)std::malloc(sizeOfReservedPage);
-  memset(scratchPage_, 0, sizeOfReservedPage);
+  scratchPage_ = (char*)std::malloc(sizeOfReservedPage_);
+  memset(scratchPage_, 0, sizeOfReservedPage_);
 
   uint16_t idx = 0;
   for (NodeIdType c : clientsSet) {
     clientIdToIndex_.insert(std::pair<NodeIdType, uint16_t>(c, idx));
-
-    indexToClientInfo_[idx].currentPendingRequest = 0;
-    indexToClientInfo_[idx].timeOfCurrentPendingRequest = MinTime;
-    indexToClientInfo_[idx].cid = std::string();
-
-    indexToClientInfo_[idx].lastSeqNumberOfReply = 0;
-    indexToClientInfo_[idx].latestReplyTime = MinTime;
     highestIdOfNonInternalClient_ = c;
+    indexToClientInfo_.push_back(ClientInfo());
     idx++;
   }
-
-  reservedPagesPerClient_ = reservedPagesPerClient(sizeOfReservedPage, maxReplysize_);
-
+  reservedPagesPerClient_ = reservedPagesPerClient(sizeOfReservedPage_, maxReplySize_);
   numOfClients_ = (uint16_t)clientsSet.size();
-
   requiredNumberOfPages_ = (numOfClients_ * reservedPagesPerClient_);
+  LOG_DEBUG(GL, KVLOG(sizeOfReservedPage_, reservedPagesPerClient_, maxReplySize_, maxNumOfReqsPerClient_));
 }
 
-uint32_t ClientsManager::reservedPagesPerClient(const uint32_t& sizeOfReservedPage, const uint32_t& maxReplysize) {
-  uint32_t reservedPagesPerClient = maxReplysize / sizeOfReservedPage;
-  if (maxReplysize % sizeOfReservedPage != 0) {
+uint32_t ClientsManager::reservedPagesPerClient(const uint32_t& sizeOfReservedPage, const uint32_t& maxReplySize) {
+  uint32_t reservedPagesPerClient = maxReplySize / sizeOfReservedPage;
+  if (maxReplySize % sizeOfReservedPage != 0) {
     reservedPagesPerClient++;
   }
   return reservedPagesPerClient;
@@ -74,12 +61,7 @@ void ClientsManager::initInternalClientInfo(const int& numReplicas) {
   auto currIdx = clientIdToIndex_[highestIdOfNonInternalClient_];
   for (int i = 0; i < numReplicas; i++) {
     clientIdToIndex_.insert(std::pair<NodeIdType, uint16_t>(++currClId, ++currIdx));
-    indexToClientInfo_[currIdx].currentPendingRequest = 0;
-    indexToClientInfo_[currIdx].timeOfCurrentPendingRequest = MinTime;
-    indexToClientInfo_[currIdx].cid = std::string();
-
-    indexToClientInfo_[currIdx].lastSeqNumberOfReply = 0;
-    indexToClientInfo_[currIdx].latestReplyTime = MinTime;
+    indexToClientInfo_.push_back(ClientInfo());
     LOG_DEBUG(GL,
               "Adding internal client, id [" << currClId << "] as index [" << currIdx << "] vector size "
                                              << indexToClientInfo_.size());
@@ -98,17 +80,12 @@ ClientsManager::~ClientsManager() { std::free(scratchPage_); }
 void ClientsManager::init(IStateTransfer* stateTransfer) {
   ConcordAssert(stateTransfer != nullptr);
   ConcordAssert(stateTransfer_ == nullptr);
-
   stateTransfer_ = stateTransfer;
 }
 
 uint32_t ClientsManager::numberOfRequiredReservedPages() const { return requiredNumberOfPages_; }
 
-void ClientsManager::clearReservedPages() {
-  for (uint32_t i = 0; i < requiredNumberOfPages_; i++) stateTransfer_->zeroReservedPage(resPageOffset() + i);
-}
-
-// per client:
+// Per client:
 // * calculate offset of reserved page start.
 // * load corresponding page from state-transfer to scratchPage.
 // * Fill its clientInfo.
@@ -123,65 +100,61 @@ void ClientsManager::loadInfoFromReservedPages() {
     ConcordAssert(replyHeader->msgType == 0 || replyHeader->msgType == MsgCode::ClientReply);
     ConcordAssert(replyHeader->currentPrimaryId == 0);
     ConcordAssert(replyHeader->replyLength >= 0);
-    ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplysize_);
+    ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplySize_);
 
-    ClientInfo& ci = indexToClientInfo_.at(e.second);
-    ci.lastSeqNumberOfReply = replyHeader->reqSeqNum;
-    ci.latestReplyTime = MinTime;
+    auto& repliesInfo = indexToClientInfo_.at(e.second).repliesInfo;
+    repliesInfo.emplace(replyHeader->reqSeqNum, MinTime);
 
-    // update pending request
-    if (ci.currentPendingRequest != 0 && (ci.currentPendingRequest <= replyHeader->reqSeqNum)) {
-      ci.currentPendingRequest = 0;
-      ci.timeOfCurrentPendingRequest = MinTime;
-      ci.waitsForExecution = false;
-      ci.cid = std::string();
-    }
+    // Remove pending request
+    auto& requestsInfo = indexToClientInfo_.at(e.second).requestsInfo;
+    const auto& reqIt = requestsInfo.find(replyHeader->reqSeqNum);
+    if (reqIt != requestsInfo.end()) requestsInfo.erase(reqIt);
   }
 }
 
-ReqId ClientsManager::seqNumberOfLastReplyToClient(NodeIdType clientId) {
+bool ClientsManager::isReplySentToClientForRequest(NodeIdType clientId, ReqId reqSeqNum) {
   uint16_t idx = clientIdToIndex_.at(clientId);
-  ReqId retVal = indexToClientInfo_.at(idx).lastSeqNumberOfReply;
-  return retVal;
+  const auto& repliesInfo = indexToClientInfo_.at(idx).repliesInfo;
+  const auto& elem = repliesInfo.find(reqSeqNum);
+  return (elem != repliesInfo.end());
+}
+
+void ClientsManager::deleteOldestReply(NodeIdType clientId) {
+  Time earliestTime = MaxTime;
+  ReqId earliestReplyId = 0;
+  const uint16_t clientIdx = clientIdToIndex_.at(clientId);
+  auto& repliesInfo = indexToClientInfo_.at(clientIdx).repliesInfo;
+  for (const auto& reply : repliesInfo) {
+    if (reply.second != MinTime && earliestTime > reply.second) {
+      earliestReplyId = reply.first;
+      earliestTime = reply.second;
+    }
+  }
+  if (earliestReplyId) {
+    repliesInfo.erase(earliestReplyId);
+    LOG_DEBUG(GL, "Deleted oldest reply message" << KVLOG(earliestReplyId));
+  }
 }
 
 bool ClientsManager::isValidClient(NodeIdType clientId) const { return (clientIdToIndex_.count(clientId) > 0); }
 
-void ClientsManager::getInfoAboutLastReplyToClient(NodeIdType clientId, ReqId& outSeqNumber, Time& outLatestTime) {
-  uint16_t idx = clientIdToIndex_.at(clientId);
-  const ClientInfo& c = indexToClientInfo_.at(idx);
-
-  outSeqNumber = c.lastSeqNumberOfReply;
-  outLatestTime = c.latestReplyTime;
-}
-
 // Reference the ClientInfo of the corresponding client:
-//* set last reply seq num to the seq num of the request we reply to.
-//* set reply time to `now`.
-//* allocate new ClientReplyMsg
-//* calculate: num of pages, size of last page.
-//* save the reply to the reserved pages.
+// * set last reply seq num to the seq num of the request we reply to.
+// * set reply time to `now`.
+// * allocate new ClientReplyMsg
+// * calculate: num of pages, size of last page.
+// * save the reply to the reserved pages.
 ClientReplyMsg* ClientsManager::allocateNewReplyMsgAndWriteToStorage(
     NodeIdType clientId, ReqId requestSeqNum, uint16_t currentPrimaryId, char* reply, uint32_t replyLength) {
-  // ConcordAssert(replyLength <= .... ) - TODO(GG)
-
   const uint16_t clientIdx = clientIdToIndex_.at(clientId);
-
   ClientInfo& c = indexToClientInfo_.at(clientIdx);
+  if (c.repliesInfo.size() >= maxNumOfReqsPerClient_) deleteOldestReply(clientId);
 
-  ConcordAssert(c.lastSeqNumberOfReply <= requestSeqNum);
-
-  c.lastSeqNumberOfReply = requestSeqNum;
-  c.latestReplyTime = getMonotonicTime();
-
-  LOG_DEBUG(GL, "requestSeqNum=" << requestSeqNum);
-
+  c.repliesInfo.emplace(requestSeqNum, getMonotonicTime());
+  LOG_DEBUG(GL, KVLOG(clientId, requestSeqNum));
   ClientReplyMsg* const r = new ClientReplyMsg(myId_, requestSeqNum, reply, replyLength);
-
   const uint32_t firstPageId = clientIdx * reservedPagesPerClient_;
-
   LOG_DEBUG(GL, "firstPageId=" << firstPageId);
-
   uint32_t numOfPages = r->size() / sizeOfReservedPage_;
   uint32_t sizeLastPage = sizeOfReservedPage_;
 
@@ -190,8 +163,7 @@ ClientReplyMsg* ClientsManager::allocateNewReplyMsgAndWriteToStorage(
     sizeLastPage = r->size() % sizeOfReservedPage_;
   }
 
-  LOG_DEBUG(GL, "numOfPages=" << numOfPages << " sizeLastPage=" << sizeLastPage);
-
+  LOG_DEBUG(GL, KVLOG(clientId, requestSeqNum, numOfPages, sizeLastPage));
   // write reply message to reserved pages
   for (uint32_t i = 0; i < numOfPages; i++) {
     const char* ptrPage = r->body() + i * sizeOfReservedPage_;
@@ -201,50 +173,39 @@ ClientReplyMsg* ClientsManager::allocateNewReplyMsgAndWriteToStorage(
 
   // write currentPrimaryId to message (we don't store the currentPrimaryId in the reserved pages)
   r->setPrimaryId(currentPrimaryId);
-
-  LOG_DEBUG(GL, "returns reply with hash=" << r->debugHash());
-
+  LOG_DEBUG(GL, "Returns reply with hash=" << r->debugHash() << KVLOG(clientId, requestSeqNum));
   return r;
 }
 
-//* load client reserve page to scratchPage
-//* cast to ClientReplyMsgHeader and validate.
-//* calculate: reply msg size, num of pages, size of last page.
-//* allocate new ClientReplyMsg.
-//* copy relpy from reserved pages to ClientReplyMsg.
-//* set primary id.
-ClientReplyMsg* ClientsManager::allocateMsgWithLatestReply(NodeIdType clientId, uint16_t currentPrimaryId) {
+// * load client reserve page to scratchPage
+// * cast to ClientReplyMsgHeader and validate.
+// * calculate: reply msg size, num of pages, size of last page.
+// * allocate new ClientReplyMsg.
+// * copy reply from reserved pages to ClientReplyMsg.
+// * set primary id.
+ClientReplyMsg* ClientsManager::allocateReplyFromSavedOne(NodeIdType clientId,
+                                                          ReqId requestSeqNum,
+                                                          uint16_t currentPrimaryId) {
   const uint16_t clientIdx = clientIdToIndex_.at(clientId);
-
-  ClientInfo& info = indexToClientInfo_.at(clientIdx);
-
-  ConcordAssert(info.lastSeqNumberOfReply != 0);
-
   const uint32_t firstPageId = clientIdx * reservedPagesPerClient_;
-
-  LOG_DEBUG(GL, "info.lastSeqNumberOfReply=" << info.lastSeqNumberOfReply << " firstPageId=" << firstPageId);
-
+  LOG_DEBUG(GL, KVLOG(requestSeqNum, firstPageId));
   stateTransfer_->loadReservedPage(resPageOffset() + firstPageId, sizeOfReservedPage_, scratchPage_);
 
   ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_;
   ConcordAssert(replyHeader->msgType == MsgCode::ClientReply);
   ConcordAssert(replyHeader->currentPrimaryId == 0);
   ConcordAssert(replyHeader->replyLength > 0);
-  ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplysize_);
+  ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplySize_);
 
   uint32_t replyMsgSize = sizeof(ClientReplyMsgHeader) + replyHeader->replyLength;
-
   uint32_t numOfPages = replyMsgSize / sizeOfReservedPage_;
   uint32_t sizeLastPage = sizeOfReservedPage_;
   if (replyMsgSize % sizeOfReservedPage_ != 0) {
     numOfPages++;
     sizeLastPage = replyMsgSize % sizeOfReservedPage_;
   }
-
-  LOG_DEBUG(GL, "numOfPages=" << numOfPages << " sizeLastPage=" << sizeLastPage);
-
+  LOG_DEBUG(GL, KVLOG(numOfPages, sizeLastPage));
   ClientReplyMsg* const r = new ClientReplyMsg(myId_, replyHeader->replyLength);
-
   // load reply message from reserved pages
   for (uint32_t i = 0; i < numOfPages; i++) {
     char* const ptrPage = r->body() + i * sizeOfReservedPage_;
@@ -252,134 +213,94 @@ ClientReplyMsg* ClientsManager::allocateMsgWithLatestReply(NodeIdType clientId, 
     stateTransfer_->loadReservedPage(resPageOffset() + firstPageId + i, sizePage, ptrPage);
   }
 
+  if (r->reqSeqNum() != requestSeqNum) {
+    LOG_WARN(GL, "Reserved page contains reply for the different request: " << r->reqSeqNum() << " => ignore");
+    delete r;
+    return nullptr;
+  }
+
   r->setPrimaryId(currentPrimaryId);
-
-  LOG_DEBUG(GL, "returns reply with hash=" << r->debugHash());
-
+  LOG_DEBUG(GL, "Returns reply with hash=" << r->debugHash());
   return r;
 }
 
 // Check that:
-//* no pending req is set for that client.
-//* request seq number is bigger than the last reply seq number.
-bool ClientsManager::noPendingAndRequestCanBecomePending(NodeIdType clientId, ReqId reqSeqNum) const {
+// * max number of pending requests not reached for that client.
+// * request seq number is bigger than the last reply seq number.
+bool ClientsManager::canBecomePending(NodeIdType clientId, ReqId reqSeqNum) const {
   uint16_t idx = clientIdToIndex_.at(clientId);
-  const ClientInfo& c = indexToClientInfo_.at(idx);
-
-  if (c.currentPendingRequest != 0 || c.waitsForExecution == true) return false;  // if has pending request
-
-  if (reqSeqNum <= c.lastSeqNumberOfReply) return false;  // if already executed a later/equivalent request
-
+  const auto& requestsInfo = indexToClientInfo_.at(idx).requestsInfo;
+  if (requestsInfo.size() == maxNumOfReqsPerClient_) {
+    LOG_INFO(GL, "Maximum number of requests per client reached" << KVLOG(maxNumOfReqsPerClient_, clientId, reqSeqNum));
+    return false;
+  }
+  const auto& reqIt = requestsInfo.find(reqSeqNum);
+  if (reqIt != requestsInfo.end()) {
+    LOG_DEBUG(GL, "The request has been executing right now" << KVLOG(clientId, reqSeqNum));
+    return false;
+  }
+  const auto& repliesInfo = indexToClientInfo_.at(idx).repliesInfo;
+  const auto& replyIt = repliesInfo.find(reqSeqNum);
+  if (replyIt != repliesInfo.end()) {
+    LOG_DEBUG(GL, "The request has been already executed" << KVLOG(clientId, reqSeqNum));
+    return false;
+  }
+  LOG_DEBUG(GL, "The request can become pending" << KVLOG(clientId, reqSeqNum, requestsInfo.size()));
   return true;
 }
 
-/*
-bool ClientsManager::isPendingOrLate(NodeIdType clientId, ReqId reqSeqNum) const
-{
-        uint16_t idx = clientIdToIndex_.at(clientId);
-        const ClientInfo& c = indexToClientInfo_.at(idx);
-        bool retVal = (reqSeqNum <= c.lastSeqNumberOfReply || reqSeqNum <= c.currentPendingRequest);
-        return retVal;
-}
-*/
-
 void ClientsManager::addPendingRequest(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid) {
   uint16_t idx = clientIdToIndex_.at(clientId);
-  ClientInfo& c = indexToClientInfo_.at(idx);
-  ConcordAssert(reqSeqNum > c.lastSeqNumberOfReply && reqSeqNum > c.currentPendingRequest);
-
-  c.currentPendingRequest = reqSeqNum;
-  c.timeOfCurrentPendingRequest = getMonotonicTime();
-  c.cid = cid;
-  c.waitsForExecution = true;
-}
-
-/*
-void ClientsManager::removePendingRequest(NodeIdType clientId, ReqId reqSeqNum)
-{
-        uint16_t idx = clientIdToIndex_.at(clientId);
-        ClientInfo& c = indexToClientInfo_.at(idx);
-
-        if (c.currentPendingRequest == reqSeqNum)
-        {
-                c.currentPendingRequest = 0;
-                c.timeOfCurrentPendingRequest = MinTime;
-        }
-}
-
-
-void ClientsManager::removeEarlierPendingRequests(NodeIdType clientId, ReqId reqSeqNum)
-{
-        uint16_t idx = clientIdToIndex_.at(clientId);
-        ClientInfo& c = indexToClientInfo_.at(idx);
-
-        if (c.currentPendingRequest < reqSeqNum)
-        {
-                c.currentPendingRequest = 0;
-                c.timeOfCurrentPendingRequest = MinTime;
-        }
-}
-
-
-void ClientsManager::removeEarlierOrEqualPendingRequests(NodeIdType clientId, ReqId reqSeqNum)
-{
-        uint16_t idx = clientIdToIndex_.at(clientId);
-        ClientInfo& c = indexToClientInfo_.at(idx);
-
-        if (c.currentPendingRequest <= reqSeqNum)
-        {
-                c.currentPendingRequest = 0;
-                c.timeOfCurrentPendingRequest = MinTime;
-        }
-}
-
-*/
-
-void ClientsManager::removePendingRequestOfClient(NodeIdType clientId) {
-  uint16_t idx = clientIdToIndex_.at(clientId);
-  ClientInfo& c = indexToClientInfo_.at(idx);
-
-  if (c.currentPendingRequest != 0) {
-    c.currentPendingRequest = 0;
-    c.timeOfCurrentPendingRequest = MinTime;
-    c.cid = std::string();
+  auto& requestsInfo = indexToClientInfo_.at(idx).requestsInfo;
+  if (requestsInfo.find(reqSeqNum) != requestsInfo.end()) {
+    LOG_WARN(GL, "The request already exists - skip adding" << KVLOG(clientId, reqSeqNum));
+    return;
   }
+  requestsInfo.emplace(reqSeqNum, RequestInfo{getMonotonicTime(), cid});
+  LOG_DEBUG(GL, "Added request" << KVLOG(clientId, reqSeqNum, requestsInfo.size()));
 }
 
-void ClientsManager::removePendingForExecutionRequestOfClient(NodeIdType clientId) {
+void ClientsManager::markRequestAsCommitted(NodeIdType clientId, ReqId reqSeqNum) {
   uint16_t idx = clientIdToIndex_.at(clientId);
-  ClientInfo& c = indexToClientInfo_.at(idx);
-  c.waitsForExecution = false;
+  auto& requestsInfo = indexToClientInfo_.at(idx).requestsInfo;
+  const auto& reqIt = requestsInfo.find(reqSeqNum);
+  if (reqIt != requestsInfo.end()) {
+    reqIt->second.committed = true;
+    LOG_DEBUG(GL, "Marked committed" << KVLOG(clientId, reqSeqNum));
+  }
+  LOG_ERROR(GL, "Request not found" << KVLOG(clientId, reqSeqNum));
+}
+
+void ClientsManager::removePendingForExecutionRequest(NodeIdType clientId, ReqId reqSeqNum) {
+  uint16_t idx = clientIdToIndex_.at(clientId);
+  auto& requestsInfo = indexToClientInfo_.at(idx).requestsInfo;
+  const auto& reqIt = requestsInfo.find(reqSeqNum);
+  if (reqIt != requestsInfo.end()) {
+    requestsInfo.erase(reqIt);
+    LOG_DEBUG(GL, "Removed request" << KVLOG(clientId, reqSeqNum, requestsInfo.size()));
+  }
 }
 
 void ClientsManager::clearAllPendingRequests() {
-  for (ClientInfo& c : indexToClientInfo_) {
-    c.currentPendingRequest = 0;
-    c.timeOfCurrentPendingRequest = MinTime;
-    c.cid = std::string();
-    c.waitsForExecution = false;
-  }
-
-  ConcordAssert(indexToClientInfo_[0].currentPendingRequest == 0);  // TODO(GG): debug
+  for (ClientInfo& clientInfo : indexToClientInfo_) clientInfo.requestsInfo.clear();
 }
 
-// iterate over all clients and choose the earliest pending request.
-Time ClientsManager::infoOfEarliestPendingRequest(
-    std::string& cid) const  // TODO(GG): naive implementation - consider to optimize
-{
-  Time t = MaxTime;
-  ClientInfo earliestClientWithPendingRequest = indexToClientInfo_.at(0);
-
-  for (const ClientInfo& c : indexToClientInfo_) {
-    if (c.timeOfCurrentPendingRequest != MinTime && t > c.timeOfCurrentPendingRequest) {
-      t = c.timeOfCurrentPendingRequest;
-      earliestClientWithPendingRequest = c;
+// Iterate over all clients and choose the earliest pending request.
+Time ClientsManager::infoOfEarliestPendingRequest(std::string& cid) const {
+  Time earliestTime = MaxTime;
+  RequestInfo earliestPendingReqInfo{MaxTime, std::string()};
+  for (const ClientInfo& clientInfo : indexToClientInfo_) {
+    for (const auto& req : clientInfo.requestsInfo) {
+      // Don't take into account already committed requests
+      if ((req.second.time != MinTime) && (earliestTime > req.second.time) && (!req.second.committed)) {
+        earliestPendingReqInfo = req.second;
+        earliestTime = earliestPendingReqInfo.time;
+      }
     }
   }
-
-  LOG_INFO(GL, "Earliest pending client request: " << KVLOG(earliestClientWithPendingRequest.currentPendingRequest));
-  cid = earliestClientWithPendingRequest.cid;
-  return t;
+  cid = earliestPendingReqInfo.cid;
+  if (earliestPendingReqInfo.time != MaxTime) LOG_INFO(GL, "Earliest pending request: " << KVLOG(cid));
+  return earliestPendingReqInfo.time;
 }
-}  // namespace impl
-}  // namespace bftEngine
+
+}  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -27,56 +27,44 @@ class ClientRequestMsg;
 
 class ClientsManager : public ResPagesClient<ClientsManager, 0> {
  public:
-  ClientsManager(ReplicaId myId,
-                 std::set<NodeIdType>& clientsSet,
-                 uint32_t sizeOfReservedPage,
-                 const uint32_t& maxReplySize);
+  ClientsManager(std::set<NodeIdType>& clientsSet);
   ~ClientsManager();
 
   void init(IStateTransfer* stateTransfer);
 
   uint32_t numberOfRequiredReservedPages() const;
 
-  void clearReservedPages();
-
   void loadInfoFromReservedPages();
 
   // Replies
 
-  ReqId seqNumberOfLastReplyToClient(
-      NodeIdType clientId);  // TODO(GG): make sure that ReqId is based on time (and ignore requests with time that does
-                             // not make sense (too high) - this will prevent some potential attacks)
+  // TODO(GG): make sure that ReqId is based on time (and ignore requests with time that does
+  // not make sense (too high) - this will prevent some potential attacks)
+  bool isReplySentToClientForRequest(NodeIdType clientId, ReqId reqSeqNum);
 
   bool isValidClient(NodeIdType clientId) const;
-
-  void getInfoAboutLastReplyToClient(NodeIdType clientId, ReqId& outseqNumber, Time& outSentTime);
 
   ClientReplyMsg* allocateNewReplyMsgAndWriteToStorage(
       NodeIdType clientId, ReqId requestSeqNum, uint16_t currentPrimaryId, char* reply, uint32_t replyLength);
 
-  ClientReplyMsg* allocateMsgWithLatestReply(NodeIdType clientId, uint16_t currentPrimaryId);
+  ClientReplyMsg* allocateReplyFromSavedOne(NodeIdType clientId, ReqId requestSeqNum, uint16_t currentPrimaryId);
 
   // Requests
 
-  bool noPendingAndRequestCanBecomePending(
-      NodeIdType clientId, ReqId reqSeqNum) const;  // return true IFF there is no pending requests for clientId, and
-                                                    // reqSeqNum can become the new pending request
-
-  // bool isPendingOrLate(NodeIdType clientId, ReqId reqSeqNum) const ;
+  // Return true IFF there is no pending requests for clientId, and reqSeqNum can become the new pending request
+  bool canBecomePending(NodeIdType clientId, ReqId reqSeqNum) const;
 
   void addPendingRequest(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid);
 
-  // void removePendingRequest(NodeIdType clientId, ReqId reqSeqNum);
+  void markRequestAsCommitted(NodeIdType clientId, ReqId reqSequenceNum);
 
-  // void removeEarlierPendingRequests(NodeIdType clientId, ReqId reqSeqNum);
+  void removePendingForExecutionRequest(NodeIdType clientId, ReqId reqSeqNum);
 
-  // void removeEarlierOrEqualPendingRequests(NodeIdType clientId, ReqId reqSeqNum);
-
-  void removePendingRequestOfClient(NodeIdType clientId);
-  void removePendingForExecutionRequestOfClient(NodeIdType clientId);
   void clearAllPendingRequests();
 
   Time infoOfEarliestPendingRequest(std::string& cid) const;
+
+  void deleteOldestReply(NodeIdType clientId);
 
   // Internal Clients
   void initInternalClientInfo(const int& numReplicas);
@@ -86,7 +74,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
   NodeIdType getHighestIdOfNonInternalClient();
 
   // General
-  static uint32_t reservedPagesPerClient(const uint32_t& sizeOfReservedPage, const uint32_t& maxReplysize);
+  static uint32_t reservedPagesPerClient(const uint32_t& sizeOfReservedPage, const uint32_t& maxReplySize);
   int getIndexOfClient(const NodeIdType& id) const;
 
  protected:
@@ -105,19 +93,24 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   std::map<NodeIdType, uint16_t> clientIdToIndex_;
 
-  struct ClientInfo {
-    // requests
-    ReqId currentPendingRequest;
-    Time timeOfCurrentPendingRequest;
+  struct RequestInfo {
+    RequestInfo() : time(MinTime) {}
+    RequestInfo(Time t, const std::string& c) : time(t), cid(c) {}
+
+    Time time;
     std::string cid;
-    bool waitsForExecution;
-    // replies
-    ReqId lastSeqNumberOfReply;
-    Time latestReplyTime;
+    bool committed = false;
+  };
+
+  struct ClientInfo {
+    std::map<ReqId, RequestInfo> requestsInfo;
+    std::map<ReqId, Time> repliesInfo;  // replyId to replyTime
   };
 
   std::vector<ClientInfo> indexToClientInfo_;
-  uint32_t maxReplysize_{};
+  const uint32_t maxReplySize_;
+  const uint16_t maxNumOfReqsPerClient_;
 };
+
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -40,7 +40,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   // TODO(GG): make sure that ReqId is based on time (and ignore requests with time that does
   // not make sense (too high) - this will prevent some potential attacks)
-  bool isReplySentToClientForRequest(NodeIdType clientId, ReqId reqSeqNum);
+  bool hasReply(NodeIdType clientId, ReqId reqSeqNum);
 
   bool isValidClient(NodeIdType clientId) const;
 

--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -39,7 +39,7 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual ReplicaId currentPrimary() const = 0;
   virtual bool isCurrentPrimary() const = 0;
   virtual bool currentViewIsActive() const = 0;
-  virtual ReqId seqNumberOfLastReplyToClient(NodeIdType clientId) const = 0;
+  virtual bool isReplyAlreadySentToClient(NodeIdType clientId, ReqId reqSeqNum) const = 0;
   virtual bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const = 0;
   virtual SeqNum getPrimaryLastUsedSeqNum() const = 0;
   virtual uint64_t getRequestsInQueue() const = 0;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -230,7 +230,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         return;
       } else {
         LOG_INFO(GL,
-                 "ClientRequestMsg is ignored because: request is old, or primary is current working on it"
+                 "ClientRequestMsg is ignored because: request is old, or primary is currently working on it"
                      << KVLOG(clientId, reqSeqNum));
       }
     } else {  // not the current primary

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018, 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -209,9 +209,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
     return;
   }
 
-  const ReqId seqNumberOfLastReply = seqNumberOfLastReplyToClient(clientId);
-
-  if (seqNumberOfLastReply < reqSeqNum) {
+  if (!isReplyAlreadySentToClient(clientId, reqSeqNum)) {
     if (isCurrentPrimary()) {
       histograms_.requestsQueueOfPrimarySize->record(requestsQueueOfPrimary.size());
       // TODO(GG): use config/parameter
@@ -222,7 +220,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         delete m;
         return;
       }
-      if (clientsManager->noPendingAndRequestCanBecomePending(clientId, reqSeqNum)) {
+      if (clientsManager->canBecomePending(clientId, reqSeqNum)) {
         LOG_DEBUG(CNSUS,
                   "Pushing to primary queue, request [" << reqSeqNum << "], client [" << clientId
                                                         << "], senderId=" << senderId);
@@ -232,38 +230,32 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         return;
       } else {
         LOG_INFO(GL,
-                 "ClientRequestMsg is ignored because: request is old, OR primary is current working on a request from "
-                 "the same client. "
+                 "ClientRequestMsg is ignored because: request is old, or primary is current working on it"
                      << KVLOG(clientId, reqSeqNum));
       }
     } else {  // not the current primary
-      if (clientsManager->noPendingAndRequestCanBecomePending(clientId, reqSeqNum)) {
+      if (clientsManager->canBecomePending(clientId, reqSeqNum)) {
         clientsManager->addPendingRequest(clientId, reqSeqNum, m->getCid());
 
         // TODO(GG): add a mechanism that retransmits (otherwise we may start unnecessary view-change)
         send(m, currentPrimary());
-
-        LOG_INFO(GL, "Forwarding ClientRequestMsg to the current primary. " << KVLOG(reqSeqNum, clientId));
+        LOG_INFO(GL, "Forwarding ClientRequestMsg to the current primary." << KVLOG(reqSeqNum, clientId));
       } else {
         LOG_INFO(GL,
-                 "ClientRequestMsg is ignored because: request is old, OR primary is current working on a request "
-                 "from the same client. "
+                 "ClientRequestMsg is ignored because: request is old, or primary is currently working on it"
                      << KVLOG(clientId, reqSeqNum));
       }
     }
-  } else if (seqNumberOfLastReply == reqSeqNum) {
-    LOG_DEBUG(
-        GL,
-        "ClientRequestMsg has already been executed: retransmitting reply to client. " << KVLOG(reqSeqNum, clientId));
-    ClientReplyMsg *repMsg = clientsManager->allocateMsgWithLatestReply(clientId, currentPrimary());
-    send(repMsg, clientId);
-    delete repMsg;
-  } else {
-    LOG_INFO(GL,
-             "ClientRequestMsg is ignored because request sequence number is not monotonically increasing. "
-                 << KVLOG(clientId, reqSeqNum, seqNumberOfLastReply));
+  } else {  // Reply has already been sent to the client for this request
+    ClientReplyMsg *repMsg = clientsManager->allocateReplyFromSavedOne(clientId, reqSeqNum, currentPrimary());
+    if (repMsg) {
+      LOG_DEBUG(
+          GL,
+          "ClientRequestMsg has already been executed: retransmitting reply to client." << KVLOG(reqSeqNum, clientId));
+      send(repMsg, clientId);
+      delete repMsg;
+    }
   }
-
   delete m;
 }
 
@@ -329,8 +321,7 @@ bool ReplicaImp::checkSendPrePrepareMsgPrerequisites() {
 void ReplicaImp::removeDuplicatedRequestsFromRequestsQueue() {
   // Remove duplicated requests that are result of client retrials from the head of the requestsQueueOfPrimary
   ClientRequestMsg *first = requestsQueueOfPrimary.front();
-  while (first != nullptr &&
-         !clientsManager->noPendingAndRequestCanBecomePending(first->clientProxyId(), first->requestSeqNum())) {
+  while (first != nullptr && !clientsManager->canBecomePending(first->clientProxyId(), first->requestSeqNum())) {
     primaryCombinedReqSize -= first->size();
     delete first;
     requestsQueueOfPrimary.pop();
@@ -409,8 +400,7 @@ ClientRequestMsg *ReplicaImp::addRequestToPrePrepareMessage(ClientRequestMsg *&n
                                                             uint16_t maxStorageForRequests) {
   if (nextRequest->size() <= prePrepareMsg.remainingSizeForRequests()) {
     SCOPED_MDC_CID(nextRequest->getCid());
-    if (clientsManager->noPendingAndRequestCanBecomePending(nextRequest->clientProxyId(),
-                                                            nextRequest->requestSeqNum())) {
+    if (clientsManager->canBecomePending(nextRequest->clientProxyId(), nextRequest->requestSeqNum())) {
       prePrepareMsg.addRequest(nextRequest->body(), nextRequest->size());
       clientsManager->addPendingRequest(
           nextRequest->clientProxyId(), nextRequest->requestSeqNum(), nextRequest->getCid());
@@ -438,6 +428,7 @@ PrePrepareMsg *ReplicaImp::finishAddingRequestsToPrePrepareMsg(PrePrepareMsg *&p
   prePrepareMsg->finishAddingRequests();
   LOG_DEBUG(GL,
             KVLOG(prePrepareMsg->seqNumber(),
+                  prePrepareMsg->getCid(),
                   maxSpaceForReqs,
                   requiredRequestsSize,
                   prePrepareMsg->requestsSize(),
@@ -3549,18 +3540,13 @@ ReplicaImp::ReplicaImp(bool firstTime,
     sigManager = sigMgr;
     repsInfo = replicasInfo;
     viewsManager = viewsMgr;
-
-    // TODO(GG): consider to add relevant asserts
   }
 
   std::set<NodeIdType> clientsSet;
   const auto numOfEntities = config_.getnumReplicas() + config_.getnumRoReplicas() + config_.getnumOfClientProxies() +
                              config_.getnumOfExternalClients();
   for (uint16_t i = config_.getnumReplicas() + config_.getnumRoReplicas(); i < numOfEntities; i++) clientsSet.insert(i);
-  clientsManager = new ClientsManager(config_.getreplicaId(),
-                                      clientsSet,
-                                      ReplicaConfig::instance().getsizeOfReservedPage(),
-                                      ReplicaConfig::instance().getmaxReplyMessageSize());
+  clientsManager = new ClientsManager(clientsSet);
   clientsManager->initInternalClientInfo(config_.getnumReplicas());
   internalBFTClient_.reset(new InternalBFTClient(
       config_.getreplicaId(), clientsManager->getHighestIdOfNonInternalClient(), msgsCommunicator_));
@@ -3845,14 +3831,15 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
           LOG_WARN(GL, "The client is not valid. " << KVLOG(clientId));
           continue;
         }
-
-        if (seqNumberOfLastReplyToClient(clientId) >= req.requestSeqNum()) {
-          ClientReplyMsg *replyMsg = clientsManager->allocateMsgWithLatestReply(clientId, currentPrimary());
-          send(replyMsg, clientId);
-          delete replyMsg;
+        if (isReplyAlreadySentToClient(clientId, req.requestSeqNum())) {
+          ClientReplyMsg *replyMsg =
+              clientsManager->allocateReplyFromSavedOne(clientId, req.requestSeqNum(), currentPrimary());
+          if (replyMsg) {
+            send(replyMsg, clientId);
+            delete replyMsg;
+          }
           continue;
         }
-
         requestSet.set(reqIdx);
         reqIdx++;
       }
@@ -4040,7 +4027,7 @@ void ReplicaImp::executeRequestsAndSendResponses(PrePrepareMsg *ppMsg,
       send(replyMsg.get(), req.clientId);
     }
     if (clientsManager->isValidClient(req.clientId))
-      clientsManager->removePendingForExecutionRequestOfClient(req.clientId);
+      clientsManager->removePendingForExecutionRequest(req.clientId, req.requestSequenceNum);
   }
 }
 
@@ -4059,7 +4046,7 @@ void ReplicaImp::tryToRemovePendingRequestsForSeqNum(SeqNum seqNum) {
     if (!clientsManager->isValidClient(req.clientProxyId())) continue;
     auto clientId = req.clientProxyId();
     LOG_DEBUG(GL, "removing pending requests for client" << KVLOG(clientId));
-    clientsManager->removePendingRequestOfClient(clientId);
+    clientsManager->markRequestAsCommitted(clientId, req.requestSeqNum());
   }
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -275,7 +275,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   bool isCurrentPrimary() const override { return (currentPrimary() == config_.replicaId); }
   bool currentViewIsActive() const override { return (viewsManager->viewIsActive(curView)); }
   bool isReplyAlreadySentToClient(NodeIdType clientId, ReqId reqSeqNum) const override {
-    return clientsManager->isReplySentToClientForRequest(clientId, reqSeqNum);
+    return clientsManager->hasReply(clientId, reqSeqNum);
   }
   bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const override {
     return !clientsManager->canBecomePending(clientId, reqSeqNum);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -274,11 +274,11 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   ReplicaId currentPrimary() const override { return repsInfo->primaryOfView(curView); }
   bool isCurrentPrimary() const override { return (currentPrimary() == config_.replicaId); }
   bool currentViewIsActive() const override { return (viewsManager->viewIsActive(curView)); }
-  ReqId seqNumberOfLastReplyToClient(NodeIdType clientId) const override {
-    return clientsManager->seqNumberOfLastReplyToClient(clientId);
+  bool isReplyAlreadySentToClient(NodeIdType clientId, ReqId reqSeqNum) const override {
+    return clientsManager->isReplySentToClientForRequest(clientId, reqSeqNum);
   }
   bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const override {
-    return !clientsManager->noPendingAndRequestCanBecomePending(clientId, reqSeqNum);
+    return !clientsManager->canBecomePending(clientId, reqSeqNum);
   }
   SeqNum getPrimaryLastUsedSeqNum() const override { return primaryLastUsedSeqNum; }
   uint64_t getRequestsInQueue() const override { return requestsQueueOfPrimary.size(); }

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -22,7 +22,7 @@ namespace bftEngine::impl {
 static uint16_t getSender(const ClientRequestMsgHeader* r) { return r->idOfClientProxy; }
 
 static int32_t compRequestMsgSize(const ClientRequestMsgHeader* r) {
-  return (sizeof(ClientRequestMsgHeader) + r->spanContextSize + r->requestLength + r->cid_length);
+  return (sizeof(ClientRequestMsgHeader) + r->spanContextSize + r->requestLength + r->cidLength);
 }
 
 uint32_t getRequestSizeTemp(const char* request)  // TODO(GG): change - TBD
@@ -66,7 +66,7 @@ bool ClientRequestMsg::isReadOnly() const { return (msgBody()->flags & READ_ONLY
 void ClientRequestMsg::validate(const ReplicasInfo& repInfo) const {
   ConcordAssert(senderId() != repInfo.myId());
   if (size() < sizeof(ClientRequestMsgHeader) ||
-      size() < (sizeof(ClientRequestMsgHeader) + msgBody()->requestLength + msgBody()->cid_length + spanContextSize()))
+      size() < (sizeof(ClientRequestMsgHeader) + msgBody()->requestLength + msgBody()->cidLength + spanContextSize()))
     throw std::runtime_error(__PRETTY_FUNCTION__);
 }
 
@@ -81,12 +81,12 @@ void ClientRequestMsg::setParams(NodeIdType sender,
   msgBody()->reqSeqNum = reqSeqNum;
   msgBody()->requestLength = requestLength;
   msgBody()->flags = flags;
-  msgBody()->cid_length = cid.size();
+  msgBody()->cidLength = cid.size();
 }
 
 std::string ClientRequestMsg::getCid() const {
   return std::string(body() + sizeof(ClientRequestMsgHeader) + msgBody()->requestLength + spanContextSize(),
-                     msgBody()->cid_length);
+                     msgBody()->cidLength);
 }
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -73,8 +73,6 @@ class ClientRequestMsg : public MessageBase {
                  const std::string& cid);
 };
 
-typedef std::unique_ptr<ClientRequestMsg> ClientRequestMsgUniquePtr;
-
 template <>
 inline size_t sizeOfHeader<ClientRequestMsg>() {
   return sizeof(ClientRequestMsgHeader);

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -24,7 +24,7 @@ class ClientRequestMsg : public MessageBase {
   static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header::msgType), "");
   static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
   static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
-  static_assert(sizeof(ClientRequestMsgHeader) == 33, "ClientRequestMsgHeader size is 21B");
+  static_assert(sizeof(ClientRequestMsgHeader) == 33, "ClientRequestMsgHeader size is 33B");
 
   // TODO(GG): more asserts
 
@@ -71,7 +71,9 @@ class ClientRequestMsg : public MessageBase {
                  uint8_t flags,
                  uint64_t reqTimeoutMilli,
                  const std::string& cid);
-};  // namespace bftEngine::impl
+};
+
+typedef std::unique_ptr<ClientRequestMsg> ClientRequestMsgUniquePtr;
 
 template <>
 inline size_t sizeOfHeader<ClientRequestMsg>() {

--- a/bftengine/src/bftengine/messages/MsgCode.hpp
+++ b/bftengine/src/bftengine/messages/MsgCode.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -46,6 +46,7 @@ class MsgCode {
     PreProcessReply,
 
     ClientRequest = 700,
+    ClientBatchRequest = 750,
     ClientReply = 800,
 
   };

--- a/bftengine/src/bftengine/messages/MsgsCertificate.hpp
+++ b/bftengine/src/bftengine/messages/MsgsCertificate.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -42,6 +42,8 @@ class MsgsCertificate {
                   const uint16_t numOfRequired,
                   const ReplicaId selfReplicaId);
 
+  MsgsCertificate(const MsgsCertificate&) = delete;
+  MsgsCertificate& operator=(const MsgsCertificate&) = delete;
   ~MsgsCertificate();
 
   bool addMsg(T* msg, ReplicaId replicaId);

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -14,6 +14,7 @@ set(preprocessor_source_files
     PreProcessor.cpp
     RequestProcessingState.cpp
     messages/ClientPreProcessRequestMsg.cpp
+    messages/ClientBatchRequestMsg.cpp
     messages/PreProcessRequestMsg.cpp
     messages/PreProcessReplyMsg.cpp)
 

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -82,10 +82,11 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       myReplicaId_(myReplica.getReplicaConfig().replicaId),
       maxPreExecResultSize_(myReplica.getReplicaConfig().maxExternalMessageSize),
       idsOfPeerReplicas_(myReplica.getIdsOfPeerReplicas()),
-      numOfReplicas_(myReplica.getReplicaConfig().numReplicas),
-      numOfRoReplicas_(myReplica.getReplicaConfig().numRoReplicas),
+      numOfReplicas_(myReplica.getReplicaConfig().numReplicas + myReplica.getReplicaConfig().numRoReplicas),
       numOfClients_(myReplica.getReplicaConfig().numOfExternalClients +
                     myReplica_.getReplicaConfig().numOfClientProxies),
+      batchingEnabled_(myReplica.getReplicaConfig().clientMiniBatchingEnabled),
+      batchSize_(batchingEnabled_ ? myReplica.getReplicaConfig().clientMiniBatchingMaxMsgsNbr : 1),
       metricsComponent_{concordMetrics::Component("preProcessor", std::make_shared<concordMetrics::Aggregator>())},
       metricsLastDumpTime_(0),
       metricsDumpIntervalInSec_{myReplica_.getReplicaConfig().metricsDumpIntervalSeconds},
@@ -106,23 +107,28 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   registerMsgHandlers();
   metricsComponent_.Register();
   sigManager_ = make_shared<SigManager>(myReplicaId_,
-                                        numOfReplicas_ + numOfRoReplicas_ + numOfClients_,
+                                        numOfReplicas_ + numOfClients_,
                                         myReplica.getReplicaConfig().replicaPrivateKey,
                                         myReplica.getReplicaConfig().publicKeysOfReplicas);
-  const uint16_t firstClientId = numOfReplicas_ + numOfRoReplicas_;
-  for (auto i = 0; i < numOfClients_; i++) {
-    // Placeholders for all clients
-    ongoingRequests_[firstClientId + i] = make_shared<ClientRequestState>();
-  }
-  // Allocate a buffer for the pre-execution result per client
-  for (auto id = 0; id < numOfClients_; id++) {
+  const uint16_t numOfReqEntries = numOfClients_ * batchSize_;
+  const uint16_t firstClientRequestId = numOfReplicas_ * batchSize_;
+  for (uint16_t i = 0; i < numOfReqEntries; i++) {
+    // Placeholders for all clients including batches
+    ongoingRequests_[firstClientRequestId + i] = make_shared<RequestState>();
+    // Allocate a buffer for the pre-execution result per client * batch
     preProcessResultBuffers_.push_back(Sliver(new char[maxPreExecResultSize_], maxPreExecResultSize_));
   }
   uint64_t numOfThreads = myReplica.getReplicaConfig().preExecConcurrencyLevel;
-  if (!numOfThreads) numOfThreads = numOfClients_;
+  if (!numOfThreads) numOfThreads = numOfReqEntries;
   threadPool_.start(numOfThreads);
   LOG_INFO(logger(),
-           KVLOG(firstClientId, numOfClients_, maxPreExecResultSize_, preExecReqStatusCheckPeriodMilli_, numOfThreads));
+           KVLOG(numOfReplicas_,
+                 numOfClients_,
+                 batchingEnabled_,
+                 batchSize_,
+                 maxPreExecResultSize_,
+                 preExecReqStatusCheckPeriodMilli_,
+                 numOfThreads));
   RequestProcessingState::init(numOfRequiredReplies(), &histograms_);
   addTimers();
 }
@@ -152,11 +158,11 @@ void PreProcessor::cancelTimers() {
   }
 }
 
-// This function should be always called under a clientEntry->mutex lock
+// This function should be always called under a reqEntry->mutex lock
 // Resend PreProcessRequestMsg to replicas that have previously rejected it
-void PreProcessor::resendPreProcessRequest(const RequestProcessingStateUniquePtr &clientReqStatePtr) {
-  const auto &rejectedReplicasList = clientReqStatePtr->getRejectedReplicasList();
-  const auto &preProcessReqMsg = clientReqStatePtr->getPreProcessRequest();
+void PreProcessor::resendPreProcessRequest(const RequestProcessingStateUniquePtr &reqStatePtr) {
+  const auto &rejectedReplicasList = reqStatePtr->getRejectedReplicasList();
+  const auto &preProcessReqMsg = reqStatePtr->getPreProcessRequest();
   if (!rejectedReplicasList.empty() && preProcessReqMsg) {
     SCOPED_MDC_CID(preProcessReqMsg->getCid());
     const auto &clientId = preProcessReqMsg->clientId();
@@ -165,50 +171,52 @@ void PreProcessor::resendPreProcessRequest(const RequestProcessingStateUniquePtr
       LOG_DEBUG(logger(), "Resending PreProcessRequestMsg" << KVLOG(clientId, reqSeqNum, destId));
       sendMsg(preProcessReqMsg->body(), destId, preProcessReqMsg->type(), preProcessReqMsg->size());
     }
-    clientReqStatePtr->resetRejectedReplicasList();
+    reqStatePtr->resetRejectedReplicasList();
   }
 }
 
 void PreProcessor::onRequestsStatusCheckTimer() {
   // Pass through all ongoing requests and abort the pre-execution for those that are timed out.
-  for (const auto &clientEntry : ongoingRequests_) {
-    lock_guard<mutex> lock(clientEntry.second->mutex);
-    const auto &clientReqStatePtr = clientEntry.second->reqProcessingStatePtr;
-    if (clientReqStatePtr) {
-      if (clientReqStatePtr->isReqTimedOut()) {
+  for (const auto &reqEntry : ongoingRequests_) {
+    lock_guard<mutex> lock(reqEntry.second->mutex);
+    const auto &reqStatePtr = reqEntry.second->reqProcessingStatePtr;
+    if (reqStatePtr) {
+      if (reqStatePtr->isReqTimedOut()) {
         preProcessorMetrics_.preProcessRequestTimedout.Get().Inc();
         preProcessorMetrics_.preProcPossiblePrimaryFaultDetected.Get().Inc();
         // The request could expire do to failed primary replica, let ReplicaImp to address that
         // TBD YS: This causes a request to retry in case the primary is OK. Consider passing a kind of NOOP message.
-        const auto &clientId = clientEntry.first;
-        const auto &reqSeqNum = clientReqStatePtr->getReqSeqNum();
-        SCOPED_MDC_CID(clientReqStatePtr->getReqCid());
-        LOG_INFO(logger(), "Let replica to handle request" << KVLOG(reqSeqNum, clientId));
+        const auto &reqEntryIndex = reqEntry.first;
+        const auto &reqSeqNum = reqStatePtr->getReqSeqNum();
+        const auto &clientId = reqStatePtr->getClientId();
+        const auto &reqOffsetInBatch = reqStatePtr->getReqOffsetInBatch();
+        SCOPED_MDC_CID(reqStatePtr->getReqCid());
+        LOG_INFO(logger(),
+                 "Let replica to handle request" << KVLOG(reqSeqNum, reqEntryIndex, clientId, reqOffsetInBatch));
         preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
-        incomingMsgsStorage_->pushExternalMsg(clientReqStatePtr->buildClientRequestMsg(true));
-        releaseClientPreProcessRequest(clientEntry.second, clientId, CANCEL);
-      } else if (myReplica_.isCurrentPrimary() && clientReqStatePtr->definePreProcessingConsensusResult() == CONTINUE)
-        resendPreProcessRequest(clientReqStatePtr);
+        incomingMsgsStorage_->pushExternalMsg(reqStatePtr->buildClientRequestMsg(true));
+        releaseClientPreProcessRequest(reqEntry.second, CANCEL);
+      } else if (myReplica_.isCurrentPrimary() && reqStatePtr->definePreProcessingConsensusResult() == CONTINUE)
+        resendPreProcessRequest(reqStatePtr);
     }
   }
 }
 
-bool PreProcessor::checkClientMsgCorrectness(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
-                                             ReqId reqSeqNum) const {
-  SCOPED_MDC_CID(clientReqMsg->getCid());
+bool PreProcessor::checkClientMsgCorrectness(
+    uint64_t reqSeqNum, const string &cid, bool isReadOnly, uint16_t clientId, NodeIdType senderId) const {
+  SCOPED_MDC_CID(cid);
   if (myReplica_.isCollectingState()) {
     LOG_INFO(logger(),
              "Ignore ClientPreProcessRequestMsg as the replica is collecting missing state from other replicas"
                  << KVLOG(reqSeqNum));
     return false;
   }
-  if (clientReqMsg->isReadOnly()) {
+  if (isReadOnly) {
     LOG_INFO(logger(), "Ignore ClientPreProcessRequestMsg as it is signed as read-only" << KVLOG(reqSeqNum));
     return false;
   }
-  const bool &invalidClient = !myReplica_.isValidClient(clientReqMsg->clientProxyId());
-  const bool &sentFromReplicaToNonPrimary =
-      myReplica_.isIdOfReplica(clientReqMsg->senderId()) && !myReplica_.isCurrentPrimary();
+  const bool &invalidClient = !myReplica_.isValidClient(clientId);
+  const bool &sentFromReplicaToNonPrimary = myReplica_.isIdOfReplica(senderId) && !myReplica_.isCurrentPrimary();
   if (invalidClient || sentFromReplicaToNonPrimary) {
     LOG_WARN(
         logger(),
@@ -218,6 +226,21 @@ bool PreProcessor::checkClientMsgCorrectness(const ClientPreProcessReqMsgUniqueP
   if (!myReplica_.currentViewIsActive()) {
     LOG_INFO(logger(), "Ignore ClientPreProcessRequestMsg as current view is inactive" << KVLOG(reqSeqNum));
     return false;
+  }
+  return true;
+}
+
+bool PreProcessor::checkClientBatchMsgCorrectness(const ClientBatchRequestMsgUniquePtr &clientBatchReqMsg) {
+  if (!batchingEnabled_) {
+    LOG_ERROR(logger(),
+              "Batching functionality is disabled => reject message"
+                  << KVLOG(clientBatchReqMsg->clientId(), clientBatchReqMsg->senderId(), clientBatchReqMsg->getCid()));
+    return false;
+  }
+  const auto &clientRequestMsgs = clientBatchReqMsg->getClientPreProcessRequestMsgs();
+  for (const auto &msg : clientRequestMsgs) {
+    if (!checkClientMsgCorrectness(msg->requestSeqNum(), msg->getCid(), false, msg->clientProxyId(), msg->senderId()))
+      return false;
   }
   return true;
 }
@@ -232,18 +255,19 @@ void PreProcessor::updateAggregatorAndDumpMetrics() {
 }
 
 void PreProcessor::sendRejectPreProcessReplyMsg(NodeIdType clientId,
+                                                uint16_t reqOffsetInBatch,
                                                 NodeIdType senderId,
                                                 SeqNum reqSeqNum,
                                                 SeqNum ongoingReqSeqNum,
                                                 uint64_t reqRetryId,
                                                 const string &cid,
                                                 const string &ongoingCid) {
-  auto replyMsg =
-      make_shared<PreProcessReplyMsg>(sigManager_, &histograms_, myReplicaId_, clientId, reqSeqNum, reqRetryId);
-  replyMsg->setupMsgBody(getPreProcessResultBuffer(clientId), 0, cid, STATUS_REJECT);
+  auto replyMsg = make_shared<PreProcessReplyMsg>(
+      sigManager_, &histograms_, myReplicaId_, clientId, reqOffsetInBatch, reqSeqNum, reqRetryId);
+  replyMsg->setupMsgBody(getPreProcessResultBuffer(clientId, reqOffsetInBatch), 0, cid, STATUS_REJECT);
   LOG_DEBUG(
       logger(),
-      KVLOG(reqSeqNum, senderId, clientId, ongoingReqSeqNum, ongoingCid)
+      KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch, ongoingReqSeqNum, ongoingCid)
           << " Sending PreProcessReplyMsg with STATUS_REJECT as another PreProcessRequest from the same client is "
              "in progress");
   sendMsg(replyMsg->body(), myReplica_.currentPrimary(), replyMsg->type(), replyMsg->size());
@@ -253,27 +277,37 @@ template <>
 void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequestMsg *msg) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onMessage);
   preProcessorMetrics_.preProcReqReceived.Get().Inc();
-  ClientPreProcessReqMsgUniquePtr clientPreProcessReqMsg(msg);
-
-  SCOPED_MDC_CID(clientPreProcessReqMsg->getCid());
-  const NodeIdType &senderId = clientPreProcessReqMsg->senderId();
-  const NodeIdType &clientId = clientPreProcessReqMsg->clientProxyId();
-  const ReqId &reqSeqNum = clientPreProcessReqMsg->requestSeqNum();
-  const auto &reqTimeoutMilli = clientPreProcessReqMsg->requestTimeoutMilli();
+  ClientPreProcessReqMsgUniquePtr clientMsg(msg);
+  const string &cid = clientMsg->getCid();
+  const NodeIdType &senderId = clientMsg->senderId();
+  const NodeIdType &clientId = clientMsg->clientProxyId();
+  const ReqId &reqSeqNum = clientMsg->requestSeqNum();
+  const auto &reqTimeoutMilli = clientMsg->requestTimeoutMilli();
+  SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(), "Received ClientPreProcessRequestMsg" << KVLOG(reqSeqNum, clientId, senderId, reqTimeoutMilli));
-  if (!checkClientMsgCorrectness(clientPreProcessReqMsg, reqSeqNum)) {
+  if (!checkClientMsgCorrectness(reqSeqNum, cid, clientMsg->isReadOnly(), clientId, senderId)) {
     preProcessorMetrics_.preProcReqIgnored.Get().Inc();
     return;
   }
+  handleSingleClientRequestMessage(move(clientMsg), false, 0);
+}
+
+void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUniquePtr clientMsg,
+                                                    bool arrivedInBatch,
+                                                    uint16_t msgOffsetInBatch) {
+  SCOPED_MDC_CID(clientMsg->getCid());
+  const NodeIdType &senderId = clientMsg->senderId();
+  const NodeIdType &clientId = clientMsg->clientProxyId();
+  const ReqId &reqSeqNum = clientMsg->requestSeqNum();
   PreProcessRequestMsgSharedPtr preProcessRequestMsg;
+  LOG_DEBUG(logger(), KVLOG(reqSeqNum, clientId, senderId, arrivedInBatch, msgOffsetInBatch));
   bool registerSucceeded = false;
-  ReqId seqNumberOfLastReply = 0;
   {
-    const auto &clientEntry = ongoingRequests_[clientId];
-    lock_guard<mutex> lock(clientEntry->mutex);
-    if (clientEntry->reqProcessingStatePtr) {
-      const auto &ongoingReqSeqNum = clientEntry->reqProcessingStatePtr->getReqSeqNum();
-      const auto &ongoingCid = clientEntry->reqProcessingStatePtr->getReqCid();
+    const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, msgOffsetInBatch)];
+    lock_guard<mutex> lock(reqEntry->mutex);
+    if (reqEntry->reqProcessingStatePtr) {
+      const auto &ongoingReqSeqNum = reqEntry->reqProcessingStatePtr->getReqSeqNum();
+      const auto &ongoingCid = reqEntry->reqProcessingStatePtr->getReqCid();
       LOG_DEBUG(logger(),
                 KVLOG(reqSeqNum, clientId, senderId)
                     << " is ignored:" << KVLOG(ongoingReqSeqNum, ongoingCid) << " is in progress");
@@ -287,35 +321,64 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
     // Verify that a request is not passing consensus/PostExec right now. The primary replica should not ignore client
     // requests forwarded by non-primary replicas, otherwise this will cause timeouts caused by missing PreProcess
     // request messages from the primary.
+    // TBD: save senderId in the header and set it before re-sending
     if ((clientId == senderId) && myReplica_.isClientRequestInProcess(clientId, reqSeqNum)) {
       LOG_DEBUG(logger(),
                 "Specified request has been processing right now - ignore" << KVLOG(reqSeqNum, clientId, senderId));
       preProcessorMetrics_.preProcReqIgnored.Get().Inc();
       return;
     }
-    seqNumberOfLastReply = myReplica_.seqNumberOfLastReplyToClient(clientId);
-    if (seqNumberOfLastReply == reqSeqNum) {
+    const bool replySentToClient = myReplica_.isReplyAlreadySentToClient(clientId, reqSeqNum);
+    if (replySentToClient) {
       LOG_INFO(logger(),
                "Request has already been executed - let replica to decide how to proceed further"
                    << KVLOG(reqSeqNum, clientId));
       preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
-      return incomingMsgsStorage_->pushExternalMsg(clientPreProcessReqMsg->convertToClientRequestMsg(false));
+      incomingMsgsStorage_->pushExternalMsg(move(clientMsg));
+      return;
     }
-    if (seqNumberOfLastReply < reqSeqNum)
-      registerSucceeded = registerReplicaDependentRequest(
-          move(clientPreProcessReqMsg), preProcessRequestMsg, ++(clientEntry->reqRetryId));
+    if (myReplica_.isCurrentPrimary())
+      registerSucceeded = registerRequestOnPrimaryReplica(
+          move(clientMsg), preProcessRequestMsg, msgOffsetInBatch, (reqEntry->reqRetryId)++);
+    else
+      registerAndHandleClientPreProcessReqOnNonPrimary(move(clientMsg), arrivedInBatch, msgOffsetInBatch);
   }
-
-  if (myReplica_.isCurrentPrimary() && registerSucceeded) {
-    preProcessorMetrics_.preProcInFlyRequestsNum.Get().Inc();  // Increase this metric on the primary replica
+  if (myReplica_.isCurrentPrimary() && registerSucceeded)
     return handleClientPreProcessRequestByPrimary(preProcessRequestMsg);
-  }
 
   LOG_DEBUG(logger(),
             "ClientPreProcessRequestMsg" << KVLOG(reqSeqNum, clientId, senderId)
                                          << " is ignored because request is old/duplicated");
   preProcessorMetrics_.preProcReqIgnored.Get().Inc();
-}  // namespace preprocessor
+}
+
+template <>
+void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) {
+  ClientBatchRequestMsgUniquePtr clientBatch(msg);
+  LOG_DEBUG(logger(),
+            "Received ClientBatchPreProcessRequestMsg"
+                << KVLOG(clientBatch->clientId(), clientBatch->getCid(), clientBatch->numOfMessagesInBatch()));
+  if (!checkClientBatchMsgCorrectness(clientBatch)) {
+    preProcessorMetrics_.preProcReqIgnored.Get().Inc();
+    return;
+  }
+  ClientMsgsList &clientMsgs = clientBatch->getClientPreProcessRequestMsgs();
+  uint16_t offset = 0;
+  for (auto &clientMsg : clientMsgs) {
+    LOG_DEBUG(logger(),
+              "Start handling single message from the batch:" << KVLOG(clientMsg->requestSeqNum(),
+                                                                       clientMsg->clientProxyId(),
+                                                                       clientMsg->senderId(),
+                                                                       clientMsg->requestTimeoutMilli()));
+    handleSingleClientRequestMessage(move(clientMsg), true, offset++);
+  }
+  if (!myReplica_.isCurrentPrimary()) {
+    sendMsg(clientBatch->body(), myReplica_.currentPrimary(), clientBatch->type(), clientBatch->size());
+    LOG_DEBUG(logger(),
+              "Sent ClientBatchRequestMsg" << KVLOG(clientBatch->clientId(), clientBatch->getCid())
+                                           << " to the current primary");
+  }
+}
 
 // Non-primary replica request handling
 template <>
@@ -325,40 +388,50 @@ void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
   const NodeIdType &senderId = preProcessReqMsg->senderId();
   const SeqNum &reqSeqNum = preProcessReqMsg->reqSeqNum();
   const NodeIdType &clientId = preProcessReqMsg->clientId();
-  LOG_DEBUG(logger(), "Received PreProcessRequestMsg" << KVLOG(reqSeqNum, senderId, clientId));
+  const uint16_t &reqOffsetInBatch = preProcessReqMsg->reqOffsetInBatch();
+  LOG_DEBUG(logger(), "Received PreProcessRequestMsg" << KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch));
 
   if (myReplica_.isCollectingState()) {
     LOG_INFO(logger(),
              "Ignore PreProcessRequestMsg as the replica is collecting missing state from other replicas"
-                 << KVLOG(reqSeqNum));
+                 << KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch));
     return;
   }
 
   if (myReplica_.isCurrentPrimary()) {
     LOG_WARN(logger(),
-             "Ignore PreProcessRequestMsg as current replica is the primary" << KVLOG(reqSeqNum, senderId, clientId));
+             "Ignore PreProcessRequestMsg as current replica is the primary"
+                 << KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch));
     return;
   }
 
   if (!myReplica_.currentViewIsActive()) {
-    LOG_INFO(logger(), "Ignore PreProcessRequestMsg as current view is inactive" << KVLOG(reqSeqNum));
+    LOG_INFO(logger(),
+             "Ignore PreProcessRequestMsg as current view is inactive"
+                 << KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch));
     return;
   }
   bool registerSucceeded = false;
   {
-    const auto &clientEntry = ongoingRequests_[clientId];
-    lock_guard<mutex> lock(clientEntry->mutex);
-    if (clientEntry->reqProcessingStatePtr && clientEntry->reqProcessingStatePtr->getPreProcessRequest()) {
-      auto const &ongoingReqSeqNum = clientEntry->reqProcessingStatePtr->getPreProcessRequest()->reqSeqNum();
-      auto const &ongoingCid = clientEntry->reqProcessingStatePtr->getPreProcessRequest()->getCid();
+    const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+    lock_guard<mutex> lock(reqEntry->mutex);
+    if (reqEntry->reqProcessingStatePtr && reqEntry->reqProcessingStatePtr->getPreProcessRequest()) {
+      auto const &ongoingReqSeqNum = reqEntry->reqProcessingStatePtr->getPreProcessRequest()->reqSeqNum();
+      auto const &ongoingCid = reqEntry->reqProcessingStatePtr->getPreProcessRequest()->getCid();
       LOG_DEBUG(logger(),
-                KVLOG(reqSeqNum, ongoingReqSeqNum, ongoingCid, senderId, clientId)
+                KVLOG(reqSeqNum, ongoingReqSeqNum, ongoingCid, senderId, clientId, reqOffsetInBatch)
                     << " Another PreProcessRequest from the same client is in progress. Sending PreProcessReplyMsg "
                        "with STATUS_REJECT");
-      return sendRejectPreProcessReplyMsg(
-          clientId, senderId, reqSeqNum, ongoingReqSeqNum, msg->reqRetryId(), msg->getCid(), ongoingCid);
+      return sendRejectPreProcessReplyMsg(clientId,
+                                          reqOffsetInBatch,
+                                          senderId,
+                                          reqSeqNum,
+                                          ongoingReqSeqNum,
+                                          msg->reqRetryId(),
+                                          msg->getCid(),
+                                          ongoingCid);
     }
-    registerSucceeded = registerRequest(ClientPreProcessReqMsgUniquePtr(), preProcessReqMsg);
+    registerSucceeded = registerRequest(ClientPreProcessReqMsgUniquePtr(), preProcessReqMsg, reqOffsetInBatch);
   }
   if (registerSucceeded) {
     preProcessorMetrics_.preProcInFlyRequestsNum.Get().Inc();  // Increase the metric on non-primary replica
@@ -373,6 +446,7 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
   PreProcessReplyMsgSharedPtr preProcessReplyMsg(msg);
   const NodeIdType &senderId = preProcessReplyMsg->senderId();
   const NodeIdType &clientId = preProcessReplyMsg->clientId();
+  const uint16_t &reqOffsetInBatch = preProcessReplyMsg->reqOffsetInBatch();
   const SeqNum &reqSeqNum = preProcessReplyMsg->reqSeqNum();
   string cid = preProcessReplyMsg->getCid();
   const auto &status = preProcessReplyMsg->status();
@@ -381,29 +455,32 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
   PreProcessingResult result = CANCEL;
   {
     SCOPED_MDC_CID(cid);
-    LOG_DEBUG(logger(), "Received PreProcessReplyMsg" << KVLOG(reqSeqNum, senderId, clientId, replyStatus));
-    const auto &clientEntry = ongoingRequests_[clientId];
-    lock_guard<mutex> lock(clientEntry->mutex);
-    if (!clientEntry->reqProcessingStatePtr || clientEntry->reqProcessingStatePtr->getReqSeqNum() != reqSeqNum) {
+    LOG_DEBUG(logger(),
+              "Received PreProcessReplyMsg" << KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch, replyStatus));
+    const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+    lock_guard<mutex> lock(reqEntry->mutex);
+    if (!reqEntry->reqProcessingStatePtr || reqEntry->reqProcessingStatePtr->getReqSeqNum() != reqSeqNum) {
       // Look for the request in the requests history and check for the non-determinism
-      for (const auto &oldReqState : clientEntry->reqProcessingHistory)
+      for (const auto &oldReqState : reqEntry->reqProcessingHistory)
         if (oldReqState->getReqSeqNum() == reqSeqNum)
           oldReqState->detectNonDeterministicPreProcessing(
               preProcessReplyMsg->resultsHash(), preProcessReplyMsg->senderId(), preProcessReplyMsg->reqRetryId());
       LOG_DEBUG(logger(),
-                KVLOG(reqSeqNum, senderId, clientId)
+                KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch)
                     << " will be ignored as no such ongoing request exists or different one found for this client");
       return;
     }
-    clientEntry->reqProcessingStatePtr->handlePreProcessReplyMsg(preProcessReplyMsg);
+    reqEntry->reqProcessingStatePtr->handlePreProcessReplyMsg(preProcessReplyMsg);
     if (status == STATUS_REJECT) {
-      LOG_DEBUG(logger(), "Received PreProcessReplyMsg with STATUS_REJECT" << KVLOG(reqSeqNum, senderId, clientId));
+      LOG_DEBUG(
+          logger(),
+          "Received PreProcessReplyMsg with STATUS_REJECT" << KVLOG(reqSeqNum, senderId, clientId, reqOffsetInBatch));
       return;
     }
-    result = clientEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
-    if (result == CONTINUE) resendPreProcessRequest(clientEntry->reqProcessingStatePtr);
+    result = reqEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
+    if (result == CONTINUE) resendPreProcessRequest(reqEntry->reqProcessingStatePtr);
   }
-  handlePreProcessReplyMsg(cid, result, clientId, reqSeqNum);
+  handlePreProcessReplyMsg(cid, result, clientId, reqOffsetInBatch, reqSeqNum);
 }
 
 template <typename T>
@@ -435,62 +512,65 @@ void PreProcessor::messageHandler<PreProcessReplyMsg>(MessageBase *msg) {
 void PreProcessor::registerMsgHandlers() {
   msgHandlersRegistrator_->registerMsgHandler(
       MsgCode::ClientPreProcessRequest, bind(&PreProcessor::messageHandler<ClientPreProcessRequestMsg>, this, _1));
+  msgHandlersRegistrator_->registerMsgHandler(MsgCode::ClientBatchRequest,
+                                              bind(&PreProcessor::messageHandler<ClientBatchRequestMsg>, this, _1));
   msgHandlersRegistrator_->registerMsgHandler(MsgCode::PreProcessRequest,
                                               bind(&PreProcessor::messageHandler<PreProcessRequestMsg>, this, _1));
   msgHandlersRegistrator_->registerMsgHandler(MsgCode::PreProcessReply,
                                               bind(&PreProcessor::messageHandler<PreProcessReplyMsg>, this, _1));
 }
 
-void PreProcessor::handlePreProcessReplyMsg(const string &cid,
-                                            PreProcessingResult result,
-                                            NodeIdType clientId,
-                                            SeqNum reqSeqNum) {
+void PreProcessor::handlePreProcessReplyMsg(
+    const string &cid, PreProcessingResult result, NodeIdType clientId, uint16_t reqOffsetInBatch, SeqNum reqSeqNum) {
   SCOPED_MDC_CID(cid);
   switch (result) {
     case NONE:      // No action required - pre-processing has been already completed
     case CONTINUE:  // Not enough equal hashes collected
       break;
     case COMPLETE:  // Pre-processing consensus reached
-      finalizePreProcessing(clientId);
+      finalizePreProcessing(clientId, reqOffsetInBatch);
       break;
     case CANCEL:  // Pre-processing consensus not reached
-      cancelPreProcessing(clientId);
+      cancelPreProcessing(clientId, reqOffsetInBatch);
       break;
     case RETRY_PRIMARY:  // Primary replica generated pre-processing result hash different that one passed consensus
       LOG_INFO(logger(), "Retry primary replica pre-processing for" << KVLOG(reqSeqNum, clientId));
       PreProcessRequestMsgSharedPtr preProcessRequestMsg;
       {
-        const auto &clientEntry = ongoingRequests_[clientId];
-        lock_guard<mutex> lock(clientEntry->mutex);
-        if (clientEntry->reqProcessingStatePtr)
-          preProcessRequestMsg = clientEntry->reqProcessingStatePtr->getPreProcessRequest();
+        const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+        lock_guard<mutex> lock(reqEntry->mutex);
+        if (reqEntry->reqProcessingStatePtr)
+          preProcessRequestMsg = reqEntry->reqProcessingStatePtr->getPreProcessRequest();
       }
       if (preProcessRequestMsg) launchAsyncReqPreProcessingJob(preProcessRequestMsg, true, true);
   }
 }
 
-void PreProcessor::cancelPreProcessing(NodeIdType clientId) {
+void PreProcessor::cancelPreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch) {
   preProcessorMetrics_.preProcConsensusNotReached.Get().Inc();
   SeqNum reqSeqNum = 0;
-  const auto &clientEntry = ongoingRequests_[clientId];
+  const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
   {
-    lock_guard<mutex> lock(clientEntry->mutex);
-    if (clientEntry->reqProcessingStatePtr) {
-      reqSeqNum = clientEntry->reqProcessingStatePtr->getReqSeqNum();
-      SCOPED_MDC_CID(clientEntry->reqProcessingStatePtr->getReqCid());
-      releaseClientPreProcessRequest(clientEntry, clientId, CANCEL);
-      LOG_WARN(logger(), "Pre-processing consensus not reached - cancel request" << KVLOG(reqSeqNum, clientId));
+    lock_guard<mutex> lock(reqEntry->mutex);
+    if (reqEntry->reqProcessingStatePtr) {
+      reqSeqNum = reqEntry->reqProcessingStatePtr->getReqSeqNum();
+      const auto &cid = reqEntry->reqProcessingStatePtr->getReqCid();
+      SCOPED_MDC_CID(cid);
+      LOG_WARN(
+          logger(),
+          "Pre-processing consensus not reached; cancel request" << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch));
+      releaseClientPreProcessRequest(reqEntry, CANCEL);
     }
   }
 }
 
-void PreProcessor::finalizePreProcessing(NodeIdType clientId) {
-  unique_ptr<ClientRequestMsg> clientRequestMsg;
-  const auto &clientEntry = ongoingRequests_[clientId];
+void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch) {
+  ClientRequestMsgUniquePtr clientRequestMsg;
+  const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
   {
     concord::diagnostics::TimeRecorder scoped_timer(*histograms_.finalizePreProcessing);
-    lock_guard<mutex> lock(clientEntry->mutex);
-    auto &reqProcessingStatePtr = clientEntry->reqProcessingStatePtr;
+    lock_guard<mutex> lock(reqEntry->mutex);
+    auto &reqProcessingStatePtr = reqEntry->reqProcessingStatePtr;
     if (reqProcessingStatePtr) {
       const auto cid = reqProcessingStatePtr->getReqCid();
       const auto reqSeqNum = reqProcessingStatePtr->getReqSeqNum();
@@ -503,20 +583,22 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId) {
                                                        reqProcessingStatePtr->getPrimaryPreProcessedResult(),
                                                        reqProcessingStatePtr->getReqTimeoutMilli(),
                                                        cid);
-      LOG_DEBUG(logger(), "Pass pre-processed request to the replica" << KVLOG(cid, reqSeqNum, clientId));
+      LOG_DEBUG(logger(),
+                "Pass pre-processed request to the replica" << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch));
       incomingMsgsStorage_->pushExternalMsg(move(clientRequestMsg));
       preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
-      releaseClientPreProcessRequest(clientEntry, clientId, COMPLETE);
-      LOG_INFO(logger(), "Pre-processing completed for" << KVLOG(cid, reqSeqNum, clientId));
+      releaseClientPreProcessRequest(reqEntry, COMPLETE);
+      LOG_INFO(logger(), "Pre-processing completed for" << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch));
     }
   }
 }
 
 uint16_t PreProcessor::numOfRequiredReplies() { return myReplica_.getReplicaConfig().fVal; }
 
-// This function should be always called under a clientEntry->mutex lock
+// This function should be always called under a reqEntry->mutex lock
 bool PreProcessor::registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
-                                   PreProcessRequestMsgSharedPtr preProcessRequestMsg) {
+                                   PreProcessRequestMsgSharedPtr preProcessRequestMsg,
+                                   uint16_t reqOffsetInBatch) {
   NodeIdType clientId = 0;
   SeqNum reqSeqNum = 0;
   string cid;
@@ -532,59 +614,59 @@ bool PreProcessor::registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
     cid = preProcessRequestMsg->getCid();
   }
   SCOPED_MDC_CID(cid);
-  // Only one request is supported per client for now
-  const auto &clientEntry = ongoingRequests_[clientId];
-  if (!clientEntry->reqProcessingStatePtr)
-    clientEntry->reqProcessingStatePtr = make_unique<RequestProcessingState>(
-        numOfReplicas_ + numOfRoReplicas_, clientId, cid, reqSeqNum, move(clientReqMsg), preProcessRequestMsg);
-  else if (!clientEntry->reqProcessingStatePtr->getPreProcessRequest())
+  const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+  if (!reqEntry->reqProcessingStatePtr)
+    reqEntry->reqProcessingStatePtr = make_unique<RequestProcessingState>(
+        numOfReplicas_, clientId, reqOffsetInBatch, cid, reqSeqNum, move(clientReqMsg), preProcessRequestMsg);
+  else if (!reqEntry->reqProcessingStatePtr->getPreProcessRequest())
     // The request was registered before as arrived directly from the client
-    clientEntry->reqProcessingStatePtr->setPreProcessRequest(preProcessRequestMsg);
+    reqEntry->reqProcessingStatePtr->setPreProcessRequest(preProcessRequestMsg);
   else {
     LOG_WARN(logger(),
-             KVLOG(reqSeqNum) << " could not be registered: the entry for" << KVLOG(clientId)
-                              << " is occupied by reqSeqNum: " << clientEntry->reqProcessingStatePtr->getReqSeqNum());
+             KVLOG(reqSeqNum) << " could not be registered: the entry for" << KVLOG(clientId, reqOffsetInBatch)
+                              << " is occupied by reqSeqNum: " << reqEntry->reqProcessingStatePtr->getReqSeqNum());
     return false;
   }
   if (clientReqMsgSpecified) {
-    LOG_DEBUG(logger(), KVLOG(reqSeqNum, clientId) << " registered ClientPreProcessReqMsg");
+    LOG_DEBUG(logger(), KVLOG(reqSeqNum, clientId, reqOffsetInBatch) << " registered ClientPreProcessReqMsg");
   } else {
-    LOG_DEBUG(logger(), KVLOG(reqSeqNum, clientId) << " registered PreProcessRequestMsg");
+    LOG_DEBUG(logger(), KVLOG(reqSeqNum, clientId, reqOffsetInBatch) << " registered PreProcessRequestMsg");
   }
   return true;
 }
 
-void PreProcessor::releaseClientPreProcessRequestSafe(uint16_t clientId, PreProcessingResult result) {
-  const auto &clientEntry = ongoingRequests_[clientId];
-  lock_guard<mutex> lock(clientEntry->mutex);
-  releaseClientPreProcessRequest(clientEntry, clientId, result);
+void PreProcessor::releaseClientPreProcessRequestSafe(uint16_t clientId,
+                                                      uint16_t reqOffsetInBatch,
+                                                      PreProcessingResult result) {
+  const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+  lock_guard<mutex> lock(reqEntry->mutex);
+  releaseClientPreProcessRequest(reqEntry, result);
 }
 
-// This function should be always called under a clientEntry->mutex lock
-void PreProcessor::releaseClientPreProcessRequest(const ClientRequestStateSharedPtr &clientEntry,
-                                                  uint16_t clientId,
-                                                  PreProcessingResult result) {
-  auto &givenReq = clientEntry->reqProcessingStatePtr;
+// This function should be always called under a reqEntry->mutex lock
+void PreProcessor::releaseClientPreProcessRequest(const RequestStateSharedPtr &reqEntry, PreProcessingResult result) {
+  auto &givenReq = reqEntry->reqProcessingStatePtr;
   if (givenReq) {
-    SeqNum requestSeqNum = 0;
+    const auto &clientId = givenReq->getClientId();
+    const auto &reqOffsetInBatch = givenReq->getReqOffsetInBatch();
+    SeqNum requestSeqNum = givenReq->getReqSeqNum();
     if (result == COMPLETE) {
-      if (clientEntry->reqProcessingHistory.size() >= clientEntry->reqProcessingHistoryHeight) {
-        auto &removeFromHistoryReq = clientEntry->reqProcessingHistory.front();
+      if (reqEntry->reqProcessingHistory.size() >= reqEntry->reqProcessingHistoryHeight) {
+        auto &removeFromHistoryReq = reqEntry->reqProcessingHistory.front();
         SCOPED_MDC_CID(removeFromHistoryReq->getReqCid());
         requestSeqNum = removeFromHistoryReq->getReqSeqNum();
-        LOG_DEBUG(logger(), KVLOG(requestSeqNum, clientId) << " removed from the history");
+        LOG_DEBUG(logger(), KVLOG(requestSeqNum, clientId, reqOffsetInBatch) << " removed from the history");
         removeFromHistoryReq.reset();
-        clientEntry->reqProcessingHistory.pop_front();
+        reqEntry->reqProcessingHistory.pop_front();
       }
       SCOPED_MDC_CID(givenReq->getReqCid());
-      requestSeqNum = givenReq->getReqSeqNum();
-      LOG_DEBUG(logger(), KVLOG(requestSeqNum, clientId) << " released and moved to the history");
+      LOG_DEBUG(logger(), KVLOG(requestSeqNum, clientId, reqOffsetInBatch) << " released and moved to the history");
       // No need to keep whole messages in the memory => release them before archiving
       givenReq->releaseResources();
-      clientEntry->reqProcessingHistory.push_back(move(givenReq));
+      reqEntry->reqProcessingHistory.push_back(move(givenReq));
     } else {  // No consensus reached => release request
       SCOPED_MDC_CID(givenReq->getReqCid());
-      LOG_INFO(logger(), KVLOG(requestSeqNum, clientId) << " no consensus reached, request released");
+      LOG_INFO(logger(), KVLOG(requestSeqNum, clientId, reqOffsetInBatch) << " no consensus reached, request released");
       givenReq.reset();
     }
     preProcessorMetrics_.preProcInFlyRequestsNum.Get().Dec();
@@ -594,28 +676,26 @@ void PreProcessor::releaseClientPreProcessRequest(const ClientRequestStateShared
 void PreProcessor::sendMsg(char *msg, NodeIdType dest, uint16_t msgType, MsgSize msgSize) {
   int errorCode = msgsCommunicator_->sendAsyncMessage(dest, msg, msgSize);
   if (errorCode != 0) {
-    LOG_ERROR(logger(), "sendMsg: sendAsyncMessage returned error: " << errorCode << " for" << KVLOG(msgType));
+    LOG_ERROR(logger(), "sendMsg: sendAsyncMessage returned error" << KVLOG(errorCode, dest, msgType));
   }
 }
 
-// This function should be called under a clientEntry->mutex lock
-bool PreProcessor::registerReplicaDependentRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+// This function should be called under a reqEntry->mutex lock
+bool PreProcessor::registerRequestOnPrimaryReplica(ClientPreProcessReqMsgUniquePtr clientReqMsg,
                                                    PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
+                                                   uint16_t reqOffsetInBatch,
                                                    uint64_t reqRetryId) {
-  if (myReplica_.isCurrentPrimary()) {
-    preProcessRequestMsg =
-        make_shared<PreProcessRequestMsg>(myReplicaId_,
-                                          clientReqMsg->clientProxyId(),
-                                          clientReqMsg->requestSeqNum(),
-                                          reqRetryId,
-                                          clientReqMsg->requestLength(),
-                                          clientReqMsg->requestBuf(),
-                                          clientReqMsg->getCid(),
-                                          clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
-    return registerRequest(move(clientReqMsg), preProcessRequestMsg);
-  }
-  handleClientPreProcessRequestByNonPrimary(move(clientReqMsg));
-  return true;
+  preProcessRequestMsg =
+      make_shared<PreProcessRequestMsg>(myReplicaId_,
+                                        clientReqMsg->clientProxyId(),
+                                        reqOffsetInBatch,
+                                        clientReqMsg->requestSeqNum(),
+                                        reqRetryId,
+                                        clientReqMsg->requestLength(),
+                                        clientReqMsg->requestBuf(),
+                                        clientReqMsg->getCid(),
+                                        clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
+  return registerRequest(move(clientReqMsg), preProcessRequestMsg, reqOffsetInBatch);
 }
 
 // Primary replica: start client request handling
@@ -633,8 +713,10 @@ void PreProcessor::handleClientPreProcessRequestByPrimary(PreProcessRequestMsgSh
 }
 
 // Non-primary replica: start client request handling
-// This function should be called under a clientEntry->mutex lock
-void PreProcessor::handleClientPreProcessRequestByNonPrimary(ClientPreProcessReqMsgUniquePtr clientReqMsg) {
+// This function should be called under a reqEntry->mutex lock
+void PreProcessor::registerAndHandleClientPreProcessReqOnNonPrimary(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+                                                                    bool arrivedInBatch,
+                                                                    uint16_t reqOffsetInBatch) {
   const auto &reqSeqNum = clientReqMsg->requestSeqNum();
   const auto &clientId = clientReqMsg->clientProxyId();
   const auto &senderId = clientReqMsg->senderId();
@@ -645,18 +727,25 @@ void PreProcessor::handleClientPreProcessRequestByNonPrimary(ClientPreProcessReq
   const auto msgSize = clientReqMsg->size();
   const auto cid = clientReqMsg->getCid();
   // Register a client request message with an empty PreProcessRequestMsg to allow follow up.
-  if (registerRequest(move(clientReqMsg), PreProcessRequestMsgSharedPtr())) {
+  if (registerRequest(move(clientReqMsg), PreProcessRequestMsgSharedPtr(), reqOffsetInBatch)) {
     LOG_INFO(logger(),
              "Start request processing by a non-primary replica"
-                 << KVLOG(reqSeqNum, cid, clientId, senderId, reqTimeoutMilli));
+                 << KVLOG(reqSeqNum, cid, clientId, reqOffsetInBatch, senderId, reqTimeoutMilli));
+    if (arrivedInBatch) return;  // Need to re-send the whole batch to the primary
     sendMsg(msgBody, myReplica_.currentPrimary(), msgType, msgSize);
     LOG_DEBUG(logger(),
-              "Sent ClientPreProcessRequestMsg" << KVLOG(reqSeqNum, cid, clientId) << " to the current primary");
+              "Sent ClientPreProcessRequestMsg" << KVLOG(reqSeqNum, cid, clientId, reqOffsetInBatch)
+                                                << " to the current primary");
   }
 }
 
-const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId) const {
-  return preProcessResultBuffers_[getClientReplyBufferId(clientId)].data();
+const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId, uint16_t reqOffsetInBatch) const {
+  const auto bufferOffset = clientId - numOfReplicas_ + reqOffsetInBatch;
+  return preProcessResultBuffers_[bufferOffset].data();
+}
+
+const uint16_t PreProcessor::getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const {
+  return clientId * batchSize_ + reqOffsetInBatch;
 }
 
 // Primary replica: ask all replicas to pre-process the request
@@ -676,22 +765,23 @@ void PreProcessor::sendPreProcessRequestToAllReplicas(const PreProcessRequestMsg
   }
 }
 
-void PreProcessor::setPreprocessingRightNow(uint16_t clientId, bool set) {
-  const auto &clientEntry = ongoingRequests_[clientId];
-  lock_guard<mutex> lock(clientEntry->mutex);
-  if (clientEntry->reqProcessingStatePtr) clientEntry->reqProcessingStatePtr->setPreprocessingRightNow(set);
+void PreProcessor::setPreprocessingRightNow(uint16_t clientId, uint16_t reqOffsetInBatch, bool set) {
+  const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+  lock_guard<mutex> lock(reqEntry->mutex);
+  if (reqEntry->reqProcessingStatePtr) reqEntry->reqProcessingStatePtr->setPreprocessingRightNow(set);
 }
 
 void PreProcessor::launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                                   bool isPrimary,
                                                   bool isRetry,
                                                   TimeRecorder &&time_recorder) {
-  setPreprocessingRightNow(preProcessReqMsg->clientId(), true);
+  setPreprocessingRightNow(preProcessReqMsg->clientId(), preProcessReqMsg->reqOffsetInBatch(), true);
   auto *preProcessJob = new AsyncPreProcessJob(*this, preProcessReqMsg, isPrimary, isRetry, std::move(time_recorder));
   threadPool_.add(preProcessJob);
 }
 
 uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
+                                              uint16_t reqOffsetInBatch,
                                               const string &cid,
                                               ReqId reqSeqNum,
                                               uint32_t reqLength,
@@ -701,7 +791,7 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   // Unused for now. Replica Specific Info not currently supported in pre-execution.
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
   SCOPED_MDC_CID(cid);
-  LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqSeqNum));
+  LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch, reqSeqNum));
   bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
   accumulatedRequests.push_back(
       bftEngine::IRequestsHandler::ExecutionRequest{clientId,
@@ -710,66 +800,78 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
                                                     reqLength,
                                                     reqBuf,
                                                     maxPreExecResultSize_,
-                                                    (char *)getPreProcessResultBuffer(clientId)});
+                                                    (char *)getPreProcessResultBuffer(clientId, reqOffsetInBatch)});
   requestsHandler_.execute(accumulatedRequests, cid, span);
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
   const auto status = request.outExecutionStatus;
   const auto resultLen = request.outActualReplySize;
-  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqSeqNum));
+  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch, reqSeqNum));
   if (status != 0 || !resultLen) {
-    LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqSeqNum, status, resultLen));
+    LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqOffsetInBatch, reqSeqNum, status, resultLen));
     ConcordAssert(false);
   }
   return resultLen;
 }
 
-ReqId PreProcessor::getOngoingReqIdForClient(uint16_t clientId) {
-  const auto &clientEntry = ongoingRequests_[clientId];
-  lock_guard<mutex> lock(clientEntry->mutex);
-  if (clientEntry->reqProcessingStatePtr) return clientEntry->reqProcessingStatePtr->getReqSeqNum();
+// For test purposes
+ReqId PreProcessor::getOngoingReqIdForClient(uint16_t clientId, uint16_t reqOffsetInBatch) {
+  const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+  lock_guard<mutex> lock(reqEntry->mutex);
+  if (reqEntry->reqProcessingStatePtr) return reqEntry->reqProcessingStatePtr->getReqSeqNum();
   return 0;
 }
 
 PreProcessingResult PreProcessor::handlePreProcessedReqByPrimaryAndGetConsensusResult(uint16_t clientId,
+                                                                                      uint16_t reqOffsetInBatch,
                                                                                       uint32_t resultBufLen) {
-  const auto &clientEntry = ongoingRequests_[clientId];
-  lock_guard<mutex> lock(clientEntry->mutex);
-  if (clientEntry->reqProcessingStatePtr) {
-    clientEntry->reqProcessingStatePtr->handlePrimaryPreProcessed(getPreProcessResultBuffer(clientId), resultBufLen);
-    return clientEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
+  const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, reqOffsetInBatch)];
+  lock_guard<mutex> lock(reqEntry->mutex);
+  if (reqEntry->reqProcessingStatePtr) {
+    reqEntry->reqProcessingStatePtr->handlePrimaryPreProcessed(getPreProcessResultBuffer(clientId, reqOffsetInBatch),
+                                                               resultBufLen);
+    return reqEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
   }
   return NONE;
 }
 
-void PreProcessor::handlePreProcessedReqPrimaryRetry(NodeIdType clientId, uint32_t resultBufLen) {
-  if (handlePreProcessedReqByPrimaryAndGetConsensusResult(clientId, resultBufLen) == COMPLETE)
-    finalizePreProcessing(clientId);
+void PreProcessor::handlePreProcessedReqPrimaryRetry(NodeIdType clientId,
+                                                     uint16_t reqOffsetInBatch,
+                                                     uint32_t resultBufLen) {
+  if (handlePreProcessedReqByPrimaryAndGetConsensusResult(clientId, reqOffsetInBatch, resultBufLen) == COMPLETE)
+    finalizePreProcessing(clientId, reqOffsetInBatch);
   else
-    cancelPreProcessing(clientId);
+    cancelPreProcessing(clientId, reqOffsetInBatch);
 }
 
 void PreProcessor::handlePreProcessedReqByPrimary(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                                   uint16_t clientId,
                                                   uint32_t resultBufLen) {
+  const uint16_t &reqOffsetInBatch = preProcessReqMsg->reqOffsetInBatch();
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.handlePreProcessedReqByPrimary);
-  const PreProcessingResult result = handlePreProcessedReqByPrimaryAndGetConsensusResult(clientId, resultBufLen);
+  const PreProcessingResult result =
+      handlePreProcessedReqByPrimaryAndGetConsensusResult(clientId, reqOffsetInBatch, resultBufLen);
   if (result != NONE)
-    handlePreProcessReplyMsg(preProcessReqMsg->getCid(), result, clientId, preProcessReqMsg->reqSeqNum());
+    handlePreProcessReplyMsg(
+        preProcessReqMsg->getCid(), result, clientId, reqOffsetInBatch, preProcessReqMsg->reqSeqNum());
 }
 
-void PreProcessor::handlePreProcessedReqByNonPrimary(
-    uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId, uint32_t resBufLen, const std::string &cid) {
+void PreProcessor::handlePreProcessedReqByNonPrimary(uint16_t clientId,
+                                                     uint16_t reqOffsetInBatch,
+                                                     ReqId reqSeqNum,
+                                                     uint64_t reqRetryId,
+                                                     uint32_t resBufLen,
+                                                     const std::string &cid) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.handlePreProcessedReqByNonPrimary);
-  setPreprocessingRightNow(clientId, false);
-  auto replyMsg =
-      make_shared<PreProcessReplyMsg>(sigManager_, &histograms_, myReplicaId_, clientId, reqSeqNum, reqRetryId);
-  replyMsg->setupMsgBody(getPreProcessResultBuffer(clientId), resBufLen, cid, STATUS_GOOD);
+  setPreprocessingRightNow(clientId, reqOffsetInBatch, false);
+  auto replyMsg = make_shared<PreProcessReplyMsg>(
+      sigManager_, &histograms_, myReplicaId_, clientId, reqOffsetInBatch, reqSeqNum, reqRetryId);
+  replyMsg->setupMsgBody(getPreProcessResultBuffer(clientId, reqOffsetInBatch), resBufLen, cid, STATUS_GOOD);
   // Release the request before sending a reply to the primary to be able accepting new messages
-  releaseClientPreProcessRequestSafe(clientId, COMPLETE);
+  releaseClientPreProcessRequestSafe(clientId, reqOffsetInBatch, COMPLETE);
   sendMsg(replyMsg->body(), myReplica_.currentPrimary(), replyMsg->type(), replyMsg->size());
   LOG_INFO(logger(),
            "Pre-processing completed by a non-primary replica"
-               << KVLOG(reqSeqNum, cid, reqRetryId, myReplica_.currentPrimary()));
+               << KVLOG(clientId, reqOffsetInBatch, reqSeqNum, cid, reqRetryId, myReplica_.currentPrimary()));
 }
 
 void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
@@ -777,23 +879,33 @@ void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr
                                              bool isRetry) {
   const string cid = preProcessReqMsg->getCid();
   const uint16_t &clientId = preProcessReqMsg->clientId();
+  const uint16_t &reqOffsetInBatch = preProcessReqMsg->reqOffsetInBatch();
   const SeqNum &reqSeqNum = preProcessReqMsg->reqSeqNum();
   const auto &span_context = preProcessReqMsg->spanContext<PreProcessRequestMsgSharedPtr::element_type>();
-  uint32_t actualResultBufLen = launchReqPreProcessing(
-      clientId, cid, reqSeqNum, preProcessReqMsg->requestLength(), preProcessReqMsg->requestBuf(), span_context);
+  uint32_t actualResultBufLen = launchReqPreProcessing(clientId,
+                                                       preProcessReqMsg->reqOffsetInBatch(),
+                                                       cid,
+                                                       reqSeqNum,
+                                                       preProcessReqMsg->requestLength(),
+                                                       preProcessReqMsg->requestBuf(),
+                                                       span_context);
   if (isPrimary && isRetry) {
-    handlePreProcessedReqPrimaryRetry(clientId, actualResultBufLen);
+    handlePreProcessedReqPrimaryRetry(clientId, reqOffsetInBatch, actualResultBufLen);
     return;
   }
   SCOPED_MDC_CID(cid);
-  LOG_DEBUG(logger(), "Request pre-processed" << KVLOG(isPrimary, reqSeqNum, clientId));
+  LOG_DEBUG(logger(), "Request pre-processed" << KVLOG(isPrimary, reqSeqNum, clientId, reqOffsetInBatch));
   if (isPrimary) {
     pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecPrimary>();
     handlePreProcessedReqByPrimary(preProcessReqMsg, clientId, actualResultBufLen);
   } else {
     pm_->Delay<concord::performance::SlowdownPhase::PreProcessorAfterPreexecNonPrimary>();
-    handlePreProcessedReqByNonPrimary(
-        clientId, reqSeqNum, preProcessReqMsg->reqRetryId(), actualResultBufLen, preProcessReqMsg->getCid());
+    handlePreProcessedReqByNonPrimary(clientId,
+                                      reqOffsetInBatch,
+                                      reqSeqNum,
+                                      preProcessReqMsg->reqRetryId(),
+                                      actualResultBufLen,
+                                      preProcessReqMsg->getCid());
   }
 }
 

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -12,8 +12,7 @@
 #pragma once
 
 #include "OpenTracing.hpp"
-#include "messages/PreProcessRequestMsg.hpp"
-#include "messages/ClientPreProcessRequestMsg.hpp"
+#include "messages/ClientBatchRequestMsg.hpp"
 #include "MsgsCommunicator.hpp"
 #include "MsgHandlersRegistrator.hpp"
 #include "SimpleThreadPool.hpp"
@@ -32,7 +31,7 @@
 
 namespace preprocessor {
 
-struct ClientRequestState {
+struct RequestState {
   std::mutex mutex;  // Define a mutex per client to avoid contentions between clients
   RequestProcessingStateUniquePtr reqProcessingStatePtr;
   // A list of requests passed a pre-processing consensus used for a non-determinism detection at later stage.
@@ -41,8 +40,11 @@ struct ClientRequestState {
   uint64_t reqRetryId = 1;
 };
 
-typedef std::shared_ptr<ClientRequestState> ClientRequestStateSharedPtr;
-typedef std::unordered_map<uint16_t, ClientRequestStateSharedPtr> OngoingReqMap;  // clientId -> ClientRequestState map
+// Pre-allocated (clientId * dataSize) buffers
+typedef std::vector<concordUtils::Sliver> PreProcessResultBuffers;
+typedef std::shared_ptr<RequestState> RequestStateSharedPtr;
+// (clientId * dataSize + reqOffsetInBatch) -> RequestStateSharedPtr
+typedef std::unordered_map<uint16_t, RequestStateSharedPtr> OngoingReqMap;
 
 using TimeRecorder = concord::diagnostics::TimeRecorder<true>;  // use atomic recorder
 //**************** Class PreProcessor ****************//
@@ -74,7 +76,7 @@ class PreProcessor {
 
   static void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
-  ReqId getOngoingReqIdForClient(uint16_t clientId);
+  ReqId getOngoingReqIdForClient(uint16_t clientId, uint16_t reqOffsetInBatch);
 
  private:
   friend class AsyncPreProcessJob;
@@ -87,61 +89,77 @@ class PreProcessor {
   template <typename T>
   void onMessage(T *msg);
 
-  bool registerReplicaDependentRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+  bool registerRequestOnPrimaryReplica(ClientPreProcessReqMsgUniquePtr clientReqMsg,
                                        PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
+                                       uint16_t reqOffsetInBatch,
                                        uint64_t reqRetryId);
   bool registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
-                       PreProcessRequestMsgSharedPtr preProcessRequestMsg);
-  void releaseClientPreProcessRequestSafe(uint16_t clientId, PreProcessingResult result);
-  void releaseClientPreProcessRequest(const ClientRequestStateSharedPtr &clientEntry,
-                                      uint16_t clientId,
-                                      PreProcessingResult result);
+                       PreProcessRequestMsgSharedPtr preProcessRequestMsg,
+                       uint16_t reqOffsetInBatch);
+  void releaseClientPreProcessRequestSafe(uint16_t clientId, uint16_t reqOffsetInBatch, PreProcessingResult result);
+  void releaseClientPreProcessRequest(const RequestStateSharedPtr &reqEntry, PreProcessingResult result);
   bool validateMessage(MessageBase *msg) const;
   void registerMsgHandlers();
-  bool checkClientMsgCorrectness(const ClientPreProcessReqMsgUniquePtr &clientReqMsg, ReqId reqSeqNum) const;
+  bool checkClientMsgCorrectness(
+      uint64_t reqSeqNum, const std::string &cid, bool isReadOnly, uint16_t clientId, NodeIdType senderId) const;
+  bool checkClientBatchMsgCorrectness(const ClientBatchRequestMsgUniquePtr &clientBatchReqMsg);
   void handleClientPreProcessRequestByPrimary(PreProcessRequestMsgSharedPtr preProcessRequestMsg);
-  void handleClientPreProcessRequestByNonPrimary(ClientPreProcessReqMsgUniquePtr msg);
+  void registerAndHandleClientPreProcessReqOnNonPrimary(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+                                                        bool arrivedInBatch,
+                                                        uint16_t reqOffsetInBatch);
   void sendMsg(char *msg, NodeIdType dest, uint16_t msgType, MsgSize msgSize);
   void sendPreProcessRequestToAllReplicas(const PreProcessRequestMsgSharedPtr &preProcessReqMsg);
-  void resendPreProcessRequest(const RequestProcessingStateUniquePtr &clientReqStatePtr);
+  void resendPreProcessRequest(const RequestProcessingStateUniquePtr &reqStatePtr);
   void sendRejectPreProcessReplyMsg(NodeIdType clientId,
+                                    uint16_t reqOffsetInBatch,
                                     NodeIdType senderId,
                                     SeqNum reqSeqNum,
                                     SeqNum ongoingReqSeqNum,
                                     uint64_t reqRetryId,
                                     const std::string &cid,
                                     const std::string &ongoingCid);
-  uint16_t getClientReplyBufferId(uint16_t clientId) const { return clientId - numOfReplicas_ - numOfRoReplicas_; }
-  const char *getPreProcessResultBuffer(uint16_t clientId) const;
+  const char *getPreProcessResultBuffer(uint16_t clientId, uint16_t reqOffsetInBatch) const;
+  const uint16_t getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,
                                       bool isRetry,
                                       TimeRecorder &&time_recorder = TimeRecorder());
   uint32_t launchReqPreProcessing(uint16_t clientId,
+                                  uint16_t reqOffsetInBatch,
                                   const std::string &cid,
                                   ReqId reqSeqNum,
                                   uint32_t reqLength,
                                   char *reqBuf,
                                   const concordUtils::SpanContext &span_context);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg, bool isPrimary, bool isRetry);
-  void handlePreProcessedReqByNonPrimary(
-      uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId, uint32_t resBufLen, const std::string &cid);
+  void handlePreProcessedReqByNonPrimary(uint16_t clientId,
+                                         uint16_t reqOffsetInBatch,
+                                         ReqId reqSeqNum,
+                                         uint64_t reqRetryId,
+                                         uint32_t resBufLen,
+                                         const std::string &cid);
   void handlePreProcessedReqByPrimary(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       uint16_t clientId,
                                       uint32_t resultBufLen);
-  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, uint32_t resultBufLen);
-  void finalizePreProcessing(NodeIdType clientId);
-  void cancelPreProcessing(NodeIdType clientId);
-  void setPreprocessingRightNow(uint16_t clientId, bool set);
-  PreProcessingResult handlePreProcessedReqByPrimaryAndGetConsensusResult(uint16_t clientId, uint32_t resultBufLen);
+  void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, uint16_t reqOffsetInBatch, uint32_t resultBufLen);
+  void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch);
+  void cancelPreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch);
+  void setPreprocessingRightNow(uint16_t clientId, uint16_t reqOffsetInBatch, bool set);
+  PreProcessingResult handlePreProcessedReqByPrimaryAndGetConsensusResult(uint16_t clientId,
+                                                                          uint16_t reqOffsetInBatch,
+                                                                          uint32_t resultBufLen);
   void handlePreProcessReplyMsg(const std::string &cid,
                                 PreProcessingResult result,
                                 NodeIdType clientId,
+                                uint16_t reqOffsetInBatch,
                                 SeqNum reqSeqNum);
   void updateAggregatorAndDumpMetrics();
   void addTimers();
   void cancelTimers();
   void onRequestsStatusCheckTimer();
+  void handleSingleClientRequestMessage(ClientPreProcessReqMsgUniquePtr clientMsg,
+                                        bool arrivedInBatch,
+                                        uint16_t msgOffsetInBatch);
 
   static logging::Logger &logger() {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
@@ -161,12 +179,13 @@ class PreProcessor {
   const uint32_t maxPreExecResultSize_;
   const std::set<ReplicaId> &idsOfPeerReplicas_;
   const uint16_t numOfReplicas_;
-  const uint16_t numOfRoReplicas_;
   const uint16_t numOfClients_;
+  const bool batchingEnabled_;
+  const uint16_t batchSize_;
   util::SimpleThreadPool threadPool_;
   // One-time allocated buffers (one per client) for the pre-execution results storage
-  std::vector<concordUtils::Sliver> preProcessResultBuffers_;
-  OngoingReqMap ongoingRequests_;  // clientId -> ClientRequestStateSharedPtr
+  PreProcessResultBuffers preProcessResultBuffers_;
+  OngoingReqMap ongoingRequests_;  // clientId + reqOffsetInBatch -> RequestStateSharedPtr
   concordMetrics::Component metricsComponent_;
   std::chrono::seconds metricsLastDumpTime_;
   std::chrono::seconds metricsDumpIntervalInSec_;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -32,7 +32,7 @@
 namespace preprocessor {
 
 struct RequestState {
-  std::mutex mutex;  // Define a mutex per client to avoid contentions between clients
+  std::mutex mutex;  // Define a mutex per request to avoid contentions
   RequestProcessingStateUniquePtr reqProcessingStatePtr;
   // A list of requests passed a pre-processing consensus used for a non-determinism detection at later stage.
   static const uint8_t reqProcessingHistoryHeight = 30;

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -30,6 +30,7 @@ class RequestProcessingState {
  public:
   RequestProcessingState(uint16_t numOfReplicas,
                          uint16_t clientId,
+                         uint16_t reqOffsetInBatch,
                          const std::string& cid,
                          ReqId reqSeqNum,
                          ClientPreProcessReqMsgUniquePtr clientReqMsg,
@@ -42,6 +43,7 @@ class RequestProcessingState {
   void setPreProcessRequest(PreProcessRequestMsgSharedPtr preProcessReqMsg);
   const PreProcessRequestMsgSharedPtr& getPreProcessRequest() const { return preProcessRequestMsg_; }
   const auto getClientId() const { return clientId_; }
+  const auto getReqOffsetInBatch() const { return reqOffsetInBatch_; }
   const SeqNum getReqSeqNum() const { return reqSeqNum_; }
   PreProcessingResult definePreProcessingConsensusResult();
   const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResult_; }
@@ -81,6 +83,7 @@ class RequestProcessingState {
   // the RequestProcessingState objects.
   const uint16_t numOfReplicas_;
   const uint16_t clientId_;
+  const uint16_t reqOffsetInBatch_;
   const std::string cid_;
   const ReqId reqSeqNum_;
   const uint64_t entryTime_;

--- a/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.cpp
@@ -1,0 +1,80 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "ClientBatchRequestMsg.hpp"
+#include "assertUtils.hpp"
+
+namespace bftEngine::impl {
+
+using namespace std;
+
+ClientBatchRequestMsg::ClientBatchRequestMsg(NodeIdType clientId,
+                                             const std::deque<ClientRequestMsg*>& batch,
+                                             uint32_t batchBufSize,
+                                             const string& cid)
+    : MessageBase(
+          clientId, MsgCode::ClientBatchRequest, 0, sizeof(ClientBatchRequestMsgHeader) + cid.size() + batchBufSize) {
+  const auto& numOfMessagesInBatch = batch.size();
+  msgBody()->msgType = MsgCode::ClientBatchRequest;
+  msgBody()->cidSize = cid.size();
+  msgBody()->clientId = clientId;
+  msgBody()->numOfMessagesInBatch = numOfMessagesInBatch;
+  msgBody()->dataSize = batchBufSize;
+  char* data = body() + sizeof(ClientBatchRequestMsgHeader);
+  if (cid.size()) {
+    memcpy(data, cid.c_str(), cid.size());
+    data += cid.size();
+  }
+  for (auto const& msg : batch) {
+    memcpy(data, msg->body(), msg->size());
+    data += msg->size();
+  }
+  LOG_DEBUG(logger(), KVLOG(cid, clientId, numOfMessagesInBatch, batchBufSize));
+}
+
+const string& ClientBatchRequestMsg::getCid() {
+  if (cid_.empty()) cid_ = string(body() + sizeof(ClientBatchRequestMsgHeader), msgBody()->cidSize);
+  return cid_;
+}
+
+void ClientBatchRequestMsg::validate(const ReplicasInfo& repInfo) const {
+  ConcordAssert(senderId() != repInfo.myId());
+  if (size() < sizeof(ClientBatchRequestMsgHeader) ||
+      size() < (sizeof(ClientBatchRequestMsgHeader) + msgBody()->dataSize))
+    throw std::runtime_error(__PRETTY_FUNCTION__);
+}
+
+ClientMsgsList& ClientBatchRequestMsg::getClientPreProcessRequestMsgs() {
+  if (!clientMsgsList_.empty()) return clientMsgsList_;
+
+  const auto& numOfMessagesInBatch = msgBody()->numOfMessagesInBatch;
+  char* dataPosition = body() + sizeof(ClientBatchRequestMsgHeader) + msgBody()->cidSize;
+  for (uint32_t i = 0; i < numOfMessagesInBatch; i++) {
+    const auto& singleMsgHeader = *(ClientRequestMsgHeader*)dataPosition;
+    const char* spanDataPosition = dataPosition + sizeof(ClientRequestMsgHeader);
+    const char* requestDataPosition = spanDataPosition + singleMsgHeader.spanContextSize;
+    const char* cidPosition = requestDataPosition + singleMsgHeader.requestLength;
+    const concordUtils::SpanContext spanContext(string(spanDataPosition, singleMsgHeader.spanContextSize));
+    auto msg = make_unique<preprocessor::ClientPreProcessRequestMsg>(singleMsgHeader.idOfClientProxy,
+                                                                     singleMsgHeader.reqSeqNum,
+                                                                     singleMsgHeader.requestLength,
+                                                                     requestDataPosition,
+                                                                     singleMsgHeader.timeoutMilli,
+                                                                     string(cidPosition, singleMsgHeader.cidLength),
+                                                                     spanContext);
+    clientMsgsList_.push_back(move(msg));
+    dataPosition += sizeof(ClientRequestMsgHeader) + singleMsgHeader.spanContextSize + singleMsgHeader.requestLength +
+                    singleMsgHeader.cidLength;
+  }
+  return clientMsgsList_;
+}
+
+}  // namespace bftEngine::impl

--- a/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.hpp
@@ -1,0 +1,65 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "ClientPreProcessRequestMsg.hpp"
+#include "ReplicasInfo.hpp"
+#include "ClientMsgs.hpp"
+#include "Logger.hpp"
+#include <deque>
+
+namespace bftEngine::impl {
+
+typedef std::deque<preprocessor::ClientPreProcessReqMsgUniquePtr> ClientMsgsList;
+
+class ClientBatchRequestMsg : public MessageBase {
+  static_assert((uint16_t)BATCH_REQUEST_MSG_TYPE == (uint16_t)MsgCode::ClientBatchRequest, "");
+  static_assert(sizeof(ClientBatchRequestMsgHeader::clientId) == sizeof(NodeIdType), "");
+  static_assert(sizeof(ClientBatchRequestMsgHeader::numOfMessagesInBatch) == sizeof(uint32_t), "");
+  static_assert(sizeof(ClientBatchRequestMsgHeader::dataSize) == sizeof(uint32_t), "");
+  static_assert(sizeof(ClientBatchRequestMsgHeader) == 16, "ClientBatchRequestMsgHeader size is 16B");
+
+ public:
+  ClientBatchRequestMsg(NodeIdType clientId,
+                        const std::deque<ClientRequestMsg*>& batch,
+                        uint32_t batchBufSize,
+                        const std::string& cid);
+
+  BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(ClientBatchRequestMsg)
+
+  uint16_t clientId() const { return msgBody()->clientId; }
+  uint32_t numOfMessagesInBatch() const { return msgBody()->numOfMessagesInBatch; }
+  uint32_t batchSize() const { return msgBody()->dataSize; }
+  const std::string& getCid();
+  ClientMsgsList& getClientPreProcessRequestMsgs();
+  void validate(const ReplicasInfo&) const override;
+
+ protected:
+  ClientBatchRequestMsgHeader* msgBody() const { return ((ClientBatchRequestMsgHeader*)msgBody_); }
+
+ private:
+  static logging::Logger& logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
+    return logger_;
+  }
+  std::string cid_;
+  ClientMsgsList clientMsgsList_;
+};
+
+template <>
+inline size_t sizeOfHeader<ClientBatchRequestMsgHeader>() {
+  return sizeof(ClientBatchRequestMsgHeader);
+}
+
+typedef std::unique_ptr<ClientBatchRequestMsg> ClientBatchRequestMsgUniquePtr;
+
+}  // namespace bftEngine::impl

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -11,7 +11,6 @@
 
 #include "ClientPreProcessRequestMsg.hpp"
 #include "SimpleClient.hpp"
-#include "assertUtils.hpp"
 
 namespace preprocessor {
 

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -26,11 +26,12 @@ PreProcessReplyMsg::PreProcessReplyMsg(SigManagerSharedPtr sigManager,
                                        preprocessor::PreProcessorRecorder* histograms,
                                        NodeIdType senderId,
                                        uint16_t clientId,
+                                       uint16_t reqOffsetInBatch,
                                        uint64_t reqSeqNum,
                                        uint64_t reqRetryId)
     : MessageBase(senderId, MsgCode::PreProcessReply, 0, maxReplyMsgSize_), sigManager_(sigManager) {
   setPreProcessorHistograms(histograms);
-  setParams(senderId, clientId, reqSeqNum, reqRetryId);
+  setParams(senderId, clientId, reqOffsetInBatch, reqSeqNum, reqRetryId);
 }
 
 void PreProcessReplyMsg::validate(const ReplicasInfo& repInfo) const {
@@ -62,10 +63,12 @@ void PreProcessReplyMsg::validate(const ReplicasInfo& repInfo) const {
   }
 }  // namespace preprocessor
 
-void PreProcessReplyMsg::setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId) {
+void PreProcessReplyMsg::setParams(
+    NodeIdType senderId, uint16_t clientId, uint16_t reqOffsetInBatch, ReqId reqSeqNum, uint64_t reqRetryId) {
   msgBody()->senderId = senderId;
   msgBody()->reqSeqNum = reqSeqNum;
   msgBody()->clientId = clientId;
+  msgBody()->reqOffsetInBatch = reqOffsetInBatch;
   msgBody()->reqRetryId = reqRetryId;
   LOG_DEBUG(logger(), KVLOG(senderId, clientId, reqSeqNum, reqRetryId));
 }

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -26,6 +26,7 @@ class PreProcessReplyMsg : public MessageBase {
                      preprocessor::PreProcessorRecorder* histograms,
                      NodeIdType senderId,
                      uint16_t clientId,
+                     uint16_t reqOffsetInBatch,
                      uint64_t reqSeqNum,
                      uint64_t reqRetryId);
 
@@ -38,6 +39,7 @@ class PreProcessReplyMsg : public MessageBase {
 
   void validate(const bftEngine::impl::ReplicasInfo&) const override;
   const uint16_t clientId() const { return msgBody()->clientId; }
+  const uint16_t reqOffsetInBatch() const { return msgBody()->reqOffsetInBatch; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
   const uint64_t reqRetryId() const { return msgBody()->reqRetryId; }
   const uint32_t replyLength() const { return msgBody()->replyLength; }
@@ -56,6 +58,7 @@ class PreProcessReplyMsg : public MessageBase {
     SeqNum reqSeqNum;
     NodeIdType senderId;
     uint16_t clientId;
+    uint16_t reqOffsetInBatch;
     uint8_t status;
     uint8_t resultsHash[concord::util::SHA3_256::SIZE_IN_BYTES];
     uint32_t replyLength;
@@ -70,7 +73,8 @@ class PreProcessReplyMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
-  void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId);
+  void setParams(
+      NodeIdType senderId, uint16_t clientId, uint16_t reqOffsetInBatch, ReqId reqSeqNum, uint64_t reqRetryId);
   Header* msgBody() const { return ((Header*)msgBody_); }
 
  private:

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -17,6 +17,7 @@ namespace preprocessor {
 
 PreProcessRequestMsg::PreProcessRequestMsg(NodeIdType senderId,
                                            uint16_t clientId,
+                                           uint16_t reqOffsetInBatch,
                                            uint64_t reqSeqNum,
                                            uint64_t reqRetryId,
                                            uint32_t reqLength,
@@ -25,7 +26,7 @@ PreProcessRequestMsg::PreProcessRequestMsg(NodeIdType senderId,
                                            const concordUtils::SpanContext& span_context)
     : MessageBase(
           senderId, MsgCode::PreProcessRequest, span_context.data().size(), (sizeof(Header) + reqLength + cid.size())) {
-  setParams(senderId, clientId, reqSeqNum, reqRetryId, reqLength);
+  setParams(senderId, clientId, reqOffsetInBatch, reqSeqNum, reqRetryId, reqLength);
   msgBody()->cidLength = cid.size();
   auto position = body() + sizeof(Header);
   memcpy(position, span_context.data().data(), span_context.data().size());
@@ -48,10 +49,15 @@ void PreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {
     throw std::runtime_error(__PRETTY_FUNCTION__);
 }
 
-void PreProcessRequestMsg::setParams(
-    NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId, uint32_t reqLength) {
+void PreProcessRequestMsg::setParams(NodeIdType senderId,
+                                     uint16_t clientId,
+                                     uint16_t reqOffsetInBatch,
+                                     ReqId reqSeqNum,
+                                     uint64_t reqRetryId,
+                                     uint32_t reqLength) {
   msgBody()->senderId = senderId;
   msgBody()->clientId = clientId;
+  msgBody()->reqOffsetInBatch = reqOffsetInBatch;
   msgBody()->reqSeqNum = reqSeqNum;
   msgBody()->reqRetryId = reqRetryId;
   msgBody()->requestLength = reqLength;

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -22,6 +22,7 @@ class PreProcessRequestMsg : public MessageBase {
  public:
   PreProcessRequestMsg(NodeIdType senderId,
                        uint16_t clientId,
+                       uint16_t reqOffsetInBatch,
                        uint64_t reqSeqNum,
                        uint64_t reqRetryId,
                        uint32_t reqLength,
@@ -35,6 +36,7 @@ class PreProcessRequestMsg : public MessageBase {
   char* requestBuf() const { return body() + sizeof(Header) + spanContextSize(); }
   const uint32_t requestLength() const { return msgBody()->requestLength; }
   const uint16_t clientId() const { return msgBody()->clientId; }
+  const uint16_t reqOffsetInBatch() const { return msgBody()->reqOffsetInBatch; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
   const uint64_t reqRetryId() const { return msgBody()->reqRetryId; }
   std::string getCid() const;
@@ -47,6 +49,7 @@ class PreProcessRequestMsg : public MessageBase {
     MessageBase::Header header;
     SeqNum reqSeqNum;
     uint16_t clientId;
+    uint16_t reqOffsetInBatch;
     NodeIdType senderId;
     uint32_t requestLength;
     uint32_t cidLength;
@@ -59,7 +62,12 @@ class PreProcessRequestMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
-  void setParams(NodeIdType senderId, uint16_t clientId, ReqId reqSeqNum, uint64_t reqRetryId, uint32_t reqLength);
+  void setParams(NodeIdType senderId,
+                 uint16_t clientId,
+                 uint16_t reqOffsetInBatch,
+                 ReqId reqSeqNum,
+                 uint64_t reqRetryId,
+                 uint32_t reqLength);
 
  private:
   Header* msgBody() const { return ((Header*)msgBody_); }

--- a/bftengine/tests/clientsManager/ClientsManager_test.cpp
+++ b/bftengine/tests/clientsManager/ClientsManager_test.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -32,7 +32,7 @@ TEST(ClientsManager, reservedPagesPerClient) {
 
 TEST(ClientsManager, constructor) {
   std::set<bftEngine::impl::NodeIdType> clset{1, 4, 50, 7};
-  bftEngine::impl::ClientsManager cm{2, clset, 1024, 1024};
+  bftEngine::impl::ClientsManager cm{clset};
   ASSERT_EQ(50, cm.getHighestIdOfNonInternalClient());
   auto i = 0;
   for (auto id : clset) {
@@ -46,7 +46,7 @@ TEST(ClientsManager, constructor) {
 // and are identifed as internal clients
 TEST(ClientsManager, initInternalClientInfo) {
   std::set<bftEngine::impl::NodeIdType> clset{1, 4, 50, 7};
-  bftEngine::impl::ClientsManager cm{2, clset, 1024, 1024};
+  bftEngine::impl::ClientsManager cm{clset};
   auto firstIntClId = cm.getHighestIdOfNonInternalClient() + 1;
   auto FirstIntIdx = cm.getIndexOfClient(cm.getHighestIdOfNonInternalClient()) + 1;
   auto numRep = 7;

--- a/kvbc/src/ClientImp.cpp
+++ b/kvbc/src/ClientImp.cpp
@@ -83,6 +83,8 @@ Status ClientImp::invokeCommandSynch(const char* request,
       return Status::GeneralError("Command timed out");
     case BUFFER_TOO_SMALL:
       return Status::InvalidArgument("Specified output buffer is too small");
+    case INVALID_REQUEST:
+      return Status::InvalidArgument("Request is invalid");
   }
   return Status::GeneralError("Unknown error");
 }

--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -77,7 +77,6 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         writeset_values = skvbc.random_values(len(writeset_keys))
         return list(zip(writeset_keys, writeset_values))
 
-    @unittest.skip("for future use")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -87,6 +86,7 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         """
         bft_network.start_all_replicas()
         await trio.sleep(SKVBC_INIT_GRACE_TIME)
+        await bft_network.init_preexec_count()
 
         for i in range(NUM_OF_SEQ_WRITES):
             client = bft_network.random_client()
@@ -94,7 +94,6 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
 
         await bft_network.assert_successful_pre_executions_count(0, NUM_OF_SEQ_WRITES * BATCH_SIZE)
 
-    @unittest.skip("for future use")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -103,7 +102,8 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         Launch concurrent requests from different clients in parallel. Ensure that created blocks are as expected.
         """
         bft_network.start_all_replicas()
-        await trio.sleep(SKVBC_INIT_GRACE_TIME) 
+        await trio.sleep(SKVBC_INIT_GRACE_TIME)
+        await bft_network.init_preexec_count()
 
         clients = bft_network.random_clients(MAX_CONCURRENCY)
         num_of_requests = NUM_OF_PARALLEL_WRITES
@@ -112,7 +112,6 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
 
         await bft_network.assert_successful_pre_executions_count(0, wr * BATCH_SIZE)
 
-    @unittest.skip("for future use")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -123,6 +122,7 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         """
         bft_network.start_all_replicas()
         await trio.sleep(SKVBC_INIT_GRACE_TIME)
+        await bft_network.init_preexec_count()
 
         client = bft_network.random_client()
         client.config = client.config._replace(
@@ -148,7 +148,6 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
                                                 err_msg="Make sure the view did not change.")
                 await trio.sleep(seconds=5)
 
-    @unittest.skip("for future use")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @with_constant_load
@@ -159,6 +158,7 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         """
         bft_network.start_all_replicas()
         await trio.sleep(SKVBC_INIT_GRACE_TIME)
+        await bft_network.init_preexec_count()
 
         client = bft_network.random_client()
         client.config = client.config._replace(
@@ -180,7 +180,6 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
                                         expected=lambda v: v == initial_primary,
                                         err_msg="Make sure the view did not change.")
 
-    @unittest.skip("for future use")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -191,6 +190,7 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         bft_network.start_all_replicas()
 
         await trio.sleep(5)
+        await bft_network.init_preexec_count()
 
         clients = bft_network.clients.values()
         for client in clients:
@@ -219,7 +219,6 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
                                             err_msg="Make sure view change has been triggered.")
             await tracker.send_tracked_write_batch(client, 2, BATCH_SIZE)
 
-    @unittest.skip("for future use")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -231,6 +230,7 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         '''
         bft_network.start_all_replicas()
         await trio.sleep(SKVBC_INIT_GRACE_TIME)
+        await bft_network.init_preexec_count()
 
         read_client = bft_network.random_client()
         submit_clients = bft_network.random_clients(MAX_CONCURRENCY)
@@ -245,7 +245,7 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
 
         log.log_message(message_type=f"Randomly picked replica indexes {crash_targets} (nonprimary) to be stopped.")
         log.log_message(message_type=f"Total of {num_of_requests} write pre-exec tx, "
-              f"concurrently submitted through {len(submit_clients)} clients.")
+                                     f"concurrently submitted through {len(submit_clients)} clients.")
         log.log_message(message_type=f"Finished at block {final_block_count}.")
         self.assertTrue(wr >= num_of_requests)
 

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -39,11 +39,12 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     bftEngine::ReplicaConfig& replicaConfig = bftEngine::ReplicaConfig::instance();
     replicaConfig.numOfClientProxies = 100;
     replicaConfig.numOfExternalClients = 30;
-    replicaConfig.concurrencyLevel = 1;
+    replicaConfig.concurrencyLevel = 3;
     replicaConfig.debugStatisticsEnabled = true;
     replicaConfig.viewChangeTimerMillisec = 45 * 1000;
     replicaConfig.statusReportTimerMillisec = 10 * 1000;
     replicaConfig.preExecutionFeatureEnabled = true;
+    replicaConfig.clientMiniBatchingEnabled = true;
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;


### PR DESCRIPTION
This PR implements changes required for support of client mini-batching feature by BFT client, PreProcessor, ReplicaImp, and ClientsManager.
This performance-driven feature allows BFT clients to collect application requests into a batch and sends them as one message (ClientBatchRequestMsg) to the replicas. This message is opened by PreProcessor and every single ClientRequest gets pre-executed as before. BFT client collects the required number of replies from the replicas for each request in a batch and only then returns the answer to a client pool. ClientsManager supports now up to a configurable maximum number of requests in a batch from the same client simultaneously. This feature works together with consensus batching and is intended to improve it.