### PR TITLE
stabilizing skvbc_batch_preexecution apollo test

### DIFF
--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -206,6 +206,12 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
                                         err_msg="Make sure we are in the initial view before crashing the primary.")
 
         last_block = await tracker.get_last_block_id(client)
+        expected_last_block =  len(clients) * BATCH_SIZE
+        with trio.move_on_after(seconds=10):
+            while last_block < expected_last_block:
+                last_block = await tracker.get_last_block_id(client)
+                await trio.sleep(seconds=1)
+        self.assertEqual(last_block, expected_last_block)
         bft_network.stop_replica(initial_primary)
 
         try:


### PR DESCRIPTION
In some intermittent failure cases, previous batch execution is not finished on all replicas when primary is stopped. As a result, new requests are ignored and if we have only f or less replicas that complains then view change is not triggered.
So, in such a case we need to send new requests for view change. 
Adding this check to make sure that, previous batch execution is finished before we stop primary to test view change
 