### PR TITLE
Fix for skipping error checks and upload artifacts steps in case of build failures

### DIFF
--- a/.github/workflows/build_and_test_clang_debug.yml
+++ b/.github/workflows/build_and_test_clang_debug.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      err_output: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -57,22 +57,36 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Prepare artifacts
+          if: failure()
+          run: |
+            sudo chown -R ${USER}:${GROUP} ${PWD}/build
+            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            du -h ${{ github.workspace }}/artifact
+            sudo df -h
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          if: failure()
+          with:
+            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
+            path: ${{ github.workspace }}/artifact/
         - name: Check ERROR/FATAL logs
+          if: always()
           run: |
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
             echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
-        - name: Prepare artifacts
-          id: prepare_artifacts
-          if: failure() || ${{ env.file_count > 0 }}
+        - name: Prepare error artifacts
+          id: prepare_err_artifacts
+          if: ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
             echo "::set-output name=test::success"
-        - name: Upload artifacts
+        - name: Upload error artifacts
           uses: actions/upload-artifact@v2
-          if: failure() || ${{ env.file_count > 0 }}
+          if: ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/

--- a/.github/workflows/build_and_test_clang_release.yml
+++ b/.github/workflows/build_and_test_clang_release.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      err_output: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -58,22 +58,36 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Prepare artifacts
+          if: failure()
+          run: |
+            sudo chown -R ${USER}:${GROUP} ${PWD}/build
+            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            du -h ${{ github.workspace }}/artifact
+            sudo df -h
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          if: failure()
+          with:
+            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
+            path: ${{ github.workspace }}/artifact/
         - name: Check ERROR/FATAL logs
+          if: always()
           run: |
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
             echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
-        - name: Prepare artifacts
-          id: prepare_artifacts
-          if: failure() || ${{ env.file_count > 0 }}
+        - name: Prepare error artifacts
+          id: prepare_err_artifacts
+          if: ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
             echo "::set-output name=test::success"
-        - name: Upload artifacts
+        - name: Upload error artifacts
           uses: actions/upload-artifact@v2
-          if: failure() || ${{ env.file_count > 0 }}
+          if: ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/

--- a/.github/workflows/build_and_test_gcc_debug.yml
+++ b/.github/workflows/build_and_test_gcc_debug.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      err_output: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -59,22 +59,36 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Prepare artifacts
+          if: failure()
+          run: |
+            sudo chown -R ${USER}:${GROUP} ${PWD}/build
+            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            du -h ${{ github.workspace }}/artifact
+            sudo df -h
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          if: failure()
+          with:
+            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
+            path: ${{ github.workspace }}/artifact/
         - name: Check ERROR/FATAL logs
+          if: always()
           run: |
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
             echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
-        - name: Prepare artifacts
-          id: prepare_artifacts
-          if: failure() || ${{ env.file_count > 0 }}
+        - name: Prepare error artifacts
+          id: prepare_err_artifacts
+          if: ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
             echo "::set-output name=test::success"
-        - name: Upload artifacts
+        - name: Upload error artifacts
           uses: actions/upload-artifact@v2
-          if: failure() || ${{ env.file_count > 0 }}
+          if: ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/

--- a/.github/workflows/build_and_test_gcc_release.yml
+++ b/.github/workflows/build_and_test_gcc_release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     outputs:
-      err_output: ${{ steps.prepare_artifacts.outputs.test}}
+      err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:
         fail-fast: false
         matrix:
@@ -60,22 +60,36 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
               && script -q -e -c "make test"
+        - name: Prepare artifacts
+          if: failure()
+          run: |
+            sudo chown -R ${USER}:${GROUP} ${PWD}/build
+            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            du -h ${{ github.workspace }}/artifact
+            sudo df -h
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          if: failure()
+          with:
+            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
+            path: ${{ github.workspace }}/artifact/
         - name: Check ERROR/FATAL logs
+          if: always()
           run: |
             ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
             echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
-        - name: Prepare artifacts
-          id: prepare_artifacts
-          if: failure() || ${{ env.file_count > 0 }}
+        - name: Prepare error artifacts
+          id: prepare_err_artifacts
+          if: ${{ env.file_count > 0 }}
           run: |
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
             echo "::set-output name=test::success"
-        - name: Upload artifacts
+        - name: Upload error artifacts
           uses: actions/upload-artifact@v2
-          if: failure() || ${{ env.file_count > 0 }}
+          if: ${{ env.file_count > 0 }}
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/


### PR DESCRIPTION
Earlier when any build failed, then all the next steps are skipped ( default git workflow behaviour), thus no artifacts were generated.

Changes:
1. When any build fails, then artifacts will be generated. Error checks will happen and error artifacts will be skipped, as we already have error logs in the generated artifacts.
2. When a build passes, then artifacts upload will be skipped and error check will happen and if errors are found, artifacts will be generated.

Tested in both scenarios:
https://github.com/situ-s/concord-bft/runs/3816271352?check_suite_focus=true
https://github.com/situ-s/concord-bft/runs/3815341635?check_suite_focus=true

