### PR TITLE
Implement non-blocking messages handling in the PreProcessor

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -130,7 +130,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       numOfThreads = myReplica.getReplicaConfig().numOfClientProxies / numOfReplicas_;
   }
   threadPool_.start(numOfThreads);
-  msg_proc_thread_ = std::thread{&PreProcessor::loop, this};
+  msgLoopThread_ = std::thread{&PreProcessor::loop, this};
   LOG_INFO(logger(),
            KVLOG(numOfReplicas_,
                  numOfExternalClients,
@@ -147,11 +147,11 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
 }
 
 PreProcessor::~PreProcessor() {
-  done_ = true;
-  msg_cv_.notify_all();
+  msgLoopDone_ = true;
+  msgLoopSignal_.notify_all();
   cancelTimers();
   threadPool_.stop();
-  if (msg_proc_thread_.joinable()) msg_proc_thread_.join();
+  if (msgLoopThread_.joinable()) msgLoopThread_.join();
 }
 
 void PreProcessor::addTimers() {
@@ -271,6 +271,7 @@ void PreProcessor::updateAggregatorAndDumpMetrics() {
 }
 
 void PreProcessor::sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
+                                                  NodeIdType destId,
                                                   uint16_t reqOffsetInBatch,
                                                   uint64_t reqRetryId) {
   const auto clientId = clientReqMsg->clientProxyId();
@@ -286,7 +287,6 @@ void PreProcessor::sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUn
                                         nullptr,
                                         clientReqMsg->getCid(),
                                         clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
-  const auto destId = clientReqMsg->senderId();
   SCOPED_MDC_CID(preProcessReqMsg->getCid());
   LOG_DEBUG(logger(), "Sending PreProcessRequestMsg with REQ_TYPE_CANCEL" << KVLOG(clientId, reqSeqNum, destId));
   sendMsg(preProcessReqMsg->body(), destId, preProcessReqMsg->type(), preProcessReqMsg->size());
@@ -314,6 +314,7 @@ void PreProcessor::sendRejectPreProcessReplyMsg(NodeIdType clientId,
 
 template <>
 void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequestMsg *msg) {
+  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onClientPreProcessRequestMsg);
   preProcessorMetrics_.preProcReqReceived.Get().Inc();
   ClientPreProcessReqMsgUniquePtr clientMsg(msg);
   const string &cid = clientMsg->getCid();
@@ -327,7 +328,7 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
     preProcessorMetrics_.preProcReqIgnored.Get().Inc();
     return;
   }
-  handleSingleClientRequestMessage(move(clientMsg), false, 0);
+  handleSingleClientRequestMessage(move(clientMsg), senderId, false, 0);
 }
 
 // Should be called under reqEntry->mutex lock
@@ -369,9 +370,6 @@ bool PreProcessor::isRequestAlreadyExecuted(ReqId reqSeqNum,
                                             const string &cid) {
   const bool replySentToClient = myReplica_.isReplyAlreadySentToClient(clientId, reqSeqNum);
   if (replySentToClient) {
-    LOG_INFO(logger(),
-             "Request has already been executed - let replica decide how to proceed further"
-                 << KVLOG(cid, reqSeqNum, senderId, clientId));
     preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
     return true;
   }
@@ -399,10 +397,10 @@ bool PreProcessor::isRequestPreProcessedBefore(const RequestStateSharedPtr &reqE
 }
 
 void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUniquePtr clientMsg,
+                                                    NodeIdType senderId,
                                                     bool arrivedInBatch,
                                                     uint16_t msgOffsetInBatch) {
   SCOPED_MDC_CID(clientMsg->getCid());
-  const NodeIdType &senderId = clientMsg->senderId();
   const NodeIdType &clientId = clientMsg->clientProxyId();
   const ReqId &reqSeqNum = clientMsg->requestSeqNum();
   PreProcessRequestMsgSharedPtr preProcessRequestMsg;
@@ -411,12 +409,6 @@ void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
   {
     const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, msgOffsetInBatch)];
     lock_guard<mutex> lock(reqEntry->mutex);
