### PR TITLE
Block new connections on addRemove command 

### DIFF
--- a/communication/include/communication/CommStateControl.hpp
+++ b/communication/include/communication/CommStateControl.hpp
@@ -1,0 +1,27 @@
+// Concord
+//
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+namespace bft::communication {
+class CommStateControl {
+ public:
+  static CommStateControl& instance() {
+    static CommStateControl instance_;
+    return instance_;
+  }
+  void setBlockNewConnectionsFlag(bool flag) { blockNewConnectionsFlag_ = flag; }
+  bool getBlockNewConnectionsFlag() { return blockNewConnectionsFlag_; }
+
+ private:
+  bool blockNewConnectionsFlag_ = false;
+};
+}  // namespace bft::communication

--- a/reconfiguration/CMakeLists.txt
+++ b/reconfiguration/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(concordbft_reconfiguration
         
 target_include_directories(concordbft_reconfiguration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(concordbft_reconfiguration PUBLIC
+ bftcommunication
  cmf_messages
  corebft
  util

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -58,7 +58,8 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
               concord::messages::ReconfigurationResponse&) override;
 
  private:
-  void handleWedgeCommands(bool bft_support, bool remove_metadata, bool restart, bool unwedge);
+  void handleWedgeCommands(
+      bool bft_support, bool remove_metadata, bool restart, bool unwedge, bool blockNewConnections);
 };
 
 class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {


### PR DESCRIPTION
On addRemove command, we may have a scenario in which a new TLS connection is created, but the replica already has the new configuration. In this case the replica search for the new TLS private key in the wrong place.
For this, we introduce a new mechanism in which the replica can decide not to start new connections.

(See #1881)