### PR TITLE
Block accumulation apollo test cases updates and fixes

### DIFF
--- a/tests/apollo/test_skvbc_block_accumulation.py
+++ b/tests/apollo/test_skvbc_block_accumulation.py
@@ -23,15 +23,12 @@ import util.bft_network_partitioning as net
 import util.eliot_logging as log
 
 SKVBC_INIT_GRACE_TIME = 2
-BATCH_SIZE = 10
+BATCH_SIZE = 4
 NUM_OF_SEQ_WRITES = 1
 NUM_OF_PARALLEL_WRITES = 100
 MAX_CONCURRENCY = 10
 SHORT_REQ_TIMEOUT_MILLI = 3000
 LONG_REQ_TIMEOUT_MILLI = 15000
-BATCH_BY_REQ_NUM = "2"
-MAX_REQ_NUM_IN_BATCH = 5
-BATCH_FLUSH_PERIOD = "250"
 
 def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
     """
@@ -51,9 +48,6 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-i", str(replica_id),
             "-s", status_timer_milli,
             "-v", view_change_timeout_milli,
-            "-b", BATCH_BY_REQ_NUM,
-            "-q", str(MAX_REQ_NUM_IN_BATCH),
-            "-z", BATCH_FLUSH_PERIOD,
             "-u", str(True)
             ]
 
@@ -116,7 +110,7 @@ class SkvbcBlockAccumulationTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
-    @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
+    @verify_linearizability(pre_exec_enabled=True, no_conflicts=True, block_Accumulation=True)
     async def test_batch_block_accumulation_request_block_count_validation(self, bft_network, tracker):
         """
         Launch concurrent requests from different clients. Ensure that created accumulated block count is as expected.
@@ -127,11 +121,11 @@ class SkvbcBlockAccumulationTest(unittest.TestCase):
 
         clients = bft_network.random_clients(MAX_CONCURRENCY)
         num_of_requests = NUM_OF_PARALLEL_WRITES
-        wr = await tracker.run_concurrent_batch_ops(num_of_requests, BATCH_SIZE, block_accumulation = True)
+        wr = await tracker.run_concurrent_batch_ops(num_of_requests, BATCH_SIZE)
         self.assertTrue(wr >= num_of_requests)
 
         await bft_network.assert_successful_pre_executions_count(0, wr * BATCH_SIZE)
-        computed_block_count = ((wr * BATCH_SIZE)/MAX_REQ_NUM_IN_BATCH);
+        computed_block_count = ((wr * BATCH_SIZE))
         await trio.sleep(seconds=3)
 
         read_client = bft_network.random_client()

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -272,16 +272,17 @@ void InternalCommandsHandler::addBlock(VersionedUpdates &verUpdates, BlockMerkle
   ConcordAssert(newBlockId == currBlock + 1);
 }
 
