### PR TITLE
ClientsManager refactoring:

### DIFF
--- a/bftengine/src/bftengine/InternalBFTClient.cpp
+++ b/bftengine/src/bftengine/InternalBFTClient.cpp
@@ -15,11 +15,6 @@
 #include "chrono"
 #include "Logger.hpp"
 
-InternalBFTClient::InternalBFTClient(const int& id,
-                                     const NodeIdType& nonInternalNum,
-                                     std::shared_ptr<MsgsCommunicator>& msgComm)
-    : repID_(id), startIdForInternalClient_(nonInternalNum + 1), msgComm_(msgComm) {}
-
 uint64_t InternalBFTClient::sendRequest(uint64_t flags,
                                         uint32_t requestLength,
                                         const char* request,

--- a/bftengine/src/bftengine/InternalBFTClient.hpp
+++ b/bftengine/src/bftengine/InternalBFTClient.hpp
@@ -28,15 +28,14 @@ class IInternalBFTClient {
 
 class InternalBFTClient : public IInternalBFTClient {
  public:
-  InternalBFTClient(const int& id, const NodeIdType& nonInternalNum, std::shared_ptr<MsgsCommunicator>& msgComm);
-  inline NodeIdType getClientId() const { return repID_ + startIdForInternalClient_; };
+  InternalBFTClient(NodeIdType id, std::shared_ptr<MsgsCommunicator>& msgComm) : id_{id}, msgComm_(msgComm) {}
+  NodeIdType getClientId() const { return id_; }
   uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid);
   uint32_t numOfConnectedReplicas(uint32_t clusterSize) { return msgComm_->numOfConnectedReplicas(clusterSize); }
   bool isUdp() const { return msgComm_->isUdp(); }
 
  private:
-  uint32_t repID_{};
-  NodeIdType startIdForInternalClient_{};
+  NodeIdType id_;
   std::shared_ptr<MsgsCommunicator> msgComm_;
 };
 

--- a/bftengine/tests/clientsManager/ClientsManager_test.cpp
+++ b/bftengine/tests/clientsManager/ClientsManager_test.cpp
@@ -18,7 +18,7 @@ using namespace std;
 using namespace bftEngine;
 concordMetrics::Component metrics{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())};
 
-TEST(ClientsManager, reservedPagesPerClient) {
+TEST(ClientsManager, ) {
   uint32_t sizeOfReservedPage = 1024;
   uint32_t maxReplysize = 1000;
   auto numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize);
@@ -32,33 +32,9 @@ TEST(ClientsManager, reservedPagesPerClient) {
 }
 
 TEST(ClientsManager, constructor) {
-  std::set<bftEngine::impl::NodeIdType> clset{1, 4, 50, 7};
-  bftEngine::impl::ClientsManager cm{metrics, clset};
-  ASSERT_EQ(50, cm.getHighestIdOfNonInternalClient());
-  auto i = 0;
-  for (auto id : clset) {
-    ASSERT_EQ(i, cm.getIndexOfClient(id));
-    ASSERT_EQ(false, cm.isInternal(id));
-    ++i;
-  }
-}
-
-// Test that interanl clients are added to Client manager data structures
-// and are identifed as internal clients
-TEST(ClientsManager, initInternalClientInfo) {
-  std::set<bftEngine::impl::NodeIdType> clset{1, 4, 50, 7};
-  bftEngine::impl::ClientsManager cm{metrics, clset};
-  auto firstIntClId = cm.getHighestIdOfNonInternalClient() + 1;
-  auto FirstIntIdx = cm.getIndexOfClient(cm.getHighestIdOfNonInternalClient()) + 1;
-  auto numRep = 7;
-  cm.initInternalClientInfo(numRep);
-  for (int i = 0; i < numRep; i++) {
-    ASSERT_EQ(true, cm.isValidClient(firstIntClId + i));
-    ASSERT_EQ(true, cm.isInternal(firstIntClId + 1));
-    ASSERT_EQ(FirstIntIdx + i, cm.getIndexOfClient(firstIntClId + i));
-  }
-  // One over the end
-  ASSERT_EQ(false, cm.isValidClient(firstIntClId + numRep));
+  bftEngine::impl::ClientsManager cm{{1, 4, 50, 7}, {3, 2, 60}, {5, 11, 55}, metrics};
+  for (auto id : {5, 11, 55}) ASSERT_EQ(true, cm.isInternal(id));
+  for (auto id : {1, 4, 50, 3, 2, 60}) ASSERT_EQ(false, cm.isInternal(id));
 }
 
 int main(int argc, char **argv) {

--- a/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
+++ b/tests/simpleKVBC/scripts/readOnlyReplicaTest.sh
@@ -4,6 +4,7 @@ cleanup() {
   killall -q skvbc_replica || true
   rm -rf simpleKVBTests_DB_*
   rm -rf ro_config_*
+  rm -rf gen-sec.*
 }
 
 trap 'cleanup' SIGINT


### PR DESCRIPTION
- Replace clientIdToIndex_ map and indexToClientInfo_ vector indirection by std::unordered_map<NodeIdType, ClientInfo> clientsInfo_;
- Simplify internal bft clients handling.