### PR TITLE
Add new functionality to kv_blockchain_db_editor

### DIFF
--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -70,6 +70,7 @@ class BlockMerkleCategory {
                              std::vector<std::optional<TaggedVersion>>& versions) const;
   void multiGetLatestVersion(const std::vector<Hash>& keys, std::vector<std::optional<TaggedVersion>>& versions) const;
 
+  std::vector<std::string> getBlockStaleKeys(BlockId, const BlockMerkleOutput&);
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
   void deleteGenesisBlock(BlockId, const BlockMerkleOutput&, storage::rocksdb::NativeWriteBatch&);

--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -70,7 +70,7 @@ class BlockMerkleCategory {
                              std::vector<std::optional<TaggedVersion>>& versions) const;
   void multiGetLatestVersion(const std::vector<Hash>& keys, std::vector<std::optional<TaggedVersion>>& versions) const;
 
-  std::vector<std::string> getBlockStaleKeys(BlockId, const BlockMerkleOutput&);
+  std::vector<std::string> getBlockStaleKeys(BlockId, const BlockMerkleOutput&) const;
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
   void deleteGenesisBlock(BlockId, const BlockMerkleOutput&, storage::rocksdb::NativeWriteBatch&);
@@ -174,7 +174,7 @@ class BlockMerkleCategory {
 
   // Retrieve the latest versions for all raw keys in a block and return them along with the hashed keys.
   std::pair<std::vector<Hash>, std::vector<std::optional<TaggedVersion>>> getLatestVersions(
-      const BlockMerkleOutput& out);
+      const BlockMerkleOutput& out) const;
 
   // Return a map from block id to all hashed keys that were still active in previously pruned blocks.
   //

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -49,6 +49,7 @@ class ImmutableKeyValueCategory {
   ImmutableOutput add(BlockId, ImmutableInput &&, storage::rocksdb::NativeWriteBatch &);
 
   std::vector<std::string> getBlockStaleKeys(BlockId, const ImmutableOutput &);
+
   // Delete the genesis block. Implemented by directly calling deleteBlock().
   void deleteGenesisBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);
 

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -48,6 +48,7 @@ class ImmutableKeyValueCategory {
   // Adding keys that already exist in this category is undefined behavior.
   ImmutableOutput add(BlockId, ImmutableInput &&, storage::rocksdb::NativeWriteBatch &);
 
+  std::vector<std::string> getBlockStaleKeys(BlockId, const ImmutableOutput &);
   // Delete the genesis block. Implemented by directly calling deleteBlock().
   void deleteGenesisBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);
 

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -48,7 +48,7 @@ class ImmutableKeyValueCategory {
   // Adding keys that already exist in this category is undefined behavior.
   ImmutableOutput add(BlockId, ImmutableInput &&, storage::rocksdb::NativeWriteBatch &);
 
-  std::vector<std::string> getBlockStaleKeys(BlockId, const ImmutableOutput &);
+  std::vector<std::string> getBlockStaleKeys(BlockId, const ImmutableOutput &) const;
 
   // Delete the genesis block. Implemented by directly calling deleteBlock().
   void deleteGenesisBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -66,15 +66,15 @@ class KeyValueBlockchain {
 
   std::vector<std::string> getStaleKeys(BlockId block_id,
                                         const std::string& category_id,
-                                        const ImmutableOutput& updates_info);
+                                        const ImmutableOutput& updates_info) const;
 
   std::vector<std::string> getStaleKeys(BlockId block_id,
                                         const std::string& category_id,
-                                        const VersionedOutput& updates_info);
+                                        const VersionedOutput& updates_info) const;
 
   std::vector<std::string> getStaleKeys(BlockId block_id,
                                         const std::string& category_id,
-                                        const BlockMerkleOutput& updates_info);
+                                        const BlockMerkleOutput& updates_info) const;
 
   /////////////////////// Read interface ///////////////////////
 
