### PR TITLE
Don't save the client keys when loading them from the reserved pages

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -59,7 +59,10 @@ class KeyExchangeManager {
   // called on a new client key
   void onClientPublicKeyExchange(const std::string& key, concord::util::crypto::KeyFormat, NodeIdType clientId);
   // called when client keys are loaded
-  void loadClientPublicKey(const std::string& key, concord::util::crypto::KeyFormat, NodeIdType clientId);
+  void loadClientPublicKey(const std::string& key,
+                           concord::util::crypto::KeyFormat,
+                           NodeIdType clientId,
+                           bool saveToReservedPages);
   ///////// end - Clients public keys interface///////////////
 
   std::string getStatus() const;

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -77,7 +77,7 @@ void ClientsManager::loadInfoFromReservedPages() {
       std::istringstream iss(scratchPage_);
       concord::serialize::Serializable::deserialize(iss, info.pubKey);
       ConcordAssertGT(info.pubKey.first.length(), 0);
-      KeyExchangeManager::instance().loadClientPublicKey(info.pubKey.first, info.pubKey.second, clientId);
+      KeyExchangeManager::instance().loadClientPublicKey(info.pubKey.first, info.pubKey.second, clientId, false);
     }
 
     if (!loadReservedPage(getReplyFirstPageId(clientId), sizeOfReservedPage(), scratchPage_.data())) continue;

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -175,15 +175,16 @@ void KeyExchangeManager::onClientPublicKeyExchange(const std::string& key,
   // persist a new key
   clientPublicKeyStore_->setClientPublicKey(clientId, key, fmt);
   // load a new key
-  loadClientPublicKey(key, fmt, clientId);
+  loadClientPublicKey(key, fmt, clientId, true);
 }
 
 void KeyExchangeManager::loadClientPublicKey(const std::string& key,
                                              concord::util::crypto::KeyFormat fmt,
-                                             NodeIdType clientId) {
+                                             NodeIdType clientId,
+                                             bool saveToReservedPages) {
   LOG_INFO(KEY_EX_LOG, "key: " << key << " fmt: " << (uint16_t)fmt << " client: " << clientId);
   SigManager::instance()->setClientPublicKey(key, clientId, fmt);
-  saveClientsPublicKeys(SigManager::instance()->getClientsPublicKeys());
+  if (saveToReservedPages) saveClientsPublicKeys(SigManager::instance()->getClientsPublicKeys());
 }
 
 void KeyExchangeManager::sendInitialKey() {


### PR DESCRIPTION
Currently, we save the client exchanged keys when reading them from the reserved pages.
Other than being redundant, it also crashes the replica when it finishes state transfer.
This PR fixes the bug as well as introducing an Apollo test to validate the fix.
The test was running without the fix and failed and with the fix, it passed.