### PR TITLE
Fix inactive window catchup up with gap

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2131,7 +2131,8 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
         }
         // help from Inactive Window
         if (mainLog->isPressentInHistory(msg->getLastExecutedSeqNum() + 1)) {
-          for (SeqNum i = msg->getLastExecutedSeqNum() + 1; i <= lastStableSeqNum; i++) {
+          SeqNum endRange = std::min(lastStableSeqNum, msgLastStable + kWorkWindowSize);
+          for (SeqNum i = msg->getLastExecutedSeqNum() + 1; i <= endRange; i++) {
             PrePrepareMsg *prePrepareMsg = mainLog->getFromHistory(i).getSelfPrePrepareMsg();
             if (prePrepareMsg != nullptr && !msg->isPrePrepareInActiveWindow(i)) {
               sendAndIncrementMetric(prePrepareMsg, msgSenderId, metric_sent_preprepare_msg_due_to_status_);


### PR DESCRIPTION
Fix for searching in Inactive Window on Status exchange and Apollo test recreating the problematic situation.
Replicas helping from Inactive Window can only send information up to the end of the peer's Active Working Window.
