### PR TITLE
extending fake_comm for unit testing of BFT client pool

### DIFF
--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -72,6 +72,8 @@ class SkvbcTest(unittest.TestCase):
         await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get(self)
 
+    
+
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_request_missing_data_from_previous_window(self, bft_network, exchange_keys=True):

--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -72,8 +72,6 @@ class SkvbcTest(unittest.TestCase):
         await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get(self)
 
-    
-
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_request_missing_data_from_previous_window(self, bft_network, exchange_keys=True):


### PR DESCRIPTION
The delayed behavior is used for testing the overload case in the BFT client pool unit tests.

Workflow:
1. Created an additional type of behavior - delayed behavior.
2. Extracted common functionality from immediate behavior - to replayConfig function.
3. In the delayed behavior function, I created the delay in the response of the client using the sleep method for 100ms.
4. In the BFT client pool unit test, using a static field(which was used as a flag), we can know when to use the delayed and immediate behavior accordingly.