### PR TITLE
Don't add new epoch in backward compatibility cases

### DIFF
--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -741,6 +741,13 @@ struct RemoveMetadata {
     if (!status.isOK()) {
       throw std::runtime_error{"Failed to delete metadata and state transfer data: " + status.toString()};
     }
+    // For backward compatibility, we add new epoch only if we have the reconfiguration category exist
+    auto categories = adapter.blockchainCategories();
+    if (categories.find(kConcordReconfigurationCategoryId) == categories.end()) {
+      std::vector<std::pair<std::string, std::string>> out;
+      out.push_back({std::string{"result"}, std::string{"true"}});
+      return toJson(out);
+    }
     // Once we managed to remove the metadata, we must start a new epoch (which means to add an epoch block)
     uint64_t epoch{0};
     {

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -154,8 +154,6 @@ class Client : public concord::storage::IDBClient {
   // Database path on directory (used for connection).
   std::string m_dbPath;
 
-  std::string default_opt_config_name = "OPTIONS_DEFAULT.ini";
-
   // Database object (created on connection).
   std::unique_ptr<::rocksdb::DB> dbInstance_;
   ::rocksdb::OptimisticTransactionDB* txn_db_ = nullptr;

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -251,21 +251,7 @@ void Client::initDB(bool readOnly, const std::optional<Options> &userOptions, bo
   // Reference: https://github.com/facebook/rocksdb/blob/v6.8.1/db/db_impl/db_impl.cc#L2187
   auto incompletelyCreatedColumnFamilies = std::vector<std::string>{};
 
-  // Try to read the stored options configuration file
-  // Note that if we recover, then rocksdb should have its option configuration file stored in the rocksdb directory.
-  // Thus, we don't need to persist our custom configuration file.
   auto s_opt = ::rocksdb::LoadLatestOptions(m_dbPath, ::rocksdb::Env::Default(), &options.db_options, &cf_descs);
-  if (!s_opt.ok()) {
-    const char kPathSeparator =
-#ifdef _WIN32
-        '\\';
-#else
-        '/';
-#endif
-    // If we couldn't read the stored configuration file, try to read the default configuration file.
-    s_opt = ::rocksdb::LoadOptionsFromFile(
-        m_dbPath + kPathSeparator + default_opt_config_name, ::rocksdb::Env::Default(), &options.db_options, &cf_descs);
-  }
   if (!s_opt.ok()) {
     // If we couldn't read the stored configuration and not the default configuration file, then create
     // one.


### PR DESCRIPTION
For backward compatibility, don't add a new epoch when removing metadata from db without reconfiguration category