### PR TITLE
Introducing epoch manager

### DIFF
--- a/bftengine/include/bftengine/EpochManager.hpp
+++ b/bftengine/include/bftengine/EpochManager.hpp
@@ -1,0 +1,84 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include "ReservedPagesClient.hpp"
+#include "Serializable.h"
+#include "Metrics.hpp"
+#include <functional>
+
+namespace bftEngine {
+class EpochManager : public bftEngine::ResPagesClient<EpochManager, 1> {
+  struct EpochData : public concord::serialize::SerializableFactory<EpochData> {
+    uint64_t epochNumber_;
+    EpochData() = default;
+    EpochData(uint64_t epochNumber) : epochNumber_{epochNumber} {}
+
+    const std::string getVersion() const override { return "1"; }
+
+    void serializeDataMembers(std::ostream& outStream) const override { serialize(outStream, epochNumber_); }
+    void deserializeDataMembers(std::istream& inStream) override { deserialize(inStream, epochNumber_); }
+  };
+
+  EpochManager()
+      : metrics_{concordMetrics::Component("epoch_manager", std::make_shared<concordMetrics::Aggregator>())},
+        epoch_number_gauge_(metrics_.RegisterGauge("epoch_number", 0)) {
+    page.resize(sizeOfReservedPage());
+    metrics_.Register();
+  }
+
+ public:
+  static EpochManager& instance() {
+    static EpochManager instance_;
+    return instance_;
+  }
+  uint64_t getEpochNumber(bool fromPages) {
+    if (!fromPages) return epochNumber_;
+    if (!loadReservedPage(0, sizeOfReservedPage(), page.data())) return 0;
+    EpochData edata;
+    std::istringstream inStream;
+    inStream.str(page);
+    concord::serialize::Serializable::deserialize(inStream, edata);
+    epochNumber_ = edata.epochNumber_;
+    return edata.epochNumber_;
+  }
+  void setEpochNumber(uint64_t newEopch, bool toPages) {
+    epoch_number_gauge_.Get().Set(newEopch);
+    metrics_.UpdateAggregator();
+    epochNumber_ = newEopch;
+    if (!toPages) return;
+    EpochData edata{newEopch};
+    std::ostringstream outStream;
+    concord::serialize::Serializable::serialize(outStream, edata);
+    auto data = outStream.str();
+    saveReservedPage(0, data.size(), data.data());
+  }
+
+  void startNewEpoch() { startNewEpoch_ = true; }
+  void markEpochAsStarted() { startNewEpoch_ = false; }
+  bool isNewEpoch() { return startNewEpoch_; }
+  void setNewEpochFlagHandler(const std::function<void(bool)>& cb) { setNewEpochFlagCallBack_ = cb; }
+  void setNewEpochFlag(bool flag) {
+    if (setNewEpochFlagCallBack_) setNewEpochFlagCallBack_(flag);
+  }
+  void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) { metrics_.SetAggregator(aggregator); }
+
+ private:
+  uint64_t epochNumber_{0};
+  bool startNewEpoch_{false};
+  std::string page;
+  std::function<void(bool)> setNewEpochFlagCallBack_;
+  concordMetrics::Component metrics_;
+  concordMetrics::GaugeHandle epoch_number_gauge_;
+};
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -23,6 +23,7 @@
 #include "MsgReceiver.hpp"
 #include "RequestHandler.h"
 #include "ReservedPagesClient.hpp"
+#include "bftengine/EpochManager.hpp"
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -171,6 +172,13 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
                              sizeof(erasedMetaData),
                              (char *)&erasedMetaData,
                              actualObjectSize);
