### PR TITLE
TRS memory leaks in getClientIdFromClientCert

### DIFF
--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -335,6 +335,7 @@ class ThinReplicaImpl {
     // read a certificate in PEM format from a BIO
     certificate = PEM_read_bio_X509(bio, NULL, NULL, NULL);
     if (!certificate) {
+      BIO_free(bio);
       throw std::runtime_error(
           "Failed to encode certificate received from client for client "
           "authorization - PEM_read_bio_X509() failed!");
@@ -349,6 +350,9 @@ class ThinReplicaImpl {
     size_t start = result.find(delim) + delim.length();
     size_t end = result.find('/', start);
     client_id = result.substr(start, end - start);
+    BIO_free(bio);
+    X509_free(certificate);
+    OPENSSL_free(subj);
     return client_id;
   }
 

--- a/util/src/openssl_crypto.cpp
+++ b/util/src/openssl_crypto.cpp
@@ -494,6 +494,7 @@ std::unique_ptr<AsymmetricPrivateKey> concord::util::openssl_utils::deserializeP
 
   EC_KEY* eckey = EVP_PKEY_get1_EC_KEY(pkey);
   if (!eckey) {
+    BIO_free(bio);
     throw UnexpectedOpenSSLCryptoFailureException("Error getting EC KEY: EVP_PKEY_get1_EC_KEY()");
   }
   EVP_PKEY_free(pkey);


### PR DESCRIPTION
In the method getClientIdFromClientCert, we observed a memory leak, which was caused in several places:
1) Calling BIO_new without freeing the allocated memory.
2) By utilizing PEM_read_bio_X509, the memory that has been allocated is not released.
3) not releasing the memory which has been allocated with X509_NAME_oneline.

I ran address sanitizer after fixing these issues, and none of the leaks were observed.