### PR TITLE
Fix for replicas graceful shutdown

### DIFF
--- a/client/reconfiguration/src/st_based_reconfiguration_client.cpp
+++ b/client/reconfiguration/src/st_based_reconfiguration_client.cpp
@@ -23,7 +23,7 @@ STBasedReconfigurationClient::STBasedReconfigurationClient(
 State STBasedReconfigurationClient::getNextState() const {
   std::unique_lock<std::mutex> lk(lock_);
   while (!stopped_ && updates_.empty()) {
-    new_updates_.wait(lk, [this]() { return !updates_.empty(); });
+    new_updates_.wait_for(lk, 1s, [this]() { return !updates_.empty(); });
   }
   if (stopped_) return {0, {}};
   auto ret = std::move(updates_.front());

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1042,7 +1042,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         await bft_network.change_configuration(conf)
         await op.add_remove_with_wedge(test_config, bft=True, restart=True)
         await self.validate_epoch_number(bft_network, 1, bft_network.all_replicas())
-        bft_network.stop_replica(4) # to have clean logs
+        bft_network.stop_replica(4, force_kill=True) # to have clean logs
         bft_network.restart_clients()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(100):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -762,7 +762,7 @@ class BftTestNetwork:
 
             return self.replicas[replica_id]
 
-    def stop_replica(self, replica_id):
+    def stop_replica(self, replica_id, force_kill=False):
         """
         Stop a replica if it is running.
         Otherwise raise an AlreadyStoppedError.
@@ -775,10 +775,13 @@ class BftTestNetwork:
                 self._stop_external_replica(replica_id)
             else:
                 p = self.procs[replica_id]
-                if os.environ.get('GRACEFUL_SHUTDOWN', "").lower() in set(["true", "on"]):
-                    p.terminate()
-                else:
+                if force_kill:
                     p.kill()
+                else:
+                    if os.environ.get('GRACEFUL_SHUTDOWN', "").lower() in set(["true", "on"]):
+                        p.terminate()
+                    else:
+                        p.kill()
                 for fd in self.open_fds.get(replica_id, ()):
                     fd.close()
                 p.wait()


### PR DESCRIPTION
Some issues with replicated graceful shutdown have been addressed in a Pull request, 
https://github.com/vmware/concord-bft/pull/1875

This PR includes changes related to condition variables that wait indefinitely for a resource, causing apollo test cases to time-out.

Also implementing adjustments for TC 'test_remove_nodes_with_f_failures' under test-suit 'test_skvbc_reconfiguration' to force replica shutdown under graceful shutdown. It's necessary because here 'skvbc_replica' binary is restarting, and some resources aren't releasing gracefully, causing the TC 'test_skvbc_reconfiguration' to time-out.