### PR TITLE
Add TRC unit tests to concord-bft

### DIFF
--- a/client/thin-replica-client/CMakeLists.txt
+++ b/client/thin-replica-client/CMakeLists.txt
@@ -27,3 +27,8 @@ target_link_libraries(thin_replica_client
 
 install(TARGETS thin_replica_client DESTINATION lib)
 install(FILES include/client/thin-replica-client/thin_replica_client.hpp include/client/thin-replica-client/health_status.hpp include/client/thin-replica-client/update.hpp DESTINATION "include/thin_replica_client")
+
+# Unit tests
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -224,11 +224,14 @@ struct ThinReplicaClientConfig {
   // connection from this TRC to a specific Thin Replica Server.
   std::vector<std::unique_ptr<TrsConnection>> trs_conns;
 
-  ThinReplicaClientConfig(std::string& client_id_,
+  ThinReplicaClientConfig(std::string client_id_,
                           std::shared_ptr<UpdateQueue> update_queue_,
                           std::size_t max_faulty_,
                           std::vector<std::unique_ptr<TrsConnection>> trs_conns_)
-      : client_id(client_id_), update_queue(update_queue_), max_faulty(max_faulty_), trs_conns(std::move(trs_conns_)) {}
+      : client_id(std::move(client_id_)),
+        update_queue(update_queue_),
+        max_faulty(max_faulty_),
+        trs_conns(std::move(trs_conns_)) {}
 };
 
 // TRC metrics

--- a/client/thin-replica-client/test/CMakeLists.txt
+++ b/client/thin-replica-client/test/CMakeLists.txt
@@ -1,0 +1,55 @@
+find_package(GTest REQUIRED)
+find_package(GMock REQUIRED)
+
+add_test(NAME thin_replica_client_tests COMMAND thin_replica_client_tests)
+add_executable(thin_replica_client_tests
+               thin_replica_client_test.cpp
+							 thin_replica_client_mocks.hpp
+							 thin_replica_client_mocks.cpp)
+target_include_directories(thin_replica_client_tests PRIVATE ../src)
+target_link_libraries(thin_replica_client_tests
+                      ${GMOCK_LIBRARY}
+											thin_replica_client
+											GTest::Main
+											GTest::GTest)
+
+add_test(NAME trc_rpc_use_tests COMMAND trc_rpc_use_tests)
+add_executable(trc_rpc_use_tests
+               trc_rpc_use_test.cpp
+							 thin_replica_client_mocks.hpp
+							 thin_replica_client_mocks.cpp)
+target_include_directories(trc_rpc_use_tests PRIVATE ../src)
+target_link_libraries(trc_rpc_use_tests
+                      ${GMOCK_LIBRARY}
+											thin_replica_client
+											GTest::Main
+											GTest::GTest)
+
+add_test(NAME trc_byzantine_tests COMMAND trc_byzantine_tests)
+add_executable(trc_byzantine_tests
+               trc_byzantine_test.cpp
+							 thin_replica_client_mocks.hpp
+							 thin_replica_client_mocks.cpp)
+target_include_directories(trc_byzantine_tests PRIVATE ../src)
+target_link_libraries(trc_byzantine_tests
+                      ${GMOCK_LIBRARY}
+											thin_replica_client
+											GTest::Main
+											GTest::GTest)
+
+add_test(NAME trc_basic_update_queue_tests COMMAND trc_basic_update_queue_tests)
+add_executable(trc_basic_update_queue_tests trc_basic_update_queue_test.cpp)
+target_include_directories(trc_basic_update_queue_tests PRIVATE ../src)
+target_link_libraries(trc_basic_update_queue_tests
+                      thin_replica_client
+                      GTest::Main
+											GTest::GTest)
+
+add_test(NAME trc_hash_tests COMMAND trc_hash_tests)
+add_executable(trc_hash_tests trc_hash_test.cpp)
+target_include_directories(trc_hash_tests PRIVATE ../src)
+target_link_libraries(trc_hash_tests
+                      thin_replica_client
+											GTest::Main
+  										GTest::GTest)
+

--- a/client/thin-replica-client/test/thin_replica_client_mocks.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_mocks.cpp
@@ -1,0 +1,1201 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client/thin-replica-client/thin_replica_client.hpp"
+#include "client/thin-replica-client/trs_connection.hpp"
+
+#include "gmock/gmock.h"
+#include "thin_replica_client_mocks.hpp"
+#include "client/thin-replica-client/trc_hash.hpp"
+
+using com::vmware::concord::thin_replica::BlockId;
+using com::vmware::concord::thin_replica::Data;
+using com::vmware::concord::thin_replica::Hash;
+using com::vmware::concord::thin_replica::KVPair;
+using com::vmware::concord::thin_replica::MockThinReplicaStub;
+using com::vmware::concord::thin_replica::ReadStateHashRequest;
+using com::vmware::concord::thin_replica::ReadStateRequest;
+using com::vmware::concord::thin_replica::SubscriptionRequest;
+using google::protobuf::Empty;
+using grpc::ClientContext;
+using grpc::ClientReaderInterface;
+using grpc::Status;
+using grpc::StatusCode;
+using std::condition_variable;
+using std::invalid_argument;
+using std::list;
+using std::lock_guard;
+using std::make_unique;
+using std::mutex;
+using std::pair;
+using std::shared_ptr;
+using std::string;
+using std::unique_lock;
+using std::unique_ptr;
+using std::vector;
+using std::this_thread::sleep_for;
+using testing::Invoke;
+using testing::InvokeWithoutArgs;
+using testing::Return;
+using thin_replica_client::hashState;
+using thin_replica_client::hashUpdate;
+using thin_replica_client::TrsConnection;
+
+MockTrsConnection::MockTrsConnection() : TrsConnection("mock_address", "mock_client_id", 1, 1) {
+  this->data_timeout_ = kTestingTimeout;
+  this->hash_timeout_ = kTestingTimeout;
+  this->stub_.reset(new MockThinReplicaStub());
+}
+MockThinReplicaStub* MockTrsConnection::GetStub() { return dynamic_cast<MockThinReplicaStub*>(this->stub_.get()); }
+bool MockTrsConnection::isConnected() { return true; }
+
+Data FilterUpdate(const Data& raw_update, const string& filter) {
+  Data filtered_update;
+  filtered_update.set_block_id(raw_update.block_id());
+  filtered_update.set_correlation_id(raw_update.correlation_id());
+  for (const KVPair& raw_kvp : raw_update.data()) {
+    const string key = raw_kvp.key();
+    if ((key.length() >= filter.length()) && (key.compare(0, filter.size(), filter) == 0)) {
+      KVPair* filtered_kvp = filtered_update.add_data();
+      *filtered_kvp = raw_kvp;
+    }
+  }
+  return filtered_update;
+}
+
+VectorMockDataStreamPreparer::DataQueue::DataQueue(const list<Data>& data) : queue_(data) {}
+VectorMockDataStreamPreparer::DataQueue::~DataQueue() {}
+Status VectorMockDataStreamPreparer::DataQueue::Finish() {
+  // Note this Finish implementation does not account for the case where the
+  // Thin Replica Client ends the stream early with TryCancel; neglecting
+  // this case should still be technically correct behavior that the Thin
+  // Replica Client needs to handle as TryCancel is not guaranteed to
+  // succeed.
+  while (!queue_.empty()) {
+    unique_lock<mutex> empty_condition_lock(empty_condition_mutex_);
+    empty_condition_.wait(empty_condition_lock);
+  }
+  return Status::OK;
+}
+
+bool VectorMockDataStreamPreparer::DataQueue::Read(Data* msg) {
+  assert(msg);
+
+  if (queue_.empty()) {
+    return false;
+  } else {
+    {
+      lock_guard<mutex> queue_lock(queue_mutex_);
+      *msg = queue_.front();
+      queue_.pop_front();
+    }
+    if (queue_.empty()) {
+      empty_condition_.notify_all();
+    }
+    return true;
+  }
+}
+
+ClientReaderInterface<Data>* VectorMockDataStreamPreparer::PrepareInitialStateDataStream(const string& filter) const {
+  auto data_stream = new MockThinReplicaStream<Data>();
+  list<Data> data_queue;
+  assert(num_updates_in_initial_state_ <= data_.size());
+  for (size_t i = 0; i < num_updates_in_initial_state_; ++i) {
+    data_queue.push_back(FilterUpdate(data_[i], filter));
+  }
+  auto data_stream_state = new DataQueue(data_queue);
+  data_stream->state.reset(data_stream_state);
+
+  ON_CALL(*data_stream, Finish).WillByDefault(Invoke(data_stream_state, &DataQueue::Finish));
+  ON_CALL(*data_stream, Read).WillByDefault(Invoke(data_stream_state, &DataQueue::Read));
+  return data_stream;
+}
+
+ClientReaderInterface<Data>* VectorMockDataStreamPreparer::PrepareSubscriptionDataStream(uint64_t block_id,
+                                                                                         const string& filter) const {
+  auto data_stream = new MockThinReplicaStream<Data>();
+  list<Data> data_queue;
+  size_t subscription_start = 0;
+  while ((subscription_start < data_.size()) && (data_[subscription_start].block_id() < block_id)) {
+    ++subscription_start;
+  }
+  for (size_t i = subscription_start; i < data_.size(); ++i) {
+    data_queue.push_back(FilterUpdate(data_[i], filter));
+  }
+  auto data_stream_state = new DataQueue(data_queue);
+  data_stream->state.reset(data_stream_state);
+
+  ON_CALL(*data_stream, Finish).WillByDefault(Invoke(data_stream_state, &DataQueue::Finish));
+  ON_CALL(*data_stream, Read).WillByDefault(Invoke(data_stream_state, &DataQueue::Read));
+  return data_stream;
+}
+
+VectorMockDataStreamPreparer::VectorMockDataStreamPreparer(const vector<Data>& data, size_t initial_state_size)
+    : data_(data), num_updates_in_initial_state_(initial_state_size) {
+  if (initial_state_size > data.size()) {
+    throw invalid_argument(
+        "Attempting to construct VectorMockDataStreamPreparer with initial "
+        "state longer than provided data.");
+  }
+}
+
+VectorMockDataStreamPreparer::~VectorMockDataStreamPreparer() {}
+ClientReaderInterface<Data>* VectorMockDataStreamPreparer::ReadStateRaw(ClientContext* context,
+                                                                        const ReadStateRequest& request) const {
+  return PrepareInitialStateDataStream(request.key_prefix());
+}
+
+ClientReaderInterface<Data>* VectorMockDataStreamPreparer::SubscribeToUpdatesRaw(
+    ClientContext* context, const SubscriptionRequest& request) const {
+  return PrepareSubscriptionDataStream(request.block_id(), request.key_prefix());
+}
+
+RepeatedMockDataStreamPreparer::DataRepeater::DataRepeater(const Data& data, uint64_t starting_block_id)
+    : data_(data), current_block_id_(starting_block_id), finite_length_(false) {}
+
+RepeatedMockDataStreamPreparer::DataRepeater::DataRepeater(const Data& data,
+                                                           uint64_t starting_block_id,
+                                                           size_t num_updates)
+    : data_(data), current_block_id_(starting_block_id), finite_length_(true), num_updates_(num_updates) {}
+
+RepeatedMockDataStreamPreparer::DataRepeater::~DataRepeater() {}
+Status RepeatedMockDataStreamPreparer::DataRepeater::Finish() {
+  // Note this Finish implementation does not account for the case where the
+  // Thin Replica Client ends the stream early with TryCancel; neglecting
+  // this case should still be technically correct behavior that the Thin
+  // Replica Client needs to handle as TryCancel is not guaranteed to
+  // succeed.
+  // Note this loop will never finish if finite_length_ is false.
+  while (!(finite_length_ && (num_updates_ < 1))) {
+    unique_lock<mutex> finished_condition_lock(finished_condition_mutex_);
+    finished_condition_.wait(finished_condition_lock);
+  }
+  return Status::OK;
+}
+
+bool RepeatedMockDataStreamPreparer::DataRepeater::Read(Data* msg) {
+  assert(msg);
+
+  lock_guard<mutex> block_id_lock(block_id_mutex_);
+  if (finite_length_ && (num_updates_ < 1)) {
+    return false;
+  } else {
+    data_.set_block_id(current_block_id_++);
+    if (finite_length_ && (--num_updates_ < 1)) {
+      finished_condition_.notify_all();
+    }
+    *msg = data_;
+    return true;
+  }
+}
+
+ClientReaderInterface<Data>* RepeatedMockDataStreamPreparer::PrepareInitialStateDataStream(const string& filter) const {
+  auto data_stream = new MockThinReplicaStream<Data>();
+  auto data_stream_state =
+      new DataRepeater(FilterUpdate(data_, filter), data_.block_id(), num_updates_in_initial_state_);
+  data_stream->state.reset(data_stream_state);
+
+  ON_CALL(*data_stream, Finish).WillByDefault(Invoke(data_stream_state, &DataRepeater::Finish));
+  ON_CALL(*data_stream, Read).WillByDefault(Invoke(data_stream_state, &DataRepeater::Read));
+  return data_stream;
+}
+
+ClientReaderInterface<Data>* RepeatedMockDataStreamPreparer::PrepareSubscriptionDataStream(uint64_t block_id,
+                                                                                           const string& filter) const {
+  auto data_stream = new MockThinReplicaStream<Data>();
+  auto data_stream_state = new DataRepeater(FilterUpdate(data_, filter), block_id);
+  data_stream->state.reset(data_stream_state);
+
+  ON_CALL(*data_stream, Finish).WillByDefault(Invoke(data_stream_state, &DataRepeater::Finish));
+  ON_CALL(*data_stream, Read).WillByDefault(Invoke(data_stream_state, &DataRepeater::Read));
+  return data_stream;
+}
+
+RepeatedMockDataStreamPreparer::RepeatedMockDataStreamPreparer(const Data& data, size_t initial_state_length)
+    : data_(data), num_updates_in_initial_state_(initial_state_length) {}
+
+RepeatedMockDataStreamPreparer::~RepeatedMockDataStreamPreparer() {}
+ClientReaderInterface<Data>* RepeatedMockDataStreamPreparer::ReadStateRaw(ClientContext* context,
+                                                                          const ReadStateRequest& request) const {
+  return PrepareInitialStateDataStream(request.key_prefix());
+}
+
+ClientReaderInterface<Data>* RepeatedMockDataStreamPreparer::SubscribeToUpdatesRaw(
+    ClientContext* context, const SubscriptionRequest& request) const {
+  return PrepareSubscriptionDataStream(request.block_id(), request.key_prefix());
+}
+
+DelayedMockDataStreamPreparer::DataDelayer::DataDelayer(ClientReaderInterface<Data>* data,
+                                                        const shared_ptr<condition_variable>& delay_condition,
+                                                        const shared_ptr<mutex>& delay_mutex,
+                                                        const shared_ptr<bool>& spurious_wakeup)
+    : undelayed_data_(data),
+      waiting_condition_(delay_condition),
+      spurious_wakeup_(spurious_wakeup),
+      condition_mutex_(delay_mutex) {}
+
+DelayedMockDataStreamPreparer::DataDelayer::~DataDelayer() {}
+
+Status DelayedMockDataStreamPreparer::DataDelayer::Finish() {
+  Status status = undelayed_data_->Finish();
+  while (*spurious_wakeup_) {
+    unique_lock<mutex> condition_lock(*condition_mutex_);
+    waiting_condition_->wait(condition_lock);
+  }
+  return status;
+}
+
+bool DelayedMockDataStreamPreparer::DataDelayer::Read(Data* msg) {
+  assert(msg);
+
+  while (*spurious_wakeup_) {
+    unique_lock<mutex> condition_lock(*condition_mutex_);
+    waiting_condition_->wait(condition_lock);
+  }
+  return undelayed_data_->Read(msg);
+}
+
+DelayedMockDataStreamPreparer::DelayedMockDataStreamPreparer(shared_ptr<MockDataStreamPreparer>& data,
+                                                             shared_ptr<condition_variable> condition,
+                                                             shared_ptr<bool> spurious_wakeup_indicator,
+                                                             shared_ptr<mutex> condition_mutex)
+    : undelayed_data_preparer_(data),
+      delay_condition_(condition),
+      spurious_wakeup_(spurious_wakeup_indicator),
+      condition_mutex_(condition_mutex) {}
+
+DelayedMockDataStreamPreparer::~DelayedMockDataStreamPreparer() {}
+
+ClientReaderInterface<Data>* DelayedMockDataStreamPreparer::ReadStateRaw(ClientContext* context,
+                                                                         const ReadStateRequest& request) const {
+  return undelayed_data_preparer_->ReadStateRaw(context, request);
+}
+
+ClientReaderInterface<Data>* DelayedMockDataStreamPreparer::SubscribeToUpdatesRaw(
+    ClientContext* context, const SubscriptionRequest& request) const {
+  auto data_stream = new MockThinReplicaStream<Data>();
+  auto data_stream_state = new DataDelayer(undelayed_data_preparer_->SubscribeToUpdatesRaw(context, request),
+                                           delay_condition_,
+                                           condition_mutex_,
+                                           spurious_wakeup_);
+  data_stream->state.reset(data_stream_state);
+
+  ON_CALL(*data_stream, Finish).WillByDefault(Invoke(data_stream_state, &DataDelayer::Finish));
+  ON_CALL(*data_stream, Read).WillByDefault(Invoke(data_stream_state, &DataDelayer::Read));
+  return data_stream;
+}
+
+MockOrderedDataStreamHasher::StreamHasher::StreamHasher(ClientReaderInterface<Data>* data) : data_stream_(data) {}
+
+MockOrderedDataStreamHasher::StreamHasher::~StreamHasher() {}
+
+Status MockOrderedDataStreamHasher::StreamHasher::Finish() { return data_stream_->Finish(); }
+
+bool MockOrderedDataStreamHasher::StreamHasher::Read(Hash* msg) {
+  assert(msg);
+
+  Data data;
+  bool read_status = data_stream_->Read(&data);
+  if (read_status) {
+    msg->set_block_id(data.block_id());
+    msg->set_hash(hashUpdate(data));
+  }
+  return read_status;
+}
+
+MockOrderedDataStreamHasher::MockOrderedDataStreamHasher(shared_ptr<MockDataStreamPreparer>& data)
+    : data_preparer_(data) {
+  // MockOrderedDataStreamHasher determines the starting block ID from the
+  // stream prepared for ReadState by the MockDataStreamPreparer.
+  auto context = make_unique<ClientContext>();
+  ReadStateRequest request;
+  request.set_key_prefix("");
+  unique_ptr<ClientReaderInterface<Data>> data_stream(data->ReadStateRaw(context.get(), request));
+  Data base_block;
+  if (!data_stream->Read(&base_block)) {
+    throw invalid_argument(
+        "Attempting to construct a MockOrderedDataStreamHasher with a "
+        "MockDataStreamPreparer that does not successfully provide any "
+        "initial state.");
+  }
+  base_block_id_ = base_block.block_id();
+}
+
+Status MockOrderedDataStreamHasher::ReadStateHash(ClientContext* context,
+                                                  const ReadStateHashRequest& request,
+                                                  Hash* response) const {
+  assert(response);
+
+  list<string> update_hashes;
+  auto data_context = make_unique<ClientContext>();
+  SubscriptionRequest data_request;
+  data_request.set_key_prefix(request.key_prefix());
+  data_request.set_block_id(base_block_id_);
+  unique_ptr<ClientReaderInterface<Data>> data_stream(
+      data_preparer_->SubscribeToUpdatesRaw(data_context.get(), data_request));
+
+  Data data;
+  uint64_t latest_block_id_in_hash = 0;
+  while (data_stream->Read(&data) && data.block_id() <= request.block_id()) {
+    update_hashes.push_back(hashUpdate(data));
+    latest_block_id_in_hash = data.block_id();
+  }
+  if (request.block_id() > latest_block_id_in_hash) {
+    return Status(StatusCode::UNKNOWN,
+                  "Attempting to read state hash from a block number that "
+                  "does not exist.");
+  }
+  response->set_block_id(request.block_id());
+  response->set_hash(hashState(update_hashes));
+  return Status::OK;
+}
+
+ClientReaderInterface<Hash>* MockOrderedDataStreamHasher::SubscribeToUpdateHashesRaw(
+    ClientContext* context, const SubscriptionRequest& request) const {
+  auto hash_stream = new MockThinReplicaStream<Hash>();
+  auto hash_stream_state = new StreamHasher(data_preparer_->SubscribeToUpdatesRaw(context, request));
+  hash_stream->state.reset(hash_stream_state);
+
+  ON_CALL(*hash_stream, Finish).WillByDefault(Invoke(hash_stream_state, &StreamHasher::Finish));
+  ON_CALL(*hash_stream, Read).WillByDefault(Invoke(hash_stream_state, &StreamHasher::Read));
+  return hash_stream;
+}
+
+void ThinReplicaCommunicationRecord::ClearRecords() {
+  lock_guard<mutex> record_lock(record_mutex_);
+  read_state_calls_.clear();
+  read_state_hash_calls_.clear();
+  subscribe_to_updates_calls_.clear();
+  ack_update_calls_.clear();
+  subscribe_to_update_hashes_calls_.clear();
+  unsubscribe_calls_.clear();
+}
+
+void ThinReplicaCommunicationRecord::RecordReadState(size_t server_index, const ReadStateRequest& request) {
+  lock_guard<mutex> record_lock(record_mutex_);
+  read_state_calls_.emplace_back(server_index, request);
+}
+
+void ThinReplicaCommunicationRecord::RecordReadStateHash(size_t server_index, const ReadStateHashRequest& request) {
+  lock_guard<mutex> record_lock(record_mutex_);
+  read_state_hash_calls_.emplace_back(server_index, request);
+}
+
+void ThinReplicaCommunicationRecord::RecordSubscribeToUpdates(size_t server_index, const SubscriptionRequest& request) {
+  lock_guard<mutex> record_lock(record_mutex_);
+  subscribe_to_updates_calls_.emplace_back(server_index, request);
+}
+
+void ThinReplicaCommunicationRecord::RecordAckUpdate(size_t server_index, const BlockId& block_id) {
+  lock_guard<mutex> record_lock(record_mutex_);
+  ack_update_calls_.emplace_back(server_index, block_id);
+}
+
+void ThinReplicaCommunicationRecord::RecordSubscribeToUpdateHashes(size_t server_index,
+                                                                   const SubscriptionRequest& request) {
+  lock_guard<mutex> record_lock(record_mutex_);
+  subscribe_to_update_hashes_calls_.emplace_back(server_index, request);
+}
+
+void ThinReplicaCommunicationRecord::RecordUnsubscribe(size_t server_index) {
+  lock_guard<mutex> record_lock(record_mutex_);
+  unsubscribe_calls_.emplace_back(server_index);
+}
+
+const list<pair<size_t, ReadStateRequest>>& ThinReplicaCommunicationRecord::GetReadStateCalls() const {
+  return read_state_calls_;
+}
+
+const list<pair<size_t, ReadStateHashRequest>>& ThinReplicaCommunicationRecord::GetReadStateHashCalls() const {
+  return read_state_hash_calls_;
+}
+
+const list<pair<size_t, SubscriptionRequest>>& ThinReplicaCommunicationRecord::GetSubscribeToUpdatesCalls() const {
+  return subscribe_to_updates_calls_;
+}
+
+const list<pair<size_t, BlockId>>& ThinReplicaCommunicationRecord::GetAckUpdateCalls() const {
+  return ack_update_calls_;
+}
+
+const list<pair<size_t, SubscriptionRequest>>& ThinReplicaCommunicationRecord::GetSubscribeToUpdateHashesCalls() const {
+  return subscribe_to_update_hashes_calls_;
+}
+
+const list<size_t>& ThinReplicaCommunicationRecord::GetUnsubscribeCalls() const { return unsubscribe_calls_; }
+
+size_t ThinReplicaCommunicationRecord::GetTotalCallCount() const {
+  return read_state_calls_.size() + read_state_hash_calls_.size() + subscribe_to_updates_calls_.size() +
+         ack_update_calls_.size() + subscribe_to_update_hashes_calls_.size() + unsubscribe_calls_.size();
+}
+
+MockThinReplicaServerRecorder::MockThinReplicaServerRecorder(shared_ptr<MockDataStreamPreparer> data,
+                                                             shared_ptr<MockOrderedDataStreamHasher> hasher,
+                                                             shared_ptr<ThinReplicaCommunicationRecord> record,
+                                                             size_t server_index)
+    : data_preparer_(data), hasher_(hasher), record_(record), server_index_(server_index) {}
+
+ClientReaderInterface<Data>* MockThinReplicaServerRecorder::ReadStateRaw(ClientContext* context,
+                                                                         const ReadStateRequest& request) {
+  assert(data_preparer_);
+  assert(record_);
+
+  record_->RecordReadState(server_index_, request);
+  return data_preparer_->ReadStateRaw(context, request);
+}
+
+Status MockThinReplicaServerRecorder::ReadStateHash(ClientContext* context,
+                                                    const ReadStateHashRequest& request,
+                                                    Hash* response) {
+  assert(hasher_);
+  assert(record_);
+
+  record_->RecordReadStateHash(server_index_, request);
+  return hasher_->ReadStateHash(context, request, response);
+}
+
+ClientReaderInterface<Data>* MockThinReplicaServerRecorder::SubscribeToUpdatesRaw(ClientContext* context,
+                                                                                  const SubscriptionRequest& request) {
+  assert(data_preparer_);
+  assert(record_);
+
+  record_->RecordSubscribeToUpdates(server_index_, request);
+  return data_preparer_->SubscribeToUpdatesRaw(context, request);
+}
+
+Status MockThinReplicaServerRecorder::AckUpdate(ClientContext* context, const BlockId& block_id, Empty* response) {
+  assert(record_);
+
+  record_->RecordAckUpdate(server_index_, block_id);
+  return Status::OK;
+}
+
+ClientReaderInterface<Hash>* MockThinReplicaServerRecorder::SubscribeToUpdateHashesRaw(
+    ClientContext* context, const SubscriptionRequest& request) {
+  assert(hasher_);
+  assert(record_);
+
+  record_->RecordSubscribeToUpdateHashes(server_index_, request);
+  return hasher_->SubscribeToUpdateHashesRaw(context, request);
+}
+
+Status MockThinReplicaServerRecorder::Unsubscribe(ClientContext* context, const Empty& request, Empty* response) {
+  assert(record_);
+
+  record_->RecordUnsubscribe(server_index_);
+  return Status::OK;
+}
+
+ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::ByzantineServerBehavior()
+    : byzantine_faulty_servers_(), faulty_server_record_mutex_() {}
+
+bool ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::IsByzantineFaulty(size_t index) {
+  lock_guard<mutex> faulty_server_record_lock_(faulty_server_record_mutex_);
+  return byzantine_faulty_servers_.count(index) > 0;
+}
+
+size_t ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::GetNumFaultyServers() {
+  lock_guard<mutex> faulty_server_record_lock_(faulty_server_record_mutex_);
+  return byzantine_faulty_servers_.size();
+}
+
+bool ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::MakeByzantineFaulty(size_t index,
+                                                                                          size_t max_faulty) {
+  lock_guard<mutex> faulty_server_record_lock_(faulty_server_record_mutex_);
+  if (byzantine_faulty_servers_.size() < max_faulty) {
+    byzantine_faulty_servers_.insert(index);
+  }
+  return byzantine_faulty_servers_.count(index) > 0;
+}
+
+ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::~ByzantineServerBehavior() {}
+
+ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::ReadStateRaw(
+    size_t server_index,
+    ClientContext* context,
+    const ReadStateRequest& request,
+    ClientReaderInterface<Data>* correct_data) {
+  return correct_data;
+}
+
+Status ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::ReadStateHash(
+    size_t server_index,
+    ClientContext* context,
+    const ReadStateHashRequest& request,
+    Hash* response,
+    Status correct_status) {
+  return correct_status;
+}
+
+ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::SubscribeToUpdatesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Data>* correct_data) {
+  return correct_data;
+}
+
+Status ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::AckUpdate(
+    size_t server_index, ClientContext* context, const BlockId& block_id, Empty* response, Status correct_status) {
+  return correct_status;
+}
+
+ClientReaderInterface<Hash>*
+ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::SubscribeToUpdateHashesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Hash>* correct_hashes) {
+  return correct_hashes;
+}
+
+Status ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior::Unsubscribe(
+    size_t server_index, ClientContext* context, const Empty& request, Empty* response, Status correct_status) {
+  return correct_status;
+}
+
+ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::ByzantineMockServer(
+    shared_ptr<MockDataStreamPreparer> non_faulty_data,
+    shared_ptr<MockOrderedDataStreamHasher> non_faulty_hasher,
+    shared_ptr<ByzantineServerBehavior> byzantine_behavior,
+    size_t index)
+    : non_faulty_data_(non_faulty_data),
+      non_faulty_hasher_(non_faulty_hasher),
+      byzantine_behavior_(byzantine_behavior),
+      index_(index) {}
+
+ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::ReadStateRaw(
+    ClientContext* context, const ReadStateRequest& request) {
+  assert(non_faulty_data_);
+  assert(byzantine_behavior_);
+
+  return byzantine_behavior_->ReadStateRaw(index_, context, request, non_faulty_data_->ReadStateRaw(context, request));
+}
+
+Status ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::ReadStateHash(ClientContext* context,
+                                                                                  const ReadStateHashRequest& request,
+                                                                                  Hash* response) {
+  assert(non_faulty_hasher_);
+  assert(byzantine_behavior_);
+
+  return byzantine_behavior_->ReadStateHash(
+      index_, context, request, response, non_faulty_hasher_->ReadStateHash(context, request, response));
+}
+
+ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::SubscribeToUpdatesRaw(
+    ClientContext* context, const SubscriptionRequest& request) {
+  assert(non_faulty_data_);
+  assert(byzantine_behavior_);
+
+  return byzantine_behavior_->SubscribeToUpdatesRaw(
+      index_, context, request, non_faulty_data_->SubscribeToUpdatesRaw(context, request));
+}
+
+Status ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::AckUpdate(ClientContext* context,
+                                                                              const BlockId& block_id,
+                                                                              Empty* response) {
+  assert(byzantine_behavior_);
+
+  return byzantine_behavior_->AckUpdate(index_, context, block_id, response, Status::OK);
+}
+
+ClientReaderInterface<Hash>* ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::SubscribeToUpdateHashesRaw(
+    ClientContext* context, const SubscriptionRequest& request) {
+  assert(non_faulty_hasher_);
+  assert(byzantine_behavior_);
+
+  return byzantine_behavior_->SubscribeToUpdateHashesRaw(
+      index_, context, request, non_faulty_hasher_->SubscribeToUpdateHashesRaw(context, request));
+}
+
+Status ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::Unsubscribe(ClientContext* context,
+                                                                                const Empty& request,
+                                                                                Empty* response) {
+  assert(byzantine_behavior_);
+
+  return byzantine_behavior_->Unsubscribe(index_, context, request, response, Status::OK);
+}
+
+ByzantineMockThinReplicaServerPreparer::ByzantineMockThinReplicaServerPreparer(
+    shared_ptr<MockDataStreamPreparer> non_faulty_data,
+    shared_ptr<MockOrderedDataStreamHasher> non_faulty_hasher,
+    shared_ptr<ByzantineServerBehavior> byzantine_behavior)
+    : non_faulty_data_(non_faulty_data),
+      non_faulty_hasher_(non_faulty_hasher),
+      byzantine_behavior_(byzantine_behavior) {}
+
+ByzantineMockThinReplicaServerPreparer::ByzantineMockServer*
+ByzantineMockThinReplicaServerPreparer::CreateByzantineMockServer(size_t index) {
+  return new ByzantineMockServer(non_faulty_data_, non_faulty_hasher_, byzantine_behavior_, index);
+}
+
+vector<unique_ptr<MockThinReplicaServerRecorder>> CreateMockServerRecorders(
+    size_t num_servers,
+    shared_ptr<MockDataStreamPreparer> data,
+    shared_ptr<MockOrderedDataStreamHasher> hasher,
+    shared_ptr<ThinReplicaCommunicationRecord> record) {
+  vector<unique_ptr<MockThinReplicaServerRecorder>> recorders;
+  for (size_t i = 0; i < num_servers; ++i) {
+    recorders.push_back(make_unique<MockThinReplicaServerRecorder>(data, hasher, record, i));
+  }
+  return recorders;
+}
+
+vector<unique_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>> CreateByzantineMockServers(
+    size_t num_servers, ByzantineMockThinReplicaServerPreparer& server_preparer) {
+  vector<unique_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>> mock_servers;
+  for (size_t i = 0; i < num_servers; ++i) {
+    mock_servers.push_back(unique_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>(
+        server_preparer.CreateByzantineMockServer(i)));
+  }
+  return mock_servers;
+}
+
+void SetMockServerBehavior(MockTrsConnection* server,
+                           const shared_ptr<MockDataStreamPreparer>& data_preparer,
+                           const MockOrderedDataStreamHasher& hasher) {
+  ON_CALL(*(server->GetStub()), ReadStateRaw)
+      .WillByDefault(Invoke(data_preparer.get(), &MockDataStreamPreparer::ReadStateRaw));
+  ON_CALL(*(server->GetStub()), ReadStateHash)
+      .WillByDefault(Invoke(&hasher, &MockOrderedDataStreamHasher::ReadStateHash));
+  ON_CALL(*(server->GetStub()), SubscribeToUpdatesRaw)
+      .WillByDefault(Invoke(data_preparer.get(), &MockDataStreamPreparer::SubscribeToUpdatesRaw));
+  ON_CALL(*(server->GetStub()), SubscribeToUpdateHashesRaw)
+      .WillByDefault(Invoke(&hasher, &MockOrderedDataStreamHasher::SubscribeToUpdateHashesRaw));
+}
+
+void SetMockServerUnresponsive(MockTrsConnection* server) {
+  ON_CALL(*(server->GetStub()), ReadStateRaw).WillByDefault(InvokeWithoutArgs(&CreateUnresponsiveMockStream<Data>));
+  ON_CALL(*(server->GetStub()), ReadStateHash)
+      .WillByDefault(Return(Status(StatusCode::UNAVAILABLE, "This server is non-responsive")));
+  ON_CALL(*(server->GetStub()), SubscribeToUpdatesRaw)
+      .WillByDefault(InvokeWithoutArgs(&CreateUnresponsiveMockStream<Data>));
+  ON_CALL(*(server->GetStub()), AckUpdate)
+      .WillByDefault(Return(Status(StatusCode::UNAVAILABLE, "This server is non-responsive")));
+  ON_CALL(*(server->GetStub()), SubscribeToUpdateHashesRaw)
+      .WillByDefault(InvokeWithoutArgs(&CreateUnresponsiveMockStream<Hash>));
+  ON_CALL(*(server->GetStub()), Unsubscribe)
+      .WillByDefault(Return(Status(StatusCode::UNAVAILABLE, "This server is non-responsive")));
+}
+
+vector<unique_ptr<TrsConnection>> CreateTrsConnections(size_t num_servers, size_t num_unresponsive) {
+  vector<unique_ptr<TrsConnection>> mock_servers;
+  for (size_t i = 0; i < num_servers; ++i) {
+    auto conn = new MockTrsConnection();
+    if (num_unresponsive > 0) {
+      SetMockServerUnresponsive(conn);
+      num_unresponsive--;
+    }
+    auto server = dynamic_cast<TrsConnection*>(conn);
+    mock_servers.push_back(unique_ptr<TrsConnection>(server));
+  }
+  return mock_servers;
+}
+
+vector<unique_ptr<TrsConnection>> CreateTrsConnections(size_t num_servers,
+                                                       shared_ptr<MockDataStreamPreparer> stream_preparer,
+                                                       MockOrderedDataStreamHasher& hasher,
+                                                       size_t num_unresponsive) {
+  vector<unique_ptr<TrsConnection>> mock_servers;
+  for (size_t i = 0; i < num_servers; ++i) {
+    auto conn = new MockTrsConnection();
+    SetMockServerBehavior(conn, stream_preparer, hasher);
+    if (num_unresponsive > 0) {
+      SetMockServerUnresponsive(conn);
+      num_unresponsive--;
+    }
+    auto server = dynamic_cast<TrsConnection*>(conn);
+    mock_servers.push_back(unique_ptr<TrsConnection>(server));
+  }
+  return mock_servers;
+}
+
+InitialStateFabricator::InitialStateFabricator(shared_ptr<MockDataStreamPreparer> fabricated_data_preparer,
+                                               size_t num_faulty_servers)
+    : fabricated_data_preparer_(fabricated_data_preparer), num_faulty_servers_(num_faulty_servers) {}
+
+InitialStateFabricator::~InitialStateFabricator() {}
+
+ClientReaderInterface<Data>* InitialStateFabricator::ReadStateRaw(size_t server_index,
+                                                                  ClientContext* context,
+                                                                  const ReadStateRequest& request,
+                                                                  ClientReaderInterface<Data>* correct_data) {
+  if (MakeByzantineFaulty(server_index, num_faulty_servers_)) {
+    delete correct_data;
+    return fabricated_data_preparer_->ReadStateRaw(context, request);
+  }
+  return correct_data;
+}
+
+UpdateDataFabricator::UpdateDataFabricator(shared_ptr<MockDataStreamPreparer> fabricated_data_preparer,
+                                           size_t num_faulty_servers)
+    : fabricated_data_preparer_(fabricated_data_preparer), num_faulty_servers_(num_faulty_servers) {}
+
+UpdateDataFabricator::~UpdateDataFabricator() {}
+
+ClientReaderInterface<Data>* UpdateDataFabricator::SubscribeToUpdatesRaw(size_t server_index,
+                                                                         ClientContext* context,
+                                                                         const SubscriptionRequest& request,
+                                                                         ClientReaderInterface<Data>* correct_data) {
+  if (MakeByzantineFaulty(server_index, num_faulty_servers_)) {
+    delete correct_data;
+    return fabricated_data_preparer_->SubscribeToUpdatesRaw(context, request);
+  }
+  return correct_data;
+}
+
+UpdateHashFabricator::UpdateHashFabricator(shared_ptr<MockDataStreamPreparer> fabricated_data_preparer,
+                                           size_t num_faulty_servers)
+    : fabricated_update_hasher_(new MockOrderedDataStreamHasher(fabricated_data_preparer)),
+      num_faulty_servers_(num_faulty_servers) {}
+
+UpdateHashFabricator::~UpdateHashFabricator() {}
+
+ClientReaderInterface<Hash>* UpdateHashFabricator::SubscribeToUpdateHashesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Hash>* correct_hashes) {
+  if (MakeByzantineFaulty(server_index, num_faulty_servers_)) {
+    delete correct_hashes;
+    return fabricated_update_hasher_->SubscribeToUpdateHashesRaw(context, request);
+  }
+  return correct_hashes;
+}
+
+StateStreamDelayer::DelayedStreamState::DelayedStreamState(ClientReaderInterface<Data>* data, size_t delay_after)
+    : undelayed_data_(data), updates_until_delay_(delay_after) {}
+
+StateStreamDelayer::DelayedStreamState::~DelayedStreamState() {}
+
+Status StateStreamDelayer::DelayedStreamState::Finish() {
+  if (updates_until_delay_ <= 0) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return undelayed_data_->Finish();
+}
+
+bool StateStreamDelayer::DelayedStreamState::Read(Data* data) {
+  if (updates_until_delay_ <= 0) {
+    sleep_for(kTestingTimeout * 2);
+  } else {
+    --updates_until_delay_;
+  }
+  return undelayed_data_->Read(data);
+}
+
+StateStreamDelayer::StateStreamDelayer(size_t delay_after) : delay_after_(delay_after) {}
+
+StateStreamDelayer::~StateStreamDelayer() {}
+
+ClientReaderInterface<Data>* StateStreamDelayer::ReadStateRaw(size_t server_index,
+                                                              ClientContext* context,
+                                                              const ReadStateRequest& request,
+                                                              ClientReaderInterface<Data>* correct_data) {
+  if (MakeByzantineFaulty(server_index, 1)) {
+    MockThinReplicaStream<Data>* data_stream = new MockThinReplicaStream<Data>();
+    DelayedStreamState* stream_state = new DelayedStreamState(correct_data, delay_after_);
+    data_stream->state.reset(stream_state);
+
+    ON_CALL(*data_stream, Finish).WillByDefault(Invoke(stream_state, &DelayedStreamState::Finish));
+    ON_CALL(*data_stream, Read).WillByDefault(Invoke(stream_state, &DelayedStreamState::Read));
+    return data_stream;
+  }
+  return correct_data;
+}
+
+DataStreamDelayer::DelayedStreamState::DelayedStreamState(ClientReaderInterface<Data>* data, size_t delay_after)
+    : undelayed_data_(data), updates_until_delay_(delay_after) {}
+
+DataStreamDelayer::DelayedStreamState::~DelayedStreamState() {}
+
+Status DataStreamDelayer::DelayedStreamState::Finish() {
+  if (updates_until_delay_ <= 0) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return undelayed_data_->Finish();
+}
+
+bool DataStreamDelayer::DelayedStreamState::Read(Data* data) {
+  if (updates_until_delay_ <= 0) {
+    sleep_for(kTestingTimeout * 2);
+  } else {
+    --updates_until_delay_;
+  }
+  return undelayed_data_->Read(data);
+}
+
+DataStreamDelayer::DataStreamDelayer(size_t delay_after) : delay_after_(delay_after) {}
+
+DataStreamDelayer::~DataStreamDelayer() {}
+
+ClientReaderInterface<Data>* DataStreamDelayer::SubscribeToUpdatesRaw(size_t server_index,
+                                                                      ClientContext* context,
+                                                                      const SubscriptionRequest& request,
+                                                                      ClientReaderInterface<Data>* correct_data) {
+  if (MakeByzantineFaulty(server_index, 1)) {
+    MockThinReplicaStream<Data>* data_stream = new MockThinReplicaStream<Data>();
+    DelayedStreamState* stream_state = new DelayedStreamState(correct_data, delay_after_);
+    data_stream->state.reset(stream_state);
+
+    ON_CALL(*data_stream, Finish).WillByDefault(Invoke(stream_state, &DelayedStreamState::Finish));
+    ON_CALL(*data_stream, Read).WillByDefault(Invoke(stream_state, &DelayedStreamState::Read));
+    return data_stream;
+  }
+  return correct_data;
+}
+
+HashStreamDelayer::DelayedStreamState::DelayedStreamState(ClientReaderInterface<Hash>* hashes, size_t delay_after)
+    : undelayed_hashes_(hashes), hashes_until_delay_(delay_after) {}
+
+HashStreamDelayer::DelayedStreamState::~DelayedStreamState() {}
+
+Status HashStreamDelayer::DelayedStreamState::Finish() {
+  if (hashes_until_delay_ <= 0) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return undelayed_hashes_->Finish();
+}
+
+bool HashStreamDelayer::DelayedStreamState::Read(Hash* hash) {
+  if (hashes_until_delay_ <= 0) {
+    sleep_for(kTestingTimeout * 2);
+  } else {
+    --hashes_until_delay_;
+  }
+  return undelayed_hashes_->Read(hash);
+}
+
+HashStreamDelayer::HashStreamDelayer(size_t delay_after) : delay_after_(delay_after) {}
+
+HashStreamDelayer::~HashStreamDelayer() {}
+
+ClientReaderInterface<Hash>* HashStreamDelayer::SubscribeToUpdateHashesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Hash>* correct_hashes) {
+  if (MakeByzantineFaulty(server_index, 1)) {
+    MockThinReplicaStream<Hash>* hash_stream = new MockThinReplicaStream<Hash>();
+    DelayedStreamState* stream_state = new DelayedStreamState(correct_hashes, delay_after_);
+    hash_stream->state.reset(stream_state);
+
+    ON_CALL(*hash_stream, Finish).WillByDefault(Invoke(stream_state, &DelayedStreamState::Finish));
+    ON_CALL(*hash_stream, Read).WillByDefault(Invoke(stream_state, &DelayedStreamState::Read));
+    return hash_stream;
+  }
+  return correct_hashes;
+}
+
+UpdateHashCorrupter::CorruptedStreamState::CorruptedStreamState(
+    ClientReaderInterface<Hash>* hashes,
+    shared_ptr<UpdateHashCorrupter::CorruptHash> corrupt_hash,
+    size_t corrupt_after)
+    : uncorrupted_hashes_(hashes),
+      corrupt_hash_(corrupt_hash),
+      corruption_applied_(false),
+      hashes_until_corruption_(corrupt_after) {}
+
+UpdateHashCorrupter::CorruptedStreamState::~CorruptedStreamState() {}
+
+Status UpdateHashCorrupter::CorruptedStreamState::Finish() { return uncorrupted_hashes_->Finish(); }
+
+bool UpdateHashCorrupter::CorruptedStreamState::Read(Hash* hash) {
+  if (!corruption_applied_) {
+    if (hashes_until_corruption_ > 0) {
+      --hashes_until_corruption_;
+    } else {
+      bool read_result = uncorrupted_hashes_->Read(hash);
+      (*corrupt_hash_)(hash);
+      corruption_applied_ = true;
+      return read_result;
+    }
+  }
+  return uncorrupted_hashes_->Read(hash);
+}
+
+UpdateHashCorrupter::UpdateHashCorrupter(shared_ptr<UpdateHashCorrupter::CorruptHash> corrupt_hash,
+                                         size_t corrupt_after)
+    : corrupt_hash_(corrupt_hash), corrupt_after_(corrupt_after) {}
+
+UpdateHashCorrupter::~UpdateHashCorrupter() {}
+
+ClientReaderInterface<Hash>* UpdateHashCorrupter::SubscribeToUpdateHashesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Hash>* correct_hashes) {
+  if (MakeByzantineFaulty(server_index, 1)) {
+    MockThinReplicaStream<Hash>* hash_stream = new MockThinReplicaStream<Hash>();
+    CorruptedStreamState* stream_state = new CorruptedStreamState(correct_hashes, corrupt_hash_, corrupt_after_);
+    hash_stream->state.reset(stream_state);
+
+    ON_CALL(*hash_stream, Finish).WillByDefault(Invoke(stream_state, &CorruptedStreamState::Finish));
+    ON_CALL(*hash_stream, Read).WillByDefault(Invoke(stream_state, &CorruptedStreamState::Read));
+    return hash_stream;
+  }
+  return correct_hashes;
+}
+
+size_t ClusterResponsivenessLimiter::GetMaxFaulty() const { return max_faulty_; }
+
+size_t ClusterResponsivenessLimiter::GetClusterSize() const { return cluster_size_; }
+
+bool ClusterResponsivenessLimiter::IsUnresponsive(size_t server_index) const {
+  assert(server_index < server_responsiveness_.size());
+  return !(server_responsiveness_[server_index]);
+}
+
+size_t ClusterResponsivenessLimiter::GetNumUnresponsiveServers() const {
+  size_t num_unresponsive = 0;
+  for (size_t i = 0; i < server_responsiveness_.size(); ++i) {
+    if (!(server_responsiveness_[i])) {
+      ++num_unresponsive;
+    }
+  }
+  return num_unresponsive;
+}
+
+void ClusterResponsivenessLimiter::SetResponsive(size_t server_index) {
+  assert(server_index < server_responsiveness_.size());
+  server_responsiveness_[server_index] = true;
+}
+
+void ClusterResponsivenessLimiter::SetUnresponsive(size_t server_index) {
+  assert(server_index < server_responsiveness_.size());
+  server_responsiveness_[server_index] = false;
+}
+
+ClusterResponsivenessLimiter::ResponsivenessManager::~ResponsivenessManager() {}
+
+ClusterResponsivenessLimiter::DataStreamState::DataStreamState(
+    grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* data,
+    ClusterResponsivenessLimiter& responsiveness_limiter,
+    size_t server_index)
+    : data_(data), responsiveness_limiter_(responsiveness_limiter), server_index_(server_index) {}
+
+ClusterResponsivenessLimiter::DataStreamState::~DataStreamState() {}
+
+Status ClusterResponsivenessLimiter::DataStreamState::Finish() {
+  bool delay;
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_limiter_.responsiveness_change_mutex_);
+    delay = !(responsiveness_limiter_.server_responsiveness_[server_index_]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return data_->Finish();
+}
+
+bool ClusterResponsivenessLimiter::DataStreamState::Read(Data* data) {
+  bool delay;
+  bool result = data_->Read(data);
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_limiter_.responsiveness_change_mutex_);
+    if (result) {
+      responsiveness_limiter_.responsiveness_manager_->UpdateResponsiveness(
+          responsiveness_limiter_, server_index_, data->block_id());
+    }
+    delay = !(responsiveness_limiter_.server_responsiveness_[server_index_]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return result;
+}
+
+ClusterResponsivenessLimiter::HashStreamState::HashStreamState(
+    grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* hashes,
+    ClusterResponsivenessLimiter& responsiveness_limiter,
+    size_t server_index)
+    : hashes_(hashes), responsiveness_limiter_(responsiveness_limiter), server_index_(server_index) {}
+
+ClusterResponsivenessLimiter::HashStreamState::~HashStreamState() {}
+
+Status ClusterResponsivenessLimiter::HashStreamState::Finish() {
+  bool delay;
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_limiter_.responsiveness_change_mutex_);
+    delay = !(responsiveness_limiter_.server_responsiveness_[server_index_]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return hashes_->Finish();
+}
+
+bool ClusterResponsivenessLimiter::HashStreamState::Read(Hash* hash) {
+  bool delay;
+  bool result = hashes_->Read(hash);
+  uint64_t block_id = result ? hash->block_id() : UINT64_MAX;
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_limiter_.responsiveness_change_mutex_);
+    if (result) {
+      responsiveness_limiter_.responsiveness_manager_->UpdateResponsiveness(
+          responsiveness_limiter_, server_index_, hash->block_id());
+    }
+    delay = !(responsiveness_limiter_.server_responsiveness_[server_index_]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return result;
+}
+
+ClusterResponsivenessLimiter::ClusterResponsivenessLimiter(size_t max_faulty,
+                                                           size_t num_servers,
+                                                           unique_ptr<ResponsivenessManager>&& responsiveness_manager)
+    : max_faulty_(max_faulty),
+      cluster_size_(num_servers),
+      responsiveness_manager_(move(responsiveness_manager)),
+      server_responsiveness_(num_servers, true),
+      responsiveness_change_mutex_() {}
+
+ClusterResponsivenessLimiter::~ClusterResponsivenessLimiter() {}
+
+ClientReaderInterface<Data>* ClusterResponsivenessLimiter::ReadStateRaw(size_t server_index,
+                                                                        ClientContext* context,
+                                                                        const ReadStateRequest& request,
+                                                                        ClientReaderInterface<Data>* correct_data) {
+  bool delay;
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_change_mutex_);
+    responsiveness_manager_->UpdateResponsiveness(*this, server_index, 0);
+    delay = !(server_responsiveness_[server_index]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  MockThinReplicaStream<Data>* state_stream = new MockThinReplicaStream<Data>();
+  DataStreamState* stream_state = new DataStreamState(correct_data, *this, server_index);
+  state_stream->state.reset(stream_state);
+  ON_CALL(*state_stream, Finish).WillByDefault(Invoke(stream_state, &DataStreamState::Finish));
+  ON_CALL(*state_stream, Read).WillByDefault(Invoke(stream_state, &DataStreamState::Read));
+  return state_stream;
+}
+
+Status ClusterResponsivenessLimiter::ReadStateHash(size_t server_index,
+                                                   ClientContext* context,
+                                                   const ReadStateHashRequest& request,
+                                                   Hash* response,
+                                                   Status correct_status) {
+  bool delay;
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_change_mutex_);
+    responsiveness_manager_->UpdateResponsiveness(*this, server_index, request.block_id());
+    delay = !(server_responsiveness_[server_index]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  return correct_status;
+}
+
+ClientReaderInterface<Data>* ClusterResponsivenessLimiter::SubscribeToUpdatesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Data>* correct_data) {
+  bool delay;
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_change_mutex_);
+    responsiveness_manager_->UpdateResponsiveness(*this, server_index, request.block_id());
+    delay = !(server_responsiveness_[server_index]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  MockThinReplicaStream<Data>* update_stream = new MockThinReplicaStream<Data>();
+  DataStreamState* stream_state = new DataStreamState(correct_data, *this, server_index);
+  update_stream->state.reset(stream_state);
+  ON_CALL(*update_stream, Finish).WillByDefault(Invoke(stream_state, &DataStreamState::Finish));
+  ON_CALL(*update_stream, Read).WillByDefault(Invoke(stream_state, &DataStreamState::Read));
+  return update_stream;
+}
+
+ClientReaderInterface<Hash>* ClusterResponsivenessLimiter::SubscribeToUpdateHashesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Hash>* correct_hashes) {
+  bool delay;
+  {
+    unique_lock<mutex> responsiveness_lock(responsiveness_change_mutex_);
+    responsiveness_manager_->UpdateResponsiveness(*this, server_index, request.block_id());
+    delay = !(server_responsiveness_[server_index]);
+  }
+  if (delay) {
+    sleep_for(kTestingTimeout * 2);
+  }
+  MockThinReplicaStream<Hash>* hash_stream = new MockThinReplicaStream<Hash>();
+  HashStreamState* stream_state = new HashStreamState(correct_hashes, *this, server_index);
+  hash_stream->state.reset(stream_state);
+  ON_CALL(*hash_stream, Finish).WillByDefault(Invoke(stream_state, &HashStreamState::Finish));
+  ON_CALL(*hash_stream, Read).WillByDefault(Invoke(stream_state, &HashStreamState::Read));
+  return hash_stream;
+}
+
+ComprehensiveDataFabricator::ComprehensiveDataFabricator(shared_ptr<MockDataStreamPreparer> fabricated_data_preparer,
+                                                         size_t num_faulty_servers)
+    : fabricated_data_preparer_(fabricated_data_preparer),
+      fabricated_update_hasher_(new MockOrderedDataStreamHasher(fabricated_data_preparer)),
+      num_faulty_servers_(num_faulty_servers) {}
+
+ComprehensiveDataFabricator::~ComprehensiveDataFabricator() {}
+
+ClientReaderInterface<Data>* ComprehensiveDataFabricator::ReadStateRaw(size_t server_index,
+                                                                       ClientContext* context,
+                                                                       const ReadStateRequest& request,
+                                                                       ClientReaderInterface<Data>* correct_data) {
+  if (MakeByzantineFaulty(server_index, num_faulty_servers_)) {
+    delete correct_data;
+    return fabricated_data_preparer_->ReadStateRaw(context, request);
+  }
+  return correct_data;
+}
+
+Status ComprehensiveDataFabricator::ReadStateHash(size_t server_index,
+                                                  ClientContext* context,
+                                                  const ReadStateHashRequest& request,
+                                                  Hash* response,
+                                                  Status correct_status) {
+  if (MakeByzantineFaulty(server_index, num_faulty_servers_)) {
+    return fabricated_update_hasher_->ReadStateHash(context, request, response);
+  }
+  return correct_status;
+}
+
+ClientReaderInterface<Data>* ComprehensiveDataFabricator::SubscribeToUpdatesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Data>* correct_data) {
+  if (MakeByzantineFaulty(server_index, num_faulty_servers_)) {
+    delete correct_data;
+    return fabricated_data_preparer_->SubscribeToUpdatesRaw(context, request);
+  }
+  return correct_data;
+}
+
+ClientReaderInterface<Hash>* ComprehensiveDataFabricator::SubscribeToUpdateHashesRaw(
+    size_t server_index,
+    ClientContext* context,
+    const SubscriptionRequest& request,
+    ClientReaderInterface<Hash>* correct_hashes) {
+  if (MakeByzantineFaulty(server_index, num_faulty_servers_)) {
+    delete correct_hashes;
+    return fabricated_update_hasher_->SubscribeToUpdateHashesRaw(context, request);
+  }
+  return correct_hashes;
+}

