### PR TITLE
Fix memory leak in ClientsManager

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <memory>
 
 namespace bftEngine {
 class IStateTransfer;
@@ -45,10 +46,12 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   bool isValidClient(NodeIdType clientId) const;
 
-  ClientReplyMsg* allocateNewReplyMsgAndWriteToStorage(
+  std::unique_ptr<ClientReplyMsg> allocateNewReplyMsgAndWriteToStorage(
       NodeIdType clientId, ReqId requestSeqNum, uint16_t currentPrimaryId, char* reply, uint32_t replyLength);
 
-  ClientReplyMsg* allocateReplyFromSavedOne(NodeIdType clientId, ReqId requestSeqNum, uint16_t currentPrimaryId);
+  std::unique_ptr<ClientReplyMsg> allocateReplyFromSavedOne(NodeIdType clientId,
+                                                            ReqId requestSeqNum,
+                                                            uint16_t currentPrimaryId);
 
   // Requests
 


### PR DESCRIPTION
Problem description:
The method `allocateReplyFromSavedOne` in case of failure returns `nullptr` and does not delete `ClientReplyMsg* const r`.

Fix:
In order to avoid such problems in the future, methods `allocateReplyFromSavedOne` and `allocateNewReplyMsgAndWriteToStorage` create and return unique pointer.