### PR TITLE
Get rid of "mini" notion in ConcordClientBatch-related code

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -69,8 +69,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   CONFIG_PARAM(autoPrimaryRotationEnabled, bool, false, "if automatic primary rotation is enabled");
   CONFIG_PARAM(autoPrimaryRotationTimerMillisec, uint16_t, 0, "timeout for automatic primary rotation");
   CONFIG_PARAM(preExecutionFeatureEnabled, bool, false, "enables the pre-execution feature");
-  CONFIG_PARAM(clientMiniBatchingEnabled, bool, false, "enables the client-mini-batch feature");
-  CONFIG_PARAM(clientMiniBatchingMaxMsgsNbr, uint16_t, 10, "Maximum messages number in one mini-batch");
+  CONFIG_PARAM(clientBatchingEnabled, bool, false, "enables the concord-client-batch feature");
+  CONFIG_PARAM(clientBatchingMaxMsgsNbr, uint16_t, 10, "Maximum messages number in one client batch");
   CONFIG_PARAM(preExecReqStatusCheckTimerMillisec,
                uint64_t,
                5000,
@@ -165,8 +165,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, autoPrimaryRotationTimerMillisec);
 
     serialize(outStream, preExecutionFeatureEnabled);
-    serialize(outStream, clientMiniBatchingEnabled);
-    serialize(outStream, clientMiniBatchingMaxMsgsNbr);
+    serialize(outStream, clientBatchingEnabled);
+    serialize(outStream, clientBatchingMaxMsgsNbr);
     serialize(outStream, preExecReqStatusCheckTimerMillisec);
     serialize(outStream, preExecConcurrencyLevel);
     serialize(outStream, batchingPolicy);
@@ -214,8 +214,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, autoPrimaryRotationTimerMillisec);
 
     deserialize(inStream, preExecutionFeatureEnabled);
-    deserialize(inStream, clientMiniBatchingEnabled);
-    deserialize(inStream, clientMiniBatchingMaxMsgsNbr);
+    deserialize(inStream, clientBatchingEnabled);
+    deserialize(inStream, clientBatchingMaxMsgsNbr);
     deserialize(inStream, preExecReqStatusCheckTimerMillisec);
     deserialize(inStream, preExecConcurrencyLevel);
     deserialize(inStream, batchingPolicy);
@@ -296,7 +296,7 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.keyExchangeOnStart,
               rc.blockAccumulation);
   os << ", ";
-  os << KVLOG(rc.clientMiniBatchingEnabled, rc.clientMiniBatchingMaxMsgsNbr, rc.keyViewFilePath);
+  os << KVLOG(rc.clientBatchingEnabled, rc.clientBatchingMaxMsgsNbr, rc.keyViewFilePath);
 
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
 

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -25,9 +25,8 @@ ClientsManager::ClientsManager(std::set<NodeIdType>& clientsSet)
       sizeOfReservedPage_(ReplicaConfig::instance().getsizeOfReservedPage()),
       indexToClientInfo_(clientsSet.size()),
       maxReplySize_(ReplicaConfig::instance().getmaxReplyMessageSize()),
-      maxNumOfReqsPerClient_(ReplicaConfig::instance().clientMiniBatchingEnabled
-                                 ? ReplicaConfig::instance().clientMiniBatchingMaxMsgsNbr
-                                 : 1) {
+      maxNumOfReqsPerClient_(
+          ReplicaConfig::instance().clientBatchingEnabled ? ReplicaConfig::instance().clientBatchingMaxMsgsNbr : 1) {
   ConcordAssert(clientsSet.size() >= 1);
   scratchPage_ = (char*)std::malloc(sizeOfReservedPage_);
   memset(scratchPage_, 0, sizeOfReservedPage_);

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -85,8 +85,8 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       numOfReplicas_(myReplica.getReplicaConfig().numReplicas + myReplica.getReplicaConfig().numRoReplicas),
       numOfClients_(myReplica.getReplicaConfig().numOfExternalClients +
                     myReplica_.getReplicaConfig().numOfClientProxies),
-      clientBatchingEnabled_(myReplica.getReplicaConfig().clientMiniBatchingEnabled),
-      clientMaxBatchSize_(clientBatchingEnabled_ ? myReplica.getReplicaConfig().clientMiniBatchingMaxMsgsNbr : 1),
+      clientBatchingEnabled_(myReplica.getReplicaConfig().clientBatchingEnabled),
+      clientMaxBatchSize_(clientBatchingEnabled_ ? myReplica.getReplicaConfig().clientBatchingMaxMsgsNbr : 1),
       metricsComponent_{concordMetrics::Component("preProcessor", std::make_shared<concordMetrics::Aggregator>())},
       metricsLastDumpTime_(0),
       metricsDumpIntervalInSec_{myReplica_.getReplicaConfig().metricsDumpIntervalSeconds},
@@ -749,7 +749,7 @@ const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId,
   // |last client's first buffer|...|last client's last buffer|
   // First client id starts after the last replica id.
   // First buffer offset = numOfReplicas_ * batchSize_
-  // The number of buffers per client comes from the configuration parameter clientMiniBatchingMaxMsgsNbr.
+  // The number of buffers per client comes from the configuration parameter clientBatchingMaxMsgsNbr.
   const auto bufferOffset = (clientId - numOfReplicas_) * clientMaxBatchSize_ + reqOffsetInBatch;
   LOG_DEBUG(logger(), KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
   return preProcessResultBuffers_[bufferOffset].data();

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -280,7 +280,7 @@ void setUpConfiguration_4() {
   replicaConfig.viewChangeTimerMillisec = viewChangeTimerMillisec;
   replicaConfig.preExecReqStatusCheckTimerMillisec = preExecReqStatusCheckTimerMillisec;
   replicaConfig.numOfExternalClients = 5;
-  replicaConfig.clientMiniBatchingEnabled = true;
+  replicaConfig.clientBatchingEnabled = true;
 
   replicaConfig.publicKeysOfReplicas.insert(pair<uint16_t, const string>(replica_0, publicKey_0));
   replicaConfig.publicKeysOfReplicas.insert(pair<uint16_t, const string>(replica_1, publicKey_1));

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.viewChangeTimerMillisec = 45 * 1000;
     replicaConfig.statusReportTimerMillisec = 10 * 1000;
     replicaConfig.preExecutionFeatureEnabled = true;
-    replicaConfig.clientMiniBatchingEnabled = true;
+    replicaConfig.clientBatchingEnabled = true;
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
@@ -69,7 +69,6 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"consensus-batching-flush-period", required_argument, 0, 'z'},
                                           {"consensus-concurrency-level", required_argument, 0, 'y'},
                                           {0, 0, 0, 0}};
-
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");


### PR DESCRIPTION
Fix ConcordClientBatch TLD review comment.