### PR TITLE
Add an option to configure RocksDB LRU cache size

### DIFF
--- a/kvbc/include/merkle_tree_storage_factory.h
+++ b/kvbc/include/merkle_tree_storage_factory.h
@@ -16,6 +16,7 @@
 #include "kv_types.hpp"
 #include "PerformanceManager.hpp"
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <unordered_set>
@@ -25,6 +26,8 @@ namespace concord::kvbc::v2MerkleTree {
 #ifdef USE_ROCKSDB
 class RocksDBStorageFactory : public IStorageFactory {
  public:
+  static const std::size_t DEFAULT_ROCKSDB_LRU_CACHE_BYTES = 1024 * 1024 * 1024 * 4ul;  // 4 GB
+
   RocksDBStorageFactory(
       const std::string& dbPath,
       const std::unordered_set<concord::kvbc::Key>& nonProvableKeySet = std::unordered_set<concord::kvbc::Key>{},
@@ -33,6 +36,7 @@ class RocksDBStorageFactory : public IStorageFactory {
 
   RocksDBStorageFactory(const std::string& dbPath,
                         const std::string& dbConfPath,
+                        std::size_t rocksdbLruCacheBytes = DEFAULT_ROCKSDB_LRU_CACHE_BYTES,
                         const std::shared_ptr<concord::performance::PerformanceManager>& pm =
                             std::make_shared<concord::performance::PerformanceManager>());
 
@@ -44,6 +48,7 @@ class RocksDBStorageFactory : public IStorageFactory {
  private:
   const std::string dbPath_;
   const std::optional<std::string> dbConfPath_;
+  std::size_t rocksdbLruCacheBytes_{DEFAULT_ROCKSDB_LRU_CACHE_BYTES};
   const std::unordered_set<concord::kvbc::Key> nonProvableKeySet_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };


### PR DESCRIPTION
Add an option to configure RocksDB LRU cache size (in bytes) to the
storage factory. Set a default value of 4 GB.