### PR TITLE
TRC: Fix legacy transition 2

### DIFF
--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -883,6 +883,7 @@ void ThinReplicaClient::Subscribe(uint64_t block_id) {
 
   config_->update_queue->Clear();
   latest_verified_block_id_ = block_id;
+  latest_verified_event_group_id_ = 0;
   is_event_group_request_ = false;
 
   // Create and launch thread to stream updates from the servers and push them


### PR DESCRIPTION
The prior change addressed the actual switch-over. This change resets the
latest verified event group id when a new legacy subscription occurs. Before
this change, we would carry over the latest verified event group id to new
subscriptions which implies that they got all those event groups already.