### PR TITLE
ClientService: Integrate ConcordClient into EventService

### DIFF
--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -9,9 +9,11 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#include <chrono>
 #include <iostream>
 #include <google/protobuf/util/time_util.h>
 #include <opentracing/tracer.h>
+#include <thread>
 
 #include "event_service.hpp"
 #include "client/concordclient/concord_client.hpp"
@@ -25,6 +27,8 @@ using google::protobuf::util::TimeUtil;
 using vmware::concord::client::v1::StreamEventGroupsRequest;
 using vmware::concord::client::v1::EventGroup;
 
+using namespace std::chrono_literals;
+
 namespace cc = concord::client::concordclient;
 
 namespace concord::client::clientservice {
@@ -32,34 +36,33 @@ namespace concord::client::clientservice {
 Status EventServiceImpl::StreamEventGroups(ServerContext* context,
                                            const StreamEventGroupsRequest* proto_request,
                                            ServerWriter<EventGroup>* stream) {
-  LOG_INFO(logger_, "EventServiceImpl::StreamEventGroups called");
-
   cc::SubscribeRequest request;
   request.event_group_id = proto_request->event_group_id();
 
-  auto callback = [this, stream](cc::SubscribeResult event) {
-    if (not std::holds_alternative<cc::EventGroup>(event)) {
+  auto callback = [this, stream](cc::SubscribeResult&& subscribe_result) {
+    if (not std::holds_alternative<cc::EventGroup>(subscribe_result)) {
       LOG_INFO(logger_, "Subscribe returned error");
       return;
     }
-    auto eg = std::get<cc::EventGroup>(event);
-    EventGroup event_group;
-    event_group.set_id(eg.id);
-    for (cc::Event e : eg.events) {
-      *event_group.add_events() = std::string(e.begin(), e.end());
+    auto event_group = std::get<cc::EventGroup>(subscribe_result);
+    EventGroup proto_event_group;
+    proto_event_group.set_id(event_group.id);
+    for (cc::Event e : event_group.events) {
+      *proto_event_group.add_events() = std::string(e.begin(), e.end());
     }
-    *event_group.mutable_record_time() = TimeUtil::MicrosecondsToTimestamp(eg.record_time.count());
-    *event_group.mutable_trace_context() = {eg.trace_context.begin(), eg.trace_context.end()};
+    *proto_event_group.mutable_record_time() = TimeUtil::MicrosecondsToTimestamp(event_group.record_time.count());
+    *proto_event_group.mutable_trace_context() = {event_group.trace_context.begin(), event_group.trace_context.end()};
 
-    stream->Write(event_group);
+    stream->Write(proto_event_group);
   };
 
   auto span = opentracing::Tracer::Global()->StartSpan("stream_event_groups", {});
   client_->subscribe(request, span, callback);
 
   // TODO: Consider all gRPC return error codes as described in concord_client.proto
-  while (!context->IsCancelled())
-    ;
+  while (!context->IsCancelled()) {
+    std::this_thread::sleep_for(10ms);
+  }
 
   client_->unsubscribe();
   return grpc::Status::OK;

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -37,7 +37,12 @@ Status EventServiceImpl::StreamEventGroups(ServerContext* context,
   cc::SubscribeRequest request;
   request.event_group_id = proto_request->event_group_id();
 
-  auto callback = [stream](cc::EventGroup eg) {
+  auto callback = [this, stream](cc::SubscribeResult event) {
+    if (not std::holds_alternative<cc::EventGroup>(event)) {
+      LOG_INFO(logger_, "Subscribe returned error");
+      return;
+    }
+    auto eg = std::get<cc::EventGroup>(event);
     EventGroup event_group;
     event_group.set_id(eg.id);
     for (cc::Event e : eg.events) {

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -52,9 +52,11 @@ Status EventServiceImpl::StreamEventGroups(ServerContext* context,
   auto span = opentracing::Tracer::Global()->StartSpan("stream_event_groups", {});
   client_->subscribe(request, span, callback);
 
-  while (!context->IsCancelled()) {
-  }
+  // TODO: Consider all gRPC return error codes as described in concord_client.proto
+  while (!context->IsCancelled())
+    ;
 
+  client_->unsubscribe();
   return grpc::Status::OK;
 }
 

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <opentracing/span.h>
 #include <string>
+#include <thread>
 #include <variant>
 #include <vector>
 
@@ -113,7 +114,8 @@ struct EventGroup {
 // observe events.
 class ConcordClient {
  public:
-  ConcordClient(const ConcordClientConfig& config) : config_(config) {}
+  ConcordClient(const ConcordClientConfig& config)
+      : logger_(logging::getLogger("concord.client.concordclient")), config_(config) {}
 
   // Register a callback that gets invoked once the handling BFT client returns.
   // void callback(SendResult result);
@@ -130,14 +132,59 @@ class ConcordClient {
 
   // Register a callback that gets invoked for every validated event received.
   // void callback(EventGroup);
+  // Return subscriber ID used to unsubscribe.
   template <class CallbackT>
   void subscribe(const SubscribeRequest& request,
                  const std::unique_ptr<opentracing::Span>& parent_span,
                  CallbackT callback);
+
+  // Unsubscribe with the subscriber ID retrieved from a prior call to subscribe.
+  // Note, if the caller doesn't unsubscribe and no runtime error occurs then resources
+  // will be occupied forever.
   void unsubscribe();
 
  private:
+  logging::Logger logger_;
   ConcordClientConfig config_;
+
+  // TODO: Allow multiple subscriptions
+  std::atomic_bool stop_subscriber_{true};
+  std::thread subscriber_;
 };
+
+template <class CallbackT>
+void ConcordClient::subscribe(const SubscribeRequest& request,
+                              const std::unique_ptr<opentracing::Span>& parent_span,
+                              CallbackT callback) {
+  if (not stop_subscriber_) {
+    LOG_ERROR(logger_, "subscription already in progress - unsubscribe first");
+    return;
+  }
+
+  stop_subscriber_ = false;
+  std::atomic_bool* stop = &stop_subscriber_;
+  subscriber_ = std::thread([stop, request, callback] {
+    while (not(*stop)) {
+      // Note: The following returns an artificial event group.
+      // This will be replaced with the actual thin replica client integration.
+      // The thread is in place to simulate the asynchronous subscription.
+      EventGroup eg;
+      eg.id = request.event_group_id;
+      std::string event = std::to_string(request.event_group_id);
+      eg.events.push_back({event.begin(), event.end()});
+      std::chrono::duration time_now = std::chrono::system_clock::now().time_since_epoch();
+      eg.record_time = std::chrono::duration_cast<std::chrono::microseconds>(time_now);
+      eg.trace_context = {};
+
+      callback(eg);
+    }
+  });
+}
+
+inline void ConcordClient::unsubscribe() {
+  LOG_INFO(logger_, "Closing subscription");
+  stop_subscriber_ = true;
+  subscriber_.join();
+}
 
 }  // namespace concord::client::concordclient


### PR DESCRIPTION
This change connect the gRPC service with the concord client subscribe() backend. For the purpose of basic manual testing, this change returns empty data but the actual integration with TRC would look similar. You can test out the backend by starting clientservice and issue the following grpcli request:
`./grpc_cli call localhost:1337 StreamEventGroups "event_group_id: 1337"`

See commit messages for details.