### PR TITLE
Read only replica pruning Apollo test

### DIFF
--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -210,6 +210,11 @@ class ReadOnlyReplicaPruningHandler : public reconfiguration::IPruningHandler {
     latest_prunable_block.replica = replica_id_;
     latest_prunable_block.block_id = latest_prunable_block_id;
     signer_.sign(latest_prunable_block);
+    LOG_INFO(GL,
+             KVLOG(latest_prunable_block.bft_sequence_number,
+                   latest_prunable_block.replica = replica_id_,
+                   latest_prunable_block.block_id,
+                   std::string(latest_prunable_block.signature.begin(), latest_prunable_block.signature.end())));
     return true;
   }
   // Read only replica doesn't perform the actual pruning

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -213,8 +213,7 @@ class ReadOnlyReplicaPruningHandler : public reconfiguration::IPruningHandler {
     LOG_INFO(GL,
              KVLOG(latest_prunable_block.bft_sequence_number,
                    latest_prunable_block.replica = replica_id_,
-                   latest_prunable_block.block_id,
-                   std::string(latest_prunable_block.signature.begin(), latest_prunable_block.signature.end())));
+                   latest_prunable_block.block_id));
     return true;
   }
   // Read only replica doesn't perform the actual pruning

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -175,7 +175,12 @@ std::optional<categorization::Updates> ReplicaImp::getBlockUpdates(BlockId block
 
 BlockId ReplicaImp::getGenesisBlockId() const { return m_kvBlockchain->getGenesisBlockId(); }
 
-BlockId ReplicaImp::getLastBlockId() const { return m_kvBlockchain->getLastReachableBlockId(); }
+BlockId ReplicaImp::getLastBlockId() const {
+  if (replicaConfig_.isReadOnly) {
+    return m_bcDbAdapter->getLastReachableBlockId();
+  }
+  return m_kvBlockchain->getLastReachableBlockId();
+}
 
 void ReplicaImp::set_command_handler(std::shared_ptr<ICommandsHandler> handler) { m_cmdHandler = handler; }
 

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -97,9 +97,11 @@ add_test(NAME skvbc_backup_restore COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_reconfiguration COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+if (USE_S3_OBJECT_STORE)
+    add_test(NAME skvbc_reconfiguration COMMAND sh -c
+            "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 add_test(NAME skvbc_consensus_batching COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_consensus_batching python3 -m unittest test_skvbc_consensus_batching ${TEST_OUTPUT}"

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -16,10 +16,9 @@ import trio
 
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+from util import operator
 import sys
 from util import eliot_logging as log
-
-sys.path.append(os.path.abspath("../../build/tests/apollo/util/"))
 import concord_msgs as cmf_msgs
 
 sys.path.append(os.path.abspath("../../util/pyclient"))
@@ -49,61 +48,6 @@ def start_replica_cmd(builddir, replica_id):
 
 class SkvbcReconfigurationTest(unittest.TestCase):
 
-    def _construct_reconfiguration_wedge_coammand(self):
-        wedge_cmd = cmf_msgs.WedgeCommand()
-        wedge_cmd.sender = 1000
-        reconf_msg = cmf_msgs.ReconfigurationRequest()
-        reconf_msg.command = wedge_cmd
-        reconf_msg.signature = bytes()
-        reconf_msg.additional_data = bytes()
-        return reconf_msg
-
-    def _construct_reconfiguration_latest_prunebale_block_coammand(self):
-        lpab_cmd = cmf_msgs.LatestPrunableBlockRequest()
-        lpab_cmd.sender = 1000
-        reconf_msg = cmf_msgs.ReconfigurationRequest()
-        reconf_msg.command = lpab_cmd
-        reconf_msg.signature = bytes()
-        reconf_msg.additional_data = bytes()
-        return reconf_msg
-
-    def _construct_reconfiguration_wedge_status(self):
-        wedge_status_cmd = cmf_msgs.WedgeStatusRequest()
-        wedge_status_cmd.sender = 1000
-        reconf_msg = cmf_msgs.ReconfigurationRequest()
-        reconf_msg.command = wedge_status_cmd
-        reconf_msg.signature = bytes()
-        reconf_msg.additional_data = bytes()
-        return reconf_msg
-
-    def _construct_reconfiguration_prune_request(self, latest_pruneble_blocks):
-        prune_cmd = cmf_msgs.PruneRequest()
-        prune_cmd.sender = 1000
-        prune_cmd.latest_prunable_block = latest_pruneble_blocks
-        reconf_msg = cmf_msgs.ReconfigurationRequest()
-        reconf_msg.command = prune_cmd
-        reconf_msg.signature = bytes()
-        reconf_msg.additional_data = bytes()
-        return reconf_msg
-
-    def _construct_reconfiguration_prune_status_request(self):
-        prune_status_cmd = cmf_msgs.PruneStatusRequest()
-        prune_status_cmd.sender = 1000
-        reconf_msg = cmf_msgs.ReconfigurationRequest()
-        reconf_msg.command = prune_status_cmd
-        reconf_msg.signature = bytes()
-        reconf_msg.additional_data = bytes()
-        return reconf_msg
-
-    def _construct_reconfiguration_keMsg_coammand(self):
-        ke_command = cmf_msgs.KeyExchangeCommand()
-        ke_command.sender_id = 1000
-        reconf_msg = cmf_msgs.ReconfigurationRequest()
-        reconf_msg.command = ke_command
-        reconf_msg.signature = bytes()
-        reconf_msg.additional_data = bytes()
-        return reconf_msg
-
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_key_exchange_command(self, bft_network):
@@ -112,8 +56,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
         client.config._replace(req_timeout_milli=10000)
-        reconf_msg = self._construct_reconfiguration_keMsg_coammand()
-        await client.write(reconf_msg.serialize(), reconfiguration=True)
+        op = operator.Operator(bft_network.config, client)
+        await op.key_exchange()
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
@@ -132,9 +76,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
         client.config._replace(req_timeout_milli=10000)
         checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
-        reconf_msg = self._construct_reconfiguration_wedge_coammand()
-        await client.write(reconf_msg.serialize(), reconfiguration=True)
-
+        op = operator.Operator(bft_network.config, client)
+        await op.wedge()
         await self.verify_replicas_are_in_wedged_checkpoint(bft_network, checkpoint_before, range(bft_network.config.n))
         await self.verify_last_executed_seq_num(bft_network, checkpoint_before)
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
@@ -169,8 +112,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         with log.start_action(action_type="send_wedge_cmd",
                               checkpoint_before=checkpoint_before,
                               late_replicas=list(late_replicas)):
-            reconf_msg = self._construct_reconfiguration_wedge_coammand()
-            await client.write(reconf_msg.serialize(), reconfiguration=True)
+            op = operator.Operator(bft_network.config, client)
+            await op.wedge()
 
         await self.verify_replicas_are_in_wedged_checkpoint(bft_network, checkpoint_before, on_time_replicas)
 
@@ -202,15 +145,13 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
         client.config._replace(req_timeout_milli=10000)
 
-        reconf_msg = self._construct_reconfiguration_wedge_coammand()
-        await client.write(reconf_msg.serialize(), reconfiguration=True)
+        op = operator.Operator(bft_network.config, client)
+        await op.wedge()
 
         with trio.fail_after(seconds=90):
             done = False
             while done is False:
-                msg = self._construct_reconfiguration_wedge_status()
-                await client.read(msg.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                    bft_network.config.n)]), reconfiguration=True)
+                await op.wedge_status()
                 rsi_rep = client.get_rsi_replies()
                 done = True
                 for r in rsi_rep.values():
