### PR TITLE
Introduce internal client reconfiguration engine  for state transfer

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -56,6 +56,7 @@ class Client {
   // Useful for testing. Shouldn't be relied on in production.
   std::optional<ReplicaId> primary() { return primary_; }
   std::string signMessage(std::vector<uint8_t>&);
+  void setTransactionSigner(concord::util::crypto::ISigner* signer) { transaction_signer_.reset(signer); }
 
  private:
   // Generic function for sending a read or write message.

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -42,6 +42,7 @@ set(corebft_source_files
     src/bcstatetransfer/STDigest.cpp
     src/bcstatetransfer/DBDataStore.cpp
     src/bcstatetransfer/SourceSelector.cpp
+    src/bcstatetransfer/AsyncStateTransferCRE.cpp
     src/simplestatetransfer/SimpleStateTran.cpp
     src/bftengine/messages/PrePrepareMsg.cpp
     src/bftengine/messages/CheckpointMsg.cpp

--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -82,6 +82,7 @@ class IStateTransfer : public IReservedPages {
 
   virtual void setReconfigurationEngine(
       std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine>) = 0;
+  virtual std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> getReconfigurationEngine() = 0;
 };
 
 // This interface may only be used when the state transfer module is runnning

--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -16,9 +16,13 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <memory>
 #include "IReservedPages.hpp"
 #include "Timers.hpp"
 
+namespace concord::client::reconfiguration {
+class ClientReconfigurationEngine;
+}
 namespace bftEngine {
 class IReplicaForStateTransfer;  // forward definition
 
@@ -75,6 +79,9 @@ class IStateTransfer : public IReservedPages {
       StateTransferCallBacksPriorities priority = StateTransferCallBacksPriorities::DEFAULT) = 0;
 
   virtual void setEraseMetadataFlag() = 0;
+
+  virtual void setReconfigurationEngine(
+      std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine>) = 0;
 };
 
 // This interface may only be used when the state transfer module is runnning

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -77,9 +77,9 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
   bool validate(const State& state) const override {
     concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
-    if (crep.epoch < bftEngine::EpochManager::instance().getSelfEpochNumber()) return false;
     return std::holds_alternative<concord::messages::ReplicaTlsExchangeKey>(crep.response);
   }
+
   bool execute(const State& state, WriteState& out) override {
     bool succ = true;
     concord::messages::ClientStateReply crep;
@@ -92,7 +92,7 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
     auto current_rep_cert = sm_.decryptFile(bft_replicas_cert_path);
     if (current_rep_cert == command.cert) return succ;
     LOG_INFO(GL, "execute replica TLS key exchange using state transfer cre" << KVLOG(sender_id));
-    std::string cert = command.cert;
+    std::string cert = std::move(command.cert);
     sm_.encryptFile(bft_replicas_cert_path, cert);
     LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
     StateControl::instance().restartComm(sender_id);

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -47,7 +47,7 @@ void Communication::setReceiver(bft::communication::NodeNum receiverNum, bft::co
   receiver_ = receiver;
 }
 
-concord::client::reconfiguration::ClientReconfigurationEngine* CreFactory::create(
+std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> CreFactory::create(
     std::shared_ptr<MsgsCommunicator> msgsCommunicator, std::shared_ptr<MsgHandlersRegistrator> msgHandlers) {
   bft::client::ClientConfig bftClientConf;
   auto& repConfig = bftEngine::ReplicaConfig::instance();
@@ -68,9 +68,7 @@ concord::client::reconfiguration::ClientReconfigurationEngine* CreFactory::creat
   cre_config.interval_timeout_ms_ = 1000;
   concord::client::reconfiguration::IStateClient* pbc = new concord::client::reconfiguration::PollBasedStateClient(
       bftClient, cre_config.interval_timeout_ms_, 0, cre_config.interval_timeout_ms_);
-  concord::client::reconfiguration::ClientReconfigurationEngine* cre =
-      new concord::client::reconfiguration::ClientReconfigurationEngine(
-          cre_config, pbc, std::make_shared<concordMetrics::Aggregator>());
-  return cre;
+  return std::make_shared<concord::client::reconfiguration::ClientReconfigurationEngine>(
+      cre_config, pbc, std::make_shared<concordMetrics::Aggregator>());
 }
 }  // namespace bftEngine::bcst::asyncCRE

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -1,0 +1,76 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+#include "AsyncStateTransferCRE.hpp"
+#include "bftengine/ReplicaConfig.hpp"
+
+namespace bftEngine::bcst::asyncCRE {
+bftEngine::bcst::asyncCRE::Communication::Communication(std::shared_ptr<MsgsCommunicator> msgsCommunicator,
+                                                        std::shared_ptr<MsgHandlersRegistrator> msgHandlers)
+    : msgsCommunicator_{msgsCommunicator} {
+  msgHandlers->registerMsgHandler(MsgCode::ClientReply, [&](bftEngine::impl::MessageBase* message) {
+    if (receiver_) receiver_->onNewMessage(message->senderId(), message->body(), message->size());
+  });
+}
+int Communication::start() {
+  is_running_ = true;
+  return 0;
+}
+int Communication::stop() {
+  is_running_ = false;
+  return 0;
+}
+bool Communication::isRunning() const { return is_running_; }
+bft::communication::ConnectionStatus Communication::getCurrentConnectionStatus(bft::communication::NodeNum) {
+  if (!is_running_) return bft::communication::ConnectionStatus::Disconnected;
+  return bft::communication::ConnectionStatus::Connected;
+}
+int Communication::send(bft::communication::NodeNum destNode, std::vector<uint8_t>&& msg) {
+  return msgsCommunicator_->sendAsyncMessage(destNode, reinterpret_cast<char*>(msg.data()), msg.size());
+}
+std::set<bft::communication::NodeNum> Communication::send(std::set<bft::communication::NodeNum> dests,
+                                                          std::vector<uint8_t>&& msg) {
+  auto ret = dests;
+  msgsCommunicator_->send(dests, reinterpret_cast<char*>(msg.data()), msg.size());
+  return ret;
+}
+void Communication::setReceiver(bft::communication::NodeNum receiverNum, bft::communication::IReceiver* receiver) {
+  receiver_ = receiver;
+}
+
+concord::client::reconfiguration::ClientReconfigurationEngine* CreFactory::create(
+    std::shared_ptr<MsgsCommunicator> msgsCommunicator, std::shared_ptr<MsgHandlersRegistrator> msgHandlers) {
+  bft::client::ClientConfig bftClientConf;
+  auto& repConfig = bftEngine::ReplicaConfig::instance();
+  bftClientConf.f_val = repConfig.fVal;
+  bftClientConf.c_val = repConfig.cVal;
+  bftClientConf.id = bft::client::ClientId{repConfig.replicaId};
+  for (uint16_t i = 0; i < repConfig.numReplicas; i++) {
+    bftClientConf.all_replicas.emplace(bft::client::ReplicaId{i});
+  }
+  for (uint16_t i = repConfig.numReplicas; i < repConfig.numReplicas + repConfig.numRoReplicas; i++) {
+    bftClientConf.ro_replicas.emplace(bft::client::ReplicaId{i});
+  }
+  std::unique_ptr<bft::communication::ICommunication> comm =
+      std::make_unique<Communication>(msgsCommunicator, msgHandlers);
+  bft::client::Client* bftClient = new bft::client::Client(std::move(comm), bftClientConf);
+  concord::client::reconfiguration::Config cre_config;
+  cre_config.id_ = repConfig.replicaId;
+  cre_config.interval_timeout_ms_ = 1000;
+  concord::client::reconfiguration::IStateClient* pbc = new concord::client::reconfiguration::PollBasedStateClient(
+      bftClient, cre_config.interval_timeout_ms_, 0, cre_config.interval_timeout_ms_);
+  concord::client::reconfiguration::ClientReconfigurationEngine* cre =
+      new concord::client::reconfiguration::ClientReconfigurationEngine(
+          cre_config, pbc, std::make_shared<concordMetrics::Aggregator>());
+  return cre;
+}
+}  // namespace bftEngine::bcst::asyncCRE

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.hpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.hpp
@@ -46,7 +46,7 @@ class Communication : public bft::communication::ICommunication {
 };
 class CreFactory {
  public:
-  static concord::client::reconfiguration::ClientReconfigurationEngine* create(
+  static std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> create(
       std::shared_ptr<MsgsCommunicator> msgsCommunicator, std::shared_ptr<MsgHandlersRegistrator> msgHandlers);
 };
 }  // namespace bftEngine::bcst::asyncCRE

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.hpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.hpp
@@ -1,0 +1,52 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "bftengine/MsgsCommunicator.hpp"
+#include "communication/ICommunication.hpp"
+#include "MsgHandlersRegistrator.hpp"
+#include "MsgsCommunicator.hpp"
+#include "client/reconfiguration/poll_based_state_client.hpp"
+#include "client/reconfiguration/client_reconfiguration_engine.hpp"
+#include "bftclient/bft_client.h"
+
+namespace bftEngine::bcst::asyncCRE {
+
+class Communication : public bft::communication::ICommunication {
+ public:
+  Communication(std::shared_ptr<MsgsCommunicator> msgsCommunicator,
+                std::shared_ptr<MsgHandlersRegistrator> msgHandlers);
+
+  int getMaxMessageSize() override { return 128 * 1024; }  // 128KB
+  int start() override;
+  int stop() override;
+  bool isRunning() const override;
+  bft::communication::ConnectionStatus getCurrentConnectionStatus(bft::communication::NodeNum node) override;
+  int send(bft::communication::NodeNum destNode, std::vector<uint8_t>&& msg) override;
+  std::set<bft::communication::NodeNum> send(std::set<bft::communication::NodeNum> dests,
+                                             std::vector<uint8_t>&& msg) override;
+  void setReceiver(bft::communication::NodeNum receiverNum, bft::communication::IReceiver* receiver) override;
+  void dispose(bft::communication::NodeNum i) override {}
+
+ private:
+  std::shared_ptr<MsgsCommunicator> msgsCommunicator_;
+  bool is_running_ = false;
+  bft::communication::IReceiver* receiver_ = nullptr;
+};
+class CreFactory {
+ public:
+  static concord::client::reconfiguration::ClientReconfigurationEngine* create(
+      std::shared_ptr<MsgsCommunicator> msgsCommunicator, std::shared_ptr<MsgHandlersRegistrator> msgHandlers);
+};
+}  // namespace bftEngine::bcst::asyncCRE

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.hpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.hpp
@@ -14,36 +14,11 @@
 #pragma once
 
 #include "bftengine/MsgsCommunicator.hpp"
-#include "communication/ICommunication.hpp"
 #include "MsgHandlersRegistrator.hpp"
 #include "MsgsCommunicator.hpp"
-#include "client/reconfiguration/poll_based_state_client.hpp"
 #include "client/reconfiguration/client_reconfiguration_engine.hpp"
-#include "bftclient/bft_client.h"
 
 namespace bftEngine::bcst::asyncCRE {
-
-class Communication : public bft::communication::ICommunication {
- public:
-  Communication(std::shared_ptr<MsgsCommunicator> msgsCommunicator,
-                std::shared_ptr<MsgHandlersRegistrator> msgHandlers);
-
-  int getMaxMessageSize() override { return 128 * 1024; }  // 128KB
-  int start() override;
-  int stop() override;
-  bool isRunning() const override;
-  bft::communication::ConnectionStatus getCurrentConnectionStatus(bft::communication::NodeNum node) override;
-  int send(bft::communication::NodeNum destNode, std::vector<uint8_t>&& msg) override;
-  std::set<bft::communication::NodeNum> send(std::set<bft::communication::NodeNum> dests,
-                                             std::vector<uint8_t>&& msg) override;
-  void setReceiver(bft::communication::NodeNum receiverNum, bft::communication::IReceiver* receiver) override;
-  void dispose(bft::communication::NodeNum i) override {}
-
- private:
-  std::shared_ptr<MsgsCommunicator> msgsCommunicator_;
-  bool is_running_ = false;
-  bft::communication::IReceiver* receiver_ = nullptr;
-};
 class CreFactory {
  public:
   static std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> create(

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -127,6 +127,10 @@ class BCStateTran : public IStateTransfer {
     cre_ = cre;
   }
 
+  std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> getReconfigurationEngine() override {
+    return cre_;
+  }
+
  protected:
   // handling messages from other context
   std::function<void(char*, uint32_t, uint16_t, LocalTimePoint)> messageHandler_;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -122,6 +122,10 @@ class BCStateTran : public IStateTransfer {
       StateTransferCallBacksPriorities priority = StateTransferCallBacksPriorities::DEFAULT) override;
 
   void setEraseMetadataFlag() override { psd_->setEraseDataStoreFlag(); }
+  void setReconfigurationEngine(
+      std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> cre) override {
+    cre_ = cre;
+  }
 
  protected:
   // handling messages from other context
@@ -653,6 +657,7 @@ class BCStateTran : public IStateTransfer {
   AsyncTimeRecorder<false> src_send_batch_duration_rec_;
   AsyncTimeRecorder<false> dst_time_between_sendFetchBlocksMsg_rec_;
   AsyncTimeRecorder<false> time_in_handoff_queue_rec_;
+  std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> cre_;
 };  // class BCStateTran
 
 }  // namespace bftEngine::bcst::impl

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -24,6 +24,7 @@
 #include "RequestHandler.h"
 #include "ReservedPagesClient.hpp"
 #include "bftengine/EpochManager.hpp"
+#include "bcstatetransfer/AsyncStateTransferCRE.hpp"
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -206,6 +207,8 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
   shared_ptr<bft::communication::IReceiver> msgReceiverPtr(new MsgReceiver(incomingMsgsStoragePtr));
   shared_ptr<MsgsCommunicator> msgsCommunicatorPtr(
       new MsgsCommunicator(communication, incomingMsgsStoragePtr, msgReceiverPtr));
+  stateTransfer->setReconfigurationEngine(
+      bftEngine::bcst::asyncCRE::CreFactory::create(msgsCommunicatorPtr, msgHandlersPtr));
   if (isNewStorage) {
     auto replicaImp = std::make_unique<ReplicaImp>(replicaConfig,
                                                    requestsHandler,

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -263,7 +263,7 @@ IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaC
   std::shared_ptr<IncomingMsgsStorage> incomingMsgsStorage{std::move(incomingMsgsStorageImpPtr)};
   auto msgReceiver = std::make_shared<MsgReceiver>(incomingMsgsStorage);
   auto msgsCommunicator = std::make_shared<MsgsCommunicator>(communication, incomingMsgsStorage, msgReceiver);
-
+  stateTransfer->setReconfigurationEngine(bftEngine::bcst::asyncCRE::CreFactory::create(msgsCommunicator, msgHandlers));
   replicaInternal->replica_ = std::make_unique<ReadOnlyReplica>(
       replicaConfig, requestsHandler, stateTransfer, msgsCommunicator, msgHandlers, timers);
   return replicaInternal;

--- a/bftengine/src/bftengine/NullStateTransfer.hpp
+++ b/bftengine/src/bftengine/NullStateTransfer.hpp
@@ -45,6 +45,8 @@ class NullStateTransfer : public IStateTransfer {
   void addOnTransferringCompleteCallback(std::function<void(uint64_t)>,
                                          StateTransferCallBacksPriorities priority) override{};
   void setEraseMetadataFlag() override {}
+  void setReconfigurationEngine(
+      std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine>) override {}
   virtual ~NullStateTransfer();
 
  protected:

--- a/bftengine/src/bftengine/NullStateTransfer.hpp
+++ b/bftengine/src/bftengine/NullStateTransfer.hpp
@@ -47,6 +47,9 @@ class NullStateTransfer : public IStateTransfer {
   void setEraseMetadataFlag() override {}
   void setReconfigurationEngine(
       std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine>) override {}
+  std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> getReconfigurationEngine() override {
+    return nullptr;
+  }
   virtual ~NullStateTransfer();
 
  protected:

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -61,10 +61,10 @@ ReplicaForStateTransfer::ReplicaForStateTransfer(const ReplicaConfig &config,
   stateTranTimer_ = timers_.add(
       defaultTimeout, Timers::Timer::RECURRING, [stateTransfer](Timers::Handle h) { stateTransfer->onTimer(); });
   metric_state_transfer_timer_.Get().Set(defaultTimeout.count());
-  stateTransfer->startRunning(this);
 }
 
 void ReplicaForStateTransfer::start() {
+  stateTransfer->startRunning(this);
   ReplicaBase::start();  // msg communicator should be last in the starting chain
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -263,7 +263,8 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
 
   // check message validity
   const bool invalidClient =
-      !isValidClient(clientId) && !(repsInfo->isIdOfReplica(clientId) && (flags & RECONFIG_FLAG));
+      !isValidClient(clientId) &&
+      !((repsInfo->isIdOfReplica(clientId) || repsInfo->isIdOfPeerRoReplica(clientId)) && (flags & RECONFIG_FLAG));
   const bool sentFromReplicaToNonPrimary =
       !(flags & RECONFIG_FLAG) && repsInfo->isIdOfReplica(senderId) && !isCurrentPrimary();
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -262,8 +262,10 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
   }
 
   // check message validity
-  const bool invalidClient = !isValidClient(clientId);
-  const bool sentFromReplicaToNonPrimary = repsInfo->isIdOfReplica(senderId) && !isCurrentPrimary();
+  const bool invalidClient =
+      !isValidClient(clientId) && !(repsInfo->isIdOfReplica(clientId) && (flags & RECONFIG_FLAG));
+  const bool sentFromReplicaToNonPrimary =
+      !(flags & RECONFIG_FLAG) && repsInfo->isIdOfReplica(senderId) && !isCurrentPrimary();
 
   if (invalidClient) {
     ++numInvalidClients;

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -205,12 +205,13 @@ bool SigManager::verifySig(
       return false;
     }
   }
-  bool idOfReplica = false, idOfExternalClient = false;
+  bool idOfReplica = false, idOfExternalClient = false, idOfReadOnlyReplica = false;
   idOfExternalClient = replicasInfo_.isIdOfExternalClient(pid);
   if (!idOfExternalClient) {
     idOfReplica = replicasInfo_.isIdOfReplica(pid);
   }
-  ConcordAssert(idOfReplica || idOfExternalClient);
+  idOfReadOnlyReplica = replicasInfo_.isIdOfPeerRoReplica(pid);
+  ConcordAssert(idOfReplica || idOfExternalClient || idOfReadOnlyReplica);
   if (!result) {  // failure
     if (idOfExternalClient)
       metrics_.externalClientReqSigVerificationFailed_++;

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -99,7 +99,8 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
   bool isIdOfExternalClient = repInfo.isIdOfExternalClient(clientId);
   bool doSigVerify = false;
   bool emptyReq = (header->requestLength == 0);
-  if ((header->flags & RECONFIG_FLAG) != 0 && repInfo.isIdOfReplica(clientId)) {
+  if ((header->flags & RECONFIG_FLAG) != 0 &&
+      (repInfo.isIdOfReplica(clientId) || repInfo.isIdOfPeerRoReplica(clientId))) {
     // Allow every reconfiguration message from replicas (it will be verified in the reconfiguration handler)
     return;
   }

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -99,7 +99,10 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
   bool isIdOfExternalClient = repInfo.isIdOfExternalClient(clientId);
   bool doSigVerify = false;
   bool emptyReq = (header->requestLength == 0);
-
+  if ((header->flags & RECONFIG_FLAG) != 0 && repInfo.isIdOfReplica(clientId)) {
+    // Allow every reconfiguration message from replicas (it will be verified in the reconfiguration handler)
+    return;
+  }
   if (!repInfo.isValidPrincipalId(clientId)) {
     msg << "Invalid clientId " << clientId;
     LOG_ERROR(GL, msg.str());

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -92,6 +92,10 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
   void setReconfigurationEngine(
       std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine>) override {}
 
+  std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> getReconfigurationEngine() override {
+    return nullptr;
+  }
+
  protected:
   //////////////////////////////////////////////////////////////////////////
   // DummyBDState

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -89,6 +89,9 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
   void markUpdate(void* ptrToUpdatedRegion, uint32_t sizeOfUpdatedRegion) override;
   void setEraseMetadataFlag() override {}
 
+  void setReconfigurationEngine(
+      std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine>) override {}
+
  protected:
   //////////////////////////////////////////////////////////////////////////
   // DummyBDState

--- a/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
@@ -18,6 +18,8 @@
 
 #include <vector>
 #include <thread>
+#include <semaphore.h>
+
 namespace concord::client::reconfiguration {
 class ClientReconfigurationEngine {
  public:
@@ -32,6 +34,8 @@ class ClientReconfigurationEngine {
   ~ClientReconfigurationEngine();
   void start();
   void stop();
+  void halt();
+  void resume();
 
  private:
   void main();
@@ -49,5 +53,6 @@ class ClientReconfigurationEngine {
   concordMetrics::CounterHandle invalid_handlers_;
   concordMetrics::CounterHandle errored_handlers_;
   concordMetrics::GaugeHandle last_known_block_;
+  sem_t main_notifier_;
 };
 }  // namespace concord::client::reconfiguration

--- a/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
@@ -30,6 +30,8 @@ class ClientReconfigurationEngine {
     metrics_.SetAggregator(aggregator_);
   }
   ~ClientReconfigurationEngine();
+  IStateClient* getStateClient() { return stateClient_.get(); }
+  uint64_t getLatestKnownUpdateBlock() { return last_known_block_.Get().Get(); }
   void start();
   void stop();
   void halt();

--- a/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/client_reconfiguration_engine.hpp
@@ -18,8 +18,6 @@
 
 #include <vector>
 #include <thread>
-#include <semaphore.h>
-
 namespace concord::client::reconfiguration {
 class ClientReconfigurationEngine {
  public:
@@ -53,6 +51,5 @@ class ClientReconfigurationEngine {
   concordMetrics::CounterHandle invalid_handlers_;
   concordMetrics::CounterHandle errored_handlers_;
   concordMetrics::GaugeHandle last_known_block_;
-  sem_t main_notifier_;
 };
 }  // namespace concord::client::reconfiguration

--- a/client/reconfiguration/include/client/reconfiguration/cre_interfaces.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/cre_interfaces.hpp
@@ -33,6 +33,8 @@ class IStateClient {
   virtual void start() = 0;
   virtual void stop() = 0;
   virtual void pushUpdate(std::vector<State>&) {}
+  virtual void halt() {}
+  virtual void resume() {}
   virtual ~IStateClient() = default;
 };
 

--- a/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
@@ -38,6 +38,7 @@ class PollBasedStateClient : public IStateClient {
   std::vector<State> getStateUpdate(bool& succ) const;
   void halt() override;
   void resume() override;
+
  private:
   concord::messages::ReconfigurationResponse sendReconfigurationRequest(concord::messages::ReconfigurationRequest& rreq,
                                                                         const std::string& cid,

--- a/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/poll_based_state_client.hpp
@@ -36,7 +36,8 @@ class PollBasedStateClient : public IStateClient {
   void start() override;
   void stop() override;
   std::vector<State> getStateUpdate(bool& succ) const;
-
+  void halt() override;
+  void resume() override;
  private:
   concord::messages::ReconfigurationResponse sendReconfigurationRequest(concord::messages::ReconfigurationRequest& rreq,
                                                                         const std::string& cid,
@@ -58,6 +59,9 @@ class PollBasedStateClient : public IStateClient {
   mutable std::condition_variable new_updates_;
   std::atomic_bool stopped{true};
   std::thread consumer_;
+  bool halted_ = false;
+  std::condition_variable resume_cond_;
+  std::mutex resume_lock_;
 };
 
 }  // namespace concord::client::reconfiguration

--- a/client/reconfiguration/src/client_reconfiguration_engine.cpp
+++ b/client/reconfiguration/src/client_reconfiguration_engine.cpp
@@ -85,9 +85,7 @@ void ClientReconfigurationEngine::stop() {
     LOG_ERROR(getLogger(), e.what());
   }
 }
-void ClientReconfigurationEngine::halt() {
-  stateClient_->halt();
-}
+void ClientReconfigurationEngine::halt() { stateClient_->halt(); }
 void ClientReconfigurationEngine::resume() {
   if (!stopped_) stateClient_->resume();
 }

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -78,6 +78,7 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
  private:
   concord::messages::ClientStateReply buildClientStateReply(kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type,
                                                             uint32_t clientid);
+  concord::messages::ClientStateReply buildReplicaStateReply(const char& command_type, uint32_t clientid);
 };
 /**
  * This component is responsible for logging reconfiguration request (issued by an authorized operator) in the

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -68,7 +68,6 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::RestartCommand&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::InstallCommand&, uint64_t, uint64_t, uint64_t);
-  bool handle(const concord::messages::ReplicaTlsExchangeKey&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::ClientTlsExchangeKey&, uint64_t, uint64_t, uint64_t);
 
   kvbc::IReader& ro_storage_;

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -238,7 +238,9 @@ Msg ClientStateReply 39 {
         ClientsAddRemoveUpdateCommand
         ClientTlsExchangeKey
         ClientsRestartCommand
+        ReplicaTlsExchangeKey
       } response
+    uint64 epoch
 }
 
 Msg ClientReconfigurationStateReply 49 {

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -552,7 +552,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
                       selected_configs=lambda n, f, c: n == 7)
-    async def test_replicas_tks_key_exchange_with_ror(self, bft_network):
+    async def test_replicas_tls_key_exchange_with_ror(self, bft_network):
         """
         """
         bft_network.start_all_replicas()

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -549,6 +549,31 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
                 self.assertGreater(nb_fast_path, fast_paths[r])
 
+    @with_trio
+    @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
+                      selected_configs=lambda n, f, c: n == 7)
+    async def test_replicas_tks_key_exchange_with_ror(self, bft_network):
+        """
+        """
+        bft_network.start_all_replicas()
+        ro_replica_id = bft_network.config.n
+        bft_network.start_replica(ro_replica_id)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        for i in range(301): # Produce 301 new blocks
+            await skvbc.send_write_kv_set()
+        # Now, lets switch keys to f replicas
+        exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f))
+        await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, affected_replicas=[r for r in range(bft_network.config.n + 1)])
+        # Now, lets exchange another replica key, to make sure the read only replica is able to exchange the keys
+        exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f, without=set(exchanged_replicas)))
+        await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, affected_replicas=[r for r in range(bft_network.config.n + 1)])
+        # Make sure that the read only replica is able to complete another state transfer
+        for i in range(500): # Produce 500 new blocks
+            await skvbc.send_write_kv_set()
+        await self._wait_for_st(bft_network, ro_replica_id, 600)
+
+
+
     async def run_replica_tls_key_exchange_cycle(self, bft_network, replicas, affected_replicas=[]):
         reps_data = {}
         if len(affected_replicas) == 0:

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -512,7 +512,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             bft_network.copy_certs_from_server_to_clients(live_replicas[0])
             bft_network.restart_clients(False, False)
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-            for i in range(500):
+            for i in range(700):
                 await skvbc.send_write_kv_set()
 
             bft_network.start_replicas(crashed_replica)


### PR DESCRIPTION
In this PR we introduce an internal client reconfiguration engine for state transfer and read-only replicas.

The state transfer-based CRE has a critical limitation, the replica must complete the state transfer cycle in order to catch up with the state change. However, there are some reconfiguration commands that may prevent a replica to complete state transfer (such as TLS key exchange and scaling). 
In addition, with very long state transfer cycles we may want to have an immediate update without waiting for state transfer compilation.
For that, we need to have an async reconfiguration mechanism that runs in parallel to state transfer.

In this PR we introduce the following:
1. For regular replica, once state transfer is starting, an internal CRE is also started.
2. For read-only replica, CRE is always is running.

To demonstrate the ability of this new approach, we implemented a TLS key exchange for state-transferred replicas using this mechanism. 
Finally, we added a test for TLS key exchange with a read-only replica.