### PR TITLE
Pruning via reconfiguration

### DIFF
--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -22,14 +22,16 @@ namespace bftEngine {
 
 class RequestHandler : public IRequestsHandler {
  public:
-  RequestHandler() : reconfig_dispatcher_{std::make_shared<concord::reconfiguration::ReconfigurationHandler>()} {}
+  RequestHandler() {
+    reconfig_handler_ = std::make_shared<concord::reconfiguration::ReconfigurationHandler>();
+    reconfig_dispatcher_.addReconfigurationHandler(reconfig_handler_);
+  }
 
   void execute(ExecutionRequestsQueue &requests, const std::string &batchCid, concordUtils::SpanWrapper &) override;
 
   void setUserRequestHandler(std::shared_ptr<IRequestsHandler> userHdlr) {
     if (userHdlr) {
       userRequestsHandler_ = userHdlr;
-      reconfig_handler_ = userHdlr->getReconfigurationHandler();
       reconfig_dispatcher_.addReconfigurationHandler(userHdlr->getReconfigurationHandler());
     }
   }

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -21,5 +21,4 @@ static const char reconfiguration_install_key = 0x27;
 static const char reconfiguration_key_exchange = 0x28;
 static const char reconfiguration_add_remove = 0x29;
 
-static const char reconfiguration_epoch = 0x2f;
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -20,4 +20,6 @@ static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;
 static const char reconfiguration_key_exchange = 0x28;
 static const char reconfiguration_add_remove = 0x29;
+
+static const char reconfiguration_epoch = 0x2f;
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -14,7 +14,7 @@
 
 namespace concord::kvbc::keyTypes {
 static const char bft_seq_num_key = 0x21;
-static const char pruning_last_agreed_prunable_block_id_key = 0x24;
+static const char reconfiguration_pruning_key = 0x24;
 static const char reconfiguration_wedge_key = 0x25;
 static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -151,19 +151,14 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               concord::messages::ReconfigurationResponse &) override;
-  static std::string lastAgreedPrunableBlockIdKey() { return std::string{kvbc::keyTypes::reconfiguration_pruning_key}; }
 
  protected:
   kvbc::BlockId latestBasedOnNumBlocksConfig() const;
   kvbc::BlockId agreedPrunableBlockId(const concord::messages::PruneRequest &) const;
-  // Returns the last agreed prunable block ID from storage, if existing.
-  std::optional<kvbc::BlockId> lastAgreedPrunableBlockId() const;
-  void persistLastAgreedPrunableBlockId(kvbc::BlockId block_id, uint64_t bft_seq_num) const;
+
   // Prune blocks in the [genesis, block_id] range (both inclusive).
   // Throws on errors.
   void pruneThroughBlockId(kvbc::BlockId block_id) const;
-  void pruneThroughLastAgreedBlockId() const;
-  void pruneOnStateTransferCompletion(uint64_t checkpoint_number) const noexcept;
   uint64_t getBlockBftSequenceNumber(kvbc::BlockId) const;
   logging::Logger logger_;
   RSAPruningSigner signer_;

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -143,11 +143,7 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   // exception if there is an issue with the configuration (for example, if the
   // configuration enables pruning but does not provide a purning operator
   // public key).
-  PruningHandler(kvbc::IReader &,
-                 kvbc::IBlockAdder &,
-                 kvbc::IBlocksDeleter &,
-                 bftEngine::IStateTransfer &,
-                 bool run_async = false);
+  PruningHandler(kvbc::IReader &, kvbc::IBlockAdder &, kvbc::IBlocksDeleter &, bool run_async = false);
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
               concord::messages::ReconfigurationResponse &) override;

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -155,9 +155,7 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               concord::messages::ReconfigurationResponse &) override;
-  static std::string lastAgreedPrunableBlockIdKey() {
-    return std::string{kvbc::keyTypes::pruning_last_agreed_prunable_block_id_key};
-  }
+  static std::string lastAgreedPrunableBlockIdKey() { return std::string{kvbc::keyTypes::reconfiguration_pruning_key}; }
 
  protected:
   kvbc::BlockId latestBasedOnNumBlocksConfig() const;

