### PR TITLE
Multi thread only on replicas

### DIFF
--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -23,7 +23,10 @@ TlsTCPCommunication::TlsTCPCommunication(const TlsTcpConfig &config) : config_(c
   // Runners can actually support multiple principals. The Communication interface does not though. Currently we are
   // focused on backwards compatibility, and will use the future runner functionality to replace client thread pools.
   const auto configs = std::vector<TlsTcpConfig>{config};
-  runner_.reset(new tls::Runner(configs, NUM_THREADS));
+  if (config.selfId > static_cast<uint64_t>(config.maxServerId))
+    runner_.reset(new tls::Runner(configs, 1));
+  else
+    runner_.reset(new tls::Runner(configs, NUM_THREADS));
 }
 
 TlsTCPCommunication::~TlsTCPCommunication() {}


### PR DESCRIPTION
With the case of the client pool, we want multithreaded connections to be created only on replicas since if each client creates 8 threads that will create a resource problem.