### PR TITLE
Check error/fatal logs in replica and notify the user via github actions

### DIFF
--- a/.github/success_action_if_err_logs_exist.sh
+++ b/.github/success_action_if_err_logs_exist.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# This script used to check if ERROR/FATAL logs are present in apollo replica logs.
+
+set -e
+
+file_name=err_logs
+file_count=$(find ${1} -name $file_name | wc -l)
+
+if [[ $file_count -gt 0 ]]; then
+    echo -e "\033[31mERROR/FATAL logs found in below paths. Please check artifacts\033[m"
+    echo -e "$(find . -type f -name err_logs)"
+else 
+    echo "File not found"
+fi

--- a/.github/success_action_if_err_logs_exist.sh
+++ b/.github/success_action_if_err_logs_exist.sh
@@ -3,12 +3,12 @@
 
 set -e
 
-file_name=err_logs
+file_name=ReplicaErrorLogs.txt
 file_count=$(find ${1} -name $file_name | wc -l)
 
 if [[ $file_count -gt 0 ]]; then
     echo -e "\033[31mERROR/FATAL logs found in below paths. Please check artifacts\033[m"
-    echo -e "$(find . -type f -name err_logs)"
+    echo -e "$(find . -type f -name ReplicaErrorLogs.txt)"
 else 
     echo "File not found"
 fi

--- a/.github/workflows/build_and_test_clang_debug.yml
+++ b/.github/workflows/build_and_test_clang_debug.yml
@@ -5,6 +5,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-18.04
+    outputs:
+      output1: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -55,16 +57,36 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Check ERROR/FATAL logs
+          id: err_report
+          run: |
+            chmod +x "./.github/success_action_if_err_logs_exist.sh"
+            ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
+            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
-          if: failure()
+          id: prepare_artifacts
+          if: failure() || ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
+            echo "::set-output name=test::success"
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
-          if: failure()
+          if: failure() || ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
+  testlog:
+    name: Check ERROR/ FATAL logs in apollo
+    runs-on: ubuntu-18.04
+    continue-on-error: true
+    needs: build
+    steps:
+        - name: Check ERROR/FATAL logs in apollo
+          if: needs.build.outputs.output1 == 'success'
+          run: |
+            echo "Errors exist in replica logs. Please check Artifacts"
+            exit 1
+   

--- a/.github/workflows/build_and_test_clang_debug.yml
+++ b/.github/workflows/build_and_test_clang_debug.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      output1: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -58,11 +58,9 @@ jobs:
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
         - name: Check ERROR/FATAL logs
-          id: err_report
           run: |
-            chmod +x "./.github/success_action_if_err_logs_exist.sh"
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
-            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
+            echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
           id: prepare_artifacts
           if: failure() || ${{ env.file_count > 0 }}
@@ -79,13 +77,13 @@ jobs:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
   testlog:
-    name: Check ERROR/ FATAL logs in apollo
+    name: Check ERROR/ FATAL logs(Apollo)
     runs-on: ubuntu-18.04
     continue-on-error: true
     needs: build
     steps:
         - name: Check ERROR/FATAL logs in apollo
-          if: needs.build.outputs.output1 == 'success'
+          if: needs.build.outputs.err_output == 'success'
           run: |
             echo "Errors exist in replica logs. Please check Artifacts"
             exit 1

--- a/.github/workflows/build_and_test_clang_release.yml
+++ b/.github/workflows/build_and_test_clang_release.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      output1: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -59,12 +59,9 @@ jobs:
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
         - name: Check ERROR/FATAL logs
-          id: err_report
-          if: always()
           run: |
-            chmod +x "./.github/success_action_if_err_logs_exist.sh"
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
-            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
+            echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
           id: prepare_artifacts
           if: failure() || ${{ env.file_count > 0 }}
@@ -81,13 +78,13 @@ jobs:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
   testlog:
-    name: Check ERROR/FATAL logs in apollo
+    name: Check ERROR/FATAL logs(Apollo)
     runs-on: ubuntu-18.04
     continue-on-error: true
     needs: build
     steps:
         - name: Check ERROR/FATAL logs in apollo
