### PR TITLE
Client's TLS key rotation basic implementation 

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -131,6 +131,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                "if true, the replica will also updates the client key file on key exchange");
   CONFIG_PARAM(replicaPrivateKey, std::string, "", "RSA private key of the current replica");
 
+  CONFIG_PARAM(certificatesRootPath, std::string, "", "the path to the certificates root directory");
+
   // Threshold crypto system
   CONFIG_PARAM(thresholdSystemType_, std::string, "", "type of threshold crypto system, [multisig-bls|threshold-bls]");
   CONFIG_PARAM(thresholdSystemSubType_, std::string, "", "sub-type of threshold crypto system [BN-254]");
@@ -255,6 +257,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, clientsKeysPrefix);
     serialize(outStream, saveClinetKeyFile);
     serialize(outStream, replicaPrivateKey);
+    serialize(outStream, certificatesRootPath);
     serialize(outStream, thresholdSystemType_);
     serialize(outStream, thresholdSystemSubType_);
     serialize(outStream, thresholdPrivateKey_);
@@ -330,6 +333,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, clientsKeysPrefix);
     deserialize(inStream, saveClinetKeyFile);
     deserialize(inStream, replicaPrivateKey);
+    deserialize(inStream, certificatesRootPath);
     deserialize(inStream, thresholdSystemType_);
     deserialize(inStream, thresholdSystemSubType_);
     deserialize(inStream, thresholdPrivateKey_);

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -27,11 +27,12 @@ static const char reconfiguration_epoch_key = 0x2d;
 static const char reconfiguration_restart_key = 0x30;
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
-  PUBLIC_KEY_EXCHANGE = 0x1,             // identifier of public key exchange request by client
-  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,     // identifier of client key exchange request by operator
-  CLIENT_SCALING_COMMAND = 0x3,          // identifier of client scaling request by operator
-  CLIENT_SCALING_COMMAND_STATUS = 0X4,   // identifier of client update request after successful scaling
-  CLIENT_SCALING_EXECUTE_COMMAND = 0x5,  // identifier of client scaling execute request by operator
+  PUBLIC_KEY_EXCHANGE = 0x1,              // identifier of public key exchange request by client
+  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,      // identifier of client key exchange request by operator
+  CLIENT_SCALING_COMMAND = 0x3,           // identifier of client scaling request by operator
+  CLIENT_SCALING_COMMAND_STATUS = 0X4,    // identifier of client update request after successful scaling
+  CLIENT_SCALING_EXECUTE_COMMAND = 0x5,   // identifier of client scaling execute request by operator
+  CLIENT_TLS_KEY_EXCHANGE_COMMAND = 0x6,  // identifier of tls key exchange request by client
   end_
 };
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -59,6 +59,10 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
               uint64_t,
               uint32_t,
               concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::ClientTlsExchangeKey&,
+              uint64_t,
+              uint32_t,
+              concord::messages::ReconfigurationResponse&) override;
 
  private:
   concord::messages::ClientStateReply buildClientStateReply(kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type,
@@ -149,8 +153,6 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               uint64_t,
               uint32_t,
               concord::messages::ReconfigurationResponse&) override;