@@ -255,16 +196,14 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # now, send a wedge command. The wedge command sequence number is 300. Hence, in this point the woeking window
         # is between 150 - 450. But, the wedge command will make the primary to send noops until 600.
         # we want to verify that the primary manages to send the noops as required.
-        reconf_msg = self._construct_reconfiguration_wedge_coammand()
-        await client.write(reconf_msg.serialize(), reconfiguration=True)
+        op = operator.Operator(bft_network.config, client)
+        await op.wedge()
 
         # now, verify that the system has managed to stop
         with trio.fail_after(seconds=90):
             done = False
             while done is False:
-                msg = self._construct_reconfiguration_wedge_status()
-                await client.read(msg.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                    bft_network.config.n)]), reconfiguration=True)
+                await op.wedge_status()
                 rsi_rep = client.get_rsi_replies()
                 done = True
                 for r in rsi_rep.values():
@@ -278,7 +217,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         await self.verify_last_executed_seq_num(bft_network, 2)
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
 
-    @unittest.skip("manual testcase - not part of CI")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_get_latest_pruneable_block(self, bft_network):
@@ -294,10 +232,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             await client.write(skvbc.write_req([], [(k, v)], 0))
 
         # Get the minimal latest pruneable block among all replicas
-        reconf_msg = self._construct_reconfiguration_latest_prunebale_block_coammand()
-        await client.read(reconf_msg.serialize(),
-                                m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                                    bft_network.config.n)]), reconfiguration=True)
+        op = operator.Operator(bft_network.config, client)
+        await op.latest_pruneable_block()
 
         rsi_rep = client.get_rsi_replies()
         min_prunebale_block = 1000
