### PR TITLE
Make use of PreProcessBatchReplyMsg

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -14,6 +14,7 @@
 #include "OpenTracing.hpp"
 #include "messages/ClientBatchRequestMsg.hpp"
 #include "messages/PreProcessBatchRequestMsg.hpp"
+#include "messages/PreProcessBatchReplyMsg.hpp"
 #include "MsgsCommunicator.hpp"
 #include "MsgHandlersRegistrator.hpp"
 #include "SimpleThreadPool.hpp"
@@ -47,16 +48,56 @@ struct RequestState {
   uint64_t reqRetryId = 1;
 };
 
-// Pre-allocated (clientId * dataSize) buffers
-typedef std::deque<std::pair<std::atomic_bool, concordUtils::Sliver>> PreProcessResultBuffers;
-typedef std::shared_ptr<RequestState> RequestStateSharedPtr;
-// (clientId * dataSize + reqOffsetInBatch) -> RequestStateSharedPtr
-typedef std::unordered_map<uint16_t, RequestStateSharedPtr> OngoingReqMap;
+using RequestStateSharedPtr = std::shared_ptr<RequestState>;
 
+//**************** Class RequestsBatch ****************//
+class PreProcessor;
+
+class RequestsBatch {
+ public:
+  RequestsBatch(PreProcessor &preProcessor, uint16_t clientId) : preProcessor_(preProcessor), clientId_(clientId) {}
+  void init();
+  void registerBatch(const std::string &cid, uint32_t batchSize);
+  void startBatch(const std::string &cid, uint32_t batchSize);
+  void addReply(PreProcessReplyMsgSharedPtr replyMsg);
+  bool isBatchRegistered() const { return batchRegistered_; }
+  bool isBatchInProcess() const { return batchInProcess_; }
+  void increaseNumOfCompletedReqs() { numOfCompletedReqs_++; }
+  RequestStateSharedPtr &getRequestState(uint16_t reqOffsetInBatch);
+  const std::string getCid() const;
+  void cancelBatch();
+  void releaseReqsAndSendBatchedReplyIfCompleted();
+  void finalizeBatchIfCompleted();
+  void handlePossiblyExpiredRequests();
+  void cancelBatchedPreProcessingOnNonPrimary(const ClientMsgsList &clientMsgs, NodeIdType destId);
+
+ private:
+  void setBatchParameters(const std::string &cid, uint32_t batchSize);
+  void resetBatchParams();
+
+ private:
+  PreProcessor &preProcessor_;
+  const uint16_t clientId_;
+  std::string cid_;
+  std::atomic_uint32_t batchSize_ = 0;
+  std::atomic_bool batchRegistered_ = false;
+  std::atomic_bool batchInProcess_ = false;
+  std::atomic_uint32_t numOfCompletedReqs_ = 0;
+  // pre-allocated map; request offset in batch -> request state
+  std::map<uint16_t, RequestStateSharedPtr> requestsMap_;
+  mutable std::mutex batchMutex_;
+  PreProcessReplyMsgsList repliesList_;
+};
+
+using RequestsBatchSharedPtr = std::shared_ptr<RequestsBatch>;
+// clientId -> RequestsBatch map
+using OngoingReqBatchesMap = std::map<uint16_t, RequestsBatchSharedPtr>;
+
+// Pre-allocated (clientId * dataSize) buffers
+using PreProcessResultBuffers = std::deque<std::pair<std::atomic_bool, concordUtils::Sliver>>;
 using TimeRecorder = concord::diagnostics::TimeRecorder<true>;  // use atomic recorder
 
 //**************** Class PreProcessor ****************//
-
 // This class is responsible for the coordination of pre-execution activities on both - primary and non-primary
 // replica types. It handles client pre-execution requests, pre-processing requests, and replies.
 // On primary replica - it collects pre-execution result hashes from other replicas and decides whether to continue
