### PR TITLE
[TESTING] Added Destructor to BFT Client

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -34,6 +34,8 @@ class Client {
  public:
   Client(std::unique_ptr<bft::communication::ICommunication> comm, const ClientConfig& config);
 
+  ~Client();
+
   void setAggregator(const std::shared_ptr<concordMetrics::Aggregator>& aggregator) {
     metrics_.setAggregator(aggregator);
   }

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -58,6 +58,13 @@ Client::Client(std::unique_ptr<bft::communication::ICommunication> comm, const C
   communication_->Start();
 }
 
+Client::~Client() {
+  try {
+    communication_->Stop();
+  } catch (...) {
+  }
+};
+
 Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool read_only, uint16_t client_id) {
   uint8_t flags = read_only ? READ_ONLY_REQ : EMPTY_FLAGS_REQ;
   size_t expected_sig_len = 0;


### PR DESCRIPTION
As part of the concord client pool refactoring, the tests required a d'tor in the BFT client in order to clean up the clients successfully.