### PR TITLE
State transfer performance improvments put block phase1

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -74,20 +74,22 @@ class IAppState {
   virtual bool hasBlock(uint64_t blockId) const = 0;
 
   // If block blockId exists, then its content is returned via the arguments
-  // outBlock and outBlockSize. Returns true IFF block blockId exists.
-  virtual bool getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) = 0;
+  // outBlock and outBlockActualSize. Returns true IFF block blockId exists.
+  // If outBlockMaxSize is too small, an exception is thrown
+  virtual bool getBlock(uint64_t blockId, char *outBlock, uint32_t outBlockMaxSize, uint32_t *outBlockActualSize) = 0;
 
   // Get a block (asynchronously)
   // An asynchronous version for the above getBlock.
   // For a given blockId, a job is invoked asynchronously, to get the block from storage and fill outBlock and
-  // outBlockSize. After job is created, this call returns immidiately with a future<bool>, while job is executed by a
-  // seperate worker thread. Before accesing buffer and size, user must call the returned future.get() to make sure that
-  // job has been done. User should 1st check the future value: if true - block exist and outBlock, outBlockSize are
-  // valid if false - block does not exist, all output should be ignored.
-  // Notice: call to future.get() us not expected to throw exception since all expected
-  // exceptions are caught inside the call implementation. If exception is thrown, some severe
-  // error happened.
-  virtual std::future<bool> getBlockAsync(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) = 0;
+  // outBlockActualSize. After job is created, this call returns immidiately with a future<bool>, while job is executed
+  // by a seperate worker thread. Before accesing buffer and size, user must call the returned future.get() to make sure
+  // that job has been done. User should 1st check the future value: if true - block exist and outBlock,
+  // outBlockActualSize are valid if false - block does not exist, all output should be ignored. If outBlockMaxSize is
+  // too small, an exception is thrown.
+  virtual std::future<bool> getBlockAsync(uint64_t blockId,
+                                          char *outBlock,
+                                          uint32_t outBlockMaxSize,
+                                          uint32_t *outBlockActualSize) = 0;
 
   // If block blockId exists, then the digest of block blockId-1 is returned via
   // the argument outPrevBlockDigest. Returns true IFF block blockId exists.

