### PR TITLE
[Client pool] Fix callback bug

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -48,8 +48,8 @@ enum ClientMsgFlag : uint8_t {
 
 enum OperationResult : int8_t { SUCCESS, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL, INVALID_REQUEST };
 // Call back for request - at this point we know for sure that a client is handling the request so we can assure that we
-// will have reply. This callback will be attached to the client reply struct and whenever we get the reply fro, the bft
-// client we will activate the callback.
+// will have reply. This callback will be attached to the client reply struct and whenever we get the reply from, the
+// bft client we will activate the callback.
 typedef std::variant<int, bft::client::Reply> SendResult;
 typedef std::function<void(SendResult&&)> RequestCallBack;
 
@@ -70,7 +70,7 @@ struct ClientReply {
   OperationResult opResult = SUCCESS;
   std::string cid;
   std::string span_context;
-  RequestCallBack cb = nullptr;
+  RequestCallBack cb = {};
 };
 
 class SimpleClient {

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -47,7 +47,11 @@ enum ClientMsgFlag : uint8_t {
 };
 
 enum OperationResult : int8_t { SUCCESS, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL, INVALID_REQUEST };
-typedef std::function<void(bft::client::Reply&&)> RequestCallBack;
+// Call back for request - at this point we know for sure that a client is handling the request so we can assure that we
+// will have reply. This callback will be attached to the client reply struct and whenever we get the reply fro, the bft
+// client we will activate the callback.
+typedef std::variant<int, bft::client::Reply> SendResult;
+typedef std::function<void(SendResult&&)> RequestCallBack;
 
 struct ClientRequest {
   uint8_t flags = 0;

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -121,19 +121,19 @@ class ConcordClientPool {
                            uint64_t seq_num,
                            std::string correlation_id = {},
                            std::string span_context = std::string(),
-                           std::function<void(bftEngine::SendResult&&)> callback = nullptr);
+                           const bftEngine::RequestCallBack& callback = {});
 
   // This method is responsible to get write requests with the new client
   // paramters and parse it to the old SimpleClient interface.
   SubmitResult SendRequest(const bft::client::WriteConfig& config,
                            bft::client::Msg&& request,
-                           const std::function<void(bftEngine::SendResult&&)> callback = nullptr);
+                           const bftEngine::RequestCallBack& callback = {});
 
   // This method is responsible to get read requests with the new client
   // paramters and parse it to the old SimpleClient interface.
   SubmitResult SendRequest(const bft::client::ReadConfig& config,
                            bft::client::Msg&& request,
-                           const std::function<void(bftEngine::SendResult&&)> callback = nullptr);
+                           const bftEngine::RequestCallBack& callback = {});
 
   void InsertClientToQueue(std::shared_ptr<concord::external_client::ConcordClient>& client,
                            std::pair<int8_t, external_client::ConcordClient::PendingReplies>&& replies);
@@ -151,7 +151,7 @@ class ConcordClientPool {
                          uint64_t seq_num,
                          const std::string& correlation_id,
                          const std::string& span_context,
-                         const std::function<void(bftEngine::SendResult&&)> callback);
+                         const bftEngine::RequestCallBack& callback);
 
   PoolStatus HealthStatus();
 
@@ -239,7 +239,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
                              std::string correlation_id,
                              uint64_t seq_num,
                              std::string span_context,
-                             const std::function<void(bftEngine::SendResult&&)> callback)
+                             const bftEngine::RequestCallBack& callback)
       : BatchRequestProcessingJob(clients, std::move(client)),
         request_(std::move(request)),
         flags_{flags},
@@ -260,7 +260,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
   uint64_t seq_num_;
   bft::client::WriteConfig write_config_;
   bft::client::ReadConfig read_config_;
-  const std::function<void(bftEngine::SendResult&&)> callback_;
+  const bftEngine::RequestCallBack callback_;
 };
 }  // namespace concord_client_pool
 

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -47,8 +47,6 @@ enum SubmitResult {
   // request
 };
 
