### PR TITLE
Don't handle PruneRequest on ST if pruning disabled

### DIFF
--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -59,15 +59,19 @@ void StReconfigurationHandler::stCallBack(uint64_t current_cp_num) {
                                                            current_cp_num);
   handleStoredCommand<concord::messages::AddRemoveWithWedgeCommand>(
       std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1}, current_cp_num);
-  handleStoredCommand<concord::messages::PruneRequest>(std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
-                                                       current_cp_num);
+  if (bftEngine::ReplicaConfig::instance().pruningEnabled_) {
+    handleStoredCommand<concord::messages::PruneRequest>(std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
+                                                         current_cp_num);
+  }
   handleStoredCommand<concord::messages::WedgeCommand>(std::string{kvbc::keyTypes::reconfiguration_wedge_key},
                                                        current_cp_num);
 }
 
 void StReconfigurationHandler::pruneOnStartup() {
-  handleStoredCommand<concord::messages::PruneRequest>(std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
-                                                       0);
+  if (bftEngine::ReplicaConfig::instance().pruningEnabled_) {
+    handleStoredCommand<concord::messages::PruneRequest>(std::string{kvbc::keyTypes::reconfiguration_pruning_key, 0x1},
+                                                         0);
+  }
 }
 template <typename T>
 bool StReconfigurationHandler::handleStoredCommand(const std::string &key, uint64_t current_cp_num) {


### PR DESCRIPTION
If pruning is disabled in configuration, do not handle stored
PruneRequest commands when State Transfer completes.

Also, make sure that pruneOnStartup() doesn't do anything if pruning is
disabled in configuration.