### PR TITLE
Refactor operator keys

### DIFF
--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -20,6 +20,7 @@
 #include "Crypto.hpp"
 #include "openssl_crypto.hpp"
 #include "SigManager.hpp"
+#include "crypto_utils.hpp"
 
 namespace concord::reconfiguration {
 class BftReconfigurationHandler : public IReconfigurationHandler {
@@ -27,8 +28,7 @@ class BftReconfigurationHandler : public IReconfigurationHandler {
   BftReconfigurationHandler();
   bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const override;
 
-  std::unique_ptr<concord::util::openssl_utils::AsymmetricPublicKey> pub_key_ = nullptr;
-  std::unique_ptr<bftEngine::impl::IVerifier> verifier_ = nullptr;
+  std::unique_ptr<concord::util::crypto::IVerifier> verifier_;
 };
 class ReconfigurationHandler : public BftReconfigurationHandler {
  public:

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -138,28 +138,25 @@ BftReconfigurationHandler::BftReconfigurationHandler() {
              "The operator public key is missing, the reconfiguration handler won't be able to execute the requests");
     return;
   }
-  try {
-    pub_key_ = concord::util::openssl_utils::deserializePublicKeyFromPem(operatorPubKeyPath, "secp256r1");
-  } catch (const std::exception& e) {
-    LOG_ERROR(
-        getLogger(),
-        "(1) Unable to read operator key, the replica won't be able to perform reconfiguration actions " << e.what());
-    pub_key_ = nullptr;
+  std::ifstream key_content;
+  key_content.open(operatorPubKeyPath);
+  if (!key_content) {
+    LOG_ERROR(getLogger(), "unable to read the operator public key file");
+    return;
   }
-  try {
-    verifier_ = std::make_unique<bftEngine::impl::ECDSAVerifier>(operatorPubKeyPath);
-  } catch (const std::exception& e) {
-    LOG_ERROR(
-        getLogger(),
-        "(2) Unable to read operator key, the replica won't be able to perform reconfiguration actions " << e.what());
-    verifier_ = nullptr;
+  auto key_str = std::string{};
+  auto buf = std::string(4096, '\0');
+  while (key_content.read(&buf[0], 4096)) {
+    key_str.append(buf, 0, key_content.gcount());
   }
+  key_str.append(buf, 0, key_content.gcount());
+  verifier_.reset(new concord::util::crypto::ECDSAVerifier(key_str, concord::util::crypto::KeyFormat::PemFormat));
 }
 bool BftReconfigurationHandler::verifySignature(uint32_t sender_id,
                                                 const std::string& data,
                                                 const std::string& signature) const {
-  if (pub_key_ == nullptr && verifier_ == nullptr) return false;
-  return pub_key_->verify(data, signature) || verifier_->verify(data, signature);
+  if (verifier_ == nullptr) return false;
+  return verifier_->verify(data, signature);
 }
 
 bool ClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& msg,

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -148,9 +148,9 @@ class KeyExchangeCommandHandler : public IStateHandler {
         std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
 
     // Generate new key pair
-    auto hex_keys = concord::util::Crypto::instance().generateRsaKeyPair(
-        2048, concord::util::Crypto::KeyFormat::HexaDecimalStrippedFormat);
-    auto pem_keys = concord::util::Crypto::instance().hexToPem(hex_keys);
+    auto hex_keys = concord::util::crypto::Crypto::instance().generateRsaKeyPair(
+        2048, concord::util::crypto::KeyFormat::HexaDecimalStrippedFormat);
+    auto pem_keys = concord::util::crypto::Crypto::instance().RsaHexToPem(hex_keys);
 
     concord::messages::ReconfigurationRequest rreq;
     concord::messages::ClientExchangePublicKey creq;

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -15,10 +15,65 @@
 #include <utility>
 #include <string>
 #include <memory>
-namespace concord::util {
+namespace concord::util::crypto {
+enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
+class IVerifier {
+ public:
+  virtual bool verify(const std::string& data, const std::string& sig) = 0;
+  virtual ~IVerifier() = default;
+};
+
+class ISigner {
+ public:
+  virtual std::string sign(const std::string& data) = 0;
+  virtual ~ISigner() = default;
+};
+
+class ECDSAVerifier : public IVerifier {
+ public:
+  ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
+  bool verify(const std::string& data, const std::string& sig) override;
+  ~ECDSAVerifier();
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+class ECDSASigner : public ISigner {
+ public:
+  ECDSASigner(const std::string& str_pub_key, KeyFormat fmt);
+  std::string sign(const std::string& data) override;
+  ~ECDSASigner();
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+class RSAVerifier : public IVerifier {
+ public:
+  RSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
+  bool verify(const std::string& data, const std::string& sig) override;
+  ~RSAVerifier();
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+class RSASigner : public ISigner {
+ public:
+  RSASigner(const std::string& str_priv_key, KeyFormat fmt);
+  std::string sign(const std::string& data) override;
+  ~RSASigner();
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
 class Crypto {
  public:
-  enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
   static Crypto& instance() {
     static Crypto crypto;
     return crypto;
@@ -27,10 +82,12 @@ class Crypto {
   Crypto();
   ~Crypto();
   std::pair<std::string, std::string> generateRsaKeyPair(const uint32_t sig_length, const KeyFormat fmt) const;
-  std::pair<std::string, std::string> hexToPem(const std::pair<std::string, std::string>& key_pair) const;
+  std::pair<std::string, std::string> generateECDSAKeyPair(const KeyFormat fmt) const;
+  std::pair<std::string, std::string> RsaHexToPem(const std::pair<std::string, std::string>& key_pair) const;
+  std::pair<std::string, std::string> ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) const;
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
 };
-}  // namespace concord::util
+}  // namespace concord::util::crypto

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -26,7 +26,7 @@ class ECDSAVerifier::Impl {
   std::unique_ptr<ECDSA<ECP, SHA256>::Verifier> verifier_;
 
  public:
-  Impl(ECDSA<ECP, SHA256>::PublicKey publicKey) {
+  Impl(ECDSA<ECP, SHA256>::PublicKey& publicKey) {
     verifier_ = std::make_unique<ECDSA<ECP, SHA256>::Verifier>(std::move(publicKey));
   }
 
@@ -56,7 +56,7 @@ class ECDSASigner::Impl {
   AutoSeededRandomPool prng_;
 
  public:
-  Impl(ECDSA<ECP, SHA256>::PrivateKey privateKey) {
+  Impl(ECDSA<ECP, SHA256>::PrivateKey& privateKey) {
     signer_ = std::make_unique<ECDSA<ECP, SHA256>::Signer>(std::move(privateKey));
   }
 
@@ -86,7 +86,7 @@ ECDSASigner::~ECDSASigner() = default;
 
 class RSAVerifier::Impl {
  public:
-  Impl(RSA::PublicKey public_key) {
+  Impl(RSA::PublicKey& public_key) {
     verifier_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Verifier>(std::move(public_key));
   }
   bool verify(const std::string& data_to_verify, const std::string& signature) {
@@ -102,7 +102,7 @@ class RSAVerifier::Impl {
 
 class RSASigner::Impl {
  public:
-  Impl(RSA::PrivateKey private_key) {
+  Impl(RSA::PrivateKey& private_key) {
     signer_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Signer>(std::move(private_key));
   }
   std::string sign(const std::string& data_to_sign) {

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -19,15 +19,15 @@
 #include <cryptopp/rsa.h>
 #pragma GCC diagnostic pop
 #include <cryptopp/oids.h>
-#include "Logger.hpp"
+
 using namespace CryptoPP;
 namespace concord::util::crypto {
 class ECDSAVerifier::Impl {
   std::unique_ptr<ECDSA<ECP, SHA256>::Verifier> verifier_;
 
  public:
-  Impl(ECDSA<ECP, SHA256>::PublicKey publicKey) {
-    verifier_ = std::make_unique<ECDSA<ECP, SHA256>::Verifier>(std::move(publicKey));
+  Impl(const ECDSA<ECP, SHA256>::PublicKey& publicKey) {
+    verifier_ = std::make_unique<ECDSA<ECP, SHA256>::Verifier>(publicKey);
   }
 
   bool verify(const std::string& data_to_verify, const std::string& signature) {
@@ -56,8 +56,8 @@ class ECDSASigner::Impl {
   AutoSeededRandomPool prng_;
 
  public:
-  Impl(ECDSA<ECP, SHA256>::PrivateKey privateKey) {
-    signer_ = std::make_unique<ECDSA<ECP, SHA256>::Signer>(std::move(privateKey));
+  Impl(const ECDSA<ECP, SHA256>::PrivateKey& privateKey) {
+    signer_ = std::make_unique<ECDSA<ECP, SHA256>::Signer>(privateKey);
   }
 
   std::string sign(const std::string& data_to_sign) {
@@ -86,8 +86,8 @@ ECDSASigner::~ECDSASigner() = default;
 
 class RSAVerifier::Impl {
  public:
-  Impl(RSA::PublicKey public_key) {
-    verifier_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Verifier>(std::move(public_key));
+  Impl(const RSA::PublicKey& public_key) {
+    verifier_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Verifier>(public_key);
   }
   bool verify(const std::string& data_to_verify, const std::string& signature) {
     return verifier_->VerifyMessage((const CryptoPP::byte*)&data_to_verify[0],
@@ -102,9 +102,7 @@ class RSAVerifier::Impl {
 
 class RSASigner::Impl {
  public:
-  Impl(RSA::PrivateKey private_key) {
-    signer_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Signer>(std::move(private_key));
-  }
+  Impl(const RSA::PrivateKey& private_key) { signer_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Signer>(private_key); }
   std::string sign(const std::string& data_to_sign) {
     size_t siglen = signer_->MaxSignatureLength();
     std::string signature(siglen, 0x00);

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -18,49 +18,215 @@
 #include <cryptopp/pem.h>
 #include <cryptopp/rsa.h>
 #pragma GCC diagnostic pop
+#include <cryptopp/oids.h>
+#include "Logger.hpp"
+using namespace CryptoPP;
+namespace concord::util::crypto {
+class ECDSAVerifier::Impl {
+  std::unique_ptr<ECDSA<ECP, SHA256>::Verifier> verifier_;
 
-namespace concord::util {
+ public:
+  Impl(ECDSA<ECP, SHA256>::PublicKey publicKey) {
+    verifier_ = std::make_unique<ECDSA<ECP, SHA256>::Verifier>(std::move(publicKey));
+  }
+
+  bool verify(const std::string& data_to_verify, const std::string& signature) {
+    return verifier_->VerifyMessage((const CryptoPP::byte*)&data_to_verify[0],
+                                    data_to_verify.size(),
+                                    (const CryptoPP::byte*)&signature[0],
+                                    signature.size());
+  }
+};
+bool ECDSAVerifier::verify(const std::string& data, const std::string& sig) { return impl_->verify(data, sig); }
+ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
+  ECDSA<ECP, SHA256>::PublicKey publicKey;
+  if (fmt == KeyFormat::PemFormat) {
+    StringSource s(str_pub_key, true);
+    PEM_Load(s, publicKey);
+  } else {
+    StringSource s(str_pub_key, true, new HexDecoder());
+    publicKey.Load(s);
+  }
+  impl_.reset(new Impl(publicKey));
+}
+ECDSAVerifier::~ECDSAVerifier() = default;
+
+class ECDSASigner::Impl {
+  std::unique_ptr<ECDSA<ECP, SHA256>::Signer> signer_;
+  AutoSeededRandomPool prng_;
+
+ public:
+  Impl(ECDSA<ECP, SHA256>::PrivateKey privateKey) {
+    signer_ = std::make_unique<ECDSA<ECP, SHA256>::Signer>(std::move(privateKey));
+  }
+
+  std::string sign(const std::string& data_to_sign) {
+    size_t siglen = signer_->MaxSignatureLength();
+    std::string signature(siglen, 0x00);
+    siglen = signer_->SignMessage(
+        prng_, (const CryptoPP::byte*)&data_to_sign[0], data_to_sign.size(), (CryptoPP::byte*)&signature[0]);
+    signature.resize(siglen);
+    return signature;
+  }
+};
+
+std::string ECDSASigner::sign(const std::string& data) { return impl_->sign(data); }
+ECDSASigner::ECDSASigner(const std::string& str_pub_key, KeyFormat fmt) {
+  ECDSA<ECP, SHA256>::PrivateKey privateKey;
+  if (fmt == KeyFormat::PemFormat) {
+    StringSource s(str_pub_key, true);
+    PEM_Load(s, privateKey);
+  } else {
+    StringSource s(str_pub_key, true, new HexDecoder());
+    privateKey.Load(s);
+  }
+  impl_.reset(new Impl(privateKey));
+}
+ECDSASigner::~ECDSASigner() = default;
+
+class RSAVerifier::Impl {
+ public:
+  Impl(RSA::PublicKey public_key) {
+    verifier_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Verifier>(std::move(public_key));
+  }
+  bool verify(const std::string& data_to_verify, const std::string& signature) {
+    return verifier_->VerifyMessage((const CryptoPP::byte*)&data_to_verify[0],
+                                    data_to_verify.size(),
+                                    (const CryptoPP::byte*)&signature[0],
+                                    signature.size());
+  }
+
+ private:
+  std::unique_ptr<RSASS<PKCS1v15, SHA256>::Verifier> verifier_;
+};
+
+class RSASigner::Impl {
+ public:
+  Impl(RSA::PrivateKey private_key) {
+    signer_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Signer>(std::move(private_key));
+  }
+  std::string sign(const std::string& data_to_sign) {
+    size_t siglen = signer_->MaxSignatureLength();
+    std::string signature(siglen, 0x00);
+    siglen = signer_->SignMessage(
+        prng_, (const CryptoPP::byte*)&data_to_sign[0], data_to_sign.size(), (CryptoPP::byte*)&signature[0]);
+    signature.resize(siglen);
+    return signature;
+  }
+
+ private:
+  std::unique_ptr<RSASS<PKCS1v15, SHA256>::Signer> signer_;
+  AutoSeededRandomPool prng_;
+};
+
+RSASigner::RSASigner(const std::string& str_priv_key, KeyFormat fmt) {
+  RSA::PrivateKey private_key;
+  if (fmt == KeyFormat::PemFormat) {
+    StringSource s(str_priv_key, true);
+    PEM_Load(s, private_key);
+  } else {
+    StringSource s(str_priv_key, true, new HexDecoder());
+    private_key.Load(s);
+  }
+  impl_.reset(new RSASigner::Impl(private_key));
+}
+
+std::string RSASigner::sign(const std::string& data) { return impl_->sign(data); }
+RSASigner::~RSASigner() = default;
+
+RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
+  RSA::PublicKey public_key;
+  if (fmt == KeyFormat::PemFormat) {
+    StringSource s(str_pub_key, true);
+    PEM_Load(s, public_key);
+  } else {
+    StringSource s(str_pub_key, true, new HexDecoder());
+    public_key.Load(s);
+  }
+  impl_.reset(new RSAVerifier::Impl(public_key));
+}
+bool RSAVerifier::verify(const std::string& data, const std::string& sig) { return impl_->verify(data, sig); }
+RSAVerifier::~RSAVerifier() = default;
+>>>>>>> Enrich crypto_utils
+
 class Crypto::Impl {
  public:
-  std::pair<std::string, std::string> hexToPem(const std::pair<std::string, std::string>& key_pair) {
+  std::pair<std::string, std::string> RsaHexToPem(const std::pair<std::string, std::string>& key_pair) {
     std::pair<std::string, std::string> out;
+    if (!key_pair.first.empty()) {
+      StringSource priv_str(key_pair.first, true, new HexDecoder());
+      RSA::PrivateKey priv;
+      priv.Load(priv_str);
+      StringSink priv_string_sink(out.first);
+      PEM_Save(priv_string_sink, priv);
+      priv_string_sink.MessageEnd();
+    }
 
-    CryptoPP::HexDecoder priv_hd;
-    CryptoPP::StringSource priv_str(key_pair.first, true, new CryptoPP::HexDecoder());
-    CryptoPP::RSA::PrivateKey priv;
-    priv.Load(priv_str);
-    CryptoPP::StringSink priv_string_sink(out.first);
-    CryptoPP::PEM_Save(priv_string_sink, priv);
-    priv_string_sink.MessageEnd();
+    if (!key_pair.second.empty()) {
+      StringSource pub_str(key_pair.second, true, new HexDecoder());
+      RSA::PublicKey pub;
+      pub.Load(pub_str);
+      StringSink pub_string_sink(out.second);
+      PEM_Save(pub_string_sink, pub);
+      pub_string_sink.MessageEnd();
+    }
+    return out;
+  }
 
-    CryptoPP::HexDecoder pub_hd;
-    CryptoPP::StringSource pub_str(key_pair.second, true, new CryptoPP::HexDecoder());
-    CryptoPP::RSA::PublicKey pub;
-    pub.Load(pub_str);
-    CryptoPP::StringSink pub_string_sink(out.second);
-    CryptoPP::PEM_Save(pub_string_sink, pub);
-    pub_string_sink.MessageEnd();
+  std::pair<std::string, std::string> ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) {
+    std::pair<std::string, std::string> out;
+    if (!key_pair.first.empty()) {
+      StringSource priv_str(key_pair.first, true, new HexDecoder());
+      ECDSA<ECP, SHA256>::PrivateKey priv;
+      priv.Load(priv_str);
+      StringSink priv_string_sink(out.first);
+      PEM_Save(priv_string_sink, priv);
+    }
+    if (!key_pair.second.empty()) {
+      StringSource pub_str(key_pair.second, true, new HexDecoder());
+      ECDSA<ECP, SHA256>::PublicKey pub;
+      pub.Load(pub_str);
+      StringSink pub_string_sink(out.second);
+      PEM_Save(pub_string_sink, pub);
+    }
     return out;
   }
 
   std::pair<std::string, std::string> generateRsaKeyPairs(uint32_t sig_length, KeyFormat fmt) {
-    CryptoPP::AutoSeededRandomPool rng;
+    AutoSeededRandomPool rng;
     std::pair<std::string, std::string> keyPair;
 
-    CryptoPP::RSAES<CryptoPP::OAEP<CryptoPP::SHA256>>::Decryptor priv(rng, sig_length);
-    CryptoPP::RSAES<CryptoPP::OAEP<CryptoPP::SHA256>>::Encryptor pub(priv);
-    CryptoPP::HexEncoder privEncoder(new CryptoPP::StringSink(keyPair.first));
+    RSAES<OAEP<SHA256>>::Decryptor priv(rng, sig_length);
+    RSAES<OAEP<SHA256>>::Encryptor pub(priv);
+    HexEncoder privEncoder(new StringSink(keyPair.first));
     priv.AccessMaterial().Save(privEncoder);
     privEncoder.MessageEnd();
 
-    CryptoPP::HexEncoder pubEncoder(new CryptoPP::StringSink(keyPair.second));
+    HexEncoder pubEncoder(new StringSink(keyPair.second));
     pub.AccessMaterial().Save(pubEncoder);
     pubEncoder.MessageEnd();
-    if (fmt == Crypto::KeyFormat::PemFormat) {
-      keyPair = hexToPem(keyPair);
+    if (fmt == KeyFormat::PemFormat) {
+      keyPair = RsaHexToPem(keyPair);
     }
     return keyPair;
   }
+  std::pair<std::string, std::string> generateECDSAKeyPair(const KeyFormat fmt) {
+    AutoSeededRandomPool prng;
+    ECDSA<ECP, SHA256>::PrivateKey privateKey;
+    ECDSA<ECP, SHA256>::PublicKey publicKey;
+    privateKey.Initialize(prng, ASN1::secp256k1());
+    privateKey.MakePublicKey(publicKey);
+    std::pair<std::string, std::string> keyPair;
+    HexEncoder privEncoder(new StringSink(keyPair.first));
+    privateKey.Save(privEncoder);
+    HexEncoder pubEncoder(new StringSink(keyPair.second));
+    publicKey.Save(pubEncoder);
+    if (fmt == KeyFormat::PemFormat) {
+      keyPair = ECDSAHexToPem(keyPair);
+    }
+    return keyPair;
+  }
+
   ~Impl() = default;
 };
 
@@ -68,10 +234,19 @@ std::pair<std::string, std::string> Crypto::generateRsaKeyPair(const uint32_t si
   return impl_->generateRsaKeyPairs(sig_length, fmt);
 }
 
-std::pair<std::string, std::string> Crypto::hexToPem(const std::pair<std::string, std::string>& key_pair) const {
-  return impl_->hexToPem(key_pair);
+std::pair<std::string, std::string> Crypto::RsaHexToPem(const std::pair<std::string, std::string>& key_pair) const {
+  return impl_->RsaHexToPem(key_pair);
+}
+
+std::pair<std::string, std::string> Crypto::generateECDSAKeyPair(KeyFormat fmt) const {
+  return impl_->generateECDSAKeyPair(fmt);
+}
+
+std::pair<std::string, std::string> Crypto::ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) const {
+  return impl_->ECDSAHexToPem(key_pair);
 }
 
 Crypto::Crypto() : impl_{new Impl()} {}
+
 Crypto::~Crypto() = default;
-}  // namespace concord::util
+}  // namespace concord::util::crypto

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -19,15 +19,15 @@
 #include <cryptopp/rsa.h>
 #pragma GCC diagnostic pop
 #include <cryptopp/oids.h>
-
+#include "Logger.hpp"
 using namespace CryptoPP;
 namespace concord::util::crypto {
 class ECDSAVerifier::Impl {
   std::unique_ptr<ECDSA<ECP, SHA256>::Verifier> verifier_;
 
  public:
-  Impl(const ECDSA<ECP, SHA256>::PublicKey& publicKey) {
-    verifier_ = std::make_unique<ECDSA<ECP, SHA256>::Verifier>(publicKey);
+  Impl(ECDSA<ECP, SHA256>::PublicKey publicKey) {
+    verifier_ = std::make_unique<ECDSA<ECP, SHA256>::Verifier>(std::move(publicKey));
   }
 
   bool verify(const std::string& data_to_verify, const std::string& signature) {
@@ -56,8 +56,8 @@ class ECDSASigner::Impl {
   AutoSeededRandomPool prng_;
 
  public:
-  Impl(const ECDSA<ECP, SHA256>::PrivateKey& privateKey) {
-    signer_ = std::make_unique<ECDSA<ECP, SHA256>::Signer>(privateKey);
+  Impl(ECDSA<ECP, SHA256>::PrivateKey privateKey) {
+    signer_ = std::make_unique<ECDSA<ECP, SHA256>::Signer>(std::move(privateKey));
   }
 
   std::string sign(const std::string& data_to_sign) {
@@ -86,8 +86,8 @@ ECDSASigner::~ECDSASigner() = default;
 
 class RSAVerifier::Impl {
  public:
-  Impl(const RSA::PublicKey& public_key) {
-    verifier_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Verifier>(public_key);
+  Impl(RSA::PublicKey public_key) {
+    verifier_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Verifier>(std::move(public_key));
   }
   bool verify(const std::string& data_to_verify, const std::string& signature) {
     return verifier_->VerifyMessage((const CryptoPP::byte*)&data_to_verify[0],
@@ -102,7 +102,9 @@ class RSAVerifier::Impl {
 
 class RSASigner::Impl {
  public:
-  Impl(const RSA::PrivateKey& private_key) { signer_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Signer>(private_key); }
+  Impl(RSA::PrivateKey private_key) {
+    signer_ = std::make_unique<RSASS<PKCS1v15, SHA256>::Signer>(std::move(private_key));
+  }
   std::string sign(const std::string& data_to_sign) {
     size_t siglen = signer_->MaxSignatureLength();
     std::string signature(siglen, 0x00);
@@ -145,7 +147,6 @@ RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
 }
 bool RSAVerifier::verify(const std::string& data, const std::string& sig) { return impl_->verify(data, sig); }
 RSAVerifier::~RSAVerifier() = default;
->>>>>>> Enrich crypto_utils
 
 class Crypto::Impl {
  public:

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -70,3 +70,7 @@ target_link_libraries(openssl_crypto_wrapper_test GTest::Main util)
 add_executable(simple_memory_pool_test simple_memory_pool_test.cpp)
 add_test(simple_memory_pool_test simple_memory_pool_test)
 target_link_libraries(simple_memory_pool_test GTest::Main util)
+
+add_executable(crypto_utils_test crypto_utils_test.cpp )
+add_test(crypto_utils_test crypto_utils_test)
+target_link_libraries(crypto_utils_test GTest::Main util)

--- a/util/test/crypto_utils_test.cpp
+++ b/util/test/crypto_utils_test.cpp
@@ -1,0 +1,124 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+
+#include "gtest/gtest.h"
+#include "crypto_utils.hpp"
+#include "Logger.hpp"
+using namespace concord::util::crypto;
+namespace {
+TEST(crypto_utils, generate_rsa_keys_hex_format) {
+  ASSERT_NO_THROW(Crypto::instance().generateRsaKeyPair(2048, KeyFormat::HexaDecimalStrippedFormat));
+  auto keys = Crypto::instance().generateRsaKeyPair(2048, KeyFormat::HexaDecimalStrippedFormat);
+  LOG_INFO(GL, keys.first << " | " << keys.second);
+}
+
+TEST(crypto_utils, generate_rsa_keys_pem_format) {
+  ASSERT_NO_THROW(Crypto::instance().generateRsaKeyPair(2048, KeyFormat::PemFormat));
+  auto keys = Crypto::instance().generateRsaKeyPair(2048, KeyFormat::PemFormat);
+  LOG_INFO(GL, keys.first << " | " << keys.second);
+}
+
+TEST(crypto_utils, generate_ECDSA_keys_pem_format) {
+  ASSERT_NO_THROW(Crypto::instance().generateECDSAKeyPair(KeyFormat::PemFormat));
+  auto keys = Crypto::instance().generateECDSAKeyPair(KeyFormat::PemFormat);
+  LOG_INFO(GL, keys.first << " | " << keys.second);
+}
+
+TEST(crypto_utils, generate_ECDSA_keys_hex_format) {
+  ASSERT_NO_THROW(Crypto::instance().generateECDSAKeyPair(KeyFormat::HexaDecimalStrippedFormat));
+  auto keys = Crypto::instance().generateECDSAKeyPair(KeyFormat::HexaDecimalStrippedFormat);
+  LOG_INFO(GL, keys.first << " | " << keys.second);
+}
+
+TEST(crypto_utils, test_rsa_keys_hex) {
+  auto keys = Crypto::instance().generateRsaKeyPair(2048, KeyFormat::HexaDecimalStrippedFormat);
+  RSASigner signer(keys.first, KeyFormat::HexaDecimalStrippedFormat);
+  RSAVerifier verifier(keys.second, KeyFormat::HexaDecimalStrippedFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+
+TEST(crypto_utils, test_rsa_keys_pem) {
+  auto keys = Crypto::instance().generateRsaKeyPair(2048, KeyFormat::PemFormat);
+  RSASigner signer(keys.first, KeyFormat::PemFormat);
+  RSAVerifier verifier(keys.second, KeyFormat::PemFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+
+TEST(crypto_utils, test_rsa_keys_combined_a) {
+  auto keys = Crypto::instance().generateRsaKeyPair(2048, KeyFormat::HexaDecimalStrippedFormat);
+  auto pemKeys = Crypto::instance().RsaHexToPem(keys);
+  RSASigner signer(keys.first, KeyFormat::HexaDecimalStrippedFormat);
+  RSAVerifier verifier(pemKeys.second, KeyFormat::PemFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+
+TEST(crypto_utils, test_rsa_keys_combined_b) {
+  auto keys = Crypto::instance().generateRsaKeyPair(2048, KeyFormat::HexaDecimalStrippedFormat);
+  auto pemKeys = Crypto::instance().RsaHexToPem(keys);
+  RSASigner signer(pemKeys.first, KeyFormat::PemFormat);
+  RSAVerifier verifier(keys.second, KeyFormat::HexaDecimalStrippedFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+
+TEST(crypto_utils, test_ecdsa_keys_hex) {
+  auto keys = Crypto::instance().generateECDSAKeyPair(KeyFormat::HexaDecimalStrippedFormat);
+  ECDSASigner signer(keys.first, KeyFormat::HexaDecimalStrippedFormat);
+  ECDSAVerifier verifier(keys.second, KeyFormat::HexaDecimalStrippedFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+
+TEST(crypto_utils, test_ecdsa_keys_pem) {
+  auto keys = Crypto::instance().generateECDSAKeyPair(KeyFormat::PemFormat);
+  ECDSASigner signer(keys.first, KeyFormat::PemFormat);
+  ECDSAVerifier verifier(keys.second, KeyFormat::PemFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+
+TEST(crypto_utils, test_ecdsa_keys_pem_combined_a) {
+  auto keys = Crypto::instance().generateECDSAKeyPair(KeyFormat::HexaDecimalStrippedFormat);
+  auto pemKeys = Crypto::instance().ECDSAHexToPem(keys);
+  ECDSASigner signer(keys.first, KeyFormat::HexaDecimalStrippedFormat);
+  ECDSAVerifier verifier(pemKeys.second, KeyFormat::PemFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+
+TEST(crypto_utils, test_ecdsa_keys_pem_combined_b) {
+  auto keys = Crypto::instance().generateECDSAKeyPair(KeyFormat::HexaDecimalStrippedFormat);
+  auto pemKeys = Crypto::instance().ECDSAHexToPem(keys);
+  ECDSASigner signer(pemKeys.first, KeyFormat::PemFormat);
+  ECDSAVerifier verifier(keys.second, KeyFormat::HexaDecimalStrippedFormat);
+  std::string data = "Hello world";
+  auto sig = signer.sign(data);
+  ASSERT_TRUE(verifier.verify(data, sig));
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
In this PR we added functionality for both RSA and ECDSA keys to crypto_utils.
This will enable us to use only one verifier in the operator as well as eventually refactor out the Crypto class from concordbft/src