### PR TITLE
Transaction signing enable test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 option(KEEP_APOLLO_LOGS "Retains logs from replicas in separate folder for each test in build/tests/apollo/logs " TRUE)
 
 # Default TXN_SIGNING_ENABLED to FALSE
-option(TXN_SIGNING_ENABLED "External concord client sign tansactionsand replicas verify signature" FALSE)
+option(TXN_SIGNING_ENABLED "External concord client sign tansactionsand replicas verify signature" TRUE)
 
 # Default BUILD_COMM_TCP_PLAIN to FALSE
 option(BUILD_COMM_TCP_PLAIN "Enable TCP communication" FALSE)

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -117,7 +117,6 @@ class SigManager {
 
   mutable concordMetrics::Component metrics_component_;
   mutable Metrics metrics_;
-  mutable std::atomic<uint64_t> updateAggregatorCounter = 0;
 
   // These methods bypass the singelton, and can be used (STRICTLY) for testing.
   // Define the below flag in order to use them in your test.


### PR DESCRIPTION
1) SigManager: modify the way we update metrics
2) CMakeLists: enable transaction signing for Apollo tests