--- a/client/thin-replica-client/test/thin_replica_client_mocks.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_mocks.cpp
@@ -64,7 +64,7 @@ Data FilterUpdate(const Data& raw_update, const string& filter) {
   filtered_update.set_block_id(raw_update.block_id());
   filtered_update.set_correlation_id(raw_update.correlation_id());
   for (const KVPair& raw_kvp : raw_update.data()) {
-    const string key = raw_kvp.key();
+    const string& key = raw_kvp.key();
     if ((key.length() >= filter.length()) && (key.compare(0, filter.size(), filter) == 0)) {
       KVPair* filtered_kvp = filtered_update.add_data();
       *filtered_kvp = raw_kvp;

--- a/client/thin-replica-client/test/thin_replica_client_mocks.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_mocks.cpp
@@ -1038,7 +1038,6 @@ Status ClusterResponsivenessLimiter::HashStreamState::Finish() {
 bool ClusterResponsivenessLimiter::HashStreamState::Read(Hash* hash) {
   bool delay;
   bool result = hashes_->Read(hash);
-  uint64_t block_id = result ? hash->block_id() : UINT64_MAX;
   {
     unique_lock<mutex> responsiveness_lock(responsiveness_limiter_.responsiveness_change_mutex_);
     if (result) {

--- a/client/thin-replica-client/test/thin_replica_client_mocks.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_mocks.cpp
@@ -14,6 +14,7 @@
 #include "client/thin-replica-client/thin_replica_client.hpp"
 #include "client/thin-replica-client/trs_connection.hpp"
 
+#include "assertUtils.hpp"
 #include "gmock/gmock.h"
 #include "thin_replica_client_mocks.hpp"
 #include "client/thin-replica-client/trc_hash.hpp"
@@ -89,7 +90,7 @@ Status VectorMockDataStreamPreparer::DataQueue::Finish() {
 }
 
 bool VectorMockDataStreamPreparer::DataQueue::Read(Data* msg) {
-  assert(msg);
+  ConcordAssertNE(msg, nullptr);
 
   if (queue_.empty()) {
     return false;
@@ -109,7 +110,7 @@ bool VectorMockDataStreamPreparer::DataQueue::Read(Data* msg) {
 ClientReaderInterface<Data>* VectorMockDataStreamPreparer::PrepareInitialStateDataStream(const string& filter) const {
   auto data_stream = new MockThinReplicaStream<Data>();
   list<Data> data_queue;
-  assert(num_updates_in_initial_state_ <= data_.size());
+  ConcordAssert(num_updates_in_initial_state_ <= data_.size());
   for (size_t i = 0; i < num_updates_in_initial_state_; ++i) {
     data_queue.push_back(FilterUpdate(data_[i], filter));
   }
@@ -184,7 +185,7 @@ Status RepeatedMockDataStreamPreparer::DataRepeater::Finish() {
 }
 
 bool RepeatedMockDataStreamPreparer::DataRepeater::Read(Data* msg) {
-  assert(msg);
+  ConcordAssertNE(msg, nullptr);
 
   lock_guard<mutex> block_id_lock(block_id_mutex_);
   if (finite_length_ && (num_updates_ < 1)) {
@@ -256,7 +257,7 @@ Status DelayedMockDataStreamPreparer::DataDelayer::Finish() {
 }
 
 bool DelayedMockDataStreamPreparer::DataDelayer::Read(Data* msg) {
-  assert(msg);
+  ConcordAssertNE(msg, nullptr);
 
   while (*spurious_wakeup_) {
     unique_lock<mutex> condition_lock(*condition_mutex_);
@@ -302,7 +303,7 @@ MockOrderedDataStreamHasher::StreamHasher::~StreamHasher() {}
 Status MockOrderedDataStreamHasher::StreamHasher::Finish() { return data_stream_->Finish(); }
 
 bool MockOrderedDataStreamHasher::StreamHasher::Read(Hash* msg) {
-  assert(msg);
+  ConcordAssertNE(msg, nullptr);
 
   Data data;
   bool read_status = data_stream_->Read(&data);
@@ -334,7 +335,7 @@ MockOrderedDataStreamHasher::MockOrderedDataStreamHasher(shared_ptr<MockDataStre
 Status MockOrderedDataStreamHasher::ReadStateHash(ClientContext* context,
                                                   const ReadStateHashRequest& request,
                                                   Hash* response) const {
-  assert(response);
+  ConcordAssertNE(response, nullptr);
 
   list<string> update_hashes;
   auto data_context = make_unique<ClientContext>();
@@ -447,8 +448,8 @@ MockThinReplicaServerRecorder::MockThinReplicaServerRecorder(shared_ptr<MockData
 
 ClientReaderInterface<Data>* MockThinReplicaServerRecorder::ReadStateRaw(ClientContext* context,
                                                                          const ReadStateRequest& request) {
-  assert(data_preparer_);
-  assert(record_);
+  ConcordAssertNE(data_preparer_, nullptr);
+  ConcordAssertNE(record_, nullptr);
 
   record_->RecordReadState(server_index_, request);
   return data_preparer_->ReadStateRaw(context, request);
@@ -457,8 +458,8 @@ ClientReaderInterface<Data>* MockThinReplicaServerRecorder::ReadStateRaw(ClientC
 Status MockThinReplicaServerRecorder::ReadStateHash(ClientContext* context,
                                                     const ReadStateHashRequest& request,
                                                     Hash* response) {
-  assert(hasher_);
-  assert(record_);
+  ConcordAssertNE(hasher_, nullptr);
+  ConcordAssertNE(record_, nullptr);
 
   record_->RecordReadStateHash(server_index_, request);
   return hasher_->ReadStateHash(context, request, response);
@@ -466,15 +467,15 @@ Status MockThinReplicaServerRecorder::ReadStateHash(ClientContext* context,
 
 ClientReaderInterface<Data>* MockThinReplicaServerRecorder::SubscribeToUpdatesRaw(ClientContext* context,
                                                                                   const SubscriptionRequest& request) {
-  assert(data_preparer_);
-  assert(record_);
+  ConcordAssertNE(data_preparer_, nullptr);
+  ConcordAssertNE(record_, nullptr);
 
   record_->RecordSubscribeToUpdates(server_index_, request);
   return data_preparer_->SubscribeToUpdatesRaw(context, request);
 }
 
 Status MockThinReplicaServerRecorder::AckUpdate(ClientContext* context, const BlockId& block_id, Empty* response) {
-  assert(record_);
+  ConcordAssertNE(record_, nullptr);
 
   record_->RecordAckUpdate(server_index_, block_id);
   return Status::OK;
@@ -482,15 +483,15 @@ Status MockThinReplicaServerRecorder::AckUpdate(ClientContext* context, const Bl
 
 ClientReaderInterface<Hash>* MockThinReplicaServerRecorder::SubscribeToUpdateHashesRaw(
     ClientContext* context, const SubscriptionRequest& request) {
-  assert(hasher_);
-  assert(record_);
+  ConcordAssertNE(hasher_, nullptr);
+  ConcordAssertNE(record_, nullptr);
 
   record_->RecordSubscribeToUpdateHashes(server_index_, request);
   return hasher_->SubscribeToUpdateHashesRaw(context, request);
 }
 
 Status MockThinReplicaServerRecorder::Unsubscribe(ClientContext* context, const Empty& request, Empty* response) {
-  assert(record_);
+  ConcordAssertNE(record_, nullptr);
 
   record_->RecordUnsubscribe(server_index_);
   return Status::OK;
@@ -576,8 +577,8 @@ ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::ByzantineMockServer
 
 ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::ReadStateRaw(
     ClientContext* context, const ReadStateRequest& request) {
-  assert(non_faulty_data_);
-  assert(byzantine_behavior_);
+  ConcordAssertNE(non_faulty_data_, nullptr);
+  ConcordAssertNE(byzantine_behavior_, nullptr);
 
   return byzantine_behavior_->ReadStateRaw(index_, context, request, non_faulty_data_->ReadStateRaw(context, request));
 }
@@ -585,8 +586,8 @@ ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineMo
 Status ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::ReadStateHash(ClientContext* context,
                                                                                   const ReadStateHashRequest& request,
                                                                                   Hash* response) {
-  assert(non_faulty_hasher_);
-  assert(byzantine_behavior_);
+  ConcordAssertNE(non_faulty_hasher_, nullptr);
+  ConcordAssertNE(byzantine_behavior_, nullptr);
 
   return byzantine_behavior_->ReadStateHash(
       index_, context, request, response, non_faulty_hasher_->ReadStateHash(context, request, response));
@@ -594,8 +595,8 @@ Status ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::ReadStateHas
 
 ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::SubscribeToUpdatesRaw(
     ClientContext* context, const SubscriptionRequest& request) {
-  assert(non_faulty_data_);
-  assert(byzantine_behavior_);
+  ConcordAssertNE(non_faulty_data_, nullptr);
+  ConcordAssertNE(byzantine_behavior_, nullptr);
 
   return byzantine_behavior_->SubscribeToUpdatesRaw(
       index_, context, request, non_faulty_data_->SubscribeToUpdatesRaw(context, request));
@@ -604,15 +605,15 @@ ClientReaderInterface<Data>* ByzantineMockThinReplicaServerPreparer::ByzantineMo
 Status ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::AckUpdate(ClientContext* context,
                                                                               const BlockId& block_id,
                                                                               Empty* response) {
-  assert(byzantine_behavior_);
+  ConcordAssertNE(byzantine_behavior_, nullptr);
 
   return byzantine_behavior_->AckUpdate(index_, context, block_id, response, Status::OK);
 }
 
 ClientReaderInterface<Hash>* ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::SubscribeToUpdateHashesRaw(
     ClientContext* context, const SubscriptionRequest& request) {
-  assert(non_faulty_hasher_);
-  assert(byzantine_behavior_);
+  ConcordAssertNE(non_faulty_hasher_, nullptr);
+  ConcordAssertNE(byzantine_behavior_, nullptr);
 
   return byzantine_behavior_->SubscribeToUpdateHashesRaw(
       index_, context, request, non_faulty_hasher_->SubscribeToUpdateHashesRaw(context, request));
@@ -621,7 +622,7 @@ ClientReaderInterface<Hash>* ByzantineMockThinReplicaServerPreparer::ByzantineMo
 Status ByzantineMockThinReplicaServerPreparer::ByzantineMockServer::Unsubscribe(ClientContext* context,
                                                                                 const Empty& request,
                                                                                 Empty* response) {
-  assert(byzantine_behavior_);
+  ConcordAssertNE(byzantine_behavior_, nullptr);
 
   return byzantine_behavior_->Unsubscribe(index_, context, request, response, Status::OK);
 }
@@ -952,7 +953,7 @@ size_t ClusterResponsivenessLimiter::GetMaxFaulty() const { return max_faulty_; 
 size_t ClusterResponsivenessLimiter::GetClusterSize() const { return cluster_size_; }
 
 bool ClusterResponsivenessLimiter::IsUnresponsive(size_t server_index) const {
-  assert(server_index < server_responsiveness_.size());
+  ConcordAssert(server_index < server_responsiveness_.size());
   return !(server_responsiveness_[server_index]);
 }
 
@@ -967,12 +968,12 @@ size_t ClusterResponsivenessLimiter::GetNumUnresponsiveServers() const {
 }
 
 void ClusterResponsivenessLimiter::SetResponsive(size_t server_index) {
-  assert(server_index < server_responsiveness_.size());
+  ConcordAssert(server_index < server_responsiveness_.size());
   server_responsiveness_[server_index] = true;
 }
 
 void ClusterResponsivenessLimiter::SetUnresponsive(size_t server_index) {
-  assert(server_index < server_responsiveness_.size());
+  ConcordAssert(server_index < server_responsiveness_.size());
   server_responsiveness_[server_index] = false;
 }
 

--- a/client/thin-replica-client/test/thin_replica_client_mocks.hpp
+++ b/client/thin-replica-client/test/thin_replica_client_mocks.hpp
@@ -1,0 +1,982 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#ifndef THIN_REPLICA_CLIENT_MOCKS_HPP
+#define THIN_REPLICA_CLIENT_MOCKS_HPP
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "thin_replica_mock.grpc.pb.h"
+#include "client/thin-replica-client/trs_connection.hpp"
+
+const std::chrono::milliseconds kTestingTimeout(10);
+
+class MockTrsConnection : public thin_replica_client::TrsConnection {
+ public:
+  MockTrsConnection();
+  ~MockTrsConnection() override {}
+  com::vmware::concord::thin_replica::MockThinReplicaStub* GetStub();
+  bool isConnected() override;
+};
+
+template <class DataType>
+class MockThinReplicaStream : public grpc::ClientReaderInterface<DataType> {
+ public:
+  // Functions the Thin Replica Client Library is known to currently use.
+  MOCK_METHOD0_T(Finish, grpc::Status());
+  MOCK_METHOD1_T(Read, bool(DataType* msg));
+
+  // Other virtual StubInterface functions currently thought to be unused by the
+  // Thin Replica Client Library.
+  MOCK_METHOD1_T(NextMessageSize, bool(uint32_t* sz));
+  MOCK_METHOD0_T(WaitForInitialMetadata, void());
+
+  // Abstract state type and unique_ptr to state of that type that testing code
+  // may attach to this MockThinReplicaStream. This can be used to tie the
+  // lifespan and destruction of auxiliary state the testing code is using with
+  // a MockThinReplicaStream object to the lifespan and destruction of that mock
+  // object.
+  class State {
+   public:
+    virtual ~State() {}
+  };
+  std::unique_ptr<State> state = std::unique_ptr<State>(nullptr);
+};
+
+// Abstract class specifying an interface for handlig mocked calls to ReadState
+// and SubscribeToUpdates.
+class MockDataStreamPreparer {
+ public:
+  virtual ~MockDataStreamPreparer() {}
+  virtual grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::ReadStateRequest& request) const = 0;
+  virtual grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::SubscriptionRequest& request) const = 0;
+};
+
+// Prepares mock data streams to return the contents of the vector it is
+// constructed with in order; the block IDs given in the vector for the Data
+// entries are preserved.
+class VectorMockDataStreamPreparer : public MockDataStreamPreparer {
+ private:
+  class DataQueue : public MockThinReplicaStream<com::vmware::concord::thin_replica::Data>::State {
+   private:
+    std::list<com::vmware::concord::thin_replica::Data> queue_;
+    std::mutex queue_mutex_;
+    std::condition_variable empty_condition_;
+    std::mutex empty_condition_mutex_;
+
+   public:
+    DataQueue(const std::list<com::vmware::concord::thin_replica::Data>& data);
+    ~DataQueue() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Data* msg);
+  };
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* PrepareInitialStateDataStream(
+      const std::string& filter) const;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* PrepareSubscriptionDataStream(
+      uint64_t block_id, const std::string& filter) const;
+
+  const std::vector<com::vmware::concord::thin_replica::Data> data_;
+  size_t num_updates_in_initial_state_;
+
+ public:
+  VectorMockDataStreamPreparer(const std::vector<com::vmware::concord::thin_replica::Data>& data,
+                               size_t initial_state_size = 1);
+  ~VectorMockDataStreamPreparer() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::ReadStateRequest& request) const override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request) const override;
+};
+
+// Prepares mock data streams that repeatedly return the same update.
+// Automatically increments the Block IDs of sequentially returned Data objects,
+// beginning from the block ID the Data object this
+// RepeatedMJockDataStreamPreparer was constructed with (for requests that do
+// not specify a block ID), or beginning with the specified block ID (for
+// requests that do specify a block ID).
+class RepeatedMockDataStreamPreparer : public MockDataStreamPreparer {
+ private:
+  class DataRepeater : public MockThinReplicaStream<com::vmware::concord::thin_replica::Data>::State {
+   private:
+    com::vmware::concord::thin_replica::Data data_;
+    uint64_t current_block_id_;
+    std::mutex block_id_mutex_;
+
+    bool finite_length_;
+    size_t num_updates_ = 0;
+
+    std::condition_variable finished_condition_;
+    std::mutex finished_condition_mutex_;
+
+   public:
+    DataRepeater(const com::vmware::concord::thin_replica::Data& data, uint64_t starting_block_id);
+    DataRepeater(const com::vmware::concord::thin_replica::Data& data, uint64_t starting_block_id, size_t num_updates);
+    ~DataRepeater() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Data* msg);
+  };
+
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* PrepareInitialStateDataStream(
+      const std::string& filter) const;
+
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* PrepareSubscriptionDataStream(
+      uint64_t block_id, const std::string& filter) const;
+
+  com::vmware::concord::thin_replica::Data data_;
+  size_t num_updates_in_initial_state_;
+
+ public:
+  RepeatedMockDataStreamPreparer(const com::vmware::concord::thin_replica::Data& data, size_t initial_state_length = 1);
+  ~RepeatedMockDataStreamPreparer() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::ReadStateRequest& request) const override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request) const override;
+};
+
+// Decorator of other MockDataStreamPreparers that waits on an external
+// condition before sending each update (excluding those that are part of the
+// initial state).
+class DelayedMockDataStreamPreparer : public MockDataStreamPreparer {
+ private:
+  class DataDelayer : public MockThinReplicaStream<com::vmware::concord::thin_replica::Data>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>> undelayed_data_;
+
+    std::shared_ptr<std::condition_variable> waiting_condition_;
+    std::shared_ptr<bool> spurious_wakeup_;
+    std::shared_ptr<std::mutex> condition_mutex_;
+
+   public:
+    DataDelayer(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* data,
+                const std::shared_ptr<std::condition_variable>& delay_condition,
+                const std::shared_ptr<std::mutex>& delay_mutex,
+                const std::shared_ptr<bool>& spurious_wakeup);
+    ~DataDelayer() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Data* msg);
+  };
+
+  std::shared_ptr<MockDataStreamPreparer> undelayed_data_preparer_;
+  std::shared_ptr<std::condition_variable> delay_condition_;
+  std::shared_ptr<bool> spurious_wakeup_;
+  std::shared_ptr<std::mutex> condition_mutex_;
+
+ public:
+  DelayedMockDataStreamPreparer(std::shared_ptr<MockDataStreamPreparer>& data,
+                                std::shared_ptr<std::condition_variable> condition,
+                                std::shared_ptr<bool> spurious_wakeup_indicator,
+                                std::shared_ptr<std::mutex> condition_mutex);
+  virtual ~DelayedMockDataStreamPreparer();
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::ReadStateRequest& request) const override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request) const override;
+};
+
+// Mock hasher class which provides a hashing implementation corresponding to
+// what hashes a Thin Replica Server (or at least a Thin Replica Server that is
+// not Byzantine-faulty in such a way that it returns hashes disagreeing with
+// its own data) would return, given a MockDataStreamPreparer object returning
+// the update data that server returns for any MockDataStreamPreparer object
+// that is guaranteed to return its updates in a consistent and monotonically
+// increasing order.
+class MockOrderedDataStreamHasher {
+ private:
+  typedef size_t StateHashType;
+  typedef size_t UpdateHashType;
+
+  class StreamHasher : public MockThinReplicaStream<com::vmware::concord::thin_replica::Hash>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>> data_stream_;
+
+   public:
+    StreamHasher(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* data);
+    ~StreamHasher() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Hash* msg);
+  };
+
+  std::shared_ptr<MockDataStreamPreparer> data_preparer_;
+  uint64_t base_block_id_;
+
+ public:
+  MockOrderedDataStreamHasher(std::shared_ptr<MockDataStreamPreparer>& data);
+
+  grpc::Status ReadStateHash(grpc::ClientContext* context,
+                             const com::vmware::concord::thin_replica::ReadStateHashRequest& request,
+                             com::vmware::concord::thin_replica::Hash* response) const;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::SubscriptionRequest& request) const;
+};
+
+// Class used for storing records of RPC calls to Thin Replica Servers made by a
+// ThinReplicaClient; this is intended for use in testing that the
+// ThinReplicaClient implementation complies with the intended use(s) of these
+// RPC calls as described in the Thin Replica Mechanism design. Note this class
+// handles synchronization of writes to these records across multiple threads.
+// Call records are structured as lists of pairs of size_ts (representing the
+// server the call was made to) and Protobuf messages (representing the
+// parameter given for the call) or as lists of just size_ts (representing the
+// server the call was made to) for RPC calls that do not use parameters.
+class ThinReplicaCommunicationRecord {
+ private:
+  std::list<std::pair<size_t, com::vmware::concord::thin_replica::ReadStateRequest>> read_state_calls_;
+  std::list<std::pair<size_t, com::vmware::concord::thin_replica::ReadStateHashRequest>> read_state_hash_calls_;
+  std::list<std::pair<size_t, com::vmware::concord::thin_replica::SubscriptionRequest>> subscribe_to_updates_calls_;
+  std::list<std::pair<size_t, com::vmware::concord::thin_replica::BlockId>> ack_update_calls_;
+  std::list<std::pair<size_t, com::vmware::concord::thin_replica::SubscriptionRequest>>
+      subscribe_to_update_hashes_calls_;
+  std::list<size_t> unsubscribe_calls_;
+
+  std::mutex record_mutex_;
+
+ public:
+  void ClearRecords();
+
+  void RecordReadState(size_t server_index, const com::vmware::concord::thin_replica::ReadStateRequest& request);
+  void RecordReadStateHash(size_t server_index,
+                           const com::vmware::concord::thin_replica::ReadStateHashRequest& request);
+  void RecordSubscribeToUpdates(size_t server_index,
+                                const com::vmware::concord::thin_replica::SubscriptionRequest& request);
+  void RecordAckUpdate(size_t server_index, const com::vmware::concord::thin_replica::BlockId& block_id);
+  void RecordSubscribeToUpdateHashes(size_t server_index,
+                                     const com::vmware::concord::thin_replica::SubscriptionRequest& request);
+  void RecordUnsubscribe(size_t server_index);
+
+  const std::list<std::pair<size_t, com::vmware::concord::thin_replica::ReadStateRequest>>& GetReadStateCalls() const;
+  const std::list<std::pair<size_t, com::vmware::concord::thin_replica::ReadStateHashRequest>>& GetReadStateHashCalls()
+      const;
+  const std::list<std::pair<size_t, com::vmware::concord::thin_replica::SubscriptionRequest>>&
+  GetSubscribeToUpdatesCalls() const;
+  const std::list<std::pair<size_t, com::vmware::concord::thin_replica::BlockId>>& GetAckUpdateCalls() const;
+  const std::list<std::pair<size_t, com::vmware::concord::thin_replica::SubscriptionRequest>>&
+  GetSubscribeToUpdateHashesCalls() const;
+  const std::list<size_t>& GetUnsubscribeCalls() const;
+  size_t GetTotalCallCount() const;
+};
+
+// Class for recording Thin Replica RPC calls to a given mocked Thin Replica
+// Server, given the data stream preparer and hasher for that server and a
+// ThinReplicaCommunicationRecord to record the calls to.
+class MockThinReplicaServerRecorder {
+ private:
+  std::shared_ptr<MockDataStreamPreparer> data_preparer_;
+  std::shared_ptr<MockOrderedDataStreamHasher> hasher_;
+  std::shared_ptr<ThinReplicaCommunicationRecord> record_;
+  size_t server_index_;
+
+ public:
+  MockThinReplicaServerRecorder(std::shared_ptr<MockDataStreamPreparer> data,
+                                std::shared_ptr<MockOrderedDataStreamHasher> hasher,
+                                std::shared_ptr<ThinReplicaCommunicationRecord> record,
+                                size_t server_index);
+
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::ReadStateRequest& request);
+  grpc::Status ReadStateHash(grpc::ClientContext* context,
+                             const com::vmware::concord::thin_replica::ReadStateHashRequest& request,
+                             com::vmware::concord::thin_replica::Hash* response);
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::SubscriptionRequest& request);
+  grpc::Status AckUpdate(grpc::ClientContext* context,
+                         const com::vmware::concord::thin_replica::BlockId& block_id,
+                         google::protobuf::Empty* response);
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+      grpc::ClientContext* context, const com::vmware::concord::thin_replica::SubscriptionRequest& request);
+  grpc::Status Unsubscribe(grpc::ClientContext* context,
+                           const google::protobuf::Empty& request,
+                           google::protobuf::Empty* response);
+};
+
+// Class for managing mocked server behavior in test cases involving
+// Byzantine-faulty servers.
+//
+// A ByzantineMockThinReplicaServerPreparer object itself is effectively a
+// factory for mock thin replica servers (of the type
+// ByzantineMockThinReplicaServerPreparer::ByzantineMockServer) for a mocked
+// cluster including some servers with Byzantine-faulty behavior.
+//
+// At its construction, a ByzantineMockThinReplicaServerPreparer takes
+// specifications of the faulty and non-faulty behavior to be used in a mock
+// cluster. The non-faulty behavior is to be specified via shared_ptrs to
+// MockDataStreamPreparer and MockOrderedDataStreamHasher objects, which are the
+// same objects we use for describing server behavior in test cases involving
+// homogenous, non-Byzantine-faulty mocked servers (see definitions of these
+// classes above). For specifying behavior of Byzantine-faulty servers, a
+// shared_ptr to an object of type
+// ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior is accepted.
+//
+// ByzantineServerBehavior is a public, abstract member class of
+// ByzantineMockThinReplicaServerPreparer defining an interface for managing
+// Byzantine behavior (see ByzantineServerBehavior's declaration below). A
+// ByzantineServerBehavior object decides, possibly dynamically, what server(s)
+// will be Byzantine-faulty, when they will start showing Byzantine-faulty
+// behavior, and what that faulty behavior will be. It is expected unit test
+// cases with server(s) with Byzantine-faulty behavior will use some extension
+// of ByzantineServerBehavior to describe that faulty behavior. Examples of such
+// test cases, such as test_read_state_fabricated_data, can be found in
+// thin-replica-client/test/trc_byzantine_test.cpp, and examples of such
+// extensions of ByzantineServerBehavior, such as InitialStateFabricator, are
+// declared later in this file.
+class ByzantineMockThinReplicaServerPreparer {
+ public:
+  // Abstract class for describing Byzantine-Faulty server behavior to a
+  // ByzantineMockThinReplicaServerPreparer; note a single
+  // ByzantineServerBehavior object is intended to be shared for an entire mock
+  // cluster with faulty and non-faulty servers.
+  //
+  // ByzantineServerBehavior has a virtual function for mocking each RPC call a
+  // Thin Replica Server supports. ByzantineMockServers created by a
+  // ByzantineMockThinReplicaServerPreparer will invoke the
+  // ByzantineServerBehavior object they are using for each RPC call they mock
+  // to determine the behavior used for that call; the ByzantineServerBehavior
+  // should choose whether, and, if so, how, behavior for that call will be
+  // faulty. ByzantineServerBehavior itself comes with an implementation for
+  // each of these functions that always chooses non-faulty behavior; it is
+  // expected ByzantineServerBehavior extensions will only override the behavior
+  // for RPC calls whose behavior is desired to be Byzantine in the specific
+  // test case(s) the extension is used for.
+  //
+  // The ByzantineServerBeahvior class also keeps a record of what servers are
+  // Byzantine-faulty by server index. This alows extensions of this abstract
+  // class to dynamically configure which servers are Byzantine-faulty at
+  // runtime, which can allow test cases to make servers Byzantine faulty as
+  // they see them called, freeing them of the need to predict or even know what
+  // order the ThinReplicaClient implementation tries servers in.
+  class ByzantineServerBehavior {
+   private:
+    std::unordered_set<size_t> byzantine_faulty_servers_;
+    std::mutex faulty_server_record_mutex_;
+
+   protected:
+    ByzantineServerBehavior();
+
+    // Protected functions for managing which servers are Byzantine-faulty. Note
+    // multiple concurrent calls to one or more of IsByzantineFaulty,
+    // GetNumFaultyServers, and MakeByzantineFaulty are thread safe.
+    bool IsByzantineFaulty(size_t index);
+    size_t GetNumFaultyServers();
+
+    // Checks whether the number of servers that are already Byzantine faulty is
+    // strictly less than max_faulty, and, if so, records that the server with
+    // index index is Byzantine faulty if it was not already. This check and
+    // write is done atomically with respect to this ByzantineServerBehavior's
+    // record of which servers are Byzantine faulty. Note the max_faulty
+    // parameter for this function can be any number and need not match the F
+    // (i.e. maximum number of Byzantine-faulty nodes the cluster can tolerate)
+    // value for the cluster being mocked.
+    //
+    // Returns whether the server with index index is listed as Byzantine faulty
+    // after this call completes (this includes returning true when it was
+    // already listed as faulty before this call).
+    bool MakeByzantineFaulty(size_t index, size_t max_faulty);
+
+   public:
+    virtual ~ByzantineServerBehavior();
+
+    // Virtual functions called by ByzantineMockServers to decide behavior for
+    // RPC calls they are mocking. It is the responsibility of the
+    // ByzantineServerBehavior object to decide whether, and, if so, how,
+    // behavior will be faulty when these functions are called. Note the
+    // ByzantineServerBehavior abstract class's own default implementations of
+    // these functions always choose non-faulty behavior, so extensions need
+    // only override those that may have faulty behavior in the specific test
+    // case(s) they are used for.
+    //
+    // Note multiple calls to the same or different RPC behavior-mocking
+    // functions may be made concurrently from the same or different
+    // ByzantineMockServers, so ByzantineServerBehavior extensions are expected
+    // to handle (as necessary) synchronization of any shared state that could
+    // be written to by calls to these functions.
+    //
+    // In terms of signature and expected behavior (at least in the
+    // non-Byzantine-faulty case) these funcitions are somewhat similar to the
+    // com::vmware::concord::thin_replica::MockThinReplicaStub functions
+    // ByzantineMockServer uses them to mock behavior for, but with the
+    // following specific differences:
+    //
+    //  - The size_t parameter server_index is added to the start of the
+    //  function's parameter list; the calling ByzantineMockServer will give the
+    //  index of the server for which behavior is being mocked for this
+    //  parameter. It is anticipated this parameter can be used in tracking
+    //  which servers it has made Byzantine-faulty.
+    //
+    //  - A parameter with type matching the function's return type is appended
+    //  to the end of each function's parameter list; the calling
+    //  ByzantineMockServer will give the return value a non-faulty server would
+    //  give for this parameter. It is anticipated this parameter can be used in
+    //  both mocking non-faulty behavior and mocking faulty behavior that is
+    //  implemented by making specific modifications to non-faulty behavior.
+    //
+    //  - In cases where the function has a raw object pointer return type and a
+    //  pointer to a newly allocated object would be returned in the case the
+    //  server handling the request is not faulty, the calling
+    //  ByzantineMockServer will in fact allocate a new object matching the
+    //  object that would be returned when using such a non-faulty server and
+    //  pass it to the ByzantineServerBehavior for its last parameter; in this
+    //  case the ByzantineServerBehavior assumes ownership of the non-faulty
+    //  object the ByzantineMockServer allocated, and should either free this
+    //  pointer or ensure ownership is transfered somewhere else (note returning
+    //  the provided pointer or a pointer to an object that itself has been
+    //  given ownership of the provided pointer can satisfy this transfer of
+    //  ownership).
+    //
+    //  - If a function has a pointer in its signature that the
+    //  com::vmware::concord::thin_replica::MockThinReplicaStub would write a
+    //  response to (for example, response in ReadStateHash), and a non-faulty
+    //  server would write back to that pointer for a particular call, then the
+    //  calling ByzantineMockServer will write the non-faulty response to that
+    //  pointer before calling its ByzantineServerBehavior object, which may
+    //  then choose to either leave or overwrite the non-faulty value.
+    virtual grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+        size_t server_index,
+        grpc::ClientContext* context,
+        const com::vmware::concord::thin_replica::ReadStateRequest& request,
+        grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data);
+    virtual grpc::Status ReadStateHash(size_t server_index,
+                                       grpc::ClientContext* context,
+                                       const com::vmware::concord::thin_replica::ReadStateHashRequest& request,
+                                       com::vmware::concord::thin_replica::Hash* response,
+                                       grpc::Status correct_status);
+    virtual grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+        size_t server_index,
+        grpc::ClientContext* context,
+        const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+        grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data);
+    virtual grpc::Status AckUpdate(size_t server_index,
+                                   grpc::ClientContext* context,
+                                   const com::vmware::concord::thin_replica::BlockId& block_id,
+                                   google::protobuf::Empty* response,
+                                   grpc::Status correct_status);
+    virtual grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+        size_t server_index,
+        grpc::ClientContext* context,
+        const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+        grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* correct_hashes);
+    virtual grpc::Status Unsubscribe(size_t server_index,
+                                     grpc::ClientContext* context,
+                                     const google::protobuf::Empty& request,
+                                     google::protobuf::Empty* response,
+                                     grpc::Status correct_status);
+  };
+
+  // Mock server type for servers in a mock cluster managed by a
+  // ByzantineMockThinReplicaServerPreparer; a
+  // ByzantineMockThinReplicaServerPreparer effectively serves as a factory for
+  // ByzantineMockServerObjects.
+  class ByzantineMockServer : public com::vmware::concord::thin_replica::MockThinReplicaStub {
+   private:
+    std::shared_ptr<MockDataStreamPreparer> non_faulty_data_;
+    std::shared_ptr<MockOrderedDataStreamHasher> non_faulty_hasher_;
+    std::shared_ptr<ByzantineServerBehavior> byzantine_behavior_;
+    size_t index_;
+
+   public:
+    ByzantineMockServer(std::shared_ptr<MockDataStreamPreparer> non_faulty_data,
+                        std::shared_ptr<MockOrderedDataStreamHasher> non_faulty_hasher,
+                        std::shared_ptr<ByzantineServerBehavior> byzantine_behavior,
+                        size_t index);
+
+    grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+        grpc::ClientContext* context, const com::vmware::concord::thin_replica::ReadStateRequest& request);
+    grpc::Status ReadStateHash(grpc::ClientContext* context,
+                               const com::vmware::concord::thin_replica::ReadStateHashRequest& request,
+                               com::vmware::concord::thin_replica::Hash* response);
+    grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+        grpc::ClientContext* context, const com::vmware::concord::thin_replica::SubscriptionRequest& request);
+    grpc::Status AckUpdate(grpc::ClientContext* context,
+                           const com::vmware::concord::thin_replica::BlockId& block_id,
+                           google::protobuf::Empty* response);
+    grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+        grpc::ClientContext* context, const com::vmware::concord::thin_replica::SubscriptionRequest& request);
+    grpc::Status Unsubscribe(grpc::ClientContext* context,
+                             const google::protobuf::Empty& request,
+                             google::protobuf::Empty* response);
+  };
+
+ private:
+  std::shared_ptr<MockDataStreamPreparer> non_faulty_data_;
+  std::shared_ptr<MockOrderedDataStreamHasher> non_faulty_hasher_;
+  std::shared_ptr<ByzantineServerBehavior> byzantine_behavior_;
+
+ public:
+  ByzantineMockThinReplicaServerPreparer(std::shared_ptr<MockDataStreamPreparer> non_faulty_data,
+                                         std::shared_ptr<MockOrderedDataStreamHasher> non_faulty_hasher,
+                                         std::shared_ptr<ByzantineServerBehavior> byzantine_behavior);
+
+  // Factory method for creating mock server objects; note
+  // ByzantineMockThinReplicaServerPreparer itself does not track which servers
+  // it has already created mock servers for, so it is possible to have multiple
+  // mock servers sharing an index, either intentionally or unintentionally.
+  ByzantineMockServer* CreateByzantineMockServer(size_t index);
+};
+
+std::vector<std::unique_ptr<MockThinReplicaServerRecorder>> CreateMockServerRecorders(
+    size_t num_servers,
+    std::shared_ptr<MockDataStreamPreparer> data,
+    std::shared_ptr<MockOrderedDataStreamHasher> hasher,
+    std::shared_ptr<ThinReplicaCommunicationRecord> record);
+std::vector<std::unique_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>> CreateByzantineMockServers(
+    size_t num_servers, ByzantineMockThinReplicaServerPreparer& server_preparer);
+
+void SetMockServerBehavior(MockTrsConnection* server,
+                           const std::shared_ptr<MockDataStreamPreparer>& data_preparer,
+                           const MockOrderedDataStreamHasher& hasher);
+
+void SetMockServerUnresponsive(thin_replica_client::TrsConnection* server);
+
+std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(size_t num_servers,
+                                                                                      size_t num_unresponsive = 0);
+std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+    size_t num_servers,
+    std::shared_ptr<MockDataStreamPreparer> stream_preparer,
+    MockOrderedDataStreamHasher& hasher,
+    size_t num_unresponsive = 0);
+
+// Templated versions of SetMockServerBehavior and CreateTrsConnections. To use
+// these specific template functions, the template parameter
+// MockThinReplicaServer needs to be a type that implements all the RPC calls a
+// normal Thin Replica Server would support.
+//
+// Note we template these functions rather than defining and having them use an
+// interface type because SetMockServerBehavior needs to refer to a specific
+// class's implementation of the RPC call functions when using gmock's
+// testing::Invoke to configure the mock connection behavior.
+template <class MockThinReplicaServer>
+void SetMockServerBehavior(MockTrsConnection* server, MockThinReplicaServer& mock_server) {
+  ON_CALL(*(server->GetStub()), ReadStateRaw)
+      .WillByDefault(testing::Invoke(&mock_server, &MockThinReplicaServer::ReadStateRaw));
+  ON_CALL(*(server->GetStub()), ReadStateHash)
+      .WillByDefault(testing::Invoke(&mock_server, &MockThinReplicaServer::ReadStateHash));
+  ON_CALL(*(server->GetStub()), SubscribeToUpdatesRaw)
+      .WillByDefault(testing::Invoke(&mock_server, &MockThinReplicaServer::SubscribeToUpdatesRaw));
+  ON_CALL(*(server->GetStub()), AckUpdate)
+      .WillByDefault(testing::Invoke(&mock_server, &MockThinReplicaServer::AckUpdate));
+  ON_CALL(*(server->GetStub()), SubscribeToUpdateHashesRaw)
+      .WillByDefault(testing::Invoke(&mock_server, &MockThinReplicaServer::SubscribeToUpdateHashesRaw));
+  ON_CALL(*(server->GetStub()), Unsubscribe)
+      .WillByDefault(testing::Invoke(&mock_server, &MockThinReplicaServer::Unsubscribe));
+}
+
+template <class MockThinReplicaServer>
+std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+    std::vector<std::unique_ptr<MockThinReplicaServer>>& mock_servers) {
+  std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> mock_connections;
+  for (size_t i = 0; i < mock_servers.size(); ++i) {
+    auto conn = new MockTrsConnection();
+    SetMockServerBehavior(conn, *(mock_servers[i]));
+    auto server = dynamic_cast<thin_replica_client::TrsConnection*>(conn);
+    mock_connections.push_back(std::unique_ptr<thin_replica_client::TrsConnection>(server));
+  }
+  return mock_connections;
+}
+
+std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+    std::vector<MockThinReplicaServerRecorder>& mock_server_recorders);
+std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+    std::vector<std::unique_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>>& mock_servers);
+
+template <class DataType>
+grpc::ClientReaderInterface<DataType>* CreateUnresponsiveMockStream() {
+  auto stream = new MockThinReplicaStream<DataType>();
+  ON_CALL(*stream, Finish)
+      .WillByDefault(testing::Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "This server is non-responsive")));
+  ON_CALL(*stream, Read).WillByDefault(testing::Return(false));
+  return stream;
+}
+
+// ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior extensions
+// for providing specific behavior in Byzantine testing.
+
+// Simulates Byzantine server behavior which can be modeled by using an
+// alternative MockDataStreamPreparer for handling faulty ReadState calls.
+class InitialStateFabricator : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ private:
+  std::shared_ptr<MockDataStreamPreparer> fabricated_data_preparer_;
+  size_t num_faulty_servers_;
+
+ public:
+  InitialStateFabricator(std::shared_ptr<MockDataStreamPreparer> fabricated_data_preparer,
+                         size_t num_faulty_servers = 1);
+  ~InitialStateFabricator() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::ReadStateRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+};
+
+// Simulates Byzantine server behavior which can be modeled by using an
+// alternative MockDataStreamPreparer for handling faulty SubscribeToUpdates
+// calls.
+class UpdateDataFabricator : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ private:
+  std::shared_ptr<MockDataStreamPreparer> fabricated_data_preparer_;
+  size_t num_faulty_servers_;
+
+ public:
+  UpdateDataFabricator(std::shared_ptr<MockDataStreamPreparer> fabricated_data_preparer, size_t num_faulty_servers = 1);
+  ~UpdateDataFabricator() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+};
+
+// Simulates Byzantine server behavior which can be modeled by hasing updates
+// from an alternative MockDataStreamPreparer for faulty SubscribeToUpdateHashes
+// calls.
+class UpdateHashFabricator : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ private:
+  std::shared_ptr<MockOrderedDataStreamHasher> fabricated_update_hasher_;
+  size_t num_faulty_servers_;
+
+ public:
+  UpdateHashFabricator(std::shared_ptr<MockDataStreamPreparer> fabricated_data_preparer, size_t num_faulty_servers = 1);
+  ~UpdateHashFabricator() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* correct_data) override;
+};
+
+// Simulates a slow server that slows down at some point when streaming data in
+// response to ReadState.
+class StateStreamDelayer : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ private:
+  class DelayedStreamState : public MockThinReplicaStream<com::vmware::concord::thin_replica::Data>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>> undelayed_data_;
+    size_t updates_until_delay_;
+
+   public:
+    DelayedStreamState(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* data, size_t delay_after);
+    ~DelayedStreamState() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Data* data);
+  };
+
+  size_t delay_after_;
+
+ public:
+  StateStreamDelayer(size_t delay_after);
+  ~StateStreamDelayer() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::ReadStateRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+};
+
+// Simulates a slow server that slows down at some point when streaming data in
+// response to SubscribeToUpdates.
+class DataStreamDelayer : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ private:
+  class DelayedStreamState : public MockThinReplicaStream<com::vmware::concord::thin_replica::Data>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>> undelayed_data_;
+    size_t updates_until_delay_;
+
+   public:
+    DelayedStreamState(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* data, size_t delay_after);
+    ~DelayedStreamState() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Data* data);
+  };
+
+  size_t delay_after_;
+
+ public:
+  DataStreamDelayer(size_t delay_after);
+  ~DataStreamDelayer() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+};
+
+// Simulates a slow server that slows down at some point when streaming hashes
+// in response to SubscribeToUpdateHashes.
+class HashStreamDelayer : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ private:
+  class DelayedStreamState : public MockThinReplicaStream<com::vmware::concord::thin_replica::Hash>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>> undelayed_hashes_;
+    size_t hashes_until_delay_;
+
+   public:
+    DelayedStreamState(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* hashes,
+                       size_t delay_after);
+    ~DelayedStreamState() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Hash* hash);
+  };
+
+  size_t delay_after_;
+
+ public:
+  HashStreamDelayer(size_t delay_after);
+  ~HashStreamDelayer() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* correct_hashes) override;
+};
+
+// Simulates Byzantine server behavior which can be described by a function
+// (passed to the UpdateHashCorrupter via a functor object) to be applied to a
+// Hash value streamed after a particular number of responses streamed in
+// response to SubscribeToUpdateHashes.
+class UpdateHashCorrupter : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ public:
+  // Functor interface to be implemented in order to describe how an
+  // UpdateHashCorrupter object should corrupt its target hash update.
+  class CorruptHash {
+   public:
+    virtual ~CorruptHash() {}
+    virtual void operator()(com::vmware::concord::thin_replica::Hash* hash) = 0;
+  };
+
+ private:
+  class CorruptedStreamState : public MockThinReplicaStream<com::vmware::concord::thin_replica::Hash>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>> uncorrupted_hashes_;
+    std::shared_ptr<CorruptHash> corrupt_hash_;
+    bool corruption_applied_;
+    size_t hashes_until_corruption_;
+
+   public:
+    CorruptedStreamState(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* hashes,
+                         std::shared_ptr<CorruptHash> corrupt_hash,
+                         size_t corrupt_after);
+    ~CorruptedStreamState() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Hash* hash);
+  };
+
+  std::shared_ptr<CorruptHash> corrupt_hash_;
+  size_t corrupt_after_;
+
+ public:
+  // Construct an UpdateHashCorrupter that will apply the corruption described
+  // by corrupt_hash to the corrupt_after-th Hash object (starting from 0)
+  // returned by hash streams this UpdateHashCorrupter gives in response to
+  // SubscribeToUpdateHashes calls to Byzantine-faulty mocked Thin Replica
+  // Servers.
+  UpdateHashCorrupter(std::shared_ptr<CorruptHash> corrupt_hash, size_t corrupt_after);
+
+  ~UpdateHashCorrupter() override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* correct_hashes) override;
+};
+
+// ByzantineServerBehavior implementation for simulating scenarios where not all
+// servers are responsive all the time, especially scenarios involving changes
+// in responsiveness over time. Server unresponsiveness is simulated by having
+// unresponsive servers wait for a period exceeding the timeout used in testing
+// before responding to calls. Note unresponsiveness ClusterResponsivnessLimiter
+// can simulate includes ClientReaderInterface<T>-type streams provided by a
+// mocked Thin Replica Server not responding to calls to Read in addition to the
+// mocked Thin Replica Server not responding to new RPC calls made to it.
+//
+// To use this class, it is expected test cases will implement the abstract
+// ClusterResponsivenessLimiter::ResponsivenessManager class to describe which
+// server(s) will be unresponsive when.
+class ClusterResponsivenessLimiter : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ public:
+  // Getter functions for information a ClusterResponsivenessLimiter is
+  // constructed with that may be relevant to ResponsivenessManager
+  // implementations.
+  size_t GetMaxFaulty() const;
+  size_t GetClusterSize() const;
+
+  // Functions for checking and configuring mock server responsiveness for use
+  // by ResponsivenessManager implementations. Note these functions are not
+  // themselves thread safe; it is expected synchronization of calls to these
+  // functions will addressed by the fact that a ClusterResponsivenessLimiter
+  // synchronizes all calls to its ResponsivenessManager for
+  // UpdateResponsiveness.
+  bool IsUnresponsive(size_t server_index) const;
+  size_t GetNumUnresponsiveServers() const;
+  void SetResponsive(size_t server_index);
+  void SetUnresponsive(size_t server_index);
+
+  // Abstract class that code constructing a ClusterResponsivenessLimiter should
+  // implement in order to describe the responsiveness behavior for the cluster
+  // under the ClusterResponsivenessLimiter's management.
+  class ResponsivenessManager {
+   public:
+    virtual ~ResponsivenessManager();
+
+    // Function called by the ClusterResponsivenessLimiter that
+    // ResponsivenessManager implementations should implement to describe
+    // responsiveness. A ClusterResponsivenessLimiter will call
+    // UpdateResponsiveness upon each call to ReadState, ReadStateHash,
+    // SubscribeToUpdates, and SubscribeToUpdateHashes, as well as on each call
+    // to Read that will return true on stream(s) returned by calls to
+    // ReadState, ReadStateHash, SubscribeToUpdates, and
+    // SubscribeToUpdatesHashes. Note UpdateResponsiveness will not be called
+    // for Read calls that will return false or for Finish calls (this decision
+    // was made primarily because there is not a meaningful Block ID to
+    // associate with such calls). When a ClusterResponsivenessLimiter calls
+    // UpdateResponsiveness, it passes a reference to itself for
+    // responsiveness_limiter, the index of the server that is being called for
+    // server_called, and either 0 in the event this call is being triggered by
+    // a ReadStateRaw call, the Block ID requested in the relevant client
+    // request for block_id in the event this call to UpdateResponsiveness is
+    // being triggered by an initial RPC call other than ReadStateRaw, or the
+    // Block ID that will be returned in response to a streamed update or update
+    // hash in the event this call to UpdateResponsiveness is being triggered by
+    // a Read call on an open stream that is going to return true.
+    //
+    // Note all calls to UpdateResponsiveness made by a single
+    // ClusterResponsivenessLimiter instance will be synchronized such that no
+    // two such calls will run concurrently even if the ThinReplicaClient
+    // implementation is using multiple threads to make multiple calls to mocked
+    // server(s) concurrently.
+    // triggered them.
+    //
+    // ResponsivenessManager implementations should use
+    // ClusterResponsivenessLimiter's functions IsUnresponsive,
+    // GetNumUnresponsiveServers, SetResponsive, and SetUnresponsive to manage
+    // cluster responsiveness. Note changes made to responsiveness will apply
+    // immediately, that is, if the ResponsivenessManager changes the
+    // responsiveness of server_called, its new responsiveness will apply in
+    // resolution of whatever call triggered ClusterResponsivenessLimiter to
+    // call UpdateResponsiveness.
+    virtual void UpdateResponsiveness(ClusterResponsivenessLimiter& responsivness_limiter,
+                                      size_t server_called,
+                                      uint64_t block_id) = 0;
+  };
+
+ private:
+  class DataStreamState : public MockThinReplicaStream<com::vmware::concord::thin_replica::Data>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>> data_;
+    ClusterResponsivenessLimiter& responsiveness_limiter_;
+    size_t server_index_;
+
+   public:
+    DataStreamState(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* data,
+                    ClusterResponsivenessLimiter& responsiveness_limiter,
+                    size_t server_index);
+    ~DataStreamState() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Data* data);
+  };
+  class HashStreamState : public MockThinReplicaStream<com::vmware::concord::thin_replica::Hash>::State {
+   private:
+    std::unique_ptr<grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>> hashes_;
+    ClusterResponsivenessLimiter& responsiveness_limiter_;
+    size_t server_index_;
+
+   public:
+    HashStreamState(grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* hashes,
+                    ClusterResponsivenessLimiter& responsiveness_limiter,
+                    size_t server_index);
+    ~HashStreamState() override;
+    grpc::Status Finish();
+    bool Read(com::vmware::concord::thin_replica::Hash* hash);
+  };
+
+  size_t max_faulty_;
+  size_t cluster_size_;
+  std::unique_ptr<ResponsivenessManager> responsiveness_manager_;
+  std::vector<bool> server_responsiveness_;
+  std::mutex responsiveness_change_mutex_;
+
+ public:
+  ClusterResponsivenessLimiter(size_t max_faulty,
+                               size_t num_servers,
+                               std::unique_ptr<ResponsivenessManager>&& responsiveness_manager);
+  ~ClusterResponsivenessLimiter() override;
+
+  // Note that, for mocked RPC calls returning streams (i.e. with return types
+  // of ClientReaderInterface<T>*), since the stream implementations returned by
+  // a ClusterResponsivenessLimiter will use that ClusterResponsivenessLimiter
+  // to track their own responsiveness, behavior is undefined if any call to
+  // such a stream is made after the end of the life of the
+  // ClusterResponsivenessLimiter that created it.
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::ReadStateRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+  grpc::Status ReadStateHash(size_t server_index,
+                             grpc::ClientContext* context,
+                             const com::vmware::concord::thin_replica::ReadStateHashRequest& request,
+                             com::vmware::concord::thin_replica::Hash* response,
+                             grpc::Status correct_status) override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* correct_hashes) override;
+};
+
+// Simulates Byzantine server behavior which can be modeled by using an
+// alternative MockDataStreamPreparer and an alternative
+// MockOrderedDataStreamHasher constructed from that preparer for handling all
+// calls to a faulty server.
+class ComprehensiveDataFabricator : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+ private:
+  std::shared_ptr<MockDataStreamPreparer> fabricated_data_preparer_;
+  std::shared_ptr<MockOrderedDataStreamHasher> fabricated_update_hasher_;
+  size_t num_faulty_servers_;
+
+ public:
+  ComprehensiveDataFabricator(std::shared_ptr<MockDataStreamPreparer> fabricated_data_preparer,
+                              size_t num_faulty_servers = 1);
+  ~ComprehensiveDataFabricator() override;
+
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* ReadStateRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::ReadStateRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+  grpc::Status ReadStateHash(size_t server_index,
+                             grpc::ClientContext* context,
+                             const com::vmware::concord::thin_replica::ReadStateHashRequest& request,
+                             com::vmware::concord::thin_replica::Hash* response,
+                             grpc::Status correct_status) override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* SubscribeToUpdatesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Data>* correct_data) override;
+  grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* SubscribeToUpdateHashesRaw(
+      size_t server_index,
+      grpc::ClientContext* context,
+      const com::vmware::concord::thin_replica::SubscriptionRequest& request,
+      grpc::ClientReaderInterface<com::vmware::concord::thin_replica::Hash>* correct_hashes) override;
+};
+
+#endif  // THIN_REPLICA_CLIENT_MOCKS_HPP

