### PR TITLE
Updates on client pool

### DIFF
--- a/client/client_pool/include/client/client_pool/client_pool_config.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_config.hpp
@@ -42,10 +42,10 @@ typedef struct Replica {
 
 typedef struct ConcordClientPoolConfig {
   std::uint16_t c_val = 0;
-  std::uint16_t client_min_retry_timeout_milli = 500;
+  std::uint16_t client_min_retry_timeout_milli = 5000;
   std::uint16_t client_periodic_reset_thresh = 30;
-  std::uint16_t client_initial_retry_timeout_milli = 500;
-  std::uint16_t client_max_retry_timeout_milli = 3000;
+  std::uint16_t client_initial_retry_timeout_milli = 5000;
+  std::uint16_t client_max_retry_timeout_milli = 10000;
   std::uint16_t client_sends_request_to_all_replicas_first_thresh = 2;
   std::uint16_t client_sends_request_to_all_replicas_period_thresh = 2;
   std::uint16_t client_number_of_standard_deviations_to_tolerate = 2;

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -82,7 +82,7 @@ struct externalRequest {
 //  the client
 class ConcordClientPool {
   using ClientPtr = std::shared_ptr<concord::external_client::ConcordClient>;
-  static constexpr uint16_t SECOND_LEG_CID_LEN = 16;
+  static constexpr uint16_t SECOND_LEG_CID_LEN = 36;
 
  public:
   // Return a unique pointer containing a ConcordClientPool. This is useful when


### PR DESCRIPTION
*Length of second leg commands has been changed and now we need to differentiate according to command type.
*Update default timeouts for clients
*Update client gauge