### PR TITLE
BCStateTran: fix assertion failure while the source was not finalize

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -410,6 +410,11 @@ class BCStateTran : public IStateTransfer {
   // returns number of jobs pushed to queue
   uint16_t getBlocksConcurrentAsync(uint64_t nextBlockId, uint64_t firstRequiredBlock, uint16_t numBlocks);
 
+  void clearIoContexts() {
+    for (auto& ctx : ioContexts_) ioPool_.free(ctx);
+    ioContexts_.clear();
+  }
+
   // lastBlock: is true if we put the oldest block (firstRequiredBlock)
   //
   // waitPolicy:
@@ -564,6 +569,9 @@ class BCStateTran : public IStateTransfer {
   logging::Logger& logger_;
 
   void onFetchingStateChange(FetchingState newFetchingState);
+
+  // When true: log historgrams, zero source flag and counter, and then unconditionally clear the iOcontexts
+  void finalizeSource(bool logSrcHistograms);
 
   // used to print periodic summary of recent checkpoints, and collected date while in state GettingMissingBlocks
   std::string logsForCollectingStatus(const uint64_t firstRequiredBlock);


### PR DESCRIPTION
When there are 2 replicas in ST at the same time or a replica that was
a source and then enters state transfer as a destination, we fail it
fails an assertion on BCStateTran.cpp:L1333. This happens due to the
fact that it might be still regarded as a source, and its iocontexts_
was not cleared.

Here we do the following changes to finalize a source correctly:
1) New member function BCStateTran::clearIoContexts() to clear
iocontexts_.
2) New member function BCStateTran::finalizeSource() to clear source
flag, counter and log its histograms. Finally, it also calls
BCStateTran::clearIoContexts().
    *) Call if needed from  BCStateTran::startCollectingState().
    *) Call as before from  BCStateTran::onTimerIm().
3) Transform DEBUG level log entries in source to INFO level to get
better visibility when sending a batch has ended.