+    bool startNewEpoch = false;
+    metadataStoragePtr->read(
+        ConstMetadataParameterIds::START_NEW_EPOCH, sizeof(startNewEpoch), (char *)&startNewEpoch, actualObjectSize);
+    if (startNewEpoch) {
+      bftEngine::EpochManager::instance().startNewEpoch();
+      LOG_INFO(GL, "We should start a new epoch");
+    }
     LOG_INFO(GL, "erasedMetaData flag = " << erasedMetaData);
     if (erasedMetaData) {
       metadataStoragePtr->eraseData();

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -73,6 +73,9 @@ class DebugPersistentStorage : public PersistentStorage {
   bool getEraseMetadataStorageFlag() override { return false; };
   void eraseMetadata() override{};
 
+  void setNewEpochFlag(bool flag) override {}
+  bool getNewEpochFlag() override { return false; };
+
  protected:
   bool setIsAllowed() const;
   bool getIsAllowed() const;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -66,7 +66,6 @@ class PersistentStorage {
   //////////////////////////////////////////////////////////////////////////
   // Update methods (should only be used in write-only transactions)
   //////////////////////////////////////////////////////////////////////////
-
   virtual void setLastExecutedSeqNum(SeqNum seqNum) = 0;
   virtual void setPrimaryLastUsedSeqNum(SeqNum seqNum) = 0;
   virtual void setStrictLowerBoundOfSeqNums(SeqNum seqNum) = 0;
@@ -120,6 +119,9 @@ class PersistentStorage {
   virtual void setEraseMetadataStorageFlag() = 0;
   virtual bool getEraseMetadataStorageFlag() = 0;
   virtual void eraseMetadata() = 0;
+
+  virtual void setNewEpochFlag(bool flag) = 0;
+  virtual bool getNewEpochFlag() = 0;
 
   //////////////////////////////////////////////////////////////////////////
   // Read methods (should only be used before using write-only transactions)

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -12,6 +12,7 @@
 
 #include "PersistentStorageImp.hpp"
 #include "Logger.hpp"
+#include "bftengine/EpochManager.hpp"
 #include <list>
 #include <sstream>
 #include <stdexcept>
@@ -91,6 +92,7 @@ ObjectDescUniquePtr PersistentStorageImp::getDefaultMetadataObjectDescriptors(ui
   metadataObjectsArray.get()[BEGINNING_OF_CHECK_WINDOW].maxSize = sizeof(SeqNum);
   metadataObjectsArray.get()[ERASE_METADATA_ON_STARTUP].maxSize = sizeof(bool);
   metadataObjectsArray.get()[USER_DATA].maxSize = kMaxUserDataSizeBytes;
+  metadataObjectsArray.get()[START_NEW_EPOCH].maxSize = sizeof(bool);
 
   for (auto i = 0; i < kWorkWindowSize; ++i) {
     metadataObjectsArray.get()[LAST_EXIT_FROM_VIEW_DESC + 1 + i].maxSize =
@@ -946,6 +948,20 @@ bool PersistentStorageImp::getEraseMetadataStorageFlag() {
   if (actualObjectSize == 0) return false;
   return eraseMetaDataOnStartup;
 }
+
+void PersistentStorageImp::setNewEpochFlag(bool flag) {
+  bool newEpoch = flag;
+  metadataStorage_->atomicWrite(START_NEW_EPOCH, (char *)&newEpoch, sizeof(newEpoch));
+}
+
+bool PersistentStorageImp::getNewEpochFlag() {
+  uint32_t actualObjectSize = 0;
+  bool newEpoch = false;
+  metadataStorage_->read(START_NEW_EPOCH, sizeof(newEpoch), (char *)&newEpoch, actualObjectSize);
+  if (actualObjectSize == 0) return false;
+  return newEpoch;
+}
+
 void PersistentStorageImp::eraseMetadata() { metadataStorage_->eraseData(); }
 
 }  // namespace impl

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -65,6 +65,7 @@ enum ConstMetadataParameterIds : uint32_t {
   LAST_STABLE_SEQ_NUM = 7,
   ERASE_METADATA_ON_STARTUP = 9,
   USER_DATA = 10,
+  START_NEW_EPOCH = 11,
   CONST_METADATA_PARAMETERS_NUM,
 };
 
@@ -140,6 +141,9 @@ class PersistentStorageImp : public PersistentStorage {
   void setEraseMetadataStorageFlag() override;
   bool getEraseMetadataStorageFlag() override;
   void eraseMetadata() override;
+
+  void setNewEpochFlag(bool flag) override;
+  bool getNewEpochFlag() override;
 
   // Getters
   std::string getStoredVersion();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4154,8 +4154,9 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
 
   if (lastExecutedSeqNum % checkpointWindowSize == 0) {
     // Load the epoch to the reserved pages
-    auto epoch = bftEngine::EpochManager::instance().getEpochNumber(false);
-    bftEngine::EpochManager::instance().setEpochNumber(epoch, true);
+    auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
+    bftEngine::EpochManager::instance().setSelfEpochNumber(epoch);
+    bftEngine::EpochManager::instance().setGlobalEpochNumber(epoch);
     Digest checkDigest;
     const uint64_t checkpointNum = lastExecutedSeqNum / checkpointWindowSize;
     stateTransfer->getDigestOfCheckpoint(checkpointNum, sizeof(Digest), (char *)&checkDigest);

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -136,7 +136,8 @@ class Replica : public IReplica,
   friend class StorageWrapperForIdleMode;
 
   void createReplicaAndSyncState();
-
+  void registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler);
+  void handleNewEpochEvent();
   // INTERNAL TYPES
 
   // represents <key,blockId>

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -21,6 +21,7 @@ static const char reconfiguration_key_exchange = 0x28;
 static const char reconfiguration_add_remove = 0x29;
 static const char reconfiguration_wedge_key = 0x2a;
 static const char reconfiguration_client_data_prefix = 0x2c;
+static const char reconfiguration_epoch_key = 0x2d;
 
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -28,7 +28,7 @@ class ReconfigurationBlockTools {
   kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data,
                                             const uint64_t bft_seq_num,
                                             string key,
-                                            bool include_epoch = false);
+                                            bool include_epoch);
   kvbc::BlockId persistReconfigurationBlock(concord::kvbc::categorization::VersionedUpdates& ver_updates,
                                             const uint64_t bft_seq_num);
   kvbc::IBlockAdder& blocks_adder_;

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -25,7 +25,10 @@ class ReconfigurationBlockTools {
  protected:
   ReconfigurationBlockTools(kvbc::IBlockAdder& block_adder, kvbc::IReader& ro_storage)
       : blocks_adder_{block_adder}, block_metadata_{ro_storage}, ro_storage_{ro_storage} {}
-  kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data, const uint64_t bft_seq_num, string key);
+  kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data,
+                                            const uint64_t bft_seq_num,
+                                            string key,
+                                            bool include_epoch = false);
   kvbc::BlockId persistReconfigurationBlock(concord::kvbc::categorization::VersionedUpdates& ver_updates,
                                             const uint64_t bft_seq_num);
   kvbc::IBlockAdder& blocks_adder_;

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -25,10 +25,7 @@ class ReconfigurationBlockTools {
  protected:
   ReconfigurationBlockTools(kvbc::IBlockAdder& block_adder, kvbc::IReader& ro_storage)
       : blocks_adder_{block_adder}, block_metadata_{ro_storage}, ro_storage_{ro_storage} {}
-  kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data,
-                                            const uint64_t bft_seq_num,
-                                            string key,
-                                            bool include_epoch);
+  kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data, const uint64_t bft_seq_num, string key);
   kvbc::BlockId persistReconfigurationBlock(concord::kvbc::categorization::VersionedUpdates& ver_updates,
                                             const uint64_t bft_seq_num);
   kvbc::IBlockAdder& blocks_adder_;

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -134,7 +134,8 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExc
       bft_seq_num,
       std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
                   static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::PUBLIC_KEY_EXCHANGE)} +
-          std::to_string(command.sender_id));
+          std::to_string(command.sender_id),
+      true);
   LOG_INFO(getLogger(), "ClientExchangePublicKey block is " << blockId);
   return true;
 }
