### PR TITLE
Reconfiguration restart command

### DIFF
--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -23,6 +23,7 @@ static const char reconfiguration_wedge_key = 0x2a;
 static const char reconfiguration_client_data_prefix = 0x2c;
 static const char reconfiguration_epoch_key = 0x2d;
 
+static const char reconfiguration_restart_key = 0x30;
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
   PUBLIC_KEY_EXCHANGE = 0x1,          // identifier of public key exchange request by client

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -104,6 +104,7 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
   bool handle(const concord::messages::ClientKeyExchangeCommand& command,
               uint64_t sequence_number,
               concord::messages::ReconfigurationResponse& response) override;
+  bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop commands)

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -227,6 +227,17 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
   return true;
 }
 
+bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& command,
+                                    uint64_t bft_seq_num,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(
+      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_restart_key});
+  LOG_INFO(getLogger(), "RestartCommand block is " << blockId);
+  return true;
+}
+
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& command,
                                     uint64_t sequence_number,
                                     concord::messages::ReconfigurationResponse& response) {

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -166,6 +166,11 @@ Msg ClientReconfigurationLastUpdate 41 {
     uint64 sender_id
 }
 
+Msg RestartCommand 42 {
+    bool bft
+    bool restart
+    string data
+}
 
 Msg ReconfigurationRequest 1 {
   uint64 sender

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -197,6 +197,7 @@ Msg ReconfigurationRequest 1 {
     ClientReconfigurationStateRequest
     ClientExchangePublicKey
     ClientReconfigurationLastUpdate
+    RestartCommand
   } command
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -123,6 +123,10 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const = 0;

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -43,6 +43,7 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
   bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
               uint64_t,
               concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::UnwedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::UnwedgeStatusRequest&,

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -119,6 +119,13 @@ class Operator:
         cke_command = cmf_msgs.ClientKeyExchangeCommand()
         cke_command.target_clients = target_clients
         return self._construct_basic_reconfiguration_request(cke_command)
+
+    def _construct_reconfiguration_restart_command(self, bft, restart, data):
+        restart_command = cmf_msgs.RestartCommand()
+        restart_command.bft = bft
+        restart_command.restart = restart
+        restart_command.data = data
+        return self._construct_basic_reconfiguration_request(restart_command)
     
     def get_rsi_replies(self):
         return self.client.get_rsi_replies()
@@ -183,6 +190,10 @@ class Operator:
     async def add_remove_with_wedge(self, new_config, bft=True, restart=True):
         reconf_msg = self._construct_reconfiguration_addRemoveWithWedge_command(new_config, bft, restart)
 
+        return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+
+    async def restart(self, data, bft=True, restart=True):
+        reconf_msg = self._construct_reconfiguration_restart_command(bft, restart, data)
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
 
     async def add_remove_status(self):


### PR DESCRIPTION
In this PR we add a special restart command to the reconfiguration engine.
This command lets the operator decide to clear the metadata of the current blockchain and start a fresh new one on top of the existing state.