### PR TITLE
Respect USE_LOG4CPP cmake option when either set or not

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 #include <optional>
+#include <atomic>
 #include "IStateTransfer.hpp"
 #include "ReservedPagesClient.hpp"
 #include "Serializable.h"

--- a/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
+++ b/bftengine/src/bftengine/SequenceWithActiveWindow.hpp
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <utility>
 #include <type_traits>
+#include <atomic>
 #include "assertUtils.hpp"
 
 // TODO(GG): ItemFuncs should have operations on ItemType: init, free, reset, save, load

--- a/client/client_pool/CMakeLists.txt
+++ b/client/client_pool/CMakeLists.txt
@@ -1,34 +1,16 @@
 project("Concord Client Pool")
-# Require C++17.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/submodules)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(.)
-include_directories(../../threshsign/include/)
-include_directories(../../bftengine/include/bcstatetransfer/)
 add_library(concord_client_pool STATIC
         "src/concord_client_pool.cpp"
         "src/client_pool_config.cpp"
         "src/external_client.cpp"
         )
-get_property(thresh_include GLOBAL PROPERTY thresh_include_folder)
-target_include_directories(concord_client_pool PRIVATE ${thresh_include})
-target_include_directories(concord_client_pool PUBLIC ${perf_include})
-target_include_directories(concord_client_pool PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../../bftengine/cmf)
 target_include_directories(concord_client_pool PUBLIC include)
 target_link_libraries(concord_client_pool PUBLIC
-        ${Boost_LIBRARIES}
-        ${yaml-cpp_LIBRARIES}
-        logging
         bftclient
         bftclient_new
-        kvbc
-        util
-        threshsign
-        secretsmanager)
+        corebft
+      	)
 
 install (TARGETS concord_client_pool DESTINATION lib${LIB_SUFFIX})

--- a/client/client_pool/src/client_pool_config.cpp
+++ b/client/client_pool/src/client_pool_config.cpp
@@ -11,10 +11,10 @@
 // terms and conditions of the sub-component's license, as noted in the LICENSE
 // file.
 
-#include "include/client/client_pool/client_pool_config.hpp"
+#include "client/client_pool/client_pool_config.hpp"
 
 namespace concord::config_pool {
 
-ClientPoolConfig::ClientPoolConfig() { logger_ = logging::getLogger("com.vmware.external_client_pool"); }
+ClientPoolConfig::ClientPoolConfig() : logger_{logging::getLogger("com.vmware.external_client_pool")} {}
 
 }  // namespace concord::config_pool

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -11,7 +11,7 @@
 // terms and conditions of the sub-component's license, as noted in the LICENSE
 // file.
 
-#include "include/client/client_pool/concord_client_pool.hpp"
+#include "client/client_pool/concord_client_pool.hpp"
 
 #include <sparse_merkle/base_types.h>
 #include <mutex>

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -11,7 +11,7 @@
 // terms and conditions of the sub-component's license, as noted in the LICENSE
 // file.
 
-#include "include/client/client_pool/external_client.hpp"
+#include "client/client_pool/external_client.hpp"
 #include <string>
 #include <utility>
 #include "SimpleClient.hpp"

--- a/client/thin-replica-client/CMakeLists.txt
+++ b/client/thin-replica-client/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library(thin_replica_client_lib STATIC
   "src/crypto_utils.cpp"
   "src/trc_hash.cpp")
 target_include_directories(thin_replica_client_lib PUBLIC include)
-target_compile_definitions(thin_replica_client_lib PUBLIC USE_LOG4CPP)
 target_include_directories(thin_replica_client_lib PRIVATE
   "${secretsmanager_SOURCE_DIR}/include")
 target_link_libraries(thin_replica_client_lib

--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -219,7 +219,6 @@ class BlockMerkleCategory {
  private:
   std::shared_ptr<storage::rocksdb::NativeClient> db_;
 
-  logging::Logger logger_;
   sparse_merkle::Tree tree_;
 };
 

--- a/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
+++ b/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
@@ -509,6 +509,5 @@ TEST(kvbc_filter_test, updates_order) {
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  auto logger = logging::getLogger("kvb_filter_test");
   return RUN_ALL_TESTS();
 }

--- a/kvbc/test/replica_state_sync_test.cpp
+++ b/kvbc/test/replica_state_sync_test.cpp
@@ -143,7 +143,7 @@ class replica_state_sync_test : public Test, public IReader {
  protected:
   BlockMetadata block_metadata_{*this};
   ReplicaStateSyncImp replica_state_sync_{new BlockMetadata{*this}};
-  logging::Logger logger_{logging::Logger::getInstance("com.vmware.replica_state_sync_test")};
+  logging::Logger logger_{logging::getLogger("com.vmware.replica_state_sync_test")};
   const std::uint32_t kMaxNumOfBlocksToDelete = 10;
   const std::uint16_t kNumOfReplicas = 4;
   const std::uint16_t kFVal = 1;

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -858,9 +858,10 @@ inline std::string usage() {
 }
 
 inline int run(const CommandLineArguments &cmd_line_args, std::ostream &out, std::ostream &err) {
+#ifdef USE_LOG4CPP
   // Make sure the output is clean
   logging::Logger::getRoot().setLogLevel(log4cplus::WARN_LOG_LEVEL);
-
+#endif
   if (cmd_line_args.values.size() < kMinCmdLineArguments) {
     err << usage();
     return EXIT_FAILURE;

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -621,6 +621,5 @@ TEST(thin_replica_server_test, getClientIdFromClientCert) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  auto logger = logging::getLogger("thin_replica_server_test");
   return RUN_ALL_TESTS();
 }

--- a/thin-replica-server/test/trs_sub_buffer_test.cpp
+++ b/thin-replica-server/test/trs_sub_buffer_test.cpp
@@ -237,6 +237,5 @@ TEST(trs_sub_buffer_test, happy_path_w_two_consumers_eg) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  auto logger = logging::getLogger("trs_sub_buffer_test");
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Since we provide an option not to use log4cplus 