### PR TITLE
Add pre, post and regular reconfiguration handlers

### DIFF
--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -23,6 +23,7 @@
 
 namespace concord::reconfiguration {
 class IReconfigurationHandler;
+enum ReconfigurationHandlerType : unsigned int;
 }  // namespace concord::reconfiguration
 
 namespace bftEngine {
@@ -55,7 +56,9 @@ class IRequestsHandler {
   std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> getReconfigurationHandler() const {
     return reconfig_handler_;
   }
-  virtual void setReconfigurationHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> rh) {
+  virtual void setReconfigurationHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> rh,
+                                         concord::reconfiguration::ReconfigurationHandlerType type =
+                                             static_cast<concord::reconfiguration::ReconfigurationHandlerType>(1)) {
     reconfig_handler_ = rh;
   }
 

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -31,8 +31,10 @@ class RequestHandler : public IRequestsHandler {
     }
   }
 
-  void setReconfigurationHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> rh) override {
-    reconfig_dispatcher_.addReconfigurationHandler(rh);
+  void setReconfigurationHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> rh,
+                                 concord::reconfiguration::ReconfigurationHandlerType type =
+                                     concord::reconfiguration::ReconfigurationHandlerType::REGULAR) override {
+    reconfig_dispatcher_.addReconfigurationHandler(rh, type);
   }
   void onFinishExecutingReadWriteRequests() override { userRequestsHandler_->onFinishExecutingReadWriteRequests(); }
 

--- a/kvbc/src/ReplicaImp.cpp
+++ b/kvbc/src/ReplicaImp.cpp
@@ -74,7 +74,8 @@ void ReplicaImp::createReplicaAndSyncState() {
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this));
   requestHandler->setReconfigurationHandler(
-      std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(*this, *this));
+      std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(*this, *this),
+      concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(std::shared_ptr<kvbc::pruning::PruningHandler>(
       new concord::kvbc::pruning::PruningHandler(*this, *this, *this, *m_stateTransfer, true)));
   m_replicaPtr = bftEngine::IReplica::createNewReplica(

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -18,7 +18,6 @@
 #include "Logger.hpp"
 
 namespace concord::reconfiguration {
-
 // The dispatcher forwards all messages to their appropriate handlers.
 // All handled messages are defined in the IReconfigurationHandler interface.
 class Dispatcher {
@@ -38,8 +37,21 @@ class Dispatcher {
   concord::messages::ReconfigurationResponse dispatch(const concord::messages::ReconfigurationRequest&,
                                                       uint64_t sequence_num);
 
-  void addReconfigurationHandler(std::shared_ptr<IReconfigurationHandler> h) {
-    if (h) reconfig_handlers_.push_back(h);
+  void addReconfigurationHandler(std::shared_ptr<IReconfigurationHandler> h,
+                                 ReconfigurationHandlerType type = ReconfigurationHandlerType::REGULAR) {
+    if (h) {
+      switch (type) {
+        case PRE:
+          pre_reconfig_handlers_.push_back(h);
+          break;
+        case REGULAR:
+          reconfig_handlers_.push_back(h);
+          break;
+        case POST:
+          post_reconfig_handlers_.push_back(h);
+          break;
+      }
+    }
   }
 
  private:
@@ -54,7 +66,9 @@ class Dispatcher {
                      std::shared_ptr<IReconfigurationHandler> handler) {
     return handler->handle(msg, bft_seq_num, rres);
   }
+  std::vector<std::shared_ptr<IReconfigurationHandler>> pre_reconfig_handlers_;
   std::vector<std::shared_ptr<IReconfigurationHandler>> reconfig_handlers_;
+  std::vector<std::shared_ptr<IReconfigurationHandler>> post_reconfig_handlers_;
 };
 
 }  // namespace concord::reconfiguration

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -18,7 +18,7 @@
 #include "Replica.hpp"
 
 namespace concord::reconfiguration {
-
+enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
 // The IReconfigurationHandler interface defines all message handler. It is
 // tightly coupled with the messages inside ReconfigurationSmRequest in the
 // message definition.


### PR DESCRIPTION
We want to have the ability to define an order on the reconfiguration actions that we take.
For example, we would like to persist the reconfiguration request to the blockchain prior to the actual execution, such that if we crash, we have the record in the blockchain.
This PR introduces the notion of pre, post, and regular reconfiguration handlers.
The dispatcher on its side first executes the pre, then the regular and only then the post.
Notice, that currently we don't have post-pre-execution handlers but we may have them in the future.