### PR TITLE
Remove wrong deleted flag assert in Versioned cat

### DIFF
--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -19,6 +19,7 @@
 #include "base_types.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <optional>
@@ -46,9 +47,9 @@ class VersionedKeyValueCategory {
 
   VersionedOutput add(BlockId, VersionedInput &&, storage::rocksdb::NativeWriteBatch &);
 
-  std::vector<std::string> getBlockStaleKeys(BlockId, const VersionedOutput &) const;
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
+  // Return the number of deleted keys from the DB.
   std::size_t deleteGenesisBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
 
   // Delete the given block ID as a last reachable one.
@@ -86,6 +87,9 @@ class VersionedKeyValueCategory {
   // Get the value of `key` and a proof for it at `block_id`.
   // Return std::nullopt if the key doesn't exist.
   std::optional<KeyValueProof> getProof(BlockId block_id, const std::string &key, const VersionedOutput &) const;
+
+  // Get all stale keys as of `block_id`.
+  std::vector<std::string> getBlockStaleKeys(BlockId block_id, const VersionedOutput &) const;
 
  private:
   void addDeletes(BlockId, std::vector<std::string> &&keys, VersionedOutput &, storage::rocksdb::NativeWriteBatch &);

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -176,7 +176,6 @@ std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId bl
   for (const auto &[key, flags] : out.keys) {
     const auto latest = getLatestVersion(key);
     ConcordAssert(latest.has_value());
-    ConcordAssertEQ(latest->deleted, flags.deleted);
     ConcordAssertLE(block_id, latest->version);
 
     // Note: Deleted keys cannot be marked as stale on update.
@@ -187,10 +186,11 @@ std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId bl
   return stale_keys_;
 }
 
-size_t VersionedKeyValueCategory::deleteGenesisBlock(BlockId block_id,
-                                                     const VersionedOutput &out,
-                                                     storage::rocksdb::NativeWriteBatch &batch) {
-  size_t number_of_deletes{0};
+std::size_t VersionedKeyValueCategory::deleteGenesisBlock(BlockId block_id,
+                                                          const VersionedOutput &out,
+                                                          storage::rocksdb::NativeWriteBatch &batch) {
+  auto number_of_deletes = std::size_t{0};
+
   // Delete active keys from previously pruned genesis blocks.
   for (const auto &[block_id, keys] : activeKeysFromPrunedBlocks(out.keys)) {
     for (const auto &key : keys) {
@@ -203,7 +203,6 @@ size_t VersionedKeyValueCategory::deleteGenesisBlock(BlockId block_id,
   for (const auto &[key, flags] : out.keys) {
     const auto latest = getLatestVersion(key);
     ConcordAssert(latest.has_value());
-    ConcordAssertEQ(latest->deleted, flags.deleted);
 
     // Note: Deleted keys cannot be marked as stale on update.
     if (flags.stale_on_update) {


### PR DESCRIPTION
Remove a wrong assert in VersionedKeyValueCategory that was checking if
a key's deleted flag in the output is equal to the latest key version's
deleted flag. There might be valid cases that violate it.

Delete and then update:
 * delete key `K` in block N
 * update key `K` with a value in block N + 1
 * prune block N

Update and then delete:
 * update key `K` in block N
 * delete key `K` in block N + 1
 * prune block N

Add unit tests to cover above valid cases.