### PR TITLE
Remove the mutex from pruning::ReservedPagesClient

### DIFF
--- a/kvbc/include/pruning_reserved_pages_client.hpp
+++ b/kvbc/include/pruning_reserved_pages_client.hpp
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <chrono>
-#include <mutex>
 
 namespace concord::kvbc::pruning {
 
@@ -96,16 +95,10 @@ class ReservedPagesClient {
   std::optional<BlockId> latestBatchBlockIdTo() const { return latest_batch_block_id_to_; }
 
  private:
-  void saveAgreementWithoutLock(const Agreement& agreement);
-
- private:
   static constexpr std::uint32_t kLatestAgreementPageId{0};
   static constexpr std::uint32_t kLatestBatchBlockIdToPageId{1};
 
  private:
-  // Use a mutex to ensure visibility between threads calling client methods - namely the main, messaging and state
-  // transfer threads.
-  std::mutex mtx_;
   std::optional<Agreement> latest_agreement_;
   std::optional<BlockId> latest_batch_block_id_to_;
   ClientType client_;


### PR DESCRIPTION
Users should be explicit and lock the whole object. That is simpler to
understand and maintain in contrast to reading the documentation of
individual methods. As an example, the util::SynchronizedValue
utility can be used to wrap the ReservedPagesClient.