### PR TITLE
GHA: Remove CI_TEST_STORAGE_TYPE from the job matrix

### DIFF
--- a/.github/workflows/build_and_test_clang_debug.yml
+++ b/.github/workflows/build_and_test_clang_debug.yml
@@ -11,7 +11,7 @@ jobs:
             compiler:
                 - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
             ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle -DBUILD_COMM_TCP_TLS=FALSE"
+                - "-DCMAKE_BUILD_TYPE=DEBUG -DBUILD_COMM_TCP_TLS=FALSE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
                 - "-DUSE_S3_OBJECT_STORE=OFF"

--- a/.github/workflows/build_and_test_clang_release.yml
+++ b/.github/workflows/build_and_test_clang_release.yml
@@ -11,9 +11,8 @@ jobs:
             compiler:
                 - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
             ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v1direct -DBUILD_COMM_TCP_TLS=FALSE"
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle -DBUILD_COMM_TCP_TLS=FALSE"
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle -DBUILD_COMM_TCP_TLS=TRUE"
+                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=FALSE"
+                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=TRUE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
                 - "-DUSE_S3_OBJECT_STORE=OFF"

--- a/.github/workflows/build_and_test_gcc_debug.yml
+++ b/.github/workflows/build_and_test_gcc_debug.yml
@@ -11,7 +11,7 @@ jobs:
             compiler:
                 - "CONCORD_BFT_CONTAINER_CC=gcc CONCORD_BFT_CONTAINER_CXX=g++"
             ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle -DBUILD_COMM_TCP_TLS=FALSE"
+                - "-DCMAKE_BUILD_TYPE=DEBUG -DBUILD_COMM_TCP_TLS=FALSE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
                 - "-DUSE_S3_OBJECT_STORE=OFF"

--- a/.github/workflows/build_and_test_gcc_release.yml
+++ b/.github/workflows/build_and_test_gcc_release.yml
@@ -11,9 +11,8 @@ jobs:
             compiler:
                 - "CONCORD_BFT_CONTAINER_CC=gcc CONCORD_BFT_CONTAINER_CXX=g++"
             ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v1direct -DBUILD_COMM_TCP_TLS=FALSE"
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle -DBUILD_COMM_TCP_TLS=FALSE"
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DCI_TEST_STORAGE_TYPE=v2merkle -DBUILD_COMM_TCP_TLS=TRUE"
+                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=FALSE"
+                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=TRUE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
                 - "-DUSE_S3_OBJECT_STORE=OFF"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,7 +10,7 @@ jobs:
             compiler:
                 - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
             ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=DEBUG -DCI_TEST_STORAGE_TYPE=v2merkle"
+                - "-DCMAKE_BUILD_TYPE=DEBUG"
             comm_type:
                 - "-DBUILD_COMM_TCP_PLAIN=FALSE -DBUILD_COMM_TCP_TLS=FALSE" #udp
                 - "-DBUILD_COMM_TCP_PLAIN=FALSE -DBUILD_COMM_TCP_TLS=TRUE" #tls


### PR DESCRIPTION
GHA: Remove CI_TEST_STORAGE_TYPE from the job matrix

While running Github Action workflows CMake reports the following warning:
```
CMake Warning:
Manually-specified variables were not used by the project:

CI_TEST_STORAGE_TYPE
```

Despite the flag is not used by the build GHA creates a redundant job for this combination of flags.