### PR TITLE
State transfer bug fixes and minor flow control improvments

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -328,11 +328,11 @@ class BCStateTran : public IStateTransfer {
   // Consistency
   ///////////////////////////////////////////////////////////////////////////
 
-  void checkConsistency(bool checkAllBlocks);
+  void checkConsistency(bool checkAllBlocks, bool duringInit = false);
   void checkConfig();
   void checkFirstAndLastCheckpoint(uint64_t firstStoredCheckpoint, uint64_t lastStoredCheckpoint);
   void checkReachableBlocks(uint64_t genesisBlockNum, uint64_t lastReachableBlockNum);
-  void checkUnreachableBlocks(uint64_t lastReachableBlockNum, uint64_t lastBlockNum);
+  void checkUnreachableBlocks(uint64_t lastReachableBlockNum, uint64_t lastBlockNum, bool duringInit);
   void checkBlocksBeingFetchedNow(bool checkAllBlocks, uint64_t lastReachableBlockNum, uint64_t lastBlockNum);
   void checkStoredCheckpoints(uint64_t firstStoredCheckpoint, uint64_t lastStoredCheckpoint);
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -298,8 +298,7 @@ class BCStateTran : public IStateTransfer {
                         int16_t& outLastChunkInRequiredBlock,
                         char* outBlock,
                         uint32_t& outBlockSize,
-                        bool isVBLock,
-                        bool& outLastInBatch);
+                        bool isVBLock);
 
   bool checkBlock(uint64_t blockNum, const STDigest& expectedBlockDigest, char* block, uint32_t blockSize) const;
 
@@ -307,7 +306,7 @@ class BCStateTran : public IStateTransfer {
                                    char* vblock,
                                    uint32_t vblockSize) const;
 
-  void processData();
+  void processData(bool lastInBatch = false);
   void cycleEndSummary();
 
   void EnterGettingCheckpointSummariesState();


### PR DESCRIPTION
Here we add multiple bug fixes and improvements observed during CI runs and manual testing:

1. BCStateTran: change the way destination handles lastInBatch flag
2. BCStateTran: add lastInBatch flag when source reply FetchResPagesMsg
2. BCStateTran: fix false assertion bug during consistency checks
3. BCStateTran: fix a bug in the source while fetching missing blocks