### PR TITLE
Tls key exchange status messages implementation 

### DIFF
--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -45,7 +45,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
     } else if (req.flags & MsgFlag::RECONFIG_FLAG) {
       ReconfigurationRequest rreq;
       deserialize(std::vector<std::uint8_t>(req.request, req.request + req.requestSize), rreq);
-      ReconfigurationResponse rsi_res = reconfig_dispatcher_.dispatch(rreq, req.executionSequenceNum);
+      ReconfigurationResponse rsi_res = reconfig_dispatcher_.dispatch(rreq, req.executionSequenceNum, timestamp);
       // in case of read request return only a success part of and replica specific info in the response
       // and the rest as additional data, since it may differ between replicas
       if (req.flags & MsgFlag::READ_ONLY_FLAG) {

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -25,6 +25,8 @@ static const char reconfiguration_client_data_prefix = 0x2c;
 static const char reconfiguration_epoch_key = 0x2d;
 
 static const char reconfiguration_restart_key = 0x30;
+static const char reconfiguration_ts_key = 0x31;
+
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
   PUBLIC_KEY_EXCHANGE = 0x1,              // identifier of public key exchange request by client

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -145,17 +145,17 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
   bool handle(const concord::messages::PruneRequest &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
 
  protected:
@@ -197,7 +197,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &rres) override {
     if (!pruning_enabled_) return true;
     concord::messages::LatestPrunableBlock latest_prunable_block;
@@ -217,7 +217,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::PruneRequest &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }
@@ -225,7 +225,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -145,14 +145,17 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse &) override;
   bool handle(const concord::messages::PruneRequest &,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse &) override;
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse &) override;
 
  protected:
@@ -194,6 +197,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::LatestPrunableBlockRequest &,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse &rres) override {
     if (!pruning_enabled_) return true;
     concord::messages::LatestPrunableBlock latest_prunable_block;
@@ -213,6 +217,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::PruneRequest &,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }
@@ -220,6 +225,7 @@ class ReadOnlyReplicaPruningHandler : public concord::reconfiguration::BftReconf
   bool handle(const concord::messages::PruneStatusRequest &,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse &) override {
     return true;
   }

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -28,9 +28,11 @@ class ReconfigurationBlockTools {
   kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data,
                                             const uint64_t bft_seq_num,
                                             std::string key,
+                                            std::optional<bftEngine::Timestamp>,
                                             bool include_wedge);
   kvbc::BlockId persistReconfigurationBlock(concord::kvbc::categorization::VersionedUpdates& ver_updates,
                                             const uint64_t bft_seq_num,
+                                            std::optional<bftEngine::Timestamp>,
                                             bool include_wedge);
   kvbc::BlockId persistNewEpochBlock(const uint64_t bft_seq_num);
 
