### PR TITLE
Allow TLS support for TRS-TRC via Clientservice

### DIFF
--- a/client/clientservice/CMakeLists.txt
+++ b/client/clientservice/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(clientservice-lib PUBLIC
   gRPC::grpc++_reflection
   logging
   yaml-cpp
+  secret_retriever
 )
 
 add_executable(clientservice "src/main.cpp")

--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -26,6 +26,7 @@ void parseConfigFile(concord::client::concordclient::ConcordClientConfig&, const
 void configureSubscription(concord::client::concordclient::ConcordClientConfig&,
                            const std::string& tr_id,
                            bool insecure,
-                           const std::string& tls_path);
+                           const std::string& tls_path,
+                           const std::string& secrets_url);
 
 }  // namespace concord::client::clientservice

--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -29,6 +29,10 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig&,
                            const std::string& tls_path,
                            const std::string& secrets_url);
 
+void configureTransport(concord::client::concordclient::ConcordClientConfig& config,
+                        bool is_insecure,
+                        const std::string& tls_path);
+
 const std::string decryptPrivateKey(const std::optional<std::string>& secrets_url, const std::string& path);
 
 // This method reads certificates from file

--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -31,7 +31,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig&,
 
 const std::string decryptPrivateKey(const std::optional<std::string>& secrets_url, const std::string& path);
 
-// This method reads certificates from file if TLS is enabled
+// This method reads certificates from file
 void readCert(const std::string& input_filename, std::string& out_data);
 
 // This method gets the client_id from the OU field in the client certificate

--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -29,7 +29,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig&,
                            const std::string& tls_path,
                            const std::string& secrets_url);
 
-const std::string decryptPK(const std::optional<std::string>& secrets_url, const std::string& path);
+const std::string decryptPrivateKey(const std::optional<std::string>& secrets_url, const std::string& path);
 
 // This method reads certificates from file if TLS is enabled
 void readCert(const std::string& input_filename, std::string& out_data);

--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -29,4 +29,16 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig&,
                            const std::string& tls_path,
                            const std::string& secrets_url);
 
+const std::string decryptPK(const std::optional<std::string>& secrets_url, const std::string& path);
+
+// This method reads certificates from file if TLS is enabled
+void readCert(const std::string& input_filename, std::string& out_data);
+
+// This method gets the client_id from the OU field in the client certificate
+std::string getClientIdFromClientCert(const std::string& client_cert_path);
+
+// This method is used by getClientIdFromClientCert to get the client_id from
+// the subject in the client certificate
+std::string parseClientIdFromSubject(const std::string& subject_str);
+
 }  // namespace concord::client::clientservice

--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -27,7 +27,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig&,
                            const std::string& tr_id,
                            bool insecure,
                            const std::string& tls_path,
