### PR TITLE
Code style: Allow #pragma once explicitly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ Our code style has the following exceptions that differ from the google C++ styl
 
  * We use `camelCase` function and method names, rather than `PascalCase`.
  * We allow, and encourage the use of exceptions.
+ * We allow and prefer `#pragma once` over include guards
 
 ## Reporting Bugs and Creating Issues
 


### PR DESCRIPTION
We already use `#pragma once` all over the code base. This change explicitly
calls it out due to the difference to the Google C++ Style Guide.