### PR TITLE
Change log level for decryptFile to WARN

### DIFF
--- a/secretsmanager/src/secrets_manager_enc.cpp
+++ b/secretsmanager/src/secrets_manager_enc.cpp
@@ -54,7 +54,7 @@ std::optional<std::string> SecretsManagerEnc::decryptFile(std::string_view path)
   try {
     data = readFile(path);
   } catch (std::exception& e) {
-    LOG_ERROR(logger_, "Error opening file for reading " << path << ": " << e.what());
+    LOG_WARN(logger_, "Error opening file for reading " << path << ": " << e.what());
     return std::nullopt;
   }
 
@@ -66,7 +66,7 @@ std::optional<std::string> SecretsManagerEnc::decryptFile(const std::ifstream& f
   try {
     data = readFile(file);
   } catch (std::exception& e) {
-    LOG_ERROR(logger_, "Error reading from file stream: " << e.what());
+    LOG_WARN(logger_, "Error reading from file stream: " << e.what());
     return std::nullopt;
   }
 

--- a/secretsmanager/src/secrets_manager_plain.cpp
+++ b/secretsmanager/src/secrets_manager_plain.cpp
@@ -34,7 +34,7 @@ std::optional<std::string> SecretsManagerPlain::decryptFile(std::string_view pat
   try {
     data = readFile(path);
   } catch (std::exception& e) {
-    LOG_ERROR(logger, "Error opening file for reading    " << path << ": " << e.what());
+    LOG_WARN(logger, "Error opening file for reading    " << path << ": " << e.what());
     return std::nullopt;
   }
 
@@ -46,7 +46,7 @@ std::optional<std::string> SecretsManagerPlain::decryptFile(const std::ifstream&
   try {
     data = readFile(file);
   } catch (std::exception& e) {
-    LOG_ERROR(logger, "Error opening stream for reading " << e.what());
+    LOG_WARN(logger, "Error opening stream for reading " << e.what());
     return std::nullopt;
   }
 


### PR DESCRIPTION
Every time concordbft starts, it seeks for genSec files (which are not there) and prints an ERROR message. In this PR we change those messages to WARN level