### PR TITLE
Generate tsan/asan report

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -34,7 +34,7 @@ jobs:
           run: |
               script -q -e -c "make pull"
               sudo df -h
-              script -q -e -c "CONCORD_BFT_CMAKE_ASAN=TRUE CONCORD_BFT_CMAKE_USE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE make build" \
+              script -q -e -c "CONCORD_BFT_CMAKE_OMIT_TEST_OUTPUT=TRUE CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE CONCORD_BFT_CMAKE_ASAN=TRUE CONCORD_BFT_CMAKE_USE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE make build" \
               && script -q -e -c "make test"
         - name: Check if ASAN passed
           if: always()
@@ -42,16 +42,16 @@ jobs:
               chmod +x "./.github/fail_action_if_sanitizer_reports_exist.sh"
               ./.github/fail_action_if_sanitizer_reports_exist.sh ./build/asan_logs
         - name: Prepare artifacts
-          if: failure()
+          if: always()
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            #tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs # Do not attempt to archive because CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE
             tar -czvf ${{ github.workspace }}/artifact/asan.logs.tar.gz ./build/asan_logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
-          if: failure()
+          if: always()
           with:
             name: artifacts-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -34,7 +34,7 @@ jobs:
           run: |
               script -q -e -c "make pull"
               sudo df -h
-              script -q -e -c "CONCORD_BFT_CMAKE_TSAN=TRUE CONCORD_BFT_CMAKE_USE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE make build" \
+              script -q -e -c "CONCORD_BFT_CMAKE_OMIT_TEST_OUTPUT=TRUE CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE CONCORD_BFT_CMAKE_TSAN=TRUE CONCORD_BFT_CMAKE_USE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE make build" \
               && script -q -e -c "make test"
         - name: Check if TSAN passed
           if: always()
@@ -42,16 +42,16 @@ jobs:
               chmod +x "./.github/fail_action_if_sanitizer_reports_exist.sh"
               ./.github/fail_action_if_sanitizer_reports_exist.sh ./build/tsan_logs
         - name: Prepare artifacts
-          if: failure()
+          if: always()
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            #tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs # Do not attempt to archive because CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE
             tar -czvf ${{ github.workspace }}/artifact/tsan.logs.tar.gz ./build/tsan_logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
-          if: failure()
+          if: always()
           with:
             name: artifacts-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,13 @@ if(THREADCHECK)
     message("-- Thread Sanitizer Enabled")
 endif()
 
+if(OMIT_TEST_OUTPUT)
+    message("-- OMIT_TEST_OUTPUT Enabled")
+endif()
+if(KEEP_APOLLO_LOGS)
+    message("-- KEEP_APOLLO_LOGS Enabled")
+endif()
+
 if(CODECOVERAGE AND THREADCHECK)
     message(FATAL_ERROR "Cannot have both Thread and Code Coverage Enabled")
 endif()


### PR DESCRIPTION
This PR ensures asan & tsan reports are generated even if the CI run fails.
The apollo logs are not required in asan & tsan CI workflows, hence disabled. The reason
for disabling apollo logs is to prevent significant increase in apollo logs' size because the
apollo test cases run for 6 hours continuously (until Github CI 6-hour timer expires).
Hence, disabling apollo logs since we are only concerned about asan & tsan reports.