### PR TITLE
Added thread safe version of bft_client send request api

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -53,6 +53,10 @@ class Client {
   // Useful for testing. Shouldn't be relied on in production.
   std::optional<ReplicaId> primary() { return primary_; }
 
+  // thread safe version of send api
+  Reply sendThreadSafe(const WriteConfig& config, Msg&& request);
+  Reply sendThreadSafe(const ReadConfig& config, Msg&& request);
+
  private:
   // Generic function for sending a read or write message.
   Reply send(const MatchConfig& match_config, const RequestConfig& request_config, Msg&& request, bool read_only);
@@ -140,6 +144,7 @@ class Client {
   static constexpr uint32_t count_between_snapshots = 200;
   uint32_t snapshot_index_ = 0;
   std::unique_ptr<Recorders> histograms_;
+  std::mutex lock_;
 };
 
 }  // namespace bft::client

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -354,5 +354,12 @@ bool Client::isServing(int numOfReplicas, int requiredNumOfReplicas) const {
   }
   return false;
 }
-
+Reply Client::sendThreadSafe(const WriteConfig& config, Msg&& request) {
+  std::lock_guard<std::mutex> lg(lock_);
+  return send(config, std::move(request));
+}
+Reply Client::sendThreadSafe(const ReadConfig& config, Msg&& request) {
+  std::lock_guard<std::mutex> lg(lock_);
+  return send(config, std::move(request));
+}
 }  // namespace bft::client


### PR DESCRIPTION
Current api to send request to replicas is not thread safe. This PR adds the thread safe version of the api, which is required if any application calls send from mutiple threads.