### PR TITLE
Working window refactor

### DIFF
--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -67,8 +67,6 @@ class CheckpointInfo {
   static void free(CheckpointInfo& i);
 
   static void reset(CheckpointInfo& i);
-
-  static void acquire(CheckpointInfo& to, CheckpointInfo& from) {}
 };
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
+++ b/bftengine/src/bftengine/CollectorOfThresholdSignatures.hpp
@@ -39,17 +39,6 @@ class CollectorOfThresholdSignatures {
  public:
   CollectorOfThresholdSignatures(void* cnt) { this->context = cnt; }
 
-  void acquire(CollectorOfThresholdSignatures* rhs) {
-    replicasInfo = rhs->replicasInfo;
-    rhs->replicasInfo.clear();
-
-    combinedValidSignatureMsg = rhs->combinedValidSignatureMsg;
-    rhs->combinedValidSignatureMsg = nullptr;
-
-    candidateCombinedSignatureMsg = rhs->candidateCombinedSignatureMsg;
-    rhs->candidateCombinedSignatureMsg = nullptr;
-  }
-
   ~CollectorOfThresholdSignatures() { resetAndFree(); }
 
   bool addMsgWithPartialSignature(PART* partialSigMsg, ReplicaId repId) {

--- a/bftengine/src/bftengine/SeqNumInfo.cpp
+++ b/bftengine/src/bftengine/SeqNumInfo.cpp
@@ -39,21 +39,6 @@ SeqNumInfo::~SeqNumInfo() {
   delete partialProofsSet;
 }
 
-void SeqNumInfo::acquire(SeqNumInfo& rhs) {
-  primary = rhs.primary;
-  forcedCompleted = rhs.forcedCompleted;
-  slowPathHasStarted = rhs.slowPathHasStarted;
-  firstSeenFromPrimary = rhs.firstSeenFromPrimary;
-  timeOfLastInfoRequest = rhs.timeOfLastInfoRequest;
-  commitUpdateTime = rhs.commitUpdateTime;
-
-  prePrepareMsg = rhs.prePrepareMsg;
-  rhs.prePrepareMsg = nullptr;
-
-  prepareSigCollector->acquire(rhs.prepareSigCollector);
-  commitMsgsCollector->acquire(rhs.commitMsgsCollector);
-  partialProofsSet->acquire(rhs.partialProofsSet);
-}
 void SeqNumInfo::resetCommitSignatres() { commitMsgsCollector->resetAndFree(); }
 
 void SeqNumInfo::resetPrepareSignatures() { prepareSigCollector->resetAndFree(); }

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -35,8 +35,6 @@ class SeqNumInfo {
   SeqNumInfo();
   ~SeqNumInfo();
 
-  void acquire(SeqNumInfo& rhs);
-
   void resetCommitSignatres();
   void resetPrepareSignatures();
   void resetAndFree();  // TODO(GG): name
@@ -203,8 +201,6 @@ class SeqNumInfo {
   static void free(SeqNumInfo& i) { i.resetAndFree(); }
 
   static void reset(SeqNumInfo& i) { i.resetAndFree(); }
-
-  static void acquire(SeqNumInfo& to, SeqNumInfo& from) { to.acquire(from); }
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
+++ b/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
@@ -22,74 +22,6 @@
 namespace bftEngine {
 namespace impl {
 
-template <uint16_t Resolution, typename NumbersType, typename ItemType, typename ItemFuncs>
-class InactiveStorage {
- public:
-  InactiveStorage(uint16_t maxSize, void *initData, NumbersType windowFirst) {
-    if (maxSize > 0) {
-      beginningOfInactiveWindow = windowFirst;
-      inactiveSavedSeqs.resize(maxSize);
-      readPosOfInactiveWindow = elementsInInactiveWindow = writePosOfInactiveWindow = 0;
-      for (uint16_t i = 0; i < maxSize; i++) {
-        ItemFuncs::init(inactiveSavedSeqs[i], initData);
-        ItemFuncs::reset(inactiveSavedSeqs[i]);
-      }
-    }
-  }
-
-  ~InactiveStorage() {
-    for (size_t i = 0; i < inactiveSavedSeqs.size(); i++) ItemFuncs::free(inactiveSavedSeqs[i]);
-  }
-
-  void clear(NumbersType newBeginningOfInactiveWindow) {
-    beginningOfInactiveWindow = newBeginningOfInactiveWindow;
-    readPosOfInactiveWindow = elementsInInactiveWindow = writePosOfInactiveWindow = 0;
-    for (size_t i = 0; i < inactiveSavedSeqs.size(); i++) {
-      ItemFuncs::reset(inactiveSavedSeqs[i]);
-    }
-  }
-
-  void add(ItemType &item) {
-    ConcordAssertGT(inactiveSavedSeqs.size(), 0);
-    ItemFuncs::reset(inactiveSavedSeqs[writePosOfInactiveWindow]);
-    ItemFuncs::acquire(inactiveSavedSeqs[writePosOfInactiveWindow], item);
-    writePosOfInactiveWindow = (writePosOfInactiveWindow + 1) % inactiveSavedSeqs.size();
-    if (++elementsInInactiveWindow > inactiveSavedSeqs.size()) {
-      elementsInInactiveWindow = inactiveSavedSeqs.size();
-      beginningOfInactiveWindow += Resolution;
-      readPosOfInactiveWindow = (readPosOfInactiveWindow + 1) % inactiveSavedSeqs.size();
-    }
-  }
-
-  ItemType &get(NumbersType n) {
-    ConcordAssert(n % Resolution == 0);
-    ConcordAssertGT(inactiveSavedSeqs.size(), 0);
-    auto index = (readPosOfInactiveWindow + (n - beginningOfInactiveWindow) / Resolution) % inactiveSavedSeqs.size();
-    LOG_DEBUG(GL,
-              "Actual get from Inactive Window" << KVLOG(index,
-                                                         readPosOfInactiveWindow,
-                                                         writePosOfInactiveWindow,
-                                                         n,
-                                                         beginningOfInactiveWindow,
-                                                         inactiveSavedSeqs.size()));
-    return inactiveSavedSeqs[index];
-  }
-
-  const NumbersType &getBeginningOfInactiveWindow() const {
-    ConcordAssertGT(inactiveSavedSeqs.size(), 0);
-    return beginningOfInactiveWindow;
-  }
-
-  const NumbersType size() const { return elementsInInactiveWindow * Resolution; }
-
- private:
-  std::vector<ItemType> inactiveSavedSeqs;
-  size_t writePosOfInactiveWindow;
-  size_t readPosOfInactiveWindow;
-  size_t elementsInInactiveWindow;
-  NumbersType beginningOfInactiveWindow;
-};
-
 template <uint16_t WindowSize,
           uint16_t Resolution,
           typename NumbersType,
@@ -105,27 +37,32 @@ class SequenceWithActiveWindow {
   static_assert(WindowSize % Resolution == 0, "");
 
  protected:
-  static const uint16_t numItems = WindowSize / Resolution;
+  static constexpr uint16_t numItemsInsideActiveWindow = WindowSize / Resolution;
+  static constexpr uint32_t maxNumItemsInsideInactiveWindow = (WindowHistory * numItemsInsideActiveWindow);
+  static constexpr uint32_t totalItems = maxNumItemsInsideInactiveWindow + numItemsInsideActiveWindow;
 
   typename std::conditional<TypeSelection, NumbersType, std::atomic<NumbersType>>::type beginningOfActiveWindow;
-  ItemType activeWindow[numItems];
-  InactiveStorage<Resolution, NumbersType, ItemType, ItemFuncs> inactiveStorage;
+  size_t firstItemOfActiveWindow;
+  size_t numItemsInsideInactiveWindow;
+  ItemType workingWindow[totalItems];
 
  public:
-  SequenceWithActiveWindow(NumbersType windowFirst, void *initData)
-      : inactiveStorage(WindowHistory * numItems, initData, windowFirst) {
+  SequenceWithActiveWindow(NumbersType windowFirst, void *initData) {
     ConcordAssert(windowFirst % Resolution == 0);
 
     beginningOfActiveWindow = windowFirst;
 
-    for (uint16_t i = 0; i < numItems; i++) {
-      ItemFuncs::init(activeWindow[i], initData);
-      ItemFuncs::reset(activeWindow[i]);
+    firstItemOfActiveWindow = 0;
+    numItemsInsideInactiveWindow = 0;
+
+    for (uint16_t i = 0; i < totalItems; i++) {
+      ItemFuncs::init(workingWindow[i], initData);
+      ItemFuncs::reset(workingWindow[i]);
     }
   }
 
   ~SequenceWithActiveWindow() {
-    for (uint16_t i = 0; i < numItems; i++) ItemFuncs::free(activeWindow[i]);
+    for (uint16_t i = 0; i < totalItems; i++) ItemFuncs::free(workingWindow[i]);
   }
 
   bool insideActiveWindow(NumbersType n) const {
@@ -133,24 +70,42 @@ class SequenceWithActiveWindow {
   }
 
   bool isPressentInHistory(NumbersType n) const {
-    auto BeginningOfInactiveWindow = inactiveStorage.getBeginningOfInactiveWindow();
-    return ((n >= BeginningOfInactiveWindow) && (n < (BeginningOfInactiveWindow + inactiveStorage.size())));
+    if (numItemsInsideInactiveWindow > 0) {
+      auto beginningOfInactiveWindow = getBeginningOfInactiveWindow();
+      return ((n >= beginningOfInactiveWindow) && (n < beginningOfActiveWindow));
+    }
+    return false;
+  }
+
+  NumbersType getBeginningOfInactiveWindow() const {
+    ConcordAssertGT(numItemsInsideInactiveWindow, 0);
+    return (beginningOfActiveWindow - (numItemsInsideInactiveWindow * Resolution));
   }
 
   ItemType &get(NumbersType n) {
     ConcordAssert(n % Resolution == 0);
     ConcordAssert(insideActiveWindow(n));
 
-    uint16_t i = ((n / Resolution) % numItems);
-    return activeWindow[i];
+    auto offsetFromActiveWinBegin = (n - beginningOfActiveWindow) / Resolution;
+    uint16_t i = ((firstItemOfActiveWindow + offsetFromActiveWinBegin) % totalItems);
+    return workingWindow[i];
   }
 
   ItemType &getFromHistory(NumbersType n) {
     ConcordAssert(isPressentInHistory(n));
-    LOG_INFO(GL,
-             "Getting info from Inactive Window for SeqNo="
-                 << n << KVLOG(beginningOfActiveWindow, inactiveStorage.getBeginningOfInactiveWindow()));
-    return inactiveStorage.get(n);
+    ConcordAssert(n % Resolution == 0);
+    ConcordAssertGT(numItemsInsideInactiveWindow, 0);
+    ConcordAssertLE(numItemsInsideInactiveWindow, maxNumItemsInsideInactiveWindow);
+
+    auto beginningOfInactiveWindow = getBeginningOfInactiveWindow();
+    LOG_DEBUG(GL,
+              "Getting info from Inactive Window for SeqNo="
+                  << n << KVLOG(beginningOfActiveWindow, beginningOfInactiveWindow));
+
+    auto offsetFromInactiveWinBegin = (n - beginningOfInactiveWindow) / Resolution;
+    auto i = ((firstItemOfActiveWindow - numItemsInsideInactiveWindow + totalItems + offsetFromInactiveWinBegin) %
+              totalItems);
+    return workingWindow[i];
   }
 
   ItemType &getFromActiveWindowOrHistory(NumbersType n) {
@@ -172,47 +127,47 @@ class SequenceWithActiveWindow {
   void resetAll(NumbersType windowFirst) {
     ConcordAssert(windowFirst % Resolution == 0);
 
-    for (uint16_t i = 0; i < numItems; i++) ItemFuncs::reset(activeWindow[i]);
+    for (uint16_t i = 0; i < totalItems; i++) ItemFuncs::reset(workingWindow[i]);
 
     beginningOfActiveWindow = windowFirst;
+    numItemsInsideInactiveWindow = 0;
   }
 
-  void advanceActiveWindow(NumbersType newFirstIndexOfActiveWindow) {
-    ConcordAssert(newFirstIndexOfActiveWindow % Resolution == 0);
-    ConcordAssert(newFirstIndexOfActiveWindow >= beginningOfActiveWindow);
+  void advanceActiveWindow(NumbersType newFirstNumOfActiveWindow) {
+    ConcordAssert(newFirstNumOfActiveWindow % Resolution == 0);
+    ConcordAssert(newFirstNumOfActiveWindow >= beginningOfActiveWindow);
 
-    if (newFirstIndexOfActiveWindow == beginningOfActiveWindow) return;
+    if (newFirstNumOfActiveWindow == beginningOfActiveWindow) return;
 
-    if (newFirstIndexOfActiveWindow - beginningOfActiveWindow >= WindowSize) {
-      if (WindowHistory > 0) {
-        inactiveStorage.clear(newFirstIndexOfActiveWindow);  // clear elements from inactiveStorage to stay in sync
-      }
-      resetAll(newFirstIndexOfActiveWindow);
+    if (newFirstNumOfActiveWindow - beginningOfActiveWindow > WindowSize) {
+      resetAll(newFirstNumOfActiveWindow);
       return;
     }
 
-    const uint16_t inactiveBegin = ((beginningOfActiveWindow / Resolution) % numItems);
+    const uint16_t numItemsToAdvanceActiveWindowWith =
+        (newFirstNumOfActiveWindow - beginningOfActiveWindow) / Resolution;
 
-    const uint16_t activeBegin = ((newFirstIndexOfActiveWindow / Resolution) % numItems);
+    const uint16_t oldActiveEnd = (firstItemOfActiveWindow + numItemsInsideActiveWindow) % totalItems;
 
-    const uint16_t inactiveEnd = ((activeBegin > 0) ? (activeBegin - 1) : (numItems - 1));
+    const uint16_t newActiveBegin = (firstItemOfActiveWindow + numItemsToAdvanceActiveWindowWith) % totalItems;
 
-    const uint16_t resetSize = (inactiveBegin <= inactiveEnd) ? (inactiveEnd - inactiveBegin + 1)
-                                                              : (inactiveEnd + 1 + numItems - inactiveBegin);
-    ConcordAssert(resetSize > 0 && resetSize < numItems);
+    const uint16_t resetSize = numItemsToAdvanceActiveWindowWith;
 
-    uint16_t debugNumOfReset = 0;
-    for (uint16_t i = inactiveBegin; i != activeBegin; (i = ((i + 1) % numItems))) {
-      if (WindowHistory > 0) {
-        inactiveStorage.add(activeWindow[i]);
-      }
+    ConcordAssert(resetSize > 0 && resetSize <= numItemsInsideActiveWindow);
 
-      ItemFuncs::reset(activeWindow[i]);
-      debugNumOfReset++;
+    // We need to reset all Items starting from (oldActiveEnd) to (oldActiveEnd + numItemsToAdvanceActiveWindowWith),
+    // because this is the amount of Items that will be included in the Active Window after scrolling it.
+    uint16_t resetCount = 0;
+    for (uint16_t i = oldActiveEnd; resetCount < resetSize; resetCount++, (i = ((i + 1) % totalItems))) {
+      ItemFuncs::reset(workingWindow[i]);
     }
 
-    ConcordAssert(debugNumOfReset == resetSize);
-    beginningOfActiveWindow = newFirstIndexOfActiveWindow;
+    firstItemOfActiveWindow = newActiveBegin;
+    beginningOfActiveWindow = newFirstNumOfActiveWindow;
+    numItemsInsideInactiveWindow += numItemsToAdvanceActiveWindowWith;
+    if (numItemsInsideInactiveWindow > maxNumItemsInsideInactiveWindow) {
+      numItemsInsideInactiveWindow = maxNumItemsInsideInactiveWindow;
+    }
   }
 
   // TODO(GG): add save & load

--- a/bftengine/src/bftengine/messages/PartialProofsSet.cpp
+++ b/bftengine/src/bftengine/messages/PartialProofsSet.cpp
@@ -42,18 +42,6 @@ PartialProofsSet::PartialProofsSet(InternalReplicaApi* const rep)
 
 PartialProofsSet::~PartialProofsSet() { resetAndFree(); }
 
-void PartialProofsSet::acquire(PartialProofsSet* rhs) {
-  fullCommitProof = rhs->fullCommitProof;
-  rhs->fullCommitProof = nullptr;
-  selfPartialCommitProof = rhs->selfPartialCommitProof;
-  rhs->selfPartialCommitProof = nullptr;
-  prePrepare_ = rhs->prePrepare_;
-  rhs->prePrepare_ = nullptr;
-  participatingReplicasInFast = rhs->participatingReplicasInFast;
-  participatingReplicasInOptimisticFast = rhs->participatingReplicasInOptimisticFast;
-  expectedDigest = rhs->expectedDigest;
-}
-
 void PartialProofsSet::resetAndFree() {
   seqNumber = 0;
   if (fullCommitProof) delete fullCommitProof;

--- a/bftengine/src/bftengine/messages/PartialProofsSet.hpp
+++ b/bftengine/src/bftengine/messages/PartialProofsSet.hpp
@@ -36,8 +36,6 @@ class PartialProofsSet {
   PartialProofsSet(InternalReplicaApi* const rep);
   ~PartialProofsSet();
 
-  void acquire(PartialProofsSet* rhs);
-
   void addSelfMsgAndPPDigest(PartialCommitProofMsg* m, Digest& digest);
 
   void setTimeOfSelfPartialProof(const Time& t);

--- a/bftengine/tests/testSequenceWithActiveWindow/testSequenceWithActiveWindow.cpp
+++ b/bftengine/tests/testSequenceWithActiveWindow/testSequenceWithActiveWindow.cpp
@@ -149,6 +149,11 @@ TEST(testSequenceWithActiveWindow_test, move_working_window_by_its_full_size_aft
   beginning += windowSize;
   windowOfInts.advanceActiveWindow(beginning);
 
+  // Verify all values from previous Active Window are transferred to history (Inactive Window)
+  for (uint64_t i = beginning - windowSize; i < beginning; i += resolution) {
+    ConcordAssert(i == windowOfInts.getFromHistory(i));
+  }
+
   // Set consecutive values in Active Window
   for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
     windowOfInts.get(i) = i;

--- a/bftengine/tests/testSequenceWithActiveWindow/testSequenceWithActiveWindow.cpp
+++ b/bftengine/tests/testSequenceWithActiveWindow/testSequenceWithActiveWindow.cpp
@@ -35,14 +35,150 @@ class MockItemFuncs {
   }
 };
 
-TEST(testSequenceWithActiveWindow_test, basic_tests) {
+void basic_tests_no_inactive_window(unsigned int initialAdvance) {
+  const int windowSize = 12;
+  const int resolution = 2;
+  uint64_t beginning = initialAdvance * (windowSize / 2);
+  SequenceWithActiveWindow<windowSize, resolution, uint64_t, uint64_t, MockItemFuncs> windowOfInts(0, nullptr);
+
+  auto initial_start = beginning;
+  windowOfInts.advanceActiveWindow(beginning);
+
+  // Set consecutive values in Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(MockItemFuncs::restarted == windowOfInts.get(i));
+    ConcordAssert(!windowOfInts.isPressentInHistory(i));
+    windowOfInts.get(i) = i;
+  }
+  // Verify consecutive values in Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(i == windowOfInts.get(i));
+  }
+
+  // MockItemFuncs::printActiveWindow(windowOfInts);
+
+  // Advance Active Window by half
+  beginning += windowSize / 2;
+  windowOfInts.advanceActiveWindow(beginning);
+
+  // MockItemFuncs::printActiveWindow(windowOfInts);
+
+  // Verify half of the values remain in the Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize / 2; i += resolution) {
+    ConcordAssert(i == windowOfInts.get(i));
+  }
+
+  // Verify other half of the Active Window is freshly reset
+  for (uint64_t i = beginning + windowSize / 2; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(MockItemFuncs::restarted == windowOfInts.get(i));
+  }
+
+  // Verify history is empty
+  for (uint64_t i = initial_start; i < initial_start + windowSize; i += resolution) {
+    ConcordAssert(!windowOfInts.isPressentInHistory(i));
+  }
+}
+
+TEST(testSequenceWithActiveWindow_test, basic_tests_no_inactive_window_no_initial_offset) {
+  basic_tests_no_inactive_window(0);
+}
+
+TEST(testSequenceWithActiveWindow_test, basic_tests_no_inactive_window_with_half_window_initial_offset) {
+  basic_tests_no_inactive_window(1);
+}
+
+TEST(testSequenceWithActiveWindow_test, basic_tests_no_inactive_window_with_window_and_half_initial_offset) {
+  basic_tests_no_inactive_window(3);
+}
+
+void basic_tests_no_inactive_window_scroll_full_window_size(unsigned int numToScroll) {
+  const int windowSize = 30;
+  const int resolution = 5;
+  uint64_t beginning = windowSize / 2;
+  SequenceWithActiveWindow<windowSize, resolution, uint64_t, uint64_t, MockItemFuncs> windowOfInts(0, nullptr);
+
+  auto advance = windowSize * numToScroll;
+  auto initial_start = beginning;
+  windowOfInts.advanceActiveWindow(beginning);
+
+  // Set consecutive values in Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(MockItemFuncs::restarted == windowOfInts.get(i));
+    ConcordAssert(!windowOfInts.isPressentInHistory(i));
+    windowOfInts.get(i) = i;
+  }
+  // Verify consecutive values in Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(i == windowOfInts.get(i));
+  }
+
+  // MockItemFuncs::printActiveWindow(windowOfInts);
+
+  // Advance Active Window
+  beginning += advance;
+  windowOfInts.advanceActiveWindow(beginning);
+
+  // MockItemFuncs::printActiveWindow(windowOfInts);
+
+  // Verify the Working Window is freshly reset
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(MockItemFuncs::restarted == windowOfInts.get(i));
+  }
+
+  // Verify history is empty
+  for (uint64_t i = initial_start; i < initial_start + advance; i += resolution) {
+    ConcordAssert(!windowOfInts.isPressentInHistory(i));
+  }
+
+  // Set consecutive values in Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(MockItemFuncs::restarted == windowOfInts.get(i));
+    ConcordAssert(!windowOfInts.isPressentInHistory(i));
+    windowOfInts.get(i) = i;
+  }
+  // Verify consecutive values in Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(i == windowOfInts.get(i));
+  }
+
+  // Advance Active Window by half
+  beginning += windowSize / 2;
+  windowOfInts.advanceActiveWindow(beginning);
+
+  // Verify half of the values remain in the Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize / 2; i += resolution) {
+    ConcordAssert(i == windowOfInts.get(i));
+  }
+
+  // Verify other half of the Active Window is freshly reset and
+  // then set consecutive values in it
+  for (uint64_t i = beginning + windowSize / 2; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(MockItemFuncs::restarted == windowOfInts.get(i));
+    ConcordAssert(!windowOfInts.isPressentInHistory(i));
+    windowOfInts.get(i) = i;
+  }
+
+  // Verify consecutive values in Active Window
+  for (uint64_t i = beginning; i < beginning + windowSize; i += resolution) {
+    ConcordAssert(i == windowOfInts.get(i));
+  }
+}
+
+TEST(testSequenceWithActiveWindow_test, basic_tests_no_inactive_window_scrow_full_window_size) {
+  basic_tests_no_inactive_window_scroll_full_window_size(1);
+}
+
+TEST(testSequenceWithActiveWindow_test, basic_tests_no_inactive_window_scrow_twice_window_size) {
+  basic_tests_no_inactive_window_scroll_full_window_size(2);
+}
+
+void basic_tests_with_inactive_window(bool initialAdvance) {
   const int windowSize = 10;
   const int resolution = 1;
-  uint64_t beginning = 0;
-  SequenceWithActiveWindow<windowSize, resolution, uint64_t, uint64_t, MockItemFuncs, 1> windowOfInts(beginning,
-                                                                                                      nullptr);
+  uint64_t beginning = initialAdvance ? 5 * windowSize : 0;
+  SequenceWithActiveWindow<windowSize, resolution, uint64_t, uint64_t, MockItemFuncs, 1> windowOfInts(0, nullptr);
 
-  auto initial_start = beginning = 5 * windowSize;
+  auto initial_start = beginning;
   windowOfInts.advanceActiveWindow(beginning);
 
   // Set consecutive values in Active Window
@@ -88,6 +224,14 @@ TEST(testSequenceWithActiveWindow_test, basic_tests) {
     ConcordAssert(windowOfInts.isPressentInHistory(i));
     ConcordAssert(i == windowOfInts.getFromHistory(i));
   }
+}
+
+TEST(testSequenceWithActiveWindow_test, basic_tests_with_inactive_window_no_initial_offset) {
+  basic_tests_with_inactive_window(false);
+}
+
+TEST(testSequenceWithActiveWindow_test, basic_tests_with_inactive_window_with_initial_offset) {
+  basic_tests_with_inactive_window(true);
 }
 
 TEST(testSequenceWithActiveWindow_test, move_working_window_7_times) {

--- a/bftengine/tests/testSequenceWithActiveWindow/testSequenceWithActiveWindow.cpp
+++ b/bftengine/tests/testSequenceWithActiveWindow/testSequenceWithActiveWindow.cpp
@@ -28,8 +28,6 @@ class MockItemFuncs {
 
   static void reset(uint64_t& i) { i = restarted; }
 
-  static void acquire(uint64_t& to, uint64_t& from) { to = from; }
-
   template <typename T>
   static void printActiveWindow(T window) {
     std::cout << "current active window = " << window.currentActiveWindow().first << ":"


### PR DESCRIPTION
Implemented circular buffer directly into SequenceWithActiveWindow.
Properly handle the situation where we only slide with the size of the Working Window.
Previously we used to clear all Items, which is not necessary.
Move log message for getting from Inactive Window to DEBUG level.

Remove acquire methods as they are no longer needed by SequenceWithActiveWindow.

Add tests for Working Window that contains only Active part.
Refactor old tests to cover more cases.

More detailed information in the comments of the Commit ID-s.