### PR TITLE
Update KvbAppFilter and TRS to Handle Event Groups

### DIFF
--- a/kvbc/include/block_update/event_group_update.hpp
+++ b/kvbc/include/block_update/event_group_update.hpp
@@ -1,0 +1,35 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+// Update added to spsc subscription queue for consumption by subscribers.
+// Note: EventGroupUpdate is NOT stored on the blockchain. Consequently it does NOT update the blockchain state.
+
+#ifndef CONCORD_KVBC_EVENTGROUP_UPDATE_H_
+#define CONCORD_KVBC_EVENTGROUP_UPDATE_H_
+
+#include <optional>
+
+#include "categorization/updates.h"
+#include "kv_types.hpp"
+
+namespace concord::kvbc {
+
+struct EventGroupUpdate {
+  kvbc::EventGroupId event_group_id;
+  kvbc::categorization::EventGroup event_group;
+  std::optional<std::string> parent_span;
+};
+
+}  // namespace concord::kvbc
+
+#endif  // CONCORD_KVBC_BLOCK_UPDATE_H_

--- a/kvbc/include/block_update/event_group_update.hpp
+++ b/kvbc/include/block_update/event_group_update.hpp
@@ -20,6 +20,7 @@
 #include <optional>
 
 #include "categorization/updates.h"
+#include "event_group_msgs.cmf.hpp"
 #include "kv_types.hpp"
 
 namespace concord::kvbc {

--- a/kvbc/include/categorization/db_categories.h
+++ b/kvbc/include/categorization/db_categories.h
@@ -19,7 +19,9 @@ inline const auto kExecutionProvableCategory = "execution_provable";
 inline const auto kExecutionPrivateCategory = "execution_private";
 inline const auto kExecutionEventsCategory = "execution_events";
 inline const auto kRequestsRecord = "requests_record";
-inline const auto kExecutionEventGroupsCategory = "execution_event_groups";
+inline const auto kExecutionGlobalEventGroupsCategory = "execution_global_event_groups";
+inline const auto kExecutionTridEventGroupsCategory = "execution_trid_event_groups";
+inline const auto kExecutionEventGroupIdsCategory = "execution_event_group_ids";
 
 // Concord and Concord-BFT internal category that is used for various kinds of metadata.
 // The type of the internal category is VersionedKeyValueCategory.

--- a/kvbc/include/categorization/db_categories.h
+++ b/kvbc/include/categorization/db_categories.h
@@ -10,6 +10,8 @@
 // notices and license terms. Your use of these subcomponents is subject to the
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
+#ifndef CONCORD_KVBC_CATEGORIZATION_H_
+#define CONCORD_KVBC_CATEGORIZATION_H_
 
 #include <string>
 
@@ -28,3 +30,5 @@ inline const auto kExecutionEventGroupIdsCategory = "execution_event_group_ids";
 inline const auto kConcordInternalCategoryId = "concord_internal";
 
 }  // namespace concord::kvbc::categorization
+
+#endif  // CONCORD_KVBC_CATEGORIZATION_H_

--- a/kvbc/include/kv_types.hpp
+++ b/kvbc/include/kv_types.hpp
@@ -34,6 +34,7 @@ typedef std::vector<Key> KeysVector;
 typedef std::set<Key> OrderedKeysSet;
 typedef KeysVector ValuesVector;
 typedef std::uint64_t BlockId;
