### PR TITLE
EventService: Fix unsubscribe

### DIFF
--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -159,8 +159,7 @@ class ConcordClient {
   std::shared_ptr<concordMetrics::Aggregator> metrics_;
 
   // TODO: Allow multiple subscriptions
-  std::atomic_bool stop_subscriber_{true};
-  std::unique_ptr<std::thread> subscriber_;
+  std::atomic_bool active_subscription_{false};
 
   std::shared_ptr<::client::thin_replica_client::BasicUpdateQueue> trc_queue_;
   std::unique_ptr<::client::thin_replica_client::ThinReplicaClient> trc_;


### PR DESCRIPTION
With the recent API change of `subscribe` we didn't adjust unsubscribe and
thereby ended up with danling subscriptions. This change use atomic compare and
swap to grant access to the calling thread.