### PR TITLE
Enable using storage from multiple threads

### DIFF
--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -98,6 +98,8 @@ class ReplicaImp : public IReplica,
   bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) override;
   bool putBlock(const uint64_t blockId, const char *blockData, const uint32_t blockSize) override;
   uint64_t getLastReachableBlockNum() const override;
+  // This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or
+  // the main blockchain
   uint64_t getLastBlockNum() const override;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -59,7 +59,10 @@ class KeyValueBlockchain {
   /////////////////////// Info ///////////////////////
   BlockId getGenesisBlockId() const { return block_chain_.getGenesisBlockId(); }
   BlockId getLastReachableBlockId() const { return block_chain_.getLastReachableBlockId(); }
-  std::optional<BlockId> getLastStatetransferBlockId() const { return state_transfer_block_chain_.getLastBlockId(); }
+  std::optional<BlockId> getLastStatetransferBlockId() const {
+    if (state_transfer_block_chain_.getLastBlockId() == 0) return std::nullopt;
+    return state_transfer_block_chain_.getLastBlockId();
+  }
 
   std::optional<Hash> parentDigest(BlockId block_id) const;
   bool hasBlock(BlockId block_id) const;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -168,13 +168,7 @@ std::optional<categorization::Updates> ReplicaImp::getBlockUpdates(BlockId block
 
 BlockId ReplicaImp::getGenesisBlockId() const { return m_kvBlockchain->getGenesisBlockId(); }
 
-BlockId ReplicaImp::getLastBlockId() const {
-  const auto lastSt = m_kvBlockchain->getLastStatetransferBlockId();
-  if (lastSt) {
-    return *lastSt;
-  }
-  return m_kvBlockchain->getLastReachableBlockId();
-}
+BlockId ReplicaImp::getLastBlockId() const { return m_kvBlockchain->getLastReachableBlockId(); }
 
 void ReplicaImp::set_command_handler(ICommandsHandler *handler) { m_cmdHandler = handler; }
 

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -141,8 +141,8 @@ BlockId KeyValueBlockchain::addBlock(Updates&& updates) {
   // Use new client batch and column families
   auto write_batch = native_client_->getBatch();
   auto block_id = addBlock(std::move(updates.category_updates_), write_batch);
-  block_chain_.setAddedBlockId(block_id);
   native_client_->write(std::move(write_batch));
+  block_chain_.setAddedBlockId(block_id);
   return block_id;
 }
 
@@ -668,9 +668,9 @@ bool KeyValueBlockchain::hasBlock(BlockId block_id) const {
 // tries to remove blocks form the state transfer chain to the blockchain
 void KeyValueBlockchain::linkSTChainFrom(BlockId block_id) {
   const auto last_block_id = state_transfer_block_chain_.getLastBlockId();
-  if (!last_block_id) return;
+  if (last_block_id == 0) return;
 
-  for (auto i = block_id; i <= last_block_id.value(); ++i) {
+  for (auto i = block_id; i <= last_block_id; ++i) {
     auto raw_block = state_transfer_block_chain_.getRawBlock(i);
     if (!raw_block) {
       return;

--- a/kvbc/test/categorization/blockchain_test.cpp
+++ b/kvbc/test/categorization/blockchain_test.cpp
@@ -167,7 +167,7 @@ TEST_F(categorized_kvbc, fail_get_raw) {
 TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
   detail::Blockchain::StateTransfer st_block_chain{db};
 
-  ASSERT_FALSE(st_block_chain.getLastBlockId().has_value());
+  ASSERT_FALSE(st_block_chain.getLastBlockId() > 0);
 
   // Add raw block 100
   {
@@ -176,7 +176,7 @@ TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
     st_block_chain.addBlock(100, rb, wb);
     db->write(std::move(wb));
     st_block_chain.loadLastBlockId();
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 100);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 100);
   }
   // delete non-existing
   {
@@ -184,7 +184,7 @@ TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
     st_block_chain.deleteBlock(101, wb);
     db->write(std::move(wb));
     st_block_chain.updateLastIdAfterDeletion(101);
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 100);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 100);
   }
   // Add raw block 300
   {
@@ -193,7 +193,7 @@ TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
     st_block_chain.addBlock(300, rb, wb);
     db->write(std::move(wb));
     st_block_chain.loadLastBlockId();
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 300);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 300);
   }
   // Add raw block 200
   {
@@ -202,7 +202,7 @@ TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
     st_block_chain.addBlock(200, rb, wb);
     db->write(std::move(wb));
     st_block_chain.loadLastBlockId();
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 300);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 300);
   }
   // Add raw block 1
   {
@@ -211,7 +211,7 @@ TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
     st_block_chain.addBlock(1, rb, wb);
     db->write(std::move(wb));
     st_block_chain.loadLastBlockId();
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 300);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 300);
   }
   // delete raw block 200
   {
@@ -219,7 +219,7 @@ TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
     st_block_chain.deleteBlock(200, wb);
     db->write(std::move(wb));
     st_block_chain.updateLastIdAfterDeletion(200);
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 300);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 300);
   }
   // delete raw block 300
   {
@@ -227,28 +227,28 @@ TEST_F(categorized_kvbc, load_and_delete_st_blocks) {
     st_block_chain.deleteBlock(300, wb);
     db->write(std::move(wb));
     st_block_chain.updateLastIdAfterDeletion(300);
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 100);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 100);
   }
   {
     auto wb = db->getBatch();
     st_block_chain.deleteBlock(100, wb);
     db->write(std::move(wb));
     st_block_chain.updateLastIdAfterDeletion(100);
-    ASSERT_EQ(st_block_chain.getLastBlockId().value(), 1);
+    ASSERT_EQ(st_block_chain.getLastBlockId(), 1);
   }
   {
     auto wb = db->getBatch();
     st_block_chain.deleteBlock(1, wb);
     db->write(std::move(wb));
     st_block_chain.updateLastIdAfterDeletion(1);
-    ASSERT_FALSE(st_block_chain.getLastBlockId().has_value());
+    ASSERT_FALSE(st_block_chain.getLastBlockId() > 0);
   }
 }
 
 TEST_F(categorized_kvbc, get_st_block) {
   detail::Blockchain::StateTransfer st_block_chain{db};
 
-  ASSERT_FALSE(st_block_chain.getLastBlockId().has_value());
+  ASSERT_FALSE(st_block_chain.getLastBlockId() > 0);
 
   {
     categorization::RawBlock rb;


### PR DESCRIPTION
Under the assumption that writes will occur only from the message-processing and state-transfer thread(s) and that those threads can't execute in parallel. 

- make last_reachable_block_id_ atomic

- make genesis_block_id_ atomic

- call setAddedBlockId() after commit to storage

- Do not use getLastStateTranferBLockId() in ReplicaImp::getLastBlockId()

- Make last_block_id_ in ST chain atomic

