### PR TITLE
Fixing the data type of maxSpaceForReqs and review of primaryCombinedReqSize

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -363,7 +363,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void onInternalMsg(GetStatus& msg) const;
 
   std::pair<PrePrepareMsg*, bool> finishAddingRequestsToPrePrepareMsg(PrePrepareMsg*& prePrepareMsg,
-                                                                      uint16_t maxSpaceForReqs,
+                                                                      uint32_t maxSpaceForReqs,
                                                                       uint32_t requiredRequestsSize,
                                                                       uint32_t requiredRequestsNum);
 
@@ -385,7 +385,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   ClientRequestMsg* addRequestToPrePrepareMessage(ClientRequestMsg*& nextRequest,
                                                   PrePrepareMsg& prePrepareMsg,
-                                                  uint16_t maxStorageForRequests);
+                                                  uint32_t maxStorageForRequests);
 
   PrePrepareMsg* createPrePrepareMessage();
 


### PR DESCRIPTION

Following 2 issues are handled in this PR
1) The datatype of maxSpaceForReqs is uint_16. This variable
stores the size of max space needed for the PrePrepareMsg.
So this variable can limit the size of PPM to 64KB.
2) The primaryCombinedReqSize variable should keep track of
actual total size of ClientRequestMsg. So every time we push CRM
into PPM, we have to increment it. And every time we pop CRM out of PPM
we have to reduce it with the removed CRM size. In this PR we will
review and change if we see some issues.