### PR TITLE
Define an execution request related CMF msgs

### DIFF
--- a/bftengine/cmf/CMakeLists.txt
+++ b/bftengine/cmf/CMakeLists.txt
@@ -2,3 +2,9 @@ cmf_generate_cpp(header cpp concord::messages::keys_and_signatures keys_and_sign
 add_library(keys_and_signatures_cmf ${cpp})
 set_target_properties(keys_and_signatures_cmf PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(keys_and_signatures_cmf PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+
+cmf_generate_cpp(header cpp concord::messages::execution_data execution_data.cmf)
+add_library(execution_data_cmf ${cpp})
+set_target_properties(execution_data_cmf PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(execution_data_cmf PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/bftengine/cmf/execution_data.cmf
+++ b/bftengine/cmf/execution_data.cmf
@@ -1,0 +1,24 @@
+
+Msg RequestInput 1 {
+    uint16 clientId
+    uint64 executionSequenceNum
+    string cid
+    uint64 flags
+    string request
+    string signature
+    uint64 requestSequenceNum
+}
+
+Msg TimeService 2 {
+    int64 time_since_epoch
+    # If the execution mode is not accumulated i.e. execution of a single request per execute, the command handler 
+    # needs to know the request_position of the request in the list.
+    uint64 request_position
+}
+
+Msg RequestsRecord 3 {
+    list RequestInput requests
+    optional TimeService timestamp
+    uint64 keys_version
+    bool keys_rotated_at_this_block 
+}

--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -39,6 +39,7 @@ class IRequestsHandler {
     uint64_t flags = 0;  // copy of ClientRequestMsg flags
     uint32_t requestSize = 0;
     const char *request;
+    std::string signature;
     uint32_t maxReplySize = 0;
     char *outReply;
     uint64_t requestSequenceNum = executionSequenceNum;

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -190,6 +190,7 @@ void ReadOnlyReplica::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_s
                                                                               request.flags(),
                                                                               request.requestLength(),
                                                                               request.requestBuf(),
+                                                                              "",
                                                                               reply.maxReplyLength(),
                                                                               reply.replyBuf()});
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3870,6 +3870,7 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
                                                                               request->flags(),
                                                                               request->requestLength(),
                                                                               request->requestBuf(),
+                                                                              "",
                                                                               reply.maxReplyLength(),
                                                                               reply.replyBuf()});
   {
@@ -4111,6 +4112,7 @@ void ReplicaImp::executeRequestsAndSendResponses(PrePrepareMsg *ppMsg,
         req.flags(),
         req.requestLength(),
         req.requestBuf(),
+        std::string(req.requestSignature(), req.requestSignatureLength()),
         static_cast<uint32_t>(config_.getmaxReplyMessageSize() - sizeof(ClientReplyMsgHeader)),
         (char *)std::malloc(config_.getmaxReplyMessageSize() - sizeof(ClientReplyMsgHeader)),
         req.requestSeqNum()});

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -141,6 +141,7 @@ class PreProcessor {
                                   ReqId reqSeqNum,
                                   uint32_t reqLength,
                                   char *reqBuf,
+                                  std::string signature,
                                   const concordUtils::SpanContext &span_context);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg, bool isPrimary, bool isRetry);
   void handlePreProcessedReqByNonPrimary(uint16_t clientId,


### PR DESCRIPTION
1. Define the CMF mags for an execution request and its container.
2. Propogate the msg signature to the execution as well, in order to persist it on-chain.