### PR TITLE
Deterministic liveness check in reconfiguration tests

### DIFF
--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -26,7 +26,6 @@ sys.path.append(os.path.abspath("../../util/pyclient"))
 
 import bft_client
 
-SKVBC_INIT_GRACE_TIME = 2
 
 def start_replica_cmd(builddir, replica_id):
     """
@@ -91,9 +90,9 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         late_replicas = bft_network.random_set_of_replicas(1, {initial_prim})
         on_time_replicas = bft_network.all_replicas(without=late_replicas)
         bft_network.start_replicas(on_time_replicas)
-        await trio.sleep(SKVBC_INIT_GRACE_TIME)
 
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        await skvbc.wait_for_liveness()
 
         checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
 


### PR DESCRIPTION
Adding a deterministic check for the skvbc to be ready (wait_for_liveness()) in the reconfiguration tests.