### PR TITLE
Exchange the client tls certs of a server

### DIFF
--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -97,6 +97,10 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
     std::string cert = std::move(command.cert);
     sm_.encryptFile(bft_replicas_cert_path, cert);
     LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
+    bft_replicas_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" +
+                             std::to_string(sender_id) + "/client/client.cert";
+    sm_.encryptFile(bft_replicas_cert_path, cert);
+    LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
     StateControl::instance().restartComm(sender_id);
     return succ;
   }

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -138,11 +138,11 @@ void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
   concord::secretsmanager::SecretsManagerPlain psm_;
   std::fstream nec_f(pk_path);
   if (nec_f.good()) {
-    secretsMgr_->encryptFile(pk_path, keys.first);
+    secretsMgr_->encryptFile(pk_path + ".tmp", keys.first);
   }
   std::fstream ec_f(pk_path + ".enc");
   if (ec_f.good()) {
-    secretsMgr_->encryptFile(pk_path + ".enc", keys.first);
+    secretsMgr_->encryptFile(pk_path + ".enc.tmp", keys.first);
   }
 
   concord::messages::ReconfigurationRequest req;

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -20,8 +20,9 @@ class StateControl {
     static StateControl instance_;
     return instance_;
   }
-  void setBlockNewConnectionsFlag(bool flag) { blockNewConnectionsFlag_ = flag; }
-  bool getBlockNewConnectionsFlag() const { return blockNewConnectionsFlag_; }
+  void lockComm() { lock_comm_.lock(); }
+  bool tryLockComm() { return lock_comm_.try_lock(); }
+  void unlockComm() { lock_comm_.unlock(); }
 
   void setCommRestartCallBack(std::function<void(uint32_t)> cb) {
     if (cb != nullptr) comm_restart_cb_registry_.add(cb);
@@ -30,7 +31,7 @@ class StateControl {
   void restartComm(uint32_t id) { comm_restart_cb_registry_.invokeAll(id); }
 
  private:
-  bool blockNewConnectionsFlag_ = false;
+  std::mutex lock_comm_;
   concord::util::CallbackRegistry<uint32_t> comm_restart_cb_registry_;
 };
 }  // namespace bft::communication

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -99,13 +99,14 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
 }
 
 void TlsTCPCommunication::dispose(NodeNum i) {
-  if (config_.selfId == i) {
-    for (auto &[_, connMgr] : runner_->principals()) {
-      if (connMgr.getCurrentConnectionStatus(_) == ConnectionStatus::Connected) connMgr.dispose(_);
+  auto &connMgr = runner_->principals().at(config_.selfId);
+  if (i == config_.selfId) {
+    auto end = std::min<size_t>(config_.selfId, config_.maxServerId + 1);
+    for (auto rep = 0u; rep < end; rep++) {
+      connMgr.dispose(rep);
     }
-  } else {
-    auto &connMgr = runner_->principals().at(config_.selfId);
-    if (connMgr.getCurrentConnectionStatus(i) == ConnectionStatus::Connected) connMgr.dispose(i);
+  } else if (i < config_.selfId) {
+    connMgr.dispose(i);
   }
 }
 }  // namespace bft::communication

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -443,7 +443,20 @@ Replica::Replica(ICommunication *comm,
       secretsManager_{secretsManager},
       blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
                                                                           : std::thread::hardware_concurrency()) {
-  bft::communication::StateControl::instance().setCommRestartCallBack([this](uint32_t i) { m_ptrComm->dispose(i); });
+  bft::communication::StateControl::instance().setCommRestartCallBack([this](uint32_t i) {
+    m_ptrComm->dispose(i);
+    // Now wait for a live quorum before continue running
+    uint32_t live_replicas = 1;
+    uint32_t minQuorumSize = 2 * replicaConfig_.fVal + replicaConfig_.cVal + 1;
+    while (live_replicas < minQuorumSize) {
+      live_replicas = 1;
+      for (uint32_t r = 0; r < replicaConfig_.numReplicas; r++) {
+        if (r == replicaConfig_.replicaId) continue;
+        live_replicas += (m_ptrComm->getCurrentConnectionStatus(r) == bft::communication::ConnectionStatus::Connected);
+      }
+    }
+    LOG_INFO(GL, "post communication restart: resuming running after getting " << live_replicas << " connected");
+  });
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {
     replicaConfig_.replicaId,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -19,6 +19,8 @@
 #include "concord.cmf.hpp"
 #include "secrets_manager_plain.h"
 #include "communication/StateControl.hpp"
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 namespace concord::kvbc::reconfiguration {
 
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
@@ -892,10 +894,35 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Repli
       ts,
       false);
   LOG_INFO(getLogger(), "ReplicaTlsExchangeKey block id: " << blockId << " for replica " << sender_id);
+  if (sender_id == bftEngine::ReplicaConfig::instance().replicaId) {
+    std::string pk_file_name = "pk.pem";
+    std::string pk_tmp_file_name = pk_file_name;
+    std::string pk_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" + std::to_string(sender_id);
+    std::ifstream pld_key(pk_path + "/server/" + pk_file_name);
+    if (pld_key.good()) {
+      pk_tmp_file_name += ".tmp";
+    } else {
+      pk_file_name += ".enc";
+      pk_tmp_file_name += ".enc.tmp";
+    }
+    // exchange the private key
+
+    fs::copy(pk_path + "/server/" + pk_tmp_file_name,
+             pk_path + "/server/" + pk_file_name,
+             fs::copy_options::update_existing);
+    fs::copy(pk_path + "/server/" + pk_tmp_file_name,
+             pk_path + "/client/" + pk_file_name,
+             fs::copy_options::update_existing);
+    fs::remove(pk_path + "/server/" + pk_tmp_file_name);
+  }
   std::string bft_replicas_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" +
                                        std::to_string(sender_id) + "/server/server.cert";
   std::string cert = command.cert;
   secretsmanager::SecretsManagerPlain sm;
+  sm.encryptFile(bft_replicas_cert_path, cert);
+  LOG_INFO(getLogger(), bft_replicas_cert_path + " is updated on the disk");
+  bft_replicas_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" + std::to_string(sender_id) +
+                           "/client/client.cert";
   sm.encryptFile(bft_replicas_cert_path, cert);
   LOG_INFO(getLogger(), bft_replicas_cert_path + " is updated on the disk");
   bft::communication::StateControl::instance().restartComm(sender_id);

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -895,25 +895,34 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Repli
       false);
   LOG_INFO(getLogger(), "ReplicaTlsExchangeKey block id: " << blockId << " for replica " << sender_id);
   if (sender_id == bftEngine::ReplicaConfig::instance().replicaId) {
+    // exchange the private key
     std::string pk_file_name = "pk.pem";
     std::string pk_tmp_file_name = pk_file_name;
     std::string pk_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" + std::to_string(sender_id);
     std::ifstream pld_key(pk_path + "/server/" + pk_file_name);
     if (pld_key.good()) {
       pk_tmp_file_name += ".tmp";
-    } else {
+      fs::copy(pk_path + "/server/" + pk_tmp_file_name,
+               pk_path + "/server/" + pk_file_name,
+               fs::copy_options::update_existing);
+      fs::copy(pk_path + "/server/" + pk_tmp_file_name,
+               pk_path + "/client/" + pk_file_name,
+               fs::copy_options::update_existing);
+      fs::remove(pk_path + "/server/" + pk_tmp_file_name);
+    }
+    pk_tmp_file_name = pk_file_name;
+    std::ifstream enc_pkey(pk_path + "/server/" + pk_file_name + ".enc");
+    if (enc_pkey.good()) {
       pk_file_name += ".enc";
       pk_tmp_file_name += ".enc.tmp";
+      fs::copy(pk_path + "/server/" + pk_tmp_file_name,
+               pk_path + "/server/" + pk_file_name,
+               fs::copy_options::update_existing);
+      fs::copy(pk_path + "/server/" + pk_tmp_file_name,
+               pk_path + "/client/" + pk_file_name,
+               fs::copy_options::update_existing);
+      fs::remove(pk_path + "/server/" + pk_tmp_file_name);
     }
-    // exchange the private key
-
-    fs::copy(pk_path + "/server/" + pk_tmp_file_name,
-             pk_path + "/server/" + pk_file_name,
-             fs::copy_options::update_existing);
-    fs::copy(pk_path + "/server/" + pk_tmp_file_name,
-             pk_path + "/client/" + pk_file_name,
-             fs::copy_options::update_existing);
-    fs::remove(pk_path + "/server/" + pk_tmp_file_name);
   }
   std::string bft_replicas_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" +
                                        std::to_string(sender_id) + "/server/server.cert";

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -114,7 +114,7 @@ void ReconfigurationHandler::handleWedgeCommands(
       });
     if (blockNewConnections) {
       bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack(
-          [=]() { bft::communication::StateControl::instance().setBlockNewConnectionsFlag(true); });
+          [=]() { bft::communication::StateControl::instance().lockComm(); });
     }
   } else {
     if (remove_metadata)
@@ -130,7 +130,7 @@ void ReconfigurationHandler::handleWedgeCommands(
       });
     if (blockNewConnections) {
       bftEngine::IControlHandler::instance()->addOnSuperStableCheckpointCallBack(
-          [=]() { bft::communication::StateControl::instance().setBlockNewConnectionsFlag(true); });
+          [=]() { bft::communication::StateControl::instance().lockComm(); });
     }
   }
 }

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -457,7 +457,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                     return None
         return ts
 
-    @unittest.skip("Unstable")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_replicas_tls_key_exchange_command_without_primary(self, bft_network):
@@ -486,7 +485,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
                 self.assertGreater(nb_fast_path, fast_paths[r])
 
-    @unittest.skip("Unstable")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
     async def test_replicas_tls_key_exchange_command_with_st(self, bft_network):
@@ -552,7 +550,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
                 self.assertGreater(nb_fast_path, fast_paths[r])
 
-    @unittest.skip("Unstable")
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
                       selected_configs=lambda n, f, c: n == 7)


### PR DESCRIPTION
In our current setup, each server has two certificates being used. One when it serves as serve and one when it serves as a client (the specific logic is: A server is a client for the servers with id smaller than its own and server to the rest)
In this PR, we adjust the TLS key rotation logic to this and fix some bugs and stabilize it.