### PR TITLE
Reset wedge state on state transfer

### DIFF
--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -120,6 +120,7 @@ bool StReconfigurationHandler::handle(const concord::messages::WedgeCommand &,
       bftEngine::ControlStateManager::instance().getCheckpointToStopAt().has_value()) {
     LOG_INFO(GL, "unwedge due to higher epoch number after state transfer");
     bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(0);
+    bftEngine::IControlHandler::instance()->resetState();
   }
   bftEngine::EpochManager::instance().setSelfEpochNumber(bftEngine::EpochManager::instance().getGlobalEpochNumber());
   return true;


### PR DESCRIPTION
When a crashed replica has done with state transfer and decides to unwedge, it needs to reset the wedge state.