### PR TITLE
 Replica side support for clients scaling

### DIFF
--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -26,8 +26,10 @@ static const char reconfiguration_epoch_key = 0x2d;
 static const char reconfiguration_restart_key = 0x30;
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
-  PUBLIC_KEY_EXCHANGE = 0x1,          // identifier of public key exchange request by client
-  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,  // identifier of client key exchange request by operator
+  PUBLIC_KEY_EXCHANGE = 0x1,            // identifier of public key exchange request by client
+  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,    // identifier of client key exchange request by operator
+  CLIENT_SCALING_COMMAND = 0x3,         // identifier of client scaling request by operator
+  CLIENT_SCALING_COMMAND_STATUS = 0X4,  // identifier of client update request after successful scaling
   end_
 };
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -147,10 +147,15 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   PruningHandler(kvbc::IReader &, kvbc::IBlockAdder &, kvbc::IBlocksDeleter &, bool run_async = false);
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse &) override;
-  bool handle(const concord::messages::PruneRequest &, uint64_t, concord::messages::ReconfigurationResponse &) override;
+  bool handle(const concord::messages::PruneRequest &,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse &) override;
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse &) override;
 
  protected:
@@ -191,6 +196,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
         replica_id_{bftEngine::ReplicaConfig::instance().replicaId} {}
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse &rres) override {
     if (!pruning_enabled_) return true;
     concord::messages::LatestPrunableBlock latest_prunable_block;
@@ -209,12 +215,14 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   // Read only replica doesn't perform the actual pruning
   bool handle(const concord::messages::PruneRequest &,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }
   // Read only replica doesn't know the pruning status
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -60,6 +60,10 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
               uint64_t,
               uint32_t,
               concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
 
  private:
   concord::messages::ClientReconfigurationStateReply buildClientStateReply(
@@ -135,6 +139,15 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               uint32_t,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::UnwedgeStatusRequest&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
+
+  bool handle(const concord::messages::ClientsAddRemoveCommand&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
               uint64_t,
               uint32_t,
               concord::messages::ReconfigurationResponse&) override;

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -49,13 +49,16 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
       : ReconfigurationBlockTools{block_adder, ro_storage} {}
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientReconfigurationLastUpdate&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientReconfigurationStateRequest&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -75,48 +78,65 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
       : ReconfigurationBlockTools{block_adder, ro_storage}, txKeysClientGroups_{txKeysClientGroups} {}
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::DownloadCommand& command,
               uint64_t bft_seq_num,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::InstallCommand& command,
               uint64_t bft_seq_num,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::KeyExchangeCommand& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveCommand& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeCommand& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveStatus& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeStatus& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::PruneRequest& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientKeyExchangeCommand& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse& response) override;
-  bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::RestartCommand&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
 
-  bool handle(const concord::messages::UnwedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::UnwedgeCommand&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::UnwedgeStatusRequest&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -134,6 +154,7 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
 
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 };
 
@@ -148,6 +169,7 @@ class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IR
 
   bool handle(const concord::messages::ClientExchangePublicKey& command,
               uint64_t sequence_number,
+              uint32_t,
               concord::messages::ReconfigurationResponse& response) override;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -139,6 +139,7 @@ PruningHandler::PruningHandler(kvbc::IReader& ro_storage,
 
 bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest& latest_prunable_block_request,
                             uint64_t,
+                            uint32_t,
                             concord::messages::ReconfigurationResponse& rres) {
   // If pruning is disabled, return 0. Otherwise, be conservative and prune the
   // smaller block range.
@@ -165,6 +166,7 @@ bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest&
 
 bool PruningHandler::handle(const concord::messages::PruneRequest& request,
                             uint64_t bftSeqNum,
+                            uint32_t,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
 
@@ -247,6 +249,7 @@ void PruningHandler::pruneThroughBlockId(kvbc::BlockId block_id) const {
 
 bool PruningHandler::handle(const concord::messages::PruneStatusRequest&,
                             uint64_t,
+                            uint32_t,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
   concord::messages::PruneStatus prune_status;

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -236,7 +236,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveSta
       auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, key);
       if (res.has_value()) {
         auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
-        concord::messages::ClientsAddRemoveCommand cmd;
+        concord::messages::ClientsAddRemoveUpdateCommand cmd;
         std::vector<uint8_t> bytesval(strval.begin(), strval.end());
         concord::messages::deserialize(bytesval, cmd);
 

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -123,6 +123,7 @@ concord::messages::ClientReconfigurationStateReply KvbcClientReconfigurationHand
 }
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientReconfigurationStateRequest& command,
                                               uint64_t bft_seq_num,
+                                              uint32_t,
                                               concord::messages::ReconfigurationResponse& rres) {
   // We want to rotate over the latest updates of this client and find the earliest one which is higher than the client
   // last known block
@@ -150,6 +151,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
 
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& command,
                                               uint64_t bft_seq_num,
+                                              uint32_t,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -165,6 +167,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExc
 }
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientReconfigurationLastUpdate& command,
                                               uint64_t,
+                                              uint32_t,
                                               concord::messages::ReconfigurationResponse& rres) {
   // We want to rotate over the latest updates of this client and find the latest one in the blockchain
   kvbc::BlockId maxKnownUpdate{0};
@@ -191,6 +194,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
 
 bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                     uint64_t bft_seq_num,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -202,6 +206,7 @@ bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& comma
 
 bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& command,
                                     uint64_t bft_seq_num,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -213,6 +218,7 @@ bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& co
 
 bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& command,
                                     uint64_t bft_seq_num,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -224,6 +230,7 @@ bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& com
 
 bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand& command,
                                     uint64_t sequence_number,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -235,6 +242,7 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
 
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& command,
                                     uint64_t sequence_number,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -246,6 +254,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& c
 
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand& command,
                                     uint64_t sequence_number,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -273,6 +282,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
 
 bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& command,
                                     uint64_t bft_seq_num,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -284,6 +294,7 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
 
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& command,
                                     uint64_t sequence_number,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse& response) {
   auto res =
       ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_add_remove});
@@ -308,6 +319,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& co
 
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeStatus& command,
                                     uint64_t sequence_number,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse& response) {
   auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId,
                                    std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
@@ -337,6 +349,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
 
 bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& command,
                                     uint64_t sequence_number,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -348,6 +361,7 @@ bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& comma
 
 bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCommand& command,
                                     uint64_t sequence_number,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse& response) {
   std::vector<uint32_t> target_clients;
   for (auto& cid : command.target_clients) {
@@ -383,6 +397,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCo
 
 bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
                                     uint64_t bft_seq_num,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse&) {
   if (!bftEngine::ControlStateManager::instance().getCheckpointToStopAt().has_value()) {
     LOG_INFO(getLogger(), "replica is already unwedge");
@@ -421,6 +436,7 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
 
 bool ReconfigurationHandler::handle(const messages::UnwedgeStatusRequest& req,
                                     uint64_t,
+                                    uint32_t,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::UnwedgeStatusResponse response;
   response.replica_id = bftEngine::ReplicaConfig::instance().replicaId;
@@ -457,6 +473,7 @@ bool InternalKvReconfigurationHandler::verifySignature(uint32_t sender_id,
 
 bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                               uint64_t bft_seq_num,
+                                              uint32_t,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -476,6 +493,7 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeComm
 
 bool InternalPostKvReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& command,
                                                   uint64_t sequence_number,
+                                                  uint32_t,
                                                   concord::messages::ReconfigurationResponse& response) {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   auto updated_client_keys = SigManager::instance()->getClientsPublicKeys();

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -154,7 +154,7 @@ bool StReconfigurationHandler::handleWedgeCommands(const T &cmd,
   // so lets invoke all original reconfiguration handlers from the product layer (without concord-bft's ones)
   concord::messages::ReconfigurationResponse response;
   for (auto &h : orig_reconf_handlers_) {
-    h->handle(cmd, bft_seq_num, response);
+    h->handle(cmd, bft_seq_num, UINT32_MAX, response);
   }
 
   if (my_last_known_epoch < last_known_global_epoch) {
@@ -211,7 +211,7 @@ bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &com
   concord::messages::ReconfigurationResponse response;
   for (auto &h : orig_reconf_handlers_) {
     // If it was written to the blockchain, it means that this is a valid request.
-    succ &= h->handle(command, bft_seq_num, response);
+    succ &= h->handle(command, bft_seq_num, UINT32_MAX, response);
   }
   return succ;
 }

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -701,7 +701,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_correct_num_bocks_to_keep) {
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, rres);
+  sm.handle(req, 0, UINT32_MAX, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, replica_idx, verifier);
   ASSERT_EQ(resp.block_id, LAST_BLOCK_ID - num_blocks_to_keep);
@@ -722,7 +722,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_big_num_blocks_to_keep) {
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, rres);
+  sm.handle(req, 0, UINT32_MAX, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, replica_idx, verifier);
   // Verify that the returned block ID is 0 when pruning_num_blocks_to_keep is
@@ -749,7 +749,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_no_pruning_conf) {
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, rres);
+  sm.handle(req, 0, UINT32_MAX, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, 1, verifier);
   // Verify that when pruning is enabled and both pruning_num_blocks_to_keep and
@@ -776,7 +776,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_pruning_disabled) {
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, rres);
+  sm.handle(req, 0, UINT32_MAX, rres);
 
   // Verify that when pruning is disabled, there is no answer.
   ASSERT_EQ(std::holds_alternative<concord::messages::LatestPrunableBlock>(rres.response), false);
@@ -796,7 +796,7 @@ TEST_F(test_rocksdb, sm_handle_prune_request_on_pruning_disabled) {
 
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas);
   concord::messages::ReconfigurationResponse rres;
-  auto res = sm.handle(req, 0, rres);
+  auto res = sm.handle(req, 0, UINT32_MAX, rres);
   ASSERT_TRUE(res);
 }
 TEST_F(test_rocksdb, sm_handle_correct_prune_request) {
@@ -818,7 +818,7 @@ TEST_F(test_rocksdb, sm_handle_correct_prune_request) {
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas, latest_prunable_block_id);
   blocks_deleter.deleteBlocksUntil(latest_prunable_block_id + 1);
   concord::messages::ReconfigurationResponse rres;
-  auto res = sm.handle(req, 0, rres);
+  auto res = sm.handle(req, 0, UINT32_MAX, rres);
 
   ASSERT_TRUE(res);
 }
@@ -848,7 +848,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     latest_prunnable_block.signature = block.signature;
     req.latest_prunable_block.push_back(std::move(latest_prunnable_block));
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);
@@ -859,7 +859,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas);
     req.latest_prunable_block.pop_back();
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);
@@ -871,7 +871,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     auto &block = req.latest_prunable_block[req.latest_prunable_block.size() - 1];
     block.signature[0] += 1;
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -228,6 +228,7 @@ Msg ReconfigurationRequest 1 {
     RestartCommand
     ClientsAddRemoveCommand
     ClientsAddRemoveStatusCommand
+    ClientsAddRemoveUpdateCommand
   } command
   bytes additional_data
 }

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -156,14 +156,6 @@ Msg ClientExchangePublicKey 38 {
     list uint64 affected_clients
 }
 
