### PR TITLE
Coverity bug fix

### DIFF
--- a/bftengine/src/bftengine/messages/MessageBase.hpp
+++ b/bftengine/src/bftengine/messages/MessageBase.hpp
@@ -111,6 +111,7 @@ class MessageBase {
   friend MsgSize maxMessageSizeInLocalBuffer();
 
   static constexpr uint64_t SPAN_CONTEXT_MAX_SIZE{1024};
+  static constexpr uint32_t MAX_BATCH_SIZE{1024};
 #pragma pack(push, 1)
   struct RawHeaderOfObjAndMsg {
     uint32_t magicNum;

--- a/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.hpp
@@ -51,6 +51,7 @@ class ClientBatchRequestMsg : public MessageBase {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
   }
+  bool checkElements() const;
   std::string cid_;
   ClientMsgsList clientMsgsList_;
 };

--- a/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.hpp
@@ -65,6 +65,7 @@ class PreProcessBatchRequestMsg : public MessageBase {
   Header* msgBody() const { return ((Header*)msgBody_); }
 
  private:
+  bool checkElements() const;
   std::string cid_;
   PreProcessReqMsgsList preProcessReqMsgsList_;
 };


### PR DESCRIPTION
PreProcessBatchRequestMsg and ClientBatchRequestMsg contains a batch of client messages and each message is parsed from the message body for requestLen, signatureLen etc. Theses len parameters are used a offset to point to the message buffer. Coverity tool complains that sanity/range check is not done on these len parameters and they are used in allocation of buffer for these message in PreProcessBatchRequestMsg::getPreProcessRequestMsgs and ClientBatchRequestMsg::getClientPreProcessRequestMsgs.
This PR, adds a function to validate these len parameters