### PR TITLE
Update trs_sub_buffer_tests and fix filterEventsInEventGroup 

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -94,10 +94,10 @@ class KvbAppFilter {
   // Filter the given update
   KvbFilteredUpdate filterUpdate(const KvbUpdate &update);
 
-  KvbFilteredEventGroupUpdate filterEventGroupUpdate(EgUpdate &update);
+  KvbFilteredEventGroupUpdate filterEventGroupUpdate(const EgUpdate &update);
 
   KvbFilteredEventGroupUpdate::EventGroup filterEventsInEventGroup(kvbc::EventGroupId event_group_id,
-                                                                   kvbc::categorization::EventGroup &event_group);
+                                                                   const kvbc::categorization::EventGroup &event_group);
 
   // Compute hash for the given update
   std::string hashUpdate(const KvbFilteredUpdate &update);

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -785,7 +785,9 @@ class ThinReplicaImpl {
 
     for (const auto& event : eg_update.event_group.events) {
       std::vector<uint8_t> output;
-      concord::kvbc::categorization::serialize(output, event);
+      // serialize only event data, we must not send tags
+      concord::kvbc::categorization::Event event_no_tags{event.data, {}};
+      concord::kvbc::categorization::serialize(output, event_no_tags);
       std::string serialized_event(output.begin(), output.end());
       data.mutable_event_group()->add_events(serialized_event);
     }


### PR DESCRIPTION
This commit adds event group tests in trs_sub_buffer_tests.hpp.
Additionally, this adds a fix in `filterEventsInEventGroup` method in `KvbAppFilter`. Please see individual commit messages for more detail.