### PR TITLE
Client Key Exchange phase 2

### DIFF
--- a/bftengine/include/bftengine/IKeyExchanger.hpp
+++ b/bftengine/include/bftengine/IKeyExchanger.hpp
@@ -13,6 +13,8 @@
 #include <string>
 #include <cstdint>
 
+enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
+
 // Interface for objects that need to be notified on key rotation
 class IKeyExchanger {
  public:
@@ -25,4 +27,10 @@ class IMultiSigKeyGenerator {
  public:
   virtual ~IMultiSigKeyGenerator() {}
   virtual std::pair<std::string, std::string> generateMultisigKeyPair() = 0;
+};
+
+class IClientPublicKeyStore {
+ public:
+  virtual ~IClientPublicKeyStore() = default;
+  virtual void setClientPublicKey(uint16_t clientId, const std::string& key, KeyFormat) = 0;
 };

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -55,7 +55,10 @@ class KeyExchangeManager {
   // Publish the public keys of the clients
   void sendInitialClientsKeys(const std::string&);
   void onPublishClientsKeys(const std::string& keys, std::optional<std::string> bootstrap_keys);
-  void onClientPublicKeyExchange(const std::string& key, std::uint16_t clientId);
+  // called on a new client key
+  void onClientPublicKeyExchange(const std::string& key, KeyFormat, NodeIdType clientId);
+  // called when client keys are loaded
+  void loadClientPublicKey(const std::string& key, KeyFormat, NodeIdType clientId);
   ///////// end - Clients public keys interface///////////////
 
   std::string getStatus() const;
@@ -151,6 +154,7 @@ class KeyExchangeManager {
     IMultiSigKeyGenerator* kg{nullptr};
     IKeyExchanger* ke{nullptr};
     std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsMgr;
+    IClientPublicKeyStore* cpks;
     concordUtil::Timers* timers{nullptr};
   };
 
@@ -192,6 +196,7 @@ class KeyExchangeManager {
   std::shared_ptr<IInternalBFTClient> client_;
   std::vector<IKeyExchanger*> registryToExchange_;
   IMultiSigKeyGenerator* multiSigKeyHdlr_{nullptr};
+  IClientPublicKeyStore* clientPublicKeyStore_{nullptr};
 
   struct Metrics {
     std::chrono::seconds lastMetricsDumpTime;

--- a/bftengine/src/bftengine/Crypto.hpp
+++ b/bftengine/src/bftengine/Crypto.hpp
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <threshsign/ThresholdSignaturesSchemes.h>
-#include "PrimitiveTypes.hpp"
+#include "bftengine/IKeyExchanger.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"

--- a/bftengine/src/bftengine/PrimitiveTypes.hpp
+++ b/bftengine/src/bftengine/PrimitiveTypes.hpp
@@ -39,7 +39,6 @@ typedef uint16_t MsgType;
 typedef uint32_t SpanContextSize;
 
 enum class CommitPath { NA = -1, OPTIMISTIC_FAST = 0, FAST_WITH_THRESHOLD = 1, SLOW = 2 };
-enum class KeyFormat { HexaDecimalStrippedFormat, PemFormat };
 
 std::string CommitPathToStr(CommitPath path);
 std::string CommitPathToMDCString(CommitPath path);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3777,7 +3777,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   for (int i = 0; i < config_.getnumOfClientProxies(); ++i) proxyClients.insert(clientId++);
   for (int i = 0; i < config_.getnumOfExternalClients(); ++i) externalClients.insert(clientId++);
   for (int i = 0; i < config_.getnumReplicas(); ++i) internalClients.insert(clientId++);
-  clientsManager = new ClientsManager(proxyClients, externalClients, internalClients, metrics_);
+  clientsManager = std::make_shared<ClientsManager>(proxyClients, externalClients, internalClients, metrics_);
   internalBFTClient_.reset(
       new InternalBFTClient(*internalClients.cbegin() + config_.getreplicaId(), msgsCommunicator_));
 
@@ -3825,7 +3825,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   }
 
   KeyExchangeManager::InitData id{
-      internalBFTClient_, &CryptoManager::instance(), &CryptoManager::instance(), sm_, &timers_};
+      internalBFTClient_, &CryptoManager::instance(), &CryptoManager::instance(), sm_, clientsManager.get(), &timers_};
 
   KeyExchangeManager::instance(&id);
 
@@ -3841,7 +3841,6 @@ ReplicaImp::~ReplicaImp() {
   delete controller;
   delete dynamicUpperLimitOfRounds;
   delete checkpointsLog;
-  delete clientsManager;
   delete repsInfo;
   free(replyBuffer);
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -131,7 +131,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   std::map<ReplicaId, CheckpointMsg*> tableOfStableCheckpoints;
 
   // managing information about the clients
-  ClientsManager* clientsManager = nullptr;
+  std::shared_ptr<ClientsManager> clientsManager;
   std::shared_ptr<InternalBFTClient> internalBFTClient_;
 
   size_t numInvalidClients = 0;

--- a/bftengine/tests/clientsManager/ClientsManager_test.cpp
+++ b/bftengine/tests/clientsManager/ClientsManager_test.cpp
@@ -11,27 +11,28 @@
 
 #include "ClientsManager.hpp"
 #include "gtest/gtest.h"
-#include <chrono>
-#include <thread>
+#include "ReservedPagesMock.hpp"
 
 using namespace std;
 using namespace bftEngine;
 concordMetrics::Component metrics{concordMetrics::Component("replica", std::make_shared<concordMetrics::Aggregator>())};
+bftEngine::test::ReservedPagesMock<bftEngine::impl::ClientsManager> res_pages_mock_;
 
-TEST(ClientsManager, ) {
+TEST(ClientsManager, reservedPagesPerClient) {
   uint32_t sizeOfReservedPage = 1024;
   uint32_t maxReplysize = 1000;
   auto numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize);
-  ASSERT_EQ(numPagesPerCl, 1);
+  ASSERT_EQ(numPagesPerCl, 2);
   maxReplysize = 3000;
   numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize);
-  ASSERT_EQ(numPagesPerCl, 3);
+  ASSERT_EQ(numPagesPerCl, 4);
   maxReplysize = 1024;
   numPagesPerCl = bftEngine::impl::ClientsManager::reservedPagesPerClient(sizeOfReservedPage, maxReplysize);
-  ASSERT_EQ(numPagesPerCl, 1);
+  ASSERT_EQ(numPagesPerCl, 2);
 }
 
 TEST(ClientsManager, constructor) {
+  bftEngine::ReservedPagesClientBase::setReservedPages(&res_pages_mock_);
   bftEngine::impl::ClientsManager cm{{1, 4, 50, 7}, {3, 2, 60}, {5, 11, 55}, metrics};
   for (auto id : {5, 11, 55}) ASSERT_EQ(true, cm.isInternal(id));
   for (auto id : {1, 4, 50, 3, 2, 60}) ASSERT_EQ(false, cm.isInternal(id));

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -231,6 +231,7 @@ void Replica::createReplicaAndSyncState() {
                      getLastReachableBlockNum(),
                      maxNumOfBlocksToDelete));
     } catch (std::exception &e) {
+      LOG_FATAL(logger, "exception: " << e.what());
       std::terminate();
     }
   }

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -305,8 +305,7 @@ struct VerifyBlockRequests {
       out << "\t\t\"signature_digest\": \"" << std::hash<std::string>{}(req.signature) << "\",\n";
       out << "\t\t\"key_digest\": \"" << std::hash<std::string>{}(client_keys.ids_to_keys[req.clientId].key) << "\",\n";
       auto verifier = std::make_unique<bftEngine::impl::RSAVerifier>(
-          client_keys.ids_to_keys[req.clientId].key.c_str(),
-          (bftEngine::impl::KeyFormat)client_keys.ids_to_keys[req.clientId].format);
+          client_keys.ids_to_keys[req.clientId].key.c_str(), (KeyFormat)client_keys.ids_to_keys[req.clientId].format);
       auto result =
           verifier->verify(req.request.c_str(), req.request.size(), req.signature.c_str(), req.signature.size());
       if (result) {

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -148,7 +148,7 @@ Msg ClientReconfigurationStateRequest 37 {
 Msg ClientExchangePublicKey 38 {
     uint64 sender_id
     string pub_key
-    list uint64 effected_clients
+    list uint64 affected_clients
 }
 
 Msg ClientReconfigurationStateReply 39 {

--- a/reconfiguration/src/dispatcher.cpp
+++ b/reconfiguration/src/dispatcher.cpp
@@ -78,6 +78,10 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
 
     if (!valid) rresp.success = false;  // If no handler was able to verify the request, it is an invalid request
   } catch (const std::exception& e) {
+    rresp.success = false;
+    LOG_ERROR(getLogger(),
+              "Reconfiguration request from sender: "
+                  << request.sender << " seqnum:" << std::to_string(sequence_num) + " failed, exception: " + e.what());
     ADDITIONAL_DATA(rresp,
                     "Reconfiguration request " + std::to_string(sequence_num) + " failed, exception: " + e.what());
   }

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -145,7 +145,10 @@ bool ClientReconfigurationHandler::handle(const concord::messages::ClientExchang
                                           uint64_t,
                                           concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "public key: " << msg.pub_key << " sender: " << msg.sender_id);
-  bftEngine::impl::KeyExchangeManager::instance().onClientPublicKeyExchange(msg.pub_key, msg.sender_id);
+  // assuming we always send hex DER over the wire
+  for (const auto& clientId : msg.affected_clients)
+    bftEngine::impl::KeyExchangeManager::instance().onClientPublicKeyExchange(
+        msg.pub_key, KeyFormat::HexaDecimalStrippedFormat, clientId);
   return true;
 }
 }  // namespace concord::reconfiguration

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -492,8 +492,11 @@ class BftTestNetwork:
             metric_clients[r.id] = bft_metrics_client.MetricsClient(r)
         self.metrics = bft_metrics.BftMetrics(metric_clients)
 
