### PR TITLE
Allocate pre-execution response buffers on first use

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -1290,7 +1290,7 @@ class BftTestNetwork:
         try:
             pre_proc_req = 0
             total_pre_exec_requests_executed = 0
-            with trio.fail_after(5):
+            with trio.fail_after(10):
                 while pre_proc_req < num_requests or \
                         total_pre_exec_requests_executed < num_requests:
                     key1 = ["preProcessor", "Counters", "preProcReqCompleted"]


### PR DESCRIPTION
Under certain configurations, we have gaps in the sequence of client_ids. In those cases, we will allocate unnecessary buffers that are never used. We can avoid that by allocating the buffers on demand.