### PR TITLE
Refactor views manager complaints processing

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -286,6 +286,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void recoverRequests();
 
   bool validateMessage(MessageBase* msg);
+  std::function<bool(MessageBase*)> getMessageValidator();
 
   // InternalReplicaApi
   bool isCollectingState() const override { return stateTransfer->isCollectingState(); }

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -1105,8 +1105,8 @@ void ViewsManager::processComplaintsFromViewChangeMessage(ViewChangeMsg* msg,
   MsgSize size = 0;
   int numberOfProcessedComplaints = 0;
 
-  while (!(hasQuorumToLeaveView() || hasQuorumToJumpToHigherView()) && iter.getAndGoToNext(complaint, size) &&
-         numberOfProcessedComplaints <= F + 1) {
+  while (msg->newView() > getCurrentView() && !(hasQuorumToLeaveView() || hasQuorumToJumpToHigherView()) &&
+         iter.getAndGoToNext(complaint, size) && numberOfProcessedComplaints <= F + 1) {
     numberOfProcessedComplaints++;
 
     auto baseMsg = MessageBase(msg->senderId(), (MessageBase::Header*)complaint, size, true);

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -1099,7 +1099,7 @@ ViewChangeMsg* ViewsManager::prepareViewChangeMsgAndSetHigherView(ViewNum nextVi
 }
 
 void ViewsManager::processComplaintsFromViewChangeMessage(ViewChangeMsg* msg,
-                                                          std::function<bool(MessageBase*)> msgValidator) {
+                                                          const std::function<bool(MessageBase*)>& msgValidator) {
   ViewChangeMsg::ComplaintsIterator iter(msg);
   char* complaint = nullptr;
   MsgSize size = 0;

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -1061,7 +1061,7 @@ void ViewsManager::addComplaintsToStatusMessage(ReplicaStatusMsg& replicaStatusM
   }
 }
 
-ViewChangeMsg* ViewsManager::PrepareViewChangeMsgAndSetHigherView(ViewNum nextView,
+ViewChangeMsg* ViewsManager::prepareViewChangeMsgAndSetHigherView(ViewNum nextView,
                                                                   const bool wasInPrevViewNumber,
                                                                   SeqNum lastStableSeqNum,
                                                                   SeqNum lastExecutedSeqNum,
@@ -1096,6 +1096,47 @@ ViewChangeMsg* ViewsManager::PrepareViewChangeMsgAndSetHigherView(ViewNum nextVi
   pVC->finalizeMessage();
 
   return pVC;
+}
+
+void ViewsManager::processComplaintsFromViewChangeMessage(ViewChangeMsg* msg,
+                                                          std::function<bool(MessageBase*)> msgValidator) {
+  ViewChangeMsg::ComplaintsIterator iter(msg);
+  char* complaint = nullptr;
+  MsgSize size = 0;
+  int numberOfProcessedComplaints = 0;
+
+  while (!(hasQuorumToLeaveView() || hasQuorumToJumpToHigherView()) && iter.getAndGoToNext(complaint, size) &&
+         numberOfProcessedComplaints <= F + 1) {
+    numberOfProcessedComplaints++;
+
+    auto baseMsg = MessageBase(msg->senderId(), (MessageBase::Header*)complaint, size, true);
+    auto complaintMsg = std::make_unique<ReplicaAsksToLeaveViewMsg>(&baseMsg);
+    LOG_INFO(VC_LOG,
+             "Got complaint in ViewChangeMsg" << KVLOG(getCurrentView(),
+                                                       msg->senderId(),
+                                                       msg->newView(),
+                                                       msg->idOfGeneratedReplica(),
+                                                       complaintMsg->senderId(),
+                                                       complaintMsg->viewNumber(),
+                                                       complaintMsg->idOfGeneratedReplica()));
+    if (msg->newView() == getCurrentView() + 1) {
+      if (getComplaintFromReplica(complaintMsg->idOfGeneratedReplica()) != nullptr) {
+        LOG_INFO(VC_LOG,
+                 "Already have a valid complaint from Replica " << complaintMsg->idOfGeneratedReplica() << " for View "
+                                                                << complaintMsg->viewNumber());
+      } else if (complaintMsg->viewNumber() == getCurrentView() && msgValidator(complaintMsg.get())) {
+        storeComplaint(std::unique_ptr<ReplicaAsksToLeaveViewMsg>(complaintMsg.release()));
+      } else {
+        LOG_WARN(VC_LOG, "Invalid complaint in ViewChangeMsg for current View.");
+      }
+    } else {
+      if (complaintMsg->viewNumber() + 1 == msg->newView() && msgValidator(complaintMsg.get())) {
+        storeComplaintForHigherView(std::move(complaintMsg));
+      } else {
+        LOG_WARN(VC_LOG, "Invalid complaint in ViewChangeMsg for a higher View.");
+      }
+    }
+  }
 }
 
 bool ViewsManager::tryToJumpToHigherViewAndMoveComplaintsOnQuorum(const ViewChangeMsg* const msg) {

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -149,12 +149,13 @@ class ViewsManager {
 
   void addComplaintsToStatusMessage(ReplicaStatusMsg &replicaStatusMessage) const;
 
-  ViewChangeMsg *PrepareViewChangeMsgAndSetHigherView(ViewNum nextView,
+  ViewChangeMsg *prepareViewChangeMsgAndSetHigherView(ViewNum nextView,
                                                       const bool wasInPrevViewNumber,
                                                       SeqNum lastStableSeqNum = 0,
                                                       SeqNum lastExecutedSeqNum = 0,
                                                       const std::vector<PrevViewInfo> *const prevViewInfo = nullptr);
 
+  void processComplaintsFromViewChangeMessage(ViewChangeMsg *msg, std::function<bool(MessageBase *)> msgValidator);
   bool tryToJumpToHigherViewAndMoveComplaintsOnQuorum(const ViewChangeMsg *const msg);
 
  protected:

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -155,7 +155,8 @@ class ViewsManager {
                                                       SeqNum lastExecutedSeqNum = 0,
                                                       const std::vector<PrevViewInfo> *const prevViewInfo = nullptr);
 
-  void processComplaintsFromViewChangeMessage(ViewChangeMsg *msg, std::function<bool(MessageBase *)> msgValidator);
+  void processComplaintsFromViewChangeMessage(ViewChangeMsg *msg,
+                                              const std::function<bool(MessageBase *)> &msgValidator);
   bool tryToJumpToHigherViewAndMoveComplaintsOnQuorum(const ViewChangeMsg *const msg);
 
  protected:


### PR DESCRIPTION
This Pull Request introduces the following changes:
1. Process complaints in ViewsManager
    Complaints are no longer processed in ReplicaImp. This work is now delegated to the ViewsManager.

2. Change some of the views manager tests
    Complaints are no longer stored in the views manager unconditionally.
 
    The quorum tests were changed so that they now rely entirely on logic, residing in the views manager.