### PR TITLE
Failed replica live restore.

### DIFF
--- a/bftengine/src/bftengine/messages/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.hpp
@@ -42,6 +42,8 @@ class CheckpointMsg : public MessageBase {
 
   void sign();
 
+  void setSenderId(NodeIdType id) { sender_ = id; }
+
  protected:
   template <typename MessageT>
   friend size_t sizeOfHeader();


### PR DESCRIPTION
Live means that no system wedge has to be performed as previously.
Additionally, removal of niether BFT metadata nor ST metadata is required.
ST metadata is updated to a state without active state transfer and without any pending reseved pages.
Replica Id is set to the one of a destination replica.
BFT metadata is updated to have a CheckpointMsg of the stable checkpoint to have a sender id of the destination replica.

This is achieved by invoking:
kv_blockchain_db_editor simpleKVBTests_DB_2 resetMetadata 3
Possible output:
{
  "new bft mdt": "0",
  "st": "replicaId 3",
  "stable seq num": "13350"
}