### PR TITLE
Remove duplicate definition of kConcordInternalCategoryId

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -12,6 +12,7 @@
 #include "st_reconfiguraion_sm.hpp"
 #include "OpenTracing.hpp"
 #include "categorization/kv_blockchain.h"
+#include "categorization/db_categories.h"
 #include "communication/ICommunication.hpp"
 #include "communication/CommFactory.hpp"
 #include "bftengine/Replica.hpp"

--- a/kvbc/include/block_metadata.hpp
+++ b/kvbc/include/block_metadata.hpp
@@ -9,6 +9,7 @@
 
 #include "Logger.hpp"
 #include "db_interfaces.h"
+#include "categorization/db_categories.h"
 
 namespace concord {
 namespace kvbc {

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -15,10 +15,6 @@
 
 namespace concord::kvbc {
 
-// Concord and Concord-BFT internal category that is used for various kinds of metadata.
-// The type of the internal category is VersionedKeyValueCategory.
-inline const auto kConcordInternalCategoryId = "concord_internal";
-
 // Add blocks to the key-value blockchain.
 class IBlockAdder {
  public:

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -40,6 +40,7 @@
 
 using bft::communication::ICommunication;
 using bftEngine::bcst::StateTransferDigest;
+using concord::kvbc::categorization::kConcordInternalCategoryId;
 using namespace concord::diagnostics;
 
 using concord::storage::DBMetadataStorage;
@@ -239,7 +240,7 @@ void Replica::handleNewEpochEvent() {
     ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key},
                           concordUtils::toBigEndianStringBuffer(bft_seq_num));
     concord::kvbc::categorization::Updates updates;
-    updates.add(kvbc::kConcordInternalCategoryId, std::move(ver_updates));
+    updates.add(kConcordInternalCategoryId, std::move(ver_updates));
     try {
       auto bid = add(std::move(updates));
       persistLastBlockIdInMetadata<false>(*m_kvBlockchain, m_replicaPtr->persistentStorage());
@@ -260,9 +261,9 @@ void Replica::handleNewEpochEvent() {
 }
 template <typename T>
 void Replica::saveReconfigurationCmdToResPages(const std::string &key) {
-  auto res = getLatest(kvbc::kConcordInternalCategoryId, key);
+  auto res = getLatest(kConcordInternalCategoryId, key);
   if (res.has_value()) {
-    auto blockid = getLatestVersion(kvbc::kConcordInternalCategoryId, key).value().version;
+    auto blockid = getLatestVersion(kConcordInternalCategoryId, key).value().version;
     auto strval = std::visit([](auto &&arg) { return arg.data; }, *res);
     T cmd;
     std::vector<uint8_t> bytesval(strval.begin(), strval.end());

--- a/kvbc/src/block_metadata.cpp
+++ b/kvbc/src/block_metadata.cpp
@@ -16,7 +16,8 @@ std::string BlockMetadata::serialize(uint64_t bft_sequence_num) const {
 }
 
 uint64_t BlockMetadata::getLastBlockSequenceNum() const {
-  const auto value = storage_.getLatest(kConcordInternalCategoryId, IBlockMetadata::kBlockMetadataKeyStr);
+  const auto value = storage_.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId,
+                                        IBlockMetadata::kBlockMetadataKeyStr);
   auto sequenceNum = uint64_t{0};
   if (value) {
     const auto& data = std::get<categorization::VersionedValue>(*value).data;

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -257,8 +257,8 @@ bool PruningHandler::handle(const concord::messages::PruneStatusRequest&,
 }
 
 uint64_t PruningHandler::getBlockBftSequenceNumber(kvbc::BlockId bid) const {
-  auto opt_value =
-      ro_storage_.get(concord::kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::bft_seq_num_key}, bid);
+  auto opt_value = ro_storage_.get(
+      concord::kvbc::categorization::kConcordInternalCategoryId, std::string{kvbc::keyTypes::bft_seq_num_key}, bid);
   uint64_t sequenceNum = 0;
   if (!opt_value) {
     LOG_WARN(logger_, "Unable to get block");

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -26,7 +26,8 @@ void StReconfigurationHandler::deserializeCmfMessage(T &msg, const std::string &
 }
 
 uint64_t StReconfigurationHandler::getStoredBftSeqNum(BlockId bid) {
-  auto value = ro_storage_.get(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::bft_seq_num_key}, bid);
+  auto value = ro_storage_.get(
+      concord::kvbc::categorization::kConcordInternalCategoryId, std::string{kvbc::keyTypes::bft_seq_num_key}, bid);
   auto sequenceNum = uint64_t{0};
   if (value) {
     const auto &data = std::get<categorization::VersionedValue>(*value).data;
@@ -37,8 +38,9 @@ uint64_t StReconfigurationHandler::getStoredBftSeqNum(BlockId bid) {
 }
 
 uint64_t StReconfigurationHandler::getStoredEpochNumber(BlockId bid) {
-  auto value =
-      ro_storage_.get(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_epoch_key}, bid);
+  auto value = ro_storage_.get(concord::kvbc::categorization::kConcordInternalCategoryId,
+                               std::string{kvbc::keyTypes::reconfiguration_epoch_key},
+                               bid);
   auto epoch = uint64_t{0};
   if (value) {
     const auto &data = std::get<categorization::VersionedValue>(*value).data;
@@ -78,9 +80,10 @@ void StReconfigurationHandler::pruneOnStartup() {
 }
 template <typename T>
 bool StReconfigurationHandler::handleStoredCommand(const std::string &key, uint64_t current_cp_num) {
-  auto res = ro_storage_.getLatest(kvbc::kConcordInternalCategoryId, key);
+  auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId, key);
   if (res.has_value()) {
-    auto blockid = ro_storage_.getLatestVersion(kvbc::kConcordInternalCategoryId, key).value().version;
+    auto blockid =
+        ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordInternalCategoryId, key).value().version;
     auto seqNum = getStoredBftSeqNum(blockid);
     auto strval = std::visit([](auto &&arg) { return arg.data; }, *res);
     T cmd;

--- a/kvbc/test/replica_state_sync_test.cpp
+++ b/kvbc/test/replica_state_sync_test.cpp
@@ -36,7 +36,7 @@ using bftEngine::impl::PersistentStorageImp;
 using concord::kvbc::BlockId;
 using concord::kvbc::BlockMetadata;
 using concord::kvbc::IReader;
-using concord::kvbc::kConcordInternalCategoryId;
+using concord::kvbc::categorization::kConcordInternalCategoryId;
 using concord::kvbc::ReplicaStateSyncImp;
 using concord::kvbc::categorization::CATEGORY_TYPE;
 using concord::kvbc::categorization::KeyValueBlockchain;

--- a/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
@@ -30,10 +30,11 @@ class DbEditorTests : public DbEditorTestsBase {
     auto adapter = KeyValueBlockchain{
         concord::storage::rocksdb::NativeClient::fromIDBClient(db),
         true,
-        std::map<std::string, CATEGORY_TYPE>{{kCategoryMerkle, CATEGORY_TYPE::block_merkle},
-                                             {kCategoryVersioned, CATEGORY_TYPE::versioned_kv},
-                                             {kCategoryImmutable, CATEGORY_TYPE::immutable},
-                                             {concord::kvbc::kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+        std::map<std::string, CATEGORY_TYPE>{
+            {kCategoryMerkle, CATEGORY_TYPE::block_merkle},
+            {kCategoryVersioned, CATEGORY_TYPE::versioned_kv},
+            {kCategoryImmutable, CATEGORY_TYPE::immutable},
+            {concord::kvbc::categorization::kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
 
     const auto mismatch_kv = std::make_pair(getSliver(std::numeric_limits<unsigned>::max()), getSliver(42));
 
@@ -746,9 +747,9 @@ TEST_F(DbEditorTests, get_categories) {
   ASSERT_EQ(EXIT_SUCCESS,
             run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getCategories"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
-  ASSERT_EQ("{\n  \"" + std::string(concord::kvbc::kConcordInternalCategoryId) + "\": \"versioned_kv\",\n  \"" +
-                kCategoryImmutable + "\": \"immutable\",\n  \"" + kCategoryMerkle + "\": \"block_merkle\",\n  \"" +
-                kCategoryVersioned + "\": \"versioned_kv\"\n}\n",
+  ASSERT_EQ("{\n  \"" + std::string(concord::kvbc::categorization::kConcordInternalCategoryId) +
+                "\": \"versioned_kv\",\n  \"" + kCategoryImmutable + "\": \"immutable\",\n  \"" + kCategoryMerkle +
+                "\": \"block_merkle\",\n  \"" + kCategoryVersioned + "\": \"versioned_kv\"\n}\n",
             out_.str());
 }
 

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -311,7 +311,7 @@ struct VerifyBlockRequests {
     std::vector<uint8_t> v{imm_val.data.begin(), imm_val.data.end()};
     concord::messages::execution_data::deserialize(v, record);
 
-    auto opt_keys_val = adapter.get(concord::kvbc::kConcordInternalCategoryId,
+    auto opt_keys_val = adapter.get(concord::kvbc::categorization::kConcordInternalCategoryId,
                                     std::string(1, concord::kvbc::kClientsPublicKeys),
                                     record.keys_version);
     if (!opt_keys_val) {
@@ -744,8 +744,8 @@ struct RemoveMetadata {
     // Once we managed to remove the metadata, we must start a new epoch (which means to add an epoch block)
     uint64_t epoch{0};
     {
-      auto value =
-          adapter.getLatest(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::reconfiguration_epoch_key});
+      auto value = adapter.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId,
+                                     std::string{kvbc::keyTypes::reconfiguration_epoch_key});
       if (value) {
         const auto &data = std::get<categorization::VersionedValue>(*value).data;
         ConcordAssertEQ(data.size(), sizeof(uint64_t));
@@ -754,7 +754,8 @@ struct RemoveMetadata {
     }
     uint64_t last_executed_sn{0};
     {
-      auto value = adapter.getLatest(kvbc::kConcordInternalCategoryId, std::string{kvbc::keyTypes::bft_seq_num_key});
+      auto value = adapter.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId,
+                                     std::string{kvbc::keyTypes::bft_seq_num_key});
       if (value) {
         const auto &data = std::get<categorization::VersionedValue>(*value).data;
         ConcordAssertEQ(data.size(), sizeof(uint64_t));
@@ -768,7 +769,7 @@ struct RemoveMetadata {
     std::string sn_str = concordUtils::toBigEndianStringBuffer(last_executed_sn);
     ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, std::move(sn_str));
     concord::kvbc::categorization::Updates updates;
-    updates.add(kvbc::kConcordInternalCategoryId, std::move(ver_updates));
+    updates.add(concord::kvbc::categorization::kConcordInternalCategoryId, std::move(ver_updates));
     adapter.addBlock(std::move(updates));
     std::vector<std::pair<std::string, std::string>> out;
     out.push_back({std::string{"result"}, std::string{"true"}});


### PR DESCRIPTION
This commit keeps the internal category definition in db_categories.h (with the rest of the category definitions) and removes the one in db_interfaces.h. The change is reflected in all the files that use internal category.