### PR TITLE
Add configuration for pruning metrics dump

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -130,6 +130,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   CONFIG_PARAM(numBlocksToKeep_, uint64_t, 0, "how much blocks to keep while pruning");
 
   CONFIG_PARAM(debugPersistentStorageEnabled, bool, false, "whether persistent storage debugging is enabled");
+  CONFIG_PARAM(deleteMetricsDumpInterval, uint64_t, 300, "delete metrics dump interval (s)");
 
   // Messages
   CONFIG_PARAM(maxExternalMessageSize, uint32_t, 131072, "maximum size of external message");
@@ -216,6 +217,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, numBlocksToKeep_);
 
     serialize(outStream, debugPersistentStorageEnabled);
+    serialize(outStream, deleteMetricsDumpInterval);
     serialize(outStream, maxExternalMessageSize);
     serialize(outStream, maxReplyMessageSize);
     serialize(outStream, maxNumOfReservedPages);
@@ -277,6 +279,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, numBlocksToKeep_);
 
     deserialize(inStream, debugPersistentStorageEnabled);
+    deserialize(inStream, deleteMetricsDumpInterval);
     deserialize(inStream, maxExternalMessageSize);
     deserialize(inStream, maxReplyMessageSize);
     deserialize(inStream, maxNumOfReservedPages);

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -27,6 +27,7 @@
 #include "Metrics.hpp"
 #include "diagnostics.h"
 #include "performance_handler.h"
+#include "bftengine/ReplicaConfig.hpp"
 
 namespace concord::kvbc::categorization {
 
@@ -225,7 +226,7 @@ class KeyValueBlockchain {
   concordMetrics::CounterHandle immutable_num_of_keys_;
   concordMetrics::CounterHandle merkle_num_of_keys_;
 
-  std::chrono::seconds dump_delete_metrics_interval_{5 * 60};  // default is 5 minutes
+  std::chrono::seconds dump_delete_metrics_interval_{bftEngine::ReplicaConfig::instance().deleteMetricsDumpInterval};
   std::chrono::seconds last_dump_time_{0};
   uint64_t latest_deleted_merkle_dump{0};
   uint64_t latest_deleted_versioned{0};


### PR DESCRIPTION
In this PR we add an option to configure the timeout for dumping the deletes metrics in concordbft