### PR TITLE
Increase max primary queue size

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -235,7 +235,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
     if (isCurrentPrimary()) {
       histograms_.requestsQueueOfPrimarySize->record(requestsQueueOfPrimary.size());
       // TODO(GG): use config/parameter
-      if (requestsQueueOfPrimary.size() >= 700) {
+      if (requestsQueueOfPrimary.size() >= maxPrimaryQueueSize) {
         LOG_WARN(GL,
                  "ClientRequestMsg dropped. Primary request queue is full. "
                      << KVLOG(clientId, reqSeqNum, requestsQueueOfPrimary.size()));

--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -64,6 +64,7 @@ static_assert(maxLegalConcurrentAgreementsByPrimary < MaxConcurrentFastPaths,
 ///////////////////////////////////////////////////////////////////////////////
 
 constexpr uint32_t maxNumOfRequestsInBatch = 1024;
+constexpr uint32_t maxPrimaryQueueSize = 1500;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Requests for missing information


### PR DESCRIPTION
This MR increases default primary queue size to 1500.
For achieving maximum performance, we boost the concurrency both in terms of concurrent consensus operations and in terms of concurrent clients. Default value of 700 is quite low for maximim primary queue size, all messages beyond this size are just ignored.
This parameter should be moved to the configuration in the future.