-                           const std::string& secrets_url);
+                           const std::optional<std::string>& secrets_url);
 
 void configureTransport(concord::client::concordclient::ConcordClientConfig& config,
                         bool is_insecure,

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -16,6 +16,9 @@
 #include <sstream>
 
 #include "assertUtils.hpp"
+#include "secret_retriever.hpp"
+#include "secrets_manager_enc.h"
+#include "secrets_manager_plain.h"
 #include "client/clientservice/client_service.hpp"
 
 using concord::client::concordclient::ConcordClientConfig;
@@ -142,7 +145,8 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
 void configureSubscription(concord::client::concordclient::ConcordClientConfig& config,
                            const std::string& tr_id,
                            bool is_insecure,
-                           const std::string& tls_path) {
+                           const std::string& tls_path,
+                           const std::string& secrets_url) {
   config.subscribe_config.id = tr_id;
   config.subscribe_config.use_tls = not is_insecure;
 

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -158,7 +158,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
     readCert(client_cert_path, config.subscribe_config.pem_cert_chain);
 
     config.subscribe_config.pem_private_key =
-        decryptPK(config.subscribe_config.secrets_url, config.subscribe_config.trsc_tls_cert_path);
+        decryptPrivateKey(config.subscribe_config.secrets_url, config.subscribe_config.trsc_tls_cert_path);
 
     config.subscribe_config.id_from_cert = getClientIdFromClientCert(client_cert_path);
 
@@ -173,7 +173,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
   config.transport.event_pem_certs = "";
 }
 
-const std::string decryptPK(const std::optional<std::string>& secrets_url, const std::string& path) {
+const std::string decryptPrivateKey(const std::optional<std::string>& secrets_url, const std::string& path) {
   std::string pkpath;
   std::unique_ptr<concord::secretsmanager::ISecretsManagerImpl> secrets_manager;
   if (secrets_url) {

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -176,16 +176,19 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
                                ") does not match the client ID in the environment variable (" +
                                config.subscribe_config.id + ").");
     }
-
-    const std::string server_cert_path = tls_path + "/server.cert";
-    for (const auto& replica : config.topology.replicas) {
-      // server_cert_path specifies the path to a composite cert file i.e., a
-      // concatentation of the certificates of all known servers
-      readCert(server_cert_path, config.subscribe_config.root_cert_chain_map[replica.id.val]);
-    }
   }
-  // TODO: Read TLS certs for this TRC instance
-  config.transport.event_pem_certs = "";
+}
+
+void configureTransport(concord::client::concordclient::ConcordClientConfig& config,
+                        bool is_insecure,
+                        const std::string& tls_path) {
+  if (not is_insecure) {
+    const std::string server_cert_path = tls_path + "/server.cert";
+    // read server TLS certs for this TRC instance
+    // server_cert_path specifies the path to a composite cert file i.e., a
+    // concatentation of the certificates of all known servers
+    readCert(server_cert_path, config.transport.event_pem_certs);
+  }
 }
 
 const std::string decryptPrivateKey(const std::optional<std::string>& secrets_url, const std::string& path) {

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -146,7 +146,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
                            const std::string& tr_id,
                            bool is_insecure,
                            const std::string& tls_path,
-                           const std::string& secrets_url) {
+                           const std::optional<std::string>& secrets_url) {
   config.subscribe_config.id = tr_id;
   config.subscribe_config.use_tls = not is_insecure;
 

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -54,8 +54,8 @@ po::variables_map parseCmdLine(int argc, char** argv) {
     ("tr-id", po::value<std::string>()->required(), "ID used to subscribe to replicas for data/hashes")
     ("tr-insecure", po::value<bool>()->default_value(false), "Testing only: Allow insecure connection with TRS on replicas")
     ("tr-tls-path", po::value<std::string>()->default_value(""), "Path to thin replica TLS certificates")
-    ("secrets-url", po::value<std::string>()->default_value(""), "URL to decrypt private keys")
     ("metrics-port", po::value<int>()->default_value(9891), "Prometheus port to query clientservice metrics")
+    ("secrets-url", po::value<std::string>(), "URL to decrypt private keys")
     ("jaeger", po::value<std::string>(), "Push trace data to this Jaeger Agent")
   ;
   // clang-format on
@@ -127,11 +127,13 @@ int main(int argc, char** argv) {
   try {
     auto yaml = YAML::LoadFile(opts["config"].as<std::string>());
     parseConfigFile(config, yaml);
+    const std::optional<std::string>& secrets_url =
+        opts.count("secrets-url") ? opts["secrets-url"].as<std::optional<std::string>>() : std::nullopt;
     configureSubscription(config,
                           opts["tr-id"].as<std::string>(),
                           opts["tr-insecure"].as<bool>(),
                           opts["tr-tls-path"].as<std::string>(),
-                          opts["secrets-url"].as<std::string>());
+                          secrets_url);
     configureTransport(config, opts["tr-insecure"].as<bool>(), opts["tr-tls-path"].as<std::string>());
   } catch (std::exception& e) {
     LOG_ERROR(logger, "Failed to configure ConcordClient: " << e.what());

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -53,6 +53,7 @@ po::variables_map parseCmdLine(int argc, char** argv) {
     ("tr-id", po::value<std::string>()->required(), "ID used to subscribe to replicas for data/hashes")
     ("tr-insecure", po::value<bool>()->default_value(false), "Testing only: Allow insecure connection with TRS on replicas")
     ("tr-tls-path", po::value<std::string>()->default_value(""), "Path to thin replica TLS certificates")
+    ("secrets-url", po::value<std::string>()->default_value(""), "URL to decrypt private keys")
     ("metrics-port", po::value<int>()->default_value(9891), "Prometheus port to query clientservice metrics")
     ("jaeger", po::value<std::string>(), "Push trace data to this Jaeger Agent")
   ;
@@ -125,8 +126,11 @@ int main(int argc, char** argv) {
   try {
     auto yaml = YAML::LoadFile(opts["config"].as<std::string>());
     parseConfigFile(config, yaml);
-    configureSubscription(
-        config, opts["tr-id"].as<std::string>(), opts["tr-insecure"].as<bool>(), opts["tr-tls-path"].as<std::string>());
+    configureSubscription(config,
+                          opts["tr-id"].as<std::string>(),
+                          opts["tr-insecure"].as<bool>(),
+                          opts["tr-tls-path"].as<std::string>(),
+                          opts["secrets-url"].as<std::string>());
   } catch (std::exception& e) {
     LOG_ERROR(logger, "Failed to configure ConcordClient: " << e.what());
     return 1;

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -27,6 +27,7 @@
 
 using concord::client::clientservice::ClientService;
 using concord::client::clientservice::configureSubscription;
+using concord::client::clientservice::configureTransport;
 using concord::client::clientservice::parseConfigFile;
 
 using concord::client::concordclient::ConcordClient;
@@ -131,6 +132,7 @@ int main(int argc, char** argv) {
                           opts["tr-insecure"].as<bool>(),
                           opts["tr-tls-path"].as<std::string>(),
                           opts["secrets-url"].as<std::string>());
+    configureTransport(config, opts["tr-insecure"].as<bool>(), opts["tr-tls-path"].as<std::string>());
   } catch (std::exception& e) {
     LOG_ERROR(logger, "Failed to configure ConcordClient: " << e.what());
     return 1;

--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -5,6 +5,7 @@ target_link_libraries(concordclient PUBLIC
   thin_replica_client_lib
   concord_client_pool
   concordclient-event-api
+  secret_retriever
   util
 )
 

--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -5,7 +5,6 @@ target_link_libraries(concordclient PUBLIC
   thin_replica_client_lib
   concord_client_pool
   concordclient-event-api
-  secret_retriever
   util
 )
 

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -80,7 +80,7 @@ struct TransportConfig {
   // TLS settings ignored if comm_type is not TlsTcp
   std::string tls_cert_root_path;
   std::string tls_cipher_suite;
-  // Buffer with the servers' PEM encoded certififactes for the event port
+  // Buffer with the servers' PEM encoded certificates for the event port
   std::string event_pem_certs;
 };
 
@@ -93,8 +93,6 @@ struct SubscribeConfig {
   std::string pem_cert_chain;
   // Buffer with the client's PEM encoded private key
   std::string pem_private_key;
-  // Map with replica ID as key and buffer with the servers' PEM encoded certificates for the host as value
-  std::unordered_map<uint16_t, std::string> root_cert_chain_map;
 };
 
 struct ConcordClientConfig {

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -97,6 +97,10 @@ struct SubscribeConfig {
   std::string pem_cert_chain;
   // Buffer with the client's PEM encoded private key
   std::string pem_private_key;
+  // TRC ID obtained from OU field in pem_cert_chain
+  std::string id_from_cert;
+  // Map with replica ID as key and buffer with the servers' PEM encoded certificates for the host as value
+  std::unordered_map<uint16_t, std::string> root_cert_chain_map;
 };
 
 struct ConcordClientConfig {
@@ -159,18 +163,6 @@ class ConcordClient {
 
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
-
-  const std::string decryptPK(const std::optional<std::string>& secrets_url, const std::string& path);
-
-  // This method reads certificates from file if TLS is enabled
-  void readCert(const std::string& input_filename, std::string& out_data);
-
-  // This method gets the client_id from the OU field in the client certificate
-  std::string getClientIdFromClientCert(const std::string& client_cert_path);
-
-  // This method is used by getClientIdFromClientCert to get the client_id from
-  // the subject in the client certificate
-  std::string parseClientIdFromSubject(const std::string& subject_str);
 
   logging::Logger logger_;
   const ConcordClientConfig& config_;

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -91,6 +91,8 @@ struct SubscribeConfig {
   bool use_tls;
   // TRC/S certificate path
   std::string trsc_tls_cert_path;
+  // URL used to decrypt private keys
+  std::string secrets_url;
   // Buffer with the client's PEM encoded certififacte chain
   std::string pem_cert_chain;
   // Buffer with the client's PEM encoded private key
@@ -157,6 +159,8 @@ class ConcordClient {
 
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
+
+  const std::string decryptPK(const std::optional<std::string>& secrets_url, const std::string& path);
 
   // This method reads certificates from file if TLS is enabled
   void readCert(const std::string& input_filename, std::string& out_data);

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -89,10 +89,6 @@ struct SubscribeConfig {
   std::string id;
   // If set to false then all certificates related to subscription will be ignored
   bool use_tls;
-  // TRC/S certificate path
-  std::string trsc_tls_cert_path;
-  // URL used to decrypt private keys
-  std::string secrets_url;
   // Buffer with the client's PEM encoded certififacte chain
   std::string pem_cert_chain;
   // Buffer with the client's PEM encoded private key

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -89,6 +89,8 @@ struct SubscribeConfig {
   std::string id;
   // If set to false then all certificates related to subscription will be ignored
   bool use_tls;
+  // TRC/S certificate path
+  std::string trsc_tls_cert_path;
   // Buffer with the client's PEM encoded certififacte chain
   std::string pem_cert_chain;
   // Buffer with the client's PEM encoded private key

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -155,6 +155,17 @@ class ConcordClient {
 
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
+
+  // This method reads certificates from file if TLS is enabled
+  void readCert(const std::string& input_filename, std::string& out_data);
+
+  // This method gets the client_id from the OU field in the client certificate
+  std::string getClientIdFromClientCert(const std::string& client_cert_path);
+
+  // This method is used by getClientIdFromClientCert to get the client_id from
+  // the subject in the client certificate
+  std::string parseClientIdFromSubject(const std::string& subject_str);
+
   logging::Logger logger_;
   const ConcordClientConfig& config_;
   std::shared_ptr<concordMetrics::Aggregator> metrics_;

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -93,8 +93,6 @@ struct SubscribeConfig {
   std::string pem_cert_chain;
   // Buffer with the client's PEM encoded private key
   std::string pem_private_key;
-  // TRC ID obtained from OU field in pem_cert_chain
-  std::string id_from_cert;
   // Map with replica ID as key and buffer with the servers' PEM encoded certificates for the host as value
   std::unordered_map<uint16_t, std::string> root_cert_chain_map;
 };

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -132,11 +132,12 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
 
     // TODO: Adapt TRC API to support PEM buffers
     if (config_.subscribe_config.use_tls) {
-      std::string trs_tls_cert_path = "";
       std::string trc_tls_key = "";
-      LOG_INFO(logger_, "TLS for thin replica client is enabled, certificate path: " << trs_tls_cert_path);
-      const std::string client_cert_path = trs_tls_cert_path + "/client.cert";
-      const std::string server_cert_path = trs_tls_cert_path + "/server.cert";
+      LOG_INFO(
+          logger_,
+          "TLS for thin replica client is enabled, certificate path: " << config_.subscribe_config.trsc_tls_cert_path);
+      const std::string client_cert_path = config_.subscribe_config.trsc_tls_cert_path + "/client.cert";
+      const std::string server_cert_path = config_.subscribe_config.trsc_tls_cert_path + "/server.cert";
 
       std::string trc_cert, root_cert;
       readCert(client_cert_path, trc_cert);

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -13,9 +13,6 @@
 #include <thread>
 
 #include "assertUtils.hpp"
-#include "secret_retriever.hpp"
-#include "secrets_manager_enc.h"
-#include "secrets_manager_plain.h"
 #include "client/concordclient/concord_client.hpp"
 #include "client/thin-replica-client/thin_replica_client.hpp"
 
@@ -134,28 +131,12 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
     auto trsc = std::make_unique<TrsConnection>(addr, config_.subscribe_config.id, /* TODO */ 3, /* TODO */ 3);
 
     // TODO: Adapt TRC API to support PEM buffers
-    if (config_.subscribe_config.use_tls) {
-      std::string trc_tls_key =
-          decryptPK(config_.subscribe_config.secrets_url, config_.subscribe_config.trsc_tls_cert_path);
-      LOG_INFO(
-          logger_,
-          "TLS for thin replica client is enabled, certificate path: " << config_.subscribe_config.trsc_tls_cert_path);
-      const std::string client_cert_path = config_.subscribe_config.trsc_tls_cert_path + "/client.cert";
-      const std::string server_cert_path = config_.subscribe_config.trsc_tls_cert_path + "/server.cert";
-
-      std::string trc_cert, root_cert;
-      readCert(client_cert_path, trc_cert);
-
-      // server_cert_path specifies the path to a composite cert file i.e., a
-      // concatentation of the certificates of all known servers
-      readCert(server_cert_path, root_cert);
-
-      std::string cert_trc_id = getClientIdFromClientCert(client_cert_path);
-      trsc_config = std::make_unique<TrsConnectionConfig>(
-          config_.subscribe_config.use_tls, trc_tls_key, trc_cert, root_cert, cert_trc_id);
-    } else {
-      trsc_config = std::make_unique<TrsConnectionConfig>(config_.subscribe_config.use_tls);
-    }
+    auto trsc_config =
+        std::make_unique<TrsConnectionConfig>(config_.subscribe_config.use_tls,
+                                              config_.subscribe_config.pem_private_key,
+                                              config_.subscribe_config.pem_cert_chain,
+                                              config_.subscribe_config.root_cert_chain_map.at(replica.id.val),
+                                              config_.subscribe_config.id_from_cert);
 
     trsc->connect(trsc_config);
     trs_connections.push_back(std::move(trsc));
@@ -174,91 +155,6 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
   } else {
     ConcordAssert(false);
   }
-}
-
-const std::string ConcordClient::decryptPK(const std::optional<std::string>& secrets_url, const std::string& path) {
-  std::string pkpath;
-  std::unique_ptr<concord::secretsmanager::ISecretsManagerImpl> secrets_manager;
-  if (secrets_url) {
-    auto secret_data = concord::secretsmanager::secretretriever::retrieveSecret(*secrets_url);
-    pkpath = path + "/pk.pem.enc";
-    secrets_manager.reset(new concord::secretsmanager::SecretsManagerEnc(secret_data));
-  } else {
-    pkpath = path + "/pk.pem";
-    secrets_manager.reset(new concord::secretsmanager::SecretsManagerPlain());
-  }
-
-  auto decrypted_data = secrets_manager->decryptFile(pkpath);
-  if (!decrypted_data) {
-    throw std::runtime_error("Error loading " + pkpath);
-  }
-
-  return *decrypted_data;
-}
-
-void ConcordClient::readCert(const std::string& input_filename, std::string& out_data) {
-  std::ifstream input_file(input_filename.c_str(), std::ios::in);
-
-  if (!input_file.is_open()) {
-    LOG_FATAL(logger_, "Failed to construct concord client.");
-    throw std::runtime_error(__PRETTY_FUNCTION__ + std::string(": Could not open the input file (") + input_filename +
-                             std::string(") to establish TLS connection with the thin replica server."));
-  } else {
-    try {
-      std::stringstream read_buffer;
-      read_buffer << input_file.rdbuf();
-      input_file.close();
-      out_data = read_buffer.str();
-      LOG_INFO(logger_, "Successfully loaded the contents of " + input_filename);
-    } catch (std::exception& e) {
-      LOG_FATAL(logger_, "Failed to construct concord client.");
-      throw std::runtime_error(__PRETTY_FUNCTION__ +
-                               std::string(": An exception occurred while trying to read the input file (") +
-                               input_filename + std::string("): ") + std::string(e.what()));
-    }
-  }
-  return;
-}
-
-std::string ConcordClient::getClientIdFromClientCert(const std::string& client_cert_path) {
-  std::array<char, 128> buffer;
-  std::string client_id;
-
-  // check if client cert can be opened
-  std::ifstream input_file(client_cert_path.c_str(), std::ios::in);
-
-  if (!input_file.is_open()) {
-    throw std::runtime_error("Could not open the input file (" + client_cert_path + ") at the thin replica client.");
-  }
-
-  // The cmd string is used to get the subject in the client cert.
-  std::string cmd =
-      "openssl crl2pkcs7 -nocrl -certfile " + client_cert_path + " | openssl pkcs7 -print_certs -noout | grep .";
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
-  if (!pipe) {
-    throw std::runtime_error("Failed to read subject fields from client cert - popen() failed!");
-  }
-  if (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-    // parse the OU field i.e., the client id from the subject field
-    client_id = parseClientIdFromSubject(buffer.data());
-  }
-  return client_id;
-}
-
-// Parses the value of the OU field i.e., the client id from the subject
-// string
-std::string ConcordClient::parseClientIdFromSubject(const std::string& subject_str) {
-  std::string delim = "OU = ";
-  size_t start = subject_str.find(delim) + delim.length();
-  size_t end = subject_str.find(',', start);
-  std::string raw_str = subject_str.substr(start, end - start);
-  size_t fstart = 0;
-  size_t fend = raw_str.length();
-  // remove surrounding whitespaces and newlines
-  if (raw_str.find_first_not_of(' ') != std::string::npos) fstart = raw_str.find_first_not_of(' ');
-  if (raw_str.find_last_not_of(' ') != std::string::npos) fend = raw_str.find_last_not_of(' ');
-  raw_str.erase(std::remove(raw_str.begin(), raw_str.end(), '\n'), raw_str.end());
-  return raw_str.substr(fstart, fend - fstart + 1);
 }
 
 void ConcordClient::unsubscribe() {

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -135,8 +135,7 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
         std::make_unique<TrsConnectionConfig>(config_.subscribe_config.use_tls,
                                               config_.subscribe_config.pem_private_key,
                                               config_.subscribe_config.pem_cert_chain,
-                                              config_.subscribe_config.root_cert_chain_map.at(replica.id.val),
-                                              config_.subscribe_config.id_from_cert);
+                                              config_.subscribe_config.root_cert_chain_map.at(replica.id.val));
 
     trsc->connect(trsc_config);
     trs_connections.push_back(std::move(trsc));

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -131,11 +131,10 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
     auto trsc = std::make_unique<TrsConnection>(addr, config_.subscribe_config.id, /* TODO */ 3, /* TODO */ 3);
 
     // TODO: Adapt TRC API to support PEM buffers
-    auto trsc_config =
-        std::make_unique<TrsConnectionConfig>(config_.subscribe_config.use_tls,
-                                              config_.subscribe_config.pem_private_key,
-                                              config_.subscribe_config.pem_cert_chain,
-                                              config_.subscribe_config.root_cert_chain_map.at(replica.id.val));
+    auto trsc_config = std::make_unique<TrsConnectionConfig>(config_.subscribe_config.use_tls,
+                                                             config_.subscribe_config.pem_private_key,
+                                                             config_.subscribe_config.pem_cert_chain,
+                                                             config_.transport.event_pem_certs);
 
     trsc->connect(trsc_config);
     trs_connections.push_back(std::move(trsc));

--- a/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
@@ -31,21 +31,25 @@ struct TrsConnectionConfig {
   // use_tls determines if a TLS enabled secure channel will be opened
   // by the thin replica client, or an insecure channel will be employed.
   const bool use_tls;
-  // thin_replica_tls_cert_path specifies the path of the certificates used for
-  // the TLS channel.
-  const std::string thin_replica_tls_cert_path;
   // client_key is the private key used by TRC to create a secure channel if
   // `is_insecure_trc_val` is false.
-  const std::string client_key;
-  const std::string client_cert_path;
-  const std::string server_cert_path;
+  const std::string& client_key;
+  const std::string& client_cert;
+  const std::string& server_cert;
+  // If TLS is enabled for TRC-TRS connection, the client cert must have the
+  // client ID in the OU field which should match the client ID of the client
+  const std::string& cert_client_id;
 
-  TrsConnectionConfig(bool use_tls_, const std::string& thin_replica_tls_cert_path_, const std::string& client_key_)
+  TrsConnectionConfig(const bool use_tls_,
+                      const std::string& client_key_,
+                      const std::string& client_cert_,
+                      const std::string& server_cert_,
+                      const std::string& cert_client_id_)
       : use_tls(use_tls_),
-        thin_replica_tls_cert_path(thin_replica_tls_cert_path_),
         client_key(client_key_),
-        client_cert_path(thin_replica_tls_cert_path + "/client.cert"),
-        server_cert_path(thin_replica_tls_cert_path + "/server.cert") {}
+        client_cert(client_cert_),
+        server_cert(server_cert_),
+        cert_client_id(cert_client_id_) {}
 };
 
 // The default message size for incoming data is 4MiB but certain workloads
@@ -184,16 +188,6 @@ class TrsConnection {
 
   std::chrono::milliseconds data_timeout_;
   std::chrono::milliseconds hash_timeout_;
-
-  // This method reads certificates from file if TLS is enabled
-  void readCert(const std::string& input_filename, std::string& out_data);
-
-  // This method gets the client_id from the OU field in the client certificate
-  std::string getClientIdFromClientCert(const std::string& client_cert_path);
-
-  // This method is used by getClientIdFromClientCert to get the client_id from
-  // the subject in the client certificate
-  std::string parseClientIdFromSubject(const std::string& subject_str);
 };
 
 }  // namespace client::thin_replica_client

--- a/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
@@ -36,20 +36,12 @@ struct TrsConnectionConfig {
   const std::string& client_key;
   const std::string& client_cert;
   const std::string& server_cert;
-  // If TLS is enabled for TRC-TRS connection, the client cert must have the
-  // client ID in the OU field which should match the client ID of the client
-  const std::string& cert_client_id;
 
   TrsConnectionConfig(const bool use_tls_,
                       const std::string& client_key_,
                       const std::string& client_cert_,
-                      const std::string& server_cert_,
-                      const std::string& cert_client_id_)
-      : use_tls(use_tls_),
-        client_key(client_key_),
-        client_cert(client_cert_),
-        server_cert(server_cert_),
-        cert_client_id(cert_client_id_) {}
+                      const std::string& server_cert_)
+      : use_tls(use_tls_), client_key(client_key_), client_cert(client_cert_), server_cert(server_cert_) {}
 };
 
 // The default message size for incoming data is 4MiB but certain workloads

--- a/client/thin-replica-client/src/trs_connection.cpp
+++ b/client/thin-replica-client/src/trs_connection.cpp
@@ -50,27 +50,6 @@ void TrsConnection::createChannel() {
   if (config_->use_tls) {
     LOG_INFO(logger_, "TLS for thin replica client is enabled for server: " << address_);
 
-    // If TLS is enabled for TRC-TRS connection, the client cert must have the
-    // client ID in the OU field, because the TRS obtains the client_id
-    // from the certificate of the connecting client.
-    if (config_->cert_client_id.empty()) {
-      LOG_FATAL(logger_, "Failed to construct thin replica client.");
-      throw std::runtime_error(
-          "The OU field in client certificate is empty. It must contain the "
-          "client ID.");
-    }
-    // cert_client_id in client cert should match the client_id_ if TLS is
-    // enabled for TRC-TRS connection. Since the TRS reads the client id from
-    // the connecting client cert, and the value of the TRID specified by the
-    // user for TRC initialization can be used by TRC's client application to
-    // generate requests, if they do not match, the TRS will filter out all the
-    // key value pairs meant for the requesting client.
-    if (config_->cert_client_id.compare(client_id_) != 0) {
-      LOG_FATAL(logger_, "Failed to construct thin replica client.");
-      throw std::runtime_error("The client ID in the OU field of the client certificate (" + config_->cert_client_id +
-                               ")does not match the client ID in the environment variable (" + client_id_ + ").");
-    }
-
     grpc::SslCredentialsOptions opts = {config_->server_cert, config_->client_key, config_->client_cert};
     channel_ = grpc::CreateCustomChannel(address_, grpc::SslCredentials(opts), args);
   } else {

--- a/client/thin-replica-client/src/trs_connection.cpp
+++ b/client/thin-replica-client/src/trs_connection.cpp
@@ -48,15 +48,12 @@ void TrsConnection::createChannel() {
   args.SetMaxReceiveMessageSize(kGrpcMaxInboundMsgSizeInBytes);
 
   if (config_->use_tls) {
-    LOG_INFO(logger_,
-             "TLS for thin replica client is enabled, certificate path: " << config_->thin_replica_tls_cert_path
-                                                                          << ", server: " << address_);
+    LOG_INFO(logger_, "TLS for thin replica client is enabled for server: " << address_);
 
-    std::string cert_client_id = getClientIdFromClientCert(config_->client_cert_path);
     // If TLS is enabled for TRC-TRS connection, the client cert must have the
     // client ID in the OU field, because the TRS obtains the client_id
     // from the certificate of the connecting client.
-    if (cert_client_id.empty()) {
+    if (config_->cert_client_id.empty()) {
       LOG_FATAL(logger_, "Failed to construct thin replica client.");
       throw std::runtime_error(
           "The OU field in client certificate is empty. It must contain the "
@@ -68,20 +65,13 @@ void TrsConnection::createChannel() {
     // user for TRC initialization can be used by TRC's client application to
     // generate requests, if they do not match, the TRS will filter out all the
     // key value pairs meant for the requesting client.
-    if (cert_client_id.compare(client_id_) != 0) {
+    if (config_->cert_client_id.compare(client_id_) != 0) {
       LOG_FATAL(logger_, "Failed to construct thin replica client.");
-      throw std::runtime_error("The client ID in the OU field of the client certificate (" + cert_client_id +
+      throw std::runtime_error("The client ID in the OU field of the client certificate (" + config_->cert_client_id +
                                ")does not match the client ID in the environment variable (" + client_id_ + ").");
     }
-    std::string client_cert, client_key, root_cert;
 
-    readCert(config_->client_cert_path, client_cert);
-
-    // server_cert_path specifies the path to a composite cert file i.e., a
-    // concatentation of the certificates of all known servers
-    readCert(config_->server_cert_path, root_cert);
-
-    grpc::SslCredentialsOptions opts = {root_cert, config_->client_key, client_cert};
+    grpc::SslCredentialsOptions opts = {config_->server_cert, config_->client_key, config_->client_cert};
     channel_ = grpc::CreateCustomChannel(address_, grpc::SslCredentials(opts), args);
   } else {
     LOG_WARN(logger_,
@@ -368,71 +358,6 @@ TrsConnection::Result TrsConnection::readHash(Hash* hash) {
 
   ConcordAssert(status == future_status::ready);
   return result.get() ? Result::kSuccess : Result::kFailure;
-}
-
-void TrsConnection::readCert(const std::string& input_filename, std::string& out_data) {
-  std::ifstream input_file(input_filename.c_str(), std::ios::in);
-
-  if (!input_file.is_open()) {
-    LOG_FATAL(logger_, "Failed to construct thin replica client.");
-    throw std::runtime_error(__PRETTY_FUNCTION__ + std::string(": Could not open the input file (") + input_filename +
-                             std::string(") to establish TLS connection with the thin replica server."));
-  } else {
-    try {
-      std::stringstream read_buffer;
-      read_buffer << input_file.rdbuf();
-      input_file.close();
-      out_data = read_buffer.str();
-      LOG_INFO(logger_, "Successfully loaded the contents of " + input_filename);
-    } catch (std::exception& e) {
-      LOG_FATAL(logger_, "Failed to construct thin replica client.");
-      throw std::runtime_error(__PRETTY_FUNCTION__ +
-                               std::string(": An exception occurred while trying to read the input file (") +
-                               input_filename + std::string("): ") + std::string(e.what()));
-    }
-  }
-  return;
-}
-
-std::string TrsConnection::getClientIdFromClientCert(const std::string& client_cert_path) {
-  std::array<char, 128> buffer;
-  std::string client_id;
-
-  // check if client cert can be opened
-  std::ifstream input_file(client_cert_path.c_str(), std::ios::in);
-
-  if (!input_file.is_open()) {
-    throw std::runtime_error("Could not open the input file (" + client_cert_path + ") at the thin replica client.");
-  }
-
-  // The cmd string is used to get the subject in the client cert.
-  std::string cmd =
-      "openssl crl2pkcs7 -nocrl -certfile " + client_cert_path + " | openssl pkcs7 -print_certs -noout | grep .";
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
-  if (!pipe) {
-    throw std::runtime_error("Failed to read subject fields from client cert - popen() failed!");
-  }
-  if (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-    // parse the OU field i.e., the client id from the subject field
-    client_id = parseClientIdFromSubject(buffer.data());
-  }
-  return client_id;
-}
-
-// Parses the value of the OU field i.e., the client id from the subject
-// string
-std::string TrsConnection::parseClientIdFromSubject(const std::string& subject_str) {
-  std::string delim = "OU = ";
-  size_t start = subject_str.find(delim) + delim.length();
-  size_t end = subject_str.find(',', start);
-  std::string raw_str = subject_str.substr(start, end - start);
-  size_t fstart = 0;
-  size_t fend = raw_str.length();
-  // remove surrounding whitespaces and newlines
-  if (raw_str.find_first_not_of(' ') != std::string::npos) fstart = raw_str.find_first_not_of(' ');
-  if (raw_str.find_last_not_of(' ') != std::string::npos) fend = raw_str.find_last_not_of(' ');
-  raw_str.erase(std::remove(raw_str.begin(), raw_str.end(), '\n'), raw_str.end());
-  return raw_str.substr(fstart, fend - fstart + 1);
 }
 
 }  // namespace client::thin_replica_client

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -283,7 +283,7 @@ void AsyncTlsConnection::initClientSSLContext(NodeNum destination) {
 
   try {
     ssl_context_.use_certificate_chain_file((path / "client.cert").string());
-    const std::string pk = decryptPK(path);
+    const std::string pk = decryptPrivateKey(path);
     ssl_context_.use_private_key(asio::const_buffer(pk.c_str(), pk.size()), asio::ssl::context::pem);
   } catch (const boost::system::system_error& e) {
     LOG_FATAL(logger_, "Failed to load certificate or private key files from path: " << path << " : " << e.what());
@@ -331,7 +331,7 @@ void AsyncTlsConnection::initServerSSLContext() {
 
   try {
     ssl_context_.use_certificate_chain_file((path / fs::path("server.cert")).string());
-    const std::string pk = decryptPK(path);
+    const std::string pk = decryptPrivateKey(path);
     ssl_context_.use_private_key(asio::const_buffer(pk.c_str(), pk.size()), asio::ssl::context::pem);
   } catch (const boost::system::system_error& e) {
     LOG_FATAL(logger_, "Failed to load certificate or private key files from path: " << path << " : " << e.what());
@@ -485,7 +485,7 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* receivedCert
 
 using namespace concord::secretsmanager;
 
-const std::string AsyncTlsConnection::decryptPK(const boost::filesystem::path& path) {
+const std::string AsyncTlsConnection::decryptPrivateKey(const boost::filesystem::path& path) {
   namespace fs = boost::filesystem;
   std::string pkpath;
 

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -174,7 +174,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                             const std::string& subject,
                                             std::optional<NodeNum> expected_peer_id);
 
-  const std::string decryptPK(const boost::filesystem::path& path);
+  const std::string decryptPrivateKey(const boost::filesystem::path& path);
 
   logging::Logger logger_;
   asio::io_context& io_context_;

--- a/secretsmanager/secretretriever/CMakeLists.txt
+++ b/secretsmanager/secretretriever/CMakeLists.txt
@@ -12,15 +12,10 @@ add_library(secret_retriever_shared SHARED
         )
 
 target_include_directories(secret_retriever PUBLIC include ../include)
-target_link_libraries(secret_retriever PRIVATE
-        nlohmann_json::nlohmann_json
-        )
-
-target_link_libraries(secret_retriever_shared PRIVATE
-        nlohmann_json::nlohmann_json
-        )
 target_include_directories(secret_retriever_shared PUBLIC include ../include)
+
 find_package(OpenSSL REQUIRED)
+
 if(OPENSSL_FOUND)
     set(HTTPLIB_IS_USING_OPENSSL TRUE)
 endif()
@@ -32,6 +27,10 @@ target_compile_definitions(secret_retriever PUBLIC
 target_compile_definitions(secret_retriever_shared PUBLIC
         $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:CPPHTTPLIB_OPENSSL_SUPPORT>
         )
+
+target_link_libraries(secret_retriever PRIVATE nlohmann_json::nlohmann_json ${OPENSSL_LIBRARIES})
+
+target_link_libraries(secret_retriever_shared PRIVATE nlohmann_json::nlohmann_json ${OPENSSL_LIBRARIES}       )
 
 install (TARGETS secret_retriever DESTINATION lib${LIB_SUFFIX})
 install (TARGETS secret_retriever_shared DESTINATION lib${LIB_SUFFIX})

--- a/secretsmanager/secretretriever/CMakeLists.txt
+++ b/secretsmanager/secretretriever/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_definitions(secret_retriever_shared PUBLIC
 
 target_link_libraries(secret_retriever PRIVATE nlohmann_json::nlohmann_json ${OPENSSL_LIBRARIES})
 
-target_link_libraries(secret_retriever_shared PRIVATE nlohmann_json::nlohmann_json ${OPENSSL_LIBRARIES}       )
+target_link_libraries(secret_retriever_shared PRIVATE nlohmann_json::nlohmann_json ${OPENSSL_LIBRARIES})
 
 install (TARGETS secret_retriever DESTINATION lib${LIB_SUFFIX})
 install (TARGETS secret_retriever_shared DESTINATION lib${LIB_SUFFIX})


### PR DESCRIPTION
This PR enables TLS support for TRS-TRC connection. Please see individual commits for more detail.
Note, this still needs manual testing, which will be done once the close-sourced change corresponding to this change is made.