### PR TITLE
Add event groups CMF

### DIFF
--- a/kvbc/cmf/CMakeLists.txt
+++ b/kvbc/cmf/CMakeLists.txt
@@ -3,6 +3,11 @@ add_library(categorized_kvbc_msgs ${cpp})
 set_target_properties(categorized_kvbc_msgs PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(categorized_kvbc_msgs PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
+cmf_generate_cpp(header cpp concord::kvbc::categorization event_group_msgs.cmf)
+add_library(event_group_msgs ${cpp})
+set_target_properties(event_group_msgs PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(event_group_msgs PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
 cmf_generate_cpp(header cpp concord::kvbc::pruning pruning_msgs.cmf)
 add_library(pruning_msgs ${cpp})
 set_target_properties(pruning_msgs PROPERTIES LINKER_LANGUAGE CXX)

--- a/kvbc/cmf/event_group_msgs.cmf
+++ b/kvbc/cmf/event_group_msgs.cmf
@@ -1,0 +1,10 @@
+# Represents an event
+Msg Event 1 {
+  string data
+  list string tags
+}
+
+# Represents an event-group
+Msg EventGroup 2 {
+  list Event events
+}

--- a/kvbc/include/categorization/db_categories.h
+++ b/kvbc/include/categorization/db_categories.h
@@ -19,6 +19,7 @@ inline const auto kExecutionProvableCategory = "execution_provable";
 inline const auto kExecutionPrivateCategory = "execution_private";
 inline const auto kExecutionEventsCategory = "execution_events";
 inline const auto kRequestsRecord = "requests_record";
+inline const auto kExecutionEventGroupsCategory = "execution_event_groups";
 
 // Concord and Concord-BFT internal category that is used for various kinds of metadata.
 // The type of the internal category is VersionedKeyValueCategory.


### PR DESCRIPTION
This PR introduces the event_group_msgs.cmf, and kExecutionEventGroupsCategory in db_categories.h.