### PR TITLE
Use epochs in reconfiguration

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -59,6 +59,6 @@ class ControlStateManager {
   std::atomic_bool onPruningProcess_ = false;
   std::function<void(bool)> removeMetadata_;
   std::function<void()> sendRestartReady_;
-  std::map<uint32_t, concord::util::CallbackRegistry<>> onRestartProofCbRegistery_;
+  std::map<uint32_t, concord::util::CallbackRegistry<>> onRestartProofCbRegistry_;
 };
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -30,13 +30,13 @@ class ControlStateManager {
   void setStopAtNextCheckpoint(int64_t currentSeqNum);
   std::optional<int64_t> getCheckpointToStopAt();
 
-  void markRemoveMetadata(bool include_st = true) { removeMetadata_(include_st); }
+  void markRemoveMetadata(bool include_st = true) { removeMetadataCbRegistry_.invokeAll(include_st); }
   void setPruningProcess(bool onPruningProcess) { onPruningProcess_ = onPruningProcess; }
   bool getPruningProcessStatus() const { return onPruningProcess_; }
   bool getRestartBftFlag() const { return restartBftEnabled_; }
   void setRestartBftFlag(bool bft) { restartBftEnabled_ = bft; }
 
-  void setRemoveMetadataFunc(std::function<void(bool)> fn) { removeMetadata_ = fn; }
+  void setRemoveMetadataFunc(std::function<void(bool)> fn) { removeMetadataCbRegistry_.add(fn); }
   void setRestartReadyFunc(std::function<void()> fn) { sendRestartReady_ = fn; }
   void sendRestartReadyToAllReplica() { sendRestartReady_(); }
   void addOnRestartProofCallBack(std::function<void()> cb,
@@ -57,7 +57,7 @@ class ControlStateManager {
   std::atomic_bool restartBftEnabled_ = false;
   std::optional<SeqNum> hasRestartProofAtSeqNum_ = std::nullopt;
   std::atomic_bool onPruningProcess_ = false;
-  std::function<void(bool)> removeMetadata_;
+  concord::util::CallbackRegistry<bool> removeMetadataCbRegistry_;
   std::function<void()> sendRestartReady_;
   std::map<uint32_t, concord::util::CallbackRegistry<>> onRestartProofCbRegistry_;
 };

--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -45,8 +45,8 @@ class ControlStateManager {
   void checkForReplicaReconfigurationAction();
   void restart();
 
-  std::pair<bool, std::string> canUnwedge();
-  bool verifyUnwedgeSignatures(std::vector<std::pair<uint64_t, std::vector<uint8_t>>> const& signatures);
+  std::pair<bool, std::string> canUnwedge(bool bft);
+  bool verifyUnwedgeSignatures(std::vector<std::pair<uint64_t, std::vector<uint8_t>>> const& signatures, bool bft);
 
  private:
   ControlStateManager() = default;

--- a/bftengine/src/bftengine/ControlStateManager.cpp
+++ b/bftengine/src/bftengine/ControlStateManager.cpp
@@ -43,10 +43,10 @@ std::optional<int64_t> ControlStateManager::getCheckpointToStopAt() {
 }
 
 void ControlStateManager::addOnRestartProofCallBack(std::function<void()> cb, RestartProofHandlerPriorities priority) {
-  if (onRestartProofCbRegistery_.find(priority) == onRestartProofCbRegistery_.end()) {
-    onRestartProofCbRegistery_[static_cast<uint32_t>(priority)];
+  if (onRestartProofCbRegistry_.find(priority) == onRestartProofCbRegistry_.end()) {
+    onRestartProofCbRegistry_[static_cast<uint32_t>(priority)];
   }
-  onRestartProofCbRegistery_.at(static_cast<uint32_t>(priority)).add(std::move(cb));
+  onRestartProofCbRegistry_.at(static_cast<uint32_t>(priority)).add(std::move(cb));
 }
 void ControlStateManager::onRestartProof(const SeqNum& seq_num) {
   // If operator sends add-remove request with bft option then
@@ -55,7 +55,7 @@ void ControlStateManager::onRestartProof(const SeqNum& seq_num) {
   // configuration update happens on stable checkpoint.
   if ((restartBftEnabled_ && IControlHandler::instance()->isOnStableCheckpoint()) ||
       IControlHandler::instance()->isOnNOutOfNCheckpoint()) {
-    for (const auto& kv : onRestartProofCbRegistery_) {
+    for (const auto& kv : onRestartProofCbRegistry_) {
       kv.second.invokeAll();
     }
   }
@@ -66,7 +66,7 @@ void ControlStateManager::checkForReplicaReconfigurationAction() {
   auto seq_num_to_stop_at = getCheckpointToStopAt();
   if (seq_num_to_stop_at.has_value() && hasRestartProofAtSeqNum_.has_value() &&
       (seq_num_to_stop_at.value() == hasRestartProofAtSeqNum_.value())) {
-    for (const auto& kv : onRestartProofCbRegistery_) {
+    for (const auto& kv : onRestartProofCbRegistry_) {
       kv.second.invokeAll();
     }
   }
@@ -128,7 +128,7 @@ bool ControlStateManager::verifyUnwedgeSignatures(
 }
 
 void ControlStateManager::restart() {
-  for (const auto& kv : onRestartProofCbRegistery_) {
+  for (const auto& kv : onRestartProofCbRegistry_) {
     kv.second.invokeAll();
   }
 }

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -40,7 +40,9 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                   metrics_.RegisterCounter("receivedInvalidMsgs"),
                   metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)} {
   LOG_INFO(GL, "");
-  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&]() { stateTransfer->setEraseMetadataFlag(); });
+  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool include_st) {
+    if (include_st) stateTransfer->setEraseMetadataFlag();
+  });
   repsInfo = new ReplicasInfo(config, dynamicCollectorForPartialProofs, dynamicCollectorForExecutionProofs);
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint,
                                    bind(&ReadOnlyReplica::messageHandler<CheckpointMsg>, this, std::placeholders::_1));

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -40,9 +40,6 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                   metrics_.RegisterCounter("receivedInvalidMsgs"),
                   metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)} {
   LOG_INFO(GL, "");
-  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool include_st) {
-    if (include_st) stateTransfer->setEraseMetadataFlag();
-  });
   repsInfo = new ReplicasInfo(config, dynamicCollectorForPartialProofs, dynamicCollectorForExecutionProofs);
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint,
                                    bind(&ReadOnlyReplica::messageHandler<CheckpointMsg>, this, std::placeholders::_1));

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -39,6 +39,9 @@ ReplicaForStateTransfer::ReplicaForStateTransfer(const ReplicaConfig &config,
       metric_state_transfer_timer_{metrics_.RegisterGauge("replicaForStateTransferTimer", 0)},
       firstTime_(firstTime) {
   LOG_INFO(GL, "");
+  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool include_st) {
+    if (include_st) this->stateTransfer->setEraseMetadataFlag();
+  });
   msgHandlers_->registerMsgHandler(
       MsgCode::StateTransfer,
       std::bind(&ReplicaForStateTransfer::messageHandler<StateTransferMsg>, this, std::placeholders::_1));

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3379,10 +3379,7 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
   ConcordAssertNE(persistentStorage, nullptr);
 
   ps_ = persistentStorage;
