### PR TITLE
Implement framework for n-f reconfiguration actions + specific implementation for n-f wedge

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -52,6 +52,11 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
     static ControlStateManager instance_;
     return instance_;
   }
+  ~ControlStateManager() {
+    if (wedged) {
+      clearCheckpointToStopAt();
+    }
+  }
   void setStopAtNextCheckpoint(int64_t currentSeqNum);
   std::optional<int64_t> getCheckpointToStopAt();
 
@@ -59,7 +64,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   std::optional<int64_t> getEraseMetadataFlag();
 
   void clearCheckpointToStopAt();
-
+  void markAsWedged() { wedged = true; }
   void setPruningProcess(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
   bool getPruningProcessStatus() const { return onPruningProcess_; }
 
@@ -70,11 +75,11 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   ControlStateManager() { scratchPage_.resize(sizeOfReservedPage()); }
   ControlStateManager& operator=(const ControlStateManager&) = delete;
   ControlStateManager(const ControlStateManager&) = delete;
-  ~ControlStateManager() = default;
 
   std::string scratchPage_;
   bool enabled_ = true;
   ControlStatePage page_;
   std::atomic_bool onPruningProcess_ = false;
+  bool wedged = false;
 };
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -52,11 +52,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
     static ControlStateManager instance_;
     return instance_;
   }
-  ~ControlStateManager() {
-    if (wedged) {
-      clearCheckpointToStopAt();
-    }
-  }
+  ~ControlStateManager() = default;
   void setStopAtNextCheckpoint(int64_t currentSeqNum);
   std::optional<int64_t> getCheckpointToStopAt();
 
@@ -64,7 +60,6 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   std::optional<int64_t> getEraseMetadataFlag();
 
   void clearCheckpointToStopAt();
