### PR TITLE
kvbcbench: Periodically dump rocksdb stats

### DIFF
--- a/storage/include/rocksdb/native_client.h
+++ b/storage/include/rocksdb/native_client.h
@@ -73,6 +73,9 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
   // Use this native client through the IDBClient interface.
   std::shared_ptr<IDBClient> asIDBClient() const;
 
+  // Return a reference to the underlying db.
+  ::rocksdb::DB &rawDB() const;
+
   // Column family single key read-write interface.
   template <typename KeySpan, typename ValueSpan>
   void put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value);
@@ -157,6 +160,9 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
   // aware of it.
   void dropColumnFamily(const std::string &cFamily);
 
+  ::rocksdb::ColumnFamilyHandle *defaultColumnFamilyHandle() const;
+  ::rocksdb::ColumnFamilyHandle *columnFamilyHandle(const std::string &cFamily) const;
+
  private:
   NativeClient(const std::string &path, bool readOnly, const DefaultOptions &);
   NativeClient(const std::string &path, bool readOnly, const ExistingOptions &);
@@ -167,8 +173,6 @@ class NativeClient : public std::enable_shared_from_this<NativeClient> {
   NativeClient &operator=(const NativeClient &) = delete;
   NativeClient &operator=(NativeClient &&) = delete;
 
-  ::rocksdb::ColumnFamilyHandle *defaultColumnFamilyHandle() const;
-  ::rocksdb::ColumnFamilyHandle *columnFamilyHandle(const std::string &cFamily) const;
   Client::CfUniquePtr createColumnFamilyHandle(const std::string &cFamily,
                                                const ::rocksdb::ColumnFamilyOptions &options);
 

--- a/storage/include/rocksdb/native_client.ipp
+++ b/storage/include/rocksdb/native_client.ipp
@@ -78,6 +78,8 @@ inline NativeClient::NativeClient(const std::shared_ptr<Client> &client) : clien
 
 inline std::shared_ptr<IDBClient> NativeClient::asIDBClient() const { return client_; }
 
+inline ::rocksdb::DB &NativeClient::rawDB() const { return *client_->dbInstance_; }
+
 template <typename KeySpan, typename ValueSpan>
 void NativeClient::put(const std::string &cFamily, const KeySpan &key, const ValueSpan &value) {
   auto s = client_->dbInstance_->Put(


### PR DESCRIPTION
Every configurable number of blocks write rocksdb stats to output. This
helps us to debug memory usage and tune the system appropriately,
especially during long running tests. It enables us to better see where
degradation is occurring.

This change requires exposing the underlying rocksdb client itself
through the NativeClient wrapper with the `rawDB` method. The
justification for exposing the underlying rocksdb client is so that we
don't have to wrap every single thing when we want to access stats or
configuration. The interfaces for these things are fine without
wrapping, and are only expected to be used for diagnostics. Future
commits should make these available through the diagnostics subsystem in
concord-bft and concord-ctl in addition to dumping all stats in
kvbcbench.

The default RocksDB block cache size for kvbcbench was increased to 16GB
and made configurable.

OptimizeForPointLookup was removed from the
BLOCK_MERKLE_LATEST_KEY_VERSION_CF column family, as it was suspected of
uncontrollable memory growth, and didn't appear to help performance. A
future change to both the BlockMerkle and VersionedKeyValue categories
is planned for an application specific LRU cache for versions to avoid
the need to hit RocksDB for this data in the common case.