### PR TITLE
[Client pool] Add with_cre flag

### DIFF
--- a/client/client_pool/include/client/client_pool/client_pool_config.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_config.hpp
@@ -70,6 +70,7 @@ typedef struct ConcordClientPoolConfig {
   std::uint64_t client_batching_flush_timeout_ms = 100;
   bool encrypted_config_enabled = false;
   bool transaction_signing_enabled = false;
+  bool with_cre = false;
   std::string secrets_url;
   std::unordered_map<bft::communication::NodeNum, Replica> node;
   std::deque<ParticipantNode> participant_nodes;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -316,7 +316,7 @@ void ConcordClientPool::setUpClientParams(SimpleClientParams &client_params,
 }
 
 void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig &config) {
-  auto num_clients = config.clients_per_participant_node;
+  auto num_clients = config.clients_per_participant_node - (int)config.with_cre;
   LOG_INFO(logger_, "Creating pool" << KVLOG(num_clients));
   auto f_val = config.f_val;
   auto c_val = config.c_val;

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -71,6 +71,7 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
   readYamlField(yaml, "signing_key_path", config.topology.signing_key_path);
   readYamlField(yaml, "encrypted_config_enabled", config.topology.encrypted_config_enabled);
   readYamlField(yaml, "transaction_signing_enabled", config.topology.transaction_signing_enabled);
+  readYamlField(yaml, "with_cre", config.topology.with_cre);
   readYamlField(yaml, "client_batching_enabled", config.topology.client_batching_enabled);
   readYamlField(yaml, "client_batching_max_messages_nbr", config.topology.client_batching_max_messages_nbr);
   readYamlField(yaml, "client_batching_flush_timeout_ms", config.topology.client_batching_flush_timeout_ms);

--- a/client/clientservice/test/example_config.hpp
+++ b/client/clientservice/test/example_config.hpp
@@ -48,6 +48,7 @@ tls_certificates_folder_path: /clientservice/bft_certs
 tls_cipher_suite_list: ECDHE-ECDSA-AES256-GCM-SHA384
 tls_1_3_cipher_suite_list: TLS_AES_256_GCM_SHA384
 transaction_signing_enabled: true
+with_cre: false
 node:
   - replica:
       - principal_id: 0

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -56,6 +56,7 @@ struct BftTopology {
   std::uint32_t external_requests_queue_size;
   bool encrypted_config_enabled;
   bool transaction_signing_enabled;
+  bool with_cre;
   bool client_batching_enabled;
   size_t client_batching_max_messages_nbr;
   std::uint64_t client_batching_flush_timeout_ms;

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -104,6 +104,7 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
   client_pool_config.external_requests_queue_size = config.topology.external_requests_queue_size;
   client_pool_config.encrypted_config_enabled = config.topology.encrypted_config_enabled;
   client_pool_config.transaction_signing_enabled = config.topology.transaction_signing_enabled;
+  client_pool_config.with_cre = config.topology.with_cre;
   client_pool_config.client_batching_enabled = config.topology.client_batching_enabled;
   client_pool_config.client_batching_max_messages_nbr = config.topology.client_batching_max_messages_nbr;
   client_pool_config.client_batching_flush_timeout_ms = config.topology.client_batching_flush_timeout_ms;


### PR DESCRIPTION
The flag for enabling cre is presented in this PR.
Assuming we have with_cre enabled, we will remove one client from the pool.