### PR TITLE
Fix an issue when using nested scopedMDC

### DIFF
--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -48,6 +48,7 @@ class ScopedMdc {
 
  private:
   const std::string key_;
+  const std::string last_value_;
 };
 
 }  // namespace logging

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -16,8 +16,15 @@
 
 namespace logging {
 
-ScopedMdc::ScopedMdc(const std::string& key, const std::string& val) : key_{key} { MDC_PUT(key, val); }
-ScopedMdc::~ScopedMdc() { MDC_REMOVE(key_); }
+ScopedMdc::ScopedMdc(const std::string& key, const std::string& val) : key_{key}, last_value_(MDC_GET(key)) {
+  MDC_PUT(key, val);
+}
+ScopedMdc::~ScopedMdc() {
+  MDC_REMOVE(key_);
+  if (!last_value_.empty()) {
+    MDC_PUT(key_, last_value_);
+  }
+}
 
 }  // namespace logging
 


### PR DESCRIPTION
ScopedMDC is a RAII class that removes the value associated with its key from the MDC map when it goes out of scope.
But if we have nested ScopedMDC objects on the same key, the inner one overwrites the outer. 
When the inner object is destroyed, it deletes the value from the MDC map instead of restoring the one from the outer scope.
This leads to a loss of information inside the logs.

The fix is to store the previous value inside the ScopedMDC object and restore it on destruction.