@@ -313,10 +249,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             await client.write(skvbc.write_req([], [(k, v)], 0))
 
         # Get the new minimal latest pruneable block
-        reconf_msg = self._construct_reconfiguration_latest_prunebale_block_coammand()
-        await client.read(reconf_msg.serialize(),
-                                m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                                    bft_network.config.n)]), reconfiguration=True)
+        await op.latest_pruneable_block()
 
         rsi_rep = client.get_rsi_replies()
         min_prunebale_block_b = 1000
@@ -341,9 +274,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 await client.write(skvbc.write_req([], [(k, v)], 0))
 
             # Get the minimal latest pruneable block among all replicas
-            reconf_msg = self._construct_reconfiguration_latest_prunebale_block_coammand()
-            await client.read(reconf_msg.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                        bft_network.config.n)]), reconfiguration=True)
+            op = operator.Operator(bft_network.config, client)
+            await op.latest_pruneable_block()
 
             latest_pruneable_blocks = []
             rsi_rep = client.get_rsi_replies()
@@ -351,8 +283,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 lpab = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
                 latest_pruneable_blocks += [lpab.response]
 
-            reconf_msg = self._construct_reconfiguration_prune_request(latest_pruneable_blocks)
-            await client.write(reconf_msg.serialize(), reconfiguration=True)
+            await op.prune(latest_pruneable_blocks)
             rsi_rep = client.get_rsi_replies()
             # we expect to have at least 2f + 1 replies
             for rep in rsi_rep:
@@ -369,10 +300,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         client = bft_network.random_client()
 
-        reconf_msg = self._construct_reconfiguration_prune_status_request()
-        await client.read(reconf_msg.serialize(),
-                                m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                                    bft_network.config.n)]), reconfiguration=True)
+        op = operator.Operator(bft_network.config, client)
+        await op.prune_status()
 
         rsi_rep = client.get_rsi_replies()
         for r in rsi_rep.values():
@@ -387,10 +316,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             await client.write(skvbc.write_req([], [(k, v)], 0))
 
         # Get the minimal latest pruneable block among all replicas
-        reconf_msg = self._construct_reconfiguration_latest_prunebale_block_coammand()
-        await client.read(reconf_msg.serialize(),
-                                m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                                    bft_network.config.n)]), reconfiguration=True)
+        await op.latest_pruneable_block()
 
         latest_pruneable_blocks = []
         rsi_rep = client.get_rsi_replies()
@@ -398,17 +324,13 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             lpab = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
             latest_pruneable_blocks += [lpab.response]
 
-        reconf_msg = self._construct_reconfiguration_prune_request(latest_pruneable_blocks)
-        await client.write(reconf_msg.serialize(), reconfiguration=True)
+        await op.prune(latest_pruneable_blocks)
 
         # Verify the system is able to get new write requests (which means that pruning has done)
         with trio.fail_after(30):
             await skvbc.write_known_kv()
 
-        reconf_msg = self._construct_reconfiguration_prune_status_request()
-        await client.read(reconf_msg.serialize(),
-                          m_of_n_quorum=bft_client.MofNQuorum.All(client.config, [r for r in range(
-                              bft_network.config.n)]), reconfiguration=True)
+        await op.prune_status()
 
         rsi_rep = client.get_rsi_replies()
         for r in rsi_rep.values():

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -23,30 +23,11 @@ from util import bft
 from util import skvbc as kvbc
 from util.skvbc import SimpleKVBCProtocol
 from util.skvbc_history_tracker import verify_linearizability
