### PR TITLE
test_skvbc_client_transaction_signing: enable disabled test

### DIFF
--- a/tests/apollo/test_skvbc_client_transaction_signing.py
+++ b/tests/apollo/test_skvbc_client_transaction_signing.py
@@ -208,7 +208,6 @@ class SkvbcTestClientTxnSigning(unittest.TestCase):
         await self.write_n_times(bft_network, skvbc, NUM_OF_SEQ_WRITES, pre_exec=True)
         await self.assert_metrics(bft_network, expected_num_signatures_verified=NUM_OF_SEQ_WRITES)
 
-    @unittest.skip("Unstable - see BC-11586")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_positive_write_batching_enabled(self, bft_network):


### PR DESCRIPTION
Enable back test_positive_write_batching_enabled. The issue which caused
the test to fail was related to the new time service.
After running many times, it doesn't fail anymore. Enabling back.