-  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool include_st) {
-    ps_->setEraseMetadataStorageFlag();
-    if (include_st) stateTransfer->setEraseMetadataFlag();
-  });
+  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool) { ps_->setEraseMetadataStorageFlag(); });
   bftEngine::ControlStateManager::instance().setRestartReadyFunc([&]() { sendRepilcaRestartReady(); });
   bftEngine::EpochManager::instance().setNewEpochFlagHandler(std::bind(&PersistentStorage::setNewEpochFlag, ps_, _1));
   lastAgreedView = ld.viewsManager->latestActiveView();
@@ -3628,10 +3625,7 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
   LOG_INFO(GL, "");
   if (persistentStorage != nullptr) {
     ps_ = persistentStorage;
-    bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool include_st) {
-      ps_->setEraseMetadataStorageFlag();
-      if (include_st) stateTransfer->setEraseMetadataFlag();
-    });
+    bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool) { ps_->setEraseMetadataStorageFlag(); });
     bftEngine::ControlStateManager::instance().setRestartReadyFunc([&]() { sendRepilcaRestartReady(); });
     bftEngine::EpochManager::instance().setNewEpochFlagHandler(std::bind(&PersistentStorage::setNewEpochFlag, ps_, _1));
   }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3379,11 +3379,10 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
   ConcordAssertNE(persistentStorage, nullptr);
 
   ps_ = persistentStorage;
