### PR TITLE
Introduce different category for reconfiguration

### DIFF
--- a/kvbc/include/categorization/db_categories.h
+++ b/kvbc/include/categorization/db_categories.h
@@ -28,6 +28,7 @@ inline const auto kExecutionEventGroupLatestCategory = "execution_event_group_la
 // Concord and Concord-BFT internal category that is used for various kinds of metadata.
 // The type of the internal category is VersionedKeyValueCategory.
 inline const auto kConcordInternalCategoryId = "concord_internal";
+inline const auto kConcordReconfigurationCategoryId = "concord_reconfiguration";
 
 }  // namespace concord::kvbc::categorization
 

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -41,6 +41,7 @@
 using bft::communication::ICommunication;
 using bftEngine::bcst::StateTransferDigest;
 using concord::kvbc::categorization::kConcordInternalCategoryId;
+using concord::kvbc::categorization::kConcordReconfigurationCategoryId;
 using namespace concord::diagnostics;
 
 using concord::storage::DBMetadataStorage;
@@ -195,7 +196,7 @@ uint64_t Replica::getStoredReconfigData(const std::string &kCategory,
 void Replica::handleWedgeEvent() {
   auto lastExecutedSeqNum = m_replicaPtr->getLastExecutedSequenceNum();
   uint64_t wedgeBlock{0};
-  auto version = getLatestVersion(kConcordInternalCategoryId, std::string{keyTypes::reconfiguration_wedge_key});
+  auto version = getLatestVersion(kConcordReconfigurationCategoryId, std::string{keyTypes::reconfiguration_wedge_key});
   if (!version.has_value()) return;
   wedgeBlock = version.value().version;
 
@@ -209,9 +210,9 @@ void Replica::handleWedgeEvent() {
   uint64_t wedgePoint = (wedgeBftSeqNum + 2 * checkpointWindowSize);
   wedgePoint = wedgePoint - (wedgePoint % checkpointWindowSize);
   uint64_t latestKnownEpoch =
-      getStoredReconfigData(kConcordInternalCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, 0);
-  uint64_t wedgeEpoch =
-      getStoredReconfigData(kConcordInternalCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, wedgeBlock);
+      getStoredReconfigData(kConcordReconfigurationCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, 0);
+  uint64_t wedgeEpoch = getStoredReconfigData(
+      kConcordReconfigurationCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, wedgeBlock);
 
   LOG_INFO(logger,
            "stored wedge info " << KVLOG(wedgePoint, wedgeBlock, wedgeEpoch, lastExecutedSeqNum, latestKnownEpoch));
@@ -225,7 +226,7 @@ void Replica::handleWedgeEvent() {
 }
 void Replica::handleNewEpochEvent() {
   uint64_t epoch = 0;
-  epoch = getStoredReconfigData(kConcordInternalCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, 0);
+  epoch = getStoredReconfigData(kConcordReconfigurationCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, 0);
 
   auto bft_seq_num = m_replicaPtr->getLastExecutedSequenceNum();
   // Create a new epoch block if needed
@@ -236,11 +237,13 @@ void Replica::handleNewEpochEvent() {
     concord::kvbc::categorization::VersionedUpdates ver_updates;
     ver_updates.addUpdate(std::string{kvbc::keyTypes::reconfiguration_epoch_key},
                           std::string(data.begin(), data.end()));
-    // All blocks are expected to have the BFT sequence number as a key.
-    ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key},
-                          concordUtils::toBigEndianStringBuffer(bft_seq_num));
     concord::kvbc::categorization::Updates updates;
-    updates.add(kConcordInternalCategoryId, std::move(ver_updates));
+    updates.add(kConcordReconfigurationCategoryId, std::move(ver_updates));
+    // All blocks are expected to have the BFT sequence number as a key.
+    concord::kvbc::categorization::VersionedUpdates sn_updates;
+    sn_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key},
+                         concordUtils::toBigEndianStringBuffer(bft_seq_num));
+    updates.add(kConcordInternalCategoryId, std::move(sn_updates));
     try {
       auto bid = add(std::move(updates));
       persistLastBlockIdInMetadata<false>(*m_kvBlockchain, m_replicaPtr->persistentStorage());
@@ -261,9 +264,9 @@ void Replica::handleNewEpochEvent() {
 }
 template <typename T>
 void Replica::saveReconfigurationCmdToResPages(const std::string &key) {
-  auto res = getLatest(kConcordInternalCategoryId, key);
+  auto res = getLatest(kConcordReconfigurationCategoryId, key);
   if (res.has_value()) {
-    auto blockid = getLatestVersion(kConcordInternalCategoryId, key).value().version;
+    auto blockid = getLatestVersion(kConcordReconfigurationCategoryId, key).value().version;
     auto strval = std::visit([](auto &&arg) { return arg.data; }, *res);
     T cmd;
     std::vector<uint8_t> bytesval(strval.begin(), strval.end());
@@ -272,8 +275,8 @@ void Replica::saveReconfigurationCmdToResPages(const std::string &key) {
     rreq.command = cmd;
     auto sequenceNum =
         getStoredReconfigData(kConcordInternalCategoryId, std::string{keyTypes::bft_seq_num_key}, blockid);
-    auto epochNum =
-        getStoredReconfigData(kConcordInternalCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, blockid);
+    auto epochNum = getStoredReconfigData(
+        kConcordReconfigurationCategoryId, std::string{keyTypes::reconfiguration_epoch_key}, blockid);
     auto wedgePoint = (sequenceNum + 2 * checkpointWindowSize);
     wedgePoint = wedgePoint - (wedgePoint % checkpointWindowSize);
     bftEngine::ReconfigurationCmd::instance().saveReconfigurationCmdToResPages(
@@ -489,12 +492,23 @@ Replica::Replica(ICommunication *comm,
 
   if (!replicaConfig.isReadOnly) {
     const auto linkStChain = true;
-    auto [it, inserted] =
-        kvbc_categories.insert(std::make_pair(kConcordInternalCategoryId, categorization::CATEGORY_TYPE::versioned_kv));
-    if (!inserted && it->second != categorization::CATEGORY_TYPE::versioned_kv) {
-      const auto msg = "Invalid Concord internal category type: " + categorization::categoryStringType(it->second);
-      LOG_ERROR(logger, msg);
-      throw std::invalid_argument{msg};
+    {
+      auto [it, inserted] = kvbc_categories.insert(
+          std::make_pair(kConcordInternalCategoryId, categorization::CATEGORY_TYPE::versioned_kv));
+      if (!inserted && it->second != categorization::CATEGORY_TYPE::versioned_kv) {
+        const auto msg = "Invalid Concord internal category type: " + categorization::categoryStringType(it->second);
+        LOG_ERROR(logger, msg);
+        throw std::invalid_argument{msg};
+      }
+    }
+    {
+      auto [it, inserted] = kvbc_categories.insert(
+          std::make_pair(kConcordReconfigurationCategoryId, categorization::CATEGORY_TYPE::versioned_kv));
+      if (!inserted && it->second != categorization::CATEGORY_TYPE::versioned_kv) {
+        const auto msg = "Invalid Concord internal category type: " + categorization::categoryStringType(it->second);
+        LOG_ERROR(logger, msg);
+        throw std::invalid_argument{msg};
+      }
     }
     m_kvBlockchain.emplace(
         storage::rocksdb::NativeClient::fromIDBClient(m_dbSet.dataDBClient), linkStChain, kvbc_categories);

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -30,7 +30,7 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
   ver_updates.addUpdate(std::move(key), std::string(data.begin(), data.end()));
 
   uint64_t epoch = 0;
-  auto value = ro_storage_.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId,
+  auto value = ro_storage_.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                      std::string{keyTypes::reconfiguration_epoch_key});
   if (value.has_value()) {
     const auto& epoch_str = std::get<categorization::VersionedValue>(*value).data;
@@ -53,7 +53,6 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
     const std::optional<bftEngine::Timestamp>& timestamp,
     bool include_wedge) {
   // All blocks are expected to have the BFT sequence number as a key.
-  ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, block_metadata_.serialize(bft_seq_num));
   if (timestamp.has_value()) {
     ver_updates.addUpdate(std::string{keyTypes::reconfiguration_ts_key},
                           concordUtils::toBigEndianStringBuffer(timestamp.value().time_since_epoch.count()));
@@ -66,7 +65,11 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
                           std::string(wedge_buf.begin(), wedge_buf.end()));
   }
   concord::kvbc::categorization::Updates updates;
-  updates.add(concord::kvbc::categorization::kConcordInternalCategoryId, std::move(ver_updates));
+  updates.add(concord::kvbc::categorization::kConcordReconfigurationCategoryId, std::move(ver_updates));
+  concord::kvbc::categorization::VersionedUpdates sn_updates;
+  sn_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, block_metadata_.serialize(bft_seq_num));
+  updates.add(concord::kvbc::categorization::kConcordInternalCategoryId, std::move(sn_updates));
+
   try {
     return blocks_adder_.add(std::move(updates));
   } catch (const std::exception& e) {
@@ -91,7 +94,7 @@ concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildClien
   concord::messages::ClientStateReply creply;
   creply.block_id = 0;
   auto res = ro_storage_.getLatest(
-      concord::kvbc::categorization::kConcordInternalCategoryId,
+      concord::kvbc::categorization::kConcordReconfigurationCategoryId,
       std::string{kvbc::keyTypes::reconfiguration_client_data_prefix, static_cast<char>(command_type)} +
           std::to_string(clientid));
   if (res.has_value()) {
@@ -237,7 +240,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveSta
           std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
                       static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_SCALING_COMMAND_STATUS)} +
           std::to_string(cid);
-      auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId, key);
+      auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key);
       if (res.has_value()) {
         auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
         concord::messages::ClientsAddRemoveUpdateCommand cmd;
@@ -269,9 +272,9 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeSt
                           static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_TLS_KEY_EXCHANGE_COMMAND)} +
               std::to_string(cid);
       }
-      auto bid = ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordInternalCategoryId, key);
+      auto bid = ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key);
       if (bid.has_value()) {
-        auto saved_ts = ro_storage_.get(concord::kvbc::categorization::kConcordInternalCategoryId,
+        auto saved_ts = ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                         std::string{kvbc::keyTypes::reconfiguration_ts_key},
                                         bid.value().version);
         uint64_t numeric_ts{0};
@@ -282,7 +285,8 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeSt
             stats.timestamps.push_back(std::make_pair(cid, numeric_ts));
           }
         }