-    if (isRequestAlreadyExecuted(reqSeqNum, senderId, clientId, clientMsg->getCid())) {
-      if (senderId != clientId) sendCancelPreProcessRequestMsg(clientMsg, msgOffsetInBatch, (reqEntry->reqRetryId)++);
-      // The request has already been committed and executed - let replica decide how to proceed further.
-      return incomingMsgsStorage_->pushExternalMsg(clientMsg->convertToClientRequestMsg(false));
-    }
-
     const bool reqToBeDeclined =
         (isRequestPreProcessingRightNow(reqEntry, reqSeqNum, clientId, senderId) ||
          isRequestPassingConsensusOrPostExec(reqSeqNum, senderId, clientId, clientMsg->getCid()) ||
@@ -425,8 +417,19 @@ void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
       if (senderId != clientId)
         // Send 'cancel' request to non-primary replicas to release them from waiting to a 'real' PreProcessRequestMsg,
         // which will not arrive in this case. Doing this to avoid request from being timed out on non-primary replicas.
-        sendCancelPreProcessRequestMsg(clientMsg, msgOffsetInBatch, (reqEntry->reqRetryId)++);
+        sendCancelPreProcessRequestMsg(clientMsg, senderId, msgOffsetInBatch, (reqEntry->reqRetryId)++);
       return;
+    }
+
+    if (isRequestAlreadyExecuted(reqSeqNum, senderId, clientId, clientMsg->getCid())) {
+      if (senderId != clientId) {
+        sendCancelPreProcessRequestMsg(clientMsg, senderId, msgOffsetInBatch, (reqEntry->reqRetryId)++);
+        return;
+      }
+      LOG_INFO(logger(),
+               "Request has already been executed - let replica decide how to proceed further"
+                   << KVLOG(reqSeqNum, clientId, senderId));
+      return incomingMsgsStorage_->pushExternalMsg(clientMsg->convertToClientRequestMsg(false));
     }
 
     if (myReplica_.isCurrentPrimary())
@@ -446,6 +449,7 @@ void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
 
 template <>
 void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) {
+  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onClientBatchPreProcessRequestMsg);
   ClientBatchRequestMsgUniquePtr clientBatch(msg);
   const auto clientId = clientBatch->clientId();
   const auto senderId = clientBatch->senderId();
@@ -459,11 +463,14 @@ void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) 
   }
   ClientMsgsList &clientMsgs = clientBatch->getClientPreProcessRequestMsgs();
   uint16_t offset = 0;
-  for (auto &clientMsg : clientMsgs) {
-    LOG_DEBUG(logger(),
-              "Start handling single message from the batch:" << KVLOG(
-                  clientMsg->requestSeqNum(), senderId, clientId, clientMsg->requestTimeoutMilli()));
-    handleSingleClientRequestMessage(move(clientMsg), true, offset++);
+  for (auto it = clientMsgs.begin(); it != clientMsgs.end(); ++it) {
+    auto &clientMsg = *it;
+    LOG_DEBUG(
+        logger(),
+        "Start handling single message from the batch:" << KVLOG(
+            clientMsg->requestSeqNum(), clientMsg->getCid(), senderId, clientId, clientMsg->requestTimeoutMilli()));
+    // senderId should be taken from ClientBatchRequestMsg as it does not get re-set in batched client messages
+    handleSingleClientRequestMessage(move(clientMsg), senderId, true, offset++);
   }
   if (!myReplica_.isCurrentPrimary()) {
     sendMsg(clientBatch->body(), myReplica_.currentPrimary(), clientBatch->type(), clientBatch->size());
@@ -474,6 +481,7 @@ void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) 
 // Non-primary replica request handling
 template <>
 void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
+  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onPreProcessRequestMsg);
   SCOPED_MDC_CID(msg->getCid());
   PreProcessRequestMsgSharedPtr preProcessReqMsg(msg);
   const auto &reqType = preProcessReqMsg->reqType();
@@ -540,6 +548,7 @@ void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
 // Primary replica handling
 template <>
 void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
+  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onPreProcessReplyMsg);
   PreProcessReplyMsgSharedPtr preProcessReplyMsg(msg);
   const NodeIdType &senderId = preProcessReplyMsg->senderId();
   const NodeIdType &clientId = preProcessReplyMsg->clientId();
