### PR TITLE
Add support with all client key exchange command

### DIFF
--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -69,8 +69,10 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
 class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurationHandler,
                                public ReconfigurationBlockTools {
  public:
-  ReconfigurationHandler(kvbc::IBlockAdder& block_adder, kvbc::IReader& ro_storage)
-      : ReconfigurationBlockTools{block_adder, ro_storage} {}
+  ReconfigurationHandler(kvbc::IBlockAdder& block_adder,
+                         kvbc::IReader& ro_storage,
+                         std::set<std::set<uint16_t>>& txKeysClientGroups)
+      : ReconfigurationBlockTools{block_adder, ro_storage}, txKeysClientGroups_{txKeysClientGroups} {}
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               concord::messages::ReconfigurationResponse&) override;
@@ -116,6 +118,9 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
   bool handle(const concord::messages::UnwedgeStatusRequest&,
               uint64_t,
               concord::messages::ReconfigurationResponse&) override;
+
+ private:
+  std::set<std::set<uint16_t>> txKeysClientGroups_;
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop commands)

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -36,6 +36,7 @@
 #include "bftengine/ReconfigurationCmd.hpp"
 #include "client/reconfiguration/st_based_reconfiguration_client.hpp"
 #include "client/reconfiguration/client_reconfiguration_engine.hpp"
+#include "bftengine/ReplicaConfig.hpp"
 
 using bft::communication::ICommunication;
 using bftEngine::bcst::StateTransferDigest;
@@ -140,8 +141,12 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
   categorization::KeyValueBlockchain &blockchain_;
 };
 void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler) {
+  std::set<std::set<uint16_t>> txSigningClientGroups;
+  for (const auto &val : bftEngine::ReplicaConfig::instance().publicKeysOfClients) {
+    txSigningClientGroups.insert(val.second);
+  }
   requestHandler->setReconfigurationHandler(
-      std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this),
+      std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this, txSigningClientGroups),
       concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(*this, *this),


### PR DESCRIPTION
In this PR we add support in "all" client key exchange command. 
If the target_clients in the request is empty, the reconfiguration handler writes the update for all clients.
Recall, that only the CRE client knows how to run this command. Thus, it is ok to write the update to all (the other option is to assume that the CRE client is a specific client from the group which we prefer not to do)