### PR TITLE
Add gRPC error codes

### DIFF
--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -63,6 +63,8 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
     return grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
   } catch (cc::ConcordClient::OutOfRangeSubscriptionRequest& e) {
     return grpc::Status(grpc::StatusCode::OUT_OF_RANGE, e.what());
+  } catch (cc::ConcordClient::InternalError& e) {
+    return grpc::Status(grpc::StatusCode::INTERNAL, e.what());
   }
 
   // TODO: Consider all gRPC return error codes as described in event.proto

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -57,13 +57,13 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
   std::shared_ptr<cc::UpdateQueue> update_queue = std::make_shared<cc::BasicUpdateQueue>();
   try {
     client_->subscribe(request, update_queue, span);
-  } catch (cc::ConcordClient::SubscriptionExists& e) {
+  } catch (cc::SubscriptionExists& e) {
     return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, e.what());
-  } catch (cc::ConcordClient::UpdateNotFound& e) {
+  } catch (cc::UpdateNotFound& e) {
     return grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
-  } catch (cc::ConcordClient::OutOfRangeSubscriptionRequest& e) {
+  } catch (cc::OutOfRangeSubscriptionRequest& e) {
     return grpc::Status(grpc::StatusCode::OUT_OF_RANGE, e.what());
-  } catch (cc::ConcordClient::InternalError& e) {
+  } catch (cc::InternalError& e) {
     return grpc::Status(grpc::StatusCode::INTERNAL, e.what());
   }
 

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -59,6 +59,10 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
     client_->subscribe(request, update_queue, span);
   } catch (cc::ConcordClient::SubscriptionExists& e) {
     return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, e.what());
+  } catch (cc::ConcordClient::UpdateNotFound& e) {
+    return grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
+  } catch (cc::ConcordClient::OutOfRangeSubscriptionRequest& e) {
+    return grpc::Status(grpc::StatusCode::OUT_OF_RANGE, e.what());
   }
 
   // TODO: Consider all gRPC return error codes as described in event.proto

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -165,6 +165,12 @@ class ConcordClient {
     OutOfRangeSubscriptionRequest() : std::runtime_error("out of range subscription request"){};
   };
 
+  // An internal error may occur, for example when max_agreeing
+  class InternalError : public std::runtime_error {
+   public:
+    InternalError() : std::runtime_error("an internal error occurred"){};
+  };
+
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
 

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -25,6 +25,7 @@
 #include "client/thin-replica-client/thin_replica_client.hpp"
 #include "client/client_pool/concord_client_pool.hpp"
 #include "client/concordclient/event_update_queue.hpp"
