### PR TITLE
Cron: check for pending ticks in the external queue

### DIFF
--- a/bftengine/src/bftengine/InternalBFTClient.cpp
+++ b/bftengine/src/bftengine/InternalBFTClient.cpp
@@ -15,15 +15,25 @@
 #include "chrono"
 #include "Logger.hpp"
 
+#include <utility>
+
 uint64_t InternalBFTClient::sendRequest(uint64_t flags,
                                         uint32_t requestLength,
                                         const char* request,
                                         const std::string& cid) {
+  return sendRequest(flags, requestLength, request, cid, std::function<void()>{});
+}
+
+uint64_t InternalBFTClient::sendRequest(uint64_t flags,
+                                        uint32_t requestLength,
+                                        const char* request,
+                                        const std::string& cid,
+                                        std::function<void()> onPoppedFromQueue) {
   auto now = getMonotonicTime().time_since_epoch();
   auto now_ms = std::chrono::duration_cast<std::chrono::microseconds>(now);
   auto sn = now_ms.count();
   auto crm = new ClientRequestMsg(getClientId(), flags, sn, requestLength, request, 60000, cid);
-  msgComm_->getIncomingMsgsStorage()->pushExternalMsg(std::unique_ptr<MessageBase>(crm));
+  msgComm_->getIncomingMsgsStorage()->pushExternalMsg(std::unique_ptr<MessageBase>(crm), std::move(onPoppedFromQueue));
   LOG_DEBUG(GL, "Sent internal consensus: seq num [" << sn << "] client id [" << getClientId() << "]");
   return sn;
 }

