### PR TITLE
Move request handler from ReplicaImp to ReplicaBase as in the future …

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -85,6 +85,7 @@ class IRequestsHandler {
     int outExecutionStatus = 1;
   };
 
+  static std::shared_ptr<IRequestsHandler> createRequestsHandler(IRequestsHandler *userReqHandler);
   typedef std::deque<ExecutionRequest> ExecutionRequestsQueue;
 
   virtual void execute(ExecutionRequestsQueue &requests,
@@ -100,7 +101,9 @@ class IRequestsHandler {
     reconfig_handler_ = rh;
   }
   std::shared_ptr<concord::reconfiguration::IPruningHandler> getPruningHandler() const { return pruning_handler_; }
-  void setPruningHandler(std::shared_ptr<concord::reconfiguration::IPruningHandler> ph) { pruning_handler_ = ph; }
+  virtual void setPruningHandler(std::shared_ptr<concord::reconfiguration::IPruningHandler> ph) {
+    pruning_handler_ = ph;
+  }
   virtual ~IRequestsHandler() = default;
 
  protected:
@@ -112,21 +115,24 @@ class IReplica {
  public:
   using IReplicaPtr = std::unique_ptr<IReplica>;
   static IReplicaPtr createNewReplica(const ReplicaConfig &,
-                                      IRequestsHandler *,
+                                      std::shared_ptr<IRequestsHandler>,
                                       IStateTransfer *,
                                       bft::communication::ICommunication *,
                                       MetadataStorage *,
                                       std::shared_ptr<concord::performance::PerformanceManager> sdm =
                                           std::make_shared<concord::performance::PerformanceManager>());
   static IReplicaPtr createNewReplica(const ReplicaConfig &,
-                                      IRequestsHandler *,
+                                      std::shared_ptr<IRequestsHandler>,
                                       IStateTransfer *,
                                       bft::communication::ICommunication *,
                                       MetadataStorage *,
                                       bool &erasedMetadata,
                                       std::shared_ptr<concord::performance::PerformanceManager> sdm);
 
-  static IReplicaPtr createNewRoReplica(const ReplicaConfig &, IStateTransfer *, bft::communication::ICommunication *);
+  static IReplicaPtr createNewRoReplica(const ReplicaConfig &,
+                                        std::shared_ptr<IRequestsHandler>,
+                                        IStateTransfer *,
+                                        bft::communication::ICommunication *);
 
   virtual ~IReplica() = default;
 
@@ -139,7 +145,7 @@ class IReplica {
   virtual void stop() = 0;
 
   // TODO(GG) : move the following methods to an "advanced interface"
-  virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator> a) = 0;
+  virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator>) = 0;
   virtual void restartForDebug(uint32_t delayMillis) = 0;  // for debug only.
 };
 

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -21,7 +21,7 @@
 #include "MsgsCommunicator.hpp"
 #include "PreProcessor.hpp"
 #include "MsgReceiver.hpp"
-
+#include "RequestHandler.h"
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -112,7 +112,7 @@ void ReplicaInternal::restartForDebug(uint32_t delayMillis) {
 namespace bftEngine {
 
 IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaConfig,
-                                                 IRequestsHandler *requestsHandler,
+                                                 shared_ptr<IRequestsHandler> requestsHandler,
                                                  IStateTransfer *stateTransfer,
                                                  bft::communication::ICommunication *communication,
                                                  MetadataStorage *metadataStorage,
@@ -195,7 +195,7 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
 }
 
 IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaConfig,
-                                                 IRequestsHandler *requestsHandler,
+                                                 std::shared_ptr<IRequestsHandler> requestsHandler,
                                                  IStateTransfer *stateTransfer,
                                                  bft::communication::ICommunication *communication,
                                                  MetadataStorage *metadataStorage,
@@ -204,6 +204,7 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
   return createNewReplica(replicaConfig, requestsHandler, stateTransfer, communication, metadataStorage, dummy, pm);
 }
 IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaConfig,
