### PR TITLE
Implement replica state sync based on block ID

### DIFF
--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -266,7 +266,7 @@ void DebugPersistentStorage::setCheckpointMsgInCheckWindow(SeqNum s, CheckpointM
 
 void DebugPersistentStorage::setUserDataAtomically(const void *data, std::size_t numberOfBytes) {
   const auto p = static_cast<const char *>(data);
-  userData_.assign(p, p + numberOfBytes);
+  userData_.emplace(p, p + numberOfBytes);
 }
 
 void DebugPersistentStorage::setUserDataInTransaction(const void *data, std::size_t numberOfBytes) {
@@ -477,7 +477,7 @@ bool DebugPersistentStorage::getCompletedMarkInCheckWindow(SeqNum seqNum) {
   return b;
 }
 
-std::vector<std::uint8_t> DebugPersistentStorage::getUserData() const { return userData_; }
+std::optional<std::vector<std::uint8_t>> DebugPersistentStorage::getUserData() const { return userData_; }
 
 bool DebugPersistentStorage::setIsAllowed() const { return isInWriteTran(); }
 

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -68,7 +68,7 @@ class DebugPersistentStorage : public PersistentStorage {
   CommitFullMsg* getAndAllocateCommitFullMsgInSeqNumWindow(SeqNum seqNum) override;
   CheckpointMsg* getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) override;
   bool getCompletedMarkInCheckWindow(SeqNum seqNum) override;
-  std::vector<std::uint8_t> getUserData() const override;
+  std::optional<std::vector<std::uint8_t>> getUserData() const override;
   void setEraseMetadataStorageFlag() override {}
   bool getEraseMetadataStorageFlag() override { return false; };
   void eraseMetadata() override{};
@@ -107,7 +107,7 @@ class DebugPersistentStorage : public PersistentStorage {
   // range: TODO(GG): !!!!!!!
   CheckWindow checkWindow;
 
-  std::vector<std::uint8_t> userData_;
+  std::optional<std::vector<std::uint8_t>> userData_;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -20,6 +20,7 @@
 #include "PersistentStorageDescriptors.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 namespace bftEngine {
@@ -151,7 +152,7 @@ class PersistentStorage {
   virtual CheckpointMsg *getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) = 0;
   virtual bool getCompletedMarkInCheckWindow(SeqNum seqNum) = 0;
 
-  virtual std::vector<std::uint8_t> getUserData() const = 0;
+  virtual std::optional<std::vector<std::uint8_t>> getUserData() const = 0;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -829,10 +829,13 @@ bool PersistentStorageImp::getCompletedMarkInCheckWindow(SeqNum seqNum) {
   return readCompletedMarkFromDisk(seqNum);
 }
 
-std::vector<std::uint8_t> PersistentStorageImp::getUserData() const {
+std::optional<std::vector<std::uint8_t>> PersistentStorageImp::getUserData() const {
   auto buf = std::vector<std::uint8_t>(kMaxUserDataSizeBytes);
   auto actualSize = std::uint32_t{0};
   metadataStorage_->read(USER_DATA, buf.size(), reinterpret_cast<char *>(buf.data()), actualSize);
+  if (0 == actualSize) {
+    return std::nullopt;
+  }
   buf.resize(actualSize);
   return buf;
 }

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -164,7 +164,7 @@ class PersistentStorageImp : public PersistentStorage {
   CheckpointMsg *getAndAllocateCheckpointMsgInCheckWindow(SeqNum seqNum) override;
   bool getCompletedMarkInCheckWindow(SeqNum seqNum) override;
 
-  std::vector<std::uint8_t> getUserData() const override;
+  std::optional<std::vector<std::uint8_t>> getUserData() const override;
 
   SharedPtrSeqNumWindow getSeqNumWindow();
   SharedPtrCheckWindow getCheckWindow();

--- a/kvbc/include/metadata_block_id.h
+++ b/kvbc/include/metadata_block_id.h
@@ -12,11 +12,14 @@
 
 #pragma once
 
+#include "assertUtils.hpp"
 #include "categorization/kv_blockchain.h"
 #include "endianness.hpp"
+#include "kv_types.hpp"
 #include "PersistentStorage.hpp"
 
 #include <memory>
+#include <optional>
 
 namespace concord::kvbc {
 
@@ -30,6 +33,16 @@ void persistLastBlockIdInMetadata(const categorization::KeyValueBlockchain &bloc
   } else {
     metadata->setUserDataAtomically(user_data.data(), user_data.size());
   }
+}
+
+inline std::optional<BlockId> getLastBlockIdFromMetadata(
+    const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
+  const auto ud = metadata->getUserData();
+  if (!ud) {
+    return std::nullopt;
+  }
+  ConcordAssertEQ(sizeof(BlockId), ud->size());
+  return concordUtils::fromBigEndianBuffer<BlockId>(ud->data());
 }
 
 }  // namespace concord::kvbc

--- a/kvbc/include/replica_state_sync.h
+++ b/kvbc/include/replica_state_sync.h
@@ -18,8 +18,10 @@
 #include "storage/db_types.h"
 #include "Logger.hpp"
 #include "db_adapter_interface.h"
-
 #include "categorization/kv_blockchain.h"
+#include "PersistentStorage.hpp"
+
+#include <memory>
 
 namespace concord::kvbc {
 
@@ -32,6 +34,7 @@ class ReplicaStateSync {
   // Synchronizes replica state and returns a number of deleted blocks.
   virtual uint64_t execute(logging::Logger& logger,
                            categorization::KeyValueBlockchain& blockchain,
+                           const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                            uint64_t lastExecutedSeqNum,
                            uint32_t maxNumOfBlocksToDelete) = 0;
 };

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -27,8 +27,19 @@ class ReplicaStateSyncImp : public ReplicaStateSync {
 
   uint64_t execute(logging::Logger& logger,
                    categorization::KeyValueBlockchain& blockchain,
+                   const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                    uint64_t lastExecutedSeqNum,
                    uint32_t maxNumOfBlocksToDelete) override;
+
+  uint64_t executeBasedOnBftSeqNum(logging::Logger& logger,
+                                   categorization::KeyValueBlockchain& blockchain,
+                                   uint64_t lastExecutedSeqNum,
+                                   uint32_t maxNumOfBlocksToDelete);
+
+  uint64_t executeBasedOnBlockId(logging::Logger& logger,
+                                 categorization::KeyValueBlockchain& blockchain,
+                                 const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
+                                 uint32_t maxNumOfBlocksToDelete);
 
  protected:
   std::unique_ptr<IBlockMetadata> blockMetadata_;

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -22,7 +22,7 @@
 #include "hex_tools.h"
 #include "replica_state_sync.h"
 #include "sliver.hpp"
-#include "persist_last_block_id_in_mtd.h"
+#include "metadata_block_id.h"
 #include "bftengine/DbMetadataStorage.hpp"
 #include "rocksdb/native_client.h"
 #include "pruning_handler.hpp"
@@ -142,8 +142,8 @@ void Replica::createReplicaAndSyncState() {
   if (!replicaConfig_.isReadOnly && !m_stateTransfer->isCollectingState()) {
     try {
       const auto maxNumOfBlocksToDelete = replicaConfig_.maxNumOfRequestsInBatch;
-      const auto removedBlocksNum =
-          replicaStateSync_->execute(logger, *m_kvBlockchain, lastExecutedSeqNum, maxNumOfBlocksToDelete);
+      const auto removedBlocksNum = replicaStateSync_->execute(
+          logger, *m_kvBlockchain, m_replicaPtr->persistentStorage(), lastExecutedSeqNum, maxNumOfBlocksToDelete);
       LOG_INFO(logger,
                KVLOG(lastExecutedSeqNum,
                      removedBlocksNum,

--- a/kvbc/src/replica_state_sync_imp.cpp
+++ b/kvbc/src/replica_state_sync_imp.cpp
@@ -12,10 +12,14 @@
 // file.
 //
 
+#include "assertUtils.hpp"
 #include "replica_state_sync_imp.hpp"
 #include "bftengine/DbMetadataStorage.hpp"
 #include "block_metadata.hpp"
 #include "kvstream.h"
+#include "metadata_block_id.h"
+
+#include <stdexcept>
 
 using concord::kvbc::Key;
 
@@ -25,8 +29,38 @@ ReplicaStateSyncImp::ReplicaStateSyncImp(IBlockMetadata* blockMetadata) : blockM
 
 uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
                                       categorization::KeyValueBlockchain& blockchain,
+                                      const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                                       uint64_t lastExecutedSeqNum,
                                       uint32_t maxNumOfBlocksToDelete) {
+  // If we don't have the last reachable block ID in metadata, assume this is the first system startup after upgrade to
+  // block ID based sync. Run the existing BFT sequence number based sync first. This is needed, because the system
+  // might be out of sync before the upgrade.
+  //
+  // After the BFT sequence number based sync completes (possibly syncing bad state before the upgrade),
+  // persist the last block ID in metadata for the block ID based sync to operate properly onwards.
+  //
+  // Additionally, we **assume** that the first block after software upgrade is successfully added to both KVBC and
+  // metadata by the replica. If that is not the case, we don't have a way of knowing how many blocks to delete and,
+  // therefore, we don't delete any as the last block ID in metadata would just be persisted with the last reachable
+  // block ID from KVBC, making them equal.
+  if (!getLastBlockIdFromMetadata(metadata)) {
+    const auto deletedBasedOnBftSeqNum =
+        executeBasedOnBftSeqNum(logger, blockchain, lastExecutedSeqNum, maxNumOfBlocksToDelete);
+
+    constexpr auto in_transaction = false;
+    persistLastBlockIdInMetadata<in_transaction>(blockchain, metadata);
+
+    return deletedBasedOnBftSeqNum;
+  }
+
+  // Run the block ID based sync.
+  return executeBasedOnBlockId(logger, blockchain, metadata, maxNumOfBlocksToDelete);
+}
+
+uint64_t ReplicaStateSyncImp::executeBasedOnBftSeqNum(logging::Logger& logger,
+                                                      categorization::KeyValueBlockchain& blockchain,
+                                                      uint64_t lastExecutedSeqNum,
+                                                      uint32_t maxNumOfBlocksToDelete) {
   if (!lastExecutedSeqNum) {
     LOG_INFO(logger, "Replica's metadata is empty => skip blocks removal");
     return 0;
@@ -41,7 +75,9 @@ uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
     lastBlockSeqNum = blockMetadata_->getLastBlockSequenceNum();
     LOG_INFO(logger, KVLOG(lastExecutedSeqNum, lastBlockSeqNum, lastReachableBlockId));
     if (lastBlockSeqNum <= lastExecutedSeqNum) {
-      LOG_INFO(logger, "Replica state is in sync " << KVLOG(removedBlocksNum, lastBlockSeqNum, lastReachableBlockId));
+      LOG_INFO(logger,
+               "Replica state is in sync (based on BFT seq num) "
+                   << KVLOG(removedBlocksNum, lastBlockSeqNum, lastReachableBlockId));
       return removedBlocksNum;
     }
     // SBFT State Metadata is not in sync with the Blockchain State.
@@ -59,6 +95,47 @@ uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
            "Inconsistent blockchain block deleted "
                << KVLOG(removedBlocksNum, lastExecutedSeqNum, lastBlockSeqNum, blockchain.getLastReachableBlockId()));
   return removedBlocksNum;
+}
+
+uint64_t ReplicaStateSyncImp::executeBasedOnBlockId(logging::Logger& logger,
+                                                    categorization::KeyValueBlockchain& blockchain,
+                                                    const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
+                                                    uint32_t maxNumOfBlocksToDelete) {
+  if (0 == maxNumOfBlocksToDelete) {
+    LOG_WARN(logger,
+             "Maximum number of blocks to delete is 0, replica state sync based on block ID will not run "
+                 << KVLOG(maxNumOfBlocksToDelete));
+    return 0;
+  }
+  const auto lastMtdBlockId = getLastBlockIdFromMetadata(metadata);
+  ConcordAssert(lastMtdBlockId.has_value());
+  const auto genesisBlockId = blockchain.getGenesisBlockId();
+  auto lastReachableKvbcBlockId = blockchain.getLastReachableBlockId();
+  auto deletedBlocks = uint64_t{0};
+  // Even though the KVBC implementation at the time of writing cannot delete the only block left (the genesis block in
+  // the loop below can be the only one left), we still write the code here so that it attempts to delete, even though
+  // it throws. Rationale is that we cannot leave the system in an unknown state. Instead, we throw, effectively
+  // stopping the system and await manual intervention as the next startup would lead to the same situation.
+  while (lastReachableKvbcBlockId > lastMtdBlockId && genesisBlockId <= lastReachableKvbcBlockId) {
+    blockchain.deleteLastReachableBlock();
+    lastReachableKvbcBlockId = blockchain.getLastReachableBlockId();
+    ++deletedBlocks;
+
+    if (deletedBlocks == maxNumOfBlocksToDelete) {
+      const auto msg = std::string{"Detected too many blocks to be deleted from the blockchain"};
+      LOG_FATAL(logger, msg);
+      throw std::runtime_error{msg};
+    }
+  }
+  if (deletedBlocks == 0) {
+    LOG_INFO(logger,
+             "Replica state is in sync (based on last reachable KVBC block ID) " << KVLOG(lastReachableKvbcBlockId));
+  } else {
+    LOG_INFO(logger,
+             "Replica state sync based on last reachable KVBC block ID deleted blocks "
+                 << KVLOG(deletedBlocks, lastReachableKvbcBlockId));
+  }
+  return deletedBlocks;
 }
 
 }  // namespace concord::kvbc

--- a/kvbc/test/replica_state_sync_test.cpp
+++ b/kvbc/test/replica_state_sync_test.cpp
@@ -12,12 +12,16 @@
 
 #include "gtest/gtest.h"
 
+#include "DbMetadataStorage.hpp"
 #include "Logger.hpp"
 #include "block_metadata.hpp"
 #include "categorization/kv_blockchain.h"
 #include "db_interfaces.h"
+#include "metadata_block_id.h"
+#include "PersistentStorageImp.hpp"
 #include "replica_state_sync_imp.hpp"
 #include "rocksdb/native_client.h"
+#include "storage/merkle_tree_key_manipulator.h"
 #include "storage/test/storage_test_common.h"
 
 #include <cstdint>
@@ -28,6 +32,7 @@
 
 namespace {
 
+using bftEngine::impl::PersistentStorageImp;
 using concord::kvbc::BlockId;
 using concord::kvbc::BlockMetadata;
 using concord::kvbc::IReader;
@@ -39,7 +44,10 @@ using concord::kvbc::categorization::TaggedVersion;
 using concord::kvbc::categorization::Updates;
 using concord::kvbc::categorization::Value;
 using concord::kvbc::categorization::VersionedUpdates;
+using concord::kvbc::getLastBlockIdFromMetadata;
+using concord::storage::DBMetadataStorage;
 using concord::storage::rocksdb::NativeClient;
+using concord::storage::v2MerkleTree::MetadataKeyManipulator;
 
 using namespace ::testing;
 using namespace std::literals;
@@ -47,11 +55,20 @@ using namespace std::literals;
 class replica_state_sync_test : public Test, public IReader {
   void SetUp() override {
     cleanup();
-    db = TestRocksDb::createNative();
+    db_ = TestRocksDb::createNative();
     const auto link_st_chain = true;
-    blockchain.emplace(db,
-                       link_st_chain,
-                       std::map<std::string, CATEGORY_TYPE>{{kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}});
+    blockchain_.emplace(
+        db_,
+        link_st_chain,
+        std::map<std::string, CATEGORY_TYPE>{{kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}});
+
+    metadata_ = std::make_shared<PersistentStorageImp>(kNumOfReplicas, kFVal, kCVal);
+    auto num_of_objects = std::uint16_t{0};
+    auto obj_descriptors = metadata_->getDefaultMetadataObjectDescriptors(num_of_objects);
+    auto db_metadata_storage =
+        std::make_unique<DBMetadataStorage>(db_->asIDBClient().get(), std::make_unique<MetadataKeyManipulator>());
+    db_metadata_storage->initMaxSizeOfObjects(obj_descriptors.get(), num_of_objects);
+    metadata_->init(std::move(db_metadata_storage));
   }
 
   void TearDown() override { cleanup(); }
@@ -62,7 +79,7 @@ class replica_state_sync_test : public Test, public IReader {
   }
 
   std::optional<Value> getLatest(const std::string &category_id, const std::string &key) const override {
-    return blockchain->getLatest(kConcordInternalCategoryId, key);
+    return blockchain_->getLatest(kConcordInternalCategoryId, key);
   }
 
   void multiGet(const std::string &category_id,
@@ -99,122 +116,331 @@ class replica_state_sync_test : public Test, public IReader {
   BlockId getLastBlockId() const override { throw std::logic_error{"IReader::getLastBlockId() should not be called"}; }
 
  protected:
-  void addBlockWithSeqNum(std::uint64_t seq_number) {
+  void addBlockWithBftSeqNum(std::uint64_t seq_number) {
     auto updates = Updates{};
     auto ver_updates = VersionedUpdates{};
-    ver_updates.addUpdate(std::string{BlockMetadata::kBlockMetadataKeyStr}, metadata.serialize(seq_number));
+    ver_updates.addUpdate(std::string{BlockMetadata::kBlockMetadataKeyStr}, block_metadata_.serialize(seq_number));
     updates.add(kConcordInternalCategoryId, std::move(ver_updates));
-    blockchain->addBlock(std::move(updates));
+    blockchain_->addBlock(std::move(updates));
+  }
+
+  void addBlockWithoutBftSeqNum() { blockchain_->addBlock(Updates{}); }
+
+  void persistLastBlockIdInMetadata() {
+    constexpr auto in_transaction = false;
+    concord::kvbc::persistLastBlockIdInMetadata<in_transaction>(*blockchain_, metadata_);
   }
 
  protected:
-  BlockMetadata metadata{*this};
-  ReplicaStateSyncImp replica_state_sync{new BlockMetadata{*this}};
-  logging::Logger logger{logging::Logger::getInstance("com.vmware.replica_state_sync_test")};
+  BlockMetadata block_metadata_{*this};
+  ReplicaStateSyncImp replica_state_sync_{new BlockMetadata{*this}};
+  logging::Logger logger_{logging::Logger::getInstance("com.vmware.replica_state_sync_test")};
+  const std::uint32_t kMaxNumOfBlocksToDelete = 10;
+  const std::uint16_t kNumOfReplicas = 4;
+  const std::uint16_t kFVal = 1;
+  const std::uint16_t kCVal = 0;
 
   // Test case specific members that are reset on SetUp() and TearDown().
-  std::shared_ptr<NativeClient> db;
-  std::optional<KeyValueBlockchain> blockchain;
-  const std::uint32_t max_num_of_blocks_to_delete = 10;
+  std::shared_ptr<NativeClient> db_;
+  std::optional<KeyValueBlockchain> blockchain_;
+  std::shared_ptr<PersistentStorageImp> metadata_;
 };
 
-TEST_F(replica_state_sync_test, empty_blockchain_and_0_bft_seq_num) {
+// Make GTest display tests differently, but still share the setup code.
+using replica_state_sync_on_bft_seq_num_test = replica_state_sync_test;
+using replica_state_sync_on_block_id_test = replica_state_sync_test;
+using replica_state_sync_test = replica_state_sync_test;
+
+TEST_F(replica_state_sync_on_bft_seq_num_test, empty_blockchain_and_0_bft_seq_num) {
   const auto last_executed_bft_seq_num = 0;
-  ASSERT_EQ(0, replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete));
+  ASSERT_EQ(0,
+            replica_state_sync_.executeBasedOnBftSeqNum(
+                logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
 }
 
-TEST_F(replica_state_sync_test, non_empty_blockchain_and_0_bft_seq_num) {
-  addBlockWithSeqNum(1);
-  addBlockWithSeqNum(2);
+TEST_F(replica_state_sync_on_bft_seq_num_test, non_empty_blockchain_and_0_bft_seq_num) {
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
   const auto last_executed_bft_seq_num = 0;
-  ASSERT_EQ(0, replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete));
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+  ASSERT_EQ(0,
+            replica_state_sync_.executeBasedOnBftSeqNum(
+                logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 }
 
-TEST_F(replica_state_sync_test, empty_blockchain_and_non_0_bft_seq_num) {
+TEST_F(replica_state_sync_on_bft_seq_num_test, empty_blockchain_and_non_0_bft_seq_num) {
   const auto last_executed_bft_seq_num = 42;
-  ASSERT_EQ(0, replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete));
+  ASSERT_EQ(0,
+            replica_state_sync_.executeBasedOnBftSeqNum(
+                logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
 }
 
-TEST_F(replica_state_sync_test, bft_seq_num_equal_to_block_seq_num) {
-  addBlockWithSeqNum(1);
-  addBlockWithSeqNum(2);
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+TEST_F(replica_state_sync_on_bft_seq_num_test, bft_seq_num_equal_to_block_seq_num) {
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 
   const auto last_executed_bft_seq_num = 2;
-  ASSERT_EQ(0, replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete));
+  ASSERT_EQ(0,
+            replica_state_sync_.executeBasedOnBftSeqNum(
+                logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
 
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 }
 
-TEST_F(replica_state_sync_test, bft_seq_num_bigger_than_block_seq_num) {
-  addBlockWithSeqNum(1);
-  addBlockWithSeqNum(2);
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+TEST_F(replica_state_sync_on_bft_seq_num_test, bft_seq_num_bigger_than_block_seq_num) {
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 
   const auto last_executed_bft_seq_num = 42;
-  ASSERT_EQ(0, replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete));
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+  ASSERT_EQ(0,
+            replica_state_sync_.executeBasedOnBftSeqNum(
+                logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 }
 
-TEST_F(replica_state_sync_test, bft_seq_num_less_than_block_seq_num) {
-  addBlockWithSeqNum(1);
-  addBlockWithSeqNum(2);
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+TEST_F(replica_state_sync_on_bft_seq_num_test, bft_seq_num_less_than_block_seq_num) {
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 
   const auto last_executed_bft_seq_num = 1;
-  ASSERT_EQ(1, replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete));
+  ASSERT_EQ(1,
+            replica_state_sync_.executeBasedOnBftSeqNum(
+                logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
 
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(1, blockchain->getLastReachableBlockId());
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
 }
 
-TEST_F(replica_state_sync_test, cannot_delete_only_block_left) {
-  addBlockWithSeqNum(2);  // block 1
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(1, blockchain->getLastReachableBlockId());
+TEST_F(replica_state_sync_on_bft_seq_num_test, cannot_delete_only_block_left) {
+  addBlockWithBftSeqNum(2);  // block 1
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
 
   const auto last_executed_bft_seq_num = 1;
-  ASSERT_THROW(replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete),
+  ASSERT_THROW(replica_state_sync_.executeBasedOnBftSeqNum(
+                   logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete),
                std::exception);
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(1, blockchain->getLastReachableBlockId());
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
 }
 
-TEST_F(replica_state_sync_test, cannot_delete_only_block_left_with_pruned_block) {
-  addBlockWithSeqNum(2);  // block 1
-  addBlockWithSeqNum(3);  // block 2
+TEST_F(replica_state_sync_on_bft_seq_num_test, cannot_delete_only_block_left_with_pruned_block) {
+  addBlockWithBftSeqNum(2);  // block 1
+  addBlockWithBftSeqNum(3);  // block 2
   // Prune block 1.
-  blockchain->deleteBlock(1);
-  ASSERT_EQ(2, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+  blockchain_->deleteBlock(1);
+  ASSERT_EQ(2, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 
   const auto last_executed_bft_seq_num = 2;
-  ASSERT_THROW(replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, max_num_of_blocks_to_delete),
+  ASSERT_THROW(replica_state_sync_.executeBasedOnBftSeqNum(
+                   logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete),
                std::exception);
-  ASSERT_EQ(2, blockchain->getGenesisBlockId());
-  ASSERT_EQ(2, blockchain->getLastReachableBlockId());
+  ASSERT_EQ(2, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
 }
 
-TEST_F(replica_state_sync_test, bft_too_many_inconsistent_blocks_detected) {
-  addBlockWithSeqNum(1);
-  addBlockWithSeqNum(2);
-  addBlockWithSeqNum(3);
-  addBlockWithSeqNum(4);
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(4, blockchain->getLastReachableBlockId());
+TEST_F(replica_state_sync_on_bft_seq_num_test, bft_too_many_inconsistent_blocks_detected) {
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+  addBlockWithBftSeqNum(3);
+  addBlockWithBftSeqNum(4);
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(4, blockchain_->getLastReachableBlockId());
 
   const auto last_executed_bft_seq_num = 2;
-  ASSERT_THROW(replica_state_sync.execute(logger, *blockchain, last_executed_bft_seq_num, 1), std::exception);
-  // Only one block is expected to be deleted
-  ASSERT_EQ(1, blockchain->getGenesisBlockId());
-  ASSERT_EQ(3, blockchain->getLastReachableBlockId());
+  ASSERT_THROW(replica_state_sync_.executeBasedOnBftSeqNum(logger_, *blockchain_, last_executed_bft_seq_num, 1),
+               std::exception);
+
+  // Only one block is expected to be deleted.
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(3, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_on_block_id_test, missing_block_id_in_metadata) {
+  ASSERT_DEATH(replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete),
+               "");
+}
+
+TEST_F(replica_state_sync_on_block_id_test, empty_db) {
+  persistLastBlockIdInMetadata();
+  ASSERT_EQ(0, replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete));
+}
+
+TEST_F(replica_state_sync_on_block_id_test, zero_max_blocks_to_delete) {
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+  addBlockWithoutBftSeqNum();  // Force out of sync by adding a second block without persisting in metadata.
+  ASSERT_EQ(0, replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, 0));
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_on_block_id_test, metadata_block_id_bigger_than_last_block_id) {
+  // Add two blocks, persist last block ID = 2 in metadata and then delete the last block.
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+  blockchain_->deleteLastReachableBlock();
+  ASSERT_EQ(0, replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_on_block_id_test, max_num_of_blocks_to_delete_is_honoured) {
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+  // Add one more block than kMaxNumOfBlocksToDelete.
+  for (auto i = 0u; i < kMaxNumOfBlocksToDelete + 1; ++i) {
+    addBlockWithoutBftSeqNum();
+  }
+  ASSERT_THROW(replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete),
+               std::runtime_error);
+  // 2 blocks added prior to metadata persistence and 1 that is not deleted as it exceeeds `kMaxNumOfBlocksToDelete`.
+  ASSERT_EQ(2 + 1, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_on_block_id_test, in_sync) {
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+  ASSERT_EQ(0, replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_on_block_id_test, out_of_sync) {
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+  ASSERT_EQ(5, blockchain_->getLastReachableBlockId());
+  ASSERT_EQ(3, replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_on_block_id_test, cannot_delete_only_block_left) {
+  persistLastBlockIdInMetadata();
+  addBlockWithoutBftSeqNum();
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
+
+  ASSERT_THROW(replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete),
+               std::exception);
+  ASSERT_EQ(1, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_on_block_id_test, cannot_delete_only_block_left_with_pruned_block) {
+  // Add 3 blocks, but persist metadata at block ID = 1.
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+
+  blockchain_->deleteBlock(1);
+
+  // Expect a throw from KVBC when trying to delete the only block (genesis, block ID = 2) in the system.
+  ASSERT_THROW(replica_state_sync_.executeBasedOnBlockId(logger_, *blockchain_, metadata_, kMaxNumOfBlocksToDelete),
+               std::exception);
+  ASSERT_EQ(2, blockchain_->getGenesisBlockId());
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_test, out_of_sync_on_upgade) {
+  // Simulate out of sync based on BFT seq number on the first startup after software upgrade that supports block ID
+  // sync.
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+
+  const auto last_executed_bft_seq_num = 1;
+  ASSERT_EQ(1,
+            replica_state_sync_.execute(
+                logger_, *blockchain_, metadata_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
+
+  // Last block ID is persisted by execute() in metadata.
+  auto last_mtd_block_id = getLastBlockIdFromMetadata(metadata_);
+  ASSERT_TRUE(last_mtd_block_id.has_value());
+  ASSERT_EQ(1, *last_mtd_block_id);
+
+  // We don't delete anything on a subsequent startup.
+  ASSERT_EQ(0,
+            replica_state_sync_.execute(
+                logger_, *blockchain_, metadata_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(1, blockchain_->getLastReachableBlockId());
+
+  // Last block ID remains the same.
+  last_mtd_block_id = getLastBlockIdFromMetadata(metadata_);
+  ASSERT_TRUE(last_mtd_block_id.has_value());
+  ASSERT_EQ(1, *last_mtd_block_id);
+}
+
+TEST_F(replica_state_sync_test, metadata_not_persisted_on_first_block_after_software_upgrade) {
+  // Add blocks as if from the old software version.
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+
+  const auto last_executed_bft_seq_num = 2;
+  ASSERT_EQ(0,
+            replica_state_sync_.executeBasedOnBftSeqNum(
+                logger_, *blockchain_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(2, blockchain_->getLastReachableBlockId());
+
+  // Add a block after the upgrade from the new software version, without persisting metadata.
+  addBlockWithoutBftSeqNum();
+  ASSERT_EQ(3, blockchain_->getLastReachableBlockId());
+
+  // Calling execute() will persist the last block ID in metadata. execute() assumes that the first block after upgrade
+  // is successfuly added to both KVBC and metadata by the replica. If that is not the case as in this test, we don't
+  // have a way of knowing how many blocks to delete and, therefore, we don't delete any as the last block ID
+  // in metadata has just been persisted by execute() with the last block ID from KVBC, making them equal.
+  ASSERT_EQ(0,
+            replica_state_sync_.execute(
+                logger_, *blockchain_, metadata_, last_executed_bft_seq_num + 1, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(3, blockchain_->getLastReachableBlockId());
+
+  // Last block ID is persisted by execute() in metadata.
+  const auto last_mtd_block_id = getLastBlockIdFromMetadata(metadata_);
+  ASSERT_TRUE(last_mtd_block_id.has_value());
+  ASSERT_EQ(3, *last_mtd_block_id);
+}
+
+TEST_F(replica_state_sync_test, out_of_sync_after_software_upgrade) {
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+  addBlockWithoutBftSeqNum();
+
+  const auto last_executed_bft_seq_num = 3;
+  ASSERT_EQ(1,
+            replica_state_sync_.execute(
+                logger_, *blockchain_, metadata_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(3, blockchain_->getLastReachableBlockId());
+}
+
+TEST_F(replica_state_sync_test, in_sync_after_software_upgrade) {
+  addBlockWithBftSeqNum(1);
+  addBlockWithBftSeqNum(2);
+  addBlockWithoutBftSeqNum();
+  addBlockWithoutBftSeqNum();
+  persistLastBlockIdInMetadata();
+
+  const auto last_executed_bft_seq_num = 4;
+  ASSERT_EQ(0,
+            replica_state_sync_.execute(
+                logger_, *blockchain_, metadata_, last_executed_bft_seq_num, kMaxNumOfBlocksToDelete));
+  ASSERT_EQ(4, blockchain_->getLastReachableBlockId());
 }
 
 }  // namespace


### PR DESCRIPTION
Persist the last reachable KVBC block ID in metadata for replica state
sync. We need that, because we write the KVBC block and metadata in two
separate storage transactions - first the KVBC block and then the
metadata. On startup, we compare the last reachable KVBC block ID to the
block ID stored in metadata and delete blocks until they match.

Previous implementation uses the BFT sequence number in the other way
around - persisting it into KVBC blocks. The drawback is that we need to
add KVBC blocks on BFT commands, incurring unnecessary overhead. The
solution in this commit avoids that as we persist the last reachable
KVBC block ID in metadata instead.

Bridge the two approaches by taking software upgrade into consideration,
i.e. when this commit goes live on an existing database storage. First,
make sure the system is in sync based on the BFT sequence number. From
that point on, rely on the new block ID based approach. See comments in
replica_state_sync_imp.cpp and replica_state_sync_test.cpp for more
details.

Note:
We **assume** that the first block after software upgrade is
successfully added to both KVBC and metadata by the replica. If that is
not the case, we don't have a way of knowing how many blocks to delete
and, therefore, we don't delete any as the last block ID in metadata
would just be persisted with the last reachable block ID from KVBC,
making them equal.