### PR TITLE
Use Metrics.hpp to update metrics in TRC/S

### DIFF
--- a/client/thin-replica-client/test/trc_byzantine_test.cpp
+++ b/client/thin-replica-client/test/trc_byzantine_test.cpp
@@ -137,6 +137,7 @@ struct ByzantineTestCaseState {
   // ByzantineTestCaseState is fully set up.
   shared_ptr<UpdateQueue> update_queue_;
   unique_ptr<ThinReplicaClientConfig> trc_config_;
+  shared_ptr<concordMetrics::Aggregator> aggregator_;
   unique_ptr<ThinReplicaClient> trc_;
 
   // Initialize this ByzantineTestCaseState such that trc_ points to a
@@ -164,7 +165,8 @@ struct ByzantineTestCaseState {
             update_queue_,
             max_faulty,
             CreateTrsConnections<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>(mock_servers_))),
-        trc_(new ThinReplicaClient(std::move(trc_config_))) {}
+        aggregator_(std::make_shared<concordMetrics::Aggregator>()),
+        trc_(new ThinReplicaClient(std::move(trc_config_), aggregator_)) {}
 };
 
 namespace {

--- a/client/thin-replica-client/test/trc_rpc_use_test.cpp
+++ b/client/thin-replica-client/test/trc_rpc_use_test.cpp
@@ -61,7 +61,8 @@ TEST(trc_rpc_use_test, test_trc_constructor_and_destructor) {
   auto mock_servers = CreateTrsConnections(server_recorders);
   auto trc_config =
       make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
-  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  std::shared_ptr<concordMetrics::Aggregator> aggregator;
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config), aggregator);
 
   EXPECT_EQ(record->GetTotalCallCount(), 0) << "ThinReplicaClient's constructor appears to have generated RPC "
                                                "call(s) (none were expected).";
@@ -91,7 +92,8 @@ TEST(trc_rpc_use_test, test_trc_subscribe) {
   auto mock_servers = CreateTrsConnections(server_recorders);
   auto trc_config =
       make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
-  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  std::shared_ptr<concordMetrics::Aggregator> aggregator;
+  auto trc = make_unique<ThinReplicaClient>(std::move(trc_config), aggregator);
 
   trc->Subscribe();
   vector<bool> servers_used(num_replicas, false);
@@ -152,7 +154,7 @@ TEST(trc_rpc_use_test, test_trc_subscribe) {
   trc.reset();
   trc_config =
       make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
-  trc = make_unique<ThinReplicaClient>(std::move(trc_config));
+  trc = make_unique<ThinReplicaClient>(std::move(trc_config), aggregator);
   update_queue->Clear();
   trc->Subscribe(1);
 

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -290,9 +290,10 @@ TEST(thin_replica_server_test, SubscribeToUpdatesAlreadySynced) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
@@ -312,9 +313,10 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGap) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
@@ -334,9 +336,10 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGapFromTheMiddleBlock) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
@@ -356,9 +359,10 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesAlreadySynced) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
@@ -378,9 +382,10 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesWithGap) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
@@ -402,9 +407,10 @@ TEST(thin_replica_server_test, ReadState) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateRequest request;
@@ -423,9 +429,10 @@ TEST(thin_replica_server_test, ReadStateHash) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateHashRequest request;
@@ -446,9 +453,10 @@ TEST(thin_replica_server_test, AckUpdate) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateHashRequest request;
@@ -470,9 +478,10 @@ TEST(thin_replica_server_test, Unsubscribe) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateHashRequest request;
@@ -502,9 +511,10 @@ TEST(thin_replica_server_test, ContextWithoutClientIdData) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, data_buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, data_buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   EXPECT_EQ(replica.ReadState(&context, &read_state_request, &data_stream).error_code(), grpc::StatusCode::UNKNOWN);
   EXPECT_EQ(replica.ReadStateHash(&context, &read_state_hash_request, &hash).error_code(), grpc::StatusCode::UNKNOWN);
@@ -526,10 +536,11 @@ TEST(thin_replica_server_test, SubscribeWithWrongBlockId) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   TestServerContext context;
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   SubscriptionRequest request;
   request.set_block_id(kLastBlockId + 100);
@@ -547,9 +558,10 @@ TEST(thin_replica_server_test, GetClientIdFromCertSubjectField) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   std::string subject_str =
       "subject=C = NA, ST = NA, L = NA, O = NA, OU = daml_ledger_api1, CN = "
