### PR TITLE
Fix some critical bugs in reconfiguration mechanism

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -332,11 +332,6 @@ void BCStateTran::init(uint64_t maxNumOfRequiredStoredCheckpoints,
       ConcordAssertLE(numberOfRequiredReservedPages, config_.maxNumOfReservedPages);
 
       DataStoreTransaction::Guard g(psd_->beginTransaction());
-      g.txn()->setReplicas(replicas_);
-      g.txn()->setMyReplicaId(config_.myReplicaId);
-      g.txn()->setFVal(config_.fVal);
-      g.txn()->setMaxNumOfStoredCheckpoints(maxNumOfRequiredStoredCheckpoints);
-      g.txn()->setNumberOfReservedPages(numberOfRequiredReservedPages);
       g.txn()->setLastStoredCheckpoint(0);
       g.txn()->setFirstStoredCheckpoint(0);
       g.txn()->setIsFetchingState(false);
@@ -345,6 +340,14 @@ void BCStateTran::init(uint64_t maxNumOfRequiredStoredCheckpoints,
       g.txn()->setAsInitialized();
 
       ConcordAssertEQ(getFetchingState(), FetchingState::NotFetching);
+    }
+    {
+      DataStoreTransaction::Guard g(psd_->beginTransaction());
+      g.txn()->setReplicas(replicas_);
+      g.txn()->setMyReplicaId(config_.myReplicaId);
+      g.txn()->setFVal(config_.fVal);
+      g.txn()->setMaxNumOfStoredCheckpoints(maxNumOfRequiredStoredCheckpoints);
+      g.txn()->setNumberOfReservedPages(numberOfRequiredReservedPages);
     }
   } catch (const std::exception &e) {
     LOG_FATAL(getLogger(), e.what());

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -141,6 +141,7 @@ class DBDataStore : public DataStore {
   void load(bool loadResPages);
   void loadResPages();
   void loadPendingPages();
+  void deleteAllResPages();
 
   void serializeCheckpoint(std::ostream& os, const CheckpointDesc& desc) const;
   void deserializeCheckpoint(std::istream& is, CheckpointDesc& desc) const;
@@ -158,6 +159,7 @@ class DBDataStore : public DataStore {
   void deleteAllPendingPagesTxn(ITransaction*);
   void deleteCoveredResPageInSmallerCheckpointsTxn(uint64_t, ITransaction*);
   void deleteDescOfSmallerCheckpointsTxn(uint64_t, ITransaction*);
+  void deleteAllDesc();
   /** *****************************************************************************************************************
    * db layer access
    */

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
@@ -30,30 +30,21 @@ bool InMemoryDataStore::initialized() { return wasInit_; }
 
 void InMemoryDataStore::setAsInitialized() { wasInit_ = true; }
 
-void InMemoryDataStore::setReplicas(const set<uint16_t> replicas) {
-  ConcordAssert(replicas_.empty());
-  replicas_ = replicas;
-}
+void InMemoryDataStore::setReplicas(const set<uint16_t> replicas) { replicas_ = replicas; }
 
 set<uint16_t> InMemoryDataStore::getReplicas() {
   ConcordAssert(!replicas_.empty());
   return replicas_;
 }
 
-void InMemoryDataStore::setMyReplicaId(uint16_t id) {
-  ConcordAssert(myReplicaId_ == UINT16_MAX);
-  myReplicaId_ = id;
-}
+void InMemoryDataStore::setMyReplicaId(uint16_t id) { myReplicaId_ = id; }
 
 uint16_t InMemoryDataStore::getMyReplicaId() {
   ConcordAssert(myReplicaId_ != UINT16_MAX);
   return myReplicaId_;
 }
 
-void InMemoryDataStore::setFVal(uint16_t fVal) {
-  ConcordAssert(fVal_ == UINT16_MAX);
-  fVal_ = fVal;
-}
+void InMemoryDataStore::setFVal(uint16_t fVal) { fVal_ = fVal; }
 
 uint16_t InMemoryDataStore::getFVal() {
   ConcordAssert(fVal_ != UINT16_MAX);
@@ -63,7 +54,6 @@ uint16_t InMemoryDataStore::getFVal() {
 void InMemoryDataStore::setMaxNumOfStoredCheckpoints(uint64_t numChecks) {
   ConcordAssert(numChecks > 0);
 
-  ConcordAssert(maxNumOfStoredCheckpoints_ == UINT64_MAX);
   maxNumOfStoredCheckpoints_ = numChecks;
 }
 
@@ -75,7 +65,6 @@ uint64_t InMemoryDataStore::getMaxNumOfStoredCheckpoints() const {
 void InMemoryDataStore::setNumberOfReservedPages(uint32_t numResPages) {
   ConcordAssert(numResPages > 0);
 
-  ConcordAssert(numberOfReservedPages_ == UINT32_MAX);
   numberOfReservedPages_ = numResPages;
 }
 

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -34,13 +34,8 @@ void PersistentStorageImp::retrieveWindowsMetadata() {
   checkWindowBeginning_ = readBeginningOfActiveWindow(BEGINNING_OF_CHECK_WINDOW);
 }
 
-bool PersistentStorageImp::init(unique_ptr<MetadataStorage> metadataStorage, bool &erasedMetadata) {
+bool PersistentStorageImp::init(unique_ptr<MetadataStorage> metadataStorage) {
   metadataStorage_ = move(metadataStorage);
-  erasedMetadata = false;
-  if (getEraseMetadataStorageFlag()) {
-    eraseMetadata();
-    erasedMetadata = true;
-  }
   try {
     if (!getStoredVersion().empty()) {
       LOG_INFO(GL, "PersistentStorageImp::init version=" << version_.c_str());
@@ -56,10 +51,6 @@ bool PersistentStorageImp::init(unique_ptr<MetadataStorage> metadataStorage, boo
   return true;
 }
 
-bool PersistentStorageImp::init(std::unique_ptr<MetadataStorage> metadataStorage) {
-  bool dummy;
-  return init(std::move(metadataStorage), dummy);
-}
 void PersistentStorageImp::setDefaultsInMetadataStorage() {
   LOG_INFO(GL, "");
   beginWriteTran();

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -174,7 +174,6 @@ class PersistentStorageImp : public PersistentStorage {
   bool hasDescriptorOfLastExecution() override;
 
   // Returns 'true' in case storage is empty
-  bool init(std::unique_ptr<MetadataStorage> metadataStorage, bool &erasedMetadata);
   bool init(std::unique_ptr<MetadataStorage> metadataStorage);
 
  protected:

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2816,6 +2816,8 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
 }
 
 void ReplicaImp::onSeqNumIsSuperStable(SeqNum superStableSeqNum) {
+  if (lastSuperStableSeqNum >= superStableSeqNum) return;
+  lastSuperStableSeqNum = superStableSeqNum;
   auto seq_num_to_stop_at = ControlStateManager::instance().getCheckpointToStopAt();
   if (seq_num_to_stop_at.has_value() && seq_num_to_stop_at.value() == superStableSeqNum) {
     LOG_INFO(GL, "Informing control state manager that consensus should be stopped: " << KVLOG(superStableSeqNum));
@@ -2877,7 +2879,7 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
       }
       clientsManager->loadInfoFromReservedPages();
     }
-
+    if (ps_) ps_->setLastExecutedSeqNum(lastExecutedSeqNum);
     CheckpointInfo &checkpointInfo = checkpointsLog->get(lastStableSeqNum);
     CheckpointMsg *checkpointMsg = checkpointInfo.selfCheckpointMsg();
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -101,6 +101,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // the latest stable SeqNum known to this replica
   SeqNum lastStableSeqNum = 0;
 
+  SeqNum lastSuperStableSeqNum = 0;
+
   //
   SeqNum strictLowerBoundOfSeqNums = 0;
 

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -15,18 +15,17 @@
 namespace concord::kvbc::keyTypes {
 static const char bft_seq_num_key = 0x21;
 static const char reconfiguration_pruning_key = 0x24;
-static const char reconfiguration_wedge_key = 0x25;
 static const char reconfiguration_download_key = 0x26;
 static const char reconfiguration_install_key = 0x27;
 static const char reconfiguration_key_exchange = 0x28;
 static const char reconfiguration_add_remove = 0x29;
-static const char reconfiguration_reserved = 0x2a;  // TODO [YB] check
+static const char reconfiguration_wedge_key = 0x2a;
 static const char reconfiguration_client_data_prefix = 0x2c;
 
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
-  PUBLIC_KEY_EXCHANGE = 0x1,          // identifier of public key exchage request by client
-  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,  // idenfier of client key exchange request by operator
+  PUBLIC_KEY_EXCHANGE = 0x1,          // identifier of public key exchange request by client
+  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,  // identifier of client key exchange request by operator
   end_
 };
 }  // namespace concord::kvbc::keyTypes


### PR DESCRIPTION
in this PR we fix some critical bugs with the reconfiguration mechanism, mostly on remove metadata from state transfer persistent storage
1. removing the whole metadata of state transfer from storage (including reserved pages)
2. mark the bft metadata as initialized after removing metadata on startup