### PR TITLE
Pass primary block id on preexecution

### DIFF
--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -49,6 +49,7 @@ class IRequestsHandler {
     uint32_t outActualReplySize = 0;
     uint32_t outReplicaSpecificInfoSize = 0;
     int outExecutionStatus = 1;
+    uint64_t blockId = 0;
   };
 
   static std::shared_ptr<IRequestsHandler> createRequestsHandler(

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -4,6 +4,7 @@ set(preprocessor_source_files
     ${bftengine_SOURCE_DIR}/src/bftengine/messages/ClientRequestMsg.cpp
     ${bftengine_SOURCE_DIR}/src/bftengine/messages/MessageBase.cpp
     PreProcessor.cpp
+    GlobalData.cpp
     RequestProcessingState.cpp
     messages/ClientPreProcessRequestMsg.cpp
     messages/ClientBatchRequestMsg.cpp

--- a/bftengine/src/preprocessor/GlobalData.cpp
+++ b/bftengine/src/preprocessor/GlobalData.cpp
@@ -1,0 +1,6 @@
+#include "GlobalData.hpp"
+
+namespace preprocessor {
+
+std::atomic_uint64_t GlobalData::current_block_id = 0;
+};  // namespace preprocessor

--- a/bftengine/src/preprocessor/GlobalData.hpp
+++ b/bftengine/src/preprocessor/GlobalData.hpp
@@ -1,0 +1,9 @@
+#include <atomic>
+
+namespace preprocessor {
+struct GlobalData {
+  // Holds the block id that was last added to storage,
+  // Used for the conflict detection optimization.
+  static std::atomic_uint64_t current_block_id;
+};
+};  // namespace preprocessor

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -30,6 +30,7 @@
 #include "diagnostics.h"
 #include "PerformanceManager.hpp"
 #include <RollingAvgAndVar.hpp>
+#include "GlobalData.hpp"
 
 // TODO[TK] till boost upgrade
 #pragma GCC diagnostic push
@@ -209,14 +210,7 @@ class PreProcessor {
                                       bool isPrimary,
                                       bool isRetry,
                                       TimeRecorder &&totalPreExecDurationRecorder = TimeRecorder());
-  uint32_t launchReqPreProcessing(uint16_t clientId,
-                                  uint16_t reqOffsetInBatch,
-                                  const std::string &cid,
-                                  ReqId reqSeqNum,
-                                  uint32_t reqLength,
-                                  char *reqBuf,
-                                  std::string signature,
-                                  const concordUtils::SpanContext &span_context);
+  uint32_t launchReqPreProcessing(const PreProcessRequestMsgSharedPtr &preProcessReqMsg);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg, bool isPrimary, bool isRetry);
   void handleReqPreProcessedByNonPrimary(uint16_t clientId,
                                          uint16_t reqOffsetInBatch,

--- a/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.cpp
@@ -94,6 +94,7 @@ PreProcessReqMsgsList& PreProcessBatchRequestMsg::getPreProcessRequestMsgs() {
                                                                             cid,
                                                                             requestSignaturePosition,
                                                                             singleMsgHeader.reqSignatureLength,
+                                                                            singleMsgHeader.primaryBlockId,
                                                                             spanContext);
     preProcessReqMsgsList_.push_back(move(preProcessReqMsg));
     dataPosition += sizeof(PreProcessRequestMsg::Header) + singleMsgHeader.spanContextSize +

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -28,6 +28,7 @@ PreProcessRequestMsg::PreProcessRequestMsg(RequestType reqType,
                                            const std::string& cid,
                                            const char* requestSignature,
                                            uint16_t requestSignatureLength,
+                                           uint64_t blockid,
                                            const concordUtils::SpanContext& span_context)
     : MessageBase(senderId,
                   MsgCode::PreProcessRequest,
@@ -43,7 +44,8 @@ PreProcessRequestMsg::PreProcessRequestMsg(RequestType reqType,
             span_context.data().size(),
             reqRetryId,
             reqLength,
-            requestSignatureLength);
+            requestSignatureLength,
+            blockid);
   auto position = body() + sizeof(Header);
   memcpy(position, span_context.data().data(), span_context.data().size());
   position += span_context.data().size();
@@ -67,7 +69,8 @@ PreProcessRequestMsg::PreProcessRequestMsg(RequestType reqType,
                   cid.size(),
                   span_context.data().size(),
                   requestSignatureLength,
-                  msgLength));
+                  msgLength,
+                  blockid));
 }
 
 void PreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {
@@ -114,7 +117,8 @@ void PreProcessRequestMsg::setParams(RequestType reqType,
                                      uint32_t spanContextSize,
                                      uint64_t reqRetryId,
                                      uint32_t reqLength,
-                                     uint16_t reqSignatureLength) {
+                                     uint16_t reqSignatureLength,
+                                     uint64_t blockId) {
   auto* header = msgBody();
   header->reqType = reqType;
   header->senderId = senderId;
@@ -126,6 +130,7 @@ void PreProcessRequestMsg::setParams(RequestType reqType,
   header->reqRetryId = reqRetryId;
   header->requestLength = reqLength;
   header->reqSignatureLength = reqSignatureLength;
+  header->primaryBlockId = blockId;
 }
 
 std::string PreProcessRequestMsg::getCid() const {

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -33,6 +33,7 @@ class PreProcessRequestMsg : public MessageBase {
                        const std::string& cid,
                        const char* requestSignature,
                        uint16_t requestSignatureLength,
+                       uint64_t blockid,
                        const concordUtils::SpanContext& span_context = concordUtils::SpanContext{});
 
   BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(PreProcessRequestMsg)
@@ -45,6 +46,7 @@ class PreProcessRequestMsg : public MessageBase {
   const uint16_t reqOffsetInBatch() const { return msgBody()->reqOffsetInBatch; }
   const SeqNum reqSeqNum() const { return msgBody()->reqSeqNum; }
   const uint64_t reqRetryId() const { return msgBody()->reqRetryId; }
+  const uint64_t primaryblockID() const { return msgBody()->primaryBlockId; }
   const uint32_t requestSignatureLength() const { return msgBody()->reqSignatureLength; }
   std::string getCid() const;
   inline char* requestSignature() const {
@@ -68,6 +70,7 @@ class PreProcessRequestMsg : public MessageBase {
     uint32_t spanContextSize;
     uint64_t reqRetryId;
     uint16_t reqSignatureLength;
+    uint64_t primaryBlockId;
   };
 #pragma pack(pop)
 
@@ -89,7 +92,8 @@ class PreProcessRequestMsg : public MessageBase {
                  uint32_t spanContextSize,
                  uint64_t reqRetryId,
                  uint32_t reqLength,
-                 uint16_t reqSignatureLength);
+                 uint16_t reqSignatureLength,
+                 uint64_t blockId);
   Header* msgBody() const { return ((Header*)msgBody_); }
 };
 

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -482,8 +482,18 @@ TEST(requestPreprocessingState_test, validatePreProcessBatchRequestMsg) {
   const auto numOfMsgs = 3;
   const auto senderId = 2;
   for (uint i = 0; i < numOfMsgs; i++) {
-    auto preProcessReqMsg = make_shared<PreProcessRequestMsg>(
-        REQ_TYPE_PRE_PROCESS, senderId, clientId, i, reqSeqNum + i, i, bufLen, buf, cid + to_string(i + 1), nullptr, 0);
+    auto preProcessReqMsg = make_shared<PreProcessRequestMsg>(REQ_TYPE_PRE_PROCESS,
+                                                              senderId,
+                                                              clientId,
+                                                              i,
+                                                              reqSeqNum + i,
+                                                              i,
+                                                              bufLen,
+                                                              buf,
+                                                              cid + to_string(i + 1),
+                                                              nullptr,
+                                                              0,
+                                                              GlobalData::current_block_id);
     batch.push_back(preProcessReqMsg);
     overallReqSize += preProcessReqMsg->size();
   }
@@ -613,6 +623,7 @@ TEST(requestPreprocessingState_test, primaryCrashNotDetected) {
                                                     cid,
                                                     nullptr,
                                                     0,
+                                                    GlobalData::current_block_id,
                                                     span);
   msgHandlerCallback = msgHandlersRegPtr->getCallback(bftEngine::impl::MsgCode::PreProcessRequest);
   msgHandlerCallback(preProcessReqMsg);
@@ -716,7 +727,7 @@ TEST(requestPreprocessingState_test, handlePreProcessBatchRequestMsg) {
   const auto numOfMsgs = 4;
   for (uint i = 0; i < numOfMsgs; i++) {
     auto preProcessReqMsg = make_shared<PreProcessRequestMsg>(
-        REQ_TYPE_PRE_PROCESS, 1, clientId, i, i + 5, i, bufLen, buf, to_string(i + 1), nullptr, 0);
+        REQ_TYPE_PRE_PROCESS, 1, clientId, i, i + 5, i, bufLen, buf, to_string(i + 1), nullptr, 0, 0);
     batch.push_back(preProcessReqMsg);
     overallReqSize += preProcessReqMsg->size();
   }

--- a/util/include/lru_cache.hpp
+++ b/util/include/lru_cache.hpp
@@ -58,7 +58,7 @@ class LruCache {
 
   Stats getStats() const { return stats_; }
 
- private:
+ protected:
   void moveToFront(typename std::list<Key>::iterator it) { keys_.splice(keys_.begin(), keys_, it); }
 
   template <typename K, typename V>
@@ -70,6 +70,7 @@ class LruCache {
       iter->second.first = std::forward<V>(value);
     } else {
       if (keys_.size() == capacity_) {
+        beforeErase();
         map_.erase(keys_.back());
         keys_.pop_back();
       }
@@ -77,6 +78,9 @@ class LruCache {
       map_.insert({std::forward<K>(key), {std::forward<V>(value), keys_.begin()}});
     }
   }
+
+  // A call back method, if a derived class needs to do something before it erases the element.
+  virtual void beforeErase() {}
 
   const size_t capacity_;
 


### PR DESCRIPTION
In order to optimize conflict detection, the primary current block_id is passed to the pre-execution handlers.