@@ -170,7 +171,7 @@ bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& comma
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key});
+      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key}, true);
   LOG_INFO(getLogger(), "WedgeCommand block is " << blockId);
   return true;
 }
@@ -181,7 +182,7 @@ bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& co
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_download_key});
+      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_download_key}, true);
   LOG_INFO(getLogger(), "DownloadCommand command block is " << blockId);
   return true;
 }
@@ -192,7 +193,7 @@ bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& com
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_install_key});
+      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_install_key}, true);
   LOG_INFO(getLogger(), "InstallCommand command block is " << blockId);
   return true;
 }
@@ -203,7 +204,7 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_key_exchange});
+      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_key_exchange}, false);
   LOG_INFO(getLogger(), "KeyExchangeCommand command block is " << blockId);
   return true;
 }
@@ -214,7 +215,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& c
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_add_remove});
+      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_add_remove}, false);
   LOG_INFO(getLogger(), "AddRemoveCommand command block is " << blockId);
   return true;
 }
@@ -225,7 +226,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
+      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1}, true);
   LOG_INFO(getLogger(), "AddRemove configuration command block is " << blockId);
   return true;
 }
@@ -284,7 +285,7 @@ bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& comma
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1});
+      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1}, false);
   LOG_INFO(getLogger(), "PruneRequest configuration command block is " << blockId);
   return true;
 }