-from util import operator
 from math import inf
 from util import eliot_logging as log
+from util.object_store import ObjectStore, start_replica_cmd_prefix
 
 from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network
-import sys
-sys.path.append(os.path.abspath("../../build/tests/apollo/util/"))
-import concord_msgs as cmf_msgs
-
-sys.path.append(os.path.abspath("../../util/pyclient"))
-
-import bft_client
-
-def start_replica_cmd_for_pruning(builddir, replica_id, config):
-    """
-    Return a command that starts an skvbc replica when passed to
-    subprocess.Popen.
-
-    Note each arguments is an element in a list.
-    """
-
-    ret = start_replica_cmd_imp(builddir, replica_id, config, "test_s3_config_prefix.txt")
-    ret.extend(["-b", "2", "-q", "1"])
-    return ret
 
 def start_replica_cmd(builddir, replica_id, config):
     """
@@ -56,41 +37,7 @@ def start_replica_cmd(builddir, replica_id, config):
     The effect of this is that on each RO replica start we have got empty S3 storage.
     This is the default behaviour for most of the tests.
     """
-    return start_replica_cmd_imp(builddir, replica_id, config, "test_s3_config.txt")
-
-def start_replica_cmd_prefix(builddir, replica_id, config):
-    """
-    In test_s3_config_prefix.txt the s3-prefix parameter is set, which means that its value
-    doesn't change between RO replica restarts.
-    This means that the state fetched on S3 is persisted on RO replica restart.
-    """
-    return start_replica_cmd_imp(builddir, replica_id, config, "test_s3_config_prefix.txt")
-
-def start_replica_cmd_imp(builddir, replica_id, config, s3_config):
-    """
-    Return a command that starts an skvbc replica when passed to
-    subprocess.Popen.
-
-    The replica is started with a short view change timeout.
-
-    Note each arguments is an element in a list.
-    """
-    statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "10000"
-    ro_params = [ "--s3-config-file",
-                    os.path.join(builddir, "tests", "simpleKVBC", "scripts", s3_config)
-                ]
-    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
-    ret = [path,
-            "-k", KEY_FILE_PREFIX,
-            "-i", str(replica_id),
-            "-s", statusTimerMilli,
-            "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties")
-            ]
-    if replica_id >= config.n and replica_id < config.n + config.num_ro_replicas and os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):
-        ret.extend(ro_params)
-        
-    return ret
+    return start_replica_cmd_prefix(builddir, replica_id, config)
 
 class SkvbcReadOnlyReplicaTest(unittest.TestCase):
     """
@@ -99,67 +46,26 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         - using internal RocksDB store
     Setting CONCORD_BFT_MINIO_BINARY_PATH env variable will triger S3 mode.
     """
-    @classmethod
-    def _start_s3_server(cls):
-        log.log_message(message_type="Starting server")
-        server_env = os.environ.copy()
-        server_env["MINIO_ACCESS_KEY"] = "concordbft"
-        server_env["MINIO_SECRET_KEY"] = "concordbft"
-
-        minio_server_fname = os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH")
-        if minio_server_fname is None:
-            shutil.rmtree(cls.work_dir)
-            raise RuntimeError("Please set path to minio binary to CONCORD_BFT_MINIO_BINARY_PATH env variable")
-
-        cls.minio_server_proc = subprocess.Popen([minio_server_fname, "server", cls.minio_server_data_dir], 
-                                                    env = server_env, 
-                                                    close_fds=True)
 
     @classmethod
-    def setUpClass(cls):        
-        log.log_message(message_type="CONCORD_BFT_MINIO_BINARY_PATH is set. Running in S3 mode.")
-
-        # We need a temp dir for data and binaries - this is cls.dest_dir
-        # self.dest_dir will contain data dir for minio buckets and the minio binary
-        # if there are any directories inside data dir - they become buckets
-        cls.work_dir = "/tmp/concord_bft_minio_datadir_" + next(tempfile._get_candidate_names())
-        cls.minio_server_data_dir = os.path.join(cls.work_dir, "data")
-        os.makedirs(os.path.join(cls.work_dir, "data", "blockchain"))     # create all dirs in one call
-
-        log.log_message(message_type=f"Working in {cls.work_dir}")
-
-        # Start server
-        cls._start_s3_server()
-        
-        log.log_message(message_type="Initialisation complete")
+    def setUpClass(cls):
+        cls.object_store = ObjectStore()
 
     @classmethod
     def tearDownClass(cls):
