### PR TITLE
TS: Time_serviceV2 apollo testcases addition

### DIFF
--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -92,7 +92,7 @@ class SkvbcStateTransferTest(unittest.TestCase):
         )
         bft_network.start_replica(stale_node)
         await bft_network.wait_for_state_transfer_to_start()
-        await bft_network.wait_for_state_transfer_to_stop(0, stale_node)
+        await bft_network.wait_for_state_transfer_to_stop_with_RFMD(0, stale_node)
         await skvbc.assert_successful_put_get()
         await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get()

--- a/tests/apollo/test_skvbc_time_service.py
+++ b/tests/apollo/test_skvbc_time_service.py
@@ -108,7 +108,8 @@ class SkvbcTimeServiceTest(unittest.TestCase):
             run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, rotate_keys=True)
+    @with_bft_network(start_replica_cmd,
+            selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_wrong_time_in_non_primary(self, bft_network, tracker):
         """
@@ -232,7 +233,8 @@ class SkvbcTimeServiceTest(unittest.TestCase):
             run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20) 
 
     @with_trio
-    @with_bft_network(start_replica_cmd, rotate_keys=True)
+    @with_bft_network(start_replica_cmd,
+            selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
     @verify_linearizability()
     async def test_wrong_time_in_f_replicas(self, bft_network, tracker):
         """

--- a/tests/apollo/test_skvbc_time_service.py
+++ b/tests/apollo/test_skvbc_time_service.py
@@ -21,6 +21,7 @@ from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
 from util import eliot_logging as log
 from util import skvbc as kvbc
+from util import bft_network_traffic_control as ntc
 
 FILE_PATH_PREFIX = "/tmp/fake_clock_"
 FILE_PATH_SUFFIX = ".config"
@@ -60,10 +61,8 @@ class SkvbcTimeServiceTest(unittest.TestCase):
         # the system should return to the fast path.
         self.evaluation_period_seq_num = 64
 
-    @unittest.skip("Disabled till Timeservice V2 is not enabled")
     @with_trio
-    @with_bft_network(start_replica_cmd,
-                      selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
     @verify_linearizability()
     async def test_wrong_time_in_primary(self, bft_network, tracker):
         """
@@ -108,10 +107,8 @@ class SkvbcTimeServiceTest(unittest.TestCase):
         await bft_network.wait_for_fast_path_to_be_prevalent(
             run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
 
-    @unittest.skip("Disabled till Timeservice V2 is not enabled")
     @with_trio
-    @with_bft_network(start_replica_cmd,
-                      selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
     @verify_linearizability()
     async def test_wrong_time_in_non_primary(self, bft_network, tracker):
         """
@@ -144,15 +141,20 @@ class SkvbcTimeServiceTest(unittest.TestCase):
         await bft_network.wait_for_slow_path_to_be_prevalent(
             run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
         
+        with log.start_action(action_type="get_hard_limit_reached_counter") as action:
+            hard_limit_cnt = await bft_network.get_metric(non_primary_replica, bft_network, "Counters",
+                    "hard_limit_reached_counter", "time_service")
+            action.log(
+                    message_type=f'hard_limit_reached_counter #{hard_limit_cnt}')
+            self.assertGreater(hard_limit_cnt, 0)       
+        
         await self.manipulate_time_file_write(path, CLOCK_NO_DRIFT)
 
         await bft_network.wait_for_fast_path_to_be_prevalent(
             run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
 
-    @unittest.skip("Disabled till Timeservice V2 is not enabled")
     @with_trio
-    @with_bft_network(start_replica_cmd_without_time_service('0'),
-                      selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
+    @with_bft_network(start_replica_cmd_without_time_service('0') , rotate_keys=True)
     @verify_linearizability()
     async def test_wrong_time_in_primary_without_ts(self, bft_network, tracker):
         """
@@ -190,10 +192,8 @@ class SkvbcTimeServiceTest(unittest.TestCase):
         await bft_network.wait_for_fast_path_to_be_prevalent(
             run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
 
-    @unittest.skip("Disabled till Timeservice V2 is not enabled")
     @with_trio
-    @with_bft_network(start_replica_cmd_without_time_service('0'),
-                      selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
+    @with_bft_network(start_replica_cmd_without_time_service('0'), rotate_keys=True)
     @verify_linearizability()
     async def test_wrong_time_in_non_primary_without_ts(self, bft_network, tracker): 
         """
@@ -230,6 +230,118 @@ class SkvbcTimeServiceTest(unittest.TestCase):
 
         await bft_network.wait_for_fast_path_to_be_prevalent(
             run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20) 
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
+    @verify_linearizability()
+    async def test_wrong_time_in_f_replicas(self, bft_network, tracker):
+        """
+        1. Launch a cluster
+        2. Make sure that the cluster works in the fast path mode
+        3. Change local time in f of the non-primary's container so that it would be behind or beyond other replica's local time
+        4. Expected result: The cluster should switch to the slow path
+        5. Change time in the f non-primary's container so that it is the same as in other replicas
+        6. Expected result: The cluster should switch to the fast path
+        """
+        
+        n = bft_network.config.n
+        f = bft_network.config.f
+        initial_view = 0
+    
+        for replica_id in range(n):
+            path = FILE_PATH_PREFIX + str(replica_id) + FILE_PATH_SUFFIX
+            await self.manipulate_time_file_write(path, CLOCK_NO_DRIFT)
+        
+        bft_network.start_all_replicas()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network,tracker)
+        await bft_network.wait_for_fast_path_to_be_prevalent(
+            run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
+
+        wrong_replicas = bft_network.random_set_of_replicas(f, without={initial_view})
+    
+        for replica_id in wrong_replicas:
+            path = FILE_PATH_PREFIX + str(replica_id) + FILE_PATH_SUFFIX
+            await self.manipulate_time_file_write(path, CLOCK_DRIFT) 
+        
+        await bft_network.wait_for_slow_path_to_be_prevalent(
+            run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
+
+        for replica_id in wrong_replicas:
+            path = FILE_PATH_PREFIX + str(replica_id) + FILE_PATH_SUFFIX
+            await self.manipulate_time_file_write(path, CLOCK_NO_DRIFT)
+
+        await bft_network.wait_for_fast_path_to_be_prevalent(
+            run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, rotate_keys=True)
+    @verify_linearizability()
+    async def test_restart_non_primary_replica(self, bft_network, tracker):
+        """
+        1. Launch a cluster
+        2. Make sure that the cluster works in the fast path mode
+        3. Stop one non-primary replica
+        4. Expected result: The cluster should switch to the slow path
+        5. Restart the stopped replica
+        6. Expected result: The cluster should switch to the fast path
+        """
+
+        initial_primary = 0
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
+        bft_network.start_all_replicas()
+
+        await bft_network.wait_for_fast_path_to_be_prevalent(
+            run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)        
+
+        non_primary_replica = random.choice(
+            bft_network.all_replicas(without={initial_primary}))
+ 
+        bft_network.stop_replica(non_primary_replica)
+
+        await bft_network.wait_for_slow_path_to_be_prevalent(
+        run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
+
+        bft_network.start_replica(non_primary_replica)
+
+        await bft_network.wait_for_fast_path_to_be_prevalent(
+        run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
+
+    @with_trio
+    @with_bft_network(start_replica_cmd,
+            selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)
+    @verify_linearizability()
+    async def test_delay_with_soft_limit_reached_counter(self, bft_network, tracker):
+        """
+        1. Start all replicas except a non-primary
+        2. Expected result: The cluster should work in slow path
+        3. Add a delay of 500ms in network
+        4. Start the stopped non-primary replica
+        5. Expected result: Increment in soft_limit_reached_counter
+        6. Remove the delay from network
+        """
+
+        initial_primary = 0
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
+        non_primary_replica = random.choice(
+            bft_network.all_replicas(without={initial_primary}))
+
+        bft_network.start_replicas(bft_network.all_replicas(without={non_primary_replica})) 
+
+        await bft_network.wait_for_slow_path_to_be_prevalent(
+        run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
+ 
+        with ntc.NetworkTrafficControl() as tc:
+            #delay added to loopback interface
+            tc.put_loop_back_interface_delay(500)
+            bft_network.start_replica(non_primary_replica)
+            await skvbc.run_concurrent_ops(100, 1)
+            
+            with log.start_action(action_type="get_soft_limit_reached_counter") as action:
+                soft_limit_cnt = await bft_network.get_metric(non_primary_replica, bft_network, "Counters",
+                        "soft_limit_reached_counter", "time_service")
+                action.log(
+                        message_type=f'soft_limit_reached_counter #{soft_limit_cnt}')
+                self.assertGreater(soft_limit_cnt, 0)
 
     @classmethod
     async def manipulate_time_file_write(self, path, data):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -1184,7 +1184,51 @@ class BftTestNetwork:
                                     return
 
                                 await trio.sleep(0.5)
-                    
+
+    async def wait_for_state_transfer_to_stop_with_RFMD(self, up_to_date_node, stale_node, stop_on_stable_seq_num=False):
+        with log.start_action(action_type="wait_for_state_transfer_to_stop_with_RFMD", up_to_date_node=up_to_date_node, stale_node=stale_node, stop_on_stable_seq_num=stop_on_stable_seq_num):
+            with trio.fail_after(30): # seconds
+                # Get the lastExecutedSeqNumber from a started node
+                if stop_on_stable_seq_num:
+                    key = ['replica', 'Gauges', 'lastStableSeqNum']
+                else:
+                    key = ['replica', 'Gauges', 'lastExecutedSeqNum']
+                expected_seq_num = await self.metrics.get(up_to_date_node, *key)
+                with log.start_action(action_type='start_polling', key=key[2], expected_seq_num=expected_seq_num) as action:
+                    last_n = -1
+                    while True:
+                        with trio.move_on_after(.5): # seconds
+                            metrics = await self.metrics.get_all(stale_node)                           
+                            try:
+                                n = self.metrics.get_local(metrics, *key)
+                                # If seq_num is not moving send the new message to advance it
+                                if (n == last_n):
+                                    skvbc = kvbc.SimpleKVBCProtocol(self)
+                                    client = self.random_client()
+                                    # Write a KV pair with a known value
+                                    known_key = skvbc.unique_random_key()
+                                    known_val = skvbc.random_value()
+                                    known_kv = [(known_key, known_val)]
+                                    await skvbc.send_write_kv_set(client, known_kv)
+                            except KeyError:
+                                # ignore - the metric will eventually become available
+                                await trio.sleep(0.1)
+                            else:
+                                # Debugging
+                                if n != last_n:
+                                    last_n = n
+                                    last_stored_checkpoint = self.metrics.get_local(metrics,
+                                        'bc_state_transfer', 'Gauges', 'last_stored_checkpoint')
+                                    on_transferring_complete = self.metrics.get_local(metrics,
+                                        'bc_state_transfer', 'Counters', 'on_transferring_complete')
+                                    action.log(message_type="Not complete yet",
+                                        seq_num=n, last_stored_checkpoint=last_stored_checkpoint, on_transferring_complete=on_transferring_complete)
+
+                                # Exit condition
+                                if n >= expected_seq_num:
+                                    action.add_success_fields(n=n, expected_seq_num=expected_seq_num)
+                                    return
+                                               
     async def wait_for_replicas_to_checkpoint(self, replica_ids, expected_checkpoint_num=None):
         """
         Wait for every replica in `replicas` to take a checkpoint.

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -68,6 +68,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.pruningEnabled_ = true;
     replicaConfig.numBlocksToKeep_ = 10;
     replicaConfig.batchedPreProcessEnabled = true;
+    replicaConfig.timeServiceEnabled = true;
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
     replicaConfig.set("concord.bft.st.runInSeparateThread", true);
     replicaConfig.set("concord.bft.keyExchage.clientKeysEnabled", false);

--- a/util/include/FakeClock.hpp
+++ b/util/include/FakeClock.hpp
@@ -32,7 +32,11 @@ class FakeClock {
     auto& config = ReplicaConfig::instance();
     std::string path = "/tmp/fake_clock_" + std::to_string(config.replicaId) + ".config";
     std::fstream file_reader(path, std::ios_base::in);
-    if (!file_reader.good()) return std::chrono::system_clock::now();
+    if (!file_reader.good()) {
+      LOG_INFO(TS_MNGR, "Fake Clock: Clock drift file not found, using system clock");
+      return std::chrono::system_clock::now();
+    }
+
     int clock_drift = 0;
     file_reader >> clock_drift;
     LOG_INFO(TS_MNGR,


### PR DESCRIPTION
Following are taken care in this PR
1. Enabling time service v2 in setup.cpp
2. Enabling all time_service test cases
3. Adding the below apollo TS test cases:
      - The drift of time in exactly f replicas
      - Adding delay in the network and check increment in soft limit counter
      - Restart of replica with timeservice
      - Check hard limit counter metric
4. Add INFO log in fake clock to let the user know other than TS, all apollo cases execute with the system clock
5. Changes in TS apollo test cases to execute for all configurations.
6. Don’t send PrePreparePartialMsg and PrePrepareCommitProof message if time is not ok.