### PR TITLE
Fix number of replicas count for ST

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -224,7 +224,7 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
       fetch_block_msg_latency_rec_(histograms_.fetch_blocks_msg_latency) {
   ConcordAssertNE(stateApi, nullptr);
   ConcordAssertGE(replicas_.size(), 3U * config_.fVal + 1U);
-  ConcordAssertEQ(replicas_.count(config_.myReplicaId), 1);
+  ConcordAssert(replicas_.count(config_.myReplicaId) == 1 || config.isReadOnly);
   ConcordAssertGE(config_.maxNumOfReservedPages, 2);
 
   // Register metrics component with the default aggregator.

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -192,7 +192,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
     replicaConfig_.replicaId,
     replicaConfig_.fVal,
     replicaConfig_.cVal,
-    (uint16_t)(replicaConfig_.numReplicas + replicaConfig_.numRoReplicas),
+    static_cast<uint16_t>(replicaConfig_.numReplicas),
     replicaConfig_.get("concord.bft.st.pedanticChecks", false),
     replicaConfig_.isReadOnly,
 


### PR DESCRIPTION
bftEngine::bcst::Config structure has a parameter numReplicas, which is
initialised with num replicas + num ro replicas.
This structure is used for State Transfer configuration so the value is
wrong - it should contain only the number of regular replicas.