### PR TITLE
Fix intermittent failure of SkvbcPersistenceTest.test_st_while_crashing_primary_with_vc

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -678,7 +678,7 @@ class BftTestNetwork:
                             for r in self.get_live_replicas():
                                 nursery.start_soon(get_view, r)
                         view = Counter(replica_views).most_common(1)[0]
-                        # wait for n-f = 2f+2c+1 replicas to be in the expected view
+                        # wait for n-f = 2f+2c+1 replicas to have agreed the expected view
                         if view[1] >= 2 * self.config.f + 2 * self.config.c + 1:
                             matching_view = view[0]
                             nb_replicas_in_matching_view = view[1]

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -706,8 +706,7 @@ class BftTestNetwork:
                         value = await bft_network.metrics.get(replica_id, *key)
                     except KeyError:
                         # metrics not yet available, continue looping
-                        log.log_message(
-                            message_type=f"KeyError! '{mname}' not yet available.")
+                        log.log_message(message_type=f"KeyError! '{mname}' not yet available.")
                         await trio.sleep(0.1)
                     else:
                         return value

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -19,7 +19,7 @@ import os.path
 import shutil
 import random
 import subprocess
-from collections import namedtuple
+from collections import namedtuple, Counter
 import tempfile
 from functools import wraps
 from datetime import datetime
