### PR TITLE
CMF: Add 'Enum' type

### DIFF
--- a/messages/compiler/cpp/serialize.cpp
+++ b/messages/compiler/cpp/serialize.cpp
@@ -84,6 +84,26 @@ void deserialize(const uint8_t*& start, const uint8_t* end, T& t) {
 }
 
 /******************************************************************************
+ * Enums
+ *
+ * Enums are type wrappers around uint8_t
+ ******************************************************************************/
+template <typename T, typename std::enable_if<std::is_enum<T>::value>::type* = nullptr>
+void serialize(std::vector<uint8_t>& output, const T& t) {
+  serialize(output, static_cast<uint8_t>(t));
+}
+
+template <typename T, typename std::enable_if<std::is_enum<T>::value>::type* = nullptr>
+void deserialize(const uint8_t*& start, const uint8_t* end, T& t) {
+  uint8_t val;
+  deserialize(start, end, val);
+  t = static_cast<T>(val);
+  if (val >= enumSize(t)) {
+    throw BadDataError(std::string("Value < ") + std::to_string(enumSize(t)), std::to_string(val));
+  }
+}
+
+/******************************************************************************
  * Strings
  *
  * Strings are preceded by a uint32_t length

--- a/messages/compiler/grammar.ebnf
+++ b/messages/compiler/grammar.ebnf
@@ -1,21 +1,25 @@
 @@grammar :: CMF
 @@comments :: /#.*/
 
-start = msgs:{msg}+ $ ;
+start = {toplevel}+ $ ;
+
+toplevel = msgs:{msg}+ | enums:{enum_def}+ ;
 
 msg = 'Msg' name:msgname id:msgid '{' fields:{field}+ '}' ;
+enum_def = 'Enum' name:enumname '{' tags:','.{name}+ '}' ;
 
 msgname = name:name;
+enumname = name:name;
 msgid = id:number;
-field = type:(compound | primitive | msgname_ref) name:name ;
+field = type:(compound | primitive | toplevel_ref) name:name ;
 
-compound = kvpair:kvpair | list:list | fixedlist:fixedlist | map:map | optional:optional | oneof:oneof;
-kvpair = 'kvpair' key:primitive value:(primitive | compound | msgname_ref) ;
-list = 'list' type:(primitive | compound | msgname_ref) ;
-fixedlist = 'fixedlist' type:(primitive | compound | msgname_ref) size:number ;
-map = 'map' key:primitive value:(primitive | compound | msgname_ref) ;
-optional = 'optional' type:(primitive | compound | msgname_ref) ;
-oneof = 'oneof' '{' msg_names:{msgname_ref}+ '}' ;
+compound = kvpair:kvpair | list:list | fixedlist:fixedlist | map:map | optional:optional | oneof:oneof ;
+kvpair = 'kvpair' key:primitive value:(primitive | compound | toplevel_ref) ;
+list = 'list' type:(primitive | compound | toplevel_ref) ;
+fixedlist = 'fixedlist' type:(primitive | compound | toplevel_ref) size:number ;
+map = 'map' key:primitive value:(primitive | compound | toplevel_ref) ;
+optional = 'optional' type:(primitive | compound | toplevel_ref) ;
+oneof = 'oneof' '{' msg_names:{toplevel_ref}+ '}' ;
 
 primitive
   =
@@ -41,6 +45,7 @@ bool = 'bool';
 string = 'string';
 bytes = 'bytes';
 
-msgname_ref = name:name;
+# A reference to an Enum or Msg used in a field
+toplevel_ref = name:name;
 name = /[a-zA-Z_][a-zA-Z0-9_]*/ ;
 number = /\d+/ ;

--- a/messages/compiler/python/py_visitor.py
+++ b/messages/compiler/python/py_visitor.py
@@ -1,6 +1,6 @@
 # Concord
 #
-# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the Apache 2.0 license (the 'License').
 # You may not use this product except in compliance with the Apache 2.0 License.
@@ -122,6 +122,9 @@ class PyVisitor(Visitor):
             [self.msg_class, self.serialize, self.deserialize, self.eq])
         self._reset()
 
