### PR TITLE
[Proposal]: Add support for concurrent pruning and block adds

### DIFF
--- a/kvbc/benchmark/kvbcbench/main.cpp
+++ b/kvbc/benchmark/kvbcbench/main.cpp
@@ -337,7 +337,11 @@ void addBlocks(const po::variables_map& config,
         kvbc.addBlock(std::move(updates));
       } else {
         auto&& merkle_input = std::move(input.block_merkle_input[i - 1]);
+        auto&& versioned_updates = std::move(input.ver_updates[i - 1]);
+        auto&& immutable_updates = std::move(input.imm_updates[i - 1]);
         updates.add(kCategoryMerkle, categorization::BlockMerkleUpdates(std::move(merkle_input)));
+        updates.add(kCategoryVersioned, std::move(versioned_updates));
+        updates.add(kCategoryImmutable, std::move(immutable_updates));
         kvbc.addBlock(std::move(updates));
       }
     }

--- a/kvbc/benchmark/kvbcbench/pruning.h
+++ b/kvbc/benchmark/kvbcbench/pruning.h
@@ -1,0 +1,73 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+//
+
+#pragma once
+
+#include <condition_variable>
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+#include "categorization/kv_blockchain.h"
+
+namespace concord::kvbc::bench {
+
+class Pruning {
+ public:
+  Pruning(size_t prune_blocks, categorization::KeyValueBlockchain& kvbc) : prune_blocks_{prune_blocks}, kvbc_{kvbc} {
+    if (prune_blocks) {
+      thread_ = std::thread{[&]() {
+        auto l = std::unique_lock{start_mtx_};
+        if (!start_) {
+          start_signal_.wait(l, [&]() { return start_; });
+        }
+        l.unlock();
+        kvbc_.deleteBlocksUntil(prune_blocks_ + 1);
+      }};
+    }
+  }
+
+  void start() {
+    auto l = std::unique_lock{start_mtx_};
+    start_ = true;
+    l.unlock();
+    start_signal_.notify_one();
+    start_time_ = std::chrono::steady_clock::now();
+  }
+
+  void stop() {
+    if (prune_blocks_) {
+      thread_.join();
+      duration_ =
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time_).count();
+    }
+  }
+
+  auto duration() const { return duration_; }
+
+  auto blocks() const { return prune_blocks_; }
+
+ private:
+  const size_t prune_blocks_{0};
+  categorization::KeyValueBlockchain& kvbc_;
+
+  std::chrono::time_point<std::chrono::steady_clock> start_time_;
+  int64_t duration_{1};
+
+  std::condition_variable start_signal_;
+  std::mutex start_mtx_;
+  bool start_{false};
+  std::thread thread_;
+};
+
+}  // namespace concord::kvbc::bench

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -112,21 +112,7 @@ void ReplicaImp::deleteGenesisBlock() {
   m_kvBlockchain->deleteBlock(genesisBlock);
 }
 
-BlockId ReplicaImp::deleteBlocksUntil(BlockId until) {
-  const auto genesisBlock = m_kvBlockchain->getGenesisBlockId();
-  if (genesisBlock == 0) {
-    throw std::logic_error{"Cannot delete a block range from an empty blockchain"};
-  } else if (until <= genesisBlock) {
-    throw std::invalid_argument{"Invalid 'until' value passed to deleteBlocksUntil()"};
-  }
-
-  const auto lastReachableBlock = m_kvBlockchain->getLastReachableBlockId();
-  const auto lastDeletedBlock = std::min(lastReachableBlock, until - 1);
-  for (auto i = genesisBlock; i <= lastDeletedBlock; ++i) {
-    ConcordAssert(m_kvBlockchain->deleteBlock(i));
-  }
-  return lastDeletedBlock;
-}
+BlockId ReplicaImp::deleteBlocksUntil(BlockId id) { return m_kvBlockchain->deleteBlocksUntil(id); }
 
 BlockId ReplicaImp::add(categorization::Updates &&updates) { return m_kvBlockchain->addBlock(std::move(updates)); }
 


### PR DESCRIPTION
Add support for concurrent pruning and block addition. In this context,
concurrent means alternating between additions and pruning, but never
executing them trully in parallel, from different threads. Rationale is:
 * no changes to storage are required
 * simplifies the implementation
 * safer

Give block addition priority over pruning by setting an atomic flag when
an addition is pending. Once seen by the pruning thread, it will yield
and let the addition proceed. When the addition finishes, it will signal
the prune thread and it can continue pruning. Doing so gives
transactions and state transfer priority over pruning.

Another possible implementation is to have a single thread call add and
delete methods and have a queue of commands for it. However, switching
between threads for the case of no pruning proves more expensive than
what the proposal in this PR does - just set an atomic, lock an unlocked
mutex and signal a condition variable that has no threads waiting on it
(in case of no pruning).

A note on the atomic `pending_add_` flag is that it is intentionally set
before locking `write_mtx_`. That way, contention for the mutex can be
resolved and we don't have to rely on a fair mutex policy.

In temrs of methods, users can call the newly-introduced
`deleteBlocksUntil()` method from a different thread that executes block
addition. More details about multi-threading and pruning is described in
a code comment.

Implement ReplicaImp::deleteBlocksUntil() by just calling
KeyValueBlockchain::deleteBlocksUntil().

Update `kvbcbench` so that it supports pruning and add options to
configure it to run after block addition or concurrently with it.

Add unit tests for the new behavior.