### PR TITLE
WIP: Remove not relevant requests from pending

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -345,7 +345,7 @@ void ClientsManager::markRequestAsCommitted(NodeIdType clientId, ReqId reqSeqNum
  * numbers. Then, we count how many bigger sequence number than the given reqSequenceNumber we have. We know for sure
  * that we shouldn't have more than maxNumOfRequestsInBatch. Thus, we can safely remove them from the client manager.
  */
-void ClientsManager::removeRequestsOutsideBoundsOfBatch(NodeIdType clientId, ReqId reqSequenceNum) {
+void ClientsManager::removeRequestsOutOfBatchBounds(NodeIdType clientId, ReqId reqSequenceNum) {
   uint16_t idx = clientIdToIndex_.at(clientId);
   auto& requestsInfo = indexToClientInfo_.at(idx).requestsInfo;
   if (requestsInfo.find(reqSequenceNum) != requestsInfo.end()) return;

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -64,6 +64,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   void markRequestAsCommitted(NodeIdType clientId, ReqId reqSequenceNum);
 
+  bool removeRequestsOutsideBoundsOfBatch(NodeIdType clientId, ReqId reqSequenceNum);
   void removePendingForExecutionRequest(NodeIdType clientId, ReqId reqSeqNum);
 
   void clearAllPendingRequests();

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -60,6 +60,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
   // Return true IFF there is no pending requests for clientId, and reqSeqNum can become the new pending request
   bool canBecomePending(NodeIdType clientId, ReqId reqSeqNum) const;
 
+  bool isPending(NodeIdType clientId, ReqId reqSeqNum) const;
   void addPendingRequest(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid);
 
   void markRequestAsCommitted(NodeIdType clientId, ReqId reqSequenceNum);

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -65,7 +65,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   void markRequestAsCommitted(NodeIdType clientId, ReqId reqSequenceNum);
 
-  void removeRequestsOutsideBoundsOfBatch(NodeIdType clientId, ReqId reqSequenceNum);
+  void removeRequestsOutOfBatchBounds(NodeIdType clientId, ReqId reqSequenceNum);
   void removePendingForExecutionRequest(NodeIdType clientId, ReqId reqSeqNum);
 
   void clearAllPendingRequests();

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -65,7 +65,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   void markRequestAsCommitted(NodeIdType clientId, ReqId reqSequenceNum);
 
-  bool removeRequestsOutsideBoundsOfBatch(NodeIdType clientId, ReqId reqSequenceNum);
+  void removeRequestsOutsideBoundsOfBatch(NodeIdType clientId, ReqId reqSequenceNum);
   void removePendingForExecutionRequest(NodeIdType clientId, ReqId reqSeqNum);
 
   void clearAllPendingRequests();
@@ -120,6 +120,7 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
   const uint16_t maxNumOfReqsPerClient_;
   concordMetrics::Component& metrics_;
   concordMetrics::CounterHandle metric_reply_inconsistency_detected_;
+  concordMetrics::CounterHandle metric_removed_due_to_out_of_boundaries_;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -712,7 +712,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
       while (reqIter.getAndGoToNext(requestBody)) {
         ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
         if (!clientsManager->isValidClient(req.clientProxyId())) continue;
-        clientsManager->removeRequestsOutsideBoundsOfBatch(req.clientProxyId(), req.requestSeqNum());
+        clientsManager->removeRequestsOutOfBatchBounds(req.clientProxyId(), req.requestSeqNum());
         if (clientsManager->canBecomePending(req.clientProxyId(), req.requestSeqNum()))
           clientsManager->addPendingRequest(req.clientProxyId(), req.requestSeqNum(), req.getCid());
       }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -712,8 +712,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
       while (reqIter.getAndGoToNext(requestBody)) {
         ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
         if (!clientsManager->isValidClient(req.clientProxyId())) continue;
-        if (clientsManager->removeRequestsOutsideBoundsOfBatch(req.clientProxyId(), req.requestSeqNum()))
-          metric_requests_removed_from_pending_.Get().Inc();
+        clientsManager->removeRequestsOutsideBoundsOfBatch(req.clientProxyId(), req.requestSeqNum());
         if (clientsManager->canBecomePending(req.clientProxyId(), req.requestSeqNum()))
           clientsManager->addPendingRequest(req.clientProxyId(), req.requestSeqNum(), req.getCid());
       }
@@ -3605,7 +3604,6 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_total_fastPath_requests_{metrics_.RegisterCounter("totalFastPathRequests")},
       metric_total_preexec_requests_executed_{metrics_.RegisterCounter("totalPreExecRequestsExecuted")},
       metric_client_req_sig_veirification_failed_{metrics_.RegisterCounter("clientReqSigVerFailed")},
-      metric_requests_removed_from_pending_{metrics_.RegisterCounter("requestsRemovedFromPendingDueToTooHighSeqNum")},
       consensus_times_(histograms_.consensus),
       checkpoint_times_(histograms_.checkpointFromCreationToStable),
       time_in_active_view_(histograms_.timeInActiveView),

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -708,6 +708,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
       while (reqIter.getAndGoToNext(requestBody)) {
         ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
         if (!clientsManager->isValidClient(req.clientProxyId())) continue;
+        if (clientsManager->removeRequestsOutsideBoundsOfBatch(req.clientProxyId(), req.requestSeqNum())) metric_requests_removed_from_pending_.Get().Inc();
         if (clientsManager->canBecomePending(req.clientProxyId(), req.requestSeqNum()))
           clientsManager->addPendingRequest(req.clientProxyId(), req.requestSeqNum(), req.getCid());
       }
@@ -3599,6 +3600,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       metric_total_fastPath_requests_{metrics_.RegisterCounter("totalFastPathRequests")},
       metric_total_preexec_requests_executed_{metrics_.RegisterCounter("totalPreExecRequestsExecuted")},
       metric_client_req_sig_veirification_failed_{metrics_.RegisterCounter("clientReqSigVerFailed")},
+      metric_requests_removed_from_pending_{metrics_.RegisterCounter("requestsRemovedFromPendingDueToTooHighSeqNum")},
       consensus_times_(histograms_.consensus),
       checkpoint_times_(histograms_.checkpointFromCreationToStable),
       time_in_active_view_(histograms_.timeInActiveView),

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -240,6 +240,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_total_fastPath_requests_;
   CounterHandle metric_total_preexec_requests_executed_;
   CounterHandle metric_client_req_sig_veirification_failed_;
+  CounterHandle metric_requests_removed_from_pending_;
   //*****************************************************
   RollingAvgAndVar consensus_time_;
   RollingAvgAndVar accumulating_batch_time_;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -240,7 +240,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_total_fastPath_requests_;
   CounterHandle metric_total_preexec_requests_executed_;
   CounterHandle metric_client_req_sig_veirification_failed_;
-  CounterHandle metric_requests_removed_from_pending_;
   //*****************************************************
   RollingAvgAndVar consensus_time_;
   RollingAvgAndVar accumulating_batch_time_;


### PR DESCRIPTION
This change is to reduce the number of VC we experienced. In this commit we want to enforce the following interval: A client cannot have more pending requests than the max client batch size.
How to force it:
In a former commit (212114f) we made a nonprimary replica to start tracking the client messages that are in the primary pre-prepare message.
Now consider the following scenario,
1. Assume the client batch size is 1
2. Due to some networks delays, data races, or Byzantine client, the primary replica started to handle request X while a nonprimary replica started to handle request Y where Y> X
3. The nonprimary will tries to send Y to the primary, however, the primary is already busy with X
4. The nonprimary also will not be able to add X to its pending requests as it is already taken by Y
5. X will be committed and removed from the primary pending requests, while Y will never be committed
6. Y will never be committed and eventually, VC will happen

To solve the above scenario, before adding a specific request in pre-prepare to the pending requests, we first try to see if there is an out-boundaries request. In the example above, we got X in the
pre-prepare and we know that the client should have only one ongoing request then we can remove Y from the pending requests