+    def create_enum(self, name, tags):
+        self.output += f'''\n{name} = enum.Enum(\'{name}\', {tags}, start=0)\n'''
+
     def field_start(self, name, type):
         self.field_name = name
         self.msg_class += f'         self.{name} = None\n'
@@ -212,3 +215,6 @@ class PyVisitor(Visitor):
 
     def oneof(self, msgs):
         self.serializers.append(('oneof', msgs))
+
+    def enum(self, name):
+        self.serializers.append(('enum', name))

--- a/messages/compiler/python/test_pygen.py
+++ b/messages/compiler/python/test_pygen.py
@@ -231,3 +231,29 @@ def test_FixedTransactionList(codegen):
     msg.transactions2 = [t1]
     with pytest.raises(example.CmfSerializeError):
         s = msg.serialize()
+
+def test_ContainsEnum(codegen):
+    import example
+
+    msg = example.ContainsEnum()
+    msg.color = example.Color(1)
+    msg.colors = [example.Color(0)]
+    msg.colors_by_name = {'red': example.Color(0)}
+    assert_roundtrip(msg)
+
+    # Try to serialize an invalid type
+    msg.color = 'red'
+    with pytest.raises(example.CmfSerializeError):
+        msg.serialize()
+
+    # Try to serialize a class with the same name but that isn't an enum
+    class Color:
+        pass
+    msg.color = Color()
+    with pytest.raises(example.CmfSerializeError):
+        msg.serialize()
+
+    # Try to deserialize a message with a value outside the enum range (0-2)
+    s = bytearray(b'\x03')
+    with pytest.raises(ValueError):
+        msg.deserialize(s)

--- a/messages/compiler/semantics.py
+++ b/messages/compiler/semantics.py
@@ -13,10 +13,16 @@ class SymbolTable:
         # Line numbers are stored as values
         self.msg_ids = dict()
         self.msg_names = dict()
+        self.enum_names = dict()
 
 
 class CmfSemantics(object):
-    """ Perform basic type checking and conversion on the AST"""
+    """
+    Perform basic type checking and conversion on the AST
+
+    Function names are the names of rules in grammar.ebnf
+    See https://tatsu.readthedocs.io/en/4.4/semantics.html
+    """
 
     def __init__(self, symbol_table):
         self.symbol_table = symbol_table
@@ -34,19 +40,37 @@ class CmfSemantics(object):
         self.symbol_table.msg_ids[id] = ast.parseinfo.line + 1
         return id
 
-    def msgname_ref(self, ast):
-        if ast.name not in self.symbol_table.msg_names.keys():
-            raise CmfParseError(
-                ast.parseinfo, "Messages must be defined before they are referenced: {}".format(ast.name))
-        return ast.name
+    def toplevel_ref(self, ast):
+        """ Determine if the name in the ast is a Msg or Enum and tag it. """
+        if ast.name in self.symbol_table.msg_names.keys():
+            return {'msg': ast.name}
+        if ast.name in self.symbol_table.enum_names.keys():
+            return {'enum': ast.name}
+        raise CmfParseError(
+            ast.parseinfo, "Messages or Enums must be defined before they are referenced: {}".format(ast.name))
 
     def msgname(self, ast):
         """ Check that message names are unique """
         if ast.name in self.symbol_table.msg_names:
             raise CmfParseError(ast.parseinfo, 'Message: "{}" already defined on line {}'.format(
                 ast.name, self.symbol_table.msg_names[ast.name]))
+        if ast.name in self.symbol_table.enum_names:
+            raise CmfParseError(ast.parseinfo, 'Message: "{}" cannot have the same name as the Enum defined on line {}'.format(
+                ast.name, self.symbol_table.enum_names[ast.name]))
         # parseinfo.line is zero-based
         self.symbol_table.msg_names[ast.name] = ast.parseinfo.line + 1
+        return ast.name
+
+    def enumname(self, ast):
+        """ Check that enum names are unique """
+        if ast.name in self.symbol_table.enum_names:
+            raise CmfParseError(ast.parseinfo, 'Enum: "{}" already defined on line {}'.format(
+                ast.name, self.symbol_table.enum_names[ast.name]))
+        if ast.name in self.symbol_table.msg_names:
+            raise CmfParseError(ast.parseinfo, 'Enum: "{}" cannot have the same name as the Msg defined on line {}'.format(
+                ast.name, self.symbol_table.msg_names[ast.name]))
+        # parseinfo.line is zero-based
+        self.symbol_table.enum_names[ast.name] = ast.parseinfo.line + 1
         return ast.name
 
     def msg(self, ast):
