### PR TITLE
ThinReplicaClient: Prepend namespace with client::

### DIFF
--- a/client/thin-replica-client/include/client/thin-replica-client/crypto_utils.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/crypto_utils.hpp
@@ -26,7 +26,7 @@
 
 #include "assertUtils.hpp"
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 // Class of exception wrappers declared in this file may throw in the event they
 // unexpectedly get a failure from some call into the underlying trusted
@@ -58,6 +58,6 @@ const size_t kExpectedSHA256HashLengthInBytes = (256 / 8);
 // a failure unexpectedly.
 std::string ComputeSHA256Hash(const std::string& data);
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client
 
 #endif  // TRC_CRYPTO_UTILS_HPP_

--- a/client/thin-replica-client/include/client/thin-replica-client/health_status.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/health_status.hpp
@@ -14,13 +14,13 @@
 #ifndef THIN_REPLICA_CLIENT_HEALTHSTATUS_HPP_
 #define THIN_REPLICA_CLIENT_HEALTHSTATUS_HPP_
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 enum HealthStatus {
   Healthy,
   Unhealthy,
 };
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client
 
 #endif  // THIN_REPLICA_CLIENT_HEALTHSTATUS_HPP_

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -58,7 +58,7 @@
 #include <condition_variable>
 #include <thread>
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 // Interface for a synchronized queue to be used to transfer updates between a
 // ThinReplicaClient and an application. The Thin Replica Client Library
@@ -487,6 +487,6 @@ class ThinReplicaClient final {
   void setMetricsCallback(const std::function<void(const ThinReplicaClientMetrics&)>& exposeAndSetMetrics);
 };
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client
 
 #endif  // THIN_REPLICA_CLIENT_HPP_

--- a/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
@@ -11,7 +11,7 @@
 
 using opentracing::expected;
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 class TraceContexts {
  public:
@@ -25,6 +25,6 @@ class TraceContexts {
                                            const log4cplus::Logger& logger);
 };
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client
 
 #endif  // THIN_REPLICA_CLIENT_TRACE_CONTEXTS_HPP_

--- a/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
@@ -21,7 +21,7 @@
 #include "thin_replica.grpc.pb.h"
 #include "update.hpp"
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 const size_t kThinReplicaHashLength = kExpectedSHA256HashLengthInBytes;
 
@@ -43,6 +43,6 @@ std::string hashUpdate(const com::vmware::concord::thin_replica::Data& update);
 // hash.
 std::string hashState(const std::list<std::string>& state);
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client
 
 #endif  // TRC_HASH_HPP_