-  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&]() {
+  bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool include_st) {
     ps_->setEraseMetadataStorageFlag();
-    stateTransfer->setEraseMetadataFlag();
+    if (include_st) stateTransfer->setEraseMetadataFlag();
   });
-
   bftEngine::ControlStateManager::instance().setRestartReadyFunc([&]() { sendRepilcaRestartReady(); });
   bftEngine::EpochManager::instance().setNewEpochFlagHandler(std::bind(&PersistentStorage::setNewEpochFlag, ps_, _1));
   lastAgreedView = ld.viewsManager->latestActiveView();
@@ -3629,9 +3628,9 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
   LOG_INFO(GL, "");
   if (persistentStorage != nullptr) {
     ps_ = persistentStorage;
-    bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&]() {
+    bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool include_st) {
       ps_->setEraseMetadataStorageFlag();
-      stateTransfer->setEraseMetadataFlag();
+      if (include_st) stateTransfer->setEraseMetadataFlag();
     });
     bftEngine::ControlStateManager::instance().setRestartReadyFunc([&]() { sendRepilcaRestartReady(); });
     bftEngine::EpochManager::instance().setNewEpochFlagHandler(std::bind(&PersistentStorage::setNewEpochFlag, ps_, _1));
@@ -3914,12 +3913,6 @@ void ReplicaImp::start() {
   if (config_.timeServiceEnabled) {
     time_service_manager_.emplace();
     LOG_INFO(GL, "Time Service enabled");
-  }
-  // If we have just unwedged, clear the wedge point
-  auto seqNumToStopAt = ControlStateManager::instance().getCheckpointToStopAt();
-  if (seqNumToStopAt.has_value() && lastStableSeqNum == seqNumToStopAt.value()) {
-    LOG_INFO(GL, "unwedge the system" << KVLOG(lastStableSeqNum));
-    ControlStateManager::instance().clearCheckpointToStopAt();
   }
 
   if (!firstTime_ || config_.getdebugPersistentStorageEnabled()) clientsManager->loadInfoFromReservedPages();

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -138,6 +138,7 @@ class Replica : public IReplica,
   void createReplicaAndSyncState();
   void registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler);
   void handleNewEpochEvent();
+  void handleWedgeEvent();
   // INTERNAL TYPES
 
   // represents <key,blockId>

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -139,6 +139,7 @@ class Replica : public IReplica,
   void registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler);
   void handleNewEpochEvent();
   void handleWedgeEvent();
+  uint64_t getStoredReconfigData(const std::string &kCategory, const std::string &key, const kvbc::BlockId &bid);
   // INTERNAL TYPES
 
   // represents <key,blockId>

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -105,6 +105,11 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               uint64_t sequence_number,
               concord::messages::ReconfigurationResponse& response) override;
   bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
+
+  bool handle(const concord::messages::UnwedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::UnwedgeStatusRequest&,
+              uint64_t,
+              concord::messages::ReconfigurationResponse&) override;
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop commands)

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -337,9 +337,9 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
   if (!bftEngine::ControlStateManager::instance().getCheckpointToStopAt().has_value()) {
     LOG_INFO(getLogger(), "replica is already unwedge");
   }
-  LOG_INFO(getLogger(), "Unwedge command started " << KVLOG(cmd.bft));
+  LOG_INFO(getLogger(), "Unwedge command started " << KVLOG(cmd.bft_support));
   auto& controlStateManager = bftEngine::ControlStateManager::instance();
