### PR TITLE
Delete transaction_signing_keys folder if it already exists

### DIFF
--- a/scripts/linux/create_concord_clients_transaction_signing_keys.sh
+++ b/scripts/linux/create_concord_clients_transaction_signing_keys.sh
@@ -98,8 +98,8 @@ parser() {
     fi
     output_path=${output_path}/${output_folder}
     if [ -d "${output_path}" ]; then
-        echo "error: --output_base_path ${output_path} already exists! Please delete it or supply a different path..."  >&2
-        exit 1
+        echo "warning: --output_base_path ${output_path} already exists! Deleting it..."  >&2
+        rm -rf ${output_path}
     fi
 }
 


### PR DESCRIPTION
This commit deletes the transaction_signing_keys folder if it
already exists instead of erroring out and exiting.