+                                                   std::shared_ptr<IRequestsHandler> requestsHandler,
                                                    IStateTransfer *stateTransfer,
                                                    bft::communication::ICommunication *communication) {
   {
@@ -223,9 +224,15 @@ IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaC
   auto msgReceiver = std::make_shared<MsgReceiver>(incomingMsgsStorage);
   auto msgsCommunicator = std::make_shared<MsgsCommunicator>(communication, incomingMsgsStorage, msgReceiver);
 
-  replicaInternal->replica_ =
-      std::make_unique<ReadOnlyReplica>(replicaConfig, stateTransfer, msgsCommunicator, msgHandlers, timers);
+  replicaInternal->replica_ = std::make_unique<ReadOnlyReplica>(
+      replicaConfig, requestsHandler, stateTransfer, msgsCommunicator, msgHandlers, timers);
   return replicaInternal;
+}
+
+std::shared_ptr<IRequestsHandler> IRequestsHandler::createRequestsHandler(IRequestsHandler *userReqHandler) {
+  auto reqHandler = new bftEngine::RequestHandler();
+  reqHandler->setUserRequestHandler(userReqHandler);
+  return std::shared_ptr<IRequestsHandler>(reqHandler);
 }
 
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -26,11 +26,12 @@ using concordUtil::Timers;
 namespace bftEngine::impl {
 
 ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
+                                 std::shared_ptr<IRequestsHandler> requestsHandler,
                                  IStateTransfer *stateTransfer,
                                  std::shared_ptr<MsgsCommunicator> msgComm,
                                  std::shared_ptr<MsgHandlersRegistrator> msgHandlerReg,
                                  concordUtil::Timers &timers)
-    : ReplicaForStateTransfer(config, stateTransfer, msgComm, msgHandlerReg, true, timers),
+    : ReplicaForStateTransfer(config, requestsHandler, stateTransfer, msgComm, msgHandlerReg, true, timers),
       ro_metrics_{metrics_.RegisterCounter("receivedCheckpointMsgs"),
                   metrics_.RegisterCounter("sentAskForCheckpointMsgs"),
                   metrics_.RegisterCounter("receivedInvalidMsgs"),

--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -23,6 +23,7 @@ class PersistentStorage;
 class ReadOnlyReplica : public ReplicaForStateTransfer {
  public:
   ReadOnlyReplica(const ReplicaConfig&,
+                  std::shared_ptr<IRequestsHandler>,
                   IStateTransfer*,
                   std::shared_ptr<MsgsCommunicator>,
                   std::shared_ptr<MsgHandlersRegistrator>,

--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -21,12 +21,14 @@ namespace bftEngine::impl {
 using namespace std::chrono_literals;
 
 ReplicaBase::ReplicaBase(const ReplicaConfig& config,
+                         std::shared_ptr<IRequestsHandler> requestsHandler,
                          std::shared_ptr<MsgsCommunicator> msgComm,
                          std::shared_ptr<MsgHandlersRegistrator> msgHandlerReg,
                          concordUtil::Timers& timers)
     : config_(config),
       msgsCommunicator_(msgComm),
       msgHandlers_(msgHandlerReg),
+      bftRequestsHandler_{requestsHandler},
       last_metrics_dump_time_(0),
       metrics_dump_interval_in_sec_(config_.metricsDumpIntervalSeconds),
       metrics_{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())},

--- a/bftengine/src/bftengine/ReplicaBase.hpp
+++ b/bftengine/src/bftengine/ReplicaBase.hpp
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <memory>
-
+#include "Replica.hpp"
 #include "PrimitiveTypes.hpp"
 #include "ReplicaConfig.hpp"
 #include "SeqNumInfo.hpp"
@@ -42,6 +42,7 @@ class ReplicaBase {
 
  public:
   ReplicaBase(const ReplicaConfig&,
+              std::shared_ptr<IRequestsHandler>,
               std::shared_ptr<MsgsCommunicator>,
               std::shared_ptr<MsgHandlersRegistrator>,
               concordUtil::Timers& timers);
@@ -61,6 +62,7 @@ class ReplicaBase {
   }
 
   std::shared_ptr<concordMetrics::Aggregator> getAggregator() const { return aggregator_; }
+  std::shared_ptr<IRequestsHandler> getRequestsHandler() { return bftRequestsHandler_; }
 
   virtual void start();
   virtual void stop();
@@ -102,6 +104,7 @@ class ReplicaBase {
   ReplicasInfo* repsInfo = nullptr;
   std::shared_ptr<MsgsCommunicator> msgsCommunicator_;
   std::shared_ptr<MsgHandlersRegistrator> msgHandlers_;
+  std::shared_ptr<IRequestsHandler> bftRequestsHandler_;
 
   // last SeqNum executed  by this replica (or its affect was transferred to this replica)
   SeqNum lastExecutedSeqNum = 0;

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -24,12 +24,13 @@ namespace bftEngine::impl {
 using namespace std::chrono_literals;
 
 ReplicaForStateTransfer::ReplicaForStateTransfer(const ReplicaConfig &config,
+                                                 std::shared_ptr<IRequestsHandler> requestsHandler,
                                                  IStateTransfer *stateTransfer,
                                                  std::shared_ptr<MsgsCommunicator> msgComm,
                                                  std::shared_ptr<MsgHandlersRegistrator> msgHandlerReg,
                                                  bool firstTime,
                                                  concordUtil::Timers &timers)
-    : ReplicaBase(config, msgComm, msgHandlerReg, timers),
+    : ReplicaBase(config, requestsHandler, msgComm, msgHandlerReg, timers),
       stateTransfer{(stateTransfer != nullptr ? stateTransfer : new NullStateTransfer())},
       metric_received_state_transfers_{metrics_.RegisterCounter("receivedStateTransferMsgs")},
       metric_state_transfer_timer_{metrics_.RegisterGauge("replicaForStateTransferTimer", 0)},

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -22,6 +22,7 @@ namespace bftEngine::impl {
 class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaBase {
  public:
   ReplicaForStateTransfer(const ReplicaConfig&,
+                          std::shared_ptr<IRequestsHandler>,
                           IStateTransfer*,
                           std::shared_ptr<MsgsCommunicator>,
                           std::shared_ptr<MsgHandlersRegistrator>,

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <string>
-#include "Replica.hpp"
 #include "ReplicaForStateTransfer.hpp"
 #include "CollectorOfThresholdSignatures.hpp"
 #include "SeqNumInfo.hpp"
@@ -133,8 +132,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // buffer used to store replies
   char* replyBuffer = nullptr;
 
-  RequestHandler bftRequestsHandler_;
-
   // used to dynamically estimate a upper bound for consensus rounds
   DynamicUpperLimitWithSimpleFilter<int64_t>* dynamicUpperLimitOfRounds = nullptr;
 
@@ -237,7 +234,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   //*****************************************************
  public:
   ReplicaImp(const ReplicaConfig&,
-             IRequestsHandler* requestsHandler,
+             shared_ptr<IRequestsHandler>,
              IStateTransfer* stateTransfer,
              shared_ptr<MsgsCommunicator> msgsCommunicator,
              shared_ptr<PersistentStorage> persistentStorage,
@@ -246,7 +243,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
              shared_ptr<concord::performance::PerformanceManager>& pm);
 
   ReplicaImp(const LoadedReplicaData&,
-             IRequestsHandler* requestsHandler,
+             shared_ptr<IRequestsHandler>,
              IStateTransfer* stateTransfer,
              shared_ptr<MsgsCommunicator> msgsCommunicator,
              shared_ptr<PersistentStorage> persistentStorage,
@@ -262,7 +259,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   virtual bool isReadOnly() const override { return false; }
 
   shared_ptr<PersistentStorage> getPersistentStorage() const { return ps_; }
-  IRequestsHandler* getRequestsHandler() { return &bftRequestsHandler_; }
 
   void recoverRequests();
 
@@ -292,7 +288,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
  protected:
   ReplicaImp(bool firstTime,
              const ReplicaConfig&,
-             IRequestsHandler*,
+             shared_ptr<IRequestsHandler>,
              IStateTransfer*,
              SigManager*,
              ReplicasInfo*,

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -23,7 +23,7 @@ namespace concord::reconfiguration {
 // All handled messages are defined in the IReconfigurationHandler interface.
 class Dispatcher {
  public:
-  Dispatcher(std::shared_ptr<IReconfigurationHandler> handler) { addReconfigurationHandler(handler); }
+  Dispatcher(std::shared_ptr<IReconfigurationHandler> rh) { addReconfigurationHandler(rh); }
 
   // This method is the gate for all reconfiguration actions. It works as
   // follows:
@@ -39,10 +39,10 @@ class Dispatcher {
                                                       uint64_t sequence_num);
 
   void addReconfigurationHandler(std::shared_ptr<IReconfigurationHandler> h) {
-    if (h != nullptr) reconfig_handlers_.push_back(h);
+    if (h) reconfig_handlers_.push_back(h);
   }
   void addPruningHandler(std::shared_ptr<IPruningHandler> h) {
-    if (h != nullptr) pruning_handlers_.push_back(h);
+    if (h) pruning_handlers_.push_back(h);
   }
 
  private:

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -157,7 +157,8 @@ class SimpleTestReplica {
                     bftEngine::SimpleInMemoryStateTransfer::ISimpleInMemoryStateTransfer *inMemoryST,
                     MetadataStorage *metaDataStorage)
       : comm{commObject}, replicaConfig{rc}, behaviorPtr{behvPtr}, statePtr(state), inMemoryST_(inMemoryST) {
-    replica = IReplica::createNewReplica(rc, state, inMemoryST, comm, metaDataStorage);
+    replica = IReplica::createNewReplica(
+        rc, std::shared_ptr<bftEngine::IRequestsHandler>(state), inMemoryST, comm, metaDataStorage);
   }
 
   ~SimpleTestReplica() {


### PR DESCRIPTION
…ROReplica would receive reconfiguration requests as well.

Move PruningHandler to kvbc.
Update RequestHandler/reconfiguration::Dispatcher/PruningHandler/ReconfigurationHandler initalization sequence.