### PR TITLE
Clientservice: Rename proto

### DIFF
--- a/client/clientservice/include/client/clientservice/event_service.hpp
+++ b/client/clientservice/include/client/clientservice/event_service.hpp
@@ -10,7 +10,7 @@
 // file.
 
 #include <grpcpp/grpcpp.h>
-#include <concord_client.grpc.pb.h>
+#include <clientservice.grpc.pb.h>
 #include <memory>
 
 #include "Logger.hpp"
@@ -18,13 +18,13 @@
 
 namespace concord::client::clientservice {
 
-class EventServiceImpl final : public vmware::concord::client::v1::EventService::Service {
+class EventServiceImpl final : public vmware::concord::clientservice::v1::EventService::Service {
  public:
   EventServiceImpl(std::shared_ptr<concord::client::concordclient::ConcordClient> client)
       : logger_(logging::getLogger("concord.client.clientservice.event")), client_(client){};
   grpc::Status Subscribe(grpc::ServerContext* context,
-                         const vmware::concord::client::v1::SubscribeRequest* request,
-                         grpc::ServerWriter<vmware::concord::client::v1::SubscribeResponse>* stream) override;
+                         const vmware::concord::clientservice::v1::SubscribeRequest* request,
+                         grpc::ServerWriter<vmware::concord::clientservice::v1::SubscribeResponse>* stream) override;
 
  private:
   logging::Logger logger_;

--- a/client/clientservice/include/client/clientservice/request_service.hpp
+++ b/client/clientservice/include/client/clientservice/request_service.hpp
@@ -10,7 +10,7 @@
 // file.
 
 #include <grpcpp/grpcpp.h>
-#include <concord_client.grpc.pb.h>
+#include <clientservice.grpc.pb.h>
 #include <memory>
 
 #include "Logger.hpp"
@@ -18,13 +18,13 @@
 
 namespace concord::client::clientservice {
 
-class RequestServiceImpl final : public vmware::concord::client::v1::RequestService::Service {
+class RequestServiceImpl final : public vmware::concord::clientservice::v1::RequestService::Service {
  public:
   RequestServiceImpl(std::shared_ptr<concord::client::concordclient::ConcordClient> client)
       : logger_(logging::getLogger("concord.client.clientservice.request")), client_(client){};
   grpc::Status Send(grpc::ServerContext* context,
-                    const vmware::concord::client::v1::Request* request,
-                    vmware::concord::client::v1::Response* response) override;
+                    const vmware::concord::clientservice::v1::Request* request,
+                    vmware::concord::clientservice::v1::Response* response) override;
 
  private:
   logging::Logger logger_;

--- a/client/clientservice/proto/CMakeLists.txt
+++ b/client/clientservice/proto/CMakeLists.txt
@@ -4,10 +4,10 @@ find_package(GRPC REQUIRED)
 include_directories(${GRPC_INCLUDE_DIR})
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
-  concord_client.proto
+  clientservice.proto
 )
 grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
-  concord_client.proto
+  clientservice.proto
 )
 
 add_library(clientservice-proto STATIC ${PROTO_SRCS} ${GRPC_SRCS})

--- a/client/clientservice/proto/clientservice.proto
+++ b/client/clientservice/proto/clientservice.proto
@@ -1,12 +1,12 @@
 // Copyright 2021 VMware, all rights reserved
 //
-// Concord Client gRPC service
+// Concord Client's gRPC service
 
 syntax = "proto3";
-package vmware.concord.client.v1;
+package vmware.concord.clientservice.v1;
 
 // Specifies Java package name, using the standard prefix "com."
-option java_package = "com.vmware.concord.client.v1";
+option java_package = "com.vmware.concord.clientservice.v1";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/client/clientservice/src/client_service.cpp
+++ b/client/clientservice/src/client_service.cpp
@@ -11,7 +11,7 @@
 
 #include "client/clientservice/client_service.hpp"
 
-#include <concord_client.grpc.pb.h>
+#include <clientservice.grpc.pb.h>
 #include <grpcpp/grpcpp.h>
 
 namespace concord::client::clientservice {

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -24,11 +24,11 @@ using grpc::ServerWriter;
 
 using google::protobuf::util::TimeUtil;
 
-using vmware::concord::client::v1::SubscribeRequest;
-using vmware::concord::client::v1::SubscribeResponse;
-using vmware::concord::client::v1::Event;
-using vmware::concord::client::v1::EventGroup;
-using vmware::concord::client::v1::Events;
+using vmware::concord::clientservice::v1::SubscribeRequest;
+using vmware::concord::clientservice::v1::SubscribeResponse;
+using vmware::concord::clientservice::v1::Event;
+using vmware::concord::clientservice::v1::EventGroup;
+using vmware::concord::clientservice::v1::Events;
 
 using namespace std::chrono_literals;
 
@@ -106,7 +106,7 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
     return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, e.what());
   }
 
-  // TODO: Consider all gRPC return error codes as described in concord_client.proto
+  // TODO: Consider all gRPC return error codes as described in clientservice.proto
   while (!context->IsCancelled()) {
     std::this_thread::sleep_for(10ms);
   }

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -20,8 +20,8 @@
 using grpc::Status;
 using grpc::ServerContext;
 
-using vmware::concord::client::v1::Request;
-using vmware::concord::client::v1::Response;
+using vmware::concord::clientservice::v1::Request;
+using vmware::concord::clientservice::v1::Response;
 
 namespace cc = concord::client::concordclient;
 

--- a/thin-replica-server/proto/thin_replica.proto
+++ b/thin-replica-server/proto/thin_replica.proto
@@ -115,9 +115,9 @@ message W3cTraceContext {
   map<string, string> key_values = 1;
 }
 
-// See concord_client.proto for documentation on EventGroups.
-// Note: We don't want to depend on concord_client.proto because any change to
-// concord_client.proto would result in a change for the TRS and therefore the
+// See clientservice.proto for documentation on EventGroups.
+// Note: We don't want to depend on clientservice.proto because any change to
+// clientservice.proto would result in a change for the TRS and therefore the
 // replica itself. By keeping them separate we will have an easier time
 // changing/maintaining those two interfaces.
 message EventGroupsRequest {


### PR DESCRIPTION
There is never a good time to rename API but if at all then it is now. The
reason is to align with our abstractions. Clientservice and concord client are
two different components. The clientservice is a gRPC wrapper around the
concord client library. Therefore, the exposed gRPC API is clientservice API
and not concord client API. For maintainability and logevity of the code, this
change will make the code easier to grasp.