### PR TITLE
Release status exchange fixes

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1902,7 +1902,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
                 << msgSenderId << ". Reported Last Stable Sequence not consistent with checkpointWindowSize "
                 << KVLOG(msgLastStable, checkpointWindowSize));
 
-  LOG_DEBUG(MSGS, KVLOG(msgSenderId));
+  LOG_DEBUG(MSGS, KVLOG(msgSenderId, msgLastStable, msgViewNum, lastStableSeqNum));
 
   /////////////////////////////////////////////////////////////////////////
   // Checkpoints

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1897,7 +1897,10 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
   const ReplicaId msgSenderId = msg->senderId();
   const SeqNum msgLastStable = msg->getLastStableSeqNum();
   const ViewNum msgViewNum = msg->getViewNumber();
-  ConcordAssertEQ(msgLastStable % checkpointWindowSize, 0);
+  LOG_ERROR(MSGS,
+            "FATAL ERROR for peer msgSenderId = "
+                << msgSenderId << ". Reported Last Stable Sequence not consistent with checkpointWindowSize "
+                << KVLOG(msgLastStable, checkpointWindowSize));
 
   LOG_DEBUG(MSGS, KVLOG(msgSenderId));
 
@@ -1915,7 +1918,6 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
     }
 
     delete msg;
-    return;
   } else if (msgLastStable > lastStableSeqNum + kWorkWindowSize) {
     tryToSendStatusReport();  // ask for help
   } else {
@@ -1960,22 +1962,20 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
   /////////////////////////////////////////////////////////////////////////
 
   else if ((msgViewNum == curView) && (!msg->currentViewIsActive())) {
-    auto sendViewChangeMsg = [&msg, &msgSenderId, this]() {
-      if (curView > 0 &&  // we only have ViewChangeMsg for View > 0
-          msg->hasListOfMissingViewChangeMsgForViewChange() &&
-          msg->isMissingViewChangeMsgForViewChange(config_.getreplicaId())) {
-        ViewChangeMsg *myVC = viewsManager->getMyLatestViewChangeMsg();
-        ConcordAssertNE(myVC, nullptr);
-        sendAndIncrementMetric(myVC, msgSenderId, metric_sent_viewchange_msg_due_to_status_);
+    auto sendViewChangeMsgs = [&msg, &msgSenderId, this]() {  // Send all View Change messages we have
+      if (curView > 0 &&                                      // we only have ViewChangeMsg for View > 0
+          msg->hasListOfMissingViewChangeMsgForViewChange()) {
+        for (auto *vcMsg : viewsManager->getViewChangeMsgsForView(curView)) {
+          if (msg->isMissingViewChangeMsgForViewChange(vcMsg->idOfGeneratedReplica())) {
+            sendAndIncrementMetric(vcMsg, msgSenderId, metric_sent_viewchange_msg_due_to_status_);
+          }
+        }
       }
     };
 
     if (isCurrentPrimary() || (repsInfo->primaryOfView(curView) == msgSenderId))  // if the primary is involved
     {
-      if (!isCurrentPrimary())  // I am not the primary of curView
-      {
-        sendViewChangeMsg();
-      } else  // I am the primary of curView
+      if (isCurrentPrimary())  // I am the primary of curView
       {
         // send NewViewMsg for View > 0
         if (curView > 0 && !msg->currentViewHasNewViewMessage() && viewsManager->viewIsActive(curView)) {
@@ -1983,20 +1983,12 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
           ConcordAssertNE(nv, nullptr);
           sendAndIncrementMetric(nv, msgSenderId, metric_sent_newview_msg_due_to_status_);
         }
-
-        // send all VC msgs that can help making progress (needed because the original senders may not send
-        // the ViewChangeMsg msgs used by the primary)
-        // if viewsManager->viewIsActive(curView), we can send only the VC msgs which are really needed for
-        // curView (see in ViewsManager)
-        // It should be taken in consideration that we do not have ViewChangeMsg-s for View 0
-        if (curView > 0 && msg->hasListOfMissingViewChangeMsgForViewChange()) {
-          for (auto *vcMsg : viewsManager->getViewChangeMsgsForView(curView)) {
-            if (msg->isMissingViewChangeMsgForViewChange(vcMsg->idOfGeneratedReplica())) {
-              send(vcMsg, msgSenderId);
-            }
-          }
-        }
       }
+      // send all VC msgs that can help making progress (needed because the original senders may not send
+      // the ViewChangeMsg msgs used by the primary)
+      // if viewsManager->viewIsActive(curView), we can send only the VC msgs which are really needed for
+      // curView (see in ViewsManager)
+      sendViewChangeMsgs();
 
       if (viewsManager->viewIsActive(curView)) {
         if (msg->hasListOfMissingPrePrepareMsgForViewChange()) {
@@ -2025,7 +2017,7 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
         }
       }
     } else {
-      sendViewChangeMsg();
+      sendViewChangeMsgs();
     }
   }
 


### PR DESCRIPTION
 1. Remove assert when peer Replica reports inconsistent stable
   sequence ID, only print an error log.
2. Refactor View Change msgs exchange mechanism in status exchange,
   now all Replicas will forward the complete set they have collected.
3. Send View Change messages even to peers that are more than a Working Window
   behind. In this case the catching Replica should be able to gather them even
   before State Transfer starts and be able to activate a View faster once ST completes.
4.  Additional logged info for status request.
