### PR TITLE
ReplicaImp: modify ReplicaImp::getReplicaState

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1115,12 +1115,27 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
   ConcordAssert(false);
 }
 
+std::string ReplicaImp::getReplicaLastStableSeqNum() const {
+  std::ostringstream oss;
+  std::unordered_map<std::string, std::string> result, nested_data;
+
+  nested_data.insert(toPair(getName(lastStableSeqNum), lastStableSeqNum));
+  result.insert(
+      toPair("Sequence Numbers ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+
+  oss << concordUtils::kContainerToJson(result);
+  return oss.str();
+}
+
 std::string ReplicaImp::getReplicaState() const {
   auto primary = getReplicasInfo().primaryOfView(curView);
   std::ostringstream oss;
   std::unordered_map<std::string, std::string> result, nested_data;
+
   result.insert(toPair("Replica ID", std::to_string(getReplicasInfo().myId())));
+
   result.insert(toPair("Primary ", std::to_string(primary)));
+
   nested_data.insert(toPair(getName(viewChangeProtocolEnabled), viewChangeProtocolEnabled));
   nested_data.insert(toPair(getName(autoPrimaryRotationEnabled), autoPrimaryRotationEnabled));
   nested_data.insert(toPair(getName(curView), curView));
@@ -1132,6 +1147,7 @@ std::string ReplicaImp::getReplicaState() const {
   result.insert(
       toPair("View Change ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
   nested_data.clear();
+
   nested_data.insert(toPair(getName(primaryLastUsedSeqNum), primaryLastUsedSeqNum));
   nested_data.insert(toPair(getName(lastStableSeqNum), lastStableSeqNum));
   nested_data.insert(toPair("lastStableCheckpoint", lastStableSeqNum / checkpointWindowSize));
@@ -1144,6 +1160,7 @@ std::string ReplicaImp::getReplicaState() const {
   result.insert(
       toPair("Sequence Numbers ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
   nested_data.clear();
+
   nested_data.insert(toPair(getName(restarted_), restarted_));
   nested_data.insert(toPair(getName(requestsQueueOfPrimary.size()), requestsQueueOfPrimary.size()));
   nested_data.insert(toPair(getName(requestsBatcg312her_->getMaxNumberOfPendingRequestsInRecentHistory()),
@@ -1162,12 +1179,17 @@ std::string ReplicaImp::getReplicaState() const {
   nested_data.insert(toPair(getName(numInvalidClients), numInvalidClients));
   nested_data.insert(toPair(getName(numValidNoOps), numValidNoOps));
   result.insert(toPair("Other ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+
   oss << concordUtils::kContainerToJson(result);
   return oss.str();
 }
 
 void ReplicaImp::onInternalMsg(GetStatus &status) const {
-  if (status.key == "replica") {
+  if (status.key == "replica") {  // TODO: change this key name (coordinate with deployment)
+    return status.output.set_value(getReplicaLastStableSeqNum());
+  }
+
+  if (status.key == "replica_state") {
     return status.output.set_value(getReplicaState());
   }
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -323,6 +323,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // Generate diagnostics status replies
   std::string getReplicaState() const;
+  std::string getReplicaLastStableSeqNum() const;
   template <typename T>
   void onMessage(T* msg);
 


### PR DESCRIPTION
1)
Former ReplicaImp::getReplicaState is renamed to
ReplicaImp::getReplicaLastStableSeqNum

2) ReplicaImp::getReplicaState now returns the minimal needed info for
agent. It returns a json formated string in the format:
{
  "Sequence Numbers ": {
  "lastStableSeqNum": "0"
    }
}

The reason for the change is data races between the message processing
thread and ST thread. which potentially cause later on crashes
(probably due to caused data corruptions).
For now, we want to minimize the probability for race condition and
apply a short-term fix which greatly reduces the change for
race-condition. Later on, we will apply a different log-term fix.