### PR TITLE
Add the ScopeExit utility class

### DIFF
--- a/util/include/scope_exit.hpp
+++ b/util/include/scope_exit.hpp
@@ -25,8 +25,10 @@ namespace concord::util {
 template <typename EF>
 class ScopeExit {
  public:
-  // Disable this constructor (accepting a forwarding reference) in favour of the move constructor in case the passed
+  // Disable this perferct forwarding constructor as it can hide the move constructor in case the passed
   // type is ScopeExit.
+  // Reported by clang-tidy:
+  // https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/misc-forwarding-reference-overload.html
   template <typename Fn, typename = std::enable_if_t<!std::is_same_v<std::decay_t<Fn>, ScopeExit>>>
   explicit ScopeExit(Fn&& fn) noexcept : fn_{std::forward<Fn>(fn)} {}
 

--- a/util/include/scope_exit.hpp
+++ b/util/include/scope_exit.hpp
@@ -1,0 +1,57 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+// Modelled after std::experimental::scope_exit
+// https://en.cppreference.com/w/cpp/experimental/scope_exit
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace concord::util {
+
+// The ScopeExit utility class calls a user-provided function when a scope is exited.
+template <typename EF>
+class ScopeExit {
+ public:
+  // Disable this constructor (accepting a forwarding reference) in favour of the move constructor in case the passed
+  // type is ScopeExit.
+  template <typename Fn, typename = std::enable_if_t<!std::is_same_v<std::decay_t<Fn>, ScopeExit>>>
+  explicit ScopeExit(Fn&& fn) noexcept : fn_{std::forward<Fn>(fn)} {}
+
+  ScopeExit(ScopeExit&& other) noexcept : active_{other.active_}, fn_{std::move(other.fn_)} { other.release(); }
+
+  ~ScopeExit() noexcept {
+    if (active_) {
+      fn_();
+    }
+  }
+
+  void release() noexcept { active_ = false; }
+
+  ScopeExit(const ScopeExit&) = delete;
+  ScopeExit& operator=(const ScopeExit&) = delete;
+  ScopeExit& operator=(ScopeExit&&) = delete;
+
+ private:
+  bool active_{true};
+  EF fn_;
+};
+
+// Deduction guide, allowing code such as:
+//   auto s = ScopeExit{[] () {}};
+template <typename EF>
+ScopeExit(EF)->ScopeExit<EF>;
+
+}  // namespace concord::util

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -52,3 +52,7 @@ target_link_libraries(hex_tools_test GTest::Main util)
 add_executable(callback_registry_test callback_registry_test.cpp)
 add_test(callback_registry_test callback_registry_test)
 target_link_libraries(callback_registry_test GTest::Main util)
+
+add_executable(scope_exit_test scope_exit_test.cpp)
+add_test(scope_exit_test scope_exit_test)
+target_link_libraries(scope_exit_test GTest::Main util)

--- a/util/test/scope_exit_test.cpp
+++ b/util/test/scope_exit_test.cpp
@@ -17,6 +17,7 @@
 
 #include <optional>
 
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using concord::util::ScopeExit;
 
 TEST(scope_exit, call_on_exit) {

--- a/util/test/scope_exit_test.cpp
+++ b/util/test/scope_exit_test.cpp
@@ -1,0 +1,77 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "scope_exit.hpp"
+
+#include <optional>
+
+using concord::util::ScopeExit;
+
+TEST(scope_exit, call_on_exit) {
+  auto called = false;
+  {
+    auto s = ScopeExit{[&]() { called = true; }};
+  }
+  ASSERT_TRUE(called);
+}
+
+TEST(scope_exit, release_does_not_call) {
+  auto called = false;
+  {
+    auto s = ScopeExit{[&]() { called = true; }};
+    s.release();
+  }
+  ASSERT_FALSE(called);
+}
+
+TEST(scope_exit, move_calls_once_only) {
+  auto called = 0;
+  {
+    auto s1 = ScopeExit{[&]() { ++called; }};
+    auto s2 = ScopeExit{std::move(s1)};
+  }
+  ASSERT_EQ(1, called);
+}
+
+TEST(scope_exit, move_deactivates_source) {
+  auto called = 0;
+  {
+    auto s1 = std::optional{ScopeExit{[&]() { ++called; }}};
+    auto s2 = ScopeExit{std::move(*s1)};
+
+    // Make sure that when the source is deactivated it doesn't call on destruction.
+    s1.reset();
+    ASSERT_EQ(0, called);
+  }
+
+  ASSERT_EQ(1, called);
+}
+
+TEST(scope_exit, move_from_inactive_does_not_call) {
+  auto called = false;
+  {
+    auto s1 = ScopeExit{[&]() { called = true; }};
+    s1.release();
+
+    // s1 is inactive at that point.
+    auto s2 = ScopeExit{std::move(s1)};
+  }
+  ASSERT_FALSE(called);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add a ScopeExit utility class that calls a user-provided function when
a scope is exited.

Modelled after:
https://en.cppreference.com/w/cpp/experimental/scope_exit