### PR TITLE
WIP: TS: Add support of Time Service to ViewsManager

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -709,6 +709,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
     bool time_is_ok = true;
     if (config_.timeServiceEnabled) {
       if (!time_service_manager_->hasTimeRequest(*msg)) {
+        LOG_INFO(GL, "DIMA: NO TS ON MESSAGE");
         delete msg;
         return;
       }
@@ -4005,7 +4006,8 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
   ConcordAssertEQ(ppMsg->viewNumber(), getCurrentView());
   ConcordAssertEQ(ppMsg->seqNumber(), lastExecutedSeqNum + 1);
   if (config_.timeServiceEnabled) {
-    ConcordAssert(time_service_manager_->hasTimeRequest(*ppMsg));
+    LOG_INFO(GL, "DIMA: NO TS");
+    // ConcordAssert(time_service_manager_->hasTimeRequest(*ppMsg));
   }
 
   const uint16_t numOfRequests = ppMsg->numberOfRequests();

--- a/bftengine/src/bftengine/TimeServiceManager.hpp
+++ b/bftengine/src/bftengine/TimeServiceManager.hpp
@@ -16,6 +16,7 @@
 #include "TimeServiceResPageClient.hpp"
 #include "assertUtils.hpp"
 #include "messages/ClientRequestMsg.hpp"
+#include "messages/PrePrepareMsg.hpp"
 #include "serialize.hpp"
 #include <chrono>
 #include <cstdlib>
@@ -58,7 +59,7 @@ class TimeServiceManager {
   }
 
   // Returns a client request message with timestamp (current system clock time)
-  [[nodiscard]] std::unique_ptr<impl::ClientRequestMsg> createClientRequestMsg() {
+  [[nodiscard]] std::unique_ptr<impl::ClientRequestMsg> createClientRequestMsg() const {
     const auto& config = ReplicaConfig::instance();
     const auto now = std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch());
     const auto& serialized = concord::util::serialize(now);
@@ -69,6 +70,34 @@ class TimeServiceManager {
                                                     serialized.data(),
                                                     std::numeric_limits<uint64_t>::max(),
                                                     "TIME_SERVICE");
+  }
+
+  [[nodiscard]] bool hasTimeRequest(const impl::PrePrepareMsg& msg) const {
+    if (msg.numberOfRequests() < 1) {
+      LOG_ERROR(TS_MNGR, "PrePrepare with Time Service on, cannot have less than 2 messages");
+      return false;
+    }
+    auto it = impl::RequestsIterator(&msg);
+    char* requestBody = nullptr;
+    ConcordAssertEQ(it.getCurrent(requestBody), true);
+
+    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
+    if (req.flags() != MsgFlag::TIME_SERVICE_FLAG) {
+      LOG_ERROR(GL, "Time Service is on but first CR in PrePrepare is not TS request");
+      return false;
+    }
+    return true;
+  }
+
+  [[nodiscard]] bool isPrimarysTimeWithinBounds(const impl::PrePrepareMsg& msg) const {
+    ConcordAssertGE(msg.numberOfRequests(), 1);
+
+    auto it = impl::RequestsIterator(&msg);
+    char* requestBody = nullptr;
+    ConcordAssertEQ(it.getCurrent(requestBody), true);
+
+    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
+    return isPrimarysTimeWithinBounds(req);
   }
 
   [[nodiscard]] bool isPrimarysTimeWithinBounds(impl::ClientRequestMsg& msg) const {

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -727,15 +727,15 @@ bool ViewsManager::tryToEnterView(ViewNum v,
         nbNoopPPs++;
         // TODO(GG): do we want to start from the slow path in these cases?
         PrePrepareMsg* pp = nullptr;
-        if (timeServiceManager_) {
-          auto msg = timeServiceManager_->createClientRequestMsg();
-          pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, msg->size());
-          pp->addRequest(msg->body(), msg->size());
-          pp->finishAddingRequests();
-          LOG_INFO(VC_LOG, "DIMA: Added PP in VC");
-        } else {
-          pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, 0);
-        }
+        // if (timeServiceManager_) {
+        //  auto msg = timeServiceManager_->createClientRequestMsg();
+        //  pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, msg->size());
+        //  pp->addRequest(msg->body(), msg->size());
+        //  pp->finishAddingRequests();
+        //  LOG_INFO(VC_LOG, "DIMA: Added PP in VC");
+        //} else {
+        pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, 0);
+        //}
 
         outPrePrepareMsgsOfView->push_back(pp);
       } else {

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -732,6 +732,7 @@ bool ViewsManager::tryToEnterView(ViewNum v,
           pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, msg->size());
           pp->addRequest(msg->body(), msg->size());
           pp->finishAddingRequests();
+          LOG_INFO(VC_LOG, "DIMA: Added PP in VC");
         } else {
           pp = new PrePrepareMsg(myId, myLatestActiveView, i, CommitPath::SLOW, 0);
         }

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -22,6 +22,8 @@
 #include "ViewChangeSafetyLogic.hpp"
 
 namespace bftEngine {
+template <typename>
+class TimeServiceManager;
 namespace impl {
 
 class PrePrepareMsg;
@@ -73,6 +75,9 @@ class ViewsManager {
                                                                           // in viewChangeMsgs
                                         std::vector<ViewChangeMsg *> viewChangeMsgs);
 
+  void setTimeManager(const TimeServiceManager<std::chrono::system_clock> *timeServiceManager) {
+    timeServiceManager_ = timeServiceManager;
+  }
   ViewNum getCurrentView() const { return myCurrentView; }
   void setHigherView(ViewNum higherViewNum);
   void setViewFromRecovery(ViewNum explicitViewNum) { myCurrentView = explicitViewNum; }
@@ -233,6 +238,9 @@ class ViewsManager {
   ///////////////////////////////////////////////////////////////////////////
   SeqNum debugHighestKnownStable;
   ViewNum debugHighestViewNumberPassedByClient;
+
+  // NOTE(DD): ViewsManager does not own time manager
+  const TimeServiceManager<std::chrono::system_clock> *timeServiceManager_ = nullptr;
 };
 
 }  // namespace impl

--- a/bftengine/tests/timeServiceManager/TimeServiceManager_test.cpp
+++ b/bftengine/tests/timeServiceManager/TimeServiceManager_test.cpp
@@ -160,7 +160,7 @@ TEST(TimeServiceManager, CompareAndSwap) {
   config.timeServiceSoftLimitMillis = std::chrono::milliseconds{500};
 
   const auto now = ConsensusTime{1000};
-  auto manager = TimeServiceManager{};
+  auto manager = TimeServiceManager<std::chrono::system_clock>{};
 
   // check that if now does not move, the manager increases it by epsilon
   for (size_t i = 0U; i < 10; ++i) {
@@ -185,6 +185,85 @@ TEST(TimeServiceManager, CreateClientRequestMsg) {
   EXPECT_EQ(now,
             concord::util::deserialize<ConsensusTime>(msg->requestBuf(), msg->requestBuf() + msg->requestLength()));
   EXPECT_EQ(MsgFlag::TIME_SERVICE_FLAG, msg->flags());
+}
+
+TEST(TimeServiceManager, hasTimeRequest_positive) {
+  ReservedPagesMock m;
+  ReplicaConfig::instance();
+  const auto now = ConsensusTime{1000};
+  FakeClock::current_time = now;
+
+  auto manager = TimeServiceManager<FakeClock>{};
+
+  const auto msg = manager.createClientRequestMsg();
+  size_t req_size = msg->size();
+  std::vector<std::unique_ptr<ClientRequestMsg>> client_request;
+  const std::string request_bytes = "bla-bla";
+  for (size_t i = 0; i < 10; ++i) {
+    client_request.emplace_back(std::make_unique<ClientRequestMsg>(
+        1u, MsgFlag::EMPTY_FLAGS, i, request_bytes.size(), request_bytes.data(), 1111u));
+    req_size += client_request.back()->size();
+  }
+
+  PrePrepareMsg pp_msg(1u, 1u, 1u, CommitPath::OPTIMISTIC_FAST, req_size);
+  pp_msg.addRequest(msg->body(), msg->size());
+  for (const auto& c : client_request) {
+    pp_msg.addRequest(c->body(), c->size());
+  }
+  pp_msg.finishAddingRequests();
+  EXPECT_TRUE(manager.hasTimeRequest(pp_msg));
+}
+
+TEST(TimeServiceManager, hasTimeRequest_ts_in_the_end) {
+  ReservedPagesMock m;
+  ReplicaConfig::instance();
+  const auto now = ConsensusTime{1000};
+  FakeClock::current_time = now;
+
+  auto manager = TimeServiceManager<FakeClock>{};
+
+  const auto msg = manager.createClientRequestMsg();
+  size_t req_size = msg->size();
+  std::vector<std::unique_ptr<ClientRequestMsg>> client_request;
+  const std::string request_bytes = "bla-bla";
+  for (size_t i = 0; i < 10; ++i) {
+    client_request.emplace_back(std::make_unique<ClientRequestMsg>(
+        1u, MsgFlag::EMPTY_FLAGS, i, request_bytes.size(), request_bytes.data(), 1111u));
+    req_size += client_request.back()->size();
+  }
+
+  PrePrepareMsg pp_msg(1u, 1u, 1u, CommitPath::OPTIMISTIC_FAST, req_size);
+  for (const auto& c : client_request) {
+    pp_msg.addRequest(c->body(), c->size());
+  }
+  pp_msg.addRequest(msg->body(), msg->size());
+  pp_msg.finishAddingRequests();
+  EXPECT_FALSE(manager.hasTimeRequest(pp_msg));
+}
+
+TEST(TimeServiceManager, hasTimeRequest_no_ts_msg) {
+  ReservedPagesMock m;
+  ReplicaConfig::instance();
+  const auto now = ConsensusTime{1000};
+  FakeClock::current_time = now;
+
+  auto manager = TimeServiceManager<FakeClock>{};
+
+  size_t req_size = 0;
+  std::vector<std::unique_ptr<ClientRequestMsg>> client_request;
+  const std::string request_bytes = "bla-bla";
+  for (size_t i = 0; i < 10; ++i) {
+    client_request.emplace_back(std::make_unique<ClientRequestMsg>(
+        1u, MsgFlag::EMPTY_FLAGS, i, request_bytes.size(), request_bytes.data(), 1111u));
+    req_size += client_request.back()->size();
+  }
+
+  PrePrepareMsg pp_msg(1u, 1u, 1u, CommitPath::OPTIMISTIC_FAST, req_size);
+  for (const auto& c : client_request) {
+    pp_msg.addRequest(c->body(), c->size());
+  }
+  pp_msg.finishAddingRequests();
+  EXPECT_FALSE(manager.hasTimeRequest(pp_msg));
 }
 
 int main(int argc, char** argv) {

--- a/tests/simpleKVBC/scripts/logging.properties
+++ b/tests/simpleKVBC/scripts/logging.properties
@@ -24,6 +24,8 @@ log4cplus.appender.R.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%
 
 log4cplus.rootLogger=INFO, STDOUT, R
 log4cplus.logger.concord.preprocessor=INFO
+log4cplus.logger.concord.bft.msgs=TRACE
+log4cplus.logger.concord.bft.threshsign=TRACE
 
 
 


### PR DESCRIPTION
Once TS is on, it requires every PrePrepare to contain TS message.
Since ViewsManager produces PrePrepares during View Change, added a
reference to TS so that PrePrepare is patched with TS message.

Additional changes

* This commit also introduces asserts for Time Service-related conditions,
apply only when TS is on.
    * PrePrepare contains a TS message
    * The TS message is the first in PrePrepare
    * PrePrepare contains only one TS message
* Add a method to check timestamp from PrePrepare
* Unit tests