### PR TITLE
Persist the last KVBC block ID in metadata

### DIFF
--- a/bftengine/include/bftengine/DbMetadataStorage.hpp
+++ b/bftengine/include/bftengine/DbMetadataStorage.hpp
@@ -41,9 +41,9 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
 
   bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) override;
   void read(uint32_t objectId, uint32_t bufferSize, char *outBufferForObject, uint32_t &outActualObjectSize) override;
-  void atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) override;
+  void atomicWrite(uint32_t objectId, const char *data, uint32_t dataLength) override;
   void beginAtomicWriteOnlyBatch() override;
-  void writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) override;
+  void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) override;
   void commitAtomicWriteOnlyBatch() override;
   concordUtils::Status multiDel(const ObjectIdsVector &objectIds);
   bool isNewStorage() override;

--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -42,11 +42,11 @@ class MetadataStorage {
                     uint32_t &outActualObjectSize) = 0;
 
   // Atomically write an object to storage
-  virtual void atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) = 0;
+  virtual void atomicWrite(uint32_t objectId, const char *data, uint32_t dataLength) = 0;
 
   // Atomic write-only transactions
   virtual void beginAtomicWriteOnlyBatch() = 0;
-  virtual void writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) = 0;
+  virtual void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) = 0;
   virtual void commitAtomicWriteOnlyBatch() = 0;
 
   // In some cases, we would like to load a new metadata after a crash (for example, on reconfiguration actions).

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -25,6 +25,7 @@
 #include "Metrics.hpp"
 #include "ReplicaConfig.hpp"
 #include "PerformanceManager.hpp"
+#include "PersistentStorage.hpp"
 #include "IRequestHandler.hpp"
 
 namespace concord::cron {
@@ -120,6 +121,9 @@ class IReplica {
 
   // Returns the internal ticks generator or nullptr if not applicable.
   virtual std::shared_ptr<concord::cron::TicksGenerator> ticksGenerator() const = 0;
+
+  // Returns the internal persistent storage object.
+  virtual std::shared_ptr<impl::PersistentStorage> persistentStorage() const = 0;
 };
 
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -82,7 +82,7 @@ void DBMetadataStorage::read(uint32_t objectId,
   }
 }
 
