### PR TITLE
Support byzantine behaviour for the conflict detection optimization

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -497,6 +497,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   bool validatePreProcessedResults(const PrePrepareMsg* msg, const ViewNum registeredView) const;
   EpochNum getSelfEpochNumber() { return static_cast<EpochNum>(EpochManager::instance().getSelfEpochNumber()); }
 
+  void setConflictDetectionBlockId(const ClientRequestMsg&, IRequestsHandler::ExecutionRequest&);
+
   // 5 years
   static constexpr int64_t MAX_VALUE_SECONDS = 60 * 60 * 24 * 365 * 5;
   // 5 Minutes

--- a/bftengine/src/preprocessor/GlobalData.cpp
+++ b/bftengine/src/preprocessor/GlobalData.cpp
@@ -3,4 +3,5 @@
 namespace preprocessor {
 
 std::atomic_uint64_t GlobalData::current_block_id = 0;
+std::atomic_uint64_t GlobalData::block_delta = 0;
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/GlobalData.hpp
+++ b/bftengine/src/preprocessor/GlobalData.hpp
@@ -5,5 +5,6 @@ struct GlobalData {
   // Holds the block id that was last added to storage,
   // Used for the conflict detection optimization.
   static std::atomic_uint64_t current_block_id;
+  static std::atomic_uint64_t block_delta;
 };
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1446,7 +1446,8 @@ const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId, ReqId req
   LOG_TRACE(logger(), KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset, reqSeqNum));
   char *buf = nullptr;
   if (!preProcessResultBuffers_[bufferOffset].first) {
-    buf = new char[maxPreExecResultSize_];
+    // sizeof(uint64_t) -> block id of conflict detection optimization
+    buf = new char[maxPreExecResultSize_ + sizeof(uint64_t)];
     {
       std::unique_lock lock(resultBufferLock_);
       if (!preProcessResultBuffers_[bufferOffset].first) {
@@ -1510,6 +1511,15 @@ uint32_t PreProcessor::launchReqPreProcessing(const PreProcessRequestMsgSharedPt
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_process_preprocess_msg");
   LOG_DEBUG(logger(), "Pass request for a pre-execution" << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch));
   bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
+  uint64_t blockId = preProcessReqMsg->primaryBlockId();
+  if (preProcessReqMsg->primaryBlockId() - GlobalData::block_delta > GlobalData::current_block_id) {
+    blockId = 0;
+    LOG_INFO(logger(),
+             "Primary block [" << preProcessReqMsg->primaryBlockId()
+                               << "] is too advance for conflict detection optimizaton, replica block id ["
+                               << GlobalData::current_block_id << "] delta [" << GlobalData::block_delta << "]");
+  }
+  auto preProcessResultBuffer = (char *)getPreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
   accumulatedRequests.push_back(bftEngine::IRequestsHandler::ExecutionRequest{
       clientId,
       reqSeqNum,
@@ -1519,12 +1529,16 @@ uint32_t PreProcessor::launchReqPreProcessing(const PreProcessRequestMsgSharedPt
       preProcessReqMsg->requestBuf(),
       std::string(preProcessReqMsg->requestSignature(), preProcessReqMsg->requestSignatureLength()),
       maxPreExecResultSize_,
-      (char *)getPreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch)});
-  accumulatedRequests.back().blockId = preProcessReqMsg->primaryBlockId();
+      preProcessResultBuffer});
   requestsHandler_.execute(accumulatedRequests, std::nullopt, cid, span);
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
   const auto status = request.outExecutionStatus;
-  const auto resultLen = request.outActualReplySize;
+  // Append the conflict detection block id and add sizeof(uint64_t) the the result length.
+  memcpy(preProcessResultBuffer + request.outActualReplySize, reinterpret_cast<char *>(&blockId), sizeof(uint64_t));
+  const auto resultLen = request.outActualReplySize + sizeof(uint64_t);
+  LOG_INFO(logger(),
+           "CD_INFO using block id " << blockId << " hash of result + block id is "
+                                     << std::hash<std::string>{}(std::string(preProcessResultBuffer, resultLen)));
   LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch));
   if (status != 0 || !resultLen) {
     LOG_FATAL(

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1516,7 +1516,7 @@ uint32_t PreProcessor::launchReqPreProcessing(const PreProcessRequestMsgSharedPt
     blockId = 0;
     LOG_INFO(logger(),
              "Primary block [" << preProcessReqMsg->primaryBlockId()
-                               << "] is too advance for conflict detection optimizaton, replica block id ["
+                               << "] is too advanced for conflict detection optimization, replica block id ["
                                << GlobalData::current_block_id << "] delta [" << GlobalData::block_delta << "]");
   }
   auto preProcessResultBuffer = (char *)getPreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
@@ -1533,13 +1533,10 @@ uint32_t PreProcessor::launchReqPreProcessing(const PreProcessRequestMsgSharedPt
   requestsHandler_.execute(accumulatedRequests, std::nullopt, cid, span);
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
   const auto status = request.outExecutionStatus;
-  // Append the conflict detection block id and add sizeof(uint64_t) the the result length.
+  // Append the conflict detection block id and add sizeof(uint64_t) the resulting length.
   memcpy(preProcessResultBuffer + request.outActualReplySize, reinterpret_cast<char *>(&blockId), sizeof(uint64_t));
   const auto resultLen = request.outActualReplySize + sizeof(uint64_t);
-  LOG_INFO(logger(),
-           "CD_INFO using block id " << blockId << " hash of result + block id is "
-                                     << std::hash<std::string>{}(std::string(preProcessResultBuffer, resultLen)));
-  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch));
+  LOG_DEBUG(logger(), "Pre-execution operation done" << KVLOG(cid, reqSeqNum, clientId, reqOffsetInBatch, blockId));
   if (status != 0 || !resultLen) {
     LOG_FATAL(
         logger(),

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -167,6 +167,33 @@ bool RequestProcessingState::isReqTimedOut() const {
   return false;
 }
 
+std::pair<std::string, concord::util::SHA3_256::Digest> RequestProcessingState::detectFailureDueToBlockID(
+    const concord::util::SHA3_256::Digest &other, uint64_t blockId) {
+  // since this scenario is rare, a new string is allocated for safety.
+  std::string modifiedResult(primaryPreProcessResult_, primaryPreProcessResultLen_);
+  memcpy(modifiedResult.data() + modifiedResult.size() - sizeof(uint64_t),
+         reinterpret_cast<char *>(&blockId),
+         sizeof(uint64_t));
+  auto modifiedHash = convertToArray(SHA3_256().digest(modifiedResult.c_str(), modifiedResult.size()).data());
+  if (other == modifiedHash) {
+    LOG_INFO(logger(), "Primary hash is different from quorum due to mismatch in block id");
+    return {modifiedResult, modifiedHash};
+  }
+  return {"", concord::util::SHA3_256::Digest{}};
+}
+
+void RequestProcessingState::modifyPrimayResult(const std::pair<std::string, concord::util::SHA3_256::Digest> &result) {
+  memcpy(const_cast<char *>(primaryPreProcessResult_), result.first.c_str(), primaryPreProcessResultLen_);
+  primaryPreProcessResultHash_ = result.second;
+  auto sm = SigManager::instance();
+  std::vector<char> sig(sm->getMySigLength());
+  sm->sign(reinterpret_cast<const char *>(primaryPreProcessResultHash_.data()),
+           primaryPreProcessResultHash_.size(),
+           sig.data(),
+           sig.size());
+  preProcessingResultHashes_[primaryPreProcessResultHash_].emplace_back(std::move(sig), myReplicaId_);
+}
+
 // The primary replica logic
 PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult() {
   SCOPED_MDC_CID(cid_);
@@ -184,22 +211,8 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
     if (primaryPreProcessResultLen_ != 0 && !retrying_) {
       // A known scenario that can cause a mismatch, is due to rejection of the block id sent by the primary.
       // In this case the difference should be only the last 64 bits that encodes the `0` as the rejection value.
-      uint64_t blockid = 0;
-      // since this scenario is rare, a new string is allocated for safety.
-      std::string newHash(primaryPreProcessResult_, primaryPreProcessResultLen_);
-      memcpy(newHash.data() + newHash.size() - sizeof(uint64_t), reinterpret_cast<char *>(&blockid), sizeof(uint64_t));
-      auto newPreProcessResultHash = convertToArray(SHA3_256().digest(newHash.c_str(), newHash.size()).data());
-      if (itOfChosenHash->first == newPreProcessResultHash) {
-        memcpy(const_cast<char *>(primaryPreProcessResult_), newHash.c_str(), primaryPreProcessResultLen_);
-        primaryPreProcessResultHash_ = newPreProcessResultHash;
-        auto sm = SigManager::instance();
-        std::vector<char> sig(sm->getMySigLength());
-        sm->sign(reinterpret_cast<const char *>(primaryPreProcessResultHash_.data()),
-                 primaryPreProcessResultHash_.size(),
-                 sig.data(),
-                 sig.size());
-        preProcessingResultHashes_[primaryPreProcessResultHash_].emplace_back(std::move(sig), myReplicaId_);
-        LOG_INFO(logger(), "Primary changed block id of result to 0");
+      if (auto modifiedResult = detectFailureDueToBlockID(itOfChosenHash->first, 0); modifiedResult.first.size() > 0) {
+        modifyPrimayResult(modifiedResult);
         return COMPLETE;
       }
       // Primary replica calculated hash is different from a hash that passed pre-execution consensus => we don't have

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -78,6 +78,8 @@ class RequestProcessingState {
   const std::list<PreProcessResultSignature>& getPreProcessResultSignatures();
 
   static void init(uint16_t numOfRequiredReplies, preprocessor::PreProcessorRecorder* histograms);
+  const concord::util::SHA3_256::Digest& getResultHash() { return primaryPreProcessResultHash_; };
+  const char* getResult() { return primaryPreProcessResult_; }
 
  private:
   static concord::util::SHA3_256::Digest convertToArray(

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -92,6 +92,14 @@ class RequestProcessingState {
                                            NodeIdType newSenderId,
                                            uint64_t reqRetryId) const;
 
+  // Detect if a hash is different from the input param because of the
+  // appended block id.
+  std::pair<std::string, concord::util::SHA3_256::Digest> detectFailureDueToBlockID(
+      const concord::util::SHA3_256::Digest&, uint64_t);
+
+  // Set a new block id at the end of the result.
+  void modifyPrimayResult(const std::pair<std::string, concord::util::SHA3_256::Digest>&);
+
  private:
   static uint16_t numOfRequiredEqualReplies_;
   static preprocessor::PreProcessorRecorder* preProcessorHistograms_;


### PR DESCRIPTION
Before this change, a replica blindly used a block id given from the primary to determine whether it could rely on its cache as a single source of truth instead of going to storage.
It means that the primary could have fooled us by sending a larger than the actual block id.

This PR introduces a mechanism to evaluate whether the primary block id is reliable.

A replica maintains a delta variable that is used to determine if the primary block id is too large.
The calculation is as follows: if the replica block id + the delta is smaller than the given primary block id, then the primary block id is rejected, and `0` is used.

The Block ID is being appended to the pre-execution result and therefore being signed.

**If a quorum of replicas decides to reject the value, the pre-execution is at a state where there is a quorum that does not include the primary, to recover, the primary modifies its appended block id to `0`.** 
