### PR TITLE
Start new epoch on metadata removal

### DIFF
--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 namespace concord::kvbc::keyTypes {
 static const char bft_seq_num_key = 0x21;
 static const char reconfiguration_pruning_key = 0x24;

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -200,10 +200,12 @@ void Replica::handleWedgeEvent() {
 
   LOG_INFO(logger,
            "stored wedge info " << KVLOG(wedgePoint, wedgeBlock, wedgeEpoch, lastExecutedSeqNum, latestKnownEpoch));
-  if (wedgeEpoch == latestKnownEpoch && (wedgePoint == (uint64_t)lastExecutedSeqNum)) {
+  if (wedgeEpoch == latestKnownEpoch) {
     bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(wedgeBftSeqNum);
-    bftEngine::IControlHandler::instance()->onStableCheckpoint();
-    LOG_INFO(logger, "wedge the system on wedgepoint: " << wedgePoint);
+    if (wedgePoint == (uint64_t)lastExecutedSeqNum) {
+      bftEngine::IControlHandler::instance()->onStableCheckpoint();
+    }
+    LOG_INFO(logger, "wedge the system on sequence number: " << lastExecutedSeqNum);
   }
 }
 void Replica::handleNewEpochEvent() {


### PR DESCRIPTION
According to the rule of "start a new epoch on metadata removal," we added logic to start a new epoch when metadata is removed using kv_blockchain_editor.
Notice that if the replicas are not synced this will break the blockchain consistency 