### PR TITLE
test_skvbc_client_transaction_signing: disable test_positive_write_batching_enabled

### DIFF
--- a/tests/apollo/test_skvbc_client_transaction_signing.py
+++ b/tests/apollo/test_skvbc_client_transaction_signing.py
@@ -208,6 +208,7 @@ class SkvbcTestClientTxnSigning(unittest.TestCase):
         await self.write_n_times(bft_network, skvbc, NUM_OF_SEQ_WRITES, pre_exec=True)
         await self.assert_metrics(bft_network, expected_num_signatures_verified=NUM_OF_SEQ_WRITES)
 
+    @unittest.skip("Unstable - see BC-11586")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_positive_write_batching_enabled(self, bft_network):


### PR DESCRIPTION
test_skvbc_client_transaction_signing: disable test_positive_write_batching_enabled

This test fails randomly. I Will have to fix it later, for now, I will disable it to keep CI stable.