### PR TITLE
AddRemoveCommand for reconfiguration engine

### DIFF
--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -19,4 +19,5 @@ static const char reconfiguration_wedge_key = 0x25;
 static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;
 static const char reconfiguration_key_exchange = 0x28;
+static const char reconfiguration_add_remove = 0x29;
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/reconfiguration_add_block_handler.hpp
+++ b/kvbc/include/reconfiguration_add_block_handler.hpp
@@ -89,6 +89,17 @@ class ReconfigurationHandler : public concord::reconfiguration::IReconfiguration
     return true;
   }
 
+  bool handle(const concord::messages::AddRemoveCommand& command,
+              concord::messages::ReconfigurationErrorMsg&,
+              uint64_t sequence_number) override {
+    std::vector<uint8_t> serialized_command;
+    concord::messages::serialize(serialized_command, command);
+    auto blockId =
+        persistReconfigurationBlock(serialized_command, sequence_number, kvbc::keyTypes::reconfiguration_add_remove);
+    LOG_INFO(getLogger(), "AddRemoveCommand command block is " << blockId);
+    return true;
+  }
+
  private:
   kvbc::IBlockAdder& blocks_adder_;
   BlockMetadata block_metadata_;

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -82,6 +82,11 @@ Msg ReconfigurationErrorMsg 24 {
 Msg KeyExchangeCommand 25 {
     uint64 sender_id
 }
+
+Msg AddRemoveCommand 26 {
+    string reconfiguration
+}
+
 Msg ReconfigurationRequest 1 {
   bytes signature
   oneof {
@@ -97,6 +102,7 @@ Msg ReconfigurationRequest 1 {
     InstallCommand
     InstallStatusCommand
     KeyExchangeCommand
+    AddRemoveCommand
   } command
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -49,6 +49,9 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::KeyExchangeCommand&,
                       concord::messages::ReconfigurationErrorMsg&,
                       uint64_t) = 0;
+  virtual bool handle(const concord::messages::AddRemoveCommand&,
+                      concord::messages::ReconfigurationErrorMsg&,
+                      uint64_t) = 0;
   virtual bool verifySignature(const concord::messages::ReconfigurationRequest&,
                                concord::messages::ReconfigurationErrorMsg&) const = 0;
 

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -46,6 +46,9 @@ class ReconfigurationHandler : public IReconfigurationHandler {
   bool handle(const concord::messages::KeyExchangeCommand&,
               concord::messages::ReconfigurationErrorMsg&,
               uint64_t) override;
+  bool handle(const concord::messages::AddRemoveCommand&,
+              concord::messages::ReconfigurationErrorMsg&,
+              uint64_t) override;
   bool verifySignature(const concord::messages::ReconfigurationRequest&,
                        concord::messages::ReconfigurationErrorMsg&) const override;
 

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -94,4 +94,10 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
   LOG_INFO(GL, "KeyExchangeCommand has been executed");
   return true;
 }
+
+bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand&,
+                                    concord::messages::ReconfigurationErrorMsg&,
+                                    uint64_t) {
+  return true;
+}
 }  // namespace concord::reconfiguration


### PR DESCRIPTION
We add the AddRemoveCommand to the reconfiguration engine.
The main benefit of this PR is to persist the new configuration in the BC