### PR TITLE
Introduce Concord Client's StateSnapshot service

### DIFF
--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -12,11 +12,11 @@ option java_package = "com.vmware.concord.client.statesnapshot.v1";
 
 // The StateSnapshot service can be used to initialize a Client Application from a
 // state snapshot visible to Concord Client. State snapshots aggregate all writes
-// to the merkle storage space from the start of the blockchain up to a specific point
+// to all storage spaces from the start of the blockchain up to a specific point
 // that is determined by the event group ID as of which the state snapshot is generated. 
-// State contains only the last write to any merkle storage space key-value and no
+// State contains only the last write to a key-value in a storage space and no
 // prior historical writes. We use `state`, `state snapshot` and
-// `merkle storage space key-values` interchangeably from now on.
+// `storage space key-values` interchangeably from now on.
 //
 // To visualize, we show how events are streamed from Concord Client to the
 // Client Application (App) and the relation between state and event group IDs:
@@ -39,7 +39,10 @@ option java_package = "com.vmware.concord.client.statesnapshot.v1";
 //
 // See `event.proto` for more information about events, event group IDs and
 // `EventService`.
-// See `execution_engine.proto` for more information about merkle storage space.
+// See `execution_engine.proto` for more information about storage spaces.
+//
+// Note: The StateSnapshot service only supports snapshots based on event group IDs
+// and not legacy events that are based on block IDs.
 service StateSnapshot {
   // Get the event group ID at which there is a recent and available snapshot.
   // Errors:
@@ -51,13 +54,22 @@ service StateSnapshot {
   // Key-values are streamed with lexicographic order on keys.
   // Errors:
   // NOT_FOUND: if the snapshot at the requested event group ID is not (or no longer) available.
-  //            Clients applications are advised to retry initialization by
+  //            Client applications are advised to retry initialization by
   //            fetching a new event group ID.
   // INVALID_ARGUMENT: if resuming a stream using `from_key` and that key is
   //                   not part of the snapshot.
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
-  rpc StreamStateSnapshot(StreamStateSnapshotRequest) returns (stream KeyValuePair);
+  rpc StreamStateSnapshot(StreamStateSnapshotRequest) returns (stream StreamStateSnapshotResponse);
+
+  // Read the values of given keys as of a specific snapshot.
+  // Errors:
+  // NOT_FOUND: if the snapshot at the requested event group ID is not (or no longer) available.
+  //            Client applications are advised to retry initialization by
+  //            fetching a new event group ID.
+  // UNAVAILABLE: if Concord Client is not ready yet to process requests.
+  // UNKNOWN: exact cause is unknown.
+  rpc ReadAsOf(ReadAsOfRequest) returns (stream ReadAsOfResponse);
 }
 
 message EventGroupId {
@@ -68,10 +80,21 @@ message EventGroupId {
 }
 
 message StreamStateSnapshotRequest {
+  // See execution_engine.proto for more details on storage spaces.
+  message StorageSpaceMerkle {}
+  
   // Mandatory field.
   //
   // The event group ID at which to stream state.
   uint64 event_group_id = 1;
+
+  // Mandatory field.
+  //
+  // Stream keys from the given `storage_space`.
+  // See execution_engine.proto for more details on storage spaces.
+  oneof storage_space {
+    StorageSpaceMerkle merkle = 2;
+  }
 
   // Optional field.
   //
@@ -96,4 +119,24 @@ message KeyValuePair {
   //
   // The value.
   bytes value = 2;
+}
+
+message StreamStateSnapshotResponse {
+  // Mandatory field.
+  KeyValuePair kv = 1;
+}
+
+message ReadAsOfRequest {
+  // Event group ID as of which to read the values.
+  uint64 event_group_id = 1;
+
+  // List of keys for which the values should be returned.
+  repeated bytes keys = 2;
+}
+
+message ReadAsOfResponse {
+  // The `key_values` list contains all the key-values that have a value,
+  // i.e. the ones that have been set and haven't been deleted. Keys that
+  // haven't been set or have been deleted will not be part of `key_values`.
+  repeated KeyValuePair key_values = 1;
 }

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -12,11 +12,14 @@ option java_package = "com.vmware.concord.client.statesnapshot.v1";
 
 // The StateSnapshot service can be used to initialize a Client Application from a
 // state snapshot visible to Concord Client. State snapshots aggregate all writes
-// to all storage spaces from the start of the blockchain up to a specific point
-// that is determined by the event group ID as of which the state snapshot is generated. 
-// State contains only the last write to a key-value in a storage space and no
-// prior historical writes. We use `state`, `state snapshot` and
-// `storage space key-values` interchangeably from now on.
+// to the `STORAGE_SPACE_MERKLE` storage space from the start of the blockchain up
+// to a specific point that is determined by the event group ID as of which the
+// state snapshot is generated.
+//
+// State contains only the last write to a key-value in the `STORAGE_SPACE_MERKLE`
+// storage space and no prior historical writes. We use `state`, `state snapshot`,
+// `snapshot` and `STORAGE_SPACE_MERKLE` to refer to all key-values that are part
+// of a snapshot from now on.
 //
 // To visualize, we show how events are streamed from Concord Client to the
 // Client Application (App) and the relation between state and event group IDs:
@@ -48,7 +51,7 @@ service StateSnapshot {
   // Errors:
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
-  rpc GetRecentStateSnapshotId(google.protobuf.Empty) returns (EventGroupId);
+  rpc GetRecentSnapshot(GetRecentSnapshotRequest) returns (GetRecentSnapshotResponse);
 
   // Stream a specific state snapshot in a resumable fashion as a finite stream of key-values.
   // Key-values are streamed with lexicographic order on keys.
@@ -60,7 +63,7 @@ service StateSnapshot {
   //                   not part of the snapshot.
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
-  rpc StreamStateSnapshot(StreamStateSnapshotRequest) returns (stream StreamStateSnapshotResponse);
+  rpc StreamSnapshot(StreamSnapshotRequest) returns (stream StreamSnapshotResponse);
 
   // Read the values of given keys as of a specific snapshot.
   // Errors:
@@ -72,29 +75,28 @@ service StateSnapshot {
   rpc ReadAsOf(ReadAsOfRequest) returns (stream ReadAsOfResponse);
 }
 
-message EventGroupId {
-  // Mandatory field.
-  //
-  // The event group ID.
-  uint64 id = 1;
+message GetRecentSnapshotRequest {
 }
 
-message StreamStateSnapshotRequest {
-  // See execution_engine.proto for more details on storage spaces.
-  message StorageSpaceMerkle {}
-  
+message GetRecentSnapshotResponse {
   // Mandatory field.
   //
-  // The event group ID at which to stream state.
+  // The event group ID at which there is a recent and available snapshot.
   uint64 event_group_id = 1;
 
   // Mandatory field.
   //
-  // Stream keys from the given `storage_space`.
-  // See execution_engine.proto for more details on storage spaces.
-  oneof storage_space {
-    StorageSpaceMerkle merkle = 2;
-  }
+  // An estimate (with reasonable accuracy) of the count of key-values
+  // contained in the snapshot. Please note that this is an estimation
+  // and *not* the actual count.
+  uint64 key_value_count_estimate = 2;
+}
+
+message StreamSnapshotRequest {  
+  // Mandatory field.
+  //
+  // The event group ID at which to stream state.
+  uint64 event_group_id = 1;
 
   // Optional field.
   //
@@ -106,7 +108,7 @@ message StreamStateSnapshotRequest {
   // The empty bytestring is a valid key.
   //
   // Key-values are streamed with lexicographic order on keys.
-  google.protobuf.BytesValue from_key = 3;
+  google.protobuf.BytesValue from_key = 2;
 }
 
 message KeyValuePair {
@@ -121,9 +123,9 @@ message KeyValuePair {
   bytes value = 2;
 }
 
-message StreamStateSnapshotResponse {
+message StreamSnapshotResponse {
   // Mandatory field.
-  KeyValuePair kv = 1;
+  KeyValuePair key_value = 1;
 }
 
 message ReadAsOfRequest {
@@ -134,9 +136,20 @@ message ReadAsOfRequest {
   repeated bytes keys = 2;
 }
 
+message OptionalValue {
+  oneof option {
+    google.protobuf.Empty non_existent = 1;
+    bytes value = 2;
+  }
+}
+
 message ReadAsOfResponse {
-  // The `key_values` list contains all the key-values that have a value,
-  // i.e. the ones that have been set and haven't been deleted. Keys that
-  // haven't been set or have been deleted will not be part of `key_values`.
-  repeated KeyValuePair key_values = 1;
+  // The `values` list contains entries for all requested keys
+  // in `ReadAsOfRequest.keys`, i.e. it is the exact same length.
+  //
+  // If a key-value has been deleted or has never been set,
+  // `OptionalValue.option.non_existent` will be set. Otherwise,
+  // `OptionalValue.option.value` will be set with the value as
+  // of the requested snapshot.
+  repeated OptionalValue values = 1;
 }

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -72,7 +72,7 @@ service StateSnapshot {
   //            fetching a new event group ID.
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
-  rpc ReadAsOf(ReadAsOfRequest) returns (stream ReadAsOfResponse);
+  rpc ReadAsOf(ReadAsOfRequest) returns (ReadAsOfResponse);
 }
 
 message GetRecentSnapshotRequest {

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -48,13 +48,9 @@ message GetRecentSnapshotRequest {
 }
 
 message GetRecentSnapshotResponse {
-  // Mandatory field.
-  //
   // The ID of a recent and available state snapshot.
   uint64 snapshot_id = 1;
 
-  // Mandatory field.
-  //
   // The event group ID at which the state snapshot with `snapshot_id` was taken.
   //
   // The event group ID can be used in the `EventService` to subscribe to events
@@ -88,8 +84,6 @@ message GetRecentSnapshotResponse {
   // group IDs and not legacy events that are based on block IDs.
   uint64 event_group_id = 2;
 
-  // Mandatory field.
-  //
   // An estimate (with reasonable accuracy) of the count of key-values contained
   // in the state snapshot. Please note that this is an estimation and *not* the
   // actual count.
@@ -97,13 +91,9 @@ message GetRecentSnapshotResponse {
 }
 
 message StreamSnapshotRequest {  
-  // Mandatory field.
-  //
   // The ID of the state snapshot to be streamed.
   uint64 snapshot_id = 1;
 
-  // Optional field.
-  //
   // If set, start streaming from `last_received_key` onwards, excluding
   // `last_received_key`.
   // If `last_received_key` is not part of the state snapshot, an INVALID_ARGUMENT
@@ -118,25 +108,15 @@ message StreamSnapshotRequest {
 }
 
 message KeyValuePair {
-  // Mandatory field.
-  //
-  // The key.
   bytes key = 1;
-
-  // Mandatory field.
-  //
-  // The value.
   bytes value = 2;
 }
 
 message StreamSnapshotResponse {
-  // Mandatory field.
   KeyValuePair key_value = 1;
 }
 
 message ReadAsOfRequest {
-  // Mandatory field.
-  //
   // The ID of the state snapshot as of which to read the values.
   uint64 snapshot_id = 1;
 

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -58,7 +58,7 @@ message GetRecentSnapshotResponse {
   // The event group ID at which the state snapshot with `snapshot_id` was taken.
   //
   // To visualize, we show how events are streamed from Concord Client to the
-  // Application and the relation between state and event group IDs:
+  // Application and the relation between state snapshot and event group IDs:
   // -----------------------------------------------------------------------------
   //                               [State Snapshot at evgN]
   //                                          |
@@ -99,8 +99,9 @@ message StreamSnapshotRequest {
 
   // Optional field.
   //
-  // If set, start streaming `from_key` onwards, including `from_key`.
-  // If `from_key` is not part of the state snapshot, an INVALID_ARGUMENT
+  // If set, start streaming from `last_received_key` onwards, excluding
+  // `last_received_key`.
+  // If `last_received_key` is not part of the state snapshot, an INVALID_ARGUMENT
   // error is returned.
   //
   // If not set, start streaming from the first key-value in the state snapshot.
@@ -108,7 +109,7 @@ message StreamSnapshotRequest {
   // The empty bytestring is a valid key.
   //
   // Key-values are streamed with lexicographic order on keys.
-  optional bytes from_key = 2;
+  optional bytes last_received_key = 2;
 }
 
 message KeyValuePair {

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -5,7 +5,6 @@
 syntax = "proto3";
 package vmware.concord.client.statesnapshot.v1;
 
-import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
 option java_package = "com.vmware.concord.client.statesnapshot.v1";
@@ -95,7 +94,7 @@ message GetRecentSnapshotResponse {
 message StreamSnapshotRequest {  
   // Mandatory field.
   //
-  // The event group ID at which to stream state.
+  // The event group ID as of which to stream state.
   uint64 event_group_id = 1;
 
   // Optional field.
@@ -137,10 +136,7 @@ message ReadAsOfRequest {
 }
 
 message OptionalValue {
-  oneof option {
-    google.protobuf.Empty non_existent = 1;
-    bytes value = 2;
-  }
+  optional bytes value = 1;
 }
 
 message ReadAsOfResponse {
@@ -148,8 +144,7 @@ message ReadAsOfResponse {
   // in `ReadAsOfRequest.keys`, i.e. it is the exact same length.
   //
   // If a key-value has been deleted or has never been set,
-  // `OptionalValue.option.non_existent` will be set. Otherwise,
-  // `OptionalValue.option.value` will be set with the value as
-  // of the requested snapshot.
+  // `OptionalValue.value` will not be set. Otherwise, it will
+  // be set to the value's bytes as of the requested snapshot.
   repeated OptionalValue values = 1;
 }

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -32,6 +32,8 @@ service StateSnapshotService {
   // NOT_FOUND: if the snapshot with this ID is not (or no longer) available.
   //            Clients applications are advised to retry initialization by
   //            fetching a new recent snapshot ID.
+  // INVALID_ARGUMENT: if resuming a stream using `from_key` and that key is
+  //                   not part of the snapshot.
   // UNAVAILABLE: if Concord Client is not ready yet to process any requests.
   // UNKNOWN: exact cause is unknown.
   rpc StreamStateSnapshot(StreamStateSnapshotRequest) returns (stream KeyValuePair);
@@ -52,9 +54,13 @@ message StreamStateSnapshotRequest {
 
   // Optional field.
   //
-  // If set, start streaming `from_key` onwards.
+  // If set, start streaming `from_key` onwards. If `from_key` is not part
+  // of the snapshot, an INVALID_ARGUMENT error is returned.
+  //
   // If not set, start streaming from the first key-value in the snapshot.
+  //
   // The empty bytestring is a valid key.
+  //
   // Key-values are streamed with lexicographic order on keys.
   google.protobuf.BytesValue from_key = 3;
 }

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -1,0 +1,72 @@
+// Copyright 2021 VMware, all rights reserved
+//
+// Concord Client's State Snapshot Service
+
+syntax = "proto3";
+package vmware.concord.client.snapshot.v1;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
+
+option java_package = "com.vmware.concord.client.snapshot.v1";
+
+// The StateSnapshotService can be used to initialize a client application from a
+// state snapshot visible to Concord Client. State snapshots aggregate all writes
+// from the start of the blockchain up to a specific point by keeping only the last
+// write to a key-value.
+//
+// Concord Client ensures that there is always at least one reasonably
+// recent snapshot that can be served. The intention is that this snapshot is
+// used to initialize a client application after the network has been pruned and
+// some set of historical events are no longer available via the EventService.
+service StateSnapshotService {
+  // Get the ID of a recent and available snapshot.
+  // Errors:
+  // UNAVAILABLE: if Concord Client is not ready yet to process requests.
+  // UNKNOWN: exact cause is unknown.
+  rpc GetRecentStateSnapshotId(google.protobuf.Empty) returns (StateSnapshotId);
+
+  // Stream a specific state snapshot in a resumable fashion as a stream of key-values.
+  // Key-values are streamed with lexicographic order on keys.
+  // Errors:
+  // NOT_FOUND: if the snapshot with this ID is not (or no longer) available.
+  //            Clients applications are advised to retry initialization by
+  //            fetching a new recent snapshot ID.
+  // UNAVAILABLE: if Concord Client is not ready yet to process any requests.
+  // UNKNOWN: exact cause is unknown.
+  rpc StreamStateSnapshot(StreamStateSnapshotRequest) returns (stream KeyValuePair);
+}
+
+message StateSnapshotId {
+  // Mandatory field.
+  //
+  // An ID for the state snapshot.
+  uint64 id = 1;
+}
+
+message StreamStateSnapshotRequest {
+  // Mandatory field.
+  //
+  // The ID of the state snapshot to stream.
+  uint64 snapshot_id = 1;
+
+  // Optional field.
+  //
+  // If set, start streaming `from_key` onwards.
+  // If not set, start streaming from the first key-value in the snapshot.
+  // The empty bytestring is a valid key.
+  // Key-values are streamed with lexicographic order on keys.
+  google.protobuf.BytesValue from_key = 3;
+}
+
+message KeyValuePair {
+  // Mandatory field.
+  //
+  // The key.
+  bytes key = 1;
+
+  // Mandatory field.
+  //
+  // The value.
+  bytes value = 2;
+}

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -149,8 +149,9 @@ message OptionalValue {
 }
 
 message ReadAsOfResponse {
-  // The `values` list contains entries for all requested keys
-  // in `ReadAsOfRequest.keys`, i.e. it is the exact same length.
+  // The `values` list contains entries for *all* requested keys
+  // in `ReadAsOfRequest.keys` in the exact same order. `values`
+  // is, therefore, the exact same length as `ReadAsOfRequest.keys`.
   //
   // If a key-value has been deleted or has never been set,
   // `OptionalValue.value` will not be set. Otherwise, it will

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -3,54 +3,75 @@
 // Concord Client's State Snapshot Service
 
 syntax = "proto3";
-package vmware.concord.client.snapshot.v1;
+package vmware.concord.client.statesnapshot.v1;
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
-option java_package = "com.vmware.concord.client.snapshot.v1";
+option java_package = "com.vmware.concord.client.statesnapshot.v1";
 
-// The StateSnapshotService can be used to initialize a client application from a
+// The StateSnapshot service can be used to initialize a Client Application from a
 // state snapshot visible to Concord Client. State snapshots aggregate all writes
-// from the start of the blockchain up to a specific point by keeping only the last
-// write to a key-value.
+// to the merkle storage space from the start of the blockchain up to a specific point
+// that is determined by the event group ID as of which the state snapshot is generated. 
+// State contains only the last write to any merkle storage space key-value and no
+// prior historical writes. We use `state`, `state snapshot` and
+// `merkle storage space key-values` interchangeably from now on.
+//
+// To visualize, we show how events are streamed from Concord Client to the
+// Client Application (App) and the relation between state and event group IDs:
+// ----------------------------------------------------------------------------
+//                               [State Snapshot at evgN]
+//                                          |
+//                                          v
+// ------------------                                            --------------
+// | Concord Client |  -- evg1, evg2, ..., evgN, evgN+1, ... ->  | Client App |
+// ------------------                                            --------------
+// ----------------------------------------------------------------------------
+// where `evgN` is the Nth event group streamed from Concord Client to the Client App.
+// After receiving a state snapshot at `evgN`, a Client App can continue operation by
+// consuming event groups from `evgN+1` onwards.
 //
 // Concord Client ensures that there is always at least one reasonably
 // recent snapshot that can be served. The intention is that this snapshot is
-// used to initialize a client application after the network has been pruned and
-// some set of historical events are no longer available via the EventService.
-service StateSnapshotService {
-  // Get the ID of a recent and available snapshot.
+// used to initialize the Client Application after the network has been pruned and
+// some set of historical events are no longer available via the `EventService`.
+//
+// See `event.proto` for more information about events, event group IDs and
+// `EventService`.
+// See `execution_engine.proto` for more information about merkle storage space.
+service StateSnapshot {
+  // Get the event group ID at which there is a recent and available snapshot.
   // Errors:
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
-  rpc GetRecentStateSnapshotId(google.protobuf.Empty) returns (StateSnapshotId);
+  rpc GetRecentStateSnapshotId(google.protobuf.Empty) returns (EventGroupId);
 
-  // Stream a specific state snapshot in a resumable fashion as a stream of key-values.
+  // Stream a specific state snapshot in a resumable fashion as a finite stream of key-values.
   // Key-values are streamed with lexicographic order on keys.
   // Errors:
-  // NOT_FOUND: if the snapshot with this ID is not (or no longer) available.
+  // NOT_FOUND: if the snapshot at the requested event group ID is not (or no longer) available.
   //            Clients applications are advised to retry initialization by
-  //            fetching a new recent snapshot ID.
+  //            fetching a new event group ID.
   // INVALID_ARGUMENT: if resuming a stream using `from_key` and that key is
   //                   not part of the snapshot.
-  // UNAVAILABLE: if Concord Client is not ready yet to process any requests.
+  // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
   rpc StreamStateSnapshot(StreamStateSnapshotRequest) returns (stream KeyValuePair);
 }
 
-message StateSnapshotId {
+message EventGroupId {
   // Mandatory field.
   //
-  // An ID for the state snapshot.
+  // The event group ID.
   uint64 id = 1;
 }
 
 message StreamStateSnapshotRequest {
   // Mandatory field.
   //
-  // The ID of the state snapshot to stream.
-  uint64 snapshot_id = 1;
+  // The event group ID at which to stream state.
+  uint64 event_group_id = 1;
 
   // Optional field.
   //

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -1,52 +1,24 @@
 // Copyright 2021 VMware, all rights reserved
 //
-// Concord Client's State Snapshot Service
+// Concord Client's StateSnapshot Service
 
 syntax = "proto3";
 package vmware.concord.client.statesnapshot.v1;
 
-import "google/protobuf/wrappers.proto";
-
 option java_package = "com.vmware.concord.client.statesnapshot.v1";
 
-// The StateSnapshot service can be used to initialize a Client Application from a
-// state snapshot visible to Concord Client. State snapshots aggregate all writes
-// to the `STORAGE_SPACE_MERKLE` storage space from the start of the blockchain up
-// to a specific point that is determined by the event group ID as of which the
-// state snapshot is generated.
+// The StateSnapshot service can be used to initialize an Application from a state
+// snapshot visible to Concord Client. A state snapshot contains all key-values
+// in the `STORAGE_SPACE_MERKLE` storage space from the start of the blockchain up
+// to a specific point and is identified by a snapshot ID.
 //
-// State contains only the last write to a key-value in the `STORAGE_SPACE_MERKLE`
-// storage space and no prior historical writes. We use `state`, `state snapshot`,
-// `snapshot` and `STORAGE_SPACE_MERKLE` to refer to all key-values that are part
-// of a snapshot from now on.
+// A state snapshot contains only the last writes (as of the state snapshot itself)
+// to key-values in the `STORAGE_SPACE_MERKLE` storage space and no prior historical
+// writes.
 //
-// To visualize, we show how events are streamed from Concord Client to the
-// Client Application (App) and the relation between state and event group IDs:
-// ----------------------------------------------------------------------------
-//                               [State Snapshot at evgN]
-//                                          |
-//                                          v
-// ------------------                                            --------------
-// | Concord Client |  -- evg1, evg2, ..., evgN, evgN+1, ... ->  | Client App |
-// ------------------                                            --------------
-// ----------------------------------------------------------------------------
-// where `evgN` is the Nth event group streamed from Concord Client to the Client App.
-// After receiving a state snapshot at `evgN`, a Client App can continue operation by
-// consuming event groups from `evgN+1` onwards.
-//
-// Concord Client ensures that there is always at least one reasonably
-// recent snapshot that can be served. The intention is that this snapshot is
-// used to initialize the Client Application after the network has been pruned and
-// some set of historical events are no longer available via the `EventService`.
-//
-// See `event.proto` for more information about events, event group IDs and
-// `EventService`.
 // See `execution_engine.proto` for more information about storage spaces.
-//
-// Note: The StateSnapshot service only supports snapshots based on event group IDs
-// and not legacy events that are based on block IDs.
 service StateSnapshot {
-  // Get the event group ID at which there is a recent and available snapshot.
+  // Get the ID of a recent and available state snapshot.
   // Errors:
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
@@ -55,20 +27,18 @@ service StateSnapshot {
   // Stream a specific state snapshot in a resumable fashion as a finite stream of key-values.
   // Key-values are streamed with lexicographic order on keys.
   // Errors:
-  // NOT_FOUND: if the snapshot at the requested event group ID is not (or no longer) available.
-  //            Client applications are advised to retry initialization by
-  //            fetching a new event group ID.
-  // INVALID_ARGUMENT: if resuming a stream using `from_key` and that key is
-  //                   not part of the snapshot.
+  // NOT_FOUND: if a state snapshot with the requested ID is not (or no longer) available.
+  //            Applications are advised to retry initialization by fetching a new snapshot ID.
+  // INVALID_ARGUMENT: if resuming a stream using `from_key` and that key is not part of the
+  //                   state snapshot.
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
   rpc StreamSnapshot(StreamSnapshotRequest) returns (stream StreamSnapshotResponse);
 
-  // Read the values of given keys as of a specific snapshot.
+  // Read the values of the given keys as of a specific state snapshot.
   // Errors:
-  // NOT_FOUND: if the snapshot at the requested event group ID is not (or no longer) available.
-  //            Client applications are advised to retry initialization by
-  //            fetching a new event group ID.
+  // NOT_FOUND: if the state snapshot with the requested ID is not (or no longer) available.
+  //            Applications are advised to retry initialization by fetching a new snapshot ID.
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
   // UNKNOWN: exact cause is unknown.
   rpc ReadAsOf(ReadAsOfRequest) returns (ReadAsOfResponse);
@@ -80,34 +50,65 @@ message GetRecentSnapshotRequest {
 message GetRecentSnapshotResponse {
   // Mandatory field.
   //
-  // The event group ID at which there is a recent and available snapshot.
-  uint64 event_group_id = 1;
+  // The ID of a recent and available state snapshot.
+  uint64 snapshot_id = 1;
 
   // Mandatory field.
   //
-  // An estimate (with reasonable accuracy) of the count of key-values
-  // contained in the snapshot. Please note that this is an estimation
-  // and *not* the actual count.
-  uint64 key_value_count_estimate = 2;
+  // The event group ID at which the state snapshot with `snapshot_id` was taken.
+  //
+  // To visualize, we show how events are streamed from Concord Client to the
+  // Application and the relation between state and event group IDs:
+  // -----------------------------------------------------------------------------
+  //                               [State Snapshot at evgN]
+  //                                          |
+  //                                          v
+  // ------------------                                            ---------------
+  // | Concord Client |  -- evg1, evg2, ..., evgN, evgN+1, ... ->  | Application |
+  // ------------------                                            ---------------
+  // -----------------------------------------------------------------------------
+  // where `evgN` is the Nth event group streamed from Concord Client to the Application.
+  // After receiving a state snapshot at `evgN`, an Application can continue operation by
+  // consuming event groups from `evgN+1` onwards.
+  //
+  // Concord Client ensures that there is always at least one reasonably recent
+  // state snapshot that can be served. The intention is that this state snapshot
+  // can be used to initialize the Application after the blockchain has been pruned and
+  // some set of historical events are no longer available via the `EventService`.
+  //
+  // See `event.proto` for more information about events, event group IDs and
+  // `EventService`.
+  //
+  // Note: The StateSnapshot service only supports state snapshots based on event
+  // group IDs and not legacy events that are based on block IDs.
+  uint64 event_group_id = 2;
+
+  // Mandatory field.
+  //
+  // An estimate (with reasonable accuracy) of the count of key-values contained
+  // in the state snapshot. Please note that this is an estimation and *not* the
+  // actual count.
+  uint64 key_value_count_estimate = 3;
 }
 
 message StreamSnapshotRequest {  
   // Mandatory field.
   //
-  // The event group ID as of which to stream state.
-  uint64 event_group_id = 1;
+  // The ID of the state snapshot to be streamed.
+  uint64 snapshot_id = 1;
 
   // Optional field.
   //
-  // If set, start streaming `from_key` onwards. If `from_key` is not part
-  // of the snapshot, an INVALID_ARGUMENT error is returned.
+  // If set, start streaming `from_key` onwards, including `from_key`.
+  // If `from_key` is not part of the state snapshot, an INVALID_ARGUMENT
+  // error is returned.
   //
-  // If not set, start streaming from the first key-value in the snapshot.
+  // If not set, start streaming from the first key-value in the state snapshot.
   //
   // The empty bytestring is a valid key.
   //
   // Key-values are streamed with lexicographic order on keys.
-  google.protobuf.BytesValue from_key = 2;
+  optional bytes from_key = 2;
 }
 
 message KeyValuePair {
@@ -128,8 +129,10 @@ message StreamSnapshotResponse {
 }
 
 message ReadAsOfRequest {
-  // Event group ID as of which to read the values.
-  uint64 event_group_id = 1;
+  // Mandatory field.
+  //
+  // The ID of the state snapshot as of which to read the values.
+  uint64 snapshot_id = 1;
 
   // List of keys for which the values should be returned.
   repeated bytes keys = 2;
@@ -145,6 +148,6 @@ message ReadAsOfResponse {
   //
   // If a key-value has been deleted or has never been set,
   // `OptionalValue.value` will not be set. Otherwise, it will
-  // be set to the value's bytes as of the requested snapshot.
+  // be set to the value's bytes as of the requested state snapshot.
   repeated OptionalValue values = 1;
 }

--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -57,6 +57,11 @@ message GetRecentSnapshotResponse {
   //
   // The event group ID at which the state snapshot with `snapshot_id` was taken.
   //
+  // The event group ID can be used in the `EventService` to subscribe to events
+  // that were created after the snapshot was taken.
+  // Note: Events and, consequently, the `EventService` are optional. The execution
+  // engine might not generate any events. In that case, the event group ID will be 0.
+  //
   // To visualize, we show how events are streamed from Concord Client to the
   // Application and the relation between state snapshot and event group IDs:
   // -----------------------------------------------------------------------------


### PR DESCRIPTION
The `StateSnapshot` service can be used to initialize a client
application from a state snapshot visible to Concord Client.

Details and explanations are given as comments inside the protobuf file.

This interface is the output of work mostly done by @meiersi-da,
@andrewjstone and @robem. I have done minor tweaks and naming changes
only.

One of the changes that is worth mentioning is that we allow empty
values when streaming key-values. Rationale is that it is a valid
value and we don't need to concern ourslves here with the special
handling of empty values between the execution engine (EE) and Concord.
Yet, I am open to discuss that also on the EE-Concord interface.