-Msg ClientReconfigurationStateReply 39 {
-    uint64 block_id
-    oneof {
-        ClientExchangePublicKey
-        ClientKeyExchangeCommand
-      } response
-}
-
 Msg ClientReconfigurationStateUpdate 40 {
     uint64 sender_id
     uint64 update_version
@@ -178,6 +170,34 @@ Msg RestartCommand 42 {
     bool bft_support
     bool restart
     string data
+}
+
+Msg ClientsAddRemoveCommand 43 {
+    string config_descriptor
+    string token
+    bool restart
+}
+
+Msg ClientsAddRemoveStatusCommand 44 {
+    uint64 sender_id
+}
+
+Msg ClientsAddRemoveStatusResponse 45 {
+    list kvpair uint64 string clients_status
+}
+
+Msg ClientsAddRemoveUpdateCommand 46 {
+    string config_descriptor
+}
+
+Msg ClientReconfigurationStateReply 39 {
+    uint64 block_id
+    oneof {
+        ClientExchangePublicKey
+        ClientKeyExchangeCommand
+        ClientsAddRemoveCommand
+        ClientsAddRemoveUpdateCommand
+      } response
 }
 
 Msg ReconfigurationRequest 1 {
@@ -206,6 +226,8 @@ Msg ReconfigurationRequest 1 {
     ClientExchangePublicKey
     ClientReconfigurationLastUpdate
     RestartCommand
+    ClientsAddRemoveCommand
+    ClientsAddRemoveStatusCommand
   } command
   bytes additional_data
 }
@@ -224,6 +246,7 @@ Msg ReconfigurationResponse 2 {
     AddRemoveWithWedgeStatusResponse
     UnwedgeStatusResponse
     ClientKeyExchangeCommandResponse
+    ClientsAddRemoveStatusResponse
   } response
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -61,9 +61,10 @@ class Dispatcher {
   template <typename T>
   bool handleRequest(const T& msg,
                      uint64_t bft_seq_num,
+                     uint32_t sender_id,
                      concord::messages::ReconfigurationResponse& rres,
                      std::shared_ptr<IReconfigurationHandler> handler) {
-    return handler->handle(msg, bft_seq_num, rres);
+    return handler->handle(msg, bft_seq_num, sender_id, rres);
   }
   std::vector<std::shared_ptr<IReconfigurationHandler>> pre_reconfig_handlers_;
   std::vector<std::shared_ptr<IReconfigurationHandler>> reconfig_handlers_;

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -25,105 +25,137 @@ enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
 class IReconfigurationHandler {
  public:
   // Message handlers
-  virtual bool handle(const concord::messages::WedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) {
+  virtual bool handle(const concord::messages::WedgeCommand&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::WedgeStatusRequest&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::GetVersionCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::DownloadCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::DownloadStatusCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
-  virtual bool handle(const concord::messages::InstallCommand&, uint64_t, concord::messages::ReconfigurationResponse&) {
+  virtual bool handle(const concord::messages::InstallCommand&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::InstallStatusCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::KeyExchangeCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveStatus&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::LatestPrunableBlockRequest&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::PruneStatusRequest&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
-  virtual bool handle(const concord::messages::PruneRequest&, uint64_t, concord::messages::ReconfigurationResponse&) {
+  virtual bool handle(const concord::messages::PruneRequest&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
     return true;
   }
-  virtual bool handle(const concord::messages::UnwedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) {
+  virtual bool handle(const concord::messages::UnwedgeCommand&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::UnwedgeStatusRequest&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientReconfigurationStateRequest&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientExchangePublicKey&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientKeyExchangeCommand&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientReconfigurationLastUpdate&,
                       uint64_t,
+                      uint32_t,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
 
-  virtual bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) {
+  virtual bool handle(const concord::messages::RestartCommand&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
     return true;
   }
 

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -159,6 +159,27 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::ClientsAddRemoveCommand&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
+
+  virtual bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
+
+  virtual bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const = 0;

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -33,21 +33,31 @@ class BftReconfigurationHandler : public IReconfigurationHandler {
 class ReconfigurationHandler : public BftReconfigurationHandler {
  public:
   ReconfigurationHandler() {}
-  bool handle(const concord::messages::WedgeCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::WedgeCommand&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::WedgeStatusRequest&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::KeyExchangeCommand&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
-  bool handle(const concord::messages::RestartCommand&, uint64_t, concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::RestartCommand&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
 
  private:
   void handleWedgeCommands(bool bft_support, bool remove_metadata, bool restart, bool unwedge);
@@ -56,6 +66,7 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
 class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
+              uint32_t,
               concord::messages::ReconfigurationResponse&) override;
 
   bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const override {

--- a/reconfiguration/src/dispatcher.cpp
+++ b/reconfiguration/src/dispatcher.cpp
@@ -46,8 +46,8 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &=
-          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, rresp, handler); }, request.command);
+      rresp.success &= std::visit(
+          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
     }
 
     // Run regular reconfiguration handlers
@@ -59,8 +59,8 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &=
-          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, rresp, handler); }, request.command);
+      rresp.success &= std::visit(
+          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
     }
 
     // Run post-reconfiguration handlers
@@ -72,8 +72,8 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &=
-          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, rresp, handler); }, request.command);
+      rresp.success &= std::visit(
+          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
     }
 
     if (!valid) rresp.success = false;  // If no handler was able to verify the request, it is an invalid request

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -112,10 +112,12 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.start_all_replicas()
         bft_network.start_cre()
 
-        client = bft_network.random_client()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(100):
             await skvbc.send_write_kv_set()
+
+        client = bft_network.random_client()
+
         op = operator.Operator(bft_network.config, client, bft_network.builddir)
         config_desc = "123456789"
         rep = await op.clients_addRemove_command(config_desc)
@@ -136,7 +138,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                     if len(res[0].response.clients_status) == 0:
                         succ = False
                     for k,v in res[0].response.clients_status:
-                        assert(k == 13)
+                        assert(k == 19)
                         assert(v == config_desc)
 
     @with_trio

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -361,7 +361,7 @@ class BftTestNetwork:
                 self.cre_fds = (stdout_file, stderr_file)
                 cre_exe = os.path.join(self.builddir, "tests", "simpleKVBC", "TesterCRE", "skvbc_cre")
                 cre_cmd = [cre_exe,
-                           "-i", str(BFT_CONFIGS_NUM_CLIENTS + RESERVED_CLIENTS_QUOTA + 1),
+                           "-i", str(self.config.n + self.config.num_ro_replicas + BFT_CONFIGS_NUM_CLIENTS + RESERVED_CLIENTS_QUOTA),
                            "-f", str(self.config.f),
                            "-c", str(self.config.c),
                            "-r", str(self.config.n),
@@ -548,7 +548,7 @@ class BftTestNetwork:
         start_id = self.config.n + self.config.num_ro_replicas
         client_ids = range(start_id, start_id + self.config.num_clients)
         start_id = self.num_total_replicas() + self.config.num_clients
-        reserved_client_ids = range(start_id, start_id + RESERVED_CLIENTS_QUOTA)
+        reserved_client_ids = range(start_id, start_id + RESERVED_CLIENTS_QUOTA + 1)
 
         principals = ""
         client_ids = sorted(client_ids)

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -37,7 +37,7 @@ class Operator:
         return self.private_key.sign_deterministic(msg.serialize())
 
 
-    def _construct_basic_reconfiguration_request(self, command):
+    def  _construct_basic_reconfiguration_request(self, command):
         reconf_msg = cmf_msgs.ReconfigurationRequest()
         reconf_msg.additional_data = bytes(0)
         reconf_msg.sender = 1000
@@ -124,6 +124,18 @@ class Operator:
         cke_command.target_clients = target_clients
         return self._construct_basic_reconfiguration_request(cke_command)
 
+    def _construct_reconfiguration_clientsAddRemove_command(self, config_desc):
+        car_command = cmf_msgs.ClientsAddRemoveCommand()
+        car_command.config_descriptor = config_desc
+        car_command.token = ""
+        car_command.restart = False
+        return self._construct_basic_reconfiguration_request(car_command)
+
+    def _construct_reconfiguration_clientsAddRemoveStatus_command(self):
+        cars_command = cmf_msgs.ClientsAddRemoveStatusCommand()
+        cars_command.sender_id = 1000
+        return self._construct_basic_reconfiguration_request(cars_command)
+
     def _construct_reconfiguration_restart_command(self, bft, restart, data):
         restart_command = cmf_msgs.RestartCommand()
         restart_command.bft_support = bft
@@ -202,6 +214,14 @@ class Operator:
     async def client_key_exchange_command(self, target_clients):
         reconf_msg = self._construct_reconfiguration_clientKe_command(target_clients)
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+
+    async def clients_addRemove_command(self, config_desc):
+        reconf_msg = self._construct_reconfiguration_clientsAddRemove_command(config_desc)
+        return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+
+    async def clients_addRemoveStatus_command(self):
+        reconf_msg = self._construct_reconfiguration_clientsAddRemoveStatus_command()
+        return await self.client.read(reconf_msg.serialize(), reconfiguration=True)
     
     async def client_exchange_public_key(self, valid=True):
         pk = ""

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -203,7 +203,8 @@ class ClientsAddRemoveHandler : public IStateHandler {
     return true;
   }
   logging::Logger getLogger() {
-    static logging::Logger logger_(logging::getLogger("concord.client.reconfiguration.testerCre.PublicKeyExchange"));
+    static logging::Logger logger_(
+        logging::getLogger("concord.client.reconfiguration.testerCre.ClientsAddRemoveHandler"));
     return logger_;
   }
 };

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -197,7 +197,7 @@ class ClientsAddRemoveHandler : public IStateHandler {
     rreq.command = creq;
     std::vector<uint8_t> req_buf;
     concord::messages::serialize(req_buf, rreq);
-    out = {req_buf, [this, &command]() {
+    out = {req_buf, [this, command]() {
              LOG_INFO(this->getLogger(), "completed scaling procedure for " << command.config_descriptor);
            }};
     return true;

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -177,6 +177,37 @@ class PublicKeyExchangeHandler : public IStateHandler {
   }
 };
 
+class ClientsAddRemoveHandler : public IStateHandler {
+ public:
+  bool validate(const State& state) const override {
+    concord::messages::ClientReconfigurationStateReply crep;
+    concord::messages::deserialize(state.data, crep);
+    return std::holds_alternative<concord::messages::ClientsAddRemoveCommand>(crep.response);
+  }
+  bool execute(const State& state, WriteState& out) override {
+    LOG_INFO(getLogger(), "execute clientsAddRemoveCommand");
+    concord::messages::ClientReconfigurationStateReply crep;
+    concord::messages::deserialize(state.data, crep);
+    concord::messages::ClientsAddRemoveCommand command =
+        std::get<concord::messages::ClientsAddRemoveCommand>(crep.response);
+
+    concord::messages::ReconfigurationRequest rreq;
+    concord::messages::ClientsAddRemoveUpdateCommand creq;
+    creq.config_descriptor = command.config_descriptor;
+    rreq.command = creq;
+    std::vector<uint8_t> req_buf;
+    concord::messages::serialize(req_buf, rreq);
+    out = {req_buf, [this, &command]() {
+             LOG_INFO(this->getLogger(), "completed scaling procedure for " << command.config_descriptor);
+           }};
+    return true;
+  }
+  logging::Logger getLogger() {
+    static logging::Logger logger_(logging::getLogger("concord.client.reconfiguration.testerCre.PublicKeyExchange"));
+    return logger_;
+  }
+};
+
 int main(int argc, char** argv) {
   auto creParams = setupCreParams(argc, argv);
   std::unique_ptr<ICommunication> comm_ptr(
@@ -187,6 +218,7 @@ int main(int argc, char** argv) {
   ClientReconfigurationEngine cre(creParams.CreConfig, pollBasedClient, std::make_shared<concordMetrics::Aggregator>());
   cre.registerHandler(std::make_shared<KeyExchangeCommandHandler>(creParams.CreConfig.id_));
   cre.registerHandler(std::make_shared<PublicKeyExchangeHandler>());
+  cre.registerHandler(std::make_shared<ClientsAddRemoveHandler>());
   cre.start();
   while (true) std::this_thread::sleep_for(1s);
 }


### PR DESCRIPTION
In this PR we add the replica side support for client scaling requests.
The procedure is using the CRE in the process:
1. The operator sends a clientsAddRemove request that contains the configuration descriptor
2. The replicas write this update to the blockchain
3. The CRE pulls the update and executes the request
4. The CRE writes an update to the ledger
5. The operator can now get the status that says that this CRE was able to execute the request