-        if not os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):
-            return
-
-        # First stop the server gracefully
-        cls.minio_server_proc.terminate()
-        cls.minio_server_proc.wait()
-
-        # Delete workdir dir
-        shutil.rmtree(cls.work_dir)
+        pass
 
     @classmethod
     def _stop_s3_server(cls):
-        cls.minio_server_proc.kill()
-        cls.minio_server_proc.wait()
+        cls.object_store.stop_s3_server()
 
     @classmethod
     def _stop_s3_for_X_secs(cls, x):
-        cls._stop_s3_server()
-        time.sleep(x)
-        cls._start_s3_server()
+        cls.object_store.stop_s3_for_X_secs(x)
 
     @classmethod
     def _start_s3_after_X_secs(cls, x):
-        time.sleep(x)
-        cls._start_s3_server()
+        cls.object_store.stop_s3_for_X_secs(x)
 
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7)
@@ -346,51 +252,6 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         )
 
         await self._wait_for_st(bft_network, ro_replica_id, 150)
-
-    @with_trio
-    @with_bft_network(start_replica_cmd=start_replica_cmd_for_pruning, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7)
-    async def test_pruning_with_ro_replica(self, bft_network):
-
-        bft_network.start_all_replicas()
-        ro_replica_id = bft_network.config.n
-        bft_network.start_replica(ro_replica_id)
-
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        client = bft_network.random_client()
-
-        op = operator.Operator(bft_network.config, client)
-
-        # Create more than 150 blocks in total, including the genesis block we have 101 blocks
-        k, v = await skvbc.write_known_kv()
-        for i in range(200):
-            v = skvbc.random_value()
-            await client.write(skvbc.write_req([], [(k, v)], 0))
-
-        # Wait for the read only replica to catch with the state
-        await self._wait_for_st(bft_network, ro_replica_id, 150)
-
-        # Get the minimal latest pruneable block among all replicas
-        await op.latest_pruneable_block()
-
-        latest_pruneable_blocks = []
-        rsi_rep = client.get_rsi_replies()
-        for r in rsi_rep.values():
-            lpab = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
-            latest_pruneable_blocks += [lpab.response]
-
-        await op.prune(latest_pruneable_blocks)
-
-        # Verify the system is able to get new write requests (which means that pruning has done)
-        with trio.fail_after(30):
-            await skvbc.write_known_kv()
-
-        await op.prune_status()
-
-        rsi_rep = client.get_rsi_replies()
-        for r in rsi_rep.values():
-            status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
-            assert status.response.in_progress is False
-            assert status.response.last_pruned_block == 150
 
     async def _wait_for_st(self, bft_network, ro_replica_id, seqnum_threshold=150):
         # TODO replace the below function with the library function:

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -161,15 +161,6 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         time.sleep(x)
         cls._start_s3_server()
 
-    def _construct_reconfiguration_latest_prunebale_block_coammand(self):
-        lpab_cmd = cmf_msgs.LatestPrunableBlockRequest()
-        lpab_cmd.sender = 1000
-        reconf_msg = cmf_msgs.ReconfigurationRequest()
-        reconf_msg.command = lpab_cmd
-        reconf_msg.signature = bytes()
-        reconf_msg.additional_data = bytes()
-        return reconf_msg
-
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability(no_conflicts=True)

--- a/tests/apollo/util/object_store.py
+++ b/tests/apollo/util/object_store.py
@@ -75,7 +75,7 @@ class ObjectStore:
         # if there are any directories inside data dir - they become buckets
         self.work_dir = MINIO_DATA_DIR
         self.minio_server_data_dir = os.path.join(self.work_dir, "data")
-
+        os.makedirs(os.path.join(self.minio_server_data_dir))
         log.log_message(message_type=f"Working in {self.work_dir}")
         self.start_s3_server()
         log.log_message(message_type="Initialisation complete")

