### PR TITLE
Disallow less blocks than CPUs in kvbcbench

### DIFF
--- a/kvbc/benchmark/kvbcbench/pre_execution.h
+++ b/kvbc/benchmark/kvbcbench/pre_execution.h
@@ -16,11 +16,21 @@
 #include <iostream>
 #include <thread>
 
+#include "assertUtils.hpp"
 #include "categorization/block_merkle_category.h"
 #include "categorization/kv_blockchain.h"
 #include "input.h"
 
 namespace concord::kvbc::bench {
+
+inline ReadKeys::const_iterator randomReadIter(const ReadKeys& keys, size_t num_keys_to_read) {
+  ConcordAssertGE(keys.size(), num_keys_to_read);
+  const auto max_read_offset = keys.size() - num_keys_to_read;
+  if (max_read_offset == 0) {
+    return keys.cbegin();
+  }
+  return keys.cbegin() + (rand() % max_read_offset);
+}
 
 struct PreExecConfig {
   size_t concurrency;
@@ -81,13 +91,11 @@ class PreExecutionSimulator {
 
  private:
   std::vector<std::string>::const_iterator randomMerkleKeyIter() {
-    auto max_read_offset = merkle_read_keys_.size() - config_.num_block_merkle_keys_to_read;
-    return merkle_read_keys_.begin() + (rand() % max_read_offset);
+    return randomReadIter(merkle_read_keys_, config_.num_block_merkle_keys_to_read);
   }
 
   std::vector<std::string>::const_iterator randomVersionedKeyIter() {
-    auto max_read_offset = versioned_read_keys_.size() - config_.num_versioned_keys_to_read;
-    return versioned_read_keys_.begin() + (rand() % max_read_offset);
+    return randomReadIter(versioned_read_keys_, config_.num_versioned_keys_to_read);
   }
 
   std::atomic_bool stop_ = false;


### PR DESCRIPTION
If the `total-blocks` configuration option is set to a value that is
less than the number of CPUs in the system, the kvbcbench tool crashes
due to:
 * divide by 0 error when calculating max read offsets
 * invalid `blocks_per_thread` calculation, leading to no data being
   generated (provided the first issue is fixed)

Avoid above by disallowing `total-blocks` being less than the CPUs in
the system and by intoducing the `randomReadIter()` function that
returns cbegin() if we want to read all keys in the vector, avoiding
divide by 0.