### PR TITLE
Making commands and keys uniform for concord-ctl

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -677,8 +677,8 @@ std::string BCStateTran::getStatus() {
   result.insert(STRPAIR(lastMsgSeqNum_));
   result.insert(toPair("cacheOfVirtualBlockForResPagesSize", cacheOfVirtualBlockForResPages.size()));
 
-  auto currentSource = sourceSelector_.currentReplica();
-  auto preferredReplicas = sourceSelector_.preferredReplicasToString();
+  auto current_source = sourceSelector_.currentReplica();
+  auto preferred_replicas = sourceSelector_.preferredReplicasToString();
 
   for (auto &[id, seq_num] : lastMsgSeqNumOfReplicas_) {
     nested_data.insert(toPair(std::to_string(id), seq_num));
@@ -698,8 +698,8 @@ std::string BCStateTran::getStatus() {
   nested_data.clear();
 
   if (isFetching()) {
-    nested_data.insert(STRPAIR(currentSource));
-    nested_data.insert(STRPAIR(preferredReplicas));
+    nested_data.insert(toPair("currentSource", current_source));
+    nested_data.insert(toPair("preferredReplicas", preferred_replicas));
     nested_data.insert(toPair("nextRequiredBlock", nextRequiredBlock_));
     nested_data.insert(STRPAIR(totalSizeOfPendingItemDataMsgs));
     result.insert(toPair("fetchingStateDetails",

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -677,14 +677,14 @@ std::string BCStateTran::getStatus() {
   result.insert(STRPAIR(lastMsgSeqNum_));
   result.insert(toPair("cacheOfVirtualBlockForResPagesSize", cacheOfVirtualBlockForResPages.size()));
 
-  auto current_source = sourceSelector_.currentReplica();
-  auto preferred_replicas = sourceSelector_.preferredReplicasToString();
+  auto currentSource = sourceSelector_.currentReplica();
+  auto preferredReplicas = sourceSelector_.preferredReplicasToString();
 
   for (auto &[id, seq_num] : lastMsgSeqNumOfReplicas_) {
     nested_data.insert(toPair(std::to_string(id), seq_num));
   }
 
-  result.insert(toPair("LastMsgSequenceNumbers(ReplicaID:SeqNum)",
+  result.insert(toPair("lastMsgSequenceNumbers(ReplicaID:SeqNum)",
                        concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
   nested_data.clear();
 
@@ -698,17 +698,17 @@ std::string BCStateTran::getStatus() {
   nested_data.clear();
 
   if (isFetching()) {
-    nested_data.insert(STRPAIR(current_source));
-    nested_data.insert(STRPAIR(preferred_replicas));
-    nested_data.insert(STRPAIR(nextRequiredBlock_));
+    nested_data.insert(STRPAIR(currentSource));
+    nested_data.insert(STRPAIR(preferredReplicas));
+    nested_data.insert(toPair("nextRequiredBlock", nextRequiredBlock_));
     nested_data.insert(STRPAIR(totalSizeOfPendingItemDataMsgs));
-    result.insert(toPair("FetchingStateDetails",
+    result.insert(toPair("fetchingStateDetails",
                          concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
 
-    result.insert(toPair("CollectingDetails", logsForCollectingStatus(psd_->getFirstRequiredBlock())));
+    result.insert(toPair("collectingDetails", logsForCollectingStatus(psd_->getFirstRequiredBlock())));
   }
 
-  result.insert(toPair("GeneralStateTransferMetrics", metrics_component_.ToJson()));
+  result.insert(toPair("generalStateTransferMetrics", metrics_component_.ToJson()));
 
   oss << concordUtils::kContainerToJson(result);
   return oss.str();
@@ -2035,18 +2035,18 @@ std::string BCStateTran::logsForCollectingStatus(const uint64_t firstRequiredBlo
   auto bytes_overall_r = bytes_collected_.getOverallResults();
 
   nested_data.insert(toPair(
-      "CollectRange", std::to_string(firstRequiredBlock) + ", " + std::to_string(first_collected_block_num_.value())));
-  nested_data.insert(toPair("LastCollectedBlock", nextRequiredBlock_));
-  nested_data.insert(toPair("BlocksLeft", (nextRequiredBlock_ - firstRequiredBlock)));
-  nested_data.insert(toPair("ElapsedTime", std::to_string(blocks_overall_r.elapsed_time_ms_) + " ms"));
-  nested_data.insert(toPair("Collected",
+      "collectRange", std::to_string(firstRequiredBlock) + ", " + std::to_string(first_collected_block_num_.value())));
+  nested_data.insert(toPair("lastCollectedBlock", nextRequiredBlock_));
+  nested_data.insert(toPair("blocksLeft", (nextRequiredBlock_ - firstRequiredBlock)));
+  nested_data.insert(toPair("elapsedTime", std::to_string(blocks_overall_r.elapsed_time_ms_) + " ms"));
+  nested_data.insert(toPair("collected",
                             std::to_string(blocks_overall_r.num_processed_items_) + " blk & " +
                                 std::to_string(bytes_overall_r.num_processed_items_) + " B"));
-  nested_data.insert(toPair("Thoughput",
+  nested_data.insert(toPair("thoughput",
                             std::to_string(blocks_overall_r.throughput_) + " blk/s & " +
                                 std::to_string(bytes_overall_r.throughput_) + " B/s"));
   result.insert(
-      toPair("OverallStats", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+      toPair("overallStats", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
   nested_data.clear();
 
   if (get_missing_blocks_summary_window_size > 0) {
@@ -2054,26 +2054,26 @@ std::string BCStateTran::logsForCollectingStatus(const uint64_t firstRequiredBlo
     auto bytes_win_r = bytes_collected_.getPrevWinResults();
     auto prev_win_index = blocks_collected_.getPrevWinIndex();
 
-    nested_data.insert(toPair("Index", prev_win_index));
-    nested_data.insert(toPair("ElapsedTime", std::to_string(blocks_win_r.elapsed_time_ms_) + " ms"));
-    nested_data.insert(toPair("Collected",
+    nested_data.insert(toPair("index", prev_win_index));
+    nested_data.insert(toPair("elapsedTime", std::to_string(blocks_win_r.elapsed_time_ms_) + " ms"));
+    nested_data.insert(toPair("collected",
                               std::to_string(blocks_win_r.num_processed_items_) + " blk & " +
                                   std::to_string(bytes_win_r.num_processed_items_) + " B"));
     nested_data.insert(toPair(
-        "Thoughput",
+        "thoughput",
         std::to_string(blocks_win_r.throughput_) + " blk/s & " + std::to_string(bytes_win_r.throughput_) + " B/s"));
     result.insert(
-        toPair("LastWindow", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+        toPair("lastWindow", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
     nested_data.clear();
   }
 
-  nested_data.insert(toPair("LastStored", psd_->getLastStoredCheckpoint()));
+  nested_data.insert(toPair("lastStored", psd_->getLastStoredCheckpoint()));
   nested_nested_data.insert(toPair("checkpointNum", fetched_cp.checkpointNum));
   nested_nested_data.insert(toPair("lastBlock", fetched_cp.lastBlock));
   nested_data.insert(
-      toPair("BeingFetched", concordUtils::kvContainerToJson(nested_nested_data, [](const auto &arg) { return arg; })));
+      toPair("beingFetched", concordUtils::kvContainerToJson(nested_nested_data, [](const auto &arg) { return arg; })));
   result.insert(
-      toPair("CheckpointInfo", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+      toPair("checkpointInfo", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
 
   oss << concordUtils::kContainerToJson(result);
   return oss.str().c_str();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1166,7 +1166,7 @@ std::string ReplicaImp::getReplicaLastStableSeqNum() const {
 
   nested_data.insert(toPair(getName(lastStableSeqNum), lastStableSeqNum));
   result.insert(
-      toPair("Sequence Numbers ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+      toPair("sequenceNumbers ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
 
   oss << concordUtils::kContainerToJson(result);
   return oss.str();
@@ -1177,9 +1177,9 @@ std::string ReplicaImp::getReplicaState() const {
   std::ostringstream oss;
   std::unordered_map<std::string, std::string> result, nested_data;
 
-  result.insert(toPair("Replica ID", std::to_string(getReplicasInfo().myId())));
+  result.insert(toPair("replicaID", std::to_string(getReplicasInfo().myId())));
 
-  result.insert(toPair("Primary ", std::to_string(primary)));
+  result.insert(toPair("primary", std::to_string(primary)));
 
   nested_data.insert(toPair(getName(viewChangeProtocolEnabled), viewChangeProtocolEnabled));
   nested_data.insert(toPair(getName(autoPrimaryRotationEnabled), autoPrimaryRotationEnabled));
@@ -1190,7 +1190,7 @@ std::string ReplicaImp::getReplicaState() const {
   nested_data.insert(toPair(getName(viewChangeTimerMilli), viewChangeTimerMilli));
   nested_data.insert(toPair(getName(autoPrimaryRotationTimerMilli), autoPrimaryRotationTimerMilli));
   result.insert(
-      toPair("View Change ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+      toPair("viewChange", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
   nested_data.clear();
 
   nested_data.insert(toPair(getName(primaryLastUsedSeqNum), primaryLastUsedSeqNum));
@@ -1203,7 +1203,7 @@ std::string ReplicaImp::getReplicaState() const {
   nested_data.insert(
       toPair(getName(lastViewThatTransferredSeqNumbersFullyExecuted), lastViewThatTransferredSeqNumbersFullyExecuted));
   result.insert(
-      toPair("Sequence Numbers ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+      toPair("sequenceNumbers", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
   nested_data.clear();
 
   nested_data.insert(toPair(getName(restarted_), restarted_));

--- a/diagnostics/include/protocol.h
+++ b/diagnostics/include/protocol.h
@@ -38,7 +38,7 @@ inline std::string usage() {
   usage += "  perf <COMMAND> [ARGS]\n\n";
   usage += "    perf get <COMPONENT> [HISTOGRAM]\n";
   usage += "        Get all histograms for <COMPONENT> or a specific [HISTOGRAM]\n\n";
-  usage += "    perf list [COMPONENT]\n";
+  usage += "    perf list-keys [COMPONENT]\n";
   usage += "        List all components or all histograms for a given [COMPONENT]\n\n";
   usage += "    perf snapshot <COMPONENT1> [COMPONENT2]...[COMPONENT_N]\n";
   usage += "        Snapshot all histograms for the given components.";
@@ -95,7 +95,7 @@ inline std::string run(const std::vector<std::string>& tokens, Registrar& regist
         }
         return usage();
       }
-      if (command == "list") {
+      if (command == "list-keys") {
         if (tokens.size() == 2) {
           return registrar.perf.list();
         }

--- a/diagnostics/include/protocol.h
+++ b/diagnostics/include/protocol.h
@@ -33,12 +33,12 @@ inline std::string usage() {
   usage += "        Get the status of the given key(s).\n\n";
   usage += "    status describe [KEY1] [KEY2]..[KEY_N]\n";
   usage += "        Get the description of the given keys, or all keys if none is given.\n\n";
-  usage += "    status list-keys\n";
+  usage += "    status list\n";
   usage += "        List all status keys.\n\n";
   usage += "  perf <COMMAND> [ARGS]\n\n";
   usage += "    perf get <COMPONENT> [HISTOGRAM]\n";
   usage += "        Get all histograms for <COMPONENT> or a specific [HISTOGRAM]\n\n";
-  usage += "    perf list-keys [COMPONENT]\n";
+  usage += "    perf list [COMPONENT]\n";
   usage += "        List all components or all histograms for a given [COMPONENT]\n\n";
   usage += "    perf snapshot <COMPONENT1> [COMPONENT2]...[COMPONENT_N]\n";
   usage += "        Snapshot all histograms for the given components.";
@@ -78,7 +78,7 @@ inline std::string run(const std::vector<std::string>& tokens, Registrar& regist
       });
     }
 
-    if (command == "list-keys") {
+    if (command == "list") {
       if (tokens.size() != 2) return usage();
       return registrar.status.listKeys();
     }
@@ -95,7 +95,7 @@ inline std::string run(const std::vector<std::string>& tokens, Registrar& regist
         }
         return usage();
       }
-      if (command == "list-keys") {
+      if (command == "list") {
         if (tokens.size() == 2) {
           return registrar.perf.list();
         }

--- a/diagnostics/test/diagnostics_tests.cpp
+++ b/diagnostics/test/diagnostics_tests.cpp
@@ -97,7 +97,7 @@ TEST(diagnostics_tests, protocol) {
   ASSERT_EQ(0, std::memcmp("Usage:", run({"status", "bad_command"}, registrar).c_str(), 6));
 
   // Listing keys works
-  ASSERT_EQ(keylist, run({"status", "list-keys"}, registrar));
+  ASSERT_EQ(keylist, run({"status", "list"}, registrar));
 
   // Describing a status handler works
   ASSERT_EQ(async_handler_description + "\n", run({"status", "describe", async_handler_name}, registrar));

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -747,11 +747,11 @@ std::string KeyValueBlockchain::getPruningStatus() {
   std::ostringstream oss;
   std::unordered_map<std::string, std::string> result;
 
-  result.insert(toPair("versioned_num_of_deletes_keys_",
+  result.insert(toPair("versionedNumOfDeletedKeys",
                        aggregator_->GetCounter("kv_blockchain_deletes", "numOfVersionedKeysDeleted").Get()));
-  result.insert(toPair("immutable_num_of_deleted_keys_",
+  result.insert(toPair("immutableNumOfDeletedKeys",
                        aggregator_->GetCounter("kv_blockchain_deletes", "numOfImmutableKeysDeleted").Get()));
-  result.insert(toPair("merkle_num_of_deleted_keys_",
+  result.insert(toPair("merkleNumOfDeletedKeys",
                        aggregator_->GetCounter("kv_blockchain_deletes", "numOfMerkleKeysDeleted").Get()));
   result.insert(toPair("getGenesisBlockId()", getGenesisBlockId()));
   result.insert(toPair("getLastReachableBlockId()", getLastReachableBlockId()));


### PR DESCRIPTION
- Changing key listing command to `list` for `status` command to be uniform with `perf` command of `concord-ctl`
- Making keys of the output of commands uniform 