### PR TITLE
Re-transmit client requests from non primary replicas

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -60,6 +60,10 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   CONFIG_PARAM(numOfExternalClients, uint16_t, 0, "number of objects that represent external clients");
   CONFIG_PARAM(sizeOfInternalThreadPool, uint16_t, 8, "number of threads in the internal replica thread pool");
   CONFIG_PARAM(statusReportTimerMillisec, uint16_t, 0, "how often the replica sends a status report to other replicas");
+  CONFIG_PARAM(clientRequestRetransmissionTimerMilli,
+               uint16_t,
+               1000,
+               "how often the replica tries to retransmit client request received by non primary");
   CONFIG_PARAM(concurrencyLevel,
                uint16_t,
                0,

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -114,6 +114,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   std::queue<ClientRequestMsg*> requestsQueueOfPrimary;  // only used by the primary
   size_t primaryCombinedReqSize = 0;                     // only used by the primary
 
+  std::map<uint64_t, ClientRequestMsg*>
+      requestsOfNonPrimary;  // used to retransmit client requests by a non primary replica
+  size_t NonPrimaryCombinedReqSize = 1000;
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]
   typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo, 1, false> WindowOfSeqNumInfo;
@@ -164,6 +167,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concordUtil::Timers::Handle infoReqTimer_;
   concordUtil::Timers::Handle statusReportTimer_;
   concordUtil::Timers::Handle viewChangeTimer_;
+  concordUtil::Timers::Handle clientRequestsRetransmissionTimer_;
 
   int viewChangeTimerMilli = 0;
   int autoPrimaryRotationTimerMilli = 0;


### PR DESCRIPTION
When a non-primary replica gets a client request, it sends it to the current primary. However, if the primary is temporarily unavailable (due to TLS key exchange for example), the message will be lost.
In this PR we added functionality to retransmit the client's requests messages.