### PR TITLE
Status handler for ReadOnlyReplica

### DIFF
--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -63,6 +63,14 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
   } ro_metrics_;
 
   void executeReadOnlyRequest(concordUtils::SpanWrapper& parent_span, const ClientRequestMsg& m);
+  std::atomic<SeqNum> last_executed_seq_num_;
+
+ private:
+  // This function serves as an ReplicaStatusHandlers alternative for ReadOnlyReplica. The reason to use this function
+  // is that regular and read-only replcias expose differen metrics and the status handlers are not interchangable. The
+  // read-only replica also hasn't got an implementation for InternalMessages which are used by the
+  // ReplicaStatusHandler.
+  void registerStatusHandlers();
 };
 
 }  // namespace bftEngine::impl


### PR DESCRIPTION
Regular replicas has got the so called class ReplicaStatusHandlers which
exposes various parameters. They can be used for diagnostic purposes for
example.
ReadOnly replica doesn't register any status handlers and it can't use
ReplicaStatusHandlers due to difference in the internal metrics used by
two replicas. For example ROR doesn't use last_stable_seq_num metric.
Solution for this is to provide a simple function which registers some
status handlers specific for the ROR.

This patch adds only a single one - last_executed_seq_num.