### PR TITLE
On ST's consistency check, take pruning under consideration

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2441,7 +2441,7 @@ void BCStateTran::checkStoredCheckpoints(uint64_t firstStoredCheckpoint, uint64_
       ConcordAssertGE(desc.lastBlock, prevLastBlockNum);
       prevLastBlockNum = desc.lastBlock;
 
-      if (desc.lastBlock >= as_->getGenesisBlockNum()) {
+      if (desc.lastBlock != 0 && desc.lastBlock >= as_->getGenesisBlockNum()) {
         auto computedBlockDigest = getBlockAndComputeDigest(desc.lastBlock);
         // Extra debugging needed here for BC-2821
         if (computedBlockDigest != desc.digestOfLastBlock) {

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2441,7 +2441,7 @@ void BCStateTran::checkStoredCheckpoints(uint64_t firstStoredCheckpoint, uint64_
       ConcordAssertGE(desc.lastBlock, prevLastBlockNum);
       prevLastBlockNum = desc.lastBlock;
 
-      if (desc.lastBlock > 0) {
+      if (desc.lastBlock >= as_->getGenesisBlockNum()) {
         auto computedBlockDigest = getBlockAndComputeDigest(desc.lastBlock);
         // Extra debugging needed here for BC-2821
         if (computedBlockDigest != desc.digestOfLastBlock) {


### PR DESCRIPTION
When we check the consistency of ST we must consider the case of pruning. In this case, the genesis block has changed, hence we need to consider this.