### PR TITLE
Rebuilding working window after restart failure due to initialization…

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -131,22 +131,19 @@ class KeyExchangeManager {
 
   struct InitData {
     std::shared_ptr<IInternalBFTClient> cl;
-    IReservedPages* reservedPages{nullptr};
     IMultiSigKeyGenerator* kg{nullptr};
     IKeyExchanger* ke{nullptr};
     std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsMgr;
     concordUtil::Timers* timers{nullptr};
-    std::shared_ptr<concordMetrics::Aggregator> a;
   };
+
+  void setAggregator(std::shared_ptr<concordMetrics::Aggregator> a) {
+    initMetrics(a, std::chrono::seconds(ReplicaConfig::instance().getmetricsDumpIntervalSeconds()));
+  }
 
   static KeyExchangeManager& instance(InitData* id = nullptr) {
     static KeyExchangeManager km{id};
     return km;
-  }
-
-  static void start(InitData* id) {
-    instance(id);
-    instance().initMetrics(id->a, std::chrono::seconds(ReplicaConfig::instance().getmetricsDumpIntervalSeconds()));
   }
 
  private:  // methods

--- a/bftengine/src/bftengine/KeyStore.cpp
+++ b/bftengine/src/bftengine/KeyStore.cpp
@@ -30,6 +30,7 @@ uint16_t ClusterKeyStore::loadAllReplicasKeyStoresFromReservedPages() {
 
 std::optional<ClusterKeyStore::PublicKeys> ClusterKeyStore::loadReplicaKeyStoreFromReserevedPages(
     const uint16_t& repID) {
+  LOG_INFO(KEY_EX_LOG, "rid: " << repID);
   if (!loadReservedPage(repID, buffer_.size(), buffer_.data())) {
     LOG_INFO(KEY_EX_LOG, "Failed to load reserved page for replica " << repID << ", first start?");
     return {};

--- a/bftengine/src/bftengine/KeyStore.h
+++ b/bftengine/src/bftengine/KeyStore.h
@@ -39,6 +39,7 @@ class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, 2> {
   };
 
   ClusterKeyStore(uint32_t size) : clusterSize_(size), buffer_(sizeOfReservedPage(), 0) {
+    LOG_INFO(KEY_EX_LOG, "size: " << size);
     ConcordAssertGT(sizeOfReservedPage(), 0);
     loadAllReplicasKeyStoresFromReservedPages();
   }

--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -69,8 +69,6 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
     concordMetrics::GaugeHandle last_executed_seq_num_;
   } ro_metrics_;
 
-  const ReplicaConfig& config_;
-
   // digital signatures
   std::unique_ptr<SigManager> sigManager_;
 

--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -33,6 +33,7 @@ ReplicaBase::ReplicaBase(const ReplicaConfig& config,
       metrics_dump_interval_in_sec_(config_.metricsDumpIntervalSeconds),
       metrics_{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())},
       timers_{timers} {
+  LOG_INFO(GL, "");
   if (config_.debugStatisticsEnabled) DebugStatistics::initDebugStatisticsData();
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3261,6 +3261,7 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
                  timers,
                  pm,
                  sm) {
+  LOG_INFO(GL, "");
   ConcordAssertNE(persistentStorage, nullptr);
 
   ps_ = persistentStorage;
@@ -3386,68 +3387,40 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
                                       config_.getreplicaId(),
                                       pp->digestOfRequests(),
                                       CryptoManager::instance().thresholdSignerForSlowPathCommit(pp->seqNumber()));
-        bool added = seqNumInfo.addSelfMsg(p, true);
-        if (!added) {
-          LOG_INFO(GL, "Failed to add sn [" << s << "] to main log, trying different crypto system");
-
-          p = PreparePartialMsg::create(curView,
-                                        pp->seqNumber(),
-                                        config_.getreplicaId(),
-                                        pp->digestOfRequests(),
-                                        CryptoManager::instance().thresholdSignerForSlowPathCommit(pp->seqNumber()));
-          added = seqNumInfo.addSelfMsg(p, true);
-        }
-        ConcordAssert(added);
+        ConcordAssert(seqNumInfo.addSelfMsg(p, true));
       }
 
       if (e.isPrepareFullMsgSet()) {
-        bool failedToAdd = false;
         try {
-          seqNumInfo.addMsg(e.getPrepareFullMsg(), true);
+          ConcordAssert(seqNumInfo.addMsg(e.getPrepareFullMsg(), true));
         } catch (const std::exception &e) {
-          failedToAdd = true;
-          LOG_INFO(GL, "Failed to add sn [" << s << "] to main log, trying different crypto system");
-          std::cout << e.what() << '\n';
+          LOG_ERROR(GL, "Failed to add sn " << s << " to main log, reason: " << e.what());
+          throw;
         }
-        if (failedToAdd) seqNumInfo.addMsg(e.getPrepareFullMsg(), true);
 
         Digest d;
         Digest::digestOfDigest(e.getPrePrepareMsg()->digestOfRequests(), d);
         CommitPartialMsg *c = CommitPartialMsg::create(
             curView, s, config_.getreplicaId(), d, CryptoManager::instance().thresholdSignerForSlowPathCommit(s));
 
-        bool added = seqNumInfo.addSelfCommitPartialMsgAndDigest(c, d, true);
-        if (!added) {
-          LOG_INFO(GL, "Failed to add sn [" << s << "] to main log, trying different crypto system");
-          c = CommitPartialMsg::create(
-              curView, s, config_.getreplicaId(), d, CryptoManager::instance().thresholdSignerForSlowPathCommit(s));
-          seqNumInfo.addSelfCommitPartialMsgAndDigest(c, d, true);
-        }
+        ConcordAssert(seqNumInfo.addSelfCommitPartialMsgAndDigest(c, d, true));
       }
 
       if (e.isCommitFullMsgSet()) {
-        bool failedToAdd = false;
         try {
-          seqNumInfo.addMsg(e.getCommitFullMsg(), true);
+          ConcordAssert(seqNumInfo.addMsg(e.getCommitFullMsg(), true));
         } catch (const std::exception &e) {
-          failedToAdd = true;
-          LOG_INFO(GL, "Failed to add sn [" << s << "] to main log, trying different crypto system");
-          std::cout << e.what() << '\n';
+          LOG_ERROR(GL, "Failed to add sn [" << s << "] to main log, reason: " << e.what());
+          throw;
         }
-        if (failedToAdd) seqNumInfo.addMsg(e.getCommitFullMsg(), true);
 
         ConcordAssert(e.getCommitFullMsg()->equals(*seqNumInfo.getValidCommitFullMsg()));
       }
 
       if (e.isFullCommitProofMsgSet()) {
         PartialProofsSet &pps = seqNumInfo.partialProofs();
-        bool added = pps.addMsg(e.getFullCommitProofMsg());  // TODO(GG): consider using a method that directly adds
+        ConcordAssert(pps.addMsg(e.getFullCommitProofMsg()));  // TODO(GG): consider using a method that directly adds
         // the message (as in the examples below)
-        if (!added) {
-          LOG_INFO(GL, "Failed to add sn [" << s << "] to main log, trying different crypto system");
-          added = pps.addMsg(e.getFullCommitProofMsg());
-        }
-        ConcordAssert(added);  // we should verify the relevant signature when it is loaded
         ConcordAssert(e.getFullCommitProofMsg()->equals(*pps.getFullProof()));
       }
 
@@ -3530,6 +3503,7 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
                  timers,
                  pm,
                  sm) {
+  LOG_INFO(GL, "");
   if (persistentStorage != nullptr) {
     ps_ = persistentStorage;
   }
@@ -3642,6 +3616,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       reqBatchingLogic_(*this, config_, metrics_, timers),
       replStatusHandlers_(*this),
       rsaSigner_(std::make_unique<bftEngine::impl::RSASigner>(config.replicaPrivateKey.c_str())) {
+  LOG_INFO(GL, "");
   ConcordAssertLT(config_.getreplicaId(), config_.getnumReplicas());
   // TODO(GG): more asserts on params !!!!!!!!!!!
 
@@ -3677,11 +3652,6 @@ ReplicaImp::ReplicaImp(bool firstTime,
   clientsManager->initInternalClientInfo(config_.getnumReplicas());
   internalBFTClient_.reset(new InternalBFTClient(
       config_.getreplicaId(), clientsManager->getHighestIdOfNonInternalClient(), msgsCommunicator_));
-
-  ClientsManager::setNumResPages(
-      (config.numOfClientProxies + config.numOfExternalClients + config.numReplicas) *
-      ClientsManager::reservedPagesPerClient(config.getsizeOfReservedPage(), config.maxReplyMessageSize));
-  ClusterKeyStore::setNumResPages(config.numReplicas);
 
   // autoPrimaryRotationEnabled implies viewChangeProtocolEnabled
   // Note: "p=>q" is equivalent to "not p or q"
@@ -3720,6 +3690,11 @@ ReplicaImp::ReplicaImp(bool firstTime,
   if (currentViewIsActive()) {
     time_in_active_view_.start();
   }
+
+  KeyExchangeManager::InitData id{
+      internalBFTClient_, &CryptoManager::instance(), &CryptoManager::instance(), sm_, &timers_};
+
+  KeyExchangeManager::instance(&id);
 
   LOG_INFO(GL, "ReplicaConfig parameters: " << config);
 }
@@ -3793,17 +3768,8 @@ void ReplicaImp::addTimers() {
 void ReplicaImp::start() {
   LOG_INFO(GL, "Running ReplicaImp");
   sigManager_->SetAggregator(aggregator_);
+  KeyExchangeManager::instance().setAggregator(aggregator_);
   ReplicaForStateTransfer::start();
-
-  // Initialize and start KeyExchangeManager after State Transfer
-  KeyExchangeManager::InitData id{};
-  id.cl = internalBFTClient_;
-  id.reservedPages = stateTransfer.get();
-  id.kg = &CryptoManager::instance();
-  id.ke = &CryptoManager::instance();
-  id.secretsMgr = sm_;
-  id.timers = &timers_;
-  id.a = aggregator_;
 
   // If we have just unwedged, clear the wedge point
   auto seqNumToStopAt = ControlStateManager::instance().getCheckpointToStopAt();
@@ -3811,8 +3777,6 @@ void ReplicaImp::start() {
     LOG_INFO(GL, "unwedge the system" << KVLOG(lastStableSeqNum));
     ControlStateManager::instance().clearCheckpointToStopAt();
   }
-
-  KeyExchangeManager::start(&id);
 
   if (!firstTime_ || config_.getdebugPersistentStorageEnabled()) clientsManager->loadInfoFromReservedPages();
   addTimers();


### PR DESCRIPTION
… sequence bug.

Due to contention between RAII and construction + start() concepts, key loading happened (ReplicaImp::start() ) after messages were added to the restored active window (ReplicaImp()).