### PR TITLE
Primary sends its own signature with PreProcessResutMsg

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -713,9 +713,9 @@ bool ReplicaImp::validatePreProcessedResults(const PrePrepareMsg *msg) {
   for (auto err : errors) {
     if (err) {
       // trigger view change
-      LOG_WARN(VC_LOG,
-               "Received PrePrepareMsg containing PreProcessResult with invalid signature: "
-                   << *err << ". Ask to leave view " << getCurrentView());
+      LOG_ERROR(VC_LOG,
+                "Received PrePrepareMsg containing PreProcessResult with invalid signature: "
+                    << *err << ". Ask to leave view " << getCurrentView());
       askToLeaveView(ReplicaAsksToLeaveViewMsg::Reason::PrimarySentBadPreProcessResult);
       return false;
     }

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -29,7 +29,8 @@ using ReplicaIdsList = std::vector<ReplicaId>;
 
 class RequestProcessingState {
  public:
-  RequestProcessingState(uint16_t numOfReplicas,
+  RequestProcessingState(ReplicaId myReplicaId,
+                         uint16_t numOfReplicas,
                          const std::string& batchCid,
                          uint16_t clientId,
                          uint16_t reqOffsetInBatch,
@@ -97,6 +98,7 @@ class RequestProcessingState {
 
   // The use of the class data members is thread-safe. The PreProcessor class uses a per-instance mutex lock for
   // the RequestProcessingState objects.
+  const ReplicaId myReplicaId_;
   const uint16_t numOfReplicas_;
   const std::string batchCid_;
   const uint16_t clientId_;

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
@@ -61,6 +61,8 @@ struct PreProcessResultSignature {
   std::vector<char> signature;
   NodeIdType sender_replica;
 
+  PreProcessResultSignature() = default;
+
   PreProcessResultSignature(std::vector<char>&& sig, NodeIdType sender)
       : signature{std::move(sig)}, sender_replica{sender} {}
 

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -365,7 +365,8 @@ void clearDiagnosticsHandlers() {
 }
 
 TEST(requestPreprocessingState_test, notEnoughRepliesReceived) {
-  RequestProcessingState reqState(replicaConfig.numReplicas,
+  RequestProcessingState reqState(replicaConfig.replicaId,
+                                  replicaConfig.numReplicas,
                                   "",
                                   clientId,
                                   0,
@@ -374,7 +375,7 @@ TEST(requestPreprocessingState_test, notEnoughRepliesReceived) {
                                   ClientPreProcessReqMsgUniquePtr(),
                                   PreProcessRequestMsgSharedPtr());
   bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
-  for (auto i = 1; i < numOfRequiredReplies; i++) {
+  for (auto i = 1; i < numOfRequiredReplies - 1; i++) {
     reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo));
     ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), CONTINUE);
   }
@@ -384,7 +385,8 @@ TEST(requestPreprocessingState_test, notEnoughRepliesReceived) {
 }
 
 TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCollected) {
-  RequestProcessingState reqState(replicaConfig.numReplicas,
+  RequestProcessingState reqState(replicaConfig.replicaId,
+                                  replicaConfig.numReplicas,
                                   "",
                                   clientId,
                                   0,
@@ -404,7 +406,8 @@ TEST(requestPreprocessingState_test, allRepliesReceivedButNotEnoughSameHashesCol
 }
 
 TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
-  RequestProcessingState reqState(replicaConfig.numReplicas,
+  RequestProcessingState reqState(replicaConfig.replicaId,
+                                  replicaConfig.numReplicas,
                                   "",
                                   clientId,
                                   0,
@@ -424,7 +427,8 @@ TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
 }
 
 TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
-  RequestProcessingState reqState(replicaConfig.numReplicas,
+  RequestProcessingState reqState(replicaConfig.replicaId,
+                                  replicaConfig.numReplicas,
                                   "",
                                   clientId,
                                   0,
@@ -448,7 +452,8 @@ TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
 }
 
 TEST(requestPreprocessingState_test, primaryReplicaDidNotCompletePreProcessingWhileNonPrimariesDid) {
-  RequestProcessingState reqState(replicaConfig.numReplicas,
+  RequestProcessingState reqState(replicaConfig.replicaId,
+                                  replicaConfig.numReplicas,
                                   "",
                                   clientId,
                                   0,


### PR DESCRIPTION
When result authentication (aka non repudiation) is enabled for
PreExecution the primary should send its own result hash signature
alongside the signatures of the replicas which have preprocessed the
client request.

Also when PreProcessResultMsg is verified by non primaries, f+1
signatures should be expected instead of just f.

Primary signs the result hash just before sending the PreProcessResult
message because it is not needed earlier. Furthermore  the computation
can be skipped if the PreProcessing is not successful.