### PR TITLE
ClientService: Wrapper for gRPC services

### DIFF
--- a/client/clientservice/CMakeLists.txt
+++ b/client/clientservice/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(clientservice PRIVATE
   clientservice-proto
   gRPC::grpc++
   gRPC::grpc++_reflection
+  logging
 )

--- a/client/clientservice/src/client_service.cpp
+++ b/client/clientservice/src/client_service.cpp
@@ -30,6 +30,11 @@ void ClientService::start(const std::string& addr) {
   builder.RegisterService(event_service_.get());
 
   auto clientservice_server = std::unique_ptr<grpc::Server>(builder.BuildAndStart());
+
+  auto health = clientservice_server->GetHealthCheckService();
+  health->SetServingStatus(kRequestService, true);
+  health->SetServingStatus(kEventService, true);
+
   clientservice_server->Wait();
 }
 

--- a/client/clientservice/src/client_service.cpp
+++ b/client/clientservice/src/client_service.cpp
@@ -16,11 +16,6 @@
 
 namespace concord::client::clientservice {
 
-ClientService::ClientService() {
-  request_service_ = std::make_unique<RequestServiceImpl>();
-  event_service_ = std::make_unique<EventServiceImpl>();
-}
-
 void ClientService::start(const std::string& addr) {
   grpc::EnableDefaultHealthCheckService(true);
 

--- a/client/clientservice/src/client_service.cpp
+++ b/client/clientservice/src/client_service.cpp
@@ -1,0 +1,36 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client_service.hpp"
+
+#include <concord_client.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
+
+namespace concord::client::clientservice {
+
+ClientService::ClientService() {
+  request_service_ = std::make_unique<RequestServiceImpl>();
+  event_service_ = std::make_unique<EventServiceImpl>();
+}
+
+void ClientService::start(const std::string& addr) {
+  grpc::EnableDefaultHealthCheckService(true);
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(addr, grpc::InsecureServerCredentials());
+  builder.RegisterService(request_service_.get());
+  builder.RegisterService(event_service_.get());
+
+  auto clientservice_server = std::unique_ptr<grpc::Server>(builder.BuildAndStart());
+  clientservice_server->Wait();
+}
+
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/client_service.hpp
+++ b/client/clientservice/src/client_service.hpp
@@ -14,18 +14,24 @@
 
 #include "event_service.hpp"
 #include "request_service.hpp"
+#include "Logger.hpp"
 
 namespace concord::client::clientservice {
 
 class ClientService {
  public:
-  ClientService();
+  ClientService()
+      : logger_(logging::getLogger("concord.client.clientservice")),
+        event_service_(std::make_unique<EventServiceImpl>()),
+        request_service_(std::make_unique<RequestServiceImpl>()){};
+
   void start(const std::string& addr);
 
   const std::string kRequestService{"vmware.concord.client.v1.RequestService"};
   const std::string kEventService{"vmware.concord.client.v1.EventService"};
 
  private:
+  logging::Logger logger_;
   std::unique_ptr<EventServiceImpl> event_service_;
   std::unique_ptr<RequestServiceImpl> request_service_;
 };

--- a/client/clientservice/src/client_service.hpp
+++ b/client/clientservice/src/client_service.hpp
@@ -22,6 +22,9 @@ class ClientService {
   ClientService();
   void start(const std::string& addr);
 
+  const std::string kRequestService{"vmware.concord.client.v1.RequestService"};
+  const std::string kEventService{"vmware.concord.client.v1.EventService"};
+
  private:
   std::unique_ptr<EventServiceImpl> event_service_;
   std::unique_ptr<RequestServiceImpl> request_service_;

--- a/client/clientservice/src/client_service.hpp
+++ b/client/clientservice/src/client_service.hpp
@@ -9,20 +9,22 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <iostream>
 #include <memory>
-#include <grpcpp/grpcpp.h>
+#include <string>
 
-#include "client_service.hpp"
+#include "event_service.hpp"
+#include "request_service.hpp"
 
-using concord::client::clientservice::ClientService;
+namespace concord::client::clientservice {
 
-int main(int argc, char** argv) {
-  std::cout << "Starting Clientservice" << std::endl;
+class ClientService {
+ public:
+  ClientService();
+  void start(const std::string& addr);
 
-  // TODO: Create ConcordClient
-  ClientService service;
-  service.start("localhost:1337");
+ private:
+  std::unique_ptr<EventServiceImpl> event_service_;
+  std::unique_ptr<RequestServiceImpl> request_service_;
+};
 
-  return 0;
-}
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -20,7 +20,7 @@ using grpc::ServerWriter;
 using vmware::concord::client::v1::StreamEventGroupsRequest;
 using vmware::concord::client::v1::EventGroup;
 
-namespace concord::client {
+namespace concord::client::clientservice {
 
 Status EventServiceImpl::StreamEventGroups(ServerContext* context,
                                            const StreamEventGroupsRequest* request,
@@ -29,4 +29,4 @@ Status EventServiceImpl::StreamEventGroups(ServerContext* context,
   return grpc::Status::OK;
 }
 
-}  // namespace concord::client
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -25,7 +25,7 @@ namespace concord::client::clientservice {
 Status EventServiceImpl::StreamEventGroups(ServerContext* context,
                                            const StreamEventGroupsRequest* request,
                                            ServerWriter<EventGroup>* stream) {
-  std::cout << "EventServiceImpl::StreamEventGroups called" << std::endl;
+  LOG_INFO(logger_, "EventServiceImpl::StreamEventGroups called");
   return grpc::Status::OK;
 }
 

--- a/client/clientservice/src/event_service.hpp
+++ b/client/clientservice/src/event_service.hpp
@@ -12,13 +12,19 @@
 #include <grpcpp/grpcpp.h>
 #include <concord_client.grpc.pb.h>
 
+#include "Logger.hpp"
+
 namespace concord::client::clientservice {
 
 class EventServiceImpl final : public vmware::concord::client::v1::EventService::Service {
  public:
+  EventServiceImpl() : logger_(logging::getLogger("concord.client.clientservice.event")){};
   grpc::Status StreamEventGroups(grpc::ServerContext* context,
                                  const vmware::concord::client::v1::StreamEventGroupsRequest* request,
                                  grpc::ServerWriter<vmware::concord::client::v1::EventGroup>* stream) override;
+
+ private:
+  logging::Logger logger_;
 };
 
 }  // namespace concord::client::clientservice

--- a/client/clientservice/src/event_service.hpp
+++ b/client/clientservice/src/event_service.hpp
@@ -12,7 +12,7 @@
 #include <grpcpp/grpcpp.h>
 #include <concord_client.grpc.pb.h>
 
-namespace concord::client {
+namespace concord::client::clientservice {
 
 class EventServiceImpl final : public vmware::concord::client::v1::EventService::Service {
  public:
@@ -21,4 +21,4 @@ class EventServiceImpl final : public vmware::concord::client::v1::EventService:
                                  grpc::ServerWriter<vmware::concord::client::v1::EventGroup>* stream) override;
 };
 
-}  // namespace concord::client
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -13,16 +13,21 @@
 #include <memory>
 #include <grpcpp/grpcpp.h>
 
+#include "Logger.hpp"
 #include "client_service.hpp"
 
 using concord::client::clientservice::ClientService;
 
 int main(int argc, char** argv) {
-  std::cout << "Starting Clientservice" << std::endl;
+  // TODO: Use config file and watch thread
+  auto logger = logging::getLogger("concord.client.clientservice.main");
+
+  std::string addr = "localhost:1337";
+  LOG_INFO(logger, "Starting clientservice at " << addr);
 
   // TODO: Create ConcordClient
   ClientService service;
-  service.start("localhost:1337");
+  service.start(addr);
 
   return 0;
 }

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -19,11 +19,11 @@ using grpc::ServerContext;
 using vmware::concord::client::v1::Request;
 using vmware::concord::client::v1::Response;
 
-namespace concord::client {
+namespace concord::client::clientservice {
 
 Status RequestServiceImpl::Send(ServerContext* context, const Request* request, Response* response) {
   std::cout << "RequestService::Send called" << std::endl;
   return grpc::Status::OK;
 }
 
-}  // namespace concord::client
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -22,7 +22,7 @@ using vmware::concord::client::v1::Response;
 namespace concord::client::clientservice {
 
 Status RequestServiceImpl::Send(ServerContext* context, const Request* request, Response* response) {
-  std::cout << "RequestService::Send called" << std::endl;
+  LOG_INFO(logger_, "RequestService::Send called");
   return grpc::Status::OK;
 }
 

--- a/client/clientservice/src/request_service.hpp
+++ b/client/clientservice/src/request_service.hpp
@@ -12,13 +12,19 @@
 #include <grpcpp/grpcpp.h>
 #include <concord_client.grpc.pb.h>
 
+#include "Logger.hpp"
+
 namespace concord::client::clientservice {
 
 class RequestServiceImpl final : public vmware::concord::client::v1::RequestService::Service {
  public:
+  RequestServiceImpl() : logger_(logging::getLogger("concord.client.clientservice.request")){};
   grpc::Status Send(grpc::ServerContext* context,
                     const vmware::concord::client::v1::Request* request,
                     vmware::concord::client::v1::Response* response) override;
+
+ private:
+  logging::Logger logger_;
 };
 
 }  // namespace concord::client::clientservice

--- a/client/clientservice/src/request_service.hpp
+++ b/client/clientservice/src/request_service.hpp
@@ -12,7 +12,7 @@
 #include <grpcpp/grpcpp.h>
 #include <concord_client.grpc.pb.h>
 
-namespace concord::client {
+namespace concord::client::clientservice {
 
 class RequestServiceImpl final : public vmware::concord::client::v1::RequestService::Service {
  public:
@@ -21,4 +21,4 @@ class RequestServiceImpl final : public vmware::concord::client::v1::RequestServ
                     vmware::concord::client::v1::Response* response) override;
 };
 
-}  // namespace concord::client
+}  // namespace concord::client::clientservice


### PR DESCRIPTION
This PR introduces the ClientService class which will host all ClientService related object. This includes the gRPC services, ConcordClient, tracing and metrics. Please check the individual commits for details.