### PR TITLE
Return valid error message for addRemoveStatus

### DIFF
--- a/kvbc/include/reconfiguration_add_block_handler.hpp
+++ b/kvbc/include/reconfiguration_add_block_handler.hpp
@@ -91,6 +91,12 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
       addRemoveResponse.reconfiguration = cmd.reconfiguration;
       LOG_INFO(getLogger(), "AddRemoveCommand response: " << addRemoveResponse.reconfiguration);
       response.response = std::move(addRemoveResponse);
+    } else {
+      concord::messages::ReconfigurationErrorMsg error_msg;
+      error_msg.error_msg = "key_not_found";
+      response.response = std::move(error_msg);
+      LOG_INFO(getLogger(), "AddRemoveCommand key not found");
+      return false;
     }
     return true;
   }

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -578,6 +578,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         for r in rsi_rep.values():
             status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
             assert status.response.error_msg == 'key_not_found'
+            assert status.success is False
 
 
     async def validate_stop_on_super_stable_checkpoint(self, bft_network, skvbc):


### PR DESCRIPTION
AddRemove status command should return a valid error message if key is not found in the block chain