### PR TITLE
WIP: Introducing CRE handler for scaling during state transfer

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -38,6 +38,12 @@ class ControlStateManager {
   void setRestartBftFlag(bool bft) { restartBftEnabled_ = bft; }
   void setRemoveMetadataFunc(std::function<void(bool)> fn) { removeMetadataCbRegistry_.add(fn); }
   void setRestartReadyFunc(std::function<void(uint8_t, const std::string&)> fn) { sendRestartReady_ = fn; }
+  void setGetNewConfigurationCallBack(std::function<void(const std::string&, const std::string&)> fn) {
+    getNewConfigurationRegistry_.add(fn);
+  }
+  void getNewConfiguration(const std::string& config_descriptor, const std::string& token) {
+    getNewConfigurationRegistry_.invokeAll(config_descriptor, token);
+  }
   void sendRestartReadyToAllReplica(uint8_t reason, const std::string& extraData) {
     sendRestartReady_(reason, extraData);
   }
@@ -58,6 +64,7 @@ class ControlStateManager {
   std::unordered_map<uint8_t, SeqNum> hasRestartProofAtSeqNum_;  // reason for restart is the key
   std::atomic_bool onPruningProcess_ = false;
   concord::util::CallbackRegistry<bool> removeMetadataCbRegistry_;
+  concord::util::CallbackRegistry<const std::string&, const std::string&> getNewConfigurationRegistry_;
   std::function<void(uint8_t, const std::string&)> sendRestartReady_;
   // reason for restart is the key
   std::unordered_map<uint8_t, std::map<uint32_t, concord::util::CallbackRegistry<>>> onRestartProofCbRegistry_;

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -42,8 +42,9 @@ class KeyExchangeManager {
   // whether initial key exchange has occurred
   bool exchanged() const {
     uint32_t liveClusterSize = ReplicaConfig::instance().waitForFullCommOnStartup ? clusterSize_ : quorumSize_;
+    bool exchange_self_keys = publicKeys_.keyExists(ReplicaConfig::instance().replicaId);
     return ReplicaConfig::instance().getkeyExchangeOnStart()
-               ? (publicKeys_.numOfExchangedReplicas() >= liveClusterSize - 1)
+               ? (publicKeys_.numOfExchangedReplicas() >= liveClusterSize - 1) && exchange_self_keys
                : true;
   }
   const std::string kInitialKeyExchangeCid = "KEY-EXCHANGE-";

--- a/bftengine/include/bftengine/KeyExchangeMsg.hpp
+++ b/bftengine/include/bftengine/KeyExchangeMsg.hpp
@@ -21,10 +21,12 @@ struct KeyExchangeMsg : public concord::serialize::SerializableFactory<KeyExchan
   std::string pubkey;
   uint16_t repID;
   uint64_t generated_sn;
+  uint64_t epoch;
 
   std::string toString() const {
     std::stringstream ss;
-    ss << "pubkey [" << pubkey << "] replica id [" << repID << "] generate sequence number [" << generated_sn << "]";
+    ss << "pubkey [" << pubkey << "] replica id [" << repID << "] generate sequence number [" << generated_sn
+       << "] epoch [" << epoch << "]";
     return ss.str();
   }
   static KeyExchangeMsg deserializeMsg(const char* serializedMsg, const int& size) {
@@ -42,11 +44,13 @@ struct KeyExchangeMsg : public concord::serialize::SerializableFactory<KeyExchan
     serialize(outStream, pubkey);
     serialize(outStream, repID);
     serialize(outStream, generated_sn);
+    serialize(outStream, epoch);
   }
   void deserializeDataMembers(std::istream& inStream) override {
     deserialize(inStream, op);
     deserialize(inStream, pubkey);
     deserialize(inStream, repID);
     deserialize(inStream, generated_sn);
+    deserialize(inStream, epoch);
   }
 };

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -163,6 +163,12 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   // Keys Management
   CONFIG_PARAM(keyExchangeOnStart, bool, false, "whether to perform initial key exchange");
   CONFIG_PARAM(keyViewFilePath, std::string, ".", "TODO");
+  // Configuration Management
+  // Keys Management
+  CONFIG_PARAM(configurationViewFilePath,
+               std::string,
+               ".",
+               "The path where we write all previous configuration in a file");
   // Time Service
   CONFIG_PARAM(timeServiceEnabled, bool, false, "whether time service enabled");
   CONFIG_PARAM(timeServiceSoftLimitMillis,
@@ -286,6 +292,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, blockAccumulation);
     serialize(outStream, sizeOfInternalThreadPool);
     serialize(outStream, keyViewFilePath);
+    serialize(outStream, configurationViewFilePath);
     serialize(outStream, timeServiceEnabled);
     serialize(outStream, timeServiceHardLimitMillis);
     serialize(outStream, timeServiceSoftLimitMillis);
@@ -363,6 +370,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, blockAccumulation);
     deserialize(inStream, sizeOfInternalThreadPool);
     deserialize(inStream, keyViewFilePath);
+    deserialize(inStream, configurationViewFilePath);
     deserialize(inStream, timeServiceEnabled);
     deserialize(inStream, timeServiceHardLimitMillis);
     deserialize(inStream, timeServiceSoftLimitMillis);

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -189,7 +189,7 @@ std::shared_ptr<ClientReconfigurationEngine> CreFactory::create(std::shared_ptr<
   Config cre_config;
   cre_config.id_ = repConfig.replicaId;
   cre_config.interval_timeout_ms_ = 1000;
-  PollBasedStateClient* pbc = new PollBasedStateClient(bftClient, cre_config.interval_timeout_ms_, 0, cre_config.id_);
+  IStateClient* pbc = new PollBasedStateClient(bftClient, cre_config.interval_timeout_ms_, 0, cre_config.id_);
   auto cre =
       std::make_shared<ClientReconfigurationEngine>(cre_config, pbc, std::make_shared<concordMetrics::Aggregator>());
   cre->registerHandler(std::make_shared<ReplicaTLSKeyExchangeHandler>());

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -146,7 +146,6 @@ class ScalingReplicaHandler : public IStateHandler {
     concord::messages::deserialize(state.data, crep);
     concord::messages::ClientsAddRemoveExecuteCommand command =
         std::get<concord::messages::ClientsAddRemoveExecuteCommand>(crep.response);
-    LOG_INFO(getLogger(), "b(1)" << KVLOG(command.token, command.config_descriptor, command.restart));
     std::ofstream configuration_file;
     configuration_file.open(bftEngine::ReplicaConfig::instance().configurationViewFilePath + "/" +
                                 concord::reconfiguration::configurationsFileName + "." +

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -392,7 +392,6 @@ void BCStateTran::startRunning(IReplicaForStateTransfer *r) {
 
 void BCStateTran::stopRunning() {
   LOG_INFO(logger_, "");
-  if (cre_) cre_->stop();
   ConcordAssert(running_);
   ConcordAssertNE(replicaForStateTransfer_, nullptr);
   if (handoff_) handoff_->stop();

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -392,6 +392,7 @@ void BCStateTran::startRunning(IReplicaForStateTransfer *r) {
 
 void BCStateTran::stopRunning() {
   LOG_INFO(logger_, "");
+  if (cre_) cre_->stop();
   ConcordAssert(running_);
   ConcordAssertNE(replicaForStateTransfer_, nullptr);
   if (handoff_) handoff_->stop();
@@ -434,7 +435,6 @@ void BCStateTran::stopRunning() {
   ConcordAssert(ioPool_.full());
   totalSizeOfPendingItemDataMsgs = 0;
   replicaForStateTransfer_ = nullptr;
-  cre_->stop();
 }
 
 bool BCStateTran::isRunning() const { return running_; }

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -435,6 +435,7 @@ void BCStateTran::stopRunning() {
   ConcordAssert(ioPool_.full());
   totalSizeOfPendingItemDataMsgs = 0;
   replicaForStateTransfer_ = nullptr;
+  cre_->stop();
 }
 
 bool BCStateTran::isRunning() const { return running_; }
@@ -2700,7 +2701,6 @@ void BCStateTran::processData(bool lastInBatch) {
         // At this point, we, if are not going to have another blocks in state transfer. So, we can safely stop CRE.
         // if there is a reconfiguration state change that prevents us from starting another state transfer (i.e.
         // scaling) then CRE probably won't work as well.
-        LOG_INFO(logger_, "halting cre");
         // 1. First, make sure we handled the most recent available updates.
         concord::client::reconfiguration::PollBasedStateClient *pbc =
             (concord::client::reconfiguration::PollBasedStateClient *)(cre_->getStateClient());
@@ -2718,6 +2718,7 @@ void BCStateTran::processData(bool lastInBatch) {
             }
           }
         }
+        LOG_INFO(logger_, "halting cre");
         // 2. Now we can safely halt cre. We know for sure that there are no update in the state transffered blocks that
         // haven't been handled yet
         cre_->halt();

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -661,7 +661,7 @@ class BCStateTran : public IStateTransfer {
   AsyncTimeRecorder<false> src_send_batch_duration_rec_;
   AsyncTimeRecorder<false> dst_time_between_sendFetchBlocksMsg_rec_;
   AsyncTimeRecorder<false> time_in_handoff_queue_rec_;
-  std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> cre_;
+  std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> cre_ = nullptr;
 };  // class BCStateTran
 
 }  // namespace bftEngine::bcst::impl

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -179,7 +179,6 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
     }
     LOG_INFO(GL, "erasedMetaData flag = " << erasedMetaData);
     if (erasedMetaData) {
-      ConcordAssert(startNewEpoch == true);
       metadataStoragePtr->eraseData();
       isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);
       auto secFileDir = ReplicaConfig::instance().getkeyViewFilePath();
@@ -207,8 +206,6 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
   shared_ptr<bft::communication::IReceiver> msgReceiverPtr(new MsgReceiver(incomingMsgsStoragePtr));
   shared_ptr<MsgsCommunicator> msgsCommunicatorPtr(
       new MsgsCommunicator(communication, incomingMsgsStoragePtr, msgReceiverPtr));
-  stateTransfer->setReconfigurationEngine(
-      bftEngine::bcst::asyncCRE::CreFactory::create(msgsCommunicatorPtr, msgHandlersPtr));
   if (isNewStorage) {
     auto replicaImp = std::make_unique<ReplicaImp>(replicaConfig,
                                                    requestsHandler,
@@ -263,7 +260,6 @@ IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaC
   std::shared_ptr<IncomingMsgsStorage> incomingMsgsStorage{std::move(incomingMsgsStorageImpPtr)};
   auto msgReceiver = std::make_shared<MsgReceiver>(incomingMsgsStorage);
   auto msgsCommunicator = std::make_shared<MsgsCommunicator>(communication, incomingMsgsStorage, msgReceiver);
-  stateTransfer->setReconfigurationEngine(bftEngine::bcst::asyncCRE::CreFactory::create(msgsCommunicator, msgHandlers));
   replicaInternal->replica_ = std::make_unique<ReadOnlyReplica>(
       replicaConfig, requestsHandler, stateTransfer, msgsCommunicator, msgHandlers, timers);
   return replicaInternal;

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -41,6 +41,9 @@ ClientsManager::ClientsManager(const std::set<NodeIdType>& proxyClients,
       metric_reply_inconsistency_detected_{metrics_.RegisterCounter("totalReplyInconsistenciesDetected")},
       metric_removed_due_to_out_of_boundaries_{metrics_.RegisterCounter("totalRemovedDueToOutOfBoundaries")} {
   reservedPagesPerClient_ = reservedPagesPerClient(sizeOfReservedPage(), maxReplySize_);
+  for (NodeIdType i = 0; i < ReplicaConfig::instance().numReplicas + ReplicaConfig::instance().numRoReplicas; i++) {
+    clientIds_.insert(i);
+  }
   clientIds_.insert(proxyClients_.begin(), proxyClients_.end());
   clientIds_.insert(externalClients_.begin(), externalClients_.end());
   clientIds_.insert(internalClients_.begin(), internalClients_.end());
@@ -81,7 +84,6 @@ void ClientsManager::loadInfoFromReservedPages() {
     }
 
     if (!loadReservedPage(getReplyFirstPageId(clientId), sizeOfReservedPage(), scratchPage_.data())) continue;
-
     ClientReplyMsgHeader* replyHeader = (ClientReplyMsgHeader*)scratchPage_.data();
     ConcordAssert(replyHeader->msgType == 0 || replyHeader->msgType == MsgCode::ClientReply);
     ConcordAssert(replyHeader->currentPrimaryId == 0);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4229,7 +4229,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
           reqIdx++;
           continue;
         }
-        const bool validClient = isValidClient(clientId);
+        const bool validClient = isValidClient(clientId) || ((req.flags() & RECONFIG_FLAG) && isIdOfReplica(clientId));
         if (!validClient) {
           ++numInvalidClients;
           LOG_WARN(GL, "The client is not valid" << KVLOG(clientId));

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -88,7 +88,7 @@ bool ClientRequestMsg::isReadOnly() const { return (msgBody()->flags & READ_ONLY
 void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
   const auto* header = msgBody();
   PrincipalId clientId = header->idOfClientProxy;
-  ConcordAssert(this->senderId() != repInfo.myId());
+  if ((header->flags & RECONFIG_FLAG) == 0) ConcordAssert(this->senderId() != repInfo.myId());
   /// to do - should it be just the header?
   auto minMsgSize = sizeof(ClientRequestMsgHeader) + header->cidLength + spanContextSize() + header->reqSignatureLength;
   const auto msgSize = size();

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -78,7 +78,7 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
  private:
   concord::messages::ClientStateReply buildClientStateReply(kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type,
                                                             uint32_t clientid);
-  concord::messages::ClientStateReply buildReplicaStateReply(const char& command_type, uint32_t clientid);
+  concord::messages::ClientStateReply buildReplicaStateReply(const std::string& command_type, uint32_t clientid);
 };
 /**
  * This component is responsible for logging reconfiguration request (issued by an authorized operator) in the

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -194,13 +194,6 @@ bool StReconfigurationHandler::handleWedgeCommands(const T &cmd,
   if (my_last_known_epoch == command_epoch && my_last_known_epoch == last_known_global_epoch && cp_sn < wedge_point)
     return true;  // We still need to complete another state transfer
 
-  //  // If we reached to this point, we are defiantly going to run the addRemove command,
-  //  // so lets invoke all original reconfiguration handlers from the product layer (without concord-bft's ones)
-  //  concord::messages::ReconfigurationResponse response;
-  //  for (auto &h : orig_reconf_handlers_) {
-  //    h->handle(cmd, bft_seq_num, UINT32_MAX, std::nullopt, response);
-  //  }
-
   if (my_last_known_epoch < last_known_global_epoch) {
     // now, we cannot rely on the received sequence number (as it may be reused), we simply want to stop immediately
     auto fake_seq_num = cp_sn - 2 * checkpointWindowSize;

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -194,12 +194,12 @@ bool StReconfigurationHandler::handleWedgeCommands(const T &cmd,
   if (my_last_known_epoch == command_epoch && my_last_known_epoch == last_known_global_epoch && cp_sn < wedge_point)
     return true;  // We still need to complete another state transfer
 
-  // If we reached to this point, we are defiantly going to run the addRemove command,
-  // so lets invoke all original reconfiguration handlers from the product layer (without concord-bft's ones)
-  concord::messages::ReconfigurationResponse response;
-  for (auto &h : orig_reconf_handlers_) {
-    h->handle(cmd, bft_seq_num, UINT32_MAX, std::nullopt, response);
-  }
+  //  // If we reached to this point, we are defiantly going to run the addRemove command,
+  //  // so lets invoke all original reconfiguration handlers from the product layer (without concord-bft's ones)
+  //  concord::messages::ReconfigurationResponse response;
+  //  for (auto &h : orig_reconf_handlers_) {
+  //    h->handle(cmd, bft_seq_num, UINT32_MAX, std::nullopt, response);
+  //  }
 
   if (my_last_known_epoch < last_known_global_epoch) {
     // now, we cannot rely on the received sequence number (as it may be reused), we simply want to stop immediately

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -20,6 +20,7 @@
 
 namespace concord::reconfiguration {
 enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
+const static std::string configurationsFileName{"configurations"};
 // The IReconfigurationHandler interface defines all message handler. It is
 // tightly coupled with the messages inside ReconfigurationSmRequest in the
 // message definition.

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1597,7 +1597,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 await bft_network.wait_for_state_transfer_to_stop(initial_prim,
                                                                   r,
                                                                   stop_on_stable_seq_num=False)
-            live_replicas = live_replicas = bft_network.all_replicas(without=replicas_for_st)
+            live_replicas = bft_network.all_replicas(without=replicas_for_st)
             await self.validate_epoch_number(bft_network, 1, live_replicas)
 
             bft_network.start_replicas(replicas_for_st)


### PR DESCRIPTION
In this PR we address a fundamental issue with reconfiguration commands that change the network topology, remove metadata and/or restart.

Our initial approach was to rely on state transfer to get an update on such changes, while the leading quorum, commits the relevant update to the chain.
The main problem with this approach is that if the network's topology has changed, we cannot assume anything about the state-transfer's ability to complete the state transfer cycle (and hence get the update).
For example, if we scaled down from 7 to 4, the replica is state transfer is unable to complete the state transfer cycle (it needs at least 5 replicas for state transfer).

To solve this issue, we designed the state transfer CRE for executing reconfiguration commands asynchronously to state transfer compilation (see https://github.com/vmware/concord-bft/commit/89484a67ba56b68db8257ed9b555661e7bba7c16).
However, with scaling the procedure is a bit more complicated due to the following reasons:
1. We cannot execute the scaling command twice - meaning, that we need some way to mark which scaling command has already been executed.
2. In order to be able to start after the scaling, we need to remove the metadata, however, this may bring the replica to an inconsistent state once it completes the state transfer (mainly due to changes in reserved pages).

To overcome this issues we do the following:
1. We save in a dedicated file the new configuration ids. The reason why we don't use the same approach as a regular client (and save an update on the chain) is that the leading quorum will be probably wedged at this time and the state-transferred replica will not be able to update its status on the chain.
2. On state transfer compilation, the replica detect if there is some new configuration block (at this point, if there were some scaling command it was already executed by the replica's CRE). If there is such an update, the replica removes its metadata and restart itself in order to be consistent with the other replicas.

This PR also contains an Apollo test that demonstrates how this should work.
Notice that read-only replica scaling is not part of this PR.