@@ -50,18 +52,22 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientReconfigurationStateRequest&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientTlsExchangeKey&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -80,78 +86,94 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::DownloadCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::InstallCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::KeyExchangeCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveStatus& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeStatus& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::PruneRequest& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientKeyExchangeCommand& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse& response) override;
   bool handle(const concord::messages::RestartCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::UnwedgeCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::UnwedgeStatusRequest&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientsAddRemoveCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientKeyExchangeStatus&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 };
 /**
@@ -167,6 +189,7 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 };
 
@@ -182,6 +205,7 @@ class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IR
   bool handle(const concord::messages::ClientExchangePublicKey& command,
               uint64_t sequence_number,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse& response) override;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -28,11 +28,11 @@ class ReconfigurationBlockTools {
   kvbc::BlockId persistReconfigurationBlock(const std::vector<uint8_t>& data,
                                             const uint64_t bft_seq_num,
                                             std::string key,
-                                            std::optional<bftEngine::Timestamp>,
+                                            const std::optional<bftEngine::Timestamp>&,
                                             bool include_wedge);
   kvbc::BlockId persistReconfigurationBlock(concord::kvbc::categorization::VersionedUpdates& ver_updates,
                                             const uint64_t bft_seq_num,
-                                            std::optional<bftEngine::Timestamp>,
+                                            const std::optional<bftEngine::Timestamp>&,
                                             bool include_wedge);
   kvbc::BlockId persistNewEpochBlock(const uint64_t bft_seq_num);
 
@@ -52,22 +52,22 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientReconfigurationStateRequest&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientTlsExchangeKey&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -86,94 +86,94 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::DownloadCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::InstallCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::KeyExchangeCommand& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveCommand& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeCommand& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::AddRemoveStatus& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::AddRemoveWithWedgeStatus& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
 
   bool handle(const concord::messages::PruneRequest& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientKeyExchangeCommand& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
   bool handle(const concord::messages::RestartCommand&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::UnwedgeCommand&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::UnwedgeStatusRequest&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientsAddRemoveCommand&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::ClientKeyExchangeStatus&,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 };
 /**
@@ -189,7 +189,7 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
   bool handle(const concord::messages::WedgeCommand& command,
               uint64_t bft_seq_num,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 };
 
@@ -205,7 +205,7 @@ class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IR
   bool handle(const concord::messages::ClientExchangePublicKey& command,
               uint64_t sequence_number,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
+              const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -131,6 +131,7 @@ PruningHandler::PruningHandler(kvbc::IReader& ro_storage,
 bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest& latest_prunable_block_request,
                             uint64_t,
                             uint32_t,
+                            std::optional<bftEngine::Timestamp>,
                             concord::messages::ReconfigurationResponse& rres) {
   // If pruning is disabled, return 0. Otherwise, be conservative and prune the
   // smaller block range.
@@ -158,6 +159,7 @@ bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest&
 bool PruningHandler::handle(const concord::messages::PruneRequest& request,
                             uint64_t bftSeqNum,
                             uint32_t,
+                            std::optional<bftEngine::Timestamp>,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
 
@@ -241,6 +243,7 @@ void PruningHandler::pruneThroughBlockId(kvbc::BlockId block_id) const {
 bool PruningHandler::handle(const concord::messages::PruneStatusRequest&,
                             uint64_t,
                             uint32_t,
+                            std::optional<bftEngine::Timestamp>,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
   concord::messages::PruneStatus prune_status;

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -131,7 +131,7 @@ PruningHandler::PruningHandler(kvbc::IReader& ro_storage,
 bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest& latest_prunable_block_request,
                             uint64_t,
                             uint32_t,
-                            std::optional<bftEngine::Timestamp>,
+                            const std::optional<bftEngine::Timestamp>&,
                             concord::messages::ReconfigurationResponse& rres) {
   // If pruning is disabled, return 0. Otherwise, be conservative and prune the
   // smaller block range.
@@ -159,7 +159,7 @@ bool PruningHandler::handle(const concord::messages::LatestPrunableBlockRequest&
 bool PruningHandler::handle(const concord::messages::PruneRequest& request,
                             uint64_t bftSeqNum,
                             uint32_t,
-                            std::optional<bftEngine::Timestamp>,
+                            const std::optional<bftEngine::Timestamp>&,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
 
@@ -243,7 +243,7 @@ void PruningHandler::pruneThroughBlockId(kvbc::BlockId block_id) const {
 bool PruningHandler::handle(const concord::messages::PruneStatusRequest&,
                             uint64_t,
                             uint32_t,
-                            std::optional<bftEngine::Timestamp>,
+                            const std::optional<bftEngine::Timestamp>&,
                             concord::messages::ReconfigurationResponse& rres) {
   if (!pruning_enabled_) return true;
   concord::messages::PruneStatus prune_status;

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -20,11 +20,12 @@
 #include "secrets_manager_plain.h"
 namespace concord::kvbc::reconfiguration {
 
-kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(const std::vector<uint8_t>& data,
-                                                                     const uint64_t bft_seq_num,
-                                                                     std::string key,
-                                                                     std::optional<bftEngine::Timestamp> timestamp,
-                                                                     bool include_wedge) {
+kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
+    const std::vector<uint8_t>& data,
+    const uint64_t bft_seq_num,
+    std::string key,
+    const std::optional<bftEngine::Timestamp>& timestamp,
+    bool include_wedge) {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   ver_updates.addUpdate(std::move(key), std::string(data.begin(), data.end()));
 
@@ -48,7 +49,7 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(const std::
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
     concord::kvbc::categorization::VersionedUpdates& ver_updates,
     const uint64_t bft_seq_num,
-    std::optional<bftEngine::Timestamp> timestamp,
+    const std::optional<bftEngine::Timestamp>& timestamp,
     bool include_wedge) {
   // All blocks are expected to have the BFT sequence number as a key.
   ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, block_metadata_.serialize(bft_seq_num));
@@ -140,7 +141,7 @@ concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildClien
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientReconfigurationStateRequest& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
-                                              std::optional<bftEngine::Timestamp> ts,
+                                              const std::optional<bftEngine::Timestamp>& ts,
                                               concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ClientReconfigurationStateReply rep;
   for (uint8_t i = kvbc::keyTypes::CLIENT_COMMAND_TYPES::start_ + 1; i < kvbc::keyTypes::CLIENT_COMMAND_TYPES::end_;
@@ -156,7 +157,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
-                                              std::optional<bftEngine::Timestamp> ts,
+                                              const std::optional<bftEngine::Timestamp>& ts,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -175,7 +176,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExc
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientTlsExchangeKey& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
-                                              std::optional<bftEngine::Timestamp> ts,
+                                              const std::optional<bftEngine::Timestamp>& ts,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -201,7 +202,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientTls
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveUpdateCommand& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
-                                              std::optional<bftEngine::Timestamp> ts,
+                                              const std::optional<bftEngine::Timestamp>& ts,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -220,7 +221,7 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientsAd
 bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveStatusCommand&,
                                     uint64_t,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ClientsAddRemoveStatusResponse stats;
   for (const auto& gr : bftEngine::ReplicaConfig::instance().clientGroups) {
@@ -248,7 +249,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveSta
 bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeStatus& command,
                                     uint64_t,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ClientKeyExchangeStatusResponse stats;
   for (const auto& gr : bftEngine::ReplicaConfig::instance().clientGroups) {
@@ -305,7 +306,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeSt
 bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -318,7 +319,7 @@ bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& comma
 bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -331,7 +332,7 @@ bool ReconfigurationHandler::handle(const concord::messages::DownloadCommand& co
 bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -344,7 +345,7 @@ bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& com
 bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -357,7 +358,7 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -370,7 +371,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveCommand& c
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -399,7 +400,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
 bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -412,7 +413,7 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& response) {
   auto res =
       ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_add_remove});
@@ -438,7 +439,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& co
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeStatus& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& response) {
   auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId,
                                    std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
@@ -469,7 +470,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
 bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -482,7 +483,7 @@ bool ReconfigurationHandler::handle(const concord::messages::PruneRequest& comma
 bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& response) {
   std::vector<uint32_t> target_clients;
   for (auto& cid : command.target_clients) {
@@ -519,7 +520,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCo
 bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t sender_id,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& response) {
   std::vector<uint32_t> target_clients;
   // ClientsAddRemoveCommand has optional list of <clientId, token>, we write update config descriptor and
@@ -560,7 +561,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveCom
 bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
   if (!bftEngine::ControlStateManager::instance().getCheckpointToStopAt().has_value()) {
     LOG_INFO(getLogger(), "replica is already unwedge");
@@ -600,7 +601,7 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
 bool ReconfigurationHandler::handle(const messages::UnwedgeStatusRequest& req,
                                     uint64_t,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp> ts,
+                                    const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::UnwedgeStatusResponse response;
   response.replica_id = bftEngine::ReplicaConfig::instance().replicaId;
@@ -638,7 +639,7 @@ bool InternalKvReconfigurationHandler::verifySignature(uint32_t sender_id,
 bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                               uint64_t bft_seq_num,
                                               uint32_t,
-                                              std::optional<bftEngine::Timestamp> ts,
+                                              const std::optional<bftEngine::Timestamp>& ts,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
@@ -659,7 +660,7 @@ bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeComm
 bool InternalPostKvReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& command,
                                                   uint64_t sequence_number,
                                                   uint32_t sender_id,
-                                                  std::optional<bftEngine::Timestamp> ts,
+                                                  const std::optional<bftEngine::Timestamp>& ts,
                                                   concord::messages::ReconfigurationResponse& response) {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   auto updated_client_keys = SigManager::instance()->getClientsPublicKeys();

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -182,7 +182,7 @@ bool StReconfigurationHandler::handleWedgeCommands(const T &cmd,
   // so lets invoke all original reconfiguration handlers from the product layer (without concord-bft's ones)
   concord::messages::ReconfigurationResponse response;
   for (auto &h : orig_reconf_handlers_) {
-    h->handle(cmd, bft_seq_num, UINT32_MAX, response);
+    h->handle(cmd, bft_seq_num, UINT32_MAX, std::nullopt, response);
   }
 
   if (my_last_known_epoch < last_known_global_epoch) {
@@ -243,7 +243,7 @@ bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &com
   concord::messages::ReconfigurationResponse response;
   for (auto &h : orig_reconf_handlers_) {
     // If it was written to the blockchain, it means that this is a valid request.
-    succ &= h->handle(command, bft_seq_num, UINT32_MAX, response);
+    succ &= h->handle(command, bft_seq_num, UINT32_MAX, std::nullopt, response);
   }
   return succ;
 }

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -701,7 +701,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_correct_num_bocks_to_keep) {
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, {}, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, replica_idx, verifier);
   ASSERT_EQ(resp.block_id, LAST_BLOCK_ID - num_blocks_to_keep);
@@ -722,7 +722,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_big_num_blocks_to_keep) {
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, {}, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, replica_idx, verifier);
   // Verify that the returned block ID is 0 when pruning_num_blocks_to_keep is
@@ -749,7 +749,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_no_pruning_conf) {
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, {}, rres);
   resp = std::get<concord::messages::LatestPrunableBlock>(rres.response);
   CheckLatestPrunableResp(resp, 1, verifier);
   // Verify that when pruning is enabled and both pruning_num_blocks_to_keep and
@@ -776,7 +776,7 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_pruning_disabled) {
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
   concord::messages::ReconfigurationResponse rres;
-  sm.handle(req, 0, UINT32_MAX, rres);
+  sm.handle(req, 0, UINT32_MAX, {}, rres);
 
   // Verify that when pruning is disabled, there is no answer.
   ASSERT_EQ(std::holds_alternative<concord::messages::LatestPrunableBlock>(rres.response), false);
@@ -796,7 +796,7 @@ TEST_F(test_rocksdb, sm_handle_prune_request_on_pruning_disabled) {
 
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas);
   concord::messages::ReconfigurationResponse rres;
-  auto res = sm.handle(req, 0, UINT32_MAX, rres);
+  auto res = sm.handle(req, 0, UINT32_MAX, {}, rres);
   ASSERT_TRUE(res);
 }
 TEST_F(test_rocksdb, sm_handle_correct_prune_request) {
@@ -818,7 +818,7 @@ TEST_F(test_rocksdb, sm_handle_correct_prune_request) {
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas, latest_prunable_block_id);
   blocks_deleter.deleteBlocksUntil(latest_prunable_block_id + 1);
   concord::messages::ReconfigurationResponse rres;
-  auto res = sm.handle(req, 0, UINT32_MAX, rres);
+  auto res = sm.handle(req, 0, UINT32_MAX, {}, rres);
 
   ASSERT_TRUE(res);
 }
@@ -848,7 +848,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     latest_prunnable_block.signature = block.signature;
     req.latest_prunable_block.push_back(std::move(latest_prunnable_block));
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, UINT32_MAX, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, {}, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);
@@ -859,7 +859,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas);
     req.latest_prunable_block.pop_back();
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, UINT32_MAX, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, {}, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);
@@ -871,7 +871,7 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
     auto &block = req.latest_prunable_block[req.latest_prunable_block.size() - 1];
     block.signature[0] += 1;
     concord::messages::ReconfigurationResponse rres;
-    auto res = sm.handle(req, 0, UINT32_MAX, rres);
+    auto res = sm.handle(req, 0, UINT32_MAX, {}, rres);
 
     // Expect that the state machine has ignored the message.
     ASSERT_FALSE(res);

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -192,7 +192,8 @@ Msg ClientKeyExchangeStatus 47 {
 }
 
 Msg ClientKeyExchangeStatusResponse 48 {
-     list kvpair uint32 ClientExchangePublicKey clients_keys
+     list kvpair uint32 string clients_data
+     list kvpair uint32 uint64 timestamps
      bool tls
 }
 

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -35,7 +35,7 @@ class Dispatcher {
   // responsibility of each handler to write its own commands to the blockchain.
   concord::messages::ReconfigurationResponse dispatch(const concord::messages::ReconfigurationRequest&,
                                                       uint64_t sequence_num,
-                                                      std::optional<bftEngine::Timestamp> timestamp);
+                                                      const std::optional<bftEngine::Timestamp>& timestamp);
 
   void addReconfigurationHandler(std::shared_ptr<IReconfigurationHandler> h,
                                  ReconfigurationHandlerType type = ReconfigurationHandlerType::REGULAR) {
@@ -63,7 +63,7 @@ class Dispatcher {
   bool handleRequest(const T& msg,
                      uint64_t bft_seq_num,
                      uint32_t sender_id,
-                     std::optional<bftEngine::Timestamp> timestamp,
+                     const std::optional<bftEngine::Timestamp>& timestamp,
                      concord::messages::ReconfigurationResponse& rres,
                      std::shared_ptr<IReconfigurationHandler> handler) {
     return handler->handle(msg, bft_seq_num, sender_id, timestamp, rres);

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -34,7 +34,8 @@ class Dispatcher {
   // blockchain and document it as part of the state. This will be under the
   // responsibility of each handler to write its own commands to the blockchain.
   concord::messages::ReconfigurationResponse dispatch(const concord::messages::ReconfigurationRequest&,
-                                                      uint64_t sequence_num);
+                                                      uint64_t sequence_num,
+                                                      std::optional<bftEngine::Timestamp> timestamp);
 
   void addReconfigurationHandler(std::shared_ptr<IReconfigurationHandler> h,
                                  ReconfigurationHandlerType type = ReconfigurationHandlerType::REGULAR) {
@@ -62,9 +63,10 @@ class Dispatcher {
   bool handleRequest(const T& msg,
                      uint64_t bft_seq_num,
                      uint32_t sender_id,
+                     std::optional<bftEngine::Timestamp> timestamp,
                      concord::messages::ReconfigurationResponse& rres,
                      std::shared_ptr<IReconfigurationHandler> handler) {
-    return handler->handle(msg, bft_seq_num, sender_id, rres);
+    return handler->handle(msg, bft_seq_num, sender_id, timestamp, rres);
   }
   std::vector<std::shared_ptr<IReconfigurationHandler>> pre_reconfig_handlers_;
   std::vector<std::shared_ptr<IReconfigurationHandler>> reconfig_handlers_;

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -26,198 +26,198 @@ enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
 class IReconfigurationHandler {
  public:
   // Message handlers
-  virtual bool handle(const concord::messages::WedgeCommand&,
+  virtual bool handle(const concord::messages::WedgeCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::WedgeStatusRequest&,
+  virtual bool handle(const concord::messages::WedgeStatusRequest &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::GetVersionCommand&,
+  virtual bool handle(const concord::messages::GetVersionCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::DownloadCommand&,
+  virtual bool handle(const concord::messages::DownloadCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::DownloadStatusCommand&,
+  virtual bool handle(const concord::messages::DownloadStatusCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::InstallCommand&,
+  virtual bool handle(const concord::messages::InstallCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::InstallStatusCommand&,
+  virtual bool handle(const concord::messages::InstallStatusCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::KeyExchangeCommand&,
+  virtual bool handle(const concord::messages::KeyExchangeCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::AddRemoveCommand&,
+  virtual bool handle(const concord::messages::AddRemoveCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
+  virtual bool handle(const concord::messages::AddRemoveWithWedgeCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::AddRemoveStatus&,
+  virtual bool handle(const concord::messages::AddRemoveStatus &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
+  virtual bool handle(const concord::messages::AddRemoveWithWedgeStatus &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::LatestPrunableBlockRequest&,
+  virtual bool handle(const concord::messages::LatestPrunableBlockRequest &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::PruneStatusRequest&,
+  virtual bool handle(const concord::messages::PruneStatusRequest &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::PruneRequest&,
+  virtual bool handle(const concord::messages::PruneRequest &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::UnwedgeCommand&,
+  virtual bool handle(const concord::messages::UnwedgeCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::UnwedgeStatusRequest&,
+  virtual bool handle(const concord::messages::UnwedgeStatusRequest &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::ClientReconfigurationStateRequest&,
+  virtual bool handle(const concord::messages::ClientReconfigurationStateRequest &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::ClientExchangePublicKey&,
+  virtual bool handle(const concord::messages::ClientExchangePublicKey &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
-  virtual bool handle(const concord::messages::ClientKeyExchangeCommand&,
+  virtual bool handle(const concord::messages::ClientKeyExchangeCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
-    return true;
-  }
-
-  virtual bool handle(const concord::messages::RestartCommand&,
-                      uint64_t,
-                      uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
 
-  virtual bool handle(const concord::messages::ClientsAddRemoveCommand&,
+  virtual bool handle(const concord::messages::RestartCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
 
-  virtual bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
+  virtual bool handle(const concord::messages::ClientsAddRemoveCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
 
-  virtual bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
+  virtual bool handle(const concord::messages::ClientsAddRemoveStatusCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
 
-  virtual bool handle(const concord::messages::ClientKeyExchangeStatus&,
+  virtual bool handle(const concord::messages::ClientsAddRemoveUpdateCommand &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
 
-  virtual bool handle(const concord::messages::ClientTlsExchangeKey&,
+  virtual bool handle(const concord::messages::ClientKeyExchangeStatus &,
                       uint64_t,
                       uint32_t,
-                      std::optional<bftEngine::Timestamp>,
-                      concord::messages::ReconfigurationResponse&) {
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
+  virtual bool handle(const concord::messages::ClientTlsExchangeKey &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
     return true;
   }
 
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
-  virtual bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const = 0;
+  virtual bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const = 0;
   virtual ~IReconfigurationHandler() = default;
 
  protected:

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -16,6 +16,7 @@
 #include "OpenTracing.hpp"
 #include "kv_types.hpp"
 #include "Replica.hpp"
+#include "bftengine/TimeService.hpp"
 
 namespace concord::reconfiguration {
 enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
@@ -28,120 +29,140 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::WedgeCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::WedgeStatusRequest&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::GetVersionCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::DownloadCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::DownloadStatusCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::InstallCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::InstallStatusCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::KeyExchangeCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveStatus&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::LatestPrunableBlockRequest&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::PruneStatusRequest&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::PruneRequest&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::UnwedgeCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::UnwedgeStatusRequest&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientReconfigurationStateRequest&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientExchangePublicKey&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
   virtual bool handle(const concord::messages::ClientKeyExchangeCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -149,6 +170,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::RestartCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -156,6 +178,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientsAddRemoveCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -163,6 +186,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientsAddRemoveStatusCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -170,6 +194,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientsAddRemoveUpdateCommand&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -177,6 +202,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientKeyExchangeStatus&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }
@@ -184,6 +210,7 @@ class IReconfigurationHandler {
   virtual bool handle(const concord::messages::ClientTlsExchangeKey&,
                       uint64_t,
                       uint32_t,
+                      std::optional<bftEngine::Timestamp>,
                       concord::messages::ReconfigurationResponse&) {
     return true;
   }

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -34,32 +34,39 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
   bool handle(const concord::messages::WedgeCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::WedgeStatusRequest&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::KeyExchangeCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::RestartCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool handle(const concord::messages::InstallCommand&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
  private:
@@ -71,6 +78,7 @@ class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigu
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
               uint32_t,
+              std::optional<bftEngine::Timestamp>,
               concord::messages::ReconfigurationResponse&) override;
 
   bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const override {

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -24,50 +24,50 @@ namespace concord::reconfiguration {
 class BftReconfigurationHandler : public IReconfigurationHandler {
  public:
   BftReconfigurationHandler();
-  bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const override;
+  bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const override;
 
   std::unique_ptr<concord::util::crypto::IVerifier> verifier_;
 };
 class ReconfigurationHandler : public BftReconfigurationHandler {
  public:
   ReconfigurationHandler() {}
-  bool handle(const concord::messages::WedgeCommand&,
+  bool handle(const concord::messages::WedgeCommand &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
-  bool handle(const concord::messages::WedgeStatusRequest&,
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
+  bool handle(const concord::messages::WedgeStatusRequest &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
-  bool handle(const concord::messages::KeyExchangeCommand&,
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
+  bool handle(const concord::messages::KeyExchangeCommand &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
-  bool handle(const concord::messages::AddRemoveWithWedgeCommand&,
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
+  bool handle(const concord::messages::AddRemoveWithWedgeCommand &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
-  bool handle(const concord::messages::AddRemoveWithWedgeStatus&,
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
+  bool handle(const concord::messages::AddRemoveWithWedgeStatus &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
 
-  bool handle(const concord::messages::RestartCommand&,
+  bool handle(const concord::messages::RestartCommand &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
 
-  bool handle(const concord::messages::InstallCommand&,
+  bool handle(const concord::messages::InstallCommand &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
 
  private:
   void handleWedgeCommands(
@@ -75,13 +75,13 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
 };
 
 class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
-  bool handle(const concord::messages::ClientExchangePublicKey&,
+  bool handle(const concord::messages::ClientExchangePublicKey &,
               uint64_t,
               uint32_t,
-              std::optional<bftEngine::Timestamp>,
-              concord::messages::ReconfigurationResponse&) override;
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
 
-  bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const override {
+  bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const override {
     if (!bftEngine::impl::SigManager::instance()->hasVerifier(sender_id)) return false;
     return bftEngine::impl::SigManager::instance()->verifySig(
         sender_id, data.data(), data.size(), signature.data(), signature.size());

--- a/reconfiguration/src/dispatcher.cpp
+++ b/reconfiguration/src/dispatcher.cpp
@@ -26,7 +26,7 @@ namespace concord::reconfiguration {
 
 ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& request,
                                              uint64_t sequence_num,
-                                             std::optional<bftEngine::Timestamp> timestamp) {
+                                             const std::optional<bftEngine::Timestamp>& timestamp) {
   ReconfigurationResponse rresp;
   concord::messages::ReconfigurationErrorMsg error_msg;
   bool valid = false;

--- a/reconfiguration/src/dispatcher.cpp
+++ b/reconfiguration/src/dispatcher.cpp
@@ -24,7 +24,9 @@ namespace concord::reconfiguration {
     std::copy(str.cbegin(), str.cend(), std::back_inserter((resp).additional_data)); \
   }
 
-ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& request, uint64_t sequence_num) {
+ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& request,
+                                             uint64_t sequence_num,
+                                             std::optional<bftEngine::Timestamp> timestamp) {
   ReconfigurationResponse rresp;
   concord::messages::ReconfigurationErrorMsg error_msg;
   bool valid = false;
@@ -46,8 +48,9 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &= std::visit(
-          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
+      rresp.success &=
+          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, timestamp, rresp, handler); },
+                     request.command);
     }
 
     // Run regular reconfiguration handlers
@@ -59,8 +62,9 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &= std::visit(
-          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
+      rresp.success &=
+          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, timestamp, rresp, handler); },
+                     request.command);
     }
 
     // Run post-reconfiguration handlers
@@ -72,8 +76,9 @@ ReconfigurationResponse Dispatcher::dispatch(const ReconfigurationRequest& reque
       }
       error_msg.error_msg.clear();
       valid = true;
-      rresp.success &= std::visit(
-          [&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, rresp, handler); }, request.command);
+      rresp.success &=
+          std::visit([&](auto&& arg) { return handleRequest(arg, sequence_num, sender_id, timestamp, rresp, handler); },
+                     request.command);
     }
 
     if (!valid) rresp.success = false;  // If no handler was able to verify the request, it is an invalid request

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -26,6 +26,7 @@ namespace concord::reconfiguration {
 bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    std::optional<bftEngine::Timestamp>,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "Wedge command instructs replica to stop at sequence number " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -35,6 +36,7 @@ bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
 bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
                                     uint64_t,
                                     uint32_t,
+                                    std::optional<bftEngine::Timestamp>,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::WedgeStatusResponse response;
   if (req.fullWedge) {
@@ -49,6 +51,7 @@ bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
 bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    std::optional<bftEngine::Timestamp>,
                                     concord::messages::ReconfigurationResponse&) {
   std::ostringstream oss;
   std::copy(command.target_replicas.begin(), command.target_replicas.end(), std::ostream_iterator<int>(oss, " "));
@@ -66,6 +69,7 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    std::optional<bftEngine::Timestamp>,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "AddRemoveWithWedgeCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -112,6 +116,7 @@ void ReconfigurationHandler::handleWedgeCommands(
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeStatus& req,
                                     uint64_t sequence_number,
                                     uint32_t,
+                                    std::optional<bftEngine::Timestamp>,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::AddRemoveWithWedgeStatusResponse response;
   if (std::holds_alternative<concord::messages::AddRemoveWithWedgeStatusResponse>(rres.response)) {
@@ -132,6 +137,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
 bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
+                                    std::optional<bftEngine::Timestamp>,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "RestartCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -141,6 +147,7 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
 bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& cmd,
                                     uint64_t sequence_num,
                                     uint32_t,
+                                    std::optional<bftEngine::Timestamp>,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ReconfigurationErrorMsg error_msg;
   if (cmd.version.empty()) {
@@ -202,6 +209,7 @@ bool BftReconfigurationHandler::verifySignature(uint32_t sender_id,
 bool ClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& msg,
                                           uint64_t,
                                           uint32_t sender_id,
+                                          std::optional<bftEngine::Timestamp>,
                                           concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "public key: " << msg.pub_key << " sender: " << sender_id);
   std::vector<uint32_t> affected_clients;

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -26,7 +26,7 @@ namespace concord::reconfiguration {
 bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp>,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "Wedge command instructs replica to stop at sequence number " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -36,7 +36,7 @@ bool ReconfigurationHandler::handle(const WedgeCommand& cmd,
 bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
                                     uint64_t,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp>,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::WedgeStatusResponse response;
   if (req.fullWedge) {
@@ -51,7 +51,7 @@ bool ReconfigurationHandler::handle(const WedgeStatusRequest& req,
 bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp>,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   std::ostringstream oss;
   std::copy(command.target_replicas.begin(), command.target_replicas.end(), std::ostream_iterator<int>(oss, " "));
@@ -69,7 +69,7 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp>,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "AddRemoveWithWedgeCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -116,7 +116,7 @@ void ReconfigurationHandler::handleWedgeCommands(
 bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeStatus& req,
                                     uint64_t sequence_number,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp>,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::AddRemoveWithWedgeStatusResponse response;
   if (std::holds_alternative<concord::messages::AddRemoveWithWedgeStatusResponse>(rres.response)) {
@@ -137,7 +137,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
 bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& command,
                                     uint64_t bft_seq_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp>,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "RestartCommand instructs replica to stop at seq_num " << bft_seq_num);
   bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(bft_seq_num);
@@ -147,7 +147,7 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
 bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& cmd,
                                     uint64_t sequence_num,
                                     uint32_t,
-                                    std::optional<bftEngine::Timestamp>,
+                                    const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ReconfigurationErrorMsg error_msg;
   if (cmd.version.empty()) {
@@ -209,7 +209,7 @@ bool BftReconfigurationHandler::verifySignature(uint32_t sender_id,
 bool ClientReconfigurationHandler::handle(const concord::messages::ClientExchangePublicKey& msg,
                                           uint64_t,
                                           uint32_t sender_id,
-                                          std::optional<bftEngine::Timestamp>,
+                                          const std::optional<bftEngine::Timestamp>&,
                                           concord::messages::ReconfigurationResponse&) {
   LOG_INFO(getLogger(), "public key: " << msg.pub_key << " sender: " << sender_id);
   std::vector<uint32_t> affected_clients;

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -143,10 +143,10 @@ class Operator:
         cars_command.sender_id = 1000
         return self._construct_basic_reconfiguration_request(cars_command)
 
-    def _construct_reconfiguration_clientsKeyExchangeStatus_command(self):
+    def _construct_reconfiguration_clientsKeyExchangeStatus_command(self, tls=False):
         ckes_command = cmf_msgs.ClientKeyExchangeStatus()
         ckes_command.sender_id = 1000
-        ckes_command.tls = False
+        ckes_command.tls = tls
         return self._construct_basic_reconfiguration_request(ckes_command)
 
     def _construct_reconfiguration_restart_command(self, bft, restart, data):
@@ -225,8 +225,8 @@ class Operator:
         reconf_msg = self._construct_reconfiguration_clientsAddRemoveStatus_command()
         return await self.client.read(reconf_msg.serialize(), reconfiguration=True)
 
-    async def clients_clientKeyExchangeStatus_command(self):
-        reconf_msg = self._construct_reconfiguration_clientsKeyExchangeStatus_command()
+    async def clients_clientKeyExchangeStatus_command(self, tls=False):
+        reconf_msg = self._construct_reconfiguration_clientsKeyExchangeStatus_command(tls)
         return await self.client.read(reconf_msg.serialize(), reconfiguration=True)
     
     async def install_cmd(self, version, bft=True):

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -78,7 +78,7 @@ static void add(std::string &&key,
 }
 
 void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequestsQueue &requests,
-                                      std::optional<Timestamp> timestamp,
+                                      std::optional<bftEngine::Timestamp> timestamp,
                                       const std::string &batchCid,
                                       concordUtils::SpanWrapper &parent_span) {
   if (requests.empty()) return;


### PR DESCRIPTION
In this PR we present the following changes:
1. We add a timestamp to each reconfiguration block
2. We add a status message for client TLS key exchange
3. We used these status messages to make TLS key exchange in Apollo tests more reliable and robust