### PR TITLE
Enable ignoring the primary in the matched part of bft replies

### DIFF
--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -286,7 +286,7 @@ void Client::wait(SeqNumToReplyMap& replies) {
       if (request == reply_certificates_.end()) continue;
       if (pending_requests_.size() > 0 && replies.size() == pending_requests_.size()) return;
       if (auto match = request->second.onReply(std::move(reply))) {
-        primary_ = match->primary;
+        request->second.getPrimary(primary_);
         replies.insert(std::make_pair(request->first, match->reply));
         reply_certificates_.erase(request->first);
       }

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -319,6 +319,12 @@ MatchConfig Client::readConfigToMatchConfig(const ReadConfig& read_config) {
 
   } else if (std::holds_alternative<All>(read_config.quorum)) {
     mc.quorum = quorum_converter_.toMofN(std::get<All>(read_config.quorum));
+    for (const auto& r : std::get<All>(read_config.quorum).destinations) {
+      if (config_.ro_replicas.find(r) != config_.ro_replicas.end()) {
+        // We are about to send a read request to ro replica, so we must ignore the primary in the replies
+        mc.ignore_primary_ = true;
+      }
+    }
 
   } else {
     mc.quorum = quorum_converter_.toMofN(std::get<MofN>(read_config.quorum));

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -286,7 +286,7 @@ void Client::wait(SeqNumToReplyMap& replies) {
       if (request == reply_certificates_.end()) continue;
       if (pending_requests_.size() > 0 && replies.size() == pending_requests_.size()) return;
       if (auto match = request->second.onReply(std::move(reply))) {
-        request->second.getPrimary(primary_);
+        primary_ = request->second.getPrimary();
         replies.insert(std::make_pair(request->first, match->reply));
         reply_certificates_.erase(request->first);
       }
@@ -322,7 +322,7 @@ MatchConfig Client::readConfigToMatchConfig(const ReadConfig& read_config) {
     for (const auto& r : std::get<All>(read_config.quorum).destinations) {
       if (config_.ro_replicas.find(r) != config_.ro_replicas.end()) {
         // We are about to send a read request to ro replica, so we must ignore the primary in the replies
-        mc.ignore_primary_ = true;
+        mc.include_primary_ = false;
       }
     }
 

--- a/bftclient/src/matcher.cpp
+++ b/bftclient/src/matcher.cpp
@@ -15,7 +15,7 @@ namespace bft::client {
 
 std::optional<Match> Matcher::onReply(UnmatchedReply&& reply) {
   if (!valid(reply)) return std::nullopt;
-
+  if (config_.ignore_primary_) reply.metadata.primary = ReplicaId{0};
   auto key = MatchKey{reply.metadata, std::move(reply.data)};
   if (matches_[key].count(reply.rsi.from)) {
     if (matches_[key][reply.rsi.from] != reply.rsi.data) {
@@ -34,6 +34,7 @@ std::optional<Match> Matcher::match() {
     return match.second.size() == config_.quorum.wait_for;
   });
   if (result == matches_.end()) return std::nullopt;
+  primary_ = result->first.metadata.primary;
   return Match{Reply{result->first.data, std::move(result->second)}, result->first.metadata.primary};
 }
 

--- a/bftclient/src/matcher.cpp
+++ b/bftclient/src/matcher.cpp
@@ -15,7 +15,7 @@ namespace bft::client {
 
 std::optional<Match> Matcher::onReply(UnmatchedReply&& reply) {
   if (!valid(reply)) return std::nullopt;
-  if (config_.ignore_primary_) reply.metadata.primary = ReplicaId{0};
+  if (!config_.include_primary_) reply.metadata.primary = std::nullopt;
   auto key = MatchKey{reply.metadata, std::move(reply.data)};
   if (matches_[key].count(reply.rsi.from)) {
     if (matches_[key][reply.rsi.from] != reply.rsi.data) {

--- a/bftclient/src/matcher.h
+++ b/bftclient/src/matcher.h
@@ -26,8 +26,7 @@ struct MatchConfig {
   // All quorums can be distilled into an MofN quorum.
   MofN quorum;
   uint64_t sequence_number;
-  bool ignore_primary_ =
-      false;  // With ro replicas, we don't want to consider the primary as ror does not know who the primary is
+  bool include_primary_ = true;  // by default part of the match is the current primary
 };
 
 // The parts of data that must match in a reply for quorum to be reached
@@ -68,9 +67,9 @@ class Matcher {
 
   void clearReplies() { matches_.clear(); }
 
-  void getPrimary(std::optional<ReplicaId>& primary) {
-    if (config_.ignore_primary_ || !primary_.has_value()) return;
-    primary = primary_;
+  std::optional<ReplicaId> getPrimary() {
+    if (!config_.include_primary_) return std::nullopt;
+    return primary_;
   }
 
  private:

--- a/bftclient/src/matcher.h
+++ b/bftclient/src/matcher.h
@@ -26,6 +26,8 @@ struct MatchConfig {
   // All quorums can be distilled into an MofN quorum.
   MofN quorum;
   uint64_t sequence_number;
+  bool ignore_primary_ =
+      false;  // With ro replicas, we don't want to consider the primary as ror does not know who the primary is
 };
 
 // The parts of data that must match in a reply for quorum to be reached
@@ -66,6 +68,11 @@ class Matcher {
 
   void clearReplies() { matches_.clear(); }
 
+  void getPrimary(std::optional<ReplicaId>& primary) {
+    if (config_.ignore_primary_ || !primary_.has_value()) return;
+    primary = primary_;
+  }
+
  private:
   // Check the validity of a reply
   bool valid(const UnmatchedReply& reply) const;
@@ -77,7 +84,7 @@ class Matcher {
   std::optional<Match> match();
 
   MatchConfig config_;
-  std::optional<uint16_t> primary_;
+  std::optional<ReplicaId> primary_;
 
   logging::Logger logger_ = logging::getLogger("bftclient.matcher");
 

--- a/bftclient/src/msg_receiver.h
+++ b/bftclient/src/msg_receiver.h
@@ -35,7 +35,7 @@ struct ReplyMetadata {
     if (primary < other.primary) {
       return true;
     }
-    if (primary == other.primary && seq_num < other.seq_num) {
+    if (seq_num < other.seq_num) {
       return true;
     }
     return false;

--- a/bftclient/src/msg_receiver.h
+++ b/bftclient/src/msg_receiver.h
@@ -35,7 +35,7 @@ struct ReplyMetadata {
     if (primary < other.primary) {
       return true;
     }
-    if (seq_num < other.seq_num) {
+    if (primary == other.primary && seq_num < other.seq_num) {
       return true;
     }
     return false;

--- a/bftclient/src/msg_receiver.h
+++ b/bftclient/src/msg_receiver.h
@@ -26,7 +26,7 @@ namespace bft::client {
 // This makes the metadata independent of the structure of the messages, allowing us to change them
 // later without changing the matcher.
 struct ReplyMetadata {
-  ReplicaId primary;
+  std::optional<ReplicaId> primary;
   uint64_t seq_num;
 
   bool operator==(const ReplyMetadata& other) const { return primary == other.primary && seq_num == other.seq_num; }
@@ -35,10 +35,7 @@ struct ReplyMetadata {
     if (primary < other.primary) {
       return true;
     }
-    if (primary == other.primary && seq_num < other.seq_num) {
-      return true;
-    }
-    return false;
+    return primary == other.primary && seq_num < other.seq_num;
   }
 };
 

--- a/bftclient/test/bft_client_test.cpp
+++ b/bftclient/test/bft_client_test.cpp
@@ -136,7 +136,7 @@ std::vector<ReplicaSpecificInfo> create_rsi(uint16_t n) {
 }
 
 std::vector<UnmatchedReply> unmatched_replies(uint16_t n,
-                                              ReplyMetadata metadata,
+                                              const ReplyMetadata& metadata,
                                               const Msg& msg,
                                               const std::vector<ReplicaSpecificInfo>& rsi) {
   ConcordAssert(n <= rsi.size());

--- a/bftclient/test/bft_client_test.cpp
+++ b/bftclient/test/bft_client_test.cpp
@@ -42,7 +42,7 @@ TEST(msg_receiver_tests, unmatched_replies_returned_no_rsi) {
   auto replies = receiver.wait(1ms);
 
   ASSERT_EQ(1, replies.size());
-  ASSERT_EQ(header->currentPrimaryId, replies[0].metadata.primary.val);
+  ASSERT_EQ(header->currentPrimaryId, replies[0].metadata.primary->val);
   ASSERT_EQ(header->reqSeqNum, replies[0].metadata.seq_num);
   ASSERT_EQ(Msg(data_len), replies[0].data);
   ASSERT_EQ(1, replies[0].rsi.from.val);
@@ -71,7 +71,7 @@ TEST(msg_receiver_tests, unmatched_replies_with_rsi) {
   auto replies = receiver.wait(1ms);
 
   ASSERT_EQ(1, replies.size());
-  ASSERT_EQ(header->currentPrimaryId, replies[0].metadata.primary.val);
+  ASSERT_EQ(header->currentPrimaryId, replies[0].metadata.primary->val);
   ASSERT_EQ(header->reqSeqNum, replies[0].metadata.seq_num);
   ASSERT_EQ(Msg(data_len - header->replicaSpecificInfoLength), replies[0].data);
   ASSERT_EQ(1, replies[0].rsi.from.val);
@@ -247,7 +247,7 @@ TEST(matcher_tests, wait_for_3_out_of_4_with_mismatches_and_dupes) {
 TEST(matcher_tests, wait_for_replies_with_ignoring_primary) {
   auto sources = destinations(3);
   uint64_t seq_num = 5;
-  MatchConfig config{MofN{4, destinations(4)}, seq_num, true};
+  MatchConfig config{MofN{4, destinations(4)}, seq_num, false};
   Matcher matcher(config);
 
   Msg msg = {'h', 'e', 'l', 'l', 'o'};
@@ -263,7 +263,7 @@ TEST(matcher_tests, wait_for_replies_with_ignoring_primary) {
   ASSERT_TRUE(match.has_value());
   ASSERT_EQ(match.value().reply.matched_data, msg);
   ASSERT_EQ(match.value().reply.rsi[last_rep], rsi.data);
-  ASSERT_EQ(match.value().primary.value(), ReplicaId{0});
+  ASSERT_FALSE(match.value().primary.has_value());
 }
 
 TEST(quorum_tests, valid_quorums_without_destinations) {


### PR DESCRIPTION
The read-only replica does not know who the primary is. However, when matching a reply we also look at the primary from the replica.
To enable reading from read-only replicas, we added another configuration option to the matcher that instructs him to ignore the primary. This way, only if the user gives a configuration that contains ro replicas, we ignore from the primary in the replies

Notice that in this case, the current primary of the client won't be affected