### PR TITLE
[Diagnostic][v0.10.x] Remove async execution of handleRequest

### DIFF
--- a/diagnostics/include/diagnostics_server.h
+++ b/diagnostics/include/diagnostics_server.h
@@ -147,9 +147,7 @@ class Server {
           return;
         }
         int sock = accept(listen_sock_, NULL, NULL);
-        // We must bind the result future or else this call blocks.
-        auto _ = std::async(std::launch::async, [&]() { handleRequest(registrar, sock); });
-        (void)_;  // unused variable hack
+        handleRequest(registrar, sock);
       }
     });
   }


### PR DESCRIPTION
Due to the way it was written the handleRequest was synchronous anyway, so for now remove the unnecessary overhead.