### PR TITLE
Fix reconfiguration bug (master)

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -195,7 +195,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
     return;
   }
 
-  if (isSeqNumToStopAt(lastExecutedSeqNum)) {
+  if ((isCurrentPrimary() && isSeqNumToStopAt(primaryLastUsedSeqNum + 1)) || isSeqNumToStopAt(lastExecutedSeqNum + 1)) {
     LOG_INFO(GL,
              "Ignoring ClientRequest because system is stopped at checkpoint pending control state operation (upgrade, "
              "etc...)");
@@ -286,7 +286,7 @@ bool ReplicaImp::checkSendPrePrepareMsgPrerequisites() {
     return false;
   }
 
-  if (isSeqNumToStopAt(lastExecutedSeqNum)) {
+  if (isSeqNumToStopAt(primaryLastUsedSeqNum + 1)) {
     LOG_INFO(GL,
              "Not sending PrePrepareMsg because system is stopped at checkpoint pending control state operation "
              "(upgrade, etc...)");
@@ -545,22 +545,19 @@ void ReplicaImp::sendInternalNoopPrePrepareMsg(CommitPath firstPath) {
 }
 
 void ReplicaImp::bringTheSystemToCheckpointBySendingNoopCommands(SeqNum seqNumToStopAt, CommitPath firstPath) {
-  if (!isCurrentPrimary()) return;
-  while (primaryLastUsedSeqNum != seqNumToStopAt) {
+  if (!isCurrentPrimary() || seqNumToStopAt <= primaryLastUsedSeqNum) return;
+  LOG_INFO(GL, "Sending noops for [" << primaryLastUsedSeqNum + 1 << " --> " << seqNumToStopAt << " ]");
+  while (primaryLastUsedSeqNum < seqNumToStopAt) {
     sendInternalNoopPrePrepareMsg(firstPath);
   }
 }
 
 bool ReplicaImp::isSeqNumToStopAt(SeqNum seq_num) {
   if (ControlStateManager::instance().getPruningProcessStatus()) return true;
-  if (seqNumToStopAt_ > 0 && seq_num == seqNumToStopAt_) return true;
-  if (seqNumToStopAt_ > 0 && seq_num > seqNumToStopAt_) return false;
   auto seq_num_to_stop_at = ControlStateManager::instance().getCheckpointToStopAt();
   if (seq_num_to_stop_at.has_value()) {
-    seqNumToStopAt_ = seq_num_to_stop_at.value();
-    if (seqNumToStopAt_ == seq_num) return true;
+    if (seq_num_to_stop_at < seq_num) return true;
   }
-
   return false;
 }
 template <typename T>
@@ -617,7 +614,7 @@ bool ReplicaImp::relevantMsgForActiveView(const T *msg) {
 
 template <>
 void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
-  if (isSeqNumToStopAt(lastExecutedSeqNum)) {
+  if (isSeqNumToStopAt(msg->seqNumber())) {
     LOG_INFO(GL,
              "Ignoring PrePrepareMsg because system is stopped at checkpoint pending control state operation (upgrade, "
              "etc...)");
@@ -2800,6 +2797,13 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
       stateTransfer->setEraseMetadataFlag();
     }
   }
+
+  // If we want to wedge the system and we got to a stable checkpoint we need to check if we need to send more noops in
+  // order to bring the system to the wedge point
+  if (isCurrentPrimary() && seq_num_to_stop_at.has_value() && seq_num_to_stop_at.value() > newStableSeqNum &&
+      primaryLastUsedSeqNum < seq_num_to_stop_at.value()) {
+    bringTheSystemToCheckpointBySendingNoopCommands(seq_num_to_stop_at.value());
+  }
 }
 
 void ReplicaImp::tryToSendReqMissingDataMsg(SeqNum seqNumber, bool slowPathOnly, uint16_t destReplicaId) {
@@ -4115,7 +4119,9 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
   if (ControlStateManager::instance().getCheckpointToStopAt().has_value()) {
     // If, following the last execution, we discover that we need to jump to the
     // next checkpoint, the primary sends noop commands until filling the working window.
-    bringTheSystemToCheckpointBySendingNoopCommands(ControlStateManager::instance().getCheckpointToStopAt().value());
+    auto checkpointToStopAt = ControlStateManager::instance().getCheckpointToStopAt().value();
+    auto next_checkpoint = checkpointToStopAt - checkpointWindowSize;
+    bringTheSystemToCheckpointBySendingNoopCommands(next_checkpoint);
   }
   if (ControlStateManager::instance().getCheckpointToStopAt().has_value() &&
       lastExecutedSeqNum == ControlStateManager::instance().getCheckpointToStopAt()) {

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -167,8 +167,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   bool recoveringFromExecutionOfRequests = false;
   Bitmap mapOfRequestsThatAreBeingRecovered;
 
-  SeqNum seqNumToStopAt_ = 0;
-
   ReplicasAskedToLeaveViewInfo complainedReplicas;
 
   shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -42,7 +42,9 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties")]
+            "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties"),
+            "-b", "2",
+            "-q", "1"]
 
 
 class SkvbcReconfigurationTest(unittest.TestCase):
@@ -159,17 +161,9 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         client = bft_network.random_client()
 
         # bring the system to sequence number 299
-        not_reached = True
-        while not_reached:
+        for i in range(299):
             await skvbc.write_known_kv()
-            with trio.fail_after(seconds=0.5):
-                for r in bft_network.all_replicas():
-                    lastExecSeqNum = await bft_network.get_metric(r, bft_network, "Gauges", "lastExecutedSeqNum")
-                    # If we have one replica that reached to 299 it is safe to break. The next sequence number will be 300
-                    if lastExecSeqNum == 299:
-                        not_reached = False
-                        break
-
+            
         # verify that all nodes are in sequence number 299
         not_reached = True
         with trio.fail_after(seconds=30):

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -171,7 +171,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 not_reached = False
                 for r in bft_network.all_replicas():
                     lastExecSeqNum = await bft_network.get_metric(r, bft_network, "Gauges", "lastExecutedSeqNum")
-                    if lastExecSeqNum != lastExecSeqNum:
+                    if lastExecSeqNum != 299:
                         not_reached = True
                         break
 

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -47,8 +47,6 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcReconfigurationTest(unittest.TestCase):
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command(self, bft_network):
@@ -69,7 +67,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         await client.write(skvbc.write_req([], [], block_id=0, wedge_command=True))
 
         await self.verify_replicas_are_in_wedged_checkpoint(bft_network, checkpoint_before, range(bft_network.config.n))
-
+        await self.verify_last_executed_seq_num(bft_network, checkpoint_before)
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
 
     @with_trio
@@ -145,6 +143,65 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                         done = False
                         break
 
+        await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    async def test_wedge_command_where_noops_should_be_sent_in_two_parts(self, bft_network):
+        """
+            Sends a wedge command on sequence number 300 and check that the system stops from processing new requests.
+            this way, when the primary tries to sent noop commands, the working window is reach only to 450.
+            Thus, it has to wait for a new stable checkpoint before sending the last 150 noops
+            Note: In this test we assume that the batch duration is no
+         """
+        bft_network.start_all_replicas()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        client = bft_network.random_client()
+
+        # bring the system to sequence number 299
+        not_reached = True
+        while not_reached:
+            await skvbc.write_known_kv()
+            with trio.fail_after(seconds=0.5):
+                for r in bft_network.all_replicas():
+                    lastExecSeqNum = await bft_network.get_metric(r, bft_network, "Gauges", "lastExecutedSeqNum")
+                    # If we have one replica that reached to 299 it is safe to break. The next sequence number will be 300
+                    if lastExecSeqNum == 299:
+                        not_reached = False
+                        break
+
+        # verify that all nodes are in sequence number 299
+        not_reached = True
+        with trio.fail_after(seconds=30):
+            while not_reached:
+                not_reached = False
+                for r in bft_network.all_replicas():
+                    lastExecSeqNum = await bft_network.get_metric(r, bft_network, "Gauges", "lastExecutedSeqNum")
+                    if lastExecSeqNum != lastExecSeqNum:
+                        not_reached = True
+                        break
+
+        # now, send a wedge command. The wedge command sequence number is 300. Hence, in this point the woeking window
+        # is between 150 - 450. But, the wedge command will make the primary to send noops until 600.
+        # we want to verify that the primary manages to send the noops as required.
+        await client.write(skvbc.write_req([], [], block_id=0, wedge_command=True))
+
+        # now, verify that the system has managed to stop
+        with trio.fail_after(seconds=90):
+            done = False
+            while done is False:
+                msg = skvbc.get_have_you_stopped_req(n_of_n=1)
+                rep = await client.read(msg, m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
+                    bft_network.config.n)]))
+                rsi_rep = client.get_rsi_replies()
+                done = True
+                for r in rsi_rep.values():
+                    if skvbc.parse_rsi_reply(rep, r) == 0:
+                        done = False
+                        break
+
+        await self.verify_replicas_are_in_wedged_checkpoint(bft_network, 2, range(bft_network.config.n))
+        await self.verify_last_executed_seq_num(bft_network, 2)
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
 
     @unittest.skip("manual testcase - not part of CI")
@@ -383,6 +440,12 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                                     break
                                 else:
                                     await trio.sleep(1)
+
+    async def verify_last_executed_seq_num(self, bft_network, previous_checkpoint):
+        expectedSeqNum = (previous_checkpoint  + 2) * 150
+        for r in bft_network.all_replicas():
+            lastExecSn = await bft_network.get_metric(r, bft_network, "Gauges", "lastExecutedSeqNum")
+            self.assertEqual(expectedSeqNum, lastExecSn)
 
 
     async def validate_state_consistency(self, skvbc, key, val):


### PR DESCRIPTION
In this PR we fix a reconfiguration bug:
Once we decide to wedge, we fill the working window with noop commands in order to get to the next-next checkpoint.
However, considering the following case:
1. The wedge command received close to checkpoint (say on 300)
2. The current latestStableCheckpoint is still 150
3.  Thus, the working window is from 0 to 300
4. But we need to send noops until 600(!)
5. The master failed to send noop and eventually, VC is happening

The fix is that once we execute the wedge command we send noops up to the near checkpoint, and once we get to a stable checkpoint, we send the rest of the noops.
Notice that now, it is possible to process some client request before we completely wedge