-void DBMetadataStorage::atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) {
+void DBMetadataStorage::atomicWrite(uint32_t objectId, const char *data, uint32_t dataLength) {
   verifyOperation(objectId, dataLength, data, true);
   Sliver copy = Sliver::copy(data, dataLength);
   lock_guard<mutex> lock(ioMutex_);
@@ -102,7 +102,7 @@ void DBMetadataStorage::beginAtomicWriteOnlyBatch() {
   batch_ = new SetOfKeyValuePairs;
 }
 
-void DBMetadataStorage::writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) {
+void DBMetadataStorage::writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) {
   LOG_TRACE(logger_, "writeInBatch: objectId=" << objectId << ", dataLength=" << dataLength);
   verifyOperation(objectId, dataLength, data, true);
   Sliver copy = Sliver::copy(data, dataLength);

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -264,6 +264,11 @@ void DebugPersistentStorage::setCheckpointMsgInCheckWindow(SeqNum s, CheckpointM
   checkData.setCheckpointMsg(msg->cloneObjAndMsg());
 }
 
+void DebugPersistentStorage::setUserData(const void *data, std::size_t numberOfBytes) {
+  const auto p = static_cast<const char *>(data);
+  userData_.assign(p, p + numberOfBytes);
+}
+
 void DebugPersistentStorage::setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) {
   ConcordAssert(mark == true);
   ConcordAssert(checkWindow.insideActiveWindow(seqNum));
@@ -467,6 +472,8 @@ bool DebugPersistentStorage::getCompletedMarkInCheckWindow(SeqNum seqNum) {
   bool b = checkWindow.get(seqNum).getCompletedMark();
   return b;
 }
+
+std::vector<std::uint8_t> DebugPersistentStorage::getUserData() const { return userData_; }
 
 bool DebugPersistentStorage::setIsAllowed() const { return isInWriteTran(); }
 

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -46,6 +46,7 @@ class DebugPersistentStorage : public PersistentStorage {
   void setCommitFullMsgInSeqNumWindow(SeqNum seqNum, CommitFullMsg* msg) override;
   void setCheckpointMsgInCheckWindow(SeqNum seqNum, CheckpointMsg* msg) override;
   void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) override;
+  void setUserData(const void* data, std::size_t numberOfBytes) override;
   SeqNum getLastExecutedSeqNum() override;
   SeqNum getPrimaryLastUsedSeqNum() override;
   SeqNum getStrictLowerBoundOfSeqNums() override;
@@ -66,6 +67,7 @@ class DebugPersistentStorage : public PersistentStorage {
   CommitFullMsg* getAndAllocateCommitFullMsgInSeqNumWindow(SeqNum seqNum) override;
   CheckpointMsg* getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) override;
   bool getCompletedMarkInCheckWindow(SeqNum seqNum) override;
+  std::vector<std::uint8_t> getUserData() const override;
   void setEraseMetadataStorageFlag() override {}
   bool getEraseMetadataStorageFlag() override { return false; };
   void eraseMetadata() override{};
@@ -103,6 +105,8 @@ class DebugPersistentStorage : public PersistentStorage {
 
   // range: TODO(GG): !!!!!!!
   CheckWindow checkWindow;
+
+  std::vector<std::uint8_t> userData_;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -110,6 +110,7 @@ class PersistentStorage {
   virtual void setCheckpointMsgInCheckWindow(SeqNum seqNum, CheckpointMsg *msg) = 0;
   virtual void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) = 0;
 
+  // User data to be persisted, e.g. application-specific local data, scratchpad data, etc.
   virtual void setUserData(const void *data, std::size_t numberOfBytes) = 0;
 
   virtual void setEraseMetadataStorageFlag() = 0;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -19,6 +19,7 @@
 #include "ReplicaConfig.hpp"
 #include "PersistentStorageDescriptors.hpp"
 
+#include <cstdint>
 #include <vector>
 
 namespace bftEngine {
@@ -109,6 +110,8 @@ class PersistentStorage {
   virtual void setCheckpointMsgInCheckWindow(SeqNum seqNum, CheckpointMsg *msg) = 0;
   virtual void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) = 0;
 
+  virtual void setUserData(const void *data, std::size_t numberOfBytes) = 0;
+
   virtual void setEraseMetadataStorageFlag() = 0;
   virtual bool getEraseMetadataStorageFlag() = 0;
   virtual void eraseMetadata() = 0;
@@ -143,6 +146,8 @@ class PersistentStorage {
   virtual CommitFullMsg *getAndAllocateCommitFullMsgInSeqNumWindow(SeqNum seqNum) = 0;
   virtual CheckpointMsg *getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) = 0;
   virtual bool getCompletedMarkInCheckWindow(SeqNum seqNum) = 0;
+
+  virtual std::vector<std::uint8_t> getUserData() const = 0;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -99,6 +99,7 @@ ObjectDescUniquePtr PersistentStorageImp::getDefaultMetadataObjectDescriptors(ui
   metadataObjectsArray.get()[BEGINNING_OF_SEQ_NUM_WINDOW].maxSize = sizeof(SeqNum);
   metadataObjectsArray.get()[BEGINNING_OF_CHECK_WINDOW].maxSize = sizeof(SeqNum);
   metadataObjectsArray.get()[ERASE_METADATA_ON_STARTUP].maxSize = sizeof(bool);
+  metadataObjectsArray.get()[USER_DATA].maxSize = kMaxUserDataSizeBytes;
 
   for (auto i = 0; i < kWorkWindowSize; ++i) {
     metadataObjectsArray.get()[LAST_EXIT_FROM_VIEW_DESC + 1 + i].maxSize =

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -14,6 +14,7 @@
 #include "Logger.hpp"
 #include <list>
 #include <sstream>
+#include <stdexcept>
 
 using namespace std;
 using namespace concord::serialize;
@@ -506,6 +507,9 @@ void PersistentStorageImp::setCheckpointMsgInCheckWindow(SeqNum seqNum, Checkpoi
 }
 
 void PersistentStorageImp::setUserData(const void *data, std::size_t numberOfBytes) {
+  if (numberOfBytes > kMaxUserDataSizeBytes) {
+    throw std::invalid_argument{"Metadata user data is too big"};
+  }
   metadataStorage_->atomicWrite(USER_DATA, static_cast<const char *>(data), numberOfBytes);
 }
 
@@ -817,7 +821,7 @@ bool PersistentStorageImp::getCompletedMarkInCheckWindow(SeqNum seqNum) {
 }
 
 std::vector<std::uint8_t> PersistentStorageImp::getUserData() const {
-  auto buf = std::vector<std::uint8_t>(2048);
+  auto buf = std::vector<std::uint8_t>(kMaxUserDataSizeBytes);
   auto actualSize = std::uint32_t{0};
   metadataStorage_->read(USER_DATA, buf.size(), reinterpret_cast<char *>(buf.data()), actualSize);
   buf.resize(actualSize);

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -505,6 +505,10 @@ void PersistentStorageImp::setCheckpointMsgInCheckWindow(SeqNum seqNum, Checkpoi
   metadataStorage_->writeInBatch(convertedIndex, buf.get(), actualSize);
 }
 
+void PersistentStorageImp::setUserData(const void *data, std::size_t numberOfBytes) {
+  metadataStorage_->atomicWrite(USER_DATA, static_cast<const char *>(data), numberOfBytes);
+}
+
 /***** Getters *****/
 
 string PersistentStorageImp::getStoredVersion() {
@@ -810,6 +814,14 @@ CheckpointMsg *PersistentStorageImp::getAndAllocateCheckpointMsgInCheckWindow(Se
 bool PersistentStorageImp::getCompletedMarkInCheckWindow(SeqNum seqNum) {
   ConcordAssert(getIsAllowed());
   return readCompletedMarkFromDisk(seqNum);
+}
+
+std::vector<std::uint8_t> PersistentStorageImp::getUserData() const {
+  auto buf = std::vector<std::uint8_t>(2048);
+  auto actualSize = std::uint32_t{0};
+  metadataStorage_->read(USER_DATA, buf.size(), reinterpret_cast<char *>(buf.data()), actualSize);
+  buf.resize(actualSize);
+  return buf;
 }
 
 PrePrepareMsg *PersistentStorageImp::getAndAllocatePrePrepareMsgInSeqNumWindow(SeqNum seqNum) {

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -101,7 +101,7 @@ typedef unique_ptr<MetadataStorage::ObjectDesc[]> ObjectDescUniquePtr;
 
 class PersistentStorageImp : public PersistentStorage {
  public:
-  static constexpr auto kMaxUserDataSizeBytes = 4096;
+  static constexpr auto kMaxUserDataSizeBytes = 256;
 
  public:
   PersistentStorageImp(uint16_t numReplicas, uint16_t fVal, uint16_t cVal);

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -49,7 +49,7 @@ namespace impl {
 //    Parameters reserved for a future use
 
 // Make a reservation for future params
-const uint16_t reservedSimpleParamsNum = 500;
+const uint16_t reservedSimpleParamsNum = 499;
 const uint16_t reservedWindowParamsNum = 3000;
 
 const uint16_t MAX_METADATA_PARAMS_NUM = 10000;
@@ -64,6 +64,7 @@ enum ConstMetadataParameterIds : uint32_t {
   LAST_VIEW_TRANSFERRED_SEQ_NUM = 6,
   LAST_STABLE_SEQ_NUM = 7,
   ERASE_METADATA_ON_STARTUP = 9,
+  USER_DATA = 10,
   CONST_METADATA_PARAMETERS_NUM,
 };
 
@@ -130,6 +131,8 @@ class PersistentStorageImp : public PersistentStorage {
   void clearSeqNumWindow() override;
   ObjectDescUniquePtr getDefaultMetadataObjectDescriptors(uint16_t &numOfObjects) const;
 
+  void setUserData(const void *data, std::size_t numberOfBytes) override;
+
   void setEraseMetadataStorageFlag() override;
   bool getEraseMetadataStorageFlag() override;
   void eraseMetadata() override;
@@ -156,6 +159,8 @@ class PersistentStorageImp : public PersistentStorage {
   CommitFullMsg *getAndAllocateCommitFullMsgInSeqNumWindow(SeqNum seqNum) override;
   CheckpointMsg *getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) override;
   bool getCompletedMarkInCheckWindow(SeqNum seqNum) override;
+
+  std::vector<std::uint8_t> getUserData() const override;
 
   SharedPtrSeqNumWindow getSeqNumWindow();
   SharedPtrCheckWindow getCheckWindow();

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -101,6 +101,9 @@ typedef unique_ptr<MetadataStorage::ObjectDesc[]> ObjectDescUniquePtr;
 
 class PersistentStorageImp : public PersistentStorage {
  public:
+  static constexpr auto kMaxUserDataSizeBytes = 4096;
+
+ public:
   PersistentStorageImp(uint16_t numReplicas, uint16_t fVal, uint16_t cVal);
   ~PersistentStorageImp() override = default;
 

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -100,7 +100,7 @@ void FileStorage::read(void *dataPtr, size_t offset, size_t itemSize, size_t cou
 }
 
 void FileStorage::write(
-    void *dataPtr, size_t offset, size_t itemSize, size_t count, const char *errorMsg, bool toFlush) {
+    const void *dataPtr, size_t offset, size_t itemSize, size_t count, const char *errorMsg, bool toFlush) {
   if (fseek(dataStream_, offset, SEEK_SET) != 0) {
     throw runtime_error("FileStorage::write " + concordUtils::errnoString(errno));
   }
@@ -174,7 +174,7 @@ void FileStorage::verifyOperation(uint32_t objectId, uint32_t dataLen, const cha
   throw runtime_error(WRONG_PARAMETER);
 }
 
-void FileStorage::handleObjectWrite(uint32_t objectId, void *dataPtr, uint32_t objectSize, bool toFlush) {
+void FileStorage::handleObjectWrite(uint32_t objectId, const void *dataPtr, uint32_t objectSize, bool toFlush) {
   MetadataObjectInfo *objectInfo = objectsMetadata_->getObjectInfo(objectId);
   if (objectInfo) {
     write(dataPtr, objectInfo->offset, objectSize, 1, FAILED_TO_WRITE_OBJECT, toFlush);
@@ -206,7 +206,7 @@ void FileStorage::read(uint32_t objectId,
   handleObjectRead(objectId, outBufferForObject, outActualObjectSize);
 }
 
-void FileStorage::atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) {
+void FileStorage::atomicWrite(uint32_t objectId, const char *data, uint32_t dataLength) {
   LOG_DEBUG(logger_, "FileStorage::atomicWrite objectId=" << objectId << ", dataLength=" << dataLength);
   lock_guard<mutex> lock(ioMutex_);
   verifyOperation(objectId, dataLength, data);
@@ -224,7 +224,7 @@ void FileStorage::beginAtomicWriteOnlyBatch() {
   transaction_ = new ObjectIdToRequestMap;
 }
 
-void FileStorage::writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) {
+void FileStorage::writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) {
   LOG_DEBUG(logger_, "FileStorage::writeInBatch objectId=" << objectId << ", dataLength=" << dataLength);
   lock_guard<mutex> lock(ioMutex_);
   verifyOperation(objectId, dataLength, data);

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -35,19 +35,20 @@ class FileStorage : public MetadataStorage {
 
   void read(uint32_t objectId, uint32_t bufferSize, char *outBufferForObject, uint32_t &outActualObjectSize) override;
 
-  void atomicWrite(uint32_t objectId, char *data, uint32_t dataLength) override;
+  void atomicWrite(uint32_t objectId, const char *data, uint32_t dataLength) override;
 
   void beginAtomicWriteOnlyBatch() override;
 
-  void writeInBatch(uint32_t objectId, char *data, uint32_t dataLength) override;
+  void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) override;
 
   void commitAtomicWriteOnlyBatch() override;
   void eraseData() override;
 
  private:
   void read(void *dataPtr, size_t offset, size_t itemSize, size_t count, const char *errorMsg);
-  void write(void *dataPtr, size_t offset, size_t itemSize, size_t count, const char *errorMsg, bool toFlush = true);
-  void handleObjectWrite(uint32_t objectId, void *dataPtr, uint32_t objectSize, bool toFlush = true);
+  void write(
+      const void *dataPtr, size_t offset, size_t itemSize, size_t count, const char *errorMsg, bool toFlush = true);
+  void handleObjectWrite(uint32_t objectId, const void *dataPtr, uint32_t objectSize, bool toFlush = true);
   void handleObjectRead(uint32_t objectId, char *outBufferForObject, uint32_t &outActualObjectSize);
   void loadFileMetadata();
   void writeFileMetadata();

--- a/bftengine/tests/simpleStorage/MetadataStorageTypes.hpp
+++ b/bftengine/tests/simpleStorage/MetadataStorageTypes.hpp
@@ -43,7 +43,7 @@ struct MetadataObjectInfo {
 
 // Object data to be stored for every write operation in transaction.
 struct RequestInfo {
-  RequestInfo(char *buf, uint32_t len) {
+  RequestInfo(const char *buf, uint32_t len) {
     dataLen = len;
     data.reset(new char[dataLen]);
     std::memcpy(data.get(), buf, dataLen);

--- a/kvbc/include/persist_last_block_id_in_mtd.h
+++ b/kvbc/include/persist_last_block_id_in_mtd.h
@@ -1,0 +1,30 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of sub-components with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the LICENSE file.
+
+#pragma once
+
+#include "categorization/kv_blockchain.h"
+#include "endianness.hpp"
+#include "PersistentStorage.hpp"
+
+#include <memory>
+
+namespace concord::kvbc {
+
+// Persist the last KVBC block ID in big-endian in metadata's user data field.
+inline void persistLastBlockIdInMetadata(const categorization::KeyValueBlockchain &blockchain,
+                                         const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
+  const auto userData = concordUtils::toBigEndianArrayBuffer(blockchain.getLastReachableBlockId());
+  metadata->setUserData(userData.data(), userData.size());
+}
+
+}  // namespace concord::kvbc

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -16,15 +16,18 @@
 #include <string_view>
 #include <utility>
 #include "assertUtils.hpp"
+#include "endianness.hpp"
 #include "communication/CommDefs.hpp"
 #include "kv_types.hpp"
 #include "hex_tools.h"
 #include "replica_state_sync.h"
 #include "sliver.hpp"
+#include "persist_last_block_id_in_mtd.h"
 #include "bftengine/DbMetadataStorage.hpp"
 #include "rocksdb/native_client.h"
 #include "pruning_handler.hpp"
 #include "IRequestHandler.hpp"
+#include "RequestHandler.h"
 #include "reconfiguration_add_block_handler.hpp"
 #include "st_reconfiguraion_sm.hpp"
 #include "bftengine/ControlHandler.hpp"
@@ -68,8 +71,48 @@ Status Replica::start() {
   return Status::OK();
 }
 
+class KvbcRequestHandler : public bftEngine::RequestHandler {
+ public:
+  static std::shared_ptr<KvbcRequestHandler> create(
+      const std::shared_ptr<IRequestsHandler> &userReqHandler,
+      const std::shared_ptr<concord::cron::CronTableRegistry> &cronTableRegistry,
+      categorization::KeyValueBlockchain &blockchain) {
+    return std::shared_ptr<KvbcRequestHandler>{new KvbcRequestHandler{userReqHandler, cronTableRegistry, blockchain}};
+  }
+
+ public:
+  // Make sure we persist the last kvbc block ID in metadata after every execute() call.
+  void onFinishExecutingReadWriteRequests() override {
+    bftEngine::RequestHandler::onFinishExecutingReadWriteRequests();
+    persistLastBlockIdInMetadata(blockchain_, persistent_storage_);
+  }
+
+  void setPersistentStorage(const std::shared_ptr<bftEngine::impl::PersistentStorage> &persistent_storage) {
+    persistent_storage_ = persistent_storage;
+  }
+
+ private:
+  KvbcRequestHandler(const std::shared_ptr<IRequestsHandler> &userReqHandler,
+                     const std::shared_ptr<concord::cron::CronTableRegistry> &cronTableRegistry,
+                     categorization::KeyValueBlockchain &blockchain)
+      : blockchain_{blockchain} {
+    setUserRequestHandler(userReqHandler);
+    setCronTableRegistry(cronTableRegistry);
+  }
+
+  KvbcRequestHandler(const KvbcRequestHandler &) = delete;
+  KvbcRequestHandler(KvbcRequestHandler &&) = delete;
+  KvbcRequestHandler &operator=(const RequestHandler &) = delete;
+  KvbcRequestHandler &operator=(KvbcRequestHandler &&) = delete;
+
+ private:
+  std::shared_ptr<bftEngine::impl::PersistentStorage> persistent_storage_;
+  categorization::KeyValueBlockchain &blockchain_;
+};
+
 void Replica::createReplicaAndSyncState() {
-  auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler, cronTableRegistry_);
+  ConcordAssert(m_kvBlockchain.has_value());
+  auto requestHandler = KvbcRequestHandler::create(m_cmdHandler, cronTableRegistry_, *m_kvBlockchain);
   stReconfigurationSM_->registerHandler(m_cmdHandler->getReconfigurationHandler());
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this));
@@ -80,6 +123,12 @@ void Replica::createReplicaAndSyncState() {
       new concord::kvbc::pruning::PruningHandler(*this, *this, *this, *m_stateTransfer, true)));
   m_replicaPtr = bftEngine::IReplica::createNewReplica(
       replicaConfig_, requestHandler, m_stateTransfer, m_ptrComm, m_metadataStorage, pm_, secretsManager_);
+  requestHandler->setPersistentStorage(m_replicaPtr->persistentStorage());
+
+  // Make sure that when state transfer completes, we persist the last kvbc block ID in metadata.
+  m_stateTransfer->addOnTransferringCompleteCallback(
+      [this](std::uint64_t) { persistLastBlockIdInMetadata(*m_kvBlockchain, m_replicaPtr->persistentStorage()); });
+
   const auto lastExecutedSeqNum = m_replicaPtr->getLastExecutedSequenceNum();
   LOG_INFO(logger, KVLOG(lastExecutedSeqNum));
   if (!replicaConfig_.isReadOnly && !m_stateTransfer->isCollectingState()) {


### PR DESCRIPTION
Perist the last KVBC block ID in metadata as part of the effort to
change replica state sync so that we no longer persist the last executed
BFT sequence number in KVBC blocks.

Introduce an user data field in metadata as a
`ConstMetadataParameterIds` type. Reduce `reservedSimpleParamsNum` to
ensure adding user data is backwards compatible.

Persist the last block ID in metadata in two cases:
 * once request processing has completed, in
   `IRequestsHandler::onFinishExecutingReadWriteRequests()`.
 * once state transfer completes, potentially adding new blocks

A subsequent commit will change replica state sync so that it uses the
block ID instead of the BFT sequence number.

Improve const-correctness in MetadataStorage as part of this commit.