### PR TITLE
Changes to increase the retry timeout for test_primary_write

### DIFF
--- a/tests/apollo/test_skvbc_pyclient.py
+++ b/tests/apollo/test_skvbc_pyclient.py
@@ -114,7 +114,6 @@ class SkvbcPyclientTest(unittest.TestCase):
                 "having made any retries even after attempting a write to a " \
                 "non-running cluster.")
 
-    @unittest.skip("Skip due to instability. Tracked in BC-9404")
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_primary_write(self, bft_network):
@@ -125,6 +124,10 @@ class SkvbcPyclientTest(unittest.TestCase):
 
         bft_network.start_all_replicas()
         client = bft_network.random_client()
+        client.config = client.config._replace(
+            retry_timeout_milli = 1000
+        )
+
         protocol = skvbc.SimpleKVBCProtocol(bft_network)
 
         key = protocol.random_key()


### PR DESCRIPTION
The python bft_client has a retry timeout of 250 miliseconds.
If the client request has not finished in 250 miliseconds, the client retries the request by sending to all replicas.
In the case of this test, we sometimes hit this timeout, making the client send more requests than expected in the test.

After Increasing retry_timeout_milli to 1000ms, we are not hitting the issue.