### PR TITLE
State transfer in separate thread

### DIFF
--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -291,7 +291,7 @@ SimpleStateTran::SimpleStateTran(
       15000,                                // sourceReplicaReplacementTimeoutMs
       250,                                  // fetchRetransmissionTimeoutMs
       5,                                    // metricsDumpIntervalSec
-      false,                                // runInSeparateThread
+      true,                                // runInSeparateThread
       true                                  // enableReservedPages
   };
 

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -291,7 +291,7 @@ SimpleStateTran::SimpleStateTran(
       15000,                                // sourceReplicaReplacementTimeoutMs
       250,                                  // fetchRetransmissionTimeoutMs
       5,                                    // metricsDumpIntervalSec
-      true,                                // runInSeparateThread
+      true,                                 // runInSeparateThread
       true                                  // enableReservedPages
   };
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -228,7 +228,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
     replicaConfig_.get<uint32_t>("concord.bft.st.sourceReplicaReplacementTimeoutMs", 15000),
     replicaConfig_.get<uint32_t>("concord.bft.st.fetchRetransmissionTimeoutMs", 1000),
     replicaConfig_.get<uint32_t>("concord.bft.st.metricsDumpIntervalSec", 5),
-    replicaConfig_.get<bool>("concord.bft.st.runInSeparateThread", true),
+    replicaConfig_.get("concord.bft.st.runInSeparateThread", replicaConfig_.isReadOnly),
     replicaConfig_.get("concord.bft.st.enableReservedPages", !replicaConfig_.isReadOnly)
   };
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -228,7 +228,7 @@ ReplicaImp::ReplicaImp(ICommunication *comm,
     replicaConfig_.get<uint32_t>("concord.bft.st.sourceReplicaReplacementTimeoutMs", 15000),
     replicaConfig_.get<uint32_t>("concord.bft.st.fetchRetransmissionTimeoutMs", 1000),
     replicaConfig_.get<uint32_t>("concord.bft.st.metricsDumpIntervalSec", 5),
-    replicaConfig_.get("concord.bft.st.runInSeparateThread", replicaConfig_.isReadOnly),
+    replicaConfig_.get<bool>("concord.bft.st.runInSeparateThread", true),
     replicaConfig_.get("concord.bft.st.enableReservedPages", !replicaConfig_.isReadOnly)
   };
 

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -59,6 +59,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.pruningEnabled_ = true;
     replicaConfig.numBlocksToKeep_ = 10;
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
+    replicaConfig.set("concord.bft.st.runInSeparateThread", true);
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
     std::string commConfigFile;


### PR DESCRIPTION
Enabling State Transfer in Separate thread. Mechanism for state transfer is already there, just turning on the flag. 