### PR TITLE
Limit the number of non-synchronised blocks to be deleted from the state

### DIFF
--- a/kvbc/include/replica_state_sync.h
+++ b/kvbc/include/replica_state_sync.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -32,7 +32,8 @@ class ReplicaStateSync {
   // Synchronizes replica state and returns a number of deleted blocks.
   virtual uint64_t execute(logging::Logger& logger,
                            categorization::KeyValueBlockchain& blockchain,
-                           uint64_t lastExecutedSeqNum) = 0;
+                           uint64_t lastExecutedSeqNum,
+                           uint32_t maxNumOfBlocksToDelete) = 0;
 };
 
 }  // namespace concord::kvbc

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -27,7 +27,8 @@ class ReplicaStateSyncImp : public ReplicaStateSync {
 
   uint64_t execute(logging::Logger& logger,
                    categorization::KeyValueBlockchain& blockchain,
-                   uint64_t lastExecutedSeqNum) override;
+                   uint64_t lastExecutedSeqNum,
+                   uint32_t maxNumOfBlocksToDelete) override;
 
  protected:
   std::unique_ptr<IBlockMetadata> blockMetadata_;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -80,8 +80,15 @@ void ReplicaImp::createReplicaAndSyncState() {
   LOG_INFO(logger, KVLOG(lastExecutedSeqNum));
   if (!replicaConfig_.isReadOnly && !m_stateTransfer->isCollectingState()) {
     try {
-      uint64_t removedBlocksNum = replicaStateSync_->execute(logger, *m_kvBlockchain, lastExecutedSeqNum);
-      LOG_INFO(logger, KVLOG(lastExecutedSeqNum, removedBlocksNum, getLastBlockNum(), getLastReachableBlockNum()));
+      const auto maxNumOfBlocksToDelete = replicaConfig_.maxNumOfRequestsInBatch;
+      const auto removedBlocksNum =
+          replicaStateSync_->execute(logger, *m_kvBlockchain, lastExecutedSeqNum, maxNumOfBlocksToDelete);
+      LOG_INFO(logger,
+               KVLOG(lastExecutedSeqNum,
+                     removedBlocksNum,
+                     getLastBlockNum(),
+                     getLastReachableBlockNum(),
+                     maxNumOfBlocksToDelete));
     } catch (std::exception &e) {
       std::terminate();
     }

--- a/kvbc/src/replica_state_sync_imp.cpp
+++ b/kvbc/src/replica_state_sync_imp.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the
 // "License").  You may not use this product except in compliance with the
@@ -25,7 +25,8 @@ ReplicaStateSyncImp::ReplicaStateSyncImp(IBlockMetadata* blockMetadata) : blockM
 
 uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
                                       categorization::KeyValueBlockchain& blockchain,
-                                      uint64_t lastExecutedSeqNum) {
+                                      uint64_t lastExecutedSeqNum,
+                                      uint32_t maxNumOfBlocksToDelete) {
   if (!lastExecutedSeqNum) {
     LOG_INFO(logger, "Replica's metadata is empty => skip blocks removal");
     return 0;
@@ -45,8 +46,8 @@ uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
     }
     // SBFT State Metadata is not in sync with the Blockchain State.
     // Remove blocks which sequence number is greater than lastExecutedSeqNum.
-    if (removedBlocksNum == 1) {
-      std::string error = " Detected more than one block needs to be deleted from the blockchain - unsupported";
+    if (removedBlocksNum >= maxNumOfBlocksToDelete) {
+      std::string error = " Detected too many blocks to be deleted from the blockchain";
       LOG_FATAL(logger, error);
       throw std::runtime_error(__PRETTY_FUNCTION__ + error);
     }


### PR DESCRIPTION
Limit it to maxNumOfRequestsInBatch instead of 1, as we can have as many blocks with the same seqNum as requests pass the consensus (without block accumulation).