### PR TITLE
Persist all Checkpoint msgs that serve as proof for Replica's lastStableSeqNum

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -139,7 +139,8 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
   uint16_t numOfObjects = 0;
   bool isNewStorage = true;
   if (metadataStorage != nullptr) {
-    persistentStoragePtr.reset(new impl::PersistentStorageImp(replicaConfig.fVal, replicaConfig.cVal));
+    persistentStoragePtr.reset(
+        new impl::PersistentStorageImp(replicaConfig.numReplicas, replicaConfig.fVal, replicaConfig.cVal));
     unique_ptr<MetadataStorage> metadataStoragePtr(metadataStorage);
     auto objectDescriptors =
         ((PersistentStorageImp *)persistentStoragePtr.get())->getDefaultMetadataObjectDescriptors(numOfObjects);

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -199,6 +199,11 @@ void DebugPersistentStorage::setDescriptorOfLastExecution(const DescriptorOfLast
   descriptorOfLastExecution_ = DescriptorOfLastExecution{d.executedSeqNum, d.validRequests};
 }
 
+void DebugPersistentStorage::setDescriptorOfLastStableCheckpoint(
+    const DescriptorOfLastStableCheckpoint &stableCheckDesc) {
+  (void)stableCheckDesc;
+}
+
 void DebugPersistentStorage::setLastStableSeqNum(SeqNum seqNum) {
   ConcordAssert(seqNum >= lastStableSeqNum_);
   lastStableSeqNum_ = seqNum;
@@ -363,6 +368,10 @@ DescriptorOfLastExecution DebugPersistentStorage::getDescriptorOfLastExecution()
   DescriptorOfLastExecution &d = descriptorOfLastExecution_;
 
   return DescriptorOfLastExecution{d.executedSeqNum, d.validRequests};
+}
+
+DescriptorOfLastStableCheckpoint DebugPersistentStorage::getDescriptorOfLastStableCheckpoint() {
+  return {uint16_t(3 * fVal_ + 2 * cVal_ + 1), {}};
 }
 
 SeqNum DebugPersistentStorage::getLastStableSeqNum() {

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -35,6 +35,7 @@ class DebugPersistentStorage : public PersistentStorage {
   void setDescriptorOfLastExitFromView(const DescriptorOfLastExitFromView& prevViewDesc) override;
   void setDescriptorOfLastNewView(const DescriptorOfLastNewView& prevViewDesc) override;
   void setDescriptorOfLastExecution(const DescriptorOfLastExecution& prevViewDesc) override;
+  void setDescriptorOfLastStableCheckpoint(const DescriptorOfLastStableCheckpoint& stableCheckDesc) override;
   void setLastStableSeqNum(SeqNum seqNum) override;
   void clearSeqNumWindow() override;
   void setPrePrepareMsgInSeqNumWindow(SeqNum seqNum, PrePrepareMsg* msg) override;
@@ -55,6 +56,7 @@ class DebugPersistentStorage : public PersistentStorage {
   DescriptorOfLastNewView getAndAllocateDescriptorOfLastNewView() override;
   bool hasDescriptorOfLastExecution() override;
   DescriptorOfLastExecution getDescriptorOfLastExecution() override;
+  DescriptorOfLastStableCheckpoint getDescriptorOfLastStableCheckpoint() override;
   SeqNum getLastStableSeqNum() override;
   PrePrepareMsg* getAndAllocatePrePrepareMsgInSeqNumWindow(SeqNum seqNum) override;
   bool getSlowStartedInSeqNumWindow(SeqNum seqNum) override;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -80,6 +80,10 @@ class PersistentStorage {
 
   virtual void setDescriptorOfLastExecution(const DescriptorOfLastExecution &prevViewDesc) = 0;
 
+  // DescriptorOfLastStableCheckpoint contains pointers to Checkpoint messages representing
+  // the proof for our latest stable Checkpoint.
+  virtual void setDescriptorOfLastStableCheckpoint(const DescriptorOfLastStableCheckpoint &stableCheckDesc) = 0;
+
   // We have two windows "SeqNumWindow" and "CheckWindow"
   // TODO(GG): explain the windows.
 
@@ -126,6 +130,8 @@ class PersistentStorage {
 
   virtual bool hasDescriptorOfLastExecution() = 0;
   virtual DescriptorOfLastExecution getDescriptorOfLastExecution() = 0;
+
+  virtual DescriptorOfLastStableCheckpoint getDescriptorOfLastStableCheckpoint() = 0;
 
   virtual SeqNum getLastStableSeqNum() = 0;
 

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
@@ -103,6 +103,7 @@ struct DescriptorOfLastExitFromView {
 /***** DescriptorOfLastNewView *****/
 
 typedef std::vector<ViewChangeMsg *> ViewChangeMsgsVector;
+typedef std::vector<CheckpointMsg *> CheckpointMsgsVector;
 
 struct DescriptorOfLastNewView {
   DescriptorOfLastNewView(ViewNum viewNum,
@@ -201,5 +202,26 @@ struct DescriptorOfLastExecution {
   Bitmap validRequests;
 };
 
+/***** DescriptorOfLastStableCheckpoint *****/
+
+struct DescriptorOfLastStableCheckpoint {
+  DescriptorOfLastStableCheckpoint(uint16_t numReplicasInQuorum, const CheckpointMsgsVector &msgs)
+      : numOfReplicas(numReplicasInQuorum), numMsgs(0), checkpointMsgs(msgs) {}
+
+  bool equals(const DescriptorOfLastStableCheckpoint &other) const;
+
+  void serialize(char *&buf, size_t bufLen, size_t &actualSize) const;
+  void deserialize(char *buf, size_t bufLen, size_t &actualSize);
+
+  static uint32_t maxSize(uint16_t numReplicas) {
+    return sizeof(numMsgs) + (maxMessageSizeInLocalBuffer<CheckpointMsg>() * numReplicas);
+  };
+
+  uint16_t numOfReplicas;
+
+  mutable uint16_t numMsgs;  // used for serialization/deserialization
+
+  CheckpointMsgsVector checkpointMsgs;
+};
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -92,6 +92,7 @@ const uint16_t numOfLastExitFromViewDescObjs = kWorkWindowSize + 1;
 enum DescMetadataParameterIds {
   LAST_EXIT_FROM_VIEW_DESC = WIN_PARAMETERS_NUM + reservedWindowParamsNum,
   LAST_EXEC_DESC = LAST_EXIT_FROM_VIEW_DESC + numOfLastExitFromViewDescObjs,
+  LAST_STABLE_CHECKPOINT_DESC,
   LAST_NEW_VIEW_DESC
 };
 
@@ -99,7 +100,7 @@ typedef unique_ptr<MetadataStorage::ObjectDesc[]> ObjectDescUniquePtr;
 
 class PersistentStorageImp : public PersistentStorage {
  public:
-  PersistentStorageImp(uint16_t fVal, uint16_t cVal);
+  PersistentStorageImp(uint16_t numReplicas, uint16_t fVal, uint16_t cVal);
   ~PersistentStorageImp() override = default;
 
   uint8_t beginWriteTran() override;
@@ -115,6 +116,7 @@ class PersistentStorageImp : public PersistentStorage {
   void setDescriptorOfLastExitFromView(const DescriptorOfLastExitFromView &prevViewDesc) override;
   void setDescriptorOfLastNewView(const DescriptorOfLastNewView &prevViewDesc) override;
   void setDescriptorOfLastExecution(const DescriptorOfLastExecution &prevViewDesc) override;
+  void setDescriptorOfLastStableCheckpoint(const DescriptorOfLastStableCheckpoint &stableCheckDesc) override;
 
   void setLastStableSeqNum(SeqNum seqNum) override;
   void setPrePrepareMsgInSeqNumWindow(SeqNum seqNum, PrePrepareMsg *msg) override;
@@ -144,6 +146,7 @@ class PersistentStorageImp : public PersistentStorage {
   DescriptorOfLastExitFromView getAndAllocateDescriptorOfLastExitFromView() override;
   DescriptorOfLastNewView getAndAllocateDescriptorOfLastNewView() override;
   DescriptorOfLastExecution getDescriptorOfLastExecution() override;
+  DescriptorOfLastStableCheckpoint getDescriptorOfLastStableCheckpoint() override;
 
   PrePrepareMsg *getAndAllocatePrePrepareMsgInSeqNumWindow(SeqNum seqNum) override;
   bool getSlowStartedInSeqNumWindow(SeqNum seqNum) override;
@@ -189,6 +192,7 @@ class PersistentStorageImp : public PersistentStorage {
   void saveDescriptorOfLastExecution(const DescriptorOfLastExecution &newDesc);
   void setDescriptorOfLastExecution(const DescriptorOfLastExecution &desc, bool init);
   void initDescriptorOfLastExecution();
+  void initDescriptorOfLastStableCheckpoint();
 
   void setVersion() const;
 
@@ -227,6 +231,7 @@ class PersistentStorageImp : public PersistentStorage {
 
   const uint32_t maxVersionSize_ = 80;
 
+  const uint16_t numReplicas_;
   const uint16_t fVal_;
   const uint16_t cVal_;
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2838,6 +2838,17 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     }
   }
 
+  if (ps_) {
+    auto &CheckpointInfo = checkpointsLog->get(lastStableSeqNum);
+    std::vector<CheckpointMsg *> msgs;
+    msgs.reserve(CheckpointInfo.getAllCheckpointMsgs().size());
+    for (const auto &m : CheckpointInfo.getAllCheckpointMsgs()) {
+      msgs.push_back(m.second);
+    }
+    DescriptorOfLastStableCheckpoint desc(config_.getnumReplicas(), msgs);
+    ps_->setDescriptorOfLastStableCheckpoint(desc);
+  }
+
   if (ps_) ps_->endWriteTran();
 
   if (!oldSeqNum && currentViewIsActive() && (currentPrimary() == config_.getreplicaId()) && !isCollectingState()) {
@@ -3277,6 +3288,13 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
                                                                      maxSeqNumTransferredFromPrevViews,
                                                                      lastViewThatTransferredSeqNumbersFullyExecuted));
 
+  if (ld.lastStableSeqNum > 0) {
+    auto &CheckpointInfo = checkpointsLog->get(ld.lastStableSeqNum);
+    for (const auto &m : ld.lastStableCheckpointProof) {
+      CheckpointInfo.addCheckpointMsg(m, m->idOfGeneratedReplica());
+    }
+  }
+
   if (inView) {
     const bool isPrimaryOfView = (repsInfo->primaryOfView(curView) == config_.getreplicaId());
 
@@ -3439,8 +3457,10 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
     ConcordAssertEQ(e.getCheckpointMsg()->senderId(), config_.getreplicaId());
     ConcordAssertOR((s != ld.lastStableSeqNum), e.getCheckpointMsg()->isStableState());
 
-    checkInfo.addCheckpointMsg(e.getCheckpointMsg(), config_.getreplicaId());
-    ConcordAssert(checkInfo.selfCheckpointMsg()->equals(*e.getCheckpointMsg()));
+    if (s != ld.lastStableSeqNum) {  // We have already added all msgs for our last stable Checkpoint
+      checkInfo.addCheckpointMsg(e.getCheckpointMsg(), config_.getreplicaId());
+      ConcordAssert(checkInfo.selfCheckpointMsg()->equals(*e.getCheckpointMsg()));
+    }
 
     if (e.getCompletedMark()) checkInfo.tryToMarkCheckpointCertificateCompleted();
   }

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -301,6 +301,8 @@ ReplicaLoader::ErrorCode loadReplicaData(shared_ptr<PersistentStorage> p, Loaded
       ld.validRequestsThatAreBeingExecuted = d.validRequests;
     }
   }
+  const auto &desc = p->getDescriptorOfLastStableCheckpoint();
+  ld.lastStableCheckpointProof = desc.checkpointMsgs;
   LOG_INFO(GL, "loadReplicaData Successfully loaded!");
   return Succ;
 }

--- a/bftengine/src/bftengine/ReplicaLoader.hpp
+++ b/bftengine/src/bftengine/ReplicaLoader.hpp
@@ -43,6 +43,7 @@ struct LoadedReplicaData {
   SeqNum lastStableSeqNum = 0;
   SeqNum lastExecutedSeqNum = 0;
   SeqNum strictLowerBoundOfSeqNums = 0;
+  std::vector<CheckpointMsg *> lastStableCheckpointProof;
 
   ViewNum lastViewThatTransferredSeqNumbersFullyExecuted = 0;
 

--- a/bftengine/src/bftengine/messages/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.hpp
@@ -13,6 +13,7 @@
 
 #include "MessageBase.hpp"
 #include "Digest.hpp"
+#include "ReplicaConfig.hpp"
 
 namespace bftEngine {
 namespace impl {
@@ -58,5 +59,10 @@ class CheckpointMsg : public MessageBase {
 
   Header* b() const { return (Header*)msgBody_; }
 };
+
+template <>
+inline MsgSize maxMessageSize<CheckpointMsg>() {
+  return ReplicaConfig::instance().getmaxExternalMessageSize() + MessageBase::SPAN_CONTEXT_MAX_SIZE;
+}
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -40,6 +40,7 @@ void printRawBuf(const UniquePtrToChar &buf, int64_t bufSize) {
 
 uint16_t fVal = 2;
 uint16_t cVal = 1;
+uint16_t numReplicas = 3 * fVal + 2 * cVal + 1;
 
 const uint16_t msgsNum = 2 * fVal + 2 * cVal + 1;
 
@@ -342,14 +343,14 @@ int main() {
   descriptorOfLastNewView = new DescriptorOfLastNewView();
   descriptorOfLastExecution = new DescriptorOfLastExecution();
 
-  persistentStorageImp = new PersistentStorageImp(fVal, cVal);
+  persistentStorageImp = new PersistentStorageImp(numReplicas, fVal, cVal);
   logging::Logger logger = logging::getLogger("testSerialization.replica");
   // uncomment if needed
   // log4cplus::Logger::getInstance( LOG4CPLUS_TEXT("serializable")).setLogLevel(log4cplus::TRACE_LOG_LEVEL);
   const string dbFile = "testPersistency.txt";
   remove(dbFile.c_str());  // Required for the init testing.
 
-  PersistentStorageImp persistentStorage(fVal, cVal);
+  PersistentStorageImp persistentStorage(numReplicas, fVal, cVal);
   metadataStorage.reset(new FileStorage(logger, dbFile));
   uint16_t numOfObjects = 0;
   ObjectDescUniquePtr objectDescArray = persistentStorage.getDefaultMetadataObjectDescriptors(numOfObjects);


### PR DESCRIPTION
After adding signatures to checkpoint messages in order for Replicas to be
able to forward them we need to also persist those messages. This way after
restart we still will be able to prove to the Peers that our lastStableSeqNum
really is stable.