### PR TITLE
Send a noop command once it is ready (instead of waiting to timeout)

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4370,9 +4370,16 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
     data_vec.clear();
     concord::messages::serialize(data_vec, req);
     std::string strMsg(data_vec.begin(), data_vec.end());
-    internalBFTClient_->sendRequest(
-        RECONFIG_FLAG, strMsg.size(), strMsg.c_str(), "wedge-noop-command-" + std::to_string(seqNumber));
+    auto sn = std::chrono::duration_cast<std::chrono::microseconds>(getMonotonicTime().time_since_epoch()).count();
+    auto crm = new ClientRequestMsg(internalBFTClient_->getClientId(),
+                                    RECONFIG_FLAG,
+                                    sn,
+                                    strMsg.size(),
+                                    strMsg.c_str(),
+                                    60000,
+                                    "wedge-noop-command-" + std::to_string(seqNumber));
     // Now, try to send a new prepreare immediately, without waiting to a new batch
+    onMessage(crm);
     tryToSendPrePrepareMsg(false);
   }
 

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -144,7 +144,6 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
     if (csrep.block_id == 0) continue;
     rep.states.push_back(csrep);
   }
-  LOG_INFO(GL, "b(2)");
   concord::messages::serialize(rres.additional_data, rep);
   return true;
 }


### PR DESCRIPTION
Prior to this change, once we called to tryToSendPrePreprapre(false) nothing happened because the noop command was not yet in the primary queue.
Now, we first push it to the primary queue and only then invoke the tryToSendPrePrepre(false)