--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -89,6 +89,11 @@ class IAppState {
   // the argument outPrevBlockDigest. Returns true IFF block blockId exists.
   virtual bool getPrevDigestFromBlock(uint64_t blockId, StateTransferDigest *outPrevBlockDigest) = 0;
 
+  // Extracts a digest out of in-memory block (raw block).
+  virtual void getPrevDigestFromBlock(const char *blockData,
+                                      const uint32_t blockSize,
+                                      StateTransferDigest *outPrevBlockDigest) = 0;
+
   // Add a block
   // blockId   - the block number
   // block     - pointer to a buffer that contains the new block

--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -89,11 +89,15 @@ class IAppState {
   // the argument outPrevBlockDigest. Returns true IFF block blockId exists.
   virtual bool getPrevDigestFromBlock(uint64_t blockId, StateTransferDigest *outPrevBlockDigest) = 0;
 
-  // adds block
+  // Add a block
   // blockId   - the block number
   // block     - pointer to a buffer that contains the new block
   // blockSize - the size of the new block
-  virtual bool putBlock(const uint64_t blockId, const char *block, const uint32_t blockSize) = 0;
+  // lastBlock - when true, for backup replica - try to remove blocks from State Transfer chain and add them to
+  // the blockchain
+  // Returns true if operation succeeded. Else, returns false. Call may also throw an exception which is also a failure
+  // (false is returned).
+  virtual bool putBlock(const uint64_t blockId, const char *block, const uint32_t blockSize, bool lastBlock = true) = 0;
 
   // returns the maximal block number n such that all blocks 1 <= i <= n exist.
   // if block 1 does not exist, returns 0.

--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <string>
 #include "IReservedPages.hpp"
+#include "Timers.hpp"
 
 namespace bftEngine {
 class IReplicaForStateTransfer;  // forward definition
@@ -92,6 +93,9 @@ class IReplicaForStateTransfer {
   // the timer is disabled when timerPeriodMilli==0
   // (notice that the state transfer module can use its own timers and threads)
   virtual void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) = 0;
+
+  // Invoke State Transfer timer callback once
+  virtual concordUtil::Timers::Handle addOneShotTimer(uint32_t timeoutMilli) = 0;
 
   virtual ~IReplicaForStateTransfer() = default;
 };

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1364,7 +1364,7 @@ uint16_t BCStateTran::asyncGetBlocksConcurrent(uint64_t nextBlockId,
       LOG_DEBUG(getLogger(), "Waiting for previous thread to finish job on context " << KVLOG(ctx.blockId, ctx.index));
     }
     ctx.blockId = i;
-    ctx.future = as_->getBlockAsync(ctx.blockId, ctx.block.get(), &ctx.blockSize);
+    ctx.future = as_->getBlockAsync(ctx.blockId, ctx.block.get(), config_.maxBlockSize, &ctx.blockSize);
   }
 
   return j;
@@ -2734,7 +2734,7 @@ void BCStateTran::checkStoredCheckpoints(uint64_t firstStoredCheckpoint, uint64_
         // Extra debugging needed here for BC-2821
         if (computedBlockDigest != desc.digestOfLastBlock) {
           uint32_t blockSize = 0;
-          as_->getBlock(desc.lastBlock, buffer_, &blockSize);
+          as_->getBlock(desc.lastBlock, buffer_, config_.maxBlockSize, &blockSize);
           concordUtils::HexPrintBuffer blockData{buffer_, blockSize};
           LOG_FATAL(getLogger(), "Invalid stored checkpoint: " << KVLOG(desc.checkpointNum, desc.lastBlock, blockData));
           ConcordAssertEQ(computedBlockDigest, desc.digestOfLastBlock);
@@ -2830,7 +2830,7 @@ STDigest BCStateTran::getBlockAndComputeDigest(uint64_t currBlock) {
   static std::unique_ptr<char[]> buffer(new char[maxItemSize_]);
   STDigest currDigest;
   uint32_t blockSize = 0;
-  as_->getBlock(currBlock, buffer.get(), &blockSize);
+  as_->getBlock(currBlock, buffer.get(), config_.maxBlockSize, &blockSize);
   computeDigestOfBlock(currBlock, buffer.get(), blockSize, &currDigest);
   return currDigest;
 }

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -113,8 +113,15 @@ void ReplicaForStateTransfer::onTransferringComplete(uint64_t checkpointNumberOf
 void ReplicaForStateTransfer::changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) {
   // TODO(GG): if this method is invoked by an external thread, then send an "internal message" to the commands
   // processing thread
+  LOG_INFO(GL, "Changing stateTranTimer_ timeout to " << KVLOG(timerPeriodMilli));
   timers_.reset(stateTranTimer_, std::chrono::milliseconds(timerPeriodMilli));
   metric_state_transfer_timer_.Get().Set(timerPeriodMilli);
+}
+
+Timers::Handle ReplicaForStateTransfer::addOneShotTimer(uint32_t timeoutMilli) {
+  return timers_.add(std::chrono::milliseconds(timeoutMilli),
+                     concordUtil::Timers::Timer::ONESHOT,
+                     [this](concordUtil::Timers::Handle h) { stateTransfer->onTimer(); });
 }
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -36,6 +36,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   void sendStateTransferMessage(char* m, uint32_t size, uint16_t replicaId) override;
   void onTransferringComplete(uint64_t checkpointNumberOfNewState) override;
   void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) override;
+  Timers::Handle addOneShotTimer(uint32_t timeoutMilli) override;
 
   bool isCollectingState() const { return stateTransfer->isCollectingState(); }
 

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -107,6 +107,10 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
     bool getPrevDigestFromBlock(uint64_t blockId, bcst::StateTransferDigest* outPrevBlockDigest) override;
 
+    void getPrevDigestFromBlock(const char* blockData,
+                                const uint32_t blockSize,
+                                bcst::StateTransferDigest* outPrevBlockDigest) override;
+
     bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize, bool lastBlock = true) override;
 
     uint64_t getLastReachableBlockNum() const override;
@@ -607,6 +611,12 @@ bool SimpleStateTran::DummyBDState::getPrevDigestFromBlock(uint64_t blockId,
                                                            bcst::StateTransferDigest* outPrevBlockDigest) {
   ConcordAssert(false);
   return false;
+}
+
+void SimpleStateTran::DummyBDState::getPrevDigestFromBlock(const char* blockData,
+                                                           const uint32_t blockSize,
+                                                           bcst::StateTransferDigest* outPrevBlockDigest) {
+  ConcordAssert(false);
 }
 
 bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId,

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -24,6 +24,7 @@
 #include "memorydb/key_comparator.h"
 #include "Logger.hpp"
 #include "storage/direct_kv_key_manipulator.h"
+#include "Timers.hpp"
 
 namespace bftEngine {
 
@@ -146,6 +147,10 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
     void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) override {
       realInterface_->changeStateTransferTimerPeriod(timerPeriodMilli);
+    }
+
+    concordUtil::Timers::Handle addOneShotTimer(uint32_t timeoutMilli) override {
+      return realInterface_->addOneShotTimer(timeoutMilli);
     }
   };
 

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -102,9 +102,12 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
     bool hasBlock(uint64_t blockId) const override;
 
