### PR TITLE
Fix shared signature verification failure processing.

### DIFF
--- a/bftengine/tests/messages/helper.hpp
+++ b/bftengine/tests/messages/helper.hpp
@@ -59,6 +59,7 @@ class IThresholdAccumulatorDummy : public IThresholdAccumulator {
   bool hasShareVerificationEnabled() const override { return true; }
   int getNumValidShares() const override { return 0; }
   void getFullSignedData(char *outThreshSig, int threshSigLen) override {}
+  std::set<ShareID> getInvalidShareIds() const override { return {}; }
 };
 
 class IThresholdVerifierDummy : public IThresholdVerifier {

--- a/bftengine/tests/testViewChange/testViewChange.cpp
+++ b/bftengine/tests/testViewChange/testViewChange.cpp
@@ -60,15 +60,6 @@ class DummyShareVerificationKey : public IShareVerificationKey {
   virtual std::string toString() const override { return std::string("123"); }
 };
 
-class DummyThresholdAccumulator : public IThresholdAccumulator {
- public:
-  virtual int add(const char* sigShareWithId, int len) override { return 0; }
-  virtual void setExpectedDigest(const unsigned char* msg, int len) override {}
-  virtual bool hasShareVerificationEnabled() const override { return true; }
-  virtual int getNumValidShares() const override { return 0; }
-  virtual void getFullSignedData(char* outThreshSig, int threshSigLen) override {}
-};
-
 class DummySigner : public IThresholdSigner {
   DummyShareSecretKey dummyShareSecretKey_;
   DummyShareVerificationKey dummyShareVerificationKey_;

--- a/threshsign/include/threshsign/IThresholdAccumulator.h
+++ b/threshsign/include/threshsign/IThresholdAccumulator.h
@@ -13,7 +13,7 @@
 #pragma once
 
 #include <cstddef>
-
+#include <set>
 #include "ThresholdSignaturesTypes.h"
 
 /**
@@ -56,6 +56,11 @@ class IThresholdAccumulator {
    * Before that, always returns 0, since shares can't be verified without a digest.
    */
   virtual int getNumValidShares() const = 0;
+
+  /**
+   * if share verification enabled, returns invalid share ids.
+   */
+  virtual std::set<ShareID> getInvalidShareIds() const = 0;
 
   /**
    * Computes and returns the final threshold signature on the digest specified in setExpectedDigest().

--- a/threshsign/include/threshsign/ThresholdAccumulatorBase.h
+++ b/threshsign/include/threshsign/ThresholdAccumulatorBase.h
@@ -44,6 +44,9 @@ class ThresholdAccumulatorBase : public IThresholdAccumulator {
   // Valid shares indexed by signer ID
   std::vector<NumType> validShares;
 
+  // Invalid shares indexed by signer ID
+  std::set<ShareID> invalidShares;
+
   // Bit vectors of pending (unverified) shares and valid shares (|validSharesBits| <= reqSigners)
   VectorOfShares validSharesBits, pendingSharesBits;
 
@@ -121,21 +124,23 @@ class ThresholdAccumulatorBase : public IThresholdAccumulator {
    * Keeps track of the digest and makes sure it's never changed.
    * Verifies and moves the pending shares into the list of valid shares.
    */
-  virtual void setExpectedDigest(const unsigned char* msg, int len);
+  void setExpectedDigest(const unsigned char* msg, int len) override;
 
   /**
    * Parses signer ID out of sigShare and calls internal addNumById() method.
    */
-  virtual int add(const char* sigShare, int len);
+  int add(const char* sigShare, int len) override;
 
   /**
    * When verification is enabled, returns the number of valid shares. Otherwise
    * returns 0.
    */
-  virtual int getNumValidShares() const {
+  int getNumValidShares() const override {
     if (!hasShareVerificationEnabled() || hasExpectedDigest())
       return validSharesBits.count();
     else
       return 0;
   }
+
+  std::set<ShareID> getInvalidShareIds() const override { return invalidShares; }
 };

--- a/threshsign/include/threshsign/bls/relic/BlsMultisigVerifier.h
+++ b/threshsign/include/threshsign/bls/relic/BlsMultisigVerifier.h
@@ -51,9 +51,6 @@ class BlsMultisigVerifier : public BlsThresholdVerifier {
   bool verify(const char *msg, int msgLen, const char *sig, int sigLen) const override;
 
   int requiredLengthForSignedData() const override;
-
- protected:
-  BlsMultisigVerifier() = default;
 };
 
 } /* namespace Relic */

--- a/threshsign/include/threshsign/bls/relic/BlsThresholdVerifier.h
+++ b/threshsign/include/threshsign/bls/relic/BlsThresholdVerifier.h
@@ -22,18 +22,17 @@
 #include <vector>
 #include <memory>
 
-namespace BLS {
-namespace Relic {
+namespace BLS::Relic {
 
 class BlsThresholdVerifier : public IThresholdVerifier {
  protected:
   BlsPublicParameters params_;
-  // For multisig publicKey_ is used only for n-out-of-n case
-  // TODO [TK] mutable for deserialization - remove as we don't need to serialize the entire class
-  mutable BlsPublicKey publicKey_;
+  // For multisig publicKey_ is used ONLY for n-out-of-n case
+  BlsPublicKey publicKey_;
   std::vector<BlsPublicKey> publicKeysVector_;
   G2T generator2_;
-  NumSharesType reqSigners_ = 0, numSigners_ = 0;
+  NumSharesType reqSigners_;
+  const NumSharesType numSigners_;
 
  public:
   BlsThresholdVerifier(const BlsPublicParameters &params,
@@ -42,7 +41,7 @@ class BlsThresholdVerifier : public IThresholdVerifier {
                        NumSharesType numSigners,
                        const std::vector<BlsPublicKey> &verificationKeys);
 
-  ~BlsThresholdVerifier() override = default;
+  BlsThresholdVerifier() = delete;
 
   bool operator==(const BlsThresholdVerifier &other) const;
   bool compare(const BlsThresholdVerifier &other) const { return (*this == other); }
@@ -72,10 +71,6 @@ class BlsThresholdVerifier : public IThresholdVerifier {
   const IPublicKey &getPublicKey() const override { return publicKey_; }
 
   const IShareVerificationKey &getShareVerificationKey(ShareID signer) const override;
-
- protected:
-  BlsThresholdVerifier() = default;
 };
 
-} /* namespace Relic */
-} /* namespace BLS */
+}  // namespace BLS::Relic

--- a/threshsign/test/ThresholdViabilityTest.h
+++ b/threshsign/test/ThresholdViabilityTest.h
@@ -84,7 +84,7 @@ class ThresholdViabilityTest {
     testAssertNotNull(verifier());
 
     LOG_INFO(THRESHSIGN_LOG,
-             "Testing " << typeid(params).name() << " on " << reqSigners << " out of " << numSigners << " signers");
+             "Testing " << reqSigners << " out of " << numSigners << " signers. Verify shares: " << verifiesShares);
     GroupType h = hashMessage(msg, msgSize);
 
     VectorOfShares signers;


### PR DESCRIPTION
Threshsign library uses signers index starting at 1 rathrer than at 0 as replica ids.
This fact wasn't taken into consideration when mapped failed signer id into replica id.
In turn this could cause the system to lose the liveness (n=4, f=1) since the combination
of 3 good sig shares was never verified.
Propper mapping is decrementing 1 from signer index to get replica id.

Appropriate test test_key_exchange_with_file_backup was added to verify the right behavior.
In the test one replica was restarted with an old private keys, which caused it to send improper signatures.