### PR TITLE
Disable test_key_exchange_command

### DIFF
--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -99,6 +99,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
+    @unittest.skip("Temporarily disabling this test due to BC-9406")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_key_exchange_command(self, bft_network):


### PR DESCRIPTION
Temporarily disabling this test due to BC-9406