### PR TITLE
Fix skvbc_pyclient_tests.test_m_of_n_quorum 

### DIFF
--- a/tests/apollo/test_skvbc_pyclient.py
+++ b/tests/apollo/test_skvbc_pyclient.py
@@ -178,11 +178,12 @@ class SkvbcPyclientTest(unittest.TestCase):
         kv_pair = [(key, value)]
         await client.write(protocol.write_req([], kv_pair, 0))
 
-        quorum = MofNQuorum(bft_network.all_replicas(), 1)
+        quorum = MofNQuorum.ByzantineSafeQuorum(
+            bft_network.config, bft_network.all_replicas())
         read_result = await client.read(protocol.read_req([key]), \
                                         m_of_n_quorum=quorum)
         value_read = (protocol.parse_reply(read_result))[key]
-        self.assertEqual(value, value_read, "Using an M of N Quorum of M==1, " \
+        self.assertEqual(value, value_read, "Using an M of N Quorum of M==f+1, "
                 "A BFT Client failed to read a key-value pair from a " \
                 "SimpleKVBC cluster matching the key-value pair it wrote " \
                 "immediately prior to the read.")


### PR DESCRIPTION
The test creates a write request and waits for 2f + c + 1 quorum.
After that it creates a read requests but it waits for only 1 quorum.
In rare cases we may get a "split brain" and read from a slower replica that hasn't written the first request yet.
With this change, the read quorum is changed from 1 to f+1