### PR TITLE
Extending fake_comm for unit testing of BFT client pool

### DIFF
--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -133,7 +133,7 @@ class FakeCommunication : public bft::communication::ICommunication {
   BehaviorThreadRunner runner_;
   std::thread fakeCommThread_;
 };
-std::vector<uint8_t> replayConfig(const MsgFromClient &msg);
+std::vector<uint8_t> replayConfig(const MsgFromClient& msg);
 
 inline void immideateBehaviour(const MsgFromClient& msg, IReceiver* client_receiver) {
   std::vector<uint8_t> reply = replayConfig(msg);
@@ -146,7 +146,7 @@ inline void delayedBehaviour(const MsgFromClient& msg, IReceiver* client_receive
   client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(reply.data()), reply.size());
 }
 
-std::vector<uint8_t> replayConfig(const MsgFromClient &msg) {
+std::vector<uint8_t> replayConfig(const MsgFromClient& msg) {
   const auto* req_header = reinterpret_cast<const bftEngine::ClientRequestMsgHeader*>(msg.data.data());
   std::string reply_data = "reply";
   auto reply_header_size = sizeof(bftEngine::ClientReplyMsgHeader);

--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -111,7 +111,7 @@ class FakeCommunication : public bft::communication::ICommunication {
     return 0;
   }
   bool isRunning() const override { return true; }
-  ConnectionStatus getCurrentConnectionStatus(NodeNum node) override { return ConnectionStatus{}; }
+  ConnectionStatus getCurrentConnectionStatus(NodeNum node) override { return ConnectionStatus::Connected; }
 
   int send(NodeNum destNode, std::vector<uint8_t>&& msg) override {
     runner_.send(MsgFromClient{ReplicaId{(uint16_t)destNode}, std::move(msg)});
@@ -133,20 +133,8 @@ class FakeCommunication : public bft::communication::ICommunication {
   BehaviorThreadRunner runner_;
   std::thread fakeCommThread_;
 };
-std::vector<uint8_t> replayConfig(const MsgFromClient& msg);
 
-inline void immideateBehaviour(const MsgFromClient& msg, IReceiver* client_receiver) {
-  std::vector<uint8_t> reply = replayConfig(msg);
-  client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(reply.data()), reply.size());
-}
-
-inline void delayedBehaviour(const MsgFromClient& msg, IReceiver* client_receiver) {
-  std::vector<uint8_t> reply = replayConfig(msg);
-  std::this_thread::sleep_for(100ms);
-  client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(reply.data()), reply.size());
-}
-
-std::vector<uint8_t> replayConfig(const MsgFromClient& msg) {
+inline std::vector<uint8_t> createReply(const MsgFromClient& msg) {
   const auto* req_header = reinterpret_cast<const bftEngine::ClientRequestMsgHeader*>(msg.data.data());
   std::string reply_data = "reply";
   auto reply_header_size = sizeof(bftEngine::ClientReplyMsgHeader);
@@ -161,4 +149,15 @@ std::vector<uint8_t> replayConfig(const MsgFromClient& msg) {
   // Copy the reply data;
   memcpy(reply.data() + reply_header_size, reply_data.data(), reply_data.size());
   return reply;
+}
+
+inline void immideateBehaviour(const MsgFromClient& msg, IReceiver* client_receiver) {
+  std::vector<uint8_t> reply = createReply(msg);
+  client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(reply.data()), reply.size());
+}
+
+inline void delayedBehaviour(const MsgFromClient& msg, IReceiver* client_receiver) {
+  std::vector<uint8_t> reply = createReply(msg);
+  std::this_thread::sleep_for(5ms);
+  client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(reply.data()), reply.size());
 }

--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -72,6 +72,8 @@ class SkvbcTest(unittest.TestCase):
         await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get(self)
 
+    
+
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_request_missing_data_from_previous_window(self, bft_network, exchange_keys=True):

--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -72,8 +72,6 @@ class SkvbcTest(unittest.TestCase):
         await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get(self)
 
-    
-
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_request_missing_data_from_previous_window(self, bft_network, exchange_keys=True):


### PR DESCRIPTION
The delayed behavior is used for testing the overload case in the BFT client pool unit tests.

Workflow:

1. Created an additional type of behavior - delayed behavior.
2. Extracted common functionality from immediate behavior - to replayConfig function.
3. In the delayed behavior function, I created the delay in the response of the client using the sleep method for 100ms.
4. In the BFT client pool unit test, using a static field(which was used as a flag), we can know when to use the delayed and immediate behavior accordingly.