### PR TITLE
bft_client: snapshot signing duration into log every 3 minutes

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <optional>
+#include <chrono>
 
 #include "communication/ICommunication.hpp"
 #include "Logger.hpp"
@@ -129,10 +130,15 @@ class Client {
       registrar.perf.unRegisterComponent(component_name_);
     }
 
+    const std::string& getComponenetName() { return component_name_; }
+
    private:
     std::string component_name_;
   };
 
+  static constexpr uint16_t time_between_snapshots_sec_ = 180;  // snapshot every 3 minutes
+  std::chrono::time_point<std::chrono::steady_clock> last_snapshot_;
+  uint32_t snapshot_counter_ = 0;
   std::unique_ptr<Recorders> histograms_;
 };
 


### PR DESCRIPTION
We do not use concord_ctl on client. In order to have an idea on how
long it takes to sign, we will take a snapshot every 3 minutes and log
log the results (debug level) every 3 minutes.