--- a/tests/apollo/util/object_store.py
+++ b/tests/apollo/util/object_store.py
@@ -1,0 +1,120 @@
+# Concord
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+import os
+import random
+import subprocess
+import tempfile
+import shutil
+import time
+from util import eliot_logging as log
+from functools import wraps
+from util.bft import KEY_FILE_PREFIX
+
+def with_object_store(async_fn):
+    @wraps(async_fn)
+    async def wrapper(*args, **kwargs):
+        await async_fn(*args, **kwargs, object_store=ObjectStore())
+    return wrapper
+
+MINIO_DATA_DIR="/tmp/concord_bft_minio_datadir"
+def start_replica_cmd_prefix(builddir, replica_id, config):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    The replica is started with a short view change timeout.
+
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    path_to_s3_config = os.path.join(builddir, "test_s3_config_prefix.txt")
+    if replica_id >= config.n and replica_id < config.n + config.num_ro_replicas:
+        bucket = "blockchain_" + ''.join(random.choice('0123456789ABCDEF') for i in range(6))
+        with open(path_to_s3_config, "w") as f:
+            f.write("# test configuration for S3-compatible storage\n"
+                    "s3-bucket-name:" + bucket + "\n"
+                    "s3-access-key: concordbft\n"
+                    "s3-protocol: HTTP\n"
+                    "s3-url: 127.0.0.1:9000\n"
+                    "s3-secret-key: concordbft\n"
+                    "s3-path-prefix: concord")
+        os.makedirs(os.path.join(MINIO_DATA_DIR, "data", bucket))     # create new bucket for this run
+
+    ro_params = [ "--s3-config-file",
+                  path_to_s3_config
+                  ]
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    ret = [path,
+           "-k", KEY_FILE_PREFIX,
+           "-i", str(replica_id),
+           "-s", statusTimerMilli,
+           "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties")
+           ]
+    if replica_id >= config.n and replica_id < config.n + config.num_ro_replicas and os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):
+        ret.extend(ro_params)
+
+    return ret
+
+
+class ObjectStore:
+
+    def __init__(self):
+        log.log_message(message_type="CONCORD_BFT_MINIO_BINARY_PATH is set. Running in S3 mode.")
+
+        # We need a temp dir for data and binaries - this is self.dest_dir
+        # self.dest_dir will contain data dir for minio buckets and the minio binary
+        # if there are any directories inside data dir - they become buckets
+        self.work_dir = MINIO_DATA_DIR
+        self.minio_server_data_dir = os.path.join(self.work_dir, "data")
+
+        log.log_message(message_type=f"Working in {self.work_dir}")
+        self.start_s3_server()
+        log.log_message(message_type="Initialisation complete")
+
+    def start_s3_server(self):
+        log.log_message(message_type="Starting server")
+        server_env = os.environ.copy()
+        server_env["MINIO_ACCESS_KEY"] = "concordbft"
+        server_env["MINIO_SECRET_KEY"] = "concordbft"
+
+        minio_server_fname = os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH")
+        if minio_server_fname is None:
+            shutil.rmtree(self.work_dir)
+            raise RuntimeError("Please set path to minio binary to CONCORD_BFT_MINIO_BINARY_PATH env variable")
+
+        self.minio_server_proc = subprocess.Popen([minio_server_fname, "server", self.minio_server_data_dir],
+                                                 env = server_env,
+                                                 close_fds=True)
+
+
+    def __del__(self):
+        if not os.environ.get("CONCORD_BFT_MINIO_BINARY_PATH"):
+            return
+        # First stop the server gracefully
+        self.minio_server_proc.kill()
+        self.minio_server_proc.wait()
+
+        # Delete workdir dir
+        shutil.rmtree(self.work_dir)
+
+    def stop_s3_server(self):
+        self.minio_server_proc.kill()
+        self.minio_server_proc.wait()
+
+    def stop_s3_for_X_secs(self, x):
+        self.stop_s3_server()
+        time.sleep(x)
+        self.start_s3_server()
+
+    def start_s3_after_X_secs(self, x):
+        time.sleep(x)
+        self.start_s3_server()

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -84,30 +84,30 @@ class Operator:
 
     async def wedge(self):
         reconf_msg = self._construct_reconfiguration_wedge_coammand()
