### PR TITLE
Add the SynchronizedValue class template utility

### DIFF
--- a/util/include/synchronized_value.hpp
+++ b/util/include/synchronized_value.hpp
@@ -1,0 +1,92 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <utility>
+
+namespace concord::util {
+
+// Syncrhonizes multi-threaded access to a value of type T.
+template <typename T>
+class SynchronizedValue {
+ private:
+  using MutexType = std::shared_mutex;
+  using ExclusiveLock = std::scoped_lock<MutexType>;
+  using SharedLock = std::shared_lock<MutexType>;
+
+ public:
+  // Construct the value in-place with the given arguments.
+  template <typename... Args>
+  SynchronizedValue(Args&&... args) {
+    replace(std::forward<Args>(args)...);
+  }
+
+  // Replace the value by constructing a new one in-place with the given arguments.
+  //
+  // Precondition: the calling thread doesn't have any accessors at the time of the call. If it does, the behaviour is
+  // undefined.
+  template <typename... Args>
+  void replace(Args&&... args) {
+    auto new_val = std::make_unique<T>(std::forward<Args>(args)...);
+    auto lock = ExclusiveLock{mtx_};
+    val_ = std::move(new_val);
+  }
+
+  // Provides read-write access to the value.
+  // Locks the mutex in the constructor and unlocks it in the dtor.
+  class Accessor {
+   public:
+    Accessor(T& val, MutexType& mtx) : val_{val}, lock_{mtx} {}
+
+    T& operator*() const noexcept { return val_; }
+    T* operator->() const noexcept { return &val_; }
+
+   private:
+    T& val_;
+    ExclusiveLock lock_;
+  };
+
+  // Provides read access to the value.
+  // Locks the mutex in the constructor and unlocks it in the dtor.
+  class ConstAccessor {
+   public:
+    ConstAccessor(const T& val, MutexType& mtx) : val_{val}, lock_{mtx} {}
+
+    const T& operator*() const noexcept { return val_; }
+    const T* operator->() const noexcept { return &val_; }
+
+   private:
+    const T& val_;
+    SharedLock lock_;
+  };
+
+  // Create an accessor to the value.
+  //
+  // Precondition: the calling thread doesn't have any other accessors at the time of the call. If it does, the
+  // behaviour is undefined.
+  //
+  // A single thread can create one accessor only at a time. Other threads will wait until it is destroyed before they
+  // can do any operations on the synchronized value.
+  Accessor access() { return Accessor{*val_, mtx_}; }
+  ConstAccessor constAccess() const { return ConstAccessor{*val_, mtx_}; }
+
+ private:
+  std::unique_ptr<T> val_;
+  mutable MutexType mtx_;
+};
+
+}  // namespace concord::util

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -74,3 +74,7 @@ target_link_libraries(simple_memory_pool_test GTest::Main util)
 add_executable(crypto_utils_test crypto_utils_test.cpp )
 add_test(crypto_utils_test crypto_utils_test)
 target_link_libraries(crypto_utils_test GTest::Main util)
+
+add_executable(synchronized_value_test synchronized_value_test.cpp)
+add_test(synchronized_value_test synchronized_value_test)
+target_link_libraries(synchronized_value_test GTest::Main util)

