### PR TITLE
PreExecution non-repudiation implementation

### DIFF
--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -40,6 +40,7 @@ struct ClientRequestMsgHeader {
   uint64_t timeoutMilli;
   uint32_t cidLength = 0;
   uint16_t reqSignatureLength = 0;
+  uint32_t extraDataLength = 0;
 
   // followed by the request (security information, such as signatures, should be part of the request)
 

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -177,6 +177,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                std::chrono::seconds{1},
                "wake up the ticks generator every ticksGeneratorPollPeriod seconds and fire pending ticks");
 
+  CONFIG_PARAM(preExecutionResultAuthEnabled, bool, false, "if PreExecution result authentication is enabled");
+
   // Not predefined configuration parameters
   // Example of usage:
   // repclicaConfig.set(someTimeout, 6000);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -42,6 +42,9 @@
 
 #include <ccron/ticks_generator.hpp>
 
+namespace preprocessor {
+class PreProcessResultMsg;
+}
 namespace bftEngine::impl {
 
 class ClientRequestMsg;
@@ -479,6 +482,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void startConsensusProcess(PrePrepareMsg* pp, bool isInternalNoop);
   void startConsensusProcess(PrePrepareMsg* pp);
   bool isSeqNumToStopAt(SeqNum seq_num);
+
+  bool validatePreProcessedResults(const PrePrepareMsg* msg, const bftEngine::impl::ReplicasInfo& replicasInfo);
+  bool validatePreProcessResultSignatures(preprocessor::PreProcessResultMsg& msg);
 
   // 5 years
   static constexpr int64_t MAX_VALUE_SECONDS = 60 * 60 * 24 * 365 * 5;

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -26,7 +26,7 @@ class ClientRequestMsg : public MessageBase {
   static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header::msgType), "");
   static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
   static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
-  static_assert(sizeof(ClientRequestMsgHeader) == 42, "ClientRequestMsgHeader size is 42B");
+  static_assert(sizeof(ClientRequestMsgHeader) == 46, "ClientRequestMsgHeader size is 46B");
   static concord::diagnostics::Recorder sigNatureVerificationRecorder;
   // TODO(GG): more asserts
 
@@ -40,7 +40,8 @@ class ClientRequestMsg : public MessageBase {
                    const std::string& cid = "",
                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{},
                    const char* requestSignature = nullptr,
-                   uint32_t requestSignatureLen = 0);
+                   uint32_t requestSignatureLen = 0,
+                   const uint32_t extraBufSize = 0);
 
   ClientRequestMsg(NodeIdType sender);
 
@@ -75,6 +76,11 @@ class ClientRequestMsg : public MessageBase {
 
   void validateImp(const ReplicasInfo& repInfo) const;
 
+  // Returns a pair of pointer and size to the extra buffer which was allocated during initialisation
+  std::pair<char*, uint32_t> getExtraBufPtr() {
+    return std::make_pair(body() + internalStorageSize() - msgBody()->extraDataLength, msgBody()->extraDataLength);
+  }
+
  private:
   void setParams(NodeIdType sender,
                  ReqId reqSeqNum,
@@ -82,7 +88,8 @@ class ClientRequestMsg : public MessageBase {
                  uint64_t flags,
                  uint64_t reqTimeoutMilli,
                  const std::string& cid,
-                 uint32_t requestSignatureLen);
+                 uint32_t requestSignatureLen,
+                 uint32_t extraBufSize);
 };
 
 template <>

--- a/bftengine/src/bftengine/messages/MsgCode.hpp
+++ b/bftengine/src/bftengine/messages/MsgCode.hpp
@@ -48,6 +48,7 @@ class MsgCode {
     PreProcessReply,
     PreProcessBatchRequest,
     PreProcessBatchReply,
+    PreProcessResult,
 
     ClientRequest = 700,
     ClientBatchRequest = 750,

--- a/bftengine/src/bftengine/messages/ReplicaAsksToLeaveViewMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReplicaAsksToLeaveViewMsg.hpp
@@ -25,7 +25,7 @@ namespace impl {
 
 class ReplicaAsksToLeaveViewMsg : public MessageBase {
  public:
-  enum class Reason : uint8_t { ClientRequestTimeout, NewPrimaryGetInChargeTimeout };
+  enum class Reason : uint8_t { ClientRequestTimeout, NewPrimaryGetInChargeTimeout, PrimarySentBadPreProcessResult };
 
   ReplicaAsksToLeaveViewMsg(ReplicaId srcReplicaId,
                             ViewNum v,

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -18,7 +18,8 @@ set(preprocessor_source_files
     messages/PreProcessRequestMsg.cpp
     messages/PreProcessBatchRequestMsg.cpp
     messages/PreProcessReplyMsg.cpp
-    messages/PreProcessBatchReplyMsg.cpp)
+    messages/PreProcessBatchReplyMsg.cpp
+    messages/PreProcessResultMsg.cpp)
 
 add_library(preprocessor STATIC ${preprocessor_source_files})
 

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -288,7 +288,8 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
                  clientMaxBatchSize_,
                  maxPreExecResultSize_,
                  preExecReqStatusCheckPeriodMilli_,
-                 numOfThreads));
+                 numOfThreads,
+                 ReplicaConfig::instance().preExecutionResultAuthEnabled));
   RequestProcessingState::init(numOfRequiredReplies(), &histograms_);
   PreProcessReplyMsg::setPreProcessorHistograms(&histograms_);
   addTimers();
