### PR TITLE
Expose TicksGenerator mocks for testing

### DIFF
--- a/ccron/CMakeLists.txt
+++ b/ccron/CMakeLists.txt
@@ -16,6 +16,7 @@ project(libccron LANGUAGES CXX)
 cmake_policy(VERSION 3.13)
 
 target_include_directories(corebft PUBLIC include)
+target_include_directories(corebft PUBLIC test/include)
 target_link_libraries(corebft PUBLIC ccron_msgs)
 
 add_subdirectory(cmf)

--- a/ccron/include/ccron/ticks_generator.hpp
+++ b/ccron/include/ccron/ticks_generator.hpp
@@ -42,6 +42,7 @@ class TicksGenerator {
   // Updates the period if generation for `component_id` has already been started.
   void start(std::uint32_t component_id, const std::chrono::seconds &period);
   void stop(std::uint32_t component_id);
+  bool isGenerating(std::uint32_t component_id) const;
 
  public:
   // Called by the main replica thread on receiving a tick as an internal message.

--- a/ccron/src/ticks_generator.cpp
+++ b/ccron/src/ticks_generator.cpp
@@ -63,6 +63,10 @@ void TicksGenerator::stop(std::uint32_t component_id) {
   }
 }
 
+bool TicksGenerator::isGenerating(std::uint32_t component_id) const {
+  return (timer_handles_.find(component_id) != timer_handles_.cend());
+}
+
 void TicksGenerator::onInternalTick(const bftEngine::impl::TickInternalMsg& internal_tick) {
   auto it = component_pending_req_seq_nums_.find(internal_tick.component_id);
   if (it == component_pending_req_seq_nums_.cend()) {

--- a/ccron/test/ccron_ticks_generator_test.cpp
+++ b/ccron/test/ccron_ticks_generator_test.cpp
@@ -16,16 +16,12 @@
 #include "ccron_msgs.cmf.hpp"
 #include "ccron/ticks_generator.hpp"
 #include "Replica.hpp"
+#include "ticks_generator_mocks.hpp"
 
-#include <algorithm>
 #include <iterator>
-#include <map>
 #include <memory>
-#include <string>
 #include <utility>
 #include <variant>
-#include <vector>
-
 namespace {
 
 using namespace concord::cron;
@@ -33,97 +29,15 @@ using namespace std::chrono_literals;
 using bftEngine::impl::TickInternalMsg;
 using bftEngine::TICK_FLAG;
 
-struct IncomingMsgsStorageMock : public IncomingMsgsStorage {
-  void start() override{};
-  void stop() override{};
-
-  bool isRunning() const override { return true; };
-
-  void pushExternalMsg(std::unique_ptr<MessageBase> msg) override {}
-  void pushExternalMsgRaw(char* msg, size_t& size) override {}
-  void pushInternalMsg(InternalMessage&& msg) override { internal_msgs_.emplace_back(std::move(msg)); }
-
-  std::vector<InternalMessage> internal_msgs_;
-};
-
-struct InternalBFTClientMock : public IInternalBFTClient {
-  NodeIdType getClientId() const override { return 42; }
-
-  // Returns the sent client request sequence number.
-  uint64_t sendRequest(uint64_t flags, uint32_t size, const char* request, const std::string& cid) override {
-    auto seq_num = 0;
-    if (!requests_.empty()) {
-      seq_num = std::prev(requests_.cend())->first + 1;
-    }
-    auto* p = reinterpret_cast<const uint8_t*>(request);
-    requests_[seq_num] = Request{flags, std::vector<uint8_t>{p, p + size}, cid};
-    return seq_num;
-  }
-
-  uint32_t numOfConnectedReplicas(uint32_t clusterSize) override { return clusterSize; }
-
-  bool isUdp() const override { return false; }
-
-  struct Request {
-    uint64_t flags{0};
-    std::vector<uint8_t> contents;
-    std::string cid;
-
-    bool operator==(const Request& r) const { return (flags == r.flags && contents == r.contents && cid == r.cid); }
-  };
-
-  // sequence number -> request
-  std::map<uint64_t, Request> requests_;
-};
-
-struct PendingRequestMock : public IPendingRequest {
-  struct PendingRequest {
-    NodeIdType client_id_{0};
-    ReqId req_seq_num_{0};
-
-    bool operator==(const PendingRequest& r) const {
-      return (client_id_ == r.client_id_ && req_seq_num_ == r.req_seq_num_);
-    }
-  };
-
-  bool isPending(NodeIdType client_id, ReqId req_seq_num) const override {
-    for (const auto& r : pending_) {
-      if (r == PendingRequest{client_id, req_seq_num}) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  void addPending(NodeIdType client_id, ReqId req_seq_num) {
-    pending_.push_back(PendingRequest{client_id, req_seq_num});
-  }
-
-  void removePending(NodeIdType client_id, ReqId req_seq_num) {
-    pending_.erase(std::remove(pending_.begin(), pending_.end(), PendingRequest{client_id, req_seq_num}),
-                   pending_.end());
-  }
-
-  std::vector<PendingRequest> pending_;
-};
-
-struct TicksGeneratorForTest : public TicksGenerator {
-  TicksGeneratorForTest(const std::shared_ptr<bftEngine::impl::IInternalBFTClient>& bft_client,
-                        const IPendingRequest& pending_req,
-                        const std::shared_ptr<IncomingMsgsStorage>& msgs_storage)
-      : TicksGenerator{bft_client, pending_req, msgs_storage, TicksGenerator::DoNotStartThread{}} {}
-  void evaluateTimers(const std::chrono::steady_clock::time_point& now) { TicksGenerator::evaluateTimers(now); }
-};
-
 class ccron_ticks_generator_test : public ::testing::Test {
  protected:
   const std::uint32_t kComponentId1 = 1;
   const std::uint32_t kComponentId2 = 2;
 
-  std::shared_ptr<InternalBFTClientMock> bft_client_ = std::make_shared<InternalBFTClientMock>();
-  PendingRequestMock pending_req_;
-  std::shared_ptr<IncomingMsgsStorageMock> msgs_ = std::make_shared<IncomingMsgsStorageMock>();
-  TicksGeneratorForTest gen_{bft_client_, pending_req_, msgs_};
+  std::shared_ptr<test::InternalBFTClientMock> bft_client_ = std::make_shared<test::InternalBFTClientMock>();
+  test::PendingRequestMock pending_req_;
+  std::shared_ptr<test::IncomingMsgsStorageMock> msgs_ = std::make_shared<test::IncomingMsgsStorageMock>();
+  test::TicksGeneratorForTest gen_{bft_client_, pending_req_, msgs_};
 
   static std::chrono::steady_clock::time_point now() { return std::chrono::steady_clock::now(); }
 };
@@ -201,6 +115,14 @@ TEST_F(ccron_ticks_generator_test, stop_tick) {
   gen_.evaluateTimers(now() + 6s);
   gen_.evaluateTimers(now() + 8s);
   ASSERT_EQ(4, msgs_->internal_msgs_.size());
+}
+
+TEST_F(ccron_ticks_generator_test, is_generating) {
+  ASSERT_FALSE(gen_.isGenerating(kComponentId1));
+  gen_.start(kComponentId1, 1s);
+  ASSERT_TRUE(gen_.isGenerating(kComponentId1));
+  gen_.stop(kComponentId1);
+  ASSERT_FALSE(gen_.isGenerating(kComponentId1));
 }
 
 TEST_F(ccron_ticks_generator_test, client_request_msg_is_generated) {

--- a/ccron/test/include/ticks_generator_mocks.hpp
+++ b/ccron/test/include/ticks_generator_mocks.hpp
@@ -1,0 +1,111 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "ccron/ticks_generator.hpp"
+
+#include "IncomingMsgsStorage.hpp"
+#include "InternalBFTClient.hpp"
+#include "IPendingRequest.hpp"
+
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace concord::cron::test {
+
+struct IncomingMsgsStorageMock : public bftEngine::impl::IncomingMsgsStorage {
+  void start() override{};
+  void stop() override{};
+
+  bool isRunning() const override { return true; };
+
+  void pushExternalMsg(std::unique_ptr<MessageBase> msg) override {}
+  void pushExternalMsgRaw(char* msg, size_t& size) override {}
+  void pushInternalMsg(InternalMessage&& msg) override { internal_msgs_.emplace_back(std::move(msg)); }
+
+  std::vector<InternalMessage> internal_msgs_;
+};
+
+struct InternalBFTClientMock : public IInternalBFTClient {
+  NodeIdType getClientId() const override { return 42; }
+
+  // Returns the sent client request sequence number.
+  uint64_t sendRequest(uint64_t flags, uint32_t size, const char* request, const std::string& cid) override {
+    auto seq_num = 0;
+    if (!requests_.empty()) {
+      seq_num = std::prev(requests_.cend())->first + 1;
+    }
+    auto* p = reinterpret_cast<const uint8_t*>(request);
+    requests_[seq_num] = Request{flags, std::vector<uint8_t>{p, p + size}, cid};
+    return seq_num;
+  }
+
+  uint32_t numOfConnectedReplicas(uint32_t clusterSize) override { return clusterSize; }
+
+  bool isUdp() const override { return false; }
+
+  struct Request {
+    uint64_t flags{0};
+    std::vector<uint8_t> contents;
+    std::string cid;
+
+    bool operator==(const Request& r) const { return (flags == r.flags && contents == r.contents && cid == r.cid); }
+  };
+
+  // sequence number -> request
+  std::map<uint64_t, Request> requests_;
+};
+
+struct PendingRequestMock : public IPendingRequest {
+  struct PendingRequest {
+    NodeIdType client_id_{0};
+    ReqId req_seq_num_{0};
+
+    bool operator==(const PendingRequest& r) const {
+      return (client_id_ == r.client_id_ && req_seq_num_ == r.req_seq_num_);
+    }
+  };
+
+  bool isPending(NodeIdType client_id, ReqId req_seq_num) const override {
+    for (const auto& r : pending_) {
+      if (r == PendingRequest{client_id, req_seq_num}) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void addPending(NodeIdType client_id, ReqId req_seq_num) {
+    pending_.push_back(PendingRequest{client_id, req_seq_num});
+  }
+
+  void removePending(NodeIdType client_id, ReqId req_seq_num) {
+    pending_.erase(std::remove(pending_.begin(), pending_.end(), PendingRequest{client_id, req_seq_num}),
+                   pending_.end());
+  }
+
+  std::vector<PendingRequest> pending_;
+};
+
+struct TicksGeneratorForTest : public TicksGenerator {
+  TicksGeneratorForTest(const std::shared_ptr<bftEngine::impl::IInternalBFTClient>& bft_client,
+                        const IPendingRequest& pending_req,
+                        const std::shared_ptr<IncomingMsgsStorage>& msgs_storage)
+      : TicksGenerator{bft_client, pending_req, msgs_storage, TicksGenerator::DoNotStartThread{}} {}
+  void evaluateTimers(const std::chrono::steady_clock::time_point& now) { TicksGenerator::evaluateTimers(now); }
+};
+
+}  // namespace concord::cron::test


### PR DESCRIPTION
Put TicksGenerator mocks in a separate header file for use in other
tests.

Introduce TicksGenerator::isGenerating() for testing purposes.