### PR TITLE
Check fatal error logs only

### DIFF
--- a/.github/success_action_if_err_logs_exist.sh
+++ b/.github/success_action_if_err_logs_exist.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This script used to check if ERROR/FATAL logs are present in apollo replica logs.
+# This script used to check if FATAL logs are present in apollo replica logs.
 
 set -e
 
@@ -7,7 +7,7 @@ file_name=ReplicaErrorLogs.txt
 file_count=$(find ${1} -name $file_name | wc -l)
 
 if [[ $file_count -gt 0 ]]; then
-    echo -e "\033[31mERROR/FATAL logs found in below paths. Please check artifacts\033[m"
+    echo -e "\033[31mFATAL logs found in below paths. Please check artifacts\033[m"
     echo -e "$(find . -type f -name ReplicaErrorLogs.txt)"
 else 
     echo "File not found"

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -649,11 +649,11 @@ class BftTestNetwork:
 
     def check_error_logs(self):
         """
-        Checking ERROR/FATAL logs in replica logs and writing in a file.
+        Checking FATAL logs in replica logs and writing in a file.
         If the file exists for any testcase, warning is displayed in CI
         """
         with log.start_action(action_type="replica_log_scanner") as action:
-            cmd = ['grep', '-R', 'ERROR\|FATAL', '--exclude=ReplicaErrorLogs.txt']
+            cmd = ['grep', '-R', 'FATAL', '--exclude=ReplicaErrorLogs.txt']
             file_path = f"{self.test_dir}ReplicaErrorLogs.txt"
 
             with open(file_path, 'w+') as outfile:


### PR DESCRIPTION
Modify the workflow so that only fatal error logs
are exported to ReplicaErrorLog.txt and would
fail the build.