### PR TITLE
Remove the usage of bftengine/src/Crypto from bftclient

### DIFF
--- a/bftclient/CMakeLists.txt
+++ b/bftclient/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(bftclient_new STATIC
   src/msg_receiver.cpp
   src/matcher.cpp
   src/quorums.cpp
-  ${bftengine_SOURCE_DIR}/src/bftengine/Crypto.cpp
 )
 
 target_include_directories(bftclient_new PUBLIC include)
@@ -19,6 +18,7 @@ target_link_libraries(bftclient_new PUBLIC
     bftheaders
     diagnostics
     secretsmanager
+    util
 )
 
 if (BUILD_TESTING)

--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -25,7 +25,7 @@
 #include "exception.h"
 #include "metrics.h"
 #include "diagnostics.h"
-#include "bftengine/Crypto.hpp"
+#include "crypto_utils.hpp"
 #include "seq_num_generator.h"
 
 namespace bft::client {
@@ -86,7 +86,7 @@ class Client {
   // This function creates a ClientBatchRequestMsg.
   Msg createClientBatchMsg(const std::deque<Msg>& client_requests,
                            uint32_t batch_buf_size,
-                           const string& cid,
+                           const std::string& cid,
                            uint16_t client_id);
 
   Msg initBatch(std::deque<WriteRequest>& write_requests,
@@ -117,7 +117,7 @@ class Client {
   Metrics metrics_;
 
   // Transaction RSA signer
-  std::optional<bftEngine::impl::RSASigner> transaction_signer_;
+  std::unique_ptr<concord::util::crypto::ISigner> transaction_signer_;
 
   static constexpr int64_t MAX_VALUE_NANOSECONDS = 1000 * 1000 * 1000;  // 1 second
   static constexpr int64_t MAX_TRANSACTION_SIZE = 100 * 1024 * 1024;    // 100MB

--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -97,10 +97,13 @@ class ClientApiTestParametrizedFixture : public ClientApiTestFixture,
       else
         signature_data--;  // corrupt the signature
     }
-    bool sig_verification_result = transaction_verifier_->verify(reinterpret_cast<const char*>(request_data),
-                                                                 request_header->requestLength,
-                                                                 reinterpret_cast<const char*>(signature_data),
-                                                                 sig_len);
+    std::string data;
+    data.resize(request_header->requestLength);
+    std::string sig;
+    sig.resize(request_header->reqSignatureLength);
+    std::memcpy(data.data(), reinterpret_cast<const char*>(request_data), request_header->requestLength);
+    std::memcpy(sig.data(), reinterpret_cast<const char*>(signature_data), sig_len);
+    bool sig_verification_result = transaction_verifier_->verify(data, sig);
     ASSERT_EQ(sig_verification_result, sig_verification_success_expected);
     PrintBehavior(msg, client_receiver);
     if (sig_verification_result)
@@ -147,7 +150,7 @@ class ClientApiTestParametrizedFixture : public ClientApiTestFixture,
     out = GetSecretData();  // return secret data
   }
 
-  unique_ptr<RSAVerifier> transaction_verifier_;
+  unique_ptr<concord::util::crypto::IVerifier> transaction_verifier_;
   bool corrupt_request_ = false;
 };
 
@@ -178,7 +181,12 @@ TEST_P(ClientApiTestParametrizedFixture, print_received_messages_and_timeout) {
 
     // initialize the test's RSAVerifier
     string public_key_full_path({keypair_path + PUB_KEY_NAME});
-    transaction_verifier_ = unique_ptr<RSAVerifier>(new RSAVerifier(public_key_full_path));
+    std::ifstream file(public_key_full_path);
+    std::stringstream stream;
+    stream << file.rdbuf();
+    auto pub_key_str = stream.str();
+    transaction_verifier_.reset(
+        new concord::util::crypto::RSAVerifier(pub_key_str, concord::util::crypto::KeyFormat::PemFormat));
   }
   unique_ptr<FakeCommunication> comm;
   if (sign_transaction) {

--- a/bftclient/test/bft_client_api_tests.cpp
+++ b/bftclient/test/bft_client_api_tests.cpp
@@ -97,12 +97,8 @@ class ClientApiTestParametrizedFixture : public ClientApiTestFixture,
       else
         signature_data--;  // corrupt the signature
     }
-    std::string data;
-    data.resize(request_header->requestLength);
-    std::string sig;
-    sig.resize(request_header->reqSignatureLength);
-    std::memcpy(data.data(), reinterpret_cast<const char*>(request_data), request_header->requestLength);
-    std::memcpy(sig.data(), reinterpret_cast<const char*>(signature_data), sig_len);
+    std::string data(reinterpret_cast<const char*>(request_data), request_header->requestLength);
+    std::string sig(reinterpret_cast<const char*>(signature_data), sig_len);
     bool sig_verification_result = transaction_verifier_->verify(data, sig);
     ASSERT_EQ(sig_verification_result, sig_verification_success_expected);
     PrintBehavior(msg, client_receiver);

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -178,7 +178,7 @@ class ConcordClientPool {
   // holds jobs that no clients was available to get.
   std::deque<externalRequest> external_requests_queue_;
   // Thread pool, on each thread on client will run
-  util::SimpleThreadPool jobs_thread_pool_;
+  ::util::SimpleThreadPool jobs_thread_pool_;
   // Clients queue mutex
   std::mutex clients_queue_lock_;
   // Metric
@@ -212,7 +212,7 @@ class ConcordClientPool {
   bftEngine::impl::RollingAvgAndVar batch_agg_dur_;
 };
 
-class BatchRequestProcessingJob : public util::SimpleThreadPool::Job {
+class BatchRequestProcessingJob : public ::util::SimpleThreadPool::Job {
  public:
   BatchRequestProcessingJob(concord_client_pool::ConcordClientPool& clients,
                             std::shared_ptr<external_client::ConcordClient> client)

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -126,7 +126,7 @@ std::pair<int8_t, ConcordClient::PendingReplies> ConcordClient::SendPendingReque
       std::to_string(client_id_) + "-" + std::to_string(seqGen_->generateUniqueSequenceNumberForRequest());
   OperationResult ret = OperationResult::SUCCESS;
   std::deque<bft::client::WriteRequest> request_queue;
-  std::map<uint64_t, string> seq_num_to_cid;
+  std::map<uint64_t, std::string> seq_num_to_cid;
   for (auto req : pending_requests_) {
     bft::client::WriteConfig single_config;
     single_config.request.timeout = std::chrono::milliseconds(req.timeoutMilli);

--- a/client/reconfiguration/src/poll_based_state_client.cpp
+++ b/client/reconfiguration/src/poll_based_state_client.cpp
@@ -12,7 +12,7 @@
 #include "client/reconfiguration/poll_based_state_client.hpp"
 namespace concord::client::reconfiguration {
 concord::messages::ReconfigurationResponse PollBasedStateClient::sendReconfigurationRequest(
-    concord::messages::ReconfigurationRequest& rreq, const string& cid, uint64_t sn, bool read_request) const {
+    concord::messages::ReconfigurationRequest& rreq, const std::string& cid, uint64_t sn, bool read_request) const {
   std::lock_guard<std::mutex> lock(bftclient_lock_);
   std::vector<uint8_t> data_vec;
   concord::messages::serialize(data_vec, rreq);

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -20,12 +20,14 @@ enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
 class IVerifier {
  public:
   virtual bool verify(const std::string& data, const std::string& sig) = 0;
+  virtual uint32_t signatureLength() = 0;
   virtual ~IVerifier() = default;
 };
 
 class ISigner {
  public:
   virtual std::string sign(const std::string& data) = 0;
+  virtual uint32_t signatureLength() = 0;
   virtual ~ISigner() = default;
 };
 
@@ -33,6 +35,7 @@ class ECDSAVerifier : public IVerifier {
  public:
   ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) override;
+  uint32_t signatureLength() override;
   ~ECDSAVerifier();
 
  private:
@@ -44,6 +47,7 @@ class ECDSASigner : public ISigner {
  public:
   ECDSASigner(const std::string& str_pub_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
+  uint32_t signatureLength() override;
   ~ECDSASigner();
 
  private:
@@ -54,6 +58,7 @@ class RSAVerifier : public IVerifier {
  public:
   RSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) override;
+  uint32_t signatureLength() override;
   ~RSAVerifier();
 
  private:
@@ -65,6 +70,7 @@ class RSASigner : public ISigner {
  public:
   RSASigner(const std::string& str_priv_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
+  uint32_t signatureLength() override;
   ~RSASigner();
 
  private:

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -20,14 +20,14 @@ enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
 class IVerifier {
  public:
   virtual bool verify(const std::string& data, const std::string& sig) = 0;
-  virtual uint32_t signatureLength() = 0;
+  virtual uint32_t signatureLength() const = 0;
   virtual ~IVerifier() = default;
 };
 
 class ISigner {
  public:
   virtual std::string sign(const std::string& data) = 0;
-  virtual uint32_t signatureLength() = 0;
+  virtual uint32_t signatureLength() const = 0;
   virtual ~ISigner() = default;
 };
 
@@ -35,7 +35,7 @@ class ECDSAVerifier : public IVerifier {
  public:
   ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) override;
-  uint32_t signatureLength() override;
+  uint32_t signatureLength() const override;
   ~ECDSAVerifier();
 
  private:
@@ -47,7 +47,7 @@ class ECDSASigner : public ISigner {
  public:
   ECDSASigner(const std::string& str_pub_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
-  uint32_t signatureLength() override;
+  uint32_t signatureLength() const override;
   ~ECDSASigner();
 
  private:
@@ -58,7 +58,7 @@ class RSAVerifier : public IVerifier {
  public:
   RSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) override;
-  uint32_t signatureLength() override;
+  uint32_t signatureLength() const override;
   ~RSAVerifier();
 
  private:
@@ -70,7 +70,7 @@ class RSASigner : public ISigner {
  public:
   RSASigner(const std::string& str_priv_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
-  uint32_t signatureLength() override;
+  uint32_t signatureLength() const override;
   ~RSASigner();
 
  private:

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -37,7 +37,7 @@ class ECDSAVerifier::Impl {
                                     signature.size());
   }
 
-  uint32_t signatureLength() { return verifier_->SignatureLength(); }
+  uint32_t signatureLength() const { return verifier_->SignatureLength(); }
 };
 bool ECDSAVerifier::verify(const std::string& data, const std::string& sig) { return impl_->verify(data, sig); }
 ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
@@ -51,7 +51,7 @@ ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
   }
   impl_.reset(new Impl(publicKey));
 }
-uint32_t ECDSAVerifier::signatureLength() { return impl_->signatureLength(); }
+uint32_t ECDSAVerifier::signatureLength() const { return impl_->signatureLength(); }
 ECDSAVerifier::~ECDSAVerifier() = default;
 
 class ECDSASigner::Impl {
@@ -71,7 +71,7 @@ class ECDSASigner::Impl {
     signature.resize(siglen);
     return signature;
   }
-  uint32_t signatureLength() { return signer_->SignatureLength(); }
+  uint32_t signatureLength() const { return signer_->SignatureLength(); }
 };
 
 std::string ECDSASigner::sign(const std::string& data) { return impl_->sign(data); }
@@ -86,7 +86,7 @@ ECDSASigner::ECDSASigner(const std::string& str_pub_key, KeyFormat fmt) {
   }
   impl_.reset(new Impl(privateKey));
 }
-uint32_t ECDSASigner::signatureLength() { return impl_->signatureLength(); }
+uint32_t ECDSASigner::signatureLength() const { return impl_->signatureLength(); }
 ECDSASigner::~ECDSASigner() = default;
 
 class RSAVerifier::Impl {
@@ -101,7 +101,7 @@ class RSAVerifier::Impl {
                                     signature.size());
   }
 
-  uint32_t signatureLength() { return verifier_->SignatureLength(); }
+  uint32_t signatureLength() const { return verifier_->SignatureLength(); }
 
  private:
   std::unique_ptr<RSASS<PKCS1v15, SHA256>::Verifier> verifier_;
@@ -120,7 +120,7 @@ class RSASigner::Impl {
     signature.resize(siglen);
     return signature;
   }
-  uint32_t signatureLength() { return signer_->SignatureLength(); }
+  uint32_t signatureLength() const { return signer_->SignatureLength(); }
 
  private:
   std::unique_ptr<RSASS<PKCS1v15, SHA256>::Signer> signer_;
@@ -140,7 +140,7 @@ RSASigner::RSASigner(const std::string& str_priv_key, KeyFormat fmt) {
 }
 
 std::string RSASigner::sign(const std::string& data) { return impl_->sign(data); }
-uint32_t RSASigner::signatureLength() { return impl_->signatureLength(); }
+uint32_t RSASigner::signatureLength() const { return impl_->signatureLength(); }
 RSASigner::~RSASigner() = default;
 
 RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
@@ -155,7 +155,7 @@ RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
   impl_.reset(new RSAVerifier::Impl(public_key));
 }
 bool RSAVerifier::verify(const std::string& data, const std::string& sig) { return impl_->verify(data, sig); }
-uint32_t RSAVerifier::signatureLength() { return impl_->signatureLength(); }
+uint32_t RSAVerifier::signatureLength() const { return impl_->signatureLength(); }
 RSAVerifier::~RSAVerifier() = default;
 
 class Crypto::Impl {

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -36,6 +36,8 @@ class ECDSAVerifier::Impl {
                                     (const CryptoPP::byte*)&signature[0],
                                     signature.size());
   }
+
+  uint32_t signatureLength() { return verifier_->SignatureLength(); }
 };
 bool ECDSAVerifier::verify(const std::string& data, const std::string& sig) { return impl_->verify(data, sig); }
 ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
@@ -49,6 +51,7 @@ ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
   }
   impl_.reset(new Impl(publicKey));
 }
+uint32_t ECDSAVerifier::signatureLength() { return impl_->signatureLength(); }
 ECDSAVerifier::~ECDSAVerifier() = default;
 
 class ECDSASigner::Impl {
@@ -68,6 +71,7 @@ class ECDSASigner::Impl {
     signature.resize(siglen);
     return signature;
   }
+  uint32_t signatureLength() { return signer_->SignatureLength(); }
 };
 
 std::string ECDSASigner::sign(const std::string& data) { return impl_->sign(data); }
@@ -82,6 +86,7 @@ ECDSASigner::ECDSASigner(const std::string& str_pub_key, KeyFormat fmt) {
   }
   impl_.reset(new Impl(privateKey));
 }
+uint32_t ECDSASigner::signatureLength() { return impl_->signatureLength(); }
 ECDSASigner::~ECDSASigner() = default;
 
 class RSAVerifier::Impl {
@@ -95,6 +100,8 @@ class RSAVerifier::Impl {
                                     (const CryptoPP::byte*)&signature[0],
                                     signature.size());
   }
+
+  uint32_t signatureLength() { return verifier_->SignatureLength(); }
 
  private:
   std::unique_ptr<RSASS<PKCS1v15, SHA256>::Verifier> verifier_;
@@ -113,6 +120,7 @@ class RSASigner::Impl {
     signature.resize(siglen);
     return signature;
   }
+  uint32_t signatureLength() { return signer_->SignatureLength(); }
 
  private:
   std::unique_ptr<RSASS<PKCS1v15, SHA256>::Signer> signer_;
@@ -132,6 +140,7 @@ RSASigner::RSASigner(const std::string& str_priv_key, KeyFormat fmt) {
 }
 
 std::string RSASigner::sign(const std::string& data) { return impl_->sign(data); }
+uint32_t RSASigner::signatureLength() { return impl_->signatureLength(); }
 RSASigner::~RSASigner() = default;
 
 RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
@@ -146,6 +155,7 @@ RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
   impl_.reset(new RSAVerifier::Impl(public_key));
 }
 bool RSAVerifier::verify(const std::string& data, const std::string& sig) { return impl_->verify(data, sig); }
+uint32_t RSAVerifier::signatureLength() { return impl_->signatureLength(); }
 RSAVerifier::~RSAVerifier() = default;
 
 class Crypto::Impl {


### PR DESCRIPTION
As part of the crypto functionality refactoring, we remove the bftengine/src/Crypto usage of bftclient  