### PR TITLE
ReplicaStatusHandlers: register replica state (bug fix)

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1206,7 +1206,7 @@ void ReplicaImp::onInternalMsg(GetStatus &status) const {
     return status.output.set_value(getReplicaLastStableSeqNum());
   }
 
-  if (status.key == "replica_state") {
+  if (status.key == "replica-state") {
     return status.output.set_value(getReplicaState());
   }
 

--- a/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
+++ b/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
@@ -38,13 +38,16 @@ void ReplicaStatusHandlers::registerStatusHandlers() const {
     });
   };
 
-  auto replica_handler = make_handler_callback("replica", "Internal state of the concord-bft replica");
+  // TODO: handler name left for backward compatibility with callers, change the name 'replica'.
+  auto replica_handler = make_handler_callback("replica", "Last stable sequence number of the concord-bft replica");
   auto state_transfer_handler = make_handler_callback("state-transfer", "Status of blockchain state transfer");
   auto preexecution_handler = make_handler_callback("pre-execution", "Status of pre-execution");
+  auto replica_state_handler = make_handler_callback("replica-state", "Internal state of the concord-bft replica");
 
   registrar.status.registerHandler(replica_handler);
   registrar.status.registerHandler(state_transfer_handler);
   registrar.status.registerHandler(preexecution_handler);
+  registrar.status.registerHandler(replica_state_handler);
 }
 
 std::string ReplicaStatusHandlers::preExecutionStatus(std::shared_ptr<concordMetrics::Aggregator> aggregator) const {


### PR DESCRIPTION
On commit 66005bb1874a2ac8e1fe8c59be76c7a8c3a0e71c we have added a new
handler, but I forgot to register the old one withit's new name.
Here I rename the handler name:
replica_state -> replica-state
and register it in ReplicaStatusHandlers (forgot to do so).