### PR TITLE
kvbcbench: Fully utilize KeyValueBlockchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CONCORD_BFT_CONTAINER_SHELL:=/bin/bash
 CONCORD_BFT_CONTAINER_CC:=clang
 CONCORD_BFT_CONTAINER_CXX:=clang++
 CONCORD_BFT_CMAKE_FLAGS:= \
-			-DCMAKE_BUILD_TYPE=Debug \
+			-DCMAKE_BUILD_TYPE=Release \
 			-DBUILD_TESTING=ON \
 			-DBUILD_COMM_TCP_PLAIN=FALSE \
 			-DBUILD_COMM_TCP_TLS=TRUE\
@@ -24,7 +24,7 @@ CONCORD_BFT_CMAKE_FLAGS:= \
 			-DOMIT_TEST_OUTPUT=OFF \
 			-DKEEP_APOLLO_LOGS=TRUE \
 			-DBUILD_SLOWDOWN=FALSE \
-			-DBUILD_KVBC_BENCH=FALSE \ # Should only run this with -DCMAKE_BUILD_TYPE=Release
+			-DBUILD_KVBC_BENCH=TRUE \ # Should only run this with -DCMAKE_BUILD_TYPE=Release
 
 # The consistency parameter makes sense only at MacOS.
 # It is ignored at all other platforms.

--- a/kvbc/benchmark/kvbcbench/input.h
+++ b/kvbc/benchmark/kvbcbench/input.h
@@ -21,6 +21,7 @@
 #include <boost/program_options/variables_map.hpp>
 
 #include "categorized_kvbc_msgs.cmf.hpp"
+#include "categorization/updates.h"
 
 const std::string kCategoryMerkle = "block_merkle";
 const std::string kCategoryVersioned = "ver_test";
