### PR TITLE
Logging: Change default format

### DIFF
--- a/logging/include/Logging.hpp
+++ b/logging/include/Logging.hpp
@@ -65,11 +65,17 @@ class LoggerImpl {
     struct timeval cur_time;
     gettimeofday(&cur_time, NULL);
 
-    std::cout << getThreadContext().getMDC().get(MDC_REPLICA_ID_KEY) << "|"
-              << std::put_time(std::localtime(&cur_time.tv_sec), "%F %T.") << (int)cur_time.tv_usec / 1000 << "|"
-              << LoggerImpl::LEVELS_STRINGS[l].c_str() << "|" << name_ << "|"
-              << getThreadContext().getMDC().get(MDC_THREAD_KEY) << "|" << getThreadContext().getMDC().get(MDC_CID_KEY)
-              << "|" << getThreadContext().getMDC().get(MDC_SEQ_NUM_KEY) << "|" << func << "|";
+    // clang-format off
+    std::cout << std::put_time(std::localtime(&cur_time.tv_sec), "%FT%T.") << (int)cur_time.tv_usec / 1000
+       << "|" << LoggerImpl::LEVELS_STRINGS[l].c_str()
+       << "|" << getThreadContext().getMDC().get(MDC_REPLICA_ID_KEY)
+       << "|" << name_
+       << "|" << getThreadContext().getMDC().get(MDC_THREAD_KEY)
+       << "|" << getThreadContext().getMDC().get(MDC_CID_KEY)
+       << "|" << getThreadContext().getMDC().get(MDC_SEQ_NUM_KEY)
+       << "|" << func
+       << "|";
+    // clang-format on
     return std::cout;
   }
 

--- a/logging/src/Logging4cplus.cpp
+++ b/logging/src/Logging4cplus.cpp
@@ -24,7 +24,7 @@ using namespace log4cplus;
 
 namespace logging {
 
-static const char* logPattern = "%X{rid}|%d{%m-%d-%Y %H:%M:%S.%q}|%-5p|%c|%X{cid}|%X{sn}|%X{thread}|%b:%L|%M|%m%n";
+static const char* logPattern = "%d{%Y-%m-%dT%H:%M:%S,%qZ}|%-5p|%X{rid}|%c|%X{thread}|%X{cid}|%X{sn}|%b:%L|%M|%m%n";
 
 void initLogger(const std::string& configFileName) {
   std::ifstream infile(configFileName);


### PR DESCRIPTION
This change aligns with the closed-source logging format. The main motivation
is to print the timestamp first so that messages can be sorted by the order in
which they appear. Having the replcia ID in the front makes sense when all
replicas print to the same destination. However, that is not the case and when
used in a docker-compose envrionment then it gets prefixed with the container
id anyways.