@@ -662,9 +662,7 @@ class BftTestNetwork:
         Returns the current view number
         """
         with log.start_action(action_type="get_current_view") as action:
-            live_replica = random.choice(self.get_live_replicas())
-            current_view = await self.wait_for_view(
-                replica_id=live_replica, expected=None)
+            current_view = await self.get_current_view()
             action.add_success_fields(current_view=current_view)
             return current_view
 
@@ -681,6 +679,52 @@ class BftTestNetwork:
                         await trio.sleep(0.1)
                     else:
                         return value
+
+    async def get_current_view(self, expected=None,
+                            err_msg="Expected view not reached"):
+        """
+        Waits for a view that matches the "expected" predicate,
+        and returns the corresponding view number.
+
+        If the "expected" predicate is not provided,
+        returns the current view number.
+
+        In case of a timeout, fails with the provided err_msg
+        """
+        with log.start_action(action_type="get_current_view", ) as action:
+            if expected is None:
+                expected = lambda _: True
+
+        matching_view = None
+        nb_replicas_in_matching_view = 0
+
+        async def get_view(replica_id ):
+            replica_view = await self._wait_for_matching_agreed_view(replica_id, expected)
+            replica_views.append(replica_view)
+        try:
+            while True:
+                replica_views = []
+                async with trio.open_nursery() as nursery:
+                    for r in self.get_live_replicas():
+                        nursery.start_soon(get_view,r)
+
+                view = Counter(replica_views).most_common(1)[0]
+                # wait for n-f = 2f+2c+1 replicas to be in the expected view
+                if view[1] >= 2 * self.config.f + 2 * self.config.c + 1:
+                    matching_view = view[0]
+                    nb_replicas_in_matching_view = view[1]
+                    break
+                await trio.sleep(0.1)
+
+            action.log(message_type=f'Matching view #{matching_view} has been agreed among replicas.')
+
+            action.log(f'View #{matching_view} is active on '
+                    f'{nb_replicas_in_matching_view} replicas '
+                    f'({nb_replicas_in_matching_view} >= n-f = {self.config.n - self.config.f}).')
+            return matching_view
+
+        except trio.TooSlowError:
+            assert False, err_msg
 
     async def wait_for_view(self, replica_id, expected=None,
                             err_msg="Expected view not reached"):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -695,36 +695,37 @@ class BftTestNetwork:
             if expected is None:
                 expected = lambda _: True
 
-        matching_view = None
-        nb_replicas_in_matching_view = 0
+            matching_view = None
+            nb_replicas_in_matching_view = 0
 
-        async def get_view(replica_id ):
-            replica_view = await self._wait_for_matching_agreed_view(replica_id, expected)
-            replica_views.append(replica_view)
-        try:
-            while True:
-                replica_views = []
-                async with trio.open_nursery() as nursery:
-                    for r in self.get_live_replicas():
-                        nursery.start_soon(get_view,r)
+            async def get_view(replica_id):
+                replica_view = await self._wait_for_matching_agreed_view(replica_id, expected)
+                replica_views.append(replica_view)
+            try:
+                while True:
+                    replica_views = []
+                    async with trio.open_nursery() as nursery:
+                        for r in self.get_live_replicas():
+                            nursery.start_soon(get_view, r)
 
-                view = Counter(replica_views).most_common(1)[0]
-                # wait for n-f = 2f+2c+1 replicas to be in the expected view
-                if view[1] >= 2 * self.config.f + 2 * self.config.c + 1:
-                    matching_view = view[0]
-                    nb_replicas_in_matching_view = view[1]
-                    break
-                await trio.sleep(0.1)
+                    view = Counter(replica_views).most_common(1)[0]
+                    # wait for n-f = 2f+2c+1 replicas to be in the expected view
+                    if view[1] >= 2 * self.config.f + 2 * self.config.c + 1:
+                        matching_view = view[0]
+                        nb_replicas_in_matching_view = view[1]
+                        break
+                    await trio.sleep(0.1)
 
-            action.log(message_type=f'Matching view #{matching_view} has been agreed among replicas.')
+                action.log(
+                    message_type=f'Matching view #{matching_view} has been agreed among replicas.')
 
-            action.log(f'View #{matching_view} is active on '
-                    f'{nb_replicas_in_matching_view} replicas '
-                    f'({nb_replicas_in_matching_view} >= n-f = {self.config.n - self.config.f}).')
-            return matching_view
+                action.log(f'View #{matching_view} is active on '
+                           f'{nb_replicas_in_matching_view} replicas '
+                           f'({nb_replicas_in_matching_view} >= n-f = {self.config.n - self.config.f}).')
+                return matching_view
 
-        except trio.TooSlowError:
-            assert False, err_msg
+            except trio.TooSlowError:
+                assert False, err_msg
 
     async def wait_for_view(self, replica_id, expected=None,
                             err_msg="Expected view not reached"):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -670,14 +670,13 @@ class BftTestNetwork:
                 replica_view = await self._wait_for_matching_agreed_view(replica_id, expected)
                 replica_views.append(replica_view)
 
-            with trio.fail_after(seconds=30):
-                try:
+            try:
+                with trio.fail_after(seconds=30):
                     while True:
                         replica_views = []
                         async with trio.open_nursery() as nursery:
                             for r in self.get_live_replicas():
                                 nursery.start_soon(get_view, r)
-
                         view = Counter(replica_views).most_common(1)[0]
                         # wait for n-f = 2f+2c+1 replicas to be in the expected view
                         if view[1] >= 2 * self.config.f + 2 * self.config.c + 1:
@@ -696,8 +695,8 @@ class BftTestNetwork:
 
                     return matching_view
 
-                except trio.TooSlowError:
-                    assert False, "Could not agree view among replicas."
+            except trio.TooSlowError:
+                assert False, "Could not agree view among replicas."
 
     async def get_metric(self, replica_id, bft_network, mtype, mname, component='replica'):
         with trio.fail_after(seconds=30):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -661,7 +661,7 @@ class BftTestNetwork:
         """
         Returns the current view number
         """
-        with log.start_action(action_type="get_current_view", ) as action:
+        with log.start_action(action_type="get_current_view") as action:
             matching_view = None
             nb_replicas_in_matching_view = 0
 


### PR DESCRIPTION
In the test we get the current view by looking at the 'lastAgreedView' metric from a random replica and then wait for n-f replicas to enter that view.
But if we are (un)lucky enough, the random replica is the one that was stopped before and if we are even more (un)lucky, it may not have updated its 'lastAgreedView' metric. So we try to wait for n-f replicas to enter the old view and timeout.

I have refactored the "get_current_view" to work as follows:
We get the lastAgreedView from every live replica.
We then see if there are 2f + 2c + 1 replicas with the same view.
If there is, then that is the current view.
Else we sleep for 1 sec and try again until timeout.

Testing: I have run the test locally more than 200 times with no failure