### PR TITLE
Coverity fix - use of pointer after delete

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3363,6 +3363,7 @@ void ReplicaImp::onMessage<ReplicaRestartReadyMsg>(ReplicaRestartReadyMsg *msg) 
               "Recieved multiple ReplicaRestartReadyMsg from sender_id "
                   << std::to_string(msg->idOfGeneratedReplica()) << " with seq_num" << std::to_string(msg->seqNum()));
     delete msg;
+    return;
   }
   LOG_INFO(GL,
            "Recieved ReplicaRestartReadyMsg from sender_id " << std::to_string(msg->idOfGeneratedReplica())


### PR DESCRIPTION
This change is fix a coverity bug in function ReplicaRestartReadyMsg handler, where pointer is used after free