### PR TITLE
Sort deletes in categorization::Updates

### DIFF
--- a/kvbc/benchmark/categorization_benchmark.cpp
+++ b/kvbc/benchmark/categorization_benchmark.cpp
@@ -17,7 +17,14 @@
 #include "categorization/details.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
 
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <random>
+#include <set>
+#include <unordered_set>
+#include <vector>
 
 namespace {
 
@@ -50,6 +57,37 @@ BenchmarkMessage message(std::size_t range) {
   return msg;
 }
 
+std::vector<std::uint8_t> randomBuffer(std::size_t size) {
+  static thread_local auto gen = std::mt19937{};
+  auto dis = std::uniform_int_distribution<std::uint16_t>{0, 255};
+  auto vec = std::vector<std::uint8_t>{};
+  vec.reserve(size);
+  for (auto i = 0ull; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  return vec;
+}
+
+std::string randomString(std::size_t size) {
+  const auto buf = randomBuffer(size);
+  return std::string{std::cbegin(buf), std::cend(buf)};
+}
+
+std::vector<std::string> randomStringVector(std::size_t string_size, std::size_t count) {
+  auto vec = std::vector<std::string>{};
+  for (auto i = 0ull; i < count; ++i) {
+    vec.push_back(randomString(string_size));
+  }
+  return vec;
+}
+
+std::vector<std::string> duplicates(std::size_t string_size, std::size_t count) {
+  const auto r = randomStringVector(string_size / 2, count / 2);
+  auto vec = std::vector<std::string>{r};
+  vec.insert(vec.end(), r.begin(), r.end());
+  return vec;
+}
+
 void serializeAlloc(benchmark::State &state) {
   const auto msg = message(state.range(0));
   for (auto _ : state) {
@@ -66,13 +104,64 @@ void serializeTls(benchmark::State &state) {
   }
 }
 
+void vectorSortAndUnique(benchmark::State &state) {
+  const auto d = duplicates(state.range(0), state.range(1));
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto vec = d;
+    state.ResumeTiming();
+
+    std::sort(vec.begin(), vec.end());
+    vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
+    benchmark::DoNotOptimize(vec);
+  }
+}
+
+void vectorToSet(benchmark::State &state) {
+  const auto d = duplicates(state.range(0), state.range(1));
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto vec = d;
+    state.ResumeTiming();
+
+    auto set = std::set<std::string>{std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end())};
+    vec.assign(std::make_move_iterator(set.begin()), std::make_move_iterator(set.end()));
+    benchmark::DoNotOptimize(set);
+    benchmark::DoNotOptimize(vec);
+  }
+}
+
+void vectorToUnorderedSet(benchmark::State &state) {
+  const auto d = duplicates(state.range(0), state.range(1));
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto vec = d;
+    state.ResumeTiming();
+
+    auto set =
+        std::unordered_set<std::string>{std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end())};
+    vec.assign(std::make_move_iterator(set.begin()), std::make_move_iterator(set.end()));
+    std::sort(vec.begin(), vec.end());
+    benchmark::DoNotOptimize(set);
+    benchmark::DoNotOptimize(vec);
+  }
+}
+
 }  // namespace
 
 const auto range_multiplier = 2;
 const auto serialize_size_start = 8;
 const auto serialize_size_end = 4096;
 
+// Ranges for string vectors:
+//   1. individual string size
+//   2. strings count in the vector
+const auto vector_ranges = std::vector<std::pair<std::int64_t, std::int64_t>>{{32, 192}, {8, 128}};
+
 BENCHMARK(serializeAlloc)->RangeMultiplier(range_multiplier)->Range(serialize_size_start, serialize_size_end);
 BENCHMARK(serializeTls)->RangeMultiplier(range_multiplier)->Range(serialize_size_start, serialize_size_end);
+BENCHMARK(vectorSortAndUnique)->RangeMultiplier(range_multiplier)->Ranges(vector_ranges);
+BENCHMARK(vectorToSet)->RangeMultiplier(range_multiplier)->Ranges(vector_ranges);
+BENCHMARK(vectorToUnorderedSet)->RangeMultiplier(range_multiplier)->Ranges(vector_ranges);
 
 BENCHMARK_MAIN();

--- a/kvbc/include/categorization/details.h
+++ b/kvbc/include/categorization/details.h
@@ -17,6 +17,7 @@
 #include "categorized_kvbc_msgs.cmf.hpp"
 #include "rocksdb/native_client.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -89,6 +90,11 @@ inline bool createColumnFamilyIfNotExisting(const std::string &cf, storage::rock
     return true;
   }
   return false;
+}
+
+inline void sortAndRemoveDuplicates(std::vector<std::string> &vec) {
+  std::sort(vec.begin(), vec.end());
+  vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
 }
 
 }  // namespace concord::kvbc::categorization::detail


### PR DESCRIPTION
Deletes in BlockMerkleInput and VersionedInput are serialized as a
vector. The order of elements in the vector is determined by insertion
order. However, deletes in BlockMerkleOutput and VersionedOutput are
contained in a map and are, therefore, sorted. In addition, the
KeyValueBlockchain contains a cached value of the last raw block set
during addBlock() so that it can avoid expensive calls to getRawBlock().

The effect of above is that a replica receiving State Transfer raw
blocks will construct its BlockMerkleInput and VersionedInput objects
with sorted order from the output data structures, whereas a replica
using the cached last raw block will use the insertion order coming from
BlockMerkleUpdates and VersionedUpdates. These two orders are
potentially different, leading to different parent digests and,
subsequently, different blockchains in these replicas.

In order to fix, sort and remove duplicate deletes in BlockMerkleUpdates
and VersionedUpdates. Implement by keeping track of when deletes are
added and only sort and remove duplicates when needed. Add unit tests to
verify the behavior.

Thanks to @cloudnoize for noticing this problem!