### PR TITLE
Clientservice: Command line options and basic config

### DIFF
--- a/client/clientservice/CMakeLists.txt
+++ b/client/clientservice/CMakeLists.txt
@@ -1,15 +1,18 @@
 add_subdirectory("proto")
 
 find_package(GRPC REQUIRED)
+find_package(Boost ${MIN_BOOST_VERSION} COMPONENTS program_options REQUIRED)
 
 file(GLOB CLIENTSERVICE_SRC "src/*.cpp")
 
 add_executable(clientservice ${CLIENTSERVICE_SRC})
 target_link_libraries(clientservice PRIVATE
+  Boost::program_options
   clientservice-proto
   concordclient
   gRPC::grpc++
   gRPC::grpc++_reflection
   logging
+  yaml-cpp
   util
 )

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -9,33 +9,139 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <iostream>
+#include <chrono>
 #include <memory>
+#include <vector>
+#include <string>
 #include <grpcpp/grpcpp.h>
+#include <boost/program_options.hpp>
+#include <yaml-cpp/yaml.h>
 
-#include "Logger.hpp"
+#include "assertUtils.hpp"
 #include "client_service.hpp"
 #include "client/concordclient/concord_client.hpp"
+#include "Logger.hpp"
 #include "Metrics.hpp"
 
 using concord::client::clientservice::ClientService;
 using concord::client::concordclient::ConcordClient;
 using concord::client::concordclient::ConcordClientConfig;
 
