### PR TITLE
ThinReplica: Small fixes

### DIFF
--- a/client/proto/event/v1/event.proto
+++ b/client/proto/event/v1/event.proto
@@ -70,7 +70,7 @@ message EventGroupsRequest {
 // Therefore, the order of EventGroups mirror the order of request executions visible to Concord Client.
 message EventGroup {
   // Sequentially increasing identifier which is unique to all Concord Clients with the same Concord Client id.
-  // The very first EventGroup is marked with EventGroup id 0.
+  // The very first EventGroup is marked with EventGroup id 1.
   uint64 id = 1;
 
   // The events visible to the client in the order produced by the execution engine.

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -903,7 +903,8 @@ void ThinReplicaClient::Subscribe(const SubscribeRequest& req) {
   }
 
   config_->update_queue->Clear();
-  latest_verified_event_group_id_ = req.event_group_id;
+  // We assume that the latest known event group for the caller is the event group prior to the requested one.
+  latest_verified_event_group_id_ = req.event_group_id > 0 ? req.event_group_id - 1 : req.event_group_id;
   is_event_group_stream_ = true;
 
   // Create and launch thread to stream updates from the servers and push them

--- a/thin-replica-server/include/thin-replica-server/subscription_buffer.hpp
+++ b/thin-replica-server/include/thin-replica-server/subscription_buffer.hpp
@@ -137,7 +137,7 @@ class SubUpdateBuffer {
 
   void waitForEventGroupUntilNonEmpty() {
     std::unique_lock<std::mutex> lock(eg_mutex_);
-    cv_.wait(lock, [this] { return queue_.read_available(); });
+    eg_cv_.wait(lock, [this] { return queue_.read_available(); });
   }
 
   template <typename RepT, typename PeriodT>


### PR DESCRIPTION
Correct the calculation of the starting update that the TRC requests and fix a typo in TRS. See commit messages for details.