### PR TITLE
Additional logs for View Change and retrieved block size

### DIFF
--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -340,6 +340,7 @@ bool ReplicaImp::getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSi
   }
   const auto &ser = categorization::RawBlock::serialize(*rawBlock);
   *outBlockSize = ser.size();
+  LOG_DEBUG(logger, KVLOG(blockId, *outBlockSize));
   std::memcpy(outBlock, ser.data(), *outBlockSize);
   return true;
 }


### PR DESCRIPTION
Added log when after View Change Replicas finish the rebuilding of the previous View's Working Window.
Added DEBUG log for size of the retrieved block.