### PR TITLE
Clear output in versioned cat multiGetLatestVersion

### DIFF
--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -377,6 +377,7 @@ void VersionedKeyValueCategory::multiGetLatestVersion(const std::vector<std::str
   auto slices = std::vector<::rocksdb::PinnableSlice>{};
   auto statuses = std::vector<::rocksdb::Status>{};
   db_->multiGet(latest_ver_cf_, keys, slices, statuses);
+  versions.clear();
   for (auto i = 0ull; i < slices.size(); ++i) {
     const auto &status = statuses[i];
     const auto &slice = slices[i];

--- a/kvbc/test/categorization/block_merkle_category_unit_test.cpp
+++ b/kvbc/test/categorization/block_merkle_category_unit_test.cpp
@@ -249,17 +249,31 @@ TEST_F(block_merkle_category, multiget) {
   // Get latest versions
   auto out_versions = std::vector<std::optional<TaggedVersion>>{};
   cat.multiGetLatestVersion(keys, out_versions);
+  ASSERT_EQ(keys.size(), out_versions.size());
   ASSERT_EQ(1, out_versions[0]->encode());
   ASSERT_EQ(1, out_versions[1].has_value());
   ASSERT_EQ(1, out_versions[2]->version);
   ASSERT_EQ(false, out_versions[3].has_value());
 
+  // Make sure subsequent calls with the same vector work
+  cat.multiGetLatestVersion({key2}, out_versions);
+  ASSERT_EQ(1, out_versions.size());
+  ASSERT_EQ(1, out_versions[0].has_value());
+  ASSERT_EQ(1, out_versions[0]->encode());
+  ASSERT_EQ(1, out_versions[0]->version);
+
   // Get latest values
   cat.multiGetLatest(keys, values);
+  ASSERT_EQ(keys.size(), values.size());
   ASSERT_EQ((MerkleValue{{block_id, val1}}), asMerkle(*values[0]));
   ASSERT_EQ((MerkleValue{{block_id, val2}}), asMerkle(*values[1]));
   ASSERT_EQ((MerkleValue{{block_id, val3}}), asMerkle(*values[2]));
   ASSERT_EQ(false, values[3].has_value());
+
+  // Make sure subsequent calls with the same vector work
+  cat.multiGetLatest({key2}, values);
+  ASSERT_EQ(1, values.size());
+  ASSERT_EQ((MerkleValue{{block_id, val2}}), asMerkle(*values[0]));
 }
 
 TEST_F(block_merkle_category, overwrite) {

--- a/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
@@ -626,12 +626,22 @@ TEST_F(immutable_kv_category, multi_get_latest) {
     add(2, std::move(update));
   }
 
-  const auto keys = std::vector<std::string>{"k1", "k2", "k3"};
   auto values = std::vector<std::optional<categorization::Value>>{};
-  cat.multiGetLatest(keys, values);
-  const auto expected = std::vector<std::optional<categorization::Value>>{
-      ImmutableValue{{1, "v1"}}, ImmutableValue{{2, "v2"}}, std::nullopt};
-  ASSERT_EQ(values, expected);
+  {
+    const auto keys = std::vector<std::string>{"k1", "k2", "k3"};
+    cat.multiGetLatest(keys, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{
+        ImmutableValue{{1, "v1"}}, ImmutableValue{{2, "v2"}}, std::nullopt};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Make sure that subsequent calls with the same vector work.
+  {
+    const auto keys = std::vector<std::string>{"k2"};
+    cat.multiGetLatest(keys, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{ImmutableValue{{2, "v2"}}};
+    ASSERT_EQ(values, expected);
+  }
 }
 
 TEST_F(immutable_kv_category, get_latest_version) {
@@ -667,12 +677,22 @@ TEST_F(immutable_kv_category, multi_get_latest_version) {
     add(2, std::move(update));
   }
 
-  const auto keys = std::vector<std::string>{"k1", "k2", "k3"};
   auto versions = std::vector<std::optional<TaggedVersion>>{};
-  cat.multiGetLatestVersion(keys, versions);
-  const auto expected = std::vector<std::optional<TaggedVersion>>{
-      TaggedVersion{key_deleted, 1}, TaggedVersion{key_deleted, 2}, std::nullopt};
-  ASSERT_EQ(versions, expected);
+  {
+    const auto keys = std::vector<std::string>{"k1", "k2", "k3"};
+    cat.multiGetLatestVersion(keys, versions);
+    const auto expected = std::vector<std::optional<TaggedVersion>>{
+        TaggedVersion{key_deleted, 1}, TaggedVersion{key_deleted, 2}, std::nullopt};
+    ASSERT_EQ(versions, expected);
+  }
+
+  // Make sure that subsequent calls with the same vector work.
+  {
+    const auto keys = std::vector<std::string>{"k2"};
+    cat.multiGetLatestVersion(keys, versions);
+    const auto expected = std::vector<std::optional<TaggedVersion>>{TaggedVersion{key_deleted, 2}};
+    ASSERT_EQ(versions, expected);
+  }
 }
 
 TEST_F(immutable_kv_category, multi_get) {
@@ -690,13 +710,24 @@ TEST_F(immutable_kv_category, multi_get) {
     add(2, std::move(update));
   }
 
-  const auto keys = std::vector<std::string>{"k1", "k2", "k3", "k1"};
-  const auto versions = std::vector<BlockId>{1, 2, 1, 3};
   auto values = std::vector<std::optional<categorization::Value>>{};
-  cat.multiGet(keys, versions, values);
-  const auto expected = std::vector<std::optional<categorization::Value>>{
-      ImmutableValue{{1, "v1"}}, ImmutableValue{{2, "v2"}}, std::nullopt, std::nullopt};
-  ASSERT_EQ(values, expected);
+  {
+    const auto keys = std::vector<std::string>{"k1", "k2", "k3", "k1"};
+    const auto versions = std::vector<BlockId>{1, 2, 1, 3};
+    cat.multiGet(keys, versions, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{
+        ImmutableValue{{1, "v1"}}, ImmutableValue{{2, "v2"}}, std::nullopt, std::nullopt};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Make sure that subsequent calls with the same vector work.
+  {
+    const auto keys = std::vector<std::string>{"k2"};
+    const auto versions = std::vector<BlockId>{2};
+    cat.multiGet(keys, versions, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{ImmutableValue{{2, "v2"}}};
+    ASSERT_EQ(values, expected);
+  }
 }
 
 }  // namespace

--- a/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
@@ -198,6 +198,11 @@ TEST_F(versioned_kv_category, multi_get_and_multi_get_latest) {
     const auto expected = std::vector<std::optional<categorization::Value>>{
         VersionedValue{{1, "va1"}}, VersionedValue{{1, "vb1"}}, std::nullopt};
     ASSERT_EQ(values, expected);
+
+    // Make sure that subsequent calls with the same vector work.
+    cat.multiGet({"kb"}, {3}, values);
+    const auto expected_subs = std::vector<std::optional<categorization::Value>>{VersionedValue{{3, "vb3"}}};
+    ASSERT_EQ(values, expected_subs);
   }
 
   // Get keys "ka" and "kb" at block 3.
@@ -228,11 +233,18 @@ TEST_F(versioned_kv_category, multi_get_and_multi_get_latest) {
   }
 
   // Get the latest values of keys.
+  auto values = std::vector<std::optional<categorization::Value>>{};
   {
-    auto values = std::vector<std::optional<categorization::Value>>{};
     cat.multiGetLatest({"ka", "kb"}, values);
     const auto expected =
         std::vector<std::optional<categorization::Value>>{VersionedValue{{3, "va3"}}, VersionedValue{{3, "vb3"}}};
+    ASSERT_EQ(values, expected);
+  }
+
+  // Make sure that subsequent calls with the same vector work.
+  {
+    cat.multiGetLatest({"kb"}, values);
+    const auto expected = std::vector<std::optional<categorization::Value>>{VersionedValue{{3, "vb3"}}};
     ASSERT_EQ(values, expected);
   }
 }
@@ -279,11 +291,18 @@ TEST_F(versioned_kv_category, get_latest_ver_and_multi_get_latest_ver) {
   }
 
   // Get multiple latest versions.
+  auto versions = std::vector<std::optional<TaggedVersion>>{};
   {
-    auto versions = std::vector<std::optional<TaggedVersion>>{};
     cat.multiGetLatestVersion({"ka", "non-existent", "kb"}, versions);
     const auto expected =
         std::vector<std::optional<TaggedVersion>>{TaggedVersion{deleted, 3}, std::nullopt, TaggedVersion{deleted, 3}};
+    ASSERT_EQ(versions, expected);
+  }
+
+  // Make sure that subsequent calls with the same vector work.
+  {
+    cat.multiGetLatestVersion({"kb"}, versions);
+    const auto expected = std::vector<std::optional<TaggedVersion>>{TaggedVersion{deleted, 3}};
     ASSERT_EQ(versions, expected);
   }
 }


### PR DESCRIPTION
The VersionedKeyValueCategory::multiGetLatestVersion() method accepts a
vector as an output parameter. If the vector already contains data,
adding to it will be the wrong thing to do as it will contain more data
at the end than requested. Therefore, clear it before adding.

Add unit tests for other multi* methods in all categories, showing
that reusing the same vectors without being cleared by callers works
properly.