### PR TITLE
Fix mini-batching issues in SimpleClientImp/PreProcessor

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -61,6 +61,7 @@ struct ClientReply {
   uint32_t lengthOfReplyBuffer = 0;
   char* replyBuffer = nullptr;
   uint32_t actualReplyLength = 0;
+  OperationResult opResult = SUCCESS;
   std::string cid;
   std::string span_context;
 };
@@ -109,7 +110,7 @@ class SimpleClient {
   // To be used only for write requests
   virtual OperationResult sendBatch(const std::deque<ClientRequest>& clientRequests,
                                     std::deque<ClientReply>& clientReplies,
-                                    const std::string& cid) = 0;
+                                    const std::string& batchCid) = 0;
 
   void setAggregator(const std::shared_ptr<concordMetrics::Aggregator>& aggregator) {
     if (aggregator) metrics_.SetAggregator(aggregator);

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -118,7 +118,7 @@ class PreProcessor {
                                     uint64_t reqRetryId,
                                     const std::string &cid,
                                     const std::string &ongoingCid);
-  const char *getPreProcessResultBuffer(uint16_t clientId, uint16_t reqOffsetInBatch) const;
+  const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
   const uint16_t getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,
@@ -180,8 +180,8 @@ class PreProcessor {
   const std::set<ReplicaId> &idsOfPeerReplicas_;
   const uint16_t numOfReplicas_;
   const uint16_t numOfClients_;
-  const bool batchingEnabled_;
-  const uint16_t batchSize_;
+  const bool clientBatchingEnabled_;
+  const uint16_t clientMaxBatchSize_;
   util::SimpleThreadPool threadPool_;
   // One-time allocated buffers (one per client) for the pre-execution results storage
   PreProcessResultBuffers preProcessResultBuffers_;


### PR DESCRIPTION
Add operation result to ClientReply structure. 
Set batch expiration timeout to the maximum single request timeout.
Fix reply buffer offset calculation in PreProcessor.
Verify arrival of all replies.