### PR TITLE
Add block id to the pre-execution batch

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -135,6 +135,8 @@ class PreProcessor {
 
   ReqId getOngoingReqIdForClient(uint16_t clientId, uint16_t reqOffsetInBatch);
 
+  static std::unordered_map<std::string, uint64_t> to_block_id;
+
  private:
   friend class AsyncPreProcessJob;
   friend class RequestsBatch;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -78,6 +78,7 @@ class RequestsBatch {
   void handlePossiblyExpiredRequests();
   void sendCancelBatchedPreProcessingMsgToNonPrimaries(const ClientMsgsList &clientMsgs, NodeIdType destId);
   void updateRegisteredBatchIfNeeded(const std::string &batchCid, const PreProcessReqMsgsList &preProcessReqs);
+  uint64_t getBlockId() const { return cidToBlockid_.second; }
 
  private:
   void setBatchParameters(const std::string &cid, uint32_t batchSize);
@@ -87,6 +88,7 @@ class RequestsBatch {
   PreProcessor &preProcessor_;
   const uint16_t clientId_;
   std::string cid_;
+  std::pair<std::string, uint64_t> cidToBlockid_;
   std::atomic_uint32_t batchSize_ = 0;
   std::atomic_bool batchRegistered_ = false;
   std::atomic_bool batchInProcess_ = false;
@@ -134,8 +136,6 @@ class PreProcessor {
   static void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
   ReqId getOngoingReqIdForClient(uint16_t clientId, uint16_t reqOffsetInBatch);
-
-  static std::unordered_map<std::string, uint64_t> to_block_id;
 
  private:
   friend class AsyncPreProcessJob;


### PR DESCRIPTION
As a batch can be retried, we want to preserve the initial block-id that was set in the initial requests on any following requests that are sent as part of the batch.
In order to do so, the block id is saved in the batch and is mapped to a cid.
The mapping of cid->block_id is not being reset but only set on setParams in order to preserve the block_id on retry,