### PR TITLE
Test disabled because of intermittent failures.

### DIFF
--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -192,7 +192,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
                     await write_req()
                     await trio.sleep(seconds=3)
 
-    # @unittest.skip("Edge case scenario - not part of CI")
+    @unittest.skip("Edge case scenario - not part of CI until intermittent failures are analysed")
     @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)


### PR DESCRIPTION
This test covers an edge case scenario, which prior to the fix for the situation used to fail consistently.
Now we have intermittent failures only, which require further analysis.
Until the intermittent failures are understood and resolved the test won't be part of CI.