-  bool valid = controlStateManager.verifyUnwedgeSignatures(cmd.signatures, cmd.bft);
+  bool valid = controlStateManager.verifyUnwedgeSignatures(cmd.signatures, cmd.bft_support);
   if (valid) {
     auto newEpoch = bftEngine::EpochManager::instance().getSelfEpochNumber() + 1;
     concord::kvbc::categorization::VersionedUpdates ver_updates;
@@ -360,7 +360,7 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeStatusRequest& req,
                                     uint64_t,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::UnwedgeStatusResponse response;
-  auto can_unwedge = bftEngine::ControlStateManager::instance().canUnwedge(req.bft);
+  auto can_unwedge = bftEngine::ControlStateManager::instance().canUnwedge(req.bft_support);
   response.replica_id = bftEngine::ReplicaConfig::instance().replicaId;
   if (!can_unwedge.first) {
     response.can_unwedge = false;

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -98,9 +98,14 @@ bool StReconfigurationHandler::handle(const concord::messages::WedgeCommand &,
 
   if (my_last_known_epoch == command_epoch && my_last_known_epoch == last_known_global_epoch) {
     bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
+    return true;
   }
-  // In any other case, it is either the case where we are already in a futuer epoch or we were in previous epoch.
-  // in both cases, there is no need to wedge.
+
+  if (command_epoch < last_known_global_epoch) {
+    LOG_INFO(GL, "unwedge due to higher epoch number after state transfer");
+    bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(0);
+  }
+  bftEngine::EpochManager::instance().setSelfEpochNumber(bftEngine::EpochManager::instance().getGlobalEpochNumber());
   return true;
 }
 bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand &command,

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -153,8 +153,8 @@ bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedg
     // So lets simple run manually the concord-bft's reconfiguration handler.
 
     // First let's set the callbacks on wedgepoint.
-    bftEngine::ControlStateManager::instance().setRestartBftFlag(command.bft);
-    if (command.bft) {
+    bftEngine::ControlStateManager::instance().setRestartBftFlag(command.bft_support);
+    if (command.bft_support) {
       bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack([=]() {
         bftEngine::ControlStateManager::instance().markRemoveMetadata();
         bftEngine::EpochManager::instance().setNewEpochFlag(true);

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -874,7 +874,6 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
 
 int main(int argc, char **argv) {
   setUpKeysConfiguration_4();
-  bftEngine::ControlStateManager::ControlStateManager::setReservedPages(&state_transfer);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -103,7 +103,7 @@ Msg AddRemoveStatusResponse 28 {
 Msg AddRemoveWithWedgeCommand 29 {
     string config_descriptor
     string token
-    bool bft
+    bool bft_support
     bool restart
 }
 
@@ -117,7 +117,7 @@ Msg AddRemoveWithWedgeStatusResponse 31 {
 
 Msg UnwedgeStatusRequest 32{
     uint64 sender
-    bool bft
+    bool bft_support
 }
 
 Msg UnwedgeStatusResponse 33{
@@ -130,7 +130,7 @@ Msg UnwedgeStatusResponse 33{
 Msg UnwedgeCommand 34{
     uint64 sender
     list kvpair uint64 bytes signatures
-    bool bft
+    bool bft_support
 }
 Msg ClientKeyExchangeCommand 35 {
     list uint64 target_clients
@@ -170,7 +170,7 @@ Msg ClientReconfigurationLastUpdate 41 {
 }
 
 Msg RestartCommand 42 {
-    bool bft
+    bool bft_support
     bool restart
     string data
 }

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -117,6 +117,7 @@ Msg AddRemoveWithWedgeStatusResponse 31 {
 
 Msg UnwedgeStatusRequest 32{
     uint64 sender
+    bool bft
 }
 
 Msg UnwedgeStatusResponse 33{
@@ -129,6 +130,7 @@ Msg UnwedgeStatusResponse 33{
 Msg UnwedgeCommand 34{
     uint64 sender
     list kvpair uint64 bytes signatures
+    bool bft
 }
 Msg ClientKeyExchangeCommand 35 {
     list uint64 target_clients

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -44,11 +44,6 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
               uint64_t,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
-
-  bool handle(const concord::messages::UnwedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
-  bool handle(const concord::messages::UnwedgeStatusRequest&,
-              uint64_t,
-              concord::messages::ReconfigurationResponse&) override;
 };
 
 class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -141,39 +141,6 @@ bool BftReconfigurationHandler::verifySignature(uint32_t sender_id,
   return pub_key_->verify(data, signature) || verifier_->verify(data, signature);
 }
 
-bool ReconfigurationHandler::handle(const UnwedgeCommand& cmd,
-                                    uint64_t bft_seq_num,
-                                    concord::messages::ReconfigurationResponse&) {
-  LOG_INFO(getLogger(), "Unwedge command started");
-  auto& controlStateManager = bftEngine::ControlStateManager::instance();
-  bool valid = controlStateManager.verifyUnwedgeSignatures(cmd.signatures);
-  if (valid) {
-    controlStateManager.setStopAtNextCheckpoint(0);
-    bftEngine::IControlHandler::instance()->resetState();
-    LOG_INFO(getLogger(), "Unwedge command completed sucessfully");
-  }
-  return valid;
-}
-
-bool ReconfigurationHandler::handle(const UnwedgeStatusRequest& req,
-                                    uint64_t,
-                                    concord::messages::ReconfigurationResponse& rres) {
-  concord::messages::UnwedgeStatusResponse response;
-  auto can_unwedge = bftEngine::ControlStateManager::instance().canUnwedge();
-  response.replica_id = bftEngine::ReplicaConfig::instance().replicaId;
-  if (!can_unwedge.first) {
-    response.can_unwedge = false;
-    response.reason = can_unwedge.second;
-    LOG_INFO(getLogger(), "Replica is not ready to unwedge. Reason: " << can_unwedge.second);
-  } else {
-    response.can_unwedge = true;
-    response.signature = std::vector<uint8_t>(can_unwedge.second.begin(), can_unwedge.second.end());
-    LOG_INFO(getLogger(), "Replica is ready to unwedge");
-  }
-  rres.response = response;
-  return true;
-}
-
 bool ClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& msg,
                                           uint64_t,
                                           concord::messages::ReconfigurationResponse&) {

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -63,8 +63,8 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "AddRemoveWithWedgeCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
-  bftEngine::ControlStateManager::instance().setRestartBftFlag(command.bft);
-  if (command.bft) {
+  bftEngine::ControlStateManager::instance().setRestartBftFlag(command.bft_support);
+  if (command.bft_support) {
     bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack([=]() {
       bftEngine::ControlStateManager::instance().markRemoveMetadata();
       bftEngine::EpochManager::instance().setNewEpochFlag(true);
@@ -91,8 +91,8 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "RestartCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
-  bftEngine::ControlStateManager::instance().setRestartBftFlag(command.bft);
-  if (command.bft) {
+  bftEngine::ControlStateManager::instance().setRestartBftFlag(command.bft_support);
+  if (command.bft_support) {
     bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack(
         [=]() { bftEngine::ControlStateManager::instance().markRemoveMetadata(); });
     if (command.restart) {

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -925,7 +925,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         for i in range(500):
             await skvbc.write_known_kv()
         client = bft_network.random_client()
-        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
         op = operator.Operator(bft_network.config, client,  bft_network.builddir)
         await op.restart("hello", bft=False, restart=False)
         await self.validate_stop_on_wedge_point(bft_network, skvbc, fullWedge=True)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1263,7 +1263,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         on_time_replicas = bft_network.all_replicas(without=new_replicas)
         bft_network.start_replicas(on_time_replicas)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
@@ -1275,7 +1275,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.start_replicas(new_replicas)
 
         # The new replicas have just removed thier metadata, to let them catch up we need to start aonther state transfer
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         await bft_network.wait_for_state_transfer_to_start()
         for r in new_replicas:
@@ -1316,7 +1316,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         on_time_replicas = bft_network.all_replicas(without=new_replicas)
         bft_network.start_replicas(on_time_replicas)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
@@ -1328,7 +1328,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.stop_replicas(new_replicas)
         bft_network.start_replicas(new_replicas)
         # The new replicas have just removed thier metadata, to let them catch up we need to start aonther state transfer
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         await bft_network.wait_for_state_transfer_to_start()
         for r in new_replicas:
@@ -1404,7 +1404,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         on_time_replicas = bft_network.all_replicas(without=new_replicas)
         bft_network.start_replicas(on_time_replicas)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         bft_network.start_replicas(new_replicas)
         await bft_network.wait_for_state_transfer_to_start()
@@ -1415,7 +1415,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
         bft_network.stop_replicas(new_replicas)
         bft_network.start_replicas(new_replicas)
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         await bft_network.wait_for_state_transfer_to_start()
         for r in new_replicas:
@@ -1457,7 +1457,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         on_time_replicas = bft_network.all_replicas(without=late_replicas)
         bft_network.start_replicas(on_time_replicas)
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         bft_network.start_replicas(late_replicas)
         await bft_network.wait_for_state_transfer_to_start()
@@ -1468,7 +1468,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
         bft_network.stop_replicas(late_replicas)
         bft_network.start_replicas(late_replicas)
-        for i in range(300):
+        for i in range(350):
             await skvbc.write_known_kv()
         await bft_network.wait_for_state_transfer_to_start()
         for r in new_replicas:
@@ -1512,78 +1512,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
             assert status.response.error_msg == 'key_not_found'
             assert status.success is False
-
-    @with_trio
-    @with_bft_network(start_replica_cmd, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}])
-    async def test_epoch_mechanism(self, bft_network):
-        """
-           Test the  epoch mechanism
-           1. start all replicas but 1
-           2. generate 2 epochs
-           3. start the crashed replica
-           4. verify that all replicas are in new epoch
-         """
-        initial_prim = 0
-        crashed_replica = bft_network.random_set_of_replicas(1, {initial_prim})
-        live_replicas = bft_network.all_replicas(without=crashed_replica)
-        bft_network.start_replicas(live_replicas)
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        for i in range(100):
-            await skvbc.write_known_kv()
-        key, val = await skvbc.write_known_kv()
-        client = bft_network.random_client()
-        client.config._replace(req_timeout_milli=10000)
-        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
-        op = operator.Operator(bft_network.config, client,  bft_network.builddir)
-        test_config = 'new_configuration_n_4_f_1_c_0'
-        await op.add_remove_with_wedge(test_config, bft=True)
-        await self.validate_stop_on_wedge_point(bft_network, skvbc, fullWedge=False)
-
-        # restart the live replicas
-        bft_network.stop_replicas(live_replicas)
-        bft_network.start_replicas(live_replicas)
-
-        for i in range(300):
-            await skvbc.write_known_kv()
-
-        # We expect the restarted replicas to be at the next quorum
-        for r in live_replicas:
-            epoch = await bft_network.get_metric(r, bft_network, "Gauges", "epoch_number", component="epoch_manager")
-            self.assertEqual(epoch, 1)
-
-        # Now, lets trigger another epoch change
-        await op.add_remove_with_wedge(test_config, bft=True)
-        await self.validate_stop_on_wedge_point(bft_network, skvbc, fullWedge=False)
-
-        # start a new epoch
-        bft_network.stop_replicas(live_replicas)
-        bft_network.start_replicas(live_replicas)
-
-        for r in live_replicas:
-            epoch = await bft_network.get_metric(r, bft_network, "Gauges", "epoch_number", component="epoch_manager")
-            self.assertEqual(epoch, 2)
-
-        for i in range(300):
-            await skvbc.write_known_kv()
-
-        # We now start the crashed replica and we expect it not to start a new epoch
-        bft_network.start_replicas(crashed_replica)
-
-        # let the crashed replica to catch up the state
-        await bft_network.wait_for_state_transfer_to_start()
-        for r in crashed_replica:
-            await bft_network.wait_for_state_transfer_to_stop(initial_prim,
-                                                              r,
-                                                              stop_on_stable_seq_num=False)
-
-        bft_network.stop_replicas(crashed_replica)
-        bft_network.start_replicas(crashed_replica)
-
-        # we expect all replicas to be now at epoch 2
-        for r in bft_network.all_replicas():
-            epoch = await bft_network.get_metric(r, bft_network, "Gauges", "epoch_number", component="epoch_manager")
-            self.assertEqual(epoch, 2)
-
 
     async def validate_stop_on_wedge_point(self, bft_network, skvbc, fullWedge=False):
         with log.start_action(action_type="validate_stop_on_stable_checkpoint") as action:

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -62,15 +62,16 @@ class Operator:
         wedge_status_cmd.fullWedge = fullWedge
         return self._construct_basic_reconfiguration_request(wedge_status_cmd)
 
-    def _construct_reconfiguration_unwedge_status(self):
+    def _construct_reconfiguration_unwedge_status(self, bft):
         unwedge_status_cmd = cmf_msgs.UnwedgeStatusRequest()
         unwedge_status_cmd.sender = 1000
+        unwedge_status_cmd.bft = bft
         return self._construct_basic_reconfiguration_request(unwedge_status_cmd)
 
-    def _construct_reconfiguration_unwedge_command(self, signatures):
+    def _construct_reconfiguration_unwedge_command(self, signatures, bft):
         unwedge_cmd = cmf_msgs.UnwedgeCommand()
         unwedge_cmd.sender = 1000
-        unwedge_cmd.noop = False
+        unwedge_cmd.bft = bft
         unwedge_cmd.signatures = signatures
         return self._construct_basic_reconfiguration_request(unwedge_cmd)
 
@@ -153,22 +154,25 @@ class Operator:
         msg = self._construct_reconfiguration_wedge_status(fullWedge)
         return await self.client.read(msg.serialize(), m_of_n_quorum=quorum, reconfiguration=True)
 
-    async def unwedge(self):
-        await self.can_unwedge()
+    async def unwedge(self, bft=False):
+        quorum = None
+        if bft is True:
+            quorum = bft_client.MofNQuorum.LinearizableQuorum(self.client.config, [r for r in range(self.config.n)])
+        await self.can_unwedge(quorum=quorum, bft=bft)
         signatures = []
         for r in self.client.get_rsi_replies().values():
             res = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
             signatures.append(
                 (res.response.replica_id, bytes(res.response.signature)))
 
-        msg = self._construct_reconfiguration_unwedge_command(signatures)
-        return await self.client.read(msg.serialize(), reconfiguration=True)
+        msg = self._construct_reconfiguration_unwedge_command(signatures, bft)
+        return await self.client.read(msg.serialize(), m_of_n_quorum=quorum, reconfiguration=True)
 
-    async def can_unwedge(self, quorum=None, fullWedge=True):
+    async def can_unwedge(self, quorum=None, bft=False):
         if quorum is None:
             quorum = bft_client.MofNQuorum.All(
                 self.client.config, [r for r in range(self.config.n)])
-        msg = self._construct_reconfiguration_unwedge_status()
+        msg = self._construct_reconfiguration_unwedge_status(bft)
         return await self.client.read(msg.serialize(), m_of_n_quorum=quorum, reconfiguration=True)
 
     async def latest_pruneable_block(self):

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -65,13 +65,13 @@ class Operator:
     def _construct_reconfiguration_unwedge_status(self, bft):
         unwedge_status_cmd = cmf_msgs.UnwedgeStatusRequest()
         unwedge_status_cmd.sender = 1000
-        unwedge_status_cmd.bft = bft
+        unwedge_status_cmd.bft_support = bft
         return self._construct_basic_reconfiguration_request(unwedge_status_cmd)
 
     def _construct_reconfiguration_unwedge_command(self, signatures, bft):
         unwedge_cmd = cmf_msgs.UnwedgeCommand()
         unwedge_cmd.sender = 1000
-        unwedge_cmd.bft = bft
+        unwedge_cmd.bft_support = bft
         unwedge_cmd.signatures = signatures
         return self._construct_basic_reconfiguration_request(unwedge_cmd)
 
@@ -103,7 +103,7 @@ class Operator:
         addRemove_command = cmf_msgs.AddRemoveWithWedgeCommand()
         addRemove_command.config_descriptor = new_config
         addRemove_command.token = "dummy"
-        addRemove_command.bft = bft
+        addRemove_command.bft_support = bft
         addRemove_command.restart = restart
         return self._construct_basic_reconfiguration_request(addRemove_command)
 
@@ -124,7 +124,7 @@ class Operator:
 
     def _construct_reconfiguration_restart_command(self, bft, restart, data):
         restart_command = cmf_msgs.RestartCommand()
-        restart_command.bft = bft
+        restart_command.bft_support = bft
         restart_command.restart = restart
         restart_command.data = data
         return self._construct_basic_reconfiguration_request(restart_command)

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -129,10 +129,11 @@ class Operator:
         restart_command.data = data
         return self._construct_basic_reconfiguration_request(restart_command)
     
-    def _construct_reconfiguration_clientExchangePublicKey_(self, clientId, clientPubKey):
+    def _construct_reconfiguration_clientExchangePublicKey_(self, clientId, clientPubKey, effected_clients = []):
         cepk = cmf_msgs.ClientExchangePublicKey()
         cepk.sender_id = clientId
         cepk.pub_key = clientPubKey
+        cepk.effected_clients = effected_clients
         return self._construct_basic_reconfiguration_request(cepk)
     
     def _generate_client_keys(self):

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -149,7 +149,6 @@ class SimpleTestReplica {
   std::thread *runnerThread = nullptr;
   ISimpleTestReplicaBehavior *behaviorPtr;
   IRequestsHandler *statePtr;
-  bftEngine::SimpleInMemoryStateTransfer::ISimpleInMemoryStateTransfer *inMemoryST_;
 
  public:
   SimpleTestReplica(ICommunication *commObject,
@@ -158,7 +157,7 @@ class SimpleTestReplica {
                     ISimpleTestReplicaBehavior *behvPtr,
                     bftEngine::SimpleInMemoryStateTransfer::ISimpleInMemoryStateTransfer *inMemoryST,
                     MetadataStorage *metaDataStorage)
-      : comm{commObject}, replicaConfig{rc}, behaviorPtr{behvPtr}, statePtr(state), inMemoryST_(inMemoryST) {
+      : comm{commObject}, replicaConfig{rc}, behaviorPtr{behvPtr}, statePtr(state) {
     replica = IReplica::createNewReplica(rc,
                                          std::shared_ptr<bftEngine::IRequestsHandler>(state),
                                          inMemoryST,
@@ -185,11 +184,7 @@ class SimpleTestReplica {
 
   uint16_t get_replica_id() { return replicaConfig.replicaId; }
 
-  void start() {
-    replica->start();
-    ControlStateManager::setReservedPages(inMemoryST_);
-    ControlStateManager::instance().disable();
-  }
+  void start() { replica->start(); }
 
   void stop() {
     replica->stop();


### PR DESCRIPTION
In this PR we use the epochs infra in reconfiguration.
We use it in two cases:
1. unwedge
2. add/remove command

By using epochs in unwedge, we let the replicas start with a read request only. As long as we don't have n-f that starts the new epoch, no new requests will be processed.
In addition, once a replica is starting, it wedges itself if needed (there is a wedge block and no new epoch block).

If some of the replicas didn't get the unwedge command (as this is a read request), we have the following options:
1. If less than f + 1 replicas are still wedged, then once they complete the next state transfer they get the update of the new epoch and they can unwedge.
2. If more than f replicas are unwedged, the operator must retransmit the original unwedge command.

For add/remove, we designed the state transfer mechanism to know when to remove the metadata (or part of it)
In addition, we improved the Apollo tests to take in consideration the epoch number