### PR TITLE
Add target replicas to hey exchange reconfiguration request

### DIFF
--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -82,6 +82,7 @@ Msg ReconfigurationErrorMsg 24 {
 
 Msg KeyExchangeCommand 25 {
     uint64 sender_id
+    list uint64 target_replicas
 }
 
 Msg AddRemoveCommand 26 {

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -89,6 +89,7 @@ class Operator:
     def _construct_reconfiguration_keMsg_coammand(self):
         ke_command = cmf_msgs.KeyExchangeCommand()
         ke_command.sender_id = 1000
+        ke_command.target_replicas = []
         reconf_msg = cmf_msgs.ReconfigurationRequest()
         reconf_msg.command = ke_command
         reconf_msg.additional_data = bytes()


### PR DESCRIPTION
We add a list of target replicas to the key exchange reconfiguration message such that the operator will be able to trigger KE for only part of the replicas