### PR TITLE
State transfer performance improvments put block phase2

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -120,7 +120,7 @@ class IAppState {
   virtual std::future<bool> putBlockAsync(uint64_t blockId,
                                           const char *block,
                                           const uint32_t blockSize,
-                                          bool trylinkSTChainFrom = true) = 0;
+                                          bool lastBlock = true) = 0;
 
   // returns the maximal block number n such that all blocks 1 <= i <= n exist.
   // if block 1 does not exist, returns 0.

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -139,6 +139,7 @@ static set<uint16_t> generateSetOfReplicas(const int16_t numberOfReplicas) {
   return retVal;
 }
 
+size_t BCStateTran::BlockIOContext::sizeOfBlockData = 0;
 BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataStore *ds)
     : as_{stateApi},
       psd_{ds},
@@ -153,11 +154,30 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
       maxNumOfStoredCheckpoints_{0},
       numberOfReservedPages_{0},
       cycleCounter_(0),
+      buffer_(new char[maxItemSize_]),
       randomGen_{randomDevice_()},
       sourceSelector_{allOtherReplicas(),
                       config_.fetchRetransmissionTimeoutMs,
                       config_.sourceReplicaReplacementTimeoutMs,
                       ST_SRC_LOG},
+      ioPool_(
+          config_.maxNumberOfChunksInBatch,
+          nullptr,                                     // alloc callback
+          [&](std::shared_ptr<BlockIOContext> &ctx) {  // free callback
+            if (ctx->future.valid()) {
+              try {
+                LOG_DEBUG(getLogger(), "Waiting for previous thread to finish job on context " << KVLOG(ctx->blockId));
+                ctx->future.get();
+              } catch (...) {
+                // ignore and continue, this job is irrlevant
+                LOG_WARN(getLogger(), "Exception on irrelevant job, ignoring..");
+              }
+            }
+          },
+          [&]() {  // ctor callback
+            BCStateTran::BlockIOContext::sizeOfBlockData = config_.maxBlockSize;
+          }),
+      oneShotTimerFlag_(true),
       last_metrics_dump_time_(0),
       metrics_dump_interval_in_sec_{std::chrono::seconds(config_.metricsDumpIntervalSec)},
       metrics_component_{
@@ -244,16 +264,11 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
   ConcordAssertGE(replicas_.size(), 3U * config_.fVal + 1U);
   ConcordAssert(replicas_.count(config_.myReplicaId) == 1 || config.isReadOnly);
   ConcordAssertGE(config_.maxNumOfReservedPages, 2);
+  ConcordAssertLT(finalizePutblockTimeoutMilli_, config_.refreshTimerMs);
 
   // Register metrics component with the default aggregator.
   metrics_component_.Register();
 
-  srcGetBlockContextes_.resize(config_.maxNumberOfChunksInBatch);
-  for (uint16_t i{0}; i < config_.maxNumberOfChunksInBatch; ++i) {
-    srcGetBlockContextes_[i].block.reset(new char[config_.maxBlockSize]);
-    srcGetBlockContextes_[i].index = i;
-  }
-  buffer_ = new char[maxItemSize_]{};
   LOG_INFO(getLogger(), "Creating BCStateTran object: " << config_);
 
   if (config_.runInSeparateThread) {
@@ -273,8 +288,6 @@ BCStateTran::~BCStateTran() {
   ConcordAssert(!running_);
   ConcordAssert(cacheOfVirtualBlockForResPages.empty());
   ConcordAssert(pendingItemDataMsgs.empty());
-
-  delete[] buffer_;
 }
 
 // Load metrics that are saved on persistent storage
@@ -403,6 +416,9 @@ void BCStateTran::stopRunning() {
   for (auto i : pendingItemDataMsgs) replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(i));
 
   pendingItemDataMsgs.clear();
+  for (auto &ctx : ioContexts_) ioPool_.free(ctx);
+  ioContexts_.clear();
+  ConcordAssert(ioPool_.full());
   totalSizeOfPendingItemDataMsgs = 0;
   replicaForStateTransfer_ = nullptr;
 }
@@ -1279,6 +1295,8 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
   ConcordAssertEQ(nextRequiredBlock_, 0);
   ConcordAssert(digestOfNextRequiredBlock.isZero());
   ConcordAssert(pendingItemDataMsgs.empty());
+  ConcordAssert(ioContexts_.empty());
+  ConcordAssert(ioPool_.full());
   ConcordAssertEQ(totalSizeOfPendingItemDataMsgs, 0);
 
   // set the preferred replicas
@@ -1345,26 +1363,16 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
   return true;
 }
 
