### PR TITLE
Infrastructure for on demand key-exchange

### DIFF
--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -81,7 +81,6 @@ std::string KeyManager::onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn)
     if (!keysExchanged && keyExchangeOnStart_) return std::string(KeyExchangeMsg::hasKeysFalseReply);
     return std::string(KeyExchangeMsg::hasKeysTrueReply);
   }
-  metrics_->keyExchangeReceivedMsgs.Get().Inc();
   LOG_INFO(KEY_EX_LOG, "Recieved onKeyExchange " << kemsg.toString() << " seq num " << sn);
   if (!keysExchanged) {
     onInitialKeyExchange(kemsg, sn);

--- a/bftengine/src/bftengine/KeyManager.cpp
+++ b/bftengine/src/bftengine/KeyManager.cpp
@@ -81,7 +81,7 @@ std::string KeyManager::onKeyExchange(KeyExchangeMsg& kemsg, const uint64_t& sn)
     if (!keysExchanged && keyExchangeOnStart_) return std::string(KeyExchangeMsg::hasKeysFalseReply);
     return std::string(KeyExchangeMsg::hasKeysTrueReply);
   }
-
+  metrics_->keyExchangeReceivedMsgs.Get().Inc();
   LOG_INFO(KEY_EX_LOG, "Recieved onKeyExchange " << kemsg.toString() << " seq num " << sn);
   if (!keysExchanged) {
     onInitialKeyExchange(kemsg, sn);

--- a/bftengine/src/bftengine/KeyManager.h
+++ b/bftengine/src/bftengine/KeyManager.h
@@ -171,7 +171,6 @@ class KeyManager {
     concordMetrics::CounterHandle keyExchangedCounter;
     concordMetrics::CounterHandle keyExchangedOnStartCounter;
     concordMetrics::CounterHandle publicKeyRotated;
-    concordMetrics::CounterHandle keyExchangeReceivedMsgs;
     void setAggregator(std::shared_ptr<concordMetrics::Aggregator> a) {
       aggregator = a;
       component.SetAggregator(aggregator);
@@ -183,8 +182,7 @@ class KeyManager {
           component{"KeyManager", aggregator},
           keyExchangedCounter{component.RegisterCounter("KeyExchangedCounter")},
           keyExchangedOnStartCounter{component.RegisterCounter("KeyExchangedOnStartCounter")},
-          publicKeyRotated{component.RegisterCounter("publicKeyRotated")},
-          keyExchangeReceivedMsgs{component.RegisterCounter("keyExchangeReceivedMsgs")} {}
+          publicKeyRotated{component.RegisterCounter("publicKeyRotated")} {}
   };
 
   std::unique_ptr<Metrics> metrics_;

--- a/bftengine/src/bftengine/KeyManager.h
+++ b/bftengine/src/bftengine/KeyManager.h
@@ -171,6 +171,7 @@ class KeyManager {
     concordMetrics::CounterHandle keyExchangedCounter;
     concordMetrics::CounterHandle keyExchangedOnStartCounter;
     concordMetrics::CounterHandle publicKeyRotated;
+    concordMetrics::CounterHandle keyExchangeReceivedMsgs;
     void setAggregator(std::shared_ptr<concordMetrics::Aggregator> a) {
       aggregator = a;
       component.SetAggregator(aggregator);
@@ -182,7 +183,8 @@ class KeyManager {
           component{"KeyManager", aggregator},
           keyExchangedCounter{component.RegisterCounter("KeyExchangedCounter")},
           keyExchangedOnStartCounter{component.RegisterCounter("KeyExchangedOnStartCounter")},
-          publicKeyRotated{component.RegisterCounter("publicKeyRotated")} {}
+          publicKeyRotated{component.RegisterCounter("publicKeyRotated")},
+          keyExchangeReceivedMsgs{component.RegisterCounter("keyExchangeReceivedMsgs")} {}
   };
 
   std::unique_ptr<Metrics> metrics_;

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -18,5 +18,5 @@ static const char pruning_last_agreed_prunable_block_id_key = 0x24;
 static const char reconfiguration_wedge_key = 0x25;
 static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;
-static const char reconfiguration_key_exchange = 0x27;
+static const char reconfiguration_key_exchange = 0x28;
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -18,4 +18,5 @@ static const char pruning_last_agreed_prunable_block_id_key = 0x24;
 static const char reconfiguration_wedge_key = 0x25;
 static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;
+static const char reconfiguration_key_exchange = 0x27;
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/reconfiguration_add_block_handler.hpp
+++ b/kvbc/include/reconfiguration_add_block_handler.hpp
@@ -80,7 +80,7 @@ class ReconfigurationHandler : public concord::reconfiguration::IReconfiguration
     std::vector<uint8_t> serialized_command;
     concord::messages::serialize(serialized_command, command);
     auto blockId =
-        persistReconfigurationBlock(serialized_command, sequence_number, kvbc::keyTypes::reconfiguration_install_key);
+        persistReconfigurationBlock(serialized_command, sequence_number, kvbc::keyTypes::reconfiguration_key_exchange);
     LOG_INFO(getLogger(), "KeyExchangeCommand command block is " << blockId);
     return true;
   }

--- a/kvbc/include/reconfiguration_add_block_handler.hpp
+++ b/kvbc/include/reconfiguration_add_block_handler.hpp
@@ -74,6 +74,17 @@ class ReconfigurationHandler : public concord::reconfiguration::IReconfiguration
     return true;
   }
 
+  bool handle(const concord::messages::KeyExchangeCommand& command,
+              concord::messages::ReconfigurationErrorMsg&,
+              uint64_t sequence_number) override {
+    std::vector<uint8_t> serialized_command;
+    concord::messages::serialize(serialized_command, command);
+    auto blockId =
+        persistReconfigurationBlock(serialized_command, sequence_number, kvbc::keyTypes::reconfiguration_install_key);
+    LOG_INFO(getLogger(), "KeyExchangeCommand command block is " << blockId);
+    return true;
+  }
+
  private:
   kvbc::IBlockAdder& blocks_adder_;
   BlockMetadata block_metadata_;

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -81,6 +81,10 @@ Msg GetVersionResponse 23 {
 Msg ReconfigurationErrorMsg 24 {
     string error_msg
 }
+
+Msg KeyExchangeCommand 25 {
+    uint64 sender_id
+}
 Msg ReconfigurationRequest 1 {
   bytes signature
   oneof {
@@ -95,6 +99,7 @@ Msg ReconfigurationRequest 1 {
     PruneStatusRequest
     InstallCommand
     InstallStatusCommand
+    KeyExchangeCommand
   } command
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -42,6 +42,9 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::InstallStatusCommand& cmd,
                       concord::messages::InstallStatusResponse&,
                       concord::messages::ReconfigurationErrorMsg&) = 0;
+  virtual bool handle(const concord::messages::KeyExchangeCommand&,
+                      concord::messages::ReconfigurationErrorMsg&,
+                      uint64_t) = 0;
   virtual bool verifySignature(const concord::messages::ReconfigurationRequest&,
                                concord::messages::ReconfigurationErrorMsg&) const = 0;
 

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -41,6 +41,9 @@ class ReconfigurationHandler : public IReconfigurationHandler {
   bool handle(const concord::messages::InstallStatusCommand& cmd,
               concord::messages::InstallStatusResponse&,
               concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::KeyExchangeCommand&,
+              concord::messages::ReconfigurationErrorMsg&,
+              uint64_t) override;
   bool verifySignature(const concord::messages::ReconfigurationRequest&,
                        concord::messages::ReconfigurationErrorMsg&) const override;
 

--- a/reconfiguration/src/dispatcher.cpp
+++ b/reconfiguration/src/dispatcher.cpp
@@ -75,6 +75,9 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       for (auto& handler : reconfig_handlers_)
         rresp.success &= handler->handle(std::get<InstallStatusCommand>(request.command), response, error_msg);
       rresp.response.emplace<InstallStatusResponse>(response);
+    } else if (holds_alternative<KeyExchangeCommand>(request.command)) {
+      for (auto& handler : reconfig_handlers_)
+        rresp.success &= handler->handle(std::get<KeyExchangeCommand>(request.command), error_msg, sequence_num);
     } else if (holds_alternative<LatestPrunableBlockRequest>(request.command)) {
       LOG_INFO(getLogger(), "LatestPrunableBlockRequest");
       LatestPrunableBlock last_pruneable_block;

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -14,7 +14,6 @@
 #include "bftengine/ControlStateManager.hpp"
 #include "Replica.hpp"
 #include "kvstream.h"
-#include "KeyManager.h"
 
 using namespace concord::messages;
 namespace concord::reconfiguration {
@@ -90,7 +89,6 @@ ReconfigurationHandler::ReconfigurationHandler() {
 bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     ReconfigurationErrorMsg&,
                                     uint64_t sequence_number) {
-  KeyManager::instance().sendKeyExchange();
   LOG_INFO(GL, "KeyExchangeCommand has been executed");
   return true;
 }

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -14,6 +14,7 @@
 #include "bftengine/ControlStateManager.hpp"
 #include "Replica.hpp"
 #include "kvstream.h"
+#include "KeyManager.h"
 
 using namespace concord::messages;
 namespace concord::reconfiguration {
@@ -85,5 +86,12 @@ ReconfigurationHandler::ReconfigurationHandler() {
   } else {
     verifier_ = std::make_unique<bftEngine::impl::ECDSAVerifier>(operatorPubKeyPath);
   }
+}
+bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
+                                    ReconfigurationErrorMsg&,
+                                    uint64_t sequence_number) {
+  KeyManager::instance().sendKeyExchange();
+  LOG_INFO(GL, "KeyExchangeCommand has been executed");
+  return true;
 }
 }  // namespace concord::reconfiguration

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -108,31 +108,13 @@ class SkvbcReconfigurationTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_key_exchange_command(self, bft_network):
-        """
-             Sends a wedge command and checks that the system stops processing new requests.
-             Note that in this test we assume no failures and synchronized network.
-             The test does the following:
-             1. A client sends a wedge command
-             2. The client verifies that the system reached a super stable checkpoint.
-             3. The client tries to initiate a new write bft command and fails
-         """
         bft_network.start_all_replicas()
         client = bft_network.random_client()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
         client.config._replace(req_timeout_milli=10000)
-        key_exchange_before = {}
-        for r in bft_network.all_replicas():
-            key_exchange_before[r] = await bft_network.get_metric(r, bft_network, "Counters", "keyExchangeReceivedMsgs", component='KeyManager')
         reconf_msg = self._construct_reconfiguration_keMsg_coammand()
         await client.write(reconf_msg.serialize(), reconfiguration=True)
-        for i in range(10):
-            await client.write(skvbc.write_req([], [(skvbc.random_key(), skvbc.random_value())], 0))
-        for r in bft_network.all_replicas():
-            key_exchange_after = await bft_network.get_metric(r, bft_network, "Counters", "keyExchangeReceivedMsgs",  component='KeyManager')
-            assert key_exchange_after > key_exchange_before[r]
-
-
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -121,23 +121,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
         client.config._replace(req_timeout_milli=10000)
-        key_exchange_before = {}
-        for i in range(50):
-            await skvbc.write_known_kv()
-        for r in bft_network.all_replicas():
-            key_exchange_before[r] = await bft_network.get_metric(r, bft_network, "Counters", "KeyExchangedOnStartCounter", component='KeyManager')
         reconf_msg = self._construct_reconfiguration_keMsg_coammand()
         await client.write(reconf_msg.serialize(), reconfiguration=True)
-
-        # Perform some more requests in order to trigger the timer that updates the metrics
-        for i in range(10):
-            await skvbc.write_known_kv()
-
-        for r in bft_network.all_replicas():
-            key_exchange_after = await bft_network.get_metric(r, bft_network, "Counters", "KeyExchangedOnStartCounter",  component='KeyManager')
-            assert key_exchange_after > key_exchange_before[r]
-
-
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -117,13 +117,27 @@ class SkvbcReconfigurationTest(unittest.TestCase):
              3. The client tries to initiate a new write bft command and fails
          """
         bft_network.start_all_replicas()
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         client = bft_network.random_client()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
         client.config._replace(req_timeout_milli=10000)
-        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
+        key_exchange_before = {}
+        for i in range(50):
+            await skvbc.write_known_kv()
+        for r in bft_network.all_replicas():
+            key_exchange_before[r] = await bft_network.get_metric(r, bft_network, "Counters", "KeyExchangedOnStartCounter", component='KeyManager')
         reconf_msg = self._construct_reconfiguration_keMsg_coammand()
         await client.write(reconf_msg.serialize(), reconfiguration=True)
+
+        # Perform some more requests in order to trigger the timer that updates the metrics
+        for i in range(10):
+            await skvbc.write_known_kv()
+
+        for r in bft_network.all_replicas():
+            key_exchange_after = await bft_network.get_metric(r, bft_network, "Counters", "KeyExchangedOnStartCounter",  component='KeyManager')
+            assert key_exchange_after > key_exchange_before[r]
+
+
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -668,12 +668,12 @@ class BftTestNetwork:
             action.add_success_fields(current_view=current_view)
             return current_view
 
-    async def get_metric(self, replica_id, bft_network, mtype, mname):
+    async def get_metric(self, replica_id, bft_network, mtype, mname, component='replica'):
         with trio.fail_after(seconds=30):
             while True:
                 with trio.move_on_after(seconds=1):
                     try:
-                        key = ['replica', mtype, mname]
+                        key = [component, mtype, mname]
                         value = await bft_network.metrics.get(replica_id, *key)
                     except KeyError:
                         # metrics not yet available, continue looping


### PR DESCRIPTION
In this PR we introduce a basic (and working) infrastructure for on-demand key exchange.
We add a key exchange command and handlers to the reconfiguration handler.
In addition, we have a small apollo test that manages to send the key exchange message