### PR TITLE
Update value of reconfiguration_client_key_exchange

### DIFF
--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -20,6 +20,6 @@ static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;
 static const char reconfiguration_key_exchange = 0x28;
 static const char reconfiguration_add_remove = 0x29;
-static const char reconfiguration_client_key_exchange = 0x30;
+static const char reconfiguration_client_key_exchange = 0x2a;
 
 }  // namespace concord::kvbc::keyTypes


### PR DESCRIPTION
This change is required to avoid collision with client app key type
value.