### PR TITLE
Get External Client Error For Testing

### DIFF
--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -163,6 +163,8 @@ class ConcordClientPool {
 
   inline bool IsBatchingEnabled() { return client_batching_enabled_; }
 
+  bftEngine::OperationResult getClientsError();
+
  private:
   void setUpClientParams(bftEngine::SimpleClientParams& client_params,
                          const concord::config_pool::ConcordClientPoolConfig&);
@@ -170,7 +172,6 @@ class ConcordClientPool {
 
   void OnBatchingTimeout(ClientPtr client);
   bool clusterHasKeys(ClientPtr& cl);
-  std::string SampleSpan(const std::string& span_blob);
   std::atomic_bool hasKeys_{false};
   std::atomic_bool stop_{false};
   size_t batch_size_ = 0UL;
@@ -206,9 +207,6 @@ class ConcordClientPool {
   std::atomic_bool is_overloaded_ = false;
   EXT_DONE_CALLBACK done_callback_ = nullptr;
   uint32_t jobs_queue_max_size_ = 0;
-  uint32_t span_rate = 0;
-  uint32_t transaction_count = 0;
-  std::mutex transaction_count_lock_;
   using Timer_t = ::concord_client_pool::Timer<ClientPtr>;
   std::unique_ptr<Timer_t> batch_timer_;
   bftEngine::impl::RollingAvgAndVar average_req_dur_;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -589,19 +589,13 @@ bool ConcordClientPool::clusterHasKeys(ClientPtr &cl) {
   return result == trueReply;
 }
 
-std::string ConcordClientPool::SampleSpan(const std::string &span_blob) {
-  if (span_rate <= 0) return kEmptySpanContext;
-  if (span_rate == 1) return span_blob;
-  std::unique_lock<std::mutex> lock(transaction_count_lock_);
-  if (transaction_count == 0) {
-    transaction_count++;
-    return span_blob;
+bftEngine::OperationResult ConcordClientPool::getClientsError() {
+  for (auto &client : this->clients_) {
+    if (client->getClientRequestError() != bftEngine::OperationResult::SUCCESS) {
+      return client->getClientRequestError();
+    }
   }
-  transaction_count++;
-  if (transaction_count == span_rate) {
-    transaction_count = 0;
-  }
-  return kEmptySpanContext;
+  return bftEngine::OperationResult::SUCCESS;
 }
 
 }  // namespace concord::concord_client_pool


### PR DESCRIPTION
To check the external client's error that happened during the handle of a request, I've added a function in the client pool to retrieve the error.

Moreover, there is a not-used code in this class and therefore I erased it.