### PR TITLE
BCStateTran, SourceSelector: Maintain an actual list of sources

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2686,15 +2686,16 @@ void BCStateTran::processData(bool lastInBatch) {
 
       checkConsistency(config_.pedanticChecks);
 
-      cycleEndSummary();
-      sourceSelector_.reset();
-
       // Completion
       LOG_INFO(logger_, "Invoking onTransferringComplete callbacks for checkpoint number: " << KVLOG(cp.checkpointNum));
       metrics_.on_transferring_complete_++;
       for (const auto &kv : on_transferring_complete_cb_registry_) {
         kv.second.invokeAll(cp.checkpointNum);
       }
+
+      cycleEndSummary();
+      sourceSelector_.reset();
+
       g.txn()->setIsFetchingState(false);
       ConcordAssertEQ(getFetchingState(), FetchingState::NotFetching);
       break;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -556,7 +556,6 @@ class BCStateTran : public IStateTransfer {
   Throughput bytes_collected_;
   std::optional<uint64_t> firstCollectedBlockId_;
   std::optional<uint64_t> lastCollectedBlockId_;
-  std::vector<uint16_t> sources_;
 
   // Duration Trackers
   DurationTracker<std::chrono::milliseconds> cycleDT_;

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -31,6 +31,16 @@ void SourceSelector::setFetchingTimeStamp(uint64_t currTimeMilli, bool retransmi
 void SourceSelector::removeCurrentReplica() {
   preferredReplicas_.erase(currentReplica_);
   currentReplica_ = NO_REPLICA;
+  receivedValidBlockFromSrc_ = false;
+}
+
+void SourceSelector::onReceivedValidBlockFromSource() {
+  ConcordAssertNE(currentReplica_, NO_REPLICA);
+  if (!receivedValidBlockFromSrc_) {
+    receivedValidBlockFromSrc_ = true;
+    LOG_INFO(logger_, "Insert source " << currentReplica_ << " into actualSources_");
+    actualSources_.push_back(currentReplica_);
+  }
 }
 
 void SourceSelector::setAllReplicasAsPreferred() { preferredReplicas_ = allOtherReplicas_; }
@@ -42,20 +52,34 @@ void SourceSelector::reset() {
   fetchingTimeStamp_ = 0;
   fetchRetransmissionCounter_ = 0;
   fetchRetransmissionOngoing_ = false;
+  receivedValidBlockFromSrc_ = false;
+  actualSources_.clear();
 }
 
 bool SourceSelector::isReset() const {
   return preferredReplicas_.empty() && (currentReplica_ == NO_REPLICA) && (sourceSelectionTimeMilli_ == 0) &&
-         (fetchingTimeStamp_ == 0) && (fetchRetransmissionCounter_ == 0) && !fetchRetransmissionOngoing_;
+         (fetchingTimeStamp_ == 0) && (fetchRetransmissionCounter_ == 0) && !fetchRetransmissionOngoing_ &&
+         actualSources_.empty() && !receivedValidBlockFromSrc_;
 }
 
 bool SourceSelector::retransmissionTimeoutExpired(uint64_t currTimeMilli) const {
   // TODO(GG): TBD - compute dynamically
   // if fetchingTimeStamp_ or fetchingTimeStamp_ are not set - no need to retransmit since destination has never yet
   // transmitted to this source
-  if (currentReplica_ == NO_REPLICA) return false;
-  if (fetchingTimeStamp_ == 0) return false;
-  return ((currTimeMilli - fetchingTimeStamp_) > retransmissionTimeoutMilli_);
+  if (currentReplica_ == NO_REPLICA) {
+    LOG_DEBUG(logger_, "Retransmit - no replica");
+    return false;
+  }
+  if (fetchingTimeStamp_ == 0) {
+    LOG_DEBUG(logger_, "Retransmit" << KVLOG(fetchingTimeStamp_));
+    return false;
+  }
+  auto diff = (currTimeMilli - fetchingTimeStamp_);
+  if (diff > retransmissionTimeoutMilli_) {
+    LOG_DEBUG(logger_, "Retransmit" << KVLOG(diff, currTimeMilli, fetchingTimeStamp_, retransmissionTimeoutMilli_));
+    return true;
+  }
+  return false;
 }
 
 uint64_t SourceSelector::timeSinceSourceSelectedMilli(uint64_t currTimeMilli) const {
@@ -146,6 +170,7 @@ void SourceSelector::selectSource(uint64_t currTimeMilli) {
   fetchRetransmissionOngoing_ = false;
   fetchingTimeStamp_ = 0;
   fetchRetransmissionCounter_ = 0;
+  receivedValidBlockFromSrc_ = false;
 }
 }  // namespace impl
 }  // namespace bcst

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -124,18 +124,22 @@ bool SourceSelector::shouldReplaceSource(uint64_t currTimeMilli, bool badDataFro
       ++fetchRetransmissionCounter_;
       fetchRetransmissionOngoing_ = false;
       LOG_WARN(logger_,
-               "Retransmission timeout expired:" << KVLOG(
-                   currTimeMilli, fetchingTimeStamp_, retransmissionTimeoutMilli_, fetchRetransmissionCounter_));
+               "Retransmission timeout expired:" << KVLOG(currentReplica_,
+                                                          currTimeMilli,
+                                                          fetchingTimeStamp_,
+                                                          retransmissionTimeoutMilli_,
+                                                          fetchRetransmissionCounter_));
     }
   }
 
