### PR TITLE
Temporarily disabled testcases test_wedge_command_with_f_failures and test_client_exchange_public_key in test_skvbc_reconfiguration.py

### DIFF
--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -444,6 +444,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
 
+    @unittest.skip("Disabling temporarily till the fix is done")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_wedge_command_with_f_failures(self, bft_network):

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -287,6 +287,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             log.log_message(message_type=f"block_id {rep.response.block_id}")
             assert rep.response.block_id == 1
     
+    @unittest.skip("Disabling temporarily till the fix is done")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_client_exchange_public_key(self, bft_network):


### PR DESCRIPTION
Temporarily disabled testcases test_wedge_command_with_f_failures and test_client_exchange_public_key in test_skvbc_reconfiguration.py