### PR TITLE
Transaction signing integration fixes

### DIFF
--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -64,7 +64,10 @@ SigManager* SigManager::initImpl(ReplicaId myId,
       ConcordAssert(!p.first.empty());
       publickeys.push_back(make_pair(p.first, clientsKeysFormat));
       for (const auto e : p.second) {
-        ConcordAssert((e >= lowBound) && (e <= highBound));
+        if ((e < lowBound) || (e > highBound)) {
+          LOG_FATAL(GL, "Invalid participant id " << KVLOG(e, lowBound, highBound));
+          std::terminate();
+        }
         publicKeysMapping.insert({e, i});
       }
       ++i;

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -115,6 +115,10 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
     // 2) request is empty. empty requests are sent from pre-processor in some cases - skip signature
     if (emptyReq) {
       expectedSigLen = 0;
+    } else if ((header->flags & RECONFIG_FLAG) != 0) {
+      // This message arrived from operator - no need at this stage to verifiy the request, since operator
+      // verifies it's own signatures on requests in the reconfiguration handler
+      doSigVerify = false;
     } else {
       expectedSigLen = sigManager->getSigLength(clientId);
       if (0 == expectedSigLen) {

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -453,7 +453,7 @@ class BftTestNetwork:
         """ Generates num_participants number of key pairs """
         script_path = "/concord-bft/scripts/linux/create_concord_clients_transaction_signing_keys.sh"
         args = [script_path, "-n", str(self.num_participants), "-o", keys_path]
-        subprocess.run(args, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(args, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     def create_principals_mapping(self):
         """


### PR DESCRIPTION
1. ClientRequestMsg: do not verify reconfiguration (operatore) requests
2. SigManager: transform assert explciit error logging
3. bft.py: redirect errs to devnull when gen transaction signing keys