### PR TITLE
Add view number to relevant logs

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2266,7 +2266,7 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
 
   const bool wasInPrevViewNumber = viewsManager->viewIsActive(curView);
 
-  LOG_INFO(VC_LOG, KVLOG(curView, nextView, wasInPrevViewNumber));
+  LOG_INFO(VC_LOG, "Moving to higher view: " << KVLOG(curView, nextView, wasInPrevViewNumber));
 
   ViewChangeMsg *pVC = nullptr;
 
@@ -2570,6 +2570,7 @@ void ReplicaImp::sendCheckpointIfNeeded() {
 }
 
 void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
+  SCOPED_MDC_SEQ_NUM(std::to_string(getCurrentView()));
   TimeRecorder scoped_timer(*histograms_.onTransferringCompleteImp);
   time_in_state_transfer_.end();
   LOG_INFO(GL, KVLOG(newStateCheckpoint));

--- a/logging/include/Logging.hpp
+++ b/logging/include/Logging.hpp
@@ -120,5 +120,6 @@ class Logger {
 #define MDC_PUT(k, v) logging::Logger::getThreadContext().getMDC().put(k, v);
 #define MDC_REMOVE(k) logging::Logger::getThreadContext().getMDC().remove(k);
 #define MDC_CLEAR logging::Logger::getThreadContext().getMDC().clear();
+#define MDC_GET(k) logging::Logger::getThreadContext().getMDC().get(k)
 
 #define LOG_CONFIGURE_AND_WATCH(config_file, millis) logging::initLogger(config_file)

--- a/logging/include/Logging4cplus.hpp
+++ b/logging/include/Logging4cplus.hpp
@@ -23,6 +23,8 @@ namespace logging {
 
 typedef log4cplus::Logger Logger;
 
+std::string get(const std::string& key);
+
 }  // namespace logging
 
 #define LOG_TRACE(l, s) LOG4CPLUS_TRACE(l, s)
@@ -35,6 +37,7 @@ typedef log4cplus::Logger Logger;
 #define MDC_PUT(k, v) log4cplus::getMDC().put(k, v)
 #define MDC_REMOVE(k) log4cplus::getMDC().remove(k)
 #define MDC_CLEAR log4cplus::getMDC().clear()
+#define MDC_GET(k) logging::get(k)
 
 #define LOG_CONFIGURE_AND_WATCH(config_file, millis) \
   log4cplus::ConfigureAndWatchThread configureThread(config_file, millis)

--- a/logging/src/Logging4cplus.cpp
+++ b/logging/src/Logging4cplus.cpp
@@ -55,4 +55,10 @@ Logger getLogger(const std::string& name) {
   return log4cplus::Logger::getInstance(name);
 }
 
+std::string get(const std::string& key) {
+  std::string result;
+  log4cplus::getMDC().get(&result, key);
+  return result;
+}
+
 }  // namespace logging


### PR DESCRIPTION
The view number will ease automated log analysis.

The view number is written in the field for seqNum so we need to restore the old value after logging where applicable.
That is why I have added a new get function for MDC.