### PR TITLE
Added skip_for_tls decorator to clean up code in apollo

### DIFF
--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -18,7 +18,7 @@ from os import environ
 
 import trio
 
-from util.bft import with_trio, with_bft_network, with_constant_load, KEY_FILE_PREFIX
+from util.bft import with_trio, with_bft_network, with_constant_load, KEY_FILE_PREFIX, skip_for_tls
 from util import bft_network_partitioning as net
 from util import eliot_logging as log
 
@@ -138,7 +138,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
                     await write_req()
                     await trio.sleep(seconds=3)
 
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_inactive_window(self, bft_network):
@@ -193,7 +193,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
                     await trio.sleep(seconds=3)
 
     @unittest.skip("Edge case scenario - not part of CI until intermittent failures are analysed")
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_view_change_with_f_replicas_collected_stable_checkpoint(self, bft_network):
@@ -624,8 +624,7 @@ class SkvbcChaoticStartupTest(unittest.TestCase):
 
         await self._wait_for_replicas_to_generate_checkpoint(bft_network, skvbc, expected_next_primary, bft_network.all_replicas(without={initial_primary}))
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd_with_vc_timeout("20000"),
                       selected_configs=lambda n, f, c: n == 7)

--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -18,7 +18,7 @@ import trio
 from util import bft_network_partitioning as net
 
 from util import skvbc as kvbc
-from util.bft import with_trio, with_bft_network, with_constant_load, KEY_FILE_PREFIX
+from util.bft import with_trio, with_bft_network, with_constant_load, KEY_FILE_PREFIX, skip_for_tls
 
 
 def start_replica_cmd(builddir, replica_id):
@@ -205,8 +205,7 @@ class SkvbcCheckpointTest(unittest.TestCase):
             bft_network.all_replicas(),
             expected_checkpoint_num=lambda ecn: ecn >= checkpoint_init_primary_after)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_checkpoint_propagation_after_f_non_primaries_isolated(self, bft_network):
@@ -249,8 +248,7 @@ class SkvbcCheckpointTest(unittest.TestCase):
             isolated_replicas,
             expected_checkpoint_num=lambda ecn: ecn == checkpoint_before + 1)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_checkpoint_propagation_after_primary_isolation(self, bft_network):
@@ -306,8 +304,7 @@ class SkvbcCheckpointTest(unittest.TestCase):
                 verify_checkpoint_persistency=False
             )
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_checkpoint_propagation_after_f_nodes_including_primary_isolated(self, bft_network):

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -19,7 +19,7 @@ import trio
 from util import bft_network_partitioning as net
 
 from util import skvbc as kvbc
-from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, skip_for_tls
 from util.skvbc_history_tracker import verify_linearizability
 from util import eliot_logging as log
 
@@ -44,7 +44,7 @@ def start_replica_cmd(builddir, replica_id):
 class SkvbcNetworkPartitioningTest(unittest.TestCase):
 
     from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability()
@@ -66,8 +66,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
 
             await self.skvbc.run_concurrent_ops(num_ops)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability()
@@ -109,8 +108,8 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
 
             await skvbc.run_concurrent_ops(100)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability()
@@ -127,7 +126,6 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
         to trigger a checkpoint.
         """
         bft_network.start_all_replicas()
-
         f = bft_network.config.f
         curr_primary = await bft_network.get_current_primary()
         isolated_replicas = bft_network.random_set_of_replicas(f, without={curr_primary})
@@ -149,8 +147,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
             await bft_network.wait_for_last_executed_seq_num(
                 replica_id=ir, expected=last_executed_seq_num)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_isolate_f_non_primaries_state_transfer(self, bft_network):
@@ -186,8 +183,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
         for ir in isolated_replicas:
             await bft_network.wait_for_state_transfer_to_stop(0, ir)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability()
@@ -243,8 +239,7 @@ class SkvbcNetworkPartitioningTest(unittest.TestCase):
             await bft_network.wait_for_last_executed_seq_num(
                 replica_id=ir, expected=expected_last_executed_seq_num)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_state_transfer_isolated(self, bft_network):

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -21,7 +21,7 @@ from util.skvbc import SimpleKVBCProtocol
 from util.skvbc_history_tracker import verify_linearizability
 from math import inf
 
-from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network
+from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network, skip_for_tls
 from util import eliot_logging as log
 
 
@@ -244,8 +244,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
                log.log_message(message_type=f'Stopping replica {stale_node}')
                bft_network.stop_replica(stale_node)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @unittest.skip("Fails because of BC-7264")
     @with_trio
     @with_bft_network(start_replica_cmd,
@@ -334,8 +333,7 @@ class SkvbcPersistenceTest(unittest.TestCase):
             log.log_message(message_type="State transfer completed before we had a chance "
                   "to stop the source replica.")
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: f >= 2)

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -16,7 +16,7 @@ import unittest
 import trio
 import random
 
-from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load, skip_for_tls
 from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
 
@@ -381,8 +381,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
 
         await bft_network.assert_successful_pre_executions_count(0, num_preexecution_requests)
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -434,8 +433,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
             last_block = await tracker.get_last_block_id(read_client)
             assert last_block > start_block
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -462,8 +460,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
             last_block = await tracker.get_last_block_id(read_client)
             assert last_block > start_block
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -500,8 +497,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
             last_block = await tracker.get_last_block_id(read_client)
             assert last_block > start_block
 
-    from os import environ
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)

--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -17,7 +17,7 @@ from util import bft_network_traffic_control as ntc
 import trio
 
 from util import skvbc as kvbc
-from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, skip_for_tls
 from util import eliot_logging as log
 
 def start_replica_cmd(builddir, replica_id):
@@ -96,8 +96,8 @@ class SkvbcStateTransferTest(unittest.TestCase):
         await skvbc.assert_successful_put_get()
         await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get()
-    
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd,
                     selected_configs=lambda n, f, c: f >= 2,

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -19,7 +19,7 @@ import trio
 
 from util import bft_network_partitioning as net
 from util import skvbc as kvbc
-from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
+from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, skip_for_tls
 from util.skvbc_history_tracker import verify_linearizability
 from util import eliot_logging as log
 
@@ -393,7 +393,7 @@ class SkvbcViewChangeTest(unittest.TestCase):
             num_consecutive_failing_primaries = 2
         )
 
-    @unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)")
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd, rotate_keys=True)
     async def test_replica_asks_to_leave_view(self, bft_network):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -106,6 +106,17 @@ def with_trio(async_fn):
 
     return trio_wrapper
 
+def skip_for_tls(async_fn):
+    """ Decorator for skipping the test for TCP/TLS. """
+    @wraps(async_fn)
+    def wrapper(*args, **kwargs):
+        if os.environ.get('BUILD_COMM_TCP_TLS', "").lower() != "true":
+            return async_fn(*args, **kwargs)
+        else:
+            pass
+
+    return wrapper
+
 def with_constant_load(async_fn):
     """
     Runs the decorated async function in parallel with constant load,


### PR DESCRIPTION
Added skip_for_tls decorator in place of unittest.skipIf(environ.get('BUILD_COMM_TCP_TLS', "").lower() == "true", "Unstable on CI (TCP/TLS only)") in required apollo test cases.