### PR TITLE
TRS: Don't block forever on updates

### DIFF
--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -266,21 +266,17 @@ class ThinReplicaImpl {
       }
       // Read, filter, and send live updates
       SubUpdate update;
-      while (!context->IsCancelled()) {
-        metrics_.queue_size.Get().Set(live_updates->Size());
-        bool is_update_available = false;
-        try {
+      try {
+        while (!context->IsCancelled()) {
+          metrics_.queue_size.Get().Set(live_updates->Size());
+          bool is_update_available = false;
           is_update_available = live_updates->TryPop(update, kWaitForUpdateTimeout);
-        } catch (concord::thin_replica::ConsumerTooSlow& error) {
-          LOG_WARN(logger_, "Closing subscription: " << error.what());
-          break;
-        }
-        if (not is_update_available) {
-          continue;
-        }
-        auto kvb_update = kvbc::KvbUpdate{update.block_id, update.correlation_id, std::move(update.immutable_kv_pairs)};
-        const auto& filtered_update = kvb_filter->filterUpdate(kvb_update);
-        try {
+          if (not is_update_available) {
+            continue;
+          }
+          auto kvb_update =
+              kvbc::KvbUpdate{update.block_id, update.correlation_id, std::move(update.immutable_kv_pairs)};
+          const auto& filtered_update = kvb_filter->filterUpdate(kvb_update);
           if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
             LOG_DEBUG(logger_, "Live updates send data");
             auto correlation_id = filtered_update.correlation_id;
@@ -299,20 +295,19 @@ class ThinReplicaImpl {
             LOG_DEBUG(logger_, "Live updates send hash");
             sendHash(stream, update.block_id, kvb_filter->hashUpdate(filtered_update));
           }
-        } catch (std::exception& error) {
-          LOG_INFO(logger_, "Subscription stream closed: " << error.what());
-          break;
+          metrics_.last_sent_block_id.Get().Set(update.block_id);
+          if (++update_aggregator_counter == config_->update_metrics_aggregator_thresh) {
+            metrics_.updateAggregator();
+            update_aggregator_counter = 0;
+          }
         }
-        metrics_.last_sent_block_id.Get().Set(update.block_id);
-        if (++update_aggregator_counter == config_->update_metrics_aggregator_thresh) {
-          metrics_.updateAggregator();
-          update_aggregator_counter = 0;
-        }
+        config_->subscriber_list.removeBuffer(live_updates);
+        live_updates->removeAllUpdates();
+        metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
+        metrics_.updateAggregator();
+      } catch (std::exception& error) {
+        LOG_INFO(logger_, "Subscription stream closed: " << error.what());
       }
-      config_->subscriber_list.removeBuffer(live_updates);
-      live_updates->removeAllUpdates();
-      metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
-      metrics_.updateAggregator();
       if (context->IsCancelled()) {
         return grpc::Status::CANCELLED;
       }
@@ -347,21 +342,16 @@ class ThinReplicaImpl {
 
     // Read, filter, and send live updates
     SubEventGroupUpdate sub_eg_update;
-    while (not context->IsCancelled()) {
-      metrics_.queue_size.Get().Set(live_updates->SizeEventGroupQueue());
-      bool is_update_available = false;
-      try {
+    try {
+      while (not context->IsCancelled()) {
+        metrics_.queue_size.Get().Set(live_updates->SizeEventGroupQueue());
+        bool is_update_available = false;
         is_update_available = live_updates->TryPopEventGroup(sub_eg_update, kWaitForUpdateTimeout);
-      } catch (concord::thin_replica::ConsumerTooSlow& error) {
-        LOG_WARN(logger_, "Closing subscription: " << error.what());
-        break;
-      }
-      if (not is_update_available) {
-        continue;
-      }
-      auto eg_update = kvbc::EgUpdate{sub_eg_update.event_group_id, std::move(sub_eg_update.event_group)};
-      const auto& filtered_eg_update = kvb_filter->filterEventGroupUpdate(eg_update);
-      try {
+        if (not is_update_available) {
+          continue;
+        }
+        auto eg_update = kvbc::EgUpdate{sub_eg_update.event_group_id, std::move(sub_eg_update.event_group)};
+        const auto& filtered_eg_update = kvb_filter->filterEventGroupUpdate(eg_update);
         if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
           //  auto correlation_id = filtered_update.correlation_id; (TODO (Shruti) - Get correlation ID)
           // TODO (Shruti) : Get and propagate span context
@@ -370,20 +360,19 @@ class ThinReplicaImpl {
           sendEventGroupHash(
               stream, sub_eg_update.event_group_id, kvb_filter->hashEventGroupUpdate(filtered_eg_update));
         }
-      } catch (std::exception& error) {
-        LOG_INFO(logger_, "Subscription stream closed: " << error.what());
-        break;
+        metrics_.last_sent_event_group_id.Get().Set(sub_eg_update.event_group_id);
+        if (++update_aggregator_counter == config_->update_metrics_aggregator_thresh) {
+          metrics_.updateAggregator();
+          update_aggregator_counter = 0;
+        }
       }
-      metrics_.last_sent_event_group_id.Get().Set(sub_eg_update.event_group_id);
-      if (++update_aggregator_counter == config_->update_metrics_aggregator_thresh) {
-        metrics_.updateAggregator();
-        update_aggregator_counter = 0;
-      }
+      config_->subscriber_list.removeBuffer(live_updates);
+      live_updates->removeAllEventGroupUpdates();
+      metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
+      metrics_.updateAggregator();
+    } catch (std::exception& error) {
+      LOG_INFO(logger_, "Subscription stream closed: " << error.what());
     }
-    config_->subscriber_list.removeBuffer(live_updates);
-    live_updates->removeAllEventGroupUpdates();
-    metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
-    metrics_.updateAggregator();
     if (context->IsCancelled()) {
       LOG_WARN(logger_, "Subscription cancelled");
       return grpc::Status::CANCELLED;


### PR DESCRIPTION
In general, the TRS is waiting for new updates unconditionally. That can consume a lot of resources if we don't get new updates and if the TRC gets impatient and retries. This PR introduces conditional blocking for a fixed amount of time in order to check if we can return early. See commit messages for details.