+#include "client/concordclient/concord_client_exceptions.hpp"
 #include "Metrics.hpp"
 
 namespace concord::client::concordclient {
@@ -145,31 +146,6 @@ class ConcordClient {
   // Note, if the caller doesn't unsubscribe and no runtime error occurs then resources
   // will be occupied forever.
   void unsubscribe();
-
-  // At the moment, we only allow one subscriber at a time. This exception is thrown if the caller subscribes while an
-  // active subscription is in progress already.
-  class SubscriptionExists : public std::runtime_error {
-   public:
-    SubscriptionExists() : std::runtime_error("subscription exists already"){};
-  };
-
-  // An ongoing subscription may request an update that has not yet been added to the blockchain
-  class UpdateNotFound : public std::runtime_error {
-   public:
-    UpdateNotFound() : std::runtime_error("requested update does not exist yet"){};
-  };
-
-  // A new subscription may request an out of range update
-  class OutOfRangeSubscriptionRequest : public std::runtime_error {
-   public:
-    OutOfRangeSubscriptionRequest() : std::runtime_error("out of range subscription request"){};
-  };
-
-  // An internal error may occur, for example when max_agreeing
-  class InternalError : public std::runtime_error {
-   public:
-    InternalError() : std::runtime_error("an internal error occurred"){};
-  };
 
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -153,6 +153,18 @@ class ConcordClient {
     SubscriptionExists() : std::runtime_error("subscription exists already"){};
   };
 
+  // An ongoing subscription may request an update that has not yet been added to the blockchain
+  class UpdateNotFound : public std::runtime_error {
+   public:
+    UpdateNotFound() : std::runtime_error("requested update does not exist yet"){};
+  };
+
+  // A new subscription may request an out of range update
+  class OutOfRangeSubscriptionRequest : public std::runtime_error {
+   public:
+    OutOfRangeSubscriptionRequest() : std::runtime_error("out of range subscription request"){};
+  };
+
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
 

--- a/client/concordclient/include/client/concordclient/concord_client_exceptions.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client_exceptions.hpp
@@ -1,0 +1,43 @@
+// Concord
+//
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+#include <stdexcept>
+
+#pragma once
+
+namespace concord::client::concordclient {
+
+// At the moment, we only allow one subscriber at a time. This exception is thrown if the caller subscribes while an
+// active subscription is in progress already.
+class SubscriptionExists : public std::runtime_error {
+ public:
+  SubscriptionExists() : std::runtime_error("subscription exists already"){};
+};
+
+// An ongoing subscription may request an update that has not yet been added to the blockchain
+class UpdateNotFound : public std::runtime_error {
+ public:
+  UpdateNotFound() : std::runtime_error("requested update does not exist yet"){};
+};
+
+// A new subscription may request an out of range update
+class OutOfRangeSubscriptionRequest : public std::runtime_error {
+ public:
+  OutOfRangeSubscriptionRequest() : std::runtime_error("out of range subscription request"){};
+};
+
+// An internal error may occur, for example when max_agreeing
+class InternalError : public std::runtime_error {
+ public:
+  InternalError() : std::runtime_error("an internal error occurred"){};
+};
+}  // namespace concord::client::concordclient

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -153,6 +153,8 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
       throw ConcordClient::UpdateNotFound();
     } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
       throw ConcordClient::OutOfRangeSubscriptionRequest();
+    } catch (ThinReplicaClient::InternalError& e) {
+      throw ConcordClient::InternalError();
     }
   } else if (std::holds_alternative<LegacyEventRequest>(sub_req.request)) {
     try {
@@ -161,6 +163,8 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
       throw ConcordClient::UpdateNotFound();
     } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
       throw ConcordClient::OutOfRangeSubscriptionRequest();
+    } catch (ThinReplicaClient::InternalError& e) {
+      throw ConcordClient::InternalError();
     }
   } else {
     ConcordAssert(false);

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -149,22 +149,22 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
     trc_request.event_group_id = std::get<EventGroupRequest>(sub_req.request).event_group_id;
     try {
       trc_->Subscribe(trc_request);
-    } catch (ThinReplicaClient::UpdateNotFound& e) {
-      throw ConcordClient::UpdateNotFound();
-    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
-      throw ConcordClient::OutOfRangeSubscriptionRequest();
-    } catch (ThinReplicaClient::InternalError& e) {
-      throw ConcordClient::InternalError();
+    } catch (UpdateNotFound& e) {
+      throw;
+    } catch (OutOfRangeSubscriptionRequest& e) {
+      throw;
+    } catch (InternalError& e) {
+      throw;
     }
   } else if (std::holds_alternative<LegacyEventRequest>(sub_req.request)) {
     try {
       trc_->Subscribe(std::get<LegacyEventRequest>(sub_req.request).block_id);
-    } catch (ThinReplicaClient::UpdateNotFound& e) {
-      throw ConcordClient::UpdateNotFound();
-    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
-      throw ConcordClient::OutOfRangeSubscriptionRequest();
-    } catch (ThinReplicaClient::InternalError& e) {
-      throw ConcordClient::InternalError();
+    } catch (UpdateNotFound& e) {
+      throw;
+    } catch (OutOfRangeSubscriptionRequest& e) {
+      throw;
+    } catch (InternalError& e) {
+      throw;
     }
   } else {
     ConcordAssert(false);

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -147,9 +147,21 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
   if (std::holds_alternative<EventGroupRequest>(sub_req.request)) {
     ::client::thin_replica_client::SubscribeRequest trc_request;
     trc_request.event_group_id = std::get<EventGroupRequest>(sub_req.request).event_group_id;
-    trc_->Subscribe(trc_request);
+    try {
+      trc_->Subscribe(trc_request);
+    } catch (ThinReplicaClient::UpdateNotFound& e) {
+      throw ConcordClient::UpdateNotFound();
+    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
+      throw ConcordClient::OutOfRangeSubscriptionRequest();
+    }
   } else if (std::holds_alternative<LegacyEventRequest>(sub_req.request)) {
-    trc_->Subscribe(std::get<LegacyEventRequest>(sub_req.request).block_id);
+    try {
+      trc_->Subscribe(std::get<LegacyEventRequest>(sub_req.request).block_id);
+    } catch (ThinReplicaClient::UpdateNotFound& e) {
+      throw ConcordClient::UpdateNotFound();
+    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
+      throw ConcordClient::OutOfRangeSubscriptionRequest();
+    }
   } else {
     ConcordAssert(false);
   }

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -251,7 +251,7 @@ class ThinReplicaClient final {
   // If none of the replicas return a hash update i.e., the connections to
   // all the replicas either time out or fail while waiting for an update,
   // findBlockHashAgreement returns false, otherwise returns true.
-  bool findBlockHashAgreement(std::vector<bool>& servers_tried,
+  void findBlockHashAgreement(std::vector<bool>& servers_tried,
                               HashRecordMap& agreeing_subset_members,
                               size_t& most_agreeing,
                               HashRecord& most_agreed_block,
@@ -431,7 +431,7 @@ class ThinReplicaClient final {
   // Register the callback to update external metrics
   void setMetricsCallback(const std::function<void(const ThinReplicaClientMetrics&)>& exposeAndSetMetrics);
 
-  // An ongoing subscription may request an update that has not yet been added to the blockchain
+  // A subscription may request a pruned update
   class UpdateNotFound : public std::runtime_error {
    public:
     UpdateNotFound() : std::runtime_error("requested update does not exist yet"){};
@@ -441,6 +441,13 @@ class ThinReplicaClient final {
   class OutOfRangeSubscriptionRequest : public std::runtime_error {
    public:
     OutOfRangeSubscriptionRequest() : std::runtime_error("out of range subscription request"){};
+  };
+
+  // An internal error can be thrown for e.g., when atleast 2f+1 replicas generate hash, and no f+1 replicas agree on a
+  // hash value
+  class InternalError : public std::runtime_error {
+   public:
+    InternalError() : std::runtime_error("an internal error occurred"){};
   };
 };
 

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -49,6 +49,7 @@
 #include <thread>
 #include "Logger.hpp"
 #include "client/concordclient/event_update_queue.hpp"
+#include "client/concordclient/concord_client_exceptions.hpp"
 
 namespace client::thin_replica_client {
 
@@ -430,25 +431,6 @@ class ThinReplicaClient final {
 
   // Register the callback to update external metrics
   void setMetricsCallback(const std::function<void(const ThinReplicaClientMetrics&)>& exposeAndSetMetrics);
-
-  // A subscription may request a pruned update
-  class UpdateNotFound : public std::runtime_error {
-   public:
-    UpdateNotFound() : std::runtime_error("requested update does not exist yet"){};
-  };
-
-  // A new subscription may request an out of range update
-  class OutOfRangeSubscriptionRequest : public std::runtime_error {
-   public:
-    OutOfRangeSubscriptionRequest() : std::runtime_error("out of range subscription request"){};
-  };
-
-  // An internal error can be thrown for e.g., when atleast 2f+1 replicas generate hash, and no f+1 replicas agree on a
-  // hash value
-  class InternalError : public std::runtime_error {
-   public:
-    InternalError() : std::runtime_error("an internal error occurred"){};
-  };
 };
 
 }  // namespace client::thin_replica_client

--- a/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
@@ -69,7 +69,7 @@ const int kGrpcMaxInboundMsgSizeInBytes = 1 << 24;
 class TrsConnection {
  public:
   // Possible results of RPC operations a TrsConnection may report.
-  enum class Result { kUnknown, kSuccess, kFailure, kTimeout };
+  enum class Result { kUnknown, kSuccess, kFailure, kTimeout, kOutOfRange, kNotFound };
 
   TrsConnection(const std::string& address,
                 const std::string& client_id,

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -34,6 +34,9 @@ using com::vmware::concord::thin_replica::SubscriptionRequest;
 using concord::client::concordclient::EventVariant;
 using concord::client::concordclient::EventGroup;
 using concord::client::concordclient::Update;
+using concord::client::concordclient::UpdateNotFound;
+using concord::client::concordclient::OutOfRangeSubscriptionRequest;
+using concord::client::concordclient::InternalError;
 using std::atomic_bool;
 using std::list;
 using std::logic_error;
@@ -730,13 +733,13 @@ ThinReplicaClient::~ThinReplicaClient() {
     ConcordAssert(subscription_thread_->joinable());
     try {
       subscription_thread_->join();
-    } catch (ThinReplicaClient::UpdateNotFound& e) {
+    } catch (UpdateNotFound& e) {
       std::string msg{"Subscription failed: Requested event group not found"};
       LOG_ERROR(logger_, msg);
-    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
+    } catch (OutOfRangeSubscriptionRequest& e) {
       std::string msg{"Subscription failed: Out of range subscription request"};
       LOG_ERROR(logger_, msg);
-    } catch (ThinReplicaClient::InternalError& e) {
+    } catch (InternalError& e) {
       std::string msg{"Subscription failed: Internal error"};
       LOG_ERROR(logger_, msg);
     }
@@ -760,15 +763,15 @@ void ThinReplicaClient::Subscribe() {
     ConcordAssert(subscription_thread_->joinable());
     try {
       subscription_thread_->join();
-    } catch (ThinReplicaClient::UpdateNotFound& e) {
+    } catch (UpdateNotFound& e) {
       std::string msg{"Subscription failed: Requested event group not found"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
+    } catch (OutOfRangeSubscriptionRequest& e) {
       std::string msg{"Subscription failed: Out of range subscription request"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::InternalError& e) {
+    } catch (InternalError& e) {
       std::string msg{"Subscription failed: Internal error"};
       LOG_ERROR(logger_, msg);
       throw;
@@ -963,15 +966,15 @@ void ThinReplicaClient::Subscribe(uint64_t block_id) {
     ConcordAssert(subscription_thread_->joinable());
     try {
       subscription_thread_->join();
-    } catch (ThinReplicaClient::UpdateNotFound& e) {
+    } catch (UpdateNotFound& e) {
       std::string msg{"Subscription failed: Requested update not found"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
+    } catch (OutOfRangeSubscriptionRequest& e) {
       std::string msg{"Subscription failed: Out of range subscription request"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::InternalError& e) {
+    } catch (InternalError& e) {
       std::string msg{"Subscription failed: Internal error"};
       LOG_ERROR(logger_, msg);
       throw;
@@ -997,15 +1000,15 @@ void ThinReplicaClient::Subscribe(const SubscribeRequest& req) {
     ConcordAssert(subscription_thread_->joinable());
     try {
       subscription_thread_->join();
-    } catch (ThinReplicaClient::UpdateNotFound& e) {
+    } catch (UpdateNotFound& e) {
       std::string msg{"Subscription failed: Requested update not found"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
+    } catch (OutOfRangeSubscriptionRequest& e) {
       std::string msg{"Subscription failed: Out of range subscription request"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::InternalError& e) {
+    } catch (InternalError& e) {
       std::string msg{"Subscription failed: Internal error"};
       LOG_ERROR(logger_, msg);
       throw;
@@ -1041,15 +1044,15 @@ void ThinReplicaClient::Unsubscribe() {
     ConcordAssert(subscription_thread_->joinable());
     try {
       subscription_thread_->join();
-    } catch (ThinReplicaClient::UpdateNotFound& e) {
+    } catch (UpdateNotFound& e) {
       std::string msg{"Subscription failed: Requested update not found"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::OutOfRangeSubscriptionRequest& e) {
+    } catch (OutOfRangeSubscriptionRequest& e) {
       std::string msg{"Subscription failed: Out of range subscription request"};
       LOG_ERROR(logger_, msg);
       throw;
-    } catch (ThinReplicaClient::InternalError& e) {
+    } catch (InternalError& e) {
       std::string msg{"Subscription failed: Internal error"};
       LOG_ERROR(logger_, msg);
       throw;

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -314,6 +314,11 @@ uint64_t KvbAppFilter::oldestTagSpecificPublicEventGroupId() {
   uint64_t public_oldest = getValueFromLatestTable(kPublicEgIdKeyOldest);
   uint64_t private_oldest = getValueFromLatestTable(client_id_ + "_oldest");
   if (!public_oldest && !private_oldest) return 0;
+  if (!public_oldest) return private_oldest;
+  if (!private_oldest) return public_oldest;
+  // Adding public and private gives you a tag-specific event group id including two query-able event groups
+  // (the oldest private and the oldest public).
+  // However, we are only interested in the oldest and not the second oldest. Hence, we have to subtract 1.
   return public_oldest + private_oldest - 1;
 }
 

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -1205,7 +1205,7 @@ TEST(thin_replica_server_test, SubscribeWithWrongBlockId) {
   request.mutable_events()->set_block_id(kLastBlockId + 100);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
-  EXPECT_EQ(status.error_code(), grpc::StatusCode::FAILED_PRECONDITION);
+  EXPECT_EQ(status.error_code(), grpc::StatusCode::OUT_OF_RANGE);
 }
 
 TEST(thin_replica_server_test, SubscribeWithWrongEventGroupId) {
@@ -1228,7 +1228,7 @@ TEST(thin_replica_server_test, SubscribeWithWrongEventGroupId) {
   request.mutable_event_groups()->set_event_group_id(kLastEventGroupId + 100);
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
-  EXPECT_EQ(status.error_code(), grpc::StatusCode::FAILED_PRECONDITION);
+  EXPECT_EQ(status.error_code(), grpc::StatusCode::OUT_OF_RANGE);
 }
 
 TEST(thin_replica_server_test, GetClientIdFromCertSubjectField) {

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -53,6 +53,7 @@ constexpr uint64_t kLastEventGroupId{5u};
 
 static inline const std::string kGlobalEgIdKey{"_global_eg_id"};
 static inline const std::string kPublicEgIdKey{"_public_eg_id"};
+static inline const std::string kClientId{"TEST_ID"};
 static inline const std::string kTagTableKeySeparator{"#"};
 
 Block generate_block(BlockId block_id) {
@@ -99,7 +100,7 @@ EventGroup generateEventGroup(EventGroupId eg_id, bool is_public) {
   // we are adding just one event per event group
   const std::string data = "val eg_id#" + std::to_string(eg_id);
   std::vector<std::string> trid_list = {};
-  if (!is_public) trid_list.emplace_back("TEST_ID");
+  if (!is_public) trid_list.emplace_back(kClientId);
   event.data = CreateTridKvbValue(data, trid_list);
   event.tags = trid_list;
   event_group.events.emplace_back(event);
@@ -267,10 +268,7 @@ class FakeStorage : public concord::kvbc::IReader {
     return {};
   }
 
-  BlockId getGenesisBlockId() const override {
-    ADD_FAILURE() << "get() should not be called by this test";
-    return 0;
-  }
+  BlockId getGenesisBlockId() const override { return genesis_block_id; }
 
   BlockId getLastBlockId() const override { return block_id_; }
   EventGroupId getLastEventGroupId() const { return eg_db_.size(); }
@@ -291,6 +289,14 @@ class FakeStorage : public concord::kvbc::IReader {
                         << concordUtils::fromBigEndianBuffer<uint64_t>(latest_table[key + "_oldest"].data())
                         << ", _newest: " << latest_id);
     }
+  }
+
+  void updateLatestTableAfterPruning(const std::string& key, uint64_t id) {
+    // ensure that the category being updated had corresponding updates in the first place
+    ConcordAssert(!latest_table[key + "_oldest"].empty());
+    // the updated eg_id will always be greater than previous eg_id
+    ConcordAssertGT(id, concordUtils::fromBigEndianBuffer<uint64_t>(latest_table[key + "_oldest"].data()));
+    latest_table[key + "_oldest"] = concordUtils::toBigEndianStringBuffer(id);
   }
 
   void updateTagTable(const std::string& trid, const uint64_t global_event_group_id) {
@@ -326,6 +332,9 @@ class FakeStorage : public concord::kvbc::IReader {
     }
   }
 
+ public:
+  BlockId genesis_block_id{0};
+
  private:
   BlockMap db_;
   BlockId block_id_{0};
@@ -339,7 +348,7 @@ class FakeStorage : public concord::kvbc::IReader {
 };
 
 class TestServerContext {
-  std::multimap<std::string, std::string> metadata_ = {{"client_id", "TEST_ID"}};
+  std::multimap<std::string, std::string> metadata_ = {{"client_id", kClientId}};
 
   class AuthContext {
    public:
@@ -565,6 +574,7 @@ class TestSubBufferList : public concord::thin_replica::SubBufferList {
 
 TEST(thin_replica_server_test, SubscribeToUpdatesAlreadySynced) {
   FakeStorage storage{generate_kvp(1, kLastBlockId)};
+  storage.genesis_block_id = 1;
   EXPECT_EQ(storage.getLastBlockId(), 5);
   auto live_update_blocks = generate_kvp(kLastBlockId + 1, kLastBlockId + 5);
   TestStateMachine<Data> state_machine{storage, live_update_blocks, 1};
@@ -664,6 +674,7 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesAlrea
 
 TEST(thin_replica_server_test, SubscribeToUpdatesWithGap) {
   FakeStorage storage{generate_kvp(1, kLastBlockId)};
+  storage.genesis_block_id = 1;
   auto live_update_blocks = generate_kvp(kLastBlockId + 2, kLastBlockId + 5);
   TestStateMachine<Data> state_machine{storage, live_update_blocks, 1};
   TestSubBufferList<Data> buffer{state_machine};
@@ -762,6 +773,7 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithG
 
 TEST(thin_replica_server_test, SubscribeToUpdatesWithGapFromTheMiddleBlock) {
   FakeStorage storage{generate_kvp(1, kLastBlockId)};
+  storage.genesis_block_id = 1;
   auto live_update_blocks = generate_kvp(kLastBlockId + 2, kLastBlockId + 5);
   TestStateMachine<Data> state_machine{storage, live_update_blocks, 3};
   TestSubBufferList<Data> buffer{state_machine};
@@ -860,6 +872,7 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithG
 
 TEST(thin_replica_server_test, SubscribeToUpdateHashesAlreadySynced) {
   FakeStorage storage{generate_kvp(1, kLastBlockId)};
+  storage.genesis_block_id = 1;
   auto live_update_blocks = generate_kvp(kLastBlockId + 1, kLastBlockId + 5);
   TestStateMachine<Hash> state_machine{storage, live_update_blocks, 1};
   TestSubBufferList<Hash> buffer{state_machine};
@@ -958,6 +971,7 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashes
 
 TEST(thin_replica_server_test, SubscribeToUpdateHashesWithGap) {
   FakeStorage storage{generate_kvp(1, kLastBlockId)};
+  storage.genesis_block_id = 1;
   auto live_update_blocks = generate_kvp(kLastBlockId + 2, kLastBlockId + 5);
   TestStateMachine<Hash> state_machine{storage, live_update_blocks, 1};
   TestSubBufferList<Hash> buffer{state_machine};
@@ -1056,6 +1070,7 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashes
 
 TEST(thin_replica_server_test, ReadState) {
   FakeStorage storage{generate_kvp(1, kLastBlockId)};
+  storage.genesis_block_id = 1;
   auto live_update_blocks = generate_kvp(0, 0);
   TestStateMachine<Data> state_machine{storage, live_update_blocks, 1};
   state_machine.set_expected_last_block_to_send(kLastBlockId);
@@ -1079,6 +1094,7 @@ TEST(thin_replica_server_test, ReadState) {
 
 TEST(thin_replica_server_test, ReadStateHash) {
   FakeStorage storage{generate_kvp(1, kLastBlockId)};
+  storage.genesis_block_id = 1;
   auto live_update_blocks = generate_kvp(0, 0);
   TestStateMachine<Hash> state_machine{storage, live_update_blocks, 0u};
   state_machine.set_expected_last_block_to_send(0u);
@@ -1185,7 +1201,7 @@ TEST(thin_replica_server_test, ContextWithoutClientIdData) {
   EXPECT_EQ(status.error_code(), grpc::StatusCode::UNKNOWN);
 }
 
-TEST(thin_replica_server_test, SubscribeWithWrongBlockId) {
+TEST(thin_replica_server_test, SubscribeWithOutOfRangeBlockId) {
   FakeStorage storage{generate_kvp(0, 0)};
   auto live_update_blocks = generate_kvp(0, 0);
   TestStateMachine<Data> state_machine{storage, live_update_blocks, 1};
@@ -1208,7 +1224,7 @@ TEST(thin_replica_server_test, SubscribeWithWrongBlockId) {
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OUT_OF_RANGE);
 }
 
-TEST(thin_replica_server_test, SubscribeWithWrongEventGroupId) {
+TEST(thin_replica_server_test, SubscribeWithOutOfRangeEventGroupId) {
   FakeStorage storage(generateEventGroupMap(0, 0, EventGroupType::PrivateEventGroupsOnly));
   auto live_update_event_groups = generateEventGroupMap(0, 0, EventGroupType::PrivateEventGroupsOnly);
   TestStateMachine<Data> state_machine{storage, live_update_event_groups, 1};
@@ -1229,6 +1245,103 @@ TEST(thin_replica_server_test, SubscribeWithWrongEventGroupId) {
   auto status =
       replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
   EXPECT_EQ(status.error_code(), grpc::StatusCode::OUT_OF_RANGE);
+}
+
+TEST(thin_replica_server_test, SubscribeWithPrunedBlockId) {
+  FakeStorage storage{generate_kvp(1, 10)};
+  storage.genesis_block_id = 5;
+  auto live_update_blocks = generate_kvp(0, 0);
+  TestStateMachine<Data> state_machine{storage, live_update_blocks, 1};
+  TestSubBufferList<Data> buffer{state_machine};
+  TestServerWriter<Data> stream{state_machine};
+
+  bool is_insecure_trs = true;
+  std::string tls_trs_cert_path;
+  std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
+
+  TestServerContext context;
+  auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
+  SubscriptionRequest request;
+  request.mutable_events()->set_block_id(1);
+  auto status =
+      replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
+  EXPECT_EQ(status.error_code(), grpc::StatusCode::NOT_FOUND);
+}
+
+TEST(thin_replica_server_test, SubscribeWithPrunedEventGroupIdPrivate) {
+  FakeStorage storage(generateEventGroupMap(1, 10, EventGroupType::PrivateEventGroupsOnly));
+  storage.updateLatestTableAfterPruning(kClientId, 5);
+  auto live_update_event_groups = generateEventGroupMap(0, 0, EventGroupType::PrivateEventGroupsOnly);
+  TestStateMachine<Data> state_machine{storage, live_update_event_groups, 1};
+  TestSubBufferList<Data> buffer{state_machine};
+  TestServerWriter<Data> stream{state_machine};
+
+  bool is_insecure_trs = true;
+  std::string tls_trs_cert_path;
+  std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
+
+  TestServerContext context;
+  auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
+  SubscriptionRequest request;
+  request.mutable_event_groups()->set_event_group_id(1);
+  auto status =
+      replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
+  EXPECT_EQ(status.error_code(), grpc::StatusCode::NOT_FOUND);
+}
+
+TEST(thin_replica_server_test, SubscribeWithPrunedEventGroupIdPublic) {
+  FakeStorage storage(generateEventGroupMap(1, 10, EventGroupType::PublicEventGroupsOnly));
+  storage.updateLatestTableAfterPruning(kPublicEgIdKey, 5);
+  auto live_update_event_groups = generateEventGroupMap(0, 0, EventGroupType::PublicEventGroupsOnly);
+  TestStateMachine<Data> state_machine{storage, live_update_event_groups, 1};
+  TestSubBufferList<Data> buffer{state_machine};
+  TestServerWriter<Data> stream{state_machine};
+
+  bool is_insecure_trs = true;
+  std::string tls_trs_cert_path;
+  std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
+
+  TestServerContext context;
+  auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
+  SubscriptionRequest request;
+  request.mutable_event_groups()->set_event_group_id(1);
+  auto status =
+      replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
+  EXPECT_EQ(status.error_code(), grpc::StatusCode::NOT_FOUND);
+}
+
+TEST(thin_replica_server_test, SubscribeWithPrunedEventGroupIdPublicAndPrivate) {
+  FakeStorage storage(generateEventGroupMap(1, 10, EventGroupType::PublicAndPrivateEventGroups));
+  storage.updateLatestTableAfterPruning(kPublicEgIdKey, 2);
+  storage.updateLatestTableAfterPruning(kClientId, 3);
+  auto live_update_event_groups = generateEventGroupMap(0, 0, EventGroupType::PublicAndPrivateEventGroups);
+  TestStateMachine<Data> state_machine{storage, live_update_event_groups, 1};
+  TestSubBufferList<Data> buffer{state_machine};
+  TestServerWriter<Data> stream{state_machine};
+
+  bool is_insecure_trs = true;
+  std::string tls_trs_cert_path;
+  std::unordered_set<std::string> client_id_set;
+  uint16_t update_metrics_aggregator_thresh = 100;
+
+  TestServerContext context;
+  auto trs_config = std::make_unique<concord::thin_replica::ThinReplicaServerConfig>(
+      is_insecure_trs, tls_trs_cert_path, &storage, buffer, client_id_set, update_metrics_aggregator_thresh);
+  concord::thin_replica::ThinReplicaImpl replica(std::move(trs_config), std::make_shared<concordMetrics::Aggregator>());
+  SubscriptionRequest request;
+  request.mutable_event_groups()->set_event_group_id(1);
+  auto status =
+      replica.SubscribeToUpdates<TestServerContext, TestServerWriter<Data>, Data>(&context, &request, &stream);
+  EXPECT_EQ(status.error_code(), grpc::StatusCode::NOT_FOUND);
 }
 
 TEST(thin_replica_server_test, GetClientIdFromCertSubjectField) {


### PR DESCRIPTION
This commit updates TRC/TRS/CC/CS to support gRPC error codes of OUT_OF_RANGE, NOT_FOUND and INTERNAL. Please see individual commits for more detail.
The unit tests will be added in a follow-up PR.