### PR TITLE
Add metrics for consensus and batch

### DIFF
--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -46,8 +46,8 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual SeqNum getLastExecutedSeqNum() const = 0;
   virtual PrePrepareMsg* buildPrePrepareMessage() { return nullptr; }
   virtual bool tryToSendPrePrepareMsg(bool batchingLogic) { return false; }
-  virtual bool tryToSendPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) { return false; }
-  virtual bool tryToSendPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) { return false; }
+  virtual PrePrepareMsg* buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) { return nullptr; }
+  virtual PrePrepareMsg* buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) { return nullptr; }
 
   virtual IncomingMsgsStorage& getIncomingMsgsStorage() = 0;
   virtual util::SimpleThreadPool& getInternalThreadPool() = 0;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -225,7 +225,9 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         LOG_DEBUG(CNSUS,
                   "Pushing to primary queue, request [" << reqSeqNum << "], client [" << clientId
                                                         << "], senderId=" << senderId);
+        if (time_to_collect_batch_ == MinTime) time_to_collect_batch_ = getMonotonicTime();
         requestsQueueOfPrimary.push(m);
+        primary_queue_size_.Get().Set(requestsQueueOfPrimary.size());
         primaryCombinedReqSize += m->size();
         tryToSendPrePrepareMsg(true);
         return;
@@ -328,40 +330,33 @@ void ReplicaImp::removeDuplicatedRequestsFromRequestsQueue() {
     requestsQueueOfPrimary.pop();
     first = (!requestsQueueOfPrimary.empty() ? requestsQueueOfPrimary.front() : nullptr);
   }
+  primary_queue_size_.Get().Set(requestsQueueOfPrimary.size());
 }
 
-bool ReplicaImp::tryToSendPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) {
+PrePrepareMsg *ReplicaImp::buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) {
   if (primaryCombinedReqSize < requiredBatchSizeInBytes) {
     LOG_DEBUG(GL,
               "Not sufficient messages size in the primary replica queue to fill a batch"
                   << KVLOG(primaryCombinedReqSize, requiredBatchSizeInBytes));
-    return false;
+    return nullptr;
   }
-  if (!checkSendPrePrepareMsgPrerequisites()) return false;
+  if (!checkSendPrePrepareMsgPrerequisites()) return nullptr;
 
   removeDuplicatedRequestsFromRequestsQueue();
-  PrePrepareMsg *prePrepareMsg = buildPrePrepareMessageByBatchSize(requiredBatchSizeInBytes);
-  if (!prePrepareMsg) return false;
-
-  startConsensusProcess(prePrepareMsg);
-  return true;
+  return buildPrePrepareMessageByBatchSize(requiredBatchSizeInBytes);
 }
 
-bool ReplicaImp::tryToSendPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
+PrePrepareMsg *ReplicaImp::buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
   if (requestsQueueOfPrimary.size() < requiredRequestsNum) {
     LOG_DEBUG(GL,
               "Not enough messages in the primary replica queue to fill a batch"
                   << KVLOG(requestsQueueOfPrimary.size(), requiredRequestsNum));
-    return false;
+    return nullptr;
   }
-  if (!checkSendPrePrepareMsgPrerequisites()) return false;
+  if (!checkSendPrePrepareMsgPrerequisites()) return nullptr;
 
   removeDuplicatedRequestsFromRequestsQueue();
-  PrePrepareMsg *prePrepareMsg = buildPrePrepareMessageByRequestsNum(requiredRequestsNum);
-  if (!prePrepareMsg) return false;
-
-  startConsensusProcess(prePrepareMsg);
-  return true;
+  return buildPrePrepareMessageByRequestsNum(requiredRequestsNum);
 }
 
 bool ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
@@ -374,6 +369,17 @@ bool ReplicaImp::tryToSendPrePrepareMsg(bool batchingLogic) {
   else
     pp = buildPrePrepareMessage();
   if (!pp) return false;
+  if (batchingLogic) {
+    batch_closed_on_logic_on_.Get().Inc();
+    accumulating_batch_time_.add(
+        std::chrono::duration_cast<std::chrono::microseconds>(getMonotonicTime() - time_to_collect_batch_).count());
+    accumulating_batch_avg_time_.Get().Set((uint64_t)accumulating_batch_time_.avg());
+    if (accumulating_batch_time_.numOfElements() == 1000)
+      accumulating_batch_time_.reset();  // We reset the average on every 1000 samples
+  } else {
+    batch_closed_on_logic_off_.Get().Inc();
+  }
+  time_to_collect_batch_ = MinTime;
   startConsensusProcess(pp);
   return true;
 }
@@ -414,6 +420,7 @@ ClientRequestMsg *ReplicaImp::addRequestToPrePrepareMessage(ClientRequestMsg *&n
   }
   delete nextRequest;
   requestsQueueOfPrimary.pop();
+  primary_queue_size_.Get().Set(requestsQueueOfPrimary.size());
   return (!requestsQueueOfPrimary.empty() ? requestsQueueOfPrimary.front() : nullptr);
 }
 
@@ -2519,6 +2526,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
     requestsQueueOfPrimary.pop();
     delete msg;
   }
+  primary_queue_size_.Get().Set(requestsQueueOfPrimary.size());
 
   // send messages
 
@@ -3486,8 +3494,13 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_sent_replica_asks_to_leave_view_msg_{metrics_.RegisterGauge("sentReplicaAsksToLeaveViewMsg", 0)},
       metric_bft_batch_size_{metrics_.RegisterGauge("bft_batch_size", 0)},
       my_id{metrics_.RegisterGauge("my_id", config.replicaId)},
