### PR TITLE
Add/remove integration with read only replica

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -59,12 +59,15 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   void setEraseMetadataFlag(int64_t currentSeqNum);
   std::optional<int64_t> getEraseMetadataFlag();
 
+  void markRemoveMetadata() { remove_metadata_(); }
   void clearCheckpointToStopAt();
   void setPruningProcess(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
   bool getPruningProcessStatus() const { return onPruningProcess_; }
 
   void disable() { enabled_ = false; }
   void enable() { enabled_ = true; }
+
+  void setRemoveMetadataFunc(std::function<void()> fn) { remove_metadata_ = fn; }
 
  private:
   ControlStateManager() { scratchPage_.resize(sizeOfReservedPage()); }
@@ -75,5 +78,6 @@ class ControlStateManager : public ResPagesClient<ControlStateManager,
   bool enabled_ = true;
   ControlStatePage page_;
   std::atomic_bool onPruningProcess_ = false;
+  std::function<void()> remove_metadata_;
 };
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -23,6 +23,7 @@ class IReplicaForStateTransfer;  // forward definition
 
 class IStateTransfer : public IReservedPages {
  public:
+  enum StateTransferCallBacksPriorities { HIGH = 0, DEFAULT = 20, LOW = 40 };
   virtual ~IStateTransfer() {}
 
   // The methods of this interface will always be called by the same thread of
@@ -68,7 +69,9 @@ class IStateTransfer : public IReservedPages {
   // Accepts the checkpoint number as a parameter.
   // Callbacks must not throw.
   // Multiple callbacks can be added.
-  virtual void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) = 0;
+  virtual void addOnTransferringCompleteCallback(
+      std::function<void(uint64_t)>,
+      StateTransferCallBacksPriorities priority = StateTransferCallBacksPriorities::DEFAULT) = 0;
 
   virtual void setEraseMetadataFlag() = 0;
 };

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -95,7 +95,9 @@ class BCStateTran : public IStateTransfer {
 
   std::string getStatus() override;
 
-  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) override;
+  void addOnTransferringCompleteCallback(
+      std::function<void(uint64_t)>,
+      StateTransferCallBacksPriorities priority = StateTransferCallBacksPriorities::DEFAULT) override;
 
   void setEraseMetadataFlag() override { psd_->setEraseDataStoreFlag(); }
 
@@ -426,7 +428,7 @@ class BCStateTran : public IStateTransfer {
 
   mutable Metrics metrics_;
 
-  concord::util::CallbackRegistry<uint64_t> on_transferring_complete_cb_registry_;
+  std::map<uint64_t, concord::util::CallbackRegistry<uint64_t>> on_transferring_complete_cb_registry_;
 
   ///////////////////////////////////////////////////////////////////////////
   // Internal Statistics

--- a/bftengine/src/bftengine/NullStateTransfer.hpp
+++ b/bftengine/src/bftengine/NullStateTransfer.hpp
@@ -42,7 +42,8 @@ class NullStateTransfer : public IStateTransfer {
   virtual void onTimer() override;
   virtual void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override;
 
-  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) override{};
+  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>,
+                                         StateTransferCallBacksPriorities priority) override{};
   void setEraseMetadataFlag() override {}
   virtual ~NullStateTransfer();
 

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -39,6 +39,7 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                   metrics_.RegisterCounter("receivedInvalidMsgs"),
                   metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)} {
   LOG_INFO(GL, "");
+  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&]() { stateTransfer->setEraseMetadataFlag(); });
   repsInfo = new ReplicasInfo(config, dynamicCollectorForPartialProofs, dynamicCollectorForExecutionProofs);
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint,
                                    bind(&ReadOnlyReplica::messageHandler<CheckpointMsg>, this, std::placeholders::_1));

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -77,7 +77,8 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
   void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override;
 
