### PR TITLE
Makefile: add test-range to run a range of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,14 @@ list-targets: gen_cmake ## Prints the list of available targets
 		"cd ${CONCORD_BFT_BUILD_DIR} && \
 		make help"
 
+.PHONY: test-range
+test-range: ## Run all tests in the range [START,END], inclusive: `make test-range START=<#start_test> END=<#end_test>`. To get test numbers, use list-tests.
+	docker run ${BASIC_RUN_PARAMS} \
+			${CONCORD_BFT_CONTAINER_SHELL} -c \
+			"mkdir -p ${CONCORD_BFT_CORE_DIR} && \
+			cd ${CONCORD_BFT_BUILD_DIR} && \
+			ctest -I ${START},${END}"
+
 .PHONY: format
 format: gen_cmake ## Format Concord-BFT source with clang-format
 	docker run ${CONCORD_BFT_USER_GROUP} ${BASIC_RUN_PARAMS} \


### PR DESCRIPTION
1) To get test numbers to use 'make list-tests'. This gives for each test
an index number;
2) This target allows running tests in a range, instead of running all
tests (e.g 'make test')).