@@ -585,7 +594,7 @@ void PreProcessor::messageHandler(MessageBase *msg) {
   T *trueTypeObj = new T(msg);
   delete msg;
   msgs_.push(trueTypeObj);
-  msg_cv_.notify_one();
+  msgLoopSignal_.notify_one();
 }
 
 template <>
@@ -594,20 +603,20 @@ void PreProcessor::messageHandler<PreProcessReplyMsg>(MessageBase *msg) {
   trueTypeObj->setPreProcessorHistograms(&histograms_);
   delete msg;
   msgs_.push(trueTypeObj);
-  msg_cv_.notify_one();
+  msgLoopSignal_.notify_one();
 }
 
 void PreProcessor::loop() {
-  while (!done_) {
+  while (!msgLoopDone_) {
     int count = 0;
     {
-      std::unique_lock<std::mutex> l(msg_lock_);
-      while (!done_ && msgs_.empty()) msg_cv_.wait(l);
-      if (done_) break;
+      std::unique_lock<std::mutex> l(msgLock_);
+      while (!msgLoopDone_ && msgs_.empty()) msgLoopSignal_.wait(l);
+      if (msgLoopDone_) break;
       count = msgs_.read_available();
     }
 
-    while (!done_ && count--) {
+    while (!msgLoopDone_ && count--) {
       auto m = msgs_.front();
       if (validateMessage(m)) {
         switch (m->type()) {
@@ -899,14 +908,14 @@ const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId,
   // The number of buffers per client comes from the configuration parameter clientBatchingMaxMsgsNbr.
   const auto bufferOffset =
       (clientId - numOfReplicas_ - numOfInternalClients_) * clientMaxBatchSize_ + reqOffsetInBatch;
-  LOG_DEBUG(logger(), KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
+  LOG_TRACE(logger(), KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
   return preProcessResultBuffers_[bufferOffset].data();
 }
 
 const uint16_t PreProcessor::getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const {
   // Index for ongoing requests starts from the first_client_id * batchSize_, e.g 28 * 10 = 280 (not from 0)
   const auto ongoingReqIndex = clientId * clientMaxBatchSize_ + reqOffsetInBatch;
-  LOG_DEBUG(logger(), KVLOG(clientId, reqOffsetInBatch, ongoingReqIndex));
+  LOG_TRACE(logger(), KVLOG(clientId, reqOffsetInBatch, ongoingReqIndex));
   return ongoingReqIndex;
 }
 
@@ -953,7 +962,7 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   // Unused for now. Replica Specific Info not currently supported in pre-execution.
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
   SCOPED_MDC_CID(cid);
-  LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch, reqSeqNum));
+  LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch));
   bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
   accumulatedRequests.push_back(bftEngine::IRequestsHandler::ExecutionRequest{
       clientId,
@@ -967,7 +976,7 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
   const auto status = request.outExecutionStatus;
   const auto resultLen = request.outActualReplySize;
-  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch, reqSeqNum));
+  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch));
   if (status != 0 || !resultLen) {
     LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqOffsetInBatch, reqSeqNum, status, resultLen));
     ConcordAssert(false);

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -591,25 +591,27 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
 
 template <typename T>
 void PreProcessor::messageHandler(MessageBase *msg) {
-  T *trueTypeObj = new T(msg);
-  delete msg;
   if (!msgs_.write_available()) {
     LOG_ERROR(logger(), "PreProcessor queue is full, returning message");
     incomingMsgsStorage_->pushExternalMsg(std::unique_ptr<MessageBase>(msg));
+    return;
   }
+  T *trueTypeObj = new T(msg);
+  delete msg;
   msgs_.push(trueTypeObj);
   msgLoopSignal_.notify_one();
 }
 
 template <>
 void PreProcessor::messageHandler<PreProcessReplyMsg>(MessageBase *msg) {
-  PreProcessReplyMsg *trueTypeObj = new PreProcessReplyMsg(msg);
-  trueTypeObj->setPreProcessorHistograms(&histograms_);
-  delete msg;
   if (!msgs_.write_available()) {
     LOG_ERROR(logger(), "PreProcessor queue is full, returning message");
     incomingMsgsStorage_->pushExternalMsg(std::unique_ptr<MessageBase>(msg));
+    return;
   }
+  PreProcessReplyMsg *trueTypeObj = new PreProcessReplyMsg(msg);
+  trueTypeObj->setPreProcessorHistograms(&histograms_);
+  delete msg;
   msgs_.push(trueTypeObj);
   msgLoopSignal_.notify_one();
 }

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -130,6 +130,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       numOfThreads = myReplica.getReplicaConfig().numOfClientProxies / numOfReplicas_;
   }
   threadPool_.start(numOfThreads);
