### PR TITLE
Transaction signing changes for Bft client and Tester Replica

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -68,6 +68,7 @@ BFT_CLIENT_TYPE = bft_client.TcpTlsClient if os.environ.get('BUILD_COMM_TCP_TLS'
 # Reserved clients (RESERVED_CLIENTS_QUOTA) are not part of NUM_CLIENTS
 RESERVED_CLIENTS_QUOTA = 2
 BFT_CONFIGS_NUM_CLIENTS = 10
+NUM_PARTICIPANTS = 5
 
 @log_call(action_type="Test_Configs", include_args=[])
 def interesting_configs(selected=None):
@@ -208,6 +209,7 @@ class BftTestNetwork:
             os.chdir(self.origdir)
             shutil.rmtree(self.testdir, ignore_errors=True)
             shutil.rmtree(self.certdir, ignore_errors=True)
+            shutil.rmtree(self.txn_signing_keys_base_path, ignore_errors=True)
             if self.test_dir and self.test_start_time:
                 with open(f"{self.test_dir}test_duration.log", 'w+') as log_file:
                     log_file.write(f"test duration = {time.time() - self.test_start_time} seconds\n")
@@ -239,6 +241,9 @@ class BftTestNetwork:
         self.test_dir = None
         self.test_start_time = None
         self.perf_proc = None
+        self.txn_signing_enabled = (os.environ.get('TXN_SIGNING_ENABLED', "").lower() == "true")
+        # Setup transaction signing parameters
+        self.setup_txn_signing()
 
     @classmethod
     def new(cls, config, background_nursery, client_factory=None):
@@ -336,6 +341,10 @@ class BftTestNetwork:
             # Generate certificates for replicas, clients, and reserved clients
             self.generate_tls_certs(self.num_total_replicas() + config.num_clients + RESERVED_CLIENTS_QUOTA)
 
+        # remove existing transaction signing keys and generate again
+        shutil.rmtree(self.txn_signing_keys_base_path, ignore_errors=True)
+        self.setup_txn_signing()
+
         self._init_metrics()
         self._create_clients()
         self._create_reserved_clients()
@@ -396,7 +405,9 @@ class BftTestNetwork:
                                  MAX_MSG_SIZE,
                                  REQ_TIMEOUT_MILLI,
                                  RETRY_TIMEOUT_MILLI,
-                                 self.certdir)
+                                 self.certdir,
+                                 self.txn_signing_keys_base_path,
+                                 self.principals_to_participant_map)
 
     def _init_metrics(self):
         metric_clients = {}
@@ -409,6 +420,77 @@ class BftTestNetwork:
 
     def random_clients(self, max_clients):
         return set(random.choices(list(self.clients.values()), k=max_clients))
