### PR TITLE
ClientService: Integrate ConcordClient into RequestService

### DIFF
--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -9,8 +9,12 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#include <chrono>
+#include <future>
 #include <iostream>
+#include <opentracing/tracer.h>
 
+#include "client/concordclient/concord_client.hpp"
 #include "request_service.hpp"
 
 using grpc::Status;
@@ -19,11 +23,51 @@ using grpc::ServerContext;
 using vmware::concord::client::v1::Request;
 using vmware::concord::client::v1::Response;
 
+namespace cc = concord::client::concordclient;
+
 namespace concord::client::clientservice {
 
-Status RequestServiceImpl::Send(ServerContext* context, const Request* request, Response* response) {
-  LOG_INFO(logger_, "RequestService::Send called");
-  return grpc::Status::OK;
+Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_request, Response* proto_response) {
+  bft::client::Msg msg(proto_request->request().begin(), proto_request->request().end());
+
+  auto seconds = std::chrono::seconds{proto_request->timeout().seconds()};
+  auto nanos = std::chrono::nanoseconds{proto_request->timeout().nanos()};
+  auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(seconds + nanos);
+
+  bft::client::RequestConfig req_config;
+  req_config.pre_execute = proto_request->pre_execute();
+  req_config.timeout = timeout;
+  req_config.correlation_id = proto_request->correlation_id();
+
+  std::promise<grpc::Status> status;
+  auto status_future = status.get_future();
+
+  auto callback = [&](cc::SendResult&& send_result) {
+    if (not std::holds_alternative<bft::client::Reply>(send_result)) {
+      LOG_INFO(logger_, "Send returned error");
+      // TODO: Use error codes according to proto file documentation
+      status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "InternalError"));
+      return;
+    }
+    auto reply = std::get<bft::client::Reply>(send_result);
+    // TODO: Can we use set_allocated_response instead of copying? (vector<uint8_t> vs string)
+    proto_response->set_response({reply.matched_data.begin(), reply.matched_data.end()});
+    status.set_value(grpc::Status::OK);
+  };
+
+  if (proto_request->read_only()) {
+    bft::client::ReadConfig config;
+    config.request = req_config;
+    auto span = opentracing::Tracer::Global()->StartSpan("send_ro", {});
+    client_->send(config, std::move(msg), span, callback);
+  } else {
+    bft::client::WriteConfig config;
+    config.request = req_config;
+    auto span = opentracing::Tracer::Global()->StartSpan("send", {});
+    client_->send(config, std::move(msg), span, callback);
+  }
+
+  return status_future.get();
 }
 
 }  // namespace concord::client::clientservice

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -127,18 +127,18 @@ class ConcordClient {
   void send(const bft::client::WriteConfig& config,
             bft::client::Msg&& msg,
             const std::unique_ptr<opentracing::Span>& parent_span,
-            std::function<void(SendResult&&)> callback);
+            const std::function<void(SendResult&&)>& callback);
   void send(const bft::client::ReadConfig& config,
             bft::client::Msg&& msg,
             const std::unique_ptr<opentracing::Span>& parent_span,
-            std::function<void(SendResult&&)> callback);
+            const std::function<void(SendResult&&)>& callback);
 
   // Register a callback that gets invoked for every validated event received.
   // void callback(SubscribeResult);
   // Return subscriber ID used to unsubscribe.
   void subscribe(const SubscribeRequest& request,
                  const std::unique_ptr<opentracing::Span>& parent_span,
-                 std::function<void(SubscribeResult&&)> callback);
+                 const std::function<void(SubscribeResult&&)>& callback);
 
   // Note, if the caller doesn't unsubscribe and no runtime error occurs then resources
   // will be occupied forever.

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -13,6 +13,25 @@
 
 namespace concord::client::concordclient {
 
+void ConcordClient::send(const bft::client::ReadConfig& config,
+                         bft::client::Msg&& msg,
+                         const std::unique_ptr<opentracing::Span>& parent_span,
+                         std::function<void(SendResult&&)> callback) {
+  LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
+  bft::client::Reply reply;
+  reply.matched_data = std::move(msg);
+  callback(SendResult{reply});
+}
+
+void ConcordClient::send(const bft::client::WriteConfig& config,
+                         bft::client::Msg&& msg,
+                         const std::unique_ptr<opentracing::Span>& parent_span,
+                         std::function<void(SendResult&&)> callback) {
+  bft::client::Reply reply;
+  reply.matched_data = std::move(msg);
+  callback(SendResult{reply});
+}
+
 void ConcordClient::subscribe(const SubscribeRequest& request,
                               const std::unique_ptr<opentracing::Span>& parent_span,
                               std::function<void(SubscribeResult&&)> callback) {

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -16,7 +16,7 @@ namespace concord::client::concordclient {
 void ConcordClient::send(const bft::client::ReadConfig& config,
                          bft::client::Msg&& msg,
                          const std::unique_ptr<opentracing::Span>& parent_span,
-                         std::function<void(SendResult&&)> callback) {
+                         const std::function<void(SendResult&&)>& callback) {
   LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
   bft::client::Reply reply;
   reply.matched_data = std::move(msg);
@@ -26,7 +26,7 @@ void ConcordClient::send(const bft::client::ReadConfig& config,
 void ConcordClient::send(const bft::client::WriteConfig& config,
                          bft::client::Msg&& msg,
                          const std::unique_ptr<opentracing::Span>& parent_span,
-                         std::function<void(SendResult&&)> callback) {
+                         const std::function<void(SendResult&&)>& callback) {
   bft::client::Reply reply;
   reply.matched_data = std::move(msg);
   callback(SendResult{reply});
@@ -34,7 +34,7 @@ void ConcordClient::send(const bft::client::WriteConfig& config,
 
 void ConcordClient::subscribe(const SubscribeRequest& request,
                               const std::unique_ptr<opentracing::Span>& parent_span,
-                              std::function<void(SubscribeResult&&)> callback) {
+                              const std::function<void(SubscribeResult&&)>& callback) {
   if (not stop_subscriber_) {
     LOG_ERROR(logger_, "subscription already in progress - unsubscribe first");
     throw SubscriptionExists();


### PR DESCRIPTION
This change is similar to the previous integration change for the EventService.
It fills the empty RequestService with concord client's send() method. The
latter will echo the request until the client pool moves to concord client.

Manual testing:
$> ./grpc_cli call localhost:1337 Send 'request:"Hello",read_only:false'
connecting to localhost:1337
response: "Hello"
Rpc succeeded with OK status