### PR TITLE
SigManager compiling 

### DIFF
--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -10,17 +10,25 @@
 // file.
 
 #include "SigManager.hpp"
-#include "Crypto.hpp"
 #include "assertUtils.hpp"
 #include "ReplicasInfo.hpp"
 
-#include <vector>
 #include <algorithm>
+#include "keys_and_signatures.cmf.hpp"
 
 using namespace std;
 
 namespace bftEngine {
 namespace impl {
+
+concord::messages::keys_and_signatures::ClientsPublicKeys clientsPublicKeys_;
+
+std::string SigManager::getClientsPublicKeys() {
+  std::shared_lock lock(mutex_);
+  std::vector<uint8_t> output;
+  concord::messages::keys_and_signatures::serialize(output, clientsPublicKeys_);
+  return std::string(output.begin(), output.end());
+}
 
 SigManager* SigManager::initImpl(ReplicaId myId,
                                  const Key& mySigPrivateKey,

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -22,8 +22,6 @@
 #include <memory>
 #include <shared_mutex>
 
-#include "keys_and_signatures.cmf.hpp"
-
 using concordMetrics::AtomicCounterHandle;
 
 namespace bftEngine {
@@ -74,16 +72,10 @@ class SigManager {
   SigManager(SigManager&&) = delete;
   SigManager& operator=(SigManager&&) = delete;
 
-  std::string getClientsPublicKeys() {
-    std::shared_lock lock(mutex_);
-    std::vector<uint8_t> output;
-    concord::messages::keys_and_signatures::serialize(output, clientsPublicKeys_);
-    return std::string(output.begin(), output.end());
-  }
+  std::string getClientsPublicKeys();
 
  protected:
   static constexpr uint16_t updateMetricsAggregatorThresh = 1000;
-  concord::messages::keys_and_signatures::ClientsPublicKeys clientsPublicKeys_;
 
   SigManager(PrincipalId myId,
              uint16_t numReplicas,

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 
 set(preprocessor_source_files
     ${bftengine_SOURCE_DIR}/src/bftengine/MsgsCommunicator.cpp
-    ${bftengine_SOURCE_DIR}/src/bftengine/SigManager.cpp
     ${bftengine_SOURCE_DIR}/src/bftengine/Crypto.cpp
     ${bftengine_SOURCE_DIR}/src/bftengine/messages/ClientRequestMsg.cpp
     ${bftengine_SOURCE_DIR}/src/bftengine/messages/MessageBase.cpp
@@ -26,7 +25,6 @@ add_library(preprocessor STATIC ${preprocessor_source_files})
 target_include_directories(preprocessor PUBLIC ${CRYPTOPP_INCLUDE_DIRS})
 target_include_directories(preprocessor PUBLIC ${OPENSSL_INCLUDE_DIR})
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/include)
-target_include_directories(preprocessor PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../../cmf)
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/include/bftengine)
 target_include_directories(preprocessor PUBLIC ${bftengine_SOURCE_DIR}/src/bftengine)
 get_property(perf_include GLOBAL PROPERTY PERF_MANAGER_INCLUDE_DIR)


### PR DESCRIPTION
- Avoid compiling SigManager.cpp twice: for corebft and for preprocessor.
- As SigManager.hpp is included from several places, move include for generated
keys_and_signatures.cmf.hpp to SigManager.cpp .