### PR TITLE
Fix undefined behavior due to up casting.

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -277,7 +277,7 @@ void DescriptorOfLastNewView::deserializeElement(uint32_t id, char *buf, size_t 
   std::unique_ptr<MessageBase> msgBase(MessageBase::deserializeMsg(buf, bufLen, actualSize));
   auto msg = new ViewChangeMsg(msgBase.get());
   ConcordAssert(viewChangeMsgs[id] == nullptr);
-  viewChangeMsgs[id] = ((ViewChangeMsg *)msg);
+  viewChangeMsgs[id] = msg;
 }
 
 /***** DescriptorOfLastExecution *****/

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -120,8 +120,10 @@ void DescriptorOfLastExitFromView::deserializeSimpleParams(char *buf, size_t buf
 
   size_t actualMsgSize = 0;
   std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, actualMsgSize));
-  myViewChangeMsg = new ViewChangeMsg(baseMsg.get());
-
+  myViewChangeMsg = nullptr;
+  if (baseMsg) {
+    myViewChangeMsg = new ViewChangeMsg(baseMsg.get());
+  }
   uint32_t elementsNum;
   size_t elementsNumSize = sizeof(elementsNum);
   memcpy(&elementsNum, buf, elementsNumSize);
@@ -140,11 +142,15 @@ void DescriptorOfLastExitFromView::deserializeElement(uint32_t id, char *buf, si
   PrepareFullMsg *prepareFullMsgPtr = nullptr;
   {
     std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, msgSize1));
-    prePrepareMsgPtr = new PrePrepareMsg(baseMsg.get());
+    if (baseMsg) {
+      prePrepareMsgPtr = new PrePrepareMsg(baseMsg.get());
+    }
   }
   {
     std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, msgSize2));
-    prepareFullMsgPtr = new PrepareFullMsg(baseMsg.get());
+    if (baseMsg) {
+      prepareFullMsgPtr = new PrepareFullMsg(baseMsg.get());
+    }
   }
 
   bool hasAllRequests = false;
@@ -259,12 +265,18 @@ void DescriptorOfLastNewView::deserializeSimpleParams(char *buf, size_t bufLen, 
   size_t newViewMsgSize = 0;
   {
     std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, newViewMsgSize));
-    newViewMsg = new NewViewMsg(baseMsg.get());
+    newViewMsg = nullptr;
+    if (baseMsg) {
+      newViewMsg = new NewViewMsg(baseMsg.get());
+    }
   }
   size_t myViewChangeMsgSize = 0;
   {
     std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, myViewChangeMsgSize));
-    myViewChangeMsg = new ViewChangeMsg(baseMsg.get());
+    myViewChangeMsg = nullptr;
+    if (baseMsg) {
+      myViewChangeMsg = new ViewChangeMsg(baseMsg.get());
+    }
   }
   actualSize = isDefaultSize + viewSize + maxSeqNumSize + stableLowerBoundWhenEnteredToViewSize + newViewMsgSize +
                myViewChangeMsgSize;
@@ -275,7 +287,10 @@ void DescriptorOfLastNewView::deserializeElement(uint32_t id, char *buf, size_t 
   ConcordAssert(id < viewChangeMsgsNum);
 
   std::unique_ptr<MessageBase> msgBase(MessageBase::deserializeMsg(buf, bufLen, actualSize));
-  auto msg = new ViewChangeMsg(msgBase.get());
+  ViewChangeMsg *msg = nullptr;
+  if (msgBase) {
+    msg = new ViewChangeMsg(msgBase.get());
+  }
   ConcordAssert(viewChangeMsgs[id] == nullptr);
   viewChangeMsgs[id] = msg;
 }

--- a/bftengine/src/bftengine/PersistentStorageWindows.cpp
+++ b/bftengine/src/bftengine/PersistentStorageWindows.cpp
@@ -151,7 +151,11 @@ uint8_t CheckData::deserializeCompletedMark(char *&buf) {
 
 CheckpointMsg *CheckData::deserializeCheckpointMsg(char *&buf, uint32_t bufLen, size_t &actualMsgSize) {
   std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, actualMsgSize));
-  return new CheckpointMsg(baseMsg.get());
+  CheckpointMsg *msg = nullptr;
+  if (baseMsg) {
+    msg = new CheckpointMsg(baseMsg.get());
+  }
+  return msg;
 }
 
 CheckData CheckData::deserialize(char *buf, uint32_t bufLen, uint32_t &actualSize) {

--- a/bftengine/src/bftengine/PersistentStorageWindows.cpp
+++ b/bftengine/src/bftengine/PersistentStorageWindows.cpp
@@ -150,7 +150,8 @@ uint8_t CheckData::deserializeCompletedMark(char *&buf) {
 }
 
 CheckpointMsg *CheckData::deserializeCheckpointMsg(char *&buf, uint32_t bufLen, size_t &actualMsgSize) {
-  return (CheckpointMsg *)MessageBase::deserializeMsg(buf, bufLen, actualMsgSize);
+  std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, actualMsgSize));
+  return new CheckpointMsg(baseMsg.get());
 }
 
 CheckData CheckData::deserialize(char *buf, uint32_t bufLen, uint32_t &actualSize) {


### PR DESCRIPTION
Everywhere we deserialize messages inheriting MessageBase we use
MessageBase::deserializeMsg, which returns a MessageBase pointer.
Up-casting it to the actual Message type is not sufficient, we need
to actually create the proper object and transfer the packed struct
containing the header and dynamic payload to it.