### PR TITLE
Add concurrent pruning parameters to PruneRequest

### DIFF
--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -134,6 +134,7 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   //  PruneRequest is equal to the number of replicas in the system
   //  - verifying the signatures of individual LatestPrunableBlock messages in the
   //  PruneRequest.
+  //  - verifying other parameters in PruneRequest
   // If all above conditions are met, the state machine will prune blocks from the
   // genesis block up to the the minimum of all the block IDs in
   // LatestPrunableBlock messages in the PruneRequest message.

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -82,6 +82,11 @@ bool RSAPruningVerifier::verify(const concord::messages::PruneRequest& request) 
     return false;
   }
 
+  // Make sure pruning parameters are in range.
+  if (request.tick_period_seconds <= 0 || request.batch_blocks_num <= 0) {
+    return false;
+  }
+
   // Note RSAPruningVerifier does not handle verification of the operator's
   // signature authorizing this pruning order, as the operator's signature is a
   // dedicated application-level signature rather than one of the Concord-BFT

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -37,8 +37,14 @@ Msg LatestPrunableBlock 14 {
 }
 
 Msg PruneRequest 15 {
-   uint64 sender
-   list LatestPrunableBlock latest_prunable_block
+  uint64 sender
+  list LatestPrunableBlock latest_prunable_block
+
+  # TicksGenerator period in seconds.
+  uint32 tick_period_seconds
+
+  # The number of blocks in a pruning batch.
+  uint64 batch_blocks_num
 }
 
 Msg PruneStatusRequest 17 {

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -73,10 +73,12 @@ class Operator:
         unwedge_cmd.signatures = signatures
         return self._construct_basic_reconfiguration_request(unwedge_cmd)
 
-    def _construct_reconfiguration_prune_request(self, latest_pruneble_blocks):
+    def _construct_reconfiguration_prune_request(self, latest_pruneble_blocks, tick_period_seconds=1, batch_blocks_num=600):
         prune_cmd = cmf_msgs.PruneRequest()
         prune_cmd.sender = 1000
         prune_cmd.latest_prunable_block = latest_pruneble_blocks
+        prune_cmd.tick_period_seconds = tick_period_seconds
+        prune_cmd.batch_blocks_num = batch_blocks_num
         return self._construct_basic_reconfiguration_request(prune_cmd)
 
     def _construct_reconfiguration_prune_status_request(self):


### PR DESCRIPTION
Add the `tick_period_seconds` and `batch_blocks_num` parameters to
PruneRequest. Make them mandatory for the following reasons:
 * simplicity
 * make sure all replicas use the same values
 * if they were optional, replicas would need to use locally configured
   default ones and risk misconfiguration and/or different values on
   different replicas
 * flexibility, allowing users of the Operator to set different values
   in different periods (e.g. busy hours, low-traffic hours)

For now, these parameters are ignored. Will be used when concurrent
pruning is fully implemented.

Make sure verification takes these parameters into account and that
tests are aware of and using them.