### PR TITLE
Allocate preexecution result buffers on first use

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -47,7 +47,7 @@ struct RequestState {
 };
 
 // Pre-allocated (clientId * dataSize) buffers
-typedef std::vector<concordUtils::Sliver> PreProcessResultBuffers;
+typedef std::unordered_map<uint16_t, std::unordered_map<uint16_t, concordUtils::Sliver>> PreProcessResultBuffers;
 typedef std::shared_ptr<RequestState> RequestStateSharedPtr;
 // (clientId * dataSize + reqOffsetInBatch) -> RequestStateSharedPtr
 typedef std::unordered_map<uint16_t, RequestStateSharedPtr> OngoingReqMap;
@@ -128,7 +128,7 @@ class PreProcessor {
                                       NodeIdType destId,
                                       uint16_t reqOffsetInBatch,
                                       uint64_t reqRetryId);
-  const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
+  const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
   const uint16_t getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,


### PR DESCRIPTION
Under certain configuration we have gaps in the sequence of client_ids. In those cases we will allocate unnecessary buffers that are never used. We can avoid that by allocating the buffers on demand.