### PR TITLE
Remove redundant passing of pre_exec_all in Apollo

### DIFF
--- a/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
+++ b/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
@@ -123,7 +123,7 @@ class SkvbcPrimaryByzantinePreExecutionTest(unittest.TestCase):
         be triggered.
         Check the view change and then get the new primary and test the counts.
         """
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker, tracker.pre_exec_all)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
         bft_network.start_all_replicas()
         await trio.sleep(SKVBC_INIT_GRACE_TIME)
         await bft_network.init_preexec_count()
@@ -149,7 +149,7 @@ class SkvbcPrimaryByzantinePreExecutionTest(unittest.TestCase):
         to different replica, view change will be triggered to elect a new primary.
         Check the view change and then get the new primary and test the counts.
         """
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker, tracker.pre_exec_all)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
         bft_network.start_all_replicas()
         await trio.sleep(SKVBC_INIT_GRACE_TIME)
         await bft_network.init_preexec_count()

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -110,7 +110,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
 
         for i in range(NUM_OF_SEQ_WRITES):
             client = bft_network.random_client()
-            skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker, tracker.pre_exec_all)
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
             await skvbc.send_write_kv_set(client, max_set_size=2)
         await bft_network.assert_successful_pre_executions_count(0, NUM_OF_SEQ_WRITES)
 
@@ -127,7 +127,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
 
         clients = bft_network.random_clients(MAX_CONCURRENCY)
         num_of_requests = NUM_OF_PARALLEL_WRITES
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker, tracker.pre_exec_all)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
         rw = await skvbc.run_concurrent_ops(num_of_requests, write_weight=0.9)
         self.assertTrue(rw[0] + rw[1] >= num_of_requests)
 
@@ -150,7 +150,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
             req_timeout_milli=LONG_REQ_TIMEOUT_MILLI,
             retry_timeout_milli=1000
         )
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker, tracker.pre_exec_all)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
         await skvbc.send_write_kv_set(client, max_set_size=2, long_exec=True)
 
         last_block = await tracker.get_last_block_id(client)
@@ -295,7 +295,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
 
         clients = bft_network.clients.values()
         client = random.choice(list(clients))
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker, tracker.pre_exec_all)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
         await skvbc.send_write_kv_set(client, max_set_size=2)
 
         await bft_network.assert_successful_pre_executions_count(0, 1)
@@ -339,7 +339,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         nonprimaries = bft_network.all_replicas(without={0}) # primary index is 0
         crash_targets = random.sample(nonprimaries, bft_network.config.f) # pick random f to crash
         bft_network.stop_replicas(crash_targets) # crash chosen nonprimary replicas
-        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker, tracker.pre_exec_all)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
         rw = await skvbc.run_concurrent_ops(num_of_requests, write_weight=1)
         final_block_count = await tracker.get_last_block_id(read_client)
 

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -49,10 +49,35 @@ class SimpleKVBCProtocol:
     requests.
     """
 
-    def __init__(self, bft_network, tracker = None, pre_process=False):
+    def __init__(self, bft_network, tracker = None, pre_exec_all = None):
+        """
+        Initializer for SimpleKVBCProtocol, given a BftTestNetwork to connect to
+        as bft_network, and optionally an SkvbcTracker to use as tracker and a
+        Boolean value specifying whether to enable pre execution on all requests
+        as pre_exec_all.
+        
+        Note pre_exec_all defaults to False if no tracker is given and to the
+        tracker's value for pre_exec_all if a tracker is given, so passing an
+        explicit value for pre_exec_all is unnecessary if a tracker is in use.
+        """
+
         self.bft_network = bft_network
         self.tracker = tracker
-        self.pre_exec_all = pre_process
+
+        if (self.tracker is not None):
+            if (pre_exec_all is not None):
+                assert (self.tracker.pre_exec_all == pre_exec_all), \
+                    "SimpleKVBCProtocol constructor was given a value for " \
+                    "pre_exec_all conflicting with the value configured in " \
+                    "the SkvbcTracker it was given."
+
+            self.pre_exec_all = self.tracker.pre_exec_all
+        else:
+            if (pre_exec_all is None):
+                self.pre_exec_all = False
+            else:
+                self.pre_exec_all = pre_exec_all
+
         self.alpha = [i for i in range(65, 91)]
         self.alphanum = [i for i in range(48, 58)]
         self.alphanum.extend(self.alpha)


### PR DESCRIPTION
This PR removes explicit values for the `pre_exec_all` parameter in instantiations of `SimpleKVBCProtocol` in Apollo where the `SimpleKVBCProtocol` is also given an `SkvbcTracker`. This PR also modifies `SimpleKVBCProtocol.__init__` to accommodate this change by defaulting the `SimpleKVBCProtocol` instance's value for `pre_exec_all` to the tracker's value of `pre_exec_all`.

This PR is intended to remove the unnecessary redundancy in instantiations of `SimpleKVBCProtocol` that give values for both tracker and `pre_exec_all`, as `SkvbcTracker`s already have a value for `pre_exec_all`, and it would be erroneous if a `SimpleKVBCProtocol` object was initialized with a tracker and an explicit value for `pre_exec_all` not matching the value the tracker already has.