### PR TITLE
PreProcessor pushes a wrong message to ReplicaImp

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -205,7 +205,7 @@ void PreProcessor::onRequestsStatusCheckTimer() {
         SCOPED_MDC_CID(reqStatePtr->getReqCid());
         LOG_INFO(logger(), "Let replica handle request" << KVLOG(reqSeqNum, reqEntryIndex, clientId, reqOffsetInBatch));
         preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
-        incomingMsgsStorage_->pushExternalMsg(reqStatePtr->buildClientRequestMsg(true, true));
+        incomingMsgsStorage_->pushExternalMsg(reqStatePtr->buildClientRequestMsg(true));
         releaseClientPreProcessRequest(reqEntry.second, CANCEL);
       } else if (myReplica_.isCurrentPrimary() && reqStatePtr->definePreProcessingConsensusResult() == CONTINUE)
         resendPreProcessRequest(reqStatePtr);
@@ -411,7 +411,7 @@ void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
     if (isRequestAlreadyExecuted(reqSeqNum, senderId, clientId, clientMsg->getCid())) {
       if (senderId != clientId) sendCancelPreProcessRequestMsg(clientMsg, msgOffsetInBatch, (reqEntry->reqRetryId)++);
       // The request has already been committed and executed - let replica decide how to proceed further.
-      return incomingMsgsStorage_->pushExternalMsg(move(clientMsg));
+      return incomingMsgsStorage_->pushExternalMsg(clientMsg->convertToClientRequestMsg(false));
     }
 
     const bool reqToBeDeclined =

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -193,8 +193,8 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
   return CONTINUE;
 }
 
-unique_ptr<MessageBase> RequestProcessingState::buildClientRequestMsg(bool resetPreProcessFlag, bool emptyReq) {
-  return clientPreProcessReqMsg_->convertToClientRequestMsg(resetPreProcessFlag, emptyReq);
+unique_ptr<MessageBase> RequestProcessingState::buildClientRequestMsg(bool emptyReq) {
+  return clientPreProcessReqMsg_->convertToClientRequestMsg(emptyReq);
 }
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -39,7 +39,7 @@ class RequestProcessingState {
 
   void handlePrimaryPreProcessed(const char* preProcessResult, uint32_t preProcessResultLen);
   void handlePreProcessReplyMsg(const PreProcessReplyMsgSharedPtr& preProcessReplyMsg);
-  std::unique_ptr<MessageBase> buildClientRequestMsg(bool resetPreProcessFlag, bool emptyReq = false);
+  std::unique_ptr<MessageBase> buildClientRequestMsg(bool emptyReq = false);
   void setPreProcessRequest(PreProcessRequestMsgSharedPtr preProcessReqMsg);
   const PreProcessRequestMsgSharedPtr& getPreProcessRequest() const { return preProcessRequestMsg_; }
   const auto getClientId() const { return clientId_; }

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -39,8 +39,8 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
   msgBody_->msgType = MsgCode::ClientPreProcessRequest;
 }
 
-unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bool resetPreProcessFlag, bool emptyReq) {
-  if (resetPreProcessFlag) msgBody()->flags &= ~(1 << 1);
+unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bool emptyReq) {
+  msgBody()->flags &= ~(1 << 1);
   unique_ptr<MessageBase> clientRequestMsg = make_unique<ClientRequestMsg>(clientProxyId(),
                                                                            flags(),
                                                                            requestSeqNum(),

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -33,7 +33,7 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
 
   ClientPreProcessRequestMsg(MessageBase* msgBase) : ClientRequestMsg(msgBase) {}
   void validate(const ReplicasInfo& repInfo) const { validateRequest(repInfo, getExpectedSignatureLength()); }
-  std::unique_ptr<MessageBase> convertToClientRequestMsg(bool resetPreProcessFlag, bool emptyReq = false);
+  std::unique_ptr<MessageBase> convertToClientRequestMsg(bool emptyReq = false);
 };
 
 typedef std::unique_ptr<ClientPreProcessRequestMsg> ClientPreProcessReqMsgUniquePtr;


### PR DESCRIPTION
Before pushing a message to ReplicaImp (e.g when it has already been executed), PreProcessor has to convert ClientPreProcessRequest to ClientRequest, otherwise, it will return again to PreProcessor as it has a registered message handler for it.