### PR TITLE
Allow primary replica rejecting client requests arrived through non-primaries

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -327,6 +327,7 @@ void ClientsManager::removePendingForExecutionRequest(NodeIdType clientId, ReqId
 
 void ClientsManager::clearAllPendingRequests() {
   for (ClientInfo& clientInfo : indexToClientInfo_) clientInfo.requestsInfo.clear();
+  LOG_DEBUG(CL_MNGR, "Cleared pending requests for all clients");
 }
 
 // Iterate over all clients and choose the earliest pending request.

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -119,6 +119,9 @@ class PreProcessor {
                                     uint64_t reqRetryId,
                                     const std::string &cid,
                                     const std::string &ongoingCid);
+  void sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
+                                      uint16_t reqOffsetInBatch,
+                                      uint64_t reqRetryId);
   const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
   const uint16_t getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
@@ -165,15 +168,14 @@ class PreProcessor {
                                       ReqId reqSeqNum,
                                       NodeIdType clientId,
                                       NodeIdType senderId);
-  bool isRequestAlreadyExecuted(ReqId reqSeqNum, NodeIdType clientId, const std::string &cid);
+  bool isRequestAlreadyExecuted(ReqId reqSeqNum, NodeIdType senderId, NodeIdType clientId, const std::string &cid);
   bool isRequestPreProcessedBefore(const RequestStateSharedPtr &reqEntry,
                                    SeqNum reqSeqNum,
                                    NodeIdType clientId,
                                    const std::string &cid);
-
   bool isRequestPassingConsensusOrPostExec(SeqNum reqSeqNum,
-                                           NodeIdType clientId,
                                            NodeIdType senderId,
+                                           NodeIdType clientId,
                                            const std::string &cid);
   static logging::Logger &logger() {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
@@ -206,11 +208,11 @@ class PreProcessor {
     concordMetrics::CounterHandle preProcReqReceived;
     concordMetrics::CounterHandle preProcReqInvalid;
     concordMetrics::CounterHandle preProcReqIgnored;
+    concordMetrics::CounterHandle preProcReqRejected;
     concordMetrics::CounterHandle preProcConsensusNotReached;
-    concordMetrics::CounterHandle preProcessRequestTimedout;
+    concordMetrics::CounterHandle preProcessRequestTimedOut;
     concordMetrics::CounterHandle preProcReqSentForFurtherProcessing;
     concordMetrics::CounterHandle preProcPossiblePrimaryFaultDetected;
-    concordMetrics::CounterHandle preProcReqForwardedByNonPrimaryNotIgnored;
     concordMetrics::GaugeHandle preProcInFlyRequestsNum;
   } preProcessorMetrics_;
   concordUtil::Timers::Handle requestsStatusCheckTimer_;

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -23,7 +23,7 @@ namespace preprocessor {
 
 // This class collects and stores data relevant to the processing of one specific client request by all replicas.
 
-typedef enum { NONE, CONTINUE, COMPLETE, CANCEL, RETRY_PRIMARY } PreProcessingResult;
+typedef enum { NONE, CONTINUE, COMPLETE, CANCEL, CANCELLED_BY_PRIMARY, RETRY_PRIMARY } PreProcessingResult;
 typedef std::vector<ReplicaId> ReplicaIdsList;
 
 class RequestProcessingState {

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -18,9 +18,12 @@
 
 namespace preprocessor {
 
+typedef enum { REQ_TYPE_PRE_PROCESS, REQ_TYPE_CANCEL } RequestType;
+
 class PreProcessRequestMsg : public MessageBase {
  public:
-  PreProcessRequestMsg(NodeIdType senderId,
+  PreProcessRequestMsg(RequestType reqType,
+                       NodeIdType senderId,
                        uint16_t clientId,
                        uint16_t reqOffsetInBatch,
                        uint64_t reqSeqNum,
@@ -34,6 +37,7 @@ class PreProcessRequestMsg : public MessageBase {
 
   void validate(const bftEngine::impl::ReplicasInfo&) const override;
   char* requestBuf() const { return body() + sizeof(Header) + spanContextSize(); }
+  const RequestType reqType() const { return msgBody()->reqType; }
   const uint32_t requestLength() const { return msgBody()->requestLength; }
   const uint16_t clientId() const { return msgBody()->clientId; }
   const uint16_t reqOffsetInBatch() const { return msgBody()->reqOffsetInBatch; }
@@ -47,6 +51,7 @@ class PreProcessRequestMsg : public MessageBase {
 #pragma pack(push, 1)
   struct Header {
     MessageBase::Header header;
+    RequestType reqType;
     SeqNum reqSeqNum;
     uint16_t clientId;
     uint16_t reqOffsetInBatch;
@@ -62,7 +67,8 @@ class PreProcessRequestMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
-  void setParams(NodeIdType senderId,
+  void setParams(RequestType reqType,
+                 NodeIdType senderId,
                  uint16_t clientId,
                  uint16_t reqOffsetInBatch,
                  ReqId reqSeqNum,

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -500,8 +500,8 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
   msgHandlerCallback(clientReqMsg);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 0) == reqSeqNum);
 
-  auto* preProcessReqMsg =
-      new PreProcessRequestMsg(replica.currentPrimary(), clientId, 0, reqSeqNum, reqRetryId, bufLen, buf, cid, span);
+  auto* preProcessReqMsg = new PreProcessRequestMsg(
+      REQ_TYPE_PRE_PROCESS, replica.currentPrimary(), clientId, 0, reqSeqNum, reqRetryId, bufLen, buf, cid, span);
   msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::PreProcessRequest);
   msgHandlerCallback(preProcessReqMsg);
   usleep(reqWaitTimeoutMilli * 1000 / 2);  // Wait for the pre-execution completion


### PR DESCRIPTION
To avoid request timeouts on non-primary replicas, the primary should send a 'reject' message in case it cannot handle the request.