-bool InternalCommandsHandler::checkKeyInBlockAccumulatedRequests(
+bool InternalCommandsHandler::hasConflictInBlockAccumulatedRequests(
     const std::string &key,
     VersionedUpdates &blockAccumulatedVerUpdates,
     BlockMerkleUpdates &blockAccumulatedMerkleUpdates) const {
-  if (auto it = blockAccumulatedVerUpdates.getData().kv.find(key);
-      it != blockAccumulatedVerUpdates.getData().kv.end()) {
+  auto itVersionUpdates = blockAccumulatedVerUpdates.getData().kv.find(key);
+  if (itVersionUpdates != blockAccumulatedVerUpdates.getData().kv.end()) {
     return true;
   }
-  if (auto it = blockAccumulatedMerkleUpdates.getData().kv.find(key);
-      it != blockAccumulatedMerkleUpdates.getData().kv.end()) {
+
+  auto itMerkleUpdates = blockAccumulatedMerkleUpdates.getData().kv.find(key);
+  if (itMerkleUpdates != blockAccumulatedMerkleUpdates.getData().kv.end()) {
     return true;
   }
   return false;
@@ -329,7 +330,7 @@ bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
     const auto latest_ver = getLatestVersion(key);
     hasConflict = (latest_ver && latest_ver > writeReq->readVersion);
     if (isBlockAccumulationEnabled && !hasConflict) {
-      if (checkKeyInBlockAccumulatedRequests(key, blockAccumulatedVerUpdates, blockAccumulatedMerkleUpdates)) {
+      if (hasConflictInBlockAccumulatedRequests(key, blockAccumulatedVerUpdates, blockAccumulatedMerkleUpdates)) {
         hasConflict = true;
       }
     }

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -217,10 +217,7 @@ void InternalCommandsHandler::writeAccumulatedBlock(ExecutionRequestsQueue &bloc
   for (auto &req : blockedRequests) {
     if (req.flags & bftEngine::MsgFlag::HAS_PRE_PROCESSED_FLAG) {
       auto *reply = (SimpleReply_ConditionalWrite *)req.outReply;
-      if (reply->success)
-        reply->latestBlock = currBlock + 1;
-      else
-        reply->latestBlock = currBlock;
+      reply->latestBlock = currBlock + 1;
       LOG_INFO(
           m_logger,
           "ConditionalWrite message handled; writesCounter=" << m_writesCounter << " currBlock=" << reply->latestBlock);
@@ -274,6 +271,22 @@ void InternalCommandsHandler::addBlock(VersionedUpdates &verUpdates, BlockMerkle
   const auto newBlockId = m_blockAdder->add(std::move(updates));
   ConcordAssert(newBlockId == currBlock + 1);
 }
+
+bool InternalCommandsHandler::checkKeyInBlockAccumulatedRequests(
+    const std::string &key,
+    VersionedUpdates &blockAccumulatedVerUpdates,
+    BlockMerkleUpdates &blockAccumulatedMerkleUpdates) const {
+  if (auto it = blockAccumulatedVerUpdates.getData().kv.find(key);
+      it != blockAccumulatedVerUpdates.getData().kv.end()) {
+    return true;
+  }
+  if (auto it = blockAccumulatedMerkleUpdates.getData().kv.find(key);
+      it != blockAccumulatedMerkleUpdates.getData().kv.end()) {
+    return true;
+  }
+  return false;
+}
+
 bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
                                                   const char *request,
                                                   uint64_t sequenceNum,
@@ -315,6 +328,11 @@ bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
     const auto key = std::string(readSetArray[i].key, KV_LEN);
     const auto latest_ver = getLatestVersion(key);
     hasConflict = (latest_ver && latest_ver > writeReq->readVersion);
+    if (isBlockAccumulationEnabled && !hasConflict) {
+      if (checkKeyInBlockAccumulatedRequests(key, blockAccumulatedVerUpdates, blockAccumulatedMerkleUpdates)) {
+        hasConflict = true;
+      }
+    }
   }
 
   if (!hasConflict) {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -92,6 +92,10 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                uint64_t sequenceNum,
                concord::kvbc::categorization::VersionedUpdates &verUpdates,
                concord::kvbc::categorization::BlockMerkleUpdates &merkleUpdates);
+  bool checkKeyInBlockAccumulatedRequests(
+      const std::string &key,
+      concord::kvbc::categorization::VersionedUpdates &blockAccumulatedVerUpdates,
+      concord::kvbc::categorization::BlockMerkleUpdates &blockAccumulatedMerkleUpdates) const;
 
  private:
   concord::kvbc::IReader *m_storage;

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -92,7 +92,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                uint64_t sequenceNum,
                concord::kvbc::categorization::VersionedUpdates &verUpdates,
                concord::kvbc::categorization::BlockMerkleUpdates &merkleUpdates);
-  bool checkKeyInBlockAccumulatedRequests(
+  bool hasConflictInBlockAccumulatedRequests(
       const std::string &key,
       concord::kvbc::categorization::VersionedUpdates &blockAccumulatedVerUpdates,
       concord::kvbc::categorization::BlockMerkleUpdates &blockAccumulatedMerkleUpdates) const;


### PR DESCRIPTION
Added changes to block accumulation test cases which include 2 commits with following changes with more details in commit description:
1. Added changes to fix occasional failures by modifying configuration.
2. Added changes to support conflict test case for block accumulation test case suite.