### PR TITLE
TLS: Remove 'time_between_reads' histogram

### DIFF
--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -29,15 +29,10 @@ void AsyncTlsConnection::readMsgSizeHeader(std::optional<size_t> bytes_already_r
   const size_t offset = bytes_already_read ? bytes_already_read.value() : 0;
   const size_t bytes_remaining = MSG_HEADER_SIZE - offset;
   auto buf = boost::asio::buffer(read_size_buf_.data() + offset, bytes_remaining);
-  const auto start_read = std::chrono::steady_clock::now();
   tlsTcpImpl_.status_->msg_size_header_read_attempts++;
 
   socket_->async_read_some(
-      buf,
-      [this, self, bytes_already_read, bytes_remaining, start_read](const auto& error_code, auto bytes_transferred) {
-        auto interval =
-            std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_read);
-        tlsTcpImpl_.histograms_.time_between_reads->record(interval.count());
+      buf, [this, self, bytes_already_read, bytes_remaining](const auto& error_code, auto bytes_transferred) {
         if (disposed_) {
           return;
         }

--- a/communication/src/TlsDiagnostics.h
+++ b/communication/src/TlsDiagnostics.h
@@ -118,7 +118,6 @@ struct Recorders {
                                       received_msg_size,
                                       send_time_in_queue,
                                       read_enqueue_time,
-                                      time_between_reads,
                                       connect_callback,
                                       on_connection_authenticated});
   }
@@ -129,7 +128,6 @@ struct Recorders {
   DEFINE_SHARED_RECORDER(write_queue_len, 1, MAX_QUEUE_LENGTH, 3, Unit::COUNT);
   DEFINE_SHARED_RECORDER(send_time_in_queue, 1, MAX_US, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(read_enqueue_time, 1, MAX_US, 3, Unit::MICROSECONDS);
-  DEFINE_SHARED_RECORDER(time_between_reads, 1, MAX_US, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(connect_callback, 1, MAX_US, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(on_connection_authenticated, 1, MAX_US, 3, Unit::MICROSECONDS);
 };


### PR DESCRIPTION
This histogram is overall pretty useless, and when there are long idle
times recording is outside the range of the histogram resulting in a
`WARN` level log message from the preformance handler. In some workloads
these messages fill logs. The simplest solution is just to remove the
histogram.