### PR TITLE
Remove unnecesary decorator from testPrimaryWrite

### DIFF
--- a/util/pyclient/test_client.py
+++ b/util/pyclient/test_client.py
@@ -148,7 +148,6 @@ class SimpleTest(unittest.TestCase):
                pass
            self.assertTrue(udp_client.retries > 0)
 
-    @verify_system_is_ready
     def testPrimaryWrite(self):
         """Test that we learn the primary and using it succeeds."""
         trio.run(self._testPrimaryWrite)


### PR DESCRIPTION
This decorator is not needed as it is applied to _testPrimaryWrite.
This decorator is meant to be used with async functions and causes the following warning:
```
2021-03-21T08:42:43.2840233Z E/usr/lib/python3.6/unittest/case.py:605: RuntimeWarning: coroutine 'SimpleTest.testPrimaryWrite' was never awaited
2021-03-21T08:42:43.2841099Z   testMethod()
```
I have suspicions that this might be the cause of some intermittent failures of the test.