### PR TITLE
Create categories on startup in KeyValueBlockchain

### DIFF
--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -109,7 +109,8 @@ class ReplicaImp : public IReplica,
              const bftEngine::ReplicaConfig &config,
              std::unique_ptr<IStorageFactory> storageFactory,
              std::shared_ptr<concordMetrics::Aggregator> aggregator,
-             const std::shared_ptr<concord::performance::PerformanceManager> &pm);
+             const std::shared_ptr<concord::performance::PerformanceManager> &pm,
+             std::map<std::string, categorization::CATEGORY_TYPE> kvbc_categories);
 
   void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 

--- a/kvbc/include/categorization/base_types.h
+++ b/kvbc/include/categorization/base_types.h
@@ -117,4 +117,17 @@ inline bool operator==(const TaggedVersion &lhs, const TaggedVersion &rhs) {
 
 enum class CATEGORY_TYPE : char { block_merkle = 0, immutable = 1, versioned_kv = 2, end_of_types };
 
+inline std::string categoryStringType(CATEGORY_TYPE t) {
+  switch (t) {
+    case CATEGORY_TYPE::block_merkle:
+      return "block_merkle";
+    case CATEGORY_TYPE::immutable:
+      return "immutable";
+    case CATEGORY_TYPE::versioned_kv:
+      return "versioned_kv";
+    default:
+      ConcordAssert(false);
+  }
+}
+
 }  // namespace concord::kvbc::categorization

--- a/kvbc/include/merkle_tree_storage_factory.h
+++ b/kvbc/include/merkle_tree_storage_factory.h
@@ -31,6 +31,11 @@ class RocksDBStorageFactory : public IStorageFactory {
       const std::shared_ptr<concord::performance::PerformanceManager>& pm =
           std::make_shared<concord::performance::PerformanceManager>());
 
+  RocksDBStorageFactory(const std::string& dbPath,
+                        const std::string& dbConfPath,
+                        const std::shared_ptr<concord::performance::PerformanceManager>& pm =
+                            std::make_shared<concord::performance::PerformanceManager>());
+
  public:
   DatabaseSet newDatabaseSet() const override;
   std::unique_ptr<storage::IMetadataKeyManipulator> newMetadataKeyManipulator() const override;
@@ -38,6 +43,7 @@ class RocksDBStorageFactory : public IStorageFactory {
 
  private:
   const std::string dbPath_;
+  const std::optional<std::string> dbConfPath_;
   const std::unordered_set<concord::kvbc::Key> nonProvableKeySet_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -71,7 +71,8 @@ TEST_F(categorized_kvbc, serialization_and_desirialization_of_block) {
 }
 
 TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{
+      db, true, std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1
@@ -160,7 +161,10 @@ TEST_F(categorized_kvbc, fail_reconstruct_merkle_updates) {
 }
 
 TEST_F(categorized_kvbc, reconstruct_immutable_updates) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{
+      db,
+      true,
+      std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable}, {"imm2", CATEGORY_TYPE::immutable}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1
@@ -233,7 +237,7 @@ TEST_F(categorized_kvbc, reconstruct_immutable_updates) {
 }
 
 TEST_F(categorized_kvbc, fail_reconstruct_immutable_updates) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db, true, std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1
@@ -263,7 +267,10 @@ TEST_F(categorized_kvbc, fail_reconstruct_immutable_updates) {
 }
 
 TEST_F(categorized_kvbc, reconstruct_versioned_kv_updates) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"ver", CATEGORY_TYPE::versioned_kv},
+                                                                      {"ver2", CATEGORY_TYPE::versioned_kv}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -53,7 +53,12 @@ TEST_F(categorized_kvbc, merkle_update) {
 // The block structure is then inserted into the DB.
 // we test that the block that is written to DB contains the expected data.
 TEST_F(categorized_kvbc, add_blocks) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
   // Add block1
   {
     Updates updates;
@@ -179,7 +184,11 @@ TEST_F(categorized_kvbc, add_blocks) {
 }
 
 TEST_F(categorized_kvbc, delete_block) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
   // Add block1
   {
     Updates updates;
@@ -366,7 +375,10 @@ TEST_F(categorized_kvbc, delete_block) {
 }
 
 TEST_F(categorized_kvbc, get_last_and_genesis_block) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"ver", CATEGORY_TYPE::versioned_kv}}};
   detail::Blockchain block_chain_imp{db};
   // Add block1
   {
@@ -403,7 +415,11 @@ TEST_F(categorized_kvbc, get_last_and_genesis_block) {
 }
 
 TEST_F(categorized_kvbc, add_raw_block) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned_kv", CATEGORY_TYPE::versioned_kv},
+                                                                      {"ver", CATEGORY_TYPE::versioned_kv}}};
   ASSERT_FALSE(block_chain.getLastStatetransferBlockId().has_value());
 
   // Add block1
