### PR TITLE
Increase maxNumOfRequestsInBatch parameter

### DIFF
--- a/bftengine/src/bftengine/SysConsts.hpp
+++ b/bftengine/src/bftengine/SysConsts.hpp
@@ -63,7 +63,9 @@ static_assert(maxLegalConcurrentAgreementsByPrimary < MaxConcurrentFastPaths,
 // Batching
 ///////////////////////////////////////////////////////////////////////////////
 
-constexpr uint32_t maxNumOfRequestsInBatch = 1024;
+// The number of requests in the consensus batch is controlled by maxExternalMessageSize.
+// This parameter is required to limit a memory allocation for the bitmap.
+constexpr uint32_t maxNumOfRequestsInBatch = 4096;
 constexpr uint32_t maxPrimaryQueueSize = 1500;
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As an internal ReplicaImp queue size has been increased from 700 to 1500, maxNumOfRequestsInBatch needs to be larger, too. The number of requests in the consensus batch is controlled by maxExternalMessageSize and the maxNumOfRequestsInBatch parameter is required only to limit a memory allocation for the bitmap.