### PR TITLE
BCStateTran: when stopped, wait for all jobs to gracefully end

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -387,6 +387,7 @@ void BCStateTran::stopRunning() {
   ConcordAssert(running_);
   ConcordAssertNE(replicaForStateTransfer_, nullptr);
   if (handoff_) handoff_->stop();
+  if (nextCommittedBlockId_ > 0) finalizePutblockAsync(false, PutBlockWaitPolicy::WAIT_ALL_JOBS);
 
   // TODO(GG): cancel timer
 


### PR DESCRIPTION
There might be some threads still working, and for a destination ST
replica we would also like to finalize all jobs to advance and persist
the last block. Call finalizePutblockAsync before stopping.