-  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>) override {}
+  void addOnTransferringCompleteCallback(std::function<void(uint64_t)>,
+                                         StateTransferCallBacksPriorities priority) override {}
 
   //////////////////////////////////////////////////////////////////////////
   // ISimpleInMemoryStateTransfer methods

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -26,7 +26,8 @@ namespace concord::kvbc {
 class StReconfigurationHandler {
  public:
   StReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
-    st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); });
+    st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); },
+                                         bftEngine::IStateTransfer::StateTransferCallBacksPriorities::HIGH);
   }
 
   void registerHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> handler) {

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -56,7 +56,7 @@ class StReconfigurationHandler {
 
   bool handle(const concord::messages::KeyExchangeCommand&, uint64_t, uint64_t) { return true; }
   bool handle(const concord::messages::AddRemoveCommand&, uint64_t, uint64_t) { return true; }
-  bool handle(const concord::messages::AddRemoveWithWedgeCommand&, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::AddRemoveWithWedgeCommand&, uint64_t, uint64_t);
   kvbc::IReader& ro_storage_;
   std::vector<std::shared_ptr<concord::reconfiguration::IReconfigurationHandler>> orig_reconf_handlers_;
 };

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -73,10 +73,10 @@ bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedg
                                // wait for restart
     if (command.bft) {
       bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack(
-          [=]() { bftEngine::ControlStateManager::instance().setEraseMetadataFlag(bft_seq_num); });
+          [=]() { bftEngine::ControlStateManager::instance().markRemoveMetadata(); });
     } else {
       bftEngine::IControlHandler::instance()->addOnSuperStableCheckpointCallBack(
-          [=]() { bftEngine::ControlStateManager::instance().setEraseMetadataFlag(bft_seq_num); });
+          [=]() { bftEngine::ControlStateManager::instance().markRemoveMetadata(); });
     }
   }
   return true;

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -13,6 +13,8 @@
 #include "st_reconfiguraion_sm.hpp"
 #include "hex_tools.h"
 #include "endianness.hpp"
+#include "SysConsts.hpp"
+#include "ControlStateManager.hpp"
 
 namespace concord::kvbc {
 template <typename T>
@@ -59,6 +61,25 @@ bool StReconfigurationHandler::handlerStoredCommand(const std::string &key, uint
     return handle(cmd, seqNum, current_cp_num);
   }
   return false;
+}
+
+bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand &command,
+                                      uint64_t bft_seq_num,
+                                      uint64_t current_cp_num) {
+  auto cp_sn = checkpointWindowSize * current_cp_num;
+  auto wedge_point = (bft_seq_num + 2 * checkpointWindowSize);
+  wedge_point = wedge_point - (wedge_point % checkpointWindowSize);
+  if (cp_sn == wedge_point) {  // We got to the wedge point, we now need to set a flag to remove the metadata and to
+                               // wait for restart
+    if (command.bft) {
+      bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack(
+          [=]() { bftEngine::ControlStateManager::instance().setEraseMetadataFlag(bft_seq_num); });
+    } else {
+      bftEngine::IControlHandler::instance()->addOnSuperStableCheckpointCallBack(
+          [=]() { bftEngine::ControlStateManager::instance().setEraseMetadataFlag(bft_seq_num); });
+    }
+  }
+  return true;
 }
 
 }  // namespace concord::kvbc

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -439,7 +439,10 @@ class TestStorage : public IReader, public IBlockAdder, public IBlocksDeleter {
 
 class TestStateTransfer : public bftEngine::impl::NullStateTransfer {
  public:
-  void addOnTransferringCompleteCallback(std::function<void(uint64_t)> callback) override { callback_ = callback; }
+  void addOnTransferringCompleteCallback(std::function<void(uint64_t)> callback,
+                                         StateTransferCallBacksPriorities priority) override {
+    callback_ = callback;
+  }
 
   void complete() { callback_(0); }
 

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -64,10 +64,10 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
   if (command.bft) {
     bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack(
-        [=]() { bftEngine::ControlStateManager::instance().setEraseMetadataFlag(bft_seq_num); });
+        [=]() { bftEngine::ControlStateManager::instance().markRemoveMetadata(); });
   } else {
     bftEngine::IControlHandler::instance()->addOnSuperStableCheckpointCallBack(
-        [=]() { bftEngine::ControlStateManager::instance().setEraseMetadataFlag(bft_seq_num); });
+        [=]() { bftEngine::ControlStateManager::instance().markRemoveMetadata(); });
   }
   return true;
 }  // namespace concord::reconfiguration

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -636,8 +636,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
              The test does the following:
              1. A client sends a remove command which will also wedge the system on next next checkpoint
              2. Validate that all replicas have stopped
+             3. Wait for read only replica to done with state transfer
              3. Load  a new configuration to the bft network
              4. Rerun the cluster with only 4 nodes and make sure they succeed to perform transactions in fast path
