### PR TITLE
Fix for deletion of messages that are being used.

### DIFF
--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -175,6 +175,9 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
                                                   descriptorOfLastNewView.viewChangeMsgs);
 
     ld.maxSeqNumTransferredFromPrevViews = descriptorOfLastNewView.maxSeqNumTransferredFromPrevViews;
+    // we have not used descriptorOfLastExitFromView, therefore
+    // we need to clean up the messages we have allocated inside it.
+    descriptorOfLastExitFromView.clean();
   } else {
     LOG_ERROR(GL,
               "Failed to load view (inconsistent state): " << KVLOG(
@@ -183,7 +186,6 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
   }
 
   ld.viewsManager = viewsManager;
-  descriptorOfLastExitFromView.clean();
   return Succ;
 }
 


### PR DESCRIPTION
In case we recover from descriptorOfLastExitFromView we pass
the messages inside it to ViewsManager. Those messages currently
are raw pointers and we cannot delete them in the end of loadViewInfo()
We only delete them if we have not used them - the case in which we
use descriptorOfLastNewView.