### PR TITLE
Initialise with zeros the array for primary result hash in PreProcessing

### DIFF
--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -108,7 +108,7 @@ class RequestProcessingState {
   ReplicaIdsList rejectedReplicaIds_;
   const char* primaryPreProcessResult_ = nullptr;  // This memory is statically pre-allocated per client in PreProcessor
   uint32_t primaryPreProcessResultLen_ = 0;
-  concord::util::SHA3_256::Digest primaryPreProcessResultHash_;
+  concord::util::SHA3_256::Digest primaryPreProcessResultHash_ = {};
   // Maps result hash to a list of replica signatures sent for this hash. Implcitly this also gives the number of
   // replicas returning a specific hash.
   std::map<concord::util::SHA3_256::Digest, std::list<PreProcessResultSignature>> preProcessingResultHashes_;


### PR DESCRIPTION
primaryPreProcessResultHash_ in RequestProcessingState is of type
concord::util::SHA3_256::Digest which actually is std::array.

std::array's default constructor default constructs each element of the
array which for POD types effectively means nothing (whatever was in the
memory).

This was causing the preprocessor test failure in
primaryReplicaDidNotCompletePreProcessingWhileNonPrimariesDid test case.

The patch initialises the array with 0 on construction.