+             5. Make sure the read only replica is able to catch up with the new state
          """
         bft_network.start_all_replicas()
         ro_replica_id = bft_network.config.n

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -828,7 +828,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_key_exchange, rotate_keys=True, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}])
+    @with_bft_network(start_replica_cmd, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}])
     async def test_add_nodes(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -865,7 +865,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                           c=0,
                           num_clients=10,
                           key_file_prefix=KEY_FILE_PREFIX,
-                          start_replica_cmd=start_replica_cmd_with_key_exchange,
+                          start_replica_cmd=start_replica_cmd,
                           stop_replica_cmd=None,
                           num_ro_replicas=0)
         await bft_network.change_configuration(conf)
@@ -904,7 +904,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                           c=0,
                           num_clients=10,
                           key_file_prefix=KEY_FILE_PREFIX,
-                          start_replica_cmd=start_replica_cmd_with_key_exchange,
+                          start_replica_cmd=start_replica_cmd,
                           stop_replica_cmd=None,
                           num_ro_replicas=0)
         await bft_network.change_configuration(conf)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -626,7 +626,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                    stop_replica_cmd=None,
                    num_ro_replicas=0)
         await bft_network.change_configuration(conf)
-        bft_network.start_all_replicas()
+        await bft_network.check_initital_key_exchange(stop_replicas=False)
+
         for r in bft_network.all_replicas():
             last_stable_checkpoint = await bft_network.get_metric(r, bft_network, "Gauges", "lastStableSeqNum")
             self.assertEqual(last_stable_checkpoint, 0)
@@ -682,7 +683,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                           num_ro_replicas=1)
         await bft_network.change_configuration(conf)
         ro_replica_id = bft_network.config.n
-        bft_network.start_all_replicas()
+        await bft_network.check_initital_key_exchange(stop_replicas=False)
         bft_network.start_replica(ro_replica_id)
 
         for r in bft_network.all_replicas():
@@ -750,7 +751,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 stop_replica_cmd=None,
                 num_ro_replicas=0)
         await bft_network.change_configuration(conf)
-        bft_network.start_all_replicas()
+        await bft_network.check_initital_key_exchange(stop_replicas=False)
+
         for r in bft_network.all_replicas():
             last_stable_checkpoint = await bft_network.get_metric(r, bft_network, "Gauges", "lastStableSeqNum")
             self.assertEqual(last_stable_checkpoint, 0)
@@ -778,7 +780,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         client = bft_network.random_client()
-        for i in range(100):
+        for i in range(151):
             await skvbc.write_known_kv()
         # choose two replicas to crash and crash them
         crashed_replicas = {3} # For simplicity, we crash the last two replicas
@@ -815,7 +817,9 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                           stop_replica_cmd=None,
                           num_ro_replicas=0)
         await bft_network.change_configuration(conf)
-        bft_network.start_all_replicas()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        await bft_network.check_initital_key_exchange(stop_replicas=False)
+
         for r in bft_network.all_replicas():
             last_stable_checkpoint = await bft_network.get_metric(r, bft_network, "Gauges", "lastStableSeqNum")
             self.assertEqual(last_stable_checkpoint, 0)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -37,6 +37,17 @@ def start_replica_cmd_with_object_store(builddir, replica_id, config):
     ret.extend(["-b", "2", "-q", "1", "-o", builddir + "/operator_pub.pem"])
     return ret
 
+def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
+    """
+    Return a command that starts an skvbc replica when passed to
+    subprocess.Popen.
+
+    Note each arguments is an element in a list.
+    """
+    ret = start_replica_cmd_prefix(builddir, replica_id, config)
+    ret.extend(["-b", "2", "-q", "1", "-e", str(True), "-o", builddir + "/operator_pub.pem"])
+    return ret
+
 def start_replica_cmd(builddir, replica_id):
     """
     Return a command that starts an skvbc replica when passed to
@@ -611,7 +622,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                    c=0,
                    num_clients=10,
                    key_file_prefix=KEY_FILE_PREFIX,
-                   start_replica_cmd=start_replica_cmd,
+                   start_replica_cmd=start_replica_cmd_with_key_exchange,
                    stop_replica_cmd=None,
                    num_ro_replicas=0)
         await bft_network.change_configuration(conf)
@@ -628,7 +639,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
 
     @with_trio