+  msg_proc_thread_ = std::thread{&PreProcessor::loop, this};
   LOG_INFO(logger(),
            KVLOG(numOfReplicas_,
                  numOfExternalClients,
@@ -146,8 +147,11 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
 }
 
 PreProcessor::~PreProcessor() {
+  done_ = true;
+  msg_cv_.notify_all();
   cancelTimers();
   threadPool_.stop();
+  if (msg_proc_thread_.joinable()) msg_proc_thread_.join();
 }
 
 void PreProcessor::addTimers() {
@@ -267,7 +271,6 @@ void PreProcessor::updateAggregatorAndDumpMetrics() {
 }
 
 void PreProcessor::sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
-                                                  NodeIdType destId,
                                                   uint16_t reqOffsetInBatch,
                                                   uint64_t reqRetryId) {
   const auto clientId = clientReqMsg->clientProxyId();
@@ -283,6 +286,7 @@ void PreProcessor::sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUn
                                         nullptr,
                                         clientReqMsg->getCid(),
                                         clientReqMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
+  const auto destId = clientReqMsg->senderId();
   SCOPED_MDC_CID(preProcessReqMsg->getCid());
   LOG_DEBUG(logger(), "Sending PreProcessRequestMsg with REQ_TYPE_CANCEL" << KVLOG(clientId, reqSeqNum, destId));
   sendMsg(preProcessReqMsg->body(), destId, preProcessReqMsg->type(), preProcessReqMsg->size());
@@ -310,7 +314,6 @@ void PreProcessor::sendRejectPreProcessReplyMsg(NodeIdType clientId,
 
 template <>
 void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequestMsg *msg) {
-  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onClientPreProcessRequestMsg);
   preProcessorMetrics_.preProcReqReceived.Get().Inc();
   ClientPreProcessReqMsgUniquePtr clientMsg(msg);
   const string &cid = clientMsg->getCid();
@@ -324,7 +327,7 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
     preProcessorMetrics_.preProcReqIgnored.Get().Inc();
     return;
   }
-  handleSingleClientRequestMessage(move(clientMsg), senderId, false, 0);
+  handleSingleClientRequestMessage(move(clientMsg), false, 0);
 }
 
 // Should be called under reqEntry->mutex lock
