### PR TITLE
TS: Harden TS requirements

### DIFF
--- a/bftengine/src/bftengine/TimeServiceManager.hpp
+++ b/bftengine/src/bftengine/TimeServiceManager.hpp
@@ -16,6 +16,7 @@
 #include "TimeServiceResPageClient.hpp"
 #include "assertUtils.hpp"
 #include "messages/ClientRequestMsg.hpp"
+#include "messages/PrePrepareMsg.hpp"
 #include "serialize.hpp"
 #include <chrono>
 #include <cstdlib>
@@ -58,7 +59,7 @@ class TimeServiceManager {
   }
 
   // Returns a client request message with timestamp (current system clock time)
-  [[nodiscard]] std::unique_ptr<impl::ClientRequestMsg> createClientRequestMsg() {
+  [[nodiscard]] std::unique_ptr<impl::ClientRequestMsg> createClientRequestMsg() const {
     const auto& config = ReplicaConfig::instance();
     const auto now = std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch());
     const auto& serialized = concord::util::serialize(now);
@@ -69,6 +70,34 @@ class TimeServiceManager {
                                                     serialized.data(),
                                                     std::numeric_limits<uint64_t>::max(),
                                                     "TIME_SERVICE");
+  }
+
+  [[nodiscard]] bool hasTimeRequest(const impl::PrePrepareMsg& msg) const {
+    if (msg.numberOfRequests() < 2) {
+      LOG_ERROR(TS_MNGR, "PrePrepare with Time Service on, cannot have less than 2 messages");
+      return false;
+    }
+    auto it = impl::RequestsIterator(&msg);
+    char* requestBody = nullptr;
+    ConcordAssertEQ(it.getCurrent(requestBody), true);
+
+    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
+    if (req.flags() != MsgFlag::TIME_SERVICE_FLAG) {
+      LOG_ERROR(GL, "Time Service is on but first CR in PrePrepare is not TS request");
+      return false;
+    }
+    return true;
+  }
+
+  [[nodiscard]] bool isPrimarysTimeWithinBounds(const impl::PrePrepareMsg& msg) const {
+    ConcordAssertGE(msg.numberOfRequests(), 1);
+
+    auto it = impl::RequestsIterator(&msg);
+    char* requestBody = nullptr;
+    ConcordAssertEQ(it.getCurrent(requestBody), true);
+
+    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
+    return isPrimarysTimeWithinBounds(req);
   }
 
   [[nodiscard]] bool isPrimarysTimeWithinBounds(impl::ClientRequestMsg& msg) const {

--- a/bftengine/tests/timeServiceManager/TimeServiceManager_test.cpp
+++ b/bftengine/tests/timeServiceManager/TimeServiceManager_test.cpp
@@ -160,7 +160,7 @@ TEST(TimeServiceManager, CompareAndSwap) {
   config.timeServiceSoftLimitMillis = std::chrono::milliseconds{500};
 
   const auto now = ConsensusTime{1000};
-  auto manager = TimeServiceManager{};
+  auto manager = TimeServiceManager<std::chrono::system_clock>{};
 
   // check that if now does not move, the manager increases it by epsilon
   for (size_t i = 0U; i < 10; ++i) {
@@ -185,6 +185,85 @@ TEST(TimeServiceManager, CreateClientRequestMsg) {
   EXPECT_EQ(now,
             concord::util::deserialize<ConsensusTime>(msg->requestBuf(), msg->requestBuf() + msg->requestLength()));
   EXPECT_EQ(MsgFlag::TIME_SERVICE_FLAG, msg->flags());
+}
+
+TEST(TimeServiceManager, hasTimeRequest_positive) {
+  ReservedPagesMock m;
+  ReplicaConfig::instance();
+  const auto now = ConsensusTime{1000};
+  FakeClock::current_time = now;
+
+  auto manager = TimeServiceManager<FakeClock>{};
+
+  const auto msg = manager.createClientRequestMsg();
+  size_t req_size = msg->size();
+  std::vector<std::unique_ptr<ClientRequestMsg>> client_request;
+  const std::string request_bytes = "bla-bla";
+  for (size_t i = 0; i < 10; ++i) {
+    client_request.emplace_back(std::make_unique<ClientRequestMsg>(
+        1u, MsgFlag::EMPTY_FLAGS, i, request_bytes.size(), request_bytes.data(), 1111u));
+    req_size += client_request.back()->size();
+  }
+
+  PrePrepareMsg pp_msg(1u, 1u, 1u, CommitPath::OPTIMISTIC_FAST, req_size);
+  pp_msg.addRequest(msg->body(), msg->size());
+  for (const auto& c : client_request) {
+    pp_msg.addRequest(c->body(), c->size());
+  }
+  pp_msg.finishAddingRequests();
+  EXPECT_TRUE(manager.hasTimeRequest(pp_msg));
+}
+
+TEST(TimeServiceManager, hasTimeRequest_ts_in_the_end) {
+  ReservedPagesMock m;
+  ReplicaConfig::instance();
+  const auto now = ConsensusTime{1000};
+  FakeClock::current_time = now;
+
+  auto manager = TimeServiceManager<FakeClock>{};
+
+  const auto msg = manager.createClientRequestMsg();
+  size_t req_size = msg->size();
+  std::vector<std::unique_ptr<ClientRequestMsg>> client_request;
+  const std::string request_bytes = "bla-bla";
+  for (size_t i = 0; i < 10; ++i) {
+    client_request.emplace_back(std::make_unique<ClientRequestMsg>(
+        1u, MsgFlag::EMPTY_FLAGS, i, request_bytes.size(), request_bytes.data(), 1111u));
+    req_size += client_request.back()->size();
+  }
+
+  PrePrepareMsg pp_msg(1u, 1u, 1u, CommitPath::OPTIMISTIC_FAST, req_size);
+  for (const auto& c : client_request) {
+    pp_msg.addRequest(c->body(), c->size());
+  }
+  pp_msg.addRequest(msg->body(), msg->size());
+  pp_msg.finishAddingRequests();
+  EXPECT_FALSE(manager.hasTimeRequest(pp_msg));
+}
+
+TEST(TimeServiceManager, hasTimeRequest_no_ts_msg) {
+  ReservedPagesMock m;
+  ReplicaConfig::instance();
+  const auto now = ConsensusTime{1000};
+  FakeClock::current_time = now;
+
+  auto manager = TimeServiceManager<FakeClock>{};
+
+  size_t req_size = 0;
+  std::vector<std::unique_ptr<ClientRequestMsg>> client_request;
+  const std::string request_bytes = "bla-bla";
+  for (size_t i = 0; i < 10; ++i) {
+    client_request.emplace_back(std::make_unique<ClientRequestMsg>(
+        1u, MsgFlag::EMPTY_FLAGS, i, request_bytes.size(), request_bytes.data(), 1111u));
+    req_size += client_request.back()->size();
+  }
+
+  PrePrepareMsg pp_msg(1u, 1u, 1u, CommitPath::OPTIMISTIC_FAST, req_size);
+  for (const auto& c : client_request) {
+    pp_msg.addRequest(c->body(), c->size());
+  }
+  pp_msg.finishAddingRequests();
+  EXPECT_FALSE(manager.hasTimeRequest(pp_msg));
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This commit introduces additional checks and asserts for PrePrepare
messages with Time Service feature is ON. The checks are performed only
for non-empty PrePrepare messages; empty messages are created during
View Change.

The list of checks:
* PrePrepare contains a TS message
* PrePrepare contains only one TS message
* The TS message is the first in PrePrepare

 Additional changes:
* Add a method to check timestamp from PrePrepare
* Unit tests