-    @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
+                      selected_configs=lambda n, f, c: n == 7)
     async def test_remove_nodes_with_ror(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -645,7 +657,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         ro_replica_id = bft_network.config.n
         bft_network.start_replica(ro_replica_id)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(149): # Produce 299 new blocks
+        for i in range(148): # Produce 149 new blocks
             await skvbc.write_known_kv()
         key, val = await skvbc.write_known_kv()
         client = bft_network.random_client()
@@ -665,7 +677,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                           c=0,
                           num_clients=10,
                           key_file_prefix=KEY_FILE_PREFIX,
-                          start_replica_cmd=start_replica_cmd_with_object_store,
+                          start_replica_cmd=start_replica_cmd_with_object_store_and_ke,
                           stop_replica_cmd=None,
                           num_ro_replicas=1)
         await bft_network.change_configuration(conf)
@@ -734,7 +746,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 c=0,
                 num_clients=10,
                 key_file_prefix=KEY_FILE_PREFIX,
-                start_replica_cmd=start_replica_cmd,
+                start_replica_cmd=start_replica_cmd_with_key_exchange,
                 stop_replica_cmd=None,
                 num_ro_replicas=0)
         await bft_network.change_configuration(conf)
@@ -747,106 +759,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             await skvbc.write_known_kv()
         for r in bft_network.all_replicas():
             assert (r < 4)
-            nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
-            self.assertGreater(nb_fast_path, 0)
-    
-    @with_trio
-    @with_bft_network(start_replica_cmd_with_key_exchange, rotate_keys=True, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}])
-    async def test_add_nodes(self, bft_network):
-        """
-             Sends a addRemove command and checks that new configuration is written to blockchain.
-             Note that in this test we assume no failures and synchronized network.
-             The test does the following:
-             1. A client sends a add node command which will also wedge the system on next next checkpoint
-             2. Validate that all replicas have stopped
-             3. Load a new configuration to the bft network
-             4. Add node is done in phases, (n=4,f=1,c=0)->(n=6,f=1,c=0)->(n=7,f=2,c=0)
-                Note: For new replicas to catch up with exiting replicas through ST, existing replicas must
-                      move the checkpoint window, that means for n=7 configuration, there must be 5 non-faulty 
-                      replicas to move the checkpoint window, hence new replicas are added in two phases
-             5. Rerun the cluster with only new configuration and make sure they succeed to perform transactions in fast path
-         """
-        bft_network.start_all_replicas()
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(100):
-            await skvbc.write_known_kv()
-        client = bft_network.random_client()
-        client.config._replace(req_timeout_milli=10000)
-        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
-        op = operator.Operator(bft_network.config, client,  bft_network.builddir)
-        test_config = 'new_configuration_n_6_f_1_c_0'
-        await op.add_remove_with_wedge(test_config)
-        await self.verify_replicas_are_in_wedged_checkpoint(bft_network, checkpoint_before, range(bft_network.config.n))
-        await self.verify_last_executed_seq_num(bft_network, checkpoint_before)
-        await self.validate_stop_on_stable_checkpoint(bft_network, skvbc)
-        await self.verify_add_remove_status(bft_network, test_config, quorum_all=False)
-        bft_network.stop_all_replicas()
-        # We now expect the replicas to start with a fresh new configuration
-        # Metadata is erased on replicas startup
-        conf = TestConfig(n=6,
-                   f=1,
-                   c=0,
-                   num_clients=10,
-                   key_file_prefix=KEY_FILE_PREFIX,
-                   start_replica_cmd=start_replica_cmd,
-                   stop_replica_cmd=None,
-                   num_ro_replicas=0)
-        await bft_network.change_configuration(conf)
-        initial_prim = 0
-        new_replicas = {4, 5}
-        on_time_replicas = bft_network.all_replicas(without=new_replicas)
-        bft_network.start_replicas(on_time_replicas)
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(151):
-            await skvbc.write_known_kv()
-        bft_network.start_replicas(new_replicas)
-        await bft_network.wait_for_state_transfer_to_start()
-        for r in new_replicas:
-            await bft_network.wait_for_state_transfer_to_stop(initial_prim,
-                                                              r,
-                                                              stop_on_stable_seq_num=False)
-        for i in range(200):
-            await skvbc.write_known_kv()
-        for r in bft_network.all_replicas():
-            nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
-            self.assertGreater(nb_fast_path, 0)
-        client = bft_network.random_client()
-        client.config._replace(req_timeout_milli=10000)
-        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
-        op = operator.Operator(bft_network.config, client,  bft_network.builddir)
-        test_config = 'new_configuration_n_7_f_2_c_0'
-        await op.add_remove_with_wedge(test_config)
-        await self.verify_replicas_are_in_wedged_checkpoint(bft_network, checkpoint_before, range(bft_network.config.n))
-        await self.verify_last_executed_seq_num(bft_network, checkpoint_before)
-        await self.validate_stop_on_stable_checkpoint(bft_network, skvbc)
-        await self.verify_add_remove_status(bft_network, test_config, quorum_all=False)
-        bft_network.stop_all_replicas()
-    
-        conf = TestConfig(n=7,
-                   f=2,
-                   c=0,
-                   num_clients=10,
-                   key_file_prefix=KEY_FILE_PREFIX,
-                   start_replica_cmd=start_replica_cmd,
-                   stop_replica_cmd=None,
-                   num_ro_replicas=0)
-        await bft_network.change_configuration(conf)
-        initial_prim = 0
-        new_replicas = {6}
-        on_time_replicas = bft_network.all_replicas(without=new_replicas)
-        bft_network.start_replicas(on_time_replicas)
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(151):
-            await skvbc.write_known_kv()
-        bft_network.start_replicas(new_replicas)
-        await bft_network.wait_for_state_transfer_to_start()
-        for r in new_replicas:
-            await bft_network.wait_for_state_transfer_to_stop(initial_prim,
-                                                              r,
-                                                              stop_on_stable_seq_num=False)
-        for i in range(300):
-            await skvbc.write_known_kv()
-        for r in bft_network.all_replicas():
             nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
             self.assertGreater(nb_fast_path, 0)
 