--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -1,0 +1,519 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client/thin-replica-client/thin_replica_client.hpp"
+#include "client/thin-replica-client/trs_connection.hpp"
+
+#include <log4cplus/configurator.h>
+#include "gtest/gtest.h"
+#include "thin_replica_client_mocks.hpp"
+
+using namespace std::chrono_literals;
+
+using com::vmware::concord::thin_replica::Data;
+using com::vmware::concord::thin_replica::KVPair;
+using std::chrono_literals::operator""ms;
+using std::condition_variable;
+using std::make_shared;
+using std::make_unique;
+using std::mutex;
+using std::pair;
+using std::shared_ptr;
+using std::string;
+using std::thread;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+using std::chrono::milliseconds;
+using std::this_thread::sleep_for;
+using thin_replica_client::BasicUpdateQueue;
+using thin_replica_client::ThinReplicaClient;
+using thin_replica_client::ThinReplicaClientConfig;
+using thin_replica_client::TrsConnection;
+using thin_replica_client::Update;
+using thin_replica_client::UpdateQueue;
+
+const string kTestingClientID = "mock_client_id";
+const string kTestingJaegerAddress = "127.0.0.1:6831";
+const milliseconds kBriefDelayDuration = 10ms;
+
+namespace {
+
+TEST(thin_replica_client_test, test_destructor_always_successful) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
+  MockOrderedDataStreamHasher hasher(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  EXPECT_NO_THROW(trc.reset()) << "ThinReplicaClient destructor failed.";
+  update_queue->Clear();
+
+  mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  trc->Subscribe("");
+  update_queue->Pop();
+  update_queue->Pop();
+  trc_config.reset();
+  EXPECT_NO_THROW(trc.reset()) << "ThinReplicaClient destructor failed when destructing a "
+                                  "ThinReplicaClient with an active subscription.";
+  update_queue->Clear();
+
+  mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  trc->Subscribe("");
+  update_queue->Pop();
+  update_queue->Pop();
+  trc->Unsubscribe();
+  trc_config.reset();
+  EXPECT_NO_THROW(trc.reset()) << "ThinReplicaClient destructor failed when destructing a "
+                                  "ThinReplicaClient after ending its subscription.";
+}
+
+TEST(thin_replica_client_test, test_1_parameter_subscribe_success_cases) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
+  MockOrderedDataStreamHasher hasher(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  EXPECT_NO_THROW(trc->Subscribe("")) << "ThinReplicaClient::Subscribe's 1-parameter overload failed.";
+
+  trc->Unsubscribe();
+  EXPECT_NO_THROW(trc->Subscribe("")) << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+                                         "subscribing after closing a subscription.";
+  EXPECT_NO_THROW(trc->Subscribe("")) << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+                                         "subscribing while there is an ongoing subscription.";
+
+  EXPECT_NO_THROW(trc->Subscribe("k")) << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+                                          "subscribing with a non-empty key prefix of an existing key.";
+  EXPECT_NO_THROW(trc->Subscribe("key")) << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+                                            "subscribing with a key prefix entirely matching an existing key.";
+  EXPECT_NO_THROW(trc->Subscribe("There should be no key with this prefix."))
+      << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+         "subscribing with a key prefix not matching any existing key.";
+}
+
+TEST(thin_replica_client_test, test_2_parameter_subscribe_success_cases) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
+  MockOrderedDataStreamHasher hasher(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  trc->Subscribe("");
+  unique_ptr<Update> update_received = update_queue->Pop();
+  uint64_t block_id = update_received->block_id;
+  trc->Unsubscribe();
+  EXPECT_NO_THROW(trc->Subscribe("", block_id)) << "ThinReplicaClient::Subscribe's 2-parameter overload failed.";
+  trc->Unsubscribe();
+
+  trc->Unsubscribe();
+  EXPECT_NO_THROW(trc->Subscribe("", block_id)) << "ThinReplicaClient::Subscribe's 2-parameter overload failed after "
+                                                   "closing an existing subscription.";
+  EXPECT_NO_THROW(trc->Subscribe("", block_id)) << "ThinReplicaClient::Subscribe's 2-parameter overload failed when "
+                                                   "there is already an existing subscription.";
+
+  EXPECT_NO_THROW(trc->Subscribe("k", block_id)) << "ThinReplicaClient::Subscribe's 2-parameter overload failed when "
+                                                    "subscribing with a non-empty prefix of an existing key.";
+  EXPECT_NO_THROW(trc->Subscribe("key", block_id))
+      << "ThinReplicaClient::Subscribe's 2-parameter overload failed failed "
+         "when subscribing with a prefix that entirely matches an existing "
+         "key.";
+  EXPECT_NO_THROW(trc->Subscribe("There should be no key with this prefix.", block_id))
+      << "ThinReplicaClient::Subscribe's 2-parameter overload failed when "
+         "subscribing with a prefix that matches no existing key.";
+
+  for (size_t i = 0; i < 8; ++i) {
+    trc->Unsubscribe();
+    update_queue->Clear();
+    uint64_t previous_block_id = block_id;
+    EXPECT_NO_THROW(trc->Subscribe("", block_id)) << "ThinReplicaClient::Subscribe's 2-parameter overload failed when "
+                                                     "subscribing with a Block ID from a previously received block.";
+    update_received = update_queue->Pop();
+    block_id = update_received->block_id;
+    EXPECT_GT(block_id, previous_block_id) << "ThinReplicaClient::Subscribe's 2-parameter overload appears to be "
+                                              "repeating already received blocks even when specifying where to "
+                                              "start the subscription to avoid them.";
+  }
+}
+
+TEST(thin_replica_client_test, test_1_parameter_subscribe_to_unresponsive_servers_fails) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
+  MockOrderedDataStreamHasher hasher(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+  size_t num_unresponsive = num_replicas - max_faulty;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher, num_unresponsive);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  EXPECT_ANY_THROW(trc->Subscribe("")) << "ThinReplicaClient::Subscribe's 1-parameter overload doesn't throw an "
+                                          "exception when trying to subscribe to a cluster with only max_faulty "
+                                          "servers responsive.";
+  trc_config.reset();
+  trc.reset();
+
+  mock_servers = CreateTrsConnections(num_replicas, num_replicas);
+  trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  EXPECT_ANY_THROW(trc->Subscribe("")) << "ThinReplicaClient::Subscribe's 1-parameter overload doesn't throw an "
+                                          "exception when trying to subscribe to a cluster with no responsive "
+                                          "servers.";
+}
+
+TEST(thin_replica_client_test, test_unsubscribe_successful) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
+  MockOrderedDataStreamHasher hasher(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  EXPECT_NO_THROW(trc->Unsubscribe()) << "ThinReplicaClient::Unsubscribe failed for a newly-constructed "
+                                         "ThinReplicaClient.";
+  trc->Subscribe("");
+  update_queue->Pop();
+  update_queue->Pop();
+  EXPECT_NO_THROW(trc->Unsubscribe()) << "ThinReplicaClient::Unsubscribe failed for a ThinReplicaClient with "
+                                         "an active subscription.";
+  EXPECT_NO_THROW(trc->Unsubscribe()) << "ThinReplicaClient::Unsubscribe failed for a ThinReplicaClient with a "
+                                         "subscription that had already been cancelled.";
+}
+
+TEST(thin_replica_client_test, test_pop_fetches_updates_) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> base_stream_preparer(new RepeatedMockDataStreamPreparer(update, 1));
+  auto delay_condition = make_shared<condition_variable>();
+  auto spurious_wakeup_indicator = make_shared<bool>(true);
+  auto delay_condition_mutex = make_shared<mutex>();
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new DelayedMockDataStreamPreparer(
+      base_stream_preparer, delay_condition, spurious_wakeup_indicator, delay_condition_mutex));
+  MockOrderedDataStreamHasher hasher(base_stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  trc->Subscribe("");
+  unique_ptr<Update> update_received = update_queue->Pop();
+  EXPECT_TRUE((bool)update_received) << "ThinReplicaClient failed to publish update from initial state.";
+
+  thread delay_thread([&]() {
+    sleep_for(kBriefDelayDuration);
+    *spurious_wakeup_indicator = false;
+    delay_condition->notify_one();
+  });
+  update_received = update_queue->Pop();
+  EXPECT_TRUE((bool)update_received) << "ThinReplicaClient failed to publish update received from servers "
+                                        "while the application is already waiting on the update queue.";
+  delay_thread.join();
+
+  // The current implementation of the ThinReplicaClient may block on Read calls
+  // trying to join threads before it completes its destructor, so we unblock
+  // any such calls here.
+  *spurious_wakeup_indicator = false;
+  sleep_for(kBriefDelayDuration);
+  delay_condition->notify_all();
+}
+
+TEST(thin_replica_client_test, test_acknowledge_block_id_success) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
+  MockOrderedDataStreamHasher hasher(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  EXPECT_NO_THROW(trc->AcknowledgeBlockID(1)) << "ThinReplicaClient::AcknowledgeBlockID fails when called on a "
+                                                 "freshly-constructed ThinReplicaClient.";
+  trc->Subscribe("");
+  update_queue->Pop();
+  update_queue->Pop();
+  EXPECT_NO_THROW(trc->AcknowledgeBlockID(2)) << "ThinReplicaClient::AcknowledgeBlockID fails when called on a "
+                                                 "ThinReplicaClient with an active subscription.";
+  trc->Unsubscribe();
+  EXPECT_NO_THROW(trc->AcknowledgeBlockID(3)) << "ThinReplicaClient::AcknowledgeBlockID fails when called on a "
+                                                 "ThinReplicaClient with an ended subscription.";
+  for (uint64_t block_id = 0; block_id <= UINT32_MAX; block_id += (block_id + 1)) {
+    EXPECT_NO_THROW(trc->AcknowledgeBlockID(block_id))
+        << "ThinReplicaClient::AcknowledgeBlockID fails when called with "
+           "arbitrary block IDs.";
+  }
+}
+
+TEST(thin_replica_client_test, test_correct_data_returned_) {
+  vector<Data> update_data;
+  for (size_t i = 0; i <= 60; ++i) {
+    Data update;
+    update.set_block_id(i);
+    for (size_t j = 1; j <= 12; ++j) {
+      if (i % j == 0) {
+        KVPair* kvp = update.add_data();
+        kvp->set_key("key" + to_string(j));
+        kvp->set_value("value" + to_string(i / j));
+      }
+    }
+    update_data.push_back(update);
+  }
+  size_t num_initial_updates = 6;
+
+  shared_ptr<MockDataStreamPreparer> base_stream_preparer(
+      new VectorMockDataStreamPreparer(update_data, num_initial_updates));
+  auto delay_condition = make_shared<condition_variable>();
+  auto spurious_wakeup_indicator = make_shared<bool>(true);
+  auto delay_condition_mutex = make_shared<mutex>();
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new DelayedMockDataStreamPreparer(
+      base_stream_preparer, delay_condition, spurious_wakeup_indicator, delay_condition_mutex));
+  MockOrderedDataStreamHasher hasher(base_stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  EXPECT_FALSE((bool)(update_queue->TryPop())) << "ThinReplicaClient appears to have published state to update queue "
+                                                  "prior to subscription.";
+
+  trc->Subscribe("");
+  trc->Unsubscribe();
+  for (size_t i = 0; i < num_initial_updates; ++i) {
+    unique_ptr<Update> received_update = update_queue->TryPop();
+    Data& expected_update = update_data[i];
+    EXPECT_TRUE((bool)received_update) << "ThinReplicaClient failed to fetch an expected update included in "
+                                          "the initial state.";
+    EXPECT_EQ(received_update->block_id, expected_update.block_id())
+        << "An update the ThinReplicaClient fetched in the initial state has "
+           "an incorrect block ID.";
+    EXPECT_EQ(received_update->kv_pairs.size(), expected_update.data_size())
+        << "An update the ThinReplicaClient fetched in the initial state has "
+           "an incorrect number of KV-pair updates.";
+    for (size_t j = 0; j < received_update->kv_pairs.size() && j < expected_update.data_size(); ++j) {
+      EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.data(j).key())
+          << "A key in an update the ThinReplicaClient fetched in the initial "
+             "state does not match its expected value.";
+      EXPECT_EQ(received_update->kv_pairs[j].second, expected_update.data(j).value())
+          << "A value in an update the ThinReplicaClient fetched in the "
+             "initial state does not match its expected value.";
+    }
+  }
+
+  EXPECT_FALSE((bool)(update_queue->TryPop())) << "ThinReplicaClient appears to have collected an unexpected number of "
+                                                  "updates in its initial state.";
+  *spurious_wakeup_indicator = false;
+  delay_condition->notify_all();
+  sleep_for(kBriefDelayDuration);
+  EXPECT_FALSE((bool)(update_queue->TryPop())) << "ThinReplicaClient appears to have received an update after "
+                                                  "unsubscribing.";
+  *spurious_wakeup_indicator = true;
+
+  trc->Subscribe("", num_initial_updates - 1);
+  for (size_t i = num_initial_updates; i < update_data.size(); ++i) {
+    *spurious_wakeup_indicator = false;
+    delay_condition->notify_one();
+    unique_ptr<Update> received_update = update_queue->Pop();
+    *spurious_wakeup_indicator = true;
+    Data& expected_update = update_data[i];
+
+    EXPECT_TRUE((bool)received_update) << "ThinReplicaClient failed to fetch an expected update from an "
+                                          "ongoing subscription.";
+    EXPECT_EQ(received_update->block_id, expected_update.block_id())
+        << "An update the ThinReplicaClient received from an ongoing "
+           "subscription has an incorrect Block ID.";
+    EXPECT_EQ(received_update->kv_pairs.size(), expected_update.data_size())
+        << "An update the ThinReplicaClient received in an ongoing "
+           "subscription has an incorrect number of KV-pair updates.";
+    for (size_t j = 0; j < received_update->kv_pairs.size() && j < expected_update.data_size(); ++j) {
+      EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.data(j).key())
+          << "A key in an update the ThinReplicaClient received in an ongoing "
+             "subscription does not match its expected value.";
+      EXPECT_EQ(received_update->kv_pairs[j].second, expected_update.data(j).value())
+          << "A value in an update the ThinReplicaClient received in an "
+             "ongoing subscription does not match its expected value.";
+    }
+  }
+
+  // The current implementation of the ThinReplicaClient may block on Read calls
+  // trying to join threads before it completes its destructor, so we unblock
+  // any such calls here.
+  *spurious_wakeup_indicator = false;
+  sleep_for(kBriefDelayDuration);
+  delay_condition->notify_all();
+}
+
+TEST(thin_replica_client_test, test_key_filtration) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key0");
+  update_data->set_value("value0");
+  update_data = update.add_data();
+  update_data->set_key("key1");
+  update_data->set_value("value1");
+  update_data = update.add_data();
+  update_data->set_key("identifier");
+  update_data->set_value("value2");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
+  MockOrderedDataStreamHasher hasher(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  shared_ptr<UpdateQueue> update_queue = make_shared<BasicUpdateQueue>();
+
+  auto mock_servers = CreateTrsConnections(num_replicas, stream_preparer, hasher);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+
+  trc->Subscribe("");
+  unique_ptr<Update> update_received = update_queue->Pop();
+  EXPECT_EQ(update_received->kv_pairs[0].first, "key0")
+      << "ThinReplicaClient fails to include a key-value pair in an update "
+         "when subscribing with an empty prefix.";
+  EXPECT_EQ(update_received->kv_pairs[1].first, "key1")
+      << "ThinReplicaClient fails to include a key-value pair in an update "
+         "when subscribing with an empty prefix.";
+  EXPECT_EQ(update_received->kv_pairs[2].first, "identifier")
+      << "ThinReplicaClient fails to include a key-value pair in an update "
+         "when subscribing with an empty prefix.";
+
+  trc->Unsubscribe();
+  trc->Subscribe("key");
+  update_received = update_queue->Pop();
+  EXPECT_EQ(update_received->kv_pairs[0].first, "key0")
+      << "ThinReplicaClient fails to include a key-value pair in an update "
+         "when subscribing with a key prefix that matches that pair.";
+  EXPECT_EQ(update_received->kv_pairs[1].first, "key1")
+      << "ThinReplicaClient fails to include a key-value pair in an update "
+         "when subscribing with a key prefix that matches that pair.";
+  EXPECT_EQ(update_received->kv_pairs.size(), 2)
+      << "ThinReplicaClient appears to include key-value pair(s) in an update "
+         "that do not match the requested prefix.";
+
+  trc->Unsubscribe();
+  trc->Subscribe("key1");
+  update_received = update_queue->Pop();
+  EXPECT_EQ(update_received->kv_pairs[0].first, "key1")
+      << "ThinReplicaClient fails to include a key-value pair in an update "
+         "when subscribing with a key prefix that matches the full length of "
+         "the key.";
+  EXPECT_EQ(update_received->kv_pairs.size(), 1)
+      << "ThinReplicaClient appears to include key-value pair(s) in an update "
+         "that do not match the requested prefix.";
+
+  trc->Unsubscribe();
+  trc->Subscribe("inexistant_key");
+  update_received = update_queue->Pop();
+  EXPECT_EQ(update_received->kv_pairs.size(), 0)
+      << "ThinReplicaClient appears to include key-value pair(s) in an update "
+         "that do not match the requested prefix.";
+}
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  log4cplus::initialize();
+  log4cplus::BasicConfigurator config;
+  config.configure();
+  return RUN_ALL_TESTS();
+}