-        await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+        return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
 
     async def wedge_status(self):
         msg = self._construct_reconfiguration_wedge_status()
-        await self.client.read(msg.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config, [r for r in range(
+        return await self.client.read(msg.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config, [r for r in range(
             self.config.n)]), reconfiguration=True)
 
     async def latest_pruneable_block(self):
         reconf_msg = self._construct_reconfiguration_latest_prunebale_block_coammand()
-        await self.client.read(reconf_msg.serialize(),
+        return await self.client.read(reconf_msg.serialize(),
                           m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config,
                                                                   [r for r in range(self.client.get_total_num_replicas())]), reconfiguration=True, include_ro=True)
 
     async def prune(self, latest_pruneable_blocks):
         reconf_msg = self._construct_reconfiguration_prune_request(latest_pruneable_blocks)
-        await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+        return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
 
     async def prune_status(self):
         reconf_msg = self._construct_reconfiguration_prune_status_request()
         # Status is not supported by read only replicas, thus, we poll only the committers
-        await self.client.read(reconf_msg.serialize(),
+        return await self.client.read(reconf_msg.serialize(),
                           m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config, [r for r in range(
                               self.config.n)]), reconfiguration=True)
 
     async def key_exchange(self):
         reconf_msg = self._construct_reconfiguration_keMsg_coammand()
-        await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+        return await self.client.write(reconf_msg.serialize(), reconfiguration=True)

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -1,0 +1,113 @@
+# Concord
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os.path
+
+import trio
+import sys
+
+sys.path.append(os.path.abspath("../../build/tests/apollo/util/"))
+import concord_msgs as cmf_msgs
+
+sys.path.append(os.path.abspath("../../util/pyclient"))
+
+import bft_client
+
+class Operator:
+    def __init__(self, config, client):
+        self.config = config
+        self.client = client
+
+    def _construct_reconfiguration_wedge_coammand(self):
+        wedge_cmd = cmf_msgs.WedgeCommand()
+        wedge_cmd.sender = 1000
+        reconf_msg = cmf_msgs.ReconfigurationRequest()
+        reconf_msg.command = wedge_cmd
+        reconf_msg.signature = bytes()
+        reconf_msg.additional_data = bytes()
+        return reconf_msg
+
+    def _construct_reconfiguration_latest_prunebale_block_coammand(self):
+        lpab_cmd = cmf_msgs.LatestPrunableBlockRequest()
+        lpab_cmd.sender = 1000
+        reconf_msg = cmf_msgs.ReconfigurationRequest()
+        reconf_msg.command = lpab_cmd
+        reconf_msg.signature = bytes()
+        reconf_msg.additional_data = bytes()
+        return reconf_msg
+
+    def _construct_reconfiguration_wedge_status(self):
+        wedge_status_cmd = cmf_msgs.WedgeStatusRequest()
+        wedge_status_cmd.sender = 1000
+        reconf_msg = cmf_msgs.ReconfigurationRequest()
+        reconf_msg.command = wedge_status_cmd
+        reconf_msg.signature = bytes()
+        reconf_msg.additional_data = bytes()
+        return reconf_msg
+
+    def _construct_reconfiguration_prune_request(self, latest_pruneble_blocks):
+        prune_cmd = cmf_msgs.PruneRequest()
+        prune_cmd.sender = 1000
+        prune_cmd.latest_prunable_block = latest_pruneble_blocks
+        reconf_msg = cmf_msgs.ReconfigurationRequest()
+        reconf_msg.command = prune_cmd
+        reconf_msg.signature = bytes()
+        reconf_msg.additional_data = bytes()
+        return reconf_msg
+
+    def _construct_reconfiguration_prune_status_request(self):
+        prune_status_cmd = cmf_msgs.PruneStatusRequest()
+        prune_status_cmd.sender = 1000
+        reconf_msg = cmf_msgs.ReconfigurationRequest()
+        reconf_msg.command = prune_status_cmd
+        reconf_msg.signature = bytes()
+        reconf_msg.additional_data = bytes()
+        return reconf_msg
+
+    def _construct_reconfiguration_keMsg_coammand(self):
+        ke_command = cmf_msgs.KeyExchangeCommand()
+        ke_command.sender_id = 1000
+        reconf_msg = cmf_msgs.ReconfigurationRequest()
+        reconf_msg.command = ke_command
+        reconf_msg.signature = bytes()
+        reconf_msg.additional_data = bytes()
+        return reconf_msg
+
+    async def wedge(self):
+        reconf_msg = self._construct_reconfiguration_wedge_coammand()
+        await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+
+    async def wedge_status(self):
+        msg = self._construct_reconfiguration_wedge_status()
+        await self.client.read(msg.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config, [r for r in range(
+            self.config.n)]), reconfiguration=True)
+
+    async def latest_pruneable_block(self):
+        reconf_msg = self._construct_reconfiguration_latest_prunebale_block_coammand()
+        await self.client.read(reconf_msg.serialize(),
+                          m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config,
+                                                                  [r for r in range(self.client.get_total_num_replicas())]), reconfiguration=True, include_ro=True)
+
+    async def prune(self, latest_pruneable_blocks):
+        reconf_msg = self._construct_reconfiguration_prune_request(latest_pruneable_blocks)
+        await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+
+    async def prune_status(self):
+        reconf_msg = self._construct_reconfiguration_prune_status_request()
+        # Status is not supported by read only replicas, thus, we poll only the committers
+        await self.client.read(reconf_msg.serialize(),
+                          m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config, [r for r in range(
+                              self.config.n)]), reconfiguration=True)
+
+    async def key_exchange(self):
+        reconf_msg = self._construct_reconfiguration_keMsg_coammand()
+        await self.client.write(reconf_msg.serialize(), reconfiguration=True)

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -155,10 +155,10 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
 
     TestCommConfig testCommConfig(logger);
     testCommConfig.GetReplicaConfig(replicaConfig.replicaId, keysFilePrefix, &replicaConfig);
