### PR TITLE
Demote SecretsManager's decrytFile error log to a warning (fix for false positive error log reports)

### DIFF
--- a/secretsmanager/src/secrets_manager_enc.cpp
+++ b/secretsmanager/src/secrets_manager_enc.cpp
@@ -54,7 +54,7 @@ std::optional<std::string> SecretsManagerEnc::decryptFile(std::string_view path)
   try {
     data = readFile(path);
   } catch (std::exception& e) {
-    LOG_ERROR(logger_, "Error opening file for reading " << path << ": " << e.what());
+    LOG_WARN(logger_, "Unable to open file for reading " << path << ": " << e.what());
     return std::nullopt;
   }
 

--- a/secretsmanager/src/secrets_manager_plain.cpp
+++ b/secretsmanager/src/secrets_manager_plain.cpp
@@ -34,7 +34,7 @@ std::optional<std::string> SecretsManagerPlain::decryptFile(std::string_view pat
   try {
     data = readFile(path);
   } catch (std::exception& e) {
-    LOG_ERROR(logger, "Error opening file for reading    " << path << ": " << e.what());
+    LOG_WARN(logger, "Unable to open file for reading    " << path << ": " << e.what());
     return std::nullopt;
   }
 


### PR DESCRIPTION
Change SecretsManager's decrytFile to log a warning 
instead of an error when failing to open a file.
This will fix false positive error log reports when all tests
have otherwise passed successfully.

Justification:
- a secrets file is not guaranteed to exist in some cases
(the replica starts from scratch or the file is not durable)
- the caller of decryptFile knows better if an empty decryptFile
result should be elevated to an error or there's an option
for recovery.