### PR TITLE
Introducing Epoch manager

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -70,6 +70,7 @@ set(corebft_source_files
     ../ccron/src/ticks_generator.cpp
     ../ccron/src/periodic_action.cpp
     ../ccron/src/cron_table.cpp
+    src/bftengine/EpochsManager.cpp
 )
 
 #

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -50,7 +50,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager, ControlHa
     return instance_;
   }
   ~ControlStateManager() = default;
-  void setStopAtNextCheckpoint(int64_t currentSeqNum);
+  void setStopAtNextCheckpoint(int64_t currentSeqNum, bool saveToReservedPages = true);
   std::optional<int64_t> getCheckpointToStopAt();
 
   void setEraseMetadataFlag(int64_t currentSeqNum);
@@ -67,6 +67,7 @@ class ControlStateManager : public ResPagesClient<ControlStateManager, ControlHa
   void setRemoveMetadataFunc(std::function<void()> fn) { remove_metadata_ = fn; }
   void startNewEpoch() { starting_new_epoch_ = true; }
   bool isNewEpoch() { return starting_new_epoch_; }
+  void clearNewEpoch() { starting_new_epoch_ = false; }
 
  private:
   ControlStateManager() { scratchPage_.resize(sizeOfReservedPage()); }

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -65,6 +65,8 @@ class ControlStateManager : public ResPagesClient<ControlStateManager, ControlHa
   void enable() { enabled_ = true; }
 
   void setRemoveMetadataFunc(std::function<void()> fn) { remove_metadata_ = fn; }
+  void startNewEpoch() { starting_new_epoch_ = true; }
+  bool isNewEpoch() { return starting_new_epoch_; }
 
  private:
   ControlStateManager() { scratchPage_.resize(sizeOfReservedPage()); }
@@ -76,5 +78,6 @@ class ControlStateManager : public ResPagesClient<ControlStateManager, ControlHa
   ControlStatePage page_;
   std::atomic_bool onPruningProcess_ = false;
   std::function<void()> remove_metadata_;
+  bool starting_new_epoch_;
 };
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/EpochsManager.hpp
+++ b/bftengine/include/bftengine/EpochsManager.hpp
@@ -15,6 +15,7 @@
 #include "ReservedPagesClient.hpp"
 #include "Serializable.h"
 #include "unordered_map"
