### PR TITLE
Don't remove the blockchain state in case lastExecutedSeqNum is zero

### DIFF
--- a/kvbc/include/replica_state_sync.h
+++ b/kvbc/include/replica_state_sync.h
@@ -32,7 +32,6 @@ class ReplicaStateSync {
   // Synchronizes replica state and returns a number of deleted blocks.
   virtual uint64_t execute(logging::Logger& logger,
                            categorization::KeyValueBlockchain& blockchain,
-                           BlockId lastReachableBlockId,
                            uint64_t lastExecutedSeqNum) = 0;
 };
 

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -27,7 +27,6 @@ class ReplicaStateSyncImp : public ReplicaStateSync {
 
   uint64_t execute(logging::Logger& logger,
                    categorization::KeyValueBlockchain& blockchain,
-                   BlockId lastReachableBlockId,
                    uint64_t lastExecutedSeqNum) override;
 
  protected:


### PR DESCRIPTION
- Avoid a whole state removal after cleaning of metadata
- Don't allow removal of more than one block