### PR TITLE
TRC: Fix last verified block id value

### DIFF
--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -899,7 +899,7 @@ void ThinReplicaClient::Subscribe(uint64_t block_id) {
   }
 
   config_->update_queue->Clear();
-  latest_verified_block_id_ = block_id;
+  latest_verified_block_id_ = block_id > 0 ? block_id - 1 : block_id;
   latest_verified_event_group_id_ = 0;
   is_event_group_request_ = false;
 

--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -93,7 +93,7 @@ TEST(thin_replica_client_test, test_destructor_always_successful) {
                                   "ThinReplicaClient after ending its subscription.";
 }
 
-TEST(thin_replica_client_test, test_1_parameter_subscribe_success_cases) {
+TEST(thin_replica_client_test, test_no_parameter_subscribe_success_cases) {
   Data update;
   update.mutable_events()->set_block_id(0);
   KVPair* events_data = update.mutable_events()->add_data();
@@ -113,16 +113,16 @@ TEST(thin_replica_client_test, test_1_parameter_subscribe_success_cases) {
       make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
   std::shared_ptr<concordMetrics::Aggregator> aggregator;
   auto trc = make_unique<ThinReplicaClient>(std::move(trc_config), aggregator);
-  EXPECT_NO_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's 1-parameter overload failed.";
+  EXPECT_NO_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's no-parameter overload failed.";
 
   trc->Unsubscribe();
-  EXPECT_NO_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+  EXPECT_NO_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's no-parameter overload failed when "
                                        "subscribing after closing a subscription.";
-  EXPECT_NO_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+  EXPECT_NO_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's no-parameter overload failed when "
                                        "subscribing while there is an ongoing subscription.";
 }
 
-TEST(thin_replica_client_test, test_2_parameter_subscribe_success_cases) {
+TEST(thin_replica_client_test, test_1_parameter_subscribe_success_cases) {
   Data update;
   update.mutable_events()->set_block_id(0);
   KVPair* events_data = update.mutable_events()->add_data();
@@ -160,12 +160,12 @@ TEST(thin_replica_client_test, test_2_parameter_subscribe_success_cases) {
     trc->Unsubscribe();
     update_queue->Clear();
     uint64_t previous_block_id = block_id;
-    EXPECT_NO_THROW(trc->Subscribe(block_id)) << "ThinReplicaClient::Subscribe's 2-parameter overload failed when "
-                                                 "subscribing with a Block ID from a previously received block.";
+    EXPECT_NO_THROW(trc->Subscribe(block_id + 1)) << "ThinReplicaClient::Subscribe's 1-parameter overload failed when "
+                                                     "subscribing with a Block ID from a previously received block.";
     update_received = update_queue->Pop();
     EXPECT_TRUE(std::holds_alternative<Update>(*update_received));
     block_id = std::get<Update>(*update_received).block_id;
-    EXPECT_GT(block_id, previous_block_id) << "ThinReplicaClient::Subscribe's 2-parameter overload appears to be "
+    EXPECT_GT(block_id, previous_block_id) << "ThinReplicaClient::Subscribe's 1-parameter overload appears to be "
                                               "repeating already received blocks even when specifying where to "
                                               "start the subscription to avoid them.";
   }
@@ -192,7 +192,7 @@ TEST(thin_replica_client_test, test_1_parameter_subscribe_to_unresponsive_server
       make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
   std::shared_ptr<concordMetrics::Aggregator> aggregator;
   auto trc = make_unique<ThinReplicaClient>(std::move(trc_config), aggregator);
-  EXPECT_ANY_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's 1-parameter overload doesn't throw an "
+  EXPECT_ANY_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's no-parameter overload doesn't throw an "
                                         "exception when trying to subscribe to a cluster with only max_faulty "
                                         "servers responsive.";
   trc_config.reset();
@@ -202,7 +202,7 @@ TEST(thin_replica_client_test, test_1_parameter_subscribe_to_unresponsive_server
   trc_config =
       make_unique<ThinReplicaClientConfig>(kTestingClientID, update_queue, max_faulty, std::move(mock_servers));
   trc = make_unique<ThinReplicaClient>(std::move(trc_config), aggregator);
-  EXPECT_ANY_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's 1-parameter overload doesn't throw an "
+  EXPECT_ANY_THROW(trc->Subscribe()) << "ThinReplicaClient::Subscribe's no-parameter overload doesn't throw an "
                                         "exception when trying to subscribe to a cluster with no responsive "
                                         "servers.";
 }
@@ -394,7 +394,7 @@ TEST(thin_replica_client_test, test_correct_data_returned_) {
                                                   "unsubscribing.";
   *spurious_wakeup_indicator = true;
 
-  trc->Subscribe(num_initial_updates - 1);
+  trc->Subscribe(num_initial_updates);
   for (size_t i = num_initial_updates; i < update_data.size(); ++i) {
     *spurious_wakeup_indicator = false;
     delay_condition->notify_one();

--- a/client/thin-replica-client/test/trc_rpc_use_test.cpp
+++ b/client/thin-replica-client/test/trc_rpc_use_test.cpp
@@ -168,27 +168,27 @@ TEST(trc_rpc_use_test, test_trc_subscribe) {
   update_queue->Pop();
   servers_used = vector<bool>(num_replicas, false);
   ASSERT_EQ(record->GetSubscribeToUpdatesCalls().size(), 1)
-      << "ThinReplicaClient::Subscribe's 2-parameter overload generated an "
+      << "ThinReplicaClient::Subscribe's 1-parameter overload generated an "
          "unexpected number of Subscribe calls.";
   servers_used[record->GetSubscribeToUpdatesCalls().front().first] = true;
-  EXPECT_EQ(record->GetSubscribeToUpdatesCalls().front().second.events().block_id(), 2)
-      << "ThinReplicaClient::Subscribe's 2-parameter overload made a "
+  EXPECT_EQ(record->GetSubscribeToUpdatesCalls().front().second.events().block_id(), 1)
+      << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
          "SubscribeToUpdates call with a Block ID inconsistent with the one "
          "given as a parameter to Subscribe.";
   EXPECT_EQ(record->GetSubscribeToUpdateHashesCalls().size(), max_faulty)
-      << "ThinReplicaClient::Subscribe's 2-parameter overloade generated an "
+      << "ThinReplicaClient::Subscribe's 1-parameter overloade generated an "
          "unexpected number of SubscribeToUpdateHashes calls.";
   for (const auto& call : record->GetSubscribeToUpdateHashesCalls()) {
-    EXPECT_FALSE(servers_used[call.first]) << "ThinReplicaClient::Subscribe's 2-parameter overload re-used a "
+    EXPECT_FALSE(servers_used[call.first]) << "ThinReplicaClient::Subscribe's 1-parameter overload re-used a "
                                               "server when opening subscription streams.";
     servers_used[call.first] = true;
-    EXPECT_EQ(call.second.events().block_id(), 2)
-        << "ThinReplicaClient::Subscribe's 2-parameter overload made a "
+    EXPECT_EQ(call.second.events().block_id(), 1)
+        << "ThinReplicaClient::Subscribe's 1-parameter overload made a "
            "SubscribeToUpdateHashes call with a Block ID inconsistent with the "
            "one given as a parameter to Subscribe.";
   }
   EXPECT_LE(record->GetTotalCallCount(), (1 + max_faulty))
-      << "ThinReplicaClient::Subscribe's 2-parameter overload generated "
+      << "ThinReplicaClient::Subscribe's 1-parameter overload generated "
          "unexpected RPC calls.";
 }
 


### PR DESCRIPTION
This commit sets the `latest_verified_block_id_` to
`block_id - 1`, when requested block_id is greater than 0.
`latest_verified_block_id_` cannot be equal to the requested block
id.