### PR TITLE
View change with f replicas collected stable checkpoint

### DIFF
--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -50,6 +50,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
+    @unittest.skip("Edge case scenario - not part of CI")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f == 2)
     async def test_view_change_with_f_replicas_collected_stable_checkpoint(self, bft_network):

--- a/tests/apollo/util/bft_network_partitioning.py
+++ b/tests/apollo/util/bft_network_partitioning.py
@@ -266,6 +266,28 @@ class ReplicaSubsetOneWayIsolatingAdversary(NetworkPartitioningAdversary):
                 if ir != r:
                     self._drop_packets_between(ir, r)
 
+class ReplicaOneWayTwoSubsetsIsolatingAdversary(NetworkPartitioningAdversary):
+    """
+    Adversary that isolates all messages except client requests
+    to a subset of replicas (blocked receivers) from another subset (blocked senders).
+    The Replicas in the blocked receivers subset will be able to send msgs to all other
+    replicas in the network, but anything addressed to them by the blocked senders set
+    of replicas will be dropped.
+    """
+
+    def __init__(self, bft_network, blocked_receivers, blocked_senders):
+        assert len(blocked_receivers) < bft_network.config.n
+        assert len(blocked_senders) < bft_network.config.n
+        self.blocked_receivers = blocked_receivers
+        self.blocked_senders = blocked_senders
+        super(ReplicaOneWayTwoSubsetsIsolatingAdversary, self).__init__(bft_network)
+
+    def interfere(self):
+        for sender in self.blocked_senders:
+            for receiver in self.blocked_receivers:
+                assert sender != receiver
+                self._drop_packets_between(sender, receiver)
+
 class ReplicaSubsetTwoWayIsolatingAdversary(NetworkPartitioningAdversary):
     """
     Adversary that isolates all messages except client requests


### PR DESCRIPTION
This test is a recreation of a infinite View Change scenario, where we have only F Replicas that have gathered a Stable Checkpoint. This causes disagreement in the computed Restrictions for the previous View's Working Window and View Change is never finalized.