### PR TITLE
Log optimization 

### DIFF
--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -913,7 +913,6 @@ class ThinReplicaImpl {
       std::string client_id = getClientIdFromClientCert(context);
       if (!client_id.empty()) {
         if (config_->client_id_set.find(client_id) != config_->client_id_set.end()) {
-          LOG_INFO(logger_, "Client " << client_id << " is authorized");
           return client_id;
         } else {
           LOG_FATAL(logger_,


### PR DESCRIPTION
As a part of log optimization this log can be removed as it may not be required and is found to be printing lot many redundant logs