### PR TITLE
Add ro replicas support in new bft client

### DIFF
--- a/bftclient/include/bftclient/config.h
+++ b/bftclient/include/bftclient/config.h
@@ -62,6 +62,7 @@ struct RetryTimeoutConfig {
 struct ClientConfig {
   ClientId id;
   std::set<ReplicaId> all_replicas;
+  std::set<ReplicaId> ro_replicas;
   uint16_t f_val;
   uint16_t c_val;
   RetryTimeoutConfig retry_timeout_config;

--- a/bftclient/include/bftclient/quorums.h
+++ b/bftclient/include/bftclient/quorums.h
@@ -51,8 +51,12 @@ typedef std::variant<LinearizableQuorum, ByzantineSafeQuorum> WriteQuorum;
 //  * C value
 class QuorumConverter {
  public:
-  QuorumConverter(const std::set<ReplicaId>& all_replicas, uint16_t f_val, uint16_t c_val)
+  QuorumConverter(const std::set<ReplicaId>& all_replicas,
+                  const std::set<ReplicaId>& ro_replicas,
+                  uint16_t f_val,
+                  uint16_t c_val)
       : all_replicas_(all_replicas),
+        ro_replicas_(ro_replicas),
         linearizable_quorum_size_(2 * f_val + c_val + 1),
         bft_safe_quorum_size_(f_val + 1) {}
 
@@ -74,7 +78,7 @@ class QuorumConverter {
   void validateDestinations(const std::set<ReplicaId>& destinations) const;
 
   std::set<ReplicaId> all_replicas_;
-
+  std::set<ReplicaId> ro_replicas_;
   size_t linearizable_quorum_size_;
   size_t bft_safe_quorum_size_;
 };

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -25,7 +25,7 @@ namespace bft::client {
 Client::Client(std::unique_ptr<bft::communication::ICommunication> comm, const ClientConfig& config)
     : communication_(std::move(comm)),
       config_(config),
-      quorum_converter_(config_.all_replicas, config_.f_val, config_.c_val),
+      quorum_converter_(config_.all_replicas, config.ro_replicas, config.f_val, config_.c_val),
       expected_commit_time_ms_(config_.retry_timeout_config.initial_retry_timeout.count(),
                                config_.retry_timeout_config.number_of_standard_deviations_to_tolerate,
                                config_.retry_timeout_config.max_retry_timeout.count(),

--- a/bftclient/src/quorums.cpp
+++ b/bftclient/src/quorums.cpp
@@ -82,7 +82,7 @@ void QuorumConverter::validateDestinations(const std::set<ReplicaId>& destinatio
   ReplicaId captured;
   if (std::any_of(destinations.begin(), destinations.end(), [this, &captured](auto replica_id) {
         captured = replica_id;
-        return all_replicas_.count(replica_id) == 0;
+        return all_replicas_.count(replica_id) == 0 && ro_replicas_.count(replica_id) == 0;
       })) {
     throw InvalidDestinationException(captured);
   }

--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -54,6 +54,7 @@ class ClientApiTestFixture : public ::testing::Test {
  public:
   ClientConfig test_config_ = {ClientId{5},
                                {ReplicaId_t{0}, ReplicaId_t{1}, ReplicaId_t{2}, ReplicaId_t{3}},
+                               {},
                                1,
                                0,
                                RetryTimeoutConfig{},


### PR DESCRIPTION
We want to enable the reconfiguration requests in the read-only replica. For this, we need to enable the client to send requests to the read-only replica.
In this PR we introduce basic support for this in the new bft client. 
This support does not break anything with the previous behavior. In order to issue a bft request to the read-only replicas, the client has to explicitly specify them in the quorum.