### PR TITLE
Log client requests that have not been committed for threshold period.

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -397,9 +397,10 @@ void ClientsManager::logAllPendingRequestsExceedingThreshold(const int64_t thres
     for (const auto& req : info.second.requestsInfo) {
       // Don't take into account already committed requests
       if ((req.second.time != MinTime) && (!req.second.committed)) {
-        const auto delay = duration_cast<milliseconds>(currTime - req.second.time).count();
-        if (delay > threshold) {
-          LOG_INFO(VC_LOG, "CID " << req.second.cid << ", delayed " << delay);
+        const auto delayed = duration_cast<milliseconds>(currTime - req.second.time).count();
+        const auto& CID = req.second.cid;
+        if (delayed > threshold) {
+          LOG_INFO(VC_LOG, "" << KVLOG(CID, delayed));
           numExceeding++;
         }
       }

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -74,8 +74,8 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
 
   Time infoOfEarliestPendingRequest(std::string& cid) const;
 
-  std::vector<std::pair<std::string, uint64_t>> getAllPendingRequestsExceedingThreshold(const int64_t threshold,
-                                                                                        const Time& currTime) const;
+  void logAllPendingRequestsExceedingThreshold(const int64_t threshold, const Time& currTime) const;
+
   void deleteOldestReply(NodeIdType clientId);
 
   bool isInternal(NodeIdType clientId) const { return internalClients_.find(clientId) != internalClients_.end(); }

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -74,6 +74,8 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
 
   Time infoOfEarliestPendingRequest(std::string& cid) const;
 
+  std::vector<std::pair<std::string, uint64_t>> getAllPendingRequestsExceedingThreshold(const int64_t threshold,
+                                                                                        const Time& currTime) const;
   void deleteOldestReply(NodeIdType clientId);
 
   bool isInternal(NodeIdType clientId) const { return internalClients_.find(clientId) != internalClients_.end(); }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3202,6 +3202,16 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
     const uint64_t diffMilli2 = duration_cast<milliseconds>(currTime - timeOfLastViewEntrance).count();
     const uint64_t diffMilli3 = duration_cast<milliseconds>(currTime - timeOfEarliestPendingRequest).count();
 
+    const auto delayedCIDs = clientsManager->getAllPendingRequestsExceedingThreshold(viewChangeTimeout / 2, currTime);
+    if (delayedCIDs.size() > 0) {
+      LOG_INFO(VC_LOG,
+               "Total Client request with more than " << viewChangeTimeout / 2 << "ms delay: " << delayedCIDs.size());
+
+      for (const auto &v : delayedCIDs) {
+        LOG_INFO(VC_LOG, "CID " << v.first << ", delayed " << v.second);
+      }
+    }
+
     if ((diffMilli1 > viewChangeTimeout) && (diffMilli2 > viewChangeTimeout) && (diffMilli3 > viewChangeTimeout)) {
       LOG_INFO(
           VC_LOG,

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3202,15 +3202,7 @@ void ReplicaImp::onViewsChangeTimer(Timers::Handle timer)  // TODO(GG): review/u
     const uint64_t diffMilli2 = duration_cast<milliseconds>(currTime - timeOfLastViewEntrance).count();
     const uint64_t diffMilli3 = duration_cast<milliseconds>(currTime - timeOfEarliestPendingRequest).count();
 
-    const auto delayedCIDs = clientsManager->getAllPendingRequestsExceedingThreshold(viewChangeTimeout / 2, currTime);
-    if (delayedCIDs.size() > 0) {
-      LOG_INFO(VC_LOG,
-               "Total Client request with more than " << viewChangeTimeout / 2 << "ms delay: " << delayedCIDs.size());
-
-      for (const auto &v : delayedCIDs) {
-        LOG_INFO(VC_LOG, "CID " << v.first << ", delayed " << v.second);
-      }
-    }
+    clientsManager->logAllPendingRequestsExceedingThreshold(viewChangeTimeout / 2, currTime);
 
     if ((diffMilli1 > viewChangeTimeout) && (diffMilli2 > viewChangeTimeout) && (diffMilli3 > viewChangeTimeout)) {
       LOG_INFO(


### PR DESCRIPTION
In order to have more information prior to Replicas complaining for the View
they are in, we will log all CID-s that have not been committed for a given
threshold amount of time. Currently the threshold will be half the
View Change Timeout period.