-  void markAsWedged() { wedged = true; }
   void setPruningProcess(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
   bool getPruningProcessStatus() const { return onPruningProcess_; }
 
@@ -80,6 +75,5 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   bool enabled_ = true;
   ControlStatePage page_;
   std::atomic_bool onPruningProcess_ = false;
-  bool wedged = false;
 };
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -80,10 +80,9 @@ std::optional<int64_t> ControlStateManager::getEraseMetadataFlag() {
   return page_.erase_metadata_at_seq_num_;
 }
 void ControlStateManager::clearCheckpointToStopAt() {
-  ControlStatePage tmpPage = page_;
-  tmpPage.seq_num_to_stop_at_ = 0;
+  page_.seq_num_to_stop_at_ = 0;
   std::ostringstream outStream;
-  concord::serialize::Serializable::serialize(outStream, tmpPage);
+  concord::serialize::Serializable::serialize(outStream, page_);
   auto data = outStream.str();
   saveReservedPage(0, data.size(), data.data());
 }

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -116,6 +116,7 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
     if (emptyReq) {
       expectedSigLen = 0;
     } else if ((header->flags & RECONFIG_FLAG) != 0) {
+      expectedSigLen = header->reqSignatureLength;
       // This message arrived from operator - no need at this stage to verifiy the request, since operator
       // verifies it's own signatures on requests in the reconfiguration handler
       doSigVerify = false;

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(kvbc  src/ClientImp.cpp
     src/direct_kv_storage_factory.cpp
     src/merkle_tree_storage_factory.cpp
     src/pruning_handler.cpp
+    src/st_reconfiguration_sm.cpp
     src/sparse_merkle/base_types.cpp
     src/sparse_merkle/keys.cpp
     src/sparse_merkle/internal_node.cpp

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <atomic>
 
+#include "st_reconfiguraion_sm.hpp"
 #include "OpenTracing.hpp"
 #include "categorization/kv_blockchain.h"
 #include "communication/ICommunication.hpp"
@@ -26,7 +27,6 @@
 #include "bftengine/DbMetadataStorage.hpp"
 #include "storage_factory_interface.h"
 #include "ControlStateManager.hpp"
-
 namespace concord::kvbc {
 
 class ReplicaImp : public IReplica,
@@ -176,7 +176,7 @@ class ReplicaImp : public IReplica,
   // secretsManager_ can be nullptr. This means that encrypted configuration is not enabled
   // and there is no instance of SecretsManagerEnc available
   const std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsManager_;
-  std::unique_ptr<concord::reconfiguration::IReconfigurationHandler> stReconfigurationSM_;
+  std::unique_ptr<concord::kvbc::StReconfigurationHandler> stReconfigurationSM_;
 
 };  // namespace concord::kvbc
 

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -176,6 +176,7 @@ class ReplicaImp : public IReplica,
   // secretsManager_ can be nullptr. This means that encrypted configuration is not enabled
   // and there is no instance of SecretsManagerEnc available
   const std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsManager_;
+  std::unique_ptr<concord::reconfiguration::IReconfigurationHandler> stReconfigurationSM_;
 
 };  // namespace concord::kvbc
 

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -36,6 +36,14 @@ class StReconfigurationHandler {
   uint64_t getStoredBftSeqNum(BlockId bid);
 
   void stCallBack(uint64_t);
+
+  /*
+   * For wedge, we need to do nothing. The wedge point is being cleared only on termination.
+   * Thus, as long no one did unwedge (currently, restarting the replicas) the late replica will get the data
+   * In the reserved pages and behave accordingly.
+   * TODO: Notice that until we have the unwedge command, we cannot distinguish between restart for unwedge and restart
+   * out of a crash
+   */
   bool handle(const concord::messages::WedgeCommand&, uint64_t, uint64_t) { return true; }
   bool handle(const concord::messages::DownloadCommand&, uint64_t, uint64_t) { return true; }
 

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -12,13 +12,17 @@
 
 #pragma once
 
-#include "reconfiguration/ireconfiguration.hpp"
 #include "bftengine/IStateTransfer.hpp"
 #include "db_interfaces.h"
 #include "kvbc_key_types.hpp"
+#include "concord.cmf.hpp"
 
-namespace concord::kvbc::reconfiguration {
-class StReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
+namespace concord::kvbc {
+/*
+ * The state transfer reconfiguration handler is meant to handler reconfiguration state changes by a replica that was
+ * not responsive during the actual reconfiguration action.
+ */
+class StReconfigurationHandler {
  public:
   StReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
     st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); });
@@ -28,68 +32,17 @@ class StReconfigurationHandler : public concord::reconfiguration::IReconfigurati
   template <typename T>
   void deserializeCmfMessage(T& msg, const std::string& strval);
   template <typename T>
-  bool handlerStoredCommand(const std::string& key, concord::messages::ReconfigurationErrorMsg& error_msg);
+  bool handlerStoredCommand(const std::string& key, uint64_t current_cp_num);
   uint64_t getStoredBftSeqNum(BlockId bid);
 
   void stCallBack(uint64_t);
-  bool handle(const concord::messages::WedgeCommand&, uint64_t, concord::messages::ReconfigurationErrorMsg&) override {
-    return true;
-  }
-  bool handle(const concord::messages::WedgeStatusRequest&,
-              concord::messages::WedgeStatusResponse&,
-              concord::messages::ReconfigurationErrorMsg&) override {
-    return true;
-  }
-  bool handle(const concord::messages::GetVersionCommand&,
-              concord::messages::GetVersionResponse&,
-              concord::messages::ReconfigurationErrorMsg&) override {
-    return true;
-  }
-  bool handle(const concord::messages::DownloadCommand&,
-              uint64_t,
-              concord::messages::ReconfigurationErrorMsg&) override {
-    return true;
-  }
-  bool handle(const concord::messages::DownloadStatusCommand&,
-              concord::messages::DownloadStatus&,
-              concord::messages::ReconfigurationErrorMsg&) override {
-    return true;
-  }
-  bool handle(const concord::messages::InstallCommand& cmd,
-              uint64_t,
-              concord::messages::ReconfigurationErrorMsg&) override {
-    return true;
-  }
-  bool handle(const concord::messages::InstallStatusCommand& cmd,
-              concord::messages::InstallStatusResponse&,
-              concord::messages::ReconfigurationErrorMsg&) override {
-    return true;
-  }
-  bool handle(const concord::messages::KeyExchangeCommand&,
-              concord::messages::ReconfigurationErrorMsg&,
-              uint64_t) override {
-    return true;
-  }
-  bool handle(const concord::messages::AddRemoveCommand&,
-              concord::messages::ReconfigurationErrorMsg&,
-              uint64_t) override {
-    return true;
-  }
-  bool verifySignature(const concord::messages::ReconfigurationRequest&,
-                       concord::messages::ReconfigurationErrorMsg&) const override {
-    return true;
-  }
-  bool handle(const concord::messages::AddRemoveCommand& cmd,
-              uint64_t bftSeqNum,
-              concord::messages::ReconfigurationErrorMsg& error_msg) {
-    return handle(cmd, error_msg, bftSeqNum);
-  }
+  bool handle(const concord::messages::WedgeCommand&, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::DownloadCommand&, uint64_t, uint64_t) { return true; }
 
-  bool handle(const concord::messages::KeyExchangeCommand& cmd,
-              uint64_t bftSeqNum,
-              concord::messages::ReconfigurationErrorMsg& error_msg) {
-    return handle(cmd, error_msg, bftSeqNum);
-  }
+  bool handle(const concord::messages::InstallCommand& cmd, uint64_t, uint64_t) { return true; }
+
+  bool handle(const concord::messages::KeyExchangeCommand&, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::AddRemoveCommand&, uint64_t, uint64_t) { return true; }
   kvbc::IReader& ro_storage_;
 };
-}  // namespace concord::kvbc::reconfiguration
+}  // namespace concord::kvbc

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -18,9 +18,9 @@
 #include "kvbc_key_types.hpp"
 
 namespace concord::kvbc::reconfiguration {
-class ReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
+class StReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
  public:
-  ReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
+  StReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
     st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); });
   }
 

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -1,0 +1,65 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "reconfiguration/ireconfiguration.hpp"
+#include "bftengine/IStateTransfer.hpp"
+#include "db_interfaces.h"
+#include "kvbc_key_types.hpp"
+
+namespace concord::kvbc::reconfiguration {
+class ReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
+ public:
+  ReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
+    st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); });
+  }
+
+ private:
+  void stCallBack(uint64_t) {
+    auto res = ro_storage_.getLatestVersion(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_wedge_key});
+    if (res.has_value()) {
+      concord::messages::WedgeCommand cmd;
+    }
+  }
+  bool handle(const concord::messages::WedgeCommand&, uint64_t, concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::WedgeStatusRequest&,
+              concord::messages::WedgeStatusResponse&,
+              concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::GetVersionCommand&,
+              concord::messages::GetVersionResponse&,
+              concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::DownloadCommand&,
+              uint64_t,
+              concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::DownloadStatusCommand&,
+              concord::messages::DownloadStatus&,
+              concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::InstallCommand& cmd,
+              uint64_t,
+              concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::InstallStatusCommand& cmd,
+              concord::messages::InstallStatusResponse&,
+              concord::messages::ReconfigurationErrorMsg&) override;
+  bool handle(const concord::messages::KeyExchangeCommand&,
+              concord::messages::ReconfigurationErrorMsg&,
+              uint64_t) override;
+  bool handle(const concord::messages::AddRemoveCommand&,
+              concord::messages::ReconfigurationErrorMsg&,
+              uint64_t) override;
+  bool verifySignature(const concord::messages::ReconfigurationRequest&,
+                       concord::messages::ReconfigurationErrorMsg&) const override;
+
+  kvbc::IReader& ro_storage_;
+
+};
+}  // namespace concord::kvbc::reconfiguration

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -16,6 +16,7 @@
 #include "db_interfaces.h"
 #include "kvbc_key_types.hpp"
 #include "concord.cmf.hpp"