@@ -477,7 +493,10 @@ TEST_F(categorized_kvbc, add_raw_block) {
 }
 
 TEST_F(categorized_kvbc, get_raw_block) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned_kv", CATEGORY_TYPE::versioned_kv}}};
 
   ASSERT_FALSE(block_chain.getLastStatetransferBlockId().has_value());
 
@@ -528,7 +547,12 @@ TEST_F(categorized_kvbc, get_raw_block) {
 }
 
 TEST_F(categorized_kvbc, link_state_transfer_chain) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"ver", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_kv", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
   detail::Blockchain block_chain_imp{db};
 
   ASSERT_FALSE(block_chain_imp.loadLastReachableBlockId().has_value());
@@ -617,7 +641,8 @@ TEST_F(categorized_kvbc, link_state_transfer_chain) {
 }
 
 TEST_F(categorized_kvbc, creation_of_category_type_cf) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{
+      db, true, std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle}}};
   ASSERT_TRUE(db->hasColumnFamily(detail::CAT_ID_TYPE_CF));
 }
 
@@ -655,19 +680,21 @@ TEST_F(categorized_kvbc, instantiation_of_categories) {
 }
 
 TEST_F(categorized_kvbc, throw_on_non_exist_category_type) {
-  KeyValueBlockchain block_chain{db, true};
-  auto wb = db->getBatch();
-  wb.put(detail::CAT_ID_TYPE_CF, std::string("merkle"), std::string(1, static_cast<char>(CATEGORY_TYPE::end_of_types)));
-  db->write(std::move(wb));
+  KeyValueBlockchain block_chain{
+      db, true, std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle}}};
+  db->put(detail::CAT_ID_TYPE_CF,
+          std::string("merkle-wrong-type"),
+          std::string(1, static_cast<char>(CATEGORY_TYPE::end_of_types)));
 
   KeyValueBlockchain::KeyValueBlockchain_tester tester;
-  ASSERT_THROW(tester.instantiateCategories(block_chain), std::runtime_error);
+  ASSERT_DEATH(tester.loadCategories(block_chain), "");
 }
 
 TEST_F(categorized_kvbc, throw_on_non_exist_category) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{
+      db, true, std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester;
-  ASSERT_THROW(tester.getCategory("merkle", block_chain), std::runtime_error);
+  ASSERT_THROW(tester.getCategory("non-existent", block_chain), std::runtime_error);
 }
 
 TEST_F(categorized_kvbc, get_category) {
@@ -681,7 +708,12 @@ TEST_F(categorized_kvbc, get_category) {
 }
 
 TEST_F(categorized_kvbc, get_block_data) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
 
   // Add block1
   {
@@ -749,8 +781,8 @@ TEST_F(categorized_kvbc, get_block_data) {
   ASSERT_FALSE(block_chain.getBlockUpdates(887));
 }
 
-TEST_F(categorized_kvbc, validate_category_creation_on_add) {
-  KeyValueBlockchain block_chain{db, true};
+TEST_F(categorized_kvbc, validate_category_creation) {
+  KeyValueBlockchain block_chain{db, true, std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable}}};
   ImmutableUpdates imm_up;
   imm_up.addUpdate("key", {"val", {"0", "1"}});
   Updates up;
@@ -769,7 +801,7 @@ TEST_F(categorized_kvbc, validate_category_creation_on_add) {
 }
 
 TEST_F(categorized_kvbc, compare_raw_blocks) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db, true, std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable}}};
   ImmutableUpdates imm_up;
   imm_up.addUpdate("key", {"val", {"0", "1"}});
   Updates up;
