### PR TITLE
TRC: Event groups

### DIFF
--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -180,8 +180,8 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
 
         callback(SubscribeResult{event_group_out});
 
-      } else if (std::holds_alternative<::client::thin_replica_client::LegacyEvent>(*update)) {
-        auto& legacy_event_in = std::get<::client::thin_replica_client::LegacyEvent>(*update);
+      } else if (std::holds_alternative<::client::thin_replica_client::Update>(*update)) {
+        auto& legacy_event_in = std::get<::client::thin_replica_client::Update>(*update);
         LegacyEvent legacy_event_out;
         legacy_event_out.block_id = legacy_event_in.block_id;
         for (const auto& [k, v] : legacy_event_in.kv_pairs) {

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -164,30 +164,35 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
         continue;
       }
 
-      // TODO: Distinguish between events and event groups. Depends on TRC API.
-      bool is_event_group = false;
-      if (is_event_group) {
-        EventGroup eg;
-        eg.id = update->block_id;
-        for (const auto& e : update->kv_pairs) {
-          eg.events.push_back({e.second.begin(), e.second.end()});
+      // TODO: We fill event group with data from legacy updates.
+      // This needs to change depending on how the legacy API will be implemented.
+      if (std::holds_alternative<::client::thin_replica_client::EventGroup>(*update)) {
+        auto& event_group_in = std::get<::client::thin_replica_client::EventGroup>(*update);
+        EventGroup event_group_out;
+        event_group_out.id = event_group_in.id;
+        // TODO: Can we **move** from std::string to a vector<uint8_t>?
+        // Maybe we should use std::vector<std::byte> and align both interfaces?
+        for (const auto& event : event_group_in.events) {
+          event_group_out.events.push_back({event.begin(), event.end()});
         }
-        std::chrono::duration time_now = std::chrono::system_clock::now().time_since_epoch();
-        eg.record_time = std::chrono::duration_cast<std::chrono::microseconds>(time_now);
-        eg.trace_context = {};
+        event_group_out.record_time = event_group_in.record_time;
+        // TODO: proto_eg.trace_context
 
-        callback(SubscribeResult{eg});
+        callback(SubscribeResult{event_group_out});
 
-      } else {
-        LegacyEvent legacy_events;
-        legacy_events.block_id = update->block_id;
-        for (const auto& [key, value] : update->kv_pairs) {
-          legacy_events.events.push_back({key, value});
+      } else if (std::holds_alternative<::client::thin_replica_client::LegacyEvent>(*update)) {
+        auto& legacy_event_in = std::get<::client::thin_replica_client::LegacyEvent>(*update);
+        LegacyEvent legacy_event_out;
+        legacy_event_out.block_id = legacy_event_in.block_id;
+        for (const auto& [k, v] : legacy_event_in.kv_pairs) {
+          legacy_event_out.events.push_back({k, v});
         }
-        legacy_events.correlation_id = update->correlation_id_;
+        legacy_event_out.correlation_id = legacy_event_in.correlation_id_;
         // TODO: legacy_events.trace_context
 
-        callback(SubscribeResult{legacy_events});
+        callback(SubscribeResult{legacy_event_out});
+      } else {
+        LOG_ERROR(logger_, "Got unexpected update type from TRC. This should never happen!");
       }
     }
   });

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -109,7 +109,7 @@ class UpdateQueue {
   // the queue. UpdateQueue implementations may choose whether they keep this
   // allocated Update or free it after storing the data from the update by some
   // other means.
-  virtual void Push(std::unique_ptr<Update> update) = 0;
+  virtual void Push(std::unique_ptr<EventVariant> update) = 0;
 
   // Synchronously pop and return the update at the front of the queue.
   // Normally, if there are no updates available in the queue, this function
@@ -125,7 +125,7 @@ class UpdateQueue {
   // to null rather than continuing to wait for new updates. Furthermore, a call
   // to ReleaseConsumers will cause any subsequent calls to Pop to return
   // nullptr and will prevent them from blocking their caller.
-  virtual std::unique_ptr<Update> Pop() = 0;
+  virtual std::unique_ptr<EventVariant> Pop() = 0;
 
   // Synchronously pop an update from the front of the queue if one is
   // available, but do not block the calling thread to wait on one if one is not
@@ -133,7 +133,7 @@ class UpdateQueue {
   // immediately found, and a unique_ptr giving ownership of an allocated Update
   // otherwise (this may involve dynamic memory allocation at the discretion of
   // the UpdateQueue implementation).
-  virtual std::unique_ptr<Update> TryPop() = 0;
+  virtual std::unique_ptr<EventVariant> TryPop() = 0;
 
   virtual uint64_t Size() = 0;
 };
@@ -145,7 +145,7 @@ class UpdateQueue {
 // more complete understanding of the needs of this library.
 class BasicUpdateQueue : public UpdateQueue {
  private:
-  std::list<std::unique_ptr<Update>> queue_data_;
+  std::list<std::unique_ptr<EventVariant>> queue_data_;
   std::mutex mutex_;
   std::condition_variable condition_;
   bool release_consumers_;
@@ -169,9 +169,9 @@ class BasicUpdateQueue : public UpdateQueue {
   virtual ~BasicUpdateQueue() override;
   virtual void ReleaseConsumers() override;
   virtual void Clear() override;
-  virtual void Push(std::unique_ptr<Update> update) override;
-  virtual std::unique_ptr<Update> Pop() override;
-  virtual std::unique_ptr<Update> TryPop() override;
+  virtual void Push(std::unique_ptr<EventVariant> update) override;
+  virtual std::unique_ptr<EventVariant> Pop() override;
+  virtual std::unique_ptr<EventVariant> TryPop() override;
   virtual uint64_t Size() override;
 };
 
@@ -318,7 +318,7 @@ class ThinReplicaClient final {
 
   // Push update to update queue for consumption by the application using TRC.
   // Set TRC metrics before receiving next update
-  void pushUpdateToUpdateQueue(std::unique_ptr<Update> update,
+  void pushUpdateToUpdateQueue(std::unique_ptr<EventVariant> update,
                                const std::chrono::steady_clock::time_point& start,
                                bool is_event_group);
 

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -244,6 +244,7 @@ struct ThinReplicaClientMetrics {
         read_ignored_per_update{metrics_component_.RegisterGauge("read_ignored_per_update", 0)},
         current_queue_size{metrics_component_.RegisterGauge("current_queue_size", 0)},
         last_verified_block_id{metrics_component_.RegisterGauge("last_verified_block_id", 0)},
+        last_verified_event_group_id{metrics_component_.RegisterGauge("last_verified_event_group_id", 0)},
         update_dur_ms{metrics_component_.RegisterGauge("update_dur_ms", 0)} {
     metrics_component_.Register();
   }
@@ -270,9 +271,9 @@ struct ThinReplicaClientMetrics {
   // current_queue_size - the current size of the update queue i.e., number of
   // updates in the update_queue
   concordMetrics::GaugeHandle current_queue_size;
-  // last_verified_block_id - block ID of the latest block that has been read
-  // and verified by TRC
+  // last_verified_*_id - block or event group ID of the latest update verified by TRC
   concordMetrics::GaugeHandle last_verified_block_id;
+  concordMetrics::GaugeHandle last_verified_event_group_id;
   // update_dur_ms - duration of time (ms) between when an update is received by
   // the TRC, to when it is pushed to the update queue for consumption by the
   // application using TRC
@@ -301,7 +302,9 @@ class ThinReplicaClient final {
   std::unique_ptr<ThinReplicaClientConfig> config_;
   size_t data_conn_index_;
 
+  bool is_event_group_stream_;
   uint64_t latest_verified_block_id_;
+  uint64_t latest_verified_event_group_id_;
 
   std::unique_ptr<std::thread> subscription_thread_;
   std::atomic_bool stop_subscription_thread_;
@@ -317,36 +320,53 @@ class ThinReplicaClient final {
   // Set TRC metrics before receiving next update
   void pushUpdateToUpdateQueue(std::unique_ptr<Update> update,
                                const std::chrono::steady_clock::time_point& start,
-                               const uint64_t& latest_verified_block_id_);
+                               bool is_event_group);
 
   // Reset metrics before next update
   void resetMetricsBeforeNextUpdate();
 
-  // Pair of block ID and the hash of the block
-  using BlockIdHashPair = std::pair<uint64_t, std::string>;
+  struct HashRecord {
+    enum Type { EventGroup, LegacyEvent };
+    Type type;
+    uint64_t id;
+    std::string hash;
+  };
+  struct CompareHashRecord {
+    bool operator()(const HashRecord& lhs, const HashRecord& rhs) const {
+      if (lhs.type == rhs.type) {
+        return lhs.id < rhs.id || (lhs.id == rhs.id && lhs.hash < rhs.hash);
+      }
+      if (lhs.type == HashRecord::Type::LegacyEvent) {
+        // LegacyEvents are considered "less than" EventGroups due to the order in which they got introduced
+        // Thereby, we assume that replicas will never stream LegacyEvents "after" EventGroups.
+        return true;
+      }
+      return false;
+    }
+  };
 
-  // Map recording every BlockIdHashPair we have seen for the update we are
+  // Map recording every HashRecord we have seen for the update we are
   // seeking and which servers support that pair. Note we choose a map over an
   // unordered_map here as std does not seem to provide a hash implementation
   // for std::pair. The sets of servers supporting each pair are represented as
   // unordered sets of server indexes.
-  using AgreeingSubsetMembers = std::map<BlockIdHashPair, std::unordered_set<size_t>>;
+  using HashRecordMap = std::map<HashRecord, std::unordered_set<size_t>, CompareHashRecord>;
 
   using SpanPtr = std::unique_ptr<opentracing::Span>;
   std::pair<bool, SpanPtr> readBlock(com::vmware::concord::thin_replica::Data& update_in,
-                                     AgreeingSubsetMembers& agreeing_subset_members,
+                                     HashRecordMap& agreeing_subset_members,
                                      size_t& most_agreeing,
-                                     BlockIdHashPair& most_agreed_block,
+                                     HashRecord& most_agreed_block,
                                      std::unique_ptr<LogCid>& cid);
   void findBlockHashAgreement(std::vector<bool>& servers_tried,
-                              AgreeingSubsetMembers& agreeing_subset_members,
+                              HashRecordMap& agreeing_subset_members,
                               size_t& most_agreeing,
-                              BlockIdHashPair& most_agreed_block,
+                              HashRecord& most_agreed_block,
                               SpanPtr& parent_span);
 
   bool rotateDataStreamAndVerify(com::vmware::concord::thin_replica::Data& update_in,
-                                 AgreeingSubsetMembers& agreeing_subset_members,
-                                 BlockIdHashPair& most_agreed_block,
+                                 HashRecordMap& agreeing_subset_members,
+                                 HashRecord& most_agreed_block,
                                  SpanPtr& parent_span,
                                  std::unique_ptr<LogCid>& cid);
 
@@ -356,18 +376,17 @@ class ThinReplicaClient final {
 
   // Helper functions to receiveUpdates.
   void logDataStreamResetResult(const TrsConnection::Result& result, size_t server_index);
-  void recordCollectedHash(
-      size_t update_source,
-      uint64_t block_id,
-      const std::string& update_hash,
-      std::map<std::pair<uint64_t, std::string>, std::unordered_set<size_t>>& server_indexes_by_reported_update,
-      size_t& maximal_agreeing_subset_size,
-      std::pair<uint64_t, std::string>& maximally_agreed_on_update);
-  void readUpdateHashFromStream(
-      size_t server_index,
-      std::map<std::pair<uint64_t, std::string>, std::unordered_set<size_t>>& server_indexes_by_reported_update,
-      size_t& maximal_agreeing_subset_size,
-      std::pair<uint64_t, std::string>& maximally_agreed_on_update);
+  void recordCollectedHash(size_t update_source,
+                           bool is_event_group,
+                           uint64_t id,
+                           const std::string& update_hash,
+                           HashRecordMap& server_indexes_by_reported_update,
+                           size_t& maximal_agreeing_subset_size,
+                           HashRecord& maximally_agreed_on_update);
+  void readUpdateHashFromStream(size_t server_index,
+                                HashRecordMap& server_indexes_by_reported_update,
+                                size_t& maximal_agreeing_subset_size,
+                                HashRecord& maximally_agreed_on_update);
 
  public:
   // Constructor for ThinReplicaClient. Note that, as the ThinReplicaClient
@@ -386,6 +405,7 @@ class ThinReplicaClient final {
         config_(std::move(config)),
         data_conn_index_(0),
         latest_verified_block_id_(0),
+        latest_verified_event_group_id_(std::numeric_limits<uint64_t>::max()),
         subscription_thread_(),
         stop_subscription_thread_(false) {
     metrics_.setAggregator(aggregator);

--- a/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
@@ -28,8 +28,8 @@ class TraceContexts {
  public:
   using SpanPtr = std::unique_ptr<opentracing::Span>;
 
-  static void InjectSpan(const SpanPtr& span, Update& update);
-  static expected<std::unique_ptr<opentracing::SpanContext>> ExtractSpan(const Update& update);
+  static void InjectSpan(const SpanPtr& span, EventVariant& update);
+  static expected<std::unique_ptr<opentracing::SpanContext>> ExtractSpan(const EventVariant& update);
   static SpanPtr CreateChildSpanFromBinary(const std::string& trace_context,
                                            const std::string& child_name,
                                            const std::string& correlation_id,

--- a/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
@@ -30,7 +30,7 @@ const size_t kThinReplicaHashLength = kExpectedSHA256HashLengthInBytes;
 // kThinReplicaHashLength. Throws an std::invalid_argument in the event the
 // update contains any duplicated keys (which is something disallowed by the
 // Thin Replica Mechanism).
-std::string hashUpdate(const Update& update);
+std::string hashUpdate(const EventVariant& update);
 std::string hashUpdate(const com::vmware::concord::thin_replica::Data& update);
 
 // Compute the Thin Replica Mechanism hash of a given state (i.e. an ordered

--- a/client/thin-replica-client/include/client/thin-replica-client/update.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/update.hpp
@@ -14,13 +14,25 @@
 #ifndef THIN_REPLICA_CLIENT_UPDATE_HPP_
 #define THIN_REPLICA_CLIENT_UPDATE_HPP_
 
+#include <chrono>
+#include <map>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace client::thin_replica_client {
 
-// Type for updates the Thin Replica Client streams from Thin Replica Servers.
-struct Update {
+// Types for updates the Thin Replica Client streams from Thin Replica Servers.
+struct EventGroup {
+  uint64_t id;
+  std::vector<std::string> events;
+  std::chrono::microseconds record_time;
+  // This map follows the W3C specification for trace context.
+  // https://www.w3.org/TR/trace-context/#trace-context-http-headers-format
+  std::map<std::string, std::string> trace_context;
+};
+
+struct LegacyEvent {
   // Block ID for this update; Block IDs can be expected to be monotonically
   // increasing with each update received in order. It is recommended that
   // applications receiving updates persist at least the Block ID of the most
@@ -34,6 +46,8 @@ struct Update {
   std::string correlation_id_;
   std::string span_context;
 };
+
+typedef std::variant<LegacyEvent, EventGroup> Update;
 
 }  // namespace client::thin_replica_client
 

--- a/client/thin-replica-client/include/client/thin-replica-client/update.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/update.hpp
@@ -32,7 +32,8 @@ struct EventGroup {
   std::map<std::string, std::string> trace_context;
 };
 
-struct LegacyEvent {
+// LegacyEvent
+struct Update {
   // Block ID for this update; Block IDs can be expected to be monotonically
   // increasing with each update received in order. It is recommended that
   // applications receiving updates persist at least the Block ID of the most
@@ -47,7 +48,7 @@ struct LegacyEvent {
   std::string span_context;
 };
 
-typedef std::variant<LegacyEvent, EventGroup> Update;
+typedef std::variant<Update, EventGroup> EventVariant;
 
 }  // namespace client::thin_replica_client
 

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -37,7 +37,6 @@ using std::list;
 using std::lock_guard;
 using std::logic_error;
 using std::make_pair;
-using std::map;
 using std::mutex;
 using std::pair;
 using std::runtime_error;
@@ -120,30 +119,39 @@ unique_ptr<Update> BasicUpdateQueue::TryPop() {
 }
 uint64_t thin_replica_client::BasicUpdateQueue::Size() { return queue_data_.size(); }
 
-void ThinReplicaClient::recordCollectedHash(
-    size_t update_source,
-    uint64_t block_id,
-    const string& update_hash,
-    map<pair<uint64_t, string>, unordered_set<size_t>>& server_indexes_by_reported_update,
-    size_t& maximal_agreeing_subset_size,
-    pair<uint64_t, string>& maximally_agreed_on_update) {
-  pair<uint64_t, string> update = make_pair(block_id, update_hash);
-  if (server_indexes_by_reported_update.count(update) < 1) {
-    server_indexes_by_reported_update.emplace(update, unordered_set<size_t>());
+void ThinReplicaClient::recordCollectedHash(size_t update_source,
+                                            bool is_event_group,
+                                            uint64_t id,
+                                            const string& update_hash,
+                                            HashRecordMap& server_indexes_by_reported_update,
+                                            size_t& maximal_agreeing_subset_size,
+                                            HashRecord& maximally_agreed_on_update) {
+  HashRecord update_record;
+  if (is_event_group) {
+    update_record.type = HashRecord::Type::EventGroup;
+    update_record.id = id;
+    update_record.hash = update_hash;
+  } else {
+    update_record.type = HashRecord::Type::LegacyEvent;
+    update_record.id = id;
+    update_record.hash = update_hash;
   }
-  server_indexes_by_reported_update[update].emplace(update_source);
-  size_t update_agreement = server_indexes_by_reported_update[update].size();
+
+  if (server_indexes_by_reported_update.count(update_record) < 1) {
+    server_indexes_by_reported_update.emplace(update_record, unordered_set<size_t>());
+  }
+  server_indexes_by_reported_update[update_record].emplace(update_source);
+  size_t update_agreement = server_indexes_by_reported_update[update_record].size();
   if (update_agreement > maximal_agreeing_subset_size) {
     maximal_agreeing_subset_size = update_agreement;
-    maximally_agreed_on_update = update;
+    maximally_agreed_on_update = update_record;
   }
 }
 
-void ThinReplicaClient::readUpdateHashFromStream(
-    size_t server_index,
-    map<pair<uint64_t, string>, unordered_set<size_t>>& server_indexes_by_reported_update,
-    size_t& maximal_agreeing_subset_size,
-    pair<uint64_t, string>& maximally_agreed_on_update) {
+void ThinReplicaClient::readUpdateHashFromStream(size_t server_index,
+                                                 HashRecordMap& server_indexes_by_reported_update,
+                                                 size_t& maximal_agreeing_subset_size,
+                                                 HashRecord& maximally_agreed_on_update) {
   Hash hash;
   LOG4CPLUS_DEBUG(logger_, "Read hash from " << server_index);
 
@@ -160,29 +168,54 @@ void ThinReplicaClient::readUpdateHashFromStream(
   }
   ConcordAssert(read_result == TrsConnection::Result::kSuccess);
 
-  if (hash.events().block_id() < latest_verified_block_id_) {
-    LOG4CPLUS_WARN(
-        logger_,
-        "Hash stream " << server_index << " gave an update with decreasing block number: " << hash.events().block_id());
-    metrics_.read_ignored_per_update++;
-    return;
+  uint64_t hash_id;
+  string hash_string;
+  if (hash.has_event_group()) {
+    hash_id = hash.event_group().event_group_id();
+    ConcordAssert(latest_verified_event_group_id_ <
+                  std::numeric_limits<decltype(latest_verified_event_group_id_)>::max());
+    if (hash_id < latest_verified_event_group_id_) {
+      LOG4CPLUS_WARN(
+          logger_, "Hash stream " << server_index << " gave an update with decreasing event group number: " << hash_id);
+      metrics_.read_ignored_per_update++;
+      return;
+    }
+    hash_string = hash.event_group().hash();
+
+    if (hash.event_group().hash().length() > kThinReplicaHashLength) {
+      LOG4CPLUS_WARN(logger_,
+                     "Hash stream " << server_index << " gave an update (event_group " << hash_id
+                                    << ") with an unexpectedly long hash: " << hash.events().hash().length());
+      metrics_.read_ignored_per_update++;
+      return;
+    }
+  } else {
+    ConcordAssert(hash.has_events());
+    hash_id = hash.events().block_id();
+    if (hash_id < latest_verified_block_id_) {
+      LOG4CPLUS_WARN(logger_,
+                     "Hash stream " << server_index << " gave an update with decreasing update number: " << hash_id);
+      metrics_.read_ignored_per_update++;
+      return;
+    }
+    hash_string = hash.events().hash();
+
+    if (hash.events().hash().length() > kThinReplicaHashLength) {
+      LOG4CPLUS_WARN(logger_,
+                     "Hash stream " << server_index << " gave an update (block " << hash_id
+                                    << ") with an unexpectedly long hash: " << hash.events().hash().length());
+      metrics_.read_ignored_per_update++;
+      return;
+    }
   }
 
-  if (hash.events().hash().length() > kThinReplicaHashLength) {
-    LOG4CPLUS_WARN(logger_,
-                   "Hash stream " << server_index << " gave an update (block " << hash.events().block_id()
-                                  << ") with an unexpectedly long hash: " << hash.events().hash().length());
-    metrics_.read_ignored_per_update++;
-    return;
-  }
-
-  LOG4CPLUS_DEBUG(logger_, "Record hash for block " << hash.events().block_id());
-  string hash_string = hash.events().hash();
+  LOG4CPLUS_DEBUG(logger_, "Record hash for update " << hash_id);
   ConcordAssert(hash_string.length() <= kThinReplicaHashLength);
   hash_string.resize(kThinReplicaHashLength, '\0');
 
   recordCollectedHash(server_index,
-                      hash.events().block_id(),
+                      hash.has_event_group(),
+                      hash_id,
                       hash_string,
                       server_indexes_by_reported_update,
                       maximal_agreeing_subset_size,
@@ -190,9 +223,9 @@ void ThinReplicaClient::readUpdateHashFromStream(
 }
 
 std::pair<bool, ThinReplicaClient::SpanPtr> ThinReplicaClient::readBlock(Data& update_in,
-                                                                         AgreeingSubsetMembers& agreeing_subset_members,
+                                                                         HashRecordMap& agreeing_subset_members,
                                                                          size_t& most_agreeing,
-                                                                         BlockIdHashPair& most_agreed_block,
+                                                                         HashRecord& most_agreed_block,
                                                                          unique_ptr<LogCid>& cid) {
   if (!config_->trs_conns[data_conn_index_]->hasDataStream()) {
     // It may be the case that there is no data stream open after the data
@@ -217,21 +250,42 @@ std::pair<bool, ThinReplicaClient::SpanPtr> ThinReplicaClient::readBlock(Data& u
   }
   ConcordAssert(read_result == TrsConnection::Result::kSuccess);
 
-  auto span = TraceContexts::CreateChildSpanFromBinary(
-      update_in.events().span_context(), "trc_read_block", update_in.events().correlation_id(), logger_);
-  cid.reset(new LogCid(update_in.events().correlation_id()));
-  if (update_in.events().block_id() < latest_verified_block_id_) {
-    LOG4CPLUS_WARN(logger_,
-                   "Data stream " << data_conn_index_
-                                  << " gave an update with decreasing block number: " << update_in.events().block_id());
-    metrics_.read_ignored_per_update++;
-    cid.reset(nullptr);
-    return {false, nullptr};
+  uint64_t id;  // block id or event group id
+  SpanPtr span;
+  if (update_in.has_event_group()) {
+    id = update_in.event_group().id();
+    // TODO: Event Group traces
+    span.reset();
+    cid.reset(new LogCid(to_string(id)));
+    ConcordAssert(latest_verified_event_group_id_ <
+                  std::numeric_limits<decltype(latest_verified_event_group_id_)>::max());
+    id = update_in.event_group().id();
+    if (id < latest_verified_event_group_id_) {
+      LOG4CPLUS_WARN(logger_,
+                     "Data stream " << data_conn_index_ << " gave an update with decreasing event group id: " << id);
+      metrics_.read_ignored_per_update++;
+      cid.reset(nullptr);
+      return {false, nullptr};
+    }
+  } else {
+    ConcordAssert(update_in.has_events());
+    span = TraceContexts::CreateChildSpanFromBinary(
+        update_in.events().span_context(), "trc_read_block", update_in.events().correlation_id(), logger_);
+    cid.reset(new LogCid(update_in.events().correlation_id()));
+    id = update_in.events().block_id();
+    if (id < latest_verified_block_id_) {
+      LOG4CPLUS_WARN(logger_,
+                     "Data stream " << data_conn_index_ << " gave an update with decreasing block number: " << id);
+      metrics_.read_ignored_per_update++;
+      cid.reset(nullptr);
+      return {false, nullptr};
+    }
   }
 
   string update_data_hash = hashUpdate(update_in);
   recordCollectedHash(data_conn_index_,
-                      update_in.events().block_id(),
+                      update_in.has_event_group(),
+                      id,
                       update_data_hash,
                       agreeing_subset_members,
                       most_agreeing,
@@ -249,9 +303,9 @@ TrsConnection::Result ThinReplicaClient::startHashStreamWith(size_t server_index
 }
 
 void ThinReplicaClient::findBlockHashAgreement(std::vector<bool>& servers_tried,
-                                               AgreeingSubsetMembers& agreeing_subset_members,
+                                               HashRecordMap& agreeing_subset_members,
                                                size_t& most_agreeing,
-                                               BlockIdHashPair& most_agreed_block,
+                                               HashRecord& most_agreed_block,
                                                SpanPtr& parent_span) {
   SpanPtr span = nullptr;
   if (parent_span) {
@@ -318,7 +372,13 @@ TrsConnection::Result ThinReplicaClient::resetDataStreamTo(size_t server_index) 
   config_->trs_conns[data_conn_index_]->cancelHashStream();
 
   SubscriptionRequest request;
-  request.mutable_events()->set_block_id(latest_verified_block_id_ + 1);
+
+  if (is_event_group_stream_) {
+    request.mutable_event_groups()->set_event_group_id(latest_verified_event_group_id_ + 1);
+  } else {
+    request.mutable_events()->set_block_id(latest_verified_block_id_ + 1);
+  }
+
   TrsConnection::Result result = config_->trs_conns[server_index]->openDataStream(request);
 
   data_conn_index_ = server_index;
@@ -334,8 +394,8 @@ void ThinReplicaClient::closeAllHashStreams() {
 }
 
 bool ThinReplicaClient::rotateDataStreamAndVerify(Data& update_in,
-                                                  AgreeingSubsetMembers& agreeing_subset_members,
-                                                  BlockIdHashPair& most_agreed_block,
+                                                  HashRecordMap& agreeing_subset_members,
+                                                  HashRecord& most_agreed_block,
                                                   SpanPtr& parent_span,
                                                   unique_ptr<LogCid>& cid) {
   SpanPtr span = nullptr;
@@ -370,12 +430,21 @@ bool ThinReplicaClient::rotateDataStreamAndVerify(Data& update_in,
     ConcordAssert(open_stream_result == TrsConnection::Result::kSuccess &&
                   read_result == TrsConnection::Result::kSuccess);
 
+    string correlation_id;
+    uint64_t update_id;  // Block id or event group id
+    if (update_in.has_event_group()) {
+      update_id = update_in.event_group().id();
+      correlation_id = to_string(update_id);
+    } else {
+      ConcordAssert(update_in.has_events());
+      update_id = update_in.events().block_id();
+      correlation_id = update_in.events().correlation_id();
+    }
     cid.reset();
-    cid.reset(new LogCid(update_in.events().correlation_id()));
-    if (update_in.events().block_id() != most_agreed_block.first) {
+    cid.reset(new LogCid(correlation_id));
+    if (update_id != most_agreed_block.id) {
       LOG4CPLUS_WARN(logger_,
-                     "Data stream " << server_index << " gave an update with a block number ("
-                                    << update_in.events().block_id()
+                     "Data stream " << server_index << " gave an update with id (" << update_id
                                     << ") in "
                                        "disagreement with the consensus and "
                                        "contradicting its own hash update.");
@@ -385,13 +454,13 @@ bool ThinReplicaClient::rotateDataStreamAndVerify(Data& update_in,
     }
 
     string update_data_hash = hashUpdate(update_in);
-    if (update_data_hash != most_agreed_block.second) {
+    if (update_data_hash != most_agreed_block.hash) {
       LOG4CPLUS_WARN(logger_,
                      "Data stream " << server_index
                                     << " gave an update hashing to a value "
                                        "in disagreement with the consensus on the "
-                                       "hash for this block ("
-                                    << update_in.events().block_id()
+                                       "hash for this update ("
+                                    << update_id
                                     << ") and contradicting the "
                                        "server's own hash update.");
       metrics_.read_ignored_per_update++;
@@ -446,8 +515,8 @@ void ThinReplicaClient::receiveUpdates() {
     SpanPtr span = nullptr;
     vector<bool> servers_tried(config_->trs_conns.size(), false);
 
-    AgreeingSubsetMembers agreeing_subset_members;
-    BlockIdHashPair most_agreed_block;
+    HashRecordMap agreeing_subset_members;
+    HashRecord most_agreed_block;
     size_t most_agreeing = 0;
     bool has_data = false;
     bool has_verified_data = false;
@@ -460,9 +529,9 @@ void ThinReplicaClient::receiveUpdates() {
         readBlock(update_in, agreeing_subset_members, most_agreeing, most_agreed_block, update_cid);
     servers_tried[data_conn_index_] = true;
 
+    uint64_t update_id = update_in.has_event_group() ? update_in.event_group().id() : update_in.events().block_id();
     LOG4CPLUS_DEBUG(logger_,
-                    "Find hash agreement amongst all servers for block "
-                        << (has_data ? to_string(update_in.events().block_id()) : "n/a"));
+                    "Find hash agreement amongst all servers for update " << (has_data ? to_string(update_id) : "n/a"));
     findBlockHashAgreement(servers_tried, agreeing_subset_members, most_agreeing, most_agreed_block, span);
     if (stop_subscription_thread_) {
       break;
@@ -506,31 +575,42 @@ void ThinReplicaClient::receiveUpdates() {
     }
 
     ConcordAssert(has_verified_data);
-    LOG4CPLUS_DEBUG(logger_, "Read and verified data for block " << update_in.events().block_id());
+    LOG4CPLUS_DEBUG(logger_, "Read and verified data for update " << update_id);
 
     ConcordAssertNE(config_->update_queue, nullptr);
 
-    unique_ptr<Update> update(new Update());
-    update->block_id = update_in.events().block_id();
-    update->correlation_id_ = update_in.events().correlation_id();
-    for (const auto& kvp_in : update_in.events().data()) {
-      update->kv_pairs.push_back(make_pair(kvp_in.key(), kvp_in.value()));
+    auto update = std::make_unique<Update>();
+    if (update_in.has_event_group()) {
+      auto& event_group = std::get<EventGroup>(*update);
+      event_group.id = update_in.event_group().id();
+      for (auto& event : update_in.event_group().events()) {
+        event_group.events.push_back(event);
+      }
+      // TODO: Set trace context
+      latest_verified_event_group_id_ = event_group.id;
+    } else {
+      ConcordAssert(update_in.has_events());
+      auto& legacy_event = std::get<LegacyEvent>(*update);
+      legacy_event.block_id = update_in.events().block_id();
+      legacy_event.correlation_id_ = update_in.events().correlation_id();
+      for (const auto& kvp_in : update_in.events().data()) {
+        legacy_event.kv_pairs.push_back(make_pair(kvp_in.key(), kvp_in.value()));
+      }
+      latest_verified_block_id_ = legacy_event.block_id;
+      TraceContexts::InjectSpan(span, *update);
     }
-    TraceContexts::InjectSpan(span, *update);
 
     if (metrics_.read_timeouts_per_update.Get().Get() > 0 || metrics_.read_failures_per_update.Get().Get() > 0 ||
         metrics_.read_ignored_per_update.Get().Get() > 0) {
       LOG4CPLUS_WARN(logger_,
                      metrics_.read_timeouts_per_update.Get().Get()
                          << " timeouts, " << metrics_.read_failures_per_update.Get().Get() << " failures, and "
-                         << metrics_.read_ignored_per_update.Get().Get() << " ignored while retrieving block id "
-                         << update_in.events().block_id());
+                         << metrics_.read_ignored_per_update.Get().Get() << " ignored while retrieving update "
+                         << update_id);
     }
 
-    latest_verified_block_id_ = update_in.events().block_id();
-
     // Push update to update queue for consumption before receiving next update
-    pushUpdateToUpdateQueue(std::move(update), start, latest_verified_block_id_);
+    pushUpdateToUpdateQueue(std::move(update), start, update_in.has_event_group());
 
     // Cleanup before the next update
 
@@ -540,7 +620,7 @@ void ThinReplicaClient::receiveUpdates() {
     // the loop's implementation.
     for (size_t trsc = 0; trsc < config_->trs_conns.size(); ++trsc) {
       if (agreeing_subset_members[most_agreed_block].count(trsc) < 1 && config_->trs_conns[trsc]->hasHashStream()) {
-        LOG4CPLUS_DEBUG(logger_, "Close hash stream " << trsc << " after block " << update_in.events().block_id());
+        LOG4CPLUS_DEBUG(logger_, "Close hash stream " << trsc << " after update " << update_id);
         config_->trs_conns[trsc]->cancelHashStream();
       }
     }
@@ -551,7 +631,7 @@ void ThinReplicaClient::receiveUpdates() {
 
 void ThinReplicaClient::pushUpdateToUpdateQueue(std::unique_ptr<Update> update,
                                                 const std::chrono::steady_clock::time_point& start,
-                                                const uint64_t& latest_verified_block_id) {
+                                                bool is_event_group) {
   // update current queue size metric before pushing to the update_queue
   metrics_.current_queue_size.Get().Set(config_->update_queue->Size());
 
@@ -564,7 +644,11 @@ void ThinReplicaClient::pushUpdateToUpdateQueue(std::unique_ptr<Update> update,
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
   metrics_.update_dur_ms.Get().Set((uint64_t)(duration.count()));
 
-  metrics_.last_verified_block_id.Get().Set(latest_verified_block_id);
+  if (is_event_group) {
+    metrics_.last_verified_event_group_id.Get().Set(latest_verified_event_group_id_);
+  } else {
+    metrics_.last_verified_block_id.Get().Set(latest_verified_block_id_);
+  }
 
   // Reset read timeout, failure and ignored metrics before the next update
   resetMetricsBeforeNextUpdate();
@@ -603,6 +687,7 @@ void ThinReplicaClient::Subscribe() {
     subscription_thread_->join();
     subscription_thread_.reset();
   }
+  is_event_group_stream_ = false;
 
   bool has_verified_state = false;
   size_t data_server_index = 0;
@@ -640,6 +725,8 @@ void ThinReplicaClient::Subscribe() {
     TrsConnection::Result read_result = TrsConnection::Result::kUnknown;
     while (!received_state_invalid && (read_result = config_->trs_conns[data_server_index]->readState(&response)) ==
                                           TrsConnection::Result::kSuccess) {
+      // ReadState is supported for legacy events only
+      ConcordAssert(response.has_events());
       if ((state.size() > 0) && (response.events().block_id() < block_id)) {
         LOG4CPLUS_WARN(logger_,
                        "While trying to fetch initial state for a "
@@ -649,12 +736,13 @@ void ThinReplicaClient::Subscribe() {
         received_state_invalid = true;
       } else {
         block_id = response.events().block_id();
-        unique_ptr<Update> update(new Update());
-        update->block_id = block_id;
-        update->correlation_id_ = response.events().correlation_id();
+        auto update = std::make_unique<Update>();
+        auto& legacy_event = std::get<LegacyEvent>(*update);
+        legacy_event.block_id = block_id;
+        legacy_event.correlation_id_ = response.events().correlation_id();
         for (int i = 0; i < response.events().data_size(); ++i) {
           const KVPair& kvp = response.events().data(i);
-          update->kv_pairs.push_back(make_pair(kvp.key(), kvp.value()));
+          legacy_event.kv_pairs.push_back(make_pair(kvp.key(), kvp.value()));
         }
         update_hashes.push_back(hashUpdate(*update));
         state.push_back(move(update));
@@ -791,6 +879,7 @@ void ThinReplicaClient::Subscribe(uint64_t block_id) {
 
   config_->update_queue->Clear();
   latest_verified_block_id_ = block_id;
+  is_event_group_stream_ = false;
 
   // Create and launch thread to stream updates from the servers and push them
   // into the queue.
@@ -798,7 +887,24 @@ void ThinReplicaClient::Subscribe(uint64_t block_id) {
   subscription_thread_.reset(new thread(&ThinReplicaClient::receiveUpdates, this));
 }
 
-void ThinReplicaClient::Subscribe(const SubscribeRequest& req) {}
+void ThinReplicaClient::Subscribe(const SubscribeRequest& req) {
+  // Stop any existing subscription before trying to start a new one.
+  stop_subscription_thread_ = true;
+  if (subscription_thread_) {
+    ConcordAssert(subscription_thread_->joinable());
+    subscription_thread_->join();
+    subscription_thread_.reset();
+  }
+
+  config_->update_queue->Clear();
+  latest_verified_event_group_id_ = req.event_group_id;
+  is_event_group_stream_ = true;
+
+  // Create and launch thread to stream updates from the servers and push them
+  // into the queue.
+  stop_subscription_thread_ = false;
+  subscription_thread_.reset(new thread(&ThinReplicaClient::receiveUpdates, this));
+}
 
 // This is a placeholder implementation as the Unsubscribe gRPC call is not yet
 // implemented on the server side.

--- a/client/thin-replica-client/src/trace_contexts.cpp
+++ b/client/thin-replica-client/src/trace_contexts.cpp
@@ -56,24 +56,24 @@ class SimpleTextMapReaderWriter : public opentracing::TextMapWriter, public open
   std::unordered_map<std::string, std::string>& text_map_;
 };
 
-void TraceContexts::InjectSpan(const TraceContexts::SpanPtr& span, Update& update) {
+void TraceContexts::InjectSpan(const TraceContexts::SpanPtr& span, EventVariant& update) {
   if (span) {
     // TODO: Event Group
-    if (std::holds_alternative<LegacyEvent>(update)) {
+    if (std::holds_alternative<Update>(update)) {
       std::unordered_map<std::string, std::string> text_map;
       SimpleTextMapReaderWriter writer(text_map);
       span->tracer().Inject(span->context(), writer);
       W3cTraceContext serialized_context;
       serialized_context.mutable_key_values()->insert(text_map.begin(), text_map.end());
-      std::get<LegacyEvent>(update).span_context = serialized_context.SerializeAsString();
+      std::get<Update>(update).span_context = serialized_context.SerializeAsString();
     }
   }
 }
 
-expected<std::unique_ptr<opentracing::SpanContext>> TraceContexts::ExtractSpan(const Update& update) {
+expected<std::unique_ptr<opentracing::SpanContext>> TraceContexts::ExtractSpan(const EventVariant& update) {
   // TODO: Event Group
-  if (std::holds_alternative<LegacyEvent>(update)) {
-    auto& legacy_event = std::get<LegacyEvent>(update);
+  if (std::holds_alternative<Update>(update)) {
+    auto& legacy_event = std::get<Update>(update);
     if (!legacy_event.span_context.empty()) {
       W3cTraceContext trace_context;
       trace_context.ParseFromString(legacy_event.span_context);

--- a/client/thin-replica-client/src/trc_hash.cpp
+++ b/client/thin-replica-client/src/trc_hash.cpp
@@ -69,8 +69,13 @@ static string hashUpdateFromEntryHashes(uint64_t block_id, const map<string, str
 }
 
 string hashUpdate(const Update& update) {
+  if (std::holds_alternative<EventGroup>(update)) {
+    // TODO: Event Group hashes
+    return std::string();
+  }
+  auto& legacy_event = std::get<LegacyEvent>(update);
   map<string, string> entry_hashes;
-  for (const auto& kvp : update.kv_pairs) {
+  for (const auto& kvp : legacy_event.kv_pairs) {
     string key_hash = ComputeSHA256Hash(kvp.first);
     if (entry_hashes.count(key_hash) > 0) {
       throw invalid_argument("hashUpdate called for an update that contains duplicate keys.");
@@ -78,11 +83,15 @@ string hashUpdate(const Update& update) {
     entry_hashes[key_hash] = ComputeSHA256Hash(kvp.second);
   }
 
-  return hashUpdateFromEntryHashes(update.block_id, entry_hashes);
+  return hashUpdateFromEntryHashes(legacy_event.block_id, entry_hashes);
 }
 
 string hashUpdate(const Data& update) {
-  ConcordAssert(update.has_events());  // EventGroups not supported yet
+  if (update.has_event_group()) {
+    // TODO: Support Event Group hashes
+    return string();
+  }
+  ConcordAssert(update.has_events());
   map<string, string> entry_hashes;
   for (const auto& kvp : update.events().data()) {
     string key_hash = ComputeSHA256Hash(kvp.key());

--- a/client/thin-replica-client/src/trc_hash.cpp
+++ b/client/thin-replica-client/src/trc_hash.cpp
@@ -68,12 +68,12 @@ static string hashUpdateFromEntryHashes(uint64_t block_id, const map<string, str
   return ComputeSHA256Hash(concatenated_entry_hashes);
 }
 
-string hashUpdate(const Update& update) {
+string hashUpdate(const EventVariant& update) {
   if (std::holds_alternative<EventGroup>(update)) {
     // TODO: Event Group hashes
     return std::string();
   }
-  auto& legacy_event = std::get<LegacyEvent>(update);
+  auto& legacy_event = std::get<Update>(update);
   map<string, string> entry_hashes;
   for (const auto& kvp : legacy_event.kv_pairs) {
     string key_hash = ComputeSHA256Hash(kvp.first);

--- a/client/thin-replica-client/test/trc_hash_test.cpp
+++ b/client/thin-replica-client/test/trc_hash_test.cpp
@@ -21,6 +21,7 @@ using std::make_pair;
 using std::string;
 using std::to_string;
 using client::thin_replica_client::hashUpdate;
+using client::thin_replica_client::EventVariant;
 using client::thin_replica_client::Update;
 
 const string kSampleUpdateExpectedHash({'\x02', '\x3D', '\x0D', '\x8B', '\xC6', '\x54', '\x07', '\xD7',
@@ -31,12 +32,12 @@ const string kSampleUpdateExpectedHash({'\x02', '\x3D', '\x0D', '\x8B', '\xC6', 
 namespace {
 
 TEST(trc_hash, hash_update) {
-  Update update;
-  update.block_id = 1337;
+  Update legacy_event;
+  legacy_event.block_id = 1337;
   for (int i = 0; i < 3; ++i) {
-    update.kv_pairs.push_back(make_pair(to_string(i), to_string(i)));
+    legacy_event.kv_pairs.push_back(make_pair(to_string(i), to_string(i)));
   }
-
+  EventVariant update = legacy_event;
   EXPECT_EQ(hashUpdate(update), kSampleUpdateExpectedHash);
 }
 


### PR DESCRIPTION
This change adds event group support to the TRC. The major focus is on backwards-compatibility, meaning, make sure that nothing breaks. Once the corresponding TRS changes are in, we will do end-to-end testing.
Please see commit messages for details.