+#include "reconfiguration/ireconfiguration.hpp"
 
 namespace concord::kvbc {
 /*
@@ -26,6 +27,10 @@ class StReconfigurationHandler {
  public:
   StReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
     st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); });
+  }
+
+  void registerHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> handler) {
+    orig_reconf_handlers_.push_back(handler);
   }
 
  private:
@@ -52,5 +57,6 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::KeyExchangeCommand&, uint64_t, uint64_t) { return true; }
   bool handle(const concord::messages::AddRemoveCommand&, uint64_t, uint64_t) { return true; }
   kvbc::IReader& ro_storage_;
+  std::vector<std::shared_ptr<concord::reconfiguration::IReconfigurationHandler>> orig_reconf_handlers_;
 };
 }  // namespace concord::kvbc

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -25,41 +25,71 @@ class ReconfigurationHandler : public concord::reconfiguration::IReconfiguration
   }
 
  private:
-  void stCallBack(uint64_t) {
-    auto res = ro_storage_.getLatestVersion(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_wedge_key});
-    if (res.has_value()) {
-      concord::messages::WedgeCommand cmd;
-    }
+  template <typename T>
+  void deserializeCmfMessage(T& msg, const std::string& strval);
+  template <typename T>
+  bool handlerStoredCommand(const std::string& key, concord::messages::ReconfigurationErrorMsg& error_msg);
+  uint64_t getStoredBftSeqNum(BlockId bid);
+
+  void stCallBack(uint64_t);
+  bool handle(const concord::messages::WedgeCommand&, uint64_t, concord::messages::ReconfigurationErrorMsg&) override {
+    return true;
   }
-  bool handle(const concord::messages::WedgeCommand&, uint64_t, concord::messages::ReconfigurationErrorMsg&) override;
   bool handle(const concord::messages::WedgeStatusRequest&,
               concord::messages::WedgeStatusResponse&,
-              concord::messages::ReconfigurationErrorMsg&) override;
+              concord::messages::ReconfigurationErrorMsg&) override {
+    return true;
+  }
   bool handle(const concord::messages::GetVersionCommand&,
               concord::messages::GetVersionResponse&,
-              concord::messages::ReconfigurationErrorMsg&) override;
+              concord::messages::ReconfigurationErrorMsg&) override {
+    return true;
+  }
   bool handle(const concord::messages::DownloadCommand&,
               uint64_t,
-              concord::messages::ReconfigurationErrorMsg&) override;
+              concord::messages::ReconfigurationErrorMsg&) override {
+    return true;
+  }
   bool handle(const concord::messages::DownloadStatusCommand&,
               concord::messages::DownloadStatus&,
-              concord::messages::ReconfigurationErrorMsg&) override;
+              concord::messages::ReconfigurationErrorMsg&) override {
+    return true;
+  }
   bool handle(const concord::messages::InstallCommand& cmd,
               uint64_t,
-              concord::messages::ReconfigurationErrorMsg&) override;
+              concord::messages::ReconfigurationErrorMsg&) override {
+    return true;
+  }
   bool handle(const concord::messages::InstallStatusCommand& cmd,
               concord::messages::InstallStatusResponse&,
-              concord::messages::ReconfigurationErrorMsg&) override;
+              concord::messages::ReconfigurationErrorMsg&) override {
+    return true;
+  }
   bool handle(const concord::messages::KeyExchangeCommand&,
               concord::messages::ReconfigurationErrorMsg&,
-              uint64_t) override;
+              uint64_t) override {
+    return true;
+  }
   bool handle(const concord::messages::AddRemoveCommand&,
               concord::messages::ReconfigurationErrorMsg&,
-              uint64_t) override;
+              uint64_t) override {
+    return true;
+  }
   bool verifySignature(const concord::messages::ReconfigurationRequest&,
-                       concord::messages::ReconfigurationErrorMsg&) const override;
+                       concord::messages::ReconfigurationErrorMsg&) const override {
+    return true;
+  }
+  bool handle(const concord::messages::AddRemoveCommand& cmd,
+              uint64_t bftSeqNum,
+              concord::messages::ReconfigurationErrorMsg& error_msg) {
+    return handle(cmd, error_msg, bftSeqNum);
+  }
 
+  bool handle(const concord::messages::KeyExchangeCommand& cmd,
+              uint64_t bftSeqNum,
+              concord::messages::ReconfigurationErrorMsg& error_msg) {
+    return handle(cmd, error_msg, bftSeqNum);
+  }
   kvbc::IReader& ro_storage_;
-
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -265,8 +265,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
-  stReconfigurationSM_ =
-      std::make_unique<concord::kvbc::reconfiguration::StReconfigurationHandler>(*m_stateTransfer, *this);
+  stReconfigurationSM_ = std::make_unique<concord::kvbc::StReconfigurationHandler>(*m_stateTransfer, *this);
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -69,6 +69,7 @@ Status ReplicaImp::start() {
 
 void ReplicaImp::createReplicaAndSyncState() {
   auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler);
+  stReconfigurationSM_->registerHandler(m_cmdHandler->getReconfigurationHandler());
   requestHandler->setPruningHandler(std::shared_ptr<concord::reconfiguration::IPruningHandler>(
       new concord::kvbc::pruning::PruningHandler(*this, *this, *this, *m_stateTransfer, true)));
   requestHandler->setReconfigurationHandler(

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -26,6 +26,7 @@
 #include "pruning_handler.hpp"
 #include "IRequestHandler.hpp"
 #include "reconfiguration_add_block_handler.hpp"
+#include "st_reconfiguraion_sm.hpp"
 
 using bft::communication::ICommunication;
 using bftEngine::bcst::StateTransferDigest;
@@ -264,6 +265,8 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
+  stReconfigurationSM_ =
+      std::make_unique<concord::kvbc::reconfiguration::StReconfigurationHandler>(*m_stateTransfer, *this);
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -265,7 +265,9 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
-  stReconfigurationSM_ = std::make_unique<concord::kvbc::StReconfigurationHandler>(*m_stateTransfer, *this);
+  if (!replicaConfig.isReadOnly) {
+    stReconfigurationSM_ = std::make_unique<concord::kvbc::StReconfigurationHandler>(*m_stateTransfer, *this);
+  }
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -16,12 +16,12 @@
 
 namespace concord::kvbc::reconfiguration {
 template <typename T>
-void ReconfigurationHandler::deserializeCmfMessage(T &msg, const std::string &strval) {
+void StReconfigurationHandler::deserializeCmfMessage(T &msg, const std::string &strval) {
   std::vector<uint8_t> bytesval(strval.begin(), strval.end());
   concord::messages::deserialize(bytesval, msg);
 }
 
-uint64_t ReconfigurationHandler::getStoredBftSeqNum(BlockId bid) {
+uint64_t StReconfigurationHandler::getStoredBftSeqNum(BlockId bid) {
   auto value = ro_storage_.get(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::bft_seq_num_key}, bid);
   auto sequenceNum = uint64_t{0};
   if (value) {
@@ -32,7 +32,7 @@ uint64_t ReconfigurationHandler::getStoredBftSeqNum(BlockId bid) {
   return sequenceNum;
 }
 
-void ReconfigurationHandler::stCallBack(uint64_t) {
+void StReconfigurationHandler::stCallBack(uint64_t) {
   concord::messages::ReconfigurationErrorMsg error_msg;
   // Handle reconfiguration state changes if exist
   handlerStoredCommand<concord::messages::WedgeCommand>(std::string{kvbc::keyTypes::reconfiguration_wedge_key},
@@ -47,8 +47,8 @@ void ReconfigurationHandler::stCallBack(uint64_t) {
                                                             error_msg);
 }
 template <typename T>
-bool ReconfigurationHandler::handlerStoredCommand(const std::string &key,
-                                                  concord::messages::ReconfigurationErrorMsg &error_msg) {
+bool StReconfigurationHandler::handlerStoredCommand(const std::string &key,
+                                                    concord::messages::ReconfigurationErrorMsg &error_msg) {
   auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, key);
   if (res.has_value()) {
     auto blockid =

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -1,0 +1,68 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "st_reconfiguraion_sm.hpp"
+#include "hex_tools.h"
+#include "endianness.hpp"
+
+namespace concord::kvbc::reconfiguration {
+template <typename T>
+void ReconfigurationHandler::deserializeCmfMessage(T &msg, const std::string &strval) {
+  std::vector<uint8_t> bytesval(strval.begin(), strval.end());
+  concord::messages::deserialize(bytesval, msg);
+}
+
+uint64_t ReconfigurationHandler::getStoredBftSeqNum(BlockId bid) {
+  auto value = ro_storage_.get(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::bft_seq_num_key}, bid);
+  auto sequenceNum = uint64_t{0};
+  if (value) {
+    const auto &data = std::get<categorization::VersionedValue>(*value).data;
+    ConcordAssertEQ(data.size(), sizeof(uint64_t));
+    sequenceNum = concordUtils::fromBigEndianBuffer<uint64_t>(data.data());
+  }
+  return sequenceNum;
+}
+
+void ReconfigurationHandler::stCallBack(uint64_t) {
+  concord::messages::ReconfigurationErrorMsg error_msg;
+  // Handle reconfiguration state changes if exist
+  handlerStoredCommand<concord::messages::WedgeCommand>(std::string{kvbc::keyTypes::reconfiguration_wedge_key},
+                                                        error_msg);
+  handlerStoredCommand<concord::messages::DownloadCommand>(std::string{kvbc::keyTypes::reconfiguration_download_key},
+                                                           error_msg);
+  handlerStoredCommand<concord::messages::InstallCommand>(std::string{kvbc::keyTypes::reconfiguration_install_key},
+                                                          error_msg);
+  handlerStoredCommand<concord::messages::KeyExchangeCommand>(std::string{kvbc::keyTypes::reconfiguration_key_exchange},
+                                                              error_msg);
+  handlerStoredCommand<concord::messages::AddRemoveCommand>(std::string{kvbc::keyTypes::reconfiguration_add_remove},
+                                                            error_msg);
+}
+template <typename T>
+bool ReconfigurationHandler::handlerStoredCommand(const std::string &key,
+                                                  concord::messages::ReconfigurationErrorMsg &error_msg) {
+  auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, key);
+  if (res.has_value()) {
+    auto blockid =
+        ro_storage_
+            .getLatestVersion(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_wedge_key})
+            .value()
+            .version;
+    auto seqNum = getStoredBftSeqNum(blockid);
+    auto strval = std::visit([](auto &&arg) { return arg.data; }, *res);
+    T cmd;
+    deserializeCmfMessage(cmd, strval);
+    return handle(cmd, seqNum, error_msg);
+  }
+  return false;
+}
+
+}  // namespace concord::kvbc::reconfiguration

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -5,6 +5,7 @@ Msg WedgeCommand 3 {
 
 Msg WedgeStatusRequest 5 {
 	uint64 sender
+	bool fullWedge
 }
 
 Msg WedgeStatusResponse 6 {

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -33,7 +33,11 @@ bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
 bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
                                     WedgeStatusResponse& response,
                                     concord::messages::ReconfigurationErrorMsg&) {
-  response.stopped = bftEngine::IControlHandler::instance()->isOnStableCheckpoint();
+  if (req.fullWedge) {
+    response.stopped = bftEngine::IControlHandler::instance()->isOnNOutOfNCheckpoint();
+  } else {
+    response.stopped = bftEngine::IControlHandler::instance()->isOnStableCheckpoint();
+  }
   return true;
 }
 

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -33,7 +33,7 @@ bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
 bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
                                     WedgeStatusResponse& response,
                                     concord::messages::ReconfigurationErrorMsg&) {
-  response.stopped = bftEngine::IControlHandler::instance()->isOnNOutOfNCheckpoint();
+  response.stopped = bftEngine::IControlHandler::instance()->isOnStableCheckpoint();
   return true;
 }
 

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -149,6 +149,77 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    async def test_wedge_command_with_f_failures(self, bft_network):
+        """
+            This test checks that even a replica that received the super stable checkpoint via the state transfer mechanism
+            is able to stop at the super stable checkpoint.
+            The test does the following:
+            1. Start all replicas but 2
+            2. A client sends a wedge command
+            3. Validate that all started replicas have reached the wedge point
+            4. Restart the live replicas and validate the system is able to make progress
+            5. Start the late replica
+            6. Validate that the late replicas completed the state transfer
+            7. Join the late replicas to the quorum and make sure the system is able to make progress
+        """
+        initial_prim = 0
+        late_replicas = bft_network.random_set_of_replicas(2, {initial_prim})
+        on_time_replicas = bft_network.all_replicas(without=late_replicas)
+        bft_network.start_replicas(on_time_replicas)
+
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        await skvbc.wait_for_liveness()
+
+        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
+
+        client = bft_network.random_client()
+        # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
+        client.config._replace(req_timeout_milli=10000)
+        with log.start_action(action_type="send_wedge_cmd",
+                              checkpoint_before=checkpoint_before,
+                              late_replicas=list(late_replicas)):
+            op = operator.Operator(bft_network.config, client,  bft_network.builddir)
+            await op.wedge()
+
+        with trio.fail_after(seconds=30):
+            done = False
+            while done is False:
+                await op.wedge_status(quorum=bft_client.MofNQuorum(on_time_replicas, len(on_time_replicas)))
+                rsi_rep = client.get_rsi_replies()
+                done = True
+                for r in rsi_rep.values():
+                    res = cmf_msgs.ReconfigurationResponse.deserialize(r)
+                    status = res[0].response.stopped
+                    if status is False:
+                        done = False
+                        break
+
+
+        # Make sure the system is able to make progress
+        bft_network.stop_replicas(on_time_replicas)
+        bft_network.start_replicas(on_time_replicas)
+        for i in range(100):
+            await skvbc.write_known_kv()
+
+        # Start late replicas and wait for state transfer to stop
+        bft_network.start_replicas(late_replicas)
+
+        await bft_network.wait_for_state_transfer_to_start()
+        for r in late_replicas:
+            await bft_network.wait_for_state_transfer_to_stop(initial_prim,
+                                                              r,
+                                                              stop_on_stable_seq_num=True)
+
+        replicas_to_stop = bft_network.random_set_of_replicas(2, late_replicas | {initial_prim})
+
+        # Make sure the system is able to make progress
+        for i in range(100):
+            await skvbc.write_known_kv()
+
+
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command_and_specific_replica_info(self, bft_network):
         """
              Sends a wedge command and check that the system stops from processing new requests.

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -184,7 +184,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         with trio.fail_after(seconds=30):
             done = False
             while done is False:
-                await op.wedge_status(quorum=bft_client.MofNQuorum(on_time_replicas, len(on_time_replicas)))
+                await op.wedge_status(quorum=bft_client.MofNQuorum(on_time_replicas, len(on_time_replicas)), fullWedge=False)
                 rsi_rep = client.get_rsi_replies()
                 done = True
                 for r in rsi_rep.values():

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -142,7 +142,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         for r in late_replicas:
             await bft_network.wait_for_state_transfer_to_stop(initial_prim,
                                                               r,
-                                                              stop_on_stable_seq_num=True)
+                                                              stop_on_stable_seq_num=False)
         await self.verify_replicas_are_in_wedged_checkpoint(bft_network, checkpoint_before, range(bft_network.config.n))
 
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -101,10 +101,11 @@ class Operator:
         reconf_msg = self._construct_reconfiguration_wedge_coammand()
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
 
-    async def wedge_status(self):
+    async def wedge_status(self, quorum=None):
+        if quorum is None:
+            quorum = bft_client.MofNQuorum.All(self.client.config, [r for r in range(self.config.n)])
         msg = self._construct_reconfiguration_wedge_status()
-        return await self.client.read(msg.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config, [r for r in range(
-            self.config.n)]), reconfiguration=True)
+        return await self.client.read(msg.serialize(), m_of_n_quorum=quorum, reconfiguration=True)
 
     async def latest_pruneable_block(self):
         reconf_msg = self._construct_reconfiguration_latest_prunebale_block_coammand()

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -55,9 +55,10 @@ class Operator:
         reconf_msg.signature = self._sign_reconf_msg(reconf_msg)
         return reconf_msg
 
-    def _construct_reconfiguration_wedge_status(self):
+    def _construct_reconfiguration_wedge_status(self, fullWedge=True):
         wedge_status_cmd = cmf_msgs.WedgeStatusRequest()
         wedge_status_cmd.sender = 1000
+        wedge_status_cmd.fullWedge = fullWedge
         reconf_msg = cmf_msgs.ReconfigurationRequest()
         reconf_msg.command = wedge_status_cmd
         reconf_msg.additional_data = bytes()
@@ -101,10 +102,10 @@ class Operator:
         reconf_msg = self._construct_reconfiguration_wedge_coammand()
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
 
-    async def wedge_status(self, quorum=None):
+    async def wedge_status(self, quorum=None, fullWedge=True):
         if quorum is None:
             quorum = bft_client.MofNQuorum.All(self.client.config, [r for r in range(self.config.n)])
-        msg = self._construct_reconfiguration_wedge_status()
+        msg = self._construct_reconfiguration_wedge_status(fullWedge)
         return await self.client.read(msg.serialize(), m_of_n_quorum=quorum, reconfiguration=True)
 
     async def latest_pruneable_block(self):


### PR DESCRIPTION
In this PR we present a framework for supporting n-f reconfiguration actions.
Until now, the reconfiguration engine has worked under the assumption that we have a n/n quorum. However, in many cases, this assumption does not hold.
To support n-f reconfiguration actions we add a dedicated reconfiguration SM that implements a callback for state transfer.
Once state transfer is completed, the call back is being called and we can change the reconfiguration state accordingly.
Notice, that the above is supported by the fact that we write every reconfiguration command to the blockchain.

In addition, in this PR we present an n-f wedge implementation.
To implement n-f wedge, we did the following:
1. A replica reports on a wedge on a stable checkpoint already (instead of n/n checkpoint)
2. In addition, once a replica is starting, it unwedge if necessary (this is a temporary solution until we implement a real unwedge request)
3. Thus, a replica that is in ST has two options: (a) it done with ST before the replicas have restarted. In this case, once ST is done, the data is in the reserved pages and the replica simply behaves like all other replicas. (b) The replica completed the ST after the other replicas have unwedged, in this case, we need to do nothing and simply continue with the quorum.

To validate the n-f wedge, we added an Apollo test for this case.
Note that it is still possible to wait for n/n wedge.