### PR TITLE
RocksDB: Use OptimisticTransactionDB

### DIFF
--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -20,7 +20,7 @@
 #ifdef USE_ROCKSDB
 #include "Logger.hpp"
 #include <rocksdb/db.h>
-#include <rocksdb/utilities/transaction_db.h>
+#include <rocksdb/utilities/optimistic_transaction_db.h>
 #include <rocksdb/sst_file_manager.h>
 #include "storage/db_interface.h"
 #include "storage/storage_metrics.h"
@@ -158,7 +158,7 @@ class Client : public concord::storage::IDBClient {
 
   // Database object (created on connection).
   std::unique_ptr<::rocksdb::DB> dbInstance_;
-  ::rocksdb::TransactionDB* txn_db_ = nullptr;
+  ::rocksdb::OptimisticTransactionDB* txn_db_ = nullptr;
   std::unique_ptr<const ::rocksdb::Comparator> comparator_;
   std::map<std::string, CfUniquePtr> cf_handles_;
 

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -182,8 +182,9 @@ void Client::openRocksDB(bool readOnly,
                                s.ToString());
     dbInstance_.reset(db);
   } else {
-    ::rocksdb::TransactionDBOptions txn_options;
-    s = ::rocksdb::TransactionDB::Open(db_options, txn_options, m_dbPath, cf_descs, &raw_cf_handles, &txn_db_);
+    ::rocksdb::OptimisticTransactionDBOptions txn_options;
+    s = ::rocksdb::OptimisticTransactionDB::Open(
+        db_options, txn_options, m_dbPath, cf_descs, &raw_cf_handles, &txn_db_);
     unique_cf_handles = raw_to_unique_cf_handles(raw_cf_handles);
     if (!s.ok())
       throw std::runtime_error("Failed to open rocksdb database at " + m_dbPath + std::string(" reason: ") +


### PR DESCRIPTION
Our metadata storage makes use of RocksDB transactions. Unfortunately,
by default RocksDB transactions have a timeout of 1s. In *very* rare
cases we hit this timeout and an exception is thrown. However, the
calling code using transactions does not take this exception into
account, and it winds up being caught at a higher level triggering a
call to `std::terminate`. It would be a relatively significant change at
this point to the behavior to try to catch these timeouts, especially
when we are considering writing a new implementation of state transfer
anyway.

As we don't expect any conflicts in these transactions, and the crash is
occurring during state collection, which is basically single threaded,
the easiest change we can make is to use an `OptimisticTransactionDB`
instead of a `TransactionDB`. An `OptimisticTransactionDB` does conflict
detection checking at commit time and never takes locks, thus
sidestepping the problem of lock timeouts altogether. Additionally, it
likely better suits this specific use case and may actually be faster.