### PR TITLE
Add internal verification and signer to reconfiguration engine

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -530,6 +530,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concord::diagnostics::AsyncTimeRecorder<false> time_in_state_transfer_;
   batchingLogic::RequestsBatchingLogic reqBatchingLogic_;
   ReplicaStatusHandlers replStatusHandlers_;
+
+  std::unique_ptr<bftEngine::impl::RSASigner> rsaSigner_;
 };  // namespace bftEngine::impl
 
 }  // namespace bftEngine::impl

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -52,12 +52,18 @@ class ReconfigurationHandler : public IReconfigurationHandler {
   bool verifySignature(const concord::messages::ReconfigurationRequest&,
                        concord::messages::ReconfigurationErrorMsg&) const override;
 
+  static const unsigned char internalCommandKey() {
+    static unsigned char key_ = 0x20;
+    return key_;
+  }
+
  protected:
   logging::Logger getLogger() const {
     static logging::Logger logger_(logging::getLogger("concord.reconfiguration"));
     return logger_;
   }
   std::unique_ptr<bftEngine::impl::IVerifier> verifier_ = nullptr;
+  std::vector<std::unique_ptr<bftEngine::impl::RSAVerifier>> internal_verifiers_;
 };
 
 }  // namespace concord::reconfiguration


### PR DESCRIPTION
There are several internal reconfiguration commands such as wedge noops (to bring the system to the next checkpoint) and key exchange.
We would like to have a verification mechanism for them as well.
In this PR we added verifiers to the reconfiguration engine and signers in the replicas.
They based on the already given RSA keys of the replicas.
In addition,  If a replica wants to mark a request as internal, it should put in the additinal_data field a specific prefix.