@@ -57,4 +81,16 @@ class CmfSemantics(object):
                 raise CmfParseError(
                     ast.parseinfo, 'Message: "{}" contains duplicate field: "{}"'.format(ast.name, field.name))
             field_names.add(field.name)
+        return ast
+
+    def enum_def(self, ast):
+        """ Ensure that an enum fits in a uint8 and that it has no duplicate fields """
+        if (len(ast.tags) > 256):
+            raise CmfParseError(ast.parseinfo, 'Enum: "{}" contains more than 256 entries. It must fit in a uint8_t'.format(ast.name))
+        tags = set()
+        for tag in ast.tags:
+            if tag in tags:
+                raise CmfParseError(
+                    ast.parseinfo, 'Enum: "{}" contains duplicate tag: "{}"'.format(ast.name, tag))
+            tags.add(tag)
         return ast

--- a/messages/compiler/visitor.py
+++ b/messages/compiler/visitor.py
@@ -38,7 +38,8 @@ class Visitor(metaclass=ABCMeta):
     `key_end`, like `kvpair_key_end`.
 
     Top level types, 'Msg' and 'Field', cannot be nested, although they also register two
-    callbacks, since they must be "opened" and "closed".
+    callbacks, since they must be "opened" and "closed". The top-level 'Enum' type does not
+    require more than one callback.
 
     See 'grammar.ebnf' for details about all types.
     """
@@ -46,6 +47,17 @@ class Visitor(metaclass=ABCMeta):
     #
     # TOP LEVEL TYPES
     #
+
+    @abstractmethod
+    def create_enum(self, name, tags):
+      """
+        A new enum has been defined.
+        Enum definitions are not nestable.
+
+        Args:
+            name (str): The name of the Enum
+            tags (list(str)): The possible values of the enumeration
+        """
 
     @abstractmethod
     def msg_start(self, name, id):
@@ -206,5 +218,15 @@ class Visitor(metaclass=ABCMeta):
 
         Args:
            msgs (dict(str, int)): A dict mapping the names of messages to their ids.
+        """
+        pass
+
+    @abstractmethod
+    def enum(self, name):
+        """
+        An enum field used to refer to a previously defined Enum.
+
+        Args:
+            name (str): The name of the Enum
         """
         pass

--- a/messages/example.cmf
+++ b/messages/example.cmf
@@ -73,9 +73,32 @@ Msg ComposedFixedList 16 {
     list fixedlist uint8 32 hashes
 }
 
+Enum Color { red, blue, yellow }
+
+Msg ContainsEnum 17 {
+    Color color
+    map string Color colors_by_name
+    list Color colors
+}
+
+Msg ComposedOneof 18 {
+    list oneof {Transaction NewViewElement} x
+}
+
 ######
 # Uncomment each message to induce various parse errors
 ######
+
+# Oneof containing enum
+#Msg OneofContainsEnum 1000 {
+#    oneof { Color } x
+#}
+
+# Duplicate Enum name
+#Enum Color {black, white}
+
+# Enum with same name as Msg
+#Enum Envelope { a, b, c}
 
 # Duplicate name
 #Msg Envelope 1000 {


### PR DESCRIPTION
A change was made to the CMF grammar to introduce a new top-level type:
`Enum`. An Enum creates an automatically numbered set of tags starting
at 0. Similar to messsages, Enum's can be directly used in fields and
compound types. We still only allow Msgs in oneofs however.

This choice to introduce a top-level type was made to allow including
Enums directly in messages rather than declaring them in a message and
then having to refer indirectly to a container messsage. It's unclear to
me whether this was the best decision, or whether we should only have
`Msg`s as top-level types. I'm open to revisiting this if need be. It
should be noted that even if we decide to change the grammar, the on the
wire format will not change.

Support for C++ and Python was added, along with tests and updated
documentation.