-    def random_client(self):
-        return random.choice(list(self.clients.values()))
+    def random_client(self, without=None):
+        if without == None:
+            without = set()
+
+        return random.choice(list(set(self.clients.values()) - without))
 
     def random_clients(self, max_clients):
         return set(random.choices(list(self.clients.values()), k=max_clients))

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -23,8 +23,9 @@ sys.path.append(os.path.abspath("../../util/pyclient"))
 import bft_client
 from ecdsa import SigningKey
 from ecdsa import SECP256k1
-from ecdsa.util import sigencode_der
 import hashlib
+from Crypto.PublicKey import RSA
+
 class Operator:
     def __init__(self, config, client, priv_key_dir):
         self.config = config
@@ -129,17 +130,18 @@ class Operator:
         restart_command.data = data
         return self._construct_basic_reconfiguration_request(restart_command)
     
-    def _construct_reconfiguration_clientExchangePublicKey_(self, clientId, clientPubKey, effected_clients = []):
+    def _construct_reconfiguration_clientExchangePublicKey_(self, clientPubKey, affected_clients = []):
         cepk = cmf_msgs.ClientExchangePublicKey()
-        cepk.sender_id = clientId
+        cepk.sender_id = 1000
         cepk.pub_key = clientPubKey
-        cepk.effected_clients = effected_clients
+        cepk.affected_clients = affected_clients
         return self._construct_basic_reconfiguration_request(cepk)
     
     def _generate_client_keys(self):