-
- private:
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop commands)

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -189,9 +189,9 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientTls
   std::string bft_clients_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath;
   secretsmanager::SecretsManagerPlain sm;
   for (const auto& [cid, cert] : command.clients_certificates) {
-    std::string cert_path = bft_clients_cert_path + "/" + std::to_string(cid) + "/client";
+    std::string cert_path = bft_clients_cert_path + "/" + std::to_string(cid) + "/client/client.cert";
     sm.encryptFile(cert_path, cert);
-    LOG_INFO(getLogger(), cert_path + "was updated on the disk");
+    LOG_INFO(getLogger(), cert_path + " is updated on the disk");
   }
   return true;
 }

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -214,6 +214,7 @@ Msg ClientStateReply 39 {
         ClientKeyExchangeCommand
         ClientsAddRemoveExecuteCommand
         ClientsAddRemoveUpdateCommand
+        ClientTlsExchangeKey
       } response
 }
 

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -140,6 +140,7 @@ Msg UnwedgeCommand 34{
 }
 Msg ClientKeyExchangeCommand 35 {
     list uint64 target_clients
+    bool tls
 }
 
 Msg ClientKeyExchangeCommandResponse 36 {
@@ -187,16 +188,23 @@ Msg ClientsAddRemoveUpdateCommand 46 {
 
 Msg ClientKeyExchangeStatus 47 {
     uint64 sender_id
+    bool tls
 }
 
 Msg ClientKeyExchangeStatusResponse 48 {
      list kvpair uint32 ClientExchangePublicKey clients_keys
+     bool tls
 }
 
 Msg ClientsAddRemoveExecuteCommand 51 {
     string config_descriptor
     string token
     bool restart
+}
+
+Msg ClientTlsExchangeKey 52 {
+    uint64 sender_id
+    list kvpair uint32 string clients_certificates
 }
 
 Msg ClientStateReply 39 {
@@ -237,6 +245,7 @@ Msg ReconfigurationRequest 1 {
     ClientKeyExchangeCommand
     ClientReconfigurationStateRequest
     ClientExchangePublicKey
+    ClientTlsExchangeKey
     RestartCommand
     ClientsAddRemoveCommand
     ClientsAddRemoveStatusCommand

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -181,6 +181,13 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::ClientTlsExchangeKey&,
+                      uint64_t,
+                      uint32_t,
+                      concord::messages::ReconfigurationResponse&) {
+    return true;
+  }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const = 0;

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -284,16 +284,36 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 succ = True
                 priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id),"client", "pk.pem")
                 new_priv_path = priv_key_path + ".new"
-                if not os.path.isfile(new_priv_path):
-                    succ = False
+
+                enc_priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id),"client", "pk.pem.enc")
+                enc_new_priv_path = enc_priv_key_path + ".new"
+                if os.path.isfile(priv_key_path):
+                    if not os.path.isfile(new_priv_path):
+                        succ = False
                     continue
-                with open(priv_key_path) as orig_key:
-                    orig_key_text = orig_key.readlines()
-                with open(new_priv_path) as new_key:
-                    new_key_text = new_key.readlines()
-                diff = difflib.unified_diff(orig_key_text, new_key_text, fromfile=priv_key_path, tofile=new_priv_path, lineterm='')
-                for line in diff:
-                    succ = False
+                    with open(priv_key_path) as orig_key:
+                        orig_key_text = orig_key.readlines()
+                    with open(new_priv_path) as new_key:
+                        new_key_text = new_key.readlines()
+                    diff = difflib.unified_diff(orig_key_text, new_key_text, fromfile=priv_key_path, tofile=new_priv_path, lineterm='')
+                    for line in diff:
+                        succ = False
+                    if not succ:
+                        continue
+
+                if os.path.isfile(enc_priv_key_path):
+                    if not os.path.isfile(enc_new_priv_path):
+                        succ = False
+                    continue
+                    with open(enc_priv_key_path) as orig_key:
+                        orig_key_text = orig_key.readlines()
+                    with open(enc_new_priv_path) as new_key:
+                        new_key_text = new_key.readlines()
+                    diff = difflib.unified_diff(orig_key_text, new_key_text, fromfile=enc_priv_key_path, tofile=enc_new_priv_path, lineterm='')
+                    for line in diff:
+                        succ = False
+                    if not succ:
+                        continue
         bft_network.stop_cre()
         bft_network.start_cre()
 

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -254,6 +254,50 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         return pub_key
 
     @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
