### PR TITLE
Fix latest block ID inconsistency with last reachable block ID

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -123,7 +123,10 @@ class Replica : public IReplica,
 
   bool getBlockFromObjectStore(uint64_t blockId, char *outBlock, uint32_t outblockMaxSize, uint32_t *outBlockSize);
   bool getPrevDigestFromObjectStoreBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *);
-  bool putBlockToObjectStore(const uint64_t blockId, const char *blockData, const uint32_t blockSize);
+  bool putBlockToObjectStore(const uint64_t blockId,
+                             const char *blockData,
+                             const uint32_t blockSize,
+                             bool lastBlock = false);
 
   Replica(bft::communication::ICommunication *comm,
           const bftEngine::ReplicaConfig &config,

--- a/kvbc/include/db_adapter_interface.h
+++ b/kvbc/include/db_adapter_interface.h
@@ -27,7 +27,7 @@ class IDbAdapter {
 
   // Adds a block from its raw representation and a block ID.
   // Typically called by state transfer when a block is received and needs to be added.
-  virtual void addRawBlock(const RawBlock& rawBlock, const BlockId& blockId) = 0;
+  virtual void addRawBlock(const RawBlock& rawBlock, const BlockId& blockId, bool lastBlock) = 0;
 
   // Get block in its raw form
   virtual RawBlock getRawBlock(const BlockId& blockId) const = 0;

--- a/kvbc/include/direct_kv_db_adapter.h
+++ b/kvbc/include/direct_kv_db_adapter.h
@@ -140,7 +140,7 @@ class DBAdapter : public IDbAdapter {
   // - adding the key/value pairs in separate keys
   // - adding the whole block (raw block) in its own key.
   // Typically called by state transfer when a block is received and needs to be added.
-  void addRawBlock(const RawBlock &, const BlockId &) override;
+  void addRawBlock(const RawBlock &, const BlockId &, bool lastBlock = false) override;
 
   std::pair<Value, BlockId> getValue(const Key &, const BlockId &blockVersion) const override;
 
@@ -191,6 +191,7 @@ class DBAdapter : public IDbAdapter {
   BlockId lastKnownReconfigurationCmdBlock_ = 0;
   bool saveKvPairsSeparately_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
+  std::mutex mutex_;
 };
 
 }  // namespace concord::kvbc::v1DirectKeyValue

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -93,7 +93,7 @@ class DBAdapter : public IDbAdapter {
   // Typically called by state transfer when a block is received.
   // If adding the next block (i.e. getLastReachableBlockId() + 1), it is done so through the merkle tree. If it is not
   // the next block, a temporary state transfer block is added instead.
-  void addRawBlock(const RawBlock &rawBlock, const BlockId &blockId) override;
+  void addRawBlock(const RawBlock &rawBlock, const BlockId &blockId, bool lastBlock = false) override;
 
   // Gets a raw block by its ID.
   // An exception is thrown if an error occurs.

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -517,7 +517,7 @@ Replica::~Replica() {
  */
 bool Replica::putBlock(const uint64_t blockId, const char *blockData, const uint32_t blockSize, bool lastBlock) {
   if (replicaConfig_.isReadOnly) {
-    return putBlockToObjectStore(blockId, blockData, blockSize);
+    return putBlockToObjectStore(blockId, blockData, blockSize, lastBlock);
   }
 
   auto view = std::string_view{blockData, blockSize};
@@ -575,7 +575,10 @@ std::future<bool> Replica::putBlockAsync(uint64_t blockId,
   return future;
 }
 
-bool Replica::putBlockToObjectStore(const uint64_t blockId, const char *blockData, const uint32_t blockSize) {
+bool Replica::putBlockToObjectStore(const uint64_t blockId,
+                                    const char *blockData,
+                                    const uint32_t blockSize,
+                                    bool lastBlock) {
   Sliver block = Sliver::copy(blockData, blockSize);
 
   if (m_bcDbAdapter->hasBlock(blockId)) {
@@ -594,7 +597,7 @@ bool Replica::putBlockToObjectStore(const uint64_t blockId, const char *blockDat
       throw std::runtime_error(__PRETTY_FUNCTION__ + std::string("data corrupted blockId: ") + std::to_string(blockId));
     }
   } else {
-    m_bcDbAdapter->addRawBlock(block, blockId);
+    m_bcDbAdapter->addRawBlock(block, blockId, lastBlock);
   }
 
   return true;

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -557,7 +557,7 @@ void DBAdapter::writeSTLinkTransaction(const Key &sTBlockKey, const Sliver &bloc
   lastReachableBlockId_ = blockId;
 }
 
-void DBAdapter::addRawBlock(const RawBlock &block, const BlockId &blockId) {
+void DBAdapter::addRawBlock(const RawBlock &block, const BlockId &blockId, bool lastBlock) {
   TimeRecorder scoped_timer(*histograms.dba_add_raw_block);
   const auto lastReachableBlock = getLastReachableBlockId();
   if (blockId <= lastReachableBlock) {


### PR DESCRIPTION
As writing blocks now happens concurrently it would result in race while
updating latest block ID with the block IDs of the first few
blocks from every checkpoint in RO replica.