@@ -334,7 +335,7 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeComm
       return false;
     }
     auto blockId = persistReconfigurationBlock(
-        serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key, 0x1});
+        serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key, 0x1}, false);
     LOG_INFO(getLogger(), "received noop command, a new block will be written" << KVLOG(bft_seq_num, blockId));
     return true;
   }

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -12,18 +12,31 @@
 
 #include "reconfiguration_kvbc_handler.hpp"
 #include "ControlStateManager.hpp"
+#include "bftengine/EpochManager.hpp"
+#include "endianness.hpp"
 
 namespace concord::kvbc::reconfiguration {
 
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(const std::vector<uint8_t>& data,
                                                                      const uint64_t bft_seq_num,
-                                                                     string key) {
+                                                                     string key,
+                                                                     bool include_epoch) {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   ver_updates.addUpdate(std::move(key), std::string(data.begin(), data.end()));
 
   // All blocks are expected to have the BFT sequence number as a key.
   ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, block_metadata_.serialize(bft_seq_num));
-
+  if (include_epoch) {
+    uint64_t epoch = 0;
+    auto value = ro_storage_.getLatest(kConcordInternalCategoryId, std::string{keyTypes::reconfiguration_epoch_key});
+    if (value.has_value()) {
+      const auto& epoch_str = std::get<categorization::VersionedValue>(*value).data;
+      ConcordAssertEQ(epoch_str.size(), sizeof(uint64_t));
+      epoch = concordUtils::fromBigEndianBuffer<uint64_t>(epoch_str.data());
+    }
+    auto current_epoch_buf = concordUtils::toBigEndianStringBuffer(epoch);
+    ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, std::move(current_epoch_buf));
+  }
   concord::kvbc::categorization::Updates updates;
   updates.add(kvbc::kConcordInternalCategoryId, std::move(ver_updates));
   try {


### PR DESCRIPTION
In this PR we introduce the epoch manager and demonstrate its power via add/remove node command with lagged replicas.
**Epoch** is a life cycle of the system. by changing epoch we indicate that we actually started a new system on top of an old state.
All replicas have to decide on starting a new epoch exactly at the same state to preserve consistency. Thus, starting a new epoch after wedge makes great sense.
Practically, when a replica decides to start a new epoch, it writes a new "genesis" block that contains this new epoch under a pre-known key.