--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -385,7 +385,7 @@ TEST(thin_replica_client_test, test_correct_data_returned_) {
     EXPECT_EQ(received_update->kv_pairs.size(), expected_update.data_size())
         << "An update the ThinReplicaClient fetched in the initial state has "
            "an incorrect number of KV-pair updates.";
-    for (size_t j = 0; j < received_update->kv_pairs.size() && j < expected_update.data_size(); ++j) {
+    for (size_t j = 0; j < received_update->kv_pairs.size() && j < (size_t)expected_update.data_size(); ++j) {
       EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.data(j).key())
           << "A key in an update the ThinReplicaClient fetched in the initial "
              "state does not match its expected value.";
@@ -420,7 +420,7 @@ TEST(thin_replica_client_test, test_correct_data_returned_) {
     EXPECT_EQ(received_update->kv_pairs.size(), expected_update.data_size())
         << "An update the ThinReplicaClient received in an ongoing "
            "subscription has an incorrect number of KV-pair updates.";
-    for (size_t j = 0; j < received_update->kv_pairs.size() && j < expected_update.data_size(); ++j) {
+    for (size_t j = 0; j < received_update->kv_pairs.size() && j < (size_t)expected_update.data_size(); ++j) {
       EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.data(j).key())
           << "A key in an update the ThinReplicaClient received in an ongoing "
              "subscription does not match its expected value.";

--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -18,11 +18,8 @@
 #include "gtest/gtest.h"
 #include "thin_replica_client_mocks.hpp"
 
-using namespace std::chrono_literals;
-
 using com::vmware::concord::thin_replica::Data;
 using com::vmware::concord::thin_replica::KVPair;
-using std::chrono_literals::operator""ms;
 using std::condition_variable;
 using std::make_shared;
 using std::make_unique;

--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -27,7 +27,6 @@ using std::condition_variable;
 using std::make_shared;
 using std::make_unique;
 using std::mutex;
-using std::pair;
 using std::shared_ptr;
 using std::string;
 using std::thread;
@@ -39,7 +38,6 @@ using std::this_thread::sleep_for;
 using thin_replica_client::BasicUpdateQueue;
 using thin_replica_client::ThinReplicaClient;
 using thin_replica_client::ThinReplicaClientConfig;
-using thin_replica_client::TrsConnection;
 using thin_replica_client::Update;
 using thin_replica_client::UpdateQueue;
 

--- a/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
+++ b/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
@@ -15,8 +15,6 @@
 
 #include "gtest/gtest.h"
 
-using namespace std::chrono_literals;
-
 using std::make_unique;
 using std::pair;
 using std::ref;
@@ -26,7 +24,6 @@ using std::to_string;
 using std::unique_ptr;
 using std::vector;
 using std::chrono::milliseconds;
-using std::chrono_literals::operator""ms;
 using std::this_thread::sleep_for;
 
 using thin_replica_client::BasicUpdateQueue;

--- a/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
+++ b/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
@@ -1,0 +1,281 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client/thin-replica-client/thin_replica_client.hpp"
+
+#include "gtest/gtest.h"
+
+using namespace std::chrono_literals;
+
+using std::make_unique;
+using std::pair;
+using std::ref;
+using std::string;
+using std::thread;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+using std::chrono::milliseconds;
+using std::chrono_literals::operator""ms;
+using std::this_thread::sleep_for;
+
+using thin_replica_client::BasicUpdateQueue;
+using thin_replica_client::Update;
+
+const milliseconds kBriefDelayDuration = 10ms;
+const uint64_t kNumUpdatesToTest = (uint64_t)1 << 18;
+const size_t kRacingThreadsToTest = 4;
+
+unique_ptr<Update> MakeUniqueUpdate(uint64_t block_id, const vector<pair<string, string>> kv_pairs) {
+  auto update = make_unique<Update>();
+  update->block_id = block_id;
+  update->kv_pairs = kv_pairs;
+  return update;
+}
+
+namespace {
+
+TEST(trc_basic_update_queue_test, test_constructor) {
+  unique_ptr<BasicUpdateQueue> queue;
+  EXPECT_NO_THROW(queue.reset(new BasicUpdateQueue())) << "BasicUpdateQueue's default constructor failed.";
+}
+
+TEST(trc_basic_update_queue_test, test_destructor) {
+  auto queue = make_unique<BasicUpdateQueue>();
+  EXPECT_NO_THROW(queue.reset()) << "BasicUpdateQueue's destructor failed to destruct an empty queue.";
+
+  queue.reset(new BasicUpdateQueue());
+  queue->Push(MakeUniqueUpdate(0, vector<pair<string, string>>{{"a", "a"}}));
+  queue->Push(MakeUniqueUpdate(1, vector<pair<string, string>>{{"key", "value"}}));
+  EXPECT_NO_THROW(queue.reset()) << "BasicUpdateQueue's destructor failed to destruct a non-empty queue.";
+}
+
+TEST(trc_basic_update_queue_test, test_release_consumers) {
+  auto queue = make_unique<BasicUpdateQueue>();
+  EXPECT_NO_THROW(queue->ReleaseConsumers()) << "BasicUpdateQueue::ReleaseConsumers fails when called on a queue with "
+                                                "no consumer threads waiting on it.";
+  queue.reset(new BasicUpdateQueue());
+  thread consumer0([&]() { queue->Pop(); });
+  thread consumer1([&]() { queue->Pop(); });
+  sleep_for(kBriefDelayDuration);
+  EXPECT_NO_THROW(queue->ReleaseConsumers()) << "BasicUpdateQueue::ReleaseConsumers fails when called on a queue with "
+                                                "consumers waiting.";
+  consumer0.join();
+  consumer1.join();
+}
+
+TEST(trc_basic_update_queue_test, test_clear) {
+  BasicUpdateQueue queue;
+  EXPECT_NO_THROW(queue.Clear()) << "BasicUpdateQueue::Clear fails when called on an already-empty queue.";
+  queue.Push(MakeUniqueUpdate(0, vector<pair<string, string>>{{"a", "a"}}));
+  queue.Push(MakeUniqueUpdate(1, vector<pair<string, string>>{{"b", "b"}}));
+  EXPECT_NO_THROW(queue.Clear()) << "BasicUpdateQueue::Clear fails when called with a non-empty queue.";
+  EXPECT_EQ(queue.Size(), 0) << "A BasicUpdateQueue appears to have non-0 size after a call to Clear.";
+  EXPECT_FALSE((bool)(queue.TryPop())) << "A BasicUpdateQueue appears to pop a non-null element after a call to "
+                                          "Clear.";
+}
+
+TEST(trc_basic_update_queue_test, test_push) {
+  BasicUpdateQueue queue;
+  EXPECT_NO_THROW(queue.Push(MakeUniqueUpdate(0, vector<pair<string, string>>{})))
+      << "BasicUpdateQueue::Push fails when pushing to an empty queue.";
+  for (uint64_t i = 1; i <= kNumUpdatesToTest; ++i) {
+    EXPECT_NO_THROW(queue.Push(MakeUniqueUpdate(i, {{"key" + to_string(i), "value" + to_string(i)}})))
+        << "Push fails when pushing to a queue with " << to_string(i) << " existing updates.";
+  }
+}
+
+TEST(trc_basic_update_queue_test, test_pop) {
+  BasicUpdateQueue queue;
+  unique_ptr<Update> update;
+  thread consumer([&]() {
+    EXPECT_NO_THROW(update = queue.Pop()) << "BasicUpdateQueue::Pop call initiated on an empty queue failed with "
+                                             "an exception.";
+    ASSERT_TRUE((bool)update) << "BasicUpdateQueue::Pop call initiated on an empty queue returned a "
+                                 "null pointer in the absence of any call to ReleaseConsumers, and "
+                                 "despite a subsequent push call prior to any competing Popping "
+                                 "calls.";
+    EXPECT_EQ(update->block_id, 0) << "BasicUpdateQueue::Pop call returned an update with a Block ID "
+                                      "not "
+                                      "matching the only update the Pop call should have had access to.";
+    EXPECT_EQ(update->kv_pairs.size(), 0) << "BasicUpdateQueue::Pop call returned an update with a set of KV "
+                                             "Pairs not matching the only update the Pop call should have had "
+                                             "access to.";
+  });
+  sleep_for(kBriefDelayDuration);
+  queue.Push(MakeUniqueUpdate(0, vector<pair<string, string>>{}));
+  consumer.join();
+  queue.Push(MakeUniqueUpdate(1, vector<pair<string, string>>{{"key1", "value1"}}));
+  queue.Push(MakeUniqueUpdate(2, vector<pair<string, string>>{{"key2", "value2"}}));
+  EXPECT_NO_THROW(update = queue.Pop()) << "BasicUpdateQueue::Pop call initiated on a queue with 2 updates "
+                                           "failed with an exception.";
+  EXPECT_TRUE((bool)update) << "BasicUpdateQueue::Pop call initiated on a queue with 2 updates "
+                               "returned a null pointer in the absence of any ReleaseConsumers call.";
+  EXPECT_NO_THROW(update = queue.Pop()) << "BasicUpdateQueue::Pop call initiated on a queue with 1 update failed "
+                                           "with an exception.";
+  EXPECT_TRUE((bool)update) << "BasicUpdateQueue::Pop call initiated on a queue with 1 update "
+                               "returned a null pointer in the absence of any ReleaseConsumers call.";
+
+  EXPECT_EQ(queue.Size(), 0) << "A BasicUpdateQueue was unexpectedly found to have a non-zero size "
+                                "after a matching number of pushes and pops.";
+  queue.Push(MakeUniqueUpdate(3, vector<pair<string, string>>{{"key3", "value3"}}));
+  queue.Push(MakeUniqueUpdate(4, vector<pair<string, string>>{{"key4", "value4"}}));
+  EXPECT_NO_THROW(update = queue.TryPop()) << "BasicUpdateQueue::TryPop call initiated on a queue with 2 updates "
+                                              "failed with an exception.";
+  EXPECT_TRUE((bool)update) << "BasicUpdateQueue::TryPop call initiated on a queue with 2 updates "
+                               "returned a null pointer in the absence of any concurrent popping "
+                               "calls.";
+  EXPECT_NO_THROW(update = queue.TryPop()) << "BasicUpdateQueue::TryPop call initiated on a queue with 1 update "
+                                              "failed with an exception.";
+  EXPECT_TRUE((bool)update) << "BasicUpdateQueue::TryPop call initiated on a "
+                               "queue with 1 update returned a null pointer in "
+                               "the absence of any concurrent popping calls.";
+
+  EXPECT_EQ(queue.Size(), 0) << "A BasicUpdateQueue was unexpectedly found to have a non-zero size "
+                                "after a matching number of pushes and pops.";
+  EXPECT_NO_THROW(update = queue.TryPop()) << "BasicUpdateQueue::TryPop call on an empty queue failed with an "
+                                              "exception.";
+  EXPECT_FALSE((bool)update) << "BasicUpdateQueue::TryPop call on an empty queue in the absence of "
+                                "any concurrent or subsequent Push calls returned a non-null update.";
+  consumer = thread([&]() {
+    update = queue.Pop();
+    EXPECT_FALSE((bool)update) << "BasicUpdateQueue::Pop call initiated on an empty queue followed by "
+                                  "a call to ReleaseConsumers and in the absence of any concurrent or "
+                                  "subsequent Push calls returned a non-null update.";
+  });
+  sleep_for(kBriefDelayDuration);
+  queue.ReleaseConsumers();
+  consumer.join();
+}
+
+TEST(test_basic_update_queue_test, test_size) {
+  BasicUpdateQueue queue;
+  EXPECT_EQ(queue.Size(), 0) << "BasicUpdateQueue::Size gives the wrong size for an empty queue.";
+  for (int i = 0; i < kNumUpdatesToTest; ++i) {
+    queue.Push(MakeUniqueUpdate(i, vector<pair<string, string>>{}));
+    EXPECT_EQ(queue.Size(), (i + 1)) << "BasicUpdateQueue::Size gives the wrong size for a queue to which "
+                                     << to_string(i + 1) << " updates have been pushed.";
+  }
+}
+
+TEST(trc_basic_update_queue_test, test_ordering) {
+  BasicUpdateQueue queue;
+  thread producer([&]() {
+    for (uint64_t i = 0; i < kNumUpdatesToTest; ++i) {
+      EXPECT_NO_THROW(queue.Push(MakeUniqueUpdate(i, vector<pair<string, string>>{})))
+          << "BasicUpdateQueue::Push call failed with an exception.";
+    }
+  });
+  thread consumer([&]() {
+    for (uint64_t i = 0; i < kNumUpdatesToTest; ++i) {
+      unique_ptr<Update> update(nullptr);
+      if (i % 2 == 0) {
+        EXPECT_NO_THROW(update = queue.Pop()) << "BasicUpdateQueue::Pop call failed with an exception.";
+        ASSERT_TRUE((bool)update) << "BasicUpdateQueue::Pop returned a null pointer in the absence "
+                                     "of a concurrent or subsequent call to ReleaseConsumers.";
+      } else {
+        while (!update) {
+          EXPECT_NO_THROW(update = queue.TryPop()) << "BasicUpdateQueue::TryPop call failed with an exception.";
+        }
+      }
+      EXPECT_EQ(update->block_id, i) << "A BasicUpdateQueue either returned an update that returned an "
+                                        "update that was never pushed to it to ordered popping calls or "
+                                        "returned updates to them in an order not matching a known "
+                                        "order in which those updates were pushed by ordered pushing  "
+                                        "calls.";
+    }
+  });
+  producer.join();
+  consumer.join();
+}
+
+// Functions test_no_update_duplication_or_loss (below) creates threads from.
+void TestNoUpdateDuplicationOrLossProducer(BasicUpdateQueue& queue, uint64_t producer_index) {
+  for (uint64_t i = producer_index; i < kNumUpdatesToTest; i += kRacingThreadsToTest) {
+    EXPECT_NO_THROW(queue.Push(MakeUniqueUpdate(
+        i,
+        vector<pair<string, string>>{{"key" + to_string(i), "value" + to_string(i)}, {"const_key", "const_value"}})));
+  }
+}
+
+void TestNoUpdateDuplicationOrLossConsumer(BasicUpdateQueue& queue,
+                                           vector<uint64_t>& observed_updates,
+                                           uint64_t consumer_index) {
+  for (uint64_t i = consumer_index; i < kNumUpdatesToTest; i += kRacingThreadsToTest) {
+    unique_ptr<Update> update(nullptr);
+    if (((i / kRacingThreadsToTest) % 2) == 0) {
+      EXPECT_NO_THROW(update = queue.Pop()) << "BasicUpdateQueue::Pop call failed with an exception.";
+      ASSERT_TRUE((bool)update) << "BasicUpdateQueue::Pop returned a null pointer in the absence of "
+                                   "a concurrent or subsequent call to ReleaseConsumers.";
+    } else {
+      while (!update) {
+        EXPECT_NO_THROW(update = queue.TryPop()) << "BasicUpdateQueue::TryPop call failed with an exception.";
+      }
+    }
+    uint64_t block_id = update->block_id;
+    observed_updates.push_back(block_id);
+    EXPECT_EQ(update->kv_pairs.size(), 2) << "A BasicUpdateQueue popping call returned an update with an "
+                                             "unexpected number of key value pairs";
+    if (update->kv_pairs.size() == 2) {
+      EXPECT_EQ(update->kv_pairs[0].first, "key" + to_string(block_id))
+          << "A BasicUpdateQueue popping call returned an update containing "
+             "an unexpected key (or keys in the wrong order).";
+      EXPECT_EQ(update->kv_pairs[0].second, "value" + to_string(block_id))
+          << "A BasicUpdateQueue popping call returned an update containing "
+             "an unexpected value (or values in the wrong order).";
+      EXPECT_EQ(update->kv_pairs[1].first, "const_key")
+          << "A BasicUpdateQueue popping call returned an update containing "
+             "an unexpected key (or keys in the wrong order).";
+      EXPECT_EQ(update->kv_pairs[1].second, "const_value")
+          << "A BasicUpdateQueue popping call returned an update containing "
+             "an unexpected value (or values in the wrong order).";
+    }
+  }
+}
+
+TEST(trc_basic_update_queue_test, test_no_update_duplication_or_loss) {
+  BasicUpdateQueue queue;
+  vector<vector<uint64_t>> observed_updates_by_thread(kRacingThreadsToTest);
+  vector<thread> threads;
+  for (uint64_t i = 0; i < kRacingThreadsToTest; ++i) {
+    threads.emplace_back(TestNoUpdateDuplicationOrLossProducer, ref(queue), i);
+  }
+  for (uint64_t i = 0; i < kRacingThreadsToTest; ++i) {
+    threads.emplace_back(TestNoUpdateDuplicationOrLossConsumer, ref(queue), ref(observed_updates_by_thread[i]), i);
+  }
+  vector<bool> updates_observed(kNumUpdatesToTest, false);
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  for (const auto& observed_by_thread : observed_updates_by_thread) {
+    for (const auto& update_observed : observed_by_thread) {
+      EXPECT_LT(update_observed, updates_observed.size())
+          << "A BasicUpdateQueue popped an updated not matching any update "
+             "that was pushed to the queue.";
+      if (update_observed < updates_observed.size()) {
+        EXPECT_FALSE(updates_observed[update_observed]) << "A BasicUpdateQueue appears to have duplicated an update.";
+        updates_observed[update_observed] = true;
+      }
+    }
+  }
+  for (const auto& update_observed : updates_observed) {
+    EXPECT_TRUE(update_observed) << "A BasicUpdateQueue appears to have lost an update.";
+  }
+}
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
+++ b/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
@@ -36,7 +36,7 @@ const milliseconds kBriefDelayDuration = 10ms;
 const uint64_t kNumUpdatesToTest = (uint64_t)1 << 18;
 const size_t kRacingThreadsToTest = 4;
 
-unique_ptr<Update> MakeUniqueUpdate(uint64_t block_id, const vector<pair<string, string>> kv_pairs) {
+unique_ptr<Update> MakeUniqueUpdate(uint64_t block_id, const vector<pair<string, string>>& kv_pairs) {
   auto update = make_unique<Update>();
   update->block_id = block_id;
   update->kv_pairs = kv_pairs;

--- a/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
+++ b/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
@@ -161,7 +161,7 @@ TEST(trc_basic_update_queue_test, test_pop) {
 TEST(test_basic_update_queue_test, test_size) {
   BasicUpdateQueue queue;
   EXPECT_EQ(queue.Size(), 0) << "BasicUpdateQueue::Size gives the wrong size for an empty queue.";
-  for (int i = 0; i < kNumUpdatesToTest; ++i) {
+  for (uint64_t i = 0; i < kNumUpdatesToTest; ++i) {
     queue.Push(MakeUniqueUpdate(i, vector<pair<string, string>>{}));
     EXPECT_EQ(queue.Size(), (i + 1)) << "BasicUpdateQueue::Size gives the wrong size for a queue to which "
                                      << to_string(i + 1) << " updates have been pushed.";

--- a/client/thin-replica-client/test/trc_byzantine_test.cpp
+++ b/client/thin-replica-client/test/trc_byzantine_test.cpp
@@ -1,0 +1,2024 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client/thin-replica-client/thin_replica_client.hpp"
+#include "client/thin-replica-client/trc_hash.hpp"
+#include "client/thin-replica-client/trs_connection.hpp"
+
+#include <log4cplus/configurator.h>
+#include "gtest/gtest.h"
+#include "thin_replica_client_mocks.hpp"
+
+using com::vmware::concord::thin_replica::Data;
+using com::vmware::concord::thin_replica::Hash;
+using com::vmware::concord::thin_replica::KVPair;
+using com::vmware::concord::thin_replica::ReadStateHashRequest;
+using com::vmware::concord::thin_replica::ReadStateRequest;
+using com::vmware::concord::thin_replica::SubscriptionRequest;
+using grpc::ClientContext;
+using grpc::ClientReaderInterface;
+using grpc::Status;
+using std::make_shared;
+using std::make_unique;
+using std::shared_ptr;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::unordered_map;
+using std::vector;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::steady_clock;
+using std::chrono::time_point;
+using std::this_thread::sleep_for;
+using thin_replica_client::BasicUpdateQueue;
+using thin_replica_client::kThinReplicaHashLength;
+using thin_replica_client::ThinReplicaClient;
+using thin_replica_client::ThinReplicaClientConfig;
+using thin_replica_client::TrsConnection;
+using thin_replica_client::Update;
+using thin_replica_client::UpdateQueue;
+
+const string kTestingClientID = "mock_client_id";
+const string kTestingJaegerAddress = "127.0.0.1:6831";
+const uint16_t kMaxFaultyIn4NodeCluster = 1;
+static_assert((kMaxFaultyIn4NodeCluster * 3 + 1) == 4);
+
+// Helper function(s) and struct(s) to test case(s) in this suite.
+
+bool UpdateMatchesExpected(const Update& update_received, const Data& update_expected) {
+  if ((update_received.block_id != update_expected.block_id()) ||
+      (update_received.kv_pairs.size() != update_expected.data_size())) {
+    return false;
+  }
+  for (size_t i = 0; i < update_expected.data_size(); ++i) {
+    if ((update_received.kv_pairs[i].first != update_expected.data(i).key()) ||
+        (update_received.kv_pairs[i].second != update_expected.data(i).value())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void VerifyInitialState(shared_ptr<UpdateQueue>& received_updates,
+                        const vector<Data>& expected_updates,
+                        size_t num_updates,
+                        const string& faulty_description) {
+  for (size_t i = 0; i < num_updates; ++i) {
+    unique_ptr<Update> received_update = received_updates->Pop();
+    ASSERT_TRUE((bool)received_update) << "ThinReplicaClient failed to fetch an expected update from the "
+                                          "initial state in the presence of "
+                                       << faulty_description << ".";
+    EXPECT_TRUE(UpdateMatchesExpected(*received_update, expected_updates[i]))
+        << "ThinReplicaClient reported an update not matching an expected "
+           "update from the initial state in the presence of "
+        << faulty_description << ".";
+  }
+}
+
+void VerifyUpdates(shared_ptr<UpdateQueue>& received_updates,
+                   const vector<Data>& expected_updates,
+                   const string& faulty_description) {
+  for (size_t i = 0; i < expected_updates.size(); ++i) {
+    unique_ptr<Update> received_update = received_updates->Pop();
+    ASSERT_TRUE((bool)received_update) << "ThinReplicaClient failed to stream an expected update from a "
+                                          "subscription in the presence of "
+                                       << faulty_description << ".";
+    EXPECT_TRUE(UpdateMatchesExpected(*received_update, expected_updates[i]))
+        << "ThinReplicaClient reported an update not matching an expected "
+           "update in the subscription stream in the presence of "
+        << faulty_description << ".";
+  }
+}
+
+vector<Data> GenerateSampleUpdateData(size_t data_size) {
+  vector<Data> data;
+  for (size_t i = 0; i < data_size; ++i) {
+    Data update;
+    update.set_block_id(i);
+    KVPair* kvp = update.add_data();
+    kvp->set_key("key" + to_string(i));
+    kvp->set_value("value" + to_string(i));
+    if (i % 2 == 0) {
+      kvp = update.add_data();
+      kvp->set_key("recurring_key");
+      kvp->set_value(to_string(i / 2));
+    }
+    data.push_back(update);
+  }
+  return data;
+}
+
+// Struct containing objects commonly used in the Byzantine test cases in this
+// suite, with constructor(s) for common pattern(s) of initializing these
+// objects. This struct exists primarilly for the purpose of factoring out
+// common declarations and initializations that follow routine patterns in the
+// test cases in this suite in order to make those cases more concise and less
+// repetitive.
+struct ByzantineTestCaseState {
+ public:
+  shared_ptr<MockDataStreamPreparer> correct_data_preparer_;
+  shared_ptr<MockOrderedDataStreamHasher> correct_hasher_;
+  shared_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior> byzantine_behavior_;
+  ByzantineMockThinReplicaServerPreparer server_preparer_;
+  vector<unique_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>> mock_servers_;
+
+  // Objects we anticipate the test case(s) will actually use once the
+  // ByzantineTestCaseState is fully set up.
+  shared_ptr<UpdateQueue> update_queue_;
+  unique_ptr<ThinReplicaClientConfig> trc_config_;
+  unique_ptr<ThinReplicaClient> trc_;
+
+  // Initialize this ByzantineTestCaseState such that trc_ points to a
+  // ThinReplicaClient object constructed to connect to a mock cluster of 4 mock
+  // servers whose non-faulty behavior is described by data_preparer and whose
+  // faulty behavior is described by byzantine_behavior, constructing objects
+  // needed to do this as needed and storing those objects (possibly either
+  // directly or by smart pointer at the discretion of ByzantineTestCaseState's
+  // implementation) in the constructed ByzantineTestCaseState. Note this
+  // construction of needed objects includes construction of a new UpdateQueue
+  // that trc_ will use and storage of a pointer to this update queue in
+  // update_queue_.
+  ByzantineTestCaseState(shared_ptr<MockDataStreamPreparer> data_preparer,
+                         shared_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior> byzantine_behavior,
+                         uint16_t max_faulty = kMaxFaultyIn4NodeCluster,
+                         size_t num_servers = 4)
+      : correct_data_preparer_(data_preparer),
+        correct_hasher_(new MockOrderedDataStreamHasher(correct_data_preparer_)),
+        byzantine_behavior_(byzantine_behavior),
+        server_preparer_(correct_data_preparer_, correct_hasher_, byzantine_behavior_),
+        mock_servers_(CreateByzantineMockServers(num_servers, server_preparer_)),
+        update_queue_(new BasicUpdateQueue()),
+        trc_config_(new ThinReplicaClientConfig(
+            kTestingClientID,
+            update_queue_,
+            max_faulty,
+            CreateTrsConnections<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>(mock_servers_))),
+        trc_(new ThinReplicaClient(std::move(trc_config_))) {}
+};
+
+namespace {
+
+TEST(trc_byzantine_test, test_read_state_empty_state) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(update_data, 0)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(
+      test_state.update_queue_, update_data, num_initial_updates, "a faulty server providing empty initial state");
+}
+
+TEST(trc_byzantine_test, test_read_state_suffix_missing) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t num_initial_updates_in_incomplete_state = 2;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        update_data, num_initial_updates_in_incomplete_state)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that omits a suffix of the initial state");
+}
+
+TEST(trc_byzantine_test, test_read_state_infix_missing) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  vector<Data> update_data_missing_state_infix = update_data;
+  update_data_missing_state_infix.erase(update_data_missing_state_infix.begin() + 1);
+  size_t num_initial_updates_in_incomplete_state = 2;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        update_data_missing_state_infix, num_initial_updates_in_incomplete_state)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that omits an infix of the initial state");
+}
+
+TEST(trc_byzantine_test, test_read_state_fabricated_state) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t fabricated_update_index = 1;
+  for (int i = fabricated_update_index; i < update_data.size(); ++i) {
+    update_data[i].set_block_id(update_data[i].block_id() + 1);
+  }
+  vector<Data> update_data_with_fabrication = update_data;
+  Data fabricated_update;
+  fabricated_update.set_block_id(fabricated_update_index);
+  KVPair* fabricated_update_entry = fabricated_update.add_data();
+  fabricated_update_entry->set_key("fabricated_key");
+  fabricated_update_entry->set_value("fabricated_value");
+  update_data_with_fabrication.insert((update_data_with_fabrication.begin() + fabricated_update_index),
+                                      fabricated_update);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        update_data_with_fabrication, num_initial_updates + 1)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that injects a fabricated update to the state");
+}
+
+TEST(trc_byzantine_test, test_read_state_erased_block_id) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 1;
+  vector<Data> corrupted_update_data = update_data;
+  corrupted_update_data[corrupted_update_index].clear_block_id();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that clears the block ID in one of the "
+                     "updates in the initial state");
+}
+
+TEST(trc_byzantine_test, test_read_state_wrong_block_id) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 1;
+  for (size_t i = corrupted_update_index; i < update_data.size(); ++i) {
+    update_data[i].set_block_id(update_data[i].block_id() + 1);
+  }
+  vector<Data> corrupted_update_data = update_data;
+  corrupted_update_data[corrupted_update_index].set_block_id(corrupted_update_data[corrupted_update_index].block_id() -
+                                                             1);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives the wrong block ID for an "
+                     "update in the initial state");
+}
+
+TEST(trc_byzantine_test, test_read_state_decreasing_block_id) {
+  vector<Data> update_data = GenerateSampleUpdateData(6);
+  size_t num_initial_updates = 4;
+  size_t corrupted_update_index = 3;
+  size_t corrupted_block_id = 1;
+  for (size_t i = corrupted_block_id; i < update_data.size(); ++i) {
+    update_data[i].set_block_id(update_data[i].block_id() + 1);
+  }
+  vector<Data> corrupted_update_data = update_data;
+  corrupted_update_data[corrupted_update_index].set_block_id(corrupted_block_id);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives a wrong block ID that is decreasing relative "
+                     "to its predecessor for an update in the initial state");
+}
+
+TEST(trc_byzantine_test, test_read_state_updates_incorrectly_ordered) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  vector<Data> incorrectly_ordered_update_data = update_data;
+  Data swap_temp = incorrectly_ordered_update_data[1];
+  incorrectly_ordered_update_data[1] = incorrectly_ordered_update_data[2];
+  incorrectly_ordered_update_data[2] = swap_temp;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        incorrectly_ordered_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that incorrectly orders initial state updates");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_erased) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 1;
+  vector<Data> corrupted_update_data = update_data;
+  corrupted_update_data[corrupted_update_index].clear_data();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives one of the initial state "
+                     "updates with its data cleared");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_subset_erased) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 2;
+  assert(update_data[corrupted_update_index].data_size() > 1);
+  vector<Data> corrupted_update_data = update_data;
+  corrupted_update_data[corrupted_update_index].clear_data();
+  KVPair* non_erased_data = corrupted_update_data[corrupted_update_index].add_data();
+  *non_erased_data = update_data[corrupted_update_index].data(0);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives one of the initial updates "
+                     "with a subset of its data missing");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_added) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t update_with_fabrication_index = 1;
+  vector<Data> update_data_with_fabrication = update_data;
+  KVPair* fabricated_entry = update_data_with_fabrication[update_with_fabrication_index].add_data();
+  fabricated_entry->set_key("fabricated_key");
+  fabricated_entry->set_value("fabricated_value");
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        update_data_with_fabrication, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that appends a fabricated entry to the "
+                     "data for one of the initial updates");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_key_erased) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 1;
+  vector<Data> corrupted_update_data = update_data;
+  (corrupted_update_data[corrupted_update_index].mutable_data(0))->clear_key();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives one of the updates in the "
+                     "initial state with a key cleared");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_value_erased) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 1;
+  vector<Data> corrupted_update_data = update_data;
+  (corrupted_update_data[corrupted_update_index].mutable_data(0))->clear_value();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives one of the updates in the "
+                     "initial state with a value cleared");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_incorrect_key) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 1;
+  vector<Data> corrupted_update_data = update_data;
+  (corrupted_update_data[corrupted_update_index].mutable_data(0))->set_key("incorrect_key");
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives one of the updates in the "
+                     "initial state with an incorrect key");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_incorrect_value) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 1;
+  vector<Data> corrupted_update_data = update_data;
+  (corrupted_update_data[corrupted_update_index].mutable_data(0))->set_value("incorrect_value");
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives one of the updates in the "
+                     "initial state with an incorrect value");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_value_swap) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  size_t corrupted_update_index = 2;
+  assert(update_data[corrupted_update_index].data_size() > 1);
+  vector<Data> corrupted_update_data = update_data;
+  Data& corrupted_update = corrupted_update_data[corrupted_update_index];
+  string swap_temp = corrupted_update.data(0).value();
+  (corrupted_update.mutable_data(0))->set_value(corrupted_update.data(1).value());
+  (corrupted_update.mutable_data(1))->set_value(swap_temp);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that swaps the values for two keys in a "
+                     "single update in the initial state");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_kvp_moved) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  vector<Data> corrupted_update_data = update_data;
+  assert(update_data[2].data_size() == 2);
+  *(corrupted_update_data[1].add_data()) = corrupted_update_data[2].data(1);
+
+  // Protobuf message objects do not appear to have a function for removing a
+  // specific instance of a repeated field, so, after copying the key/value pair
+  // we are moving to an earlier update, we clear the data from the update it
+  // was taken from and then re-add the key/value pair not moved in order to
+  // remove the moved key/value pair from its source update.
+  KVPair kvp_retained = corrupted_update_data[2].data(0);
+  corrupted_update_data[2].clear_data();
+  *(corrupted_update_data[2].add_data()) = kvp_retained;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that reports the initial state with a "
+                     "key/value pair moved from a later to an earlier update");
+}
+
+TEST(trc_byzantine_test, test_read_state_update_data_value_swapped_between_updates) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+  vector<Data> corrupted_update_data = update_data;
+  assert(update_data[0].data_size() == 2);
+  assert(update_data[2].data_size() == 2);
+  assert(update_data[0].data(1).key() == update_data[2].data(1).key());
+  assert(update_data[0].data(1).value() != update_data[2].data(1).value());
+  string swap_temp = update_data[0].data(1).value();
+  update_data[0].mutable_data(1)->set_value(update_data[2].data(1).value());
+  update_data[2].mutable_data(1)->set_value(swap_temp);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<InitialStateFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that reports the initial state with two different "
+                     "values for the same key in two different updates swapped such that the "
+                     "most recent value for that key is the wrong one");
+}
+
+TEST(trc_byzantine_test, test_read_state_hash_block_id_erased) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateHashBlockIdOmitter : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        response->clear_block_id();
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashBlockIdOmitter>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that omits Block IDs from its response "
+                     "to ReadStateHash");
+}
+
+TEST(trc_byzantine_test, test_read_state_hash_hash_erased) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateHashHashOmitter : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        response->clear_hash();
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashHashOmitter>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that omits hashes from its responses to ReadStateHash");
+}
+
+TEST(trc_byzantine_test, test_read_state_hash_wrong_block_id) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateHashBlockIdCorrupter : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        response->set_block_id(response->block_id() + 1);
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashBlockIdCorrupter>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives incorrect Block IDs in its "
+                     "responses to ReadStateHash");
+}
+
+TEST(trc_byzantine_test, test_read_state_hash_wrong_hash) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateHashHashCorrupter : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        string hash_string = response->hash();
+        assert(hash_string.length() > 0);
+        ++(hash_string[0]);
+        response->set_hash(hash_string);
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashHashCorrupter>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives incorrect hashes in response "
+                     "to ReadStateHash");
+}
+
+TEST(trc_byzantine_test, test_read_state_hash_hash_too_short) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateHashHashTruncater : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        string hash_string = response->hash();
+        assert(hash_string.length() > 1);
+        hash_string = hash_string.substr(1);
+        assert(hash_string.length() < kThinReplicaHashLength);
+        response->set_hash(hash_string);
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashHashTruncater>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives incorrect hashes shorter than "
+                     "the expected length in response to ReadStateHash");
+}
+
+TEST(trc_byzantine_test, test_read_state_hash_hash_too_long) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateHashHashExtender : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        string hash_string = response->hash();
+        assert(hash_string.length() > 1);
+        while (hash_string.length() < kThinReplicaHashLength) {
+          hash_string.append(hash_string);
+        }
+        response->set_hash(hash_string);
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashHashExtender>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that gives incorrect hashes longer than "
+                     "the expected length in response to ReadStateHash");
+}
+
+TEST(trc_byzantine_test, test_read_state_times_out) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateDelayer : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    ClientReaderInterface<Data>* ReadStateRaw(size_t server_index,
+                                              ClientContext* context,
+                                              const ReadStateRequest& request,
+                                              ClientReaderInterface<Data>* correct_data) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        sleep_for(kTestingTimeout * 2);
+      }
+      return correct_data;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateDelayer>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that responds to ReadState more slowly "
+                     "than the timeout");
+}
+
+TEST(trc_byzantine_test, test_first_state_stream_read_times_out) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<StateStreamDelayer>(0));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that opens a state stream that responds "
+                     "to reads more slowly than the timeout");
+}
+
+TEST(trc_byzantine_test, test_in_progress_state_stream_read_times_out) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<StateStreamDelayer>(2));
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that opens a state stream that starts "
+                     "responding to reads more slowly than the timeout after "
+                     "responding to the first two reads in a timely manner");
+}
+
+TEST(trc_byzantine_test, test_read_state_hash_times_out) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  class ReadStateHashDelayer : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        sleep_for(kTestingTimeout * 2);
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashDelayer>());
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     "a faulty server that responds to ReadStateHash more "
+                     "slowly than the timeout");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_times_out) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+
+  class SubscribeToUpdatesDelayer : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    ClientReaderInterface<Data>* SubscribeToUpdatesRaw(size_t server_index,
+                                                       ClientContext* context,
+                                                       const SubscriptionRequest& request,
+                                                       ClientReaderInterface<Data>* correct_data) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        sleep_for(kTestingTimeout * 2);
+      }
+      return correct_data;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<SubscribeToUpdatesDelayer>());
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that responds to SubscribeToUpdates more "
+                "slowly than the timeout");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_stream_ends_immediately) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  vector<Data> missing_update_data;
+  size_t num_initial_updates = 2;
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(missing_update_data, 0)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to "
+                "SubscribeToUpdates calls but then reports those streams have "
+                "ended before sending any data over them");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_stream_immediately_unresponsive) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<DataStreamDelayer>(0));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to SubscribeToUpdate "
+                "calls that respond to reads slower than the timeout");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_stream_becomes_unresponsive) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<DataStreamDelayer>(2));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to SubscribeToUpdate "
+                "which are initially responsive but begin responding to read calls "
+                "slower than the timeout after streaming a few updates.");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_stream_ends_unexpectedly) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t num_updates_to_truncate = 3;
+  assert((num_initial_updates + num_updates_to_truncate) < update_data.size());
+  vector<Data> truncated_update_data(update_data.begin(), update_data.end() - num_updates_to_truncate);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        truncated_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to "
+                "SubscribeToUpdates calls but, after returning some updates "
+                "over them normally, unexpectedly indicates they have ended");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_prefix_of_updates_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> incomplete_update_data = update_data;
+  size_t num_updates_to_omit = 2;
+  assert((num_initial_updates + num_updates_to_omit) < update_data.size());
+  for (size_t i = 0; i < num_updates_to_omit; ++i) {
+    incomplete_update_data.erase(incomplete_update_data.begin() + num_initial_updates);
+  }
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        incomplete_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits a prefix of the relevant updates "
+                "when it streams data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_infix_of_updates_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> incomplete_update_data = update_data;
+  size_t num_updates_to_omit = 2;
+  size_t omitted_update_offset = num_initial_updates + 2;
+  assert((omitted_update_offset + num_updates_to_omit) < update_data.size());
+  for (size_t i = 0; i < num_updates_to_omit; ++i) {
+    incomplete_update_data.erase(incomplete_update_data.begin() + omitted_update_offset);
+  }
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        incomplete_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits an infix of the relevant updates "
+                "when it streams data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_updates_reordered) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> reordered_update_data = update_data;
+  size_t reordered_update_offset = num_initial_updates + 2;
+  assert((reordered_update_offset + 1) < update_data.size());
+  Data swap_temp = reordered_update_data[reordered_update_offset];
+  reordered_update_data[reordered_update_offset] = reordered_update_data[reordered_update_offset + 1];
+  reordered_update_data[reordered_update_offset + 1] = swap_temp;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        reordered_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that reorders some of the relevant updates "
+                "when it streams data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_fabricated_update) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = num_initial_updates + 2;
+  assert(fabricated_update_offset < update_data.size());
+
+  // Note erasing an update from the correct data is simpler to implement and
+  // will achieve the same desired result as inserting a fabricated update to
+  // the incorrect data (that is, causing the incorrect data to have an update
+  // the correct data doesn't).
+  update_data.erase(update_data.begin() + fabricated_update_offset);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        update_data_with_fabrication, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that includes a fabricated update when it "
+                "streams data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_block_id_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  corrupted_update_data[corrupted_update_offset].clear_block_id();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits the Block ID from an update while "
+                "streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_block_id_incorrect) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert((corrupted_update_offset + 1) < update_data.size());
+  corrupted_update_data[corrupted_update_offset].set_block_id(update_data[corrupted_update_offset + 1].block_id());
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect Block ID for an update while "
+                "streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_block_id_decreasing) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  corrupted_update_data[corrupted_update_offset].set_block_id(update_data[corrupted_update_offset - 1].block_id() - 1);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives a decreasing Block ID for an update while "
+                "streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_kvps_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  corrupted_update_data[corrupted_update_offset].clear_data();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits all key value pairs for an update "
+                "while streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_kvps_partially_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  assert(corrupted_update_data[corrupted_update_offset].data_size() > 1);
+  corrupted_update_data[corrupted_update_offset].clear_data();
+  KVPair* non_erased_data = corrupted_update_data[corrupted_update_offset].add_data();
+  *non_erased_data = update_data[corrupted_update_offset].data(0);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits a subset of the key value pairs for an "
+                "update while streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_includes_fabricated_kvp) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = num_initial_updates + 2;
+  assert(fabricated_update_offset < update_data.size());
+  KVPair* fabricated_data = update_data_with_fabrication[fabricated_update_offset].add_data();
+  fabricated_data->set_key("fabricated_key");
+  fabricated_data->set_value("fabricated_value");
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        update_data_with_fabrication, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that includes a fabricated key-value pair in an update "
+                "while streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_key_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  corrupted_update_data[corrupted_update_offset].mutable_data(0)->clear_key();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits the key for one of the key value pairs for "
+                "an update while streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_value_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  corrupted_update_data[corrupted_update_offset].mutable_data(0)->clear_value();
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits the value for one of the key value pairs for "
+                "an update while streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_incorrect_key) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  corrupted_update_data[corrupted_update_offset].mutable_data(0)->set_key("incorrect_key");
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect key for one of the "
+                "key value pairs for an update while streaming data in "
+                "response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_update_incorrect_value) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  corrupted_update_data[corrupted_update_offset].mutable_data(0)->set_value("incorrect_value");
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect value for one of the "
+                "key value pairs for an update while streaming data in "
+                "response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_updates_keys_swapped_within_updat) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> corrupted_update_data = update_data;
+  size_t corrupted_update_offset = num_initial_updates + 2;
+  assert(corrupted_update_offset < update_data.size());
+  assert(corrupted_update_data[corrupted_update_offset].data_size() > 1);
+  string swap_temp = corrupted_update_data[corrupted_update_offset].data(0).key();
+  corrupted_update_data[corrupted_update_offset].mutable_data(0)->set_key(
+      corrupted_update_data[corrupted_update_offset].data(1).key());
+  corrupted_update_data[corrupted_update_offset].mutable_data(1)->set_key(swap_temp);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateDataFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        corrupted_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that swaps the keys between two key-value pairs within "
+                "an update while streaming data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_times_out) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+
+  class SubscribeToUpdateHashesDelayer : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   public:
+    ClientReaderInterface<Hash>* SubscribeToUpdateHashesRaw(size_t server_index,
+                                                            ClientContext* context,
+                                                            const SubscriptionRequest& request,
+                                                            ClientReaderInterface<Hash>* correct_hashes) override {
+      if (MakeByzantineFaulty(server_index, 1)) {
+        sleep_for(kTestingTimeout * 2);
+      }
+      return correct_hashes;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<SubscribeToUpdateHashesDelayer>());
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that responds to SubscribeToUpdateHashes more "
+                "slowly than the timeout");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_stream_ends_immediately) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+
+  // Note MockOrderedDataStreamHasher (used internally by UpdateHashFabricator)
+  // does not support construction with no initial state updates, so we
+  // construct our UpdateHashFabricator that gives immediately-ending streams in
+  // response to SubscribeToUpdateHashes with data truncated to include just the
+  // initial state rather than a completely empty data vector.
+  vector<Data> incomplete_update_data(update_data.begin(), update_data.begin() + num_initial_updates);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        incomplete_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to "
+                "SubscribeToUpdateHashes calls but then reports those streams "
+                "have ended before sending any hashes over them");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_stream_immediately_unresponsive) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<HashStreamDelayer>(0));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to "
+                "SubscribeToUpdateHashes calls that respond to reads slower "
+                "than the timeout");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_stream_becomes_unresponsive) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<HashStreamDelayer>(2));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to "
+                "SubscribeToUpdateHashes which are initially responsive but "
+                "begin responding to read calls slower than the timeout after "
+                "streaming a few updates.");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_stream_ends_unexpectedly) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t num_updates_to_truncate = 3;
+  assert((num_initial_updates + num_updates_to_truncate) < update_data.size());
+  vector<Data> truncated_update_data(update_data.begin(), update_data.end() - num_updates_to_truncate);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        truncated_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that opens streams in response to "
+                "SubscribeToUpdateHashes calls but, after returning some hashes over "
+                "them normally, unexpectedly indicates they have ended");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_prefix_of_hashes_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> incomplete_update_data = update_data;
+  size_t num_updates_to_omit = 2;
+  assert((num_initial_updates + num_updates_to_omit) < update_data.size());
+  for (size_t i = 0; i < num_updates_to_omit; ++i) {
+    incomplete_update_data.erase(incomplete_update_data.begin() + num_initial_updates);
+  }
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        incomplete_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits a prefix of the relevant update hashes when "
+                "it streams update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_infix_of_hashes_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> incomplete_update_data = update_data;
+  size_t num_updates_to_omit = 2;
+  size_t omitted_update_offset = num_initial_updates + 2;
+  assert((omitted_update_offset + num_updates_to_omit) < update_data.size());
+  for (size_t i = 0; i < num_updates_to_omit; ++i) {
+    incomplete_update_data.erase(incomplete_update_data.begin() + omitted_update_offset);
+  }
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        incomplete_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits an infix of the relevant update hashes when "
+                "it streams update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hashes_reordered) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> reordered_update_data = update_data;
+  size_t reordered_update_offset = num_initial_updates + 2;
+  assert((reordered_update_offset + 1) < update_data.size());
+  Data swap_temp = reordered_update_data[reordered_update_offset];
+  reordered_update_data[reordered_update_offset] = reordered_update_data[reordered_update_offset + 1];
+  reordered_update_data[reordered_update_offset + 1] = swap_temp;
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        reordered_update_data, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that reorders some of the relevant update hashes when "
+                "it streams update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_fabricated_hash) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = num_initial_updates + 2;
+  assert(fabricated_update_offset < update_data.size());
+
+  // Note erasing an update from the correct data is simpler to implement and
+  // will achieve the same desired result as inserting a fabricated update to
+  // the incorrect data (that is, causing the incorrect hashes to include a hash
+  // update that the correct data and hashes don't).
+  update_data.erase(update_data.begin() + fabricated_update_offset);
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashFabricator>(make_shared<VectorMockDataStreamPreparer>(
+                                        update_data_with_fabrication, num_initial_updates)));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that includes a fabricated hash when it "
+                "streams update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_block_id_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t corrupted_hash_offset = 2;
+  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+
+  class OmitBlockId : public UpdateHashCorrupter::CorruptHash {
+    void operator()(Hash* hash) override { hash->clear_block_id(); }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateHashCorrupter>(make_shared<OmitBlockId>(), corrupted_hash_offset));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits the Block ID from an update hash while "
+                "streaming update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_block_id_incorrect) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t corrupted_hash_offset = 2;
+  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+
+  class CorruptBlockId : public UpdateHashCorrupter::CorruptHash {
+    void operator()(Hash* hash) override { hash->set_block_id(hash->block_id() + 1); }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateHashCorrupter>(make_shared<CorruptBlockId>(), corrupted_hash_offset));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect Block ID for an update hash "
+                "while streaming update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_block_id_decreasing) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t corrupted_hash_offset = 2;
+  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+
+  assert(update_data[num_initial_updates + corrupted_hash_offset - 1].block_id() > 1);
+  class MakeBlockIdDecreasing : public UpdateHashCorrupter::CorruptHash {
+    void operator()(Hash* hash) override { hash->set_block_id(1); }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateHashCorrupter>(make_shared<MakeBlockIdDecreasing>(), corrupted_hash_offset));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect and decreasing Block "
+                "ID for an update hash while streaming update hashes in "
+                "response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_omitted) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t corrupted_hash_offset = 2;
+  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+
+  class OmitHash : public UpdateHashCorrupter::CorruptHash {
+    void operator()(Hash* hash) override { hash->clear_hash(); }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashCorrupter>(make_shared<OmitHash>(), corrupted_hash_offset));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that omits the hash from an update hash while streaming "
+                "update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_incorrect) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t corrupted_hash_offset = 2;
+  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+
+  class MakeHashIncorrect : public UpdateHashCorrupter::CorruptHash {
+    void operator()(Hash* hash) override {
+      string hash_value = hash->hash();
+      assert(hash_value.length() > 0);
+      ++hash_value[0];
+      hash->set_hash(hash_value);
+    }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateHashCorrupter>(make_shared<MakeHashIncorrect>(), corrupted_hash_offset));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect hash for an update hash while "
+                "streaming update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_too_short) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t corrupted_hash_offset = 2;
+  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+
+  class TruncateHash : public UpdateHashCorrupter::CorruptHash {
+    void operator()(Hash* hash) override {
+      string hash_value = hash->hash();
+      assert(hash_value.length() > 0);
+      while (hash_value.length() >= kThinReplicaHashLength) {
+        hash_value = hash_value.substr(1);
+      }
+      hash->set_hash(hash_value);
+    }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateHashCorrupter>(make_shared<TruncateHash>(), corrupted_hash_offset));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect hash that is too "
+                "short for an update hash while streaming update hashes in "
+                "response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_too_long) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  size_t corrupted_hash_offset = 2;
+  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+
+  class ExtendHash : public UpdateHashCorrupter::CorruptHash {
+    void operator()(Hash* hash) override {
+      string hash_value = hash->hash();
+      assert(hash_value.length() > 0);
+      while (hash_value.length() <= kThinReplicaHashLength) {
+        hash_value += hash_value[0];
+      }
+      hash->set_hash(hash_value);
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<UpdateHashCorrupter>(make_shared<ExtendHash>(), corrupted_hash_offset));
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a faulty server that gives an incorrect hash that is too long "
+                "for an update hash while streaming update hashes in response "
+                "to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_multiple_servers_timeout) {
+  vector<Data> update_data = GenerateSampleUpdateData(12);
+  size_t num_initial_updates = 4;
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  class FServerUnresponsiveness : public ClusterResponsivenessLimiter::ResponsivenessManager {
+    void UpdateResponsiveness(ClusterResponsivenessLimiter& responsiveness_limiter,
+                              size_t server_called,
+                              uint64_t block_id) override {
+      if (responsiveness_limiter.GetNumUnresponsiveServers() < responsiveness_limiter.GetMaxFaulty()) {
+        responsiveness_limiter.SetUnresponsive(server_called);
+      }
+    }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<ClusterResponsivenessLimiter>(max_faulty, num_servers, make_unique<FServerUnresponsiveness>()),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                to_string(max_faulty) + " faulty servers in a " + to_string(num_servers) +
+                    "-node cluster that respond to all calls more slowly than "
+                    "the timeout");
+}
+
+TEST(trc_byzantine_test, test_multiple_servers_begin_timing_out) {
+  vector<Data> update_data = GenerateSampleUpdateData(12);
+  size_t num_initial_updates = 4;
+  uint64_t block_id_to_limit_responsiveness_at = update_data[6].block_id();
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  class FServerUnresponsivenessAtBlockID : public ClusterResponsivenessLimiter::ResponsivenessManager {
+   private:
+    uint64_t block_id_;
+
+   public:
+    FServerUnresponsivenessAtBlockID(uint64_t block_id) : block_id_(block_id) {}
+    void UpdateResponsiveness(ClusterResponsivenessLimiter& responsiveness_limiter,
+                              size_t server_called,
+                              uint64_t block_id) override {
+      if ((block_id >= block_id_) &&
+          (responsiveness_limiter.GetNumUnresponsiveServers() < responsiveness_limiter.GetMaxFaulty())) {
+        responsiveness_limiter.SetUnresponsive(server_called);
+      }
+    }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<ClusterResponsivenessLimiter>(
+          max_faulty, num_servers, make_unique<FServerUnresponsivenessAtBlockID>(block_id_to_limit_responsiveness_at)),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                to_string(max_faulty) + " faulty servers in a " + to_string(num_servers) +
+                    "-node cluster that begin responding to all calls more slowly than "
+                    "the timeout after a few updates have been streamed");
+}
+
+TEST(trc_byzantine_test, test_minimal_subset_of_servers_responsive) {
+  vector<Data> update_data = GenerateSampleUpdateData(12);
+  size_t num_initial_updates = 4;
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  class MinimalResponsivenessForSubscription : public ClusterResponsivenessLimiter::ResponsivenessManager {
+    void UpdateResponsiveness(ClusterResponsivenessLimiter& responsiveness_limiter,
+                              size_t server_called,
+                              uint64_t block_id) override {
+      size_t target_num_unresponsive_servers =
+          responsiveness_limiter.GetClusterSize() - (responsiveness_limiter.GetMaxFaulty() + 1);
+      if (responsiveness_limiter.GetNumUnresponsiveServers() < target_num_unresponsive_servers) {
+        responsiveness_limiter.SetUnresponsive(server_called);
+      }
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ClusterResponsivenessLimiter>(
+                                        max_faulty, num_servers, make_unique<MinimalResponsivenessForSubscription>()),
+                                    max_faulty,
+                                    num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "all but " + to_string(max_faulty + 1) + " servers in a " + to_string(num_servers) +
+                    "-node cluster responding to all calls more slowly than "
+                    "the timeout");
+}
+
+TEST(trc_byzantine_test, test_minimal_subset_of_servers_left_responsive_after_others_timeout) {
+  vector<Data> update_data = GenerateSampleUpdateData(12);
+  size_t num_initial_updates = 4;
+  uint64_t block_id_to_limit_responsiveness_at = update_data[6].block_id();
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  class MinimalResponsivenessForSubscriptionAtBlockID : public ClusterResponsivenessLimiter::ResponsivenessManager {
+   private:
+    uint64_t block_id_;
+
+   public:
+    MinimalResponsivenessForSubscriptionAtBlockID(uint64_t block_id) : block_id_(block_id) {}
+    void UpdateResponsiveness(ClusterResponsivenessLimiter& responsiveness_limiter,
+                              size_t server_called,
+                              uint64_t block_id) override {
+      size_t target_num_unresponsive_servers =
+          responsiveness_limiter.GetClusterSize() - (responsiveness_limiter.GetMaxFaulty() + 1);
+      if ((block_id >= block_id_) &&
+          (responsiveness_limiter.GetNumUnresponsiveServers() < target_num_unresponsive_servers)) {
+        responsiveness_limiter.SetUnresponsive(server_called);
+      }
+    }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<ClusterResponsivenessLimiter>(
+          max_faulty,
+          num_servers,
+          make_unique<MinimalResponsivenessForSubscriptionAtBlockID>(block_id_to_limit_responsiveness_at)),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "all but " + to_string(max_faulty + 1) + " servers in a " + to_string(num_servers) +
+                    "-node cluster responding to all calls more slowly than "
+                    "the timeout after a few updates have been streamed");
+}
+
+TEST(trc_byzantine_test, test_cluster_temporarily_becomes_unresponsive) {
+  vector<Data> update_data = GenerateSampleUpdateData(12);
+  size_t num_initial_updates = 4;
+  uint64_t block_id_to_limit_responsiveness_at = update_data[6].block_id();
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  class TemporaryClusterUnresponsiveness : public ClusterResponsivenessLimiter::ResponsivenessManager {
+   private:
+    uint64_t block_id_;
+    bool unresponsiveness_started_;
+    time_point<steady_clock> unresponsiveness_start_time_;
+
+   public:
+    TemporaryClusterUnresponsiveness(uint64_t block_id)
+        : block_id_(block_id), unresponsiveness_started_(false), unresponsiveness_start_time_() {}
+    void UpdateResponsiveness(ClusterResponsivenessLimiter& responsiveness_limiter,
+                              size_t server_called,
+                              uint64_t block_id) override {
+      if (block_id >= block_id_) {
+        if (!unresponsiveness_started_) {
+          unresponsiveness_start_time_ = steady_clock::now();
+          unresponsiveness_started_ = true;
+        }
+        milliseconds target_unresponsiveness_window = kTestingTimeout * responsiveness_limiter.GetClusterSize() * 5;
+        time_point<steady_clock> current_time = steady_clock::now();
+        milliseconds time_unresponsive = duration_cast<milliseconds>(current_time - unresponsiveness_start_time_);
+        if (time_unresponsive <= target_unresponsiveness_window) {
+          responsiveness_limiter.SetUnresponsive(server_called);
+        } else {
+          responsiveness_limiter.SetResponsive(server_called);
+        }
+      }
+    }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<ClusterResponsivenessLimiter>(
+          max_faulty, num_servers, make_unique<TemporaryClusterUnresponsiveness>(block_id_to_limit_responsiveness_at)),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "all servers in a " + to_string(num_servers) +
+                    "-node cluster responding to all calls more slowly than "
+                    "the timeout after a few updates have been streamed, then "
+                    "returning to normal responsiveness after some delay");
+}
+
+TEST(trc_byzantine_test, test_cluster_reponsiveness_unstable) {
+  vector<Data> update_data = GenerateSampleUpdateData(24);
+  size_t num_initial_updates = 1;
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  class UnstableResponsiveness : public ClusterResponsivenessLimiter::ResponsivenessManager {
+   private:
+    unordered_map<size_t, uint64_t> most_recent_blocks_responded_to_;
+
+   public:
+    void UpdateResponsiveness(ClusterResponsivenessLimiter& responsiveness_limiter,
+                              size_t server_called,
+                              uint64_t block_id) override {
+      if ((most_recent_blocks_responded_to_.count(server_called) > 0) &&
+          (most_recent_blocks_responded_to_[server_called] == (block_id - 1))) {
+        responsiveness_limiter.SetUnresponsive(server_called);
+      } else {
+        responsiveness_limiter.SetResponsive(server_called);
+        most_recent_blocks_responded_to_[server_called] = block_id;
+      }
+    }
+  };
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<ClusterResponsivenessLimiter>(max_faulty, num_servers, make_unique<UnstableResponsiveness>()),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                "a cluster of " + to_string(num_servers) +
+                    " nodes of unstable responsiveness all of which will individually "
+                    "respond to any stream reads more slowly than the timeout if those "
+                    "reads would return a block immediately consecutive to the previous "
+                    "block read from that specific server");
+}
+
+TEST(trc_byzantine_test, test_f_servers_give_false_state) {
+  vector<Data> update_data = GenerateSampleUpdateData(6);
+  size_t num_initial_updates = 3;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = 1;
+
+  // Note erasing an update from the correct data is simpler to implement and
+  // will achieve the same desired result as inserting a fabricated update to
+  // the incorrect data (that is, causing the incorrect data to have an update
+  // the correct data doesn't).
+  update_data.erase(update_data.begin() + fabricated_update_offset);
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<InitialStateFabricator>(
+          make_shared<VectorMockDataStreamPreparer>(update_data_with_fabrication, num_initial_updates + 1), max_faulty),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     to_string(max_faulty) + " faulty servers in a " + to_string(num_servers) +
+                         "-node cluster that inject a fabricated update to the state");
+}
+
+TEST(trc_byzantine_test, test_f_servers_give_false_state_hashes) {
+  vector<Data> update_data = GenerateSampleUpdateData(5);
+  size_t num_initial_updates = 3;
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  class ReadStateHashHashCorrupter : public ByzantineMockThinReplicaServerPreparer::ByzantineServerBehavior {
+   private:
+    uint16_t max_faulty_;
+
+   public:
+    ReadStateHashHashCorrupter(uint16_t max_faulty) : max_faulty_(max_faulty) {}
+    Status ReadStateHash(size_t server_index,
+                         ClientContext* context,
+                         const ReadStateHashRequest& request,
+                         Hash* response,
+                         Status correct_status) override {
+      if (MakeByzantineFaulty(server_index, max_faulty_)) {
+        string hash_string = response->hash();
+        assert(hash_string.length() > 0);
+        ++(hash_string[0]);
+        response->set_hash(hash_string);
+      }
+      return correct_status;
+    }
+  };
+
+  ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+                                    make_shared<ReadStateHashHashCorrupter>(max_faulty),
+                                    max_faulty,
+                                    num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     to_string(max_faulty) + " serves in a " + to_string(num_servers) +
+                         "-node cluster that give incorrect hashes in response "
+                         "to ReadStateHash");
+}
+
+TEST(trc_byzantine_test, test_f_servers_give_false_updates) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = num_initial_updates + 2;
+  assert(fabricated_update_offset < update_data.size());
+
+  // Note erasing an update from the correct data is simpler to implement and
+  // will achieve the same desired result as inserting a fabricated update to
+  // the incorrect data (that is, causing the incorrect data to have an update
+  // the correct data doesn't).
+  update_data.erase(update_data.begin() + fabricated_update_offset);
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateDataFabricator>(
+          make_shared<VectorMockDataStreamPreparer>(update_data_with_fabrication, num_initial_updates), max_faulty),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                to_string(max_faulty) + " servers in a " + to_string(num_servers) +
+                    "-node cluster that include a fabricated update when they "
+                    "stream data in response to SubscribeToUpdates");
+}
+
+TEST(trc_byzantine_test, test_f_servers_give_false_update_hashes) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = num_initial_updates + 2;
+  assert(fabricated_update_offset < update_data.size());
+
+  // Note erasing an update from the correct data is simpler to implement and
+  // will achieve the same desired result as inserting a fabricated update to
+  // the incorrect data (that is, causing the incorrect hashes to include a hash
+  // update that the correct data and hashes don't).
+  update_data.erase(update_data.begin() + fabricated_update_offset);
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<UpdateHashFabricator>(
+          make_shared<VectorMockDataStreamPreparer>(update_data_with_fabrication, num_initial_updates), max_faulty),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                to_string(max_faulty) + " servers in a " + to_string(num_servers) +
+                    "-node cluster that includes a fabricated hash when they stream "
+                    "update hashes in response to SubscribeToUpdateHashes");
+}
+
+TEST(trc_byzantine_test, test_f_servers_collude_on_false_initial_state) {
+  vector<Data> update_data = GenerateSampleUpdateData(6);
+  size_t num_initial_updates = 3;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = 1;
+
+  // Note erasing an update from the correct data is simpler to implement and
+  // will achieve the same desired result as inserting a fabricated update to
+  // the incorrect data (that is, causing the incorrect data to have an update
+  // the correct data doesn't).
+  update_data.erase(update_data.begin() + fabricated_update_offset);
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<ComprehensiveDataFabricator>(
+          make_shared<VectorMockDataStreamPreparer>(update_data_with_fabrication, num_initial_updates + 1), max_faulty),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyInitialState(test_state.update_queue_,
+                     update_data,
+                     num_initial_updates,
+                     to_string(max_faulty) + " faulty servers in a " + to_string(num_servers) +
+                         "-node cluster that collude (in their responses to "
+                         "both ReadState and ReadStateHash) to present an "
+                         "initial state with a fabricated update");
+}
+
+TEST(trc_byzantine_test, test_f_servers_collude_on_streaming_fabricated_update) {
+  vector<Data> update_data = GenerateSampleUpdateData(8);
+  size_t num_initial_updates = 2;
+  vector<Data> update_data_with_fabrication = update_data;
+  size_t fabricated_update_offset = num_initial_updates + 2;
+  assert(fabricated_update_offset < update_data.size());
+
+  // Note erasing an update from the correct data is simpler to implement and
+  // will achieve the same desired result as inserting a fabricated update to
+  // the incorrect data (that is, causing the incorrect data to have an update
+  // the correct data doesn't).
+  update_data.erase(update_data.begin() + fabricated_update_offset);
+
+  uint16_t max_faulty = 3;
+  size_t num_servers = max_faulty * 3 + 1;
+
+  ByzantineTestCaseState test_state(
+      make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
+      make_shared<ComprehensiveDataFabricator>(
+          make_shared<VectorMockDataStreamPreparer>(update_data_with_fabrication, num_initial_updates), max_faulty),
+      max_faulty,
+      num_servers);
+
+  test_state.trc_->Subscribe("");
+  VerifyUpdates(test_state.update_queue_,
+                update_data,
+                to_string(max_faulty) + " servers in a " + to_string(num_servers) +
+                    "-node cluster that collude (in their responses to both "
+                    "SubscribeToUpdates and SubscribeToUpdateHashes) to "
+                    "present a fabricated update");
+}
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  log4cplus::initialize();
+  log4cplus::BasicConfigurator config;
+  config.configure();
+  return RUN_ALL_TESTS();
+}

