### PR TITLE
Enable transaction signing on CI and fix test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 option(KEEP_APOLLO_LOGS "Retains logs from replicas in separate folder for each test in build/tests/apollo/logs " TRUE)
 
 # Default TXN_SIGNING_ENABLED to FALSE
-option(TXN_SIGNING_ENABLED "External concord client sign tansactionsand replicas verify signature" FALSE)
+option(TXN_SIGNING_ENABLED "Enable External concord client transcattion signing" TRUE)
 
 # Default BUILD_COMM_TCP_PLAIN to FALSE
 option(BUILD_COMM_TCP_PLAIN "Enable TCP communication" FALSE)

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -117,7 +117,6 @@ class SigManager {
 
   mutable concordMetrics::Component metrics_component_;
   mutable Metrics metrics_;
-  mutable std::atomic<uint64_t> updateAggregatorCounter = 0;
 
   // These methods bypass the singelton, and can be used (STRICTLY) for testing.
   // Define the below flag in order to use them in your test.

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -251,7 +251,7 @@ class BftTestNetwork:
         self.test_start_time = None
         self.perf_proc = None
         self.ro_replicas = ro_replicas
-        self.txn_signing_enabled = (os.environ.get('TXN_SIGNING_ENABLED', "").lower() == "true")
+        self.txn_signing_enabled = (os.environ.get('TXN_SIGNING_ENABLED', "").lower() in ["true", "on"])
         self.with_cre = False
         self.cre_pid = None
         self.cre_fds = None


### PR DESCRIPTION
Here we enable transaction signing on CI by setting TXN_SIGNING_ENABLED=TRUE in CMakeLists.txt.
This enables transaction signing deployment + signing/verification for all Apollo tests.
It also enables the test test_skvbc_client_transaction_signing. This test failed due to some changes in concord and wrong estimation for the number of signatures in test body. In order to be more accurate, a change in SigManager update aggregator is required.