### PR TITLE
Cre refactoring

### DIFF
--- a/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
@@ -43,7 +43,6 @@ class ClientReconfigurationEngine {
   std::unique_ptr<IStateClient> stateClient_;
   Config config_;
   std::atomic_bool stopped_{true};
-  uint64_t lastKnownBlock_{0};
   std::thread mainThread_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
   concordMetrics::Component metrics_;

--- a/client/reconfiguration/include/client/reconfiguration/cre_interfaces.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/cre_interfaces.hpp
@@ -28,10 +28,9 @@ struct WriteState {
 
 class IStateClient {
  public:
-  virtual State getNextState(uint64_t lastKnownBlockId) const = 0;
-  virtual State getLatestClientUpdate(uint16_t clientId) const = 0;
+  virtual State getNextState() const = 0;
   virtual bool updateState(const WriteState& state) = 0;
-  virtual void start(uint64_t lastKnownBlock) = 0;
+  virtual void start() = 0;
   virtual void stop() = 0;
   virtual void pushUpdate(std::vector<State>&) {}
   virtual ~IStateClient() = default;

--- a/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
@@ -30,15 +30,14 @@ class PollBasedStateClient : public IStateClient {
                        uint64_t interval_timeout_ms,
                        uint64_t last_known_block,
                        const uint16_t id_);
-  State getNextState(uint64_t lastKnownBlockId) const override;
-  State getLatestClientUpdate(uint16_t clientId) const override;
+  State getNextState() const override;
   bool updateState(const WriteState& state) override;
   ~PollBasedStateClient();
-  void start(uint64_t lastKnownBlock) override;
+  void start() override;
   void stop() override;
 
  private:
-  State getStateUpdate(uint64_t lastKnownBlockId) const;
+  std::vector<State> getStateUpdate() const;
   concord::messages::ReconfigurationResponse sendReconfigurationRequest(concord::messages::ReconfigurationRequest& rreq,
                                                                         const std::string& cid,
                                                                         uint64_t sn,

--- a/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
@@ -35,9 +35,9 @@ class PollBasedStateClient : public IStateClient {
   ~PollBasedStateClient();
   void start() override;
   void stop() override;
+  std::vector<State> getStateUpdate(bool& succ) const;
 
  private:
-  std::vector<State> getStateUpdate() const;
   concord::messages::ReconfigurationResponse sendReconfigurationRequest(concord::messages::ReconfigurationRequest& rreq,
                                                                         const std::string& cid,
                                                                         uint64_t sn,

--- a/client/reconfiguration/include/client/reconfiguration/st_based_reconfiguration_client.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/st_based_reconfiguration_client.hpp
@@ -29,10 +29,9 @@ class STBasedReconfigurationClient : public IStateClient {
   STBasedReconfigurationClient(std::function<void(const std::vector<uint8_t>&)> updateStateCb,
                                const uint64_t& blockId,
                                uint64_t intervalTimeoutMs = 1000);
-  State getNextState(uint64_t lastKnownBlockId) const override;
-  State getLatestClientUpdate(uint16_t clientId) const override;
+  State getNextState() const override;
   bool updateState(const WriteState& state) override;
-  void start(uint64_t lastKnownBlock) override { stopped_ = false; }
+  void start() override { stopped_ = false; }
   void stop() override { stopped_ = true; }
   void pushUpdate(std::vector<State>&) override;
 

--- a/client/reconfiguration/test/cre_test_api.cpp
+++ b/client/reconfiguration/test/cre_test_api.cpp
@@ -23,17 +23,17 @@ std::string invalids_counter = "invalid_handlers";
 std::string errors_counter = "errored_handlers";
 class TestStateClient : public IStateClient {
  public:
-  State getNextState(uint64_t lastKnownBlockId) const override {
-    std::string lastKnownBid = std::to_string(lastKnownBlockId + 1);
-    return State{lastKnownBlockId + 1, std::vector<uint8_t>(lastKnownBid.begin(), lastKnownBid.end())};
+  State getNextState() const override {
+    std::string lastKnownBid = std::to_string(blocks_size_ + 1);
+    return State{blocks_size_ + 1, std::vector<uint8_t>(lastKnownBid.begin(), lastKnownBid.end())};
   }
-  State getLatestClientUpdate(uint16_t clientId) const override { return {0, {}}; }
+
   bool updateState(const WriteState& state) override {
     blocks_.push_back(blocks_.size() + 1);
     blocks_size_ = blocks_.size();
     return true;
   }
-  void start(uint64_t lastKnownBlock) override {}
+  void start() override {}
   void stop() override {}
   std::vector<uint64_t> blocks_;
   std::atomic_uint64_t blocks_size_{0};

--- a/client/reconfiguration/test/poll_based_state_client_test.cpp
+++ b/client/reconfiguration/test/poll_based_state_client_test.cpp
@@ -34,14 +34,14 @@ std::string last_known_block_gauge = "last_known_block";
 
 template <typename T>
 bool hasValue(const State& state) {
-  concord::messages::ClientReconfigurationStateReply crep;
+  concord::messages::ClientStateReply crep;
   concord::messages::deserialize(state.data, crep);
   return std::holds_alternative<T>(crep.response);
 }
 
 template <typename T>
 T getData(const State& state) {
-  concord::messages::ClientReconfigurationStateReply crep;
+  concord::messages::ClientStateReply crep;
   concord::messages::deserialize(state.data, crep);
   return std::get<T>(crep.response);
 }
@@ -78,29 +78,11 @@ class KeyExchangeHandler : public IStateHandler {
   std::atomic_uint32_t exchanges_{0};
 };
 
-class PublicKeyExchangeHandler : public IStateHandler {
- public:
-  bool validate(const State& state) const override {
-    return hasValue<concord::messages::ClientExchangePublicKey>(state);
-  }
-  bool execute(const State&, WriteState&) override {
-    LOG_INFO(getLogger(), "restart client components");
-    exchanges_++;
-    return true;
-  }
-  logging::Logger getLogger() {
-    static logging::Logger logger_(logging::getLogger("concord.client.reconfiguration.test.PublicKeyExchange"));
-    return logger_;
-  }
-  std::atomic_uint32_t exchanges_{0};
-};
-
 class ClientApiTestFixture : public ::testing::Test {
  public:
   void init(uint32_t number_of_ops) {
     for (uint32_t i = 0; i < number_of_ops; i++) {
-      blockchain_.emplace_back(
-          concord::messages::ClientReconfigurationStateReply{i + 1, concord::messages::ClientKeyExchangeCommand{{5}}});
+      blockchain_.emplace_back(concord::messages::ClientKeyExchangeCommand{{5}});
     }
   }
   ClientConfig test_config_ = {ClientId{5},
@@ -127,38 +109,24 @@ class ClientApiTestFixture : public ::testing::Test {
     deserialize(data, rreq);
     if (std::holds_alternative<concord::messages::ClientReconfigurationStateRequest>(rreq.command)) {
       concord::messages::ReconfigurationResponse rres;
-      uint32_t index = number_of_messages_ / 4;
-      if (index < blockchain_.size() - 1) {
-        number_of_messages_++;
+      concord::messages::ClientReconfigurationStateReply srep;
+      uint64_t i{1};
+      for (const auto& s : blockchain_) {
+        concord::messages::ClientStateReply rep;
+        rep.block_id = i;
+        rep.response = s;
+        srep.states.push_back(rep);
+        i++;
       }
-      concord::messages::ClientReconfigurationStateReply update{0, {}};
-      if (!blockchain_.empty()) update = blockchain_[index];
-      concord::messages::serialize(rres.additional_data, update);
+      rres.response = srep;
       rres.success = true;
       std::vector<uint8_t> msg_buf;
       concord::messages::serialize(msg_buf, rres);
       auto rep = createReply(msg, msg_buf);
       client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(rep.data()), rep.size());
     } else if (std::holds_alternative<concord::messages::ClientExchangePublicKey>(rreq.command)) {
-      auto update = std::get<concord::messages::ClientExchangePublicKey>(rreq.command);
-      if (number_of_updates_ % 4 == 0) {
-        concord::messages::ClientReconfigurationStateReply element{blockchain_.size() + 1, update};
-        blockchain_.push_back(element);
-      }
-      number_of_updates_++;
       concord::messages::ReconfigurationResponse rres;
-      rres.success = true;
-      std::vector<uint8_t> msg_buf;
-      concord::messages::serialize(msg_buf, rres);
-      auto rep = createReply(msg, msg_buf);
-      client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(rep.data()), rep.size());
-    } else if (std::holds_alternative<concord::messages::ClientReconfigurationLastUpdate>(rreq.command)) {
-      concord::messages::ClientReconfigurationStateReply crep = {0, {}};
-      if (updated_state && !blockchain_.empty()) {
-        crep = blockchain_.back();
-      }
-      concord::messages::ReconfigurationResponse rres;
-      concord::messages::serialize(rres.additional_data, crep);
+      pub_keys_.push_back(std::get<concord::messages::ClientExchangePublicKey>(rreq.command));
       rres.success = true;
       std::vector<uint8_t> msg_buf;
       concord::messages::serialize(msg_buf, rres);
@@ -166,10 +134,8 @@ class ClientApiTestFixture : public ::testing::Test {
       client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(rep.data()), rep.size());
     }
   }
-  std::vector<concord::messages::ClientReconfigurationStateReply> blockchain_;
-  uint32_t number_of_messages_{0};
-  uint32_t number_of_updates_{0};
-  bool updated_state = false;
+  std::vector<concord::messages::ClientKeyExchangeCommand> blockchain_;
+  std::vector<concord::messages::ClientExchangePublicKey> pub_keys_;
 };
 
 /*
@@ -202,10 +168,10 @@ TEST_F(ClientApiTestFixture, single_key_exchange_command) {
   auto keyExchangeHandler = std::make_shared<KeyExchangeHandler>(cre_config.id_);
   cre.registerHandler(keyExchangeHandler);
   cre.start();
-  while (aggregator->GetGauge(metrics_component, last_known_block_gauge).Get() < 2 ||
-         keyExchangeHandler->exchanges_ < 1) {
+  while (keyExchangeHandler->exchanges_ < 1 ||
+         aggregator->GetGauge(metrics_component, last_known_block_gauge).Get() < 1) {
   }
-  ASSERT_GE(aggregator->GetGauge(metrics_component, last_known_block_gauge).Get(), 2);
+  ASSERT_GE(aggregator->GetGauge(metrics_component, last_known_block_gauge).Get(), 1);
   ASSERT_GE(keyExchangeHandler->exchanges_, 1);
   cre.stop();
 }
@@ -222,16 +188,14 @@ TEST_F(ClientApiTestFixture, single_key_two_phases_exchange_command) {
   std::shared_ptr<concordMetrics::Aggregator> aggregator = std::make_shared<concordMetrics::Aggregator>();
   ClientReconfigurationEngine cre(cre_config, state_client, aggregator);
   auto keyExchangeHandler = std::make_shared<KeyExchangeHandler>(cre_config.id_);
-  auto clientPubKeyExchangeHandler = std::make_shared<PublicKeyExchangeHandler>();
   cre.registerHandler(keyExchangeHandler);
-  cre.registerHandler(clientPubKeyExchangeHandler);
   cre.start();
-  while (aggregator->GetGauge(metrics_component, last_known_block_gauge).Get() < 2 ||
-         keyExchangeHandler->exchanges_ < 1 || clientPubKeyExchangeHandler->exchanges_ < 1) {
+  while (aggregator->GetGauge(metrics_component, last_known_block_gauge).Get() < 1 ||
+         keyExchangeHandler->exchanges_ < 1 || pub_keys_.size() < 1) {
   }
-  ASSERT_GE(aggregator->GetGauge(metrics_component, last_known_block_gauge).Get(), 2);
-  ASSERT_GE(keyExchangeHandler->exchanges_, 1);
-  ASSERT_GE(clientPubKeyExchangeHandler->exchanges_, 1);
+  ASSERT_EQ(aggregator->GetGauge(metrics_component, last_known_block_gauge).Get(), 1);
+  ASSERT_EQ(keyExchangeHandler->exchanges_, 1);
+  ASSERT_GE(pub_keys_.size(), 1);
   cre.stop();
 }
 
@@ -247,44 +211,16 @@ TEST_F(ClientApiTestFixture, multiple_key_two_phases_exchange_command) {
   std::shared_ptr<concordMetrics::Aggregator> aggregator = std::make_shared<concordMetrics::Aggregator>();
   ClientReconfigurationEngine cre(cre_config, state_client, aggregator);
   auto keyExchangeHandler = std::make_shared<KeyExchangeHandler>(cre_config.id_);
-  auto clientPubKeyExchangeHandler = std::make_shared<PublicKeyExchangeHandler>();
   cre.registerHandler(keyExchangeHandler);
-  cre.registerHandler(clientPubKeyExchangeHandler);
   cre.start();
-  while (aggregator->GetGauge(metrics_component, last_known_block_gauge).Get() < 21 ||
-         keyExchangeHandler->exchanges_ < 10 || clientPubKeyExchangeHandler->exchanges_ < 10) {
-  }
-  ASSERT_GE(aggregator->GetGauge(metrics_component, last_known_block_gauge).Get(), 21);
-  ASSERT_GE(keyExchangeHandler->exchanges_, 10);
-  ASSERT_GE(clientPubKeyExchangeHandler->exchanges_, 10);
-  cre.stop();
-}
-
-/*
- * Test starting with an update
- */
-TEST_F(ClientApiTestFixture, start_witn_an_update_exchange_command) {
-  init(10);
-  updated_state = true;
-  std::unique_ptr<FakeCommunication> comm(new FakeCommunication(
-      [&](const MsgFromClient& msg, IReceiver* client_receiver) { HandleClientStateRequests(msg, client_receiver); }));
-  IStateClient* state_client = new PollBasedStateClient(
-      new bft::client::Client(std::move(comm), test_config_), cre_config.interval_timeout_ms_, 0, cre_config.id_);
-  std::shared_ptr<concordMetrics::Aggregator> aggregator = std::make_shared<concordMetrics::Aggregator>();
-  ClientReconfigurationEngine cre(cre_config, state_client, aggregator);
-  auto keyExchangeHandler = std::make_shared<KeyExchangeHandler>(cre_config.id_);
-  auto clientPubKeyExchangeHandler = std::make_shared<PublicKeyExchangeHandler>();
-  cre.registerHandler(keyExchangeHandler);
-  cre.registerHandler(clientPubKeyExchangeHandler);
-  cre.start();
-  while (aggregator->GetGauge(metrics_component, last_known_block_gauge).Get() < 10) {
+  while (aggregator->GetGauge(metrics_component, last_known_block_gauge).Get() < 10 ||
+         keyExchangeHandler->exchanges_ < 10 || pub_keys_.size() < 10) {
   }
   ASSERT_EQ(aggregator->GetGauge(metrics_component, last_known_block_gauge).Get(), 10);
-  ASSERT_EQ(keyExchangeHandler->exchanges_, 0);
-  ASSERT_EQ(clientPubKeyExchangeHandler->exchanges_, 0);
+  ASSERT_EQ(keyExchangeHandler->exchanges_, 10);
+  ASSERT_GE(pub_keys_.size(), 10);
   cre.stop();
 }
-
 }  // namespace
 
 int main(int argc, char* argv[]) {

--- a/client/reconfiguration/test/poll_based_state_client_test.cpp
+++ b/client/reconfiguration/test/poll_based_state_client_test.cpp
@@ -118,7 +118,7 @@ class ClientApiTestFixture : public ::testing::Test {
         srep.states.push_back(rep);
         i++;
       }
-      rres.response = srep;
+      concord::messages::serialize(rres.additional_data, srep);
       rres.success = true;
       std::vector<uint8_t> msg_buf;
       concord::messages::serialize(msg_buf, rres);

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -51,11 +51,6 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
               uint64_t,
               uint32_t,
               concord::messages::ReconfigurationResponse&) override;
-
-  bool handle(const concord::messages::ClientReconfigurationLastUpdate&,
-              uint64_t,
-              uint32_t,
-              concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientReconfigurationStateRequest&,
               uint64_t,
               uint32_t,
@@ -66,8 +61,8 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
               concord::messages::ReconfigurationResponse&) override;
 
  private:
-  concord::messages::ClientReconfigurationStateReply buildClientStateReply(
-      kvbc::BlockId, kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type, uint32_t clientid);
+  concord::messages::ClientStateReply buildClientStateReply(kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type,
+                                                            uint32_t clientid);
 };
 /**
  * This component is responsible for logging reconfiguration request (issued by an authorized operator) in the

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -140,9 +140,12 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
   concord::messages::ClientReconfigurationStateReply rep;
   for (uint8_t i = kvbc::keyTypes::CLIENT_COMMAND_TYPES::start_ + 1; i < kvbc::keyTypes::CLIENT_COMMAND_TYPES::end_;
        i++) {
-    rep.states.push_back(buildClientStateReply(static_cast<keyTypes::CLIENT_COMMAND_TYPES>(i), sender_id));
+    auto csrep = buildClientStateReply(static_cast<keyTypes::CLIENT_COMMAND_TYPES>(i), sender_id);
+    if (csrep.block_id == 0) continue;
+    rep.states.push_back(csrep);
   }
-  rres.response = rep;
+  LOG_INFO(GL, "b(2)");
+  concord::messages::serialize(rres.additional_data, rep);
   return true;
 }
 

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -86,17 +86,15 @@ kvbc::BlockId ReconfigurationBlockTools::persistNewEpochBlock(const uint64_t bft
   LOG_INFO(GL, "Starting new epoch " << KVLOG(newEpoch, block_id));
   return block_id;
 }
-concord::messages::ClientReconfigurationStateReply KvbcClientReconfigurationHandler::buildClientStateReply(
-    kvbc::BlockId blockid, kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type, uint32_t clientid) {
-  concord::messages::ClientReconfigurationStateReply creply;
+concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildClientStateReply(
+    kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type, uint32_t clientid) {
+  concord::messages::ClientStateReply creply;
   creply.block_id = 0;
-  if (blockid > 0) {
-    creply.block_id = blockid;
-    auto res = ro_storage_.get(
-        kvbc::kConcordInternalCategoryId,
-        std::string{kvbc::keyTypes::reconfiguration_client_data_prefix, static_cast<char>(command_type)} +
-            std::to_string(clientid),
-        blockid);
+  auto res = ro_storage_.getLatest(
+      kvbc::kConcordInternalCategoryId,
+      std::string{kvbc::keyTypes::reconfiguration_client_data_prefix, static_cast<char>(command_type)} +
+          std::to_string(clientid));
+  if (res.has_value()) {
     std::visit(
         [&](auto&& arg) {
           auto strval = arg.data;
@@ -129,6 +127,7 @@ concord::messages::ClientReconfigurationStateReply KvbcClientReconfigurationHand
             default:
               break;
           }
+          creply.block_id = arg.block_id;
         },
         *res);
   }
@@ -138,27 +137,12 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
                                               concord::messages::ReconfigurationResponse& rres) {
-  // We want to rotate over the latest updates of this client and find the earliest one which is higher than the client
-  // last known block
-  kvbc::BlockId minKnownUpdate{0};
-  uint8_t command_type = 0;
+  concord::messages::ClientReconfigurationStateReply rep;
   for (uint8_t i = kvbc::keyTypes::CLIENT_COMMAND_TYPES::start_ + 1; i < kvbc::keyTypes::CLIENT_COMMAND_TYPES::end_;
        i++) {
-    auto key = std::string{kvbc::keyTypes::reconfiguration_client_data_prefix, static_cast<char>(i)} +
-               std::to_string(sender_id);
-    auto res = ro_storage_.getLatestVersion(kvbc::kConcordInternalCategoryId, key);
-    if (res.has_value()) {
-      auto blockid = res.value().version;
-      if (blockid > command.last_known_block && (minKnownUpdate == 0 || minKnownUpdate > blockid)) {
-        minKnownUpdate = blockid;
-        command_type = i;
-      }
-      LOG_INFO(getLogger(), "found a client update on chain " << KVLOG(sender_id, i, blockid));
-    }
+    rep.states.push_back(buildClientStateReply(static_cast<keyTypes::CLIENT_COMMAND_TYPES>(i), sender_id));
   }
-  auto creply =
-      buildClientStateReply(minKnownUpdate, static_cast<keyTypes::CLIENT_COMMAND_TYPES>(command_type), sender_id);
-  concord::messages::serialize(rres.additional_data, creply);
+  rres.response = rep;
   return true;
 }
 
@@ -176,32 +160,6 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExc
           std::to_string(sender_id),
       false);
   LOG_INFO(getLogger(), "block id: " << blockId);
-  return true;
-}
-bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientReconfigurationLastUpdate& command,
-                                              uint64_t,
-                                              uint32_t sender_id,
-                                              concord::messages::ReconfigurationResponse& rres) {
-  // We want to rotate over the latest updates of this client and find the latest one in the blockchain
-  kvbc::BlockId maxKnownUpdate{0};
-  uint8_t command_type = 0;
-  for (uint8_t i = kvbc::keyTypes::CLIENT_COMMAND_TYPES::start_ + 1; i < kvbc::keyTypes::CLIENT_COMMAND_TYPES::end_;
-       i++) {
-    auto key = std::string{kvbc::keyTypes::reconfiguration_client_data_prefix, static_cast<char>(i)} +
-               std::to_string(sender_id);
-    auto res = ro_storage_.getLatestVersion(kvbc::kConcordInternalCategoryId, key);
-    if (res.has_value()) {
-      auto blockid = res.value().version;
-      if (maxKnownUpdate < blockid) {
-        maxKnownUpdate = blockid;
-        command_type = i;
-      }
-      LOG_INFO(getLogger(), "found a client update on chain " << KVLOG(sender_id, i, blockid));
-    }
-  }
-  auto creply =
-      buildClientStateReply(maxKnownUpdate, static_cast<keyTypes::CLIENT_COMMAND_TYPES>(command_type), sender_id);
-  concord::messages::serialize(rres.additional_data, creply);
   return true;
 }
 

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -158,12 +158,6 @@ Msg ClientExchangePublicKey 38 {
 
 Msg ClientReconfigurationStateUpdate 40 {
     uint64 sender_id
-    uint64 update_version
-    string data
-}
-
-Msg ClientReconfigurationLastUpdate 41 {
-    uint64 sender_id
 }
 
 Msg RestartCommand 42 {
@@ -198,7 +192,7 @@ Msg ClientKeyExchangeStatusResponse 48 {
      list kvpair uint32 ClientExchangePublicKey clients_keys
 }
 
-Msg ClientReconfigurationStateReply 39 {
+Msg ClientStateReply 39 {
     uint64 block_id
     oneof {
         ClientExchangePublicKey
@@ -206,6 +200,10 @@ Msg ClientReconfigurationStateReply 39 {
         ClientsAddRemoveCommand
         ClientsAddRemoveUpdateCommand
       } response
+}
+
+Msg ClientReconfigurationStateReply 49 {
+    list ClientStateReply states
 }
 
 Msg ReconfigurationRequest 1 {
@@ -232,7 +230,6 @@ Msg ReconfigurationRequest 1 {
     ClientKeyExchangeCommand
     ClientReconfigurationStateRequest
     ClientExchangePublicKey
-    ClientReconfigurationLastUpdate
     RestartCommand
     ClientsAddRemoveCommand
     ClientsAddRemoveStatusCommand
@@ -255,6 +252,7 @@ Msg ReconfigurationResponse 2 {
     AddRemoveStatusResponse
     AddRemoveWithWedgeStatusResponse
     UnwedgeStatusResponse
+    ClientReconfigurationStateReply
     ClientKeyExchangeCommandResponse
     ClientsAddRemoveStatusResponse
     ClientKeyExchangeStatusResponse

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -145,12 +145,6 @@ class IReconfigurationHandler {
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
-  virtual bool handle(const concord::messages::ClientReconfigurationLastUpdate&,
-                      uint64_t,
-                      uint32_t,
-                      concord::messages::ReconfigurationResponse&) {
-    return true;
-  }
 
   virtual bool handle(const concord::messages::RestartCommand&,
                       uint64_t,

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -133,13 +133,13 @@ class KeyExchangeCommandHandler : public IStateHandler {
     sm_.reset(new concord::secretsmanager::SecretsManagerPlain());
   }
   bool validate(const State& state) const {
-    concord::messages::ClientReconfigurationStateReply crep;
+    concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
     return std::holds_alternative<concord::messages::ClientKeyExchangeCommand>(crep.response);
   };
   bool execute(const State& state, WriteState& out) {
     LOG_INFO(getLogger(), "execute key exchange request");
-    concord::messages::ClientReconfigurationStateReply crep;
+    concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
     concord::messages::ClientKeyExchangeCommand command =
         std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
@@ -184,13 +184,13 @@ class KeyExchangeCommandHandler : public IStateHandler {
 class ClientsAddRemoveHandler : public IStateHandler {
  public:
   bool validate(const State& state) const override {
-    concord::messages::ClientReconfigurationStateReply crep;
+    concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
     return std::holds_alternative<concord::messages::ClientsAddRemoveCommand>(crep.response);
   }
   bool execute(const State& state, WriteState& out) override {
     LOG_INFO(getLogger(), "execute clientsAddRemoveCommand");
-    concord::messages::ClientReconfigurationStateReply crep;
+    concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
     concord::messages::ClientsAddRemoveCommand command =
         std::get<concord::messages::ClientsAddRemoveCommand>(crep.response);


### PR DESCRIPTION
In this PR we refactor and improve the CRE code.
The main change is, instead of fetching only the next state update, we fetch all the updates at once. 
This solves a bug with recovering after CRE crash if there were multiple state changes in the meantime 