### PR TITLE
State transfer fix assert failure and modify flow control on storage error

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2679,7 +2679,7 @@ void BCStateTran::processData(bool lastInBatch) {
       bool retransmissionTimeoutExpired = sourceSelector_.retransmissionTimeoutExpired(currTime);
       if (newSourceReplica || retransmissionTimeoutExpired || lastInBatch) {
         if (isGettingBlocks) {
-          ConcordAssertEQ(psd_->getLastRequiredBlock(), nextRequiredBlock_);
+          ConcordAssertEQ(psd_->getLastRequiredBlock(), nextCommittedBlockId_);
           LOG_INFO(logger_,
                    "Sending FetchBlocksMsg: " << KVLOG(newSourceReplica, retransmissionTimeoutExpired, lastInBatch));
           sendFetchBlocksMsg(psd_->getFirstRequiredBlock(), nextRequiredBlock_, lastChunkInRequiredBlock);

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -204,9 +204,10 @@ class BCStateTran : public IStateTransfer {
 
   void sendAskForCheckpointSummariesMsg();
 
-  void sendFetchBlocksMsg(uint64_t firstRequiredBlock,
-                          uint64_t lastRequiredBlock,
-                          int16_t lastKnownChunkInLastRequiredBlock);
+  void trySendFetchBlocksMsg(uint64_t firstRequiredBlock,
+                             uint64_t lastRequiredBlock,
+                             int16_t lastKnownChunkInLastRequiredBlock,
+                             string&& reason);
 
   void sendFetchResPagesMsg(int16_t lastKnownChunkInLastRequiredBlock);
 
@@ -277,6 +278,7 @@ class BCStateTran : public IStateTransfer {
   uint64_t nextRequiredBlock_ = 0;
   uint64_t nextCommittedBlockId_ = 0;
   STDigest digestOfNextRequiredBlock;
+  bool posponedSendFetchBlocksMsg_;
 
   struct compareItemDataMsg {
     bool operator()(const ItemDataMsg* l, const ItemDataMsg* r) const {


### PR DESCRIPTION
Due to issues seen in RO replica, where the storage layer of RO replica was not functioning, I've found an assertion bug, and modified flow control to avoid sending FetchBlocksMsg to source when the context pool (ioPool) is empty.

Commits:
1) BCStateTran: fix wrong assertion
2) BCStateTran: avoid sending FetchBlocksMsg when ioPool is empty