-        auto res = ro_storage_.get(concord::kvbc::categorization::kConcordInternalCategoryId, key, bid.value().version);
+        auto res =
+            ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key, bid.value().version);
         if (res.has_value()) {
           auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
           if (!command.tls) {
@@ -423,7 +427,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveStatus& co
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& response) {
-  auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId,
+  auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                    std::string{kvbc::keyTypes::reconfiguration_add_remove});
   if (res.has_value()) {
     auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
@@ -449,7 +453,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeS
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& response) {
-  auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId,
+  auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                    std::string{kvbc::keyTypes::reconfiguration_add_remove, 0x1});
   if (res.has_value()) {
     auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
@@ -604,9 +608,9 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsRestartStatu
       std::string key = std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
                                     static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_RESTART_STATUS)} +
                         std::to_string(cid);
-      auto bid = ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordInternalCategoryId, key);
+      auto bid = ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key);
       if (bid.has_value()) {
-        auto saved_ts = ro_storage_.get(concord::kvbc::categorization::kConcordInternalCategoryId,
+        auto saved_ts = ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                         std::string{kvbc::keyTypes::reconfiguration_ts_key},
                                         bid.value().version);
         uint64_t numeric_ts{0};

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -38,7 +38,7 @@ uint64_t StReconfigurationHandler::getStoredBftSeqNum(BlockId bid) {
 }
 
 uint64_t StReconfigurationHandler::getStoredEpochNumber(BlockId bid) {
-  auto value = ro_storage_.get(concord::kvbc::categorization::kConcordInternalCategoryId,
+  auto value = ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                std::string{kvbc::keyTypes::reconfiguration_epoch_key},
                                bid);
   auto epoch = uint64_t{0};
@@ -80,10 +80,11 @@ void StReconfigurationHandler::pruneOnStartup() {
 }
 template <typename T>
 bool StReconfigurationHandler::handleStoredCommand(const std::string &key, uint64_t current_cp_num) {
-  auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId, key);
+  auto res = ro_storage_.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key);
   if (res.has_value()) {
-    auto blockid =
-        ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordInternalCategoryId, key).value().version;
+    auto blockid = ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key)
+                       .value()
+                       .version;
     auto seqNum = getStoredBftSeqNum(blockid);
     auto strval = std::visit([](auto &&arg) { return arg.data; }, *res);
     T cmd;

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -366,7 +366,7 @@ class TestStorage : public IReader, public IBlockAdder, public IBlocksDeleter {
   TestStorage(std::shared_ptr<::concord::storage::rocksdb::NativeClient> native_client)
       : bc_{native_client,
             false,
-            std::map<std::string, CATEGORY_TYPE>{{kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}} {}
+            std::map<std::string, CATEGORY_TYPE>{{kConcordReconfigurationCategoryId, CATEGORY_TYPE::versioned_kv}}} {}
 
   // IBlockAdder interface
   BlockId add(categorization::Updates &&updates) override { return bc_.addBlock(std::move(updates)); }
@@ -489,7 +489,7 @@ void InitBlockchainStorage(std::size_t replica_count,
     versioned_updates.calculateRootHash(false);
 
     concord::kvbc::categorization::Updates updates;
-    updates.add(kConcordInternalCategoryId, std::move(versioned_updates));
+    updates.add(kConcordReconfigurationCategoryId, std::move(versioned_updates));
 
     BlockId blockId;
     blockId = s.add(std::move(updates));
@@ -499,7 +499,7 @@ void InitBlockchainStorage(std::size_t replica_count,
 
     // Make sure our storage mock works properly.
     {
-      auto stored_val = s.get(kConcordInternalCategoryId, std::string({0x20}), blockId);
+      auto stored_val = s.get(kConcordReconfigurationCategoryId, std::string({0x20}), blockId);
       ASSERT_TRUE(stored_val.has_value());
       VersionedValue out = std::get<VersionedValue>(stored_val.value());
       ASSERT_EQ(blockId, out.block_id);

--- a/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
@@ -34,7 +34,8 @@ class DbEditorTests : public DbEditorTestsBase {
             {kCategoryMerkle, CATEGORY_TYPE::block_merkle},
             {kCategoryVersioned, CATEGORY_TYPE::versioned_kv},
             {kCategoryImmutable, CATEGORY_TYPE::immutable},
-            {concord::kvbc::categorization::kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+            {concord::kvbc::categorization::kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv},
+            {concord::kvbc::categorization::kConcordReconfigurationCategoryId, CATEGORY_TYPE::versioned_kv}}};
 
     const auto mismatch_kv = std::make_pair(getSliver(std::numeric_limits<unsigned>::max()), getSliver(42));
 
@@ -748,6 +749,8 @@ TEST_F(DbEditorTests, get_categories) {
             run(CommandLineArguments{{kTestName, rocksDbPath(main_path_db_id_), "getCategories"}}, out_, err_));
   ASSERT_TRUE(err_.str().empty());
   ASSERT_EQ("{\n  \"" + std::string(concord::kvbc::categorization::kConcordInternalCategoryId) +
+                "\": \"versioned_kv\",\n  \"" +
+                std::string{concord::kvbc::categorization::kConcordReconfigurationCategoryId} +
                 "\": \"versioned_kv\",\n  \"" + kCategoryImmutable + "\": \"immutable\",\n  \"" + kCategoryMerkle +
                 "\": \"block_merkle\",\n  \"" + kCategoryVersioned + "\": \"versioned_kv\"\n}\n",
             out_.str());

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -744,7 +744,7 @@ struct RemoveMetadata {
     // Once we managed to remove the metadata, we must start a new epoch (which means to add an epoch block)
     uint64_t epoch{0};
     {
-      auto value = adapter.getLatest(concord::kvbc::categorization::kConcordInternalCategoryId,
+      auto value = adapter.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                      std::string{kvbc::keyTypes::reconfiguration_epoch_key});
       if (value) {
         const auto &data = std::get<categorization::VersionedValue>(*value).data;
@@ -766,10 +766,12 @@ struct RemoveMetadata {
     std::string epoch_str = concordUtils::toBigEndianStringBuffer(epoch);
     concord::kvbc::categorization::VersionedUpdates ver_updates;
     ver_updates.addUpdate(std::string{kvbc::keyTypes::reconfiguration_epoch_key}, std::move(epoch_str));
-    std::string sn_str = concordUtils::toBigEndianStringBuffer(last_executed_sn);
-    ver_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, std::move(sn_str));
     concord::kvbc::categorization::Updates updates;
-    updates.add(concord::kvbc::categorization::kConcordInternalCategoryId, std::move(ver_updates));
+    updates.add(concord::kvbc::categorization::kConcordReconfigurationCategoryId, std::move(ver_updates));
+    concord::kvbc::categorization::VersionedUpdates sn_updates;
+    std::string sn_str = concordUtils::toBigEndianStringBuffer(last_executed_sn);
+    sn_updates.addUpdate(std::string{kvbc::keyTypes::bft_seq_num_key}, std::move(sn_str));
+    updates.add(concord::kvbc::categorization::kConcordInternalCategoryId, std::move(sn_updates));
     adapter.addBlock(std::move(updates));
     std::vector<std::pair<std::string, std::string>> out;
     out.push_back({std::string{"result"}, std::string{"true"}});

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -139,6 +139,7 @@ void Client::initDBFromFile(bool readOnly, const Options &user_options) {
   // Some options, notably pointers, are not configurable via the config file. We set them in code here.
   user_options.completeInit(db_options, cf_descs);
   db_options.wal_dir = m_dbPath;
+  db_options.create_missing_column_families = true;
   openRocksDB(readOnly, db_options, cf_descs);
 
   initialized_ = true;


### PR DESCRIPTION
In this PR we introduce two major changes:
1. A unique category for all reconfiguration requests
2. For backward compatibility, create missing column families 

This change will be also pushed into v0.12x