### PR TITLE
Fixes on BATCH_ADAPTIVE consensus policy

### DIFF
--- a/bftengine/src/bftengine/RequestsBatchingLogic.cpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.cpp
@@ -36,14 +36,14 @@ RequestsBatchingLogic::RequestsBatchingLogic(InternalReplicaApi &replica,
       initialBatchSize_(config.maxNumOfRequestsInBatch),
       maxBatchSizeInBytes_(config.maxBatchSizeInBytes),
       timers_(timers) {
-  if (batchingPolicy_ == BATCH_BY_REQ_SIZE || batchingPolicy_ == BATCH_BY_REQ_NUM)
+  if (batchingPolicy_ != BATCH_SELF_ADJUSTED)
     batchFlushTimer_ = timers_.add(milliseconds(batchFlushPeriodMs_),
                                    Timers::Timer::RECURRING,
                                    [this](Timers::Handle h) { onBatchFlushTimer(h); });
 }
 
 RequestsBatchingLogic::~RequestsBatchingLogic() {
-  if (batchingPolicy_ == BATCH_BY_REQ_SIZE || batchingPolicy_ == BATCH_BY_REQ_NUM) timers_.cancel(batchFlushTimer_);
+  if (batchingPolicy_ != BATCH_SELF_ADJUSTED) timers_.cancel(batchFlushTimer_);
 }
 
 void RequestsBatchingLogic::onBatchFlushTimer(Timers::Handle) {

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         }
         case 'b': {
           auto policy = concord::util::to<std::uint32_t>(std::string(optarg));
-          if (policy < bftEngine::BATCH_SELF_ADJUSTED || policy > bftEngine::BATCH_BY_REQ_NUM)
+          if (policy < bftEngine::BATCH_SELF_ADJUSTED || policy > bftEngine::BATCH_ADAPTIVE)
             throw std::runtime_error{"invalid argument for --consensus-batching-policy"};
           replicaConfig.batchingPolicy = policy;
           break;


### PR DESCRIPTION
This PR fix the addition and remove of the timers for BATCH_ADAPTIVE consensus policy just like the size and number policies.