### PR TITLE
updateAggregatorCounter is used from multiple threads

### DIFF
--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -224,8 +224,7 @@ bool SigManager::verifySig(
       metrics_.externalClientReqSigVerified_.Get().Inc();
     else
       metrics_.replicaSigVerified_.Get().Inc();
-    ++updateAggregatorCounter;
-    if ((updateAggregatorCounter % updateMetricsAggregatorThresh) == 0) {
+    if ((++updateAggregatorCounter % updateMetricsAggregatorThresh) == 0) {
       metrics_component_.UpdateAggregator();
     }
   }

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -109,7 +109,7 @@ class SigManager {
 
   mutable concordMetrics::Component metrics_component_;
   mutable Metrics metrics_;
-  mutable uint64_t updateAggregatorCounter = 0;
+  mutable std::atomic<uint64_t> updateAggregatorCounter = 0;
 
   // These methods bypass the singelton, and can be used (STRICTLY) for testing.
   // Define the below flag in order to use them in your test.


### PR DESCRIPTION
updateAggregatorCounter should be atomic since it's being touched from multiple threads