-  if (fetchRetransmissionCounter_ > maxFetchRetransmissions_) {
+  if (fetchRetransmissionCounter_ >= maxFetchRetransmissions_) {
     LOG_INFO(logger_,
-             "Should replace source: retransmission timeoute expired: " << KVLOG(currTimeMilli,
-                                                                                 fetchingTimeStamp_,
-                                                                                 retransmissionTimeoutMilli_,
-                                                                                 fetchRetransmissionCounter_,
-                                                                                 maxFetchRetransmissions_));
+             "Should replace source: retransmission timeout expired: " << KVLOG(currentReplica_,
+                                                                                currTimeMilli,
+                                                                                fetchingTimeStamp_,
+                                                                                retransmissionTimeoutMilli_,
+                                                                                fetchRetransmissionCounter_,
+                                                                                maxFetchRetransmissions_));
     return true;
   }
 

--- a/bftengine/src/bcstatetransfer/SourceSelector.hpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.hpp
@@ -41,6 +41,7 @@ class SourceSelector {
         maxFetchRetransmissions_(maxFetchRetransmissions),
         retransmissionTimeoutMilli_(retransmissionTimeoutMilli),
         fetchRetransmissionOngoing_(false),
+        receivedValidBlockFromSrc_(false),
         logger_(logger) {}
 
   bool hasSource() const;
@@ -78,6 +79,10 @@ class SourceSelector {
 
   uint16_t currentReplica() const { return currentReplica_; }
 
+  void onReceivedValidBlockFromSource();
+
+  const std::vector<uint16_t> &getActualSources() { return actualSources_; }
+
  private:
   uint64_t timeSinceSourceSelectedMilli(uint64_t currTimeMilli) const;
   void selectSource(uint64_t currTimeMilli);
@@ -95,6 +100,11 @@ class SourceSelector {
   uint64_t fetchingTimeStamp_ = 0;
   mutable uint32_t fetchRetransmissionCounter_ = 0;
   mutable bool fetchRetransmissionOngoing_ = false;
+
+  // Actual Sources
+  // An actual source is one which at least one block has been received from
+  std::vector<uint16_t> actualSources_;
+  bool receivedValidBlockFromSrc_;
 
   logging::Logger &logger_;
 };

--- a/bftengine/tests/bcstatetransfer/source_selector_test.cpp
+++ b/bftengine/tests/bcstatetransfer/source_selector_test.cpp
@@ -242,35 +242,28 @@ TEST_F(SourceSelectorTestFixture, change_source_after_too_many_retransmissions) 
   // should return false - fetch time never set
   ASSERT_FALSE(source_selector.retransmissionTimeoutExpired(curTimeMs));
 
-  // opration: send fetch msg and than advance 10ms
+  // operation: send fetch msg and than advance 10ms
   // validate: source should not yet be replaced and retransmission not expired
   source_selector.setFetchingTimeStamp(curTimeMs, true);
   curTimeMs += 10;
   ASSERT_FALSE(source_selector.retransmissionTimeoutExpired(curTimeMs));
   ASSERT_FALSE(source_selector.shouldReplaceSource(curTimeMs, false));
 
-  // opration: send fetch msg and than advance kRetransmissionTimeoutMs + 10 ms
+  // operation: send fetch msg and than advance kRetransmissionTimeoutMs + 10 ms
   // validate: source should not yet be replaced and retransmission expired (counter = 1)
   source_selector.setFetchingTimeStamp(curTimeMs, true);
   curTimeMs += kRetransmissionTimeoutMs + 10;
   ASSERT_TRUE(source_selector.retransmissionTimeoutExpired(curTimeMs));
   ASSERT_FALSE(source_selector.shouldReplaceSource(curTimeMs, false));
 
-  // opration: send fetch msg and than advance kRetransmissionTimeoutMs + 10 ms
-  // validate: source should not yet be replaced and retransmission expired (counter = 2)
-  source_selector.setFetchingTimeStamp(curTimeMs, true);
-  curTimeMs += kRetransmissionTimeoutMs + 10;
-  ASSERT_TRUE(source_selector.retransmissionTimeoutExpired(curTimeMs));
-  ASSERT_FALSE(source_selector.shouldReplaceSource(curTimeMs, false));
-
-  // opration: send fetch msg and than advance kRetransmissionTimeoutMs + 10 ms
-  // validate: source should be replaced and retransmission expired (counter = 3 > maxFetchRetransmissions)
+  // operation: send fetch msg and than advance kRetransmissionTimeoutMs + 10 ms
+  // validate: source should be replaced and retransmission expired (counter = 2 and >= maxFetchRetransmissions)
   source_selector.setFetchingTimeStamp(curTimeMs, true);
   curTimeMs += kRetransmissionTimeoutMs + 10;
   ASSERT_TRUE(source_selector.retransmissionTimeoutExpired(curTimeMs));
   ASSERT_TRUE(source_selector.shouldReplaceSource(curTimeMs, false));
 
-  // opration: update source, send fetch msg and than advance 10ms
+  // operation: update source, send fetch msg and than advance 10ms
   // validate: source should not yet be replaced and retransmission not expired
   source_selector.updateSource(curTimeMs);
   source_selector.setFetchingTimeStamp(curTimeMs, true);


### PR DESCRIPTION
Till now, every time a new source is selected, a list of sources (which
isused for cycle end report) is updated immediately.
But if a source does not answer, or if it sends a corrupted data etc.,
it is not really a source.
An actual or "real" source, is one in which at least one block has been
received from (during Gettingmissingblocks or GettingMissingResPages).

Here we move the maintenance of this list into source selector, and
report to it with a new API function whenever a new block is received.