### PR TITLE
Identify the case where we restart during pruning

### DIFF
--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -200,7 +200,10 @@ void Replica::handleWedgeEvent() {
 
   uint64_t wedgeBftSeqNum =
       getStoredReconfigData(kConcordInternalCategoryId, std::string{keyTypes::bft_seq_num_key}, wedgeBlock);
-  ConcordAssert(wedgeBftSeqNum > 0);
+  if (wedgeBftSeqNum == 0) {
+    // We may have a pruning that run in the background
+    return;
+  }
 
   uint64_t wedgePoint = (wedgeBftSeqNum + 2 * checkpointWindowSize);
   wedgePoint = wedgePoint - (wedgePoint % checkpointWindowSize);


### PR DESCRIPTION
When pruning run in the background, we may delete old overridden values (like wedge key) from the database.
For this, we need to remove the assert that assumes we always have the wedge value in the blockchain.