### PR TITLE
Always start important traces

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -746,16 +746,17 @@ bool PreProcessor::registerRequestOnPrimaryReplica(ClientPreProcessReqMsgUniqueP
                                                    PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
                                                    uint16_t reqOffsetInBatch,
                                                    uint64_t reqRetryId) {
-  preProcessRequestMsg =
-      make_shared<PreProcessRequestMsg>(myReplicaId_,
-                                        clientReqMsg->clientProxyId(),
-                                        reqOffsetInBatch,
-                                        clientReqMsg->requestSeqNum(),
-                                        reqRetryId,
-                                        clientReqMsg->requestLength(),
-                                        clientReqMsg->requestBuf(),
-                                        clientReqMsg->getCid(),
-                                        clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
+  auto span_context = clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>();
+  auto span = concordUtils::startChildSpanFromContextOrRoot(span_context, "register_pre_process_req_in_primary");
+  preProcessRequestMsg = make_shared<PreProcessRequestMsg>(myReplicaId_,
+                                                           clientReqMsg->clientProxyId(),
+                                                           reqOffsetInBatch,
+                                                           clientReqMsg->requestSeqNum(),
+                                                           reqRetryId,
+                                                           clientReqMsg->requestLength(),
+                                                           clientReqMsg->requestBuf(),
+                                                           clientReqMsg->getCid(),
+                                                           span.context());
   return registerRequest(move(clientReqMsg), preProcessRequestMsg, reqOffsetInBatch);
 }
 

--- a/util/include/OpenTracing.hpp
+++ b/util/include/OpenTracing.hpp
@@ -64,8 +64,12 @@ class SpanWrapper {
   SpanContext context() const;
 
   friend SpanWrapper startSpan(const std::string& operation_name);
-  friend SpanWrapper startChildSpan(const std::string& operation_name, const SpanWrapper& parent_span);
-  friend SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name);
+  friend SpanWrapper startChildSpanUtil(const std::string& operation_name,
+                                        const SpanWrapper& parent_span,
+                                        bool needSpan);
+  friend SpanWrapper startChildSpanFromContextUtil(const SpanContext& context,
+                                                   const std::string& child_operation_name,
+                                                   bool needSpan);
 #ifdef USE_OPENTRACING
   friend SpanWrapper startChildSpanFromContext(const opentracing::SpanContext& context,
                                                const std::string& child_operation_name);
@@ -83,8 +87,14 @@ class SpanWrapper {
 };
 
 SpanWrapper startSpan(const std::string& operation_name);
+SpanWrapper startChildSpanUtil(const std::string& operation_name, const SpanWrapper& parent_span, bool needSpan);
+SpanWrapper startChildSpanFromContextUtil(const SpanContext& context,
+                                          const std::string& child_operation_name,
+                                          bool needSpan);
 SpanWrapper startChildSpan(const std::string& child_operation_name, const SpanWrapper& parent_span);
+SpanWrapper startChildSpanOrRoot(const std::string& child_operation_name, const SpanWrapper& parent_span);
 SpanWrapper startChildSpanFromContext(const SpanContext& context, const std::string& child_operation_name);
+SpanWrapper startChildSpanFromContextOrRoot(const SpanContext& context, const std::string& child_operation_name);
 #ifdef USE_OPENTRACING
 SpanWrapper startChildSpanFromContext(const opentracing::SpanContext& context, const std::string& child_operation_name);
 #endif


### PR DESCRIPTION
Add root traces in the absences of span context in the client request messages.