### PR TITLE
Unordered_map race condition fix

### DIFF
--- a/bftengine/src/bcstatetransfer/MsgsCertificate.hpp
+++ b/bftengine/src/bcstatetransfer/MsgsCertificate.hpp
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <unordered_map>
 #include <forward_list>
+#include <atomic>
 
 namespace bftEngine {
 namespace bcst {
@@ -74,7 +75,7 @@ class MsgsCertificate {
   const uint16_t required;
   const uint16_t selfId;
 
-  std::unordered_map<uint16_t, T*> msgsFromReplicas;
+  std::unordered_map<uint16_t, std::atomic<T*>> msgsFromReplicas;
 
   struct MsgClassInfo {
     uint16_t size;


### PR DESCRIPTION
This PR fixes a race-condition observed in reading and writing an unordered_map, while running thread sanitiser on back of crash observed in Concord.

In favour of performance, have avoided using locks. Instead, I have made value part of unordered_map as atomic so that reader thread doesn't read a stale value while writer has updated the value for that key.