### PR TITLE
Update licenses in TRC files to make them uniform

### DIFF
--- a/client/thin-replica-client/include/client/thin-replica-client/crypto_utils.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/crypto_utils.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0

--- a/client/thin-replica-client/include/client/thin-replica-client/health_status.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/health_status.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0

--- a/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
@@ -1,4 +1,15 @@
-// Copyright (c) 2021 VMware, Inc. All rights reserved. VMware Confidential
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
 
 #ifndef THIN_REPLICA_CLIENT_TRACE_CONTEXTS_HPP_
 #define THIN_REPLICA_CLIENT_TRACE_CONTEXTS_HPP_

--- a/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0

--- a/client/thin-replica-client/include/client/thin-replica-client/update.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/update.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0

--- a/client/thin-replica-client/src/crypto_utils.cpp
+++ b/client/thin-replica-client/src/crypto_utils.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0

--- a/client/thin-replica-client/src/trace_contexts.cpp
+++ b/client/thin-replica-client/src/trace_contexts.cpp
@@ -1,4 +1,15 @@
-// Copyright 2021 VMware, all rights reserved
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
 
 #include "client/thin-replica-client/trace_contexts.hpp"
 

--- a/client/thin-replica-client/src/trc_hash.cpp
+++ b/client/thin-replica-client/src/trc_hash.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0

--- a/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
+++ b/client/thin-replica-client/test/trc_basic_update_queue_test.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0


### PR DESCRIPTION
This commit corrects the date in the licenses in TRC files and adds the missing license
in trace_context files.