### PR TITLE
Remove duplicates in requestsQueueOfPrimary.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -361,14 +361,14 @@ void ReplicaImp::removeDuplicatedRequestsFromRequestsQueue() {
 
   LOG_INFO(GL, "" << KVLOG(requestsQueueOfPrimary.size()));
 
-  struct ClientsReqCmparator {
+  struct ClientsReqComparator {
     bool operator()(const ClientRequestMsg *const lhs, const ClientRequestMsg *const rhs) {
       return (lhs->clientProxyId() < rhs->clientProxyId() ||
               (lhs->clientProxyId() == rhs->clientProxyId() && lhs->requestSeqNum() < rhs->requestSeqNum()));
     }
   };
 
-  std::set<ClientRequestMsg *, ClientsReqCmparator> uniqueReqs;
+  std::set<ClientRequestMsg *, ClientsReqComparator> uniqueReqs;
   for (ClientRequestMsg *c : requestsQueueOfPrimary) {
     auto res = uniqueReqs.insert(c);
     if (res.second == false) {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -363,7 +363,8 @@ void ReplicaImp::removeDuplicatedRequestsFromRequestsQueue() {
 
   struct ClientsReqCmparator {
     bool operator()(const ClientRequestMsg *const lhs, const ClientRequestMsg *const rhs) {
-      return (lhs->clientProxyId() < rhs->clientProxyId() || lhs->requestSeqNum() < rhs->requestSeqNum());
+      return (lhs->clientProxyId() < rhs->clientProxyId() ||
+              (lhs->clientProxyId() == rhs->clientProxyId() && lhs->requestSeqNum() < rhs->requestSeqNum()));
     }
   };
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -104,8 +104,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   SeqNum maxSeqNumTransferredFromPrevViews = 0;
 
   // requests queue (used by the primary)
-  std::queue<ClientRequestMsg*> requestsQueueOfPrimary;  // only used by the primary
-  size_t primaryCombinedReqSize = 0;                     // only used by the primary
+  std::list<ClientRequestMsg*> requestsQueueOfPrimary;  // only used by the primary
+  size_t primaryCombinedReqSize = 0;                    // only used by the primary
 
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]


### PR DESCRIPTION
Because of the frequent dropping of Client Requests due to full queue under high load we need to clean duplicates more frequently. Prior to this change the actual filtration happened only when we create the PrePrepare. This is a quick fix. We might consider changing the data structure holding the Client Requests to something more suitable.