### PR TITLE
BFT client return sequence number

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -28,6 +28,8 @@
 
 namespace bft::client {
 
+typedef std::unordered_map<uint64_t, Reply> SeqNumToReplyMap;
+
 class Client {
  public:
   Client(std::unique_ptr<bft::communication::ICommunication> comm, const ClientConfig& config);
@@ -44,7 +46,7 @@ class Client {
   // Throws a BftClientException on error.
   Reply send(const WriteConfig& config, Msg&& request);
   Reply send(const ReadConfig& config, Msg&& request);
-  std::unordered_map<uint64_t, Reply> sendBatch(std::deque<WriteRequest>& write_requests, const std::string& cid);
+  SeqNumToReplyMap sendBatch(std::deque<WriteRequest>& write_requests, const std::string& cid);
   bool isServing(int numOfReplicas, int requiredNumOfReplicas) const;
 
   // Useful for testing. Shouldn't be relied on in production.

--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -44,7 +44,7 @@ class Client {
   // Throws a BftClientException on error.
   Reply send(const WriteConfig& config, Msg&& request);
   Reply send(const ReadConfig& config, Msg&& request);
-  std::deque<Reply> sendBatch(std::deque<WriteRequest>& write_requests, const std::string& cid);
+  std::unordered_map<uint64_t, Reply> sendBatch(std::deque<WriteRequest>& write_requests, const std::string& cid);
   bool isServing(int numOfReplicas, int requiredNumOfReplicas) const;
 
   // Useful for testing. Shouldn't be relied on in production.
@@ -57,7 +57,7 @@ class Client {
   // Wait for messages until we get a quorum or a retry timeout.
   //
   // Inserts the Replies to the input queue.
-  void wait(std::deque<Reply>& replies);
+  void wait(std::unordered_map<uint64_t, Reply>& replies);
 
   // Return a Reply on quorum, or std::nullopt on timeout.
   std::optional<Reply> wait();

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -218,9 +218,8 @@ Reply Client::send(const MatchConfig& match_config,
   throw TimeoutException(request_config.sequence_number, request_config.correlation_id);
 }
 
-std::unordered_map<uint64_t, Reply> Client::sendBatch(std::deque<WriteRequest>& write_requests,
-                                                      const std::string& cid) {
-  std::unordered_map<uint64_t, Reply> replies;
+SeqNumToReplyMap Client::sendBatch(std::deque<WriteRequest>& write_requests, const std::string& cid) {
+  SeqNumToReplyMap replies;
   std::chrono::milliseconds max_time_to_wait = 0s;
   MatchConfig match_config = writeConfigToMatchConfig(write_requests.front().config);
   auto batch_msg = initBatch(write_requests, cid, max_time_to_wait);
@@ -253,7 +252,7 @@ std::unordered_map<uint64_t, Reply> Client::sendBatch(std::deque<WriteRequest>& 
 }
 
 std::optional<Reply> Client::wait() {
-  std::unordered_map<uint64_t, Reply> replies;
+  SeqNumToReplyMap replies;
   wait(replies);
   if (replies.empty()) {
     static constexpr size_t CLEAR_MATCHER_REPLIES_THRESHOLD = 5;
@@ -270,7 +269,7 @@ std::optional<Reply> Client::wait() {
   return reply;
 }
 
-void Client::wait(std::unordered_map<uint64_t, Reply>& replies) {
+void Client::wait(SeqNumToReplyMap& replies) {
   auto now = std::chrono::steady_clock::now();
   auto retry_timeout = std::chrono::milliseconds(expected_commit_time_ms_.upperLimit());
   auto end_wait = now + retry_timeout;

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -218,8 +218,9 @@ Reply Client::send(const MatchConfig& match_config,
   throw TimeoutException(request_config.sequence_number, request_config.correlation_id);
 }
 
-std::deque<Reply> Client::sendBatch(std::deque<WriteRequest>& write_requests, const std::string& cid) {
-  std::deque<Reply> replies;
+std::unordered_map<uint64_t, Reply> Client::sendBatch(std::deque<WriteRequest>& write_requests,
+                                                      const std::string& cid) {
+  std::unordered_map<uint64_t, Reply> replies;
   std::chrono::milliseconds max_time_to_wait = 0s;
   MatchConfig match_config = writeConfigToMatchConfig(write_requests.front().config);
   auto batch_msg = initBatch(write_requests, cid, max_time_to_wait);
@@ -252,7 +253,7 @@ std::deque<Reply> Client::sendBatch(std::deque<WriteRequest>& write_requests, co
 }
 
 std::optional<Reply> Client::wait() {
-  std::deque<Reply> replies;
+  std::unordered_map<uint64_t, Reply> replies;
   wait(replies);
   if (replies.empty()) {
     static constexpr size_t CLEAR_MATCHER_REPLIES_THRESHOLD = 5;
@@ -265,11 +266,11 @@ std::optional<Reply> Client::wait() {
     primary_ = std::nullopt;
     return std::nullopt;
   }
-  auto reply = std::move(replies.front());
+  auto reply = std::move(replies.begin()->second);
   return reply;
 }
 
-void Client::wait(std::deque<Reply>& replies) {
+void Client::wait(std::unordered_map<uint64_t, Reply>& replies) {
   auto now = std::chrono::steady_clock::now();
   auto retry_timeout = std::chrono::milliseconds(expected_commit_time_ms_.upperLimit());
   auto end_wait = now + retry_timeout;
@@ -282,7 +283,7 @@ void Client::wait(std::deque<Reply>& replies) {
       if (request == reply_certificates_.end()) continue;
       if (auto match = request->second.onReply(std::move(reply))) {
         primary_ = match->primary;
-        replies.push_back(match->reply);
+        replies.insert(std::make_pair(request->first, match->reply));
         reply_certificates_.erase(request->first);
       }
     }

--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -403,8 +403,8 @@ TEST_F(ClientApiTestFixture, batch_of_writes) {
   auto replies = client.sendBatch(request_queue, request1.config.request.correlation_id);
   Msg expected{'w', 'o', 'r', 'l', 'd'};
   ASSERT_EQ(replies.size(), request_queue.size());
-  ASSERT_EQ(expected, replies.front().matched_data);
-  ASSERT_EQ(replies.front().rsi.size(), 2);
+  ASSERT_EQ(expected, replies.begin()->second.matched_data);
+  ASSERT_EQ(replies.begin()->second.rsi.size(), 2);
   ASSERT_EQ(client.primary(), ReplicaId{0});
   client.stop();
 }


### PR DESCRIPTION
When working with PerfTool, we need to match the reply with the sequence number, so instead of just returning a reply, we need to return a map.