@@ -88,6 +129,7 @@ class PreProcessor {
 
  private:
   friend class AsyncPreProcessJob;
+  friend class RequestsBatch;
 
   uint16_t numOfRequiredReplies();
 
@@ -97,12 +139,16 @@ class PreProcessor {
   template <typename T>
   void onMessage(T *msg);
 
-  bool registerRequestOnPrimaryReplica(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+  bool registerRequestOnPrimaryReplica(const std::string &batchCid,
+                                       uint32_t batchSize,
+                                       ClientPreProcessReqMsgUniquePtr clientReqMsg,
                                        PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
                                        uint16_t reqOffsetInBatch,
                                        RequestStateSharedPtr reqEntry);
   void countRetriedRequests(const ClientPreProcessReqMsgUniquePtr &clientReqMsg, const RequestStateSharedPtr &reqEntry);
-  bool registerRequest(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+  bool registerRequest(const std::string &batchCid,
+                       uint32_t batchSize,
+                       ClientPreProcessReqMsgUniquePtr clientReqMsg,
                        PreProcessRequestMsgSharedPtr preProcessRequestMsg,
                        uint16_t reqOffsetInBatch);
   void releaseClientPreProcessRequestSafe(uint16_t clientId, uint16_t reqOffsetInBatch, PreProcessingResult result);
@@ -116,7 +162,9 @@ class PreProcessor {
       SeqNum reqSeqNum, const std::string &cid, NodeIdType senderId, NodeIdType clientId, uint16_t reqOffsetInBatch);
   bool checkPreProcessBatchReqMsgCorrectness(const PreProcessBatchReqMsgSharedPtr &batchReq);
   void handleClientPreProcessRequestByPrimary(PreProcessRequestMsgSharedPtr preProcessRequestMsg, bool arrivedInBatch);
-  void registerAndHandleClientPreProcessReqOnNonPrimary(ClientPreProcessReqMsgUniquePtr clientReqMsg,
+  void registerAndHandleClientPreProcessReqOnNonPrimary(const std::string &batchCid,
+                                                        uint32_t batchSize,
+                                                        ClientPreProcessReqMsgUniquePtr clientReqMsg,
                                                         bool arrivedInBatch,
                                                         uint16_t reqOffsetInBatch);
   void sendMsg(char *msg, NodeIdType dest, uint16_t msgType, MsgSize msgSize);
@@ -133,12 +181,12 @@ class PreProcessor {
                                     uint64_t reqRetryId,
                                     const std::string &cid,
                                     const std::string &ongoingCid);
-  void sendCancelPreProcessRequestMsg(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
-                                      NodeIdType destId,
-                                      uint16_t reqOffsetInBatch,
-                                      uint64_t reqRetryId);
+  void cancelPreProcessingOnNonPrimary(const ClientPreProcessReqMsgUniquePtr &clientReqMsg,
+                                       NodeIdType destId,
+                                       uint16_t reqOffsetInBatch,
+                                       uint64_t reqRetryId,
+                                       const std::string &batchCid = "");
   const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
-  const uint16_t getOngoingReqIndex(uint16_t clientId, uint16_t reqOffsetInBatch) const;
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       bool isPrimary,
                                       bool isRetry,
@@ -152,17 +200,17 @@ class PreProcessor {
                                   std::string signature,
                                   const concordUtils::SpanContext &span_context);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg, bool isPrimary, bool isRetry);
-  void handlePreProcessedReqByNonPrimary(uint16_t clientId,
+  void handleReqPreProcessedByNonPrimary(uint16_t clientId,
                                          uint16_t reqOffsetInBatch,
                                          ReqId reqSeqNum,
                                          uint64_t reqRetryId,
                                          uint32_t resBufLen,
                                          const std::string &cid);
-  void handlePreProcessedReqByPrimary(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
+  void handleReqPreProcessedByPrimary(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       uint16_t clientId,
                                       uint32_t resultBufLen);
   void handlePreProcessedReqPrimaryRetry(NodeIdType clientId, uint16_t reqOffsetInBatch, uint32_t resultBufLen);
-  void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch);
+  void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch, const std::string &batchCid = "");
   void cancelPreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch);
   void setPreprocessingRightNow(uint16_t clientId, uint16_t reqOffsetInBatch, bool set);
   PreProcessingResult handlePreProcessedReqByPrimaryAndGetConsensusResult(uint16_t clientId,
@@ -172,22 +220,31 @@ class PreProcessor {
                                 PreProcessingResult result,
                                 NodeIdType clientId,
                                 uint16_t reqOffsetInBatch,
-                                SeqNum reqSeqNum);
+                                SeqNum reqSeqNum,
+                                const std::string &batchCid = "");
   void updateAggregatorAndDumpMetrics();
   void addTimers();
   void cancelTimers();
   void onRequestsStatusCheckTimer();
-  void handleSingleClientRequestMessage(const std::string &batchCid,
-                                        ClientPreProcessReqMsgUniquePtr clientMsg,
+  bool handleSingleClientRequestMessage(ClientPreProcessReqMsgUniquePtr clientMsg,
                                         NodeIdType senderId,
                                         bool arrivedInBatch,
                                         uint16_t msgOffsetInBatch,
-                                        PreProcessRequestMsgSharedPtr &preProcessRequestMsg);
-  void handleSinglePreProcessRequestMsg(PreProcessRequestMsgSharedPtr preProcessReqMsg, const std::string &batchCid);
+                                        PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
+                                        const std::string &batchCid = "",
+                                        uint32_t batchSize = 1);
+  void handleSinglePreProcessRequestMsg(PreProcessRequestMsgSharedPtr preProcessReqMsg,
+                                        const std::string &batchCid = "",
+                                        uint32_t batchSize = 1);
+  void handleSinglePreProcessReplyMsg(PreProcessReplyMsgSharedPtr preProcessReplyMsg, const std::string &batchCid = "");
   bool isRequestPreProcessingRightNow(const RequestStateSharedPtr &reqEntry,
                                       ReqId reqSeqNum,
                                       NodeIdType clientId,
                                       NodeIdType senderId);
+  bool isBatchAlreadyRegistered(const std::string &batchCid,
+                                const RequestsBatchSharedPtr &batchEntry,
+                                NodeIdType clientId,
+                                NodeIdType senderId) const;
   bool isRequestPreProcessedBefore(const RequestStateSharedPtr &reqEntry,
                                    SeqNum reqSeqNum,
                                    NodeIdType clientId,
@@ -196,6 +253,9 @@ class PreProcessor {
                                            NodeIdType senderId,
                                            NodeIdType clientId,
                                            const std::string &cid);
+  void releaseReqAndSendReplyMsg(PreProcessReplyMsgSharedPtr replyMsg);
+  void handlePossiblyExpiredRequest(const RequestStateSharedPtr &reqStateEntry);
+
   static logging::Logger &logger() {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
@@ -222,15 +282,15 @@ class PreProcessor {
   const InternalReplicaApi &myReplica_;
   const ReplicaId myReplicaId_;
   const uint32_t maxPreExecResultSize_;
-  const std::set<ReplicaId> &idsOfPeerReplicas_;
   const uint16_t numOfReplicas_;
   const uint16_t numOfInternalClients_;
   const bool clientBatchingEnabled_;
-  const uint16_t clientMaxBatchSize_;
+  inline static uint16_t clientMaxBatchSize_ = 0;
   util::SimpleThreadPool threadPool_;
   // One-time allocated buffers (one per client) for the pre-execution results storage
   PreProcessResultBuffers preProcessResultBuffers_;
-  OngoingReqMap ongoingRequests_;  // clientId + reqOffsetInBatch -> RequestStateSharedPtr
+  OngoingReqBatchesMap ongoingReqBatches_;  // clientId -> RequestsBatch
+
   concordMetrics::Component metricsComponent_;
   std::chrono::seconds metricsLastDumpTime_;
   std::chrono::seconds metricsDumpIntervalInSec_;

--- a/bftengine/src/preprocessor/PreProcessorRecorder.hpp
+++ b/bftengine/src/preprocessor/PreProcessorRecorder.hpp
@@ -24,6 +24,7 @@ class PreProcessorRecorder {
                                       onPreProcessRequestMsg,
                                       onPreProcessBatchRequestMsg,
                                       onPreProcessReplyMsg,
+                                      onPreProcessBatchReplyMsg,
                                       launchReqPreProcessing,
                                       handlePreProcessedReqByNonPrimary,
                                       handlePreProcessedReqPrimaryRetry,
@@ -48,6 +49,7 @@ class PreProcessorRecorder {
   DEFINE_SHARED_RECORDER(onClientBatchPreProcessRequestMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(onPreProcessRequestMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(onPreProcessBatchRequestMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+  DEFINE_SHARED_RECORDER(onPreProcessBatchReplyMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(onPreProcessReplyMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(launchReqPreProcessing, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
   DEFINE_SHARED_RECORDER(handlePreProcessedReqByNonPrimary, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "PrimitiveTypes.hpp"
 #include "messages/ClientPreProcessRequestMsg.hpp"
 #include "messages/PreProcessRequestMsg.hpp"
 #include "messages/PreProcessReplyMsg.hpp"
@@ -24,7 +23,7 @@ namespace preprocessor {
 // This class collects and stores data relevant to the processing of one specific client request by all replicas.
 
 typedef enum { NONE, CONTINUE, COMPLETE, CANCEL, CANCELLED_BY_PRIMARY, RETRY_PRIMARY } PreProcessingResult;
-typedef std::vector<ReplicaId> ReplicaIdsList;
+using ReplicaIdsList = std::vector<ReplicaId>;
 
 class RequestProcessingState {
  public:
@@ -113,6 +112,6 @@ class RequestProcessingState {
   uint64_t reqRetryId_ = 0;
 };
 
-typedef std::unique_ptr<RequestProcessingState> RequestProcessingStateUniquePtr;
+using RequestProcessingStateUniquePtr = std::unique_ptr<RequestProcessingState>;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.hpp
@@ -17,7 +17,7 @@
 
 namespace preprocessor {
 
-typedef std::list<preprocessor::PreProcessReplyMsgSharedPtr> PreProcessReplyMsgsList;
+using PreProcessReplyMsgsList = std::list<PreProcessReplyMsgSharedPtr>;
 
 class PreProcessBatchReplyMsg : public MessageBase {
  public:
@@ -25,7 +25,7 @@ class PreProcessBatchReplyMsg : public MessageBase {
                           NodeIdType senderId,
                           const PreProcessReplyMsgsList& batch,
                           const std::string& cid,
-                          uint32_t replyMsgsSize);
+                          uint32_t repliesSize);
 
   BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(PreProcessBatchReplyMsg)
 
@@ -55,7 +55,7 @@ class PreProcessBatchReplyMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
-  void setParams(NodeIdType senderId, uint16_t clientId, uint32_t numOfMessagesInBatch);
+  void setParams(NodeIdType senderId, uint16_t clientId, uint32_t numOfMessagesInBatch, uint32_t repliesSize);
   Header* msgBody() const { return ((Header*)msgBody_); }
 
  private:
@@ -63,6 +63,6 @@ class PreProcessBatchReplyMsg : public MessageBase {
   PreProcessReplyMsgsList preProcessReplyMsgsList_;
 };
 
-typedef std::shared_ptr<PreProcessReplyMsg> PreProcessReplyMsgSharedPtr;
+using PreProcessBatchReplyMsgSharedPtr = std::shared_ptr<PreProcessBatchReplyMsg>;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.cpp
@@ -24,7 +24,7 @@ PreProcessBatchRequestMsg::PreProcessBatchRequestMsg(RequestType reqType,
                                                      uint32_t requestsSize)
     : MessageBase(senderId, MsgCode::PreProcessBatchRequest, 0, sizeof(Header) + requestsSize + cid.size()) {
   const uint32_t numOfMessagesInBatch = batch.size();
-  setParams(clientId, senderId, reqType, numOfMessagesInBatch);
+  setParams(clientId, senderId, reqType, numOfMessagesInBatch, requestsSize);
   msgBody()->cidLength = cid.size();
   auto position = body() + sizeof(Header);
   if (cid.size()) {
@@ -54,15 +54,14 @@ void PreProcessBatchRequestMsg::validate(const ReplicasInfo& repInfo) const {
   }
 }
 
-void PreProcessBatchRequestMsg::setParams(uint16_t clientId,
-                                          NodeIdType senderId,
-                                          RequestType reqType,
-                                          uint32_t numOfMessagesInBatch) {
+void PreProcessBatchRequestMsg::setParams(
+    uint16_t clientId, NodeIdType senderId, RequestType reqType, uint32_t numOfMessagesInBatch, uint32_t requestsSize) {
   auto* header = msgBody();
   header->reqType = reqType;
   header->clientId = clientId;
   header->senderId = senderId;
   header->numOfMessagesInBatch = numOfMessagesInBatch;
+  header->requestsSize = requestsSize;
 }
 
 string PreProcessBatchRequestMsg::getCid() const { return string(body() + sizeof(Header), msgBody()->cidLength); }

--- a/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.hpp
@@ -16,7 +16,7 @@
 
 namespace preprocessor {
 
-typedef std::list<preprocessor::PreProcessRequestMsgSharedPtr> PreProcessReqMsgsList;
+using PreProcessReqMsgsList = std::list<preprocessor::PreProcessRequestMsgSharedPtr>;
 
 class PreProcessBatchRequestMsg : public MessageBase {
  public:
@@ -57,7 +57,11 @@ class PreProcessBatchRequestMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
-  void setParams(uint16_t clientId, NodeIdType senderId, RequestType reqType, uint32_t numOfMessagesInBatch);
+  void setParams(uint16_t clientId,
+                 NodeIdType senderId,
+                 RequestType reqType,
+                 uint32_t numOfMessagesInBatch,
+                 uint32_t requestsSize);
   Header* msgBody() const { return ((Header*)msgBody_); }
 
  private:
@@ -65,6 +69,6 @@ class PreProcessBatchRequestMsg : public MessageBase {
   PreProcessReqMsgsList preProcessReqMsgsList_;
 };
 
-typedef std::shared_ptr<PreProcessBatchRequestMsg> PreProcessBatchReqMsgSharedPtr;
+using PreProcessBatchReqMsgSharedPtr = std::shared_ptr<PreProcessBatchRequestMsg>;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -464,31 +464,71 @@ TEST(requestPreprocessingState_test, primaryReplicaDidNotCompletePreProcessingWh
   ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), COMPLETE);
 }
 
-TEST(requestPreprocessingState_test, validatePreProcessBatchMsg) {
+TEST(requestPreprocessingState_test, validatePreProcessBatchRequestMsg) {
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, false, false);
 
-  list<PreProcessRequestMsgSharedPtr> batch;
+  PreProcessReqMsgsList batch;
   uint overallReqSize = 0;
   const auto numOfMsgs = 3;
+  const auto senderId = 2;
   for (uint i = 0; i < numOfMsgs; i++) {
     auto preProcessReqMsg = make_shared<PreProcessRequestMsg>(
-        REQ_TYPE_PRE_PROCESS, 1, clientId, i, reqSeqNum + i, i, bufLen, buf, cid + to_string(i + 1), nullptr, 0);
+        REQ_TYPE_PRE_PROCESS, senderId, clientId, i, reqSeqNum + i, i, bufLen, buf, cid + to_string(i + 1), nullptr, 0);
     batch.push_back(preProcessReqMsg);
     overallReqSize += preProcessReqMsg->size();
   }
   auto preProcessBatchReqMsg =
-      make_shared<PreProcessBatchRequestMsg>(REQ_TYPE_PRE_PROCESS, clientId, 1, batch, cid, overallReqSize);
+      make_shared<PreProcessBatchRequestMsg>(REQ_TYPE_PRE_PROCESS, clientId, senderId, batch, cid, overallReqSize);
   preProcessBatchReqMsg->validate(repInfo);
   const auto msgs = preProcessBatchReqMsg->getPreProcessRequestMsgs();
+  ConcordAssertEQ(preProcessBatchReqMsg->clientId(), clientId);
+  ConcordAssertEQ(preProcessBatchReqMsg->senderId(), senderId);
   ConcordAssertEQ(preProcessBatchReqMsg->getCid(), cid);
   ConcordAssertEQ(msgs.size(), numOfMsgs);
   uint i = 0;
   for (const auto& msg : msgs) {
     msg->validate(repInfo);
-    ConcordAssertEQ(msg->reqOffsetInBatch(), i);
+    ConcordAssertEQ(msg->clientId(), clientId);
+    ConcordAssertEQ(msg->senderId(), senderId);
     ConcordAssertEQ(msg->reqSeqNum(), (int64_t)reqSeqNum + i);
+    ConcordAssertEQ(msg->reqOffsetInBatch(), i);
     ConcordAssertEQ(msg->getCid(), cid + to_string(i + 1));
     ConcordAssertEQ(msg->requestLength(), bufLen);
+    i++;
+  }
+}
+
+TEST(requestPreprocessingState_test, validatePreProcessBatchReplyMsg) {
+  bftEngine::impl::ReplicasInfo repInfo(replicaConfig, false, false);
+
+  PreProcessReplyMsgsList batch;
+  uint overallRepliesSize = 0;
+  const auto numOfMsgs = 3;
+  const auto senderId = 2;
+  SigManager::instance(sigManager[senderId].get());
+  for (uint i = 0; i < numOfMsgs; i++) {
+    auto preProcessReplyMsg = make_shared<PreProcessReplyMsg>(
+        senderId, clientId, i, reqSeqNum + i, i, buf, bufLen, cid + to_string(i + 1), STATUS_GOOD);
+    batch.push_back(preProcessReplyMsg);
+    overallRepliesSize += preProcessReplyMsg->size();
+  }
+  auto preProcessBatchReplyMsg =
+      make_shared<PreProcessBatchReplyMsg>(clientId, senderId, batch, cid, overallRepliesSize);
+  preProcessBatchReplyMsg->validate(repInfo);
+  const auto msgs = preProcessBatchReplyMsg->getPreProcessReplyMsgs();
+  ConcordAssertEQ(preProcessBatchReplyMsg->clientId(), clientId);
+  ConcordAssertEQ(preProcessBatchReplyMsg->senderId(), senderId);
+  ConcordAssertEQ(preProcessBatchReplyMsg->getCid(), cid);
+  ConcordAssertEQ(msgs.size(), numOfMsgs);
+  uint i = 0;
+  SigManager::instance(sigManager[repInfo.myId()].get());
+  for (const auto& msg : msgs) {
+    msg->validate(repInfo);
+    ConcordAssertEQ(msg->clientId(), clientId);
+    ConcordAssertEQ(msg->senderId(), senderId);
+    ConcordAssertEQ(msg->reqSeqNum(), (int64_t)reqSeqNum + i);
+    ConcordAssertEQ(msg->reqOffsetInBatch(), i);
+    ConcordAssertEQ(msg->getCid(), cid + to_string(i + 1));
     i++;
   }
 }
@@ -661,9 +701,9 @@ TEST(requestPreprocessingState_test, handlePreProcessBatchRequestMsg) {
   concordUtil::Timers timers;
   PreProcessor preProcessor(msgsCommunicator, msgsStorage, msgHandlersRegPtr, requestsHandler, replica, timers, sdm);
 
-  list<PreProcessRequestMsgSharedPtr> batch;
+  PreProcessReqMsgsList batch;
   uint overallReqSize = 0;
-  const auto numOfMsgs = 3;
+  const auto numOfMsgs = 4;
   for (uint i = 0; i < numOfMsgs; i++) {
     auto preProcessReqMsg = make_shared<PreProcessRequestMsg>(
         REQ_TYPE_PRE_PROCESS, 1, clientId, i, i + 5, i, bufLen, buf, to_string(i + 1), nullptr, 0);
@@ -678,6 +718,7 @@ TEST(requestPreprocessingState_test, handlePreProcessBatchRequestMsg) {
   ConcordAssertEQ(preProcessor.getOngoingReqIdForClient(clientId, 0), 0);
   ConcordAssertEQ(preProcessor.getOngoingReqIdForClient(clientId, 1), 0);
   ConcordAssertEQ(preProcessor.getOngoingReqIdForClient(clientId, 2), 0);
+  ConcordAssertEQ(preProcessor.getOngoingReqIdForClient(clientId, 3), 0);
   clearDiagnosticsHandlers();
 }
 


### PR DESCRIPTION
This MR implements the last part of PreProcessor full batch awareness functionality.
Now all PreProcessor messages have a batched version used in inter-replica communication for batched client requests, which should significantly reduce the IncomingStorage queue size.
The functionality is currently disabled by default using batchedPreProcessEnabled=false configuration parameter. 
Previous parts are https://github.com/vmware/concord-bft/pull/1562, https://github.com/vmware/concord-bft/pull/1602, and https://github.com/vmware/concord-bft/pull/1585.