### PR TITLE
Introduce UnwedgeStatusRequest and UnwedgeCommand in reconfiguration handler

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -75,6 +75,9 @@ class ControlStateManager : public ResPagesClient<ControlStateManager, ControlHa
                                  RestartProofHandlerPriorities priority = ControlStateManager::DEFAULT);
   void onRestartProof();
 
+  std::optional<std::string> canUnwedge();
+  bool verifyUnwedgeSignatures(std::vector<std::pair<uint64_t, std::vector<uint8_t>>> const& signatures);
+
  private:
   ControlStateManager() { scratchPage_.resize(sizeOfReservedPage()); }
   ControlStateManager& operator=(const ControlStateManager&) = delete;

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -75,7 +75,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager, ControlHa
                                  RestartProofHandlerPriorities priority = ControlStateManager::DEFAULT);
   void onRestartProof();
 
-  std::optional<std::string> canUnwedge();
+  std::pair<bool, std::string> canUnwedge();
   bool verifyUnwedgeSignatures(std::vector<std::pair<uint64_t, std::vector<uint8_t>>> const& signatures);
 
  private:

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -115,6 +115,7 @@ Msg UnwedgeStatusResponse 33{
     uint64 replica_id
     bool can_unwedge
     bytes signature
+    string reason
 }
 
 Msg UnwedgeCommand 34{

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -107,6 +107,21 @@ Msg AddRemoveWithWedgeStatusResponse 31 {
     string config_descriptor
 }
 
+Msg UnwedgeStatusRequest 32{
+    uint64 sender
+}
+
+Msg UnwedgeStatusResponse 33{
+    uint64 replica_id
+    bool can_unwedge
+    bytes signature
+}
+
+Msg UnwedgeCommand 34{
+    uint64 sender
+    list kvpair uint64 bytes signatures
+}
+
 Msg ReconfigurationRequest 1 {
   bytes signature
   oneof {
@@ -125,6 +140,8 @@ Msg ReconfigurationRequest 1 {
     AddRemoveStatus
     AddRemoveWithWedgeCommand
     AddRemoveWithWedgeStatus
+    UnwedgeStatusRequest
+    UnwedgeCommand
   } command
   bytes additional_data
 }
@@ -141,6 +158,7 @@ Msg ReconfigurationResponse 2 {
     ReconfigurationErrorMsg
     AddRemoveStatusResponse
     AddRemoveWithWedgeStatusResponse
+    UnwedgeStatusResponse
   } response
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -94,6 +94,15 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::PruneRequest&, uint64_t, concord::messages::ReconfigurationResponse&) {
     return true;
   }
+
+  virtual bool handle(const concord::messages::UnwedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
+  virtual bool handle(const concord::messages::UnwedgeStatusRequest&,
+                      uint64_t,
+                      concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(const std::string& data, const std::string& signature) const = 0;

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -47,5 +47,10 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
   bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
               uint64_t,
               concord::messages::ReconfigurationResponse&) override;
+
+  bool handle(const concord::messages::UnwedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::UnwedgeStatusRequest&,
+              uint64_t,
+              concord::messages::ReconfigurationResponse&) override;
 };
 }  // namespace concord::reconfiguration

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -132,7 +132,7 @@ bool ReconfigurationHandler::handle(const UnwedgeStatusRequest& req,
   if (!can_unwedge.first) {
     response.can_unwedge = false;
     response.reason = can_unwedge.second;
-    LOG_INFO(getLogger(), "Replica is not ready to unwedge");
+    LOG_INFO(getLogger(), "Replica is not ready to unwedge. Reason: " << can_unwedge.second);
   } else {
     response.can_unwedge = true;
     response.signature = std::vector<uint8_t>(can_unwedge.second.begin(), can_unwedge.second.end());

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -127,14 +127,15 @@ bool ReconfigurationHandler::handle(const UnwedgeStatusRequest& req,
                                     uint64_t,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::UnwedgeStatusResponse response;
-  auto status = bftEngine::ControlStateManager::instance().canUnwedge();
+  auto can_unwedge = bftEngine::ControlStateManager::instance().canUnwedge();
   response.replica_id = bftEngine::ReplicaConfig::instance().replicaId;
-  if (!status.has_value()) {
+  if (!can_unwedge.first) {
     response.can_unwedge = false;
+    response.reason = can_unwedge.second;
     LOG_INFO(getLogger(), "Replica is not ready to unwedge");
   } else {
     response.can_unwedge = true;
-    response.signature = std::vector<uint8_t>(status.value().begin(), status.value().end());
+    response.signature = std::vector<uint8_t>(can_unwedge.second.begin(), can_unwedge.second.end());
     LOG_INFO(getLogger(), "Replica is ready to unwedge");
   }
   rres.response = response;


### PR DESCRIPTION
This is the first part of the unwedge command implementation.

First is the unwedgeStatus command in the reconfiguration commands handler.
If the replica can unwedge, we return a signed answer by the replica's private key.

The unwedge command receives the signatures collected with the unwedgeStatus command.
Each replica verifies the signatures and if a quorum of them are valid, it unwedges.

