### PR TITLE
Fix order of block deletes relative to adds on ST

### DIFF
--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -125,6 +125,10 @@ class KeyValueBlockchain {
   void linkSTChainFrom(BlockId block_id);
   void writeSTLinkTransaction(const BlockId block_id, RawBlock& block);
 
+  // If a block has the genesis ID key, prune up to it. Rationale is that this will preserve the same order of block
+  // deletes relative to block adds on source and destination replicas.
+  void pruneOnSTLink(const RawBlock& block);
+
   // computes the digest of a raw block which is the parent of block_id i.e. block_id - 1
   std::future<BlockDigest> computeParentBlockDigest(const BlockId block_id, VersionedRawBlock&& cached_raw_block);
 
@@ -198,6 +202,8 @@ class KeyValueBlockchain {
                                         const std::string& category_id,
                                         ImmutableInput&& updates,
                                         concord::storage::rocksdb::NativeWriteBatch& write_batch);
+
+  void addGenesisBlockKey(Updates& updates) const;
 
   /////////////////////// Members ///////////////////////
 

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -241,6 +241,11 @@ struct Updates {
   template <typename Update>
   bool appendKeyValue(const std::string& category_id, std::string&& key, typename Update::ValueType&& value);
 
+  template <typename InputType>
+  void addCategoryIfNotExisting(const std::string& category_id) {
+    category_updates_.kv.try_emplace(category_id, InputType{});
+  }
+
   std::size_t size() const { return block_merkle_size + versioned_kv_size + immutable_size; }
   bool empty() const { return size() == 0; }
   std::size_t block_merkle_size{};

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -13,6 +13,8 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+
 namespace concord::kvbc::keyTypes {
 static const char bft_seq_num_key = 0x21;
 static const char reconfiguration_pruning_key = 0x24;
@@ -27,6 +29,7 @@ static const char reconfiguration_tls_exchange_key = 0x2e;
 
 static const char reconfiguration_restart_key = 0x30;
 static const char reconfiguration_ts_key = 0x31;
+static const std::string genesis_block_key(1, 0x32);
 
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,

--- a/kvbc/include/pruning_handler.hpp
+++ b/kvbc/include/pruning_handler.hpp
@@ -178,7 +178,6 @@ class PruningHandler : public concord::reconfiguration::BftReconfigurationHandle
   std::uint64_t replica_id_{0};
   std::uint64_t num_blocks_to_keep_{0};
   bool run_async_{false};
-  mutable std::optional<kvbc::BlockId> last_scheduled_block_for_pruning_;
   mutable std::mutex pruning_status_lock_;
   mutable std::future<void> async_pruning_res_;
 };

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -245,7 +245,7 @@ bool PruningHandler::handle(const concord::messages::PruneStatusRequest&,
   concord::messages::PruneStatus prune_status;
   std::lock_guard lock(pruning_status_lock_);
   const auto genesis_id = ro_storage_.getGenesisBlockId();
-  prune_status.last_pruned_block = ((genesis_id != INITIAL_GENESIS_BLOCK_ID && genesis_id != 0) ? genesis_id - 1 : 0);
+  prune_status.last_pruned_block = (genesis_id > INITIAL_GENESIS_BLOCK_ID ? genesis_id - 1 : 0);
   prune_status.in_progress = bftEngine::ControlStateManager::instance().getPruningProcessStatus();
   rres.response = prune_status;
   LOG_INFO(logger_, "Pruning status is " << KVLOG(prune_status.in_progress));

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -210,10 +210,6 @@ void PruningHandler::pruneThroughBlockId(kvbc::BlockId block_id) const {
   const auto genesis_block_id = ro_storage_.getGenesisBlockId();
   if (block_id >= genesis_block_id) {
     bftEngine::ControlStateManager::instance().setPruningProcess(true);
-    // last_scheduled_block_for_pruning_ is being updated only here, thus, once
-    // we set the control_state_manager, no other write request will be executed
-    // and we can set it without grabing the mutex
-    last_scheduled_block_for_pruning_ = block_id;
     auto prune = [this](kvbc::BlockId until) {
       try {
         blocks_deleter_.deleteBlocksUntil(until);
@@ -248,8 +244,8 @@ bool PruningHandler::handle(const concord::messages::PruneStatusRequest&,
   if (!pruning_enabled_) return true;
   concord::messages::PruneStatus prune_status;
   std::lock_guard lock(pruning_status_lock_);
-  prune_status.last_pruned_block =
-      last_scheduled_block_for_pruning_.has_value() ? last_scheduled_block_for_pruning_.value() : 0;
+  const auto genesis_id = ro_storage_.getGenesisBlockId();
+  prune_status.last_pruned_block = ((genesis_id != INITIAL_GENESIS_BLOCK_ID && genesis_id != 0) ? genesis_id - 1 : 0);
   prune_status.in_progress = bftEngine::ControlStateManager::instance().getPruningProcessStatus();
   rres.response = prune_status;
   LOG_INFO(logger_, "Pruning status is " << KVLOG(prune_status.in_progress));

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -19,6 +19,7 @@
 #include "categorization/column_families.h"
 #include "categorization/updates.h"
 #include "categorization/kv_blockchain.h"
+#include "categorization/db_categories.h"
 #include <iostream>
 #include <string>
 #include <utility>
@@ -79,7 +80,10 @@ TEST_F(categorized_kvbc, serialization_and_desirialization_of_block) {
 
 TEST_F(categorized_kvbc, reconstruct_merkle_updates) {
   KeyValueBlockchain block_chain{
-      db, true, std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle}}};
+      db,
+      true,
+      std::map<std::string, CATEGORY_TYPE>{{"merkle", CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1
@@ -171,7 +175,9 @@ TEST_F(categorized_kvbc, reconstruct_immutable_updates) {
   KeyValueBlockchain block_chain{
       db,
       true,
-      std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable}, {"imm2", CATEGORY_TYPE::immutable}}};
+      std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable},
+                                           {"imm2", CATEGORY_TYPE::immutable},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1
@@ -244,7 +250,11 @@ TEST_F(categorized_kvbc, reconstruct_immutable_updates) {
 }
 
 TEST_F(categorized_kvbc, fail_reconstruct_immutable_updates) {
-  KeyValueBlockchain block_chain{db, true, std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable}}};
+  KeyValueBlockchain block_chain{
+      db,
+      true,
+      std::map<std::string, CATEGORY_TYPE>{{"imm", CATEGORY_TYPE::immutable},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1
@@ -274,10 +284,12 @@ TEST_F(categorized_kvbc, fail_reconstruct_immutable_updates) {
 }
 
 TEST_F(categorized_kvbc, reconstruct_versioned_kv_updates) {
-  KeyValueBlockchain block_chain{db,
-                                 true,
-                                 std::map<std::string, CATEGORY_TYPE>{{"ver", CATEGORY_TYPE::versioned_kv},
-                                                                      {"ver2", CATEGORY_TYPE::versioned_kv}}};
+  KeyValueBlockchain block_chain{
+      db,
+      true,
+      std::map<std::string, CATEGORY_TYPE>{{"ver", CATEGORY_TYPE::versioned_kv},
+                                           {"ver2", CATEGORY_TYPE::versioned_kv},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
   KeyValueBlockchain::KeyValueBlockchain_tester tester{};
 
   // Add block1

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -366,7 +366,8 @@ class TestStorage : public IReader, public IBlockAdder, public IBlocksDeleter {
   TestStorage(std::shared_ptr<::concord::storage::rocksdb::NativeClient> native_client)
       : bc_{native_client,
             false,
-            std::map<std::string, CATEGORY_TYPE>{{kConcordReconfigurationCategoryId, CATEGORY_TYPE::versioned_kv}}} {}
+            std::map<std::string, CATEGORY_TYPE>{{kConcordReconfigurationCategoryId, CATEGORY_TYPE::versioned_kv},
+                                                 {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}} {}
 
   // IBlockAdder interface
   BlockId add(categorization::Updates &&updates) override { return bc_.addBlock(std::move(updates)); }

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1087,14 +1087,16 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             log.log_message(message_type=f"pruned_block {pruned_block}")
             assert pruned_block <= 90
 
-            # creates 300 new blocks
-            for i in range(300):
+            # creates 1000 new blocks
+            for i in range(1000):
                 v = skvbc.random_value()
                 await client.write(skvbc.write_req([], [(k, v)], 0))
 
-            # now, return the crashed replica and wait for it to done with state transfer
+            # Now, restart the crashed replica and wait for it to finish state transfer.
+            # The total number of seq numbers is 1101 (1000 + 100 writes + 1 prune request).
+            # This translates to 7 checkpoints and, therefore, 7 * 150 = 1050.
             bft_network.start_replica(crashed_replica)
-            await self._wait_for_st(bft_network, crashed_replica, 300)
+            await self._wait_for_st(bft_network, crashed_replica, 1050)
 
             # We expect the late replica to catch up with the state and to perform pruning
             with trio.fail_after(seconds=30):
@@ -1105,12 +1107,25 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                     for r in rsi_rep.values():
                         status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
                         last_prune_blockid = status.response.last_pruned_block
+                        log.log_message(message_type=f"last_prune_blockid {last_prune_blockid}, status.response.sender {status.response.sender}")
                         if status.response.in_progress is False and last_prune_blockid <= 90 and last_prune_blockid > 0:
                             num_replies += 1
                     if num_replies == bft_network.config.n:
                         break
 
+            # Now, crash the same replica again.
+            crashed_replica = 3
+            bft_network.stop_replica(crashed_replica)
 
+            # Execute 1000 writes.
+            for i in range(1000):
+              v = skvbc.random_value()
+              await client.write(skvbc.write_req([], [(k, v)], 0))
+
+            # Make sure ST completes again. Wait for 2100 = 14 checkpoints * 150 seq numbers.
+            bft_network.start_replica(crashed_replica)
+            await self._wait_for_st(bft_network, crashed_replica, 2100)
+    
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_pruning_status_command(self, bft_network):


### PR DESCRIPTION
Given healthy replicas execute pruning (block deletes) and block
additions in a specified order, e.g.:
  "block(1, 1), block(2, 1), block(3, 1), prune 1, prune 2, block(4, 3)"
where block(X, Y) means block X being added when current genesis is Y
and prune N means prune block N, we want that a fallen-behind or crashed
replica executes them in the same order on top of its blockchain. This
is required so that all replicas reach to the same hash commitments at
the end. Currently, the replica that receives blocks from ST will do the
following:
  1. Add all blocks to its chain.
  2. Prune up to the same point as other replicas.
However, this would lead to the following different order:
  "block(1, 1), block(2, 1), block(3, 1), block(4, 1), prune 1, prune 2"

In order to provide the same order, we persist the genesis block ID at
the time any subsequent block is added in that block. That allows us to
then iterate over blocks received by ST and before adding them to the local
blockchain, we first prune up to the genesis block ID in the ST block
currently being processed. For example, if block 1 is already existing
at the crashed replica, its actions would be:
1. block(2, 1) -> add block 2
2. block(3, 1) -> add block 3
3. block(4, 3):
  * prune block 1 and 2 (up to 3)
  * add block 4 as block (4, 3)

Above solution adds a single 8-byte "concord_internal" category key-value in every block.

Remove `last_scheduled_block_for_pruning_` in PruningHandler and just
use the genesis block ID for pruning status.

Change unit tests so that they accommodate the new key.

Introduce a new unit test that tests the new behaviour. Update the
`test_pruning_command_with_failures` reconfiguration test so that it
always does ST and add an extra step - a subsequent ST after pruning.