### PR TITLE
Add perf logs + histograms to find wait time

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -644,6 +644,7 @@ void BCStateTran::startCollectingState() {
 // this function can be executed in context of another thread.
 void BCStateTran::onTimerImp() {
   if (!running_) return;
+  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.on_timer);
 
   metrics_.on_timer_.Get().Inc();
   // Send all metrics to the aggregator

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -445,15 +445,17 @@ class BCStateTran : public IStateTransfer {
   ///////////////////////////////////////////////////////////////////////////
  private:
   static constexpr int64_t MAX_VALUE_MILLISECONDS = 1000 * 60;  // 60 Seconds
+  static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60;
   using Recorder = concord::diagnostics::Recorder;
 
   struct Recorders {
     Recorders() {
       auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      registrar.perf.registerComponent("state_transfer", {fetch_blocks_msg_latency});
+      registrar.perf.registerComponent("state_transfer", {fetch_blocks_msg_latency, on_timer});
     }
-    std::shared_ptr<Recorder> fetch_blocks_msg_latency = std::make_shared<Recorder>(
-        "fetch_blocks_msg_latency", 1, MAX_VALUE_MILLISECONDS, 3, concord::diagnostics::Unit::MILLISECONDS);
+    DEFINE_SHARED_RECORDER(
+        fetch_blocks_msg_latency, 1, MAX_VALUE_MILLISECONDS, 3, concord::diagnostics::Unit::MILLISECONDS);
+    DEFINE_SHARED_RECORDER(on_timer, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
   };
   Recorders histograms_;
 

--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
@@ -105,7 +105,7 @@ class IncomingMsgsStorageImp : public IncomingMsgsStorage {
     DEFINE_SHARED_RECORDER(internal_queue_len_at_swap, 1, 10000, 3, concord::diagnostics::Unit::COUNT);
     DEFINE_SHARED_RECORDER(take_lock, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(wait_for_cv, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
-    DEFINE_SHARED_RECORDER(evaluate_timers, 1, MAX_VALUE_NANOSECONDS, 3, concord::diagnostics::Unit::NANOSECONDS);
+    DEFINE_SHARED_RECORDER(evaluate_timers, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(dropped_msgs_in_a_row, 1, 100000, 3, concord::diagnostics::Unit::COUNT);
   };
   Recorders histograms_;

--- a/bftengine/src/bftengine/RequestsBatchingLogic.cpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.cpp
@@ -48,6 +48,7 @@ RequestsBatchingLogic::~RequestsBatchingLogic() {
 
 void RequestsBatchingLogic::onBatchFlushTimer(Timers::Handle) {
   if (replica_.isCurrentPrimary()) {
+    concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onBatchFlushTimer);
     lock_guard<mutex> lock(batchProcessingLock_);
     if (replica_.tryToSendPrePrepareMsg(false)) {
       LOG_INFO(GL, "Batching flush period expired" << KVLOG(batchFlushPeriodMs_));

--- a/bftengine/src/bftengine/RequestsBatchingLogic.hpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.hpp
@@ -16,6 +16,8 @@
 #include "InternalReplicaApi.hpp"
 #include "messages/PrePrepareMsg.hpp"
 #include "Timers.hpp"
+#include "diagnostics.h"
+#include "performance_handler.h"
 
 namespace bftEngine::batchingLogic {
 
@@ -64,6 +66,18 @@ class RequestsBatchingLogic {
   concordUtil::Timers &timers_;
   concordUtil::Timers::Handle batchFlushTimer_;
   std::mutex batchProcessingLock_;
+
+  static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60;
+  using Recorder = concord::diagnostics::Recorder;
+
+  struct Recorders {
+    Recorders() {
+      auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+      registrar.perf.registerComponent("batching", {onBatchFlushTimer});
+    }
+    DEFINE_SHARED_RECORDER(onBatchFlushTimer, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+  };
+  Recorders histograms_;
 };
 
 }  // namespace bftEngine::batchingLogic

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -189,6 +189,7 @@ void PreProcessor::resendPreProcessRequest(const RequestProcessingStateUniquePtr
 }
 
 void PreProcessor::onRequestsStatusCheckTimer() {
+  concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onRequestsStatusCheckTimer);
   // Pass through all ongoing requests and abort the pre-execution for those that are timed out.
   for (const auto &reqEntry : ongoingRequests_) {
     lock_guard<mutex> lock(reqEntry.second->mutex);

--- a/bftengine/src/preprocessor/PreProcessorRecorder.hpp
+++ b/bftengine/src/preprocessor/PreProcessorRecorder.hpp
@@ -30,7 +30,8 @@ class PreProcessorRecorder {
                                       finalizePreProcessing,
                                       signPreProcessReplyHash,
                                       verifyPreProcessReplySig,
-                                      totalPreExecutionDuration});
+                                      totalPreExecutionDuration,
+                                      onRequestsStatusCheckTimer});
   }
 
   // 5 Minutes, 300 seconds
@@ -51,6 +52,7 @@ class PreProcessorRecorder {
   DEFINE_SHARED_RECORDER(signPreProcessReplyHash, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(finalizePreProcessing, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(totalPreExecutionDuration, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  DEFINE_SHARED_RECORDER(onRequestsStatusCheckTimer, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
 };
 
 }  // namespace preprocessor


### PR DESCRIPTION
Add trace logs for messages being put on and pulled off the
`InternalMsgsQueue` and log messages relating to the queue condition
variable.  The goal here is to see what message is received after
waiting on a condition variable. We are attempting to find what message
is being delayed if there is nothing in the external queue for a full
20ms (default condition variablel timeout).

Also, it was noticed on the primary that the 99th+ percentiles of the
`evaluate_timers` histogram in test runs was taking over 30ms. This time
correlates almost exactly with the wait time for a `PrePrepare` to be
received on a backup after no messages were received for a while. This
indicates that the primary sending of PrePrepares were getting delayed
due to a timer callback. Therefore a few new histograms to measure timer
callbacks were added. It turns out that `onBatchFlushTimer` matches this
time, and all percentages are pretty expensive. We need to see if we can
take this out of the hot path.

This change just adds the tools to debug this stuff. It doesn't add the
fix.