### PR TITLE
Remove all gen-sec files on metadata removal

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -112,6 +112,7 @@ target_link_libraries(corebft PUBLIC
   secretsmanager
   keys_and_signatures_cmf
   cre
+  stdc++fs
   )
 
 


### PR DESCRIPTION
On replicas scaling, we may end up with a replica that gets the id of another replica. In that case, the old gen-sec file won't be removed.
In this PR we remove all gen-sec files on metadata removal