@@ -30,87 +31,262 @@ namespace concord::kvbc::bench {
 
 namespace po = boost::program_options;
 using categorization::BlockMerkleInput;
+using categorization::ImmutableUpdates;
+using categorization::VersionedUpdates;
 using ReadKeys = std::vector<std::string>;
 
 struct InputData {
   std::vector<BlockMerkleInput> block_merkle_input;
   ReadKeys block_merkle_read_keys;
+  std::vector<ImmutableUpdates> imm_updates;
+  std::vector<VersionedUpdates> ver_updates;
+  ReadKeys ver_read_keys;
 };
 
-inline InputData createBlockInput(const po::variables_map& config) {
+inline size_t blockSize(const po::variables_map& config) {
+  // General config
+  auto batch_size = config["batch-size"].as<size_t>();
+
+  // BlockMerkle config
+  auto key_size_merkle = config["block-merkle-key-size"].as<size_t>();
+  auto value_size_merkle = config["block-merkle-value-size"].as<size_t>();
+  auto num_adds_merkle = config["num-block-merkle-keys-add"].as<size_t>() * batch_size;
+  auto num_deletes_merkle = config["num-block-merkle-keys-delete"].as<size_t>() * batch_size;
+
+  // Immutable config
+  auto num_adds_immutable = config["num-immutable-keys-add"].as<size_t>() * batch_size;
+  auto key_size_immutable = config["immutable-key-size"].as<size_t>() * batch_size;
+  auto value_size_immutable = config["immutable-value-size"].as<size_t>() * batch_size;
+
+  // Versioned KV config
+  auto key_size_versioned = config["versioned-key-size"].as<size_t>();
+  auto value_size_versioned = config["versioned-value-size"].as<size_t>();
+  auto num_adds_versioned = config["num-versioned-keys-add"].as<size_t>() * batch_size;
+  auto num_deletes_versioned = config["num-versioned-keys-delete"].as<size_t>() * batch_size;
+
+  const auto merkle_size =
+      (key_size_merkle + value_size_merkle) * num_adds_merkle + key_size_merkle * num_deletes_merkle;
+  const auto versioned_size =
+      (key_size_versioned + value_size_versioned) * num_adds_versioned + key_size_versioned * num_deletes_versioned;
+  const auto immutable_size = (key_size_immutable + value_size_immutable) * num_adds_immutable;
+  return merkle_size + versioned_size + immutable_size;
+}
+
+inline size_t numBlocks(const po::variables_map& config) {
   auto total_blocks = config["total-blocks"].as<size_t>();
+  auto max_memory_for_kv = config["max-memory-for-kv-gen"].as<size_t>();
+  auto block_size = blockSize(config);
+  return std::min(max_memory_for_kv / block_size, total_blocks);
+}
+
+// Create block input of a given type by applying UpdateFn in parallel
+// read_keys will be filled in by the generator if needed.
+template <typename Input, typename UpdateFn>
+inline std::vector<Input> parallelInputGen(size_t num_blocks, UpdateFn f) {
+  // Run generation in parallel
+  auto num_cpus = std::thread::hardware_concurrency();
+
+  // One future per thread
+  auto futures = std::vector<std::future<std::vector<Input>>>{};
+  futures.reserve(num_cpus);
+
+  // Launch random key-value generation in parallel
+  for (auto i = 0u; i < num_cpus; i++) {
+    futures.push_back(std::async(std::launch::async, f, i));
+  }
+
+  auto rv = std::vector<Input>{};
+  rv.reserve(num_blocks);
+
+  // Merge the results
+  for (auto i = 0u; i < num_cpus; i++) {
+    for (auto&& input : futures[i].get()) {
+      rv.emplace_back(std::move(input));
+    }
+  }
+  return rv;
+}
+
+template <typename GenRandChar>
+inline std::string randKey(GenRandChar rand_char, size_t key_size) {
+  auto key = std::string{};
+  key.reserve(key_size);
+  generate_n(std::back_inserter(key), key_size, rand_char);
+  return key;
+}
+
+template <typename GenRandChar>
+inline std::pair<std::string, std::string> randKvPair(GenRandChar rand_char, size_t key_size, size_t value_size) {
+  auto key = std::string{};
+  auto val = std::string{};
+  key.reserve(key_size);
+  val.reserve(value_size);
+  generate_n(std::back_inserter(key), key_size, rand_char);
+  generate_n(std::back_inserter(val), value_size, rand_char);
+  return std::make_pair(key, val);
+}
+
+// Return the total number of read keys along with a factory for a generator for a vector of BlockMerkleInput.
+inline auto makeBlockMerkleInputGenerator(const po::variables_map& config) {
   auto key_size = config["block-merkle-key-size"].as<size_t>();
   auto value_size = config["block-merkle-value-size"].as<size_t>();
   auto batch_size = config["batch-size"].as<size_t>();
   auto num_adds = config["num-block-merkle-keys-add"].as<size_t>() * batch_size;
   auto num_deletes = config["num-block-merkle-keys-delete"].as<size_t>() * batch_size;
-  auto max_memory_for_kv = config["max-memory-for-kv-gen"].as<size_t>();
   auto max_read_keys = config["max-total-block-merkle-read-keys"].as<size_t>();
 
-  const auto block_size = (key_size + value_size) * num_adds + key_size * num_deletes;
-  const size_t num_blocks = std::min(max_memory_for_kv / block_size, total_blocks);
-  auto blocks = std::vector<BlockMerkleInput>{};
-  blocks.reserve(num_blocks);
-
-  // Run generation in parallel
+  auto num_blocks = numBlocks(config);
   auto num_cpus = std::thread::hardware_concurrency();
-  std::cout << "Generating blocks in parallel across " << num_cpus << " cpus" << std::endl;
   auto blocks_per_thread = num_blocks / num_cpus;
 
   // Each thread fills in their subset of keys in a pre-allocated vector. There is no race here, and
   // no need for locks as the buffer segments in each thread are disjoint.
   auto total_read_keys = std::min(num_adds * num_blocks, max_read_keys);
   auto read_keys_per_thread = total_read_keys / num_cpus;
-  auto read_keys = ReadKeys(total_read_keys);
 
-  auto gen = [&](size_t thread_id) -> std::vector<categorization::BlockMerkleInput> {
+  // Return a factory that takes a reference to readKeys and returns a generator for BlockMerkle input
+  auto makeGen = [=](ReadKeys& read_keys) {
+    auto gen = [=, &read_keys](size_t thread_id) -> std::vector<BlockMerkleInput> {
+      static thread_local std::mt19937 generator;
+      auto distribution = std::uniform_int_distribution<unsigned short>(0, 255);
+      auto rand_char = [&]() -> uint8_t { return static_cast<uint8_t>(distribution(generator)); };
+      size_t read_key_start = thread_id * read_keys_per_thread;
+      size_t read_key_end = read_key_start + read_keys_per_thread;
+      auto output = std::vector<BlockMerkleInput>{};
+      output.reserve(blocks_per_thread);
+      std::cout << "BlockMerkle thread " << thread_id << " generating " << blocks_per_thread << " blocks with "
+                << num_adds + num_deletes << " keys per block and " << read_keys_per_thread << " read keys"
+                << std::endl;
+      for (auto j = 0u; j < blocks_per_thread; j++) {
+        auto input = BlockMerkleInput{};
+        for (auto i = 0u; i < num_adds; i++) {
+          auto [key, value] = randKvPair(rand_char, key_size, value_size);
+          if (read_key_start != read_key_end) {
+            read_keys[read_key_start] = key;
+            read_key_start++;
+          }
+          input.kv.emplace(key, value);
+        }
+
+        for (auto i = 0u; i < num_deletes; i++) {
+          auto key = randKey(rand_char, key_size);
+          input.deletes.push_back(key);
+        }
+        output.push_back(input);
+      }
+      return output;
+    };
+    return gen;
+  };
+  return std::make_pair(total_read_keys, makeGen);
+}
+
+// Return the total number of read keys along with a factory for a generator for a vector of VersionedUpdates.
+inline auto makeVersionedUpdateGenerator(const po::variables_map& config) {
+  auto key_size = config["versioned-key-size"].as<size_t>();
+  auto value_size = config["versioned-value-size"].as<size_t>();
+  auto batch_size = config["batch-size"].as<size_t>();
+  auto num_adds = config["num-versioned-keys-add"].as<size_t>() * batch_size;
+  auto num_deletes = config["num-versioned-keys-delete"].as<size_t>() * batch_size;
+  auto max_read_keys = config["max-total-versioned-read-keys"].as<size_t>();
+
+  auto num_blocks = numBlocks(config);
+  auto num_cpus = std::thread::hardware_concurrency();
+  auto blocks_per_thread = num_blocks / num_cpus;
+
+  // Each thread fills in their subset of keys in a pre-allocated vector. There is no race here, and
+  // no need for locks as the buffer segments in each thread are disjoint.
+  auto total_read_keys = std::min(num_adds * num_blocks, max_read_keys);
+  auto read_keys_per_thread = total_read_keys / num_cpus;
+
+  // Return a factory that takes a reference to readKeys and returns a generator for VersionedUpdates input
+  auto makeGen = [=](ReadKeys& read_keys) {
+    auto gen = [=, &read_keys](size_t thread_id) -> std::vector<VersionedUpdates> {
+      static thread_local std::mt19937 generator;
+      auto distribution = std::uniform_int_distribution<unsigned short>(0, 255);
+      auto rand_char = [&]() -> uint8_t { return static_cast<uint8_t>(distribution(generator)); };
+      size_t read_key_start = thread_id * read_keys_per_thread;
+      size_t read_key_end = read_key_start + read_keys_per_thread;
+      auto output = std::vector<VersionedUpdates>{};
+      output.reserve(blocks_per_thread);
+      std::cout << "Versioned thread " << thread_id << " generating " << blocks_per_thread << " blocks with "
+                << num_adds + num_deletes << " keys per block and " << read_keys_per_thread << " read keys"
+                << std::endl;
+      for (auto j = 0u; j < blocks_per_thread; j++) {
+        auto updates = VersionedUpdates{};
+        for (auto i = 0u; i < num_adds; i++) {
+          auto [key, val] = randKvPair(rand_char, key_size, value_size);
+          if (read_key_start != read_key_end) {
+            read_keys[read_key_start] = key;
+            read_key_start++;
+          }
+          updates.addUpdate(std::move(key), std::move(val));
+        }
+
+        for (auto i = 0u; i < num_deletes; i++) {
+          auto key = randKey(rand_char, key_size);
+          updates.addDelete(std::move(key));
+        }
+        output.emplace_back(std::move(updates));
+      }
+      return output;
+    };
+    return gen;
+  };
+  return std::make_pair(total_read_keys, makeGen);
+}
+
+// Return a generator that will create a vector of ImmutableUpdates based on the given configuration.
+inline auto makeImmutableUpdateGenerator(const po::variables_map& config) {
+  auto key_size = config["immutable-key-size"].as<size_t>();
+  auto value_size = config["immutable-value-size"].as<size_t>();
+  auto batch_size = config["batch-size"].as<size_t>();
+  auto num_adds = config["num-immutable-keys-add"].as<size_t>() * batch_size;
+
+  auto num_blocks = numBlocks(config);
+  auto num_cpus = std::thread::hardware_concurrency();
+  auto blocks_per_thread = num_blocks / num_cpus;
+
+  auto gen = [=](size_t thread_id) -> std::vector<ImmutableUpdates> {
     static thread_local std::mt19937 generator;
     auto distribution = std::uniform_int_distribution<unsigned short>(0, 255);
     auto rand_char = [&]() -> uint8_t { return static_cast<uint8_t>(distribution(generator)); };
-    size_t read_key_start = thread_id * read_keys_per_thread;
-    size_t read_key_end = read_key_start + read_keys_per_thread;
-    auto output = std::vector<BlockMerkleInput>{};
+    auto output = std::vector<ImmutableUpdates>{};
     output.reserve(blocks_per_thread);
+    std::cout << "Immutable thread " << thread_id << " generating " << blocks_per_thread << " blocks with " << num_adds
+              << " keys per block." << std::endl;
     for (auto j = 0u; j < blocks_per_thread; j++) {
-      auto input = BlockMerkleInput{};
+      auto updates = ImmutableUpdates{};
       for (auto i = 0u; i < num_adds; i++) {
-        auto key = std::string{};
-        auto val = std::string{};
-        key.reserve(key_size);
-        val.reserve(value_size);
-        generate_n(std::back_inserter(key), key_size, rand_char);
-        generate_n(std::back_inserter(val), value_size, rand_char);
-        if (read_key_start != read_key_end) {
-          read_keys[read_key_start] = key;
-          read_key_start++;
-        }
-        input.kv.emplace(key, val);
+        auto [key, value] = randKvPair(rand_char, key_size, value_size);
+        updates.addUpdate(std::move(key), ImmutableUpdates::ImmutableValue{std::move(value), {}});
       }
-
-      for (auto i = 0u; i < num_deletes; i++) {
-        auto key = std::string{};
-        key.reserve(key_size);
-        generate_n(std::back_inserter(key), key_size, rand_char);
-        input.deletes.push_back(key);
-      }
-      output.push_back(input);
+      output.emplace_back(std::move(updates));
     }
     return output;
   };
+  return gen;
+}
 
-  auto output_futures = std::vector<std::future<std::vector<categorization::BlockMerkleInput>>>{};
-  output_futures.reserve(num_cpus);
+inline InputData createBlockInput(const po::variables_map& config) {
+  auto num_blocks = numBlocks(config);
+  auto data = InputData{};
 
-  // Launch random key-value generation in parallel
-  for (auto i = 0u; i < num_cpus; i++) {
-    output_futures.push_back(std::async(std::launch::async, gen, i));
-  }
-  // Merge the results
-  for (auto i = 0u; i < num_cpus; i++) {
-    auto batch = output_futures[i].get();
-    blocks.insert(blocks.end(), batch.begin(), batch.end());
-  }
-  return InputData{blocks, read_keys};
+  // Create BlockMerkle Input
+  auto [total_read_keys_merkle, make_block_merkle_gen] = makeBlockMerkleInputGenerator(config);
+  data.block_merkle_read_keys = ReadKeys(total_read_keys_merkle);
+  data.block_merkle_input =
+      parallelInputGen<BlockMerkleInput>(num_blocks, make_block_merkle_gen(data.block_merkle_read_keys));
+
+  // Create Versioned KeyValue input
+  auto [total_read_keys_versioned, make_versioned_gen] = makeVersionedUpdateGenerator(config);
+  data.ver_read_keys = ReadKeys(total_read_keys_versioned);
+  data.ver_updates = parallelInputGen<VersionedUpdates>(num_blocks, make_versioned_gen(data.ver_read_keys));
+
+  auto immutable_gen = makeImmutableUpdateGenerator(config);
+  data.imm_updates = parallelInputGen<ImmutableUpdates>(num_blocks, immutable_gen);
+
+  return data;
 }
 
 }  // namespace concord::kvbc::bench

--- a/kvbc/benchmark/kvbcbench/input.h
+++ b/kvbc/benchmark/kvbcbench/input.h
@@ -55,8 +55,8 @@ inline size_t blockSize(const po::variables_map& config) {
 
   // Immutable config
   auto num_adds_immutable = config["num-immutable-keys-add"].as<size_t>() * batch_size;
-  auto key_size_immutable = config["immutable-key-size"].as<size_t>() * batch_size;
-  auto value_size_immutable = config["immutable-value-size"].as<size_t>() * batch_size;
+  auto key_size_immutable = config["immutable-key-size"].as<size_t>();
+  auto value_size_immutable = config["immutable-value-size"].as<size_t>();
 
   // Versioned KV config
   auto key_size_versioned = config["versioned-key-size"].as<size_t>();
@@ -270,6 +270,9 @@ inline auto makeImmutableUpdateGenerator(const po::variables_map& config) {
 
 inline InputData createBlockInput(const po::variables_map& config) {
   auto num_blocks = numBlocks(config);
+  std::cout << "Generated Input Data for " << num_blocks << " blocks, with block size = " << blockSize(config)
+            << " bytes." << std::endl;
+
   auto data = InputData{};
 
   // Create BlockMerkle Input

--- a/kvbc/benchmark/kvbcbench/pre_execution.h
+++ b/kvbc/benchmark/kvbcbench/pre_execution.h
@@ -26,29 +26,45 @@ struct PreExecConfig {
   size_t concurrency;
   std::chrono::milliseconds delay;
   size_t num_block_merkle_keys_to_read;
+  size_t num_versioned_keys_to_read;
 };
 
+// We read a number of block merkle keys and versioned keys, and then sleep for a given time to
+// simulate pre-execution.
 class PreExecutionSimulator {
  public:
   PreExecutionSimulator(const PreExecConfig& config,
-                        const ReadKeys& read_keys,
+                        const ReadKeys& merkle_read_keys,
+                        const ReadKeys& versioned_read_keys,
                         categorization::KeyValueBlockchain& kvbc)
-      : config_(config), read_keys_(read_keys), kvbc_(kvbc) {}
+      : config_(config), merkle_read_keys_(merkle_read_keys), versioned_read_keys_(versioned_read_keys), kvbc_(kvbc) {}
 
   void start() {
     std::cout << "Starting Simulated Pre-Execution Reads" << std::endl;
     for (auto i = 0u; i < config_.concurrency; i++) {
       threads_.emplace_back([this]() {
         // Only alloacate the read_keys vector once
-        auto read_keys = std::vector<std::string>{};
-        read_keys.reserve(config_.num_block_merkle_keys_to_read);
-        auto values = std::vector<std::optional<categorization::Value>>{};
+        auto merkle_read_keys = std::vector<std::string>{};
+        merkle_read_keys.reserve(config_.num_block_merkle_keys_to_read);
+        auto merkle_values = std::vector<std::optional<categorization::Value>>{};
+        auto versioned_read_keys = std::vector<std::string>{};
+        versioned_read_keys.reserve(config_.num_versioned_keys_to_read);
+        auto versioned_values = std::vector<std::optional<categorization::Value>>{};
         while (!stop_) {
-          read_keys.clear();
-          values.clear();
-          auto start = randomKeyIter();
-          std::copy(start, start + config_.num_block_merkle_keys_to_read, std::back_inserter(read_keys));
-          kvbc_.multiGetLatest(kCategoryMerkle, read_keys, values);
+          merkle_read_keys.clear();
+          merkle_values.clear();
+          versioned_read_keys.clear();
+          versioned_values.clear();
+          auto merkle_start = randomMerkleKeyIter();
+          auto versioned_start = randomVersionedKeyIter();
+
+          std::copy(
+              merkle_start, merkle_start + config_.num_block_merkle_keys_to_read, std::back_inserter(merkle_read_keys));
+          kvbc_.multiGetLatest(kCategoryMerkle, merkle_read_keys, merkle_values);
+          std::copy(versioned_start,
+                    versioned_start + config_.num_versioned_keys_to_read,
+                    std::back_inserter(versioned_read_keys));
+          kvbc_.multiGetLatest(kCategoryVersioned, versioned_read_keys, versioned_values);
           std::this_thread::sleep_for(config_.delay);
         }
       });
@@ -64,16 +80,23 @@ class PreExecutionSimulator {
   }
 
  private:
-  std::vector<std::string>::const_iterator randomKeyIter() {
-    auto max_read_offset = read_keys_.size() - config_.num_block_merkle_keys_to_read;
-    return read_keys_.begin() + (rand() % max_read_offset);
+  std::vector<std::string>::const_iterator randomMerkleKeyIter() {
+    auto max_read_offset = merkle_read_keys_.size() - config_.num_block_merkle_keys_to_read;
+    return merkle_read_keys_.begin() + (rand() % max_read_offset);
   }
+
+  std::vector<std::string>::const_iterator randomVersionedKeyIter() {
+    auto max_read_offset = versioned_read_keys_.size() - config_.num_versioned_keys_to_read;
+    return versioned_read_keys_.begin() + (rand() % max_read_offset);
+  }
+
   std::atomic_bool stop_ = false;
 
   std::vector<std::thread> threads_;
 
   const PreExecConfig config_;
-  const ReadKeys& read_keys_;
+  const ReadKeys& merkle_read_keys_;
+  const ReadKeys& versioned_read_keys_;
 
   categorization::KeyValueBlockchain& kvbc_;
 };

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -41,9 +41,14 @@ struct ImmutableUpdates {
   ImmutableUpdates(ImmutableUpdates&& other) = default;
   ImmutableUpdates& operator=(ImmutableUpdates&& other) = default;
 
-  // Do not allow copy
+// Do not allow copy outside of benchmarks.
+#ifndef KVBCBENCH
   ImmutableUpdates(ImmutableUpdates& other) = delete;
-  ImmutableUpdates& operator=(ImmutableUpdates& other) = delete;
+  ImmutableUpdates& operator=(const ImmutableUpdates& other) = delete;
+#else
+  ImmutableUpdates(ImmutableUpdates& other) = default;
+  ImmutableUpdates& operator=(const ImmutableUpdates& other) = default;
+#endif
 
   struct ImmutableValue {
     ImmutableValue(std::string&& val, std::set<std::string>&& tags) {
@@ -86,9 +91,15 @@ struct VersionedUpdates {
   VersionedUpdates(VersionedUpdates&& other) = default;
   VersionedUpdates& operator=(VersionedUpdates&& other) = default;
 
-  // Do not allow copy
+  // Do not allow copy outside of benchmarks.
+#ifndef KVBCBENCH
   VersionedUpdates(const VersionedUpdates& other) = delete;
-  VersionedUpdates& operator=(VersionedUpdates& other) = delete;
+  VersionedUpdates& operator=(const VersionedUpdates& other) = delete;
+#else
+  VersionedUpdates(const VersionedUpdates& other) = default;
+  VersionedUpdates& operator=(const VersionedUpdates& other) = default;
+#endif
+
   struct Value {
     std::string data;
 


### PR DESCRIPTION
Realistic pre-execution workloads where contention check reads and block
writes are performed as fast as possible while pre-execution
reads take place in parallel are now possible.

Random keys and values for all 3 categories: `VersionedKeyValue`, `Immutable`,
and `BlockMerkle` are generated up front such that they can fill a
maximum number of blocks up to `max-memory-for-kv-gen` bytes. If more
blocks are created in a kvbcbench run than can be generated with the
configured memory usage, then the keys and values are reused as blocks
are being written. This is a tradeoff between entropy and memory usage.
If you want 3TB of completely random data in one run, you need 3TB of
RAM. To work around this, you can reuse the existing database and
execute a sequence of shorter runs. This will show impact of a large
database on disk, but the caches will not be the same as one long run,
and those prior keys will be "cold", although they will participate in
compactions and seeks.

The current default size of a transaction is ~20KB of total keys and
values. By default pre-execution reads 100 values in a multiget per transaction,
while contention checks in the hot path read 100 key versions per
transaction. The `batch-size` parameter writes multiple transactions
into a single batch. However, contention check reads are still performed
per request. Therefore in a batch of 10 transactions, 10 multiget
operations will be run for each of the `VersionedKeyValue` category and
`BlockMerkle` category. By default, 50 key versions are read for each
category in each of the simulated contention checks. To minimize the
time taken to choose which keys to read (which would happen outside the
kvbc code in a real system), we pick a random offset in the read key
vectors for each category then grab a consecutive block. We don't just
pick 50 random keys from anywhere in the vector as that would be
additional work not representative of a real storage workload.

Since data now has to be generated for 3 categories, the `InputData`
generation was refactored. To speed up input generation we want to use
all of our cores. Therefore a `parallelInputGen` function that computes a
subset of the random data on each core given a generator, and then
combines the output in a map-reduce fashion, was created. This is used
for all three categories. For the `VersionedKeyValue` and `BlockMerkle`
categories, ReadKeys are also created from a subset of the generated key
value pairs. These are written in parallell to disjoint parts of a
pre-allocated vector during the `parallelInputGen` run. However, in
order to properly do this we actually need a double closure that
properly closes over the pre-allocated `read_keys` vector in the outer
closure and returns a generator that can fill it during the map-reduce
run. This is the reason for the added complexity in
`makeBlockMerkleInputGenerator` and `makeVersionedInputGenerator` as
opposed to `makeImmutableUpdateGenerator` which doesn't have read keys,
as that category does not participate in pre-execution in our current
workloads. In the future, we may make it possible to also have immutable
keys read during pre-execution simulation, although it would make no
sense to do conflict checks on them, since they are immutable.

Due to the constraints on memory when trying to run long benchmarks, we
must be able to copy the generated input. However, to prevent expensive
mistakes in production code, the copy assignment and copy constructors
are deleted for `ImmutableUpdates` and `VersionedUpdates`. We get around
this by adding conditional compilation that allows them only when
building kvbcbench.

Lastly, this commit enables building kvbcbench by default and also
defaults the concord-bft build to Release mode. The rationale is to
always run the fastest code when testing locally. I'm open to reverting
this, but I don't see a good reason not to change it at this point.