### PR TITLE
Schedule gcc builds once per week (Saturday)

### DIFF
--- a/.github/workflows/build_and_test_gcc_debug.yml
+++ b/.github/workflows/build_and_test_gcc_debug.yml
@@ -1,5 +1,7 @@
 name: Debug build (gcc)
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: "0 12 * * 6" # Every Saturday at 12PM UTC
 
 jobs:
   build:

--- a/.github/workflows/build_and_test_gcc_release.yml
+++ b/.github/workflows/build_and_test_gcc_release.yml
@@ -1,5 +1,7 @@
 name: Release build (gcc)
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: "0 12 * * 6" # Every Saturday at 12PM UTC
 
 jobs:
   build:


### PR DESCRIPTION
As gcc build workflows having lower priority because production binaries are compiled with clang.
So, Scheduling gcc builds workflows once per week (Saturday) to increase the overall throughput.