--- a/client/thin-replica-client/test/trc_byzantine_test.cpp
+++ b/client/thin-replica-client/test/trc_byzantine_test.cpp
@@ -45,7 +45,6 @@ using thin_replica_client::BasicUpdateQueue;
 using thin_replica_client::kThinReplicaHashLength;
 using thin_replica_client::ThinReplicaClient;
 using thin_replica_client::ThinReplicaClientConfig;
-using thin_replica_client::TrsConnection;
 using thin_replica_client::Update;
 using thin_replica_client::UpdateQueue;
 

--- a/client/thin-replica-client/test/trc_byzantine_test.cpp
+++ b/client/thin-replica-client/test/trc_byzantine_test.cpp
@@ -58,10 +58,10 @@ static_assert((kMaxFaultyIn4NodeCluster * 3 + 1) == 4);
 
 bool UpdateMatchesExpected(const Update& update_received, const Data& update_expected) {
   if ((update_received.block_id != update_expected.block_id()) ||
-      (update_received.kv_pairs.size() != update_expected.data_size())) {
+      (update_received.kv_pairs.size() != (size_t)update_expected.data_size())) {
     return false;
   }
-  for (size_t i = 0; i < update_expected.data_size(); ++i) {
+  for (size_t i = 0; i < (size_t)update_expected.data_size(); ++i) {
     if ((update_received.kv_pairs[i].first != update_expected.data(i).key()) ||
         (update_received.kv_pairs[i].second != update_expected.data(i).value())) {
       return false;
@@ -220,7 +220,7 @@ TEST(trc_byzantine_test, test_read_state_fabricated_state) {
   vector<Data> update_data = GenerateSampleUpdateData(5);
   size_t num_initial_updates = 3;
   size_t fabricated_update_index = 1;
-  for (int i = fabricated_update_index; i < update_data.size(); ++i) {
+  for (size_t i = fabricated_update_index; i < update_data.size(); ++i) {
     update_data[i].set_block_id(update_data[i].block_id() + 1);
   }
   vector<Data> update_data_with_fabrication = update_data;

--- a/client/thin-replica-client/test/trc_byzantine_test.cpp
+++ b/client/thin-replica-client/test/trc_byzantine_test.cpp
@@ -17,6 +17,7 @@
 
 #include <log4cplus/configurator.h>
 #include "gtest/gtest.h"
+#include "assertUtils.hpp"
 #include "thin_replica_client_mocks.hpp"
 
 using com::vmware::concord::thin_replica::Data;
@@ -349,7 +350,7 @@ TEST(trc_byzantine_test, test_read_state_update_data_subset_erased) {
   vector<Data> update_data = GenerateSampleUpdateData(5);
   size_t num_initial_updates = 3;
   size_t corrupted_update_index = 2;
-  assert(update_data[corrupted_update_index].data_size() > 1);
+  ConcordAssert(update_data[corrupted_update_index].data_size() > 1);
   vector<Data> corrupted_update_data = update_data;
   corrupted_update_data[corrupted_update_index].clear_data();
   KVPair* non_erased_data = corrupted_update_data[corrupted_update_index].add_data();
@@ -468,7 +469,7 @@ TEST(trc_byzantine_test, test_read_state_update_data_value_swap) {
   vector<Data> update_data = GenerateSampleUpdateData(5);
   size_t num_initial_updates = 3;
   size_t corrupted_update_index = 2;
-  assert(update_data[corrupted_update_index].data_size() > 1);
+  ConcordAssert(update_data[corrupted_update_index].data_size() > 1);
   vector<Data> corrupted_update_data = update_data;
   Data& corrupted_update = corrupted_update_data[corrupted_update_index];
   string swap_temp = corrupted_update.data(0).value();
@@ -491,7 +492,7 @@ TEST(trc_byzantine_test, test_read_state_update_data_kvp_moved) {
   vector<Data> update_data = GenerateSampleUpdateData(5);
   size_t num_initial_updates = 3;
   vector<Data> corrupted_update_data = update_data;
-  assert(update_data[2].data_size() == 2);
+  ConcordAssert(update_data[2].data_size() == 2);
   *(corrupted_update_data[1].add_data()) = corrupted_update_data[2].data(1);
 
   // Protobuf message objects do not appear to have a function for removing a
@@ -519,10 +520,10 @@ TEST(trc_byzantine_test, test_read_state_update_data_value_swapped_between_updat
   vector<Data> update_data = GenerateSampleUpdateData(5);
   size_t num_initial_updates = 3;
   vector<Data> corrupted_update_data = update_data;
-  assert(update_data[0].data_size() == 2);
-  assert(update_data[2].data_size() == 2);
-  assert(update_data[0].data(1).key() == update_data[2].data(1).key());
-  assert(update_data[0].data(1).value() != update_data[2].data(1).value());
+  ConcordAssert(update_data[0].data_size() == 2);
+  ConcordAssert(update_data[2].data_size() == 2);
+  ConcordAssert(update_data[0].data(1).key() == update_data[2].data(1).key());
+  ConcordAssert(update_data[0].data(1).value() != update_data[2].data(1).value());
   string swap_temp = update_data[0].data(1).value();
   update_data[0].mutable_data(1)->set_value(update_data[2].data(1).value());
   update_data[2].mutable_data(1)->set_value(swap_temp);
@@ -639,7 +640,7 @@ TEST(trc_byzantine_test, test_read_state_hash_wrong_hash) {
                          Status correct_status) override {
       if (MakeByzantineFaulty(server_index, 1)) {
         string hash_string = response->hash();
-        assert(hash_string.length() > 0);
+        ConcordAssert(hash_string.length() > 0);
         ++(hash_string[0]);
         response->set_hash(hash_string);
       }
@@ -671,9 +672,9 @@ TEST(trc_byzantine_test, test_read_state_hash_hash_too_short) {
                          Status correct_status) override {
       if (MakeByzantineFaulty(server_index, 1)) {
         string hash_string = response->hash();
-        assert(hash_string.length() > 1);
+        ConcordAssert(hash_string.length() > 1);
         hash_string = hash_string.substr(1);
-        assert(hash_string.length() < kThinReplicaHashLength);
+        ConcordAssert(hash_string.length() < kThinReplicaHashLength);
         response->set_hash(hash_string);
       }
       return correct_status;
@@ -704,7 +705,7 @@ TEST(trc_byzantine_test, test_read_state_hash_hash_too_long) {
                          Status correct_status) override {
       if (MakeByzantineFaulty(server_index, 1)) {
         string hash_string = response->hash();
-        assert(hash_string.length() > 1);
+        ConcordAssert(hash_string.length() > 1);
         while (hash_string.length() < kThinReplicaHashLength) {
           hash_string.append(hash_string);
         }
@@ -890,7 +891,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_stream_ends_unexpectedly) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t num_updates_to_truncate = 3;
-  assert((num_initial_updates + num_updates_to_truncate) < update_data.size());
+  ConcordAssert((num_initial_updates + num_updates_to_truncate) < update_data.size());
   vector<Data> truncated_update_data(update_data.begin(), update_data.end() - num_updates_to_truncate);
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -910,7 +911,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_prefix_of_updates_omitted) {
   size_t num_initial_updates = 2;
   vector<Data> incomplete_update_data = update_data;
   size_t num_updates_to_omit = 2;
-  assert((num_initial_updates + num_updates_to_omit) < update_data.size());
+  ConcordAssert((num_initial_updates + num_updates_to_omit) < update_data.size());
   for (size_t i = 0; i < num_updates_to_omit; ++i) {
     incomplete_update_data.erase(incomplete_update_data.begin() + num_initial_updates);
   }
@@ -932,7 +933,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_infix_of_updates_omitted) {
   vector<Data> incomplete_update_data = update_data;
   size_t num_updates_to_omit = 2;
   size_t omitted_update_offset = num_initial_updates + 2;
-  assert((omitted_update_offset + num_updates_to_omit) < update_data.size());
+  ConcordAssert((omitted_update_offset + num_updates_to_omit) < update_data.size());
   for (size_t i = 0; i < num_updates_to_omit; ++i) {
     incomplete_update_data.erase(incomplete_update_data.begin() + omitted_update_offset);
   }
@@ -953,7 +954,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_updates_reordered) {
   size_t num_initial_updates = 2;
   vector<Data> reordered_update_data = update_data;
   size_t reordered_update_offset = num_initial_updates + 2;
-  assert((reordered_update_offset + 1) < update_data.size());
+  ConcordAssert((reordered_update_offset + 1) < update_data.size());
   Data swap_temp = reordered_update_data[reordered_update_offset];
   reordered_update_data[reordered_update_offset] = reordered_update_data[reordered_update_offset + 1];
   reordered_update_data[reordered_update_offset + 1] = swap_temp;
@@ -974,7 +975,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_fabricated_update) {
   size_t num_initial_updates = 2;
   vector<Data> update_data_with_fabrication = update_data;
   size_t fabricated_update_offset = num_initial_updates + 2;
-  assert(fabricated_update_offset < update_data.size());
+  ConcordAssert(fabricated_update_offset < update_data.size());
 
   // Note erasing an update from the correct data is simpler to implement and
   // will achieve the same desired result as inserting a fabricated update to
@@ -998,7 +999,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_block_id_omitted) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_offset < update_data.size());
   corrupted_update_data[corrupted_update_offset].clear_block_id();
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1017,7 +1018,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_block_id_incorrect) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert((corrupted_update_offset + 1) < update_data.size());
+  ConcordAssert((corrupted_update_offset + 1) < update_data.size());
   corrupted_update_data[corrupted_update_offset].set_block_id(update_data[corrupted_update_offset + 1].block_id());
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1036,7 +1037,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_block_id_decreasing) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_offset < update_data.size());
   corrupted_update_data[corrupted_update_offset].set_block_id(update_data[corrupted_update_offset - 1].block_id() - 1);
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1055,8 +1056,8 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_kvps_omitted) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
-  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  ConcordAssert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
   corrupted_update_data[corrupted_update_offset].clear_data();
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1075,8 +1076,8 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_kvps_partially_omitted
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
-  assert(corrupted_update_data[corrupted_update_offset].data_size() > 1);
+  ConcordAssert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_data[corrupted_update_offset].data_size() > 1);
   corrupted_update_data[corrupted_update_offset].clear_data();
   KVPair* non_erased_data = corrupted_update_data[corrupted_update_offset].add_data();
   *non_erased_data = update_data[corrupted_update_offset].data(0);
@@ -1097,7 +1098,7 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_includes_fabricated_kv
   size_t num_initial_updates = 2;
   vector<Data> update_data_with_fabrication = update_data;
   size_t fabricated_update_offset = num_initial_updates + 2;
-  assert(fabricated_update_offset < update_data.size());
+  ConcordAssert(fabricated_update_offset < update_data.size());
   KVPair* fabricated_data = update_data_with_fabrication[fabricated_update_offset].add_data();
   fabricated_data->set_key("fabricated_key");
   fabricated_data->set_value("fabricated_value");
@@ -1118,8 +1119,8 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_key_omitted) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
-  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  ConcordAssert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
   corrupted_update_data[corrupted_update_offset].mutable_data(0)->clear_key();
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1138,8 +1139,8 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_value_omitted) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
-  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  ConcordAssert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
   corrupted_update_data[corrupted_update_offset].mutable_data(0)->clear_value();
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1158,8 +1159,8 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_incorrect_key) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
-  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  ConcordAssert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
   corrupted_update_data[corrupted_update_offset].mutable_data(0)->set_key("incorrect_key");
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1179,8 +1180,8 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_update_incorrect_value) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
-  assert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
+  ConcordAssert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_data[corrupted_update_offset].data_size() > 0);
   corrupted_update_data[corrupted_update_offset].mutable_data(0)->set_value("incorrect_value");
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1200,8 +1201,8 @@ TEST(trc_byzantine_test, test_subscribe_to_updates_keys_swapped_within_updat) {
   size_t num_initial_updates = 2;
   vector<Data> corrupted_update_data = update_data;
   size_t corrupted_update_offset = num_initial_updates + 2;
-  assert(corrupted_update_offset < update_data.size());
-  assert(corrupted_update_data[corrupted_update_offset].data_size() > 1);
+  ConcordAssert(corrupted_update_offset < update_data.size());
+  ConcordAssert(corrupted_update_data[corrupted_update_offset].data_size() > 1);
   string swap_temp = corrupted_update_data[corrupted_update_offset].data(0).key();
   corrupted_update_data[corrupted_update_offset].mutable_data(0)->set_key(
       corrupted_update_data[corrupted_update_offset].data(1).key());
@@ -1303,7 +1304,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_stream_ends_unexpectedl
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t num_updates_to_truncate = 3;
-  assert((num_initial_updates + num_updates_to_truncate) < update_data.size());
+  ConcordAssert((num_initial_updates + num_updates_to_truncate) < update_data.size());
   vector<Data> truncated_update_data(update_data.begin(), update_data.end() - num_updates_to_truncate);
 
   ByzantineTestCaseState test_state(make_shared<VectorMockDataStreamPreparer>(update_data, num_initial_updates),
@@ -1323,7 +1324,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_prefix_of_hashes_omitte
   size_t num_initial_updates = 2;
   vector<Data> incomplete_update_data = update_data;
   size_t num_updates_to_omit = 2;
-  assert((num_initial_updates + num_updates_to_omit) < update_data.size());
+  ConcordAssert((num_initial_updates + num_updates_to_omit) < update_data.size());
   for (size_t i = 0; i < num_updates_to_omit; ++i) {
     incomplete_update_data.erase(incomplete_update_data.begin() + num_initial_updates);
   }
@@ -1345,7 +1346,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_infix_of_hashes_omitted
   vector<Data> incomplete_update_data = update_data;
   size_t num_updates_to_omit = 2;
   size_t omitted_update_offset = num_initial_updates + 2;
-  assert((omitted_update_offset + num_updates_to_omit) < update_data.size());
+  ConcordAssert((omitted_update_offset + num_updates_to_omit) < update_data.size());
   for (size_t i = 0; i < num_updates_to_omit; ++i) {
     incomplete_update_data.erase(incomplete_update_data.begin() + omitted_update_offset);
   }
@@ -1366,7 +1367,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hashes_reordered) {
   size_t num_initial_updates = 2;
   vector<Data> reordered_update_data = update_data;
   size_t reordered_update_offset = num_initial_updates + 2;
-  assert((reordered_update_offset + 1) < update_data.size());
+  ConcordAssert((reordered_update_offset + 1) < update_data.size());
   Data swap_temp = reordered_update_data[reordered_update_offset];
   reordered_update_data[reordered_update_offset] = reordered_update_data[reordered_update_offset + 1];
   reordered_update_data[reordered_update_offset + 1] = swap_temp;
@@ -1387,7 +1388,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_fabricated_hash) {
   size_t num_initial_updates = 2;
   vector<Data> update_data_with_fabrication = update_data;
   size_t fabricated_update_offset = num_initial_updates + 2;
-  assert(fabricated_update_offset < update_data.size());
+  ConcordAssert(fabricated_update_offset < update_data.size());
 
   // Note erasing an update from the correct data is simpler to implement and
   // will achieve the same desired result as inserting a fabricated update to
@@ -1410,7 +1411,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_block_id_omitted) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t corrupted_hash_offset = 2;
-  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+  ConcordAssert(num_initial_updates + corrupted_hash_offset < update_data.size());
 
   class OmitBlockId : public UpdateHashCorrupter::CorruptHash {
     void operator()(Hash* hash) override { hash->clear_block_id(); }
@@ -1431,7 +1432,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_block_id_incorrect) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t corrupted_hash_offset = 2;
-  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+  ConcordAssert(num_initial_updates + corrupted_hash_offset < update_data.size());
 
   class CorruptBlockId : public UpdateHashCorrupter::CorruptHash {
     void operator()(Hash* hash) override { hash->set_block_id(hash->block_id() + 1); }
@@ -1452,9 +1453,9 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_block_id_decreasing) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t corrupted_hash_offset = 2;
-  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+  ConcordAssert(num_initial_updates + corrupted_hash_offset < update_data.size());
 
-  assert(update_data[num_initial_updates + corrupted_hash_offset - 1].block_id() > 1);
+  ConcordAssert(update_data[num_initial_updates + corrupted_hash_offset - 1].block_id() > 1);
   class MakeBlockIdDecreasing : public UpdateHashCorrupter::CorruptHash {
     void operator()(Hash* hash) override { hash->set_block_id(1); }
   };
@@ -1475,7 +1476,7 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_omitted) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t corrupted_hash_offset = 2;
-  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+  ConcordAssert(num_initial_updates + corrupted_hash_offset < update_data.size());
 
   class OmitHash : public UpdateHashCorrupter::CorruptHash {
     void operator()(Hash* hash) override { hash->clear_hash(); }
@@ -1495,12 +1496,12 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_incorrect) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t corrupted_hash_offset = 2;
-  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+  ConcordAssert(num_initial_updates + corrupted_hash_offset < update_data.size());
 
   class MakeHashIncorrect : public UpdateHashCorrupter::CorruptHash {
     void operator()(Hash* hash) override {
       string hash_value = hash->hash();
-      assert(hash_value.length() > 0);
+      ConcordAssert(hash_value.length() > 0);
       ++hash_value[0];
       hash->set_hash(hash_value);
     }
@@ -1521,12 +1522,12 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_too_short) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t corrupted_hash_offset = 2;
-  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+  ConcordAssert(num_initial_updates + corrupted_hash_offset < update_data.size());
 
   class TruncateHash : public UpdateHashCorrupter::CorruptHash {
     void operator()(Hash* hash) override {
       string hash_value = hash->hash();
-      assert(hash_value.length() > 0);
+      ConcordAssert(hash_value.length() > 0);
       while (hash_value.length() >= kThinReplicaHashLength) {
         hash_value = hash_value.substr(1);
       }
@@ -1550,12 +1551,12 @@ TEST(trc_byzantine_test, test_subscribe_to_update_hashes_hash_too_long) {
   vector<Data> update_data = GenerateSampleUpdateData(8);
   size_t num_initial_updates = 2;
   size_t corrupted_hash_offset = 2;
-  assert(num_initial_updates + corrupted_hash_offset < update_data.size());
+  ConcordAssert(num_initial_updates + corrupted_hash_offset < update_data.size());
 
   class ExtendHash : public UpdateHashCorrupter::CorruptHash {
     void operator()(Hash* hash) override {
       string hash_value = hash->hash();
-      assert(hash_value.length() > 0);
+      ConcordAssert(hash_value.length() > 0);
       while (hash_value.length() <= kThinReplicaHashLength) {
         hash_value += hash_value[0];
       }
@@ -1864,7 +1865,7 @@ TEST(trc_byzantine_test, test_f_servers_give_false_state_hashes) {
                          Status correct_status) override {
       if (MakeByzantineFaulty(server_index, max_faulty_)) {
         string hash_string = response->hash();
-        assert(hash_string.length() > 0);
+        ConcordAssert(hash_string.length() > 0);
         ++(hash_string[0]);
         response->set_hash(hash_string);
       }
@@ -1891,7 +1892,7 @@ TEST(trc_byzantine_test, test_f_servers_give_false_updates) {
   size_t num_initial_updates = 2;
   vector<Data> update_data_with_fabrication = update_data;
   size_t fabricated_update_offset = num_initial_updates + 2;
-  assert(fabricated_update_offset < update_data.size());
+  ConcordAssert(fabricated_update_offset < update_data.size());
 
   // Note erasing an update from the correct data is simpler to implement and
   // will achieve the same desired result as inserting a fabricated update to
@@ -1922,7 +1923,7 @@ TEST(trc_byzantine_test, test_f_servers_give_false_update_hashes) {
   size_t num_initial_updates = 2;
   vector<Data> update_data_with_fabrication = update_data;
   size_t fabricated_update_offset = num_initial_updates + 2;
-  assert(fabricated_update_offset < update_data.size());
+  ConcordAssert(fabricated_update_offset < update_data.size());
 
   // Note erasing an update from the correct data is simpler to implement and
   // will achieve the same desired result as inserting a fabricated update to
@@ -1985,7 +1986,7 @@ TEST(trc_byzantine_test, test_f_servers_collude_on_streaming_fabricated_update) 
   size_t num_initial_updates = 2;
   vector<Data> update_data_with_fabrication = update_data;
   size_t fabricated_update_offset = num_initial_updates + 2;
-  assert(fabricated_update_offset < update_data.size());
+  ConcordAssert(fabricated_update_offset < update_data.size());
 
   // Note erasing an update from the correct data is simpler to implement and
   // will achieve the same desired result as inserting a fabricated update to

--- a/client/thin-replica-client/test/trc_hash_test.cpp
+++ b/client/thin-replica-client/test/trc_hash_test.cpp
@@ -1,0 +1,63 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <log4cplus/configurator.h>
+#include "gtest/gtest.h"
+
+#include "client/thin-replica-client/trc_hash.hpp"
+
+using com::vmware::concord::thin_replica::Data;
+using std::make_pair;
+using std::string;
+using std::to_string;
+using thin_replica_client::hashUpdate;
+using thin_replica_client::Update;
+
+const string kSampleUpdateExpectedHash({'\x02', '\x3D', '\x0D', '\x8B', '\xC6', '\x54', '\x07', '\xD7',
+                                        '\x33', '\x94', '\x99', '\xFE', '\x9F', '\x6E', '\x8E', '\xB3',
+                                        '\x1A', '\x76', '\xB3', '\x70', '\xE6', '\xDA', '\x69', '\x9F',
+                                        '\x64', '\x52', '\xDD', '\xA5', '\x5B', '\xD3', '\xF6', '\x62'});
+
+namespace {
+
+TEST(trc_hash, hash_update) {
+  Update update;
+  update.block_id = 1337;
+  for (int i = 0; i < 3; ++i) {
+    update.kv_pairs.push_back(make_pair(to_string(i), to_string(i)));
+  }
+
+  EXPECT_EQ(hashUpdate(update), kSampleUpdateExpectedHash);
+}
+
+TEST(trc_hash, hash_data) {
+  Data update;
+  update.set_block_id(1337);
+  for (int i = 0; i < 3; ++i) {
+    auto data = update.add_data();
+    data->set_key(to_string(i));
+    data->set_value(to_string(i));
+  }
+
+  EXPECT_EQ(hashUpdate(update), kSampleUpdateExpectedHash);
+}
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  log4cplus::initialize();
+  log4cplus::BasicConfigurator config;
+  config.configure();
+  return RUN_ALL_TESTS();
+}

--- a/client/thin-replica-client/test/trc_rpc_use_test.cpp
+++ b/client/thin-replica-client/test/trc_rpc_use_test.cpp
@@ -35,8 +35,6 @@ using std::vector;
 using thin_replica_client::BasicUpdateQueue;
 using thin_replica_client::ThinReplicaClient;
 using thin_replica_client::ThinReplicaClientConfig;
-using thin_replica_client::TrsConnection;
-using thin_replica_client::UpdateQueue;
 
 const string kTestingClientID = "mock_client_id";
 const string kTestingJaegerAddress = "127.0.0.1:6831";

--- a/client/thin-replica-client/test/trc_rpc_use_test.cpp
+++ b/client/thin-replica-client/test/trc_rpc_use_test.cpp
@@ -1,0 +1,228 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+// This test suite is intended to test that the ThinReplicaClient implementation
+// makes Thin Replica RPC calls to the Thin Replica Servers as intended by the
+// Thin Replica mechanism design. While the servers should tolerate
+// Byzantine-faulty Thin Replica Clients, the production ThinReplicaClient
+// implementation is not intended to be Byzantine-faulty, so we expect it will
+// only use the RPC calls as intended.
+
+#include "client/thin-replica-client/thin_replica_client.hpp"
+#include "client/thin-replica-client/trs_connection.hpp"
+
+#include <log4cplus/configurator.h>
+#include "gtest/gtest.h"
+#include "thin_replica_client_mocks.hpp"
+
+using com::vmware::concord::thin_replica::Data;
+using com::vmware::concord::thin_replica::KVPair;
+using std::make_shared;
+using std::make_unique;
+using std::shared_ptr;
+using std::string;
+using std::vector;
+using thin_replica_client::BasicUpdateQueue;
+using thin_replica_client::ThinReplicaClient;
+using thin_replica_client::ThinReplicaClientConfig;
+using thin_replica_client::TrsConnection;
+using thin_replica_client::UpdateQueue;
+
+const string kTestingClientID = "mock_client_id";
+const string kTestingJaegerAddress = "127.0.0.1:6831";
+
+namespace {
+
+TEST(trc_rpc_use_test, test_trc_constructor_and_destructor) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update, 1));
+  auto hasher = make_shared<MockOrderedDataStreamHasher>(stream_preparer);
+
+  uint16_t max_faulty = 1;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  auto update_queue = make_shared<BasicUpdateQueue>();
+  auto record = make_shared<ThinReplicaCommunicationRecord>();
+
+  auto server_recorders = CreateMockServerRecorders(num_replicas, stream_preparer, hasher, record);
+  auto mock_servers = CreateTrsConnections(server_recorders);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+
+  EXPECT_EQ(record->GetTotalCallCount(), 0) << "ThinReplicaClient's constructor appears to have generated RPC "
+                                               "call(s) (none were expected).";
+  trc_config.reset();
+  trc.reset();
+  EXPECT_EQ(record->GetTotalCallCount(), 0) << "ThinReplicaClient's destructor appears to have generated RPC call(s) "
+                                               "(none were expected).";
+}
+
+TEST(trc_rpc_use_test, test_trc_subscribe) {
+  Data update;
+  update.set_block_id(0);
+  KVPair* update_data = update.add_data();
+  update_data->set_key("key");
+  update_data->set_value("value");
+
+  shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update, 1));
+  auto hasher = make_shared<MockOrderedDataStreamHasher>(stream_preparer);
+
+  uint16_t max_faulty = 3;
+  size_t num_replicas = 3 * max_faulty + 1;
+
+  auto update_queue = make_shared<BasicUpdateQueue>();
+  auto record = make_shared<ThinReplicaCommunicationRecord>();
+
+  auto server_recorders = CreateMockServerRecorders(num_replicas, stream_preparer, hasher, record);
+  auto mock_servers = CreateTrsConnections(server_recorders);
+  auto trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+
+  trc->Subscribe("k");
+  vector<bool> servers_used(num_replicas, false);
+  ASSERT_EQ(record->GetReadStateCalls().size(), 1)
+      << "ThinReplicaClient::Subscribe's 1-parameter overload generated an "
+         "unexpected number of ReadState calls.";
+  servers_used[record->GetReadStateCalls().front().first] = true;
+  EXPECT_EQ(record->GetReadStateCalls().front().second.key_prefix(), "k")
+      << "ThinReplicaClient::Subscribe's 1-parameter overload made a ReadState "
+         "call with a prefix not matching the prefix given as a parameter to "
+         "Subscribe.";
+  EXPECT_EQ(record->GetReadStateHashCalls().size(), max_faulty)
+      << "ThinReplicaClient::Subscribe's 1-parameter overload generated an "
+         "unexpected number of ReadStateHash calls.";
+  for (const auto& call : record->GetReadStateHashCalls()) {
+    EXPECT_FALSE(servers_used[call.first]) << "ThinReplicaClient::Subscribe's 1-parameter overload re-used a "
+                                              "server when looking for state consensus.";
+    servers_used[call.first] = true;
+    EXPECT_EQ(call.second.key_prefix(), "k") << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
+                                                "ReadStateHash call with a prefix not matching the prefix given as "
+                                                "a parameter to Subscribe.";
+    EXPECT_EQ(call.second.block_id(), 0) << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
+                                            "ReadStateHash call with a Block ID inconsistent with the state the "
+                                            "mock servers have been configured to return for ReadState.";
+  }
+
+  // Block until an update is received through the subscription stream; we pop 2
+  // updates to do this in order to account for the single update the mock
+  // server we are using will provide via initial state.
+  update_queue->Pop();
+  update_queue->Pop();
+  servers_used = vector<bool>(num_replicas, false);
+  ASSERT_EQ(record->GetSubscribeToUpdatesCalls().size(), 1)
+      << "ThinReplicaClient::Subscribe's 1-parameter overload generated an "
+         "unexpected number of Subscribe calls.";
+  servers_used[record->GetSubscribeToUpdatesCalls().front().first] = true;
+  EXPECT_EQ(record->GetSubscribeToUpdatesCalls().front().second.key_prefix(), "k")
+      << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
+         "SubscribeToUpdates call with a prefix not matching the prefix given "
+         "as a parameter to Subscribe.";
+  EXPECT_EQ(record->GetSubscribeToUpdatesCalls().front().second.block_id(), 1)
+      << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
+         "SubscribeToUpdates call with a Block ID inconsistent with the "
+         "initial state it was provided.";
+  EXPECT_EQ(record->GetSubscribeToUpdateHashesCalls().size(), max_faulty)
+      << "ThinReplicaClient::Subscribe's 1-parameter overloader generated an "
+         "unexpected number of SubscribeToUpdateHashes calls.";
+  for (const auto& call : record->GetSubscribeToUpdateHashesCalls()) {
+    EXPECT_FALSE(servers_used[call.first]) << "ThinReplicaClient::Subscribe's 1-parameter overload re-used a "
+                                              "server when opening subscription streams.";
+    servers_used[call.first] = true;
+    EXPECT_EQ(call.second.key_prefix(), "k") << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
+                                                "SubscribeToUpdateHashes call with a key prefix not matching the "
+                                                "prefix given as a parameter to Subscribe.";
+    EXPECT_EQ(call.second.block_id(), 1) << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
+                                            "SubscribeToUpdateHashes call with a Block ID inconsistent with the "
+                                            "initial state it was provided.";
+  }
+
+  EXPECT_LE(record->GetTotalCallCount(), 2 * (1 + max_faulty))
+      << "ThinReplicaClient::Subscribe's 1-parameter overload generated "
+         "unexpected RPC calls.";
+
+  record->ClearRecords();
+  mock_servers = CreateTrsConnections(server_recorders);
+
+  // Note we explicitly reset the trc pointer before the line constructing a new
+  // ThinReplicaClient and assigning it to the pointer in order to force the
+  // destruction of the existing ThinReplicaClient before construction of a new
+  // one.
+  trc_config.reset();
+  trc.reset();
+  trc_config =
+      make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
+  trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  update_queue->Clear();
+  trc->Subscribe("key", 1);
+
+  // Block until an update is received through the subscription stream.
+  update_queue->Pop();
+  servers_used = vector<bool>(num_replicas, false);
+  ASSERT_EQ(record->GetSubscribeToUpdatesCalls().size(), 1)
+      << "ThinReplicaClient::Subscribe's 2-parameter overload generated an "
+         "unexpected number of Subscribe calls.";
+  servers_used[record->GetSubscribeToUpdatesCalls().front().first] = true;
+  EXPECT_EQ(record->GetSubscribeToUpdatesCalls().front().second.key_prefix(), "key")
+      << "ThinReplicaClient::Subscribe's 2-parameter overload made a "
+         "SubscribeToUpdates call with a key prefix not matching the prefix "
+         "given as a parameter to Subscribe.";
+  EXPECT_EQ(record->GetSubscribeToUpdatesCalls().front().second.block_id(), 2)
+      << "ThinReplicaClient::Subscribe's 2-parameter overload made a "
+         "SubscribeToUpdates call with a Block ID inconsistent with the one "
+         "given as a parameter to Subscribe.";
+  EXPECT_EQ(record->GetSubscribeToUpdateHashesCalls().size(), max_faulty)
+      << "ThinReplicaClient::Subscribe's 2-parameter overloade generated an "
+         "unexpected number of SubscribeToUpdateHashes calls.";
+  for (const auto& call : record->GetSubscribeToUpdateHashesCalls()) {
+    EXPECT_FALSE(servers_used[call.first]) << "ThinReplicaClient::Subscribe's 2-parameter overload re-used a "
+                                              "server when opening subscription streams.";
+    servers_used[call.first] = true;
+    EXPECT_EQ(call.second.key_prefix(), "key") << "ThinReplicaClient::Subscribe's 2-parameter overload made a "
+                                                  "SubscribeToUpdateHashes call with a key prefix not matching the "
+                                                  "prefix given as a parameter to Subscribe.";
+    EXPECT_EQ(call.second.block_id(), 2) << "ThinReplicaClient::Subscribe's 2-parameter overload made a "
+                                            "SubscribeToUpdateHashes call with a Block ID inconsistent with the "
+                                            "one given as a parameter to Subscribe.";
+  }
+  EXPECT_LE(record->GetTotalCallCount(), (1 + max_faulty))
+      << "ThinReplicaClient::Subscribe's 2-parameter overload generated "
+         "unexpected RPC calls.";
+}
+
+// The following additional behaviors should be tested in this unit test suite
+// once the AckUpate and Unsubscribe calls are implemented on the Thin Replica
+// Server side and the lines to actually make those calls have been added to the
+// ThinReplicaClient implementation:
+// - A call to ThinReplicaClient::AcknowledgeBlockID should generate exactly one
+//   RPC call to AckUpdate.
+// - If a ThinReplicaClient has an active subscription, a call to Unsubscribe
+//   should generate exactly one RPC call to Unsubscribe.
+// - RPC calls to AckUpdate generated by calls to AcknowlegeBlockId should be
+//   made with block_id values matching the ones passed to AcknowledgeBlockID.
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  log4cplus::initialize();
+  log4cplus::BasicConfigurator config;
+  config.configure();
+  return RUN_ALL_TESTS();
+}

--- a/cmake/FindGMock.cmake
+++ b/cmake/FindGMock.cmake
@@ -1,0 +1,19 @@
+find_path(GMOCK_INCLUDE_DIR gmock/gmock.h
+        HINTS ${CMAKE_CURRENT_SOURCE_DIR}/../googletest/googlemock/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../googletest/googlemock/include)
+
+if(DEFINED GMOCK_INCLUDE_DIR_NOTFOUND)
+  message(SEND_ERROR "GMOCK not found")
+else(DEFINED GMOCK_INCLUDE_DIR_FOUND)
+  message(STATUS "GMOCK found at " ${GMOCK_INCLUDE_DIR})
+  set(GMOCK_FOUND 1)
+
+  set(GMOCK_DIR "${GTEST_INCLUDE_DIR}/../../_build/googlemock")
+
+  find_library(GMOCK_LIBRARY
+          NAMES gmock
+          libgmock
+          libgmock.a
+          PATHS "${GMOCK_DIR}")
+
+endif(DEFINED GMOCK_INCLUDE_DIR_NOTFOUND)


### PR DESCRIPTION
This PR adds a commit that adds TRC unit tests. This PR also includes commits with minor fixes.
Note that`trace_context_test.cpp` has not yet been added. Once it is verified that trace_contexts are safely propagated to/from TRC and concord with the move to open-source, the test will be added.