### PR TITLE
TRS: Do not remove live_updates when transitioning to event groups

### DIFF
--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -347,10 +347,12 @@ class ThinReplicaImpl {
             update_aggregator_counter = 0;
           }
         }
-        config_->subscriber_list.removeBuffer(live_updates);
-        live_updates->removeAllUpdates();
-        metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
-        metrics_.updateAggregator();
+        if (!is_event_group_transition) {
+          config_->subscriber_list.removeBuffer(live_updates);
+          live_updates->removeAllUpdates();
+          metrics_.subscriber_list_size.Get().Set(config_->subscriber_list.Size());
+          metrics_.updateAggregator();
+        }
       } catch (std::exception& error) {
         LOG_INFO(logger_, "Subscription stream closed: " << error.what());
       }


### PR DESCRIPTION
When there are no more legacy events, and TRS is preparing to transition
to event groups, TRS removes the live_updates buffer from the subscriber
list, while still using live_updates buffer to sync event groups with
storage.
TRS incorrectly tries to remove the buffer again from the subscriber_list
whenever the server context is cancelled. If is_event_group_transition
is set to true, live_updates must not be removed from the subscriber list
to avoid double removal from subscriber_list.