### PR TITLE
ConcordClient: Offer metrics API

### DIFF
--- a/client/clientservice/CMakeLists.txt
+++ b/client/clientservice/CMakeLists.txt
@@ -11,4 +11,5 @@ target_link_libraries(clientservice PRIVATE
   gRPC::grpc++
   gRPC::grpc++_reflection
   logging
+  util
 )

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -16,6 +16,7 @@
 #include "Logger.hpp"
 #include "client_service.hpp"
 #include "client/concordclient/concord_client.hpp"
+#include "Metrics.hpp"
 
 using concord::client::clientservice::ClientService;
 using concord::client::concordclient::ConcordClient;
@@ -31,6 +32,8 @@ int main(int argc, char** argv) {
   // TODO: Setup ConcordClientConfig and read from config file
   ConcordClientConfig config{};
   auto concord_client = std::make_unique<ConcordClient>(config);
+  auto metrics = std::make_shared<concordMetrics::Aggregator>();
+  concord_client->setMetricsAggregator(metrics);
   ClientService service(std::move(concord_client));
   service.start(addr);
 

--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -4,4 +4,5 @@ target_include_directories(concordclient PUBLIC include)
 target_link_libraries(concordclient PUBLIC
   bftclient_new # temporary until client pool is available
   thin_replica_client_lib
+  util
 )

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -21,6 +21,7 @@
 
 #include "bftclient/base_types.h"
 #include "bftclient/bft_client.h"
+#include "Metrics.hpp"
 
 namespace concord::client::concordclient {
 
@@ -123,6 +124,8 @@ class ConcordClient {
       : logger_(logging::getLogger("concord.client.concordclient")), config_(config) {}
   ~ConcordClient() { unsubscribe(); }
 
+  void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> m) { metrics_ = m; }
+
   // Register a callback that gets invoked once the handling BFT client returns.
   void send(const bft::client::WriteConfig& config,
             bft::client::Msg&& msg,
@@ -154,6 +157,7 @@ class ConcordClient {
  private:
   logging::Logger logger_;
   const ConcordClientConfig& config_;
+  std::shared_ptr<concordMetrics::Aggregator> metrics_;
 
   // TODO: Allow multiple subscriptions
   std::atomic_bool stop_subscriber_{true};


### PR DESCRIPTION
In order to collect metrics in concord client and its subcomponents, we are
using our own basic metrics framework. We didn't want to depend on another 3rd
party dependency but the user can still choose to use Prometheus,
OpenTelemetry, ... on top of it.
The actual usage of the Aggregator will come with the integration of the client
pool and the thin replica client.