### PR TITLE
Fix the case of "Protobuf" in a CMake file.

### DIFF
--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(concordclient PUBLIC
   util
 )
 
-find_package(PROTOBUF REQUIRED)
+find_package(Protobuf REQUIRED)
 add_library(concordclient-event-api STATIC "src/event_update_queue.cpp")
 target_include_directories(concordclient-event-api PUBLIC include)
 target_link_libraries(concordclient-event-api PRIVATE


### PR DESCRIPTION
On my machine, using the incorrect case means that CMake can't find the
appropriate package, because the file it's looking for is called
"FindProtobuf.cmake", not "FindPROTOBUF.cmake".