### PR TITLE
Replica.cpp: fix histogram recording

### DIFF
--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -549,7 +549,7 @@ std::future<bool> Replica::putBlockAsync(uint64_t blockId,
         auto jobDuration =
             std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count();
         LOG_TRACE(logger, "Job done: " << KVLOG(result, blockId, jobDuration));
-        histograms_.put_block_duration->record(jobDuration);
+        histograms_.put_block_duration->recordAtomic(jobDuration);
         return result;
       },
       std::forward<decltype(blockId)>(blockId),
@@ -661,7 +661,7 @@ std::future<bool> Replica::getBlockAsync(uint64_t blockId,
         auto jobDuration =
             std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count();
         LOG_TRACE(logger, "Job done: " << KVLOG(result, blockId, *outBlockActualSize, jobDuration));
-        histograms_.get_block_duration->record(jobDuration);
+        histograms_.get_block_duration->recordAtomic(jobDuration);
         return result;
       },
       std::forward<decltype(blockId)>(blockId),


### PR DESCRIPTION
Since 2 of the recordings are donw in worker thread context, recording
must be done by calling recordAdomic.