### PR TITLE
State transfer functionality for TLS key exchange

### DIFF
--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -136,7 +136,7 @@ void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
 
   concord::messages::ReconfigurationRequest req;
   req.sender = repId;
-  req.command = concord::messages::ReplicaTlsExchangeKey{cert};
+  req.command = concord::messages::ReplicaTlsExchangeKey{repId, cert};
   // Mark this request as an internal one
   std::vector<uint8_t> data_vec;
   concord::messages::serialize(data_vec, req);

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -69,6 +69,7 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::InstallCommand&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::ReplicaTlsExchangeKey&, uint64_t, uint64_t, uint64_t);
+  bool handle(const concord::messages::ClientTlsExchangeKey&, uint64_t, uint64_t, uint64_t);
 
   kvbc::IReader& ro_storage_;
   BlockMetadata block_metadata_;

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -19,6 +19,7 @@
 #include "reconfiguration/ireconfiguration.hpp"
 #include "SysConsts.hpp"
 #include "block_metadata.hpp"
+#include "secrets_manager_plain.h"
 
 namespace concord::kvbc {
 /*
@@ -67,9 +68,11 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::RestartCommand&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::InstallCommand&, uint64_t, uint64_t, uint64_t);
+  bool handle(const concord::messages::ReplicaTlsExchangeKey&, uint64_t, uint64_t, uint64_t);
 
   kvbc::IReader& ro_storage_;
   BlockMetadata block_metadata_;
   std::vector<std::shared_ptr<concord::reconfiguration::IReconfigurationHandler>> orig_reconf_handlers_;
+  concord::secretsmanager::SecretsManagerPlain sm_;
 };
 }  // namespace concord::kvbc

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -165,9 +165,10 @@ void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IReques
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::KvbcClientReconfigurationHandler>(*this, *this),
       concord::reconfiguration::ReconfigurationHandlerType::PRE);
-  requestHandler->setReconfigurationHandler(
-      std::make_shared<kvbc::reconfiguration::InternalPostKvReconfigurationHandler>(*this, *this),
-      concord::reconfiguration::ReconfigurationHandlerType::POST);
+  auto internal_reconf_handler =
+      std::make_shared<kvbc::reconfiguration::InternalPostKvReconfigurationHandler>(*this, *this);
+  requestHandler->setReconfigurationHandler(internal_reconf_handler,
+                                            concord::reconfiguration::ReconfigurationHandlerType::POST);
   auto pruning_handler = std::shared_ptr<kvbc::pruning::PruningHandler>(
       new concord::kvbc::pruning::PruningHandler(*this, *this, *this, true));
   requestHandler->setReconfigurationHandler(pruning_handler);
@@ -176,6 +177,7 @@ void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IReques
   if (bftEngine::ReplicaConfig::instance().pruningEnabled_) {
     stReconfigurationSM_->pruneOnStartup();
   }
+  stReconfigurationSM_->registerHandler(internal_reconf_handler);
 }
 uint64_t Replica::getStoredReconfigData(const std::string &kCategory,
                                         const std::string &key,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -185,7 +185,13 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientTls
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
                                               const std::optional<bftEngine::Timestamp>& ts,
-                                              concord::messages::ReconfigurationResponse&) {
+                                              concord::messages::ReconfigurationResponse& response) {
+  if (command.sender_id != sender_id) {
+    concord::messages::ReconfigurationErrorMsg error_msg;
+    error_msg.error_msg = "sender_id of the message does not match the real sender id";
+    response.response = error_msg;
+    return false;
+  }
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -782,6 +782,12 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Repli
                                                   uint32_t sender_id,
                                                   const std::optional<bftEngine::Timestamp>& ts,
                                                   concord::messages::ReconfigurationResponse& response) {
+  if (command.sender_id != sender_id) {
+    concord::messages::ReconfigurationErrorMsg error_msg;
+    error_msg.error_msg = "sender_id of the message does not match the real sender id";
+    response.response = error_msg;
+    return false;
+  }
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -70,6 +70,12 @@ void StReconfigurationHandler::stCallBack(uint64_t current_cp_num) {
                                                        current_cp_num);
   handleStoredCommand<concord::messages::InstallCommand>(std::string{kvbc::keyTypes::reconfiguration_install_key},
                                                          current_cp_num);
+
+  // Check for every replica if there is a TLS key exchange command
+  for (uint32_t i = 0; i < bftEngine::ReplicaConfig::instance().numReplicas; i++) {
+    handleStoredCommand<concord::messages::ReplicaTlsExchangeKey>(
+        std::string{kvbc::keyTypes::reconfiguration_tls_exchange_key} + std::to_string(i), current_cp_num);
+  }
 }
 
 void StReconfigurationHandler::pruneOnStartup() {
@@ -244,6 +250,27 @@ bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &com
   // saved command and try to execute it
   bool succ = true;
   concord::messages::ReconfigurationResponse response;
+  for (auto &h : orig_reconf_handlers_) {
+    // If it was written to the blockchain, it means that this is a valid request.
+    succ &= h->handle(command, bft_seq_num, UINT32_MAX, std::nullopt, response);
+  }
+  return succ;
+}
+
+bool StReconfigurationHandler::handle(const concord::messages::ReplicaTlsExchangeKey &command,
+                                      uint64_t bft_seq_num,
+                                      uint64_t,
+                                      uint64_t) {
+  // We actually need to run exactly the same logic as in the original handler. As we have only one
+  // implemented handler, it is OK to simply run all the registered handlers.
+  bool succ = true;
+  auto sender_id = command.sender_id;
+  concord::messages::ReconfigurationResponse response;
+  std::string bft_replicas_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" +
+                                       std::to_string(sender_id) + "/server/server.cert";
+  auto current_rep_cert = sm_.decryptFile(bft_replicas_cert_path);
+  if (current_rep_cert == command.cert) return succ;
+  LOG_INFO(GL, "execute replica TLS key exchange after state transfer");
   for (auto &h : orig_reconf_handlers_) {
     // If it was written to the blockchain, it means that this is a valid request.
     succ &= h->handle(command, bft_seq_num, UINT32_MAX, std::nullopt, response);

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -225,6 +225,7 @@ Msg ClientsRestartUpdate 56 {
 }
 
 Msg ReplicaTlsExchangeKey 57 {
+    uint64 sender_id
     string cert
 }
 


### PR DESCRIPTION
In this PR we introduce the replicas logic for handling TLS key exchange after state transfer (including Apollo tests).
Note that client reconfiguration for replicas TLS keys and Read only replica reconfiguration are not part of this PR
