### PR TITLE
Make SynchronizedValue::replace() return an accessor

### DIFF
--- a/util/test/synchronized_value_test.cpp
+++ b/util/test/synchronized_value_test.cpp
@@ -69,12 +69,29 @@ TEST(synchronized_value, replace_with_arguments) {
   ASSERT_EQ(42, *v.constAccess());
 }
 
+TEST(synchronized_value, replace_accessor_changes_value) {
+  auto v = SynchronizedValue<int>{41};
+
+  {
+    auto a = v.replace(42);
+    ASSERT_EQ(42, *a);
+    *a = 43;
+  }
+
+  auto a = v.constAccess();
+  ASSERT_EQ(43, *a);
+}
+
 TEST(synchronized_value, accessor_changes_value) {
   auto v = SynchronizedValue<int>{42};
-  auto a = v.access();
-  ASSERT_EQ(42, *a);
 
-  *a = 43;
+  {
+    auto a = v.access();
+    ASSERT_EQ(42, *a);
+    *a = 43;
+  }
+
+  auto a = v.constAccess();
   ASSERT_EQ(43, *a);
 }
 


### PR DESCRIPTION
Do this to make it more usable in cases where one might want to replace
the value and retain the lock for further processing.

Do not use replace() in the constructor as it unnecessarily locks the
mutex. Instead, directly call std::make_unique().