### PR TITLE
Write the new client public key to disk

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -123,7 +123,12 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   // RSA public keys of all clients. Each public key holds set of distinct client (principal) ids which are expected to
   // sign with the matching private key
   std::set<std::pair<const std::string, std::set<uint16_t>>> publicKeysOfClients;
-
+  std::unordered_map<uint16_t, std::set<uint16_t>> clientGroups;
+  CONFIG_PARAM(clientsKeysPrefix, std::string, "", "the path to the client keys directory");
+  CONFIG_PARAM(saveClinetKeyFile,
+               bool,
+               false,
+               "if true, the replica will also updates the client key file on key exchange");
   CONFIG_PARAM(replicaPrivateKey, std::string, "", "RSA private key of the current replica");
 
   // Threshold crypto system
@@ -246,6 +251,9 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
     serialize(outStream, publicKeysOfReplicas);
     serialize(outStream, publicKeysOfClients);
+    serialize(outStream, clientGroups);
+    serialize(outStream, clientsKeysPrefix);
+    serialize(outStream, saveClinetKeyFile);
     serialize(outStream, replicaPrivateKey);
     serialize(outStream, thresholdSystemType_);
     serialize(outStream, thresholdSystemSubType_);
@@ -318,6 +326,9 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
     deserialize(inStream, publicKeysOfReplicas);
     deserialize(inStream, publicKeysOfClients);
+    deserialize(inStream, clientGroups);
+    deserialize(inStream, clientsKeysPrefix);
+    deserialize(inStream, saveClinetKeyFile);
     deserialize(inStream, replicaPrivateKey);
     deserialize(inStream, thresholdSystemType_);
     deserialize(inStream, thresholdSystemSubType_);

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -76,10 +76,8 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
 class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurationHandler,
                                public ReconfigurationBlockTools {
  public:
-  ReconfigurationHandler(kvbc::IBlockAdder& block_adder,
-                         kvbc::IReader& ro_storage,
-                         std::set<std::set<uint16_t>>& txKeysClientGroups)
-      : ReconfigurationBlockTools{block_adder, ro_storage}, txKeysClientGroups_{txKeysClientGroups} {}
+  ReconfigurationHandler(kvbc::IBlockAdder& block_adder, kvbc::IReader& ro_storage)
+      : ReconfigurationBlockTools{block_adder, ro_storage} {}
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
@@ -174,7 +172,6 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               concord::messages::ReconfigurationResponse&) override;
 
  private:
-  std::set<std::set<uint16_t>> txKeysClientGroups_;
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop commands)

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -141,12 +141,8 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
   categorization::KeyValueBlockchain &blockchain_;
 };
 void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler) {
-  std::set<std::set<uint16_t>> txSigningClientGroups;
-  for (const auto &val : bftEngine::ReplicaConfig::instance().publicKeysOfClients) {
-    txSigningClientGroups.insert(val.second);
-  }
   requestHandler->setReconfigurationHandler(
-      std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this, txSigningClientGroups),
+      std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(*this, *this),
       concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(*this, *this),

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -401,10 +401,12 @@ void TestSetup::setPublicKeysOfClients(
       }
       const std::string key = keyPlaintext.value();
       publicKeysOfClients.insert(std::pair<const std::string, std::set<uint16_t>>(key, clientIdsSet));
+      bftEngine::ReplicaConfig::instance().clientGroups.emplace(i + 1, clientIdsSet);
     } else {
       throw std::runtime_error("Key public_key.pem not found in directory " + keysDirectories.at(i));
     }
   }
+  bftEngine::ReplicaConfig::instance().clientsKeysPrefix = keysRootPath;
 }
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
The client's key exchange procedure in the replica side saves the new client public key in the reserved pages only.
However, in case we remove metadata (using kv_blockchain_editor) we also remove the reserved pages, and hence we left a mismatch between the client's latest private key and the replicas' public key for this client.
In this PR we introduce an ability to save the new public key in the file system in addition to the reserved pages. 