### PR TITLE
Fixing the difference in blockchain due to indeterminism

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4074,8 +4074,12 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
                                                 PrePrepareMsg *ppMsg,
                                                 bool recoverFromErrorInRequestsExecution) {
   TimeRecorder scoped_timer(*histograms_.executeRequestsInPrePrepareMsg);
+  if (bftEngine::ControlStateManager::instance().getPruningProcessStatus()) {
+    return;
+  }
   auto span = concordUtils::startChildSpan("bft_execute_requests_in_preprepare", parent_span);
   if (!isCollectingState()) ConcordAssert(currentViewIsActive());
+
   ConcordAssertNE(ppMsg, nullptr);
   ConcordAssertEQ(ppMsg->viewNumber(), getCurrentView());
   ConcordAssertEQ(ppMsg->seqNumber(), lastExecutedSeqNum + 1);

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -11,6 +11,7 @@
 # file.
 import os.path
 import unittest
+import time
 from shutil import copy2
 import trio
 import difflib
@@ -756,11 +757,13 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             log.log_message(message_type=f"pruned_block {pruned_block}")
             assert pruned_block <= 90   
 
-            # creates 100 new blocks
-            for i in range(100):
+            # creates 300 new blocks
+            for i in range(300):
                 v = skvbc.random_value()
                 await client.write(skvbc.write_req([], [(k, v)], 0))
 
+            #wait for sometime
+            time.sleep(1)
             # now, return the crashed replica and wait for it to done with state transfer
             bft_network.start_replica(crashed_replica)
             await self._wait_for_st(bft_network, crashed_replica, 150)


### PR DESCRIPTION
This fix removes the race between execute of preprepare message
and Pruning. During the execution of preprepare message, pruning
check is added to avoid the execution. But the check is kept in
such a manner that commit of pre prepare message is happening.

fixup! Fixing the difference in blockchain due to indeterminism