+      primary_queue_size_{metrics_.RegisterGauge("primary_queue_size", 0)},
+      consensus_avg_time_{metrics_.RegisterGauge("consensus_rolling_avg_time", 0)},
+      accumulating_batch_avg_time_{metrics_.RegisterGauge("accumualating_batch_avg_time", 0)},
       metric_first_commit_path_{metrics_.RegisterStatus(
           "firstCommitPath", CommitPathToStr(ControllerWithSimpleHistory_debugInitialFirstPath))},
+      batch_closed_on_logic_off_{metrics_.RegisterCounter("total_number_batch_closed_on_logic_off")},
+      batch_closed_on_logic_on_{metrics_.RegisterCounter("total_number_batch_closed_on_logic_on")},
       metric_indicator_of_non_determinism_{metrics_.RegisterCounter("indicator_of_non_determinism")},
       metric_total_committed_sn_{metrics_.RegisterCounter("total_committed_seqNum")},
       metric_slow_path_count_{metrics_.RegisterCounter("slowPathCount", 0)},
@@ -4097,6 +4110,7 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
   consensus_times_.end(seqNumber);
   // First of all, we remove the pending request before the execution, to prevent long execution from affecting VC
   tryToRemovePendingRequestsForSeqNum(seqNumber);
+
   while (lastExecutedSeqNum < lastStableSeqNum + kWorkWindowSize) {
     SeqNum nextExecutedSeqNum = lastExecutedSeqNum + 1;
     SCOPED_MDC_SEQ_NUM(std::to_string(nextExecutedSeqNum));
@@ -4120,6 +4134,9 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
     const uint16_t numOfRequests = prePrepareMsg->numberOfRequests();
 
     executeRequestsInPrePrepareMsg(span, prePrepareMsg);
+    consensus_time_.add(seqNumInfo.getCommitDurationMs());
+    consensus_avg_time_.Get().Set((uint64_t)consensus_time_.avg());
+    if (consensus_time_.numOfElements() == 1000) consensus_time_.reset();  // We reset the average every 1000 samples
     metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
     metric_total_finished_consensuses_.Get().Inc();
     if (seqNumInfo.slowPathStarted()) {

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -186,9 +186,14 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   GaugeHandle metric_sent_replica_asks_to_leave_view_msg_;
   GaugeHandle metric_bft_batch_size_;
   GaugeHandle my_id;
+  GaugeHandle primary_queue_size_;
+  GaugeHandle consensus_avg_time_;
+  GaugeHandle accumulating_batch_avg_time_;
   // The first commit path being attempted for a new request.
   StatusHandle metric_first_commit_path_;
 
+  CounterHandle batch_closed_on_logic_off_;
+  CounterHandle batch_closed_on_logic_on_;
   CounterHandle metric_indicator_of_non_determinism_;
   CounterHandle metric_total_committed_sn_;
   CounterHandle metric_slow_path_count_;
@@ -230,6 +235,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_total_fastPath_requests_;
   CounterHandle metric_total_preexec_requests_executed_;
   //*****************************************************
+  RollingAvgAndVar consensus_time_;
+  RollingAvgAndVar accumulating_batch_time_;
+  Time time_to_collect_batch_ = MinTime;
+
  public:
   ReplicaImp(const ReplicaConfig&,
              shared_ptr<IRequestsHandler>,
@@ -280,8 +289,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   SeqNum getLastExecutedSeqNum() const override { return lastExecutedSeqNum; }
   PrePrepareMsg* buildPrePrepareMessage() override;
   bool tryToSendPrePrepareMsg(bool batchingLogic = false) override;
-  bool tryToSendPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) override;
-  bool tryToSendPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) override;
+  PrePrepareMsg* buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) override;
+  PrePrepareMsg* buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) override;
 
  protected:
   ReplicaImp(bool firstTime,

--- a/bftengine/src/bftengine/RequestsBatchingLogic.cpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.cpp
@@ -93,13 +93,13 @@ PrePrepareMsg *RequestsBatchingLogic::batchRequests() {
       break;
     case BATCH_BY_REQ_NUM: {
       lock_guard<mutex> lock(batchProcessingLock_);
-      if (replica_.tryToSendPrePrepareMsgBatchByRequestsNum(maxNumOfRequestsInBatch_))
-        timers_.reset(batchFlushTimer_, milliseconds(batchFlushPeriodMs_));
+      prePrepareMsg = replica_.buildPrePrepareMsgBatchByRequestsNum(maxNumOfRequestsInBatch_);
+      if (prePrepareMsg) timers_.reset(batchFlushTimer_, milliseconds(batchFlushPeriodMs_));
     } break;
     case BATCH_BY_REQ_SIZE: {
       lock_guard<mutex> lock(batchProcessingLock_);
-      if (replica_.tryToSendPrePrepareMsgBatchByOverallSize(maxBatchSizeInBytes_))
-        timers_.reset(batchFlushTimer_, milliseconds(batchFlushPeriodMs_));
+      prePrepareMsg = replica_.buildPrePrepareMsgBatchByOverallSize(maxBatchSizeInBytes_);
+      if (prePrepareMsg) timers_.reset(batchFlushTimer_, milliseconds(batchFlushPeriodMs_));
     } break;
   }
   return prePrepareMsg;

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -113,6 +113,10 @@ class SeqNumInfo {
     commitMsgsCollector->onCompletionOfCombinedSigVerification(seqNumber, viewNumber, isValid);
   }
 
+  uint64_t getCommitDurationMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(commitUpdateTime - firstSeenFromPrimary).count();
+  }
+
  protected:
   class ExFuncForPrepareCollector {
    public:


### PR DESCRIPTION
Here we add the following metrics:

1. number of batches closed with batching logic
2. number of batches closed without batching logic
3. primary queue size
4. a rolling average of consensus duration
5. a rolling average of closing batch duration