### PR TITLE
Fix bug with initiate state transfer after pruning

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -89,6 +89,9 @@ class IAppState {
   // returns the maximal block number n such that all blocks 1 <= i <= n exist.
   // if block 1 does not exist, returns 0.
   virtual uint64_t getLastReachableBlockNum() const = 0;
+
+  // returns the current genesis block in the system
+  virtual uint64_t getGenesisBlockNum() const = 0;
   // returns the maximum block number that is currently stored in
   // the application/storage layer.
   virtual uint64_t getLastBlockNum() const = 0;

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2318,6 +2318,7 @@ void BCStateTran::checkConsistency(bool checkAllBlocks) {
 
   const uint64_t lastReachableBlockNum = as_->getLastReachableBlockNum();
   const uint64_t lastBlockNum = as_->getLastBlockNum();
+  const uint64_t genesisBlockNum = as_->getGenesisBlockNum();
   LOG_INFO(getLogger(), KVLOG(lastBlockNum, lastReachableBlockNum));
 
   const uint64_t firstStoredCheckpoint = psd_->getFirstStoredCheckpoint();
@@ -2327,7 +2328,7 @@ void BCStateTran::checkConsistency(bool checkAllBlocks) {
   checkConfig();
   checkFirstAndLastCheckpoint(firstStoredCheckpoint, lastStoredCheckpoint);
   if (checkAllBlocks) {
-    checkReachableBlocks(lastReachableBlockNum);
+    checkReachableBlocks(genesisBlockNum, lastReachableBlockNum);
   }
   checkUnreachableBlocks(lastReachableBlockNum, lastBlockNum);
   checkBlocksBeingFetchedNow(checkAllBlocks, lastReachableBlockNum, lastBlockNum);
@@ -2369,9 +2370,9 @@ void BCStateTran::checkFirstAndLastCheckpoint(uint64_t firstStoredCheckpoint, ui
   }
 }
 
-void BCStateTran::checkReachableBlocks(uint64_t lastReachableBlockNum) {
+void BCStateTran::checkReachableBlocks(uint64_t genesisBlockNum, uint64_t lastReachableBlockNum) {
   if (lastReachableBlockNum > 0) {
-    for (uint64_t currBlock = lastReachableBlockNum - 1; currBlock >= 1; currBlock--) {
+    for (uint64_t currBlock = lastReachableBlockNum - 1; currBlock >= genesisBlockNum; currBlock--) {
       auto currDigest = getBlockAndComputeDigest(currBlock);
       ConcordAssert(!currDigest.isZero());
       STDigest prevFromNextBlockDigest;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -315,7 +315,7 @@ class BCStateTran : public IStateTransfer {
   void checkConsistency(bool checkAllBlocks);
   void checkConfig();
   void checkFirstAndLastCheckpoint(uint64_t firstStoredCheckpoint, uint64_t lastStoredCheckpoint);
-  void checkReachableBlocks(uint64_t lastReachableBlockNum);
+  void checkReachableBlocks(uint64_t genesisBlockNum, uint64_t lastReachableBlockNum);
   void checkUnreachableBlocks(uint64_t lastReachableBlockNum, uint64_t lastBlockNum);
   void checkBlocksBeingFetchedNow(bool checkAllBlocks, uint64_t lastReachableBlockNum, uint64_t lastBlockNum);
   void checkStoredCheckpoints(uint64_t firstStoredCheckpoint, uint64_t lastStoredCheckpoint);

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -106,6 +106,7 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
     bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) override;
 
     uint64_t getLastReachableBlockNum() const override;
+    uint64_t getGenesisBlockNum() const override;
     uint64_t getLastBlockNum() const override;
   };
 
@@ -602,6 +603,8 @@ bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId, const char*
 }
 
 uint64_t SimpleStateTran::DummyBDState::getLastReachableBlockNum() const { return 0; }
+
+uint64_t SimpleStateTran::DummyBDState::getGenesisBlockNum() const { return 0; }
 
 uint64_t SimpleStateTran::DummyBDState::getLastBlockNum() const { return 0; }
 

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -66,6 +66,7 @@ class TestAppState : public IAppState {
 
   // TODO(AJS): How does this differ from getLastBlockNum?
   uint64_t getLastReachableBlockNum() const override { return last_block_; }
+  uint64_t getGenesisBlockNum() const override { return 1; }
   uint64_t getLastBlockNum() const override { return last_block_; };
 
  private:

--- a/kvbc/include/ReplicaImp.h
+++ b/kvbc/include/ReplicaImp.h
@@ -96,6 +96,7 @@ class ReplicaImp : public IReplica,
   bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) override;
   bool putBlock(const uint64_t blockId, const char *blockData, const uint32_t blockSize) override;
   uint64_t getLastReachableBlockNum() const override;
+  uint64_t getGenesisBlockNum() const override;
   // This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or
   // the main blockchain
   uint64_t getLastBlockNum() const override;

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -182,7 +182,10 @@ std::optional<categorization::Updates> ReplicaImp::getBlockUpdates(BlockId block
   return m_kvBlockchain->getBlockUpdates(block_id);
 }
 
-BlockId ReplicaImp::getGenesisBlockId() const { return m_kvBlockchain->getGenesisBlockId(); }
+BlockId ReplicaImp::getGenesisBlockId() const {
+  if (replicaConfig_.isReadOnly) return m_bcDbAdapter->getGenesisBlockId();
+  return m_kvBlockchain->getGenesisBlockId();
+}
 
 BlockId ReplicaImp::getLastBlockId() const {
   if (replicaConfig_.isReadOnly) {
@@ -347,6 +350,8 @@ uint64_t ReplicaImp::getLastReachableBlockNum() const {
   }
   return m_kvBlockchain->getLastReachableBlockId();
 }
+
+uint64_t ReplicaImp::getGenesisBlockNum() const { return getGenesisBlockId(); }
 
 uint64_t ReplicaImp::getLastBlockNum() const {
   if (replicaConfig_.isReadOnly) {


### PR DESCRIPTION
When we initiate state transfer we travel over the blocks from the latestReachable block to the genesis block and validate they exist. However, the genesis block is hardcoded to 1, which is not true after pruning.
In this PR we fix this.