### PR TITLE
Honour calculate_root_hash in all categories

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -54,12 +54,22 @@ Msg VersionedKeyFlags 1002 {
 
 Msg VersionedOutput 1003 {
     map string VersionedKeyFlags keys
+
+    # - If nullopt, no root calculation was requested in the input.
+    # - If it contains a value, root calculation was requested in the input.
+    #   Furthermore, if there weren't any keys in the input, the hash value
+    #   will be equal to the hash of an empty string.
     optional fixedlist uint8 32 root_hash
 }
 
 Msg ImmutableOutput 1004 {
     # key -> [tag1, tag2...]
     map string list string tagged_keys
+
+    # - If nullopt, no tag root calculation was requested in the input.
+    # - If it contains a value, root calculation was requested in the input.
+    #   Furthermore, if no tags were provided for any of the keys or there were
+    #   no keys at all in the input, the map itself will be empty.
     optional map string fixedlist uint8 32 tag_root_hashes
 }
 

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -46,9 +46,6 @@ void updateTagHash(const std::string &tag,
 }
 
 void finishTagHashes(std::map<std::string, Hasher> &tag_hashers, ImmutableOutput &update_info) {
-  if (tag_hashers.empty()) {
-    return;
-  }
   auto tag_root_hashes = std::map<std::string, Hash>{};
   for (auto &[tag, hasher] : tag_hashers) {
     tag_root_hashes[tag] = hasher.finish();

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -73,11 +73,8 @@ void VersionedKeyValueCategory::addDeletes(BlockId block_id,
   const auto stale_on_update = false;
   for (auto &&key : keys) {
     auto versioned_key = VersionedRawKey{std::move(key), block_id};
-
     updateLatestKeyVersion(versioned_key.value, TaggedVersion{deleted, block_id}, batch);
-
     putValue(versioned_key, deleted, ""sv, batch);
-
     addKeyToUpdateInfo(std::move(versioned_key.value), deleted, stale_on_update, out);
   }
 }
@@ -94,10 +91,6 @@ void VersionedKeyValueCategory::addUpdates(BlockId block_id,
                                            std::map<std::string, ValueWithFlags> &&updates,
                                            VersionedOutput &out,
                                            storage::rocksdb::NativeWriteBatch &batch) {
-  if (updates.empty()) {
-    return;
-  }
-
   auto hasher = Hasher{};
   hasher.init();
   const auto deleted = false;
@@ -114,11 +107,8 @@ void VersionedKeyValueCategory::addUpdates(BlockId block_id,
     }
 
     auto versioned_key = VersionedRawKey{std::move(key), block_id};
-
     updateLatestKeyVersion(versioned_key.value, TaggedVersion{deleted, block_id}, batch);
-
     putValue(versioned_key, deleted, value.data, batch);
-
     addKeyToUpdateInfo(std::move(versioned_key.value), deleted, value.stale_on_update, out);
   }
 

--- a/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
@@ -88,7 +88,8 @@ TEST_F(immutable_kv_category, empty_updates) {
     auto batch = db->getBatch();
     const auto update_info = cat.add(1, std::move(update), batch);
     ASSERT_EQ(batch.count(), 0);
-    ASSERT_FALSE(update_info.tag_root_hashes);
+    ASSERT_TRUE(update_info.tag_root_hashes);
+    ASSERT_TRUE(update_info.tag_root_hashes->empty());
     ASSERT_TRUE(update_info.tagged_keys.empty());
   }
 }
@@ -110,6 +111,16 @@ TEST_F(immutable_kv_category, calculate_root_hash_toggle) {
     update.kv["k"] = ImmutableValueUpdate{"v", {"t"}};
     const auto update_info = cat.add(1, std::move(update), batch);
     ASSERT_FALSE(update_info.tag_root_hashes);
+  }
+
+  {
+    auto update = ImmutableInput{};
+    update.calculate_root_hash = true;
+    update.kv["k1"] = ImmutableValueUpdate{"v1", {}};
+    update.kv["k2"] = ImmutableValueUpdate{"v2", {}};
+    const auto update_info = cat.add(1, std::move(update), batch);
+    ASSERT_TRUE(update_info.tag_root_hashes);
+    ASSERT_TRUE(update_info.tag_root_hashes->empty());
   }
 }
 

--- a/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
@@ -89,7 +89,11 @@ TEST_F(versioned_kv_category, empty_updates) {
     auto batch = db->getBatch();
     const auto out = cat.add(1, std::move(in), batch);
     ASSERT_EQ(batch.count(), 0);
-    ASSERT_FALSE(out.root_hash);
+    ASSERT_TRUE(out.root_hash);
+    // Expect the empty SHA3-256 hash.
+    ASSERT_THAT(*out.root_hash, ContainerEq(Hash{0xa7, 0xff, 0xc6, 0xf8, 0xbf, 0x1e, 0xd7, 0x66, 0x51, 0xc1, 0x47,
+                                                 0x56, 0xa0, 0x61, 0xd6, 0x62, 0xf5, 0x80, 0xff, 0x4d, 0xe4, 0x3b,
+                                                 0x49, 0xfa, 0x82, 0xd8, 0x0a, 0x4b, 0x80, 0xf8, 0x43, 0x4a}));
     ASSERT_TRUE(out.keys.empty());
   }
 }


### PR DESCRIPTION
If root hash calculation has been requested via the flag in both
VersionedUpdates and ImmutableUpdates, make sure the root hash optional
in the output always contains a value, irrespective of input keys and
tags. In case of VersionedUpdates with no keys, the output contains the
hash of an empty string. In case of ImmutableUpdates with keys and no
tags or without any keys, the output contains an empty map of tags to
hashes.

Above is important in case of State Transfer, because the fact that an
output root hash optional has a value (even if it is the empty string
hash or an empty map) signifies that root hash calculation was
originally requested and a receiving replica can use that fact to
reconstruct the exact same update.

Put comments describing possible optional values (or lack of) in the
CMF file.

Update unit tests to reflect the changed behaviour.