### PR TITLE
Sync MT access of TicksGen and Pruning res pages

### DIFF
--- a/kvbc/src/pruning_reserved_pages_client.cpp
+++ b/kvbc/src/pruning_reserved_pages_client.cpp
@@ -52,7 +52,7 @@ ReservedPagesClient::ReservedPagesClient() {
   }
 }
 
-void ReservedPagesClient::saveAgreement(const Agreement& agreement) {
+void ReservedPagesClient::saveAgreementWithoutLock(const Agreement& agreement) {
   auto out = std::vector<std::uint8_t>{};
   serialize(out, agreement);
   client_.saveReservedPage(kLatestAgreementPageId, out.size(), cdata(out));
@@ -62,27 +62,37 @@ void ReservedPagesClient::saveAgreement(const Agreement& agreement) {
   latest_agreement_ = agreement;
 }
 
+void ReservedPagesClient::saveAgreement(const Agreement& agreement) {
+  auto lock = std::scoped_lock{mtx_};
+  saveAgreementWithoutLock(agreement);
+}
+
 void ReservedPagesClient::updateExistingAgreement(const std::chrono::seconds& tick_period,
                                                   std::uint64_t batch_blocks_num) {
+  auto lock = std::scoped_lock{mtx_};
   ConcordAssert(latest_agreement_.has_value());
-  saveAgreement(createAgreement(tick_period, batch_blocks_num, latest_agreement_->last_agreed_prunable_block_id));
+  saveAgreementWithoutLock(
+      createAgreement(tick_period, batch_blocks_num, latest_agreement_->last_agreed_prunable_block_id));
 }
 
 void ReservedPagesClient::updateExistingAgreement(const std::chrono::seconds& tick_period) {
+  auto lock = std::scoped_lock{mtx_};
   ConcordAssert(latest_agreement_.has_value());
-  saveAgreement(createAgreement(
+  saveAgreementWithoutLock(createAgreement(
       tick_period, latest_agreement_->batch_blocks_num, latest_agreement_->last_agreed_prunable_block_id));
 }
 
 void ReservedPagesClient::updateExistingAgreement(std::uint64_t batch_blocks_num) {
+  auto lock = std::scoped_lock{mtx_};
   ConcordAssert(latest_agreement_.has_value());
-  saveAgreement(createAgreement(std::chrono::seconds{latest_agreement_->tick_period_seconds},
-                                batch_blocks_num,
-                                latest_agreement_->last_agreed_prunable_block_id));
+  saveAgreementWithoutLock(createAgreement(std::chrono::seconds{latest_agreement_->tick_period_seconds},
+                                           batch_blocks_num,
+                                           latest_agreement_->last_agreed_prunable_block_id));
 }
 
 void ReservedPagesClient::saveLatestBatch(BlockId to) {
   auto out = std::vector<std::uint8_t>{};
+  auto lock = std::scoped_lock{mtx_};
   serialize(out, Batch{to});
   client_.saveReservedPage(kLatestBatchBlockIdToPageId, out.size(), cdata(out));
   latest_batch_block_id_to_ = to;


### PR DESCRIPTION
Make sure that users can safely call public methods of the
TicksGenerator and pruning::ReservedPagesClient classes. Rationale is
that these objects are:
 * constructed in the main thread
 * accessed/modified in the messaging and state transfer threads

Mutexes are used to make sure changes by one thread are visible to other
threads, even though these changes are never done in parallel.