### PR TITLE
Fix SPSC queue usage by adding timeout

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -608,13 +608,8 @@ void PreProcessor::msgProcessingLoop() {
   while (!msgLoopDone_) {
     {
       std::unique_lock<std::mutex> l(msgLock_);
-      while (!msgLoopDone_ && msgs_.empty()) {
+      while (!msgLoopDone_ && !msgs_.read_available()) {
         msgLoopSignal_.wait_until(l, chrono::steady_clock::now() + std::chrono::milliseconds(WAIT_TIMEOUT_MILLI));
-      }
-      if (msgLoopDone_) break;
-      if (!msgs_.read_available()) {
-        LOG_FATAL(logger(), "queue empty on wakeup");
-        ConcordAssert(false);
       }
     }
 

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -190,6 +190,7 @@ class PreProcessor {
 
  private:
   const uint32_t MAX_MSGS = 10000;
+  const uint32_t WAIT_TIMEOUT_MILLI = 100;
   void msgProcessingLoop();
 
   boost::lockfree::spsc_queue<MessageBase *> msgs_{MAX_MSGS};


### PR DESCRIPTION
This MR fixes usage of spsc queue in the PreProcessor, by introducing timeout to wait when the queue is empty.
In the worst case, only first message will wait for the timeout. Under heavy loads, it will be probably negligible.
