### PR TITLE
Set primaryLastUsedSeqNum to lastExecutedSeqNum on reset metadata

### DIFF
--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -889,6 +889,7 @@ struct ResetMetadata {
       cpm->setSenderId(repId);
       p->beginWriteTran();
       p->setCheckpointMsgInCheckWindow(stableSeqNum, cpm);
+      p->setPrimaryLastUsedSeqNum(p->getPrimaryLastUsedSeqNum());
       p->endWriteTran();
       result["stable seq num"] = std::to_string(stableSeqNum);
     }

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -889,7 +889,7 @@ struct ResetMetadata {
       cpm->setSenderId(repId);
       p->beginWriteTran();
       p->setCheckpointMsgInCheckWindow(stableSeqNum, cpm);
-      p->setPrimaryLastUsedSeqNum(p->getPrimaryLastUsedSeqNum());
+      p->setPrimaryLastUsedSeqNum(p->getLastExecutedSeqNum());
       p->endWriteTran();
       result["stable seq num"] = std::to_string(stableSeqNum);
     }


### PR DESCRIPTION
The primary is calculated by view_num / replicas_num. When we run a live backup, we may end up with a replica that thinks it is the primary and it isn't. 
In this case, the replica may throw an exception for having lastPrimarySeqNum < lastExecuteSeqNum
To solve this we set the lastPrimarySeqNum to lastExecutedSeqNum on resetMetadata 