### PR TITLE
Keep flushing consensus's in noop scenario

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4269,7 +4269,7 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
     internalBFTClient_->sendRequest(
         RECONFIG_FLAG, strMsg.size(), strMsg.c_str(), "wedge-noop-command-" + std::to_string(seqNumber));
     // Now, try to send a new prepreare immediately, without waiting to a new batch
-    if ((BatchingPolicy)config_.batchingPolicy == BATCH_SELF_ADJUSTED) tryToSendPrePrepareMsg(false);
+    tryToSendPrePrepareMsg(false);
   }
 
   if (ControlStateManager::instance().getCheckpointToStopAt().has_value() &&


### PR DESCRIPTION
In this scenario, we are trying to flush consensus to fill the 300 window as fast as possible; that's why we need to remove the check if it self adjust policy.