### PR TITLE
More specific histograms for IncomingMsgsStorage

### DIFF
--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
@@ -87,6 +87,8 @@ class IncomingMsgsStorageImp : public IncomingMsgsStorage {
 
   // 5 seconds
   static constexpr int64_t MAX_VALUE_NANOSECONDS = 1000 * 1000 * 1000 * 5l;
+  // 60 seconds
+  static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60l;
   using Recorder = concord::diagnostics::Recorder;
   struct Recorders {
     Recorders() {
@@ -94,22 +96,22 @@ class IncomingMsgsStorageImp : public IncomingMsgsStorage {
       registrar.perf.registerComponent("incomingMsgsStorageImp",
                                        {external_queue_len_at_swap,
                                         internal_queue_len_at_swap,
-                                        get_msg_for_processing,
                                         evaluate_timers,
+                                        take_lock,
+                                        wait_for_cv,
                                         dropped_msgs_in_a_row});
     }
     DEFINE_SHARED_RECORDER(external_queue_len_at_swap, 1, 10000, 3, concord::diagnostics::Unit::COUNT);
-
     DEFINE_SHARED_RECORDER(internal_queue_len_at_swap, 1, 10000, 3, concord::diagnostics::Unit::COUNT);
-
-    DEFINE_SHARED_RECORDER(
-        get_msg_for_processing, 1, MAX_VALUE_NANOSECONDS, 3, concord::diagnostics::Unit::NANOSECONDS);
-
+    DEFINE_SHARED_RECORDER(take_lock, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(wait_for_cv, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(evaluate_timers, 1, MAX_VALUE_NANOSECONDS, 3, concord::diagnostics::Unit::NANOSECONDS);
-
     DEFINE_SHARED_RECORDER(dropped_msgs_in_a_row, 1, 100000, 3, concord::diagnostics::Unit::COUNT);
   };
   Recorders histograms_;
+
+  concord::diagnostics::AsyncTimeRecorder<false> take_lock_recorder_;
+  concord::diagnostics::AsyncTimeRecorder<false> wait_for_cv_recorder_;
 };
 
 }  // namespace bftEngine::impl

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -128,14 +128,6 @@ void AsyncTlsConnection::readMsg() {
           concord::diagnostics::TimeRecorder<true> scoped_timer(*histograms_.read_enqueue_time);
           receiver_->onNewMessage(peer_id_.value(), read_msg_.data(), bytes_transferred);
         }
-        if (config_.statusCallback && connection_manager_.isReplica(peer_id_.value()) &&
-            (status_.msg_reads % 1000 == 1)) {
-          concord::diagnostics::TimeRecorder<true> scoped_timer(*histograms_.msg_received_callback);
-          PeerConnectivityStatus pcs{};
-          pcs.peerId = static_cast<int64_t>(peer_id_.value());
-          pcs.statusType = StatusType::MessageReceived;
-          config_.statusCallback(pcs);
-        }
         readMsgSizeHeader();
       }));
 }

--- a/communication/src/TlsDiagnostics.h
+++ b/communication/src/TlsDiagnostics.h
@@ -128,8 +128,6 @@ struct Recorders {
                                       async_read_header_partial,
                                       async_read_header_full,
                                       async_read_msg,
-                                      msg_sent_callback,
-                                      msg_received_callback,
                                       on_connection_authenticated});
   }
 
@@ -145,8 +143,6 @@ struct Recorders {
   DEFINE_SHARED_RECORDER(async_read_header_full, 1, MAX_US, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(async_read_header_partial, 1, MAX_US, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(async_read_msg, 1, MAX_US, 3, Unit::MICROSECONDS);
-  DEFINE_SHARED_RECORDER(msg_sent_callback, 1, MAX_US, 3, Unit::MICROSECONDS);
-  DEFINE_SHARED_RECORDER(msg_received_callback, 1, MAX_US, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(on_connection_authenticated, 1, MAX_US, 3, Unit::MICROSECONDS);
 };
 


### PR DESCRIPTION
Instead of measuring the overall time of `getMsgForProcessing`, which
doesn't give us enough information, and includes internal queue time as well as
queue waiting and swapping, we now measure lock time and wait time
specifically.

This commit also removes unnecessary callbacks in TLS code, as they are
no longer used upstream. Eventually we will remove support for status
callbacks altogether.