### PR TITLE
Fix potential race with metrics aggregator while starting replicas

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -61,8 +61,8 @@ class ReplicaInternal : public IReplica {
 bool ReplicaInternal::isRunning() const { return replica_->isRunning(); }
 
 void ReplicaInternal::start() {
-  replica_->start();
   preprocessor::PreProcessor::setAggregator(replica_->getAggregator());
+  replica_->start();
 }
 
 void ReplicaInternal::stop() {


### PR DESCRIPTION
In ReplicaInternal::start() we first start the replica and then update the preprocessor aggregator with the replica one.
The last step of ReplicaInternal::start() is to async sendInitialKey().
In rare conditions we may get a race where we try to update some metrics in key-exchange while we are updating the aggregator, which may lead to map.at() throwing std::out_of_range
The fix is to update the aggregator before starting the replica.