### PR TITLE
Support writing and reading of multiple replies on reserved pages

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -132,7 +132,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   CONFIG_PARAM(debugPersistentStorageEnabled, bool, false, "whether persistent storage debugging is enabled");
 
   // Messages
-  CONFIG_PARAM(maxExternalMessageSize, uint32_t, 131072, "maximum size of external message");
+  CONFIG_PARAM(maxExternalMessageSize, uint32_t, 1310720, "maximum size of external message");
   CONFIG_PARAM(maxReplyMessageSize, uint32_t, 8192, "maximum size of reply message");
 
   // StateTransfer

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -31,7 +31,7 @@ ClientsManager::ClientsManager(concordMetrics::Component& metrics, std::set<Node
       metric_reply_inconsistency_detected_{metrics_.RegisterCounter("totalReplyInconsistenciesDetected")},
       metric_removed_due_to_out_of_boundaries_{metrics_.RegisterCounter("totalRemovedDueToOutOfBoundaries")} {
   ConcordAssert(clientsSet.size() >= 1);
-  scratchPage_ = std::string(sizeOfReservedPage_ * maxNumOfReqsPerClient_, 0);
+  scratchPage_ = std::string(sizeOfReservedPage_, 0);
 
   uint16_t idx = 0;
   for (NodeIdType c : clientsSet) {
@@ -77,8 +77,6 @@ int ClientsManager::getIndexOfClient(const NodeIdType& id) const {
   return clientIdToIndex_.at(id);
 }
 
-ClientsManager::~ClientsManager() {}
-
 void ClientsManager::init(IStateTransfer* stateTransfer) {
   ConcordAssert(stateTransfer != nullptr);
   ConcordAssert(stateTransfer_ == nullptr);
@@ -89,20 +87,22 @@ uint32_t ClientsManager::numberOfRequiredReservedPages() const { return required
 
 // Per client:
 // * calculate offset of reserved page start.
+// * Iterate for max number of requests per client
 // * load corresponding page from state-transfer to scratchPage.
 // * Fill its clientInfo.
-// * remove pending request if loaded reply is newer.
+// * At the end of the loop take the latest loaded reply and remove pending request if latest reply is newer.
 void ClientsManager::loadInfoFromReservedPages() {
   for (auto const& [clientId, clientIdx] : clientIdToIndex_) {
     const uint32_t firstPageId = clientIdx * reservedPagesPerClient_;
 
     // load all replies into the map of replies one by one
     for (int i = 0; i < maxNumOfReqsPerClient_; i++) {
-      if (!stateTransfer_->loadReservedPage(
-              resPageOffset() + firstPageId + i, sizeOfReservedPage_, scratchPage_.data() + i * sizeOfReservedPage_))
-        continue;
+      if (!stateTransfer_->loadReservedPage(resPageOffset() + firstPageId + (i * singleReplyMaxNumOfPages_),
+                                            sizeOfReservedPage_,
+                                            scratchPage_.data()))
+        break;
 
-      auto replyHeader = (ClientReplyMsgHeader*)(scratchPage_.data() + i * sizeOfReservedPage_);
+      auto replyHeader = (ClientReplyMsgHeader*)(scratchPage_.data());
       auto replyPtr = std::make_shared<ClientReplyMsg>(myId_, replyHeader->replyLength);
       ConcordAssert(replyHeader->msgType == 0 || replyHeader->msgType == MsgCode::ClientReply);
       ConcordAssert(replyHeader->currentPrimaryId == 0);
@@ -111,21 +111,22 @@ void ClientsManager::loadInfoFromReservedPages() {
 
       auto& repliesInfo = indexToClientInfo_.at(clientIdx).repliesInfo;
       if (repliesInfo.size() >= maxNumOfReqsPerClient_) deleteOldestReply(clientId);
-      const auto& res = repliesInfo.insert({replyHeader->reqSeqNum, replyPtr});
+      const auto& res = repliesInfo.insert_or_assign(replyHeader->reqSeqNum, replyPtr);
       const bool added = res.second;
       LOG_INFO(CL_MNGR, "Added/updated reply message" << KVLOG(clientId, replyHeader->reqSeqNum, added));
     }
     // get the newest reply from the map of replies.
-    auto lastReply = indexToClientInfo_.at(clientIdx).repliesInfo.cend();
-    auto lastReplyHeader = lastReply->second->b();
-    // Remove old pending requests
-    auto& requestsInfo = indexToClientInfo_.at(clientIdx).requestsInfo;
-    for (auto it = requestsInfo.begin(); it != requestsInfo.end();) {
-      if (it->first <= lastReplyHeader->reqSeqNum) {
-        LOG_INFO(CL_MNGR, "Remove old pending request" << KVLOG(clientId, lastReplyHeader->reqSeqNum));
-        it = requestsInfo.erase(it);
-      } else
-        it++;
+    if (!indexToClientInfo_.at(clientIdx).repliesInfo.empty()) {
+      auto lastReply = indexToClientInfo_.at(clientIdx).repliesInfo.rbegin();
+      // Remove old pending requests
+      auto& requestsInfo = indexToClientInfo_.at(clientIdx).requestsInfo;
+      for (auto it = requestsInfo.begin(); it != requestsInfo.end();) {
+        if (it->first <= lastReply->first) {
+          LOG_INFO(CL_MNGR, "Remove old pending request" << KVLOG(clientId, lastReply->first));
+          it = requestsInfo.erase(it);
+        } else
+          break;
+      }
     }
   }
 }
@@ -140,26 +141,26 @@ bool ClientsManager::hasReply(NodeIdType clientId, ReqId reqSeqNum) {
 }
 
 void ClientsManager::deleteOldestReply(NodeIdType clientId) {
-  // YS TBD: Once multiple replies for client batching are sorted by incoming time, they could be deleted properly
   Time earliestTime = MaxTime;
   ReqId earliestReplyId = 0;
   const uint16_t clientIdx = clientIdToIndex_.at(clientId);
   auto& repliesInfo = indexToClientInfo_.at(clientIdx).repliesInfo;
   // Since seqnum is always growing we can be sure that the first element on the map is the oldest reply so we want to
   // remove this reply.
-  earliestReplyId = repliesInfo.cbegin()->first;
-  repliesInfo.erase(earliestReplyId);
-  LOG_DEBUG(CL_MNGR,
-            "Deleted reply message" << KVLOG(
-                clientId, earliestReplyId, earliestTime.time_since_epoch().count(), repliesInfo.size()));
+  if (!repliesInfo.empty()) {
+    earliestReplyId = repliesInfo.cbegin()->first;
+    repliesInfo.erase(earliestReplyId);
+    LOG_DEBUG(CL_MNGR,
+              "Deleted reply message" << KVLOG(
+                  clientId, earliestReplyId, earliestTime.time_since_epoch().count(), repliesInfo.size()));
+  }
 }
 
 bool ClientsManager::isValidClient(NodeIdType clientId) const { return (clientIdToIndex_.count(clientId) > 0); }
 
 // Reference the ClientInfo of the corresponding client:
-// * set last reply seq num to the seq num of the request we reply to.
-// * set reply time to `now`.
-// * allocate new ClientReplyMsg
+// * Remove the oldest reply from the replies map
+// * allocate client reply message and hold it inside the replies map
 // * calculate: num of pages, size of last page.
 // * save the reply to the reserved pages.
 std::shared_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToStorage(
@@ -175,10 +176,10 @@ std::shared_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToSto
 
   LOG_DEBUG(CL_MNGR, KVLOG(clientId, requestSeqNum));
   auto r = std::make_shared<ClientReplyMsg>(myId_, requestSeqNum, reply, replyLength);
-  c.repliesInfo.insert({requestSeqNum, r});
+  c.repliesInfo.insert_or_assign(requestSeqNum, r);
   const uint32_t firstPageId = clientIdx * reservedPagesPerClient_;
   LOG_DEBUG(CL_MNGR, "firstPageId=" << firstPageId);
-  uint16_t requestNum = 0;
+  uint16_t replyNum = 0;
   for (auto& rep : c.repliesInfo) {
     uint32_t numOfPages = rep.second->size() / sizeOfReservedPage_;
     uint32_t sizeLastPage = sizeOfReservedPage_;
@@ -203,9 +204,9 @@ std::shared_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToSto
       const char* ptrPage = rep.second->body() + i * sizeOfReservedPage_;
       const uint32_t sizePage = ((i < numOfPages - 1) ? sizeOfReservedPage_ : sizeLastPage);
       stateTransfer_->saveReservedPage(
-          resPageOffset() + firstPageId + i + requestNum * singleReplyMaxNumOfPages_, sizePage, ptrPage);
+          resPageOffset() + firstPageId + i + (replyNum * singleReplyMaxNumOfPages_), sizePage, ptrPage);
     }
-    requestNum++;
+    replyNum++;
   }
 
   // write currentPrimaryId to message (we don't store the currentPrimaryId in the reserved pages)
@@ -214,8 +215,9 @@ std::shared_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToSto
   return r;
 }
 
+// * Iterate over all the replies of the client
 // * load client reserve page to scratchPage
-// * cast to ClientReplyMsgHeader and validate.
+// * cast to ClientReplyMsgHeader and validate if this is the requested sequence number.
 // * calculate: reply msg size, num of pages, size of last page.
 // * allocate new ClientReplyMsg.
 // * copy reply from reserved pages to ClientReplyMsg.
@@ -226,15 +228,16 @@ std::shared_ptr<ClientReplyMsg> ClientsManager::allocateReplyFromSavedOne(NodeId
   const uint16_t clientIdx = clientIdToIndex_.at(clientId);
   const uint32_t firstPageId = clientIdx * reservedPagesPerClient_;
   LOG_DEBUG(CL_MNGR, KVLOG(clientId, requestSeqNum, firstPageId));
-  for (int j = 0; j < maxNumOfReqsPerClient_; j++) {
-    stateTransfer_->loadReservedPage(resPageOffset() + firstPageId + j, sizeOfReservedPage_, scratchPage_.data());
+  for (uint16_t j = 0; j < maxNumOfReqsPerClient_; j++) {
+    stateTransfer_->loadReservedPage(
+        resPageOffset() + firstPageId + (j * singleReplyMaxNumOfPages_), sizeOfReservedPage_, scratchPage_.data());
 
     ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_.data();
+    if (replyHeader->reqSeqNum != requestSeqNum) continue;
     ConcordAssert(replyHeader->msgType == MsgCode::ClientReply);
     ConcordAssert(replyHeader->currentPrimaryId == 0);
     ConcordAssert(replyHeader->replyLength > 0);
     ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplySize_);
-    if (replyHeader->reqSeqNum != requestSeqNum) continue;
 
     uint32_t replyMsgSize = sizeof(ClientReplyMsgHeader) + replyHeader->replyLength;
     uint32_t numOfPages = replyMsgSize / sizeOfReservedPage_;
@@ -249,13 +252,17 @@ std::shared_ptr<ClientReplyMsg> ClientsManager::allocateReplyFromSavedOne(NodeId
     for (uint32_t i = 0; i < numOfPages; i++) {
       char* const ptrPage = r->body() + i * sizeOfReservedPage_;
       const uint32_t sizePage = ((i < numOfPages - 1) ? sizeOfReservedPage_ : sizeLastPage);
-      stateTransfer_->loadReservedPage(resPageOffset() + firstPageId + j + i, sizePage, ptrPage);
+      stateTransfer_->loadReservedPage(
+          resPageOffset() + firstPageId + (j * singleReplyMaxNumOfPages_) + i, sizePage, ptrPage);
     }
 
     r->setPrimaryId(currentPrimaryId);
     LOG_DEBUG(CL_MNGR, "Returns reply with hash=" << r->debugHash());
     return r;
   }
+  LOG_ERROR(CL_MNGR,
+            "Client reply with sequence number=" << requestSeqNum
+                                                 << " has not been found on the reserved pages of client=" << clientId);
   return nullptr;
 }
 

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -105,7 +105,6 @@ void ClientsManager::loadInfoFromReservedPages() {
       auto replyHeader = (ClientReplyMsgHeader*)(scratchPage_.data());
       auto replyPtr = std::make_shared<ClientReplyMsg>(myId_, replyHeader->replyLength);
       ConcordAssert(replyHeader->msgType == 0 || replyHeader->msgType == MsgCode::ClientReply);
-      ConcordAssert(replyHeader->currentPrimaryId == 0);
       ConcordAssert(replyHeader->replyLength >= 0);
       ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplySize_);
 
@@ -235,7 +234,6 @@ std::shared_ptr<ClientReplyMsg> ClientsManager::allocateReplyFromSavedOne(NodeId
     ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_.data();
     if (replyHeader->reqSeqNum != requestSeqNum) continue;
     ConcordAssert(replyHeader->msgType == MsgCode::ClientReply);
-    ConcordAssert(replyHeader->currentPrimaryId == 0);
     ConcordAssert(replyHeader->replyLength > 0);
     ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplySize_);
 

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -30,7 +30,6 @@ class ClientRequestMsg;
 class ClientsManager : public ResPagesClient<ClientsManager, 0> {
  public:
   ClientsManager(concordMetrics::Component& metrics, std::set<NodeIdType>& clientsSet);
-  ~ClientsManager();
 
   void init(IStateTransfer* stateTransfer);
 

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -46,7 +46,8 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
       MsgCode::ClientRequest, bind(&ReadOnlyReplica::messageHandler<ClientRequestMsg>, this, std::placeholders::_1));
   metrics_.Register();
   // must be initialized although is not used by ReadOnlyReplica for proper behavior of StateTransfer
-  auto maxNumOfReqsPerClient = config.clientBatchingEnabled ? ReplicaConfig::instance().clientBatchingMaxMsgsNbr : 1;
+  const auto maxNumOfReqsPerClient =
+      config.clientBatchingEnabled ? ReplicaConfig::instance().clientBatchingMaxMsgsNbr : 1;
   ClientsManager::setNumResPages((config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
                                  ClientsManager::reservedPagesPerClient(
                                      config.sizeOfReservedPage, config.maxReplyMessageSize, maxNumOfReqsPerClient));

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -46,9 +46,10 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
       MsgCode::ClientRequest, bind(&ReadOnlyReplica::messageHandler<ClientRequestMsg>, this, std::placeholders::_1));
   metrics_.Register();
   // must be initialized although is not used by ReadOnlyReplica for proper behavior of StateTransfer
-  ClientsManager::setNumResPages(
-      (config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
-      ClientsManager::reservedPagesPerClient(config.sizeOfReservedPage, config.maxReplyMessageSize));
+  auto maxNumOfReqsPerClient = config.clientBatchingEnabled ? ReplicaConfig::instance().clientBatchingMaxMsgsNbr : 1;
+  ClientsManager::setNumResPages((config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
+                                 ClientsManager::reservedPagesPerClient(
+                                     config.sizeOfReservedPage, config.maxReplyMessageSize, maxNumOfReqsPerClient));
   ClusterKeyStore::setNumResPages(config.numReplicas);
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3675,7 +3675,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
   clientsManager->initInternalClientInfo(config_.getnumReplicas());
   internalBFTClient_.reset(new InternalBFTClient(
       config_.getreplicaId(), clientsManager->getHighestIdOfNonInternalClient(), msgsCommunicator_));
-  auto maxNumOfReqsPerClient = config.clientBatchingEnabled ? ReplicaConfig::instance().clientBatchingMaxMsgsNbr : 1;
+  const auto maxNumOfReqsPerClient =
+      config.clientBatchingEnabled ? ReplicaConfig::instance().clientBatchingMaxMsgsNbr : 1;
   ClientsManager::setNumResPages((config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
                                  ClientsManager::reservedPagesPerClient(config.getsizeOfReservedPage(),
                                                                         config.maxReplyMessageSize,

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3675,10 +3675,11 @@ ReplicaImp::ReplicaImp(bool firstTime,
   clientsManager->initInternalClientInfo(config_.getnumReplicas());
   internalBFTClient_.reset(new InternalBFTClient(
       config_.getreplicaId(), clientsManager->getHighestIdOfNonInternalClient(), msgsCommunicator_));
-
-  ClientsManager::setNumResPages(
-      (config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
-      ClientsManager::reservedPagesPerClient(config.getsizeOfReservedPage(), config.maxReplyMessageSize));
+  auto maxNumOfReqsPerClient = config.clientBatchingEnabled ? ReplicaConfig::instance().clientBatchingMaxMsgsNbr : 1;
+  ClientsManager::setNumResPages((config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
+                                 ClientsManager::reservedPagesPerClient(config.getsizeOfReservedPage(),
+                                                                        config.maxReplyMessageSize,
+                                                                        maxNumOfReqsPerClient));
   ClusterKeyStore::setNumResPages(config.numReplicas);
 
   clientsManager->init(stateTransfer.get());

--- a/bftengine/tests/clientsManager/ClientsManager_test.cpp
+++ b/bftengine/tests/clientsManager/ClientsManager_test.cpp
@@ -21,14 +21,22 @@ concordMetrics::Component metrics{concordMetrics::Component("replica", std::make
 TEST(ClientsManager, reservedPagesPerClient) {
   uint32_t sizeOfReservedPage = 1024;
   uint32_t maxReplysize = 1000;
-  auto numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, 1);
+  uint16_t maxNumOfReqsPerClient = 1;
+  auto numPagesPerCl =
+      bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, maxNumOfReqsPerClient);
   ASSERT_EQ(numPagesPerCl, 1);
   maxReplysize = 3000;
-  numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, 1);
+  numPagesPerCl =
+      bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, maxNumOfReqsPerClient);
   ASSERT_EQ(numPagesPerCl, 3);
   maxReplysize = 1024;
-  numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, 1);
+  numPagesPerCl =
+      bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, maxNumOfReqsPerClient);
   ASSERT_EQ(numPagesPerCl, 1);
+  maxNumOfReqsPerClient = 10;
+  numPagesPerCl =
+      bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, maxNumOfReqsPerClient);
+  ASSERT_EQ(numPagesPerCl, 10);
 }
 
 TEST(ClientsManager, constructor) {

--- a/bftengine/tests/clientsManager/ClientsManager_test.cpp
+++ b/bftengine/tests/clientsManager/ClientsManager_test.cpp
@@ -21,13 +21,13 @@ concordMetrics::Component metrics{concordMetrics::Component("replica", std::make
 TEST(ClientsManager, reservedPagesPerClient) {
   uint32_t sizeOfReservedPage = 1024;
   uint32_t maxReplysize = 1000;
-  auto numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize);
+  auto numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, 1);
   ASSERT_EQ(numPagesPerCl, 1);
   maxReplysize = 3000;
-  numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize);
+  numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, 1);
   ASSERT_EQ(numPagesPerCl, 3);
   maxReplysize = 1024;
-  numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize);
+  numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize, 1);
   ASSERT_EQ(numPagesPerCl, 1);
 }
 

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -159,7 +159,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
             len(bft_network.procs), 2 * f + 2 * c + 1,
             "Make sure enough replicas are up to allow a successful view change")
 
-        await self._send_random_writes(tracker)
+        await self._send_random_writes(tracker,3)
 
         await bft_network.wait_for_view(
             replica_id=random.choice(bft_network.all_replicas(without=crashed_replicas)),
@@ -501,8 +501,8 @@ class SkvbcViewChangeTest(unittest.TestCase):
                     else:
                         break
 
-    async def _send_random_writes(self, tracker):
-        with trio.move_on_after(seconds=1):
+    async def _send_random_writes(self, tracker, timeout=1):
+        with trio.move_on_after(seconds=timeout):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(tracker.send_indefinite_tracked_ops, 1)
 

--- a/tests/config/test_comm_config.hpp
+++ b/tests/config/test_comm_config.hpp
@@ -69,7 +69,7 @@ class TestCommConfig : public ITestCommConfig {
   // Network port of the first replica. Other replicas use ports
   // basePort + (2 * index).
   static const uint16_t base_port_ = 3710;
-  static const uint32_t buf_length_ = 128 * 1024;  // 128 kB
+  static const uint32_t buf_length_ = 1280 * 1024;  // 128 kB
   static const std::string default_ip_;
   static const std::string default_listen_ip_;
   static const char* ip_port_delimiter_;


### PR DESCRIPTION
This PR is intended to add support on several replies per client on reserved pages.
The main changes are:

1. Replies info will hold all the replies ordered by sequence number.
2. The reserved pages per client will be calculated also with the number of requests per client so it will be - (maxReplySize%reservedPageSize)*numberOfRequestsPerClient.
3. The scratchPage used to hold temporary data will hold a reserved page for each request assuming each reserved page holds 1 reply.
4. On allocateNewReplyMsgAndWriteToStorage - the idea is to delete the oldest reply from the map of replies and then insert the new reply to the map and write all the map again 1 by 1 on the reserved pages, we will also keep that each reply will start after the maximum number of pages of the last reply.
5. On allocateReplyFromSavedOne - the idea is to iterate over the reserved pages and take reply by reply and check if the reply sequence number is equal to the one we search if so we are creating the reply and returning it, if the reserved pages are not holding this sequence number we return nullptr.
6. On loadInfoFromReservedPages - the idea is to iterate over all the replies and insert them to the replies map one by one, at the end, we are taking the newest sequence number and removing all the requests that have a sequence number that is before this reply.