### PR TITLE
DBDataStore Transaction

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -258,6 +258,7 @@ BCStateTran::~BCStateTran() {
   ConcordAssert(pendingItemDataMsgs.empty());
 
   delete[] buffer_;
+  concord::diagnostics::RegistrarSingleton::getInstance().perf.unRegisterComponent("state_transfer");
 }
 
 // Load metrics that are saved on persistent storage

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -218,6 +218,13 @@ class DBDataStore : public DataStore {
     std::string s(val.data(), val.length());
     return concord::util::to<T>(s);
   }
+
+  void addCommitCallback(std::function<void()> f) {
+    if (txn_)
+      txn_->addCommitCallback(f);
+    else
+      f();
+  }
   /** *****************************************************************************************************************
    * keys generation
    */

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -261,7 +261,7 @@ class DataStoreTransaction : public DataStore, public ITransaction {
   /**
    * ITransaction implementation
    */
-  void commit() override { txn_->commit(); }
+  void commitImpl() override { txn_->commit(); }
   void rollback() override { txn_->rollback(); };
   void put(const concordUtils::Sliver& key, const concordUtils::Sliver& value) override { txn_->put(key, value); }
   std::string get(const concordUtils::Sliver& key) override { return txn_->get(key); }

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -129,7 +129,7 @@ class InMemoryDataStore : public DataStore {
   class NullTransaction : public ITransaction {
    public:
     NullTransaction() : concord::storage::ITransaction(0) {}
-    void commit() override {}
+    void commitImpl() override {}
     void rollback() override {}
     void put(const concordUtils::Sliver& key, const concordUtils::Sliver& value) override {}
     std::string get(const concordUtils::Sliver& key) override { return ""; }
@@ -146,30 +146,30 @@ class InMemoryDataStore : public DataStore {
  protected:
   const uint32_t sizeOfReservedPage_;
 
-  bool wasInit_ = false;
+  std::atomic<bool> wasInit_ = false;
 
   set<uint16_t> replicas_;
 
-  uint16_t myReplicaId_ = UINT16_MAX;
+  std::atomic<uint16_t> myReplicaId_ = UINT16_MAX;
 
-  uint16_t fVal_ = UINT16_MAX;
+  std::atomic<uint16_t> fVal_ = UINT16_MAX;
 
-  uint64_t maxNumOfStoredCheckpoints_ = UINT64_MAX;
+  std::atomic<uint64_t> maxNumOfStoredCheckpoints_ = UINT64_MAX;
 
-  uint32_t numberOfReservedPages_ = UINT32_MAX;
+  std::atomic<uint32_t> numberOfReservedPages_ = UINT32_MAX;
 
-  uint64_t lastStoredCheckpoint = UINT64_MAX;
-  uint64_t firstStoredCheckpoint = UINT64_MAX;
+  std::atomic<uint64_t> lastStoredCheckpoint = UINT64_MAX;
+  std::atomic<uint64_t> firstStoredCheckpoint = UINT64_MAX;
 
   map<uint64_t, CheckpointDesc> descMap;
 
-  bool fetching = false;
+  std::atomic<bool> fetching = false;
 
   CheckpointDesc checkpointBeingFetched;
   // none if checkpointBeingFetched.checkpointNum == 0
 
-  uint64_t firstRequiredBlock = UINT64_MAX;
-  uint64_t lastRequiredBlock = UINT64_MAX;
+  std::atomic<uint64_t> firstRequiredBlock = UINT64_MAX;
+  std::atomic<uint64_t> lastRequiredBlock = UINT64_MAX;
 
   map<uint32_t, char*> pendingPages;
 

--- a/storage/include/memorydb/transaction.h
+++ b/storage/include/memorydb/transaction.h
@@ -22,8 +22,6 @@ class Transaction : public ITransaction {
  public:
   Transaction(Client& client, ITransaction::ID id) : ITransaction{id}, client_{client} {}
 
-  void commit() override { commitImpl(); }
-
   void rollback() override { updates_.clear(); }
 
   void put(const concordUtils::Sliver& key, const concordUtils::Sliver& value) override {
@@ -59,7 +57,7 @@ class Transaction : public ITransaction {
   };
 
   // Make sure the commit operation cannot throw. If it does, abort the program.
-  void commitImpl() noexcept {
+  void commitImpl() override {
     for (const auto& update : updates_) {
       auto status = concordUtils::Status::OK();
       if (update.second.isDelete) {

--- a/storage/include/rocksdb/transaction.h
+++ b/storage/include/rocksdb/transaction.h
@@ -27,7 +27,7 @@ class Transaction : public ITransaction {
  public:
   Transaction(::rocksdb::Transaction* txn, ID id) : ITransaction(id), txn_(txn) {}
   ~Transaction() { LOG_TRACE(logger(), "txn: " << getId()); }
-  void commit() override {
+  void commitImpl() override {
     LOG_DEBUG(logger(), "commit txn: " << getId());
     ::rocksdb::Status s = txn_->Commit();
     if (!s.ok()) ROCKSDB_THROW("Commit", s);

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -51,7 +51,7 @@ class Client : public concord::storage::IDBClient {
   class Transaction : public ITransaction {
    public:
     Transaction(Client* client) : ITransaction(nextId()), client_{client} {}
-    void commit() override {
+    void commitImpl() override {
       for (auto& pair : multiput_)
         if (concordUtils::Status s = client_->put(pair.first, pair.second); !s.isOK())
           throw std::runtime_error("S3 commit failed while putting a value for key: " + pair.first.toString() +

--- a/util/include/callback_registry.hpp
+++ b/util/include/callback_registry.hpp
@@ -19,6 +19,8 @@
 #include <optional>
 #include <stdexcept>
 #include <utility>
+#include "Logger.hpp"
+#include "demangle.hpp"
 
 namespace concord::util {
 
@@ -117,6 +119,8 @@ class CallbackRegistry {
   template <typename... InvokeArgs>
   void invokeAll(InvokeArgs&&... args) const {
     for (auto& callback : callbacks_) {
+      LOG_TRACE(logging::getLogger("concord.util.callback_registry"),
+                "invoking callback: " << demangler::demangle(callback.target_type()));
       callback(std::forward<InvokeArgs>(args)...);
     }
   }


### PR DESCRIPTION
Copy on write inconsistency.
Updating the InMemoryDataStore took place immediately, while DBDataStore update occurred only on transaction commit.
Solution: call to InMemoryDataStore updates as callback functions to DataStore transactions commit(), which are invoked AFTER updates are committed to DB.