### PR TITLE
Remove config generated as metadata

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -17,6 +17,7 @@
 #include "Timers.hpp"
 #include "Metrics.hpp"
 #include "secrets_manager_impl.h"
+#include "SysConsts.hpp"
 
 namespace bftEngine::impl {
 
@@ -90,7 +91,7 @@ class KeyExchangeManager {
 
     PrivateKeys(std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsMgr)
         : secretsMgr_{secretsMgr},
-          secrets_file_{ReplicaConfig::instance().getkeyViewFilePath() + std::string("/gen-sec.") +
+          secrets_file_{ReplicaConfig::instance().getkeyViewFilePath() + std::string("/" + secFilePrefix + ".") +
                         std::to_string(ReplicaConfig::instance().getreplicaId())} {
       load();
     }

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -26,6 +26,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <stdio.h>
 
 bftEngine::IReservedPages *bftEngine::ReservedPagesClientBase::res_pages_ = nullptr;
 
@@ -147,7 +148,17 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
     isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);
     bool erasedMetaData;
     ((PersistentStorageImp *)persistentStoragePtr.get())->init(move(metadataStoragePtr), erasedMetaData);
-    if (erasedMetaData) isNewStorage = true;
+    if (erasedMetaData) {
+      isNewStorage = true;
+      auto secFile = ReplicaConfig::instance().getkeyViewFilePath() + std::string("/" + secFilePrefix + ".") +
+                     std::to_string(ReplicaConfig::instance().getreplicaId());
+      LOG_INFO(GL, "removing " << secFile << " if exist");
+      try {
+        std::remove(secFile.c_str());
+      } catch (std::exception &e) {
+        LOG_FATAL(GL, "unable to remove the secret file, as we erased the metadata we won't be able to restart");
+      }
+    }
     LOG_INFO(GL, "erasedMetaData flag = " << erasedMetaData);
   }
   auto replicaInternal = std::make_unique<ReplicaInternal>();

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -26,7 +26,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
-#include <stdio.h>
+#include <cstdio>
 
 bftEngine::IReservedPages *bftEngine::ReservedPagesClientBase::res_pages_ = nullptr;
 

--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -126,3 +126,5 @@ constexpr uint32_t maxSizeOfCombinedSignature = 1024;  // TODO(GG): should be ch
 
 constexpr uint32_t MaxSizeOfPrivateKey = 1024;  // TODO(GG): should be checked
 constexpr uint32_t MaxSizeOfPublicKey = 1024;   // TODO(GG): should be checked
+
+static const std::string secFilePrefix = "gen-sec";

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -691,7 +691,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
     
     @with_trio
-    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 4, rotate_keys=True)
+    @with_bft_network(start_replica_cmd_with_key_exchange, rotate_keys=True, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}])
     async def test_add_nodes(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -58,6 +58,27 @@ def start_replica_cmd(builddir, replica_id):
             "-o", builddir + "/operator_pub.pem"]
 
 