+#include "IStateTransfer.hpp"
 
 namespace bftEngine::impl {
 class IInternalBFTClient;
@@ -27,6 +28,7 @@ class EpochManager : public ResPagesClient<EpochManager, 1> {
   struct InitData {
     std::shared_ptr<impl::IInternalBFTClient> cl;
     std::shared_ptr<impl::RSASigner> signer;
+    IStateTransfer& state_transfer;
     uint32_t replica_id;
     uint32_t n;
     uint32_t f;

--- a/bftengine/include/bftengine/EpochsManager.hpp
+++ b/bftengine/include/bftengine/EpochsManager.hpp
@@ -61,7 +61,8 @@ class EpochManager : public ResPagesClient<EpochManager, 1> {
   }
   EpochManager(InitData* id);
   ~EpochManager() = default;
-  void updateEpochForReplica(uint32_t replica_id, uint64_t epoch_id);
+  void updateEpochForReplica(uint32_t replica_id, uint64_t epoch_id, bool save = false);
+  void save();
   uint64_t getEpochForReplica(uint32_t replica_id);
   const EpochsData& getEpochData();
   void sendUpdateEpochMsg(uint64_t epoch);

--- a/bftengine/include/bftengine/EpochsManager.hpp
+++ b/bftengine/include/bftengine/EpochsManager.hpp
@@ -30,6 +30,7 @@ class EpochManager : public ResPagesClient<EpochManager, 1> {
     uint32_t replica_id;
     uint32_t n;
     uint32_t f;
+    bool is_ro;
   };
 
   struct EpochsData : public concord::serialize::SerializableFactory<EpochsData> {
@@ -71,5 +72,6 @@ class EpochManager : public ResPagesClient<EpochManager, 1> {
   uint32_t replica_id_;
   EpochsData epochs_data_;
   std::string scratchPage_;
+  bool is_ro_;
 };
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/EpochsManager.hpp
+++ b/bftengine/include/bftengine/EpochsManager.hpp
@@ -70,6 +70,7 @@ class EpochManager : public ResPagesClient<EpochManager, 1> {
     metrics_.SetAggregator(aggregator);
     metrics_.UpdateAggregator();
   }
+  uint64_t getSelfEpoch() { return epochs_data_.epochs_[replica_id_]; }
 
  private:
   EpochManager& operator=(const EpochManager&) = delete;

--- a/bftengine/include/bftengine/EpochsManager.hpp
+++ b/bftengine/include/bftengine/EpochsManager.hpp
@@ -1,0 +1,83 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include "IStateTransfer.hpp"
+#include "ReservedPagesClient.hpp"
+#include "Serializable.h"
+#include "unordered_map"
+
+namespace bftEngine::impl {
+class IInternalBFTClient;
+class ISigner;
+}  // namespace bftEngine::impl
+
+namespace bftEngine {
+class EpochManager : public ResPagesClient<EpochManager, 1> {
+ public:
+  struct InitData {
+    std::shared_ptr<impl::IInternalBFTClient> cl;
+    std::shared_ptr<impl::ISigner> signer;
+    bool first_time;
+    uint32_t n;
+    uint32_t f;
+  };
+
+  struct EpochsData : public concord::serialize::SerializableFactory<EpochsData> {
+    std::unordered_map<uint32_t, uint64_t> epochs_;
+    uint32_t n_;
+    EpochsData(uint32_t n) {
+      static_assert(sizeof(EpochsData) < 4096, "The page exceeds the maximal size of reserved page");
+      for (uint32_t i = 0; i < n; i++) {
+        epochs_.emplace(i, 0);
+      }
+      n_ = n;
+    }
+
+    const std::string getVersion() const override { return "1"; }
+
+    void serializeDataMembers(std::ostream& outStream) const override;
+    void deserializeDataMembers(std::istream& inStream) override;
+  };
+
+ public:
+  static EpochManager& instance(InitData* id = nullptr) {
+    static EpochManager instance_(id);
+    return instance_;
+  }
+  EpochManager(InitData* id) : bft_client_{id->cl}, signer_{id->signer}, epochs_data_{id->n} {
+    scratchPage_.resize(sizeOfReservedPage());
+    if (loadReservedPage(0, sizeOfReservedPage(), scratchPage_.data())) {
+      std::istringstream inStream;
+      inStream.str(scratchPage_);
+      concord::serialize::Serializable::deserialize(inStream, epochs_data_);
+    }
+    if (id->first_time) {
+      // Send a message with the current replica epoch
+    }
+  }
+  ~EpochManager() = default;
+  void updateEpochForReplica(uint32_t replica_id, uint64_t epoch_id);
+  uint64_t getEpochForReplica(uint32_t replica_id);
+  const EpochsData& getEpochData();
+
+ private:
+  EpochManager& operator=(const EpochManager&) = delete;
+  EpochManager(const EpochManager&) = delete;
+
+  std::shared_ptr<impl::IInternalBFTClient> bft_client_;
+  std::shared_ptr<impl::ISigner> signer_;
+  EpochsData epochs_data_;
+  std::string scratchPage_;
+};
+}  // namespace bftEngine

--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -23,7 +23,7 @@ class IReplicaForStateTransfer;  // forward definition
 
 class IStateTransfer : public IReservedPages {
  public:
-  enum StateTransferCallBacksPriorities { HIGH = 0, DEFAULT = 20, LOW = 40 };
+  enum StateTransferCallBacksPriorities { FIRST = 0, HIGH = 10, DEFAULT = 20, LOW = 40 };
   virtual ~IStateTransfer() {}
 
   // The methods of this interface will always be called by the same thread of

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2295,7 +2295,6 @@ void BCStateTran::processData() {
         kv.second.invokeAll(cp.checkpointNum);
       }
       g.txn()->setIsFetchingState(false);
-      bftEngine::EpochManager::instance().sendEpochNumberAfterStateTransfer();
       break;
     }
     //////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -33,6 +33,7 @@
 #include "storage/db_interface.h"
 #include "storage/key_manipulator_interface.h"
 #include "memorydb/client.h"
+#include "EpochsManager.hpp"
 
 // TODO(GG): for debugging - remove
 // #define DEBUG_SEND_CHECKPOINTS_IN_REVERSE_ORDER (1)
@@ -2294,6 +2295,7 @@ void BCStateTran::processData() {
         kv.second.invokeAll(cp.checkpointNum);
       }
       g.txn()->setIsFetchingState(false);
+      bftEngine::EpochManager::instance().sendEpochNumberAfterStateTransfer();
       break;
     }
     //////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -170,6 +170,8 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
       auto secFile = ReplicaConfig::instance().getkeyViewFilePath() + std::string("/" + secFilePrefix + ".") +
                      std::to_string(ReplicaConfig::instance().getreplicaId());
       LOG_INFO(GL, "removing " << secFile << " if exist");
+      bftEngine::ControlStateManager::instance().startNewEpoch();
+      LOG_INFO(GL, "will try to start a new epoch (right after the KE phase)");
       try {
         std::remove(secFile.c_str());
       } catch (std::exception &e) {

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -24,12 +24,13 @@ namespace bftEngine {
  * The next possible checkpoint to stop at is 450 (rather than 300). Thus, we calculate the next next checkpoint w.r.t
  * given sequence number and mark it as a checkpoint to stop at in the reserved pages.
  */
-void ControlStateManager::setStopAtNextCheckpoint(int64_t currentSeqNum) {
+void ControlStateManager::setStopAtNextCheckpoint(int64_t currentSeqNum, bool saveToReservedPages) {
   if (!enabled_) return;
   uint64_t seq_num_to_stop_at = (currentSeqNum + 2 * checkpointWindowSize);
   seq_num_to_stop_at = seq_num_to_stop_at - (seq_num_to_stop_at % checkpointWindowSize);
-  std::ostringstream outStream;
   page_.seq_num_to_stop_at_ = seq_num_to_stop_at;
+  if (!saveToReservedPages) return;
+  std::ostringstream outStream;
   concord::serialize::Serializable::serialize(outStream, page_);
   auto data = outStream.str();
   saveReservedPage(0, data.size(), data.data());

--- a/bftengine/src/bftengine/EpochsManager.cpp
+++ b/bftengine/src/bftengine/EpochsManager.cpp
@@ -35,6 +35,7 @@ EpochManager::EpochManager(EpochManager::InitData* id)
     inStream.str(scratchPage_);
     concord::serialize::Serializable::deserialize(inStream, epochs_data_);
   }
+  epoch_number.Get().Set(epochs_data_.epochs_[replica_id_]);
 
   id->state_transfer.addOnTransferringCompleteCallback(
       [&](uint64_t) {

--- a/bftengine/src/bftengine/EpochsManager.cpp
+++ b/bftengine/src/bftengine/EpochsManager.cpp
@@ -26,6 +26,16 @@ EpochManager::EpochManager(EpochManager::InitData* id)
     inStream.str(scratchPage_);
     concord::serialize::Serializable::deserialize(inStream, epochs_data_);
   }
+
+  id->state_transfer.addOnTransferringCompleteCallback(
+      [&](uint64_t) {
+        if (loadReservedPage(0, sizeOfReservedPage(), scratchPage_.data())) {
+          std::istringstream inStream;
+          inStream.str(scratchPage_);
+          concord::serialize::Serializable::deserialize(inStream, epochs_data_);
+        }
+      },
+      IStateTransfer::HIGH);
 }
 
 void EpochManager::updateEpochForReplica(uint32_t replica_id, uint64_t epoch_id) {

--- a/bftengine/src/bftengine/EpochsManager.cpp
+++ b/bftengine/src/bftengine/EpochsManager.cpp
@@ -1,0 +1,42 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "EpochsManager.hpp"
+
+namespace bftEngine {
+
+void EpochManager::updateEpochForReplica(uint32_t replica_id, uint64_t epoch_id) {
+  epochs_data_.epochs_[replica_id] = epoch_id;
+  // update the data and save it on the reserved pages
+  std::ostringstream outStream;
+  concord::serialize::Serializable::serialize(outStream, epochs_data_);
+  auto data = outStream.str();
+  saveReservedPage(0, data.size(), data.data());
+}
+uint64_t EpochManager::getEpochForReplica(uint32_t replica_id) { return epochs_data_.epochs_[replica_id]; }
+const EpochManager::EpochsData& EpochManager::getEpochData() { return epochs_data_; }
+void EpochManager::EpochsData::serializeDataMembers(std::ostream& outStream) const {
+  serialize(outStream, n_);
+  for (uint32_t i = 0; i < n_; i++) {
+    serialize(outStream, epochs_.at(i));
+  }
+}
+void EpochManager::EpochsData::deserializeDataMembers(std::istream& inStream) {
+  uint32_t n = n_;
+  deserialize(inStream, n);
+  for (uint32_t i = 0; i < n_; i++) {
+    deserialize(inStream, epochs_[i]);
+  }
+  for (uint32_t i = n; i < n_; i++) {
+    epochs_.emplace(i, 0);
+  }
+}
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/InternalBFTClient.cpp
+++ b/bftengine/src/bftengine/InternalBFTClient.cpp
@@ -32,3 +32,6 @@ uint64_t InternalBFTClient::sendRequest(uint64_t flags,
   LOG_DEBUG(GL, "Sent internal consensus: seq num [" << sn << "] client id [" << getClientId() << "]");
   return sn;
 }
+void InternalBFTClient::sendRequest(ClientRequestMsg* msg) {
+  msgComm_->getIncomingMsgsStorage()->pushExternalMsg(std::unique_ptr<MessageBase>(msg));
+}

--- a/bftengine/src/bftengine/InternalBFTClient.hpp
+++ b/bftengine/src/bftengine/InternalBFTClient.hpp
@@ -23,6 +23,7 @@ class IInternalBFTClient {
   // Returns the sent client request sequence number.
   virtual uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid) = 0;
   virtual uint32_t numOfConnectedReplicas(uint32_t clusterSize) = 0;
+  virtual bool isNodeConnected(uint32_t nodeId) = 0;
   virtual bool isUdp() const = 0;
 };
 
@@ -32,6 +33,7 @@ class InternalBFTClient : public IInternalBFTClient {
   inline NodeIdType getClientId() const { return repID_ + startIdForInternalClient_; };
   uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid);
   uint32_t numOfConnectedReplicas(uint32_t clusterSize) { return msgComm_->numOfConnectedReplicas(clusterSize); }
+  bool isNodeConnected(uint32_t nodeId) { return msgComm_->isNodeConnected(nodeId); }
   bool isUdp() const { return msgComm_->isUdp(); }
 
  private:

--- a/bftengine/src/bftengine/InternalBFTClient.hpp
+++ b/bftengine/src/bftengine/InternalBFTClient.hpp
@@ -13,6 +13,7 @@
 
 #include "PrimitiveTypes.hpp"
 #include "MsgsCommunicator.hpp"
+#include "messages/ClientRequestMsg.hpp"
 
 namespace bftEngine {
 namespace impl {
@@ -23,6 +24,7 @@ class IInternalBFTClient {
   // Returns the sent client request sequence number.
   virtual uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid) = 0;
   virtual uint32_t numOfConnectedReplicas(uint32_t clusterSize) = 0;
+  virtual void sendRequest(ClientRequestMsg*) = 0;
   virtual bool isNodeConnected(uint32_t nodeId) = 0;
   virtual bool isUdp() const = 0;
 };
@@ -32,6 +34,7 @@ class InternalBFTClient : public IInternalBFTClient {
   InternalBFTClient(const int& id, const NodeIdType& nonInternalNum, std::shared_ptr<MsgsCommunicator>& msgComm);
   inline NodeIdType getClientId() const { return repID_ + startIdForInternalClient_; };
   uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid);
+  void sendRequest(ClientRequestMsg*);
   uint32_t numOfConnectedReplicas(uint32_t clusterSize) { return msgComm_->numOfConnectedReplicas(clusterSize); }
   bool isNodeConnected(uint32_t nodeId) { return msgComm_->isNodeConnected(nodeId); }
   bool isUdp() const { return msgComm_->isUdp(); }

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -66,6 +66,10 @@ uint32_t MsgsCommunicator::numOfConnectedReplicas(uint32_t clusterSize) {
   return ret;
 }
 
+bool MsgsCommunicator::isNodeConnected(uint32_t nodeId) {
+  return communication_->getCurrentConnectionStatus(nodeId) != ConnectionStatus::Disconnected;
+}
+
 bool MsgsCommunicator::isUdp() {
   if (dynamic_cast<PlainUDPCommunication*>(communication_) == nullptr) return false;
   return true;

--- a/bftengine/src/bftengine/MsgsCommunicator.hpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.hpp
@@ -37,6 +37,7 @@ class MsgsCommunicator {
   void send(std::set<bft::communication::NodeNum> dests, char* message, size_t messageLength);
 
   std::shared_ptr<IncomingMsgsStorage>& getIncomingMsgsStorage() { return incomingMsgsStorage_; }
+  bool isNodeConnected(uint32_t nodeId);
 
  private:
   uint16_t replicaId_ = 0;

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -55,7 +55,8 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                                      config_.clientTransactionSigningEnabled ? &config_.publicKeysOfClients : nullptr,
                                      KeyFormat::PemFormat,
                                      *repsInfo));
-  EpochManager::InitData eid{nullptr, nullptr, config_.replicaId, config.numReplicas, config.fVal, true};
+  EpochManager::InitData eid{
+      nullptr, nullptr, *(this->stateTransfer), config_.replicaId, config.numReplicas, config.fVal, true};
   EpochManager::instance(&eid);
 }
 

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -22,6 +22,7 @@
 #include "PersistentStorage.hpp"
 #include "MsgsCommunicator.hpp"
 #include "SigManager.hpp"
+#include "EpochsManager.hpp"
 
 using concordUtil::Timers;
 
@@ -54,6 +55,8 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                                      config_.clientTransactionSigningEnabled ? &config_.publicKeysOfClients : nullptr,
                                      KeyFormat::PemFormat,
                                      *repsInfo));
+  EpochManager::InitData eid{nullptr, nullptr, config_.replicaId, config.numReplicas, config.fVal, true};
+  EpochManager::instance(&eid);
 }
 
 void ReadOnlyReplica::start() {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -194,7 +194,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
     if (!(flags & KEY_EXCHANGE_FLAG) && !(flags & CLIENTS_PUB_KEYS_FLAG)) {
       LOG_INFO(KEY_EX_LOG, "Didn't complete yet, dropping msg");
       if (flags & RECONFIG_FLAG) {
-        LOG_INFO(KEY_EX_LOG, "a reconfiguration message has been found, returning it to the queue");
+        LOG_DEBUG(KEY_EX_LOG, "a reconfiguration message has been found, returning it to the queue");
         msgsCommunicator_->getIncomingMsgsStorage()->pushExternalMsg(std::unique_ptr<MessageBase>(m));
         return;
       }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3753,7 +3753,13 @@ ReplicaImp::ReplicaImp(bool firstTime,
 
   std::unordered_map<uint32_t, uint64_t> epochs;
 
-  EpochManager::InitData eid{internalBFTClient_, rsaSigner_, config_.replicaId, config.numReplicas, config.fVal, false};
+  EpochManager::InitData eid{internalBFTClient_,
+                             rsaSigner_,
+                             *(this->stateTransfer),
+                             config_.replicaId,
+                             config.numReplicas,
+                             config.fVal,
+                             false};
   EpochManager::instance(&eid);
 
   LOG_INFO(GL, "ReplicaConfig parameters: " << config);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3753,7 +3753,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
 
   std::unordered_map<uint32_t, uint64_t> epochs;
 
-  EpochManager::InitData eid{internalBFTClient_, rsaSigner_, config_.replicaId, config.numReplicas, config.fVal};
+  EpochManager::InitData eid{internalBFTClient_, rsaSigner_, config_.replicaId, config.numReplicas, config.fVal, false};
   EpochManager::instance(&eid);
 
   LOG_INFO(GL, "ReplicaConfig parameters: " << config);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -193,6 +193,11 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
   if (!KeyExchangeManager::instance().exchanged() || !KeyExchangeManager::instance().clientKeysPublished()) {
     if (!(flags & KEY_EXCHANGE_FLAG) && !(flags & CLIENTS_PUB_KEYS_FLAG)) {
       LOG_INFO(KEY_EX_LOG, "Didn't complete yet, dropping msg");
+      if (flags & RECONFIG_FLAG) {
+        LOG_INFO(KEY_EX_LOG, "a reconfiguration message has been found, returning it to the queue");
+        msgsCommunicator_->getIncomingMsgsStorage()->pushExternalMsg(std::unique_ptr<MessageBase>(m));
+        return;
+      }
       delete m;
       return;
     }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -44,6 +44,7 @@
 #include "ControlHandler.hpp"
 #include "bftengine/KeyExchangeManager.hpp"
 #include "secrets_manager_plain.h"
+#include "EpochsManager.hpp"
 
 #include <memory>
 #include <string>
@@ -3665,7 +3666,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       time_in_state_transfer_(histograms_.timeInStateTransfer),
       reqBatchingLogic_(*this, config_, metrics_, timers),
       replStatusHandlers_(*this),
-      rsaSigner_(std::make_unique<bftEngine::impl::RSASigner>(config.replicaPrivateKey.c_str())) {
+      rsaSigner_(std::make_shared<bftEngine::impl::RSASigner>(config.replicaPrivateKey.c_str())) {
   LOG_INFO(GL, "");
   ConcordAssertLT(config_.getreplicaId(), config_.getnumReplicas());
   // TODO(GG): more asserts on params !!!!!!!!!!!
@@ -3748,8 +3749,12 @@ ReplicaImp::ReplicaImp(bool firstTime,
 
   KeyExchangeManager::InitData id{
       internalBFTClient_, &CryptoManager::instance(), &CryptoManager::instance(), sm_, &timers_};
-
   KeyExchangeManager::instance(&id);
+
+  std::unordered_map<uint32_t, uint64_t> epochs;
+
+  EpochManager::InitData eid{internalBFTClient_, rsaSigner_, config_.replicaId, config.numReplicas, config.fVal};
+  EpochManager::instance(&eid);
 
   LOG_INFO(GL, "ReplicaConfig parameters: " << config);
 }

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -557,7 +557,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   batchingLogic::RequestsBatchingLogic reqBatchingLogic_;
   ReplicaStatusHandlers replStatusHandlers_;
 
-  std::unique_ptr<bftEngine::impl::RSASigner> rsaSigner_;
+  std::shared_ptr<bftEngine::impl::RSASigner> rsaSigner_;
 };  // namespace bftEngine::impl
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -156,6 +156,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concordUtil::Timers::Handle infoReqTimer_;
   concordUtil::Timers::Handle statusReportTimer_;
   concordUtil::Timers::Handle viewChangeTimer_;
+  concordUtil::Timers::Handle updateEpochTimer_;
 
   int viewChangeTimerMilli = 0;
   int autoPrimaryRotationTimerMilli = 0;

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -325,6 +325,7 @@ struct DummyClient : public IInternalBFTClient {
   inline NodeIdType getClientId() const { return 1; };
   uint64_t sendRequest(uint8_t flags, uint32_t requestLength, const char* request, const std::string& cid) { return 0; }
   uint32_t numOfConnectedReplicas(uint32_t clusterSize) { return clusterSize; }
+  isNodeConnected(uint32_t nodeId) { return false; }
   bool isUdp() const { return false; }
 };
 

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -327,6 +327,7 @@ struct DummyClient : public IInternalBFTClient {
   uint32_t numOfConnectedReplicas(uint32_t clusterSize) { return clusterSize; }
   isNodeConnected(uint32_t nodeId) { return false; }
   bool isUdp() const { return false; }
+  virtual void sendRequest(ClientRequestMsg*){};
 };
 
 TEST(KeyExchangeManager, initialKeyExchange) {

--- a/ccron/test/ccron_ticks_generator_test.cpp
+++ b/ccron/test/ccron_ticks_generator_test.cpp
@@ -63,7 +63,7 @@ struct InternalBFTClientMock : public IInternalBFTClient {
   uint32_t numOfConnectedReplicas(uint32_t clusterSize) override { return clusterSize; }
 
   bool isUdp() const override { return false; }
-
+  bool isNodeConnected(uint32_t) override { return false; }
   struct Request {
     uint64_t flags{0};
     std::vector<uint8_t> contents;

--- a/ccron/test/ccron_ticks_generator_test.cpp
+++ b/ccron/test/ccron_ticks_generator_test.cpp
@@ -64,11 +64,11 @@ struct InternalBFTClientMock : public IInternalBFTClient {
 
   bool isUdp() const override { return false; }
   bool isNodeConnected(uint32_t) override { return false; }
+  void sendRequest(ClientRequestMsg*) override {}
   struct Request {
     uint64_t flags{0};
     std::vector<uint8_t> contents;
     std::string cid;
-
     bool operator==(const Request& r) const { return (flags == r.flags && contents == r.contents && cid == r.cid); }
   };
 

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(kvbc  src/ClientImp.cpp
     src/sparse_merkle/update_cache.cpp
     src/sparse_merkle/walker.cpp
     src/kvbc_app_filter/kvbc_app_filter.cpp
+    src/reconfiguration_add_block_handler.cpp
 )
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -20,5 +20,5 @@ static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;
 static const char reconfiguration_key_exchange = 0x28;
 static const char reconfiguration_add_remove = 0x29;
-
+static const char reconfiguration_epoch_prefix = 0x2f;
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/reconfiguration_add_block_handler.hpp
+++ b/kvbc/include/reconfiguration_add_block_handler.hpp
@@ -64,8 +64,8 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
 };
 class InternalKvReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
  public:
-  InternalKvReconfigurationHandler(kvbc::IBlockAdder& block_adder, kvbc::IReader& ro_storage)
-      : blocks_adder_{block_adder}, block_metadata_{ro_storage}, ro_storage_{ro_storage} {
+  InternalKvReconfigurationHandler(kvbc::IBlockAdder& block_adder, kvbc::IReader& ro_storage, uint32_t num_replicas)
+      : blocks_adder_{block_adder}, block_metadata_{ro_storage}, ro_storage_{ro_storage}, num_replicas_(num_replicas) {
     (void)ro_storage_;
     for (const auto& [rep, pk] : bftEngine::ReplicaConfig::instance().publicKeysOfReplicas) {
       internal_verifiers_.emplace_back(std::make_unique<bftEngine::impl::RSAVerifier>(pk.c_str()));
@@ -92,5 +92,6 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
   kvbc::IBlockAdder& blocks_adder_;
   BlockMetadata block_metadata_;
   kvbc::IReader& ro_storage_;
+  uint32_t num_replicas_;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/include/reconfiguration_add_block_handler.hpp
+++ b/kvbc/include/reconfiguration_add_block_handler.hpp
@@ -51,7 +51,8 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeStatus& command,
-              uint64_t sequence_number, concord::messages::ReconfigurationResponse& response) override;
+              uint64_t sequence_number,
+              concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::PruneRequest& command,
               uint64_t sequence_number,

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -32,6 +32,7 @@ class StReconfigurationHandler {
   }
 
   void registerHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> handler) {
+    if (handler == nullptr) return;
     orig_reconf_handlers_.push_back(handler);
   }
 

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -45,23 +45,17 @@ class StReconfigurationHandler {
   template <typename T>
   bool handlerStoredCommand(const std::string& key, uint64_t current_cp_num);
   uint64_t getStoredBftSeqNum(BlockId bid);
-  /*
-   * For wedge, we need to do nothing. The wedge point is being cleared only on termination.
-   * Thus, as long no one did unwedge (currently, restarting the replicas) the late replica will get the data
-   * In the reserved pages and behave accordingly.
-   * TODO: Notice that until we have the unwedge command, we cannot distinguish between restart for unwedge and restart
-   * out of a crash
-   */
-  bool handle(const concord::messages::WedgeCommand&, uint64_t, uint64_t) { return true; }
-  bool handle(const concord::messages::DownloadCommand&, uint64_t, uint64_t) { return true; }
+  uint64_t getEpochNumber(uint64_t bid);
 
-  bool handle(const concord::messages::InstallCommand& cmd, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::WedgeCommand&, uint64_t, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::DownloadCommand&, uint64_t, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::InstallCommand& cmd, uint64_t, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::KeyExchangeCommand&, uint64_t, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::AddRemoveCommand&, uint64_t, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::AddRemoveWithWedgeCommand&, uint64_t, uint64_t, uint64_t);
+  bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
 
-  bool handle(const concord::messages::KeyExchangeCommand&, uint64_t, uint64_t) { return true; }
-  bool handle(const concord::messages::AddRemoveCommand&, uint64_t, uint64_t) { return true; }
-  bool handle(const concord::messages::AddRemoveWithWedgeCommand&, uint64_t, uint64_t);
-  bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t);
-
+  >>>>>>> Consider the epoch number on state transfer handler
   kvbc::IReader& ro_storage_;
   std::vector<std::shared_ptr<concord::reconfiguration::IReconfigurationHandler>> orig_reconf_handlers_;
 };

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -55,8 +55,7 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::AddRemoveWithWedgeCommand&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
 
-  >>>>>>> Consider the epoch number on state transfer handler
-  kvbc::IReader& ro_storage_;
   std::vector<std::shared_ptr<concord::reconfiguration::IReconfigurationHandler>> orig_reconf_handlers_;
+  kvbc::IReader& ro_storage_;
 };
 }  // namespace concord::kvbc

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -128,9 +128,9 @@ void Replica::createReplicaAndSyncState() {
   stReconfigurationSM_->registerHandler(m_cmdHandler->getReconfigurationHandler());
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this));
-  requestHandler->setReconfigurationHandler(
-      std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(*this, *this),
-      concord::reconfiguration::ReconfigurationHandlerType::PRE);
+  requestHandler->setReconfigurationHandler(std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(
+      *this, *this, replicaConfig_.numReplicas),
+                                            concord::reconfiguration::ReconfigurationHandlerType::PRE);
   auto pruning_handler = std::shared_ptr<kvbc::pruning::PruningHandler>(
       new concord::kvbc::pruning::PruningHandler(*this, *this, *this, true));
   requestHandler->setReconfigurationHandler(pruning_handler);
@@ -178,6 +178,7 @@ void Replica::createReplicaAndSyncState() {
         bftEngine::EpochManager::instance().updateEpochForReplica(i, epoch);
       }
     }
+    bftEngine::EpochManager::instance().save();
   }
 }
 

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -64,6 +64,13 @@ Status Replica::start() {
   }
   bftEngine::EpochManager::instance().setAggregator(aggregator_);
   m_replicaPtr->SetAggregator(aggregator_);
+  if (bftEngine::ControlStateManager::instance().isNewEpoch()) {
+    auto prevEpoch = bftEngine::EpochManager::instance().getSelfEpoch();
+    LOG_INFO(logger,
+             "We need to switch epochs. Lets make sure that the first message on the queue is the new epoch message"
+                 << KVLOG(prevEpoch));
+    bftEngine::EpochManager::instance().sendUpdateEpochMsg(prevEpoch + 1);
+  }
   m_replicaPtr->start();
   m_currentRepStatus = RepStatus::Running;
 

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -116,7 +116,6 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
 void Replica::createReplicaAndSyncState() {
   ConcordAssert(m_kvBlockchain.has_value());
   auto requestHandler = KvbcRequestHandler::create(m_cmdHandler, cronTableRegistry_, *m_kvBlockchain);
-  stReconfigurationSM_->registerHandler(requestHandler->getReconfigurationHandler());
   stReconfigurationSM_->registerHandler(m_cmdHandler->getReconfigurationHandler());
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this));

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -62,6 +62,7 @@ Status Replica::start() {
   } else {
     createReplicaAndSyncState();
   }
+  bftEngine::EpochManager::instance().setAggregator(aggregator_);
   m_replicaPtr->SetAggregator(aggregator_);
   m_replicaPtr->start();
   m_currentRepStatus = RepStatus::Running;

--- a/kvbc/src/reconfiguration_add_block_handler.cpp
+++ b/kvbc/src/reconfiguration_add_block_handler.cpp
@@ -178,17 +178,17 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
   return true;
 }
 bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& command,
-       uint64_t sequence_number,
-       concord::messages::ReconfigurationResponse&) {
-std::vector<uint8_t> serialized_command;
-concord::messages::serialize(serialized_command, command);
-auto blockId = persistReconfigurationBlock(blocks_adder_,
-                                           block_metadata_,
-                                           serialized_command,
-                                           sequence_number,
-                                           std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1});
-LOG_INFO(getLogger(), "PruneRequest configuration command block is " << blockId);
-return true;
+                                    uint64_t sequence_number,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                             block_metadata_,
+                                             serialized_command,
+                                             sequence_number,
+                                             std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1});
+  LOG_INFO(getLogger(), "PruneRequest configuration command block is " << blockId);
+  return true;
 }
 bool InternalKvReconfigurationHandler::verifySignature(const std::string& data, const std::string& signature) const {
   bool valid = false;
@@ -224,6 +224,7 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::EpochUpda
                                               uint64_t bft_seq_num,
                                               concord::messages::ReconfigurationResponse&) {
   auto source = command.replica_id;
+  if (bftEngine::EpochManager::instance().getEpochForReplica(source) >= command.epoch_number) return true;
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId =

--- a/kvbc/src/reconfiguration_add_block_handler.cpp
+++ b/kvbc/src/reconfiguration_add_block_handler.cpp
@@ -1,0 +1,227 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "reconfiguration_add_block_handler.hpp"
+#include "bftengine/ControlStateManager.hpp"
+
+namespace concord::kvbc::reconfiguration {
+kvbc::BlockId persistReconfigurationBlock(kvbc::IBlockAdder& blocks_adder,
+                                          BlockMetadata& block_metadata,
+                                          const std::vector<uint8_t>& data,
+                                          const uint64_t bft_seq_num,
+                                          string key) {
+  concord::kvbc::categorization::VersionedUpdates ver_updates;
+  ver_updates.addUpdate(std::move(key), std::string(data.begin(), data.end()));
+
+  // All blocks are expected to have the BFT sequence number as a key.
+  ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, block_metadata.serialize(bft_seq_num));
+
+  concord::kvbc::categorization::Updates updates;
+  updates.add(kvbc::kConcordInternalCategoryId, std::move(ver_updates));
+  try {
+    return blocks_adder.add(std::move(updates));
+  } catch (...) {
+    LOG_FATAL(GL, "Reconfiguration Handler failed to persist the reconfiguration block");
+  }
+  return 0;
+}
+bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
+                                    uint64_t bft_seq_num,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                             block_metadata_,
+                                             serialized_command,
+                                             bft_seq_num,
+                                             std::string{kvbc::keyTypes::reconfiguration_wedge_key});
+  LOG_INFO(getLogger(), "WedgeCommand block is " << blockId);
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& command,
+                                    uint64_t bft_seq_num,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                             block_metadata_,
+                                             serialized_command,
+                                             bft_seq_num,
+                                             std::string{kvbc::keyTypes::reconfiguration_download_key});
+  LOG_INFO(getLogger(), "DownloadCommand command block is " << blockId);
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& command,
+                                    uint64_t bft_seq_num,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                             block_metadata_,
+                                             serialized_command,
+                                             bft_seq_num,
+                                             std::string{kvbc::keyTypes::reconfiguration_install_key});
+  LOG_INFO(getLogger(), "InstallCommand command block is " << blockId);
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand& command,
+                                    uint64_t sequence_number,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                             block_metadata_,
+                                             serialized_command,
+                                             sequence_number,
+                                             std::string{kvbc::keyTypes::reconfiguration_key_exchange});
+  LOG_INFO(getLogger(), "KeyExchangeCommand command block is " << blockId);
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& command,
+                                    uint64_t sequence_number,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                             block_metadata_,
+                                             serialized_command,
+                                             sequence_number,
+                                             std::string{kvbc::keyTypes::reconfiguration_add_remove});
+  LOG_INFO(getLogger(), "AddRemoveCommand command block is " << blockId);
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand& command,
+                                    uint64_t sequence_number,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                             block_metadata_,
+                                             serialized_command,
+                                             sequence_number,
+                                             std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
+  LOG_INFO(getLogger(), "AddRemove configuration command block is " << blockId);
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& command,
+                                    uint64_t sequence_number,
+                                    concord::messages::ReconfigurationResponse& response) {
+  auto res =
+      ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_add_remove});
+  if (res.has_value()) {
+    auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
+    concord::messages::AddRemoveCommand cmd;
+    std::vector<uint8_t> bytesval(strval.begin(), strval.end());
+    concord::messages::deserialize(bytesval, cmd);
+    concord::messages::AddRemoveStatusResponse addRemoveResponse;
+    addRemoveResponse.reconfiguration = cmd.reconfiguration;
+    LOG_INFO(getLogger(), "AddRemoveCommand response: " << addRemoveResponse.reconfiguration);
+    response.response = std::move(addRemoveResponse);
+  } else {
+    concord::messages::ReconfigurationErrorMsg error_msg;
+    error_msg.error_msg = "key_not_found";
+    response.response = std::move(error_msg);
+    LOG_INFO(getLogger(), "AddRemoveCommand key not found");
+    return false;
+  }
+  return true;
+}
+bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeStatus& command,
+                                    uint64_t sequence_number,
+                                    concord::messages::ReconfigurationResponse& response) {
+  auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId,
+                                   std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
+  if (res.has_value()) {
+    auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
+    concord::messages::AddRemoveWithWedgeCommand cmd;
+    std::vector<uint8_t> bytesval(strval.begin(), strval.end());
+    concord::messages::deserialize(bytesval, cmd);
+    concord::messages::AddRemoveWithWedgeStatusResponse addRemoveResponse;
+    addRemoveResponse.config_descriptor = cmd.config_descriptor;
+    LOG_INFO(getLogger(), "AddRemoveWithWedgeCommand response: " << addRemoveResponse.config_descriptor);
+    response.response = std::move(addRemoveResponse);
+  } else {
+    concord::messages::ReconfigurationErrorMsg error_msg;
+    error_msg.error_msg = "key_not_found";
+    response.response = std::move(error_msg);
+    LOG_INFO(getLogger(), "AddRemoveWithWedgeCommand key not found");
+    return false;
+  }
+  return true;
+}
+bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& command,
+       uint64_t sequence_number,
+       concord::messages::ReconfigurationResponse&) {
+std::vector<uint8_t> serialized_command;
+concord::messages::serialize(serialized_command, command);
+auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                           block_metadata_,
+                                           serialized_command,
+                                           sequence_number,
+                                           std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1});
+LOG_INFO(getLogger(), "PruneRequest configuration command block is " << blockId);
+return true;
+}
+bool InternalKvReconfigurationHandler::verifySignature(const std::string& data, const std::string& signature) const {
+  bool valid = false;
+  for (auto& verifier : internal_verifiers_) {
+    valid |= verifier->verify(data.c_str(), data.size(), signature.c_str(), signature.size());
+    if (valid) break;
+  }
+  return valid;
+}
+bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
+                                              uint64_t bft_seq_num,
+                                              concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  if (command.noop) {
+    auto seq_num_to_stop_at = bftEngine::ControlStateManager::instance().getCheckpointToStopAt();
+    if (!seq_num_to_stop_at.has_value() || bft_seq_num > seq_num_to_stop_at) {
+      LOG_ERROR(getLogger(), "Invalid noop wedge command, it won't be writen to the blockchain");
+      return false;
+    }
+    auto blockId = persistReconfigurationBlock(blocks_adder_,
+                                               block_metadata_,
+                                               serialized_command,
+                                               bft_seq_num,
+                                               std::string{kvbc::keyTypes::reconfiguration_wedge_key, 0x1});
+    LOG_INFO(getLogger(), "received noop command, a new block will be written" << KVLOG(bft_seq_num, blockId));
+    return true;
+  }
+  return false;
+}
+
+bool InternalKvReconfigurationHandler::handle(const concord::messages::EpochUpdateMsg& command,
+                                              uint64_t bft_seq_num,
+                                              concord::messages::ReconfigurationResponse&) {
+  auto source = command.replica_id;
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId =
+      persistReconfigurationBlock(blocks_adder_,
+                                  block_metadata_,
+                                  serialized_command,
+                                  bft_seq_num,
+                                  std::string{kvbc::keyTypes::reconfiguration_epoch_prefix, static_cast<char>(source)});
+  LOG_INFO(getLogger(),
+           "received new epoch message, a new block will be written" << KVLOG(source, bft_seq_num, blockId));
+  // We also need to update the reserved pages via epoch manager
+  return true;
+}
+}  // namespace concord::kvbc::reconfiguration

