### PR TITLE
Fix BC-12790

### DIFF
--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -224,15 +224,23 @@ struct ThinReplicaClientConfig {
   // trs_conns is a vector of connection objects. Each representing a direct
   // connection from this TRC to a specific Thin Replica Server.
   std::vector<std::unique_ptr<TrsConnection>> trs_conns;
+  // the time duration the TRC waits before printing warning logs when
+  // responsive agreeing servers are less than config_->max_faulty + 1
+  std::chrono::seconds duration;
 
   ThinReplicaClientConfig(std::string client_id_,
                           std::shared_ptr<UpdateQueue> update_queue_,
                           std::size_t max_faulty_,
-                          std::vector<std::unique_ptr<TrsConnection>> trs_conns_)
+                          std::vector<std::unique_ptr<TrsConnection>> trs_conns_,
+                          std::chrono::seconds duration_ = kNonAgreemntLogDuration)
       : client_id(std::move(client_id_)),
         update_queue(update_queue_),
         max_faulty(max_faulty_),
-        trs_conns(std::move(trs_conns_)) {}
+        trs_conns(std::move(trs_conns_)),
+        duration(duration_) {}
+
+ private:
+  static constexpr std::chrono::seconds kNonAgreemntLogDuration = 60s;
 };
 
 // TRC metrics

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -958,7 +958,7 @@ class ThinReplicaImpl {
         std::stringstream msg;
         msg << "Block " << request->events().block_id() << " doesn't exist yet "
             << " latest block is " << last_block_id;
-        LOG_ERROR(logger_, msg.str());
+        LOG_DEBUG(logger_, msg.str());
         return {grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, msg.str()), live_updates};
       }
     } else {
@@ -974,7 +974,7 @@ class ThinReplicaImpl {
         std::stringstream msg;
         msg << "Event group ID " << request->event_groups().event_group_id() << " doesn't exist yet "
             << " latest event_group_id is " << last_eg_id;
-        LOG_ERROR(logger_, msg.str());
+        LOG_DEBUG(logger_, msg.str());
         return {grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, msg.str()), live_updates};
       }
     }


### PR DESCRIPTION
A client may request a block id that doesn't exist on the blockchain,
esp., after a wedge/crash-restart. The commit updates TRS s.t., it
doesn't return a `FAILED_PRECONDITION` status in that scenario.
The corresponding logs have also been updated to DEBUG from ERROR.