### PR TITLE
TRS: Transition from legacy events to event groups

### DIFF
--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -302,7 +302,7 @@ class ThinReplicaClient final {
   std::unique_ptr<ThinReplicaClientConfig> config_;
   size_t data_conn_index_;
 
-  bool is_event_group_stream_;
+  bool is_event_group_request_;
   uint64_t latest_verified_block_id_;
   uint64_t latest_verified_event_group_id_;
 
@@ -405,7 +405,7 @@ class ThinReplicaClient final {
         config_(std::move(config)),
         data_conn_index_(0),
         latest_verified_block_id_(0),
-        latest_verified_event_group_id_(std::numeric_limits<uint64_t>::max()),
+        latest_verified_event_group_id_(0),
         subscription_thread_(),
         stop_subscription_thread_(false) {
     metrics_.setAggregator(aggregator);

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -297,7 +297,7 @@ TrsConnection::Result ThinReplicaClient::startHashStreamWith(size_t server_index
   config_->trs_conns[server_index]->cancelHashStream();
 
   SubscriptionRequest request;
-  if (is_event_group_stream_) {
+  if (is_event_group_request_) {
     request.mutable_event_groups()->set_event_group_id(latest_verified_event_group_id_ + 1);
   } else {
     request.mutable_events()->set_block_id(latest_verified_block_id_ + 1);
@@ -376,7 +376,7 @@ TrsConnection::Result ThinReplicaClient::resetDataStreamTo(size_t server_index) 
 
   SubscriptionRequest request;
 
-  if (is_event_group_stream_) {
+  if (is_event_group_request_) {
     request.mutable_event_groups()->set_event_group_id(latest_verified_event_group_id_ + 1);
   } else {
     request.mutable_events()->set_block_id(latest_verified_block_id_ + 1);
@@ -690,7 +690,7 @@ void ThinReplicaClient::Subscribe() {
     subscription_thread_->join();
     subscription_thread_.reset();
   }
-  is_event_group_stream_ = false;
+  is_event_group_request_ = false;
 
   bool has_verified_state = false;
   size_t data_server_index = 0;
@@ -882,7 +882,7 @@ void ThinReplicaClient::Subscribe(uint64_t block_id) {
 
   config_->update_queue->Clear();
   latest_verified_block_id_ = block_id;
-  is_event_group_stream_ = false;
+  is_event_group_request_ = false;
 
   // Create and launch thread to stream updates from the servers and push them
   // into the queue.
@@ -902,7 +902,7 @@ void ThinReplicaClient::Subscribe(const SubscribeRequest& req) {
   config_->update_queue->Clear();
   // We assume that the latest known event group for the caller is the event group prior to the requested one.
   latest_verified_event_group_id_ = req.event_group_id > 0 ? req.event_group_id - 1 : req.event_group_id;
-  is_event_group_stream_ = true;
+  is_event_group_request_ = true;
 
   // Create and launch thread to stream updates from the servers and push them
   // into the queue.

--- a/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
+++ b/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
@@ -106,8 +106,7 @@ class FakeStorage : public concord::kvbc::IReader {
     if (category_id == concord::kvbc::categorization::kExecutionEventGroupIdsCategory) {
       // get latest trid event_group_id
       if (latest_trid_eg_id.find(key) == latest_trid_eg_id.end()) {
-        throw std::runtime_error("The key: " + key +
-                                 "for category kExecutionEventGroupIdsCategory doesn't exist in storage!");
+        throw std::runtime_error("The key: " + key + "for category  doesn't exist in storage!");
       }
       return concord::kvbc::categorization::VersionedValue{{block_id, latest_trid_eg_id.at(key)}};
     } else if (category_id == concord::kvbc::categorization::kExecutionTridEventGroupsCategory) {
@@ -148,6 +147,10 @@ class FakeStorage : public concord::kvbc::IReader {
 
   std::optional<concord::kvbc::categorization::TaggedVersion> getLatestVersion(const std::string &category_id,
                                                                                const std::string &key) const override {
+    if (category_id == concord::kvbc::categorization::kExecutionGlobalEventGroupsCategory) {
+      // Event groups not enabled
+      return std::nullopt;
+    }
     ADD_FAILURE() << "getLatestVersion() should not be called by this test";
     return {};
   }

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -231,21 +231,36 @@ class ThinReplicaImpl {
     auto [subscribe_status, live_updates] = subscribeToLiveUpdates(request, getClientId(context));
     if (!subscribe_status.ok()) {
       LOG_WARN(logger_,
-               "SubscribeToUpdates createKvbFilter failed: (" << subscribe_status.error_code() << ") "
-                                                              << subscribe_status.error_message());
+               "SubscribeToUpdates subscribeToLiveUpdates failed: (" << subscribe_status.error_code() << ") "
+                                                                     << subscribe_status.error_message());
       return subscribe_status;
     }
+
     // TRS metrics
     ThinReplicaServerMetrics metrics_(stream_type, getClientId(context));
     metrics_.setAggregator(aggregator_);
     uint16_t update_aggregator_counter = 0;
     metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
 
+    // If legacy event request then mark whether we need to transition into event groups
+    bool is_event_group_transition = false;
+
     kvbc::BlockId start_block_id;
     if (request->has_events()) {
       start_block_id = request->events().block_id();
+      if (auto opt = kvb_filter->getFirstEventGroupBlockId()) {
+        if (start_block_id >= opt.value()) {
+          is_event_group_transition = true;
+        }
+      }
+    }
+
+    if (request->has_events() && !is_event_group_transition) {
       try {
         syncAndSend<ServerContextT, ServerWriterT, DataT>(context, start_block_id, live_updates, stream, kvb_filter);
+      } catch (concord::kvbc::NoLegacyEvents& error) {
+        LOG_WARN(logger_, error.what());
+        is_event_group_transition = true;
       } catch (StreamCancelled& error) {
         config_->subscriber_list.removeBuffer(live_updates);
         live_updates->removeAllUpdates();
@@ -261,13 +276,13 @@ class ThinReplicaImpl {
         metrics_.updateAggregator();
 
         std::stringstream msg;
-        msg << "Couldn't transition from block id " << request->events().block_id() << " to new blocks";
+        msg << "Couldn't transition from block id " << start_block_id << " to new blocks";
         return grpc::Status(grpc::StatusCode::UNKNOWN, msg.str());
       }
       // Read, filter, and send live updates
       SubUpdate update;
       try {
-        while (!context->IsCancelled()) {
+        while (!context->IsCancelled() && !is_event_group_transition) {
           metrics_.queue_size.Get().Set(live_updates->Size());
           bool is_update_available = false;
           is_update_available = live_updates->TryPop(update, kWaitForUpdateTimeout);
@@ -311,11 +326,25 @@ class ThinReplicaImpl {
       if (context->IsCancelled()) {
         return grpc::Status::CANCELLED;
       }
-      return grpc::Status::OK;
+      if (not is_event_group_transition) {
+        return grpc::Status::OK;
+      }
     }
 
-    // Request is an event group request
-    uint64_t event_group_id = request->event_groups().event_group_id();
+    // A legacy event request might transition into an event group stream
+    uint64_t event_group_id;
+    if (is_event_group_transition) {
+      ConcordAssert(request->has_events());
+      // We assume that the caller wants updates but we cannot determine the event group id the caller is looking for.
+      // Therefore, we start at the beginning.
+      // TODO: Doesn't work with pruning - use "global_event_group_id_oldest" once it is supported
+      event_group_id = 1;
+      LOG_INFO(logger_, "Legacy event request will receive event groups");
+    } else {
+      ConcordAssert(request->has_event_groups());
+      event_group_id = request->event_groups().event_group_id();
+    }
+
     try {
       syncAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(
           context, event_group_id, live_updates, stream, kvb_filter);
@@ -335,8 +364,7 @@ class ThinReplicaImpl {
       metrics_.updateAggregator();
 
       std::stringstream msg;
-      msg << "Couldn't transition from event_group_id " << request->event_groups().event_group_id()
-          << " to new event groups";
+      msg << "Couldn't transition from event_group_id " << event_group_id << " to new event groups";
       return grpc::Status(grpc::StatusCode::UNKNOWN, msg.str());
     }
 
@@ -675,6 +703,11 @@ class ThinReplicaImpl {
       is_update_available = live_updates->waitUntilNonEmpty(kWaitForUpdateTimeout);
       if (context->IsCancelled()) {
         throw StreamCancelled("StreamCancelled while waiting for the first live update");
+      }
+      // If event groups are enabled then all live updates will be event groups but they won't show up in the legacy
+      // event queue. Therefore, let's query storage directly.
+      if (kvb_filter->getFirstEventGroupBlockId()) {
+        throw concord::kvbc::NoLegacyEvents();
       }
     }
 

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -163,6 +163,10 @@ class FakeStorage : public concord::kvbc::IReader {
 
   std::optional<concord::kvbc::categorization::TaggedVersion> getLatestVersion(const std::string& category_id,
                                                                                const std::string& key) const override {
+    if (category_id == concord::kvbc::categorization::kExecutionGlobalEventGroupsCategory) {
+      // Event groups not enabled
+      return std::nullopt;
+    }
     ADD_FAILURE() << "getLatestVersion() should not be called by this test";
     return {};
   }


### PR DESCRIPTION
This PR introduces transitioning into event groups when a legacy event subscription request is present. In addition, we update the kvb app filter and thin replica server tests.
Please see commit messages for details.