### PR TITLE
Add root hash to raw block

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -92,7 +92,10 @@ Msg BlockData 2001 {
 Msg RawBlockData 2005 {
     fixedlist uint8 32 parent_digest
     CategoryInput updates
-    map string optional fixedlist uint8 32 category_root_hash
+    map string fixedlist uint8 32 block_merkle_root_hash
+    map string fixedlist uint8 32 versioned_root_hash 
+    map string map string fixedlist uint8 32 immutable_root_hashes
+
 }
 
 # Used to deserialize the parent_digest only from RawBlockData and BlockData.

--- a/kvbc/include/categorization/blocks.h
+++ b/kvbc/include/categorization/blocks.h
@@ -122,6 +122,21 @@ struct RawBlock {
   RawBlockData data;
 };
 
+inline void addRootHash(const std::string& category_id, RawBlockData& data, const BlockMerkleOutput& update_info) {
+  data.block_merkle_root_hash[category_id] = update_info.root_hash;
+}
+
+// If optional is null do not include in the raw block
+inline void addRootHash(const std::string& category_id, RawBlockData& data, const VersionedOutput& update_info) {
+  if (!update_info.root_hash) return;
+  data.versioned_root_hash[category_id] = update_info.root_hash.value();
+}
+
+inline void addRootHash(const std::string& category_id, RawBlockData& data, const ImmutableOutput& update_info) {
+  if (!update_info.tag_root_hashes) return;
+  data.immutable_root_hashes[category_id] = update_info.tag_root_hashes.value();
+}
+
 inline bool operator==(const RawBlock& l, const RawBlock& r) { return l.data == r.data; }
 inline bool operator!=(const RawBlock& l, const RawBlock& r) { return !(l == r); }
 

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -226,7 +226,7 @@ class KeyValueBlockchain {
 
     detail::Blockchain& getBlockchain(KeyValueBlockchain& kvbc) { return kvbc.block_chain_; }
 
-    const VersionedRawBlock& getLastRawBlocked(KeyValueBlockchain& kvbc) { return kvbc.last_raw_block_; }
+    const VersionedRawBlock& getLastRawBlock(KeyValueBlockchain& kvbc) { return kvbc.last_raw_block_; }
   };  // namespace concord::kvbc::categorization
 
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {

--- a/kvbc/src/categorization/blocks.cpp
+++ b/kvbc/src/categorization/blocks.cpp
@@ -47,6 +47,7 @@ BlockMerkleInput RawBlock::getUpdates(const std::string& category_id,
                                       const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
                                       const CategoriesMap& categorires) {
   ConcordAssert(categorires.count(category_id) == 1);
+  addRootHash(category_id, data, update_info);
   BlockMerkleInput data;
   const auto& cat = std::get<detail::BlockMerkleCategory>(categorires.at(category_id));
   for (auto& [key, flag] : update_info.keys) {
@@ -74,6 +75,7 @@ VersionedInput RawBlock::getUpdates(const std::string& category_id,
                                     const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
                                     const CategoriesMap& categorires) {
   ConcordAssert(categorires.count(category_id) == 1);
+  addRootHash(category_id, data, update_info);
   VersionedInput data;
   data.calculate_root_hash = update_info.root_hash.has_value();
   const auto& cat = std::get<detail::VersionedKeyValueCategory>(categorires.at(category_id));
@@ -104,6 +106,7 @@ ImmutableInput RawBlock::getUpdates(const std::string& category_id,
                                     const std::shared_ptr<storage::rocksdb::NativeClient>& native_client,
                                     const CategoriesMap& categorires) {
   ConcordAssert(categorires.count(category_id) == 1);
+  addRootHash(category_id, data, update_info);
   ImmutableInput data;
   data.calculate_root_hash = update_info.tag_root_hashes.has_value();
   const auto& cat = std::get<detail::ImmutableKeyValueCategory>(categorires.at(category_id));

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -158,9 +158,10 @@ BlockId KeyValueBlockchain::addBlock(CategoryInput&& category_updates,
   // Per category updates
   for (auto&& [category_id, update] : category_updates.kv) {
     std::visit(
-        [&new_block, category_id = category_id, &write_batch, this](auto&& update) {
+        [&new_block, category_id = category_id, &write_batch, &last_raw_block, this](auto&& update) {
           auto block_updates =
               handleCategoryUpdates(new_block.id(), category_id, std::forward<decltype(update)>(update), write_batch);
+          addRootHash(category_id, last_raw_block, block_updates);
           new_block.add(category_id, std::move(block_updates));
         },
         std::move(update));

--- a/kvbc/test/categorization/blockchain_test.cpp
+++ b/kvbc/test/categorization/blockchain_test.cpp
@@ -254,12 +254,12 @@ TEST_F(categorized_kvbc, get_st_block) {
     categorization::RawBlock rb;
     std::array<uint8_t, 32> arr{'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',
                                 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'};
-    rb.data.category_root_hash["merkle"] = arr;
+    rb.data.block_merkle_root_hash["merkle"] = arr;
     auto wb = db->getBatch();
     st_block_chain.addBlock(100, rb, wb);
     db->write(std::move(wb));
     auto db_rb = st_block_chain.getRawBlock(100);
-    ASSERT_EQ(db_rb.value().data.category_root_hash["merkle"], arr);
+    ASSERT_EQ(db_rb.value().data.block_merkle_root_hash["merkle"], arr);
   }
 }
 


### PR DESCRIPTION
Adding the root hash of each category instance to the raw block.

note:
Some category has the root hash defined as a std::optional,
if the optional is set the category root hash will be present in the raw block,
otherwise, it won't i.e. the raw block root hash is not using std::optional.