### PR TITLE
ConcordClient: TRC integration

### DIFF
--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -46,7 +46,7 @@ po::variables_map parseCmdLine(int argc, char** argv) {
 }
 
 void configureConcordClient(ConcordClientConfig& config, po::variables_map& opts, logging::Logger& l) {
-  auto file_path = opts["c"].as<std::string>();
+  auto file_path = opts["config"].as<std::string>();
   LOG_INFO(l, "config file name " << file_path);
 
   auto yaml = YAML::LoadFile(file_path);

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -161,7 +161,7 @@ class ConcordClient {
 
   // TODO: Allow multiple subscriptions
   std::atomic_bool stop_subscriber_{true};
-  std::thread subscriber_;
+  std::unique_ptr<std::thread> subscriber_;
 };
 
 }  // namespace concord::client::concordclient

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <functional>
 #include <opentracing/span.h>
+#include <memory>
 #include <string>
 #include <thread>
 #include <variant>
@@ -21,6 +22,7 @@
 
 #include "bftclient/base_types.h"
 #include "bftclient/bft_client.h"
+#include "client/thin-replica-client/thin_replica_client.hpp"
 #include "Metrics.hpp"
 
 namespace concord::client::concordclient {
@@ -120,8 +122,7 @@ typedef std::variant<SubscribeError, EventGroup> SubscribeResult;
 // observe events.
 class ConcordClient {
  public:
-  ConcordClient(const ConcordClientConfig& config)
-      : logger_(logging::getLogger("concord.client.concordclient")), config_(config) {}
+  ConcordClient(const ConcordClientConfig& config);
   ~ConcordClient() { unsubscribe(); }
 
   void setMetricsAggregator(std::shared_ptr<concordMetrics::Aggregator> m) { metrics_ = m; }
@@ -162,6 +163,9 @@ class ConcordClient {
   // TODO: Allow multiple subscriptions
   std::atomic_bool stop_subscriber_{true};
   std::unique_ptr<std::thread> subscriber_;
+
+  std::shared_ptr<::client::thin_replica_client::BasicUpdateQueue> trc_queue_;
+  std::unique_ptr<::client::thin_replica_client::ThinReplicaClient> trc_;
 };
 
 }  // namespace concord::client::concordclient


### PR DESCRIPTION
This PR integrates the thin replica client into concord client. There is more to be done but with this change we got to play around with TRC initialization, using ConcordClientConfig, and subscribe/unsubscribe.
See commit messages for detail.

$> ./grpc_cli call localhost:1337 StreamEventGroups 'event_group_id:12'
connecting to localhost:1337