--- a/util/test/synchronized_value_test.cpp
+++ b/util/test/synchronized_value_test.cpp
@@ -1,0 +1,163 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "synchronized_value.hpp"
+
+#include <thread>
+
+namespace {
+
+using namespace concord::util;
+
+TEST(synchronized_value, ctor_built_in_type_default_init) {
+  auto v = SynchronizedValue<int>{};
+  ASSERT_EQ(0, *v.access());
+}
+
+TEST(synchronized_value, ctor_user_type_default_init) {
+  struct UserType {
+    UserType() = default;
+    UserType(int data) : data_{data} {}
+
+    int data_{42};
+  };
+
+  auto v = SynchronizedValue<UserType>{};
+  ASSERT_EQ(42, v.access()->data_);
+}
+
+TEST(synchronized_value, ctor_with_arguments) {
+  auto v = SynchronizedValue<int>{42};
+  ASSERT_EQ(42, *v.access());
+}
+
+TEST(synchronized_value, replace_built_in_type_default_init) {
+  auto v = SynchronizedValue<int>{42};
+  v.replace();
+  ASSERT_EQ(0, *v.access());
+}
+
+TEST(synchronized_value, replace_user_type_default_init) {
+  struct UserType {
+    UserType() = default;
+    UserType(int data) : data_{data} {}
+
+    int data_{42};
+  };
+
+  auto v = SynchronizedValue<UserType>{7};
+  v.replace();
+  ASSERT_EQ(42, v.access()->data_);
+}
+
+TEST(synchronized_value, replace_with_arguments) {
+  auto v = SynchronizedValue<int>{41};
+  ASSERT_EQ(41, *v.access());
+  v.replace(42);
+  ASSERT_EQ(42, *v.access());
+}
+
+TEST(synchronized_value, accessor_changes_value) {
+  auto v = SynchronizedValue<int>{42};
+  auto a = v.access();
+  ASSERT_EQ(42, *a);
+
+  *a = 43;
+  ASSERT_EQ(43, *a);
+}
+
+TEST(synchronized_value, ctor_creates_in_place) {
+  struct NonCopyableAndNonMovable {
+    NonCopyableAndNonMovable(int data) : data_{data} {}
+    NonCopyableAndNonMovable(const NonCopyableAndNonMovable&) = delete;
+    NonCopyableAndNonMovable& operator=(const NonCopyableAndNonMovable&) = delete;
+    NonCopyableAndNonMovable(NonCopyableAndNonMovable&&) = delete;
+    NonCopyableAndNonMovable& operator=(NonCopyableAndNonMovable&&) = delete;
+
+    int data_{0};
+  };
+
+  auto v = SynchronizedValue<NonCopyableAndNonMovable>{42};
+  ASSERT_EQ(42, v.access()->data_);
+}
+
+TEST(synchronized_value, multi_member_ctor) {
+  struct MultiMember {
+    MultiMember(int data1, int data2) : data1_{data1}, data2_{data2} {}
+    int data1_{0};
+    int data2_{0};
+  };
+
+  auto v = SynchronizedValue<MultiMember>{42, 43};
+  auto a = v.access();
+  ASSERT_EQ(42, a->data1_);
+  ASSERT_EQ(43, a->data2_);
+}
+
+TEST(synchronized_value, two_threads_with_accessors) {
+  auto v = SynchronizedValue<int>{7};
+
+  auto t1 = std::thread{[&]() {
+    auto a = v.access();
+    *a = 42;
+  }};
+
+  auto t2 = std::thread{[&]() {
+    auto a = v.access();
+    *a = 43;
+  }};
+
+  t1.join();
+  t2.join();
+
+  auto a = v.access();
+  ASSERT_TRUE((42 == *a || 43 == *a));
+}
+
+TEST(synchronized_value, two_threads_with_const_accessors) {
+  auto v = SynchronizedValue<int>{42};
+
+  auto t1 = std::thread{[&]() {
+    auto a = v.constAccess();
+    ASSERT_EQ(42, *a);
+  }};
+
+  auto t2 = std::thread{[&]() {
+    auto a = v.constAccess();
+    ASSERT_EQ(42, *a);
+  }};
+
+  t1.join();
+  t2.join();
+}
+
+TEST(synchronized_value, one_thread_with_accessor_and_one_calls_replace) {
+  auto v = SynchronizedValue<int>{7};
+
+  auto t1 = std::thread{[&]() {
+    auto a = v.access();
+    *a = 42;
+  }};
+
+  auto t2 = std::thread{[&]() { v.replace(43); }};
+
+  t1.join();
+  t2.join();
+
+  auto a = v.access();
+  ASSERT_TRUE((42 == *a || 43 == *a));
+}
+
+}  // namespace

--- a/util/test/synchronized_value_test.cpp
+++ b/util/test/synchronized_value_test.cpp
@@ -156,8 +156,34 @@ TEST(synchronized_value, one_thread_with_accessor_and_one_calls_replace) {
   t1.join();
   t2.join();
 
-  auto a = v.access();
+  auto a = v.constAccess();
   ASSERT_TRUE((42 == *a || 43 == *a));
+}
+
+TEST(synchronized_value, two_threads_with_const_accessors_and_one_with_non_const) {
+  auto v = SynchronizedValue<int>{7};
+
+  auto t1 = std::thread{[&]() {
+    auto a = v.access();
+    *a = 42;
+  }};
+
+  auto t2 = std::thread{[&]() {
+    auto a = v.access();
+    *a = 43;
+  }};
+
+  auto t3 = std::thread{[&]() {
+    auto a = v.constAccess();
+    ASSERT_TRUE((7 == *a || 42 == *a || 43 == *a));
+  }};
+
+  t1.join();
+  t2.join();
+  t3.join();
+
+  auto a = v.constAccess();
+  ASSERT_TRUE((7 == *a || 42 == *a || 43 == *a));
 }
 
 }  // namespace