--- a/kvbc/src/reconfiguration_add_block_handler.cpp
+++ b/kvbc/src/reconfiguration_add_block_handler.cpp
@@ -248,6 +248,9 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::EpochUpda
       epoch = epoch_msg.epoch_number;
       bftEngine::EpochManager::instance().updateEpochForReplica(i, epoch);
     }
+    if (source == bftEngine::ReplicaConfig::instance().replicaId) {
+      bftEngine::ControlStateManager::instance().clearNewEpoch();
+    }
   }
   bftEngine::EpochManager::instance().save();
   return true;

--- a/kvbc/src/reconfiguration_add_block_handler.cpp
+++ b/kvbc/src/reconfiguration_add_block_handler.cpp
@@ -12,6 +12,7 @@
 
 #include "reconfiguration_add_block_handler.hpp"
 #include "bftengine/ControlStateManager.hpp"
+#include "bftengine/EpochsManager.hpp"
 
 namespace concord::kvbc::reconfiguration {
 kvbc::BlockId persistReconfigurationBlock(kvbc::IBlockAdder& blocks_adder,
@@ -115,6 +116,8 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
                                              sequence_number,
                                              std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
   LOG_INFO(getLogger(), "AddRemove configuration command block is " << blockId);
+
+  // From now on, we are going to start wedge process, at the end of this process we will conisdered
   return true;
 }
 
@@ -221,7 +224,8 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::EpochUpda
                                   std::string{kvbc::keyTypes::reconfiguration_epoch_prefix, static_cast<char>(source)});
   LOG_INFO(getLogger(),
            "received new epoch message, a new block will be written" << KVLOG(source, bft_seq_num, blockId));