@@ -366,6 +369,9 @@ bool PreProcessor::isRequestAlreadyExecuted(ReqId reqSeqNum,
                                             const string &cid) {
   const bool replySentToClient = myReplica_.isReplyAlreadySentToClient(clientId, reqSeqNum);
   if (replySentToClient) {
+    LOG_INFO(logger(),
+             "Request has already been executed - let replica decide how to proceed further"
+                 << KVLOG(cid, reqSeqNum, senderId, clientId));
     preProcessorMetrics_.preProcReqSentForFurtherProcessing.Get().Inc();
     return true;
   }
@@ -393,10 +399,10 @@ bool PreProcessor::isRequestPreProcessedBefore(const RequestStateSharedPtr &reqE
 }
 
 void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUniquePtr clientMsg,
-                                                    NodeIdType senderId,
                                                     bool arrivedInBatch,
                                                     uint16_t msgOffsetInBatch) {
   SCOPED_MDC_CID(clientMsg->getCid());
+  const NodeIdType &senderId = clientMsg->senderId();
   const NodeIdType &clientId = clientMsg->clientProxyId();
   const ReqId &reqSeqNum = clientMsg->requestSeqNum();
   PreProcessRequestMsgSharedPtr preProcessRequestMsg;
@@ -405,6 +411,12 @@ void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
   {
     const auto &reqEntry = ongoingRequests_[getOngoingReqIndex(clientId, msgOffsetInBatch)];
     lock_guard<mutex> lock(reqEntry->mutex);
+    if (isRequestAlreadyExecuted(reqSeqNum, senderId, clientId, clientMsg->getCid())) {
+      if (senderId != clientId) sendCancelPreProcessRequestMsg(clientMsg, msgOffsetInBatch, (reqEntry->reqRetryId)++);
+      // The request has already been committed and executed - let replica decide how to proceed further.
+      return incomingMsgsStorage_->pushExternalMsg(clientMsg->convertToClientRequestMsg(false));
+    }
+
     const bool reqToBeDeclined =
         (isRequestPreProcessingRightNow(reqEntry, reqSeqNum, clientId, senderId) ||
          isRequestPassingConsensusOrPostExec(reqSeqNum, senderId, clientId, clientMsg->getCid()) ||
@@ -413,19 +425,8 @@ void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
       if (senderId != clientId)
         // Send 'cancel' request to non-primary replicas to release them from waiting to a 'real' PreProcessRequestMsg,
         // which will not arrive in this case. Doing this to avoid request from being timed out on non-primary replicas.
-        sendCancelPreProcessRequestMsg(clientMsg, senderId, msgOffsetInBatch, (reqEntry->reqRetryId)++);
+        sendCancelPreProcessRequestMsg(clientMsg, msgOffsetInBatch, (reqEntry->reqRetryId)++);
       return;
-    }
-
-    if (isRequestAlreadyExecuted(reqSeqNum, senderId, clientId, clientMsg->getCid())) {
-      if (senderId != clientId) {
-        sendCancelPreProcessRequestMsg(clientMsg, senderId, msgOffsetInBatch, (reqEntry->reqRetryId)++);
-        return;
-      }
-      LOG_INFO(logger(),
-               "Request has already been executed - let replica decide how to proceed further"
-                   << KVLOG(reqSeqNum, clientId, senderId));
-      return incomingMsgsStorage_->pushExternalMsg(clientMsg->convertToClientRequestMsg(false));
     }
 
     if (myReplica_.isCurrentPrimary())
@@ -445,7 +446,6 @@ void PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
 
 template <>
 void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) {
-  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onClientBatchPreProcessRequestMsg);
   ClientBatchRequestMsgUniquePtr clientBatch(msg);
   const auto clientId = clientBatch->clientId();
   const auto senderId = clientBatch->senderId();
@@ -459,14 +459,11 @@ void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) 
   }
   ClientMsgsList &clientMsgs = clientBatch->getClientPreProcessRequestMsgs();
   uint16_t offset = 0;
-  for (auto it = clientMsgs.begin(); it != clientMsgs.end(); ++it) {
-    auto &clientMsg = *it;
-    LOG_DEBUG(
-        logger(),
-        "Start handling single message from the batch:" << KVLOG(
-            clientMsg->requestSeqNum(), clientMsg->getCid(), senderId, clientId, clientMsg->requestTimeoutMilli()));
-    // senderId should be taken from ClientBatchRequestMsg as it does not get re-set in batched client messages
-    handleSingleClientRequestMessage(move(clientMsg), senderId, true, offset++);
+  for (auto &clientMsg : clientMsgs) {
+    LOG_DEBUG(logger(),
+              "Start handling single message from the batch:" << KVLOG(
+                  clientMsg->requestSeqNum(), senderId, clientId, clientMsg->requestTimeoutMilli()));
+    handleSingleClientRequestMessage(move(clientMsg), true, offset++);
   }
   if (!myReplica_.isCurrentPrimary()) {
     sendMsg(clientBatch->body(), myReplica_.currentPrimary(), clientBatch->type(), clientBatch->size());
@@ -477,7 +474,6 @@ void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) 
 // Non-primary replica request handling
 template <>
 void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
-  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onPreProcessRequestMsg);
   SCOPED_MDC_CID(msg->getCid());
   PreProcessRequestMsgSharedPtr preProcessReqMsg(msg);
   const auto &reqType = preProcessReqMsg->reqType();
@@ -544,7 +540,6 @@ void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *msg) {
 // Primary replica handling
 template <>
 void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *msg) {
-  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onPreProcessReplyMsg);
   PreProcessReplyMsgSharedPtr preProcessReplyMsg(msg);
   const NodeIdType &senderId = preProcessReplyMsg->senderId();
   const NodeIdType &clientId = preProcessReplyMsg->clientId();