-        sk = SigningKey.generate(curve=SECP256k1)
-        pk = sk.get_verifying_key()
-        print(f'verification key {pk.to_string().hex()}')
+        sk = RSA.generate(2048)
+        pk = sk.public_key().export_key(format='DER').hex()
+        print(f'verification key {pk}')
+        
         return sk, pk 
     
     def get_rsi_replies(self):
@@ -201,9 +203,14 @@ class Operator:
         reconf_msg = self._construct_reconfiguration_clientKe_command(target_clients)
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
     
-    async def client_exchange_public_key(self):
-        sk, pk = self._generate_client_keys()
-        reconf_msg = self._construct_reconfiguration_clientExchangePublicKey_(self.client.client_id, pk.to_string().hex())
+    async def client_exchange_public_key(self, valid=True):
+        pk = ""
+        if valid is True:
+            sk, pk = self._generate_client_keys()
+        else:
+            pk = "invalid client public key".encode("utf-8").hex()
+                
+        reconf_msg = self._construct_reconfiguration_clientExchangePublicKey_(pk, [self.client.client_id])
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
         
     async def add_remove(self, new_config):

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -292,7 +292,8 @@ class SimpleKVBCProtocol:
             self, initial_nodes,
             num_of_checkpoints_to_add=2,
             verify_checkpoint_persistency=True,
