### PR TITLE
Improve checkpoint summary consensus time

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -698,6 +698,8 @@ void BCStateTran::onTimerImp() {
   }
   if (fs == FetchingState::GettingCheckpointSummaries) {
     if ((currTime - lastTimeSentAskForCheckpointSummariesMsg) > config_.checkpointSummariesRetransmissionTimeoutMs) {
+      LOG_DEBUG(getLogger(),
+                KVLOG(retransmissionNumberOfAskForCheckpointSummariesMsg, kResetCount_AskForCheckpointSummaries));
       if (++retransmissionNumberOfAskForCheckpointSummariesMsg > kResetCount_AskForCheckpointSummaries)
         clearInfoAboutGettingCheckpointSummary();
 

--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -66,11 +66,19 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
   uint64_t requestMsgSeqNum;
 
   static bool equivalent(const CheckpointSummaryMsg* a, const CheckpointSummaryMsg* b) {
-    return (memcmp(a, b, sizeof(CheckpointSummaryMsg)) == 0);
+    static_assert((sizeof(CheckpointSummaryMsg) - sizeof(requestMsgSeqNum) == 82),
+                  "Should newly added field be compared below?");
+    return ((a->lastBlock == b->lastBlock) and (a->checkpointNum == b->checkpointNum) and
+            (a->digestOfLastBlock == b->digestOfLastBlock) and
+            (a->digestOfResPagesDescriptor == b->digestOfResPagesDescriptor));
   }
 
   static bool equivalent(const CheckpointSummaryMsg* a, uint16_t a_id, const CheckpointSummaryMsg* b, uint16_t b_id) {
-    if (memcmp(a, b, sizeof(CheckpointSummaryMsg)) != 0) {
+    static_assert((sizeof(CheckpointSummaryMsg) - sizeof(requestMsgSeqNum) == 82),
+                  "Should newly added field be compared below?");
+    if ((a->lastBlock != b->lastBlock) || (a->checkpointNum != b->checkpointNum) ||
+        (a->digestOfLastBlock != b->digestOfLastBlock) ||
+        (a->digestOfResPagesDescriptor != b->digestOfResPagesDescriptor)) {
       auto logger = logging::getLogger("state-transfer");
       LOG_WARN(logger,
                "Mismatched Checkpoints for checkpointNum="


### PR DESCRIPTION
While comparing checkpoint summary messages received from 2 different
replicas there is no need to compare sequence numbers as some of
the checkpoint summary messages could have been received in earlier
window before retransmission happens.