-  // We also need to update the reserved pages via epoch manager
+  LOG_INFO(getLogger(), "updating epoch of replica " << source << " to " << command.epoch_number);
+  bftEngine::EpochManager::instance().updateEpochForReplica(source, command.epoch_number);
   return true;
 }
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -118,7 +118,7 @@ bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedg
   }
   // We just join the network, we know nothing about previous epochs. Then just anounce it and join
   if (!bftEngine::ControlStateManager::instance().isNewEpoch()) {
-    bftEngine::EpochManager::instance().markToSendEpochNumberAfterStateTransfer((uint64_t)maxEpochNumber);
+    bftEngine::EpochManager::instance().reserveEpochNumberForLaterUse((uint64_t)maxEpochNumber);
     return true;
   }
   // Else, we are in a previous epoch, we need to resync ourselves immidietly.
@@ -128,7 +128,10 @@ bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedg
   return true;
 }
 
-bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &command, uint64_t bft_seq_num, uint64_t, uint64_t) {
+bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &command,
+                                      uint64_t bft_seq_num,
+                                      uint64_t,
+                                      uint64_t) {
   // Actual pruning will be done from the lowest latestPruneableBlock returned by the replicas. It means, that even
   // on every state transfer there might be at most one relevant pruning command. Hence it is enough to take the latest
   // saved command and try to execute it

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -106,6 +106,11 @@ Msg AddRemoveWithWedgeStatusResponse 31 {
     string config_descriptor
 }
 
+Msg EpochUpdateMsg 32 {
+    uint32 replica_id
+    uint64 epoch_number
+}
+
 Msg ReconfigurationRequest 1 {
   bytes signature
   oneof {
@@ -124,6 +129,7 @@ Msg ReconfigurationRequest 1 {
     AddRemoveStatus
     AddRemoveWithWedgeCommand
     AddRemoveWithWedgeStatus
+    EpochUpdateMsg
   } command
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -98,6 +98,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::EpochUpdateMsg&, uint64_t, concord::messages::ReconfigurationResponse&) {
     return true;
   }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(const std::string& data, const std::string& signature) const = 0;

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -94,6 +94,10 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::PruneRequest&, uint64_t, concord::messages::ReconfigurationResponse&) {
     return true;
   }
+
+  virtual bool handle(const concord::messages::EpochUpdateMsg&, uint64_t, concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(const std::string& data, const std::string& signature) const = 0;

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1016,7 +1016,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.start_replicas(on_time_replicas)
         await self.validate_epoch_number(bft_network=bft_network, replicas=on_time_replicas, expected_epoch=1)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(151):
+        for i in range(301):
             await skvbc.write_known_kv()
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
@@ -1058,7 +1058,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         on_time_replicas = bft_network.all_replicas(without=new_replicas)
         bft_network.start_replicas(on_time_replicas)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(151):
+        for i in range(301):
             await skvbc.write_known_kv()
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
@@ -1136,7 +1136,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.start_replicas(on_time_replicas)
         await self.validate_epoch_number(bft_network=bft_network, replicas=on_time_replicas, expected_epoch=1)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(151):
+        for i in range(301):
             await skvbc.write_known_kv()
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
@@ -1178,7 +1178,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.start_replicas(on_time_replicas)
         await self.validate_epoch_number(bft_network=bft_network, replicas=on_time_replicas, expected_epoch=2)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(151):
+        for i in range(301):
             await skvbc.write_known_kv()
         bft_network.start_replicas(late_replicas)
         await bft_network.wait_for_state_transfer_to_start()

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1018,12 +1018,16 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(301):
             await skvbc.write_known_kv()
+        await bft_network.wait_for_last_stable_seq_num(initial_prim, 300)
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
         for r in new_replicas:
             await bft_network.wait_for_state_transfer_to_stop(initial_prim,
                                                               r,
-                                                              stop_on_stable_seq_num=False)
+                                                              stop_on_stable_seq_num=True)
+        # We now restart the new replicas in order to let them starting the new epoch
+        bft_network.stop_replicas(new_replicas)
+        bft_network.start_replicas(new_replicas)
         for i in range(200):
             await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=1)