+    async def test_client_tls_key_exchange_command(self, bft_network):
+        """
+            Operator sends client key exchange command for cre client
+        """
+        with log.start_action(action_type="test_client_key_exchange_command"):
+            bft_network.start_all_replicas()
+            bft_network.start_cre()
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+            for i in range(100):
+                await skvbc.send_write_kv_set()
+            await self.run_client_tls_key_exchange_cycle(bft_network)
+            await self.run_client_tls_key_exchange_cycle(bft_network)
+            for i in range(100):
+                await skvbc.send_write_kv_set()
+
+    async def run_client_tls_key_exchange_cycle(self, bft_network):
+        client = bft_network.random_client()
+        op = operator.Operator(bft_network.config, client, bft_network.builddir)
+        rep = await op.client_key_exchange_command([bft_network.cre_id], tls=True)
+        rep = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
+        assert rep.success is True
+        log.log_message(message_type=f"block_id {rep.response.block_id}")
+        with trio.fail_after(30):
+            succ = False
+            while not succ:
+                await trio.sleep(1)
+                succ = True
+                priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id),"client", "pk.pem")
+                new_priv_path = priv_key_path + ".new"
+                if not os.path.isfile(new_priv_path):
+                    succ = False
+                    continue
+                with open(priv_key_path) as orig_key:
+                    orig_key_text = orig_key.readlines()
+                with open(new_priv_path) as new_key:
+                    new_key_text = new_key.readlines()
+                diff = difflib.unified_diff(orig_key_text, new_key_text, fromfile=priv_key_path, tofile=new_priv_path, lineterm='')
+                for line in diff:
+                    succ = False
+        bft_network.stop_cre()
+        bft_network.start_cre()
+
+    @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_key_exchange(self, bft_network):
         """

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -128,6 +128,7 @@ class Operator:
     def _construct_reconfiguration_clientKe_command(self, target_clients = []):
         cke_command = cmf_msgs.ClientKeyExchangeCommand()
         cke_command.target_clients = target_clients
+        cke_command.tls = False
         return self._construct_basic_reconfiguration_request(cke_command)
 
     def _construct_reconfiguration_clientsAddRemove_command(self, config_desc, tokens):
@@ -145,6 +146,7 @@ class Operator:
     def _construct_reconfiguration_clientsKeyExchangeStatus_command(self):
         ckes_command = cmf_msgs.ClientKeyExchangeStatus()
         ckes_command.sender_id = 1000
+        ckes_command.tls = False
         return self._construct_basic_reconfiguration_request(ckes_command)
 
     def _construct_reconfiguration_restart_command(self, bft, restart, data):

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -125,10 +125,10 @@ class Operator:
         addRemoveStatus_command.sender_id = 1000
         return self._construct_basic_reconfiguration_request(addRemoveStatus_command)
 
-    def _construct_reconfiguration_clientKe_command(self, target_clients = []):
+    def _construct_reconfiguration_clientKe_command(self, target_clients = [], tls = False):
         cke_command = cmf_msgs.ClientKeyExchangeCommand()
         cke_command.target_clients = target_clients
-        cke_command.tls = False
+        cke_command.tls = tls
         return self._construct_basic_reconfiguration_request(cke_command)
 
     def _construct_reconfiguration_clientsAddRemove_command(self, config_desc, tokens):
@@ -210,8 +210,8 @@ class Operator:
         reconf_msg = self._construct_reconfiguration_keMsg_command(target_replicas)
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
     
-    async def client_key_exchange_command(self, target_clients):
-        reconf_msg = self._construct_reconfiguration_clientKe_command(target_clients)
+    async def client_key_exchange_command(self, target_clients, tls=False):
+        reconf_msg = self._construct_reconfiguration_clientKe_command(target_clients, tls)
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
 
     async def clients_addRemove_command(self, config_desc):

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -211,7 +211,7 @@ class KeyExchangeCommandHandler : public IStateHandler {
                fs::path enc_path = this->key_path_;
                enc_path += ".enc";
                fs::path old_path = enc_path;
-               old_path += "old";
+               old_path += ".old";
                fs::copy(enc_path, old_path, fs::copy_options::update_existing);
                fs::copy(enc_file_path, enc_path, fs::copy_options::update_existing);
                fs::remove(old_path);

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -257,7 +257,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     bft::communication::PlainUdpConfig conf =
         testCommConfig.GetUDPConfig(true, replicaConfig.replicaId, numOfClients, numOfReplicas, commConfigFile);
 #endif
-
+    replicaConfig.certificatesRootPath = certRootPath;
     std::unique_ptr<bft::communication::ICommunication> comm(bft::communication::CommFactory::create(conf));
 
     if (!byzantineStrategies.empty()) {

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 namespace concord::util::crypto {
 enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
+enum class CurveType : std::uint16_t { secp256k1, secp384r1 };
 class IVerifier {
  public:
   virtual bool verify(const std::string& data, const std::string& sig) const = 0;
@@ -88,7 +89,8 @@ class Crypto {
   Crypto();
   ~Crypto();
   std::pair<std::string, std::string> generateRsaKeyPair(const uint32_t sig_length, const KeyFormat fmt) const;
-  std::pair<std::string, std::string> generateECDSAKeyPair(const KeyFormat fmt) const;
+  std::pair<std::string, std::string> generateECDSAKeyPair(const KeyFormat fmt,
+                                                           CurveType curve_type = CurveType::secp256k1) const;
   std::pair<std::string, std::string> RsaHexToPem(const std::pair<std::string, std::string>& key_pair) const;
   std::pair<std::string, std::string> ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) const;
   std::string generateSelfSignedCertificate(const std::pair<std::string, std::string>& keyPair_pem,


### PR DESCRIPTION
In this PR we present a basic implementation for client's TLS key rotation, including:
1. server-side functionality - update the on-chain data and write the new certificate to the file system
2. CRE support (for testing) - generate the new keys and certificate and send them to the servers
3. A basic Apollo test
4. Some bugs fixed

**Not part of this PR** (and will be added in a future PR):
1. state transfer support
2. status request for tls key exchange
2. Exchanging TLS keys to other bft clients (in Apollo tests)