### PR TITLE
Fix issues with new client batching

### DIFF
--- a/bftclient/src/matcher.cpp
+++ b/bftclient/src/matcher.cpp
@@ -17,14 +17,14 @@ std::optional<Match> Matcher::onReply(UnmatchedReply&& reply) {
   if (!valid(reply)) return std::nullopt;
 
   auto key = MatchKey{reply.metadata, std::move(reply.data)};
-  const auto [it, success] = matches_[key].insert_or_assign(reply.rsi.from, std::move(reply.rsi.data));
-  (void)it;  // unused variable hack needed by GCC
-  if (!success) {
-    LOG_ERROR(logger_,
-              "Received two different pieces of replica specific information from: " << reply.rsi.from.val
-                                                                                     << ". Keeping the new one.");
-    return std::nullopt;
+  if (matches_[key].count(reply.rsi.from)) {
+    if (matches_[key][reply.rsi.from] != reply.rsi.data) {
+      LOG_ERROR(logger_,
+                "Received two different pieces of replica specific information from: " << reply.rsi.from.val
+                                                                                       << ". Keeping the new one.");
+    }
   }
+  matches_[key].insert_or_assign(reply.rsi.from, std::move(reply.rsi.data));
 
   return match();
 }


### PR DESCRIPTION
In this PR I'm fixing issues with new client batching.
1. pending_requests queue is holding all the requests that arrive in batch requests, before this PR I didn't reset the pending_requests that caused an issue in which we got more and more requests inside this queue.
2. After each wait() if we didn't get enough replies for the request and its still part of reply_certificates_ we should reset the replies in the matcher because if we don't in the next round we will ask all the other replicas for replies and we will get other RSI for the same request which causes an error.


A unit test has also been added to test several batch requests that are sent through the same client.