### PR TITLE
TS: Provide timestamp to Reconfiguration handlers and save it in blocks

### DIFF
--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -45,7 +45,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
     } else if (req.flags & MsgFlag::RECONFIG_FLAG) {
       ReconfigurationRequest rreq;
       deserialize(std::vector<std::uint8_t>(req.request, req.request + req.requestSize), rreq);
-      ReconfigurationResponse rsi_res = reconfig_dispatcher_.dispatch(rreq, req.executionSequenceNum);
+      ReconfigurationResponse rsi_res = reconfig_dispatcher_.dispatch(rreq, req.executionSequenceNum, timestamp);
       // in case of read request return only a success part of and replica specific info in the response
       // and the rest as additional data, since it may differ between replicas
       if (req.flags & MsgFlag::READ_ONLY_FLAG) {

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -22,6 +22,7 @@ static const char reconfiguration_add_remove = 0x29;
 static const char reconfiguration_wedge_key = 0x2a;
 static const char reconfiguration_client_data_prefix = 0x2c;
 static const char reconfiguration_epoch_key = 0x2d;
+static const char timestamp_key = 0x2e;
 
 static const char reconfiguration_restart_key = 0x30;
 enum CLIENT_COMMAND_TYPES : uint8_t {

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -148,14 +148,17 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
   bool handle(const concord::messages::PruneRequest &,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
 
  protected:
@@ -197,6 +200,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &rres) override {
     if (!pruning_enabled_) return true;
     concord::messages::LatestPrunableBlock latest_prunable_block;
@@ -216,6 +220,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::PruneRequest &,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }
@@ -223,6 +228,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "TimeService.hpp"
 #include "reconfiguration/ireconfiguration.hpp"
 #include "db_interfaces.h"
 #include "hex_tools.h"
@@ -27,12 +28,14 @@ class ReconfigurationBlockTools {
       : blocks_adder_{block_adder}, block_metadata_{ro_storage}, ro_storage_{ro_storage} {}
   kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data,
                                             const uint64_t bft_seq_num,
+                                            const std::optional<bftEngine::Timestamp>& timestamp,
                                             string key,
                                             bool include_wedge);
   kvbc::BlockId persistReconfigurationBlock(concord::kvbc::categorization::VersionedUpdates& ver_updates,
                                             const uint64_t bft_seq_num,
+                                            const std::optional<bftEngine::Timestamp>& timestamp,
                                             bool include_wedge);
-  kvbc::BlockId persistNewEpochBlock(const uint64_t bft_seq_num);
+  kvbc::BlockId persistNewEpochBlock(const uint64_t bft_seq_num, const std::optional<bftEngine::Timestamp>& timestamp);
 
   kvbc::IBlockAdder& blocks_adder_;
   BlockMetadata block_metadata_;
@@ -50,19 +53,23 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientReconfigurationLastUpdate&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientReconfigurationStateRequest&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -83,78 +90,94 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::DownloadCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::InstallCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::KeyExchangeCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveStatus& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeStatus& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::PruneRequest& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientKeyExchangeCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
   bool handle(const concord::messages::RestartCommand&,
               uint64_t,
               uint32_t,
-              concord::messages::ReconfigurationResponse&) override;
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::UnwedgeCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::UnwedgeStatusRequest&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientsAddRemoveCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientKeyExchangeStatus&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -173,6 +196,7 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 };
 
@@ -188,6 +212,7 @@ class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IR
   bool handle(const concord::messages::ClientExchangePublicKey& command,
               uint64_t sequence_number,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -19,6 +19,7 @@
 #include "reconfiguration/ireconfiguration.hpp"
 #include "SysConsts.hpp"
 #include "block_metadata.hpp"
+#include "TimeService.hpp"
 
 namespace concord::kvbc {
 /*
@@ -52,6 +53,7 @@ class StReconfigurationHandler {
                            uint64_t bid,
                            uint64_t current_cp,
                            uint64_t bft_seq_num,
+                           const std::optional<bftEngine::Timestamp>&,
                            bool bft_support,
                            bool remove_metadata,
                            bool restart,
@@ -59,16 +61,50 @@ class StReconfigurationHandler {
   uint64_t getStoredBftSeqNum(BlockId bid);
   uint64_t getStoredEpochNumber(BlockId bid);
 
-  bool handle(const concord::messages::WedgeCommand&, uint64_t, uint64_t, uint64_t);
-  bool handle(const concord::messages::DownloadCommand&, uint64_t, uint64_t, uint64_t) { return true; }
+  bool handle(
+      const concord::messages::WedgeCommand&, uint64_t, uint64_t, uint64_t, const std::optional<bftEngine::Timestamp>&);
+  bool handle(const concord::messages::DownloadCommand&,
+              uint64_t,
+              uint64_t,
+              uint64_t,
+              const std::optional<bftEngine::Timestamp>&) {
+    return true;
+  }
 
-  bool handle(const concord::messages::InstallCommand&, uint64_t, uint64_t, uint64_t) { return true; }
+  bool handle(const concord::messages::InstallCommand&,
+              uint64_t,
+              uint64_t,
+              uint64_t,
+              const std::optional<bftEngine::Timestamp>&) {
+    return true;
+  }
 
-  bool handle(const concord::messages::KeyExchangeCommand&, uint64_t, uint64_t, uint64_t) { return true; }
-  bool handle(const concord::messages::AddRemoveCommand&, uint64_t, uint64_t, uint64_t) { return true; }
-  bool handle(const concord::messages::AddRemoveWithWedgeCommand&, uint64_t, uint64_t, uint64_t);
-  bool handle(const concord::messages::RestartCommand&, uint64_t, uint64_t, uint64_t);
-  bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
+  bool handle(const concord::messages::KeyExchangeCommand&,
+              uint64_t,
+              uint64_t,
+              uint64_t,
+              const std::optional<bftEngine::Timestamp>&) {
+    return true;
+  }
+  bool handle(const concord::messages::AddRemoveCommand&,
+              uint64_t,
+              uint64_t,
+              uint64_t,
+              const std::optional<bftEngine::Timestamp>&) {
+    return true;
+  }
+  bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
+              uint64_t,
+              uint64_t,
+              uint64_t,
+              const std::optional<bftEngine::Timestamp>&);
+  bool handle(const concord::messages::RestartCommand&,
+              uint64_t,
+              uint64_t,
+              uint64_t,
+              const std::optional<bftEngine::Timestamp>&);
+  bool handle(
+      const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t, const std::optional<bftEngine::Timestamp>&);
 
   kvbc::IReader& ro_storage_;
   BlockMetadata block_metadata_;

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -140,6 +140,7 @@ PruningHandler::PruningHandler(kvbc::IReader& ro_storage,
 bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest& latest_prunable_block_request,
                             uint64_t,
                             uint32_t,
+                            const std::optional<bftEngine::Timestamp>&,
                             concord::messages::ReconfigurationResponse& rres) {
   // If pruning is disabled, return 0. Otherwise, be conservative and prune the
   // smaller block range.
@@ -167,6 +168,7 @@ bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest&
 bool PruningHandler::handle(const concord::messages::PruneRequest& request,
                             uint64_t bftSeqNum,
                             uint32_t,
+                            const std::optional<bftEngine::Timestamp>&,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
 
@@ -250,6 +252,7 @@ void PruningHandler::pruneThroughBlockId(kvbc::BlockId block_id) const {
 bool PruningHandler::handle(const concord::messages::PruneStatusRequest&,
                             uint64_t,
                             uint32_t,
+                            const std::optional<bftEngine::Timestamp>&,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
   concord::messages::PruneStatus prune_status;

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -14,20 +14,21 @@
 #include "ControlStateManager.hpp"
 #include "bftengine/EpochManager.hpp"
 #include "bftengine/ReconfigurationCmd.hpp"
+#include "concord.cmf.hpp"
 #include "endianness.hpp"
 #include "kvbc_app_filter/kvbc_key_types.h"
 
 namespace concord::kvbc::reconfiguration {
 
-kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(const std::vector<uint8_t>& data,
-                                                                     const uint64_t bft_seq_num,
-                                                                     string key,
-                                                                     bool include_wedge) {
+kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
+    const std::vector<uint8_t>& data,
+    const uint64_t bft_seq_num,
+    const std::optional<bftEngine::Timestamp>& timestamp,
+    string key,
+    bool include_wedge) {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   ver_updates.addUpdate(std::move(key), std::string(data.begin(), data.end()));
 
-  // All blocks are expected to have the BFT sequence number as a key.
-  ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, block_metadata_.serialize(bft_seq_num));
   uint64_t epoch = 0;
   auto value = ro_storage_.getLatest(kConcordInternalCategoryId, std::string{keyTypes::reconfiguration_epoch_key});
   if (value.has_value()) {
@@ -37,25 +38,15 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(const std::
   }
   auto current_epoch_buf = concordUtils::toBigEndianStringBuffer(epoch);
   ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, std::move(current_epoch_buf));
-  if (include_wedge) {
-    concord::messages::WedgeCommand wedge_command;
-    std::vector<uint8_t> wedge_buf;
-    concord::messages::serialize(wedge_buf, wedge_command);
-    ver_updates.addUpdate(std::string{keyTypes::reconfiguration_wedge_key},
-                          std::string(wedge_buf.begin(), wedge_buf.end()));
-  }
-  concord::kvbc::categorization::Updates updates;
-  updates.add(kvbc::kConcordInternalCategoryId, std::move(ver_updates));
-  try {
-    return blocks_adder_.add(std::move(updates));
-  } catch (const std::exception& e) {
-    LOG_ERROR(GL, "failed to persist the reconfiguration block: " << e.what());
-    throw;
-  }
+
+  return persistReconfigurationBlock(ver_updates, bft_seq_num, timestamp, include_wedge);
 }
 
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
-    concord::kvbc::categorization::VersionedUpdates& ver_updates, const uint64_t bft_seq_num, bool include_wedge) {
+    concord::kvbc::categorization::VersionedUpdates& ver_updates,
+    const uint64_t bft_seq_num,
+    const std::optional<bftEngine::Timestamp>& timestamp,
+    bool include_wedge) {
   // All blocks are expected to have the BFT sequence number as a key.
   ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, block_metadata_.serialize(bft_seq_num));
   if (include_wedge) {
@@ -65,6 +56,16 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
     ver_updates.addUpdate(std::string{keyTypes::reconfiguration_wedge_key},
                           std::string(wedge_buf.begin(), wedge_buf.end()));
   }
+  if (timestamp) {
+    concord::messages::Timestamp cmf_ts;
+    cmf_ts.time_since_epoch = timestamp->time_since_epoch.count();
+    cmf_ts.request_position = timestamp->request_position;
+    std::vector<uint8_t> serialized_ts;
+    concord::messages::serialize(serialized_ts, cmf_ts);
+    ver_updates.addUpdate(std::string{keyTypes::timestamp_key},
+                          std::string(serialized_ts.begin(), serialized_ts.end()));
+  }
+
   concord::kvbc::categorization::Updates updates;
   updates.add(kvbc::kConcordInternalCategoryId, std::move(ver_updates));
   try {
@@ -75,12 +76,13 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
   }
 }
 
-kvbc::BlockId ReconfigurationBlockTools::persistNewEpochBlock(const uint64_t bft_seq_num) {
+kvbc::BlockId ReconfigurationBlockTools::persistNewEpochBlock(const uint64_t bft_seq_num,
+                                                              const std::optional<bftEngine::Timestamp>& timestamp) {
   auto newEpoch = bftEngine::EpochManager::instance().getSelfEpochNumber() + 1;
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   ver_updates.addUpdate(std::string{kvbc::keyTypes::reconfiguration_epoch_key},
                         concordUtils::toBigEndianStringBuffer(newEpoch));
-  auto block_id = persistReconfigurationBlock(ver_updates, bft_seq_num, false);
+  auto block_id = persistReconfigurationBlock(ver_updates, bft_seq_num, timestamp, false);
   bftEngine::EpochManager::instance().setSelfEpochNumber(newEpoch);
   bftEngine::EpochManager::instance().setGlobalEpochNumber(newEpoch);
   LOG_INFO(GL, "Starting new epoch " << KVLOG(newEpoch, block_id));
@@ -137,6 +139,7 @@ concord::messages::ClientReconfigurationStateReply KvbcClientReconfigurationHand
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientReconfigurationStateRequest& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
+                                              const std::optional<bftEngine::Timestamp>&,
                                               concord::messages::ReconfigurationResponse& rres) {
   // We want to rotate over the latest updates of this client and find the earliest one which is higher than the client
   // last known block
@@ -165,12 +168,14 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
+                                              const std::optional<bftEngine::Timestamp>& timestamp,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
       serialized_command,
       bft_seq_num,
+      timestamp,
       std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
                   static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::PUBLIC_KEY_EXCHANGE)} +
           std::to_string(sender_id),
@@ -181,6 +186,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExc
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientReconfigurationLastUpdate& command,
                                               uint64_t,
                                               uint32_t sender_id,
+                                              const std::optional<bftEngine::Timestamp>&,
                                               concord::messages::ReconfigurationResponse& rres) {
   // We want to rotate over the latest updates of this client and find the latest one in the blockchain
   kvbc::BlockId maxKnownUpdate{0};
@@ -208,12 +214,14 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveUpdateCommand& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
+                                              const std::optional<bftEngine::Timestamp>& timestamp,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
       serialized_command,
       bft_seq_num,
+      timestamp,
       std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
                   static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_SCALING_COMMAND_STATUS)} +
           std::to_string(sender_id),
@@ -225,6 +233,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientsAd
 bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveStatusCommand&,
                                     uint64_t,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ClientsAddRemoveStatusResponse stats;
   for (const auto& gr : txKeysClientGroups_) {
@@ -252,6 +261,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveSta
 bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeStatus&,
                                     uint64_t,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ClientKeyExchangeStatusResponse stats;
   for (const auto& gr : txKeysClientGroups_) {
@@ -278,11 +288,12 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeSt
 bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key}, false);
+      serialized_command, bft_seq_num, timestamp, std::string{kvbc::keyTypes::reconfiguration_wedge_key}, false);
   LOG_INFO(getLogger(), "WedgeCommand block is " << blockId);
   return true;
 }
@@ -290,11 +301,12 @@ bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& comma
 bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_download_key}, false);
+      serialized_command, bft_seq_num, timestamp, std::string{kvbc::keyTypes::reconfiguration_download_key}, false);
   LOG_INFO(getLogger(), "DownloadCommand command block is " << blockId);
   return true;
 }
@@ -302,11 +314,12 @@ bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& co
 bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_install_key}, false);
+      serialized_command, bft_seq_num, timestamp, std::string{kvbc::keyTypes::reconfiguration_install_key}, false);
   LOG_INFO(getLogger(), "InstallCommand command block is " << blockId);
   return true;
 }
@@ -314,11 +327,12 @@ bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& com
 bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_key_exchange}, false);
+      serialized_command, sequence_number, timestamp, std::string{kvbc::keyTypes::reconfiguration_key_exchange}, false);
   LOG_INFO(getLogger(), "KeyExchangeCommand command block is " << blockId);
   return true;
 }
@@ -326,11 +340,12 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_add_remove}, false);
+      serialized_command, sequence_number, timestamp, std::string{kvbc::keyTypes::reconfiguration_add_remove}, false);
   LOG_INFO(getLogger(), "AddRemoveCommand command block is " << blockId);
   return true;
 }
@@ -338,6 +353,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& c
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -346,7 +362,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
                         std::string(serialized_command.begin(), serialized_command.end()));
   auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
   ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, concordUtils::toBigEndianStringBuffer(epoch));
-  auto blockId = persistReconfigurationBlock(ver_updates, sequence_number, true);
+  auto blockId = persistReconfigurationBlock(ver_updates, sequence_number, timestamp, true);
   LOG_INFO(getLogger(), "AddRemove configuration command block is " << blockId);
   // update reserved pages for RO replica
   auto epochNum = bftEngine::EpochManager::instance().getSelfEpochNumber();
@@ -366,11 +382,12 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
 bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_restart_key}, true);
+      serialized_command, bft_seq_num, timestamp, std::string{kvbc::keyTypes::reconfiguration_restart_key}, true);
   LOG_INFO(getLogger(), "RestartCommand block is " << blockId);
   return true;
 }
@@ -378,6 +395,7 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& response) {
   auto res =
       ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_add_remove});
@@ -403,6 +421,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& co
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeStatus& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& response) {
   auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId,
                                    std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
@@ -433,11 +452,15 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
 bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
-  auto blockId = persistReconfigurationBlock(
-      serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1}, false);
+  auto blockId = persistReconfigurationBlock(serialized_command,
+                                             sequence_number,
+                                             timestamp,
+                                             std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
+                                             false);
   LOG_INFO(getLogger(), "PruneRequest configuration command block is " << blockId);
   return true;
 }
@@ -445,6 +468,7 @@ bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& comma
 bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse& response) {
   std::vector<uint32_t> target_clients;
   for (auto& cid : command.target_clients) {
@@ -472,7 +496,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCo
     ver_updates.addUpdate(key_prefix + std::to_string(clientid),
                           std::string(serialized_command.begin(), serialized_command.end()));
   }
-  ckecr.block_id = persistReconfigurationBlock(ver_updates, sequence_number, false);
+  ckecr.block_id = persistReconfigurationBlock(ver_updates, sequence_number, timestamp, false);
   LOG_INFO(getLogger(), "target clients: [" << oss.str() << "] block: " << ckecr.block_id);
   response.response = ckecr;
   return true;
@@ -481,6 +505,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCo
 bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t sender_id,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse& response) {
   std::vector<uint32_t> target_clients;
   // We don't want to assume anything about the CRE client id. Hence, we write the update to all clients.
@@ -499,7 +524,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveCom
     ver_updates.addUpdate(key_prefix + std::to_string(clientid),
                           std::string(serialized_command.begin(), serialized_command.end()));
   }
-  auto block_id = persistReconfigurationBlock(ver_updates, sequence_number, false);
+  auto block_id = persistReconfigurationBlock(ver_updates, sequence_number, timestamp, false);
   LOG_INFO(getLogger(), "ClientsAddRemoveCommand block_id is: " << block_id);
   return true;
 }
@@ -507,6 +532,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveCom
 bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse&) {
   if (!bftEngine::ControlStateManager::instance().getCheckpointToStopAt().has_value()) {
     LOG_INFO(getLogger(), "replica is already unwedge");
@@ -531,7 +557,7 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
   bool can_unwedge = (valid_sigs >= quorum_size);
   if (can_unwedge) {
     if (!cmd.restart) {
-      persistNewEpochBlock(bft_seq_num);
+      persistNewEpochBlock(bft_seq_num, timestamp);
       bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(0);
       bftEngine::IControlHandler::instance()->resetState();
       LOG_INFO(getLogger(), "Unwedge command completed successfully");
@@ -546,6 +572,7 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
 bool ReconfigurationHandler::handle(const messages::UnwedgeStatusRequest& req,
                                     uint64_t,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::UnwedgeStatusResponse response;
   response.replica_id = bftEngine::ReplicaConfig::instance().replicaId;
@@ -583,6 +610,7 @@ bool InternalKvReconfigurationHandler::verifySignature(uint32_t sender_id,
 bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                               uint64_t bft_seq_num,
                                               uint32_t,
+                                              const std::optional<bftEngine::Timestamp>& timestamp,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -593,7 +621,7 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeComm
       return false;
     }
     auto blockId = persistReconfigurationBlock(
-        serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key, 0x1}, false);
+        serialized_command, bft_seq_num, timestamp, std::string{kvbc::keyTypes::reconfiguration_wedge_key, 0x1}, false);
     LOG_INFO(getLogger(), "received noop command, a new block will be written" << KVLOG(bft_seq_num, blockId));
     return true;
   }
@@ -603,12 +631,13 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeComm
 bool InternalPostKvReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& command,
                                                   uint64_t sequence_number,
                                                   uint32_t,
+                                                  const std::optional<bftEngine::Timestamp>& timestamp,
                                                   concord::messages::ReconfigurationResponse& response) {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   auto updated_client_keys = SigManager::instance()->getClientsPublicKeys();
 
   ver_updates.addUpdate(std::string(1, concord::kvbc::kClientsPublicKeys), std::string(updated_client_keys));
-  auto id = persistReconfigurationBlock(ver_updates, sequence_number, false);
+  auto id = persistReconfigurationBlock(ver_updates, sequence_number, timestamp, false);
   LOG_INFO(getLogger(),
            "Writing client keys to block [" << id << "] after key exchange, keys "
                                             << std::hash<std::string>{}(updated_client_keys));

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -10,6 +10,10 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#include <optional>
+#include "TimeService.hpp"
+#include "concord.cmf.hpp"
+#include "kvbc_key_types.hpp"
 #include "st_reconfiguraion_sm.hpp"
 #include "hex_tools.h"
 #include "endianness.hpp"
@@ -78,15 +82,25 @@ bool StReconfigurationHandler::handleStoredCommand(const std::string &key, uint6
     auto strval = std::visit([](auto &&arg) { return arg.data; }, *res);
     T cmd;
     deserializeCmfMessage(cmd, strval);
-    return handle(cmd, seqNum, current_cp_num, blockid);
+    std::optional<bftEngine::Timestamp> timestamp = std::nullopt;
+    auto value = ro_storage_.get(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::timestamp_key}, blockid);
+    if (value) {
+      const auto &data = std::get<categorization::VersionedValue>(*value).data;
+      concord::messages::Timestamp cmf_ts;
+      deserializeCmfMessage(cmf_ts, data);
+      timestamp.emplace(
+          bftEngine::Timestamp{bftEngine::ConsensusTime{cmf_ts.time_since_epoch}, cmf_ts.request_position});
+    }
+    return handle(cmd, seqNum, current_cp_num, blockid, timestamp);
   }
   return false;
-}
+}  // namespace concord::kvbc
 
 bool StReconfigurationHandler::handle(const concord::messages::WedgeCommand &,
                                       uint64_t bft_seq_num,
                                       uint64_t current_cp_num,
-                                      uint64_t bid) {
+                                      uint64_t bid,
+                                      const std::optional<bftEngine::Timestamp> &) {
   auto my_last_known_epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
   auto last_known_global_epoch = bftEngine::EpochManager::instance().getGlobalEpochNumber();
   auto command_epoch = getStoredEpochNumber(bid);
@@ -113,23 +127,40 @@ bool StReconfigurationHandler::handle(const concord::messages::WedgeCommand &,
 bool StReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand &command,
                                       uint64_t bft_seq_num,
                                       uint64_t current_cp_num,
-                                      uint64_t bid) {
-  return handleWedgeCommands(
-      command, bid, current_cp_num, bft_seq_num, command.bft_support, true, command.restart, command.restart);
+                                      uint64_t bid,
+                                      const std::optional<bftEngine::Timestamp> &timestamp) {
+  return handleWedgeCommands(command,
+                             bid,
+                             current_cp_num,
+                             bft_seq_num,
+                             timestamp,
+                             command.bft_support,
+                             true,
+                             command.restart,
+                             command.restart);
 }
 
 bool StReconfigurationHandler::handle(const concord::messages::RestartCommand &command,
                                       uint64_t bft_seq_num,
                                       uint64_t current_cp_num,
-                                      uint64_t bid) {
-  return handleWedgeCommands(
-      command, bid, current_cp_num, bft_seq_num, command.bft_support, true, command.restart, command.restart);
+                                      uint64_t bid,
+                                      const std::optional<bftEngine::Timestamp> &timestamp) {
+  return handleWedgeCommands(command,
+                             bid,
+                             current_cp_num,
+                             bft_seq_num,
+                             timestamp,
+                             command.bft_support,
+                             true,
+                             command.restart,
+                             command.restart);
 }
 template <typename T>
 bool StReconfigurationHandler::handleWedgeCommands(const T &cmd,
                                                    uint64_t bid,
                                                    uint64_t current_cp,
                                                    uint64_t bft_seq_num,
+                                                   const std::optional<bftEngine::Timestamp> &timestamp,
                                                    bool bft_support,
                                                    bool remove_metadata,
                                                    bool restart,
@@ -150,28 +181,32 @@ bool StReconfigurationHandler::handleWedgeCommands(const T &cmd,
   if (my_last_known_epoch == command_epoch && my_last_known_epoch == last_known_global_epoch && cp_sn < wedge_point)
     return true;  // We still need to complete another state transfer
 
-  // If we reached to this point, we are defiantly going to run the addRemove command,
-  // so lets invoke all original reconfiguration handlers from the product layer (without concord-bft's ones)
+  // If we reached to this point, we are defiantly going to run the addRemove
+  // command, so lets invoke all original reconfiguration handlers from the
+  // product layer (without concord-bft's ones)
   concord::messages::ReconfigurationResponse response;
   for (auto &h : orig_reconf_handlers_) {
-    h->handle(cmd, bft_seq_num, UINT32_MAX, response);
+    h->handle(cmd, bft_seq_num, UINT32_MAX, timestamp, response);
   }
 
   if (my_last_known_epoch < last_known_global_epoch) {
-    // now, we cannot rely on the received sequence number (as it may be reused), we simply want to stop immediately
+    // now, we cannot rely on the received sequence number (as it may be reused),
+    // we simply want to stop immediately
     auto fake_seq_num = cp_sn - 2 * checkpointWindowSize;
     bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(fake_seq_num);
     bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack([=]() {
       if (remove_metadata) bftEngine::ControlStateManager::instance().markRemoveMetadata(false);
-      // We want to rely on the new transferred epoch and not to start a new one (in case someone marked it)
+      // We want to rely on the new transferred epoch and not to start a new one
+      // (in case someone marked it)
       if (unwedge) bftEngine::EpochManager::instance().setNewEpochFlag(false);
       bftEngine::ControlStateManager::instance().restart();
     });
     return true;
   }
   if (my_last_known_epoch == command_epoch && cp_sn == wedge_point) {
-    // Now we want to act normally as we just managed to catch the "correct state" from our point of view.
-    // So lets simple run manually the concord-bft's reconfiguration handler.
+    // Now we want to act normally as we just managed to catch the "correct state"
+    // from our point of view. So lets simple run manually the concord-bft's
+    // reconfiguration handler.
     bftEngine::ControlStateManager::instance().setRestartBftFlag(bft_support);
     if (bft_support) {
       if (remove_metadata)
@@ -203,15 +238,17 @@ bool StReconfigurationHandler::handleWedgeCommands(const T &cmd,
 bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &command,
                                       uint64_t bft_seq_num,
                                       uint64_t,
-                                      uint64_t) {
-  // Actual pruning will be done from the lowest latestPruneableBlock returned by the replicas. It means, that even
-  // on every state transfer there might be at most one relevant pruning command. Hence it is enough to take the latest
+                                      uint64_t,
+                                      const std::optional<bftEngine::Timestamp> &timestamp) {
+  // Actual pruning will be done from the lowest latestPruneableBlock returned by
+  // the replicas. It means, that even on every state transfer there might be at
+  // most one relevant pruning command. Hence it is enough to take the latest
   // saved command and try to execute it
   bool succ = true;
   concord::messages::ReconfigurationResponse response;
   for (auto &h : orig_reconf_handlers_) {
     // If it was written to the blockchain, it means that this is a valid request.
-    succ &= h->handle(command, bft_seq_num, UINT32_MAX, response);
+    succ &= h->handle(command, bft_seq_num, UINT32_MAX, timestamp, response);
   }
   return succ;
 }

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -701,7 +701,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_correct_num_bocks_to_keep) {
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, replica_idx, verifier);
   ASSERT_EQ(resp.block_id, LAST_BLOCK_ID - num_blocks_to_keep);
@@ -722,7 +722,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_big_num_blocks_to_keep) {
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, replica_idx, verifier);
   // Verify that the returned block ID is 0 when pruning_num_blocks_to_keep is
@@ -749,7 +749,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_no_pruning_conf) {
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, 1, verifier);
   // Verify that when pruning is enabled and both pruning_num_blocks_to_keep and
@@ -776,7 +776,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_pruning_disabled) {
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
 
   // Verify that when pruning is disabled, there is no answer.
   ASSERT_EQ(std::holds_alternative<concord::messages::LatestPrunableBlock>(rres.response), false);
@@ -796,7 +796,7 @@ TEST_F(test_rocksdb, sm_handle_prune_request_on_pruning_disabled) {
 
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas);
   concord::messages::ReconfigurationResponse rres;
-  auto res = sm.handle(req, 0, UINT32_MAX, rres);
+  auto res = sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
   ASSERT_TRUE(res);
 }
 TEST_F(test_rocksdb, sm_handle_correct_prune_request) {
@@ -818,7 +818,7 @@ TEST_F(test_rocksdb, sm_handle_correct_prune_request) {
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas, latest_prunable_block_id);
   blocks_deleter.deleteBlocksUntil(latest_prunable_block_id + 1);
   concord::messages::ReconfigurationResponse rres;
-  auto res = sm.handle(req, 0, UINT32_MAX, rres);
+  auto res = sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
 
   ASSERT_TRUE(res);
 }
@@ -848,7 +848,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     latest_prunnable_block.signature = block.signature;
     req.latest_prunable_block.push_back(std::move(latest_prunnable_block));
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, UINT32_MAX, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);
@@ -859,7 +859,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas);
     req.latest_prunable_block.pop_back();
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, UINT32_MAX, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);
@@ -871,7 +871,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     auto &block = req.latest_prunable_block[req.latest_prunable_block.size() - 1];
     block.signature[0] += 1;
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, UINT32_MAX, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, std::nullopt, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -198,6 +198,11 @@ Msg ClientKeyExchangeStatusResponse 48 {
      list kvpair uint32 ClientExchangePublicKey clients_keys
 }
 
+Msg Timestamp 49 {
+    int64 time_since_epoch
+    uint64 request_position
+}
+
 Msg ClientReconfigurationStateReply 39 {
     uint64 block_id
     oneof {

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -16,6 +16,7 @@
 #include "concord.cmf.hpp"
 #include "OpenTracing.hpp"
 #include "Logger.hpp"
+#include "TimeService.hpp"
 
 namespace concord::reconfiguration {
 // The dispatcher forwards all messages to their appropriate handlers.
@@ -34,7 +35,8 @@ class Dispatcher {
   // blockchain and document it as part of the state. This will be under the
   // responsibility of each handler to write its own commands to the blockchain.
   concord::messages::ReconfigurationResponse dispatch(const concord::messages::ReconfigurationRequest&,
-                                                      uint64_t sequence_num);
+                                                      uint64_t sequence_num,
+                                                      const std::optional<bftEngine::Timestamp>& timestamp);
 
   void addReconfigurationHandler(std::shared_ptr<IReconfigurationHandler> h,
                                  ReconfigurationHandlerType type = ReconfigurationHandlerType::REGULAR) {
@@ -62,9 +64,10 @@ class Dispatcher {
   bool handleRequest(const T& msg,
                      uint64_t bft_seq_num,
                      uint32_t sender_id,
+                     const std::optional<bftEngine::Timestamp>& timestamp,
                      concord::messages::ReconfigurationResponse& rres,
                      std::shared_ptr<IReconfigurationHandler> handler) {
-    return handler->handle(msg, bft_seq_num, sender_id, rres);
+    return handler->handle(msg, bft_seq_num, sender_id, timestamp, rres);
   }
   std::vector<std::shared_ptr<IReconfigurationHandler>> pre_reconfig_handlers_;
   std::vector<std::shared_ptr<IReconfigurationHandler>> reconfig_handlers_;

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -12,10 +12,12 @@
 
 #pragma once
 
+#include <optional>
 #include "concord.cmf.hpp"
 #include "OpenTracing.hpp"
 #include "kv_types.hpp"
 #include "Replica.hpp"
+#include "TimeService.hpp"
 
 namespace concord::reconfiguration {
 enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
@@ -28,126 +30,147 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::WedgeCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::WedgeStatusRequest&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::GetVersionCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::DownloadCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::DownloadStatusCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::InstallCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::InstallStatusCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::KeyExchangeCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveStatus&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::LatestPrunableBlockRequest&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::PruneStatusRequest&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::PruneRequest&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::UnwedgeCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::UnwedgeStatusRequest&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientReconfigurationStateRequest&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientExchangePublicKey&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientKeyExchangeCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientReconfigurationLastUpdate&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -155,6 +178,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::RestartCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -162,6 +186,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientsAddRemoveCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -169,6 +194,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -176,6 +202,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -183,6 +210,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientKeyExchangeStatus&,
                       uint64_t,
                       uint32_t,
+                      const std::optional<bftEngine::Timestamp>&,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -36,27 +36,33 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
   bool handle(const concord::messages::WedgeCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::WedgeStatusRequest&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::KeyExchangeCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::RestartCommand&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -67,6 +73,7 @@ class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigu
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
               uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const override {

--- a/reconfiguration/src/dispatcher.cpp
+++ b/reconfiguration/src/dispatcher.cpp
@@ -24,7 +24,9 @@ namespace concord::reconfiguration {
     std::copy(str.cbegin(), str.cend(), std::back_inserter((resp).additional_data)); \
   }
 
-ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& request, uint64_t sequence_num) {
+ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& request,
+                                             uint64_t sequence_num,
+                                             const std::optional<bftEngine::Timestamp>& timestamp) {
   ReconfigurationResponse rresp;
   concord::messages::ReconfigurationErrorMsg error_msg;
   bool valid = false;
@@ -46,8 +48,9 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &= std::visit(
-          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
+      rresp.success &=
+          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, timestamp, rresp, handler); },
+                     request.command);
     }
 
     // Run regular reconfiguration handlers
@@ -59,8 +62,9 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &= std::visit(
-          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
+      rresp.success &=
+          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, timestamp, rresp, handler); },
+                     request.command);
     }
 
     // Run post-reconfiguration handlers
@@ -72,8 +76,9 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &= std::visit(
-          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
+      rresp.success &=
+          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, timestamp, rresp, handler); },
+                     request.command);
     }
 
     if (!valid) rresp.success = false;  // If no handler was able to verify the request, it is an invalid request

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -12,6 +12,7 @@
 
 #include "reconfiguration/reconfiguration_handler.hpp"
 
+#include "TimeService.hpp"
 #include "bftengine/KeyExchangeManager.hpp"
 #include "bftengine/ControlStateManager.hpp"
 #include "bftengine/EpochManager.hpp"
@@ -24,6 +25,7 @@ namespace concord::reconfiguration {
 bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "Wedge command instructs replica to stop at sequence number " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -33,6 +35,7 @@ bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
 bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
                                     uint64_t,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::WedgeStatusResponse response;
   if (req.fullWedge) {
@@ -47,6 +50,7 @@ bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
 bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   std::ostringstream oss;
   std::copy(command.target_replicas.begin(), command.target_replicas.end(), std::ostream_iterator<int>(oss, " "));
@@ -64,6 +68,7 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "AddRemoveWithWedgeCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -97,6 +102,7 @@ void ReconfigurationHandler::handleWedgeCommands(bool bft_support, bool remove_m
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeStatus& req,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::AddRemoveWithWedgeStatusResponse response;
   if (std::holds_alternative<concord::messages::AddRemoveWithWedgeStatusResponse>(rres.response)) {
@@ -117,6 +123,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
 bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "RestartCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -158,6 +165,7 @@ bool BftReconfigurationHandler::verifySignature(uint32_t sender_id,
 bool ClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& msg,
                                           uint64_t,
                                           uint32_t sender_id,
+                                          const std::optional<bftEngine::Timestamp>&,
                                           concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "public key: " << msg.pub_key << " sender: " << sender_id);
   std::vector<uint32_t> affected_clients;


### PR DESCRIPTION
**NOTE**: Do not merge until the product supports both Time Service.


Reason:
* The time will be used by the time-based pruning and other
reconfiguration handlers in the future.
* In certain cases, replicas replay reconfiguration commands saved in the
blockchain. For the time-based pruning, the system has to replay the
command together with the time when the command was submitted.  In order
to achieve it, reconfiguration requests will be saved with the timestamp
(as CMF message).

Changes:
* Updated Reconfiguration-related interfaces
* Added a new CMF-message
* Added saving and retrieving the timestamp from the reconf block
* Refactored persistReconfigurationBlock