### PR TITLE
Persist metadata user data in a transaction

### DIFF
--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -264,9 +264,13 @@ void DebugPersistentStorage::setCheckpointMsgInCheckWindow(SeqNum s, CheckpointM
   checkData.setCheckpointMsg(msg->cloneObjAndMsg());
 }
 
-void DebugPersistentStorage::setUserData(const void *data, std::size_t numberOfBytes) {
+void DebugPersistentStorage::setUserDataAtomically(const void *data, std::size_t numberOfBytes) {
   const auto p = static_cast<const char *>(data);
   userData_.assign(p, p + numberOfBytes);
+}
+
+void DebugPersistentStorage::setUserDataInTransaction(const void *data, std::size_t numberOfBytes) {
+  setUserDataAtomically(data, numberOfBytes);
 }
 
 void DebugPersistentStorage::setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) {

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -46,7 +46,8 @@ class DebugPersistentStorage : public PersistentStorage {
   void setCommitFullMsgInSeqNumWindow(SeqNum seqNum, CommitFullMsg* msg) override;
   void setCheckpointMsgInCheckWindow(SeqNum seqNum, CheckpointMsg* msg) override;
   void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) override;
-  void setUserData(const void* data, std::size_t numberOfBytes) override;
+  void setUserDataAtomically(const void* data, std::size_t numberOfBytes) override;
+  void setUserDataInTransaction(const void* data, std::size_t numberOfBytes) override;
   SeqNum getLastExecutedSeqNum() override;
   SeqNum getPrimaryLastUsedSeqNum() override;
   SeqNum getStrictLowerBoundOfSeqNums() override;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -110,8 +110,11 @@ class PersistentStorage {
   virtual void setCheckpointMsgInCheckWindow(SeqNum seqNum, CheckpointMsg *msg) = 0;
   virtual void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) = 0;
 
-  // User data to be persisted, e.g. application-specific local data, scratchpad data, etc.
-  virtual void setUserData(const void *data, std::size_t numberOfBytes) = 0;
+  // User data to be persisted, e.g. application-specific replica-local data, scratchpad data, etc.
+  // Provide two methods - one that does it atomically and one that does it in an already created transaction.
+  // setUserDataInTransaction() has a precondition that a transaction has already been created.
+  virtual void setUserDataAtomically(const void *data, std::size_t numberOfBytes) = 0;
+  virtual void setUserDataInTransaction(const void *data, std::size_t numberOfBytes) = 0;
 
   virtual void setEraseMetadataStorageFlag() = 0;
   virtual bool getEraseMetadataStorageFlag() = 0;

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -508,10 +508,11 @@ void PersistentStorageImp::setCheckpointMsgInCheckWindow(SeqNum seqNum, Checkpoi
 }
 
 void PersistentStorageImp::setUserData(const void *data, std::size_t numberOfBytes) {
+  ConcordAssert(setIsAllowed());
   if (numberOfBytes > kMaxUserDataSizeBytes) {
     throw std::invalid_argument{"Metadata user data is too big"};
   }
-  metadataStorage_->atomicWrite(USER_DATA, static_cast<const char *>(data), numberOfBytes);
+  metadataStorage_->writeInBatch(USER_DATA, static_cast<const char *>(data), numberOfBytes);
 }
 
 /***** Getters *****/

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -507,7 +507,14 @@ void PersistentStorageImp::setCheckpointMsgInCheckWindow(SeqNum seqNum, Checkpoi
   metadataStorage_->writeInBatch(convertedIndex, buf.get(), actualSize);
 }
 
-void PersistentStorageImp::setUserData(const void *data, std::size_t numberOfBytes) {
+void PersistentStorageImp::setUserDataAtomically(const void *data, std::size_t numberOfBytes) {
+  if (numberOfBytes > kMaxUserDataSizeBytes) {
+    throw std::invalid_argument{"Metadata user data is too big"};
+  }
+  metadataStorage_->atomicWrite(USER_DATA, static_cast<const char *>(data), numberOfBytes);
+}
+
+void PersistentStorageImp::setUserDataInTransaction(const void *data, std::size_t numberOfBytes) {
   ConcordAssert(setIsAllowed());
   if (numberOfBytes > kMaxUserDataSizeBytes) {
     throw std::invalid_argument{"Metadata user data is too big"};

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -134,7 +134,8 @@ class PersistentStorageImp : public PersistentStorage {
   void clearSeqNumWindow() override;
   ObjectDescUniquePtr getDefaultMetadataObjectDescriptors(uint16_t &numOfObjects) const;
 
-  void setUserData(const void *data, std::size_t numberOfBytes) override;
+  void setUserDataAtomically(const void *data, std::size_t numberOfBytes) override;
+  void setUserDataInTransaction(const void *data, std::size_t numberOfBytes) override;
 
   void setEraseMetadataStorageFlag() override;
   bool getEraseMetadataStorageFlag() override;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4072,9 +4072,9 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
     CryptoManager::instance().onCheckpoint(checkpointNum);
   }
 
-  if (ps_) ps_->endWriteTran();
-
   if (numOfRequests > 0) bftRequestsHandler_->onFinishExecutingReadWriteRequests();
+
+  if (ps_) ps_->endWriteTran();
 
   sendCheckpointIfNeeded();
 

--- a/kvbc/include/persist_last_block_id_in_mtd.h
+++ b/kvbc/include/persist_last_block_id_in_mtd.h
@@ -21,10 +21,15 @@
 namespace concord::kvbc {
 
 // Persist the last KVBC block ID in big-endian in metadata's user data field.
-inline void persistLastBlockIdInMetadata(const categorization::KeyValueBlockchain &blockchain,
-                                         const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
-  const auto userData = concordUtils::toBigEndianArrayBuffer(blockchain.getLastReachableBlockId());
-  metadata->setUserData(userData.data(), userData.size());
+template <bool in_transaction>
+void persistLastBlockIdInMetadata(const categorization::KeyValueBlockchain &blockchain,
+                                  const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
+  const auto user_data = concordUtils::toBigEndianArrayBuffer(blockchain.getLastReachableBlockId());
+  if constexpr (in_transaction) {
+    metadata->setUserDataInTransaction(user_data.data(), user_data.size());
+  } else {
+    metadata->setUserDataAtomically(user_data.data(), user_data.size());
+  }
 }
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
Persist the metadata user data in an already created transaction. That
ensures it is consistent with other metadata.

Move the call to `endWriteTran()` after the call to
`onFinishExecutingReadWriteRequests()`, allowing users to persist
metadata safely and consistently.