-    uint16_t numOfReplicas = (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1);
+    uint16_t numOfReplicas =
+        (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1 + replicaConfig.numRoReplicas);
     auto numOfClients =
         replicaConfig.numOfClientProxies ? replicaConfig.numOfClientProxies : replicaConfig.numOfExternalClients;
-
 #ifdef USE_COMM_PLAIN_TCP
     bft::communication::PlainTcpConfig conf =
         testCommConfig.GetTCPConfig(true, replicaConfig.replicaId, numOfClients, numOfReplicas, commConfigFile);

--- a/util/pyclient/test_msgs.py
+++ b/util/pyclient/test_msgs.py
@@ -68,7 +68,6 @@ class TestRepliesManager(unittest.TestCase):
         common_key = rsi_reply.get_matched_reply_key()
         rsi_replies = replies_manager.pop(common_key)
         self.assertEqual(replies_manager.num_matching_replies(common_key), 0)
-        self.assertEqual(common_key.header.primary_id, 0)
         self.assertEqual(common_key.header.req_seq_num, 1)
         self.assertEqual(common_key.data, b'hello')
         self.assertEqual(b'1', rsi_replies[0].get_rsi_data())
@@ -110,7 +109,6 @@ class TestSpecificReplyInfo(unittest.TestCase):
         rsi_reply = rsi.MsgWithReplicaSpecificInfo(packed, 0)
         self.assertEqual(rsi_reply.sender_id, 0)
         common_header, common_data = rsi_reply.get_common_reply()
-        self.assertEqual(primary_id, common_header.primary_id)
         self.assertEqual(req_seq_num, common_header.req_seq_num)
         self.assertEqual(common_data, b'hello')
 
@@ -122,7 +120,6 @@ class TestSpecificReplyInfo(unittest.TestCase):
         rsi_reply = rsi.MsgWithReplicaSpecificInfo(packed, 0)
         self.assertEqual(rsi_reply.sender_id, 0)
         common_header, common_data = rsi_reply.get_common_reply()
-        self.assertEqual(primary_id, common_header.primary_id)
         self.assertEqual(req_seq_num, common_header.req_seq_num)
         self.assertEqual(rsi_reply.get_rsi_data(), b'rsi')
         self.assertEqual(common_data, b'hello')


### PR DESCRIPTION
In this PR we introduce a full RO replica pruning support.
The pruning is done using a bft client and the new reconfiguration engine