### PR TITLE
BCStateTran: add and maintain logger_ member

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -156,9 +156,6 @@ class BCStateTran : public IStateTransfer {
   std::random_device randomDevice_;
   std::mt19937 randomGen_;
 
-  // get ST client or ST server logger according to getFetchingState()
-  logging::Logger& getLogger() const { return (psd_->getIsFetchingState() ? ST_DST_LOG : ST_SRC_LOG); }
-
   ///////////////////////////////////////////////////////////////////////////
   // Unique message IDs
   ///////////////////////////////////////////////////////////////////////////
@@ -507,6 +504,7 @@ class BCStateTran : public IStateTransfer {
   DurationTracker<std::chrono::milliseconds> gettingMissingResPagesDT_;
 
   FetchingState lastFetchingState_;
+  logging::Logger& logger_;
 
   void onFetchingStateChange(FetchingState newFetchingState);
 


### PR DESCRIPTION
logging::Logger& logger_ is added to BCStateTran:
* By default, it is set to ST_SRC_LOG
* Every time state is changed, logger_ might be re-assigned with
ST_SRC_LOG or ST_DST_LOG.

This change saves us the multiple function calls to getLogger() and then
psd_->getIsFetchingState() every time we just want to log something.