### PR TITLE
Fix undefined behavior due to up casting. (#1328)

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageWindows.cpp
+++ b/bftengine/src/bftengine/PersistentStorageWindows.cpp
@@ -150,7 +150,12 @@ uint8_t CheckData::deserializeCompletedMark(char *&buf) {
 }
 
 CheckpointMsg *CheckData::deserializeCheckpointMsg(char *&buf, uint32_t bufLen, size_t &actualMsgSize) {
-  return (CheckpointMsg *)MessageBase::deserializeMsg(buf, bufLen, actualMsgSize);
+  std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, actualMsgSize));
+  CheckpointMsg *msg = nullptr;
+  if (baseMsg) {
+    msg = new CheckpointMsg(baseMsg.get());
+  }
+  return msg;
 }
 
 CheckData CheckData::deserialize(char *buf, uint32_t bufLen, uint32_t &actualSize) {


### PR DESCRIPTION
* Fix undefined behavior due to up casting.

Everywhere we deserialize messages inheriting MessageBase we use
MessageBase::deserializeMsg, which returns a MessageBase pointer.
Up-casting it to the actual Message type is not sufficient, we need
to actually create the proper object and transfer the packed struct
containing the header and dynamic payload to it.

* Remove unnecessary C-cast.

* Take in consideration that MessageBase::deserializeMsg might return nullptr.

If the storage is empty we might get a nullptr for a given message.
In this case we must not construct anything and simply set to nullptr.