@@ -1060,12 +1064,17 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(301):
             await skvbc.write_known_kv()
+        await bft_network.wait_for_last_stable_seq_num(initial_prim, 300)
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
         for r in new_replicas:
             await bft_network.wait_for_state_transfer_to_stop(initial_prim,
                                                               r,
-                                                              stop_on_stable_seq_num=False)
+                                                              stop_on_stable_seq_num=True)
+
+        # We now restart the new replicas in order to let them starting the new epoch
+        bft_network.stop_replicas(new_replicas)
+        bft_network.start_replicas(new_replicas)
         for i in range(300):
             await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=2)
@@ -1136,14 +1145,18 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.start_replicas(on_time_replicas)
         await self.validate_epoch_number(bft_network=bft_network, replicas=on_time_replicas, expected_epoch=1)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(301):
+        for i in range(300):
             await skvbc.write_known_kv()
+        await bft_network.wait_for_last_stable_seq_num(initial_prim, 300)
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
         for r in new_replicas:
             await bft_network.wait_for_state_transfer_to_stop(initial_prim,
                                                               r,
-                                                              stop_on_stable_seq_num=False)
+                                                              stop_on_stable_seq_num=True)
+        # Now, we want to restart the state transffered replicas (as they just finished the state transfer of the previous epoch)
+        bft_network.stop_replicas(new_replicas)
+        bft_network.start_replicas(new_replicas)
         for i in range(200):
             await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=1)
