### PR TITLE
ConcordClient: Sync all logger prefixes

### DIFF
--- a/client/client_pool/src/client_pool_config.cpp
+++ b/client/client_pool/src/client_pool_config.cpp
@@ -15,6 +15,6 @@
 
 namespace concord::config_pool {
 
-ClientPoolConfig::ClientPoolConfig() : logger_{logging::getLogger("com.vmware.external_client_pool")} {}
+ClientPoolConfig::ClientPoolConfig() : logger_{logging::getLogger("concord.client.client_pool.config")} {}
 
 }  // namespace concord::config_pool

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -35,7 +35,7 @@ bftEngine::OperationResult ConcordClient::clientRequestError_ = SUCCESS;
 ConcordClient::ConcordClient(int client_id,
                              ConcordClientPoolConfig& struct_config,
                              const SimpleClientParams& client_params)
-    : logger_(logging::getLogger("com.vmware.external_client_pool")) {
+    : logger_(logging::getLogger("concord.client.client_pool.external_client")) {
   client_id_ = client_id;
   CreateClient(struct_config, client_params);
 }

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -401,7 +401,7 @@ class ThinReplicaClient final {
   ThinReplicaClient(std::unique_ptr<ThinReplicaClientConfig> config,
                     const std::shared_ptr<concordMetrics::Aggregator>& aggregator)
       : metrics_(),
-        logger_(logging::getLogger("com.vmware.thin_replica_client")),
+        logger_(logging::getLogger("concord.client.thin_replica")),
         config_(std::move(config)),
         data_conn_index_(0),
         latest_verified_block_id_(0),

--- a/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
@@ -79,7 +79,7 @@ class TrsConnection {
                 const std::string& client_id,
                 uint16_t data_operation_timeout_seconds,
                 uint16_t hash_operation_timeout_seconds)
-      : logger_(logging::getLogger("thin_replica_client.trsconn")),
+      : logger_(logging::getLogger("concord.client.thin_replica.trscon")),
         address_(address),
         client_id_(client_id),
         data_timeout_(std::chrono::seconds(data_operation_timeout_seconds)),


### PR DESCRIPTION
For logging configuration and for reading logs it makes the most sense to align
all logger names to start with the same `concord.client` prefix which is based
on the project name and directory path.