### PR TITLE
Maintain reserved pages client indices in one place

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include "IStateTransfer.hpp"
 #include "ReservedPagesClient.hpp"
+#include "ReservedPagesClientIndex.hpp"
 #include "Serializable.h"
 #include "SysConsts.hpp"
 
@@ -41,11 +42,10 @@ class ControlStatePage : public concord::serialize::SerializableFactory<ControlS
   }
 };
 
-static constexpr uint32_t ControlHandlerStateManagerReservedPagesIndex = 1;
 static constexpr uint32_t ControlHandlerStateManagerNumOfReservedPages = 1;
 
 class ControlStateManager : public ResPagesClient<ControlStateManager,
-                                                  ControlHandlerStateManagerReservedPagesIndex,
+                                                  ReservedPagesClientIndex::kControlStateManager,
                                                   ControlHandlerStateManagerNumOfReservedPages> {
  public:
   static ControlStateManager& instance() {

--- a/bftengine/include/bftengine/ReservedPagesClient.hpp
+++ b/bftengine/include/bftengine/ReservedPagesClient.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <iostream>
 #include "demangle.hpp"
+#include "ReservedPagesClientIndex.hpp"
 
 namespace bftEngine {
 
@@ -37,7 +38,7 @@ class ReservedPagesClientBase {
 
  protected:
   // [idx, typeid, numberOfPages]
-  typedef std::vector<std::tuple<std::uint8_t, std::type_index, std::uint32_t>> Registry;
+  typedef std::vector<std::tuple<ReservedPagesClientIndex, std::type_index, std::uint32_t>> Registry;
 
   static Registry& registry() {
     static Registry registry_;
@@ -51,10 +52,10 @@ class ReservedPagesClientBase {
  *
  * Become a Reserved Pages client by sub-classing:
  * class MyClass: public ResPagesClient<MyClass, idx, requiredNumberOfPages> {};
- * where idx is a unique integer used for dividing a reserved pages space into sub-spaces.
+ * where idx is a unique identifier used for dividing a reserved pages space into sub-spaces.
  * If requiredNumberOfPages is not known at compile time call setNumResPages(requiredNumberOfPages).
  */
-template <typename T, uint8_t Idx, uint32_t NumPages = 0>
+template <typename T, ReservedPagesClientIndex Idx, uint32_t NumPages = 0>
 class ResPagesClient : public ReservedPagesClientBase, public IReservedPages {
  public:
   ResPagesClient() { (void)registered_; }
@@ -122,7 +123,7 @@ class ResPagesClient : public ReservedPagesClientBase, public IReservedPages {
   static bool registered_;
 };
 // static registration
-template <typename T, uint8_t Idx, uint32_t NumPages>
+template <typename T, ReservedPagesClientIndex Idx, uint32_t NumPages>
 bool ResPagesClient<T, Idx, NumPages>::registered_ = ResPagesClient<T, Idx, NumPages>::registerT();
 
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/ReservedPagesClientIndex.hpp
+++ b/bftengine/include/bftengine/ReservedPagesClientIndex.hpp
@@ -1,0 +1,29 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <cstdint>
+
+namespace bftEngine {
+
+// A central place to maintain reserved pages client indices.
+enum class ReservedPagesClientIndex : std::uint8_t {
+  kClientsManager = 0,
+  kControlStateManager = 1,
+  kClusterKeyStore = 2,
+  kTimeService = 3,
+  kPeriodicCronEntries = 4,
+};
+
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -14,6 +14,7 @@
 #include "PrimitiveTypes.hpp"
 #include "TimeUtils.hpp"
 #include "bftengine/ReservedPagesClient.hpp"
+#include "bftengine/ReservedPagesClientIndex.hpp"
 #include "Metrics.hpp"
 #include "IPendingRequest.hpp"
 #include <map>
@@ -28,7 +29,8 @@ namespace impl {
 class ClientReplyMsg;
 class ClientRequestMsg;
 
-class ClientsManager : public ResPagesClient<ClientsManager, 0>, public IPendingRequest {
+class ClientsManager : public ResPagesClient<ClientsManager, ReservedPagesClientIndex::kClientsManager>,
+                       public IPendingRequest {
  public:
   ClientsManager(concordMetrics::Component& metrics, std::set<NodeIdType>& clientsSet);
   ~ClientsManager();

--- a/bftengine/src/bftengine/KeyStore.h
+++ b/bftengine/src/bftengine/KeyStore.h
@@ -13,6 +13,7 @@
 #include "Serializable.h"
 #include "IReservedPages.hpp"
 #include "ReservedPagesClient.hpp"
+#include "ReservedPagesClientIndex.hpp"
 #include "KeyExchangeMsg.hpp"
 #include <map>
 #include <optional>
@@ -23,7 +24,7 @@ typedef int64_t SeqNum;  // TODO [TK] redefinition
 /**
  *  Holds and persists public keys of all replicas.
  */
-class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, 2> {
+class ClusterKeyStore : public ResPagesClient<ClusterKeyStore, ReservedPagesClientIndex::kClusterKeyStore> {
  public:
   /**
    * Persistent public keys store

--- a/bftengine/src/bftengine/TimeServiceResPageClient.hpp
+++ b/bftengine/src/bftengine/TimeServiceResPageClient.hpp
@@ -12,11 +12,13 @@
 #pragma once
 
 #include "ReservedPagesClient.hpp"
+#include "ReservedPagesClientIndex.hpp"
 #include <chrono>
 
 namespace bftEngine {
 using ConsensusTime = std::chrono::milliseconds;
-class TimeServiceResPageClient : private ResPagesClient<TimeServiceResPageClient, 3, 1> {
+class TimeServiceResPageClient
+    : private ResPagesClient<TimeServiceResPageClient, ReservedPagesClientIndex::kTimeService, 1> {
  public:
   TimeServiceResPageClient();
   ~TimeServiceResPageClient() = default;


### PR DESCRIPTION
Introduce the `ReservedPagesClientIndex` enum that maintains the
reserved pages client indices in one place. Additionally, making it an
`enum class` ensures one cannot instantiate the `ResPagesClient` class
with an arbitrary integer.