### PR TITLE
Fix SimpleTest

### DIFF
--- a/tests/simpleTest/simple_test_client.hpp
+++ b/tests/simpleTest/simple_test_client.hpp
@@ -77,12 +77,13 @@ class SimpleTestClient {
     client->setAggregator(aggregator);
     comm->Start();
 
-    // hack that copies the behaviour of the protected function of SimpleClient (
-    auto readyReplicas = 0;
-    while (readyReplicas < cp.numOfReplicas - cp.numOfFaulty) {
+    // hack that copies the behaviour of the protected function of SimpleClient
+    while (true) {
+      auto readyReplicas = 0;
       this_thread::sleep_for(1s);
       for (int i = 0; i < cp.numOfReplicas; ++i)
         readyReplicas += (comm->getCurrentConnectionStatus(i) == ConnectionStatus::Connected);
+      if (readyReplicas >= cp.numOfReplicas - cp.numOfFaulty) break;
     }
 
     // The state number that the latest write operation returned.

--- a/tests/simpleTest/simple_test_client.hpp
+++ b/tests/simpleTest/simple_test_client.hpp
@@ -68,7 +68,7 @@ class SimpleTestClient {
     LOG_INFO(clientLogger,
              "ClientParams: clientId: " << cp.clientId << ", numOfReplicas: " << cp.numOfReplicas << ", numOfClients: "
                                         << cp.numOfClients << ", numOfIterations: " << cp.numOfOperations
-                                        << ", fVal: " << cp.numOfFaulty << ", cVal: " << cp.numOfFaulty);
+                                        << ", fVal: " << cp.numOfFaulty << ", cVal: " << cp.numOfSlow);
 
     ICommunication* comm = bft::communication::CommFactory::create(conf);
 


### PR DESCRIPTION
This PR fixes SimpleTest client to wait for the communication layer to connect to at least N - F replicas.