### PR TITLE
send empty client request on pre process time out

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4054,8 +4054,9 @@ void ReplicaImp::executeRequestsAndSendResponses(PrePrepareMsg *ppMsg,
       continue;
     }
     ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
-    if (req.requestLength() == 0) continue;
-    if (req.flags() & EMPTY_CLIENT_FLAG) {
+    if (req.requestLength() == 0 || (req.flags() & EMPTY_CLIENT_FLAG)) {
+      if (clientsManager->isValidClient(req.clientProxyId()))
+        clientsManager->removePendingForExecutionRequest(req.clientProxyId(), req.requestSeqNum());
       continue;
     }
     SCOPED_MDC_CID(req.getCid());

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4054,6 +4054,7 @@ void ReplicaImp::executeRequestsAndSendResponses(PrePrepareMsg *ppMsg,
       continue;
     }
     ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
+    if (req.requestLength() == 0) continue;
     if (req.flags() & EMPTY_CLIENT_FLAG) {
       continue;
     }

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -200,7 +200,7 @@ void PreProcessor::onRequestsStatusCheckTimer() {
         SCOPED_MDC_CID(reqStatePtr->getReqCid());
         LOG_INFO(logger(), "Let replica handle request" << KVLOG(reqSeqNum, reqEntryIndex, clientId, reqOffsetInBatch));
         preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
-        incomingMsgsStorage_->pushExternalMsg(reqStatePtr->buildClientRequestMsg(true));
+        incomingMsgsStorage_->pushExternalMsg(reqStatePtr->buildClientRequestMsg(true, true));
         releaseClientPreProcessRequest(reqEntry.second, CANCEL);
       } else if (myReplica_.isCurrentPrimary() && reqStatePtr->definePreProcessingConsensusResult() == CONTINUE)
         resendPreProcessRequest(reqStatePtr);

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -193,8 +193,8 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
   return CONTINUE;
 }
 
-unique_ptr<MessageBase> RequestProcessingState::buildClientRequestMsg(bool resetPreProcessFlag) {
-  return clientPreProcessReqMsg_->convertToClientRequestMsg(resetPreProcessFlag);
+unique_ptr<MessageBase> RequestProcessingState::buildClientRequestMsg(bool resetPreProcessFlag, bool empty) {
+  return clientPreProcessReqMsg_->convertToClientRequestMsg(resetPreProcessFlag, empty);
 }
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -193,8 +193,8 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
   return CONTINUE;
 }
 
-unique_ptr<MessageBase> RequestProcessingState::buildClientRequestMsg(bool resetPreProcessFlag, bool empty) {
-  return clientPreProcessReqMsg_->convertToClientRequestMsg(resetPreProcessFlag, empty);
+unique_ptr<MessageBase> RequestProcessingState::buildClientRequestMsg(bool resetPreProcessFlag, bool emptyReq) {
+  return clientPreProcessReqMsg_->convertToClientRequestMsg(resetPreProcessFlag, emptyReq);
 }
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -39,7 +39,7 @@ class RequestProcessingState {
 
   void handlePrimaryPreProcessed(const char* preProcessResult, uint32_t preProcessResultLen);
   void handlePreProcessReplyMsg(const PreProcessReplyMsgSharedPtr& preProcessReplyMsg);
-  std::unique_ptr<MessageBase> buildClientRequestMsg(bool resetPreProcessFlag, bool empty = false);
+  std::unique_ptr<MessageBase> buildClientRequestMsg(bool resetPreProcessFlag, bool emptyReq = false);
   void setPreProcessRequest(PreProcessRequestMsgSharedPtr preProcessReqMsg);
   const PreProcessRequestMsgSharedPtr& getPreProcessRequest() const { return preProcessRequestMsg_; }
   const auto getClientId() const { return clientId_; }

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -39,7 +39,7 @@ class RequestProcessingState {
 
   void handlePrimaryPreProcessed(const char* preProcessResult, uint32_t preProcessResultLen);
   void handlePreProcessReplyMsg(const PreProcessReplyMsgSharedPtr& preProcessReplyMsg);
-  std::unique_ptr<MessageBase> buildClientRequestMsg(bool resetPreProcessFlag);
+  std::unique_ptr<MessageBase> buildClientRequestMsg(bool resetPreProcessFlag, bool empty = false);
   void setPreProcessRequest(PreProcessRequestMsgSharedPtr preProcessReqMsg);
   const PreProcessRequestMsgSharedPtr& getPreProcessRequest() const { return preProcessRequestMsg_; }
   const auto getClientId() const { return clientId_; }

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -28,12 +28,12 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 
-unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bool resetPreProcessFlag, bool empty) {
+unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bool resetPreProcessFlag, bool emptyReq) {
   if (resetPreProcessFlag) msgBody()->flags &= ~(1 << 1);
   unique_ptr<MessageBase> clientRequestMsg = make_unique<ClientRequestMsg>(clientProxyId(),
                                                                            flags(),
                                                                            requestSeqNum(),
-                                                                           empty ? 0 : requestLength(),
+                                                                           emptyReq ? 0 : requestLength(),
                                                                            requestBuf(),
                                                                            requestTimeoutMilli(),
                                                                            getCid(),

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -28,12 +28,12 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 
-unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bool resetPreProcessFlag) {
+unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bool resetPreProcessFlag, bool empty) {
   if (resetPreProcessFlag) msgBody()->flags &= ~(1 << 1);
   unique_ptr<MessageBase> clientRequestMsg = make_unique<ClientRequestMsg>(clientProxyId(),
                                                                            flags(),
                                                                            requestSeqNum(),
-                                                                           requestLength(),
+                                                                           empty ? 0 : requestLength(),
                                                                            requestBuf(),
                                                                            requestTimeoutMilli(),
                                                                            getCid(),

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -31,7 +31,7 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
 
   ClientPreProcessRequestMsg(MessageBase* msgBase) : ClientRequestMsg(msgBase) {}
 
-  std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag);
+  std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag, bool empty = false);
 };
 
 typedef std::unique_ptr<ClientPreProcessRequestMsg> ClientPreProcessReqMsgUniquePtr;

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -31,7 +31,7 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
 
   ClientPreProcessRequestMsg(MessageBase* msgBase) : ClientRequestMsg(msgBase) {}
 
-  std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag, bool empty = false);
+  std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag, bool emptyReq = false);
 };
 
 typedef std::unique_ptr<ClientPreProcessRequestMsg> ClientPreProcessReqMsgUniquePtr;


### PR DESCRIPTION
In order to avoid executing a request that has been timed out on pre-processing, we now send an empty request.
Correspondingly, empty requests will be ignored in the execution loop.