### PR TITLE
Allow overwriting the latest checkpoint

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -509,7 +509,7 @@ void BCStateTran::createCheckpointOfCurrentState(uint64_t checkpointNumber) {
   ConcordAssert(running_);
   ConcordAssert(!isFetching());
   ConcordAssertGT(checkpointNumber, 0);
-  ConcordAssertGT(checkpointNumber, lastStoredCheckpointNumber);
+  ConcordAssertGE(checkpointNumber, lastStoredCheckpointNumber);
 
   metrics_.create_checkpoint_++;
 
@@ -519,8 +519,8 @@ void BCStateTran::createCheckpointOfCurrentState(uint64_t checkpointNumber) {
     auto checkDesc = createCheckpointDesc(checkpointNumber, digestOfResPagesDescriptor);
     g.txn()->setCheckpointDesc(checkpointNumber, checkDesc);
     deleteOldCheckpoints(checkpointNumber, g.txn());
-    metrics_.last_stored_checkpoint_.Get().Set(psd_->getLastStoredCheckpoint());
   }
+  metrics_.last_stored_checkpoint_.Get().Set(psd_->getLastStoredCheckpoint());
 }
 
 void BCStateTran::markCheckpointAsStable(uint64_t checkpointNumber) {


### PR DESCRIPTION
State transfer and bft persistent storage are using two different transactions. Thus, if a replica is crashed while executing checkpoint sequence number we may end up with a situation where the new checkpoint was already stored in the ST persistent storage, while the latestExecutedSeqNum was not persisted yet. 
(see https://github.com/vmware/concord-bft/blob/master/bftengine/src/bftengine/ReplicaImp.cpp#L4107)
Then, when the replica is restarting, it hits an assert and crashed.

To solve the problem, we decided to allow overwriting the latest checkpoint descriptor in the ST persistent data.