--- a/util/test/synchronized_value_test.cpp
+++ b/util/test/synchronized_value_test.cpp
@@ -23,7 +23,7 @@ using namespace concord::util;
 
 TEST(synchronized_value, ctor_built_in_type_default_init) {
   auto v = SynchronizedValue<int>{};
-  ASSERT_EQ(0, *v.access());
+  ASSERT_EQ(0, *v.constAccess());
 }
 
 TEST(synchronized_value, ctor_user_type_default_init) {
@@ -35,18 +35,18 @@ TEST(synchronized_value, ctor_user_type_default_init) {
   };
 
   auto v = SynchronizedValue<UserType>{};
-  ASSERT_EQ(42, v.access()->data_);
+  ASSERT_EQ(42, v.constAccess()->data_);
 }
 
 TEST(synchronized_value, ctor_with_arguments) {
   auto v = SynchronizedValue<int>{42};
-  ASSERT_EQ(42, *v.access());
+  ASSERT_EQ(42, *v.constAccess());
 }
 
 TEST(synchronized_value, replace_built_in_type_default_init) {
   auto v = SynchronizedValue<int>{42};
   v.replace();
-  ASSERT_EQ(0, *v.access());
+  ASSERT_EQ(0, *v.constAccess());
 }
 
 TEST(synchronized_value, replace_user_type_default_init) {
@@ -59,14 +59,14 @@ TEST(synchronized_value, replace_user_type_default_init) {
 
   auto v = SynchronizedValue<UserType>{7};
   v.replace();
-  ASSERT_EQ(42, v.access()->data_);
+  ASSERT_EQ(42, v.constAccess()->data_);
 }
 
 TEST(synchronized_value, replace_with_arguments) {
   auto v = SynchronizedValue<int>{41};
-  ASSERT_EQ(41, *v.access());
+  ASSERT_EQ(41, *v.constAccess());
   v.replace(42);
-  ASSERT_EQ(42, *v.access());
+  ASSERT_EQ(42, *v.constAccess());
 }
 
 TEST(synchronized_value, accessor_changes_value) {
@@ -90,7 +90,7 @@ TEST(synchronized_value, ctor_creates_in_place) {
   };
 
   auto v = SynchronizedValue<NonCopyableAndNonMovable>{42};
-  ASSERT_EQ(42, v.access()->data_);
+  ASSERT_EQ(42, v.constAccess()->data_);
 }
 
 TEST(synchronized_value, multi_member_ctor) {
@@ -101,7 +101,7 @@ TEST(synchronized_value, multi_member_ctor) {
   };
 
   auto v = SynchronizedValue<MultiMember>{42, 43};
-  auto a = v.access();
+  auto a = v.constAccess();
   ASSERT_EQ(42, a->data1_);
   ASSERT_EQ(43, a->data2_);
 }
@@ -143,7 +143,7 @@ TEST(synchronized_value, two_threads_with_const_accessors) {
   t2.join();
 }
 
-TEST(synchronized_value, one_thread_with_accessor_and_one_calls_replace) {
+TEST(synchronized_value, one_thread_with_accessor_and_one_calling_replace) {
   auto v = SynchronizedValue<int>{7};
 
   auto t1 = std::thread{[&]() {
@@ -160,7 +160,7 @@ TEST(synchronized_value, one_thread_with_accessor_and_one_calls_replace) {
   ASSERT_TRUE((42 == *a || 43 == *a));
 }
 
-TEST(synchronized_value, two_threads_call_replace) {
+TEST(synchronized_value, two_threads_calling_replace) {
   auto v = SynchronizedValue<int>{7};
 
   auto t1 = std::thread{[&]() { v.replace(42); }};
@@ -173,7 +173,7 @@ TEST(synchronized_value, two_threads_call_replace) {
   ASSERT_TRUE((42 == *a || 43 == *a));
 }
 
-TEST(synchronized_value, two_threads_with_const_accessors_and_one_with_non_const) {
+TEST(synchronized_value, two_threads_with_accessors_and_one_with_const_accessor) {
   auto v = SynchronizedValue<int>{7};
 
   auto t1 = std::thread{[&]() {

--- a/util/test/synchronized_value_test.cpp
+++ b/util/test/synchronized_value_test.cpp
@@ -160,6 +160,19 @@ TEST(synchronized_value, one_thread_with_accessor_and_one_calls_replace) {
   ASSERT_TRUE((42 == *a || 43 == *a));
 }
 
+TEST(synchronized_value, two_threads_call_replace) {
+  auto v = SynchronizedValue<int>{7};
+
+  auto t1 = std::thread{[&]() { v.replace(42); }};
+  auto t2 = std::thread{[&]() { v.replace(43); }};
+
+  t1.join();
+  t2.join();
+
+  auto a = v.constAccess();
+  ASSERT_TRUE((42 == *a || 43 == *a));
+}
+
 TEST(synchronized_value, two_threads_with_const_accessors_and_one_with_non_const) {
   auto v = SynchronizedValue<int>{7};
 


### PR DESCRIPTION
The `SynchronizedValue` utility allows for synchronized access to a
value from multiple threads. It supports:
 * in-place construction of values with arbitrary arguments, thus
   allowing users to use it with non-copyable and/or non-movable types
 * ability to replace the value without using type T's copy/move
   operations (that might be deleted)
 * const and non-const accessors that utilize read-write mutexes
 * RAII stype accessors that guarantee release of the mutex in all cases

Add an unit test to cover typical use cases.