-// Request callback, will return SubmitResult::overloaded when no clients available
-typedef std::variant<SubmitResult, bft::client::Reply> SendResult;
 // An internal error has occurred. Reason is recorded in logs.
 class InternalError : public std::exception {
  public:
@@ -123,19 +121,19 @@ class ConcordClientPool {
                            uint64_t seq_num,
                            std::string correlation_id = {},
                            std::string span_context = std::string(),
-                           const std::function<void(SendResult&&)>& callback = nullptr);
+                           std::function<void(bftEngine::SendResult&&)> callback = nullptr);
 
   // This method is responsible to get write requests with the new client
   // paramters and parse it to the old SimpleClient interface.
   SubmitResult SendRequest(const bft::client::WriteConfig& config,
                            bft::client::Msg&& request,
-                           const std::function<void(SendResult&&)>& callback = nullptr);
+                           const std::function<void(bftEngine::SendResult&&)> callback = nullptr);
 
   // This method is responsible to get read requests with the new client
   // paramters and parse it to the old SimpleClient interface.
   SubmitResult SendRequest(const bft::client::ReadConfig& config,
                            bft::client::Msg&& request,
-                           const std::function<void(SendResult&&)>& callback = nullptr);
+                           const std::function<void(bftEngine::SendResult&&)> callback = nullptr);
 
   void InsertClientToQueue(std::shared_ptr<concord::external_client::ConcordClient>& client,
                            std::pair<int8_t, external_client::ConcordClient::PendingReplies>&& replies);
@@ -153,7 +151,7 @@ class ConcordClientPool {
                          uint64_t seq_num,
                          const std::string& correlation_id,
                          const std::string& span_context,
-                         const std::function<void(SendResult&&)>& callback);
+                         const std::function<void(bftEngine::SendResult&&)> callback);
 
   PoolStatus HealthStatus();
 
@@ -241,7 +239,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
                              std::string correlation_id,
                              uint64_t seq_num,
                              std::string span_context,
-                             const std::function<void(SendResult&&)>& callback)
+                             const std::function<void(bftEngine::SendResult&&)> callback)
       : BatchRequestProcessingJob(clients, std::move(client)),
         request_(std::move(request)),
         flags_{flags},
@@ -262,7 +260,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
   uint64_t seq_num_;
   bft::client::WriteConfig write_config_;
   bft::client::ReadConfig read_config_;
-  const std::function<void(SendResult&&)> callback_;
+  const std::function<void(bftEngine::SendResult&&)> callback_;
 };
 }  // namespace concord_client_pool
 

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -61,9 +61,9 @@ class ConcordClient {
                          std::chrono::milliseconds timeout_ms,
                          std::uint32_t reply_size,
                          uint64_t seq_num,
-                         const bftEngine::RequestCallBack callback,
                          const std::string& correlation_id = {},
-                         const std::string& span_context = {});
+                         const std::string& span_context = {},
+                         bftEngine::RequestCallBack callback = {});
 
   size_t PendingRequestsCount() const { return pending_requests_.size(); }
 

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -29,11 +29,6 @@ class ConcordConfiguration;
 }
 
 namespace external_client {
-// Call back for request - at this point we know for sure that a client is handling the request so we can assure that we
-// will have reply. This callback will be attached to the client reply struct and whenever we get the reply fro, the bft
-// client we will activate the callback.
-typedef std::function<void(bft::client::Reply&&)> RequestCallBack;
-
 // Represents a Concord BFT client. The purpose of this class is to be easy to
 // use for external users. This is achieved by:
 //  * providing a simple public interface
@@ -66,7 +61,7 @@ class ConcordClient {
                          std::chrono::milliseconds timeout_ms,
                          std::uint32_t reply_size,
                          uint64_t seq_num,
-                         const RequestCallBack& callback,
+                         const bftEngine::RequestCallBack callback,
                          const std::string& correlation_id = {},
                          const std::string& span_context = {});
 

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -42,7 +42,7 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
                                             uint64_t seq_num,
                                             std::string correlation_id,
                                             std::string span_context,
-                                            std::function<void(bftEngine::SendResult &&)> callback) {
+                                            const bftEngine::RequestCallBack &callback) {
   externalRequest external_request;
   std::unique_lock<std::mutex> lock(clients_queue_lock_);
   metricsComponent_.UpdateAggregator();
@@ -76,9 +76,9 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
                                 timeout_ms,
                                 max_reply_size,
                                 seq_num,
-                                callback,
                                 correlation_id,
-                                span_context);
+                                span_context,
+                                callback);
 
       if (correlation_id.length() > SECOND_LEG_CID_LEN) {
         ClientPoolMetrics_.first_leg_counter++;
@@ -148,14 +148,7 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
     ClientPoolMetrics_.rejected_counter++;
     is_overloaded_ = true;
     LOG_WARN(logger_, "Cannot allocate client for" << KVLOG(correlation_id));
-    try {
-      if (callback) {
-        LOG_INFO(logger_, "Got callback, sending response");
-        callback(bftEngine::SendResult{SubmitResult::Overloaded});
-      }
-    } catch (std::bad_variant_access &e) {
-      LOG_ERROR(KEY_EX_LOG, "Bad variant exception in send request" << e.what());
-    }
+    if (callback) callback(bftEngine::SendResult{SubmitResult::Overloaded});
     return SubmitResult::Overloaded;
   }
 }
