### PR TITLE
TS: Add timestamp to ClientRequestMsg

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -40,7 +40,8 @@ enum MsgFlag : uint8_t {
   HAS_PRE_PROCESSED_FLAG = 0x4,
   KEY_EXCHANGE_FLAG = 0x8,  // TODO [TK] use reconfig_flag
   EMPTY_CLIENT_FLAG = 0x10,
-  RECONFIG_FLAG = 0x20
+  RECONFIG_FLAG = 0x20,
+  TIME_SERVICE_FLAG = 0x40,
 };
 
 // The IControlHandler is a group of methods that enables the userRequestHandler to perform infrastructure

--- a/util/include/serialize.hpp
+++ b/util/include/serialize.hpp
@@ -1,0 +1,50 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <cstring>
+#include <type_traits>
+#include "assertUtils.hpp"
+
+// Please note that methods in this file do not take endianness into consideration
+
+namespace concord::util {
+
+template <typename T>
+std::string serialize(const T& value) {
+  static_assert(std::is_integral_v<T>);
+  auto serialized = std::string(sizeof(value), 0);
+  std::memcpy(serialized.data(), &value, sizeof(T));
+  return serialized;
+}
+
+template <typename T>
+T deserialize(const std::string& serialized) {
+  static_assert(std::is_integral_v<T>);
+  ConcordAssert(serialized.size() == sizeof(T));
+  auto value = T{};
+  std::memcpy(&value, serialized.data(), sizeof(T));
+  return value;
+}
+
+template <typename T>
+T deserialize(const char* begin, const char* end) {
+  static_assert(std::is_integral_v<T>);
+  ConcordAssertEQ((end - begin), sizeof(T));
+  auto value = T{};
+  std::memcpy(&value, begin, sizeof(T));
+  return value;
+}
+
+}  // namespace concord::util


### PR DESCRIPTION
Changes:
* Added flag `TIME_SERVICE_FLAG = 0x40` to distinguish `ClientRequestMsg`
with timestamp from others
* Added serialize/deserialize methods for integral types (do not take
        endiannes into consideration)
* Unit tests for ClientRequestMsg