### PR TITLE
Client pool - add callback to requests

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -21,6 +21,7 @@
 #include "Metrics.hpp"
 #include "communication/ICommunication.hpp"
 #include "PerformanceManager.hpp"
+#include "../../../bftclient/include/bftclient/base_types.h"
 
 namespace bftEngine {
 struct SimpleClientParams {
@@ -46,6 +47,7 @@ enum ClientMsgFlag : uint8_t {
 };
 
 enum OperationResult : int8_t { SUCCESS, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL, INVALID_REQUEST };
+typedef std::function<void(bft::client::Reply&&)> RequestCallBack;
 
 struct ClientRequest {
   uint8_t flags = 0;
@@ -64,6 +66,7 @@ struct ClientReply {
   OperationResult opResult = SUCCESS;
   std::string cid;
   std::string span_context;
+  RequestCallBack cb = nullptr;
 };
 
 class SimpleClient {

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -29,6 +29,10 @@ class ConcordConfiguration;
 }
 
 namespace external_client {
+// Call back for request - at this point we know for sure that a client is handling the request so we can assure that we
+// will have reply. This callback will be attached to the client reply struct and whenever we get the reply fro, the bft
+// client we will activate the callback.
+typedef std::function<void(bft::client::Reply&&)> RequestCallBack;
 
 // Represents a Concord BFT client. The purpose of this class is to be easy to
 // use for external users. This is achieved by:
@@ -62,6 +66,7 @@ class ConcordClient {
                          std::chrono::milliseconds timeout_ms,
                          std::uint32_t reply_size,
                          uint64_t seq_num,
+                         const RequestCallBack& callback,
                          const std::string& correlation_id = {},
                          const std::string& span_context = {});
 

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -45,8 +45,8 @@ Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_req
   auto callback = [&](cc::SendResult&& send_result) {
     if (not std::holds_alternative<bft::client::Reply>(send_result)) {
       LOG_INFO(logger_, "Send returned error");
-      // TODO: Use error codes according to proto file documentation
-      status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "InternalError"));
+      if (std::get<concord_client_pool::SubmitResult>(send_result) == concord_client_pool::Overloaded)
+        status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "Overloaded"));
       return;
     }
     auto reply = std::get<bft::client::Reply>(send_result);

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -35,7 +35,7 @@ struct SendError {
   };
   ErrorType type;
 };
-typedef std::variant<SendError, bft::client::Reply> SendResult;
+typedef std::variant<concord_client_pool::SubmitResult, bft::client::Reply> SendResult;
 
 struct ReplicaInfo {
   bft::client::ReplicaId id;

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -121,18 +121,14 @@ void ConcordClient::send(const bft::client::ReadConfig& config,
                          const std::unique_ptr<opentracing::Span>& parent_span,
                          const std::function<void(SendResult&&)>& callback) {
   LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
-  bft::client::Reply reply;
-  reply.matched_data = std::move(msg);
-  callback(SendResult{reply});
+  client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
 }
 
 void ConcordClient::send(const bft::client::WriteConfig& config,
                          bft::client::Msg&& msg,
                          const std::unique_ptr<opentracing::Span>& parent_span,
                          const std::function<void(SendResult&&)>& callback) {
-  bft::client::Reply reply;
-  reply.matched_data = std::move(msg);
-  callback(SendResult{reply});
+  client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
 }
 
 void ConcordClient::subscribe(const SubscribeRequest& sub_req,


### PR DESCRIPTION
As part of moving to the client service, one of the requirements was the ability to get a response to requests from the client pool.
For this purpose, we are sending the request along with a callback; through this callback, we will return the reply once the request has been completed.

Changes made to the flow do not affect the existing flow and have been verified using Docker compose.