@@ -103,7 +103,7 @@ class KeyValueBlockchain {
   std::optional<Updates> getBlockUpdates(BlockId block_id) const;
 
   // Get a map of category_id and stale keys for `block_id`
-  std::map<std::string, std::vector<std::string>> getBlockStaleKeys(BlockId block_id);
+  std::map<std::string, std::vector<std::string>> getBlockStaleKeys(BlockId block_id) const;
 
   // Get a map from category ID -> type for all known categories in the blockchain.
   const std::map<std::string, CATEGORY_TYPE>& blockchainCategories() const { return category_types_; }

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -64,6 +64,18 @@ class KeyValueBlockchain {
   std::optional<Hash> parentDigest(BlockId block_id) const;
   bool hasBlock(BlockId block_id) const;
 
+  std::vector<std::string> getStaleKeys(BlockId block_id,
+                                        const std::string& category_id,
+                                        const ImmutableOutput& updates_info);
+
+  std::vector<std::string> getStaleKeys(BlockId block_id,
+                                        const std::string& category_id,
+                                        const VersionedOutput& updates_info);
+
+  std::vector<std::string> getStaleKeys(BlockId block_id,
+                                        const std::string& category_id,
+                                        const BlockMerkleOutput& updates_info);
+
   /////////////////////// Read interface ///////////////////////
 
   // Gets the value of a key by the exact blockVersion.
@@ -90,6 +102,7 @@ class KeyValueBlockchain {
   // Get the updates that were used to create `block_id`.
   std::optional<Updates> getBlockUpdates(BlockId block_id) const;
 
+  std::unordered_map<std::string, std::vector<std::string>> getBlockStaleKeys(BlockId block_id);
   // Get a map from category ID -> type for all known categories in the blockchain.
   const std::map<std::string, CATEGORY_TYPE>& blockchainCategories() const { return category_types_; }
 

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -102,7 +102,9 @@ class KeyValueBlockchain {
   // Get the updates that were used to create `block_id`.
   std::optional<Updates> getBlockUpdates(BlockId block_id) const;
 
-  std::unordered_map<std::string, std::vector<std::string>> getBlockStaleKeys(BlockId block_id);
+  // Get a map of category_id and stale keys for `block_id`
+  std::map<std::string, std::vector<std::string>> getBlockStaleKeys(BlockId block_id);
+
   // Get a map from category ID -> type for all known categories in the blockchain.
   const std::map<std::string, CATEGORY_TYPE>& blockchainCategories() const { return category_types_; }
 

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -46,7 +46,7 @@ class VersionedKeyValueCategory {
 
   VersionedOutput add(BlockId, VersionedInput &&, storage::rocksdb::NativeWriteBatch &);
 
-  std::vector<std::string> getBlockStaleKeys(BlockId, const VersionedOutput &);
+  std::vector<std::string> getBlockStaleKeys(BlockId, const VersionedOutput &) const;
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
   void deleteGenesisBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -46,6 +46,7 @@ class VersionedKeyValueCategory {
 
   VersionedOutput add(BlockId, VersionedInput &&, storage::rocksdb::NativeWriteBatch &);
 
+  std::vector<std::string> getBlockStaleKeys(BlockId, const VersionedOutput &);
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
   void deleteGenesisBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -541,7 +541,7 @@ std::pair<SetOfKeyValuePairs, KeysVector> BlockMerkleCategory::rewriteAlreadyPru
   return std::make_pair(merkle_blocks_to_rewrite, merkle_blocks_to_delete);
 }
 
-std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id, const BlockMerkleOutput& out) {
+std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id, const BlockMerkleOutput& out) const {
   std::vector<Hash> hash_stale_keys;
   auto [hashed_keys, latest_versions] = getLatestVersions(out);
   for (auto i = 0u; i < hashed_keys.size(); i++) {
@@ -622,7 +622,7 @@ void BlockMerkleCategory::deleteLastReachableBlock(BlockId block_id,
 }
 
 std::pair<std::vector<Hash>, std::vector<std::optional<TaggedVersion>>> BlockMerkleCategory::getLatestVersions(
-    const BlockMerkleOutput& out) {
+    const BlockMerkleOutput& out) const {
   std::vector<Hash> hashed_keys;
   hashed_keys.reserve(out.keys.size());
   for (auto& [key, _] : out.keys) {

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -552,12 +552,12 @@ std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id
 
     if (block_id == tagged_version->version) {
       if (tagged_version->deleted) {
-        // The latest version is a tombstone. We can delete the key and version.
+        // The latest version is a tombstone.
         hash_stale_keys.push_back(hashed_key);
       }
     } else {
       // block_id < tagged_version->version
-      // The key has been overwritten. Delete it.
+      // The key has been overwritten.
       hash_stale_keys.push_back(hashed_key);
     }
   }

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -118,7 +118,8 @@ ImmutableOutput ImmutableKeyValueCategory::add(BlockId block_id,
   }
   return update_info;
 }
-std::vector<std::string> ImmutableKeyValueCategory::getBlockStaleKeys(BlockId, const ImmutableOutput &updates_info) {
+std::vector<std::string> ImmutableKeyValueCategory::getBlockStaleKeys(BlockId,
+                                                                      const ImmutableOutput &updates_info) const {
   std::vector<std::string> stale_keys;
   for (auto &kv : updates_info.tagged_keys) {
     stale_keys.push_back(kv.first);

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -118,6 +118,13 @@ ImmutableOutput ImmutableKeyValueCategory::add(BlockId block_id,
   }
   return update_info;
 }
+std::vector<std::string> ImmutableKeyValueCategory::getBlockStaleKeys(BlockId, const ImmutableOutput &updates_info) {
+  std::vector<std::string> stale_keys;
+  for (auto &kv : updates_info.tagged_keys) {
+    stale_keys.push_back(kv.first);
+  }
+  return stale_keys;
+}
 
 void ImmutableKeyValueCategory::deleteGenesisBlock(BlockId,
                                                    const ImmutableOutput &updates_info,
@@ -282,5 +289,4 @@ std::optional<KeyValueProof> ImmutableKeyValueCategory::getProof(const std::stri
 
   return proof;
 }
-
 }  // namespace concord::kvbc::categorization::detail

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -320,7 +320,7 @@ std::optional<Updates> KeyValueBlockchain::getBlockUpdates(BlockId block_id) con
   return Updates{std::move(raw->data.updates)};
 }
 
-std::map<std::string, std::vector<std::string>> KeyValueBlockchain::getBlockStaleKeys(BlockId block_id) {
+std::map<std::string, std::vector<std::string>> KeyValueBlockchain::getBlockStaleKeys(BlockId block_id) const {
   // Get block node from storage
   auto block = block_chain_.getBlock(block_id);
   if (!block) {
@@ -467,21 +467,21 @@ void KeyValueBlockchain::deleteLastReachableBlock() {
 
 std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
                                                           const std::string& category_id,
-                                                          const ImmutableOutput& updates_info) {
+                                                          const ImmutableOutput& updates_info) const {
   return std::get<detail::ImmutableKeyValueCategory>(getCategoryRef(category_id))
       .getBlockStaleKeys(block_id, updates_info);
 }
 
 std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
                                                           const std::string& category_id,
-                                                          const VersionedOutput& updates_info) {
+                                                          const VersionedOutput& updates_info) const {
   return std::get<detail::VersionedKeyValueCategory>(getCategoryRef(category_id))
       .getBlockStaleKeys(block_id, updates_info);
 }
 
 std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
                                                           const std::string& category_id,
-                                                          const BlockMerkleOutput& updates_info) {
+                                                          const BlockMerkleOutput& updates_info) const {
   return std::get<detail::BlockMerkleCategory>(getCategoryRef(category_id)).getBlockStaleKeys(block_id, updates_info);
 }
 

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -320,6 +320,26 @@ std::optional<Updates> KeyValueBlockchain::getBlockUpdates(BlockId block_id) con
   return Updates{std::move(raw->data.updates)};
 }
 
+std::unordered_map<std::string, std::vector<std::string>> KeyValueBlockchain::getBlockStaleKeys(BlockId block_id) {
+  // Get block node from storage
+  auto block = block_chain_.getBlock(block_id);
+  if (!block) {
+    const auto msg = "Failed to get block node for block ID = " + std::to_string(block_id);
+    throw std::runtime_error{msg};
+  }
+
+  std::unordered_map<std::string, std::vector<std::string>> stale_keys;
+  // Iterate over groups and call corresponding deleteGenesisBlock,
+  // Each group is responsible to put its deletes into the batch
+  for (auto&& [category_id, update_info] : block.value().data.categories_updates_info) {
+    stale_keys[category_id] =
+        std::visit([&block_id, category_id = category_id, this](
+                       const auto& update_info) { return getStaleKeys(block_id, category_id, update_info); },
+                   update_info);
+  }
+  return stale_keys;
+}
+
 /////////////////////// Delete block ///////////////////////
 bool KeyValueBlockchain::deleteBlock(const BlockId& block_id) {
   // Deleting blocks that don't exist is not an error.
@@ -445,6 +465,26 @@ void KeyValueBlockchain::deleteLastReachableBlock() {
     // Decrement the last reachable block ID cache.
     block_chain_.setLastReachableBlockId(last_id - 1);
   }
+}
+
+std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
+                                                          const std::string& category_id,
+                                                          const ImmutableOutput& updates_info) {
+  return std::get<detail::ImmutableKeyValueCategory>(getCategory(category_id))
+      .getBlockStaleKeys(block_id, updates_info);
+}
+
+std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
+                                                          const std::string& category_id,
+                                                          const VersionedOutput& updates_info) {
+  return std::get<detail::VersionedKeyValueCategory>(getCategory(category_id))
+      .getBlockStaleKeys(block_id, updates_info);
+}
+
+std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
+                                                          const std::string& category_id,
+                                                          const BlockMerkleOutput& updates_info) {
+  return std::get<detail::BlockMerkleCategory>(getCategory(category_id)).getBlockStaleKeys(block_id, updates_info);
 }
 
 // Deletes per category

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -470,21 +470,21 @@ void KeyValueBlockchain::deleteLastReachableBlock() {
 std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
                                                           const std::string& category_id,
                                                           const ImmutableOutput& updates_info) {
-  return std::get<detail::ImmutableKeyValueCategory>(getCategory(category_id))
+  return std::get<detail::ImmutableKeyValueCategory>(getCategoryRef(category_id))
       .getBlockStaleKeys(block_id, updates_info);
 }
 
 std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
                                                           const std::string& category_id,
                                                           const VersionedOutput& updates_info) {
-  return std::get<detail::VersionedKeyValueCategory>(getCategory(category_id))
+  return std::get<detail::VersionedKeyValueCategory>(getCategoryRef(category_id))
       .getBlockStaleKeys(block_id, updates_info);
 }
 
 std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
                                                           const std::string& category_id,
                                                           const BlockMerkleOutput& updates_info) {
-  return std::get<detail::BlockMerkleCategory>(getCategory(category_id)).getBlockStaleKeys(block_id, updates_info);
+  return std::get<detail::BlockMerkleCategory>(getCategoryRef(category_id)).getBlockStaleKeys(block_id, updates_info);
 }
 
 // Deletes per category

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -320,7 +320,7 @@ std::optional<Updates> KeyValueBlockchain::getBlockUpdates(BlockId block_id) con
   return Updates{std::move(raw->data.updates)};
 }
 
-std::unordered_map<std::string, std::vector<std::string>> KeyValueBlockchain::getBlockStaleKeys(BlockId block_id) {
+std::map<std::string, std::vector<std::string>> KeyValueBlockchain::getBlockStaleKeys(BlockId block_id) {
   // Get block node from storage
   auto block = block_chain_.getBlock(block_id);
   if (!block) {
@@ -328,9 +328,7 @@ std::unordered_map<std::string, std::vector<std::string>> KeyValueBlockchain::ge
     throw std::runtime_error{msg};
   }
 
-  std::unordered_map<std::string, std::vector<std::string>> stale_keys;
-  // Iterate over groups and call corresponding deleteGenesisBlock,
-  // Each group is responsible to put its deletes into the batch
+  std::map<std::string, std::vector<std::string>> stale_keys;
   for (auto&& [category_id, update_info] : block.value().data.categories_updates_info) {
     stale_keys[category_id] =
         std::visit([&block_id, category_id = category_id, this](

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -170,7 +170,8 @@ std::unordered_map<BlockId, std::vector<std::string>> VersionedKeyValueCategory:
   return found;
 }
 
-std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId block_id, const VersionedOutput &out) {
+std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId block_id,
+                                                                      const VersionedOutput &out) const {
   std::vector<std::string> stale_keys_;
   for (const auto &[key, flags] : out.keys) {
     const auto latest = getLatestVersion(key);

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -176,6 +176,7 @@ std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId bl
     const auto latest = getLatestVersion(key);
     ConcordAssert(latest.has_value());
     ConcordAssertEQ(latest->deleted, flags.deleted);
+    ConcordAssertLE(block_id, latest->version);
 
     // Note: Deleted keys cannot be marked as stale on update.
     if (flags.stale_on_update || flags.deleted || latest->version > block_id) {

--- a/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
@@ -435,6 +435,64 @@ TEST_F(DbEditorTests, get_block_key_values) {
   ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
 }
 
+TEST_F(DbEditorTests, get_latest_category_updates_merkle) {
+  ASSERT_EQ(EXIT_SUCCESS,
+            run(
+                CommandLineArguments{
+                    {kTestName, rocksDbPath(main_path_db_id_), "getEarliestCategoryUpdates", kCategoryMerkle}},
+                out_,
+                err_));
+  ASSERT_TRUE(err_.str().empty());
+  ASSERT_THAT(out_.str(), StartsWith("{\n  \"blockID\":"));
+  ASSERT_THAT(out_.str(), HasSubstr("\"category\": \"" + kCategoryMerkle + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"0x00000000\": \"0x00000000\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"0x0000000a\": \"0x00000014\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"0x00000014\": \"0x00000028\""));
+  ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
+}
+
+TEST_F(DbEditorTests, get_latest_category_updates_immutable) {
+  ASSERT_EQ(EXIT_SUCCESS,
+            run(
+                CommandLineArguments{
+                    {kTestName, rocksDbPath(main_path_db_id_), "getEarliestCategoryUpdates", kCategoryImmutable}},
+                out_,
+                err_));
+  ASSERT_TRUE(err_.str().empty());
+  ASSERT_THAT(out_.str(), StartsWith("{\n  \"blockID\":"));
+  ASSERT_THAT(out_.str(), HasSubstr("\"category\": \"" + kCategoryImmutable + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"0x696d6d757461626c655f6b657931\": \"0x696d6d757461626c655f76616c31\""));
+  ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
+}
+
+TEST_F(DbEditorTests, get_latest_category_updates_versioned) {
+  ASSERT_EQ(EXIT_SUCCESS,
+            run(
+                CommandLineArguments{
+                    {kTestName, rocksDbPath(main_path_db_id_), "getEarliestCategoryUpdates", kCategoryVersioned}},
+                out_,
+                err_));
+  ASSERT_TRUE(err_.str().empty());
+  ASSERT_THAT(out_.str(), StartsWith("{\n  \"blockID\":"));
+  ASSERT_THAT(out_.str(), HasSubstr("\"category\": \"" + kCategoryVersioned + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("\"0x766b657930\": \"0x7676616c30\""));
+  ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
+}
+
+TEST_F(DbEditorTests, get_category_earliest_stale_immutable) {
+  ASSERT_EQ(EXIT_SUCCESS,
+            run(
+                CommandLineArguments{
+                    {kTestName, rocksDbPath(main_path_db_id_), "getCategoryEarliestStale", kCategoryImmutable}},
+                out_,
+                err_));
+  ASSERT_TRUE(err_.str().empty());
+  ASSERT_THAT(out_.str(), StartsWith("{\n  \"blockID\":"));
+  ASSERT_THAT(out_.str(), HasSubstr("\"category\": \"" + kCategoryImmutable + "\""));
+  ASSERT_THAT(out_.str(), HasSubstr("[\"0x696d6d757461626c655f6b657931\"]"));
+  ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
+}
+
 TEST_F(DbEditorTests, get_empty_block_key_values) {
   ASSERT_EQ(EXIT_SUCCESS,
             run(

--- a/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
@@ -435,7 +435,7 @@ TEST_F(DbEditorTests, get_block_key_values) {
   ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
 }
 
-TEST_F(DbEditorTests, get_latest_category_updates_merkle) {
+TEST_F(DbEditorTests, get_earliest_category_updates_merkle) {
   ASSERT_EQ(EXIT_SUCCESS,
             run(
                 CommandLineArguments{
@@ -451,7 +451,7 @@ TEST_F(DbEditorTests, get_latest_category_updates_merkle) {
   ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
 }
 
-TEST_F(DbEditorTests, get_latest_category_updates_immutable) {
+TEST_F(DbEditorTests, get_earliest_category_updates_immutable) {
   ASSERT_EQ(EXIT_SUCCESS,
             run(
                 CommandLineArguments{
@@ -461,11 +461,12 @@ TEST_F(DbEditorTests, get_latest_category_updates_immutable) {
   ASSERT_TRUE(err_.str().empty());
   ASSERT_THAT(out_.str(), StartsWith("{\n  \"blockID\":"));
   ASSERT_THAT(out_.str(), HasSubstr("\"category\": \"" + kCategoryImmutable + "\""));
+  // Assert that we have the immutable_key1 and its value in the blockchain
   ASSERT_THAT(out_.str(), HasSubstr("\"0x696d6d757461626c655f6b657931\": \"0x696d6d757461626c655f76616c31\""));
   ASSERT_THAT(out_.str(), EndsWith("\n}\n"));
 }
 
-TEST_F(DbEditorTests, get_latest_category_updates_versioned) {
+TEST_F(DbEditorTests, get_earliest_category_updates_versioned) {
   ASSERT_EQ(EXIT_SUCCESS,
             run(
                 CommandLineArguments{

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -305,8 +305,10 @@ struct GetEarliestCategoryUpdates {
   const bool read_only = true;
   std::string description() const {
     return "getEarliestCategoryUpdates CATEGORY-ID [BLOCK-VERSION-TO]\n"
-           "  Returns the latest blockID that contains the given category, started from BLOCK-VERSION-TO. If "
-           "BLOCK-VERSION-TO is not set, we start from the lastReachableBlock.";
+           "  Returns the first blockID and a category updates that contains the given category in the "
+           "[genesisBlockID, BLOCK-VERSION-TO] range.\n"
+           "If BLOCK-VERSION-TO is not set, the search range is [genesisBlockID, lastReachableBlockID].\n"
+           "Note that this method performs linear search which may take time on gig blockchains";
   }
 
   std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
@@ -339,7 +341,7 @@ struct GetEarliestCategoryUpdates {
   }
 };
 
-inline std::string getStaleKeysStr(std::vector<std::string> stale_keys) {
+inline std::string getStaleKeysStr(const std::vector<std::string> &stale_keys) {
   if (stale_keys.empty()) return std::string();
   std::string strKeys;
   strKeys += "[";
@@ -355,8 +357,10 @@ struct GetCategoryEarliestStale {
   const bool read_only = true;
   std::string description() const {
     return "getCategoryEarliestStale CATEGORY-ID [BLOCK-VERSION-TO]\n"
-           "  Returns the latest blockID that contains the given category, started from BLOCK-VERSION-TO. If "
-           "BLOCK-VERSION-TO is not set, we start from the lastReachableBlock.";
+           "  Returns the first blockID and a list of stale keys for this blockID a given category has in the "
+           "[genesisBlockID, BLOCK-VERSION-TO] range.\n"
+           "If BLOCK-VERSION-TO is not set, the search range is [genesisBlockID, lastReachableBlockID].\n"
+           "Note that this method performs linear search which may take time on gig blockchains";
   }
 
   std::string execute(KeyValueBlockchain &adapter, const CommandArguments &args) const {
@@ -369,7 +373,7 @@ struct GetCategoryEarliestStale {
     }
     auto cat = args.values.front();
     BlockId relevantBlockId = adapter.getGenesisBlockId();
-    std::unordered_map<std::string, std::vector<std::string>> stale_keys;
+    std::map<std::string, std::vector<std::string>> stale_keys;
     std::string keys_as_string;
     for (auto block = adapter.getGenesisBlockId(); block <= latestBlockID; block++) {
       stale_keys = adapter.getBlockStaleKeys(block);

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -308,7 +308,7 @@ struct GetEarliestCategoryUpdates {
            "  Returns the first blockID and a category updates that contains the given category in the "
            "[genesisBlockID, BLOCK-VERSION-TO] range.\n"
            "If BLOCK-VERSION-TO is not set, the search range is [genesisBlockID, lastReachableBlockID].\n"
-           "Note that this method performs linear search which may take time on gig blockchains";
+           "Note that this method performs linear search which may take time on big blockchains";
   }
 
   std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
@@ -360,7 +360,7 @@ struct GetCategoryEarliestStale {
            "  Returns the first blockID and a list of stale keys for this blockID a given category has in the "
            "[genesisBlockID, BLOCK-VERSION-TO] range.\n"
            "If BLOCK-VERSION-TO is not set, the search range is [genesisBlockID, lastReachableBlockID].\n"
-           "Note that this method performs linear search which may take time on gig blockchains";
+           "Note that this method performs linear search which may take time on big blockchains";
   }
 
   std::string execute(KeyValueBlockchain &adapter, const CommandArguments &args) const {

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -350,6 +350,7 @@ inline std::string getStaleKeysStr(const std::variant<BlockMerkleInput, Versione
           keys = arg.deletes;
         } else if constexpr (std::is_same_v<T, ImmutableInput>) {
           for (auto &[k, v] : arg.kv) {
+            (void)v;
             keys.push_back(k);
           }
         }

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -304,7 +304,7 @@ struct GetCategories {
 struct GetCategoryBlockID {
   const bool read_only = true;
   std::string description() const {
-    return "getCategories CATEGORY-ID [BLOCK-VERSION]\n"
+    return "getCategoryBlockID CATEGORY-ID [BLOCK-VERSION]\n"
            "  Returns the latest blockID that contains the givenb category, started from BLOCK-VERSION. If "
            "BLOCK-VERSION is not set, we start from the lastReachableBlock";
   }

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -301,10 +301,10 @@ struct GetCategories {
   }
 };
 
-struct GetCategoryBlockID {
+struct GetLatestCategoryInfo {
   const bool read_only = true;
   std::string description() const {
-    return "getCategoryBlockID CATEGORY-ID [BLOCK-VERSION]\n"
+    return "getLatestCategoryInfo CATEGORY-ID [BLOCK-VERSION]\n"
            "  Returns the latest blockID that contains the givenb category, started from BLOCK-VERSION. If "
            "BLOCK-VERSION is not set, we start from the lastReachableBlock";
   }
@@ -325,6 +325,11 @@ struct GetCategoryBlockID {
       if (updates->categoryUpdates().kv.count(cat)) {
         relevantBlockId = block;
         cat_updates_map = getKVStr(updates->categoryUpdates().kv.at(cat));
+      }
+    }
+    if (relevantBlockId == adapter.getGenesisBlockId()) {
+      if (!adapter.getBlockUpdates(relevantBlockId)->categoryUpdates().kv.count(cat)) {
+        throw NotFoundException{"Couldn't find category id in any block in the given range"};
       }
     }
     std::map<std::string, std::string> out{
@@ -472,7 +477,7 @@ using Command = std::variant<GetGenesisBlockID,
                              GetBlockInfo,
                              GetBlockKeyValues,
                              GetCategories,
-                             GetCategoryBlockID,
+                             GetLatestCategoryInfo,
                              GetValue,
                              CompareTo,
                              RemoveMetadata>;
@@ -486,7 +491,7 @@ inline const auto commands_map = std::map<std::string, Command>{
     std::make_pair("getBlockInfo", GetBlockInfo{}),
     std::make_pair("getBlockKeyValues", GetBlockKeyValues{}),
     std::make_pair("getCategories", GetCategories{}),
-    std::make_pair("getCategoryBlockID", GetCategoryBlockID{}),
+    std::make_pair("getCategoryBlockID", GetLatestCategoryInfo{}),
     std::make_pair("getValue", GetValue{}),
     std::make_pair("compareTo", CompareTo{}),
     std::make_pair("removeMetadata", RemoveMetadata{}),

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -304,7 +304,7 @@ struct GetCategories {
 struct GetEarliestCategoryUpdates {
   const bool read_only = true;
   std::string description() const {
-    return "GetEarliestCategoryUpdates CATEGORY-ID [BLOCK-VERSION-TO]\n"
+    return "getEarliestCategoryUpdates CATEGORY-ID [BLOCK-VERSION-TO]\n"
            "  Returns the latest blockID that contains the given category, started from BLOCK-VERSION-TO. If "
            "BLOCK-VERSION-TO is not set, we start from the lastReachableBlock.";
   }
@@ -354,6 +354,7 @@ inline std::string getStaleKeysStr(const std::variant<BlockMerkleInput, Versione
             keys.push_back(k);
           }
         }
+        if (keys.empty()) return std::string();
         std::string strKeys;
         strKeys += "[";
         for (auto &k : keys) {
@@ -369,7 +370,7 @@ inline std::string getStaleKeysStr(const std::variant<BlockMerkleInput, Versione
 struct GetCategoryEarliestStale {
   const bool read_only = true;
   std::string description() const {
-    return "GetCategoryEarliestStale CATEGORY-ID [BLOCK-VERSION-TO]\n"
+    return "getCategoryEarliestStale CATEGORY-ID [BLOCK-VERSION-TO]\n"
            "  Returns the latest blockID that contains the given category, started from BLOCK-VERSION-TO. If "
            "BLOCK-VERSION-TO is not set, we start from the lastReachableBlock.";
   }

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -301,12 +301,12 @@ struct GetCategories {
   }
 };
 
-struct GetLatestCategoryInfo {
+struct GetLatestCategoryUpdates {
   const bool read_only = true;
   std::string description() const {
-    return "getLatestCategoryInfo CATEGORY-ID [BLOCK-VERSION]\n"
-           "  Returns the latest blockID that contains the givenb category, started from BLOCK-VERSION. If "
-           "BLOCK-VERSION is not set, we start from the lastReachableBlock";
+    return "getLatestCategoryInfo CATEGORY-ID [BLOCK-VERSION-TO]\n"
+           "  Returns the latest blockID that contains the given category, started from BLOCK-VERSION-TO. If "
+           "BLOCK-VERSION is not set, we start from the lastReachableBlock.";
   }
 
   std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
@@ -314,7 +314,7 @@ struct GetLatestCategoryInfo {
       throw NotFoundException{"No Category ID was given"};
     }
     auto latestBlockID = adapter.getLastReachableBlockId();
-    if (args.values.size() == 2) {
+    if (args.values.size() >= 2) {
       latestBlockID = toBlockId(args.values[1]);
     }
     auto cat = args.values.front();
@@ -477,7 +477,7 @@ using Command = std::variant<GetGenesisBlockID,
                              GetBlockInfo,
                              GetBlockKeyValues,
                              GetCategories,
-                             GetLatestCategoryInfo,
+                             GetLatestCategoryUpdates,
                              GetValue,
                              CompareTo,
                              RemoveMetadata>;
@@ -491,7 +491,7 @@ inline const auto commands_map = std::map<std::string, Command>{
     std::make_pair("getBlockInfo", GetBlockInfo{}),
     std::make_pair("getBlockKeyValues", GetBlockKeyValues{}),
     std::make_pair("getCategories", GetCategories{}),
-    std::make_pair("getCategoryBlockID", GetLatestCategoryInfo{}),
+    std::make_pair("getLatestCategoryUpdates", GetLatestCategoryUpdates{}),
     std::make_pair("getValue", GetValue{}),
     std::make_pair("compareTo", CompareTo{}),
     std::make_pair("removeMetadata", RemoveMetadata{}),

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -373,13 +373,13 @@ struct GetCategoryEarliestStale {
     std::string keys_as_string;
     for (auto block = adapter.getGenesisBlockId(); block <= latestBlockID; block++) {
       stale_keys = adapter.getBlockStaleKeys(block);
-      if (stale_keys.count(cat)) {
+      if (stale_keys.count(cat) && !stale_keys[cat].empty()) {
         relevantBlockId = block;
         keys_as_string = getStaleKeysStr(stale_keys[cat]);
         break;
       }
     }
-    if (stale_keys.empty()) {
+    if (keys_as_string.empty()) {
       throw NotFoundException{"Couldn't find stale keys for category id in any block in the given range"};
     }
     std::map<std::string, std::string> out{

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -301,6 +301,38 @@ struct GetCategories {
   }
 };
 
+struct GetCategoryBlockID {
+  const bool read_only = true;
+  std::string description() const {
+    return "getCategories CATEGORY-ID [BLOCK-VERSION]\n"
+           "  Returns the latest blockID that contains the givenb category, started from BLOCK-VERSION. If "
+           "BLOCK-VERSION is not set, we start from the lastReachableBlock";
+  }
+
+  std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
+    if (args.values.empty()) {
+      throw NotFoundException{"No Category ID was given"};
+    }
+    auto latestBlockID = adapter.getLastReachableBlockId();
+    if (args.values.size() == 2) {
+      latestBlockID = toBlockId(args.values[1]);
+    }
+    auto cat = args.values.front();
+    std::map<std::string, std::string> cat_updates_map;
+    BlockId relevantBlockId = adapter.getGenesisBlockId();
+    for (auto block = adapter.getGenesisBlockId(); block <= latestBlockID; block++) {
+      auto updates = adapter.getBlockUpdates(block);
+      if (updates->categoryUpdates().kv.count(cat)) {
+        relevantBlockId = block;
+        cat_updates_map = getKVStr(updates->categoryUpdates().kv.at(cat));
+      }
+    }
+    std::map<std::string, std::string> out{
+        {"blockID", std::to_string(relevantBlockId)}, {"category", cat}, {"updates", toJson(cat_updates_map)}};
+    return toJson(out);
+  }
+};
+
 struct GetValue {
   const bool read_only = true;
   std::string description() const {
@@ -440,6 +472,7 @@ using Command = std::variant<GetGenesisBlockID,
                              GetBlockInfo,
                              GetBlockKeyValues,
                              GetCategories,
+                             GetCategoryBlockID,
                              GetValue,
                              CompareTo,
                              RemoveMetadata>;
@@ -453,6 +486,7 @@ inline const auto commands_map = std::map<std::string, Command>{
     std::make_pair("getBlockInfo", GetBlockInfo{}),
     std::make_pair("getBlockKeyValues", GetBlockKeyValues{}),
     std::make_pair("getCategories", GetCategories{}),
+    std::make_pair("getCategoryBlockID", GetCategoryBlockID{}),
     std::make_pair("getValue", GetValue{}),
     std::make_pair("compareTo", CompareTo{}),
     std::make_pair("removeMetadata", RemoveMetadata{}),


### PR DESCRIPTION
We add the following functionality to kv_blockchain_db_editor:
1. getEarliestCategoryUpdates - to get the earliest updates of a given category between genesis and an (optionally) given block
2. getCategoryEarliestStale - to get the earliest stale keys (grouped in a block) of a given category between  genesis and an (optionally) given block 
These two new functionalities will help us to test pruning 