--- a/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
@@ -25,7 +25,7 @@
 
 using namespace std::chrono_literals;
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 struct TrsConnectionConfig {
   // thin_replica_tls_cert_path specifies the path of the certificates used for
@@ -198,6 +198,6 @@ class TrsConnection {
   std::string parseClientIdFromSubject(const std::string& subject_str);
 };
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client
 
 #endif  // THIN_REPLICA_CLIENT_TRS_CONNECTION_HPP_

--- a/client/thin-replica-client/include/client/thin-replica-client/update.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/update.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 // Type for updates the Thin Replica Client streams from Thin Replica Servers.
 struct Update {
@@ -35,6 +35,6 @@ struct Update {
   std::string span_context;
 };
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client
 
 #endif  // THIN_REPLICA_CLIENT_UPDATE_HPP_

--- a/client/thin-replica-client/src/crypto_utils.cpp
+++ b/client/thin-replica-client/src/crypto_utils.cpp
@@ -24,8 +24,8 @@
 
 using std::string;
 using std::unique_ptr;
-using thin_replica_client::kExpectedSHA256HashLengthInBytes;
-using thin_replica_client::UnexpectedCryptoImplementationFailureException;
+
+namespace client::thin_replica_client {
 
 // Deleter class for deleting EVP_MD_CTX objects; this is needed to construct
 // smart pointers that correctly memory manage EVP_MD_CTX objects as they use a
@@ -35,7 +35,7 @@ class EVPMDCTXDeleter {
   void operator()(EVP_MD_CTX* obj) const { EVP_MD_CTX_free(obj); }
 };
 
-string thin_replica_client::ComputeSHA256Hash(const string& data) {
+string ComputeSHA256Hash(const string& data) {
   unique_ptr<EVP_MD_CTX, EVPMDCTXDeleter> digest_context(EVP_MD_CTX_new(), EVPMDCTXDeleter());
   if (!digest_context) {
     throw UnexpectedCryptoImplementationFailureException(
@@ -71,3 +71,5 @@ string thin_replica_client::ComputeSHA256Hash(const string& data) {
 
   return hash;
 }
+
+}  // namespace client::thin_replica_client

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -50,11 +50,8 @@ using std::unique_ptr;
 using std::unordered_set;
 using std::vector;
 using std::chrono::steady_clock;
-using thin_replica_client::BasicUpdateQueue;
-using thin_replica_client::LogCid;
-using thin_replica_client::ThinReplicaClient;
-using thin_replica_client::TrsConnection;
-using thin_replica_client::Update;
+
+namespace client::thin_replica_client {
 
 const string LogCid::cid_key_ = "cid";
 atomic_bool LogCid::cid_set_ = false;
@@ -858,3 +855,5 @@ void ThinReplicaClient::AcknowledgeBlockID(uint64_t block_id) {
   ConcordAssert(config_->trs_conns.size() > server_to_acknowledge_to);
   ConcordAssertNE(config_->trs_conns[server_to_acknowledge_to], nullptr);
 }
+
+}  // namespace client::thin_replica_client

--- a/client/thin-replica-client/src/trace_contexts.cpp
+++ b/client/thin-replica-client/src/trace_contexts.cpp
@@ -17,11 +17,10 @@ using opentracing::expected;
 using opentracing::string_view;
 using opentracing::TextMapReader;
 using opentracing::TextMapWriter;
-using thin_replica_client::Update;
 
 using SpanPtr = std::unique_ptr<opentracing::Span>;
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 const std::string kCorrelationIdTag = "cid";
 
@@ -92,4 +91,4 @@ SpanPtr TraceContexts::CreateChildSpanFromBinary(const std::string& trace_contex
     }
   }
 }
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client

--- a/client/thin-replica-client/src/trc_hash.cpp
+++ b/client/thin-replica-client/src/trc_hash.cpp
@@ -22,8 +22,8 @@ using std::invalid_argument;
 using std::list;
 using std::map;
 using std::string;
-using thin_replica_client::ComputeSHA256Hash;
-using thin_replica_client::kExpectedSHA256HashLengthInBytes;
+
+namespace client::thin_replica_client {
 
 // Hash functions in this file may be defined in a way assuming char is an 8 bit
 // type.
@@ -67,7 +67,7 @@ static string hashUpdateFromEntryHashes(uint64_t block_id, const map<string, str
   return ComputeSHA256Hash(concatenated_entry_hashes);
 }
 
-string thin_replica_client::hashUpdate(const Update& update) {
+string hashUpdate(const Update& update) {
   map<string, string> entry_hashes;
   for (const auto& kvp : update.kv_pairs) {
     string key_hash = ComputeSHA256Hash(kvp.first);
@@ -80,7 +80,7 @@ string thin_replica_client::hashUpdate(const Update& update) {
   return hashUpdateFromEntryHashes(update.block_id, entry_hashes);
 }
 
-string thin_replica_client::hashUpdate(const Data& update) {
+string hashUpdate(const Data& update) {
   map<string, string> entry_hashes;
   for (const auto& kvp : update.data()) {
     string key_hash = ComputeSHA256Hash(kvp.key());
@@ -93,7 +93,7 @@ string thin_replica_client::hashUpdate(const Data& update) {
   return hashUpdateFromEntryHashes(update.block_id(), entry_hashes);
 }
 
-string thin_replica_client::hashState(const list<string>& state) {
+string hashState(const list<string>& state) {
   string concatenated_update_hashes;
   concatenated_update_hashes.reserve(state.size() * kThinReplicaHashLength);
   for (const auto& update_hash : state) {
@@ -107,3 +107,5 @@ string thin_replica_client::hashState(const list<string>& state) {
 
   return ComputeSHA256Hash(concatenated_update_hashes);
 }
+
+}  // namespace client::thin_replica_client

--- a/client/thin-replica-client/src/trs_connection.cpp
+++ b/client/thin-replica-client/src/trs_connection.cpp
@@ -37,7 +37,7 @@ using std::launch;
 
 using namespace std::chrono_literals;
 
-namespace thin_replica_client {
+namespace client::thin_replica_client {
 
 void TrsConnection::createStub() {
   ConcordAssertNE(channel_, nullptr);
@@ -436,4 +436,4 @@ std::string TrsConnection::parseClientIdFromSubject(const std::string& subject_s
   return raw_str.substr(fstart, fend - fstart + 1);
 }
 
-}  // namespace thin_replica_client
+}  // namespace client::thin_replica_client

--- a/client/thin-replica-client/test/thin_replica_client_mocks.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_mocks.cpp
@@ -48,9 +48,9 @@ using std::this_thread::sleep_for;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
 using testing::Return;
-using thin_replica_client::hashState;
-using thin_replica_client::hashUpdate;
-using thin_replica_client::TrsConnection;
+using client::thin_replica_client::hashState;
+using client::thin_replica_client::hashUpdate;
+using client::thin_replica_client::TrsConnection;
 
 MockTrsConnection::MockTrsConnection() : TrsConnection("mock_address", "mock_client_id", 1, 1) {
   this->data_timeout_ = kTestingTimeout;

--- a/client/thin-replica-client/test/thin_replica_client_mocks.hpp
+++ b/client/thin-replica-client/test/thin_replica_client_mocks.hpp
@@ -21,7 +21,7 @@
 
 const std::chrono::milliseconds kTestingTimeout(10);
 
-class MockTrsConnection : public thin_replica_client::TrsConnection {
+class MockTrsConnection : public client::thin_replica_client::TrsConnection {
  public:
   MockTrsConnection();
   ~MockTrsConnection() override {}
@@ -539,11 +539,11 @@ void SetMockServerBehavior(MockTrsConnection* server,
                            const std::shared_ptr<MockDataStreamPreparer>& data_preparer,
                            const MockOrderedDataStreamHasher& hasher);
 
-void SetMockServerUnresponsive(thin_replica_client::TrsConnection* server);
+void SetMockServerUnresponsive(client::thin_replica_client::TrsConnection* server);
 
-std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(size_t num_servers,
-                                                                                      size_t num_unresponsive = 0);
-std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+std::vector<std::unique_ptr<client::thin_replica_client::TrsConnection>> CreateTrsConnections(
+    size_t num_servers, size_t num_unresponsive = 0);
+std::vector<std::unique_ptr<client::thin_replica_client::TrsConnection>> CreateTrsConnections(
     size_t num_servers,
     std::shared_ptr<MockDataStreamPreparer> stream_preparer,
     MockOrderedDataStreamHasher& hasher,
@@ -575,21 +575,21 @@ void SetMockServerBehavior(MockTrsConnection* server, MockThinReplicaServer& moc
 }
 
 template <class MockThinReplicaServer>
-std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+std::vector<std::unique_ptr<client::thin_replica_client::TrsConnection>> CreateTrsConnections(
     std::vector<std::unique_ptr<MockThinReplicaServer>>& mock_servers) {
-  std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> mock_connections;
+  std::vector<std::unique_ptr<client::thin_replica_client::TrsConnection>> mock_connections;
   for (size_t i = 0; i < mock_servers.size(); ++i) {
     auto conn = new MockTrsConnection();
     SetMockServerBehavior(conn, *(mock_servers[i]));
-    auto server = dynamic_cast<thin_replica_client::TrsConnection*>(conn);
-    mock_connections.push_back(std::unique_ptr<thin_replica_client::TrsConnection>(server));
+    auto server = dynamic_cast<client::thin_replica_client::TrsConnection*>(conn);
+    mock_connections.push_back(std::unique_ptr<client::thin_replica_client::TrsConnection>(server));
   }
   return mock_connections;
 }
 
-std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+std::vector<std::unique_ptr<client::thin_replica_client::TrsConnection>> CreateTrsConnections(
     std::vector<MockThinReplicaServerRecorder>& mock_server_recorders);
-std::vector<std::unique_ptr<thin_replica_client::TrsConnection>> CreateTrsConnections(
+std::vector<std::unique_ptr<client::thin_replica_client::TrsConnection>> CreateTrsConnections(
     std::vector<std::unique_ptr<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>>& mock_servers);
 
 template <class DataType>

--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -32,11 +32,11 @@ using std::unique_ptr;
 using std::vector;
 using std::chrono::milliseconds;
 using std::this_thread::sleep_for;
-using thin_replica_client::BasicUpdateQueue;
-using thin_replica_client::ThinReplicaClient;
-using thin_replica_client::ThinReplicaClientConfig;
-using thin_replica_client::Update;
-using thin_replica_client::UpdateQueue;
+using client::thin_replica_client::BasicUpdateQueue;
+using client::thin_replica_client::ThinReplicaClient;
+using client::thin_replica_client::ThinReplicaClientConfig;
+using client::thin_replica_client::Update;
+using client::thin_replica_client::UpdateQueue;
 
 const string kTestingClientID = "mock_client_id";
 const string kTestingJaegerAddress = "127.0.0.1:6831";

--- a/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
+++ b/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
@@ -26,8 +26,8 @@ using std::vector;
 using std::chrono::milliseconds;
 using std::this_thread::sleep_for;
 
-using thin_replica_client::BasicUpdateQueue;
-using thin_replica_client::Update;
+using client::thin_replica_client::BasicUpdateQueue;
+using client::thin_replica_client::Update;
 
 const milliseconds kBriefDelayDuration = 10ms;
 const uint64_t kNumUpdatesToTest = (uint64_t)1 << 18;

--- a/client/thin-replica-client/test/trc_byzantine_test.cpp
+++ b/client/thin-replica-client/test/trc_byzantine_test.cpp
@@ -42,12 +42,12 @@ using std::chrono::milliseconds;
 using std::chrono::steady_clock;
 using std::chrono::time_point;
 using std::this_thread::sleep_for;
-using thin_replica_client::BasicUpdateQueue;
-using thin_replica_client::kThinReplicaHashLength;
-using thin_replica_client::ThinReplicaClient;
-using thin_replica_client::ThinReplicaClientConfig;
-using thin_replica_client::Update;
-using thin_replica_client::UpdateQueue;
+using client::thin_replica_client::BasicUpdateQueue;
+using client::thin_replica_client::kThinReplicaHashLength;
+using client::thin_replica_client::ThinReplicaClient;
+using client::thin_replica_client::ThinReplicaClientConfig;
+using client::thin_replica_client::Update;
+using client::thin_replica_client::UpdateQueue;
 
 const string kTestingClientID = "mock_client_id";
 const string kTestingJaegerAddress = "127.0.0.1:6831";

--- a/client/thin-replica-client/test/trc_hash_test.cpp
+++ b/client/thin-replica-client/test/trc_hash_test.cpp
@@ -20,8 +20,8 @@ using com::vmware::concord::thin_replica::Data;
 using std::make_pair;
 using std::string;
 using std::to_string;
-using thin_replica_client::hashUpdate;
-using thin_replica_client::Update;
+using client::thin_replica_client::hashUpdate;
+using client::thin_replica_client::Update;
 
 const string kSampleUpdateExpectedHash({'\x02', '\x3D', '\x0D', '\x8B', '\xC6', '\x54', '\x07', '\xD7',
                                         '\x33', '\x94', '\x99', '\xFE', '\x9F', '\x6E', '\x8E', '\xB3',

--- a/client/thin-replica-client/test/trc_rpc_use_test.cpp
+++ b/client/thin-replica-client/test/trc_rpc_use_test.cpp
@@ -32,9 +32,9 @@ using std::make_unique;
 using std::shared_ptr;
 using std::string;
 using std::vector;
-using thin_replica_client::BasicUpdateQueue;
-using thin_replica_client::ThinReplicaClient;
-using thin_replica_client::ThinReplicaClientConfig;
+using client::thin_replica_client::BasicUpdateQueue;
+using client::thin_replica_client::ThinReplicaClient;
+using client::thin_replica_client::ThinReplicaClientConfig;
 
 const string kTestingClientID = "mock_client_id";
 const string kTestingJaegerAddress = "127.0.0.1:6831";


### PR DESCRIPTION
In order to keep folder struture, include paths, and namespaces in sync, this
change moves the existing thin_replica_client namespace to
client::thin_replica_client.