### PR TITLE
Fix a race condition in RSASigner::Impl::sign()

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -36,11 +36,6 @@ bftEngine::IReservedPages *bftEngine::ReservedPagesClientBase::res_pages_ = null
 
 namespace bftEngine::impl {
 
-namespace {
-bool cryptoInitialized = false;
-std::mutex mutexForCryptoInitialization;
-}  // namespace
-
 class ReplicaInternal : public IReplica {
   friend class IReplica;
 
@@ -141,14 +136,6 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
                                                  MetadataStorage *metadataStorage,
                                                  std::shared_ptr<concord::performance::PerformanceManager> pm,
                                                  const shared_ptr<concord::secretsmanager::ISecretsManagerImpl> &sm) {
-  {
-    std::lock_guard<std::mutex> lock(mutexForCryptoInitialization);
-    if (!cryptoInitialized) {
-      cryptoInitialized = true;
-      CryptographyWrapper::init();
-    }
-  }
-
   shared_ptr<PersistentStorage> persistentStoragePtr;
   if (replicaConfig.debugPersistentStorageEnabled)
     if (metadataStorage == nullptr)
@@ -251,14 +238,6 @@ IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaC
                                                    std::shared_ptr<IRequestsHandler> requestsHandler,
                                                    IStateTransfer *stateTransfer,
                                                    bft::communication::ICommunication *communication) {
-  {
-    std::lock_guard<std::mutex> lock(mutexForCryptoInitialization);
-    if (!cryptoInitialized) {
-      cryptoInitialized = true;
-      CryptographyWrapper::init();
-    }
-  }
-
   auto replicaInternal = std::make_unique<ReplicaInternal>();
   auto msgHandlers = std::make_shared<MsgHandlersRegistrator>();
   auto incomingMsgsStorageImpPtr =

--- a/bftengine/src/bftengine/Crypto.hpp
+++ b/bftengine/src/bftengine/Crypto.hpp
@@ -28,12 +28,6 @@ using std::string;
 
 namespace bftEngine {
 namespace impl {
-class CryptographyWrapper {
- public:
-  static void init(const char* randomSeed);
-  static void init();
-};
-
 // TODO(GG): define generic signer/verifier (not sure we want to use RSA)
 
 class ISigner {


### PR DESCRIPTION
The sign() method of RSASigner::Impl is const and thread-safe by itself
however it uses an instance of RandomPool which is not thread safe. As a
result concurrent calls to sign() lead to data races inside the
RandomPool.

This patch fixes this by making the RandomPool instance thread local.
This way each thread works with its own object and there are no races.

RandomPool is wrapped in a new type because an adequate default
constructor needs to be provided. Otherwise the object initialisation
becomes complicated.

Big  thanks to @dartdart26 for helping with the fix.