@@ -888,7 +800,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                           c=0,
                           num_clients=10,
                           key_file_prefix=KEY_FILE_PREFIX,
-                          start_replica_cmd=start_replica_cmd,
+                          start_replica_cmd=start_replica_cmd_with_key_exchange,
                           stop_replica_cmd=None,
                           num_ro_replicas=0)
         await bft_network.change_configuration(conf)
@@ -927,7 +839,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                           c=0,
                           num_clients=10,
                           key_file_prefix=KEY_FILE_PREFIX,
-                          start_replica_cmd=start_replica_cmd,
+                          start_replica_cmd=start_replica_cmd_with_key_exchange,
                           stop_replica_cmd=None,
                           num_ro_replicas=0)
         await bft_network.change_configuration(conf)

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -1246,7 +1246,7 @@ class BftTestNetwork:
             
         return await self.wait_for(the_number_of_slow_path_requests, 5, .5)
         
-    async def check_initital_key_exchange(self):
+    async def check_initital_key_exchange(self, stop_replicas=True):
         """
         Performs initial key exchange, starts all replicas, validate the exchange and stops all replicas.
         The stop is done in order for a test who uses this functionality, to proceed without imposing n up replicas.
@@ -1280,7 +1280,8 @@ class BftTestNetwork:
             with trio.fail_after(seconds=5):
                 lastExecutedKey = ['replica', 'Gauges', 'lastExecutedSeqNum']
                 lastExecutedVal = await self.metrics.get(0, *lastExecutedKey)
-            self.stop_all_replicas()
+            if stop_replicas:
+                self.stop_all_replicas()
             return lastExecutedVal
 
     async def assert_successful_pre_executions_count(self, replica_id, num_requests):


### PR DESCRIPTION
In this PR we present add/Remove functionality in read-only replica via state transfer mechanism.
For this we added the following:
1. priorities in state-transfer callbacks (we need the reconfiguration call back to be called first)
2. Handler for addRemove command in reconfiguration state transfer handler
3. The handler is invoked only if the state transfer checkpoint is equal to the wedge point, which prevents multiple invocations for the same reconfiguration action once we continue beyond it.
Note that this solution also solves the scenario of late replicas.

In addition, we fixed some more issues:
1. We mark directly to remove the metadata (instead of raising a flag to mark it)
2. We add an Apollo test for removing nodes with a read-only replica
3. We add an Apollo test for removing nodes with late replica 
4. We fixed the key exchange feature in the tests
