### PR TITLE
Reserved Pages convenience improvements

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -14,7 +14,7 @@
 #pragma once
 #include <optional>
 #include "IStateTransfer.hpp"
-#include "ReservedPages.hpp"
+#include "ReservedPagesClient.hpp"
 #include "Serializable.h"
 #include "SysConsts.hpp"
 
@@ -48,8 +48,8 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
                                                   ControlHandlerStateManagerReservedPagesIndex,
                                                   ControlHandlerStateManagerNumOfReservedPages> {
  public:
-  static ControlStateManager& instance(IReservedPages* rp = nullptr) {
-    static ControlStateManager instance_(rp);
+  static ControlStateManager& instance() {
+    static ControlStateManager instance_;
     return instance_;
   }
   void setStopAtNextCheckpoint(int64_t currentSeqNum);
@@ -67,12 +67,11 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   void enable() { enabled_ = true; }
 
  private:
-  ControlStateManager(IReservedPages* reserved_pages);
+  ControlStateManager() { scratchPage_.resize(sizeOfReservedPage()); }
   ControlStateManager& operator=(const ControlStateManager&) = delete;
   ControlStateManager(const ControlStateManager&) = delete;
   ~ControlStateManager() = default;
 
-  IReservedPages* reserved_pages_;
   std::string scratchPage_;
   bool enabled_ = true;
   ControlStatePage page_;

--- a/bftengine/include/bftengine/IReservedPages.hpp
+++ b/bftengine/include/bftengine/IReservedPages.hpp
@@ -13,6 +13,7 @@
 #pragma once
 #include <cstdint>
 
+namespace bftEngine {
 class IReservedPages {
  public:
   virtual ~IReservedPages(){};
@@ -22,3 +23,4 @@ class IReservedPages {
   virtual void saveReservedPage(uint32_t reservedPageId, uint32_t copyLength, const char *inReservedPage) = 0;
   virtual void zeroReservedPage(uint32_t reservedPageId) = 0;
 };
+}  // namespace bftEngine

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -27,6 +27,7 @@
 #include "STDigest.hpp"
 #include "InMemoryDataStore.hpp"
 #include "json_output.hpp"
+#include "ReservedPagesClient.hpp"
 
 #include "DBDataStore.hpp"
 #include "storage/db_interface.h"
@@ -75,7 +76,9 @@ IStateTransfer *create(const Config &config,
     ds = new impl::InMemoryDataStore(config.sizeOfReservedPage);
   else
     ds = new impl::DBDataStore(dbc, config.sizeOfReservedPage, stKeyManipulator, config.enableReservedPages);
-  return new impl::BCStateTran(config, stateApi, ds);
+  auto st = new impl::BCStateTran(config, stateApi, ds);
+  ReservedPagesClientBase::setReservedPages(st);
+  return st;
 }
 
 IStateTransfer *create(const Config &config,

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -22,9 +22,12 @@
 #include "PreProcessor.hpp"
 #include "MsgReceiver.hpp"
 #include "RequestHandler.h"
+#include "ReservedPagesClient.hpp"
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+
+bftEngine::IReservedPages *bftEngine::ReservedPagesClientBase::res_pages_ = nullptr;
 
 namespace bftEngine::impl {
 

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -13,7 +13,7 @@
 
 #include "PrimitiveTypes.hpp"
 #include "TimeUtils.hpp"
-#include "ReservedPages.hpp"
+#include "bftengine/ReservedPagesClient.hpp"
 #include "Metrics.hpp"
 #include <map>
 #include <set>
@@ -31,8 +31,6 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
  public:
   ClientsManager(concordMetrics::Component& metrics, std::set<NodeIdType>& clientsSet);
   ~ClientsManager();
-
-  void init(IStateTransfer* stateTransfer);
 
   uint32_t numberOfRequiredReservedPages() const;
 
@@ -88,8 +86,6 @@ class ClientsManager : public ResPagesClient<ClientsManager, 0> {
  protected:
   const ReplicaId myId_;
   const uint32_t sizeOfReservedPage_;
-
-  IStateTransfer* stateTransfer_ = nullptr;
 
   char* scratchPage_ = nullptr;
 

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -32,13 +32,13 @@ void ControlStateManager::setStopAtNextCheckpoint(int64_t currentSeqNum) {
   page_.seq_num_to_stop_at_ = seq_num_to_stop_at;
   concord::serialize::Serializable::serialize(outStream, page_);
   auto data = outStream.str();
-  reserved_pages_->saveReservedPage(resPageOffset(), data.size(), data.data());
+  saveReservedPage(0, data.size(), data.data());
 }
 
 std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
   if (!enabled_) return {};
   if (page_.seq_num_to_stop_at_ != 0) return page_.seq_num_to_stop_at_;
-  if (!reserved_pages_->loadReservedPage(resPageOffset(), reserved_pages_->sizeOfReservedPage(), scratchPage_.data())) {
+  if (!loadReservedPage(0, sizeOfReservedPage(), scratchPage_.data())) {
     return {};
   }
   std::istringstream inStream;
@@ -52,10 +52,6 @@ std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
   return page_.seq_num_to_stop_at_;
 }
 
-ControlStateManager::ControlStateManager(IReservedPages* reserved_pages) : reserved_pages_{reserved_pages} {
-  scratchPage_.resize(reserved_pages_->sizeOfReservedPage());
-}
-
 void ControlStateManager::setEraseMetadataFlag(int64_t currentSeqNum) {
   if (!enabled_) return;
   uint64_t seq_num_to_erase_at = (currentSeqNum + 2 * checkpointWindowSize);
@@ -64,13 +60,13 @@ void ControlStateManager::setEraseMetadataFlag(int64_t currentSeqNum) {
   page_.erase_metadata_at_seq_num_ = seq_num_to_erase_at;
   concord::serialize::Serializable::serialize(outStream, page_);
   auto data = outStream.str();
-  reserved_pages_->saveReservedPage(resPageOffset(), data.size(), data.data());
+  saveReservedPage(0, data.size(), data.data());
 }
 
 std::optional<int64_t> ControlStateManager::getEraseMetadataFlag() {
   if (!enabled_) return {};
   if (page_.erase_metadata_at_seq_num_ != 0) return page_.erase_metadata_at_seq_num_;
-  if (!reserved_pages_->loadReservedPage(resPageOffset(), reserved_pages_->sizeOfReservedPage(), scratchPage_.data())) {
+  if (!loadReservedPage(0, sizeOfReservedPage(), scratchPage_.data())) {
     return {};
   }
   std::istringstream inStream;
@@ -89,7 +85,7 @@ void ControlStateManager::clearCheckpointToStopAt() {
   std::ostringstream outStream;
   concord::serialize::Serializable::serialize(outStream, tmpPage);
   auto data = outStream.str();
-  reserved_pages_->saveReservedPage(resPageOffset(), data.size(), data.data());
+  saveReservedPage(0, data.size(), data.data());
 }
 
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -27,7 +27,7 @@ KeyExchangeManager::KeyExchangeManager(InitData* id)
     : repID_(id->id),
       clusterSize_(id->clusterSize),
       client_(id->cl),
-      keyStore_{id->clusterSize, id->reservedPages, id->sizeOfReservedPage},
+      keyStore_{id->clusterSize, id->sizeOfReservedPage},
       multiSigKeyHdlr_(id->kg),
       keysView_(id->sec, id->backupSec, id->clusterSize),
       keyExchangeOnStart_(id->keyExchangeOnStart),

--- a/bftengine/src/bftengine/KeyStore.cpp
+++ b/bftengine/src/bftengine/KeyStore.cpp
@@ -102,10 +102,8 @@ ReplicaKeyStore::ReplicaKey::ReplicaKey(const KeyExchangeMsg& other, const uint6
 
 //////////////////////CLUSTER KEY STORE////////////////////////
 
-ClusterKeyStore::ClusterKeyStore(const uint32_t& clusterSize,
-                                 IReservedPages* reservedPages,
-                                 const uint32_t& sizeOfReservedPage)
-    : clusterKeys_(clusterSize), reservedPages_(reservedPages), buffer_(sizeOfReservedPage, 0) {
+ClusterKeyStore::ClusterKeyStore(const uint32_t& clusterSize, const uint32_t& sizeOfReservedPage)
+    : clusterKeys_(clusterSize), buffer_(sizeOfReservedPage, 0) {
   ConcordAssertGT(sizeOfReservedPage, 0);
   loadAllReplicasKeyStoresFromReservedPages();
 }
@@ -142,7 +140,7 @@ std::optional<ReplicaKeyStore> ClusterKeyStore::loadReplicaKeyStoreFromResereved
   // being 0 and a failure to load. However, the check is still needed as a failure to load might leave the buffer_
   // variable in a wrong state. Additionally, we need to be sure that returning an empty optional is the right thing to
   // do.
-  if (!reservedPages_->loadReservedPage(resPageOffset() + repID, buffer_.size(), buffer_.data())) {
+  if (!loadReservedPage(repID, buffer_.size(), buffer_.data())) {
     LOG_INFO(KEY_EX_LOG, "Couldn't load replica key store [" << repID << "] from reserved pages, first start?");
     return {};
   }
@@ -164,7 +162,7 @@ void ClusterKeyStore::saveReplicaKeyStoreToReserevedPages(const uint16_t& repID)
   std::stringstream ss;
   concord::serialize::Serializable::serialize(ss, clusterKeys_.at(repID));
   auto rkStr = ss.str();
-  reservedPages_->saveReservedPage(resPageOffset() + repID, rkStr.size(), rkStr.c_str());
+  saveReservedPage(repID, rkStr.size(), rkStr.c_str());
 }
 
 bool ClusterKeyStore::push(const KeyExchangeMsg& kem, const uint64_t& sn) {

--- a/bftengine/src/bftengine/KeyStore.h
+++ b/bftengine/src/bftengine/KeyStore.h
@@ -12,8 +12,7 @@
 #pragma once
 #include "Serializable.h"
 #include "deque"
-#include "IReservedPages.hpp"
-#include "ReservedPages.hpp"
+#include "bftengine/ReservedPagesClient.hpp"
 #include "KeyExchangeMsg.hpp"
 namespace bftEngine::impl {
 
@@ -64,7 +63,7 @@ class ReplicaKeyStore : public concord::serialize::SerializableFactory<ReplicaKe
 // Responsible on reserved pages operations.
 class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, 2> {
  public:
-  ClusterKeyStore(const uint32_t& clusterSize, IReservedPages* reservedPages, const uint32_t& sizeOfReservedPage);
+  ClusterKeyStore(const uint32_t& clusterSize, const uint32_t& sizeOfReservedPage);
   bool push(const KeyExchangeMsg& kem, const uint64_t& sn);
   // iterate on all replcias
   std::vector<uint16_t> rotate(const uint64_t& chknum);
@@ -81,7 +80,6 @@ class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, 2> {
 
  private:
   std::vector<ReplicaKeyStore> clusterKeys_;
-  IReservedPages* reservedPages_;
   std::string buffer_;
 };
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -10,6 +10,7 @@
 // file.
 
 #include "ReplicaForStateTransfer.hpp"
+
 #include "Timers.hpp"
 #include "assertUtils.hpp"
 #include "Logger.hpp"
@@ -18,7 +19,7 @@
 #include "MsgsCommunicator.hpp"
 #include "ReplicasInfo.hpp"
 #include "messages/StateTransferMsg.hpp"
-#include "ReservedPages.hpp"
+#include "ReservedPagesClient.hpp"
 
 namespace bftEngine::impl {
 using namespace std::chrono_literals;
@@ -44,7 +45,7 @@ ReplicaForStateTransfer::ReplicaForStateTransfer(const ReplicaConfig &config,
 void ReplicaForStateTransfer::start() {
   if (firstTime_ || !config_.debugPersistentStorageEnabled)
     stateTransfer->init(kWorkWindowSize / checkpointWindowSize + 1,
-                        ReservedPages::totalNumberOfPages(),
+                        ReservedPagesClientBase::totalNumberOfPages(),
                         ReplicaConfig::instance().getsizeOfReservedPage());
   const std::chrono::milliseconds defaultTimeout = 5s;
   stateTranTimer_ =

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3682,8 +3682,6 @@ ReplicaImp::ReplicaImp(bool firstTime,
       ClientsManager::reservedPagesPerClient(config.getsizeOfReservedPage(), config.maxReplyMessageSize));
   ClusterKeyStore::setNumResPages(config.numReplicas);
 
-  clientsManager->init(stateTransfer.get());
-
   // autoPrimaryRotationEnabled implies viewChangeProtocolEnabled
   // Note: "p=>q" is equivalent to "not p or q"
   ConcordAssertOR(!autoPrimaryRotationEnabled, viewChangeProtocolEnabled);

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -63,6 +63,7 @@ struct ReservedPagesMock : public IReservedPages {
       if (!clean) continue;
       memset(c, 0, size);
     }
+    ReservedPagesClientBase::setReservedPages(this);
   }
   ~ReservedPagesMock() {
     for (auto c : resPages) {
@@ -262,8 +263,8 @@ TEST(ReplicaKeyStore, rotate) {
 
 TEST(ClusterKeyStore, push) {
   uint32_t clustersize{7};
-  ReservedPagesMock rpm(ReservedPages::totalNumberOfPages() + clustersize, true);
-  ClusterKeyStore cks{7, &rpm, 4094};
+  ReservedPagesMock rpm(ReservedPagesClientBase::totalNumberOfPages() + clustersize, true);
+  ClusterKeyStore cks{7, 4094};
   {
     KeyExchangeMsg kem;
     kem.key = "a";
@@ -306,8 +307,8 @@ TEST(ClusterKeyStore, push) {
 
 TEST(ClusterKeyStore, rotate) {
   uint32_t clustersize{7};
-  ReservedPagesMock rpm(ReservedPages::totalNumberOfPages() + clustersize, true);
-  ClusterKeyStore cks{7, &rpm, 4094};
+  ReservedPagesMock rpm(ReservedPagesClientBase::totalNumberOfPages() + clustersize, true);
+  ClusterKeyStore cks{7, 4094};
 
   KeyExchangeMsg kem;
   kem.key = "a";
@@ -364,7 +365,7 @@ TEST(KeyExchangeManager, initialKeyExchange) {
   DummyKeyGen dkg{clusterSize};
   dkg.prv = "private";
   dkg.pub = "public";
-  ReservedPagesMock rpm(ReservedPages::totalNumberOfPages() + clusterSize, true);
+  ReservedPagesMock rpm(ReservedPagesClientBase::totalNumberOfPages() + clusterSize, true);
   concordUtil::Timers timers;
 
   KeyExchangeManager::InitData id{};
@@ -425,7 +426,7 @@ TEST(KeyExchangeManager, endToEnd) {
   DummyKeyGen dkg{clustersize};
   dkg.prv = "private";
   dkg.pub = "public";
-  ReservedPagesMock rpm(ReservedPages::totalNumberOfPages() + clustersize, true);
+  ReservedPagesMock rpm(ReservedPagesClientBase::totalNumberOfPages() + clustersize, true);
   concordUtil::Timers timers;
 
   KeyExchangeManager::InitData id{};
@@ -555,8 +556,8 @@ TEST(KeyExchangeManager, endToEnd) {
 
 TEST(ClusterKeyStore, dirty_first_load) {
   uint32_t clustersize{4};
-  ReservedPagesMock rpm(ReservedPages::totalNumberOfPages() + clustersize, false);
-  ClusterKeyStore cks{4, &rpm, 4094};
+  ReservedPagesMock rpm(ReservedPagesClientBase::totalNumberOfPages() + clustersize, false);
+  ClusterKeyStore cks{4, 4094};
 
   for (int i = 0; i < 4; i++) {
     ASSERT_EQ(cks.numKeys(i), 0);
@@ -565,8 +566,8 @@ TEST(ClusterKeyStore, dirty_first_load) {
 
 TEST(ClusterKeyStore, dirty_first_load_save_keys_and_reload) {
   uint32_t clustersize{4};
-  ReservedPagesMock rpm(ReservedPages::totalNumberOfPages() + clustersize, false);
-  ClusterKeyStore cks{4, &rpm, 4094};
+  ReservedPagesMock rpm(ReservedPagesClientBase::totalNumberOfPages() + clustersize, false);
+  ClusterKeyStore cks{4, 4094};
 
   KeyExchangeMsg kem;
   kem.key = "a";
@@ -598,7 +599,7 @@ TEST(ClusterKeyStore, dirty_first_load_save_keys_and_reload) {
   kem5.repID = 0;
   cks.push(kem5, 2);
 
-  ClusterKeyStore reloadCks{4, &rpm, 4094};
+  ClusterKeyStore reloadCks{4, 4094};
   for (int i = 0; i < 4; i++) {
     if (i == 0) {
       ASSERT_EQ(reloadCks.numKeys(i), 2);
@@ -610,8 +611,8 @@ TEST(ClusterKeyStore, dirty_first_load_save_keys_and_reload) {
 
 TEST(ClusterKeyStore, clean_first_load_save_keys_rotate_and_reload) {
   uint32_t clustersize = 4;
-  ReservedPagesMock rpm(ReservedPages::totalNumberOfPages() + clustersize, false);
-  ClusterKeyStore cks{4, &rpm, 4094};
+  ReservedPagesMock rpm(ReservedPagesClientBase::totalNumberOfPages() + clustersize, false);
+  ClusterKeyStore cks{4, 4094};
 
   KeyExchangeMsg kem;
   kem.key = "a";
@@ -651,7 +652,7 @@ TEST(ClusterKeyStore, clean_first_load_save_keys_rotate_and_reload) {
 
   cks.rotate(2);
 
-  ClusterKeyStore reloadCks{4, &rpm, 4094};
+  ClusterKeyStore reloadCks{4, 4094};
   ASSERT_EQ(reloadCks.exchangedReplicas.size(), 4);
   for (int i = 0; i < 4; i++) {
     if (i == 0) {

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -264,7 +264,6 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
-  bftEngine::ControlStateManager::instance(m_stateTransfer);
 }
 
 ReplicaImp::~ReplicaImp() {

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -935,7 +935,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
 
 int main(int argc, char **argv) {
   setUpKeysConfiguration_4();
-  bftEngine::ControlStateManager::ControlStateManager::instance(&state_transfer);
+  bftEngine::ControlStateManager::ControlStateManager::setReservedPages(&state_transfer);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -185,7 +185,8 @@ class SimpleTestReplica {
 
   void start() {
     replica->start();
-    ControlStateManager::instance(inMemoryST_).disable();
+    ControlStateManager::setReservedPages(inMemoryST_);
+    ControlStateManager::instance().disable();
   }
 
   void stop() {


### PR DESCRIPTION
- Initialize ReservedPagesCLient only once instead of initializing every client with ReservedPages;
- ReservedPagesClient to implemet IReservedPages;
- Make res pages offset implicit making each RP client to use relative page id instead of explicitly adding its resPagesOffset()