@@ -571,9 +583,11 @@ TEST(thin_replica_server_test, GetClientIdSetFromRootCert) {
   std::unordered_set<std::string> parsed_client_id_set;
   std::unordered_set<std::string> client_id_set(
       {"daml_ledger_api1", "daml_ledger_api2", "daml_ledger_api3", "daml_ledger_api4", "trutil"});
+  uint16_t update_metrics_aggregator_thresh = 100;
+
   concord::thin_replica::ThinReplicaImpl::getClientIdFromRootCert(logger, root_cert_path, parsed_client_id_set);
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, parsed_client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, parsed_client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   EXPECT_GT(parsed_client_id_set.size(), 0);
   for (auto& client_id : client_id_set) {
@@ -594,9 +608,10 @@ TEST(thin_replica_server_test, getClientIdFromClientCert) {
   bool is_insecure_trs = true;
   std::string tls_trs_cert_path;
   std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
-      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
 
   std::string expected_client_id = "daml_ledger_api1";

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -38,7 +38,6 @@ using com::vmware::concord::thin_replica::Hash;
 using com::vmware::concord::thin_replica::ReadStateHashRequest;
 using com::vmware::concord::thin_replica::ReadStateRequest;
 using com::vmware::concord::thin_replica::SubscriptionRequest;
-using concord::thin_replica::IgnoreTrsMetrics;
 
 using concord::thin_replica::SubUpdateBuffer;
 
@@ -294,8 +293,7 @@ TEST(thin_replica_server_test, SubscribeToUpdatesAlreadySynced) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
   request.set_block_id(1u);
@@ -317,8 +315,7 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGap) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
   request.set_block_id(1u);
@@ -340,8 +337,7 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGapFromTheMiddleBlock) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
   request.set_block_id(3u);
@@ -363,8 +359,7 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesAlreadySynced) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
   request.set_block_id(1u);
@@ -386,8 +381,7 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesWithGap) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
   request.set_block_id(1u);
@@ -411,8 +405,7 @@ TEST(thin_replica_server_test, ReadState) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateRequest request;
   auto status = replica.ReadState(&context, &request, &stream);
@@ -433,8 +426,7 @@ TEST(thin_replica_server_test, ReadStateHash) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateHashRequest request;
   request.set_block_id(kLastBlockId);
@@ -457,8 +449,7 @@ TEST(thin_replica_server_test, AckUpdate) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateHashRequest request;
   request.set_block_id(kLastBlockId);
@@ -482,8 +473,7 @@ TEST(thin_replica_server_test, Unsubscribe) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateHashRequest request;
   request.set_block_id(kLastBlockId);
@@ -515,8 +505,7 @@ TEST(thin_replica_server_test, ContextWithoutClientIdData) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, data_buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   EXPECT_EQ(replica.ReadState(&context, &read_state_request, &data_stream).error_code(), grpc::StatusCode::UNKNOWN);
   EXPECT_EQ(replica.ReadStateHash(&context, &read_state_hash_request, &hash).error_code(), grpc::StatusCode::UNKNOWN);
   auto status = replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(
@@ -539,10 +528,9 @@ TEST(thin_replica_server_test, SubscribeWithWrongBlockId) {
   std::unordered_set<std::string> client_id_set;
 
   TestServerContext context;
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   SubscriptionRequest request;
   request.set_block_id(kLastBlockId + 100);
   auto status =
@@ -562,8 +550,7 @@ TEST(thin_replica_server_test, GetClientIdFromCertSubjectField) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   std::string subject_str =
       "subject=C = NA, ST = NA, L = NA, O = NA, OU = daml_ledger_api1, CN = "
       "daml_ledger_api1";
@@ -587,8 +574,7 @@ TEST(thin_replica_server_test, GetClientIdSetFromRootCert) {
   concord::thin_replica::ThinReplicaImpl::getClientIdFromRootCert(logger, root_cert_path, parsed_client_id_set);
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, parsed_client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   EXPECT_GT(parsed_client_id_set.size(), 0);
   for (auto& client_id : client_id_set) {
     auto parsed_client_id_it = parsed_client_id_set.find(client_id);
@@ -611,8 +597,7 @@ TEST(thin_replica_server_test, getClientIdFromClientCert) {
 
   auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set);
-  auto mock_metrics = std::make_unique<IgnoreTrsMetrics>();
-  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::move(mock_metrics));
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
 
   std::string expected_client_id = "daml_ledger_api1";
   std::string client_id = replica.getClientIdFromClientCert<TestServerContext>(&context);


### PR DESCRIPTION
This PR updates TRC/S such that they use concord-bft metrics.hpp to update metrics instead of supporting third-party metric frameworks such as prometheus via the use of callbacks. The main motivation of this change is to avoid potential performance degradation and to reduce complexity. 