### PR TITLE
BCStateTran: add new config param enableSourceBlocksPreFetch

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -139,6 +139,7 @@ struct Config {
   // misc
   bool runInSeparateThread = false;
   bool enableReservedPages = true;
+  bool enableSourceBlocksPreFetch = true;
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Config &c) {
@@ -163,7 +164,8 @@ inline std::ostream &operator<<(std::ostream &os, const Config &c) {
               c.fetchRetransmissionTimeoutMs,
               c.metricsDumpIntervalSec,
               c.runInSeparateThread,
-              c.enableReservedPages);
+              c.enableReservedPages,
+              c.enableSourceBlocksPreFetch);
   return os;
 }
 // creates an instance of the state transfer module.

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -297,7 +297,8 @@ SimpleStateTran::SimpleStateTran(
       250,                                  // fetchRetransmissionTimeoutMs
       5,                                    // metricsDumpIntervalSec
       true,                                 // runInSeparateThread
-      true                                  // enableReservedPages
+      true,                                 // enableReservedPages
+      true,                                 // enableSourceBlocksPreFetch
   };
 
   auto comparator = concord::storage::memorydb::KeyComparator();

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -58,7 +58,8 @@ Config TestConfig() {
       250,                // fetchRetransmissionTimeoutMs
       5,                  // metricsDumpIntervalSec
       false,              // runInSeparateThread
-      true                // enableReservedPages
+      true,               // enableReservedPages
+      true                // enableSourceBlocksPreFetch
   };
 }
 

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -307,7 +307,8 @@ Replica::Replica(ICommunication *comm,
     replicaConfig_.get<uint32_t>("concord.bft.st.fetchRetransmissionTimeoutMs", 1000),
     replicaConfig_.get<uint32_t>("concord.bft.st.metricsDumpIntervalSec", 5),
     replicaConfig_.get("concord.bft.st.runInSeparateThread", replicaConfig_.isReadOnly),
-    replicaConfig_.get("concord.bft.st.enableReservedPages", !replicaConfig_.isReadOnly)
+    replicaConfig_.get("concord.bft.st.enableReservedPages", !replicaConfig_.isReadOnly),
+    replicaConfig_.get("concord.bft.st.enableSourceBlocksPreFetch", true)
   };
 
 #if !defined USE_COMM_PLAIN_TCP && !defined USE_COMM_TLS_TCP


### PR DESCRIPTION
enableSourceBlocksPreFetch is set to true by default.
When true, pre-fetch is enabled - source try to fetch future batch(es)
blocks for improved performance.