@@ -1180,12 +1193,16 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(301):
             await skvbc.write_known_kv()
+        await bft_network.wait_for_last_stable_seq_num(initial_prim, 300)
         bft_network.start_replicas(late_replicas)
         await bft_network.wait_for_state_transfer_to_start()
         for r in late_replicas:
             await bft_network.wait_for_state_transfer_to_stop(initial_prim,
                                                               r,
-                                                              stop_on_stable_seq_num=False)
+                                                              stop_on_stable_seq_num=True)
+        # Now, we want to restart the new replica (as it just finished the state transfer of the previous epoch)
+        bft_network.stop_replicas({6})
+        bft_network.start_replicas({6})
         for i in range(300):
             await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=2)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -891,8 +891,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # Now, we want to restart the new replica (as it just finished the state transfer of the previous epoch)
         bft_network.stop_replicas(crashed_replicas)
         bft_network.start_replicas(crashed_replicas)
-        for i in range(300):
-            await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=crashed_replicas, expected_epoch=2)
 
 
@@ -1090,10 +1088,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # We now restart the new replicas in order to let them starting the new epoch
         bft_network.stop_replicas(new_replicas)
         bft_network.start_replicas(new_replicas)
-        for i in range(200):
-            await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=1)
-
+        # Make sure that we are able to execute requests in fast path
+        for i in range(100):
+            await skvbc.write_known_kv()
         for r in bft_network.all_replicas():
             nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
             self.assertGreater(nb_fast_path, 0)
