### PR TITLE
Do not prune on startup if pruning disabled

### DIFF
--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -162,7 +162,9 @@ void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IReques
   requestHandler->setReconfigurationHandler(pruning_handler);
   stReconfigurationSM_->registerHandler(m_cmdHandler->getReconfigurationHandler());
   stReconfigurationSM_->registerHandler(pruning_handler);
-  stReconfigurationSM_->pruneOnStartup();
+  if (bftEngine::ReplicaConfig::instance().pruningEnabled_) {
+    stReconfigurationSM_->pruneOnStartup();
+  }
 }
 uint64_t Replica::getStoredReconfigData(const std::string &kCategory,
                                         const std::string &key,


### PR DESCRIPTION
Do not call `pruneOnStartup()` on the ST reconfiguration SM if pruning
is disabled in configuration.