### PR TITLE
Destroy RocksDB object before cleanup in tests

### DIFF
--- a/kvbc/test/categorization/block_merkle_category_unit_test.cpp
+++ b/kvbc/test/categorization/block_merkle_category_unit_test.cpp
@@ -136,11 +136,19 @@ std::set<LeafKey> deserializeLeafKeys(const std::vector<std::vector<uint8_t>> &s
 
 class block_merkle_category : public Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
     cat = BlockMerkleCategory{db};
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    cat = BlockMerkleCategory{};
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   auto add(BlockId block_id, BlockMerkleInput &&update) {

--- a/kvbc/test/categorization/blockchain_test.cpp
+++ b/kvbc/test/categorization/blockchain_test.cpp
@@ -31,10 +31,17 @@ namespace {
 
 class categorized_kvbc : public ::testing::Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   std::shared_ptr<NativeClient> db;

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -35,12 +35,19 @@ namespace {
 
 class categorized_kvbc : public ::testing::Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
     db->createColumnFamily(BLOCKS_CF);
     db->createColumnFamily(ST_CHAIN_CF);
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   std::shared_ptr<NativeClient> db;

--- a/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/immutable_kv_category_unit_test.cpp
@@ -40,11 +40,19 @@ using namespace std::literals;
 
 class immutable_kv_category : public Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
     cat = ImmutableKeyValueCategory{category_id, db};
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    cat = ImmutableKeyValueCategory{};
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   auto add(BlockId block_id, ImmutableInput &&update) {

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -31,10 +31,17 @@ namespace {
 
 class categorized_kvbc : public ::testing::Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   std::shared_ptr<NativeClient> db;

--- a/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
@@ -40,11 +40,19 @@ using namespace std::literals;
 
 class versioned_kv_category : public Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
     cat = VersionedKeyValueCategory{category_id, db};
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    cat = VersionedKeyValueCategory{};
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   auto add(BlockId block_id, VersionedInput &&in) {

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -338,10 +338,17 @@ void setUpKeysConfiguration_4() {
 
 class test_rocksdb : public ::testing::Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   std::shared_ptr<NativeClient> db;

--- a/kvbc/test/replica_state_sync_test.cpp
+++ b/kvbc/test/replica_state_sync_test.cpp
@@ -54,7 +54,7 @@ using namespace std::literals;
 
 class replica_state_sync_test : public Test, public IReader {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db_ = TestRocksDb::createNative();
     const auto link_st_chain = true;
     blockchain_.emplace(
@@ -71,7 +71,16 @@ class replica_state_sync_test : public Test, public IReader {
     metadata_->init(std::move(db_metadata_storage));
   }
 
-  void TearDown() override { cleanup(); }
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    blockchain_.reset();
+    metadata_.reset();
+    db_.reset();
+    ASSERT_EQ(0, db_.use_count());
+    ASSERT_EQ(0, metadata_.use_count());
+    cleanup();
+  }
 
  public:
   std::optional<Value> get(const std::string &category_id, const std::string &key, BlockId block_id) const override {

--- a/storage/test/native_rocksdb_client_test.cpp
+++ b/storage/test/native_rocksdb_client_test.cpp
@@ -32,10 +32,17 @@ using namespace std::literals;
 
 class native_rocksdb_test : public Test {
   void SetUp() override {
-    cleanup();
+    destroyDb();
     db = TestRocksDb::createNative();
   }
-  void TearDown() override { cleanup(); }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
 
  protected:
   std::shared_ptr<NativeClient> db;


### PR DESCRIPTION
Make sure the RocksDB object is destroyed before removing the RocksDB
directory. This ensures RocksDB is shutdown properly.

In order to achieve it, make sure no references to the DB are kept as
test members.