+typedef std::uint64_t EventGroupId;
 
 inline constexpr auto INITIAL_GENESIS_BLOCK_ID = BlockId{1};
 

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -95,6 +95,7 @@ class KvbAppFilter {
 
   // Compute hash for the given update
   std::string hashUpdate(const KvbFilteredUpdate &update);
+  std::string hashEventGroupUpdate(const KvbFilteredEventGroup &update);
 
   // Return all key-value pairs from the KVB in the block range [earliest block
   // available, given block_id] with the following conditions:

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -28,6 +28,7 @@
 #include "categorization/db_categories.h"
 #include "kv_types.hpp"
 #include "event_group_msgs.cmf.hpp"
+#include "endianness.hpp"
 
 namespace concord {
 namespace kvbc {
@@ -44,7 +45,7 @@ struct KvbFilteredUpdate {
   OrderedKVPairs kv_pairs;
 };
 
-struct KvbFilteredEventGroup {
+struct KvbFilteredEventGroupUpdate {
   using EventGroup = concord::kvbc::categorization::EventGroup;
   uint64_t event_group_id;
   EventGroup event_group;
@@ -91,12 +92,12 @@ class KvbAppFilter {
   // Filter the given update
   KvbFilteredUpdate filterUpdate(const KvbUpdate &update);
 
-  KvbFilteredEventGroup::EventGroup filterEventsInEventGroup(kvbc::EventGroupId event_group_id,
-                                                             kvbc::categorization::EventGroup &event_group);
+  KvbFilteredEventGroupUpdate::EventGroup filterEventsInEventGroup(kvbc::EventGroupId event_group_id,
+                                                                   kvbc::categorization::EventGroup &event_group);
 
   // Compute hash for the given update
   std::string hashUpdate(const KvbFilteredUpdate &update);
-  std::string hashEventGroupUpdate(const KvbFilteredEventGroup &update);
+  std::string hashEventGroupUpdate(const KvbFilteredEventGroupUpdate &update);
 
   // Return all key-value pairs from the KVB in the block range [earliest block
   // available, given block_id] with the following conditions:
@@ -112,7 +113,7 @@ class KvbAppFilter {
 
   void readEventGroupRange(kvbc::EventGroupId event_group_id_start,
                            kvbc::EventGroupId event_group_id_end,
-                           boost::lockfree::spsc_queue<KvbFilteredEventGroup> &queue_out,
+                           boost::lockfree::spsc_queue<KvbFilteredEventGroupUpdate> &queue_out,
                            const std::atomic_bool &stop_execution);
 
   // Compute the state hash of all key-value pairs in the range of [earliest

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -25,6 +25,7 @@
 
 #include "block_update/block_update.hpp"
 #include "db_interfaces.h"
+#include "categorization/db_categories.h"
 #include "kv_types.hpp"
 #include "event_group_msgs.cmf.hpp"
 

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -24,6 +24,7 @@
 #include "Logger.hpp"
 
 #include "block_update/block_update.hpp"
+#include "block_update/event_group_update.hpp"
 #include "db_interfaces.h"
 #include "categorization/db_categories.h"
 #include "kv_types.hpp"
@@ -37,6 +38,7 @@ namespace kvbc {
 typedef size_t KvbStateHash;
 
 typedef BlockUpdate KvbUpdate;
+typedef EventGroupUpdate EgUpdate;
 
 struct KvbFilteredUpdate {
   using OrderedKVPairs = std::vector<std::pair<std::string, std::string>>;
@@ -91,6 +93,8 @@ class KvbAppFilter {
 
   // Filter the given update
   KvbFilteredUpdate filterUpdate(const KvbUpdate &update);
+
+  KvbFilteredEventGroupUpdate filterEventGroupUpdate(EgUpdate &update);
 
   KvbFilteredEventGroupUpdate::EventGroup filterEventsInEventGroup(kvbc::EventGroupId event_group_id,
                                                                    kvbc::categorization::EventGroup &event_group);

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -24,7 +24,6 @@
 #include "Logger.hpp"
 
 #include "concord_kvbc.pb.h"
-#include "categorization/db_categories.h"
 #include "kv_types.hpp"
 #include "kvbc_app_filter/kvbc_key_types.h"
 #include "openssl_crypto.hpp"

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -127,6 +127,11 @@ KvbFilteredUpdate KvbAppFilter::filterUpdate(const KvbUpdate &update) {
   return KvbFilteredUpdate{block_id, cid, filterKeyValuePairs(updates)};
 }
 
+KvbFilteredEventGroupUpdate KvbAppFilter::filterEventGroupUpdate(EgUpdate &update) {
+  auto &[event_group_id, event_group, _] = update;
+  return KvbFilteredEventGroupUpdate{event_group_id, filterEventsInEventGroup(event_group_id, event_group)};
+}
+
 string KvbAppFilter::hashUpdate(const KvbFilteredUpdate &update) {
   // Note we store the hashes of the keys and values in an std::map as an
   // intermediate step in the computation of the update hash so the map can be

--- a/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
+++ b/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
@@ -20,7 +20,6 @@
 #include <vector>
 #include "Logger.hpp"
 #include "categorization/updates.h"
-#include "categorization/db_categories.h"
 #include "endianness.hpp"
 #include "gtest/gtest.h"
 #include "kv_types.hpp"

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -28,7 +28,6 @@
 #include "Logger.hpp"
 #include "Metrics.hpp"
 
-#include "categorization/db_categories.h"
 #include "db_interfaces.h"
 #include "kv_types.hpp"
 #include "kvbc_app_filter/kvbc_app_filter.h"

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -146,29 +146,56 @@ class ThinReplicaImpl {
 
     LOG_DEBUG(logger_, "ReadStateHash");
 
-    // TODO: Determine oldest block available (pruning)
-    kvbc::BlockId block_id_start = 1;
-    kvbc::BlockId block_id_end = request->events().block_id();
+    if (request->has_events()) {
+      // TODO: Determine oldest block available (pruning)
+      kvbc::BlockId block_id_start = 1;
+      kvbc::BlockId block_id_end = request->events().block_id();
 
-    if (block_id_end < block_id_start) {
-      std::string msg{"Invalid block range"};
-      msg += " [" + std::to_string(block_id_start) + "," + std::to_string(block_id_end) + "]";
+      if (block_id_end < block_id_start) {
+        std::string msg{"Invalid block range"};
+        msg += " [" + std::to_string(block_id_start) + "," + std::to_string(block_id_end) + "]";
+        LOG_WARN(logger_, msg);
+        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, msg);
+      }
+
+      std::string kvb_hash;
+      try {
+        kvb_hash = kvb_filter->readBlockRangeHash(block_id_start, block_id_end);
+      } catch (std::exception& error) {
+        LOG_ERROR(logger_, error.what());
+        std::stringstream msg;
+        msg << "Reading StateHash for block " << block_id_end << " failed";
+        return grpc::Status(grpc::StatusCode::UNKNOWN, msg.str());
+      }
+
+      hash->mutable_events()->set_block_id(block_id_end);
+      hash->mutable_events()->set_hash(kvb_hash);
+
+      return grpc::Status::OK;
+    }
+    // Request is an event_group request
+    kvbc::EventGroupId event_group_id_start = 1;
+    kvbc::EventGroupId event_group_id_end = request->event_groups().event_group_id();
+
+    if (event_group_id_end < event_group_id_start) {
+      std::string msg{"Invalid event group range"};
+      msg += " [" + std::to_string(event_group_id_start) + "," + std::to_string(event_group_id_end) + "]";
       LOG_WARN(logger_, msg);
       return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, msg);
     }
 
-    std::string kvb_hash;
+    std::string kvb_eg_hash;
     try {
-      kvb_hash = kvb_filter->readBlockRangeHash(block_id_start, block_id_end);
+      kvb_eg_hash = kvb_filter->readEventGroupRangeHash(event_group_id_start, event_group_id_end);
     } catch (std::exception& error) {
       LOG_ERROR(logger_, error.what());
       std::stringstream msg;
-      msg << "Reading StateHash for block " << block_id_end << " failed";
+      msg << "Reading StateHash for event_group_id " << event_group_id_end << " failed";
       return grpc::Status(grpc::StatusCode::UNKNOWN, msg.str());
     }
 
-    hash->mutable_events()->set_block_id(block_id_end);
-    hash->mutable_events()->set_hash(kvb_hash);
+    hash->mutable_event_group()->set_event_group_id(event_group_id_end);
+    hash->mutable_event_group()->set_hash(kvb_eg_hash);
 
     return grpc::Status::OK;
   }
@@ -197,7 +224,7 @@ class ThinReplicaImpl {
       return kvb_status;
     }
 
-    auto [subscribe_status, live_updates] = subscribeToLiveUpdates(request);
+    auto [subscribe_status, live_updates] = subscribeToLiveUpdates(request, getClientId(context));
     if (!subscribe_status.ok()) {
       return subscribe_status;
     }
@@ -230,75 +257,115 @@ class ThinReplicaImpl {
         msg << "Couldn't transition from block id " << request->events().block_id() << " to new blocks";
         return grpc::Status(grpc::StatusCode::UNKNOWN, msg.str());
       }
-    } else {
-      uint64_t event_group_id = request->event_groups().event_group_id();
-      bool event_group_enabled = true;
-      try {
-        syncAndSend<ServerContextT, ServerWriterT, DataT>(
-            context, event_group_id, live_updates, stream, kvb_filter, event_group_enabled);
-      } catch (StreamCancelled& error) {
-        config_->subscriber_list.removeBuffer(live_updates);
-        live_updates->removeAllUpdates();
-        metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
-        metrics_.updateAggregator();
-        return grpc::Status(grpc::StatusCode::CANCELLED, error.what());
-      } catch (std::exception& error) {
-        LOG_ERROR(logger_, error.what());
-        config_->subscriber_list.removeBuffer(live_updates);
-        live_updates->removeAllUpdates();
-
-        metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
-        metrics_.updateAggregator();
-
-        std::stringstream msg;
-        msg << "Couldn't transition from block id " << request->events().block_id() << " to new blocks";
-        return grpc::Status(grpc::StatusCode::UNKNOWN, msg.str());
+      // Read, filter, and send live updates
+      SubUpdate update;
+      while (!context->IsCancelled()) {
+        metrics_.queue_size.Get().Set(live_updates->Size());
+        try {
+          live_updates->Pop(update);
+        } catch (concord::thin_replica::ConsumerTooSlow& error) {
+          LOG_WARN(logger_, "Closing subscription: " << error.what());
+          break;
+        }
+        auto kvb_update = kvbc::KvbUpdate{update.block_id, update.correlation_id, std::move(update.immutable_kv_pairs)};
+        const auto& filtered_update = kvb_filter->filterUpdate(kvb_update);
+        try {
+          if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
+            LOG_DEBUG(logger_, "Live updates send data");
+            auto correlation_id = filtered_update.correlation_id;
+            if (update.parent_span) {
+              sendData(stream, filtered_update, {*update.parent_span});
+            } else {
+              auto span = opentracing::Tracer::Global()->StartSpan(
+                  "trs_stream_update", {opentracing::SetTag{kCorrelationIdTag, correlation_id}});
+              std::ostringstream context;
+              const opentracing::Span& span_to_serialize = *span;
+              span_to_serialize.tracer().Inject(span_to_serialize.context(), context);
+              auto propagated_span_context = context.str();
+              sendData(stream, filtered_update, {propagated_span_context});
+            }
+          } else if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Hash>()) {
+            LOG_DEBUG(logger_, "Live updates send hash");
+            sendHash(stream, update.block_id, kvb_filter->hashUpdate(filtered_update));
+          }
+        } catch (std::exception& error) {
+          LOG_INFO(logger_, "Subscription stream closed: " << error.what());
+          break;
+        }
+        metrics_.last_sent_block_id.Get().Set(update.block_id);
+        if (++update_aggregator_counter == config_->update_metrics_aggregator_thresh) {
+          metrics_.updateAggregator();
+          update_aggregator_counter = 0;
+        }
       }
+      config_->subscriber_list.removeBuffer(live_updates);
+      live_updates->removeAllUpdates();
+      metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
+      metrics_.updateAggregator();
+      if (context->IsCancelled()) {
+        return grpc::Status::CANCELLED;
+      }
+      return grpc::Status::OK;
     }
+    // Request is an event group request
+    uint64_t event_group_id = request->event_groups().event_group_id();
+    try {
+      syncAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(
+          context, event_group_id, live_updates, stream, kvb_filter);
+    } catch (StreamCancelled& error) {
+      config_->subscriber_list.removeBuffer(live_updates);
+      live_updates->removeAllEventGroupUpdates();
+      metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
+      metrics_.updateAggregator();
+      return grpc::Status(grpc::StatusCode::CANCELLED, error.what());
+    } catch (std::exception& error) {
+      LOG_ERROR(logger_, error.what());
+      config_->subscriber_list.removeBuffer(live_updates);
+      live_updates->removeAllEventGroupUpdates();
 
+      metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
+      metrics_.updateAggregator();
+
+      std::stringstream msg;
+      msg << "Couldn't transition from event_group_id " << request->event_groups().event_group_id()
+          << " to new event groups";
+      return grpc::Status(grpc::StatusCode::UNKNOWN, msg.str());
+    }
     // Read, filter, and send live updates
-    SubUpdate update;
+    SubEventGroupUpdate sub_eg_update;
     while (!context->IsCancelled()) {
-      metrics_.queue_size.Get().Set(live_updates->Size());
+      metrics_.queue_size.Get().Set(live_updates->SizeEventGroupQueue());
       try {
-        live_updates->Pop(update);
+        live_updates->PopEventGroup(sub_eg_update);
       } catch (concord::thin_replica::ConsumerTooSlow& error) {
         LOG_WARN(logger_, "Closing subscription: " << error.what());
         break;
       }
-      auto kvb_update = kvbc::KvbUpdate{update.block_id, update.correlation_id, std::move(update.immutable_kv_pairs)};
-      const auto& filtered_update = kvb_filter->filterUpdate(kvb_update);
+      auto eg_update = kvbc::EgUpdate{sub_eg_update.event_group_id, std::move(sub_eg_update.event_group)};
+      const auto& filtered_eg_update = kvb_filter->filterEventGroupUpdate(eg_update);
       try {
         if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
           LOG_DEBUG(logger_, "Live updates send data");
-          auto correlation_id = filtered_update.correlation_id;
-          if (update.parent_span) {
-            sendData(stream, filtered_update, {*update.parent_span});
-          } else {
-            auto span = opentracing::Tracer::Global()->StartSpan(
-                "trs_stream_update", {opentracing::SetTag{kCorrelationIdTag, correlation_id}});
-            std::ostringstream context;
-            const opentracing::Span& span_to_serialize = *span;
-            span_to_serialize.tracer().Inject(span_to_serialize.context(), context);
-            auto propagated_span_context = context.str();
-            sendData(stream, filtered_update, {propagated_span_context});
-          }
+          //  auto correlation_id = filtered_update.correlation_id; (TODO (Shruti) - Get correlation ID)
+          // TODO (Shruti) : Get and propagate span context
+          sendEventGroupData(stream, filtered_eg_update);
         } else if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Hash>()) {
           LOG_DEBUG(logger_, "Live updates send hash");
-          sendHash(stream, update.block_id, kvb_filter->hashUpdate(filtered_update));
+          sendEventGroupHash(
+              stream, sub_eg_update.event_group_id, kvb_filter->hashEventGroupUpdate(filtered_eg_update));
         }
       } catch (std::exception& error) {
         LOG_INFO(logger_, "Subscription stream closed: " << error.what());
         break;
       }
-      metrics_.last_sent_block_id.Get().Set(update.block_id);
+      metrics_.last_sent_event_group_id.Get().Set(sub_eg_update.event_group_id);
       if (++update_aggregator_counter == config_->update_metrics_aggregator_thresh) {
         metrics_.updateAggregator();
         update_aggregator_counter = 0;
       }
     }
     config_->subscriber_list.removeBuffer(live_updates);
-    live_updates->removeAllUpdates();
+    live_updates->removeAllEventGroupUpdates();
     metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
     metrics_.updateAggregator();
     if (context->IsCancelled()) {
@@ -460,6 +527,55 @@ class ThinReplicaImpl {
   }
 
   template <typename ServerContextT, typename ServerWriterT>
+  void readEventGroupsFromKvbAndSendData(logging::Logger logger,
+                                         ServerContextT* context,
+                                         ServerWriterT* stream,
+                                         kvbc::EventGroupId start,
+                                         kvbc::EventGroupId end,
+                                         std::shared_ptr<kvbc::KvbAppFilter> kvb_filter) {
+    using namespace std::chrono_literals;
+    boost::lockfree::spsc_queue<kvbc::KvbFilteredEventGroupUpdate> queue{10};
+    std::atomic_bool close_stream = false;
+
+    auto kvb_reader = std::async(std::launch::async,
+                                 &kvbc::KvbAppFilter::readEventGroupRange,
+                                 kvb_filter,
+                                 start,
+                                 end,
+                                 std::ref(queue),
+                                 std::ref(close_stream));
+
+    kvbc::KvbFilteredEventGroupUpdate kvb_eg_update;
+    while (kvb_reader.wait_for(0s) != std::future_status::ready || !queue.empty()) {
+      if (context->IsCancelled()) {
+        close_stream = true;
+        while (!queue.empty()) {
+          queue.pop(kvb_eg_update);
+        }
+        throw StreamCancelled("Kvb event group data stream cancelled");
+      }
+      while (queue.pop(kvb_eg_update)) {
+        try {
+          sendEventGroupData(stream, kvb_eg_update);
+        } catch (StreamClosed& error) {
+          LOG_WARN(logger, "Data stream closed at event group id " << kvb_eg_update.event_group_id);
+
+          // Stop kvb_reader and empty queue
+          close_stream = true;
+          while (!queue.empty()) {
+            queue.pop(kvb_eg_update);
+          }
+          throw;
+        }
+      }
+    }
+    ConcordAssert(queue.empty());
+
+    // Throws exception if something goes wrong
+    kvb_reader.get();
+  }
+
+  template <typename ServerContextT, typename ServerWriterT>
   void readFromKvbAndSendHashes(logging::Logger logger,
                                 ServerContextT* context,
                                 ServerWriterT* stream,
@@ -472,6 +588,22 @@ class ThinReplicaImpl {
       }
       std::string hash = kvb_filter->readBlockHash(block_id);
       sendHash(stream, block_id, hash);
+    }
+  }
+
+  template <typename ServerContextT, typename ServerWriterT>
+  void readEventGroupsFromKvbAndSendHashes(logging::Logger logger,
+                                           ServerContextT* context,
+                                           ServerWriterT* stream,
+                                           kvbc::EventGroupId start,
+                                           kvbc::EventGroupId end,
+                                           std::shared_ptr<kvbc::KvbAppFilter> kvb_filter) {
+    for (auto event_group_id = start; event_group_id <= end; ++event_group_id) {
+      if (context->IsCancelled()) {
+        throw StreamCancelled("Kvb event group hash stream cancelled");
+      }
+      std::string hash = kvb_filter->readEventGroupHash(event_group_id);
+      sendEventGroupHash(stream, event_group_id, hash);
     }
   }
 
@@ -493,6 +625,24 @@ class ThinReplicaImpl {
     }
   }
 
+  // Read event groups from KVB and send to the given stream depending on the data type
+  template <typename ServerContextT, typename ServerWriterT, typename DataT>
+  inline void readAndSendEventGroups(logging::Logger logger,
+                                     ServerContextT* context,
+                                     ServerWriterT* stream,
+                                     kvbc::EventGroupId start,
+                                     kvbc::EventGroupId end,
+                                     std::shared_ptr<kvbc::KvbAppFilter> kvb_filter) {
+    static_assert(std::is_same<DataT, com::vmware::concord::thin_replica::Data>() ||
+                      std::is_same<DataT, com::vmware::concord::thin_replica::Hash>(),
+                  "We expect either a Data or Hash type");
+    if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
+      readEventGroupsFromKvbAndSendData(logger, context, stream, start, end, kvb_filter);
+    } else if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Hash>()) {
+      readEventGroupsFromKvbAndSendHashes(logger, context, stream, start, end, kvb_filter);
+    }
+  }
+
   // Read from KVB until we are in sync with the live updates. This function
   // returns when the next update can be taken from the given live updates.
   // We assume that the Commands handler is already filling the queue. Also, we
@@ -500,7 +650,7 @@ class ThinReplicaImpl {
   // use the queue as soon as he consumes it.
   template <typename ServerContextT, typename ServerWriterT, typename DataT>
   void syncAndSend(ServerContextT* context,
-                   uint64_t start,  // TODO (Shruti) - Add another SyncAndSend method for event groups
+                   kvbc::BlockId start,
                    std::shared_ptr<SubUpdateBuffer> live_updates,
                    ServerWriterT* stream,
                    std::shared_ptr<kvbc::KvbAppFilter> kvb_filter,
@@ -546,6 +696,62 @@ class ThinReplicaImpl {
     } while (update.block_id < end);
   }
 
+  // Read from KVB until we are in sync with the live updates. This function
+  // returns when the next update can be taken from the given live updates.
+  // We assume that the Commands handler is already filling the queue. Also, we
+  // don't care if the queue fills up. In that case, the caller won't be able to
+  // use the queue as soon as he consumes it.
+  template <typename ServerContextT, typename ServerWriterT, typename DataT>
+  void syncAndSendEventGroups(ServerContextT* context,
+                              kvbc::EventGroupId start,
+                              std::shared_ptr<SubUpdateBuffer> live_updates,
+                              ServerWriterT* stream,
+                              std::shared_ptr<kvbc::KvbAppFilter> kvb_filter) {
+    const auto& last_trid_eg_id_var =
+        (config_->rostorage)
+            ->getLatest(concord::kvbc::categorization::kExecutionEventGroupIdsCategory, getClientId(context));
+    const auto& val = std::get<concord::kvbc::categorization::ImmutableValue>(*last_trid_eg_id_var);
+    kvbc::EventGroupId end = concordUtils::fromBigEndianBuffer<uint64_t>(val.data.data());
+    ConcordAssert(start <= end);
+
+    // Let's not wait for a live update yet due to there might be lots of
+    // history we have to catch up with first
+    LOG_INFO(logger_, "Sync reading event groups from KVB [" << start << ", " << end << "]");
+    readAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(logger_, context, stream, start, end, kvb_filter);
+
+    // Let's wait until we have at least one live update
+    live_updates->waitForEventGroupUntilNonEmpty();
+
+    // We are in sync already
+    if (live_updates->oldestEventGroupId() == (end + 1)) {
+      return;
+    }
+
+    // Gap:
+    // If the first live update is not the follow-up to the last read block from
+    // KVB then we need to fill the gap. Let's read from KVB starting at end + 1
+    // up to updates that are part of the live updates already. Thereby, we
+    // create an overlap between what we read from KVB and what is currently in
+    // the live updates.
+    if (live_updates->oldestEventGroupId() > (end + 1)) {
+      start = end + 1;
+      end = live_updates->newestEventGroupId();
+
+      LOG_INFO(logger_, "Sync filling gap [" << start << ", " << end << "]");
+      readAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(logger_, context, stream, start, end, kvb_filter);
+    }
+
+    // Overlap:
+    // If we read updates from KVB that were added to the live updates already
+    // then we just need to drop the overlap and return
+    ConcordAssert(live_updates->oldestEventGroupId() <= end);
+    SubEventGroupUpdate update;
+    do {
+      live_updates->PopEventGroup(update);
+      LOG_INFO(logger_, "Sync dropping " << update.event_group_id);
+    } while (update.event_group_id < end);
+  }
+
   // Send* prepares the response object and puts it on the stream
   template <typename ServerWriterT>
   void sendData(ServerWriterT* stream,
@@ -569,6 +775,27 @@ class ThinReplicaImpl {
     }
   }
 
+  // Send* prepares the response object and puts it on the stream
+  template <typename ServerWriterT>
+  void sendEventGroupData(ServerWriterT* stream,
+                          const kvbc::KvbFilteredEventGroupUpdate& eg_update,
+                          const std::optional<std::string>& span = std::nullopt) {
+    com::vmware::concord::thin_replica::Data data;
+    data.mutable_event_group()->set_id(eg_update.event_group_id);
+
+    for (const auto& event : eg_update.event_group.events) {
+      std::vector<uint8_t> output;
+      concord::kvbc::categorization::serialize(output, event);
+      std::string serialized_event(output.begin(), output.end());
+      data.mutable_event_group()->add_events(serialized_event);
+    }
+    // TODO (Shruti) Add record time
+    // TODO (Shruti) Add trace context
+    if (!stream->Write(data)) {
+      throw StreamClosed("Data event group stream closed");
+    }
+  }
+
   template <typename ServerWriterT>
   void sendHash(ServerWriterT* stream, kvbc::BlockId block_id, const std::string& update_hash) {
     com::vmware::concord::thin_replica::Hash hash;
@@ -577,6 +804,17 @@ class ThinReplicaImpl {
     LOG_DEBUG(logger_, "COMPARE SendHash block_id " << block_id << " update_hash " << update_hash);
     if (!stream->Write(hash)) {
       throw StreamClosed("Hash stream closed");
+    }
+  }
+
+  template <typename ServerWriterT>
+  void sendEventGroupHash(ServerWriterT* stream, kvbc::EventGroupId event_group_id, const std::string& update_hash) {
+    com::vmware::concord::thin_replica::Hash hash;
+    hash.mutable_event_group()->set_event_group_id(event_group_id);
+    hash.mutable_event_group()->set_hash(update_hash);
+    LOG_DEBUG(logger_, "COMPARE SendHash event group id " << event_group_id << " update_hash " << update_hash);
+    if (!stream->Write(hash)) {
+      throw StreamClosed("Hash event group stream closed");
     }
   }
 
@@ -633,7 +871,8 @@ class ThinReplicaImpl {
   }
 
   template <typename RequestT>
-  std::tuple<grpc::Status, std::shared_ptr<SubUpdateBuffer>> subscribeToLiveUpdates(RequestT* request) {
+  std::tuple<grpc::Status, std::shared_ptr<SubUpdateBuffer>> subscribeToLiveUpdates(RequestT* request,
+                                                                                    const std::string& client_id) {
     auto live_updates = std::make_shared<SubUpdateBuffer>(kSubUpdateBufferSize);
     bool success = config_->subscriber_list.addBuffer(live_updates);
     if (!success) {
@@ -642,16 +881,33 @@ class ThinReplicaImpl {
       LOG_ERROR(logger_, msg.str());
       return {grpc::Status(grpc::StatusCode::INTERNAL, msg.str()), live_updates};
     }
-    auto last_block_id = (config_->rostorage)->getLastBlockId();
-    if (request->events().block_id() > last_block_id) {
-      config_->subscriber_list.removeBuffer(live_updates);
-      live_updates->removeAllUpdates();
-      std::stringstream msg;
-      msg << "Block " << request->events().block_id() << " doesn't exist yet "
-          << " latest block is " << last_block_id;
-      LOG_ERROR(logger_, msg.str());
-      return {grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, msg.str()), live_updates};
+    if (request->has_events()) {
+      auto last_block_id = (config_->rostorage)->getLastBlockId();
+      if (request->events().block_id() > last_block_id) {
+        config_->subscriber_list.removeBuffer(live_updates);
+        live_updates->removeAllUpdates();
+        std::stringstream msg;
+        msg << "Block " << request->events().block_id() << " doesn't exist yet "
+            << " latest block is " << last_block_id;
+        LOG_ERROR(logger_, msg.str());
+        return {grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, msg.str()), live_updates};
+      }
+    } else {
+      const auto& last_trid_eg_id_var =
+          (config_->rostorage)->getLatest(concord::kvbc::categorization::kExecutionEventGroupIdsCategory, client_id);
+      const auto& val = std::get<concord::kvbc::categorization::ImmutableValue>(*last_trid_eg_id_var);
+      const auto& last_eg_id = concordUtils::fromBigEndianBuffer<uint64_t>(val.data.data());
+      if (request->event_groups().event_group_id() > last_eg_id) {
+        config_->subscriber_list.removeBuffer(live_updates);
+        live_updates->removeAllEventGroupUpdates();
+        std::stringstream msg;
+        msg << "Event group ID " << request->event_groups().event_group_id() << " doesn't exist yet "
+            << " latest event_group_id is " << last_eg_id;
+        LOG_ERROR(logger_, msg.str());
+        return {grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, msg.str()), live_updates};
+      }
     }
+
     return {grpc::Status::OK, live_updates};
   }
 

--- a/thin-replica-server/include/thin-replica-server/trs_metrics.hpp
+++ b/thin-replica-server/include/thin-replica-server/trs_metrics.hpp
@@ -23,7 +23,9 @@ struct ThinReplicaServerMetrics {
       : metrics_component_{"ThinReplicaServer", std::make_shared<concordMetrics::Aggregator>()},
         subscriber_list_size{metrics_component_.RegisterGauge("subscriber_list_size", 0)},
         queue_size{metrics_component_.RegisterGauge(stream_type + client_id + "queue_size", 0)},
-        last_sent_block_id{metrics_component_.RegisterGauge(stream_type + client_id + "last_sent_block_id", 0)} {
+        last_sent_block_id{metrics_component_.RegisterGauge(stream_type + client_id + "last_sent_block_id", 0)},
+        last_sent_event_group_id{
+            metrics_component_.RegisterGauge(stream_type + client_id + "last_sent_event_group_id", 0)} {
     metrics_component_.Register();
   }
 
@@ -43,6 +45,8 @@ struct ThinReplicaServerMetrics {
   concordMetrics::GaugeHandle queue_size;
   // last sent block id
   concordMetrics::GaugeHandle last_sent_block_id;
+  // last sent event group id
+  concordMetrics::GaugeHandle last_sent_event_group_id;
 };
 }  // namespace thin_replica
 }  // namespace concord

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -20,7 +20,6 @@
 #include "thin-replica-server/grpc_services.hpp"
 #include "Logger.hpp"
 
-#include "categorization/db_categories.h"
 #include "kv_types.hpp"
 #include "thin-replica-server/subscription_buffer.hpp"
 #include "thin-replica-server/thin_replica_impl.hpp"


### PR DESCRIPTION
This PR updates KvbAppFilter and TRS to handle event groups. Please see individual commits for more detail.
Note - This PR does not include the corresponding unit tests  yet.