### PR TITLE
Wip send proof for stable checkpoint

### DIFF
--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -49,6 +49,8 @@ class CheckpointInfo {
 
   CheckpointMsg* selfCheckpointMsg() const;
 
+  const auto& getAllCheckpointMsgs() const { return checkpointCertificate->getAllMsgs(); }
+
   void tryToMarkCheckpointCertificateCompleted();
 
   bool checkpointSentAllOrApproved() const;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2001,11 +2001,12 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
     CheckpointMsg *checkMsg = checkpointsLog->get(lastStableSeqNum).selfCheckpointMsg();
 
     if (checkMsg == nullptr || !checkMsg->isStableState()) {
-      LOG_WARN(GL, "Misalignment in lastStableSeqNum and my CheckpointMsg for it");
+      LOG_WARN(
+          GL, "Misalignment in lastStableSeqNum and my CheckpointMsg for it" << KVLOG(lastStableSeqNum, msgLastStable));
     }
 
-    auto &CheckpointInfo = checkpointsLog->get(lastStableSeqNum);
-    for (const auto &it : CheckpointInfo.getAllCheckpointMsgs()) {
+    auto &checkpointInfo = checkpointsLog->get(lastStableSeqNum);
+    for (const auto &it : checkpointInfo.getAllCheckpointMsgs()) {
       if (msgSenderId != it.first) {
         sendAndIncrementMetric(it.second, msgSenderId, metric_sent_checkpoint_msg_due_to_status_);
       }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1996,15 +1996,20 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
   // Checkpoints
   /////////////////////////////////////////////////////////////////////////
 
-  if (lastStableSeqNum > msgLastStable + kWorkWindowSize) {
+  if ((lastStableSeqNum > msgLastStable + kWorkWindowSize) ||
+      (!currentViewIsActive() && (lastStableSeqNum > msgLastStable))) {
     CheckpointMsg *checkMsg = checkpointsLog->get(lastStableSeqNum).selfCheckpointMsg();
 
     if (checkMsg == nullptr || !checkMsg->isStableState()) {
-      // TODO(GG): warning
-    } else {
-      sendAndIncrementMetric(checkMsg, msgSenderId, metric_sent_checkpoint_msg_due_to_status_);
+      LOG_WARN(GL, "Misalignment in lastStableSeqNum and my CheckpointMsg for it");
     }
 
+    auto &CheckpointInfo = checkpointsLog->get(lastStableSeqNum);
+    for (const auto &it : CheckpointInfo.getAllCheckpointMsgs()) {
+      if (msgSenderId != it.first) {
+        sendAndIncrementMetric(it.second, msgSenderId, metric_sent_checkpoint_msg_due_to_status_);
+      }
+    }
   } else if (msgLastStable > lastStableSeqNum + kWorkWindowSize) {
     tryToSendStatusReport();  // ask for help
   } else {

--- a/bftengine/src/bftengine/messages/MsgsCertificate.hpp
+++ b/bftengine/src/bftengine/messages/MsgsCertificate.hpp
@@ -56,6 +56,8 @@ class MsgsCertificate {
 
   T* selfMsg() const;
 
+  const auto& getAllMsgs() const;
+
   T* bestCorrectMsg() const;
 
   void tryToMarkComplete();
@@ -318,6 +320,11 @@ T* MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::sel
   if (pos != msgsFromReplicas.end()) retVal = pos->second;
 
   return retVal;
+}
+
+template <typename T, bool SelfTrust, bool SelfIsRequired, bool KeepAllMsgs, typename ExternalFunc>
+const auto& MsgsCertificate<T, SelfTrust, SelfIsRequired, KeepAllMsgs, ExternalFunc>::getAllMsgs() const {
+  return msgsFromReplicas;
 }
 
 template <typename T, bool SelfTrust, bool SelfIsRequired, bool KeepAllMsgs, typename ExternalFunc>

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -50,7 +50,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @unittest.skip("After CheckpointMsg-s forwarding, in this situation the late Replica initiates State Transfer.")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_inactive_window_catchup_up_to_gap(self, bft_network):


### PR DESCRIPTION
This is a work in progress to resend all the Checkpoint messages a Replica has to peers that report to be more than 1 Working Window behind, or are behind even by 1 Checkpoint and the system is in View Change. It uses the changes in [PR 1478](https://github.com/vmware/concord-bft/pull/1478). 
To finalize this effort we also need to persist the CheckpointMsgs that form the proof for our latest Stable Checkpoint.

The functionality of this PR is in the last commit, the others are taken from PR 1478, since PR 1478 is not yet merged to master because of ongoing performance analysis.