### PR TITLE
[Client pool] Send Clientptr copy instead of refrence

### DIFF
--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -165,7 +165,7 @@ class ConcordClientPool {
                          const concord::config_pool::ConcordClientPoolConfig&);
   void CreatePool(concord::config_pool::ConcordClientPoolConfig&);
 
-  void OnBatchingTimeout(const ClientPtr& client);
+  void OnBatchingTimeout(ClientPtr client);
   bool clusterHasKeys(ClientPtr& cl);
   std::string SampleSpan(const std::string& span_blob);
   std::atomic_bool hasKeys_{false};

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -336,7 +336,8 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
   } else {
     LOG_INFO(logger_, "Batching for client pool is disabled");
   }
-  batch_timer_ = std::make_unique<Timer_t>(timeout, [this](ClientPtr &&client) -> void { OnBatchingTimeout(client); });
+  batch_timer_ =
+      std::make_unique<Timer_t>(timeout, [this](ClientPtr client) -> void { OnBatchingTimeout(std::move(client)); });
   external_client::ConcordClient::setStatics(required_num_of_replicas, num_replicas, max_buf_size, batch_size_);
   bftEngine::SimpleClientParams clientParams;
   setUpClientParams(clientParams, config);
@@ -348,7 +349,7 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
   jobs_queue_max_size_ = config.external_requests_queue_size;
 }
 
-void ConcordClientPool::OnBatchingTimeout(const ClientPtr &client) {
+void ConcordClientPool::OnBatchingTimeout(std::shared_ptr<concord::external_client::ConcordClient> client) {
   {
     std::unique_lock<std::mutex> lock(clients_queue_lock_);
     const auto client_id = client->getClientId();


### PR DESCRIPTION
In this PR I'm fixing an issue in the client pool. 
We had a situation that we send a const reference of a shared ptr which caused us not to get the ownership for this than if at some point no one will hold this shared ptr we will just delete it and the place which we get as const reference will cause a collapse because the ptr does not exist anymore.
To solve it I changed it to get a copy of the ptr and then it will take ownership.