### PR TITLE
Enable USE_GRPC cmake compiling option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if(SLEEP_FOR_DBG)
 endif()
 
 option(USE_OPENTRACING "Enable OpenTracing" ON)
+option(USE_GRPC "Enable GRPC and Protobuf" ON)
 #
 # Compiler options
 #
@@ -149,8 +150,11 @@ add_subdirectory(diagnostics)
 add_subdirectory(bftclient)
 add_subdirectory(reconfiguration)
 add_subdirectory(client)
-add_subdirectory(thin-replica-server)
+if(USE_GRPC)
+	add_subdirectory(thin-replica-server)
+endif()
 add_subdirectory(ccron)
+
 #
 # Setup testing
 #

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,8 +1,11 @@
 project("Concord Client")
 
-add_subdirectory("concordclient")
-add_subdirectory("clientservice")
-add_subdirectory("thin-replica-client")
 add_subdirectory("reconfiguration")
 add_subdirectory("client_pool")
-add_subdirectory("proto")
+
+if(USE_GRPC)
+	add_subdirectory("clientservice")
+	add_subdirectory("concordclient")
+	add_subdirectory("thin-replica-client")
+	add_subdirectory("proto")
+endif()

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required (VERSION 3.2)
 project(libkvbc VERSION 0.1.0.0 LANGUAGES CXX)
 
-add_subdirectory("proto")
 
 add_library(concord_block_update INTERFACE)
 target_include_directories(concord_block_update INTERFACE
@@ -29,7 +28,7 @@ add_library(kvbc  src/ClientImp.cpp
     src/sparse_merkle/tree.cpp
     src/sparse_merkle/update_cache.cpp
     src/sparse_merkle/walker.cpp
-    src/kvbc_app_filter/kvbc_app_filter.cpp
+    
     src/reconfiguration_kvbc_handler.cpp
 )
 
@@ -44,7 +43,12 @@ if (BUILD_ROCKSDB_STORAGE)
 endif (BUILD_ROCKSDB_STORAGE)
 target_link_libraries(kvbc PUBLIC corebft util)
 target_link_libraries(kvbc PUBLIC categorized_kvbc_msgs pruning_msgs event_group_msgs)
-target_link_libraries(kvbc PUBLIC concord_block_update concord-kvbc-proto)
+
+if(USE_GRPC)
+	add_subdirectory("proto")
+	target_sources(kvbc PRIVATE src/kvbc_app_filter/kvbc_app_filter.cpp)
+	target_link_libraries(kvbc PUBLIC concord_block_update concord-kvbc-proto)
+endif()
 
 target_include_directories(kvbc PUBLIC include util)
 


### PR DESCRIPTION
A part of an effort of making order in the project compilation.
For now disabling GRPC will cause to thin-replica-server, clientservice and kvbc_app_filter.cpp not to be compiled as tightly coupled to GRPC and Protobuf.
  