### PR TITLE
Wire Concord Cron into Concord-BFT

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -65,6 +65,9 @@ set(corebft_source_files
     src/bftengine/InternalBFTClient.cpp
     src/bftengine/KeyStore.cpp
     src/bftengine/TimeServiceResPageClient.cpp
+    ../ccron/src/ticks_generator.cpp
+    ../ccron/src/periodic_action.cpp
+    ../ccron/src/cron_table.cpp
 )
 
 #

--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -26,6 +26,10 @@ class IReconfigurationHandler;
 enum ReconfigurationHandlerType : unsigned int;
 }  // namespace concord::reconfiguration
 
+namespace concord::cron {
+class CronTableRegistry;
+}
+
 namespace bftEngine {
 class IRequestsHandler {
  public:
@@ -44,7 +48,8 @@ class IRequestsHandler {
     int outExecutionStatus = 1;
   };
 
-  static std::shared_ptr<IRequestsHandler> createRequestsHandler(std::shared_ptr<IRequestsHandler> userReqHandler);
+  static std::shared_ptr<IRequestsHandler> createRequestsHandler(
+      std::shared_ptr<IRequestsHandler> userReqHandler, const std::shared_ptr<concord::cron::CronTableRegistry> &);
   typedef std::deque<ExecutionRequest> ExecutionRequestsQueue;
 
   virtual void execute(ExecutionRequestsQueue &requests,

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -27,6 +27,10 @@
 #include "PerformanceManager.hpp"
 #include "IRequestHandler.hpp"
 
+namespace concord::cron {
+class TicksGenerator;
+}
+
 namespace concord::secretsmanager {
 class ISecretsManagerImpl;
 }
@@ -110,6 +114,9 @@ class IReplica {
   // TODO(GG) : move the following methods to an "advanced interface"
   virtual void SetAggregator(std::shared_ptr<concordMetrics::Aggregator>) = 0;
   virtual void restartForDebug(uint32_t delayMillis) = 0;  // for debug only.
+
+  // Returns the internal ticks generator or nullptr if not applicable.
+  virtual std::shared_ptr<concord::cron::TicksGenerator> ticksGenerator() const = 0;
 };
 
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -163,6 +163,12 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                std::chrono::milliseconds{1},
                "time provided to execution is max(consensus_time, last_time + timeServiceEpsilonMillis)");
 
+  // Ticks Generator
+  CONFIG_PARAM(ticksGeneratorPollPeriod,
+               std::chrono::seconds,
+               std::chrono::seconds{1},
+               "wake up the ticks generator every ticksGeneratorPollPeriod seconds and fire pending ticks");
+
   // Not predefined configuration parameters
   // Example of usage:
   // repclicaConfig.set(someTimeout, 6000);

--- a/bftengine/include/bftengine/ReservedPagesClient.hpp
+++ b/bftengine/include/bftengine/ReservedPagesClient.hpp
@@ -92,12 +92,13 @@ class ResPagesClient : public ReservedPagesClientBase, public IReservedPages {
     res_pages_->zeroReservedPage(my_offset() + reservedPageId);
   }
 
- private:
   /** is called when calculating absolute pageId */
   uint32_t my_offset() const {
     static uint32_t offset_ = calc_my_offset();
     return offset_;
   }
+
+ private:
   // is done once per client
   uint32_t calc_my_offset() const {
     uint32_t offset = 0;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -40,6 +40,8 @@
 #include "secrets_manager_impl.h"
 #include "SigManager.hpp"
 
+#include <ccron/ticks_generator.hpp>
+
 namespace bftEngine::impl {
 
 class ClientRequestMsg;
@@ -174,6 +176,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // it will be initialized to a SecretsManagerPlain
   shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
 
+  std::shared_ptr<concord::cron::TicksGenerator> ticks_gen_;
+
   //******** METRICS ************************************
   GaugeHandle metric_view_;
   GaugeHandle metric_last_stable_seq_num_;
@@ -270,6 +274,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   void start() override;
   void stop() override;
+
+  std::shared_ptr<concord::cron::TicksGenerator> ticksGenerator() const { return ticks_gen_; }
 
   virtual bool isReadOnly() const override { return false; }
 

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -15,6 +15,9 @@
 
 #include "bftengine/KeyExchangeManager.hpp"
 
+#include <ccron/cron_table_registry.hpp>
+#include "ccron_msgs.cmf.hpp"
+
 using concord::messages::ReconfigurationRequest;
 using concord::messages::ReconfigurationResponse;
 
@@ -61,7 +64,32 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
         req.outActualReplySize = 0;
       }
       req.outExecutionStatus = 0;  // stop further processing of this request
+    } else if (req.flags & TICK_FLAG) {
+      // Make sure the reply always contains one dummy 0 byte. Needed as empty replies are not supported at that stage.
+      // Also, set replica specific information size to 0.
+      req.outActualReplySize = 1;
+      req.outReply[0] = '\0';
+      req.outReplicaSpecificInfoSize = 0;
+
+      // Default is success (0).
+      req.outExecutionStatus = 0;
+
+      if (req.flags & READ_ONLY_FLAG) {
+        LOG_ERROR(GL, "Received a read-only Tick, ignoring");
+        req.outExecutionStatus = 1;
+      } else if (cron_table_registry_) {
+        using namespace concord::cron;
+        auto payload = ClientReqMsgTickPayload{};
+        auto req_ptr = reinterpret_cast<const uint8_t*>(req.request);
+        deserialize(req_ptr, req_ptr + req.requestSize, payload);
+        const auto tick = Tick{payload.component_id, req.executionSequenceNum};
+        cron_table_registry_->operator[](payload.component_id).evaluate(tick);
+      } else {
+        LOG_ERROR(GL, "Received a Tick, but the cron table registry is not initialized");
+        req.outExecutionStatus = 2;
+      }
     }
+
     if (req.flags & READ_ONLY_FLAG) {
       // Backward compatible with read only flag prior BC-5126
       req.flags = READ_ONLY_FLAG;

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -83,7 +83,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
         auto req_ptr = reinterpret_cast<const uint8_t*>(req.request);
         deserialize(req_ptr, req_ptr + req.requestSize, payload);
         const auto tick = Tick{payload.component_id, req.executionSequenceNum};
-        cron_table_registry_->operator[](payload.component_id).evaluate(tick);
+        (*cron_table_registry_)[payload.component_id].evaluate(tick);
       } else {
         LOG_ERROR(GL, "Received a Tick, but the cron table registry is not initialized");
         req.outExecutionStatus = 2;

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -10,10 +10,13 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#pragma once
+
 #include "reconfiguration/reconfiguration_handler.hpp"
 #include "reconfiguration/dispatcher.hpp"
 #include "IRequestHandler.hpp"
-#pragma once
+
+#include <ccron/cron_table_registry.hpp>
 
 namespace bftEngine {
 
@@ -36,11 +39,17 @@ class RequestHandler : public IRequestsHandler {
                                      concord::reconfiguration::ReconfigurationHandlerType::REGULAR) override {
     reconfig_dispatcher_.addReconfigurationHandler(rh, type);
   }
+
+  void setCronTableRegistry(const std::shared_ptr<concord::cron::CronTableRegistry> &reg) {
+    cron_table_registry_ = reg;
+  }
+
   void onFinishExecutingReadWriteRequests() override { userRequestsHandler_->onFinishExecutingReadWriteRequests(); }
 
  private:
   std::shared_ptr<IRequestsHandler> userRequestsHandler_ = nullptr;
   concord::reconfiguration::Dispatcher reconfig_dispatcher_;
+  std::shared_ptr<concord::cron::CronTableRegistry> cron_table_registry_;
 };
 
 }  // namespace bftEngine

--- a/ccron/CMakeLists.txt
+++ b/ccron/CMakeLists.txt
@@ -1,13 +1,22 @@
 cmake_minimum_required (VERSION 3.2)
 project(libccron LANGUAGES CXX)
 
-add_library(ccron
-  src/ticks_generator.cpp
-  src/periodic_action.cpp
-  src/cron_table.cpp)
+# Set the minumum version to 3.13 as we want the NEW CMP0079 behavior:
+# https://cmake.org/cmake/help/latest/policy/CMP0079.html
+# We need it in order to be able to call target_link_libraries() for corebft from the ccron directory.
+# That will essentially make ccron part of the corebft library. We do that, because we want to:
+#  1. Avoid cyclic dependencies between the potential ccron and the corebft libraries.
+#  2. Avoid the need for type erasure, i.e. by using a std::function callback or inheritance for calling
+#     onInternalTick() inside ReplicaImp.
+#  3. Avoid encapsulation violations - reason is that all parameters needed to construct a TicksGenerator are
+#     protected ReplicaImp members and due to point 1), we cannot make the TicksGenerator a member of ReplicaImp
+#     if ccron was a separate library.
+# All of above might change when code is refactored such that corebft is split further.
+# Another option is to move ccron inside the bftengine directory. 
+cmake_policy(VERSION 3.13)
 
-target_include_directories(ccron PUBLIC include)
-target_link_libraries(ccron PUBLIC ccron_msgs corebft)
+target_include_directories(corebft PUBLIC include)
+target_link_libraries(corebft PUBLIC ccron_msgs)
 
 add_subdirectory(cmf)
 

--- a/ccron/include/ccron/cron_res_page_client.hpp
+++ b/ccron/include/ccron/cron_res_page_client.hpp
@@ -1,0 +1,22 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "ReservedPagesClient.hpp"
+
+namespace concord::cron {
+
+static constexpr auto kCronResPageCount = 1;
+
+class CronResPagesClient : public bftEngine::ResPagesClient<CronResPagesClient, kCronResPageCount> {};
+
+}  // namespace concord::cron

--- a/ccron/include/ccron/periodic_action.hpp
+++ b/ccron/include/ccron/periodic_action.hpp
@@ -13,15 +13,14 @@
 
 #include "cron_entry.hpp"
 
-#include "IReservedPages.hpp"
-
 #include <cstdint>
 #include <chrono>
 
 namespace concord::cron {
 
-// TODO: Use an ID from a reserved pages client.
-static constexpr auto kPeriodicCronReservedPageId = 3;
+// Functions below persist the cron schedule in reserved pages.
+
+static constexpr auto kPeriodicCronReservedPageId = 0;
 
 // Create a cron table entry that represents a periodic `action` that occurs every `period` milliseconds.
 // Works in conjunction with the `persistPeriodicSchedule()` entry:
@@ -37,13 +36,10 @@ static constexpr auto kPeriodicCronReservedPageId = 3;
 // entries. Rationale is that we want to avoid serializing the schedule to reserved pages multiple times (for every
 // periodic action in the table) per tick. Instead, we accumulate the changes in memory and then use the
 // `persistPeriodicSchedule()` entry to persist once, at the end.
-CronEntry periodicAction(std::uint32_t position,
-                         const Action& action,
-                         const std::chrono::milliseconds& period,
-                         bftEngine::IReservedPages& reserved_pages);
+CronEntry periodicAction(std::uint32_t position, const Action& action, const std::chrono::milliseconds& period);
 
 // Create a cron entry that persists the periodic actions schedule. To work as expected, users must ensure that its
 // position is bigger than the positions of all other periodic action entries (see above).
-CronEntry persistPeriodicSchedule(std::uint32_t position, bftEngine::IReservedPages& reserved_pages);
+CronEntry persistPeriodicSchedule(std::uint32_t position);
 
 }  // namespace concord::cron

--- a/ccron/test/CMakeLists.txt
+++ b/ccron/test/CMakeLists.txt
@@ -2,8 +2,8 @@ find_package(GTest REQUIRED)
 
 add_executable(ccron_table_test ccron_table_test.cpp)
 add_test(ccron_table_test ccron_table_test)
-target_link_libraries(ccron_table_test GTest::Main ccron corebft)
+target_link_libraries(ccron_table_test GTest::Main corebft)
 
 add_executable(ccron_ticks_generator_test ccron_ticks_generator_test.cpp)
 add_test(ccron_ticks_generator_test ccron_ticks_generator_test)
-target_link_libraries(ccron_ticks_generator_test GTest::Main ccron corebft)
+target_link_libraries(ccron_ticks_generator_test GTest::Main corebft)

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -27,6 +27,10 @@
 #include "bftengine/DbMetadataStorage.hpp"
 #include "storage_factory_interface.h"
 #include "ControlStateManager.hpp"
+
+#include <ccron/cron_table_registry.hpp>
+#include <ccron/ticks_generator.hpp>
+
 namespace concord::kvbc {
 
 class Replica : public IReplica,
@@ -118,6 +122,9 @@ class Replica : public IReplica,
 
   bftEngine::IStateTransfer &getStateTransfer() { return *m_stateTransfer; }
 
+  const std::shared_ptr<cron::CronTableRegistry> &cronTableRegistry() const { return cronTableRegistry_; }
+  std::shared_ptr<cron::TicksGenerator> ticksGenerator() const { return m_replicaPtr->ticksGenerator(); }
+
   ~Replica() override;
 
  protected:
@@ -178,7 +185,7 @@ class Replica : public IReplica,
   // and there is no instance of SecretsManagerEnc available
   const std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsManager_;
   std::unique_ptr<concord::kvbc::StReconfigurationHandler> stReconfigurationSM_;
-
+  std::shared_ptr<cron::CronTableRegistry> cronTableRegistry_{std::make_shared<cron::CronTableRegistry>()};
 };  // namespace concord::kvbc
 
 }  // namespace concord::kvbc

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -122,7 +122,7 @@ class Replica : public IReplica,
 
   bftEngine::IStateTransfer &getStateTransfer() { return *m_stateTransfer; }
 
-  const std::shared_ptr<cron::CronTableRegistry> &cronTableRegistry() const { return cronTableRegistry_; }
+  std::shared_ptr<cron::CronTableRegistry> cronTableRegistry() const { return cronTableRegistry_; }
   std::shared_ptr<cron::TicksGenerator> ticksGenerator() const { return m_replicaPtr->ticksGenerator(); }
 
   ~Replica() override;

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -52,7 +52,7 @@ Status Replica::start() {
 
   if (replicaConfig_.isReadOnly) {
     LOG_INFO(logger, "ReadOnly mode");
-    auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler);
+    auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler, cronTableRegistry_);
     requestHandler->setReconfigurationHandler(std::make_shared<pruning::ReadOnlyReplicaPruningHandler>(*this));
     m_replicaPtr = bftEngine::IReplica::createNewRoReplica(replicaConfig_, requestHandler, m_stateTransfer, m_ptrComm);
   } else {
@@ -69,7 +69,7 @@ Status Replica::start() {
 }
 
 void Replica::createReplicaAndSyncState() {
-  auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler);
+  auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler, cronTableRegistry_);
   stReconfigurationSM_->registerHandler(m_cmdHandler->getReconfigurationHandler());
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this));

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -133,3 +133,7 @@ endif()
 add_test(NAME skvbc_pyclient_tests COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_pyclient_tests python3 -m unittest test_skvbc_pyclient ${TEST_OUTPUT}"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME skvbc_cron COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_cron python3 -m unittest test_skvbc_cron ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/apollo/test_skvbc_cron.py
+++ b/tests/apollo/test_skvbc_cron.py
@@ -1,0 +1,73 @@
+# Concord
+#
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os.path
+import unittest
+
+import trio
+
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+
+expected_number_of_executes = 3
+
+def start_replica_cmd(builddir, replica_id):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    Note each arguments is an element in a list.
+    """
+    status_timer_milli = "500"
+    view_change_timeout_milli = "10000"
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", status_timer_milli,
+            "-v", view_change_timeout_milli,
+            "-e", str(True),
+            "-r", str(expected_number_of_executes)
+            ]
+
+class SkvbcTestCron(unittest.TestCase):
+    __test__ = False  # so that PyTest ignores this test scenario
+
+    period_after_executes_seconds = 7
+    expected_component_id = "42"
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
+    async def test_cron_action_called_correct_number_of_times(self, bft_network):
+        """
+        Test that Concord Cron actions are called the correct number of times.
+
+        Instruct TesterReplica to add a cron entry that is executed a specific
+        number of times. Verify that number after an additional period of time,
+        ensuring that the cron table doesn't execute the entry any more, even
+        though ticks generation is proceeding.
+        """
+        bft_network.start_all_replicas()
+
+        # Since the cron entry is called every second, wait for the number of expected executes + a period after them.
+        await trio.sleep(seconds=expected_number_of_executes + self.period_after_executes_seconds)
+
+        for r in bft_network.all_replicas():
+          # Make sure the number of executes is exactly as expected and not more, even after an additional period has elapsed.
+          num_executes = await bft_network.get_metric(r, bft_network, "Gauges", "cron_entry_number_of_executes", "cron_test")
+          self.assertEqual(num_executes, expected_number_of_executes)
+
+          # Make sure the component ID in ticks is correct.
+          component_id = await bft_network.get_metric(r, bft_network, "Statuses", "cron_ticks_component_id", "cron_test")
+          self.assertEqual(component_id, self.expected_component_id)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -68,6 +68,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::string logPropsFile = "logging.properties";
     std::string principalsMapping;
     std::string txnSigningKeysPath;
+    std::optional<std::uint32_t> cronEntryNumberOfExecutes;
 
     static struct option longOptions[] = {{"replica-id", required_argument, 0, 'i'},
                                           {"key-file-prefix", required_argument, 0, 'k'},
@@ -87,11 +88,12 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"principals-mapping", optional_argument, 0, 'p'},
                                           {"txn-signing-key-path", optional_argument, 0, 't'},
                                           {"operator-public-key-path", optional_argument, 0, 'o'},
+                                          {"cron-entry-number-of-executes", optional_argument, 0, 'r'},
                                           {0, 0, 0, 0}};
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
-    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:l:e:c:b:m:q:z:y:u:p:t:o:", longOptions, &optionIndex)) != -1) {
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:l:e:c:b:m:q:z:y:u:p:t:o:r:", longOptions, &optionIndex)) != -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -173,6 +175,10 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           replicaConfig.pathToOperatorPublicKey_ = optarg;
           break;
         }
+        case 'r': {
+          cronEntryNumberOfExecutes = concord::util::to<std::uint32_t>(optarg);
+          break;
+        }
         case '?': {
           throw std::runtime_error("invalid arguments");
         } break;
@@ -223,7 +229,8 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                                     metricsPort,
                                                     persistMode == PersistencyMode::RocksDB,
                                                     s3ConfigFile,
-                                                    logPropsFile});
+                                                    logPropsFile,
+                                                    cronEntryNumberOfExecutes});
 
   } catch (const std::exception& e) {
     LOG_FATAL(GL, "failed to parse command line arguments: " << e.what());

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -13,7 +13,9 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
+#include <optional>
 #include <utility>
 #include "ReplicaConfig.hpp"
 #include "communication/ICommunication.hpp"
@@ -42,6 +44,10 @@ class TestSetup {
   const bool UsePersistentStorage() const { return usePersistentStorage_; }
   std::string getLogPropertiesFile() { return logPropsFile_; }
   std::shared_ptr<concord::performance::PerformanceManager> GetPerformanceManager() { return pm_; }
+  std::optional<std::uint32_t> GetCronEntryNumberOfExecutes() const { return cronEntryNumberOfExecutes_; }
+
+  static inline constexpr auto kCronTableComponentId = 42;
+  static inline constexpr auto kTickGeneratorPeriod = std::chrono::seconds{1};
 
  private:
   TestSetup(const bftEngine::ReplicaConfig& config,
@@ -50,7 +56,8 @@ class TestSetup {
             uint16_t metricsPort,
             bool usePersistentStorage,
             const std::string& s3ConfigFile,
-            const std::string& logPropsFile)
+            const std::string& logPropsFile,
+            const std::optional<std::uint32_t>& cronEntryNumberOfExecutes)
       : replicaConfig_(config),
         communication_(std::move(comm)),
         logger_(logger),
@@ -58,7 +65,8 @@ class TestSetup {
         usePersistentStorage_(usePersistentStorage),
         s3ConfigFile_(s3ConfigFile),
         logPropsFile_(logPropsFile),
-        pm_{std::make_shared<concord::performance::PerformanceManager>()} {}
+        pm_{std::make_shared<concord::performance::PerformanceManager>()},
+        cronEntryNumberOfExecutes_{cronEntryNumberOfExecutes} {}
 
   TestSetup() = delete;
 
@@ -79,6 +87,7 @@ class TestSetup {
   std::string s3ConfigFile_;
   std::string logPropsFile_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
+  std::optional<std::uint32_t> cronEntryNumberOfExecutes_;
 };
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
Wire Concord Cron (ccron) so that users can take advantage of it. In
general, there are 2 main components that users need to operate ccron
and they are both exposed by kvbc::Replica:
 * TicksGenerator
 * CronTableRegistry

Add the `ticksGeneratorPollPeriod` replica configuration option with a
default value of 1 second. It controls how often the ticks generator
wakes up and, consequently, fires pending ticks. This option specifies
the resolution of cron entry triggers and not how often an entry is
executed - that is dependent on the entry's rule.

Dispatch TickInternalMsg messages to the ticks generator in
ReplicaImp.

Call the relevant cron table from the cron table registry on a tick
ClientRequestMsg in RequestHandler.

Add a ccron reserved pages client and use it directly. Remove the
IReservedPages parameter from periodic action functions.

Add the `skvbc_cron` Apollo test with a single basic test that,
nevertheless, tests Concord Cron end to end. More tests will be added in
the future.

For the time being, the `ccron` library is removed and ccron is part of
the `corbeft` library. Rationale is explained in the
ccron/CMakeLists.txt file. To sum it up here, doing it doesn't break
encapsulation and doesn't require huge amounts of refactoring.