### PR TITLE
Data race on udpSockFd fixed.

### DIFF
--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -682,7 +682,7 @@ TEST(requestPreprocessingState_test, batchMsgTimedOutOnPrimary) {
   }
   auto* clientBatchReqMsg = new ClientBatchRequestMsg(clientId, batch, batchSize, cid);
   msgHandlerCallback(clientBatchReqMsg);
-  usleep(replicaConfig.preExecReqStatusCheckTimerMillisec * 1000);
+  usleep(waitForExecTimerMillisec * 1000);
   ConcordAssertEQ(preProcessor.getOngoingReqIdForClient(clientId, 0), 5);
   ConcordAssertEQ(preProcessor.getOngoingReqIdForClient(clientId, 1), 6);
   ConcordAssertEQ(preProcessor.getOngoingReqIdForClient(clientId, 2), 7);


### PR DESCRIPTION
Two threads try to access `udpSockFd` file descriptor variable, resulting in data race.
One thread reads continuously, and another thread `close`es the socket using the file descriptor.

Change done: The thread responsible for reading/using `udpSockFd` now `close`es the file descriptor.