### PR TITLE
Add support for encrypted private keys on TLS comm

### DIFF
--- a/communication/CMakeLists.txt
+++ b/communication/CMakeLists.txt
@@ -24,6 +24,13 @@ target_link_libraries(bftcommunication PUBLIC util)
 target_include_directories(bftcommunication_shared PUBLIC include)
 target_link_libraries(bftcommunication_shared PUBLIC util_shared)
 
+target_include_directories(bftcommunication PUBLIC ../secretsmanager/include)
+target_include_directories(bftcommunication_shared PUBLIC ../secretsmanager/include)
+if(${BUILD_COMM_TCP_TLS})
+    target_link_libraries(bftcommunication PUBLIC secretsmanager)
+    target_link_libraries(bftcommunication_shared PUBLIC secretsmanager_shared)
+endif()
+
 if(${BUILD_COMM_TCP_PLAIN} OR ${BUILD_COMM_TCP_TLS})
     set(Boost_USE_STATIC_LIBS OFF) # find all kind of libs
     set(Boost_USE_MULTITHREADED ON)

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -24,6 +24,7 @@
 
 #include "communication/ICommunication.hpp"
 #include "communication/StatusInfo.h"
+#include "secret_data.h"
 
 namespace bft::communication {
 typedef struct sockaddr_in Addr;
@@ -108,6 +109,8 @@ struct TlsTcpConfig : PlainTcpConfig {
   // https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
   std::string cipherSuite;
 
+  std::optional<concord::secretsmanager::SecretData> secretData;
+
   TlsTcpConfig(std::string host,
                uint16_t port,
                uint32_t bufLength,
@@ -116,11 +119,13 @@ struct TlsTcpConfig : PlainTcpConfig {
                NodeNum _selfId,
                std::string certRootPath,
                std::string ciphSuite,
-               UPDATE_CONNECTIVITY_FN _statusCallback = nullptr)
+               UPDATE_CONNECTIVITY_FN _statusCallback = nullptr,
+               std::optional<concord::secretsmanager::SecretData> decryptionSecretData = std::nullopt)
       : PlainTcpConfig(
             move(host), port, bufLength, std::move(_nodes), _maxServerId, _selfId, std::move(_statusCallback)),
         certificatesRootPath{std::move(certRootPath)},
-        cipherSuite{std::move(ciphSuite)} {
+        cipherSuite{std::move(ciphSuite)},
+        secretData{std::move(decryptionSecretData)} {
     commType = CommType::TlsTcp;
   }
 };

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -20,6 +20,7 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/filesystem.hpp>
 
 #include "Logger.hpp"
 #include "communication/CommDefs.hpp"
@@ -146,6 +147,8 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                             std::string connectionType,
                                             const std::string& subject,
                                             std::optional<NodeNum> expected_peer_id);
+
+  const std::string decryptPK(const boost::filesystem::path& path);
 
   logging::Logger logger_;
   boost::asio::io_service& io_service_;

--- a/scripts/linux/create_tls_certs.sh
+++ b/scripts/linux/create_tls_certs.sh
@@ -48,6 +48,14 @@ while [ $i -le $last_node_id ]; do
    openssl req -new -key $clientDir/pk.pem -nodes -days 365 -x509 \
         -subj "/C=NA/ST=NA/L=NA/O=NA/OU=${i}/CN=node${i}cli" -out $clientDir/client.cert
 
+   openssl enc -base64 -aes-256-cbc -e -in $serverDir/pk.pem -md sha256 -pass pass:XaQZrOYEQw \
+         -p -out $serverDir/pk.pem.enc 2>/dev/null
+   openssl enc -base64 -aes-256-cbc -e -in $clientDir/pk.pem -md sha256 -pass pass:XaQZrOYEQw \
+         -p -out $clientDir/pk.pem.enc 2>/dev/null
+
+   # rm $serverDir/pk.pem
+   # rm $clientDir/pk.pem
+
    (( i=i+1 ))
 done
 

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -181,6 +181,13 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
   std::unordered_map<NodeNum, NodeInfo> nodes =
       SetUpNodes(is_replica, id, ip, port, num_of_clients, num_of_replicas, config_file_name);
 
+  // private key decryption configuration for tests
+  concord::secretsmanager::SecretData secretData;
+  secretData.algo = "AES/CBC/PKCS5Padding";
+  secretData.digest = "SHA-256";
+  secretData.key_length = 256;
+  secretData.password = "XaQZrOYEQw";
+
   // need to move the default cipher suite to the config file
   TlsTcpConfig retVal(default_listen_ip_,
                       port,
@@ -189,6 +196,8 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
                       num_of_replicas - 1,
                       id,
                       cert_root_path,
-                      "ECDHE-ECDSA-AES256-GCM-SHA384");
+                      "ECDHE-ECDSA-AES256-GCM-SHA384",
+                      nullptr,
+                      secretData);
   return retVal;
 }


### PR DESCRIPTION
The tester replica will now decrypt it's private keys used for TLS communication.