### PR TITLE
Several fixes related to the client batching feature

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -267,6 +267,17 @@ std::unique_ptr<ClientReplyMsg> ClientsManager::allocateReplyFromSavedOne(NodeId
   return r;
 }
 
+bool ClientsManager::isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const {
+  uint16_t idx = clientIdToIndex_.at(clientId);
+  const auto& requestsInfo = indexToClientInfo_.at(idx).requestsInfo;
+  const auto& reqIt = indexToClientInfo_.at(idx).requestsInfo.find(reqSeqNum);
+  if (reqIt != requestsInfo.end()) {
+    LOG_DEBUG(CL_MNGR, "The request is executing right now" << KVLOG(clientId, reqSeqNum));
+    return true;
+  }
+  return false;
+}
+
 // Check that:
 // * max number of pending requests not reached for that client.
 // * request seq number is bigger than the last reply seq number.

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -55,6 +55,8 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
 
   // Requests
 
+  bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const;
+
   // Return true IFF there is no pending requests for clientId, and reqSeqNum can become the new pending request
   bool canBecomePending(NodeIdType clientId, ReqId reqSeqNum) const;
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -293,7 +293,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
     return clientsManager->hasReply(clientId, reqSeqNum);
   }
   bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const override {
-    return !clientsManager->canBecomePending(clientId, reqSeqNum);
+    return clientsManager->isClientRequestInProcess(clientId, reqSeqNum);
   }
   SeqNum getPrimaryLastUsedSeqNum() const override { return primaryLastUsedSeqNum; }
   uint64_t getRequestsInQueue() const override { return requestsQueueOfPrimary.size(); }

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -120,6 +120,7 @@ class PreProcessor {
                                     const std::string &cid,
                                     const std::string &ongoingCid);
   void sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
+                                      NodeIdType destId,
                                       uint16_t reqOffsetInBatch,
                                       uint64_t reqRetryId);
   const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
@@ -162,6 +163,7 @@ class PreProcessor {
   void cancelTimers();
   void onRequestsStatusCheckTimer();
   void handleSingleClientRequestMessage(ClientPreProcessReqMsgUniquePtr clientMsg,
+                                        NodeIdType senderId,
                                         bool arrivedInBatch,
                                         uint16_t msgOffsetInBatch);
   bool isRequestPreProcessingRightNow(const RequestStateSharedPtr &reqEntry,

--- a/bftengine/src/preprocessor/PreProcessorRecorder.hpp
+++ b/bftengine/src/preprocessor/PreProcessorRecorder.hpp
@@ -19,7 +19,10 @@ class PreProcessorRecorder {
   PreProcessorRecorder() {
     auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
     registrar.perf.registerComponent("pre-execution",
-                                     {onMessage,
+                                     {onClientPreProcessRequestMsg,
+                                      onClientBatchPreProcessRequestMsg,
+                                      onPreProcessRequestMsg,
+                                      onPreProcessReplyMsg,
                                       launchReqPreProcessing,
                                       handlePreProcessedReqByNonPrimary,
                                       handlePreProcessedReqByPrimary,
@@ -38,7 +41,10 @@ class PreProcessorRecorder {
   using Recorder = concord::diagnostics::Recorder;
   using Unit = concord::diagnostics::Unit;
 
-  DEFINE_SHARED_RECORDER(onMessage, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  DEFINE_SHARED_RECORDER(onClientPreProcessRequestMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  DEFINE_SHARED_RECORDER(onClientBatchPreProcessRequestMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  DEFINE_SHARED_RECORDER(onPreProcessRequestMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  DEFINE_SHARED_RECORDER(onPreProcessReplyMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(launchReqPreProcessing, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(handlePreProcessedReqByNonPrimary, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(handlePreProcessedReqByPrimary, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);

--- a/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.cpp
@@ -70,19 +70,22 @@ ClientMsgsList& ClientBatchRequestMsg::getClientPreProcessRequestMsgs() {
         isClientTransactionSigningEnabled ? (cidPosition + singleMsgHeader.cidLength) : nullptr;
     uint32_t requestSignatureLength =
         isClientTransactionSigningEnabled ? sigManager->getSigLength(singleMsgHeader.idOfClientProxy) : 0;
+    auto const cid = string(cidPosition, singleMsgHeader.cidLength);
     auto msg = make_unique<preprocessor::ClientPreProcessRequestMsg>(singleMsgHeader.idOfClientProxy,
                                                                      singleMsgHeader.reqSeqNum,
                                                                      singleMsgHeader.requestLength,
                                                                      requestDataPosition,
                                                                      singleMsgHeader.timeoutMilli,
-                                                                     string(cidPosition, singleMsgHeader.cidLength),
+                                                                     cid,
                                                                      spanContext,
                                                                      requestSignaturePosition,
                                                                      requestSignatureLength);
+    LOG_DEBUG(logger(), KVLOG(msg->clientProxyId(), msg->getCid(), msg->requestSeqNum()));
     clientMsgsList_.push_back(move(msg));
     dataPosition += sizeof(ClientRequestMsgHeader) + singleMsgHeader.spanContextSize + singleMsgHeader.requestLength +
                     singleMsgHeader.cidLength;
   }
+  LOG_DEBUG(logger(), KVLOG(msgBody()->clientId, clientMsgsList_.size(), numOfMessagesInBatch));
   return clientMsgsList_;
 }
 


### PR DESCRIPTION
1. Use isClientRequestInProcess instead of canBecomePending to define if a request is in process by ReplicaImp
2. As batched client requests don't have a correct senderId, use ClientBatchRequestMsg senderId to identify that a message was forwarded by a non-primary replica.
3. Don't resend replies to the client for messages forwarded by non-primary replicas.