### PR TITLE
Add periodic log that summarizes the deletes

### DIFF
--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -223,6 +223,12 @@ class KeyValueBlockchain {
   concordMetrics::CounterHandle immutable_num_of_keys_;
   concordMetrics::CounterHandle merkle_num_of_keys_;
 
+  std::chrono::seconds dump_delete_metrics_interval_{5 * 60};  // default is 5 minutes
+  std::chrono::seconds last_dump_time_{0};
+  uint64_t latest_deleted_merkle_dump{0};
+  uint64_t latest_deleted_versioned{0};
+  uint64_t latest_deleted_immutbale{0};
+
  public:
   struct KeyValueBlockchain_tester {
     void loadCategories(KeyValueBlockchain& kvbc) { kvbc.loadCategories(); }


### PR DESCRIPTION
In order to ease the pruning analysis, we add a prebiotic log that logs every 5 minutes the status of deletes (if ever called).
Once we have a long pruing, eventually we will have a call to the delete block after 5 minutes has passed and then we will log the deletes status