### PR TITLE
Use log4cplus.properties In Client Service

### DIFF
--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -32,8 +32,9 @@ namespace po = boost::program_options;
 
 const static int kLogConfigRefreshIntervalInMs = 60 * 1000;
 
-const static char* GetLog4CplusConfigLocation() {
+const static char* getLog4CplusConfigLocation() {
   auto log_location = std::getenv("LOG4CPLUS_CONFIGURATION");
+  if (!log_location) std::cerr << "ClientService log4cplus configuration file was not set" << std::endl;
   return log_location ? log_location : "LOG4CPLUS_CONFIGURATION_NOT_SET";
 }
 
@@ -58,8 +59,8 @@ po::variables_map parseCmdLine(int argc, char** argv) {
 }
 
 int main(int argc, char** argv) {
+  LOG_CONFIGURE_AND_WATCH(getLog4CplusConfigLocation(), kLogConfigRefreshIntervalInMs);
   auto logger = logging::getLogger("concord.client.clientservice.main");
-  LOG_CONFIGURE_AND_WATCH(GetLog4CplusConfigLocation(), kLogConfigRefreshIntervalInMs);
   auto opts = parseCmdLine(argc, argv);
 
   ConcordClientConfig config;

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -30,6 +30,13 @@ using concord::client::concordclient::ConcordClientConfig;
 
 namespace po = boost::program_options;
 
+const static int kLogConfigRefreshIntervalInMs = 60 * 1000;
+
+const static char* GetLog4CplusConfigLocation() {
+  auto log_location = std::getenv("LOG4CPLUS_CONFIGURATION");
+  return log_location ? log_location : "LOG4CPLUS_CONFIGURATION_NOT_SET";
+}
+
 po::variables_map parseCmdLine(int argc, char** argv) {
   po::options_description desc;
   // clang-format off
@@ -51,9 +58,8 @@ po::variables_map parseCmdLine(int argc, char** argv) {
 }
 
 int main(int argc, char** argv) {
-  // TODO: Use config file and watch thread for logger
   auto logger = logging::getLogger("concord.client.clientservice.main");
-
+  LOG_CONFIGURE_AND_WATCH(GetLog4CplusConfigLocation(), kLogConfigRefreshIntervalInMs);
   auto opts = parseCmdLine(argc, argv);
 
   ConcordClientConfig config;


### PR DESCRIPTION
Added watch thread for the client service logger.
The path for the log4cplus.properties is defined by an environment variable.