### PR TITLE
Improve noop mechanism on wedge command

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -467,8 +467,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void startConsensusProcess(PrePrepareMsg* pp, bool isInternalNoop);
   void startConsensusProcess(PrePrepareMsg* pp);
   void sendInternalNoopPrePrepareMsg(CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
-  void bringTheSystemToCheckpointBySendingNoopCommands(SeqNum seqNumToStopAt,
-                                                       CommitPath firstPath = CommitPath::OPTIMISTIC_FAST);
   bool isSeqNumToStopAt(SeqNum seq_num);
 
   // 5 years

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -1,5 +1,6 @@
 Msg WedgeCommand 3 {
   uint64 sender
+  bool noop
 }
 
 Msg WedgeStatusRequest 5 {

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -21,6 +21,10 @@ namespace concord::reconfiguration {
 bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
                                     uint64_t bft_seq_num,
                                     concord::messages::ReconfigurationErrorMsg&) {
+  if (cmd.noop) {
+    LOG_INFO(getLogger(), "received noop command, a new block will be written" << KVLOG(bft_seq_num));
+    return true;
+  }
   LOG_INFO(getLogger(), "Wedge command instructs replica to stop at sequence number " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
   return true;

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -97,11 +97,11 @@ add_test(NAME skvbc_backup_restore COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-# if (USE_S3_OBJECT_STORE)
-#     add_test(NAME skvbc_reconfiguration COMMAND sh -c
-#             "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
-#            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-# endif()
+ if (USE_S3_OBJECT_STORE)
+     add_test(NAME skvbc_reconfiguration COMMAND sh -c
+             "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+ endif()
 
 add_test(NAME skvbc_consensus_batching COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_consensus_batching python3 -m unittest test_skvbc_consensus_batching ${TEST_OUTPUT}"

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -30,6 +30,7 @@ class Operator:
     def _construct_reconfiguration_wedge_coammand(self):
         wedge_cmd = cmf_msgs.WedgeCommand()
         wedge_cmd.sender = 1000
+        wedge_cmd.noop = False
         reconf_msg = cmf_msgs.ReconfigurationRequest()
         reconf_msg.command = wedge_cmd
         reconf_msg.signature = bytes()


### PR DESCRIPTION
The former implementation of the noop mechanism was as follows:
Once a primary replica has detected that we need to wedge on seq num X it sent empty prepreapres up to X.
This created several problems:
1. It violates the concurrency level - creating many slow path commits
2. No new blocks were written for these sequence numbers, this can damage the sync mechanism in case of a crash

In this PR we introduce a new mechanism:
1. Once the primary done executing a request, and it detects that we need to wedge on seqNum X, it uses the internal client to send a special noop reconfiguration request. This noop request is executed by the reconfiguration engine which means that it also creates a new block.
2. In addition, now, we send a new prepreapre (containing the noop) only after executing one - which means we don't violate the concurrency level principle.

In the future, we plan to add a verification step to validate this noop request. However, even now, it does not violate anything, if a malicious client wants to launch a DOS attack, it can also send a regular heavy computed requests (rather than noops)