### PR TITLE
Replicas' TLS key exchange - basic implementation 

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -40,7 +40,7 @@ class Client {
     metrics_.setAggregator(aggregator);
   }
 
-  void stop() { communication_->Stop(); }
+  void stop() { communication_->stop(); }
 
   // Send a message where the reply gets allocated by the callee and returned in a vector.
   // The message to be sent is moved into the caller to prevent unnecessary copies.

--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -100,12 +100,12 @@ class FakeCommunication : public bft::communication::ICommunication {
   FakeCommunication(Behavior&& behavior) : runner_(std::move(behavior)) {}
 
   int getMaxMessageSize() override { return 1024; }
-  int Start() override {
+  int start() override {
     runner_.setClientReceiver(receiver_);
     fakeCommThread_ = std::thread(std::ref(runner_));
     return 0;
   }
-  int Stop() override {
+  int stop() override {
     runner_.stop();
     fakeCommThread_.join();
     return 0;

--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -128,6 +128,7 @@ class FakeCommunication : public bft::communication::ICommunication {
 
   void setReceiver(NodeNum id, IReceiver* receiver) override { receiver_ = receiver; }
 
+  void dispose(NodeNum i) override {}
  private:
   IReceiver* receiver_;
   BehaviorThreadRunner runner_;

--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -129,6 +129,7 @@ class FakeCommunication : public bft::communication::ICommunication {
   void setReceiver(NodeNum id, IReceiver* receiver) override { receiver_ = receiver; }
 
   void dispose(NodeNum i) override {}
+
  private:
   IReceiver* receiver_;
   BehaviorThreadRunner runner_;

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -56,7 +56,7 @@ Client::Client(std::unique_ptr<bft::communication::ICommunication> comm, const C
         key_plaintext.value().c_str(), concord::util::crypto::KeyFormat::PemFormat);
   }
   communication_->setReceiver(config_.id.val, &receiver_);
-  communication_->Start();
+  communication_->start();
 }
 
 Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool read_only, uint16_t client_id) {

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -28,6 +28,7 @@ typedef int64_t SeqNum;  // TODO [TK] redefinition
 
 class KeyExchangeManager {
  public:
+  void exchangeTlsKeys(const SeqNum&);
   // Generates and publish key to consensus
   void sendKeyExchange(const SeqNum&);
   // Generates and publish the first replica's key,
@@ -212,6 +213,7 @@ class KeyExchangeManager {
     concordMetrics::CounterHandle sent_key_exchange_counter;
     concordMetrics::CounterHandle self_key_exchange_counter;
     concordMetrics::CounterHandle public_key_exchange_for_peer_counter;
+    concordMetrics::CounterHandle tls_key_exchange_requests_;
 
     void setAggregator(std::shared_ptr<concordMetrics::Aggregator> a) {
       aggregator = a;
@@ -226,13 +228,14 @@ class KeyExchangeManager {
           clients_keys_published_status{component.RegisterStatus("clients_keys_published", "False")},
           sent_key_exchange_counter{component.RegisterCounter("sent_key_exchange")},
           self_key_exchange_counter{component.RegisterCounter("self_key_exchange")},
-          public_key_exchange_for_peer_counter{component.RegisterCounter("public_key_exchange_for_peer")} {}
+          public_key_exchange_for_peer_counter{component.RegisterCounter("public_key_exchange_for_peer")},
+          tls_key_exchange_requests_{component.RegisterCounter("tls_key_exchange_requests")} {}
   };
 
   std::unique_ptr<Metrics> metrics_;
   concordUtil::Timers::Handle metricsTimer_;
   concordUtil::Timers& timers_;
-
+  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsMgr_;
   friend class TestKeyManager;
 };
 

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -150,7 +150,7 @@ void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
   std::string cid = "replicaTlsKeyExchange_" + std::to_string(bft_sn) + "_" + std::to_string(repId);
   client_->sendRequest(RECONFIG_FLAG, strMsg.size(), strMsg.c_str(), cid);
   metrics_->tls_key_exchange_requests_++;
-  LOG_INFO(KEY_EX_LOG, "Replica have generated a new tls keys");
+  LOG_INFO(KEY_EX_LOG, "Replica has generated a new tls keys");
 }
 void KeyExchangeManager::sendKeyExchange(const SeqNum& sn) {
   // first check whether we've already generated keys lately

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -127,7 +127,7 @@ void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
   concord::secretsmanager::SecretsManagerPlain psm_;
   std::fstream nec_f(pk_path);
   if (nec_f.good()) {
-    psm_.encryptFile(pk_path, keys.first);
+    secretsMgr_->encryptFile(pk_path, keys.first);
   }
   std::fstream ec_f(pk_path + ".enc");
   if (ec_f.good()) {

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -26,14 +26,14 @@ MsgsCommunicator::MsgsCommunicator(ICommunication* comm,
 int MsgsCommunicator::startCommunication(uint16_t replicaId) {
   replicaId_ = replicaId;
   communication_->setReceiver(replicaId_, msgReceiver_.get());
-  int commStatus = communication_->Start();
+  int commStatus = communication_->start();
   ConcordAssert(commStatus == 0);
   LOG_INFO(GL, "Communication for replica " << replicaId_ << " started");
   return commStatus;
 }
 
 int MsgsCommunicator::stopCommunication() {
-  int res = communication_->Stop();
+  int res = communication_->stop();
   LOG_INFO(GL, "Communication for replica " << replicaId_ << " stopped");
   return res;
 }

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -329,7 +329,7 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
                   spanContext.empty()));
   ConcordAssert(!(isReadOnly && isPreProcessRequired));
 
-  if (!communication_->isRunning()) communication_->Start();
+  if (!communication_->isRunning()) communication_->start();
   if (!isReadOnly && !isSystemReady()) {
     LOG_WARN(logger_,
              "The system is not ready yet to handle requests => reject"
@@ -403,7 +403,7 @@ OperationResult SimpleClientImp::isBatchRequestValid(const ClientRequest& req) {
 }
 
 OperationResult SimpleClientImp::isBatchValid(uint64_t requestsNbr, uint64_t repliesNbr) {
-  if (!communication_->isRunning()) communication_->Start();
+  if (!communication_->isRunning()) communication_->start();
   OperationResult res = SUCCESS;
   if (!requestsNbr) {
     LOG_ERROR(logger_, "An empty request list specified");

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -342,7 +342,7 @@ void setUpCommunication() {
 
   PlainUdpConfig configuration("128.0.0.1", 1234, 4096, nodes, replicaConfig.replicaId);
   communicatorPtr.reset(CommFactory::create(configuration), [](ICommunication* c) {
-    c->Stop();
+    c->stop();
     delete c;
   });
   msgsCommunicator.reset(new MsgsCommunicator(communicatorPtr.get(), msgsStorage, msgReceiver));

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -124,8 +124,8 @@ class PlainUDPCommunication : public ICommunication {
   static PlainUDPCommunication *create(const PlainUdpConfig &config);
 
   int getMaxMessageSize() override;
-  int Start() override;
-  int Stop() override;
+  int start() override;
+  int stop() override;
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
@@ -151,8 +151,8 @@ class PlainTCPCommunication : public ICommunication {
   static PlainTCPCommunication *create(const PlainTcpConfig &config);
 
   int getMaxMessageSize() override;
-  int Start() override;
-  int Stop() override;
+  int start() override;
+  int stop() override;
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
@@ -180,8 +180,8 @@ class TlsTCPCommunication : public ICommunication {
   static TlsTCPCommunication *create(const TlsTcpConfig &config);
 
   int getMaxMessageSize() override;
-  int Start() override;
-  int Stop() override;
+  int start() override;
+  int stop() override;
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -134,7 +134,7 @@ class PlainUDPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  void dispose(NodeNum i) override {};
+  void dispose(NodeNum i) override{};
   ~PlainUDPCommunication() override;
 
  private:

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -134,6 +134,7 @@ class PlainUDPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
+  void dispose(NodeNum i) override {};
   ~PlainUDPCommunication() override;
 
  private:
@@ -160,6 +161,7 @@ class PlainTCPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
+  void dispose(NodeNum i) override {}
   ~PlainTCPCommunication() override;
 
  private:
@@ -188,6 +190,7 @@ class TlsTCPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
+  void dispose(NodeNum i) override;
   ~TlsTCPCommunication() override;
 
  private:

--- a/communication/include/communication/CommStateControl.hpp
+++ b/communication/include/communication/CommStateControl.hpp
@@ -11,6 +11,8 @@
 // LICENSE file.
 
 #pragma once
+#include <functional>
+#include "callback_registry.hpp"
 namespace bft::communication {
 class CommStateControl {
  public:
@@ -21,7 +23,14 @@ class CommStateControl {
   void setBlockNewConnectionsFlag(bool flag) { blockNewConnectionsFlag_ = flag; }
   bool getBlockNewConnectionsFlag() { return blockNewConnectionsFlag_; }
 
+  void setCommRestartCallBack(std::function<void()> cb) {
+    if (cb != nullptr) comm_restart_cb_registry_.add(cb);
+  }
+
+  void restartComm() { comm_restart_cb_registry_.invokeAll(); }
+
  private:
   bool blockNewConnectionsFlag_ = false;
+  concord::util::CallbackRegistry<> comm_restart_cb_registry_;
 };
 }  // namespace bft::communication

--- a/communication/include/communication/CommStateControl.hpp
+++ b/communication/include/communication/CommStateControl.hpp
@@ -23,14 +23,14 @@ class CommStateControl {
   void setBlockNewConnectionsFlag(bool flag) { blockNewConnectionsFlag_ = flag; }
   bool getBlockNewConnectionsFlag() { return blockNewConnectionsFlag_; }
 
-  void setCommRestartCallBack(std::function<void()> cb) {
+  void setCommRestartCallBack(std::function<void(uint32_t)> cb) {
     if (cb != nullptr) comm_restart_cb_registry_.add(cb);
   }
 
-  void restartComm() { comm_restart_cb_registry_.invokeAll(); }
+  void restartComm(uint32_t id) { comm_restart_cb_registry_.invokeAll(id); }
 
  private:
   bool blockNewConnectionsFlag_ = false;
-  concord::util::CallbackRegistry<> comm_restart_cb_registry_;
+  concord::util::CallbackRegistry<uint32_t> comm_restart_cb_registry_;
 };
 }  // namespace bft::communication

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -42,11 +42,11 @@ class ICommunication {
 
   // Starts the object (including its internal threads).
   // On success, returns 0.
-  virtual int Start() = 0;
+  virtual int start() = 0;
 
   // Stops the object (including its internal threads).
   // On success, returns 0.
-  virtual int Stop() = 0;
+  virtual int stop() = 0;
 
   virtual bool isRunning() const = 0;
 

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -67,6 +67,7 @@ class ICommunication {
 
   virtual void setReceiver(NodeNum receiverNum, IReceiver* receiver) = 0;
 
+  virtual void dispose(NodeNum i) = 0;
   virtual ~ICommunication() = default;
 };
 }  // namespace bft::communication

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -14,14 +14,14 @@
 #include <functional>
 #include "callback_registry.hpp"
 namespace bft::communication {
-class CommStateControl {
+class StateControl {
  public:
-  static CommStateControl& instance() {
-    static CommStateControl instance_;
+  static StateControl& instance() {
+    static StateControl instance_;
     return instance_;
   }
   void setBlockNewConnectionsFlag(bool flag) { blockNewConnectionsFlag_ = flag; }
-  bool getBlockNewConnectionsFlag() { return blockNewConnectionsFlag_; }
+  bool getBlockNewConnectionsFlag() const { return blockNewConnectionsFlag_; }
 
   void setCommRestartCallBack(std::function<void(uint32_t)> cb) {
     if (cb != nullptr) comm_restart_cb_registry_.add(cb);

--- a/communication/src/PlainTcpCommunication.cpp
+++ b/communication/src/PlainTcpCommunication.cpp
@@ -835,9 +835,9 @@ PlainTCPCommunication *PlainTCPCommunication::create(const PlainTcpConfig &confi
 
 int PlainTCPCommunication::getMaxMessageSize() { return _ptrImpl->getMaxMessageSize(); }
 
-int PlainTCPCommunication::Start() { return _ptrImpl->Start(); }
+int PlainTCPCommunication::start() { return _ptrImpl->Start(); }
 
-int PlainTCPCommunication::Stop() {
+int PlainTCPCommunication::stop() {
   if (!_ptrImpl) return 0;
 
   auto res = _ptrImpl->Stop();

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -405,9 +405,9 @@ PlainUDPCommunication *PlainUDPCommunication::create(const PlainUdpConfig &confi
 
 int PlainUDPCommunication::getMaxMessageSize() { return _ptrImpl->getMaxMessageSize(); }
 
-int PlainUDPCommunication::Start() { return _ptrImpl->Start(); }
+int PlainUDPCommunication::start() { return _ptrImpl->Start(); }
 
-int PlainUDPCommunication::Stop() {
+int PlainUDPCommunication::stop() {
   if (!_ptrImpl) return 0;
 
   auto res = _ptrImpl->Stop();

--- a/communication/src/TlsConnectionManager.cpp
+++ b/communication/src/TlsConnectionManager.cpp
@@ -352,5 +352,8 @@ ConnectionStatus ConnectionManager::getCurrentConnectionStatus(const NodeNum id)
   }
   return ConnectionStatus::Disconnected;
 }
+void ConnectionManager::dispose(NodeNum i) {
+  connections_.at(i)->dispose(true);
+}
 
 }  // namespace bft::communication::tls

--- a/communication/src/TlsConnectionManager.cpp
+++ b/communication/src/TlsConnectionManager.cpp
@@ -18,7 +18,7 @@
 #include "assertUtils.hpp"
 #include "TlsConnectionManager.h"
 #include "AsyncTlsConnection.h"
-#include "communication/CommStateControl.hpp"
+#include "communication/StateControl.hpp"
 
 namespace bft::communication::tls {
 
@@ -258,7 +258,7 @@ void ConnectionManager::startClientSSLHandshake(asio::ip::tcp::socket&& socket, 
 
 void ConnectionManager::accept() {
   acceptor_.async_accept(asio::bind_executor(strand_, [this](asio::error_code ec, asio::ip::tcp::socket sock) {
-    if (bft::communication::CommStateControl::instance().getBlockNewConnectionsFlag()) {
+    if (bft::communication::StateControl::instance().getBlockNewConnectionsFlag()) {
       LOG_WARN(logger_, "replica is blocked from creating new connections");
       return;
     } else if (ec) {

--- a/communication/src/TlsConnectionManager.cpp
+++ b/communication/src/TlsConnectionManager.cpp
@@ -353,6 +353,7 @@ ConnectionStatus ConnectionManager::getCurrentConnectionStatus(const NodeNum id)
   return ConnectionStatus::Disconnected;
 }
 void ConnectionManager::dispose(NodeNum i) {
+  if (connections_.find(i) == connections_.end()) return;
   connections_.at(i)->dispose(true);
 }
 

--- a/communication/src/TlsConnectionManager.h
+++ b/communication/src/TlsConnectionManager.h
@@ -46,6 +46,7 @@ class ConnectionManager {
   void send(const std::set<NodeNum> &destinations, const std::shared_ptr<OutgoingMsg> &msg);
   int getMaxMessageSize() const;
   void dispose(NodeNum i);
+
  private:
   void start();
   void stop();

--- a/communication/src/TlsConnectionManager.h
+++ b/communication/src/TlsConnectionManager.h
@@ -45,7 +45,7 @@ class ConnectionManager {
   void send(const NodeNum destination, const std::shared_ptr<OutgoingMsg> &msg);
   void send(const std::set<NodeNum> &destinations, const std::shared_ptr<OutgoingMsg> &msg);
   int getMaxMessageSize() const;
-
+  void dispose(NodeNum i);
  private:
   void start();
   void stop();

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -42,12 +42,12 @@ int TlsTCPCommunication::getMaxMessageSize() {
   }
 }
 
-int TlsTCPCommunication::Start() {
+int TlsTCPCommunication::start() {
   runner_->start();
   return 0;
 }
 
-int TlsTCPCommunication::Stop() {
+int TlsTCPCommunication::stop() {
   if (!runner_) {
     return -1;
   }

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -100,11 +100,11 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
 
 void TlsTCPCommunication::dispose(NodeNum i) {
   if (config_.selfId == i) {
-    for (auto& [_, connMgr] : runner_->principals()) {
+    for (auto &[_, connMgr] : runner_->principals()) {
       if (connMgr.getCurrentConnectionStatus(_) == ConnectionStatus::Connected) connMgr.dispose(_);
     }
   } else {
-    auto& connMgr = runner_->principals().at(config_.selfId);
+    auto &connMgr = runner_->principals().at(config_.selfId);
     if (connMgr.getCurrentConnectionStatus(i) == ConnectionStatus::Connected) connMgr.dispose(i);
   }
 }

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -98,4 +98,13 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
   }
 }
 
+void TlsTCPCommunication::dispose(NodeNum i) {
+  if (config_.selfId == i) {
+    for (auto& [_, connMgr] : runner_->principals()) {
+      connMgr.dispose(_);
+    }
+  } else {
+      runner_->principals().at(config_.selfId).dispose(i);
+  }
+}
 }  // namespace bft::communication

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -101,10 +101,11 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
 void TlsTCPCommunication::dispose(NodeNum i) {
   if (config_.selfId == i) {
     for (auto& [_, connMgr] : runner_->principals()) {
-      connMgr.dispose(_);
+      if (connMgr.getCurrentConnectionStatus(_) == ConnectionStatus::Connected) connMgr.dispose(_);
     }
   } else {
-      runner_->principals().at(config_.selfId).dispose(i);
+    auto& connMgr = runner_->principals().at(config_.selfId);
+    if (connMgr.getCurrentConnectionStatus(i) == ConnectionStatus::Connected) connMgr.dispose(i);
   }
 }
 }  // namespace bft::communication

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -23,6 +23,7 @@ static const char reconfiguration_add_remove = 0x29;
 static const char reconfiguration_wedge_key = 0x2a;
 static const char reconfiguration_client_data_prefix = 0x2c;
 static const char reconfiguration_epoch_key = 0x2d;
+static const char reconfiguration_tls_exchange_key = 0x2e;
 
 static const char reconfiguration_restart_key = 0x30;
 static const char reconfiguration_ts_key = 0x31;

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -224,5 +224,11 @@ class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IR
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
+
+  bool handle(const concord::messages::ReplicaTlsExchangeKey&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/src/ClientImp.cpp
+++ b/kvbc/src/ClientImp.cpp
@@ -39,14 +39,14 @@ Status ClientImp::start() {
   bftClient_ = bftEngine::SimpleClient::createSimpleClient(comm_, clientId, fVal, cVal);
 
   // Only start the communication after creating the client, because the client sets the receiver of communication
-  comm_->Start();
+  comm_->start();
 
   return Status::OK();
 }
 
 Status ClientImp::stop() {
   // TODO: implement
-  if (0 != comm_->Stop()) {
+  if (0 != comm_->stop()) {
     return Status::GeneralError("No tls runner to stop");
   }
   return Status::OK();

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -440,9 +440,7 @@ Replica::Replica(ICommunication *comm,
       secretsManager_{secretsManager},
       blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
                                                                           : std::thread::hardware_concurrency()) {
-  bft::communication::CommStateControl::instance().setCommRestartCallBack([this]() {
-    this->m_ptrComm->Stop();
-    this->m_ptrComm->Start();
+  bft::communication::CommStateControl::instance().setCommRestartCallBack([this](uint32_t i) { m_ptrComm->dispose(i);
   });
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -37,7 +37,7 @@
 #include "client/reconfiguration/st_based_reconfiguration_client.hpp"
 #include "client/reconfiguration/client_reconfiguration_engine.hpp"
 #include "bftengine/ReplicaConfig.hpp"
-#include "communication/CommStateControl.hpp"
+#include "communication/StateControl.hpp"
 
 using bft::communication::ICommunication;
 using bftEngine::bcst::StateTransferDigest;
@@ -440,8 +440,7 @@ Replica::Replica(ICommunication *comm,
       secretsManager_{secretsManager},
       blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
                                                                           : std::thread::hardware_concurrency()) {
-  bft::communication::CommStateControl::instance().setCommRestartCallBack(
-      [this](uint32_t i) { m_ptrComm->dispose(i); });
+  bft::communication::StateControl::instance().setCommRestartCallBack([this](uint32_t i) { m_ptrComm->dispose(i); });
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {
     replicaConfig_.replicaId,

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -440,8 +440,8 @@ Replica::Replica(ICommunication *comm,
       secretsManager_{secretsManager},
       blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
                                                                           : std::thread::hardware_concurrency()) {
-  bft::communication::CommStateControl::instance().setCommRestartCallBack([this](uint32_t i) { m_ptrComm->dispose(i);
-  });
+  bft::communication::CommStateControl::instance().setCommRestartCallBack(
+      [this](uint32_t i) { m_ptrComm->dispose(i); });
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {
     replicaConfig_.replicaId,

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -37,6 +37,7 @@
 #include "client/reconfiguration/st_based_reconfiguration_client.hpp"
 #include "client/reconfiguration/client_reconfiguration_engine.hpp"
 #include "bftengine/ReplicaConfig.hpp"
+#include "communication/CommStateControl.hpp"
 
 using bft::communication::ICommunication;
 using bftEngine::bcst::StateTransferDigest;
@@ -439,6 +440,10 @@ Replica::Replica(ICommunication *comm,
       secretsManager_{secretsManager},
       blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
                                                                           : std::thread::hardware_concurrency()) {
+  bft::communication::CommStateControl::instance().setCommRestartCallBack([this]() {
+    this->m_ptrComm->Stop();
+    this->m_ptrComm->Start();
+  });
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {
     replicaConfig_.replicaId,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -357,7 +357,8 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
                                     const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& rres) {
   if (command.tls && command.target_replicas.size() > bftEngine::ReplicaConfig::instance().fVal) {
-    concord::messages::ReconfigurationErrorMsg error_msg{"Unable to perform tls key exchange for more than f replicas at once"};
+    concord::messages::ReconfigurationErrorMsg error_msg{
+        "Unable to perform tls key exchange for more than f replicas at once"};
     rres.response = error_msg;
     return false;
   }

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -360,6 +360,9 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
   auto blockId = persistReconfigurationBlock(
       serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_key_exchange}, ts, false);
   LOG_INFO(getLogger(), "KeyExchangeCommand command block is " << blockId);
+  if (command.tls) {
+    LOG_INFO(getLogger(), "replica tls key exchange command");
+  }
   return true;
 }
 

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -18,6 +18,7 @@
 #include "kvbc_app_filter/kvbc_key_types.h"
 #include "concord.cmf.hpp"
 #include "secrets_manager_plain.h"
+#include "communication/CommStateControl.hpp"
 namespace concord::kvbc::reconfiguration {
 
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
@@ -788,6 +789,7 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Repli
                                        std::to_string(sender_id) + "/server/server.cert";
   secretsmanager::SecretsManagerPlain sm;
   sm.encryptFile(bft_replicas_cert_path, command.cert);
+  bft::communication::CommStateControl::instance().restartComm();
   LOG_INFO(getLogger(), bft_replicas_cert_path + " is updated on the disk");
   return true;
 }

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -360,9 +360,6 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
   auto blockId = persistReconfigurationBlock(
       serialized_command, sequence_number, std::string{kvbc::keyTypes::reconfiguration_key_exchange}, ts, false);
   LOG_INFO(getLogger(), "KeyExchangeCommand command block is " << blockId);
-  if (command.tls) {
-    LOG_INFO(getLogger(), "replica tls key exchange command");
-  }
   return true;
 }
 

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -18,7 +18,7 @@
 #include "kvbc_app_filter/kvbc_key_types.h"
 #include "concord.cmf.hpp"
 #include "secrets_manager_plain.h"
-#include "communication/CommStateControl.hpp"
+#include "communication/StateControl.hpp"
 namespace concord::kvbc::reconfiguration {
 
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
@@ -797,7 +797,7 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Repli
   secretsmanager::SecretsManagerPlain sm;
   sm.encryptFile(bft_replicas_cert_path, cert);
   LOG_INFO(getLogger(), bft_replicas_cert_path + " is updated on the disk");
-  bft::communication::CommStateControl::instance().restartComm(sender_id);
+  bft::communication::StateControl::instance().restartComm(sender_id);
   return true;
 }
 

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -224,6 +224,10 @@ Msg ClientsRestartUpdate 56 {
     uint64 sender_id
 }
 
+Msg ReplicaTlsExchangeKey 57 {
+    string cert
+}
+
 Msg ClientStateReply 39 {
     uint64 block_id
     oneof {
@@ -266,6 +270,7 @@ Msg ReconfigurationRequest 1 {
     ClientExchangePublicKey
     ClientTlsExchangeKey
     RestartCommand
+    ReplicaTlsExchangeKey
     ClientsAddRemoveCommand
     ClientsAddRemoveStatusCommand
     ClientsAddRemoveUpdateCommand

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -87,6 +87,7 @@ Msg ReconfigurationErrorMsg 24 {
 Msg KeyExchangeCommand 25 {
     uint64 sender_id
     list uint64 target_replicas
+    bool tls
 }
 
 Msg AddRemoveCommand 26 {

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -236,6 +236,14 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::ReplicaTlsExchangeKey &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const = 0;

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -19,6 +19,7 @@
 #include "OpenTracing.hpp"
 #include "SigManager.hpp"
 #include "crypto_utils.hpp"
+#include "bftengine/InternalBFTClient.hpp"
 
 namespace concord::reconfiguration {
 class BftReconfigurationHandler : public IReconfigurationHandler {

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -19,7 +19,6 @@
 #include "OpenTracing.hpp"
 #include "SigManager.hpp"
 #include "crypto_utils.hpp"
-#include "bftengine/InternalBFTClient.hpp"
 
 namespace concord::reconfiguration {
 class BftReconfigurationHandler : public IReconfigurationHandler {

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -18,7 +18,7 @@
 #include "bftengine/EpochManager.hpp"
 #include "Replica.hpp"
 #include "kvstream.h"
-#include "communication/CommStateControl.hpp"
+#include "communication/StateControl.hpp"
 #include "secrets_manager_plain.h"
 
 using namespace concord::messages;
@@ -102,7 +102,7 @@ void ReconfigurationHandler::handleWedgeCommands(
       });
     if (blockNewConnections) {
       bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack(
-          [=]() { bft::communication::CommStateControl::instance().setBlockNewConnectionsFlag(true); });
+          [=]() { bft::communication::StateControl::instance().setBlockNewConnectionsFlag(true); });
     }
   } else {
     if (remove_metadata)
@@ -118,7 +118,7 @@ void ReconfigurationHandler::handleWedgeCommands(
       });
     if (blockNewConnections) {
       bftEngine::IControlHandler::instance()->addOnSuperStableCheckpointCallBack(
-          [=]() { bft::communication::CommStateControl::instance().setBlockNewConnectionsFlag(true); });
+          [=]() { bft::communication::StateControl::instance().setBlockNewConnectionsFlag(true); });
     }
   }
 }

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -53,7 +53,12 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     uint64_t sequence_number,
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>&,
-                                    concord::messages::ReconfigurationResponse&) {
+                                    concord::messages::ReconfigurationResponse& rres) {
+  if (command.tls && command.target_replicas.size() > bftEngine::ReplicaConfig::instance().fVal) {
+    concord::messages::ReconfigurationErrorMsg error_msg{"Unable to perform tls key exchange for more than f replicas at once"};
+    rres.response = error_msg;
+    return false;
+  }
   std::ostringstream oss;
   std::copy(command.target_replicas.begin(), command.target_replicas.end(), std::ostream_iterator<int>(oss, " "));
 

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -53,6 +53,7 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse&) {
+  if (command.tls) return true;
   std::ostringstream oss;
   std::copy(command.target_replicas.begin(), command.target_replicas.end(), std::ostream_iterator<int>(oss, " "));
 

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -55,7 +55,8 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
   if (command.tls && command.target_replicas.size() > bftEngine::ReplicaConfig::instance().fVal) {
-    concord::messages::ReconfigurationErrorMsg error_msg{"Unable to perform tls key exchange for more than f replicas at once"};
+    concord::messages::ReconfigurationErrorMsg error_msg{
+        "Unable to perform tls key exchange for more than f replicas at once"};
     rres.response = error_msg;
     return false;
   }

--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -119,7 +119,7 @@ add_test(NAME skvbc_backup_restore COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-if (USE_S3_OBJECT_STORE)
+if (USE_S3_OBJECT_STORE AND BUILD_COMM_TCP_TLS)
      add_test(NAME skvbc_reconfiguration COMMAND sh -c
              "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -231,7 +231,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         """
             Operator sends client key exchange command for cre client
         """
-        with log.start_action(action_type="test_client_key_exchange_command"):
+        with log.start_action(action_type="test_client_tls_key_exchange_command"):
             bft_network.start_all_replicas()
             bft_network.start_cre()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
@@ -297,10 +297,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             while not succ:
                 await trio.sleep(1)
                 succ = True
-                priv_key_path = os.path.join(bft_network.certdir + "/" + str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem")
+                priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem")
                 new_priv_path = priv_key_path + ".new"
 
-                enc_priv_key_path = os.path.join(bft_network.certdir + "/" + str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem.enc")
+                enc_priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem.enc")
                 enc_new_priv_path = enc_priv_key_path + ".new"
                 if os.path.isfile(priv_key_path):
                     if not os.path.isfile(new_priv_path):
@@ -390,7 +390,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         """
         with log.start_action(action_type="test_replica_key_exchange_command"):
             bft_network.start_all_replicas()
-            bft_network.start_cre()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             initial_prim = 0
             exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f, {initial_prim}))

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -384,9 +384,9 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
-    async def test_replicas_key_exchange_command_without_primary(self, bft_network):
+    async def test_replicas_tls_key_exchange_command_without_primary(self, bft_network):
         """
-            Operator sends client key exchange command for all the clients
+            Operator sends client key exchange command for f replicas
         """
         with log.start_action(action_type="test_replica_key_exchange_command"):
             bft_network.start_all_replicas()

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -297,10 +297,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             while not succ:
                 await trio.sleep(1)
                 succ = True
-                priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id),"client", "pk.pem")
+                priv_key_path = os.path.join(bft_network.certdir + "/" + str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem")
                 new_priv_path = priv_key_path + ".new"
 
-                enc_priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id),"client", "pk.pem.enc")
+                enc_priv_key_path = os.path.join(bft_network.certdir + "/" + str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem.enc")
                 enc_new_priv_path = enc_priv_key_path + ".new"
                 if os.path.isfile(priv_key_path):
                     if not os.path.isfile(new_priv_path):
@@ -381,6 +381,66 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 if ts != v:
                     return None
         return ts
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    async def test_replicas_key_exchange_command_without_primary(self, bft_network):
+        """
+            Operator sends client key exchange command for all the clients
+        """
+        with log.start_action(action_type="test_replica_key_exchange_command"):
+            bft_network.start_all_replicas()
+            bft_network.start_cre()
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+            initial_prim = 0
+            exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f, {initial_prim}))
+            for i in range(100):
+                await skvbc.send_write_kv_set()
+            fast_paths = {}
+            for r in bft_network.all_replicas():
+                nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
+                fast_paths[r] = nb_fast_path
+            await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas)
+            # Manually copy the new certs from one of the replicas to clients and restart clients
+            bft_network.copy_certs_from_server_to_clients(1)
+            bft_network.restart_clients(False, False)
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+            for i in range(100):
+                await skvbc.send_write_kv_set()
+            for r in bft_network.all_replicas():
+                nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
+                self.assertGreater(nb_fast_path, fast_paths[r])
+
+    async def run_replica_tls_key_exchange_cycle(self, bft_network, replicas):
+        reps_data = {}
+        for rep in bft_network.all_replicas():
+            reps_data[rep] = {}
+            for r in replicas:
+                cert_path = os.path.join(bft_network.certdir + "/" + str(r), str(r),"server", "server.cert")
+                with open(cert_path) as orig_key:
+                    cert_text = orig_key.readlines()
+                    reps_data[rep][r] = cert_text
+        client = bft_network.random_client()
+        op = operator.Operator(bft_network.config, client, bft_network.builddir)
+        rep = await op.key_exchange(replicas, tls=True)
+        rep = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
+        assert rep.success is True
+
+        with trio.fail_after(30):
+            succ = False
+            while not succ:
+                await trio.sleep(1)
+                succ = True
+                for rep in bft_network.all_replicas():
+                    for r in replicas:
+                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r),"server", "server.cert")
+                        with open(cert_path) as orig_key:
+                            cert_text = orig_key.readlines()
+                            diff = difflib.unified_diff(reps_data[rep][r], cert_text, fromfile="new", tofile="old", lineterm='')
+                            lines = sum(1 for l in diff)
+                            if lines == 0:
+                                succ = False
+                                continue
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -308,7 +308,7 @@ class BftTestNetwork:
         os.chdir(bft_network.testdir)
         bft_network._generate_crypto_keys()
         if bft_network.comm_type() == bft_config.COMM_TYPE_TCP_TLS:
-            generate_cre = 0 if bft_network.with_cre is True else 1
+            generate_cre = 0 if bft_network.with_cre is False else 1
             # Generate certificates for all replicas, clients, and reserved clients
             bft_network.generate_tls_certs(bft_network.num_total_replicas() + config.num_clients + RESERVED_CLIENTS_QUOTA + generate_cre)
 
@@ -417,7 +417,7 @@ class BftTestNetwork:
         self._generate_crypto_keys()
 
         if generate_tls and self.comm_type() == bft_config.COMM_TYPE_TCP_TLS:
-            generate_cre = 0 if self.with_cre is True else 1
+            generate_cre = 0 if self.with_cre is False else 1
             # Generate certificates for replicas, clients, and reserved clients
             self.generate_tls_certs(self.num_total_replicas() + config.num_clients + RESERVED_CLIENTS_QUOTA + generate_cre)
 

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -90,10 +90,11 @@ class Operator:
         prune_status_cmd.sender = 1000
         return self._construct_basic_reconfiguration_request(prune_status_cmd)
 
-    def _construct_reconfiguration_keMsg_command(self, target_replicas = []):
+    def _construct_reconfiguration_keMsg_command(self, target_replicas = [], tls=False):
         ke_command = cmf_msgs.KeyExchangeCommand()
         ke_command.sender_id = 1000
         ke_command.target_replicas = target_replicas
+        ke_command.tls = tls
         return self._construct_basic_reconfiguration_request(ke_command)
 
     def _construct_reconfiguration_addRemove_command(self, new_config):

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -217,8 +217,8 @@ class Operator:
                           m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config, [r for r in range(
                               self.config.n)]), reconfiguration=True)
 
-    async def key_exchange(self, target_replicas):
-        reconf_msg = self._construct_reconfiguration_keMsg_command(target_replicas)
+    async def key_exchange(self, target_replicas, tls=False):
+        reconf_msg = self._construct_reconfiguration_keMsg_command(target_replicas, tls)
         return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
     
     async def client_key_exchange_command(self, target_clients, tls=False):

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -263,7 +263,7 @@ class KeyExchangeCommandHandler : public IStateHandler {
     rreq.command = creq;
     std::vector<uint8_t> req_buf;
     concord::messages::serialize(req_buf, rreq);
-    out = {req_buf, [this, non_encrypted, new_key_path, orig_pk_path, enc, enc_file_path]() {
+    out = {req_buf, [this, non_encrypted, new_key_path, orig_pk_path, enc, enc_file_path, cert]() {
              if (enc) {
                fs::path orig_enc_key_path = orig_pk_path;
                orig_enc_key_path += ".enc";
@@ -282,6 +282,9 @@ class KeyExchangeCommandHandler : public IStateHandler {
                fs::remove(old_pk_path);
                LOG_INFO(this->getLogger(), "exchanged tls keys (non encrypted)");
              }
+             plain_sm_.encryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert").string(),
+                                   cert);
+             LOG_INFO(this->getLogger(), "exchanged tls certificate");
            }};
     return true;
   }

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
@@ -44,6 +44,7 @@ class WrapCommunication : public ICommunication {
     communication_->setReceiver(receiverNum, receiver);
   }
 
+  void dispose(NodeNum i) override {}
   static void addStrategies(
       std::string const &strategies,
       char delim,

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
@@ -30,8 +30,8 @@ class WrapCommunication : public ICommunication {
       : communication_(std::move(comm)), separate_communication_(separate_communication), logger_(logger) {}
 
   int getMaxMessageSize() override { return communication_->getMaxMessageSize(); }
-  int Start() override { return communication_->Start(); }
-  int Stop() override { return communication_->Stop(); }
+  int start() override { return communication_->start(); }
+  int stop() override { return communication_->stop(); }
   bool isRunning() const override { return communication_->isRunning(); }
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override {
     return communication_->getCurrentConnectionStatus(node);

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -123,7 +123,7 @@ void run_replica(int argc, char** argv) {
                                       std::map<std::string, categorization::CATEGORY_TYPE>{
                                           {VERSIONED_KV_CAT_ID, categorization::CATEGORY_TYPE::versioned_kv},
                                           {BLOCK_MERKLE_CAT_ID, categorization::CATEGORY_TYPE::block_merkle}},
-                                      std::make_shared<concord::secretsmanager::SecretsManagerPlain>());
+                                      setup->GetSecretManager());
   bftEngine::ControlStateManager::instance().addOnRestartProofCallBack(
       [argv, &setup]() {
         setup->GetCommunication()->Stop();

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -126,7 +126,7 @@ void run_replica(int argc, char** argv) {
                                       setup->GetSecretManager());
   bftEngine::ControlStateManager::instance().addOnRestartProofCallBack(
       [argv, &setup]() {
-        setup->GetCommunication()->Stop();
+        setup->GetCommunication()->stop();
         setup->GetMetricsServer().Stop();
         execv(argv[0], argv);
       },

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -248,7 +248,8 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1 + replicaConfig.numRoReplicas);
     auto numOfClients =
         replicaConfig.numOfClientProxies ? replicaConfig.numOfClientProxies : replicaConfig.numOfExternalClients;
-    std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_ = std::make_shared<concord::secretsmanager::SecretsManagerPlain>();
+    std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_ =
+        std::make_shared<concord::secretsmanager::SecretsManagerPlain>();
 #ifdef USE_COMM_PLAIN_TCP
     bft::communication::PlainTcpConfig conf =
         testCommConfig.GetTCPConfig(true, replicaConfig.replicaId, numOfClients, numOfReplicas, commConfigFile);
@@ -287,13 +288,13 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     LOG_INFO(logger, "\nReplica Configuration: \n" << replicaConfig);
     std::unique_ptr<TestSetup> setup = nullptr;
     setup.reset(new TestSetup(replicaConfig,
-                             std::move(comm),
-                             logger,
-                             metricsPort,
-                             persistMode == PersistencyMode::RocksDB,
-                             s3ConfigFile,
-                             logPropsFile,
-                             cronEntryNumberOfExecutes));
+                              std::move(comm),
+                              logger,
+                              metricsPort,
+                              persistMode == PersistencyMode::RocksDB,
+                              s3ConfigFile,
+                              logPropsFile,
+                              cronEntryNumberOfExecutes));
     setup->sm_ = sm_;
     return setup;
 

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -40,6 +40,7 @@
 #include "strategy/ShufflePrePrepareMsgStrategy.hpp"
 #include "strategy/MangledPreProcessResultMsgStrategy.hpp"
 #include "WrapCommunication.hpp"
+#include "secrets_manager_enc.h"
 
 namespace fs = std::experimental::filesystem;
 
@@ -247,12 +248,18 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         (uint16_t)(3 * replicaConfig.fVal + 2 * replicaConfig.cVal + 1 + replicaConfig.numRoReplicas);
     auto numOfClients =
         replicaConfig.numOfClientProxies ? replicaConfig.numOfClientProxies : replicaConfig.numOfExternalClients;
+    std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_ = std::make_shared<concord::secretsmanager::SecretsManagerPlain>();
 #ifdef USE_COMM_PLAIN_TCP
     bft::communication::PlainTcpConfig conf =
         testCommConfig.GetTCPConfig(true, replicaConfig.replicaId, numOfClients, numOfReplicas, commConfigFile);
 #elif USE_COMM_TLS_TCP
     bft::communication::TlsTcpConfig conf = testCommConfig.GetTlsTCPConfig(
         true, replicaConfig.replicaId, numOfClients, numOfReplicas, commConfigFile, certRootPath);
+    if (conf.secretData.has_value()) {
+      sm_ = std::make_shared<concord::secretsmanager::SecretsManagerEnc>(conf.secretData.value());
+    } else {
+      sm_ = std::make_shared<concord::secretsmanager::SecretsManagerPlain>();
+    }
 #else
     bft::communication::PlainUdpConfig conf =
         testCommConfig.GetUDPConfig(true, replicaConfig.replicaId, numOfClients, numOfReplicas, commConfigFile);
@@ -278,15 +285,17 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     uint16_t metricsPort = conf.listenPort + 1000;
 
     LOG_INFO(logger, "\nReplica Configuration: \n" << replicaConfig);
-
-    return std::unique_ptr<TestSetup>(new TestSetup{replicaConfig,
-                                                    std::move(comm),
-                                                    logger,
-                                                    metricsPort,
-                                                    persistMode == PersistencyMode::RocksDB,
-                                                    s3ConfigFile,
-                                                    logPropsFile,
-                                                    cronEntryNumberOfExecutes});
+    std::unique_ptr<TestSetup> setup = nullptr;
+    setup.reset(new TestSetup(replicaConfig,
+                             std::move(comm),
+                             logger,
+                             metricsPort,
+                             persistMode == PersistencyMode::RocksDB,
+                             s3ConfigFile,
+                             logPropsFile,
+                             cronEntryNumberOfExecutes));
+    setup->sm_ = sm_;
+    return setup;
 
   } catch (const std::exception& e) {
     LOG_FATAL(GL, "failed to parse command line arguments: " << e.what());

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -37,7 +37,7 @@ class TestSetup {
   static std::unique_ptr<TestSetup> ParseArgs(int argc, char** argv);
 
   std::unique_ptr<IStorageFactory> GetStorageFactory();
-  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> GetSecretManager() { return sm_; }
+  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> GetSecretManager() const { return sm_; }
   const bftEngine::ReplicaConfig& GetReplicaConfig() const { return replicaConfig_; }
   bft::communication::ICommunication* GetCommunication() const { return communication_.get(); }
   concordMetrics::Server& GetMetricsServer() { return metricsServer_; }

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -24,6 +24,7 @@
 #include "config/test_parameters.hpp"
 #include "storage_factory_interface.h"
 #include "PerformanceManager.hpp"
+#include "secrets_manager_impl.h"
 
 #ifdef USE_S3_OBJECT_STORE
 #include "s3/client.hpp"
@@ -36,7 +37,7 @@ class TestSetup {
   static std::unique_ptr<TestSetup> ParseArgs(int argc, char** argv);
 
   std::unique_ptr<IStorageFactory> GetStorageFactory();
-
+  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> GetSecretManager() { return sm_; }
   const bftEngine::ReplicaConfig& GetReplicaConfig() const { return replicaConfig_; }
   bft::communication::ICommunication* GetCommunication() const { return communication_.get(); }
   concordMetrics::Server& GetMetricsServer() { return metricsServer_; }
@@ -88,6 +89,7 @@ class TestSetup {
   std::string logPropsFile_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
   std::optional<std::uint32_t> cronEntryNumberOfExecutes_;
+  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
 };
 
 }  // namespace concord::kvbc

--- a/tests/simpleTest/simple_test_client.hpp
+++ b/tests/simpleTest/simple_test_client.hpp
@@ -75,7 +75,7 @@ class SimpleTestClient {
     SimpleClient* client = SimpleClient::createSimpleClient(comm, id, cp.numOfFaulty, cp.numOfSlow);
     auto aggregator = std::make_shared<concordMetrics::Aggregator>();
     client->setAggregator(aggregator);
-    comm->Start();
+    comm->start();
 
     // The state number that the latest write operation returned.
     uint64_t expectedStateNum = 0;
@@ -208,7 +208,7 @@ class SimpleTestClient {
     }
 
     // After all requests have been issued, stop communication and clean up.
-    comm->Stop();
+    comm->stop();
     std::string metric_comp_name = "clientMetrics_" + std::to_string(id);
     LOG_INFO(clientLogger,
              "clientMetrics::retransmissions " << aggregator->GetCounter(metric_comp_name, "retransmissions").Get());

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -171,7 +171,7 @@ class SimpleTestReplica {
     // TODO(DD): Reset manually because apparently the order matters - fixit
     replica.reset();
     if (comm) {
-      comm->Stop();
+      comm->stop();
       delete comm;
     }
     if (behaviorPtr) {


### PR DESCRIPTION
In this PR we introduce a basic implementation for replicas' TLS key exchange.
A replica TLS key exchange is composed of two phases:
1. The operator sends a request with up to f replicas that we want to exchange (see below why we don't exchange for more than f replicas at once)
2. Once the request is executed, each replica in the target_replicas generates a new key-pair and certificate and sends another BFT request that contains the new certificate.
3. On this second request execution, the replica saves the new certificate and closes the old TLS channel to the exchanged replica.

Note: 
We have a basic problem with TLS replicas' TLS key exchange: While the replicas in the lead quorum replace the key on the same stage, the clients need to fetch the data from the replicas in order to exchange the replicas' key.
However, once the replicas changed their TLS keys, the clients cannot connect to the replica and fetch the data.
To overcome the problem we don't allow to rotate more than f replicas at once. This way, both, CRE and ST are still able to work with the remaining quorum. It is the user's responsibility to verify that the clients were able to get the replicas key exchange command before exchanging more keys.
Note, that in case we have lagged/ST replicas, it is the client's responsibility to include these replicas in the exchanged f replicas (otherwise, we won't have a functional quorum).

To complete the feature we need to implement also the following:
1. ST handler for this command
2. Client's reconfiguration handler for this command