-          if: needs.build.outputs.output1 == 'success'
+          if: needs.build.outputs.err_output == 'success'
           run: |
             echo "Errors exist in replica logs. Please check Artifacts"
             exit 1

--- a/.github/workflows/build_and_test_clang_release.yml
+++ b/.github/workflows/build_and_test_clang_release.yml
@@ -5,6 +5,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-18.04
+    outputs:
+      output1: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -56,16 +58,37 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Check ERROR/FATAL logs
+          id: err_report
+          if: always()
+          run: |
+            chmod +x "./.github/success_action_if_err_logs_exist.sh"
+            ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
+            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
-          if: failure()
+          id: prepare_artifacts
+          if: failure() || ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
+            echo "::set-output name=test::success"
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
-          if: failure()
+          if: failure() || ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
+  testlog:
+    name: Check ERROR/FATAL logs in apollo
+    runs-on: ubuntu-18.04
+    continue-on-error: true
+    needs: build
+    steps:
+        - name: Check ERROR/FATAL logs in apollo
+          if: needs.build.outputs.output1 == 'success'
+          run: |
+            echo "Errors exist in replica logs. Please check Artifacts"
+            exit 1
+

--- a/.github/workflows/build_and_test_gcc_debug.yml
+++ b/.github/workflows/build_and_test_gcc_debug.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      output1: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -60,11 +60,9 @@ jobs:
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
         - name: Check ERROR/FATAL logs
-          id: err_report
           run: |
-            chmod +x "./.github/success_action_if_err_logs_exist.sh"
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
-            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
+            echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
           id: prepare_artifacts
           if: failure() || ${{ env.file_count > 0 }}
@@ -81,13 +79,13 @@ jobs:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
   testlog:
-    name: Check ERROR/ FATAL logs in apollo
+    name: Check ERROR/FATAL logs(Apollo)
     runs-on: ubuntu-18.04
     continue-on-error: true
     needs: build
     steps:
         - name: Check ERROR/FATAL logs in apollo
-          if: needs.build.outputs.output1 == 'success'
+          if: needs.build.outputs.err_output == 'success'
           run: |
             echo "Errors exist in replica logs. Please check Artifacts"
             exit 1

--- a/.github/workflows/build_and_test_gcc_debug.yml
+++ b/.github/workflows/build_and_test_gcc_debug.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-18.04
+    outputs:
+      output1: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -57,16 +59,35 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Check ERROR/FATAL logs
+          id: err_report
+          run: |
+            chmod +x "./.github/success_action_if_err_logs_exist.sh"
+            ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
+            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
-          if: failure()
+          id: prepare_artifacts
+          if: failure() || ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
+            echo "::set-output name=test::success"
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
-          if: failure()
+          if: failure() || ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
+  testlog:
+    name: Check ERROR/ FATAL logs in apollo
+    runs-on: ubuntu-18.04
+    continue-on-error: true
+    needs: build
+    steps:
+        - name: Check ERROR/FATAL logs in apollo
+          if: needs.build.outputs.output1 == 'success'
+          run: |
+            echo "Errors exist in replica logs. Please check Artifacts"
+            exit 1

--- a/.github/workflows/build_and_test_gcc_release.yml
+++ b/.github/workflows/build_and_test_gcc_release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      output1: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -61,11 +61,9 @@ jobs:
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
         - name: Check ERROR/FATAL logs
-          id: err_report
           run: |
-            chmod +x "./.github/success_action_if_err_logs_exist.sh"
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
-            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
+            echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
           id: prepare_artifacts
           if: failure() || ${{ env.file_count > 0 }}
@@ -82,13 +80,13 @@ jobs:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
   testlog:
-    name: Check ERROR/ FATAL logs in apollo
+    name: Check ERROR/FATAL logs(Apollo)
     runs-on: ubuntu-18.04
     continue-on-error: true
     needs: build
     steps:
         - name: Check ERROR/FATAL logs in apollo