+namespace po = boost::program_options;
+
+po::variables_map parseCmdLine(int argc, char** argv) {
+  po::options_description desc;
+  // clang-format off
+  desc.add_options()
+    ("server-port", po::value<int>()->default_value(1337), "Clientservice gRPC service port")
+    ("config", po::value<std::string>()->required(), "YAML configuration file for the RequestService")
+    ("event-service-id", po::value<std::string>()->required(), "ID used to subscribe to replicas for data/hashes")
+  ;
+  // clang-format on
+  po::variables_map opts;
+  po::store(po::parse_command_line(argc, argv, desc), opts);
+  po::notify(opts);
+
+  return opts;
+}
+
+void configureConcordClient(ConcordClientConfig& config, po::variables_map& opts, logging::Logger& l) {
+  auto file_path = opts["c"].as<std::string>();
+  LOG_INFO(l, "config file name " << file_path);
+
+  auto yaml = YAML::LoadFile(file_path);
+  config.topology.f_val = yaml["f_val"].as<uint16_t>();
+  config.topology.c_val = yaml["c_val"].as<uint16_t>();
+
+  ConcordAssert(yaml["node"].IsSequence());
+  for (const auto& node : yaml["node"]) {
+    ConcordAssert(node.IsMap());
+    ConcordAssert(node["replica"].IsSequence());
+    ConcordAssert(node["replica"][0].IsMap());
+    auto replica = node["replica"][0];
+
+    concord::client::concordclient::ReplicaInfo ri;
+    ri.id.val = replica["principal_id"].as<uint16_t>();
+    ri.host = replica["replica_host"].as<std::string>();
+    ri.bft_port = replica["replica_port"].as<uint16_t>();
+    // TODO: Should come from the configuration as well
+    ri.event_port = 50051;
+
+    config.topology.replicas.push_back(ri);
+  }
+
+  config.topology.client_retry_config.initial_retry_timeout =
+      std::chrono::milliseconds(yaml["client_initial_retry_timeout_milli"].as<unsigned>());
+  config.topology.client_retry_config.min_retry_timeout =
+      std::chrono::milliseconds(yaml["client_min_retry_timeout_milli"].as<unsigned>());
+  config.topology.client_retry_config.max_retry_timeout =
+      std::chrono::milliseconds(yaml["client_max_retry_timeout_milli"].as<unsigned>());
+  config.topology.client_retry_config.number_of_standard_deviations_to_tolerate =
+      yaml["client_number_of_standard_deviations_to_tolerate"].as<uint16_t>();
+  config.topology.client_retry_config.samples_per_evaluation = yaml["client_samples_per_evaluation"].as<uint16_t>();
+  config.topology.client_retry_config.samples_until_reset = yaml["client_samples_until_reset"].as<int16_t>();
+
+  config.transport.buffer_length = yaml["concord-bft_communication_buffer_length"].as<uint32_t>();
+  concord::client::concordclient::TransportConfig::CommunicationType comm_type;
+  auto comm = yaml["comm_to_use"].as<std::string>();
+  if (comm == "tls") {
+    comm_type = concord::client::concordclient::TransportConfig::TlsTcp;
+    config.transport.tls_cert_root_path = yaml["tls_certificates_folder_path"].as<std::string>();
+    config.transport.tls_cipher_suite = yaml["tls_cipher_suite_list"].as<std::string>();
+  } else if (comm == "udp") {
+    comm_type = concord::client::concordclient::TransportConfig::PlainUdp;
+  } else {
+    comm_type = concord::client::concordclient::TransportConfig::Invalid;
+  }
+  config.transport.comm_type = comm_type;
+
+  auto node = yaml["participant_nodes"][0];
+  ConcordAssert(node.IsMap());
+  ConcordAssert(node["participant_node"].IsSequence());
+  ConcordAssert(node["participant_node"][0].IsMap());
+  ConcordAssert(node["participant_node"][0]["external_clients"].IsSequence());
+  for (const auto& item : node["participant_node"][0]["external_clients"]) {
+    ConcordAssert(item.IsMap());
+    ConcordAssert(item["client"].IsSequence());
+    ConcordAssert(item["client"][0].IsMap());
+    auto client = item["client"][0];
+
+    concord::client::concordclient::BftClientInfo ci;
+    ci.id.val = client["principal_id"].as<uint16_t>();
+    // TODO: client_port
+    config.bft_clients.push_back(ci);
+  }
+
+  // Event service
+  config.subscribe_config.id = opts["event-service-id"].as<std::string>();
+
+  // TODO: Read TLS certs and fill config struct
+
+  // TODO: Configure TRS endpoints
+}
+
 int main(int argc, char** argv) {
-  // TODO: Use config file and watch thread
+  // TODO: Use config file and watch thread for logger
   auto logger = logging::getLogger("concord.client.clientservice.main");
 
-  std::string addr = "localhost:1337";
-  LOG_INFO(logger, "Starting clientservice at " << addr);
+  auto opts = parseCmdLine(argc, argv);
 
-  // TODO: Setup ConcordClientConfig and read from config file
-  ConcordClientConfig config{};
+  ConcordClientConfig config;
+  try {
+    configureConcordClient(config, opts, logger);
+  } catch (std::exception& e) {
+    LOG_ERROR(logger, "Failed to configure ConcordClient: " << e.what());
+    return 1;
+  }
+
   auto concord_client = std::make_unique<ConcordClient>(config);
   auto metrics = std::make_shared<concordMetrics::Aggregator>();
   concord_client->setMetricsAggregator(metrics);
   ClientService service(std::move(concord_client));
-  service.start(addr);
+
+  auto server_addr = std::string("localhost:") + std::to_string(opts["server-port"].as<int>());
+  LOG_INFO(logger, "Starting clientservice at " << server_addr);
+  service.start(server_addr);
 
   return 0;
 }

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -66,18 +66,18 @@ struct TransportConfig {
 
 struct SubscribeServer {
   // If set to false then the fields below won't be evaluated
-  const bool use_tls;
+  bool use_tls;
   // Buffer with the server's PEM encoded certififactes
-  const std::string pem_certs;
+  std::string pem_certs;
 };
 
 struct SubscribeConfig {
   // Subscription ID
-  const std::string id;
+  std::string id;
   // Buffer with the client's PEM encoded certififacte chain
-  const std::string pem_cert_chain;
+  std::string pem_cert_chain;
   // Buffer with the client's PEM encoded private key
-  const std::string pem_private_key;
+  std::string pem_private_key;
   // List of SubscribeServer endpoints
   std::vector<SubscribeServer> servers;
 };


### PR DESCRIPTION
With this change we introduce command line options to the clientservice. One of the options expects a YAML configuration file. We changed [install_deps.sh in a separate PR](https://github.com/vmware/concord-bft/pull/1680).
Once the config file is parsed we fill `ConcordClientConfig`. There are still some holes and not all information is present yet but this change gives a good starting point to add more later instead of bloating this PR. Note: ConcordClientConfig is actively used yet. Its users will be the thin replica client and the client pool once they integrate.
Please see commit messages for details.