@@ -1137,10 +1135,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # We now restart the new replicas in order to let them starting the new epoch
         bft_network.stop_replicas(new_replicas)
         bft_network.start_replicas(new_replicas)
-        for i in range(300):
-            await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=2)
-
+        # Make sure that we are able to execute requests in fast path
+        for i in range(100):
+            await skvbc.write_known_kv()
         for r in bft_network.all_replicas():
             nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
             self.assertGreater(nb_fast_path, 0)
@@ -1219,9 +1217,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # Now, we want to restart the state transffered replicas (as they just finished the state transfer of the previous epoch)
         bft_network.stop_replicas(new_replicas)
         bft_network.start_replicas(new_replicas)
-        for i in range(200):
-            await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=1)
+        # Make sure that we are able to execute requests in fast path
+        for i in range(100):
+            await skvbc.write_known_kv()
         for r in bft_network.all_replicas():
             nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
             self.assertGreater(nb_fast_path, 0)
@@ -1265,10 +1264,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # Now, we want to restart the new replica (as it just finished the state transfer of the previous epoch)
         bft_network.stop_replicas({6})
         bft_network.start_replicas({6})
-        for i in range(300):
-            await skvbc.write_known_kv()
         await self.validate_epoch_number(bft_network=bft_network, replicas=bft_network.all_replicas(), expected_epoch=2)