--- a/kvbc/include/reconfiguration_add_block_handler.hpp
+++ b/kvbc/include/reconfiguration_add_block_handler.hpp
@@ -135,6 +135,17 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
     return true;
   }
 
+  bool handle(const concord::messages::PruneRequest& command,
+              uint64_t sequence_number,
+              concord::messages::ReconfigurationResponse&) override {
+    std::vector<uint8_t> serialized_command;
+    concord::messages::serialize(serialized_command, command);
+    auto blockId = persistReconfigurationBlock(
+        serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1});
+    LOG_INFO(getLogger(), "PruneRequest configuration command block is " << blockId);
+    return true;
+  }
+
  protected:
   kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data, const uint64_t bft_seq_num, string key) {
     concord::kvbc::categorization::VersionedUpdates ver_updates;

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -58,6 +58,8 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::KeyExchangeCommand&, uint64_t, uint64_t) { return true; }
   bool handle(const concord::messages::AddRemoveCommand&, uint64_t, uint64_t) { return true; }
   bool handle(const concord::messages::AddRemoveWithWedgeCommand&, uint64_t, uint64_t);
+  bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t);
+
   kvbc::IReader& ro_storage_;
   std::vector<std::shared_ptr<concord::reconfiguration::IReconfigurationHandler>> orig_reconf_handlers_;
 };

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -33,6 +33,7 @@ class StReconfigurationHandler {
   void registerHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> handler) {
     orig_reconf_handlers_.push_back(handler);
   }
+  void stCallBack(uint64_t);
 
  private:
   template <typename T>