-    bool getBlock(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) override;
+    bool getBlock(uint64_t blockId, char* outBlock, uint32_t outBlockMaxSize, uint32_t* outBlockActualSize) override;
 
-    std::future<bool> getBlockAsync(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) override;
+    std::future<bool> getBlockAsync(uint64_t blockId,
+                                    char* outBlock,
+                                    uint32_t outBlockMaxSize,
+                                    uint32_t* outBlockActualSize) override;
 
     bool getPrevDigestFromBlock(uint64_t blockId, bcst::StateTransferDigest* outPrevBlockDigest) override;
 
@@ -605,14 +608,18 @@ void SimpleStateTran::onComplete(int64_t checkpointNumberOfNewState) {
 
 bool SimpleStateTran::DummyBDState::hasBlock(uint64_t blockId) const { return false; }
 
-bool SimpleStateTran::DummyBDState::getBlock(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) {
+bool SimpleStateTran::DummyBDState::getBlock(uint64_t blockId,
+                                             char* outBlock,
+                                             uint32_t outBlockMaxSize,
+                                             uint32_t* outBlockActualSize) {
   ConcordAssert(false);
   return false;
 }
 
 std::future<bool> SimpleStateTran::DummyBDState::getBlockAsync(uint64_t blockId,
                                                                char* outBlock,
-                                                               uint32_t* outBlockSize) {
+                                                               uint32_t outBlockMaxSize,
+                                                               uint32_t* outBlockActualSize) {
   ConcordAssert(false);
   return std::async([]() { return false; });
 }

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -107,7 +107,7 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
     bool getPrevDigestFromBlock(uint64_t blockId, bcst::StateTransferDigest* outPrevBlockDigest) override;
 
-    bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) override;
+    bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize, bool lastBlock = true) override;
 
     uint64_t getLastReachableBlockNum() const override;
     uint64_t getGenesisBlockNum() const override;
@@ -609,7 +609,10 @@ bool SimpleStateTran::DummyBDState::getPrevDigestFromBlock(uint64_t blockId,
   return false;
 }
 
-bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) {
+bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId,
+                                             const char* block,
+                                             const uint32_t blockSize,
+                                             bool lastBlock) {
   ConcordAssert(false);
   return false;
 }

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -114,6 +114,11 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
 
     bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize, bool lastBlock = true) override;
 
+    std::future<bool> putBlockAsync(uint64_t blockId,
+                                    const char* block,
+                                    const uint32_t blockSize,
+                                    bool trylinkSTChainFrom = true) override;
+
     uint64_t getLastReachableBlockNum() const override;
     uint64_t getGenesisBlockNum() const override;
     uint64_t getLastBlockNum() const override;
@@ -630,6 +635,14 @@ bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId,
                                              bool lastBlock) {
   ConcordAssert(false);
   return false;
+}
+
+std::future<bool> SimpleStateTran::DummyBDState::putBlockAsync(uint64_t blockId,
+                                                               const char* block,
+                                                               const uint32_t blockSize,
+                                                               bool trylinkSTChainFrom) {
+  ConcordAssert(false);
+  return std::async([]() { return false; });
 }
 
 uint64_t SimpleStateTran::DummyBDState::getLastReachableBlockNum() const { return 0; }

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -58,6 +58,13 @@ class TestAppState : public IAppState {
     return true;
   };
 
