### PR TITLE
Make rocksDB row_cache configurable

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -361,6 +361,7 @@ void ClientsManager::removeRequestsOutOfBatchBounds(NodeIdType clientId, ReqId r
   }
 }
 void ClientsManager::removePendingForExecutionRequest(NodeIdType clientId, ReqId reqSeqNum) {
+  if (!isValidClient(clientId)) return;
   auto& requestsInfo = clientsInfo_[clientId].requestsInfo;
   const auto& reqIt = requestsInfo.find(reqSeqNum);
   if (reqIt != requestsInfo.end()) {
@@ -392,7 +393,7 @@ Time ClientsManager::infoOfEarliestPendingRequest(std::string& cid) const {
   return earliestPendingReqInfo.time;
 }
 
-// Iterate over all clients and log the ones that have not been committed for more than threshold miliseconds.
+// Iterate over all clients and log the ones that have not been committed for more than threshold milliseconds.
 void ClientsManager::logAllPendingRequestsExceedingThreshold(const int64_t threshold, const Time& currTime) const {
   int numExceeding = 0;
   for (const auto& info : clientsInfo_) {

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -416,6 +416,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                       bool recoverFromErrorInRequestsExecution = false);
 
   void executeRequestsAndSendResponses(PrePrepareMsg* pp, Bitmap& requestSet, concordUtils::SpanWrapper& span);
+  void sendResponses(PrePrepareMsg* ppMsg, IRequestsHandler::ExecutionRequestsQueue& accumulatedRequests);
 
   void onSeqNumIsStable(
       SeqNum newStableSeqNum,
@@ -508,6 +509,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                         executeReadOnlyRequest,
                                         executeWriteRequest,
                                         executeRequestsInPrePrepareMsg,
+                                        executeRequestsAndSendResponses,
+                                        prepareAndSendResponses,
+                                        advanceActiveWindowMainLog,
                                         numRequestsInPrePrepareMsg,
                                         requestsQueueOfPrimarySize,
                                         onSeqNumIsStable,
@@ -532,10 +536,13 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
     DEFINE_SHARED_RECORDER(executeReadOnlyRequest, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(executeWriteRequest, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(executeRequestsInPrePrepareMsg, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(executeRequestsAndSendResponses, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(prepareAndSendResponses, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(advanceActiveWindowMainLog, 1, MAX_VALUE_MICROSECONDS, 3, Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(numRequestsInPrePrepareMsg, 1, 2500, 3, Unit::COUNT);
     DEFINE_SHARED_RECORDER(requestsQueueOfPrimarySize,
                            1,
-                           // Currently hardcoded to 700 in ReplicaImp.cpp
+                           // Currently, hardcoded to 700 in ReplicaImp.cpp
                            701,
                            3,
                            Unit::COUNT);

--- a/bftengine/src/bftengine/RequestsBatchingLogic.cpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.cpp
@@ -48,7 +48,6 @@ RequestsBatchingLogic::~RequestsBatchingLogic() {
 
 void RequestsBatchingLogic::onBatchFlushTimer(Timers::Handle) {
   if (replica_.isCurrentPrimary()) {
-    concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onBatchFlushTimer);
     lock_guard<mutex> lock(batchProcessingLock_);
     if (replica_.tryToSendPrePrepareMsg(false)) {
       LOG_INFO(GL, "Batching flush period expired" << KVLOG(batchFlushPeriodMs_));

--- a/bftengine/src/bftengine/RequestsBatchingLogic.hpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.hpp
@@ -18,7 +18,6 @@
 #include "InternalReplicaApi.hpp"
 #include "messages/PrePrepareMsg.hpp"
 #include "Timers.hpp"
-#include "diagnostics.h"
 #include "performance_handler.h"
 
 namespace bftEngine::batchingLogic {
@@ -41,7 +40,6 @@ class RequestsBatchingLogic {
   std::pair<PrePrepareMsg *, bool> batchRequestsSelfAdjustedPolicy(SeqNum primaryLastUsedSeqNum,
                                                                    uint64_t requestsInQueue,
                                                                    SeqNum lastExecutedSeqNum);
-
   void adjustPreprepareSize();
 
  private:
@@ -69,17 +67,7 @@ class RequestsBatchingLogic {
   concordUtil::Timers::Handle batchFlushTimer_;
   std::mutex batchProcessingLock_;
 
-  static constexpr int64_t MAX_VALUE_MICROSECONDS = 1000 * 1000 * 60;
-  using Recorder = concord::diagnostics::Recorder;
-
-  struct Recorders {
-    Recorders() {
-      auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      registrar.perf.registerComponent("batching", {onBatchFlushTimer});
-    }
-    DEFINE_SHARED_RECORDER(onBatchFlushTimer, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
-  };
-  Recorders histograms_;
+  static constexpr uint64_t MAX_VALUE_MICROSECONDS = 1000lu * 1000 * 60;
 };
 
 }  // namespace bftEngine::batchingLogic

--- a/kvbc/include/merkle_tree_storage_factory.h
+++ b/kvbc/include/merkle_tree_storage_factory.h
@@ -26,7 +26,8 @@ namespace concord::kvbc::v2MerkleTree {
 #ifdef USE_ROCKSDB
 class RocksDBStorageFactory : public IStorageFactory {
  public:
-  static const std::size_t DEFAULT_ROCKSDB_LRU_CACHE_BYTES = 1024 * 1024 * 1024 * 4ul;  // 4 GB
+  static const std::size_t DEFAULT_ROCKSDB_BLOCK_CACHE_BYTES = 1024 * 1024 * 1024 * 8ul;  // 8 GB
+  static const std::size_t DEFAULT_ROCKSDB_ROW_CACHE_BYTES = 1024 * 1024 * 1024 * 8ul;    // 8 GB
 
   RocksDBStorageFactory(
       const std::string& dbPath,
@@ -36,7 +37,8 @@ class RocksDBStorageFactory : public IStorageFactory {
 
   RocksDBStorageFactory(const std::string& dbPath,
                         const std::string& dbConfPath,
-                        std::size_t rocksdbLruCacheBytes = DEFAULT_ROCKSDB_LRU_CACHE_BYTES,
+                        std::size_t rocksdbBlockCacheBytes = DEFAULT_ROCKSDB_BLOCK_CACHE_BYTES,
+                        std::size_t rocksdbRowCacheBytes = DEFAULT_ROCKSDB_ROW_CACHE_BYTES,
                         const std::shared_ptr<concord::performance::PerformanceManager>& pm =
                             std::make_shared<concord::performance::PerformanceManager>());
 
@@ -48,7 +50,8 @@ class RocksDBStorageFactory : public IStorageFactory {
  private:
   const std::string dbPath_;
   const std::optional<std::string> dbConfPath_;
-  std::size_t rocksdbLruCacheBytes_{DEFAULT_ROCKSDB_LRU_CACHE_BYTES};
+  std::size_t rocksdbBlockCacheBytes_{DEFAULT_ROCKSDB_BLOCK_CACHE_BYTES};
+  std::size_t rocksdbRowCacheBytes_{DEFAULT_ROCKSDB_ROW_CACHE_BYTES};
   const std::unordered_set<concord::kvbc::Key> nonProvableKeySet_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
 };


### PR DESCRIPTION
- Configure rocksDB to start using row_cache with a default size of 8GB 
- Change the default block cache size to 8GB
- Add a few histograms
- Fix compilation with OPENTRACE flag off