### PR TITLE
TRC: Fix legacy transition

### DIFF
--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -592,6 +592,8 @@ void ThinReplicaClient::receiveUpdates() {
       // TODO: Set trace context
       latest_verified_event_group_id_ = event_group.id;
       update->emplace<EventGroup>(std::move(event_group));
+      // If we started with a legacy request then the transition has happened now
+      is_event_group_request_ = true;
     } else {
       ConcordAssert(update_in.has_events());
       Update legacy_event;


### PR DESCRIPTION
If we start subscribing via a legacy request but get an event group from the
server then we will never advance our request parameters because we are still
requesting for legacy events. However, as soon as the server returns event
groups, we can switch to requesting further event groups because there cannot
be anymore legacy events left to consume.