@@ -40,9 +41,6 @@ class StReconfigurationHandler {
   template <typename T>
   bool handlerStoredCommand(const std::string& key, uint64_t current_cp_num);
   uint64_t getStoredBftSeqNum(BlockId bid);
-
-  void stCallBack(uint64_t);
-
   /*
    * For wedge, we need to do nothing. The wedge point is being cleared only on termination.
    * Thus, as long no one did unwedge (currently, restarting the replicas) the late replica will get the data

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -29,20 +29,21 @@ class StReconfigurationHandler {
   StReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
     st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); },
                                          bftEngine::IStateTransfer::StateTransferCallBacksPriorities::HIGH);
-    onStartup(ro_storage_.getLastBlockId() / checkpointWindowSize);
   }
 
   void registerHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> handler) {
     orig_reconf_handlers_.push_back(handler);
   }
-  void stCallBack(uint64_t);
+
+  void pruneOnStartup();
 
  private:
+  void stCallBack(uint64_t);
+
   template <typename T>
   void deserializeCmfMessage(T& msg, const std::string& strval);
   template <typename T>
   bool handlerStoredCommand(const std::string& key, uint64_t current_cp_num);
-  void onStartup(uint64_t current_cp_num);
   uint64_t getStoredBftSeqNum(BlockId bid);
   /*
    * For wedge, we need to do nothing. The wedge point is being cleared only on termination.

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -17,6 +17,7 @@
 #include "kvbc_key_types.hpp"
 #include "concord.cmf.hpp"
 #include "reconfiguration/ireconfiguration.hpp"
+#include "SysConsts.hpp"
 
 namespace concord::kvbc {
 /*
@@ -28,6 +29,7 @@ class StReconfigurationHandler {
   StReconfigurationHandler(bftEngine::IStateTransfer& st, IReader& ro_storage) : ro_storage_(ro_storage) {
     st.addOnTransferringCompleteCallback([&](uint64_t cp) { stCallBack(cp); },
                                          bftEngine::IStateTransfer::StateTransferCallBacksPriorities::HIGH);
+    onStartup(ro_storage_.getLastBlockId() / checkpointWindowSize);
   }
 
   void registerHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> handler) {
@@ -40,6 +42,7 @@ class StReconfigurationHandler {
   void deserializeCmfMessage(T& msg, const std::string& strval);
   template <typename T>
   bool handlerStoredCommand(const std::string& key, uint64_t current_cp_num);
+  void onStartup(uint64_t current_cp_num);
   uint64_t getStoredBftSeqNum(BlockId bid);
   /*
    * For wedge, we need to do nothing. The wedge point is being cleared only on termination.

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -81,6 +81,7 @@ void Replica::createReplicaAndSyncState() {
       new concord::kvbc::pruning::PruningHandler(*this, *this, *this, true));
   requestHandler->setReconfigurationHandler(pruning_handler);
   stReconfigurationSM_->registerHandler(pruning_handler);
+  stReconfigurationSM_->pruneOnStartup();
   m_replicaPtr = bftEngine::IReplica::createNewReplica(
       replicaConfig_, requestHandler, m_stateTransfer, m_ptrComm, m_metadataStorage, pm_, secretsManager_);
   const auto lastExecutedSeqNum = m_replicaPtr->getLastExecutedSequenceNum();
@@ -282,12 +283,12 @@ Replica::Replica(ICommunication *comm,
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
-  bftEngine::IControlHandler::instance(new bftEngine::ControlHandler());
   if (!replicaConfig.isReadOnly) {
     stReconfigurationSM_ = std::make_unique<concord::kvbc::StReconfigurationHandler>(*m_stateTransfer, *this);
   }
   // Instantiate IControlHandler.
   // If an application instantiation has already taken a place this will have no effect.
+  bftEngine::IControlHandler::instance(new bftEngine::ControlHandler());
 }
 
 Replica::~Replica() {

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -221,8 +221,8 @@ kvbc::BlockId PruningHandler::agreedPrunableBlockId(const concord::messages::Pru
 }
 
 std::optional<kvbc::BlockId> PruningHandler::lastAgreedPrunableBlockId() const {
-  auto opt_val = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId,
-                                       std::string{kvbc::keyTypes::pruning_last_agreed_prunable_block_id_key});
+  auto opt_val =
+      ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_pruning_key});
   // if it's not found return nullopt, if any other error occurs storage throws.
   if (!opt_val) {
     return std::nullopt;
@@ -233,7 +233,7 @@ std::optional<kvbc::BlockId> PruningHandler::lastAgreedPrunableBlockId() const {
 
 void PruningHandler::persistLastAgreedPrunableBlockId(kvbc::BlockId block_id, uint64_t bft_seq_num) const {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
-  ver_updates.addUpdate(std::string{kvbc::keyTypes::pruning_last_agreed_prunable_block_id_key},
+  ver_updates.addUpdate(std::string{kvbc::keyTypes::reconfiguration_pruning_key},
                         concordUtils::toBigEndianStringBuffer(block_id));
 
   // All blocks are expected to have the BFT sequence number as a key.

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -13,7 +13,6 @@
 #include "st_reconfiguraion_sm.hpp"
 #include "hex_tools.h"
 #include "endianness.hpp"
-#include "SysConsts.hpp"
 #include "ControlStateManager.hpp"
 
 namespace concord::kvbc {
@@ -48,6 +47,12 @@ void StReconfigurationHandler::stCallBack(uint64_t current_cp_num) {
                                                             current_cp_num);
   handlerStoredCommand<concord::messages::AddRemoveWithWedgeCommand>(
       std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1}, current_cp_num);
+  handlerStoredCommand<concord::messages::PruneRequest>(std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
+                                                        current_cp_num);
+}
+
+void StReconfigurationHandler::onStartup(uint64_t current_cp_num) {
+  // Handle reconfiguration state on startup
   handlerStoredCommand<concord::messages::PruneRequest>(std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
                                                         current_cp_num);
 }

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -51,10 +51,9 @@ void StReconfigurationHandler::stCallBack(uint64_t current_cp_num) {
                                                         current_cp_num);
 }
 
-void StReconfigurationHandler::onStartup(uint64_t current_cp_num) {
-  // Handle reconfiguration state on startup
+void StReconfigurationHandler::pruneOnStartup() {
   handlerStoredCommand<concord::messages::PruneRequest>(std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
-                                                        current_cp_num);
+                                                        0);
 }
 template <typename T>
 bool StReconfigurationHandler::handlerStoredCommand(const std::string &key, uint64_t current_cp_num) {
@@ -89,9 +88,7 @@ bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedg
   return true;
 }
 
-bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &command,
-                                      uint64_t bft_seq_num,
-                                      uint64_t current_cp_num) {
+bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &command, uint64_t bft_seq_num, uint64_t) {
   // Actual pruning will be done from the lowest latestPruneableBlock returned by the replicas. It means, that even
   // on every state transfer there might be at most one relevant pruning command. Hence it is enough to take the latest
   // saved command and try to execute it

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -23,7 +23,7 @@ namespace concord::reconfiguration {
 class Dispatcher {
  public:
   Dispatcher(std::shared_ptr<IReconfigurationHandler> rh) { addReconfigurationHandler(rh); }
-
+  Dispatcher() = default;
   // This method is the gate for all reconfiguration actions. It works as
   // follows:
   // 1. Validate the request against the reconfiguration system operator (RSO)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -513,7 +513,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 lpab = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
                 latest_pruneable_blocks += [lpab.response]
 
-            # Now, crash on of the non-primary replicas
+            # Now, crash one of the non-primary replicas
             crashed_replica = 3
             bft_network.stop_replica(crashed_replica)
             await op.prune(latest_pruneable_blocks)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -491,6 +491,66 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    async def test_pruning_command_with_failures(self, bft_network):
+        with log.start_action(action_type="test_pruning_command_with_faliures"):
+            bft_network.start_all_replicas()
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+            client = bft_network.random_client()
+
+            # Create 100 blocks in total, including the genesis block we have 101 blocks
+            k, v = await skvbc.write_known_kv()
+            for i in range(99):
+                v = skvbc.random_value()
+                await client.write(skvbc.write_req([], [(k, v)], 0))
+
+            # Get the minimal latest pruneable block among all replicas
+            op = operator.Operator(bft_network.config, client,  bft_network.builddir)
+            await op.latest_pruneable_block()
+
+            latest_pruneable_blocks = []
+            rsi_rep = client.get_rsi_replies()
+            for r in rsi_rep.values():
+                lpab = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
+                latest_pruneable_blocks += [lpab.response]
+
+            # Now, crash on of the non-primary replicas
+            crashed_replica = 3
+            bft_network.stop_replica(crashed_replica)
+            await op.prune(latest_pruneable_blocks)
+            rsi_rep = client.get_rsi_replies()
+            # we expect to have at least 2f + 1 replies
+            for rep in rsi_rep:
+                r = rsi_rep[rep]
+                data = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
+                pruned_block = int(data.additional_data.decode('utf-8'))
+                assert pruned_block <= 90
+
+            # creates 100 new blocks
+            for i in range(100):
+                v = skvbc.random_value()
+                await client.write(skvbc.write_req([], [(k, v)], 0))
+
+            # now, return the crashed replica and wait for it to done with state transfer
+            bft_network.start_replica(crashed_replica)
+            await self._wait_for_st(bft_network, crashed_replica, 150)
+
+            # We expect the late replica to catch up with the state and to perform pruning
+            with trio.fail_after(seconds=30):
+                while True:
+                    num_replies = 0
+                    await op.prune_status()
+                    rsi_rep = client.get_rsi_replies()
+                    for r in rsi_rep.values():
+                        status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
+                        last_prune_blockid = status.response.last_pruned_block
+                        if status.response.in_progress is False and last_prune_blockid <= 90 and last_prune_blockid > 0:
+                            num_replies += 1
+                    if num_replies == bft_network.config.n:
+                        break
+
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_pruning_status_command(self, bft_network):
 
         bft_network.start_all_replicas()


### PR DESCRIPTION
In this PR we complete the implementation of pruning via reconfiguration. The main purpose of this PR is to move the functionality of pruning after state transfer and on startup to the reconfiguration mechanism:
1. Writing the prune request under the following key std::string{0x24, 0x1} (for backward compatibility)
2. Adding pruning handler to the state transfer reconfiguration handler
3. Remove the functionality for recovering and state transfer from the default pruning handler
4. Adapting the default pruning tests to these changes
5. Add Apollo test to test the recovery mechanism with state transfer