### PR TITLE
ThinReplica: Introduce EventGroups

### DIFF
--- a/client/thin-replica-client/src/trc_hash.cpp
+++ b/client/thin-replica-client/src/trc_hash.cpp
@@ -16,6 +16,7 @@
 #include <map>
 
 #include "boost/detail/endian.hpp"
+#include "assertUtils.hpp"
 
 using com::vmware::concord::thin_replica::Data;
 using std::invalid_argument;
@@ -81,8 +82,9 @@ string hashUpdate(const Update& update) {
 }
 
 string hashUpdate(const Data& update) {
+  ConcordAssert(update.has_events());  // EventGroups not supported yet
   map<string, string> entry_hashes;
-  for (const auto& kvp : update.data()) {
+  for (const auto& kvp : update.events().data()) {
     string key_hash = ComputeSHA256Hash(kvp.key());
     if (entry_hashes.count(key_hash) > 0) {
       throw invalid_argument("hashUpdate called for an update that contains duplicate keys.");
@@ -90,7 +92,7 @@ string hashUpdate(const Data& update) {
     entry_hashes[key_hash] = ComputeSHA256Hash(kvp.value());
   }
 
-  return hashUpdateFromEntryHashes(update.block_id(), entry_hashes);
+  return hashUpdateFromEntryHashes(update.events().block_id(), entry_hashes);
 }
 
 string hashState(const list<string>& state) {

--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -46,10 +46,10 @@ namespace {
 
 TEST(thin_replica_client_test, test_destructor_always_successful) {
   Data update;
-  update.set_block_id(0);
-  KVPair* update_data = update.add_data();
-  update_data->set_key("key");
-  update_data->set_value("value");
+  update.mutable_events()->set_block_id(0);
+  KVPair* events_data = update.mutable_events()->add_data();
+  events_data->set_key("key");
+  events_data->set_value("value");
 
   shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
   MockOrderedDataStreamHasher hasher(stream_preparer);
@@ -94,10 +94,10 @@ TEST(thin_replica_client_test, test_destructor_always_successful) {
 
 TEST(thin_replica_client_test, test_1_parameter_subscribe_success_cases) {
   Data update;
-  update.set_block_id(0);
-  KVPair* update_data = update.add_data();
-  update_data->set_key("key");
-  update_data->set_value("value");
+  update.mutable_events()->set_block_id(0);
+  KVPair* events_data = update.mutable_events()->add_data();
+  events_data->set_key("key");
+  events_data->set_value("value");
 
   shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
   MockOrderedDataStreamHasher hasher(stream_preparer);
@@ -123,10 +123,10 @@ TEST(thin_replica_client_test, test_1_parameter_subscribe_success_cases) {
 
 TEST(thin_replica_client_test, test_2_parameter_subscribe_success_cases) {
   Data update;
-  update.set_block_id(0);
-  KVPair* update_data = update.add_data();
-  update_data->set_key("key");
-  update_data->set_value("value");
+  update.mutable_events()->set_block_id(0);
+  KVPair* events_data = update.mutable_events()->add_data();
+  events_data->set_key("key");
+  events_data->set_value("value");
 
   shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
   MockOrderedDataStreamHasher hasher(stream_preparer);
@@ -170,10 +170,10 @@ TEST(thin_replica_client_test, test_2_parameter_subscribe_success_cases) {
 
 TEST(thin_replica_client_test, test_1_parameter_subscribe_to_unresponsive_servers_fails) {
   Data update;
-  update.set_block_id(0);
-  KVPair* update_data = update.add_data();
-  update_data->set_key("key");
-  update_data->set_value("value");
+  update.mutable_events()->set_block_id(0);
+  KVPair* events_data = update.mutable_events()->add_data();
+  events_data->set_key("key");
+  events_data->set_value("value");
 
   shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
   MockOrderedDataStreamHasher hasher(stream_preparer);
@@ -206,10 +206,10 @@ TEST(thin_replica_client_test, test_1_parameter_subscribe_to_unresponsive_server
 
 TEST(thin_replica_client_test, test_unsubscribe_successful) {
   Data update;
-  update.set_block_id(0);
-  KVPair* update_data = update.add_data();
-  update_data->set_key("key");
-  update_data->set_value("value");
+  update.mutable_events()->set_block_id(0);
+  KVPair* events_data = update.mutable_events()->add_data();
+  events_data->set_key("key");
+  events_data->set_value("value");
 
   shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
   MockOrderedDataStreamHasher hasher(stream_preparer);
@@ -237,10 +237,10 @@ TEST(thin_replica_client_test, test_unsubscribe_successful) {
 
 TEST(thin_replica_client_test, test_pop_fetches_updates_) {
   Data update;
-  update.set_block_id(0);
-  KVPair* update_data = update.add_data();
-  update_data->set_key("key");
-  update_data->set_value("value");
+  update.mutable_events()->set_block_id(0);
+  KVPair* events_data = update.mutable_events()->add_data();
+  events_data->set_key("key");
+  events_data->set_value("value");
 
   shared_ptr<MockDataStreamPreparer> base_stream_preparer(new RepeatedMockDataStreamPreparer(update, 1));
   auto delay_condition = make_shared<condition_variable>();
@@ -284,10 +284,10 @@ TEST(thin_replica_client_test, test_pop_fetches_updates_) {
 
 TEST(thin_replica_client_test, test_acknowledge_block_id_success) {
   Data update;
-  update.set_block_id(0);
-  KVPair* update_data = update.add_data();
-  update_data->set_key("key");
-  update_data->set_value("value");
+  update.mutable_events()->set_block_id(0);
+  KVPair* events_data = update.mutable_events()->add_data();
+  events_data->set_key("key");
+  events_data->set_value("value");
 
   shared_ptr<MockDataStreamPreparer> stream_preparer(new RepeatedMockDataStreamPreparer(update));
   MockOrderedDataStreamHasher hasher(stream_preparer);
@@ -323,10 +323,10 @@ TEST(thin_replica_client_test, test_correct_data_returned_) {
   vector<Data> update_data;
   for (size_t i = 0; i <= 60; ++i) {
     Data update;
-    update.set_block_id(i);
+    update.mutable_events()->set_block_id(i);
     for (size_t j = 1; j <= 12; ++j) {
       if (i % j == 0) {
-        KVPair* kvp = update.add_data();
+        KVPair* kvp = update.mutable_events()->add_data();
         kvp->set_key("key" + to_string(j));
         kvp->set_value("value" + to_string(i / j));
       }
@@ -364,17 +364,17 @@ TEST(thin_replica_client_test, test_correct_data_returned_) {
     Data& expected_update = update_data[i];
     EXPECT_TRUE((bool)received_update) << "ThinReplicaClient failed to fetch an expected update included in "
                                           "the initial state.";
-    EXPECT_EQ(received_update->block_id, expected_update.block_id())
+    EXPECT_EQ(received_update->block_id, expected_update.events().block_id())
         << "An update the ThinReplicaClient fetched in the initial state has "
            "an incorrect block ID.";
-    EXPECT_EQ(received_update->kv_pairs.size(), expected_update.data_size())
+    EXPECT_EQ(received_update->kv_pairs.size(), expected_update.events().data_size())
         << "An update the ThinReplicaClient fetched in the initial state has "
            "an incorrect number of KV-pair updates.";
-    for (size_t j = 0; j < received_update->kv_pairs.size() && j < (size_t)expected_update.data_size(); ++j) {
-      EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.data(j).key())
+    for (size_t j = 0; j < received_update->kv_pairs.size() && j < (size_t)expected_update.events().data_size(); ++j) {
+      EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.events().data(j).key())
           << "A key in an update the ThinReplicaClient fetched in the initial "
              "state does not match its expected value.";
-      EXPECT_EQ(received_update->kv_pairs[j].second, expected_update.data(j).value())
+      EXPECT_EQ(received_update->kv_pairs[j].second, expected_update.events().data(j).value())
           << "A value in an update the ThinReplicaClient fetched in the "
              "initial state does not match its expected value.";
     }
@@ -399,17 +399,17 @@ TEST(thin_replica_client_test, test_correct_data_returned_) {
 
     EXPECT_TRUE((bool)received_update) << "ThinReplicaClient failed to fetch an expected update from an "
                                           "ongoing subscription.";
-    EXPECT_EQ(received_update->block_id, expected_update.block_id())
+    EXPECT_EQ(received_update->block_id, expected_update.events().block_id())
         << "An update the ThinReplicaClient received from an ongoing "
            "subscription has an incorrect Block ID.";
-    EXPECT_EQ(received_update->kv_pairs.size(), expected_update.data_size())
+    EXPECT_EQ(received_update->kv_pairs.size(), expected_update.events().data_size())
         << "An update the ThinReplicaClient received in an ongoing "
            "subscription has an incorrect number of KV-pair updates.";
-    for (size_t j = 0; j < received_update->kv_pairs.size() && j < (size_t)expected_update.data_size(); ++j) {
-      EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.data(j).key())
+    for (size_t j = 0; j < received_update->kv_pairs.size() && j < (size_t)expected_update.events().data_size(); ++j) {
+      EXPECT_EQ(received_update->kv_pairs[j].first, expected_update.events().data(j).key())
           << "A key in an update the ThinReplicaClient received in an ongoing "
              "subscription does not match its expected value.";
-      EXPECT_EQ(received_update->kv_pairs[j].second, expected_update.data(j).value())
+      EXPECT_EQ(received_update->kv_pairs[j].second, expected_update.events().data(j).value())
           << "A value in an update the ThinReplicaClient received in an "
              "ongoing subscription does not match its expected value.";
     }

--- a/client/thin-replica-client/test/trc_hash_test.cpp
+++ b/client/thin-replica-client/test/trc_hash_test.cpp
@@ -42,9 +42,9 @@ TEST(trc_hash, hash_update) {
 
 TEST(trc_hash, hash_data) {
   Data update;
-  update.set_block_id(1337);
+  update.mutable_events()->set_block_id(1337);
   for (int i = 0; i < 3; ++i) {
-    auto data = update.add_data();
+    auto data = update.mutable_events()->add_data();
     data->set_key(to_string(i));
     data->set_value(to_string(i));
   }

--- a/thin-replica-server/proto/thin_replica.proto
+++ b/thin-replica-server/proto/thin_replica.proto
@@ -21,6 +21,7 @@ syntax = "proto3";
 package com.vmware.concord.thin_replica;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 service ThinReplica {
   // Finite stream which sends the current state that is visible to the Thin Replica client
@@ -46,15 +47,23 @@ service ThinReplica {
   rpc Unsubscribe(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
-message ReadStateRequest {
-}
+message ReadStateRequest {}
 
 message ReadStateHashRequest {
-  // Block id from a prior ReadState response
-  uint64 block_id = 1;
+  oneof request {
+    EventsRequest events = 1;
+    EventGroupsRequest event_groups = 2;
+  }
 }
 
 message SubscriptionRequest {
+  oneof request {
+    EventsRequest events = 1;
+    EventGroupsRequest event_groups = 2;
+  }
+}
+
+message EventsRequest {
   // Subscribe from (including) the given block id
   uint64 block_id = 1;
 }
@@ -65,6 +74,13 @@ message BlockId {
 }
 
 message Data {
+  oneof data {
+    Events events = 1;
+    EventGroup event_group = 2;
+  }
+}
+
+message Events {
   // The data was found in this block
   uint64 block_id = 1;
   repeated KVPair data = 2;
@@ -78,11 +94,38 @@ message KVPair {
 }
 
 message Hash {
+  oneof hash {
+    EventsHash events = 1;
+    EventGroupHash event_group = 2;
+  }
+}
+
+message EventsHash {
   uint64 block_id = 1;
+  bytes hash = 2;
+}
+
+message EventGroupHash {
+  uint64 event_group_id = 1;
   bytes hash = 2;
 }
 
 // Trace contexts are serialized as the below message in Updates sent to clients.
 message W3cTraceContext {
   map<string, string> key_values = 1;
+}
+
+// See concord_client.proto for documentation on EventGroups.
+// Note: We don't want to depend on concord_client.proto because any change to
+// concord_client.proto would result in a change for the TRS and therefore the
+// replica itself. By keeping them separate we will have an easier time
+// changing/maintaining those two interfaces.
+message EventGroupsRequest {
+  uint64 event_group_id = 1;
+}
+message EventGroup {
+  uint64 id = 1;
+  repeated bytes events = 2;
+  google.protobuf.Timestamp record_time = 3;
+  map<string, string> trace_context = 4;
 }

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -219,7 +219,7 @@ class TestStateMachine {
   void return_false_on_last_block(bool on) { return_false_on_last_block_ = on; }
 
   bool on_server_write(const DataT& data) {
-    EXPECT_EQ(current_block_to_send_, data.block_id());
+    EXPECT_EQ(current_block_to_send_, data.events().block_id());
     if (current_block_to_send_ == last_block_to_send_) {
       return !return_false_on_last_block_;
     }
@@ -297,7 +297,7 @@ TEST(thin_replica_server_test, SubscribeToUpdatesAlreadySynced) {
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
-  request.set_block_id(1u);
+  request.mutable_events()->set_block_id(1u);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OK);
@@ -320,7 +320,7 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGap) {
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
-  request.set_block_id(1u);
+  request.mutable_events()->set_block_id(1u);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OK);
@@ -343,7 +343,7 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGapFromTheMiddleBlock) {
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
-  request.set_block_id(3u);
+  request.mutable_events()->set_block_id(3u);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OK);
@@ -366,7 +366,7 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesAlreadySynced) {
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
-  request.set_block_id(1u);
+  request.mutable_events()->set_block_id(1u);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Hash>, Hash>(&context, &request, &stream);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OK);
@@ -389,7 +389,7 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesWithGap) {
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   SubscriptionRequest request;
-  request.set_block_id(1u);
+  request.mutable_events()->set_block_id(1u);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Hash>, Hash>(&context, &request, &stream);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OK);
@@ -436,11 +436,11 @@ TEST(thin_replica_server_test, ReadStateHash) {
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
   ReadStateHashRequest request;
-  request.set_block_id(kLastBlockId);
+  request.mutable_events()->set_block_id(kLastBlockId);
   Hash hash;
   auto status = replica.ReadStateHash(&context, &request, &hash);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OK);
-  EXPECT_EQ(hash.block_id(), kLastBlockId);
+  EXPECT_EQ(hash.events().block_id(), kLastBlockId);
 }
 
 TEST(thin_replica_server_test, AckUpdate) {
@@ -459,8 +459,8 @@ TEST(thin_replica_server_test, AckUpdate) {
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
-  ReadStateHashRequest request;
-  request.set_block_id(kLastBlockId);
+  SubscriptionRequest request;
+  request.mutable_events()->set_block_id(kLastBlockId);
 
   com::vmware::concord::thin_replica::BlockId block_id;
   block_id.set_block_id(1u);
@@ -484,8 +484,8 @@ TEST(thin_replica_server_test, Unsubscribe) {
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   TestServerContext context;
-  ReadStateHashRequest request;
-  request.set_block_id(kLastBlockId);
+  SubscriptionRequest request;
+  request.mutable_events()->set_block_id(kLastBlockId);
 
   com::vmware::concord::thin_replica::BlockId block_id;
   block_id.set_block_id(1u);
@@ -543,7 +543,7 @@ TEST(thin_replica_server_test, SubscribeWithWrongBlockId) {
       is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
   concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
   SubscriptionRequest request;
-  request.set_block_id(kLastBlockId + 100);
+  request.mutable_events()->set_block_id(kLastBlockId + 100);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::FAILED_PRECONDITION);


### PR DESCRIPTION
We already have EventGroups defined in `concord_client.proto`. This PR adds EventGroups to the thin replica protocol so that we can use them in subsequent changes. Note, we make sure that this PR doesn't change any behavior. From now on, all tests use "legacy" events and not EventGroups. We have to re-evaluate our tests to maybe find a generic solution.