### PR TITLE
This PR fixes a race condition observed in accessing variable beginningOfActiveWindow from two threads

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -109,7 +109,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]
-  typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo, 1> WindowOfSeqNumInfo;
+  typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo, 1, false> WindowOfSeqNumInfo;
   std::shared_ptr<WindowOfSeqNumInfo> mainLog;
 
   // bounded log used to store information about checkpoints in the range [lastStableSeqNum,lastStableSeqNum +

--- a/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
+++ b/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include <utility>
+#include <type_traits>
 #include "assertUtils.hpp"
 
 // TODO(GG): ItemFuncs should have operations on ItemType: init, free, reset, save, load
@@ -94,7 +95,8 @@ template <uint16_t WindowSize,
           typename NumbersType,
           typename ItemType,
           typename ItemFuncs,
-          uint16_t WindowHistory = 0>
+          uint16_t WindowHistory = 0,
+          bool TypeSelection = true>
 class SequenceWithActiveWindow {
   static_assert(WindowSize >= 8, "");
   static_assert(WindowSize < UINT16_MAX, "");
@@ -105,7 +107,7 @@ class SequenceWithActiveWindow {
  protected:
   static const uint16_t numItems = WindowSize / Resolution;
 
-  NumbersType beginningOfActiveWindow;
+  typename std::conditional<TypeSelection, NumbersType, std::atomic<NumbersType>>::type beginningOfActiveWindow;
   ItemType activeWindow[numItems];
   InactiveStorage<Resolution, NumbersType, ItemType, ItemFuncs> inactiveStorage;
 


### PR DESCRIPTION
I have made this variable conditional atomic as it is not required to be atomic in all cases, only for the case reported using thread sanitiser. In our case only mainLog template instantiation is the culprit.