-
+        # Make sure that we are able to execute requests in fast path
+        for i in range(100):
+            await skvbc.write_known_kv()
         for r in bft_network.all_replicas():
             nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
             self.assertGreater(nb_fast_path, 0)
@@ -1326,7 +1325,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
     async def validate_epoch_number(self, bft_network, replicas, expected_epoch):
         with log.start_action(action_type="validate_epoch_number") as action:
-            with trio.fail_after(seconds=60):
+            with trio.fail_after(seconds=90):
                 for replica_id in replicas:
                     while True:
                         with trio.move_on_after(seconds=1):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -1134,6 +1134,17 @@ class BftTestNetwork:
             
             return await self.wait_for(expected_seq_num_to_be_reached, 30, .5)
 
+    async def wait_for_last_stable_seq_num(self, replica_id=0, expected=0):
+        with log.start_action(action_type="wait_for_last_executed_seq_num"):
+            async def expected_stable_seq_num_to_be_reached():
+                key = ['replica', 'Gauges', 'lastStableSeqNum']
+                last_stable_seq_num = await self.retrieve_metric(replica_id, *key)
+
+                if last_stable_seq_num is not None and last_stable_seq_num >= expected:
+                    return last_stable_seq_num
+
+            return await self.wait_for(expected_stable_seq_num_to_be_reached, 30, .5)
+
     async def assert_state_transfer_not_started_all_up_nodes(self, up_replica_ids):
         with log.start_action(action_type="assert_state_transfer_not_started_all_up_nodes"):
             with trio.fail_after(METRICS_TIMEOUT_SEC):


### PR DESCRIPTION
**An epoch** is a life cycle of the system between two events that define the system differently. For example, adding or removing nodes, updating software, and other reconfiguration events.
We need the ability to differentiate between commands of different epochs. 
For example, if a replica gets (via state transfer) a reconfiguration command that is not relevant to its current epoch, it should ignore it.
In this PR we introduce concord-bft's epoch manager.
it preserves several principles:
1. To update its epoch, a replica issues a special reconfiguration request to the consensus mechanism, the execution result is that all on-time replicas update the epoch number of the replica on the chain
2. The epochs are also written to the reserved pages - this is to let read-only replica get updated
3. Because we save the epochs on-chain, we don't remove them when we remove the metadata
4. When we write a command that changes the epoch, we also write its epoch number

The power of knowing the epochs is demonstrated in the state transfer call back for reconfiguration https://github.com/vmware/concord-bft/blob/ee708c78f0b7256d66573e4c2ae00b8fdce80871/kvbc/src/st_reconfiguration_sm.cpp#L85

On a replica state transfer, if we found an addRemove command in the blockchain, we compute the next 3 numbers:
* The replica epoch (read from the blockchain)
* The command epoch (read from the blockchain)
* The max known by quorum epoch (read from reserved pages)

Based on these 3 numbers we cover all cases:
1. If the replica epoch is greater than the command epoch, it means that we already executed this command and we don't need to do anything
2. If the replica epoch is the same as the command epoch, but the checkpoint is smaller than the wedge point, it means that we are not in the wedge point yet. Thus, we return without doing anything and wait for the next checkpoint (notice that this case can only happen if we start state transfer for the last checkpoint before the wedge)
3. If the replica checkpoint is (a) the same as the command epoch and (b) the same as the max known epoch and (c) the checkpoint number is the same as the wedge point, it means that we are in the same state as all other replicas (as far as we know). Thus, we need to run the relevant command handler, wedge and remove the metadata.
Notice, that in this case, if we started state transfer for a checkpoint that does not reflect the reality (for example,  all other replicas are in an advanced epoch, but we started the state transfer for this checkpoint), then eventually another state transfer will happen and we will fall under the next case
4. If the replica epoch is less than the command epoch or less than the max known epoch, it means that we are behind and we want to jump to the max known epoch as fast as we can. 

**Note** that as for (4.) the jump is done to the highest recorded global epoch (tied to the latest addRemove command) + 1. In case that the other replicas have advanced to a newer epoch, it means that eventually, we will start a state transfer and achieve this epoch as well. 

**Note**  that even when we will have other epoch changers (such as unwedge), we will also have every state transfer reconfiguration handler doing its own relevant part, such that once we restart and jump to the new epoch, the replica will be aligned with the state and epochs

**Note** that to complete this feature, we need to add an epoch number to the messages. However, this will be part of a future PR
In addition, we updated the reconfiguration tests to test also that we change epochs