@@ -794,7 +826,12 @@ TEST_F(categorized_kvbc, compare_raw_blocks) {
 }
 
 TEST_F(categorized_kvbc, single_read_with_version) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
 
   // Add block1
   {
@@ -884,7 +921,12 @@ TEST_F(categorized_kvbc, single_read_with_version) {
 }
 
 TEST_F(categorized_kvbc, single_get_latest) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
 
   // Add block1
   {
@@ -962,7 +1004,12 @@ TEST_F(categorized_kvbc, single_get_latest) {
 }
 
 TEST_F(categorized_kvbc, multi_read_with_version) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
 
   // Add block1
   {
@@ -1037,8 +1084,8 @@ TEST_F(categorized_kvbc, multi_read_with_version) {
     std::vector<BlockId> bad_size{3, 4, 2, 1};
     std::vector<std::optional<categorization::Value>> values;
     ASSERT_DEATH(block_chain.multiGet("merkle", merkle_keys, bad_size, values), "");
-    // #0 -> merkle_value1 | #1 -> not exist | #2 -> merkle_value3 | #3 merkle_key4 -> not exist | #4 -> update | #5 ->
-    // not exist(deleted)
+    // #0 -> merkle_value1 | #1 -> not exist | #2 -> merkle_value3 | #3 merkle_key4 -> not exist | #4 -> update | #5
+    // -> not exist(deleted)
     std::vector<BlockId> versions{1, 2, 2, 1, 3, 2};
     block_chain.multiGet("merkle", merkle_keys, versions, values);
     ASSERT_FALSE(values[1].has_value());
@@ -1058,8 +1105,8 @@ TEST_F(categorized_kvbc, multi_read_with_version) {
     std::vector<BlockId> bad_size{3};
     std::vector<std::optional<categorization::Value>> values;
     ASSERT_DEATH(block_chain.multiGet("versioned", keys, bad_size, values), "");
-    // #0 -> ver_val1 | #1 -> update | #2 -> not exist | #3-> ver_val2 | #4 -> not exist(deleted) |#5 -> ver_val3 |#6 ->
-    // not exist | #7 -> not exist
+    // #0 -> ver_val1 | #1 -> update | #2 -> not exist | #3-> ver_val2 | #4 -> not exist(deleted) |#5 -> ver_val3
+    // |#6 -> not exist | #7 -> not exist
     std::vector<BlockId> versions{1, 2, 3, 1, 2, 2, 12, 1};
     block_chain.multiGet("versioned", keys, versions, values);
     ASSERT_FALSE(values[2].has_value());
@@ -1111,7 +1158,12 @@ TEST_F(categorized_kvbc, multi_read_with_version) {
 }
 
 TEST_F(categorized_kvbc, multi_read_latest) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
 
   // Add block1
   {
@@ -1300,7 +1352,12 @@ TEST_F(categorized_kvbc, multi_read_latest) {
 }
 
 TEST_F(categorized_kvbc, single_get_latest_version) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
 
   // Add block1
   {
@@ -1404,7 +1461,12 @@ TEST_F(categorized_kvbc, single_get_latest_version) {
 }
 
 TEST_F(categorized_kvbc, multi_get_latest_version) {
-  KeyValueBlockchain block_chain{db, true};
+  KeyValueBlockchain block_chain{db,
+                                 true,
+                                 std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                      {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                      {"versioned_2", CATEGORY_TYPE::versioned_kv},
+                                                                      {"immutable", CATEGORY_TYPE::immutable}}};
 
   // Add block1
   {
@@ -1525,6 +1587,110 @@ TEST_F(categorized_kvbc, multi_get_latest_version) {
     ASSERT_FALSE(versions[1].value().deleted);
     ASSERT_EQ(versions[1].value().version, 1);
   }
+}
+
+TEST_F(categorized_kvbc, pass_same_categories_on_construction) {
+  const auto categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                               {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                               {"immutable", CATEGORY_TYPE::immutable}};
+  {
+    auto blockchain = KeyValueBlockchain{db, true, categories};
+    ASSERT_EQ(blockchain.blockchainCategories(), categories);
+  }
+
+  {
+    auto blockchain = KeyValueBlockchain{db, true, categories};
+    ASSERT_EQ(blockchain.blockchainCategories(), categories);
+  }
+}
+
+TEST_F(categorized_kvbc, no_categories_on_construction) {
+  const auto categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                               {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                               {"immutable", CATEGORY_TYPE::immutable}};
+  {
+    auto blockchain = KeyValueBlockchain{db, true, categories};
+    ASSERT_EQ(blockchain.blockchainCategories(), categories);
+  }
+
+  {
+    auto blockchain = KeyValueBlockchain{db, true};
+    ASSERT_EQ(blockchain.blockchainCategories(), categories);
+  }
+}
+
+TEST_F(categorized_kvbc, pass_additional_categories_on_construction) {
+  const auto initial_categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                       {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                       {"immutable", CATEGORY_TYPE::immutable}};
+
+  const auto all_categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                   {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                   {"versioned2", CATEGORY_TYPE::versioned_kv},
+                                                                   {"immutable", CATEGORY_TYPE::immutable}};
+  {
+    auto blockchain = KeyValueBlockchain{db, true, initial_categories};
+    ASSERT_EQ(blockchain.blockchainCategories(), initial_categories);
+  }
+
+  {
+    auto blockchain = KeyValueBlockchain{db, true, all_categories};
+    ASSERT_EQ(blockchain.blockchainCategories(), all_categories);
+  }
+
+  // Make sure additional categories are persisted.
+  {
+    auto blockchain = KeyValueBlockchain{db, true};
+    ASSERT_EQ(blockchain.blockchainCategories(), all_categories);
+  }
+}
+
+TEST_F(categorized_kvbc, missing_categories_on_construction) {
+  const auto persisted_categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                         {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                         {"immutable", CATEGORY_TYPE::immutable}};
+
+  const auto missing_categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                       {"versioned2", CATEGORY_TYPE::versioned_kv},
+                                                                       {"immutable", CATEGORY_TYPE::immutable}};
+  {
+    auto blockchain = KeyValueBlockchain{db, true, persisted_categories};
+    ASSERT_EQ(blockchain.blockchainCategories(), persisted_categories);
+  }
+
+  { ASSERT_THROW(KeyValueBlockchain(db, true, missing_categories), std::invalid_argument); }
+
+  // Make sure no additional categories are persisted when throwing.
+  {
+    auto blockchain = KeyValueBlockchain{db, true};
+    ASSERT_EQ(blockchain.blockchainCategories(), persisted_categories);
+  }
+}
+
+TEST_F(categorized_kvbc, changed_category_type_on_construction) {
+  const auto persisted_categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                         {"versioned", CATEGORY_TYPE::versioned_kv},
+                                                                         {"immutable", CATEGORY_TYPE::immutable}};
+
+  const auto wrongly_typed_categories = std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                                                             {"versioned", CATEGORY_TYPE::block_merkle},
+                                                                             {"immutable", CATEGORY_TYPE::immutable}};
+  {
+    auto blockchain = KeyValueBlockchain{db, true, persisted_categories};
+    ASSERT_EQ(blockchain.blockchainCategories(), persisted_categories);
+  }
+
+  { ASSERT_THROW(KeyValueBlockchain(db, true, wrongly_typed_categories), std::invalid_argument); }
+
+  // Make sure no additional categories are persisted when throwing.
+  {
+    auto blockchain = KeyValueBlockchain{db, true};
+    ASSERT_EQ(blockchain.blockchainCategories(), persisted_categories);
+  }
+}
+
+TEST_F(categorized_kvbc, no_categories_on_first_construction) {
+  ASSERT_THROW(KeyValueBlockchain(db, true), std::invalid_argument);
 }
 
 TEST_F(categorized_kvbc, updates_append_single_key_value_non_existent_category) {

--- a/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
@@ -27,7 +27,12 @@ class DbEditorTests : public DbEditorTestsBase {
  public:
   void CreateBlockchain(std::size_t db_id, BlockId blocks, std::optional<BlockId> mismatch_at = std::nullopt) override {
     auto db = TestRocksDb::create(db_id);
-    auto adapter = KeyValueBlockchain{concord::storage::rocksdb::NativeClient::fromIDBClient(db), true};
+    auto adapter =
+        KeyValueBlockchain{concord::storage::rocksdb::NativeClient::fromIDBClient(db),
+                           true,
+                           std::map<std::string, CATEGORY_TYPE>{{kCategoryMerkle, CATEGORY_TYPE::block_merkle},
+                                                                {kCategoryVersioned, CATEGORY_TYPE::versioned_kv},
+                                                                {kCategoryImmutable, CATEGORY_TYPE::immutable}}};
 
     const auto mismatch_kv = std::make_pair(getSliver(std::numeric_limits<unsigned>::max()), getSliver(42));
 

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -35,8 +35,6 @@ using Hasher = concord::util::SHA3_256;
 using Hash = Hasher::Digest;
 
 const uint64_t LONG_EXEC_CMD_TIME_IN_SEC = 11;
-static const std::string VERSIONED_KV_CAT_ID{"replica_tester_versioned_kv_category"};
-static const std::string BLOCK_MERKLE_CAT_ID{"replica_tester_block_merkle_category"};
 
 template <typename Span>
 static Hash hash(const Span &span) {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -25,6 +25,9 @@
 #include <chrono>
 #include <thread>
 
+static const std::string VERSIONED_KV_CAT_ID{"replica_tester_versioned_kv_category"};
+static const std::string BLOCK_MERKLE_CAT_ID{"replica_tester_block_merkle_category"};
+
 class InternalControlHandlers : public bftEngine::ControlHandlers {
   bool stoppedOnSuperStableCheckpoint = false;
   bool stoppedOnStableCheckpoint = false;

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -38,11 +38,15 @@ void run_replica(int argc, char** argv) {
   MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(setup->GetReplicaConfig().replicaId));
   MDC_PUT(MDC_THREAD_KEY, "main");
 
-  std::shared_ptr<ReplicaImp> replica = std::make_shared<ReplicaImp>(setup->GetCommunication(),
-                                                                     setup->GetReplicaConfig(),
-                                                                     setup->GetStorageFactory(),
-                                                                     setup->GetMetricsServer().GetAggregator(),
-                                                                     setup->GetPerformanceManager());
+  std::shared_ptr<ReplicaImp> replica =
+      std::make_shared<ReplicaImp>(setup->GetCommunication(),
+                                   setup->GetReplicaConfig(),
+                                   setup->GetStorageFactory(),
+                                   setup->GetMetricsServer().GetAggregator(),
+                                   setup->GetPerformanceManager(),
+                                   std::map<std::string, categorization::CATEGORY_TYPE>{
+                                       {VERSIONED_KV_CAT_ID, categorization::CATEGORY_TYPE::versioned_kv},
+                                       {BLOCK_MERKLE_CAT_ID, categorization::CATEGORY_TYPE::block_merkle}});
 
   auto* blockMetadata = new BlockMetadata(*replica);
 


### PR DESCRIPTION
Pass a map from category ID to type in KeyValueBlockchain's constructor.
Rationale is that this allows us to have concurrent reads and writes
without locking for access to internal in-memory category maps in
KeyValueBlockchain, namely `categories_` and `category_types_`. By
passing the map at construction, we no longer have the ability to create
categories on demand. However, we don't need that at the moment.

We allow addition of new categories to an existing blockchain. We also
require that either all existing categories (+ optionally new ones) are
passed on construction or no categories are passed at all, leading to
the system using the persisted ones only.

Add the category ID to type map to kvbc::ReplicaImp's constructor too.
Make sure that the `kConcordInternalCategoryId` is always created, even
if not passed explicitly by the user.

Add support for an optional RocksDB configuration file path in
RocksDBStorageFactory.