### PR TITLE
Reset control handler state after unwedge

### DIFF
--- a/bftengine/include/bftengine/ControlHandler.hpp
+++ b/bftengine/include/bftengine/ControlHandler.hpp
@@ -42,6 +42,14 @@ class ControlHandler : public IControlHandler {
     onStableCheckpointCallBack.emplace_back(cb);
   }
 
+  void resetState() override {
+    onNoutOfNCheckpoint_ = false;
+    onNMinusFOutOfNCheckpoint_ = false;
+    onPruningProcess_ = false;
+    onSuperStableCheckpointCallBack.clear();
+    onStableCheckpointCallBack.clear();
+  }
+
  private:
   bool onNoutOfNCheckpoint_ = false;
   bool onNMinusFOutOfNCheckpoint_ = false;

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -78,6 +78,7 @@ class IControlHandler {
   virtual void setOnPruningProcess(bool inProcess) = 0;
   virtual void addOnSuperStableCheckpointCallBack(const std::function<void()> &cb) = 0;
   virtual void addOnStableCheckpointCallBack(const std::function<void()> &cb) = 0;
+  virtual void resetState() = 0;
   virtual ~IControlHandler() = default;
 };
 

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -118,6 +118,7 @@ bool ReconfigurationHandler::handle(const UnwedgeCommand& cmd,
   bool valid = controlStateManager.verifyUnwedgeSignatures(cmd.signatures);
   if (valid) {
     controlStateManager.clearCheckpointToStopAt();
+    bftEngine::IControlHandler::instance()->resetState();
     LOG_INFO(getLogger(), "Unwedge command completed sucessfully");
   }
   return valid;


### PR DESCRIPTION
Some checks like the 'wedge status' command rely on the control handler state.
Until now, we restarted the replicas to 'unwedge' and that reset the state.
Now that we have a proper unwedge mechanism, we should reset the state as part of it.