+
+    def setup_txn_signing(self):
+        self.txn_signing_keys_base_path = ""
+        self.principals_mapping = ""
+        self.principals_to_participant_map = {}
+        if self.txn_signing_enabled:
+            self.txn_signing_keys_base_path = tempfile.mkdtemp()
+            self.principals_mapping, self.principals_to_participant_map = self.create_principals_mapping()
+            self.generate_txn_signing_keys(self.txn_signing_keys_base_path)
+            
+    def generate_txn_signing_keys(self, keys_path):
+        """ Generates num_participants number of key pairs """
+        script_path = "/concord-bft/scripts/linux/create_concord_clients_transaction_signing_keys.sh"
+        args = [script_path, "-n", str(self.num_participants), "-o", keys_path]
+        subprocess.run(args, check=True, stdout=subprocess.DEVNULL)
+
+    def create_principals_mapping(self):
+        """
+        If client principal ids range from 11-20, for example, this method splits them into groups based on 
+        NUM_PARTICIPANTS and self.num_participants.
+        Client ids in each group will be space separated, and each group will be semicolon separated. 
+        E.g. "11 12;13 14;15 16;17 18;19 20" for 10 client ids divided into 5 participants.
+        If there are reserved clients, they are added at the end of the group in round robin manner.
+        Thus, if there are 2 reserved client, with ids 21 and 22, the final string would look like:
+        "11 12 21;13 14 22;15 16;17 18,19 20".
+        This method also returns a principals to participants map, with the key being the principal id
+        of the client or reserved client, and the value being the participant it belongs to (numbered 1 onwards).
+        If number of clients is not default, but modified from outside, there might be cases where self.num_participants
+        will be less than NUM_PARTICIPANTS.
+        """
+        def split(a, n):
+            """ Splits list 'a' into n chunks """
+            k, m = divmod(len(a), n)
+            return [a[i * k + min(i, m):(i + 1) * k + min(i + 1, m)] for i in range(n)]
+
+        start_id = self.config.n + self.config.num_ro_replicas
+        client_ids = range(start_id, start_id + self.config.num_clients)
+        start_id = self.num_total_replicas() + self.config.num_clients
+        reserved_client_ids = range(start_id, start_id + RESERVED_CLIENTS_QUOTA)
+
+        principals = ""
+        client_ids = sorted(client_ids)
+        reserved_client_ids = sorted(reserved_client_ids)
+        combined_clients = client_ids + reserved_client_ids
+        combined_clients_set = set(combined_clients)
+        assert len(combined_clients_set) == len(combined_clients), "Client Ids and Reserved Client Ids must all be unique ids"
+        self.num_participants = min(NUM_PARTICIPANTS, len(client_ids))
+        client_ids_chunks = split(client_ids, self.num_participants)
+        reserved_client_ids_chunks = split(reserved_client_ids, self.num_participants)
+        principals_to_participant_map = {}
+
+        # iterate number of participants
+        for i in range(self.num_participants):
+            # add client_ids to principals
+            for cid in client_ids_chunks[i]:
+                principals = principals + str(cid) + " "
+                principals_to_participant_map[cid] = i+1
+            # add reserved_client_ids to principals
+            for rcid in reserved_client_ids_chunks[i]:
+                principals = principals + str(rcid) + " "
+                principals_to_participant_map[rcid] = i+1
+            # remove last space
+            if principals[-1] == ' ':
+                principals = principals[:-1]
+            # add , to separate next set of client_ids
+            principals = principals + ";"
+
+        # remove last semicolon
+        if principals[-1] == ';':
+            principals = principals[:-1]
+        return principals, principals_to_participant_map
 
     def start_replica_cmd(self, replica_id):
         """
@@ -425,6 +507,12 @@ class BftTestNetwork:
             if self.certdir:
                 cmd.append("-c")
                 cmd.append(self.certdir)
+            if self.txn_signing_enabled:
+                cmd.append("-p")
+                cmd.append(self.principals_mapping)
+                keys_path = os.path.join(self.txn_signing_keys_base_path, "transaction_signing_keys")
+                cmd.append("-t")
+                cmd.append(keys_path)
             return cmd
 
     def stop_replica_cmd(self, replica_id):
@@ -501,8 +589,9 @@ class BftTestNetwork:
             if self.is_existing and self.config.stop_replica_cmd is not None:
                 self.procs[replica_id] = self._start_external_replica(replica_id)
             else:
+                s = self.start_replica_cmd(replica_id)
                 self.procs[replica_id] = subprocess.Popen(
-                                            self.start_replica_cmd(replica_id),
+                                            s,
                                             stdout=stdout_file,
                                             stderr=stderr_file,
                                             close_fds=True)

--- a/tests/simpleKVBC/TesterReplica/CMakeLists.txt
+++ b/tests/simpleKVBC/TesterReplica/CMakeLists.txt
@@ -19,7 +19,7 @@ if(BUILD_ROCKSDB_STORAGE)
 	target_compile_definitions(skvbc_replica PUBLIC "USE_ROCKSDB=1")
 endif()
 
-target_link_libraries(skvbc_replica PUBLIC kvbc corebft threshsign util test_config_lib )
+target_link_libraries(skvbc_replica PUBLIC kvbc corebft threshsign util test_config_lib stdc++fs)
 
 target_include_directories(skvbc_replica PUBLIC ..)
 target_include_directories(skvbc_replica PUBLIC ../..)

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -30,10 +30,21 @@
 #include "config/config_file_parser.hpp"
 #include "direct_kv_storage_factory.h"
 #include "merkle_tree_storage_factory.h"
+#include "secrets_manager_plain.h"
+
+#include <boost/algorithm/string.hpp>
+#include <experimental/filesystem>
+
+namespace fs = std::experimental::filesystem;
 
 namespace concord::kvbc {
 
 std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
+  std::stringstream args;
+  for (int i{1}; i < argc; ++i) {
+    args << argv[i] << " ";
+  }
+  LOG_INFO(GL, "Parsing" << KVLOG(argc) << " arguments, args:" << args.str());
   try {
     // used to get info from parsing the key file
     bftEngine::ReplicaConfig& replicaConfig = bftEngine::ReplicaConfig::instance();
@@ -54,6 +65,8 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::string s3ConfigFile;
     std::string certRootPath = "certs";
     std::string logPropsFile = "logging.properties";
+    std::string principalsMapping;
+    std::string txnSigningKeysPath;
 
     static struct option longOptions[] = {{"replica-id", required_argument, 0, 'i'},
                                           {"key-file-prefix", required_argument, 0, 'k'},
@@ -70,11 +83,13 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"consensus-batching-max-req-num", required_argument, 0, 'q'},
                                           {"consensus-batching-flush-period", required_argument, 0, 'z'},
                                           {"consensus-concurrency-level", required_argument, 0, 'y'},
+                                          {"principals-mapping", optional_argument, 0, 'p'},
+                                          {"txn-signing-key-path", optional_argument, 0, 't'},
                                           {0, 0, 0, 0}};
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
-    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:t:l:c:e:b:m:q:y:z:", longOptions, &optionIndex)) != -1) {
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:t:l:c:e:b:m:q:y:z:p:t", longOptions, &optionIndex)) != -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -140,6 +155,13 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           replicaConfig.batchFlushPeriod = batchFlushPeriod;
           break;
         }
+        case 'p': {
+          principalsMapping = optarg;
+          break;
+        }
+        case 't': {
+          txnSigningKeysPath = optarg;
+        } break;
         case '?': {
           throw std::runtime_error("invalid arguments");
         } break;
@@ -150,6 +172,15 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     }
 
     if (keysFilePrefix.empty()) throw std::runtime_error("missing --key-file-prefix");
+
+    // If -p and -t are set, enable clientTransactionSigningEnabled. If only one of them is set, throw an error
+    if (!principalsMapping.empty() && !txnSigningKeysPath.empty()) {
+      replicaConfig.clientTransactionSigningEnabled = true;
+      TestSetup::setPublicKeysOfClients(principalsMapping, txnSigningKeysPath, replicaConfig.publicKeysOfClients);
+    } else if ((!principalsMapping.empty() && txnSigningKeysPath.empty()) ||
+               (principalsMapping.empty() && !txnSigningKeysPath.empty())) {
+      throw std::runtime_error("Params principals-mapping and txn-signing-key-path must be set simultaneously.");
+    }
 
     logging::Logger logger = logging::getLogger("skvbctest.replica");
 
@@ -241,6 +272,66 @@ std::unique_ptr<IStorageFactory> TestSetup::GetStorageFactory() {
   }
 #endif
   return std::make_unique<v2MerkleTree::RocksDBStorageFactory>(dbPath.str());
+}
+
+std::vector<std::string> TestSetup::getKeyDirectories(const std::string& path) {
+  std::vector<std::string> result;
+  if (!fs::exists(path) || !fs::is_directory(path)) {
+    throw std::invalid_argument{"Transaction signing keys path doesn't exist at " + path};
+  }
+  for (auto& dir : fs::directory_iterator(path)) {
+    if (fs::exists(dir) && fs::is_directory(dir)) {
+      result.push_back(dir.path().string());
+    }
+  }
+  return result;
+}
+
+void TestSetup::setPublicKeysOfClients(
+    const std::string& principalsMapping,
+    const std::string& keysRootPath,
+    std::set<std::pair<const std::string, std::set<uint16_t>>>& publicKeysOfClients) {
+  // The string principalsMapping looks like:
+  // "11 12;13 14;15 16;17 18;19 20", for 10 client ids divided into 5 participants.
+
+  LOG_INFO(GL, "" << KVLOG(principalsMapping, keysRootPath));
+  std::vector<std::string> keysDirectories = TestSetup::getKeyDirectories(keysRootPath);
+  std::vector<std::string> clientIdChunks;
+  boost::split(clientIdChunks, principalsMapping, boost::is_any_of(";"));
+
+  if (clientIdChunks.size() != keysDirectories.size()) {
+    std::stringstream msg;
+    msg << "Number of keys directory should match the number of sets of clientIds mappings in principals "
+           "mapping string "
+        << KVLOG(keysDirectories.size(), clientIdChunks.size(), principalsMapping);
+    throw std::runtime_error(msg.str());
+  }
+
+  // Sort keysDirectories just to ensure ordering of the folders
+  std::sort(keysDirectories.begin(), keysDirectories.end());
+
+  // Build publicKeysOfClients of replicaConfig
+  for (std::size_t i = 0; i < clientIdChunks.size(); ++i) {
+    std::string keyFilePath =
+        keysDirectories.at(i) + "/transaction_signing_pub.pem";  // Will be "../1/transaction_signing_pub.pem" etc.
+
+    secretsmanager::SecretsManagerPlain smp;
+    std::optional<std::string> keyPlaintext;
+    keyPlaintext = smp.decryptFile(keyFilePath);
+    if (keyPlaintext.has_value()) {
+      // Each clientIdChunk would look like "11 12 13 14"
+      std::vector<std::string> clientIds;
+      boost::split(clientIds, clientIdChunks.at(i), boost::is_any_of(" "));
+      std::set<uint16_t> clientIdsSet;
+      for (const std::string clientId : clientIds) {
+        clientIdsSet.insert(std::stoi(clientId));
+      }
+      const std::string key = keyPlaintext.value();
+      publicKeysOfClients.insert(std::pair<const std::string, std::set<uint16_t>>(key, clientIdsSet));
+    } else {
+      throw std::runtime_error("Key public_key.pem not found in directory " + keysDirectories.at(i));
+    }
+  }
 }
 
 }  // namespace concord::kvbc

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -61,6 +61,13 @@ class TestSetup {
         pm_{std::make_shared<concord::performance::PerformanceManager>()} {}
 
   TestSetup() = delete;
+
+  static std::vector<std::string> getKeyDirectories(const std::string& keysRootPath);
+
+  static void setPublicKeysOfClients(const std::string& principalsMapping,
+                                     const std::string& keysRootPath,
+                                     std::set<std::pair<const std::string, std::set<uint16_t>>>& publicKeysOfClients);
+
 #ifdef USE_S3_OBJECT_STORE
   concord::storage::s3::StoreConfig ParseS3Config(const std::string& s3ConfigFile);
 #endif

--- a/util/pyclient/bft_config.py
+++ b/util/pyclient/bft_config.py
@@ -14,7 +14,7 @@
 from collections import namedtuple
 
 Config = namedtuple('Config', ['id', 'f', 'c', 'max_msg_size', 'req_timeout_milli',
-    'retry_timeout_milli', "certs_path"])
+    'retry_timeout_milli', "certs_path", "txn_signing_keys_path", "principals_to_participant_map"])
 
 Replica = namedtuple('Replica', ['id', 'ip', 'port', 'metrics_port'])
 

--- a/util/pyclient/test_client.py
+++ b/util/pyclient/test_client.py
@@ -28,7 +28,7 @@ def verify_system_is_ready(async_fn):
     """ Decorator for running a coroutine (async_fn) with trio. """
     @wraps(async_fn)
     async def sys_ready_wrapper(*args, **kwargs):
-        config = bft_config.Config(4, 1, 0, 4096, 10000, 500, "")
+        config = bft_config.Config(4, 1, 0, 4096, 10000, 500, "", "", {})
         class_object = args[0]
         with bft_client.UdpClient(config, class_object.replicas, None) as udp_client:
             await udp_client.sendSync(class_object.writeRequest(1989), False)
@@ -63,7 +63,7 @@ class SimpleTest(unittest.TestCase):
         cls.serverbin = os.path.join(cls.builddir,"tests/simpleTest/server")
         os.chdir(cls.testdir)
         cls.generateKeys()
-        cls.config = bft_config.Config(4, 1, 0, 4096, 1000, 50, "")
+        cls.config = bft_config.Config(4, 1, 0, 4096, 1000, 50, "", "", {})
         cls.replicas = [bft_config.Replica(id=i,
                                            ip="127.0.0.1",
                                            port=bft_config.bft_msg_port_from_node_id(i),


### PR DESCRIPTION
When transaction signing is enabled in Apollo tests, these changes will setup the transaction signing keys and the principals mapping of clients to participants in BftTestNetwork. Messages are signed in Bft Client, and the transaction signing key path and principals mapping is sent to Tester Replica and sets up the Tester Replica to so that the signatures can be verified downstream.