### PR TITLE
Fix stale keys deleted metrics

### DIFF
--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -73,7 +73,7 @@ class BlockMerkleCategory {
   std::vector<std::string> getBlockStaleKeys(BlockId, const BlockMerkleOutput&) const;
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
-  void deleteGenesisBlock(BlockId, const BlockMerkleOutput&, storage::rocksdb::NativeWriteBatch&);
+  std::size_t deleteGenesisBlock(BlockId, const BlockMerkleOutput&, storage::rocksdb::NativeWriteBatch&);
 
   // Delete the given block ID as a last reachable one.
   // Precondition: The given block ID must be the last reachable one.

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -51,7 +51,7 @@ class ImmutableKeyValueCategory {
   std::vector<std::string> getBlockStaleKeys(BlockId, const ImmutableOutput &) const;
 
   // Delete the genesis block. Implemented by directly calling deleteBlock().
-  void deleteGenesisBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);
+  std::size_t deleteGenesisBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);
 
   // Delete the last reachable block. Implemented by directly calling deleteBlock().
   void deleteLastReachableBlock(BlockId, const ImmutableOutput &, storage::rocksdb::NativeWriteBatch &);

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -49,7 +49,7 @@ class VersionedKeyValueCategory {
   std::vector<std::string> getBlockStaleKeys(BlockId, const VersionedOutput &) const;
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
-  void deleteGenesisBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
+  std::size_t deleteGenesisBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
 
   // Delete the given block ID as a last reachable one.
   // Precondition: The given block ID must be the last reachable one.

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -127,10 +127,11 @@ std::vector<std::string> ImmutableKeyValueCategory::getBlockStaleKeys(BlockId,
   return stale_keys;
 }
 
-void ImmutableKeyValueCategory::deleteGenesisBlock(BlockId,
-                                                   const ImmutableOutput &updates_info,
-                                                   storage::rocksdb::NativeWriteBatch &batch) {
+size_t ImmutableKeyValueCategory::deleteGenesisBlock(BlockId,
+                                                     const ImmutableOutput &updates_info,
+                                                     storage::rocksdb::NativeWriteBatch &batch) {
   deleteBlock(updates_info, batch);
+  return updates_info.tagged_keys.size();
 }
 
 void ImmutableKeyValueCategory::deleteLastReachableBlock(BlockId,

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -490,26 +490,27 @@ void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const ImmutableOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch& batch) {
-  immutable_num_of_deleted_keys_.Get().Inc(updates_info.tagged_keys.size());
-  std::get<detail::ImmutableKeyValueCategory>(getCategoryRef(category_id))
-      .deleteGenesisBlock(block_id, updates_info, batch);
+  auto num_of_deletes = std::get<detail::ImmutableKeyValueCategory>(getCategoryRef(category_id))
+                            .deleteGenesisBlock(block_id, updates_info, batch);
+  immutable_num_of_deleted_keys_.Get().Inc(num_of_deletes);
 }
 
 void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const VersionedOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch& batch) {
-  versioned_num_of_deletes_keys_.Get().Inc(updates_info.keys.size());
-  std::get<detail::VersionedKeyValueCategory>(getCategoryRef(category_id))
-      .deleteGenesisBlock(block_id, updates_info, batch);
+  auto num_of_deletes = std::get<detail::VersionedKeyValueCategory>(getCategoryRef(category_id))
+                            .deleteGenesisBlock(block_id, updates_info, batch);
+  versioned_num_of_deletes_keys_.Get().Inc(num_of_deletes);
 }
 
 void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const BlockMerkleOutput& updates_info,
                                             storage::rocksdb::NativeWriteBatch& batch) {
-  merkle_num_of_deleted_keys_.Get().Inc(updates_info.keys.size());
-  std::get<detail::BlockMerkleCategory>(getCategoryRef(category_id)).deleteGenesisBlock(block_id, updates_info, batch);
+  auto num_of_deletes = std::get<detail::BlockMerkleCategory>(getCategoryRef(category_id))
+                            .deleteGenesisBlock(block_id, updates_info, batch);
+  merkle_num_of_deleted_keys_.Get().Inc(num_of_deletes);
 }
 
 void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,


### PR DESCRIPTION
In this PR we fix the metrics for keys deletions.
On deleteGenesisBlock we count only the deletions of stale keys