@@ -179,7 +172,7 @@ void ConcordClientPool::assignJobToClient(const ClientPtr &client,
                                           uint64_t seq_num,
                                           const std::string &correlation_id,
                                           const std::string &span_context,
-                                          const std::function<void(bftEngine::SendResult &&)> callback) {
+                                          const bftEngine::RequestCallBack &callback) {
   if (max_reply_size) client->setReplyBuffer(reply_buffer, max_reply_size);
 
   LOG_INFO(logger_,
@@ -197,7 +190,7 @@ void ConcordClientPool::assignJobToClient(const ClientPtr &client,
 
 SubmitResult ConcordClientPool::SendRequest(const bft::client::WriteConfig &config,
                                             bft::client::Msg &&request,
-                                            const std::function<void(bftEngine::SendResult &&)> callback) {
+                                            const bftEngine::RequestCallBack &callback) {
   LOG_DEBUG(logger_, "Received write request with cid=" << config.request.correlation_id);
   auto request_flag = ClientMsgFlag::EMPTY_FLAGS_REQ;
   if (config.request.pre_execute) request_flag = ClientMsgFlag::PRE_PROCESS_REQ;
@@ -214,7 +207,7 @@ SubmitResult ConcordClientPool::SendRequest(const bft::client::WriteConfig &conf
 
 SubmitResult ConcordClientPool::SendRequest(const bft::client::ReadConfig &config,
                                             bft::client::Msg &&request,
-                                            const std::function<void(bftEngine::SendResult &&)> callback) {
+                                            const bftEngine::RequestCallBack &callback) {
   LOG_INFO(logger_, "Received read request with cid=" << config.request.correlation_id);
   return SendRequest(std::forward<std::vector<uint8_t>>(request),
                      ClientMsgFlag::READ_ONLY_REQ,
@@ -407,14 +400,7 @@ void SingleRequestProcessingJob::execute() {
     read_config_.request.span_context = span_context_;
     res = processing_client_->SendRequest(read_config_, std::move(request_));
     reply_size = res.matched_data.size();
-    try {
-      if (callback_) {
-        LOG_INFO(KEY_EX_LOG, "got callback sending response");
-        callback_(bftEngine::SendResult{res});
-      }
-    } catch (std::bad_variant_access &e) {
-      LOG_ERROR(KEY_EX_LOG, "Bad variant exception in single request" << e.what());
-    }
+    if (callback_) callback_(bftEngine::SendResult{res});
   } else {
     write_config_.request.timeout = timeout_ms_;
     write_config_.request.sequence_number = seq_num_;
@@ -423,14 +409,7 @@ void SingleRequestProcessingJob::execute() {
     write_config_.request.pre_execute = flags_ & PRE_PROCESS_REQ;
     res = processing_client_->SendRequest(write_config_, std::move(request_));
     reply_size = res.matched_data.size();
-    try {
-      if (callback_) {
-        LOG_INFO(KEY_EX_LOG, "got callback sending response");
-        callback_(bftEngine::SendResult{res});
-      }
-    } catch (std::bad_variant_access &e) {
-      LOG_ERROR(KEY_EX_LOG, "Bad variant exception in single request" << e.what());
-    }
+    if (callback_) callback_(bftEngine::SendResult{res});
   }
   external_client::ConcordClient::PendingReplies replies;
   replies.push_back(ClientReply{static_cast<uint32_t>(request_.size()),
@@ -482,7 +461,6 @@ void ConcordClientPool::InsertClientToQueue(
                                   req.timeout_ms,
                                   req.reply_size,
                                   req.seq_num,
-                                  nullptr,
                                   req.correlation_id,
                                   req.span_context);
 

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -89,7 +89,7 @@ void ConcordClient::AddPendingRequest(std::vector<uint8_t>&& request,
                                       std::chrono::milliseconds timeout_ms,
                                       std::uint32_t reply_size,
                                       uint64_t seq_num,
-                                      const RequestCallBack& callback,
+                                      const RequestCallBack callback,
                                       const std::string& correlation_id,
                                       const std::string& span_context) {
   bftEngine::ClientRequest pending_request;
@@ -147,7 +147,11 @@ std::pair<int8_t, ConcordClient::PendingReplies> ConcordClient::SendPendingReque
         if (reply.cid == cid) {
           reply.actualReplyLength = rep.second.matched_data.size();
           memcpy(reply.replyBuffer, rep.second.matched_data.data(), rep.second.matched_data.size());
-          if (reply.cb) reply.cb(std::move(rep.second));
+          if (reply.cb) {
+            LOG_INFO(logger_, "Got callback - sending response");
+            Reply t = rep.second;
+            reply.cb(bftEngine::SendResult{t});
+          }
           LOG_DEBUG(logger_, "Request has completed processing" << KVLOG(client_id_, batch_cid, reply.cid));
         }
       }
@@ -155,6 +159,8 @@ std::pair<int8_t, ConcordClient::PendingReplies> ConcordClient::SendPendingReque
   } catch (BatchTimeoutException& e) {
     LOG_ERROR(logger_, "Batch cid =" << batch_cid << " has failed to invoke, timeout has been reached");
     ret = OperationResult::TIMEOUT;
+  } catch (std::bad_variant_access& e) {
+    LOG_ERROR(logger_, "Bad variant exception in batch" << e.what());
   }
   batching_buffer_reply_offset_ = 0UL;
   pending_requests_.clear();

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -89,9 +89,9 @@ void ConcordClient::AddPendingRequest(std::vector<uint8_t>&& request,
                                       std::chrono::milliseconds timeout_ms,
                                       std::uint32_t reply_size,
                                       uint64_t seq_num,
-                                      const RequestCallBack callback,
                                       const std::string& correlation_id,
-                                      const std::string& span_context) {
+                                      const std::string& span_context,
+                                      RequestCallBack callback) {
   bftEngine::ClientRequest pending_request;
   pending_request.lengthOfRequest = request.size();
   pending_request.request = std::move(request);
@@ -117,7 +117,7 @@ void ConcordClient::AddPendingRequest(std::vector<uint8_t>&& request,
   pending_reply.actualReplyLength = 0UL;
   pending_reply.cid = correlation_id;
   pending_reply.span_context = span_context;
-  pending_reply.cb = callback;
+  pending_reply.cb = std::move(callback);
   pending_replies_.push_back(std::move(pending_reply));
 }
 
@@ -147,11 +147,8 @@ std::pair<int8_t, ConcordClient::PendingReplies> ConcordClient::SendPendingReque
         if (reply.cid == cid) {
           reply.actualReplyLength = rep.second.matched_data.size();
           memcpy(reply.replyBuffer, rep.second.matched_data.data(), rep.second.matched_data.size());
-          if (reply.cb) {
-            LOG_INFO(logger_, "Got callback - sending response");
-            Reply t = rep.second;
-            reply.cb(bftEngine::SendResult{t});
-          }
+          auto result = bftEngine::SendResult{rep.second};
+          if (reply.cb) reply.cb(std::move(result));
           LOG_DEBUG(logger_, "Request has completed processing" << KVLOG(client_id_, batch_cid, reply.cid));
         }
       }
@@ -159,8 +156,6 @@ std::pair<int8_t, ConcordClient::PendingReplies> ConcordClient::SendPendingReque
   } catch (BatchTimeoutException& e) {
     LOG_ERROR(logger_, "Batch cid =" << batch_cid << " has failed to invoke, timeout has been reached");
     ret = OperationResult::TIMEOUT;
-  } catch (std::bad_variant_access& e) {
-    LOG_ERROR(logger_, "Bad variant exception in batch" << e.what());
   }
   batching_buffer_reply_offset_ = 0UL;
   pending_requests_.clear();

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -45,7 +45,7 @@ Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_req
   auto callback = [&](cc::SendResult&& send_result) {
     if (not std::holds_alternative<bft::client::Reply>(send_result)) {
       LOG_INFO(logger_, "Send returned error");
-      if (std::get<concord_client_pool::SubmitResult>(send_result) == concord_client_pool::Overloaded)
+      if (std::get<int>(send_result) == concord_client_pool::Overloaded)
         status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "Overloaded"));
       return;
     }

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -35,7 +35,7 @@ struct SendError {
   };
   ErrorType type;
 };
-typedef std::variant<concord_client_pool::SubmitResult, bft::client::Reply> SendResult;
+typedef std::variant<int, bft::client::Reply> SendResult;
 
 struct ReplicaInfo {
   bft::client::ReplicaId id;


### PR DESCRIPTION
On this PR I'm fixing 2 issues that we had:
1) we passed a function that gets enum and replies to a place taking a function that uses only replies.
2) initialized reference with nullptr.