### PR TITLE
Return when request marked committed

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -268,6 +268,7 @@ void ClientsManager::markRequestAsCommitted(NodeIdType clientId, ReqId reqSeqNum
   if (reqIt != requestsInfo.end()) {
     reqIt->second.committed = true;
     LOG_DEBUG(GL, "Marked committed" << KVLOG(clientId, reqSeqNum));
+    return;
   }
   LOG_DEBUG(GL, "Request not found" << KVLOG(clientId, reqSeqNum));
 }


### PR DESCRIPTION
An error log is printed when a request is marked committed.
This commit adds a return statement to avoid that.