-            assert_state_transfer_not_started=True):
+            assert_state_transfer_not_started=True,
+            without_clients=None):
         """
         A helper function used by tests to fill a window with data and then
         checkpoint it.
@@ -303,7 +304,7 @@ class SimpleKVBCProtocol:
         TODO: Make filling concurrent to speed up tests
         """
         with log.start_action(action_type="fill_and_wait_for_checkpoint"):
-            client = self.bft_network.random_client()
+            client = self.bft_network.random_client(without_clients)
             checkpoint_before = await self.bft_network.wait_for_checkpoint(
                 replica_id=random.choice(initial_nodes))
             # Write enough data to checkpoint and create a need for state transfer

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 
 namespace concord::kvbc::test {
+std::shared_ptr<concord::kvbc::Replica> replica;
 
 std::atomic_bool timeToExit = false;
 
@@ -77,16 +78,15 @@ void run_replica(int argc, char** argv) {
   MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(setup->GetReplicaConfig().replicaId));
   MDC_PUT(MDC_THREAD_KEY, "main");
 
-  std::shared_ptr<Replica> replica =
-      std::make_shared<Replica>(setup->GetCommunication(),
-                                setup->GetReplicaConfig(),
-                                setup->GetStorageFactory(),
-                                setup->GetMetricsServer().GetAggregator(),
-                                setup->GetPerformanceManager(),
-                                std::map<std::string, categorization::CATEGORY_TYPE>{
-                                    {VERSIONED_KV_CAT_ID, categorization::CATEGORY_TYPE::versioned_kv},
-                                    {BLOCK_MERKLE_CAT_ID, categorization::CATEGORY_TYPE::block_merkle}},
-                                std::make_shared<concord::secretsmanager::SecretsManagerPlain>());
+  replica = std::make_shared<Replica>(setup->GetCommunication(),
+                                      setup->GetReplicaConfig(),
+                                      setup->GetStorageFactory(),
+                                      setup->GetMetricsServer().GetAggregator(),
+                                      setup->GetPerformanceManager(),
+                                      std::map<std::string, categorization::CATEGORY_TYPE>{
+                                          {VERSIONED_KV_CAT_ID, categorization::CATEGORY_TYPE::versioned_kv},
+                                          {BLOCK_MERKLE_CAT_ID, categorization::CATEGORY_TYPE::block_merkle}},
+                                      std::make_shared<concord::secretsmanager::SecretsManagerPlain>());
 
   auto* blockMetadata = new BlockMetadata(*replica);
 


### PR DESCRIPTION
- store client public key in ClientsManager reserved pages;
- SigManager will first load bootstrap client public keys as now, and then will be updated by the keys loaded from reserved pages;
- few small refactorings: smart_ptrs instead of plain ptr, logs, etc.