@@ -1032,7 +1033,7 @@ void PreProcessor::cancelPreProcessing(NodeIdType clientId, uint16_t reqOffsetIn
 }
 
 void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch, const string &batchCid) {
-  std::unique_ptr<ClientRequestMsg> clientRequestMsg;
+  std::unique_ptr<impl::MessageBase> clientRequestMsg;
   const auto &batchEntry = ongoingReqBatches_[clientId];
   const auto &reqEntry = batchEntry->getRequestState(reqOffsetInBatch);
   {
@@ -1046,16 +1047,21 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
       const auto &span_context = preProcessReqMsg->spanContext<PreProcessRequestMsgSharedPtr::element_type>();
       // Copy of the message body is unavoidable here, as we need to create a new message type which lifetime is
       // controlled by the replica while all PreProcessReply messages get released here.
-      clientRequestMsg = make_unique<ClientRequestMsg>(clientId,
-                                                       HAS_PRE_PROCESSED_FLAG,
-                                                       reqSeqNum,
-                                                       reqProcessingStatePtr->getPrimaryPreProcessedResultLen(),
-                                                       reqProcessingStatePtr->getPrimaryPreProcessedResult(),
-                                                       reqProcessingStatePtr->getReqTimeoutMilli(),
-                                                       cid,
-                                                       span_context,
-                                                       reqProcessingStatePtr->getReqSignature(),
-                                                       reqProcessingStatePtr->getReqSignatureLength());
+      if (ReplicaConfig::instance().preExecutionResultAuthEnabled) {
+          // send PreProcessedResultMsg
+      } else {
+        clientRequestMsg = make_unique<ClientRequestMsg>(clientId,
+                                                         HAS_PRE_PROCESSED_FLAG,
+                                                         reqSeqNum,
+                                                         reqProcessingStatePtr->getPrimaryPreProcessedResultLen(),
+                                                         reqProcessingStatePtr->getPrimaryPreProcessedResult(),
+                                                         reqProcessingStatePtr->getReqTimeoutMilli(),
+                                                         cid,
+                                                         span_context,
+                                                         reqProcessingStatePtr->getReqSignature(),
+                                                         reqProcessingStatePtr->getReqSignatureLength());
+      }
+
       LOG_DEBUG(logger(),
                 "Pass pre-processed request to ReplicaImp for consensus"
                     << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch));

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -14,9 +14,11 @@
 #include "messages/ClientPreProcessRequestMsg.hpp"
 #include "messages/PreProcessRequestMsg.hpp"
 #include "messages/PreProcessReplyMsg.hpp"
+#include "messages/PreProcessResultMsg.hpp"
 #include "PreProcessorRecorder.hpp"
 #include <vector>
 #include <map>
+#include <list>
 
 namespace preprocessor {
 
@@ -38,6 +40,7 @@ class RequestProcessingState {
                          const uint32_t signatureLen = 0);
   ~RequestProcessingState() = default;
 
+  // None of RequestProcessingState functions is thread-safe. They are guarded by RequestState::mutex from PreProcessor.
   void handlePrimaryPreProcessed(const char* preProcessResult, uint32_t preProcessResultLen);
   void handlePreProcessReplyMsg(const PreProcessReplyMsgSharedPtr& preProcessReplyMsg);
   std::unique_ptr<MessageBase> buildClientRequestMsg(bool emptyReq = false);
@@ -69,6 +72,7 @@ class RequestProcessingState {
   ReplicaIdsList getRejectedReplicasList() { return rejectedReplicaIds_; }
   void resetRejectedReplicasList() { rejectedReplicaIds_.clear(); }
   void setPreprocessingRightNow(bool set) { preprocessingRightNow_ = set; }
+  const std::list<PreProcessResultSignature>& getPreProcessResultSignatures();
 
   static void init(uint16_t numOfRequiredReplies, preprocessor::PreProcessorRecorder* histograms);
 
@@ -105,8 +109,9 @@ class RequestProcessingState {
   const char* primaryPreProcessResult_ = nullptr;  // This memory is statically pre-allocated per client in PreProcessor
   uint32_t primaryPreProcessResultLen_ = 0;
   concord::util::SHA3_256::Digest primaryPreProcessResultHash_;
-  // Maps result hash to the number of equal hashes
-  std::map<concord::util::SHA3_256::Digest, int> preProcessingResultHashes_;
+  // Maps result hash to a list of replica signatures sent for this hash. Implcitly this also gives the number of
+  // replicas returning a specific hash.
+  std::map<concord::util::SHA3_256::Digest, std::list<PreProcessResultSignature>> preProcessingResultHashes_;
   bool retrying_ = false;
   bool preprocessingRightNow_ = false;
   uint64_t reqRetryId_ = 0;

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -87,6 +87,15 @@ void PreProcessReplyMsg::validate(const ReplicasInfo& repInfo) const {
   }
 }  // namespace preprocessor
 
+std::vector<char> PreProcessReplyMsg::getResultHashSignature() const {
+  const uint64_t headerSize = sizeof(Header);
+  const auto& msgHeader = *msgBody();
+  auto sigManager = SigManager::instance();
+  uint16_t sigLen = sigManager->getSigLength(msgHeader.senderId);
+
+  return std::vector<char>((char*)msgBody() + headerSize, (char*)msgBody() + headerSize + sigLen);
+}
+
 void PreProcessReplyMsg::setParams(NodeIdType senderId,
                                    uint16_t clientId,
                                    uint16_t reqOffsetInBatch,

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -52,6 +52,7 @@ class PreProcessReplyMsg : public MessageBase {
   const uint32_t replyLength() const { return msgBody()->replyLength; }
   const uint8_t* resultsHash() const { return msgBody()->resultsHash; }
   const uint8_t status() const { return msgBody()->status; }
+  std::vector<char> getResultHashSignature() const;
   std::string getCid() const;
   static void setPreProcessorHistograms(preprocessor::PreProcessorRecorder* histograms) {
     preProcessorHistograms_ = histograms;

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
@@ -1,0 +1,105 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "PreProcessResultMsg.hpp"
+#include "Replica.hpp"  // for HAS_PRE_PROCESSED_FLAG
+#include "endianness.hpp"
+namespace preprocessor {
+
+PreProcessResultMsg::PreProcessResultMsg(NodeIdType sender,
+                                         uint64_t reqSeqNum,
+                                         uint32_t resultLength,
+                                         const char* result,
+                                         uint64_t reqTimeoutMilli,
+                                         const std::string& cid,
+                                         const concordUtils::SpanContext& spanContext,
+                                         const char* messageSignature,
+                                         uint32_t messageSignatureLen,
+                                         const std::string& resultSignatures)
+    : ClientRequestMsg(sender,
+                       bftEngine::HAS_PRE_PROCESSED_FLAG,
+                       reqSeqNum,
+                       resultLength,  // check the comment in the header to
+                       result,        // understand why result is passed as request here
+                       reqTimeoutMilli,
+                       cid,
+                       spanContext,
+                       messageSignature,
+                       messageSignatureLen,
+                       resultSignatures.size()) {
+  msgBody_->msgType = MsgCode::PreProcessResult;
+  // ClientRequestMsg allocates additional memory for the signatures
+  // Get pointer to it here and assert that the buffer is big enough
+  auto [pos, max_len] = getExtraBufPtr();
+  ConcordAssert(max_len >= resultSignatures.size());
+
+  memcpy(pos, resultSignatures.data(), resultSignatures.size());
+}
+
+PreProcessResultMsg::PreProcessResultMsg(bftEngine::ClientRequestMsgHeader* body) : ClientRequestMsg(body) {}
+
+std::pair<char*, uint32_t> PreProcessResultMsg::getResultSignaturesBuf() { return getExtraBufPtr(); }
+
+std::string PreProcessResultSignature::serializeResultSignatureList(
+    const std::list<PreProcessResultSignature>& signatures) {
+  size_t buf_len = 0;
+  for (const auto& s : signatures) {
+    buf_len += sizeof(s.sender_replica) + sizeof(uint32_t) + s.signature.size();
+  }
+
+  std::string output;
+  output.reserve(buf_len);
+
+  for (const auto& s : signatures) {
+    output.append(concordUtils::toBigEndianStringBuffer(s.sender_replica));
+    output.append(concordUtils::toBigEndianStringBuffer<uint32_t>(s.signature.size()));
+    output.append(s.signature.begin(), s.signature.end());
+  }
+
+  return output;
+}
+
+std::list<PreProcessResultSignature> PreProcessResultSignature::deserializeResultSignatureList(const char* buf,
+                                                                                               size_t len) {
+  size_t pos = 0;
+  std::list<PreProcessResultSignature> ret;
+  while (1) {
+    bftEngine::impl::NodeIdType sender_id;
+    uint32_t signature_size;
+
+    if (sizeof(sender_id) + sizeof(signature_size) > len - pos) {
+      throw std::runtime_error(
+          "PreProcessResultSignature deserialisation error - remaining buffer length less than fixed size values size");
+    }
+
+    // Read fixed size values
+    sender_id = concordUtils::fromBigEndianBuffer<bftEngine::impl::NodeIdType>(buf + pos);
+    pos += sizeof(bftEngine::impl::NodeIdType);
+    signature_size = concordUtils::fromBigEndianBuffer<uint32_t>(buf + pos);
+    pos += sizeof(uint32_t);
+
+    if (signature_size > len - pos) {
+      throw std::runtime_error(
+          "PreProcessResultSignature deserialisation error - remaining buffer length less than signature size");
+    }
+
+    ret.emplace_back(std::vector<char>(buf + pos, buf + pos + signature_size), sender_id);
+    pos += signature_size;
+
+    if (len - pos == 0) {
+      break;
+    }
+  }
+
+  return ret;
+}
+
+}  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
@@ -1,0 +1,72 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <list>
+
+#include "messages/ClientRequestMsg.hpp"
+
+namespace preprocessor {
+
+// PreProcessResultMsg is a ClientRequestMsg which have been preprocessed. It is inserted in the message queue of
+// the primary and is bundled in PrePrepare with other PreProcessResultMsg or ClientRequestMsg.
+//
+// The message inherits from ClientRequestMsg mainly because it needs to be bundled with ClientRequestMsg in PrePrepare.
+// Code reuse is a side benefit, but not the main reason for the inheritance.
+//
+// The PreExecution implementation before NonRepudiation improvement reused ClientRequestMsg instead of
+// PreProcessResultMsg. This was convenient but lead to some 'hacks' which should be considered when working with this
+// code.
+//
+// If ClientRequestMsg is used as 'internal' message in the PreExecution a special flag (PRE_PROCESS_REQ) is set. In
+// this case the request field of the message contains the pre-executed result instead of the request itself. As
+// PreProcessResultMsg should respect this approach (for now), the result buffer in the constructor below is passed as a
+// request to the ClientRequestMsg constructor.
+//
+// Ideally PrePrepare message should be reworked to bundle ClientRequestMsg and PreProcessResultMsg messages. Then the
+// inheritance for this message won't be needed. For the moment (Jun 2021) this change is not implemented though.
+class PreProcessResultMsg : public ClientRequestMsg {
+ public:
+  PreProcessResultMsg(NodeIdType sender,
+                      uint64_t reqSeqNum,
+                      uint32_t resultLength,
+                      const char* result,
+                      uint64_t reqTimeoutMilli,
+                      const std::string& cid = "",
+                      const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{},
+                      const char* messageSignature = nullptr,
+                      uint32_t messageSignatureLen = 0,
+                      const std::string& resultSignatures = "");
+
+  PreProcessResultMsg(bftEngine::ClientRequestMsgHeader* body);
+
+  PreProcessResultMsg(MessageBase* msgBase) : ClientRequestMsg(msgBase) {}
+
+  std::pair<char*, uint32_t> getResultSignaturesBuf();
+};
+
+struct PreProcessResultSignature {
+  std::vector<char> signature;
+  NodeIdType sender_replica;
+
+  PreProcessResultSignature(std::vector<char>&& sig, NodeIdType sender)
+      : signature{std::move(sig)}, sender_replica{sender} {}
+
+  bool operator==(const PreProcessResultSignature& rhs) const {
+    return signature == rhs.signature && sender_replica == rhs.sender_replica;
+  }
+
+  static std::string serializeResultSignatureList(const std::list<PreProcessResultSignature>& signatures);
+  static std::list<PreProcessResultSignature> deserializeResultSignatureList(const char* buf, size_t len);
+};
+
+}  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
@@ -36,6 +36,8 @@ namespace preprocessor {
 // inheritance for this message won't be needed. For the moment (Jun 2021) this change is not implemented though.
 class PreProcessResultMsg : public ClientRequestMsg {
  public:
+  using ErrorMessage = std::optional<std::string>;
+
   PreProcessResultMsg(NodeIdType sender,
                       uint64_t reqSeqNum,
                       uint32_t resultLength,
@@ -52,6 +54,7 @@ class PreProcessResultMsg : public ClientRequestMsg {
   PreProcessResultMsg(MessageBase* msgBase) : ClientRequestMsg(msgBase) {}
 
   std::pair<char*, uint32_t> getResultSignaturesBuf();
+  ErrorMessage validatePreProcessResultSignatures(ReplicaId myReplicaId, int16_t fVal);
 };
 
 struct PreProcessResultSignature {

--- a/bftengine/src/preprocessor/tests/messages/CMakeLists.txt
+++ b/bftengine/src/preprocessor/tests/messages/CMakeLists.txt
@@ -12,3 +12,17 @@ target_link_libraries(ClientPreProcessRequestMsg_test GTest::Main)
 target_link_libraries(ClientPreProcessRequestMsg_test corebft )
 target_compile_options(ClientPreProcessRequestMsg_test PUBLIC "-Wno-sign-compare")
 
+add_executable(PreProcessReplyMsg_test 
+  PreProcessReplyMsg_test.cpp
+  ${bftengine_SOURCE_DIR}/tests/messages/helper.cpp)
+target_include_directories(PreProcessReplyMsg_test
+  PRIVATE
+  ${bftengine_SOURCE_DIR}/src/bftengine
+  ${bftengine_SOURCE_DIR}/tests/messages/
+  ../..)
+target_link_libraries(PreProcessReplyMsg_test 
+  GTest::Main
+  corebft)
+target_compile_options(PreProcessReplyMsg_test PUBLIC "-Wno-sign-compare")
+
+add_test(PreProcessReplyMsg_test PreProcessReplyMsg_test)

--- a/bftengine/src/preprocessor/tests/messages/CMakeLists.txt
+++ b/bftengine/src/preprocessor/tests/messages/CMakeLists.txt
@@ -1,28 +1,20 @@
-add_executable(ClientPreProcessRequestMsg_test
-  ClientPreProcessRequestMsg_test.cpp
-  ${bftengine_SOURCE_DIR}/tests/messages/helper.cpp)
-add_test(ClientPreProcessRequestMsg_test ClientPreProcessRequestMsg_test)
 find_package(GTest REQUIRED)
-target_include_directories(ClientPreProcessRequestMsg_test
+
+function(add_preexec_msg_test test_name sources extra_link_libs)
+  add_executable(${test_name}
+  ${sources}
+  ${bftengine_SOURCE_DIR}/tests/messages/helper.cpp)
+  add_test(${test_name} ${test_name})
+  target_include_directories(${test_name}
       PRIVATE
       ${bftengine_SOURCE_DIR}/src/bftengine
       ${bftengine_SOURCE_DIR}/tests/messages/
       ../..)
-target_link_libraries(ClientPreProcessRequestMsg_test GTest::Main)
-target_link_libraries(ClientPreProcessRequestMsg_test corebft )
-target_compile_options(ClientPreProcessRequestMsg_test PUBLIC "-Wno-sign-compare")
+  target_link_libraries(${test_name} GTest::Main)
+  target_link_libraries(${test_name} corebft )
+  target_compile_options(${test_name} PUBLIC "-Wno-sign-compare")
+endfunction(add_preexec_msg_test)
 
-add_executable(PreProcessReplyMsg_test 
-  PreProcessReplyMsg_test.cpp
-  ${bftengine_SOURCE_DIR}/tests/messages/helper.cpp)
-target_include_directories(PreProcessReplyMsg_test
-  PRIVATE
-  ${bftengine_SOURCE_DIR}/src/bftengine
-  ${bftengine_SOURCE_DIR}/tests/messages/
-  ../..)
-target_link_libraries(PreProcessReplyMsg_test 
-  GTest::Main
-  corebft)
-target_compile_options(PreProcessReplyMsg_test PUBLIC "-Wno-sign-compare")
-
-add_test(PreProcessReplyMsg_test PreProcessReplyMsg_test)
+add_preexec_msg_test(ClientPreProcessRequestMsg_test ClientPreProcessRequestMsg_test.cpp "")
+add_preexec_msg_test(PreProcessReplyMsg_test PreProcessReplyMsg_test.cpp "")
+add_preexec_msg_test(PreProcessResultMsg_test PreProcessResultMsg_test.cpp "")

--- a/bftengine/src/preprocessor/tests/messages/PreProcessReplyMsg_test.cpp
+++ b/bftengine/src/preprocessor/tests/messages/PreProcessReplyMsg_test.cpp
@@ -1,0 +1,72 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "PrimitiveTypes.hpp"
+#include "messages/PreProcessReplyMsg.hpp"
+#include "helper.hpp"
+#include "sha_hash.hpp"
+
+namespace {
+using namespace bftEngine::impl;
+using namespace bftEngine;
+using namespace preprocessor;
+
+class PreProcessReplyMsgTestFixture : public testing::Test {
+ protected:
+  PreProcessReplyMsgTestFixture()
+      : config{createReplicaConfig()},
+        replicaInfo{config, false, false},
+        sigManager(createSigManager(config.replicaId,
+                                    config.replicaPrivateKey,
+                                    KeyFormat::HexaDecimalStrippedFormat,
+                                    config.publicKeysOfReplicas,
+                                    replicaInfo)) {
+    PreProcessReplyMsg::setPreProcessorHistograms(&preProcessorRecorder);
+  }
+
+  ReplicaConfig& config;
+  ReplicasInfo replicaInfo;
+  std::unique_ptr<SigManager> sigManager;
+  PreProcessorRecorder preProcessorRecorder;
+};
+
+TEST_F(PreProcessReplyMsgTestFixture, getResultHashSignature) {
+  ASSERT_TRUE(sigManager);
+  const NodeIdType senderId = 1;
+  const uint16_t clientId = 1;
+  const uint16_t reqOffsetInBatch = 0;
+  const uint64_t reqSeqNum = 100;
+  const uint64_t reqRetryId = 0;
+  const char preProcessResultBuf[] = "request body";
+  const uint32_t preProcessResultBufLen = sizeof(preProcessResultBuf);
+  const std::string& cid = "";
+  const ReplyStatus status = STATUS_GOOD;
+
+  auto m = PreProcessReplyMsg(senderId,
+                              clientId,
+                              reqOffsetInBatch,
+                              reqSeqNum,
+                              reqRetryId,
+                              preProcessResultBuf,
+                              preProcessResultBufLen,
+                              cid,
+                              status);
+
+  auto hash = concord::util::SHA3_256().digest(preProcessResultBuf, preProcessResultBufLen);
+  auto expected_signature = std::vector<char>(sigManager->getMySigLength(), 0);
+  sigManager->sign((char*)hash.data(), sizeof(hash), expected_signature.data(), expected_signature.size());
+  EXPECT_THAT(expected_signature, testing::ContainerEq(m.getResultHashSignature()));
+}
+
+}  // namespace

--- a/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
+++ b/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
@@ -1,0 +1,240 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "PrimitiveTypes.hpp"
+#include "messages/PreProcessResultMsg.hpp"
+#include "helper.hpp"
+#include "RequestProcessingState.hpp"
+#include "Replica.hpp"
+
+namespace {
+using namespace bftEngine::impl;
+using namespace bftEngine;
+using namespace preprocessor;
+
+bftEngine::ReplicaConfig& createReplicaConfigWithExtClient(uint16_t fVal, uint16_t cVal) {
+  auto& config = createReplicaConfig(fVal, cVal);
+  config.numOfExternalClients = 1;
+  config.numOfClientProxies = 1;
+
+  auto clientPrincipalIds = std::set<uint16_t>{uint16_t(config.numReplicas + 1)};
+  config.publicKeysOfClients.insert(make_pair(config.publicKeysOfReplicas.begin()->second, clientPrincipalIds));
+  return config;
+}
+
+bftEngine::impl::SigManager* createSigManagerWithSigning(
+    size_t myId,
+    std::string& myPrivateKey,
+    KeyFormat replicasKeysFormat,
+    std::set<std::pair<uint16_t, const std::string>>& publicKeysOfReplicas,
+    const std::set<std::pair<const std::string, std::set<uint16_t>>>* publicKeysOfClients,
+    ReplicasInfo& replicasInfo) {
+  return SigManager::init(myId,
+                          myPrivateKey,
+                          publicKeysOfReplicas,
+                          replicasKeysFormat,
+                          publicKeysOfClients,
+                          KeyFormat::HexaDecimalStrippedFormat,
+                          replicasInfo);
+}
+
+class PreProcessResultMsgTestFixture : public testing::Test {
+ protected:
+  PreProcessResultMsgTestFixture()
+      : config{createReplicaConfigWithExtClient(1, 0)},
+        replicaInfo{config, false, false},
+        sigManager(createSigManagerWithSigning(config.replicaId,
+                                               config.replicaPrivateKey,
+                                               KeyFormat::HexaDecimalStrippedFormat,
+                                               config.publicKeysOfReplicas,
+                                               &config.publicKeysOfClients,
+                                               replicaInfo)) {}
+
+  ReplicaConfig& config;
+  ReplicasInfo replicaInfo;
+  std::unique_ptr<SigManager> sigManager;
+
+  std::unique_ptr<PreProcessResultMsg> createMessage(NodeIdType senderId,
+                                                     uint64_t reqSeqNum,
+                                                     const char* result,
+                                                     const int resultSize,
+                                                     const uint64_t requestTimeoutMilli,
+                                                     const std::string& correlationId,
+                                                     const std::string& spanContext) {
+    auto msgSigSize = sigManager->getMySigLength();
+    std::vector<char> msgSig(msgSigSize, 0);
+    sigManager->sign(result, resultSize, msgSig.data(), msgSigSize);
+
+    // for simplicity, copy the same signatures
+    std::list<PreProcessResultSignature> resultSigs;
+    for (int i = 0; i < replicaInfo.getNumberOfReplicas(); i++) {
+      resultSigs.emplace_back(std::vector<char>(msgSig), 0);
+    }
+    auto resultSigsBuf = PreProcessResultSignature::serializeResultSignatureList(resultSigs);
+
+    return std::make_unique<PreProcessResultMsg>(senderId,
+                                                 reqSeqNum,
+                                                 resultSize,
+                                                 result,
+                                                 requestTimeoutMilli,
+                                                 correlationId,
+                                                 concordUtils::SpanContext{spanContext},
+                                                 msgSig.data(),
+                                                 msgSig.size(),
+                                                 resultSigsBuf);
+  }
+};
+
+TEST_F(PreProcessResultMsgTestFixture, ClientRequestMsgSanityChecks) {
+  NodeIdType senderId = 5u;
+  uint64_t reqSeqNum = 100u;
+  const char result[] = {"result body"};
+  const uint64_t requestTimeoutMilli = 0;
+  const std::string correlationId = "correlationId";
+  const char rawSpanContext[] = {"span_\0context"};  // make clnag-tidy happy
+  const std::string spanContext{rawSpanContext};
+
+  auto m = createMessage(senderId, reqSeqNum, result, sizeof(result), requestTimeoutMilli, correlationId, spanContext);
+
+  // sanity check for ClientRequestMsg part of the message (the inherited part)
+  EXPECT_EQ(m->clientProxyId(), senderId);
+  EXPECT_EQ(m->flags(), MsgFlag::HAS_PRE_PROCESSED_FLAG);
+  EXPECT_EQ(m->requestSeqNum(), reqSeqNum);
+  EXPECT_EQ(m->requestLength(), sizeof(result));
+  EXPECT_NE(m->requestBuf(), result);
+  EXPECT_TRUE(std::memcmp(m->requestBuf(), result, sizeof(result)) == 0u);
+  EXPECT_EQ(m->getCid(), correlationId);
+  EXPECT_EQ(m->spanContext<ClientRequestMsg>().data(), spanContext);
+  EXPECT_EQ(m->requestTimeoutMilli(), requestTimeoutMilli);
+  EXPECT_NO_THROW(m->validate(replicaInfo));
+
+  // check message type
+  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
+  EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
+}
+
+TEST_F(PreProcessResultMsgTestFixture, SignatureDeserialisation) {
+  std::vector<char> msgSig{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
+
+  std::list<PreProcessResultSignature> resultSigs;
+  for (int i = 0; i < replicaInfo.getNumberOfReplicas(); i++) {
+    resultSigs.emplace_back(std::vector<char>(msgSig), 0);
+  }
+  auto resultSigsBuf = PreProcessResultSignature::serializeResultSignatureList(resultSigs);
+  auto deserialized =
+      PreProcessResultSignature::deserializeResultSignatureList(resultSigsBuf.data(), resultSigsBuf.size());
+  EXPECT_THAT(resultSigs, deserialized);
+}
+
+TEST_F(PreProcessResultMsgTestFixture, MsgDeserialisation) {
+  NodeIdType senderId = 5u;
+  uint64_t reqSeqNum = 100u;
+  const char result[] = {"result body"};
+  const uint64_t requestTimeoutMilli = 0;
+  const std::string correlationId = "correlationId";
+  const char rawSpanContext[] = {"span_\0context"};  // make clnag-tidy happy
+  const std::string spanContext{rawSpanContext};
+
+  auto serialised =
+      createMessage(senderId, reqSeqNum, result, sizeof(result), requestTimeoutMilli, correlationId, spanContext);
+  auto m = std::make_unique<PreProcessResultMsg>((ClientRequestMsgHeader*)serialised->body());
+
+  // sanity check for ClientRequestMsg part of the message (the inherited part)
+  EXPECT_EQ(m->clientProxyId(), senderId);
+  EXPECT_EQ(m->flags(), MsgFlag::HAS_PRE_PROCESSED_FLAG);
+  EXPECT_EQ(m->requestSeqNum(), reqSeqNum);
+  EXPECT_EQ(m->requestLength(), sizeof(result));
+  EXPECT_NE(m->requestBuf(), result);
+  EXPECT_TRUE(std::memcmp(m->requestBuf(), result, sizeof(result)) == 0u);
+  EXPECT_EQ(m->getCid(), correlationId);
+  EXPECT_EQ(m->spanContext<ClientRequestMsg>().data(), spanContext);
+  EXPECT_EQ(m->requestTimeoutMilli(), requestTimeoutMilli);
+  EXPECT_NO_THROW(m->validate(replicaInfo));
+
+  // check message type
+  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
+  EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
+
+  // check the result is correct
+  ASSERT_EQ(sizeof(result), m->requestLength());
+  for (int i = 0; i < m->requestLength(); i++) {
+    ASSERT_EQ(result[i], m->requestBuf()[i]);
+  }
+
+  // Deserialise result signatures
+  auto [sigBuf, sigBufLen] = m->getResultSignaturesBuf();
+  auto sigs = PreProcessResultSignature::deserializeResultSignatureList(sigBuf, sigBufLen);
+
+  // Verify the signatures - SigManager can't veryfy its own signature so first the result
+  // from the message is signed and then it is compared to each signature in the message
+  auto msgSigSize = sigManager->getMySigLength();
+  std::vector<char> msgSig(msgSigSize, 0);
+  sigManager->sign(m->requestBuf(), m->requestLength(), msgSig.data(), msgSigSize);
+  for (const auto& s : sigs) {
+    ASSERT_EQ(s.sender_replica, 0);
+    EXPECT_THAT(msgSig, s.signature);
+  }
+}
+
+TEST_F(PreProcessResultMsgTestFixture, MsgDeserialisationFromBase) {
+  NodeIdType senderId = 5u;
+  uint64_t reqSeqNum = 100u;
+  const char result[] = {"result body"};
+  const uint64_t requestTimeoutMilli = 0;
+  const std::string correlationId = "correlationId";
+  const char rawSpanContext[] = {"span_\0context"};  // make clnag-tidy happy
+  const std::string spanContext{rawSpanContext};
+
+  auto serialised =
+      createMessage(senderId, reqSeqNum, result, sizeof(result), requestTimeoutMilli, correlationId, spanContext);
+  auto m = std::make_unique<PreProcessResultMsg>((MessageBase*)serialised.get());
+
+  // sanity check for ClientRequestMsg part of the message (the inherited part)
+  EXPECT_EQ(m->clientProxyId(), senderId);
+  EXPECT_EQ(m->flags(), MsgFlag::HAS_PRE_PROCESSED_FLAG);
+  EXPECT_EQ(m->requestSeqNum(), reqSeqNum);
+  EXPECT_EQ(m->requestLength(), sizeof(result));
+  EXPECT_NE(m->requestBuf(), result);
+  EXPECT_TRUE(std::memcmp(m->requestBuf(), result, sizeof(result)) == 0u);
+  EXPECT_EQ(m->getCid(), correlationId);
+  EXPECT_EQ(m->spanContext<ClientRequestMsg>().data(), spanContext);
+  EXPECT_EQ(m->requestTimeoutMilli(), requestTimeoutMilli);
+  EXPECT_NO_THROW(m->validate(replicaInfo));
+
+  // check message type
+  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
+  EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
+
+  // check the result is correct
+  ASSERT_EQ(sizeof(result), m->requestLength());
+  for (int i = 0; i < m->requestLength(); i++) {
+    ASSERT_EQ(result[i], m->requestBuf()[i]);
+  }
+
+  // Deserialise result signatures
+  auto [sigBuf, sigBufLen] = m->getResultSignaturesBuf();
+  auto sigs = PreProcessResultSignature::deserializeResultSignatureList(sigBuf, sigBufLen);
+
+  // Verify the signatures - SigManager can't veryfy its own signature so first the result
+  // from the message is signed and then it is compared to each signature in the message
+  auto msgSigSize = sigManager->getMySigLength();
+  std::vector<char> msgSig(msgSigSize, 0);
+  sigManager->sign(m->requestBuf(), m->requestLength(), msgSig.data(), msgSigSize);
+  for (const auto& s : sigs) {
+    ASSERT_EQ(s.sender_replica, 0);
+    EXPECT_THAT(msgSig, s.signature);
+  }
+}
+
+}  // namespace

--- a/bftengine/tests/messages/ClientRequestMsg_test.cpp
+++ b/bftengine/tests/messages/ClientRequestMsg_test.cpp
@@ -219,6 +219,62 @@ TEST_F(ClientRequestMsgTestFixture, base_methods) {
   testMessageBaseMethods(msg, MsgCode::ClientRequest, senderId, spanContext);
 }
 
+TEST_F(ClientRequestMsgTestFixture, extra_buffer) {
+  // Inherit from ClientRequestMsg so that some protected methods can be exposed for the test
+  struct TestClientRequestMsg : ClientRequestMsg {
+    TestClientRequestMsg(NodeIdType sender,
+                         uint64_t flags,
+                         uint64_t reqSeqNum,
+                         uint32_t requestLength,
+                         const char* request,
+                         uint64_t reqTimeoutMilli,
+                         const std::string& cid,
+                         const concordUtils::SpanContext& spanContext,
+                         const char* requestSignature,
+                         uint32_t requestSignatureLen,
+                         const uint32_t extraBufSize)
+        : ClientRequestMsg(sender,
+                           flags,
+                           reqSeqNum,
+                           requestLength,
+                           request,
+                           reqTimeoutMilli,
+                           cid,
+                           spanContext,
+                           requestSignature,
+                           requestSignatureLen,
+                           extraBufSize) {}
+
+    std::pair<char*, uint32_t> getExtraBufPtr() { return ClientRequestMsg::getExtraBufPtr(); }
+  };
+
+  NodeIdType senderId = 1u;
+  uint64_t flags = 'F';
+  uint64_t reqSeqNum = 100u;
+  const char request[] = {"request body"};
+  const uint64_t requestTimeoutMilli = 0;
+  const std::string correlationId = "correlationId";
+  const char rawSpanContext[] = {"span_\0context"};
+  const std::string spanContext{rawSpanContext, sizeof(rawSpanContext)};
+  const size_t extraBufSize = 1024;
+  TestClientRequestMsg msg(senderId,
+                           flags,
+                           reqSeqNum,
+                           sizeof(request),
+                           request,
+                           requestTimeoutMilli,
+                           correlationId,
+                           concordUtils::SpanContext{spanContext},
+                           nullptr,
+                           0,
+                           extraBufSize);
+  EXPECT_NO_THROW(msg.validate(replicaInfo));
+  testMessageBaseMethods<ClientRequestMsg>(msg, MsgCode::ClientRequest, senderId, spanContext);
+
+  size_t mainMsgSize = sizeof(ClientRequestMsgHeader) + sizeof(request) + correlationId.size() + spanContext.size();
+  ASSERT_EQ(msg.size(), mainMsgSize + extraBufSize);
+  ASSERT_EQ(msg.getExtraBufPtr().first, msg.body() + mainMsgSize);
+}
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -75,8 +75,12 @@ add_test(NAME skvbc_auto_view_change_tests COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_auto_view_change_tests python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+# PreExecution tests are executed two times - with PreExecution Result Authentication enabled and disabled.
 add_test(NAME skvbc_preexecution_tests COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_preexecution_tests python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME skvbc_preexecution_with_result_auth_tests COMMAND sh -c
+        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} PRE_EXEC_RESULT_AUTH_ENABLED=True TEST_NAME=skvbc_preexecution_with_result_auth_tests python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME skvbc_batch_preexecution_tests COMMAND sh -c

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -11,6 +11,7 @@
 # file.
 
 import os.path
+import os
 import unittest
 import trio
 import random
@@ -41,12 +42,16 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
 
     status_timer_milli = "500"
 
+    # Decide from the environment if PreExecution result authentication feature should be enabled or not
+    pre_exec_result_auth_enabled = os.environ.get("PRE_EXEC_RESULT_AUTH_ENABLED", default="False").lower() == "true"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
-            "-v", view_change_timeout_milli
+            "-v", view_change_timeout_milli,
+            "-x" if pre_exec_result_auth_enabled else ""
             ]
 
 def start_replica_cmd_with_vc_timeout(vc_timeout):

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -67,6 +67,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
     replicaConfig.set("concord.bft.st.runInSeparateThread", true);
     replicaConfig.set("concord.bft.keyExchage.clientKeysEnabled", false);
+    replicaConfig.preExecutionResultAuthEnabled = false;
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
     std::string commConfigFile;
@@ -100,11 +101,12 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"operator-public-key-path", optional_argument, 0, 'o'},
                                           {"cron-entry-number-of-executes", optional_argument, 0, 'r'},
                                           {"replica-byzantine-strategies", optional_argument, 0, 'g'},
+                                          {"pre-exec-result-auth", no_argument, 0, 'x'},
                                           {0, 0, 0, 0}};
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
-    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:l:e:w:c:b:m:q:z:y:up:t:o:r:g:", longOptions, &optionIndex)) !=
+    while ((o = getopt_long(argc, argv, "i:k:n:s:v:a:3:l:e:w:c:b:m:q:z:y:up:t:o:r:g:x", longOptions, &optionIndex)) !=
            -1) {
       switch (o) {
         case 'i': {
@@ -196,6 +198,10 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         }
         case 'g': {
           byzantineStrategies = optarg;
+          break;
+        }
+        case 'x': {
+          replicaConfig.preExecutionResultAuthEnabled = true;
           break;
         }
         case '?': {

--- a/util/pyclient/bft_msgs.py
+++ b/util/pyclient/bft_msgs.py
@@ -34,7 +34,7 @@ MSG_TYPE_SIZE = struct.calcsize(MSG_TYPE_FMT)
 # Little Endian format with no padding
 # We don't include the msg type here, since we have to read it first to
 # understand what message is incoming.
-REQUEST_HEADER_FMT = "<LHQQLQLH"
+REQUEST_HEADER_FMT = "<LHQQLQLHL"
 REQUEST_HEADER_SIZE = struct.calcsize(REQUEST_HEADER_FMT)
 
 # The struct definition of the client batch request msg header
@@ -51,7 +51,7 @@ REPLY_HEADER_FMT = "<LHQLL"
 REPLY_HEADER_SIZE = struct.calcsize(REPLY_HEADER_FMT)
 
 RequestHeader = namedtuple('RequestHeader', ['span_context_size', 'client_id', 'flags',
-    'req_seq_num', 'length', 'timeout_milli', 'cid', 'req_sig_len'])
+    'req_seq_num', 'length', 'timeout_milli', 'cid', 'req_sig_len', 'extra_data_length'])
 BatchRequestHeader = namedtuple('BatchRequestHeader', ['cid', 'client_id', 
     'num_of_messages_in_batch', 'data_size'])
 
@@ -74,7 +74,8 @@ def pack_request(client_id, req_seq_num, read_only, timeout_milli, cid, msg, pre
     if reconfiguration:
         flags |= RECONFIG_FLAG
     sig_len = len(signature) if signature else 0
-    header = RequestHeader(len(span_context), client_id, flags, req_seq_num, len(msg), timeout_milli, len(cid), sig_len)
+    extra_data_len = 0
+    header = RequestHeader(len(span_context), client_id, flags, req_seq_num, len(msg), timeout_milli, len(cid), sig_len, extra_data_len)
     data = b''.join([pack_request_header(header, pre_process), span_context, msg, cid.encode(), signature])
     return data
 


### PR DESCRIPTION
This PR implements PreExecution result verification by non-primary replicas (aka PreExecution non-repudiation).

What it does:
1. Adds flag to the PreProcessor indicating if the feature should be enabled or not (feature flag).
2. Adds new parameter to ClientRequestMessage, which allows allocating extra buffer space by MessageBase class. This buffer can be used by messages inheriting from ClientRequestMessage to store additional fields (see next point).
3. Adds new PreExecution message - PreProcessedResult message. It is carries the result from the PreExecution and the signatures of all f+1 replicas which has preexecuted the concrete request. This message is implemented by inheriting from ClientRequestMessage. The feature described in point 2 is used to allocate additional buffer space for the signatures.
4. Result verification logic handling.

How the result verification logic changes the PreExecution flow?
================================================
The flow remains unchanged up to receiving a PreProcessReply message on the primary. Now instead of adding a ClientRequestMsg to its internal queue the primary uses PreProcessedResult for this purpose. A clear benefit from this is responsibility separation - ClientRequest messages are used for client requests and PreProcessedResult - for pre-executed requests. All hash signatures from the non-primary replicas are added in the PreProcessedResult message. All its other fields are 1:1 compared to ClientRequest.

On finalise preprocessing phase (finalizePreprocessing method) the Primary bundles some ClientRequest and PreProcessedResult messages in a PrePrepare message. There is another benefit from the inheritance here - PrePrepare handling logic doesn't care about the new message. From its point of view it is just another ClientRequest message.

When a non-primary receives a PrePrepare message it unbundles all ClientRequest and PreProcessedResult messages from it. They are discriminated by the message type in the message header. If the non-primary find a PreProcessedResult message it verifies the validity of all signatures in it and additionally if f+1 signatures are assigned. If both requirements are satisfied the message is processed as usual.

However if a non-primary finds a PreProcessedResult message with invalid signature or less than f+1 signatures it assumes that the primary is malicious and triggers a view change. New reason is added to ReplicaAsksToLeaveViewMsg -  PrimarySentBadPreProcessedResult.