-          if: needs.build.outputs.output1 == 'success'
+          if: needs.build.outputs.err_output == 'success'
           run: |
             echo "Errors exist in replica logs. Please check Artifacts"
             exit 1

--- a/.github/workflows/build_and_test_gcc_release.yml
+++ b/.github/workflows/build_and_test_gcc_release.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-18.04
+    outputs:
+      output1: ${{ steps.prepare_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -58,16 +60,35 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Check ERROR/FATAL logs
+          id: err_report
+          run: |
+            chmod +x "./.github/success_action_if_err_logs_exist.sh"
+            ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
+            echo "file_count=$(find ./build/tests/apollo/logs -name err_logs | wc -l)" >> $GITHUB_ENV
         - name: Prepare artifacts
-          if: failure()
+          id: prepare_artifacts
+          if: failure() || ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
+            echo "::set-output name=test::success"
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
-          if: failure()
+          if: failure() || ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
+  testlog:
+    name: Check ERROR/ FATAL logs in apollo
+    runs-on: ubuntu-18.04
+    continue-on-error: true
+    needs: build
+    steps:
+        - name: Check ERROR/FATAL logs in apollo
+          if: needs.build.outputs.output1 == 'success'
+          run: |
+            echo "Errors exist in replica logs. Please check Artifacts"
+            exit 1

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -637,8 +637,8 @@ class BftTestNetwork:
         If the file exists for any testcase, warning is displayed in CI
         """
         with log.start_action(action_type="replica_log_scanner") as action:
-            cmd = ['grep', '-R', 'ERROR\|FATAL', '--exclude=err_logs']
-            file_path = f"{self.test_dir}err_logs"
+            cmd = ['grep', '-R', 'ERROR\|FATAL', '--exclude=ReplicaErrorLogs.txt']
+            file_path = f"{self.test_dir}ReplicaErrorLogs.txt"
 
             with open(file_path, 'w+') as outfile:
                 subprocess.run(cmd, stdout=outfile, cwd=self.test_dir)

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -236,6 +236,8 @@ class BftTestNetwork:
             if self.perf_proc:
                 self.perf_proc.wait()
 
+            self.check_error_logs()
+
     def __init__(self, is_existing, origdir, config, testdir, certdir, builddir, toolsdir,
                  procs, replicas, clients, metrics, client_factory, background_nursery, ro_replicas=[]):
         self.is_existing = is_existing
@@ -628,6 +630,24 @@ class BftTestNetwork:
                 cmd.append("-t")
                 cmd.append(keys_path)
             return cmd
+
+    def check_error_logs(self):
+        """
+        Checking ERROR/FATAL logs in replica logs and writing in a file.
+        If the file exists for any testcase, warning is displayed in CI
+        """
+        with log.start_action(action_type="replica_log_scanner") as action:
+            cmd = ['grep', '-R', 'ERROR\|FATAL', '--exclude=err_logs']
+            file_path = f"{self.test_dir}err_logs"
+
+            with open(file_path, 'w+') as outfile:
+                subprocess.run(cmd, stdout=outfile, cwd=self.test_dir)
+
+            if os.path.isfile(file_path):
+                if  os.stat(file_path).st_size > 0:
+                    action.log(message_type=f'Error in Replica logs')
+                else:
+                    os.remove(file_path)
 
     def stop_replica_cmd(self, replica_id):
         """


### PR DESCRIPTION
In this PR, we have introduced a way to get all error/fatal logs if found in replica logs respective to each testcase. If error/fatal logs are found, then user will be notified via a job failure in github actions.

Implementation:
1. Once the testcase is executed, check_error_logs api will scan all the replica logs and write in a file err_logs per testcase.
2. Script is added to check if error logs are found during workflow.
3. Job check ERROR/FATAL logs added to highlight the failure to user without failing the CI.
4. Artifacts will be generated for the failures. Path respective to each testcase will be shown in build jobs.

Gcc builds passed:
https://github.com/situ-s/concord-bft/actions/runs/1291780005
https://github.com/situ-s/concord-bft/actions/runs/1291779997