+  // TODO - implement
+  void getPrevDigestFromBlock(const char* blockData,
+                              const uint32_t blockSize,
+                              StateTransferDigest* outPrevBlockDigest) override {
+    ConcordAssert(false);
+  }
+
   bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize, bool lastBlock) override {
     ConcordAssert(blockId < last_block_);
     Block bl;

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -46,8 +46,10 @@ class TestAppState : public IAppState {
     return true;
   };
 
+  // TODO - implement
   std::future<bool> getBlockAsync(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) override {
     ConcordAssert(false);
+    return std::async([]() { return false; });
   }
 
   bool getPrevDigestFromBlock(uint64_t blockId, StateTransferDigest* outPrevBlockDigest) override {
@@ -73,6 +75,15 @@ class TestAppState : public IAppState {
     bl.actualSize = blockSize;
     last_block_ = blockId;
     return true;
+  }
+
+  // TODO - implement
+  std::future<bool> putBlockAsync(uint64_t blockId,
+                                  const char* block,
+                                  const uint32_t blockSize,
+                                  bool trylinkSTChainFrom = true) override {
+    ConcordAssert(false);
+    return std::async([]() { return false; });
   }
 
   // TODO(AJS): How does this differ from getLastBlockNum?

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -58,7 +58,7 @@ class TestAppState : public IAppState {
     return true;
   };
 
-  bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize) override {
+  bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize, bool lastBlock) override {
     ConcordAssert(blockId < last_block_);
     Block bl;
     computeBlockDigest(blockId, block, blockSize, &bl.digest);

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -38,16 +38,19 @@ class TestAppState : public IAppState {
     return it != blocks_.end();
   }
 
-  bool getBlock(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) override {
+  bool getBlock(uint64_t blockId, char* outBlock, uint32_t outBlockMaxSize, uint32_t* outBlockActualSize) override {
     auto it = blocks_.find(blockId);
     if (it == blocks_.end()) return false;
     std::memcpy(outBlock, it->second.block, it->second.actualSize);
-    *outBlockSize = it->second.actualSize;
+    *outBlockActualSize = it->second.actualSize;
     return true;
   };
 
   // TODO - implement
-  std::future<bool> getBlockAsync(uint64_t blockId, char* outBlock, uint32_t* outBlockSize) override {
+  std::future<bool> getBlockAsync(uint64_t blockId,
+                                  char* outBlock,
+                                  uint32_t outBlockMaxSize,
+                                  uint32_t* outBlockActualSize) override {
     ConcordAssert(false);
     return std::async([]() { return false; });
   }

--- a/bftengine/tests/bcstatetransfer/test_replica.hpp
+++ b/bftengine/tests/bcstatetransfer/test_replica.hpp
@@ -52,6 +52,7 @@ class TestReplica : public IReplicaForStateTransfer {
 
   void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) override{};
 
+  concordUtil::Timers::Handle addOneShotTimer(uint32_t timeoutMilli) override { return concordUtil::Timers::Handle(); }
   ///////////////////////////////////////////////////////////////////////////
   // Data - All public on purpose, so that it can be accessed by tests
   ///////////////////////////////////////////////////////////////////////////

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -97,8 +97,11 @@ class Replica : public IReplica,
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IAppState implementation
   bool hasBlock(BlockId blockId) const override;
-  bool getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override;
-  std::future<bool> getBlockAsync(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override;
+  bool getBlock(uint64_t blockId, char *outBlock, uint32_t outBlockMaxSize, uint32_t *outBlockActualSize) override;
+  std::future<bool> getBlockAsync(uint64_t blockId,
+                                  char *outBlock,
+                                  uint32_t outBlockMaxSize,
+                                  uint32_t *outBlockActualSize) override;
   bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) override;
   void getPrevDigestFromBlock(const char *blockData,
                               const uint32_t blockSize,
@@ -118,7 +121,7 @@ class Replica : public IReplica,
   uint64_t getLastBlockNum() const override;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  bool getBlockFromObjectStore(uint64_t blockId, char *outBlock, uint32_t *outBlockSize);
+  bool getBlockFromObjectStore(uint64_t blockId, char *outBlock, uint32_t outblockMaxSize, uint32_t *outBlockSize);
   bool getPrevDigestFromObjectStoreBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *);
   bool putBlockToObjectStore(const uint64_t blockId, const char *blockData, const uint32_t blockSize);
 

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -100,6 +100,9 @@ class Replica : public IReplica,
   bool getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override;
   std::future<bool> getBlockAsync(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override;
   bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) override;
+  void getPrevDigestFromBlock(const char *blockData,
+                              const uint32_t blockSize,
+                              bftEngine::bcst::StateTransferDigest *outPrevBlockDige) override;
   bool putBlock(const uint64_t blockId,
                 const char *blockData,
                 const uint32_t blockSize,

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -100,7 +100,10 @@ class Replica : public IReplica,
   bool getBlock(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override;
   std::future<bool> getBlockAsync(uint64_t blockId, char *outBlock, uint32_t *outBlockSize) override;
   bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) override;
-  bool putBlock(const uint64_t blockId, const char *blockData, const uint32_t blockSize) override;
+  bool putBlock(const uint64_t blockId,
+                const char *blockData,
+                const uint32_t blockSize,
+                bool lastBlock = true) override;
   uint64_t getLastReachableBlockNum() const override;
   uint64_t getGenesisBlockNum() const override;
   // This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -107,6 +107,10 @@ class Replica : public IReplica,
                 const char *blockData,
                 const uint32_t blockSize,
                 bool lastBlock = true) override;
+  std::future<bool> putBlockAsync(uint64_t blockId,
+                                  const char *block,
+                                  const uint32_t blockSize,
+                                  bool lastBlock = true) override;
   uint64_t getLastReachableBlockNum() const override;
   uint64_t getGenesisBlockNum() const override;
   // This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or
@@ -201,13 +205,14 @@ class Replica : public IReplica,
 
  private:
   struct Recorders {
-    static constexpr uint64_t MAX_VALUE_MICROSECONDS = 60ULL * 1000ULL * 1000ULL;  // 60 seconds
+    static constexpr uint64_t MAX_VALUE_MICROSECONDS = 2ULL * 1000ULL * 1000ULL;  // 2 seconds
 
     Recorders() {
       auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      registrar.perf.registerComponent("iappstate", {get_block_duration});
+      registrar.perf.registerComponent("iappstate", {get_block_duration, put_block_duration});
     }
     DEFINE_SHARED_RECORDER(get_block_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(put_block_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
   };
   Recorders histograms_;
 };  // namespace concord::kvbc

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -56,7 +56,8 @@ class KeyValueBlockchain {
   /////////////////////// Raw Blocks ///////////////////////
 
   // Adds raw block and tries to link the state transfer blockchain to the main blockchain
-  void addRawBlock(const RawBlock& block, const BlockId& block_id);
+  // If linkSTChainFrom is true, try to remove blocks form the state transfer chain to the blockchain
+  void addRawBlock(const RawBlock& block, const BlockId& block_id, bool lastBlock = true);
   std::optional<RawBlock> getRawBlock(const BlockId& block_id) const;
 
   /////////////////////// Info ///////////////////////

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -601,6 +601,18 @@ bool Replica::getPrevDigestFromBlock(BlockId blockId, StateTransferDigest *outPr
   return true;
 }
 
+void Replica::getPrevDigestFromBlock(const char *blockData,
+                                     const uint32_t blockSize,
+                                     StateTransferDigest *outPrevBlockDigest) {
+  ConcordAssertGT(blockSize, 0);
+  auto view = std::string_view{blockData, blockSize};
+  const auto rawBlock = categorization::RawBlock::deserialize(view);
+
+  static_assert(rawBlock.data.parent_digest.size() == BLOCK_DIGEST_SIZE);
+  static_assert(sizeof(StateTransferDigest) == BLOCK_DIGEST_SIZE);
+  std::memcpy(outPrevBlockDigest, rawBlock.data.parent_digest.data(), BLOCK_DIGEST_SIZE);
+}
+
 bool Replica::getPrevDigestFromObjectStoreBlock(uint64_t blockId,
                                                 bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) {
   ConcordAssert(blockId > 0);

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -441,7 +441,7 @@ Replica::~Replica() {
  * This method can't return false by current insertBlockInternal impl.
  * It is used only by State Transfer to synchronize state between replicas.
  */
-bool Replica::putBlock(const uint64_t blockId, const char *blockData, const uint32_t blockSize) {
+bool Replica::putBlock(const uint64_t blockId, const char *blockData, const uint32_t blockSize, bool lastBlock) {
   if (replicaConfig_.isReadOnly) {
     return putBlockToObjectStore(blockId, blockData, blockSize);
   }
@@ -462,7 +462,7 @@ bool Replica::putBlock(const uint64_t blockId, const char *blockData, const uint
           std::to_string(blockId));
     }
   } else {
-    m_kvBlockchain->addRawBlock(rawBlock, blockId);
+    m_kvBlockchain->addRawBlock(rawBlock, blockId, lastBlock);
   }
   return true;
 }


### PR DESCRIPTION
This is the 1st phase of the stage 2 series of commits for state transfer improvements.
The series of commits here concentrate on API changes + minor comments and API refactoring.
The implemented changes are done to support the 2nd phase of this stage, which will be submitted imminently after. It will include additional performance improvements. The main improvement: committing blocks concurrently.

3 new APIS:

1. IAppState::putBlockAsync
2. IAppState::getPrevDigestFromBlock (overloaded)
3. IStateTransfer::addOneShotTimer

1 API modified:
- IAppState::putBlock - added a new argument

I suggest reviewing this PR by separate commits.