-uint16_t BCStateTran::asyncGetBlocksConcurrent(uint64_t nextBlockId,
-                                               uint64_t firstRequiredBlock,
-                                               uint16_t numBlocks,
-                                               size_t startContextIndex) {
+uint16_t BCStateTran::getBlocksConcurrentAsync(uint64_t nextBlockId, uint64_t firstRequiredBlock, uint16_t numBlocks) {
   ConcordAssertGE(config_.maxNumberOfChunksInBatch, numBlocks);
-  auto j{startContextIndex};
+  auto j{0};
 
-  LOG_DEBUG(getLogger(), KVLOG(nextBlockId, firstRequiredBlock, numBlocks, startContextIndex));
-  for (uint64_t i{nextBlockId}; (i >= firstRequiredBlock) && (j < startContextIndex + numBlocks); --i, ++j) {
-    auto &ctx = srcGetBlockContextes_[j];
-    // start the job ASAP, return result to on-stack future
-    if (ctx.future.valid()) {
-      // wait for previous thread to finish - we must call it explicitly here, can't relay on dtor
-      // TODO(GL)- get() can be optimize by waiting 0 time and continue calling next jobs which might have finished. 1st
-      // research if wait time > 0.
-      ctx.future.get();
-      LOG_DEBUG(getLogger(), "Waiting for previous thread to finish job on context " << KVLOG(ctx.blockId, ctx.index));
-    }
-    ctx.blockId = i;
-    ctx.future = as_->getBlockAsync(ctx.blockId, ctx.block.get(), config_.maxBlockSize, &ctx.blockSize);
+  LOG_DEBUG(getLogger(), KVLOG(nextBlockId, firstRequiredBlock, numBlocks, ioPool_.numFreeElements()));
+  for (uint64_t i{nextBlockId}; (i >= firstRequiredBlock) && (j < numBlocks) && !ioPool_.empty(); --i, ++j) {
+    auto ctx = ioPool_.alloc();
+    ctx->blockId = i;
+    ctx->future = as_->getBlockAsync(ctx->blockId, ctx->blockData.get(), config_.maxBlockSize, &ctx->actualBlockSize);
+    ioContexts_.push_back(std::move(ctx));
   }
 
   return j;
@@ -1426,7 +1434,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 
   // start recording time to send a whole batch, and its size
   uint64_t batchSizeBytes = 0;
-  uint64_t batchSizeBlocks = 0;
+  uint64_t batchSizeChunks = 0;
   src_send_batch_duration_rec_.clear();
   src_send_batch_duration_rec_.start();
 
@@ -1435,12 +1443,20 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
   uint16_t nextChunk = m->lastKnownChunkInLastRequiredBlock + 1;
   uint16_t numOfSentChunks = 0;
 
-  if (!config_.enableSourceBlocksPreFetch || !srcGetBlockContextes_[0].future.valid() ||
-      (srcGetBlockContextes_[0].blockId != nextBlockId)) {
-    LOG_INFO(getLogger(),
-             "Call asyncGetBlocksConcurrent: source blocks prefetch disabled (first batch or retransmission): "
-                 << KVLOG(srcGetBlockContextes_[0].blockId, nextBlockId));
-    asyncGetBlocksConcurrent(nextBlockId, m->firstRequiredBlock, config_.maxNumberOfChunksInBatch);
+  if (!config_.enableSourceBlocksPreFetch || ioContexts_.empty() || (ioContexts_.front()->blockId != nextBlockId)) {
+    if (ioContexts_.empty()) {
+      LOG_INFO(getLogger(),
+               "Call getBlocksConcurrentAsync: source blocks prefetch disabled (first batch or retransmission): "
+                   << config_.enableSourceBlocksPreFetch);
+    } else {
+      LOG_INFO(getLogger(),
+               "Call getBlocksConcurrentAsync: source blocks prefetch disabled (first batch or retransmission): "
+                   << KVLOG(config_.enableSourceBlocksPreFetch, ioContexts_.front()->blockId, nextBlockId));
+      for (auto &ctx : ioContexts_) ioPool_.free(ctx);
+      ioContexts_.clear();
+    }
+
+    getBlocksConcurrentAsync(nextBlockId, m->firstRequiredBlock, config_.maxNumberOfChunksInBatch);
   }
 
   // Fetch blocks and send all chunks for the batch. Also, while looping start to pre-fetch next batch
@@ -1455,37 +1471,43 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
                                              m->lastRequiredBlock,
                                              m->lastKnownChunkInLastRequiredBlock,
                                              preFetchBlockId));
-  size_t ctxIndex = 0;
-  DurationTracker<std::chrono::microseconds> waitFutureDuration;  // TODO(GG) - remove when unneeded
-  bool getNextBlock = true;
+  ++sourceBatchCounter_;
+  DurationTracker<std::chrono::microseconds> waitFutureDuration;  // TODO(GL) - remove when unneeded
+  bool getNextBlock = (nextChunk == 1);
   char *buffer = nullptr;
   uint32_t sizeOfNextBlock = 0;
   do {
+    auto &ctx = ioContexts_.front();
     if (getNextBlock) {
       // wait for worker to finish getting next block
-      auto &ctx = srcGetBlockContextes_[ctxIndex];
-      ConcordAssert(ctx.future.valid());
+      ConcordAssert(ctx->future.valid());
       waitFutureDuration.start();
-      if (!ctx.future.get()) {
-        LOG_ERROR(getLogger(), "Block not found in storage, abort batch:" << KVLOG(ctx.index, ctx.blockId));
-        rejectFetchingMsg();
-        return false;
+      try {
+        if (!ctx->future.get()) {
+          LOG_ERROR(getLogger(), "Block not found in storage, abort batch:" << KVLOG(ctx->blockId));
+          rejectFetchingMsg();
+          return false;
+        }
+      } catch (const std::exception &ex) {
+        LOG_FATAL(getLogger(), "exception:" << ex.what());
+        ConcordAssert(false);
+      } catch (...) {
+        LOG_FATAL(getLogger(), "Unknown exception!");
+        ConcordAssert(false);
       }
-      ConcordAssertGT(ctx.blockSize, 0);
-      ConcordAssertEQ(ctx.blockId, nextBlockId);
-      sizeOfNextBlock = ctx.blockSize;
-      buffer = ctx.block.get();
-      LOG_DEBUG(
-          getLogger(),
-          "Start sending next block: " << KVLOG(nextBlockId, sizeOfNextBlock, waitFutureDuration.totalDuration(true)));
+      ConcordAssertGT(ctx->actualBlockSize, 0);
+      ConcordAssertEQ(ctx->blockId, nextBlockId);
+      LOG_DEBUG(getLogger(),
+                "Start sending next block: " << KVLOG(
+                    sourceBatchCounter_, nextBlockId, ctx->actualBlockSize, waitFutureDuration.totalDuration(true)));
       waitFutureDuration.reset();
 
       // some statistics
-      histograms_.src_get_block_size_bytes->record(ctx.blockSize);
-      batchSizeBytes += sizeOfNextBlock;
-      ++batchSizeBlocks;
+      histograms_.src_get_block_size_bytes->record(ctx->actualBlockSize);
       getNextBlock = false;
     }
+    buffer = ctx->blockData.get();
+    sizeOfNextBlock = ctx->actualBlockSize;
 
     uint32_t sizeOfLastChunk = config_.maxChunkSize;
     uint32_t numOfChunksInNextBlock = sizeOfNextBlock / config_.maxChunkSize;
@@ -1503,6 +1525,8 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 
     SCOPED_MDC_SEQ_NUM(getSequenceNumber(replicaId, m->msgSeqNum, nextChunk, nextBlockId));
     uint32_t chunkSize = (nextChunk < numOfChunksInNextBlock) ? config_.maxChunkSize : sizeOfLastChunk;
+    batchSizeBytes += chunkSize;
+    ++batchSizeChunks;
 
     ConcordAssertGT(chunkSize, 0);
 
@@ -1530,7 +1554,6 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 
     metrics_.sent_item_data_msg_++;
     replicaForStateTransfer_->sendStateTransferMessage(reinterpret_cast<char *>(outMsg), outMsg->size(), replicaId);
-
     ItemDataMsg::free(outMsg);
     numOfSentChunks++;
 
@@ -1541,30 +1564,32 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
     } else if (static_cast<uint16_t>(nextChunk + 1) <= numOfChunksInNextBlock) {
       // we still have chunks in block
       nextChunk++;
-    } else if ((nextBlockId - 1) < m->firstRequiredBlock) {
-      LOG_DEBUG(getLogger(), "Batch end - sent all relevant blocks: " << KVLOG(m->firstRequiredBlock));
-      break;
     } else {
-      // no more chunks in the block
-      --nextBlockId;
-      nextChunk = 1;
+      ioPool_.free(ctx);
+      ioContexts_.pop_front();
+
       // this context is usage us done. We can now use it to prefetch future batch block
       if (preFetchBlockId > 0) {
-        asyncGetBlocksConcurrent(preFetchBlockId, m->firstRequiredBlock, 1, ctxIndex);
+        getBlocksConcurrentAsync(preFetchBlockId, m->firstRequiredBlock, 1);
         --preFetchBlockId;
       }
-      ++ctxIndex;
-      getNextBlock = true;
+
+      if ((nextBlockId - 1) < m->firstRequiredBlock) {
+        LOG_DEBUG(getLogger(), "Batch end - sent all relevant blocks: " << KVLOG(m->firstRequiredBlock));
+        break;
+      } else {
+        // no more chunks in the block, continue to next block
+        --nextBlockId;
+        nextChunk = 1;
+        getNextBlock = true;
+      }
     }
   } while (true);
 
   histograms_.src_send_batch_size_bytes->record(batchSizeBytes);
-  histograms_.src_send_batch_size_blocks->record(batchSizeBlocks);
+  histograms_.src_send_batch_size_chunks->record(batchSizeChunks);
   src_send_batch_duration_rec_.end();
 
-  if (preFetchBlockId > 0) {
-    asyncGetBlocksConcurrent(preFetchBlockId, m->firstRequiredBlock, 1, ctxIndex);
-  }
   return false;
 }
 
@@ -2294,6 +2319,54 @@ std::string BCStateTran::logsForCollectingStatus(const uint64_t firstRequiredBlo
   return oss.str().c_str();
 }
 
+bool BCStateTran::finalizePutblockAsync(bool lastBlock, PutBlockWaitPolicy waitPolicy) {
+  // Comment on committing asynchronously:
+  // In the very rare case of a core dump or temination, we will just fetch the committed blocks again.
+  // Putting an existing block is completely valid operation as long as the block we put before core dump and the block
+  // we put now are identical.
+  bool doneProcesssing = true;
+
+  if (ioContexts_.empty()) {
+    return doneProcesssing;
+  }
+  ConcordAssertGT(nextCommittedBlockId_, 0);
+
+  DataStoreTransaction::Guard g(psd_->beginTransaction());
+  while (!ioContexts_.empty()) {
+    auto &ctx = ioContexts_.front();
+    ConcordAssert(ctx->future.valid());
+    if ((waitPolicy == PutBlockWaitPolicy::NO_WAIT) && !lastBlock &&
+        (ctx->future.wait_for(std::chrono::nanoseconds(0)) != std::future_status::ready)) {
+      doneProcesssing = false;
+      // to reduce the number of one shot timer invocations by more than 90%, we do an approximation and use
+      // oneShotTimerFlag_
+      if (oneShotTimerFlag_) {
+        // processing not done. We must call finalizePutblockAsync in a short time to finish commit
+        metrics_.one_shot_timer_++;
+        replicaForStateTransfer_->addOneShotTimer(finalizePutblockTimeoutMilli_);
+        oneShotTimerFlag_ = false;
+      }
+      break;
+    }
+    ConcordAssertEQ(ctx->blockId, nextCommittedBlockId_);
+    try {
+      ConcordAssertEQ(ctx->future.get(), true);
+    } catch (const std::exception &e) {
+      LOG_FATAL(getLogger(), e.what());
+      ConcordAssert(false);
+    }
+
+    LOG_TRACE(getLogger(), "Finalized putBlockAsync:" << KVLOG(ctx->blockId, nextCommittedBlockId_));
+    ioPool_.free(ctx);
+    ioContexts_.pop_front();  // free memory
+    ConcordAssertGT(nextCommittedBlockId_, 0);
+    --nextCommittedBlockId_;
+    if (waitPolicy == PutBlockWaitPolicy::WAIT_SINGLE_JOB) waitPolicy = PutBlockWaitPolicy::NO_WAIT;
+  }
+  g.txn()->setLastRequiredBlock(nextCommittedBlockId_);
+  return doneProcesssing;
+}
+
 void BCStateTran::processData() {
   const FetchingState fs = getFetchingState();
   const auto fetchingState = fs;
@@ -2380,7 +2453,7 @@ void BCStateTran::processData() {
     const bool newBlock = getNextFullBlock(nextRequiredBlock_,
                                            badDataFromCurrentSourceReplica,
                                            lastChunkInRequiredBlock,
-                                           buffer_,
+                                           buffer_.get(),
                                            actualBlockSize,
                                            !isGettingBlocks,
                                            lastInBatch);
@@ -2389,14 +2462,14 @@ void BCStateTran::processData() {
     if (newBlock && isGettingBlocks) {
       TimeRecorder scoped_timer(*histograms_.dst_digest_calc_duration);
       ConcordAssert(!badDataFromCurrentSourceReplica);
-      newBlockIsValid = checkBlock(nextRequiredBlock_, digestOfNextRequiredBlock, buffer_, actualBlockSize);
+      newBlockIsValid = checkBlock(nextRequiredBlock_, digestOfNextRequiredBlock, buffer_.get(), actualBlockSize);
       badDataFromCurrentSourceReplica = !newBlockIsValid;
     } else if (newBlock && !isGettingBlocks) {
       ConcordAssert(!badDataFromCurrentSourceReplica);
       if (!config_.enableReservedPages)
         newBlockIsValid = true;
       else
-        newBlockIsValid = checkVirtualBlockOfResPages(digestOfNextRequiredBlock, buffer_, actualBlockSize);
+        newBlockIsValid = checkVirtualBlockOfResPages(digestOfNextRequiredBlock, buffer_.get(), actualBlockSize);
 
       badDataFromCurrentSourceReplica = !newBlockIsValid;
     } else {
@@ -2489,10 +2562,10 @@ void BCStateTran::processData() {
 
       if (config_.enableReservedPages) {
         // set the updated pages
-        uint32_t numOfUpdates = getNumberOfElements(buffer_);
+        uint32_t numOfUpdates = getNumberOfElements(buffer_.get());
         LOG_DEBUG(getLogger(), "numOfUpdates in vblock: " << numOfUpdates);
         for (uint32_t i = 0; i < numOfUpdates; i++) {
-          ElementOfVirtualBlock *e = getVirtualElement(i, config_.sizeOfReservedPage, buffer_);
+          ElementOfVirtualBlock *e = getVirtualElement(i, config_.sizeOfReservedPage, buffer_.get());
           g.txn()->setResPage(e->pageId, e->checkpointNumber, e->pageDigest, e->page);
           LOG_DEBUG(getLogger(), "Update page " << e->pageId);
         }
@@ -2734,8 +2807,8 @@ void BCStateTran::checkStoredCheckpoints(uint64_t firstStoredCheckpoint, uint64_
         // Extra debugging needed here for BC-2821
         if (computedBlockDigest != desc.digestOfLastBlock) {
           uint32_t blockSize = 0;
-          as_->getBlock(desc.lastBlock, buffer_, config_.maxBlockSize, &blockSize);
-          concordUtils::HexPrintBuffer blockData{buffer_, blockSize};
+          as_->getBlock(desc.lastBlock, buffer_.get(), config_.maxBlockSize, &blockSize);
+          concordUtils::HexPrintBuffer blockData{buffer_.get(), blockSize};
           LOG_FATAL(getLogger(), "Invalid stored checkpoint: " << KVLOG(desc.checkpointNum, desc.lastBlock, blockData));
           ConcordAssertEQ(computedBlockDigest, desc.digestOfLastBlock);
         }

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -505,8 +505,7 @@ class BCStateTran : public IStateTransfer {
   DurationTracker<std::chrono::milliseconds> gettingCheckpointSummariesDT_;
   DurationTracker<std::chrono::milliseconds> gettingMissingBlocksDT_;
   DurationTracker<std::chrono::milliseconds> gettingMissingResPagesDT_;
-  DurationTracker<std::chrono::milliseconds> betweenPutBlocksStTempDT_;  // TODO(GL) - remove later when unneeded
-  DurationTracker<std::chrono::milliseconds> putBlocksStTempDT_;         // TODO(GL) - remove later when unneeded
+
   FetchingState lastFetchingState_;
 
   void onFetchingStateChange(FetchingState newFetchingState);
@@ -532,6 +531,7 @@ class BCStateTran : public IStateTransfer {
     static constexpr uint64_t MAX_BATCH_SIZE_BYTES = 10ULL * 1024ULL * 1024ULL * 1024ULL;  // 10GB
     static constexpr uint64_t MAX_BATCH_SIZE_BLOCKS = 1000ULL;
     static constexpr uint64_t MAX_HANDOFF_QUEUE_SIZE = 10000ULL;
+    static constexpr uint64_t MAX_PENDING_BLOCKS_SIZE = 1000ULL;
 
     Recorders() {
       auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
@@ -542,7 +542,7 @@ class BCStateTran : public IStateTransfer {
                                        {
                                            dst_handle_ItemData_msg,
                                            dst_time_between_sendFetchBlocksMsg,
-                                           dst_put_block_duration,
+                                           dst_num_pending_blocks_to_commit,
                                            dst_digest_calc_duration,
                                        });
       // source component
@@ -567,7 +567,7 @@ class BCStateTran : public IStateTransfer {
     DEFINE_SHARED_RECORDER(
         dst_time_between_sendFetchBlocksMsg, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(
-        dst_put_block_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+        dst_num_pending_blocks_to_commit, 1, MAX_PENDING_BLOCKS_SIZE, 3, concord::diagnostics::Unit::COUNT);
     DEFINE_SHARED_RECORDER(
         dst_digest_calc_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
     // source

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -120,7 +120,7 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
     std::future<bool> putBlockAsync(uint64_t blockId,
                                     const char* block,
                                     const uint32_t blockSize,
-                                    bool trylinkSTChainFrom = true) override;
+                                    bool lastBlock = true) override;
 
     uint64_t getLastReachableBlockNum() const override;
     uint64_t getGenesisBlockNum() const override;
@@ -648,7 +648,7 @@ bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId,
 std::future<bool> SimpleStateTran::DummyBDState::putBlockAsync(uint64_t blockId,
                                                                const char* block,
                                                                const uint32_t blockSize,
-                                                               bool trylinkSTChainFrom) {
+                                                               bool lastBlock) {
   ConcordAssert(false);
   return std::async([]() { return false; });
 }

--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -84,7 +84,7 @@ class TestAppState : public IAppState {
   std::future<bool> putBlockAsync(uint64_t blockId,
                                   const char* block,
                                   const uint32_t blockSize,
-                                  bool trylinkSTChainFrom = true) override {
+                                  bool lastBlock = true) override {
     ConcordAssert(false);
     return std::async([]() { return false; });
   }

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -477,17 +477,17 @@ bool Replica::putBlock(const uint64_t blockId, const char *blockData, const uint
 std::future<bool> Replica::putBlockAsync(uint64_t blockId,
                                          const char *block,
                                          const uint32_t blockSize,
-                                         bool trylinkSTChainFrom) {
+                                         bool lastBlock) {
   static uint64_t callCounter = 0;
   static constexpr size_t snapshotThresh = 1000;
 
   auto future = blocksIOWorkersPool_.async(
-      [this](uint64_t blockId, const char *block, const uint32_t blockSize, bool trylinkSTChainFrom) {
+      [this](uint64_t blockId, const char *block, const uint32_t blockSize, bool lastBlock) {
         auto start = std::chrono::steady_clock::now();
         bool result = false;
 
         LOG_TRACE(logger, "Job Started: " << KVLOG(blockId, blockSize));
-        result = putBlock(blockId, block, blockSize, trylinkSTChainFrom);
+        result = putBlock(blockId, block, blockSize, lastBlock);
 
         auto jobDuration =
             std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count();
@@ -498,7 +498,7 @@ std::future<bool> Replica::putBlockAsync(uint64_t blockId,
       std::forward<decltype(blockId)>(blockId),
       std::forward<decltype(block)>(block),
       std::forward<decltype(blockSize)>(blockSize),
-      std::forward<decltype(trylinkSTChainFrom)>(trylinkSTChainFrom));
+      std::forward<decltype(lastBlock)>(lastBlock));
 
   if ((++callCounter % snapshotThresh) == 0) {
     auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();

--- a/util/include/SimpleMemoryPool.hpp
+++ b/util/include/SimpleMemoryPool.hpp
@@ -1,0 +1,96 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <stdint.h>
+#include <functional>
+#include <deque>
+#include <memory>
+
+#include "assertUtils.hpp"
+
+namespace concord::util {
+
+/**
+ * This is a template class that implements a simple memory pool for a single type of element.
+ * A common use case for this class is the pre-allocation of N elements at the start. This is done in order to:
+ * 1) Make sure the only possible allocation failures in the module can happen on boot (startup).
+ * 2) Avoid allocation/deallocation of memory. Specifically, for small memory chunks, in the long term this can cause
+ * performance issues and memory defragmentation.
+ * Currently, the class does not implements pool of elements of pointer or array type.
+ */
+
+template <typename T>
+class SimpleMemoryPool {
+  static_assert(!std::is_array<T>::value, "Array type not supported!");
+  static_assert(!std::is_pointer<T>::value, "Pointer type not supported!");
+
+ public:
+  using ElementPtr = std::shared_ptr<T>;
+  SimpleMemoryPool(size_t maxNumElements,
+                   std::function<void(ElementPtr&)> allocCallback = nullptr,
+                   std::function<void(ElementPtr&)> freeCallback = nullptr,
+                   std::function<void()> ctorCallback = nullptr)
+      : maxNumElements_(maxNumElements), allocCallback_{allocCallback}, freeCallback_(freeCallback) {
+    if (maxNumElements == 0) throw std::invalid_argument("maxNumElements cannnot be 0!");
+    if (ctorCallback) ctorCallback();
+    for (size_t i{0}; i < maxNumElements_; ++i) {
+      auto element = std::make_shared<T>();
+      freeQ_.push_back(element);
+    }
+  }
+
+  size_t numFreeElements() const { return freeQ_.size(); }
+  size_t numAllocatedElements() const { return allocatedQ_.size(); }
+  bool empty() { return freeQ_.empty(); };
+  bool full() { return allocatedQ_.empty(); };
+  size_t maxElements() { return maxNumElements_; };
+
+  ElementPtr alloc() {
+    if (freeQ_.empty()) {
+      throw std::runtime_error("No more free elements!");
+    }
+    auto ret = freeQ_.front();
+    freeQ_.pop_front();
+    allocatedQ_.push_back(ret);
+    if (allocCallback_) {
+      allocCallback_(ret);
+    }
+    return ret;
+  }
+
+  void free(ElementPtr& element) {
+    if (freeQ_.size() == maxNumElements_) {
+      throw std::runtime_error("All elements have been already returned!");
+    }
+    if (std::find(allocatedQ_.begin(), allocatedQ_.end(), element) == allocatedQ_.end()) {
+      throw std::runtime_error("Trying to free unrocognized element (element was not allocated by this pool)!");
+    }
+
+    auto ret = allocatedQ_.front();
+    allocatedQ_.pop_front();
+    if (freeCallback_) {
+      freeCallback_(ret);
+    }
+    freeQ_.push_back(std::move(element));
+  }
+
+ private:
+  const size_t maxNumElements_;
+  std::deque<ElementPtr> freeQ_;
+  std::deque<ElementPtr> allocatedQ_;
+  std::function<void(ElementPtr&)> allocCallback_;
+  std::function<void(ElementPtr&)> freeCallback_;
+};  // SimpleMemoryPool
+}  // namespace concord::util

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -63,3 +63,7 @@ target_link_libraries(lru_cache_test GTest::Main util)
 add_executable(openssl_crypto_wrapper_test openssl_crypto_wrapper_tests.cpp)
 add_test(openssl_crypto_wrapper_test openssl_crypto_wrapper_test)
 target_link_libraries(openssl_crypto_wrapper_test GTest::Main util)
+
+add_executable(simple_memory_pool_test simple_memory_pool_test.cpp)
+add_test(simple_memory_pool_test simple_memory_pool_test)
+target_link_libraries(simple_memory_pool_test GTest::Main util)

--- a/util/test/simple_memory_pool_test.cpp
+++ b/util/test/simple_memory_pool_test.cpp
@@ -1,0 +1,115 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "SimpleMemoryPool.hpp"
+
+namespace {
+using namespace std;
+using namespace concord::util;
+
+TEST(SimpleMemoryPoolTest, check_input_maxNumElements) {
+  EXPECT_THROW(SimpleMemoryPool<int> pool(0), std::invalid_argument);
+  EXPECT_NO_THROW(SimpleMemoryPool<int> pool1(1));
+  EXPECT_NO_THROW(SimpleMemoryPool<int> pool2(1000));
+}
+
+TEST(SimpleMemoryPoolTest, basic_test) {
+  constexpr size_t poolSize = 100;
+  SimpleMemoryPool<int> pool(poolSize);
+  std::vector<std::shared_ptr<int>> vec1;
+
+  // before alloc
+  ASSERT_EQ(pool.numFreeElements(), poolSize);
+  ASSERT_EQ(pool.numAllocatedElements(), 0);
+  ASSERT_FALSE(pool.empty());
+  ASSERT_TRUE(pool.full());
+
+  // alloc
+  for (size_t i{1}; i <= poolSize; ++i) {
+    vec1.emplace_back(pool.alloc());
+    ASSERT_EQ(pool.numFreeElements(), poolSize - i);
+    ASSERT_EQ(pool.numAllocatedElements(), i);
+  }
+
+  // after alloc, before free
+  ASSERT_TRUE(pool.empty());
+  ASSERT_FALSE(pool.full());
+
+  // free
+  size_t i{0};
+  for (auto &element : vec1) {
+    pool.free(element);
+    ++i;
+    ASSERT_EQ(pool.numFreeElements(), i);
+    ASSERT_EQ(pool.numAllocatedElements(), poolSize - i);
+  }
+
+  // after free
+  ASSERT_FALSE(pool.empty());
+  ASSERT_TRUE(pool.full());
+}
+
+TEST(SimpleMemoryPoolTest, test_callbacks) {
+  int a = 10, b = 20, c = 30;
+  SimpleMemoryPool<int> pool(
+      100, [&](std::shared_ptr<int> &) { ++a; }, [&](std::shared_ptr<int> &) { ++b; }, [&]() { ++c; });
+
+  ASSERT_EQ(a, 10);
+  ASSERT_EQ(b, 20);
+  ASSERT_EQ(c, 31);
+
+  auto element = pool.alloc();
+
+  ASSERT_EQ(a, 11);
+  ASSERT_EQ(b, 20);
+  ASSERT_EQ(c, 31);
+
+  pool.free(element);
+
+  ASSERT_EQ(a, 11);
+  ASSERT_EQ(b, 21);
+  ASSERT_EQ(c, 31);
+}
+
+TEST(SimpleMemoryPoolTest, test_alloc_free_errors) {
+  constexpr size_t poolSize = 100;
+  SimpleMemoryPool<int> pool(poolSize);
+  std::vector<std::shared_ptr<int>> vec1;
+
+  for (size_t i{0}; i < poolSize; ++i) vec1.emplace_back(pool.alloc());
+
+  ASSERT_TRUE(pool.empty());
+  ASSERT_FALSE(pool.full());
+
+  // no more elements in pool
+  EXPECT_THROW(pool.alloc(), std::runtime_error);
+
+  // try to return element which does not belong to pool
+  auto element = std::make_shared<int>();
+  EXPECT_THROW(pool.free(element), std::runtime_error);
+
+  // free all elements and try double free
+  for (auto &element : vec1) {
+    pool.free(element);
+  }
+  ASSERT_FALSE(pool.empty());
+  ASSERT_TRUE(pool.full());
+  EXPECT_THROW(pool.free(vec1[0]), std::runtime_error);
+}
+
+}  // namespace


### PR DESCRIPTION
This PR includes one main improvement - putting blocks concurrently. This improves the channel throughput (MB/s) by approx 25%. It was tested also to work correctly with block chunking.
Changes rely on the interface changes done in phase1.
In addition, I had to add an IO context pool and refactor getBlock as well (using the same contexts) to simplify the code.
PR also includes a small bug fix and refactoring.
I suggest reviewing by commits to get a better understanding.

Commits:
1. BCStateTran: intro BlockIODataPool, refactor getBlock at source, fix bug.
2. BCStateTran: perform putBlock to temporary ST concurrently.
3. BCStateTran: minor refactoring (reword comments, remove unneeded code).