### PR TITLE
Kvbc: Protobuf is not gRPC

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -44,11 +44,9 @@ endif (BUILD_ROCKSDB_STORAGE)
 target_link_libraries(kvbc PUBLIC corebft util)
 target_link_libraries(kvbc PUBLIC categorized_kvbc_msgs pruning_msgs event_group_msgs)
 
-if(USE_GRPC)
-	add_subdirectory("proto")
-	target_sources(kvbc PRIVATE src/kvbc_app_filter/kvbc_app_filter.cpp)
-	target_link_libraries(kvbc PUBLIC concord_block_update concord-kvbc-proto)
-endif()
+add_subdirectory("proto")
+target_sources(kvbc PRIVATE src/kvbc_app_filter/kvbc_app_filter.cpp)
+target_link_libraries(kvbc PUBLIC concord_block_update concord-kvbc-proto)
 
 target_include_directories(kvbc PUBLIC include util)
 

--- a/kvbc/proto/CMakeLists.txt
+++ b/kvbc/proto/CMakeLists.txt
@@ -1,16 +1,10 @@
 find_package(Protobuf REQUIRED)
-find_package(GRPC REQUIRED)
-
-include_directories(${GRPC_INCLUDE_DIR})
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   concord_kvbc.proto
 )
-grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
-  concord_kvbc.proto
-)
-message(STATUS "Concord KVBC gRPC/protobuf generated - see " ${CMAKE_CURRENT_BINARY_DIR})
+message(STATUS "Concord KVBC protobuf generated - see " ${CMAKE_CURRENT_BINARY_DIR})
 
-add_library(concord-kvbc-proto STATIC ${PROTO_SRCS} ${GRPC_SRCS})
-target_link_libraries(concord-kvbc-proto protobuf::libprotobuf gRPC::grpc++)
+add_library(concord-kvbc-proto STATIC ${PROTO_SRCS})
+target_link_libraries(concord-kvbc-proto protobuf::libprotobuf)
 target_include_directories(concord-kvbc-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
The concord-kvbc-proto target contains protobuf messages only and hence pulls
in a protobuf library as a dependency. It doesn't need gRPC because there are
no RPCs. In addition, the guarding `USE_GRPC` variable doesn't apply in this
case and therefore it can be removed as well.