### PR TITLE
Apollo test fixes for client_transaction_signing and ro_replica

### DIFF
--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -177,7 +177,8 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
             num_of_checkpoints_to_add=1,
-            verify_checkpoint_persistency=False
+            verify_checkpoint_persistency=False,
+            assert_state_transfer_not_started=False
         )
 
         await self._wait_for_st(bft_network, ro_replica_id)
@@ -207,7 +208,8 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
             num_of_checkpoints_to_add=1,
-            verify_checkpoint_persistency=False
+            verify_checkpoint_persistency=False,
+            assert_state_transfer_not_started=False
         )
 
         await self._wait_for_st(bft_network, ro_replica_id)
@@ -237,7 +239,8 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
             num_of_checkpoints_to_add=1,
-            verify_checkpoint_persistency=False
+            verify_checkpoint_persistency=False,
+            assert_state_transfer_not_started=False
         )
 
         await self._wait_for_st(bft_network, ro_replica_id)
@@ -273,7 +276,8 @@ class SkvbcReadOnlyReplicaTest(unittest.TestCase):
         await skvbc.fill_and_wait_for_checkpoint(
             initial_nodes=bft_network.all_replicas(),
             num_of_checkpoints_to_add=1,
-            verify_checkpoint_persistency=False
+            verify_checkpoint_persistency=False,
+            assert_state_transfer_not_started=False
         )
         n = bft_network.config.n
         f = bft_network.config.f

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -364,15 +364,15 @@ class BftClient(ABC):
 
         if "corrupt_msg" in corrupt_params:
             pos = random.randint(1, len(msg)-2)
-            val = msg[pos] + 1
+            val = (msg[pos] + 1)  % 256     # to avoid ValueError: bytes must be in range(0, 256)
             msg = bytes(msg[0:pos]) + bytes([val]) + bytes(msg[pos+1:])
         if "corrupt_signature" in corrupt_params:
             pos = random.randint(1, len(signature)-2)
-            val = signature[pos] + 1
+            val = (signature[pos] + 1) % 256    # to avoid ValueError: bytes must be in range(0, 256)
             signature = bytes(signature[0:pos]) + bytes([val]) + bytes(signature[pos+1:])
         if "wrong_msg_length" in corrupt_params:
             pos = random.randint(1, len(msg)-2)
-            val = msg[pos]
+            val = msg[pos] % 256    # to avoid ValueError: bytes must be in range(0, 256)
             msg = bytes(msg) + bytes([val])
         if "wrong_signature_length" in corrupt_params:
             pos = random.randint(1, len(signature)-2)


### PR DESCRIPTION
This PR fixes two failing Apollo tests.

* test_skvbc_client_transaction_signing - a bug _corrupt_signing_params was causing error. 
* test_skvbc_ro_replica - bad call fill_and_wait_for_checkpoint was causing assert error.

Check the individual commit messages for details about each fix.