### PR TITLE
Fixes for building without log4cplus.

### DIFF
--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -54,7 +54,6 @@
 #include "assertUtils.hpp"
 #include "Metrics.hpp"
 
-#include <log4cplus/loggingmacros.h>
 #include <opentracing/span.h>
 #include <condition_variable>
 #include <thread>

--- a/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
@@ -14,7 +14,6 @@
 #ifndef THIN_REPLICA_CLIENT_TRACE_CONTEXTS_HPP_
 #define THIN_REPLICA_CLIENT_TRACE_CONTEXTS_HPP_
 
-#include <log4cplus/logger.h>
 #include <opentracing/span.h>
 
 #include "thin_replica.pb.h"

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -13,7 +13,6 @@
 
 #include "client/thin-replica-client/thin_replica_client.hpp"
 
-#include <log4cplus/mdc.h>
 #include <opentracing/propagation.h>
 #include <opentracing/span.h>
 #include <opentracing/tracer.h>

--- a/client/thin-replica-client/src/trace_contexts.cpp
+++ b/client/thin-replica-client/src/trace_contexts.cpp
@@ -13,7 +13,6 @@
 
 #include "client/thin-replica-client/trace_contexts.hpp"
 
-#include <log4cplus/loggingmacros.h>
 #include <opentracing/propagation.h>
 #include <opentracing/span.h>
 #include <opentracing/tracer.h>

--- a/logging/include/Logging.hpp
+++ b/logging/include/Logging.hpp
@@ -111,9 +111,9 @@ class Logger {
 
 }  // namespace logging
 
-#define LOG_COMMON(logger, level, s)                            \
-  if (logger.getLogLevel() <= level) {                          \
-    logger.print(level, __PRETTY_FUNCTION__) << s << std::endl; \
+#define LOG_COMMON(logger, level, s)                              \
+  if ((logger).getLogLevel() <= level) {                          \
+    (logger).print(level, __PRETTY_FUNCTION__) << s << std::endl; \
   }
 
 #define LOG_TRACE(l, s) LOG_COMMON(l, logging::LogLevel::trace, s)
@@ -128,4 +128,8 @@ class Logger {
 #define MDC_CLEAR logging::Logger::getThreadContext().getMDC().clear();
 #define MDC_GET(k) logging::Logger::getThreadContext().getMDC().get(k)
 
-#define LOG_CONFIGURE_AND_WATCH(config_file, millis) logging::initLogger(config_file)
+#define LOG_CONFIGURE_AND_WATCH(config_file, millis) \
+  {                                                  \
+    logging::initLogger(config_file);                \
+    (void)(millis);                                  \
+  }


### PR DESCRIPTION
Remove direct includes of log4cplus headers.
Wrap logger used in macros in braces.