@@ -589,12 +584,8 @@ template <typename T>
 void PreProcessor::messageHandler(MessageBase *msg) {
   T *trueTypeObj = new T(msg);
   delete msg;
-  if (validateMessage(trueTypeObj)) {
-    onMessage<T>(trueTypeObj);
-  } else {
-    preProcessorMetrics_.preProcReqInvalid.Get().Inc();
-    delete trueTypeObj;
-  }
+  msgs_.push(trueTypeObj);
+  msg_cv_.notify_one();
 }
 
 template <>
@@ -602,11 +593,49 @@ void PreProcessor::messageHandler<PreProcessReplyMsg>(MessageBase *msg) {
   PreProcessReplyMsg *trueTypeObj = new PreProcessReplyMsg(msg);
   trueTypeObj->setPreProcessorHistograms(&histograms_);
   delete msg;
-  if (validateMessage(trueTypeObj)) {
-    onMessage(trueTypeObj);
-  } else {
-    preProcessorMetrics_.preProcReqInvalid.Get().Inc();
-    delete trueTypeObj;
+  msgs_.push(trueTypeObj);
+  msg_cv_.notify_one();
+}
+
+void PreProcessor::loop() {
+  while (!done_) {
+    int count = 0;
+    {
+      std::unique_lock<std::mutex> l(msg_lock_);
+      while (!done_ && msgs_.empty()) msg_cv_.wait(l);
+      if (done_) break;
+      count = msgs_.read_available();
+    }
+
+    while (!done_ && count--) {
+      auto m = msgs_.front();
+      if (validateMessage(m)) {
+        switch (m->type()) {
+          case (MsgCode::ClientBatchRequest): {
+            onMessage<ClientBatchRequestMsg>(static_cast<ClientBatchRequestMsg *>(m));
+            break;
+          }
+          case (MsgCode::ClientPreProcessRequest): {
+            onMessage<ClientPreProcessRequestMsg>(static_cast<ClientPreProcessRequestMsg *>(m));
+            break;
+          }
+          case (MsgCode::PreProcessRequest): {
+            onMessage<PreProcessRequestMsg>(static_cast<PreProcessRequestMsg *>(m));
+            break;
+          }
+          case (MsgCode::PreProcessReply): {
+            onMessage<PreProcessReplyMsg>(static_cast<PreProcessReplyMsg *>(m));
+            break;
+          }
+          default:
+            LOG_ERROR(logger(), "Unknown message" << KVLOG(m->type()));
+        }
+
+      } else {
+        preProcessorMetrics_.preProcReqInvalid.Get().Inc();
+      }
+      msgs_.pop();
+    }
   }
 }
 
@@ -870,14 +899,14 @@ const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId,
   // The number of buffers per client comes from the configuration parameter clientBatchingMaxMsgsNbr.
   const auto bufferOffset =
       (clientId - numOfReplicas_ - numOfInternalClients_) * clientMaxBatchSize_ + reqOffsetInBatch;
-  LOG_TRACE(logger(), KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
+  LOG_DEBUG(logger(), KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
   return preProcessResultBuffers_[bufferOffset].data();
 }
 
 const uint16_t PreProcessor::getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const {
   // Index for ongoing requests starts from the first_client_id * batchSize_, e.g 28 * 10 = 280 (not from 0)
   const auto ongoingReqIndex = clientId * clientMaxBatchSize_ + reqOffsetInBatch;
-  LOG_TRACE(logger(), KVLOG(clientId, reqOffsetInBatch, ongoingReqIndex));
+  LOG_DEBUG(logger(), KVLOG(clientId, reqOffsetInBatch, ongoingReqIndex));
   return ongoingReqIndex;
 }
 
@@ -924,7 +953,7 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   // Unused for now. Replica Specific Info not currently supported in pre-execution.
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
   SCOPED_MDC_CID(cid);
-  LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch));
+  LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch, reqSeqNum));
   bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
   accumulatedRequests.push_back(bftEngine::IRequestsHandler::ExecutionRequest{
       clientId,
@@ -938,7 +967,7 @@ uint32_t PreProcessor::launchReqPreProcessing(uint16_t clientId,
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
   const auto status = request.outExecutionStatus;
   const auto resultLen = request.outActualReplySize;
-  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch));
+  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(reqSeqNum, clientId, reqOffsetInBatch, reqSeqNum));
   if (status != 0 || !resultLen) {
     LOG_FATAL(logger(), "Pre-execution failed!" << KVLOG(clientId, reqOffsetInBatch, reqSeqNum, status, resultLen));
     ConcordAssert(false);

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -189,9 +189,10 @@ class PreProcessor {
   }
 
  private:
-  void loop();
+  const uint32_t MAX_MSGS = 10000;
+  void msgProcessingLoop();
 
-  boost::lockfree::spsc_queue<MessageBase *> msgs_{10000};
+  boost::lockfree::spsc_queue<MessageBase *> msgs_{MAX_MSGS};
   std::thread msgLoopThread_;
   std::mutex msgLock_;
   std::condition_variable msgLoopSignal_;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -124,6 +124,7 @@ class PreProcessor {
                                     const std::string &cid,
                                     const std::string &ongoingCid);
   void sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
+                                      NodeIdType destId,
                                       uint16_t reqOffsetInBatch,
                                       uint64_t reqRetryId);
   const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
