### PR TITLE
Pause status request during collecting state.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3112,6 +3112,8 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
 }
 
 void ReplicaImp::onStatusReportTimer(Timers::Handle timer) {
+  if (isCollectingState()) return;
+
   tryToSendStatusReport(true);
 
 #ifdef DEBUG_MEMORY_MSG


### PR DESCRIPTION
For the destination replica in State Transfer we delegate the
access to state variables to the BCStateTran. We need to pause
this timer as we do for all other timers.