--- a/bftengine/src/bftengine/InternalBFTClient.cpp
+++ b/bftengine/src/bftengine/InternalBFTClient.cpp
@@ -21,14 +21,14 @@ uint64_t InternalBFTClient::sendRequest(uint64_t flags,
                                         uint32_t requestLength,
                                         const char* request,
                                         const std::string& cid) {
-  return sendRequest(flags, requestLength, request, cid, std::function<void()>{});
+  return sendRequest(flags, requestLength, request, cid, IncomingMsgsStorage::Callback{});
 }
 
 uint64_t InternalBFTClient::sendRequest(uint64_t flags,
                                         uint32_t requestLength,
                                         const char* request,
                                         const std::string& cid,
-                                        std::function<void()> onPoppedFromQueue) {
+                                        IncomingMsgsStorage::Callback onPoppedFromQueue) {
   auto now = getMonotonicTime().time_since_epoch();
   auto now_ms = std::chrono::duration_cast<std::chrono::microseconds>(now);
   auto sn = now_ms.count();

--- a/bftengine/src/bftengine/InternalBFTClient.hpp
+++ b/bftengine/src/bftengine/InternalBFTClient.hpp
@@ -11,10 +11,9 @@
 
 #pragma once
 
+#include "IncomingMsgsStorage.hpp"
 #include "PrimitiveTypes.hpp"
 #include "MsgsCommunicator.hpp"
-
-#include <functional>
 
 namespace bftEngine {
 namespace impl {
@@ -33,7 +32,7 @@ class IInternalBFTClient {
                                uint32_t requestLength,
                                const char* request,
                                const std::string& cid,
-                               std::function<void()> onPoppedFromQueue) = 0;
+                               IncomingMsgsStorage::Callback onPoppedFromQueue) = 0;
 
   virtual uint32_t numOfConnectedReplicas(uint32_t clusterSize) = 0;
   virtual bool isUdp() const = 0;
@@ -48,7 +47,7 @@ class InternalBFTClient : public IInternalBFTClient {
                        uint32_t requestLength,
                        const char* request,
                        const std::string& cid,
-                       std::function<void()> onPoppedFromQueue) override;
+                       IncomingMsgsStorage::Callback onPoppedFromQueue) override;
   uint32_t numOfConnectedReplicas(uint32_t clusterSize) override {
     return msgComm_->numOfConnectedReplicas(clusterSize);
   }

--- a/bftengine/src/bftengine/InternalBFTClient.hpp
+++ b/bftengine/src/bftengine/InternalBFTClient.hpp
@@ -14,14 +14,27 @@
 #include "PrimitiveTypes.hpp"
 #include "MsgsCommunicator.hpp"
 
+#include <functional>
+
 namespace bftEngine {
 namespace impl {
 class IInternalBFTClient {
  public:
   virtual ~IInternalBFTClient() {}
   virtual NodeIdType getClientId() const = 0;
-  // Returns the sent client request sequence number.
+
+  // send* methods return the sent client request sequence number.
+  // The optional `onPoppedFromQueue` function is called in the consumer/replica thread(s) when the given request is
+  // popped.
+  // Note: users should be aware that if they push a request from the consumer/replica thread(s), the given callback
+  // will be called in the same thread.
   virtual uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid) = 0;
+  virtual uint64_t sendRequest(uint64_t flags,
+                               uint32_t requestLength,
+                               const char* request,
+                               const std::string& cid,
+                               std::function<void()> onPoppedFromQueue) = 0;
+
   virtual uint32_t numOfConnectedReplicas(uint32_t clusterSize) = 0;
   virtual bool isUdp() const = 0;
 };
@@ -29,10 +42,17 @@ class IInternalBFTClient {
 class InternalBFTClient : public IInternalBFTClient {
  public:
   InternalBFTClient(NodeIdType id, std::shared_ptr<MsgsCommunicator>& msgComm) : id_{id}, msgComm_(msgComm) {}
-  NodeIdType getClientId() const { return id_; }
-  uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid);
-  uint32_t numOfConnectedReplicas(uint32_t clusterSize) { return msgComm_->numOfConnectedReplicas(clusterSize); }
-  bool isUdp() const { return msgComm_->isUdp(); }
+  NodeIdType getClientId() const override { return id_; }
+  uint64_t sendRequest(uint64_t flags, uint32_t requestLength, const char* request, const std::string& cid) override;
+  uint64_t sendRequest(uint64_t flags,
+                       uint32_t requestLength,
+                       const char* request,
+                       const std::string& cid,
+                       std::function<void()> onPoppedFromQueue) override;
+  uint32_t numOfConnectedReplicas(uint32_t clusterSize) override {
+    return msgComm_->numOfConnectedReplicas(clusterSize);
+  }
+  bool isUdp() const override { return msgComm_->isUdp(); }
 
  private:
   NodeIdType id_;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3815,10 +3815,10 @@ ReplicaImp::ReplicaImp(bool firstTime,
   else
     retransmissionsManager = nullptr;
 
-  ticks_gen_ = std::make_shared<concord::cron::TicksGenerator>(internalBFTClient_,
-                                                               *clientsManager,
-                                                               msgsCommunicator_->getIncomingMsgsStorage(),
-                                                               config.ticksGeneratorPollPeriod);
+  ticks_gen_ = concord::cron::TicksGenerator::create(internalBFTClient_,
+                                                     *clientsManager,
+                                                     msgsCommunicator_->getIncomingMsgsStorage(),
+                                                     config.ticksGeneratorPollPeriod);
 
   if (currentViewIsActive()) {
     time_in_active_view_.start();

--- a/ccron/src/ticks_generator.cpp
+++ b/ccron/src/ticks_generator.cpp
@@ -24,6 +24,14 @@ namespace concord::cron {
 using concordUtil::Timers;
 using bftEngine::impl::TickInternalMsg;
 
+std::shared_ptr<TicksGenerator> TicksGenerator::create(
+    const std::shared_ptr<bftEngine::impl::IInternalBFTClient>& bft_client,
+    const IPendingRequest& pending_req,
+    const std::shared_ptr<IncomingMsgsStorage>& msgs_storage,
+    const std::chrono::seconds& poll_period) {
+  return std::shared_ptr<TicksGenerator>{new TicksGenerator{bft_client, pending_req, msgs_storage, poll_period}};
+}
+
 TicksGenerator::TicksGenerator(const std::shared_ptr<bftEngine::impl::IInternalBFTClient>& bft_client,
                                const IPendingRequest& pending_req,
                                const std::shared_ptr<IncomingMsgsStorage>& msgs_storage,
@@ -71,16 +79,23 @@ bool TicksGenerator::isGenerating(std::uint32_t component_id) const {
 }
 
 void TicksGenerator::onInternalTick(const bftEngine::impl::TickInternalMsg& internal_tick) {
-  // No need to lock the mutex as this method is expected to be called from the main thread only.
-  auto it = component_pending_req_seq_nums_.find(internal_tick.component_id);
-  if (it == component_pending_req_seq_nums_.cend()) {
+  // No need to lock the mutex as this method is expected to be called from the messaging thread only.
+  auto ext_queue_it = pending_ticks_in_ext_queue_.find(internal_tick.component_id);
+  auto req_it = pending_tick_requests_.find(internal_tick.component_id);
+  // In the beginning, always send.
+  if (ext_queue_it == pending_ticks_in_ext_queue_.cend() && req_it == pending_tick_requests_.cend()) {
     sendClientRequestMsgTick(internal_tick.component_id);
-  } else {
-    if (!pending_req_->isPending(bft_client_->getClientId(), it->second)) {
-      component_pending_req_seq_nums_.erase(it);
+  } else if (ext_queue_it == pending_ticks_in_ext_queue_.cend()) {
+    // If the tick for the given component ID is not in the external queue, check if it is pending. If yes, don't send.
+    if (!pending_req_->isPending(bft_client_->getClientId(), req_it->second)) {
       sendClientRequestMsgTick(internal_tick.component_id);
     }
   }
+}
+
+void TicksGenerator::onTickPoppedFromExtQueue(std::uint32_t component_id) {
+  // No need to lock the mutex as this method is expected to be called from the messaging thread only.
+  pending_ticks_in_ext_queue_.erase(component_id);
 }
 
 void TicksGenerator::run() {
@@ -93,9 +108,14 @@ void TicksGenerator::run() {
 void TicksGenerator::sendClientRequestMsgTick(std::uint32_t component_id) {
   auto payload = std::vector<std::uint8_t>{};
   serialize(payload, ClientReqMsgTickPayload{component_id});
-  const auto seq_num = bft_client_->sendRequest(
-      bftEngine::TICK_FLAG, payload.size(), reinterpret_cast<const char*>(payload.data()), kTickCid);
-  component_pending_req_seq_nums_[component_id] = seq_num;
+  const auto seq_num =
+      bft_client_->sendRequest(bftEngine::TICK_FLAG,
+                               payload.size(),
+                               reinterpret_cast<const char*>(payload.data()),
+                               kTickCid,
+                               [p = shared_from_this(), component_id]() { p->onTickPoppedFromExtQueue(component_id); });
+  pending_tick_requests_[component_id] = seq_num;
+  pending_ticks_in_ext_queue_.insert(component_id);
 }
 
 void TicksGenerator::evaluateTimers(const std::chrono::steady_clock::time_point& now) { timers_.evaluate(now); }


### PR DESCRIPTION
Fix a bug in the Concord Cron's TickGenerator that would allow
generating a tick for a component ID when there is already a pending one
for the same component ID. The path of a tick is the following:
   `internal msg queue -> external msg queue -> consensus`
Make sure that we treat ticks in the external message queue as pending
too instead of only treating ticks that are in consensus as pending.

In order to implement, introduce a set of ticks (per component ID) that
are pending in the external message queue. Attach a callback to ticks in
the external message queue that is called when the tick is processed
(either dropped or consumed for consensus). This callback deletes the
tick from the set of pending ones in the external queue.

Use unordered_set/map instead of ordered ones.

Add support for a callback when a request is popped from the external
queue in the messaging thread in IInternalBFTClient.

Force that TicksGenerator is only created as a shared_ptr as we want to
pass it around to callbacks. It is already used as a shared_ptr anyway.

Add a test case for the new behaviour.