### PR TITLE
SigManager: (temporary patch) - define instance_ in header

### DIFF
--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -21,8 +21,6 @@ using namespace std;
 namespace bftEngine {
 namespace impl {
 
-SigManager* SigManager::instance_{nullptr};
-
 SigManager* SigManager::initImpl(ReplicaId myId,
                                  const Key& mySigPrivateKey,
                                  const std::set<std::pair<PrincipalId, const std::string>>& publicKeysOfReplicas,

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -111,8 +111,12 @@ class SigManager {
   }
   static void setInstance(SigManager* instance) { instance_ = instance; }
 #endif
+};
 
-};  // namespace impl
+// temporary patch - see https://jira.eng.vmware.com/browse/BC-8242. Definition should be moved back to SigManager.cpp
+#ifdef _DEFINE_SIGMANAGER_INSTANCE_
+SigManager* SigManager::instance_{nullptr};
+#endif
 
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -9,6 +9,10 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+
+// temporary patch - see https://jira.eng.vmware.com/browse/BC-8242. remove this flag after issue is solved
+#define _DEFINE_SIGMANAGER_INSTANCE_
+
 #include <queue>
 #include <unordered_map>
 #include <mutex>


### PR DESCRIPTION
This is a temporary patch. Task BC-8242 should revert after solving the
the issue in the right way.

Since some external modules, such as concord external client, include
all concord bftengine (core) header files - we must move Signature
Manager static instance_ definition into the header file. External
modules look for a definition and must find it.

To avoid multiple definitions the flag _SIG_MANAGER_CPP_ must be
defined to allow defining instance_ only once. I have chosen
SimpleClientImp.cpp to define this flag on the top since this is a
common file for both concord-bft core library, and external client.