+def start_replica_cmd_with_key_exchange(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    Note each arguments is an element in a list.
+    """
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "10000"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-v", viewChangeTimeoutMilli,
+            "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties"),
+            "-b", "2",
+            "-q", "1",
+            "-e", str(True),
+            "-o", builddir + "/operator_pub.pem"]
+
 class SkvbcReconfigurationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -556,7 +577,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             assert status.response.reconfiguration == test_config
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True)
     async def test_remove_nodes(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -607,7 +628,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
     
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True)
     async def test_remove_nodes_with_f_failures(self, bft_network):
         """
         In this test we show how a system operator can remove nodes (and thus reduce the cluster) from 7 nodes cluster
@@ -670,7 +691,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
     
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True)
     async def test_add_nodes(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -685,15 +706,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                       replicas to move the checkpoint window, hence new replicas are added in two phases
              5. Rerun the cluster with only new configuration and make sure they succeed to perform transactions in fast path
          """
-        conf = TestConfig(n=4,
-                   f=1,
-                   c=0,
-                   num_clients=10,
-                   key_file_prefix=KEY_FILE_PREFIX,
-                   start_replica_cmd=start_replica_cmd,
-                   stop_replica_cmd=None,
-                   num_ro_replicas=0)
-        await bft_network.change_configuration(conf)
+
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(100):

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -691,7 +691,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
     
     @with_trio
-    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True)
+    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 4, rotate_keys=True)
     async def test_add_nodes(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -706,15 +706,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                       replicas to move the checkpoint window, hence new replicas are added in two phases
              5. Rerun the cluster with only new configuration and make sure they succeed to perform transactions in fast path
          """
-        conf = TestConfig(n=4,
-                   f=1,
-                   c=0,
-                   num_clients=10,
-                   key_file_prefix=KEY_FILE_PREFIX,
-                   start_replica_cmd=start_replica_cmd,
-                   stop_replica_cmd=None,
-                   num_ro_replicas=0)
-        await bft_network.change_configuration(conf)
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(100):

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -706,7 +706,15 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                       replicas to move the checkpoint window, hence new replicas are added in two phases
              5. Rerun the cluster with only new configuration and make sure they succeed to perform transactions in fast path
          """
-
+        conf = TestConfig(n=4,
+                   f=1,
+                   c=0,
+                   num_clients=10,
+                   key_file_prefix=KEY_FILE_PREFIX,
+                   start_replica_cmd=start_replica_cmd,
+                   stop_replica_cmd=None,
+                   num_ro_replicas=0)
+        await bft_network.change_configuration(conf)
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(100):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -132,7 +132,7 @@ def with_constant_load(async_fn):
                 nursery.cancel_scope.cancel()
     return wrapper
 
-def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None, num_ro_replicas=0, rotate_keys=False):
+def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None, num_ro_replicas=0, rotate_keys=False, bft_configs=None):
     """
     Runs the decorated async function for all selected BFT configs
     start_replica_cmd is a callback which is used to start a replica. It should have the following
@@ -153,7 +153,8 @@ def with_bft_network(start_replica_cmd, selected_configs=None, num_clients=None,
                 with log.start_task(action_type=async_fn.__name__):
                     await async_fn(*args, **kwargs, bft_network=bft_network)
             else:
-                for bft_config in interesting_configs(selected_configs):
+                configs = bft_configs if bft_configs is not None else interesting_configs(selected_configs)
+                for bft_config in configs:
 
                     config = TestConfig(n=bft_config['n'],
                                         f=bft_config['f'],

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -77,7 +77,7 @@ def interesting_configs(selected=None):
 
     bft_configs = [{'n': 6, 'f': 1, 'c': 1, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
-                   {'n': 4, 'f': 1, 'c': 0, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
+                   # {'n': 4, 'f': 1, 'c': 0, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': BFT_CONFIGS_NUM_CLIENTS}
                    # {'n': 12, 'f': 3, 'c': 1, 'num_clients': BFT_CONFIGS_NUM_CLIENTS}
                    ]

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -77,7 +77,7 @@ def interesting_configs(selected=None):
 
     bft_configs = [{'n': 6, 'f': 1, 'c': 1, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
                    {'n': 7, 'f': 2, 'c': 0, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
-                   # {'n': 4, 'f': 1, 'c': 0, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
+                   {'n': 4, 'f': 1, 'c': 0, 'num_clients': BFT_CONFIGS_NUM_CLIENTS},
                    # {'n': 9, 'f': 2, 'c': 1, 'num_clients': BFT_CONFIGS_NUM_CLIENTS}
                    # {'n': 12, 'f': 3, 'c': 1, 'num_clients': BFT_CONFIGS_NUM_CLIENTS}
                    ]


### PR DESCRIPTION
When we remove the metadata on startup, we also need to remove the gen-sec key that contains the rotated private key.
This PR handles it as well as change the Apollo tests to support key exchange and test this functionality