### PR TITLE
Add consensus metrics v0.10

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -191,9 +191,14 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   GaugeHandle metric_sent_replica_asks_to_leave_view_msg_;
   GaugeHandle metric_bft_batch_size_;
   GaugeHandle my_id;
+  GaugeHandle primary_queue_size_;
+  GaugeHandle consensus_avg_time_;
+  GaugeHandle accumulating_batch_avg_time_;
   // The first commit path being attempted for a new request.
   StatusHandle metric_first_commit_path_;
 
+  CounterHandle batch_closed_on_logic_off_;
+  CounterHandle batch_closed_on_logic_on_;
   CounterHandle metric_indicator_of_non_determinism_;
   CounterHandle metric_total_committed_sn_;
   CounterHandle metric_slow_path_count_;
@@ -235,6 +240,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_total_fastPath_requests_;
   CounterHandle metric_total_preexec_requests_executed_;
   //*****************************************************
+  RollingAvgAndVar consensus_time_;
+  RollingAvgAndVar accumulating_batch_time_;
+  Time time_to_collect_batch_ = MinTime;
+
  public:
   ReplicaImp(const ReplicaConfig&,
              IRequestsHandler* requestsHandler,

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -113,6 +113,10 @@ class SeqNumInfo {
     commitMsgsCollector->onCompletionOfCombinedSigVerification(seqNumber, viewNumber, isValid);
   }
 
+  uint64_t getCommitDurationMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(firstSeenFromPrimary - commitUpdateTime).count();
+  }
+
  protected:
   class ExFuncForPrepareCollector {
    public:


### PR DESCRIPTION
Here we add the following metrics:
1. number of batches closed with batching logic
2. number of batches closed without batching logic
3. primary queue size 
4. a rolling average of consensus duration
5. a rolling average of closing batch duration