### PR TITLE
Rename ReplicaImp to Replica

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(concord_block_update INTERFACE
 )
 
 add_library(kvbc  src/ClientImp.cpp
-    src/ReplicaImp.cpp
+    src/Replica.cpp
     src/replica_state_sync_imp.cpp
     src/block_metadata.cpp
     src/direct_kv_db_adapter.cpp

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -29,11 +29,11 @@
 #include "ControlStateManager.hpp"
 namespace concord::kvbc {
 
-class ReplicaImp : public IReplica,
-                   public IBlocksDeleter,
-                   public IReader,
-                   public IBlockAdder,
-                   public bftEngine::bcst::IAppState {
+class Replica : public IReplica,
+                public IBlocksDeleter,
+                public IReader,
+                public IBlockAdder,
+                public bftEngine::bcst::IAppState {
  public:
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IReplica implementation
@@ -106,19 +106,19 @@ class ReplicaImp : public IReplica,
   bool getPrevDigestFromObjectStoreBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *);
   bool putBlockToObjectStore(const uint64_t blockId, const char *blockData, const uint32_t blockSize);
 
-  ReplicaImp(bft::communication::ICommunication *comm,
-             const bftEngine::ReplicaConfig &config,
-             std::unique_ptr<IStorageFactory> storageFactory,
-             std::shared_ptr<concordMetrics::Aggregator> aggregator,
-             const std::shared_ptr<concord::performance::PerformanceManager> &pm,
-             std::map<std::string, categorization::CATEGORY_TYPE> kvbc_categories,
-             const std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> &secretsManager);
+  Replica(bft::communication::ICommunication *comm,
+          const bftEngine::ReplicaConfig &config,
+          std::unique_ptr<IStorageFactory> storageFactory,
+          std::shared_ptr<concordMetrics::Aggregator> aggregator,
+          const std::shared_ptr<concord::performance::PerformanceManager> &pm,
+          std::map<std::string, categorization::CATEGORY_TYPE> kvbc_categories,
+          const std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> &secretsManager);
 
   void setReplicaStateSync(ReplicaStateSync *rss) { replicaStateSync_.reset(rss); }
 
   bftEngine::IStateTransfer &getStateTransfer() { return *m_stateTransfer; }
 
-  ~ReplicaImp() override;
+  ~Replica() override;
 
  protected:
   RawBlock getBlockInternal(BlockId blockId) const;

--- a/performance/test/slowdown_test.cpp
+++ b/performance/test/slowdown_test.cpp
@@ -21,7 +21,7 @@
 #include <chrono>
 #include <mutex>
 #include <condition_variable>
-#include <ReplicaImp.h>
+#include <Replica.h>
 #include <communication/ICommunication.hpp>
 #include <ReplicaConfig.hpp>
 #include "merkle_tree_storage_factory.h"

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -12,7 +12,7 @@
 // file.
 
 #include "setup.hpp"
-#include "ReplicaImp.h"
+#include "Replica.h"
 #include "internalCommandsHandler.hpp"
 #include "replica_state_sync_imp.hpp"
 #include "block_metadata.hpp"
@@ -39,16 +39,16 @@ void run_replica(int argc, char** argv) {
   MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(setup->GetReplicaConfig().replicaId));
   MDC_PUT(MDC_THREAD_KEY, "main");
 
-  std::shared_ptr<ReplicaImp> replica =
-      std::make_shared<ReplicaImp>(setup->GetCommunication(),
-                                   setup->GetReplicaConfig(),
-                                   setup->GetStorageFactory(),
-                                   setup->GetMetricsServer().GetAggregator(),
-                                   setup->GetPerformanceManager(),
-                                   std::map<std::string, categorization::CATEGORY_TYPE>{
-                                       {VERSIONED_KV_CAT_ID, categorization::CATEGORY_TYPE::versioned_kv},
-                                       {BLOCK_MERKLE_CAT_ID, categorization::CATEGORY_TYPE::block_merkle}},
-                                   std::make_shared<concord::secretsmanager::SecretsManagerPlain>());
+  std::shared_ptr<Replica> replica =
+      std::make_shared<Replica>(setup->GetCommunication(),
+                                setup->GetReplicaConfig(),
+                                setup->GetStorageFactory(),
+                                setup->GetMetricsServer().GetAggregator(),
+                                setup->GetPerformanceManager(),
+                                std::map<std::string, categorization::CATEGORY_TYPE>{
+                                    {VERSIONED_KV_CAT_ID, categorization::CATEGORY_TYPE::versioned_kv},
+                                    {BLOCK_MERKLE_CAT_ID, categorization::CATEGORY_TYPE::block_merkle}},
+                                std::make_shared<concord::secretsmanager::SecretsManagerPlain>());
 
   auto* blockMetadata = new BlockMetadata(*replica);
 


### PR DESCRIPTION
There are two classes named ReplicaImp in the codebase:
(1) concord::kvbc::ReplicaImp
(2) bftEngine::impl::ReplicaImp

They are in different namespaces but the name collision causes a lot of
confusion.

(1) looks like more general representation of a replica. It
has got generic methods as start, stop, get, add, etc.

(2) has got far more specifics and ReplicaImp is a good name for it.

This patch renames (1) to just Replica so that there is less confusion
in terms of reading the code.