### PR TITLE
Add batching to the new client

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -44,7 +44,7 @@ class Client {
   // Throws a BftClientException on error.
   Reply send(const WriteConfig& config, Msg&& request);
   Reply send(const ReadConfig& config, Msg&& request);
-  std::deque<Reply> sendBatch(std::deque<ClientRequest>& clientRequests, const std::string& cid);
+  std::deque<Reply> sendBatch(std::deque<WriteRequest>& write_requests, const std::string& cid);
   bool isServing(int numOfReplicas, int requiredNumOfReplicas) const;
 
   // Useful for testing. Shouldn't be relied on in production.
@@ -58,6 +58,9 @@ class Client {
   //
   // Inserts the Replies to the input queue.
   void wait(std::deque<Reply>& replies);
+
+  // Return a Reply on quorum, or std::nullopt on timeout.
+  std::optional<Reply> wait();
 
   // Extract a matcher configurations from operational configurations
   //
@@ -74,18 +77,22 @@ class Client {
   Msg createClientMsg(const RequestConfig& req_config, Msg&& request, bool read_only, uint16_t client_id);
 
   // This function creates a ClientBatchRequestMsg.
-  Msg createClientBatchMsg(const std::deque<Msg>& clientRequests,
-                           uint32_t batchBufSize,
+  Msg createClientBatchMsg(const std::deque<Msg>& client_requests,
+                           uint32_t batch_buf_size,
                            const string& cid,
                            uint16_t client_id);
+
+  Msg initBatch(std::deque<WriteRequest>& write_requests,
+                const std::string& cid,
+                std::chrono::milliseconds& max_time_to_wait);
 
   MsgReceiver receiver_;
 
   std::unique_ptr<bft::communication::ICommunication> communication_;
   ClientConfig config_;
   logging::Logger logger_ = logging::getLogger("bftclient");
-  std::deque<Msg> pendingRequests_;
-  std::unordered_map<uint64_t, Matcher> replyCertificates_;
+  std::deque<Msg> pending_requests_;
+  std::unordered_map<uint64_t, Matcher> reply_certificates_;
 
   // The client doesn't always know the current primary.
   std::optional<ReplicaId> primary_;

--- a/bftclient/include/bftclient/config.h
+++ b/bftclient/include/bftclient/config.h
@@ -92,7 +92,7 @@ struct ReadConfig {
   ReadQuorum quorum;
 };
 
-struct ClientRequest {
+struct WriteRequest {
   WriteConfig config;
   Msg request;
 };

--- a/bftclient/include/bftclient/config.h
+++ b/bftclient/include/bftclient/config.h
@@ -92,4 +92,9 @@ struct ReadConfig {
   ReadQuorum quorum;
 };
 
+struct ClientRequest {
+  WriteConfig config;
+  Msg request;
+};
+
 }  // namespace bft::client

--- a/bftclient/include/bftclient/exception.h
+++ b/bftclient/include/bftclient/exception.h
@@ -41,8 +41,12 @@ class TimeoutException : public BftClientException {
   TimeoutException(uint64_t seq_num, const std::string& cid)
       : BftClientException("Timeout for request sequence number: " + std::to_string(seq_num) +
                            ", and correlation id: " + cid) {}
+};
 
-  TimeoutException(const std::string& cid) : BftClientException("Timeout for correlation id: " + cid) {}
+class BatchTimeoutException : public BftClientException {
+ public:
+  BatchTimeoutException(const std::string& cid)
+      : BftClientException("Timeout for a batch request with correlation id: " + cid) {}
 };
 
 class InvalidPrivateKeyException : public BftClientException {

--- a/bftclient/include/bftclient/exception.h
+++ b/bftclient/include/bftclient/exception.h
@@ -41,6 +41,8 @@ class TimeoutException : public BftClientException {
   TimeoutException(uint64_t seq_num, const std::string& cid)
       : BftClientException("Timeout for request sequence number: " + std::to_string(seq_num) +
                            ", and correlation id: " + cid) {}
+
+  TimeoutException(const std::string& cid) : BftClientException("Timeout for correlation id: " + cid) {}
 };
 
 class InvalidPrivateKeyException : public BftClientException {

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -254,14 +254,13 @@ std::optional<Reply> Client::wait() {
   if (replies.empty()) {
     static constexpr size_t CLEAR_MATCHER_REPLIES_THRESHOLD = 5;
     // reply_certificates_ should hold just one request when using this wait method
-    for (auto& req : reply_certificates_) {
-      if (req.second.numDifferentReplies() > CLEAR_MATCHER_REPLIES_THRESHOLD) {
-        req.second.clearReplies();
-        metrics_.repliesCleared.Get().Inc();
-      }
-      primary_ = std::nullopt;
-      return std::nullopt;
+    auto req = reply_certificates_.begin();
+    if (req->second.numDifferentReplies() > CLEAR_MATCHER_REPLIES_THRESHOLD) {
+      req->second.clearReplies();
+      metrics_.repliesCleared.Get().Inc();
     }
+    primary_ = std::nullopt;
+    return std::nullopt;
   }
   auto reply = std::move(replies.front());
   return reply;

--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -362,6 +362,53 @@ TEST_F(ClientApiTestFixture, write_f_plus_one) {
   client.stop();
 }
 
+TEST_F(ClientApiTestFixture, batch_of_writes) {
+  auto BatchBehavior = [&](const MsgFromClient& msg, IReceiver* client_receiver) {
+    const auto* req_header = reinterpret_cast<const ClientBatchRequestMsgHeader*>(msg.data.data());
+    auto* position = msg.data.data();
+    position += sizeof(ClientBatchRequestMsgHeader) + req_header->cidSize;
+    string reply_data = "world";
+    auto reply_header_size = sizeof(ClientReplyMsgHeader);
+    Msg reply(reply_header_size + reply_data.size());
+
+    auto* reply_header = reinterpret_cast<ClientReplyMsgHeader*>(reply.data());
+    reply_header->currentPrimaryId = 0;
+    reply_header->msgType = REPLY_MSG_TYPE;
+    reply_header->replicaSpecificInfoLength = 0;
+    reply_header->replyLength = reply_data.size();
+    for (uint32_t i = 0; i < req_header->numOfMessagesInBatch; i++) {
+      const auto* req_header1 = reinterpret_cast<const ClientRequestMsgHeader*>(position);
+      reply_header->reqSeqNum = req_header1->reqSeqNum;
+      reply_header->spanContextSize = 0;
+      // Copy the reply data;
+      memcpy(reply.data() + reply_header_size, reply_data.data(), reply_data.size());
+      client_receiver->onNewMessage((NodeNum)msg.destination.val, (const char*)reply.data(), reply.size());
+      position += sizeof(ClientRequestMsgHeader) + req_header1->cidLength + req_header1->requestLength +
+                  req_header1->spanContextSize;
+    }
+  };
+
+  unique_ptr<FakeCommunication> comm(new FakeCommunication(BatchBehavior));
+  Client client(move(comm), test_config_);
+  // Ensure we only wait for F+1 replies (ByzantineSafeQuorum)
+  WriteConfig config{RequestConfig{false, 1}, ByzantineSafeQuorum{}};
+  WriteConfig config2{RequestConfig{false, 2}, ByzantineSafeQuorum{}};
+  config.request.timeout = 500ms;
+  config2.request.timeout = 500ms;
+  ClientRequest request1{config, Msg({'c', 'o', 'n', 'c', 'o', 'r', 'd'})};
+  ClientRequest request2{config2, Msg({'h', 'e', 'l', 'l', 'o'})};
+  std::deque<ClientRequest> request_queue;
+  request_queue.push_back(request1);
+  request_queue.push_back(request2);
+  auto replies = client.sendBatch(request_queue, request1.config.request.correlation_id);
+  Msg expected{'w', 'o', 'r', 'l', 'd'};
+  ASSERT_EQ(replies.size(), request_queue.size());
+  ASSERT_EQ(expected, replies.front().matched_data);
+  ASSERT_EQ(replies.front().rsi.size(), 2);
+  ASSERT_EQ(client.primary(), ReplicaId{0});
+  client.stop();
+}
+
 TEST_F(ClientApiTestFixture, write_f_plus_one_get_differnt_rsi) {
   map<ReplicaId, Msg> rsi = {{ReplicaId{0}, {0}}, {ReplicaId{1}, {1}}};
   auto WriteBehavior = [&](const MsgFromClient& msg, IReceiver* client_receiver) {


### PR DESCRIPTION
As part of the work on client-side batching, we need to support a batch of requests also as part of the new bft client.
on this PR:

1) Added a method that creates a ClientBatchRequestMsg from several requests.
2) Add clientRequest struct which holds the necessary part for every request.
3) Added sendBatch method which gets queue of clientRequest and returns a queue of replies for each of the requests.
4) Refactored the wait method to support several requests and return the replies through a queue of replies.
5) Add unit test for the batch scenario.