### PR TITLE
ConcordClient: Use std::function over templates

### DIFF
--- a/client/clientservice/proto/concord_client.proto
+++ b/client/clientservice/proto/concord_client.proto
@@ -85,6 +85,7 @@ service EventService {
   // RESOURCE_EXHAUSTED: if Concord Client is overloaded. The caller should retry with a backoff.
   // UNAVAILABLE: if Concord Client is currently unable to process any requests. The caller should retry with a backoff.
   // INTERNAL: if Concord Client cannot progress independent of the request.
+  // ALREADY_EXISTS: if Concord Client serves an active stream already. See note above.
   rpc StreamEventGroups(StreamEventGroupsRequest) returns (stream EventGroup);
 }
 

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -57,7 +57,11 @@ Status EventServiceImpl::StreamEventGroups(ServerContext* context,
   };
 
   auto span = opentracing::Tracer::Global()->StartSpan("stream_event_groups", {});
-  client_->subscribe(request, span, callback);
+  try {
+    client_->subscribe(request, span, callback);
+  } catch (cc::ConcordClient::SubscriptionExists& e) {
+    return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, e.what());
+  }
 
   // TODO: Consider all gRPC return error codes as described in concord_client.proto
   while (!context->IsCancelled()) {

--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -1,6 +1,7 @@
-add_library(concordclient INTERFACE)
-target_include_directories(concordclient INTERFACE include)
-target_link_libraries(concordclient INTERFACE
+add_library(concordclient "src/concord_client.cpp")
+target_include_directories(concordclient PUBLIC include)
+# TODO: Mark libraries as PRIVATE once the interface is selfcontained
+target_link_libraries(concordclient PUBLIC
   bftclient_new # temporary until client pool is available
   thin_replica_client_lib
 )

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -121,6 +121,7 @@ class ConcordClient {
  public:
   ConcordClient(const ConcordClientConfig& config)
       : logger_(logging::getLogger("concord.client.concordclient")), config_(config) {}
+  ~ConcordClient() { unsubscribe(); }
 
   // Register a callback that gets invoked once the handling BFT client returns.
   void send(const bft::client::WriteConfig& config,
@@ -142,6 +143,13 @@ class ConcordClient {
   // Note, if the caller doesn't unsubscribe and no runtime error occurs then resources
   // will be occupied forever.
   void unsubscribe();
+
+  // At the moment, we only allow one subscriber at a time. This exception is thrown if the caller subscribes while an
+  // active subscription is in progress already.
+  class SubscriptionExists : public std::runtime_error {
+   public:
+    SubscriptionExists() : std::runtime_error("subscription exists already"){};
+  };
 
  private:
   logging::Logger logger_;

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -18,8 +18,7 @@ void ConcordClient::subscribe(const SubscribeRequest& request,
                               std::function<void(SubscribeResult&&)> callback) {
   if (not stop_subscriber_) {
     LOG_ERROR(logger_, "subscription already in progress - unsubscribe first");
-    callback(SubscribeResult{SubscribeError{}});
-    return;
+    throw SubscriptionExists();
   }
 
   stop_subscriber_ = false;

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#include "client/concordclient/concord_client.hpp"
+
+namespace concord::client::concordclient {
+
+void ConcordClient::subscribe(const SubscribeRequest& request,
+                              const std::unique_ptr<opentracing::Span>& parent_span,
+                              std::function<void(SubscribeResult&&)> callback) {
+  if (not stop_subscriber_) {
+    LOG_ERROR(logger_, "subscription already in progress - unsubscribe first");
+    callback(SubscribeResult{SubscribeError{}});
+    return;
+  }
+
+  stop_subscriber_ = false;
+  subscriber_ = std::thread([&] {
+    while (not stop_subscriber_) {
+      // Note: The following returns an artificial event group.
+      // This will be replaced with the actual thin replica client integration.
+      // The thread is in place to simulate the asynchronous subscription.
+      EventGroup eg;
+      eg.id = request.event_group_id;
+      std::string event = std::to_string(request.event_group_id);
+      eg.events.push_back({event.begin(), event.end()});
+      std::chrono::duration time_now = std::chrono::system_clock::now().time_since_epoch();
+      eg.record_time = std::chrono::duration_cast<std::chrono::microseconds>(time_now);
+      eg.trace_context = {};
+
+      callback(SubscribeResult{eg});
+    }
+  });
+}
+
+void ConcordClient::unsubscribe() {
+  if (stop_subscriber_ == false) {
+    LOG_INFO(logger_, "Closing subscription");
+    stop_subscriber_ = true;
+    subscriber_.join();
+  }
+}
+
+}  // namespace concord::client::concordclient


### PR DESCRIPTION
The main change in this PR is switching from templates to std::function. This is the result of a discussion with @f-squirrel. See https://github.com/vmware/concord-bft/pull/1628#discussion_r659796019 for more information. In addition, this PR fixes a bug with multiple subscriptions. Tests are still missing and will be introduced in the future. Please take a look at the commit messages for more details.