### PR TITLE
Fix latest block ID inconsistency with last reachable block ID

### DIFF
--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -191,6 +191,7 @@ class DBAdapter : public IDbAdapter {
   BlockId lastKnownReconfigurationCmdBlock_ = 0;
   bool saveKvPairsSeparately_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
+  std::mutex mutex_;
 };
 
 }  // namespace concord::kvbc::v1DirectKeyValue

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -32,6 +32,7 @@
 #include <utility>
 #include <sstream>
 #include <iomanip>
+#include <mutex>
 
 using logging::Logger;
 using concordUtils::Status;
@@ -412,9 +413,11 @@ void DBAdapter::addRawBlock(const RawBlock &block, const BlockId &blockId) {
   // when ST runs, blocks arrive in batches in reverse order. we need to keep
   // track on the "Gap" and to close it. Only when it is closed, the last
   // reachable block becomes the same as the last block
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (blockId > getLatestBlockId()) setLatestBlock(blockId);
+  }
   BlockId lastReachableBlock = getLastReachableBlockId();
-  if (blockId > getLatestBlockId()) setLatestBlock(blockId);
-
   if (blockId == lastReachableBlock + 1) setLastReachableBlockNum(getLatestBlockId());
 }
 


### PR DESCRIPTION
As putBlock now runs concurrently it would result in race while updating latest block ID with the block IDs of the first few blocks from every checkpoint in RO replica.