### PR TITLE
Add ability to crate self signed certificates

### DIFF
--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -91,6 +91,9 @@ class Crypto {
   std::pair<std::string, std::string> generateECDSAKeyPair(const KeyFormat fmt) const;
   std::pair<std::string, std::string> RsaHexToPem(const std::pair<std::string, std::string>& key_pair) const;
   std::pair<std::string, std::string> ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) const;
+  std::string generateSelfSignedCertificate(const std::pair<std::string, std::string>& keyPair_pem,
+                                            const std::string& host,
+                                            uint32_t node_id);
 
  private:
   class Impl;


### PR DESCRIPTION
To enable client TLS key rotation, we need to have the ability to create new certificates programmatically. 
This PR is the first effort for clients' TLS key exchange 