@@ -166,6 +167,7 @@ class PreProcessor {
   void cancelTimers();
   void onRequestsStatusCheckTimer();
   void handleSingleClientRequestMessage(ClientPreProcessReqMsgUniquePtr clientMsg,
+                                        NodeIdType senderId,
                                         bool arrivedInBatch,
                                         uint16_t msgOffsetInBatch);
   bool isRequestPreProcessingRightNow(const RequestStateSharedPtr &reqEntry,
@@ -190,10 +192,10 @@ class PreProcessor {
   void loop();
 
   boost::lockfree::spsc_queue<MessageBase *> msgs_{10000};
-  std::thread msg_proc_thread_;
-  std::mutex msg_lock_;
-  std::condition_variable msg_cv_;
-  bool done_ = false;
+  std::thread msgLoopThread_;
+  std::mutex msgLock_;
+  std::condition_variable msgLoopSignal_;
+  bool msgLoopDone_ = false;
 
   static std::vector<std::shared_ptr<PreProcessor>> preProcessors_;  // The place holder for PreProcessor objects
 

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -455,6 +455,7 @@ TEST(requestPreprocessingState_test, requestTimedOut) {
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
   msgHandlerCallback(clientReqMsg);
+  usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 0) == reqSeqNum);
   usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
   timers.evaluate();
@@ -475,6 +476,7 @@ TEST(requestPreprocessingState_test, primaryCrashDetected) {
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
   msgHandlerCallback(clientReqMsg);
+  usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 0) == reqSeqNum);
 
   usleep(reqWaitTimeoutMilli * 1000);
@@ -498,6 +500,7 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
   auto msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::ClientPreProcessRequest);
   auto* clientReqMsg = new ClientPreProcessRequestMsg(clientId, reqSeqNum, bufLen, buf, reqTimeoutMilli, cid);
   msgHandlerCallback(clientReqMsg);
+  usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 0) == reqSeqNum);
 
   auto* preProcessReqMsg = new PreProcessRequestMsg(
@@ -531,6 +534,7 @@ TEST(requestPreprocessingState_test, batchMsgTimedOutOnNonPrimary) {
   }
   auto* clientBatchReqMsg = new ClientBatchRequestMsg(clientId, batch, batchSize, cid);
   msgHandlerCallback(clientBatchReqMsg);
+  usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 0) == 5);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 1) == 6);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 2) == 7);
@@ -569,6 +573,7 @@ TEST(requestPreprocessingState_test, batchMsgTimedOutOnPrimary) {
   }
   auto* clientBatchReqMsg = new ClientBatchRequestMsg(clientId, batch, batchSize, cid);
   msgHandlerCallback(clientBatchReqMsg);
+  usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 0) == 5);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 1) == 6);
   ConcordAssert(preProcessor.getOngoingReqIdForClient(clientId, 2) == 7);


### PR DESCRIPTION
This PR implememts asynchronous PreProcessor.
The idea is to release dispatching thread, which is main replica's thread, ASAP when any PreProcessor message is handled by replica.
This implementation uses lockfree SPSC queue from Boost, since it perfectly fits this scenario