### PR TITLE
SigManager: (temporary patch) - move instance definition to another file

### DIFF
--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -21,8 +21,6 @@ using namespace std;
 namespace bftEngine {
 namespace impl {
 
-SigManager* SigManager::instance_{nullptr};
-
 SigManager* SigManager::initImpl(ReplicaId myId,
                                  const Key& mySigPrivateKey,
                                  const std::set<std::pair<PrincipalId, const std::string>>& publicKeysOfReplicas,

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -34,6 +34,11 @@ using namespace preprocessor;
 
 namespace bftEngine {
 namespace impl {
+
+// start of temporary patch - see https://jira.eng.vmware.com/browse/BC-8242. Remove this flag after issue is solved
+SigManager* SigManager::instance_{nullptr};
+// end of temporary patch
+
 class SimpleClientImp : public SimpleClient, public IReceiver {
  public:
   SimpleClientImp(ICommunication* communication,


### PR DESCRIPTION
This is a temporary patch. Task BC-8242 should revert after solving the
the issue in the right way.

Since some external modules, such as concord external client, include
all concord bftengine (core) header files - linker will look to the
instance definition, which is in SigManager.cpp before the change.
Here we must move Signature Manager static instance_ definition a new
commonplace - SimpleClientimp.cpp. This file is also compiled
by the external client.