### PR TITLE
Fix assertion on !isFetching() in BCStateTran::getDigestOfCheckpoint()

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -524,7 +524,6 @@ void BCStateTran::markCheckpointAsStable(uint64_t checkpointNumber) {
 
 void BCStateTran::getDigestOfCheckpoint(uint64_t checkpointNumber, uint16_t sizeOfDigestBuffer, char *outDigestBuffer) {
   ConcordAssert(running_);
-  ConcordAssert(!isFetching());
   ConcordAssertGE(sizeOfDigestBuffer, sizeof(STDigest));
   ConcordAssertGT(checkpointNumber, 0);
   ConcordAssertGE(checkpointNumber, psd_->getFirstStoredCheckpoint());


### PR DESCRIPTION
This method is called during both fetching and states. So it should be removed.
For some reason, probably related to the transaction policy, which has recently changed,
this long sleeping bug has been recently revealed.