### PR TITLE
Enabling State Transfer in Separate thread by default in tester replica

### DIFF
--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -291,7 +291,7 @@ SimpleStateTran::SimpleStateTran(
       15000,                                // sourceReplicaReplacementTimeoutMs
       250,                                  // fetchRetransmissionTimeoutMs
       5,                                    // metricsDumpIntervalSec
-      false,                                // runInSeparateThread
+      true,                                // runInSeparateThread
       true                                  // enableReservedPages
   };
 

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -291,7 +291,7 @@ SimpleStateTran::SimpleStateTran(
       15000,                                // sourceReplicaReplacementTimeoutMs
       250,                                  // fetchRetransmissionTimeoutMs
       5,                                    // metricsDumpIntervalSec
-      true,                                // runInSeparateThread
+      true,                                 // runInSeparateThread
       true                                  // enableReservedPages
   };
 


### PR DESCRIPTION
We have the option to run state transfer mechanism in a separate thread from BFT message processing. Running ST in a separate thread has become an established way for the system in real deployments. So enabling option to run ST in separate thread.