### PR TITLE
Revise error log levels (based on PR #2000)

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -639,7 +639,7 @@ void BCStateTran::saveReservedPage(uint32_t reservedPageId, uint32_t copyLength,
 
     psd_->setPendingResPage(reservedPageId, inReservedPage, copyLength);
   } catch (std::out_of_range &e) {
-    LOG_ERROR(logger_, "Failed to save pending reserved page: " << e.what() << ": " << KVLOG(reservedPageId));
+    LOG_FATAL(logger_, "Failed to save pending reserved page: " << e.what() << ": " << KVLOG(reservedPageId));
     throw;
   }
 }

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -108,7 +108,7 @@ void DBMetadataStorage::writeInBatch(uint32_t objectId, const char *data, uint32
   Sliver copy = Sliver::copy(data, dataLength);
   lock_guard<mutex> lock(ioMutex_);
   if (!batch_) {
-    LOG_ERROR(logger_, WRONG_FLOW);
+    LOG_FATAL(logger_, WRONG_FLOW);
     throw runtime_error(WRONG_FLOW);
   }
   // Delete an older parameter with the same key (if exists) before inserting a new one.
@@ -121,13 +121,13 @@ void DBMetadataStorage::commitAtomicWriteOnlyBatch() {
   lock_guard<mutex> lock(ioMutex_);
   LOG_DEBUG(logger_, "Begin Commit atomic transaction");
   if (!batch_) {
-    LOG_ERROR(logger_, WRONG_FLOW);
+    LOG_FATAL(logger_, WRONG_FLOW);
     throw runtime_error(WRONG_FLOW);
   }
   Status status = dbClient_->multiPut(*batch_);
   LOG_DEBUG(logger_, "End Commit atomic transaction");
   if (!status.isOK()) {
-    LOG_ERROR(logger_, "DBClient multiPut operation failed");
+    LOG_FATAL(logger_, "DBClient multiPut operation failed");
     throw runtime_error("DBClient multiPut operation failed");
   }
   delete batch_;

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -204,7 +204,7 @@ void ReadOnlyReplica::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_s
       reply.setReplicaSpecificInfoLength(actualReplicaSpecificInfoLength);
       send(&reply, clientId);
     } else {
-      LOG_ERROR(GL, "Received zero size response. " << KVLOG(clientId));
+      LOG_WARN(GL, "Received zero size response. " << KVLOG(clientId));
     }
 
   } else {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -848,7 +848,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
   if (!getReplicaConfig().prePrepareFinalizeAsyncEnabled) {
     if (!validatePreProcessedResults(msg, getCurrentView())) {
       // trigger view change
-      LOG_ERROR(VC_LOG, "PreProcessResult Signature failure. Ask to leave view" << KVLOG(getCurrentView()));
+      LOG_WARN(VC_LOG, "PreProcessResult Signature failure. Ask to leave view" << KVLOG(getCurrentView()));
       askToLeaveView(ReplicaAsksToLeaveViewMsg::Reason::PrimarySentBadPreProcessResult);
       return;
     }
@@ -1365,7 +1365,7 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
       return;
     } else {
       // trigger view change
-      LOG_ERROR(VC_LOG, "PreProcessResult Signature failure. Ask to leave view" << KVLOG(getCurrentView()));
+      LOG_WARN(VC_LOG, "PreProcessResult Signature failure. Ask to leave view" << KVLOG(getCurrentView()));
       askToLeaveView(vciim->reasonToLeave_);
       return;
     }
@@ -3690,7 +3690,7 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
         try {
           ConcordAssert(seqNumInfo.addMsg(e.getPrepareFullMsg(), true));
         } catch (const std::exception &e) {
-          LOG_ERROR(GL, "Failed to add sn " << s << " to main log, reason: " << e.what());
+          LOG_FATAL(GL, "Failed to add sn " << s << " to main log, reason: " << e.what());
           throw;
         }
 
@@ -3709,7 +3709,7 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
         try {
           ConcordAssert(seqNumInfo.addMsg(e.getCommitFullMsg(), true));
         } catch (const std::exception &e) {
-          LOG_ERROR(GL, "Failed to add sn [" << s << "] to main log, reason: " << e.what());
+          LOG_FATAL(GL, "Failed to add sn [" << s << "] to main log, reason: " << e.what());
           throw;
         }
 
@@ -4194,7 +4194,7 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
       reply.setReplicaSpecificInfoLength(actualReplicaSpecificInfoLength);
       send(&reply, clientId);
     } else {
-      LOG_ERROR(GL, "Received zero size response. " << KVLOG(clientId));
+      LOG_WARN(GL, "Received zero size response. " << KVLOG(clientId));
     }
 
   } else {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -887,7 +887,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
     bool time_is_ok = true;
     if (config_.timeServiceEnabled && msg->numberOfRequests() > 0) {
       if (!time_service_manager_->hasTimeRequest(*msg)) {
-        LOG_ERROR(CNSUS, "PrePrepare will be ignored");
+        LOG_WARN(CNSUS, "PrePrepare will be ignored");
         delete msg;
         return;
       }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4198,7 +4198,7 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
     }
 
   } else {
-    LOG_ERROR(GL, "Received error while executing RO request. " << KVLOG(clientId, status));
+    LOG_WARN(GL, "Received error while executing RO request. " << KVLOG(clientId, status));
   }
 
   if (config_.getdebugStatisticsEnabled()) {

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -98,7 +98,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
       req.outExecutionStatus = 0;
 
       if (req.flags & READ_ONLY_FLAG) {
-        LOG_ERROR(GL, "Received a read-only Tick, ignoring");
+        LOG_WARN(GL, "Received a read-only Tick, ignoring");
         req.outExecutionStatus = 1;
       } else if (cron_table_registry_) {
         using namespace concord::cron;
@@ -108,7 +108,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
         const auto tick = Tick{payload.component_id, req.executionSequenceNum};
         (*cron_table_registry_)[payload.component_id].evaluate(tick);
       } else {
-        LOG_ERROR(GL, "Received a Tick, but the cron table registry is not initialized");
+        LOG_WARN(GL, "Received a Tick, but the cron table registry is not initialized");
         req.outExecutionStatus = 2;
       }
     }

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -183,7 +183,7 @@ uint16_t SigManager::getSigLength(PrincipalId pid) const {
     if (auto pos = verifiers_.find(pid); pos != verifiers_.end()) {
       return pos->second->signatureLength();
     } else {
-      LOG_WARN(GL, "Unrecognized pid " << pid);
+      LOG_ERROR(GL, "Unrecognized pid " << pid);
       return 0;
     }
   }
@@ -199,7 +199,7 @@ bool SigManager::verifySig(
     if (auto pos = verifiers_.find(pid); pos != verifiers_.end()) {
       result = pos->second->verify(str_data, str_sig);
     } else {
-      LOG_WARN(GL, "Unrecognized pid " << pid);
+      LOG_ERROR(GL, "Unrecognized pid " << pid);
       metrics_.sigVerificationFailedOnUnrecognizedParticipantId_++;
       metrics_component_.UpdateAggregator();
       return false;

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -183,7 +183,7 @@ uint16_t SigManager::getSigLength(PrincipalId pid) const {
     if (auto pos = verifiers_.find(pid); pos != verifiers_.end()) {
       return pos->second->signatureLength();
     } else {
-      LOG_ERROR(GL, "Unrecognized pid " << pid);
+      LOG_WARN(GL, "Unrecognized pid " << pid);
       return 0;
     }
   }
@@ -199,7 +199,7 @@ bool SigManager::verifySig(
     if (auto pos = verifiers_.find(pid); pos != verifiers_.end()) {
       result = pos->second->verify(str_data, str_sig);
     } else {
-      LOG_ERROR(GL, "Unrecognized pid " << pid);
+      LOG_WARN(GL, "Unrecognized pid " << pid);
       metrics_.sigVerificationFailedOnUnrecognizedParticipantId_++;
       metrics_component_.UpdateAggregator();
       return false;

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -390,12 +390,12 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
 OperationResult SimpleClientImp::isBatchRequestValid(const ClientRequest& req) {
   OperationResult res = SUCCESS;
   if (req.flags & READ_ONLY_REQ) {
-    LOG_ERROR(logger_, "Read-only requests cannot be sent in a batch" << KVLOG(req.reqSeqNum, clientId_, req.cid));
+    LOG_WARN(logger_, "Read-only requests cannot be sent in a batch" << KVLOG(req.reqSeqNum, clientId_, req.cid));
     res = INVALID_REQUEST;
   } else if (!(req.flags & PRE_PROCESS_REQ)) {
-    LOG_ERROR(logger_,
-              "Requests batching is supported only for requests intended for pre-processing"
-                  << KVLOG(req.reqSeqNum, clientId_, req.cid));
+    LOG_WARN(logger_,
+             "Requests batching is supported only for requests intended for pre-processing"
+                 << KVLOG(req.reqSeqNum, clientId_, req.cid));
     res = INVALID_REQUEST;
   }
   if (res != SUCCESS) reset();

--- a/bftengine/src/bftengine/TimeServiceManager.hpp
+++ b/bftengine/src/bftengine/TimeServiceManager.hpp
@@ -84,7 +84,7 @@ class TimeServiceManager {
 
   [[nodiscard]] bool hasTimeRequest(const impl::PrePrepareMsg& msg) const {
     if (msg.numberOfRequests() < 2) {
-      LOG_ERROR(TS_MNGR, "PrePrepare with Time Service on, cannot have less than 2 messages");
+      LOG_WARN(TS_MNGR, "PrePrepare with Time Service on, cannot have less than 2 messages");
       ill_formed_preprepare_++;
       metrics_component_.UpdateAggregator();
       return false;
@@ -95,7 +95,7 @@ class TimeServiceManager {
 
     ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
     if (req.flags() != MsgFlag::TIME_SERVICE_FLAG) {
-      LOG_ERROR(GL, "Time Service is on but first CR in PrePrepare is not TS request");
+      LOG_WARN(GL, "Time Service is on but first CR in PrePrepare is not TS request");
       ill_formed_preprepare_++;
       metrics_component_.UpdateAggregator();
       return false;
@@ -124,11 +124,11 @@ class TimeServiceManager {
     auto min = now - config.timeServiceHardLimitMillis;
     auto max = now + config.timeServiceHardLimitMillis;
     if (min > t || t > max) {
-      LOG_ERROR(TS_MNGR,
-                "Current primary's time reached hard limit, requests will be ignored. Please synchronize local clocks! "
-                    << "Primary's time: " << t.count() << ", local time: " << now.count()
-                    << ", difference: " << (t - now).count() << ", time limits: +/-"
-                    << config.timeServiceHardLimitMillis.count() << ". Time is presented as ms since epoch");
+      LOG_WARN(TS_MNGR,
+               "Current primary's time reached hard limit, requests will be ignored. Please synchronize local clocks! "
+                   << "Primary's time: " << t.count() << ", local time: " << now.count()
+                   << ", difference: " << (t - now).count() << ", time limits: +/-"
+                   << config.timeServiceHardLimitMillis.count() << ". Time is presented as ms since epoch");
       hard_limit_reached_counter_++;
       metrics_component_.UpdateAggregator();
       return false;

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -106,12 +106,12 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
   }
   if (!repInfo.isValidPrincipalId(clientId)) {
     msg << "Invalid clientId " << clientId;
-    LOG_ERROR(CNSUS, msg.str());
+    LOG_WARN(CNSUS, msg.str());
     throw std::runtime_error(msg.str());
   }
   if (!repInfo.isValidPrincipalId(this->senderId())) {
     msg << "Invalid senderId " << this->senderId();
-    LOG_ERROR(CNSUS, msg.str());
+    LOG_WARN(CNSUS, msg.str());
     throw std::runtime_error(msg.str());
   }
   if (isIdOfExternalClient && isClientTransactionSigningEnabled) {
@@ -147,7 +147,7 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
                  header->reqSignatureLength,
                  isIdOfExternalClient,
                  isClientTransactionSigningEnabled);
-    LOG_ERROR(CNSUS, msg.str());
+    LOG_WARN(CNSUS, msg.str());
     throw std::runtime_error(msg.str());
   }
   auto expectedMsgSize = sizeof(ClientRequestMsgHeader) + header->requestLength + header->cidLength +
@@ -155,14 +155,14 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
 
   if ((msgSize < minMsgSize) || (msgSize != expectedMsgSize)) {
     msg << "Invalid msgSize: " << KVLOG(msgSize, minMsgSize, expectedMsgSize);
-    LOG_ERROR(CNSUS, msg.str());
+    LOG_WARN(CNSUS, msg.str());
     throw std::runtime_error(msg.str());
   }
   if (doSigVerify) {
     if (!sigManager->verifySig(
             clientId, requestBuf(), header->requestLength, requestSignature(), header->reqSignatureLength)) {
       std::stringstream msg;
-      LOG_ERROR(CNSUS, "Signature verification failed for " << KVLOG(header->reqSeqNum, this->senderId(), clientId));
+      LOG_WARN(CNSUS, "Signature verification failed for " << KVLOG(header->reqSeqNum, this->senderId(), clientId));
       msg << "Signature verification failed for: "
           << KVLOG(clientId,
                    this->senderId(),

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -281,7 +281,7 @@ bool PreProcessor::validateMessage(MessageBase *msg) const {
     msg->validate(myReplica_.getReplicasInfo());
     return true;
   } catch (std::exception &e) {
-    LOG_ERROR(logger(), "Message validation failed: " << e.what());
+    LOG_WARN(logger(), "Message validation failed: " << e.what());
     return false;
   }
 }
@@ -479,9 +479,9 @@ bool PreProcessor::checkClientMsgCorrectness(uint64_t reqSeqNum,
 
 bool PreProcessor::checkClientBatchMsgCorrectness(const ClientBatchRequestMsgUniquePtr &clientBatchReqMsg) {
   if (!clientBatchingEnabled_) {
-    LOG_ERROR(logger(),
-              "Batching functionality is disabled => reject message"
-                  << KVLOG(clientBatchReqMsg->clientId(), clientBatchReqMsg->senderId(), clientBatchReqMsg->getCid()));
+    LOG_WARN(logger(),
+             "Batching functionality is disabled => reject message"
+                 << KVLOG(clientBatchReqMsg->clientId(), clientBatchReqMsg->senderId(), clientBatchReqMsg->getCid()));
     preProcessorMetrics_.preProcReqIgnored++;
     return false;
   }
@@ -995,7 +995,7 @@ void PreProcessor::onMessage<PreProcessBatchReplyMsg>(PreProcessBatchReplyMsg *m
 template <typename T>
 void PreProcessor::messageHandler(MessageBase *msg) {
   if (!msgs_.write_available()) {
-    LOG_ERROR(logger(), "PreProcessor queue is full, returning message");
+    LOG_WARN(logger(), "PreProcessor queue is full, returning message");
     incomingMsgsStorage_->pushExternalMsg(std::unique_ptr<MessageBase>(msg));
     return;
   }
@@ -1102,8 +1102,8 @@ void PreProcessor::handlePreProcessReplyMsg(const string &cid,
       break;
     }
     case CANCELLED_BY_PRIMARY:
-      LOG_ERROR(logger(),
-                "Received reply message with status CANCELLED_BY_PRIMARY" << KVLOG(reqSeqNum, clientId, batchCid));
+      LOG_WARN(logger(),
+               "Received reply message with status CANCELLED_BY_PRIMARY" << KVLOG(reqSeqNum, clientId, batchCid));
       break;
   }
 }

--- a/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.cpp
@@ -52,16 +52,16 @@ void ClientBatchRequestMsg::validate(const ReplicasInfo& repInfo) const {
     throw std::runtime_error(__PRETTY_FUNCTION__);
 
   if (type() != MsgCode::ClientBatchRequest) {
-    LOG_ERROR(logger(), "Message type is incorrect" << KVLOG(type()));
+    LOG_WARN(logger(), "Message type is incorrect" << KVLOG(type()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 
   if (senderId() == repInfo.myId()) {
-    LOG_ERROR(logger(), "Message sender is invalid" << KVLOG(senderId()));
+    LOG_WARN(logger(), "Message sender is invalid" << KVLOG(senderId()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
   if (!checkElements()) {
-    LOG_ERROR(logger(), "One or more ClientMsg in the list is invalid");
+    LOG_WARN(logger(), "One or more ClientMsg in the list is invalid");
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 }
@@ -70,7 +70,7 @@ bool ClientBatchRequestMsg::checkElements() const {
   const auto totalMsgSize = size();
   const auto& numOfMessagesInBatch = msgBody()->numOfMessagesInBatch;
   if (!numOfMessagesInBatch || (numOfMessagesInBatch > MAX_BATCH_SIZE)) {
-    LOG_ERROR(logger(), KVLOG(numOfMessagesInBatch));
+    LOG_WARN(logger(), KVLOG(numOfMessagesInBatch));
     return false;
   }
   char* dataPosition = body() + sizeof(ClientBatchRequestMsgHeader) + msgBody()->cidSize;
@@ -82,13 +82,13 @@ bool ClientBatchRequestMsg::checkElements() const {
     auto expectedSigLen = (isClientTransactionSigningEnabled ? sigManager->getSigLength(clientId) : 0);
     if ((expectedSigLen != singleMsgHeader.reqSignatureLength) || (totalMsgSize < singleMsgHeader.requestLength) ||
         (totalMsgSize < singleMsgHeader.cidLength)) {
-      LOG_ERROR(logger(),
-                KVLOG(clientId,
-                      totalMsgSize,
-                      expectedSigLen,
-                      singleMsgHeader.reqSignatureLength,
-                      singleMsgHeader.requestLength,
-                      singleMsgHeader.cidLength));
+      LOG_WARN(logger(),
+               KVLOG(clientId,
+                     totalMsgSize,
+                     expectedSigLen,
+                     singleMsgHeader.reqSignatureLength,
+                     singleMsgHeader.requestLength,
+                     singleMsgHeader.cidLength));
       return false;
     }
     dataPosition += sizeof(ClientRequestMsgHeader) + singleMsgHeader.spanContextSize + singleMsgHeader.requestLength +

--- a/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.cpp
@@ -46,12 +46,12 @@ void PreProcessBatchReplyMsg::validate(const ReplicasInfo& repInfo) const {
     throw std::runtime_error(__PRETTY_FUNCTION__);
 
   if (type() != MsgCode::PreProcessBatchReply) {
-    LOG_ERROR(logger(), "Message type is incorrect" << KVLOG(type()));
+    LOG_WARN(logger(), "Message type is incorrect" << KVLOG(type()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 
   if (senderId() == repInfo.myId()) {
-    LOG_ERROR(logger(), "Message sender is invalid" << KVLOG(senderId()));
+    LOG_WARN(logger(), "Message sender is invalid" << KVLOG(senderId()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 }

--- a/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.cpp
@@ -44,16 +44,16 @@ void PreProcessBatchRequestMsg::validate(const ReplicasInfo& repInfo) const {
     throw std::runtime_error(__PRETTY_FUNCTION__);
 
   if (type() != MsgCode::PreProcessBatchRequest) {
-    LOG_ERROR(logger(), "Message type is incorrect" << KVLOG(type()));
+    LOG_WARN(logger(), "Message type is incorrect" << KVLOG(type()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 
   if (senderId() == repInfo.myId()) {
-    LOG_ERROR(logger(), "Message sender is invalid" << KVLOG(senderId()));
+    LOG_WARN(logger(), "Message sender is invalid" << KVLOG(senderId()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
   if (!checkElements()) {
-    LOG_ERROR(logger(), "One or more PreProcessReqMsg in the list is invalid");
+    LOG_WARN(logger(), "One or more PreProcessReqMsg in the list is invalid");
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 }
@@ -62,7 +62,7 @@ bool PreProcessBatchRequestMsg::checkElements() const {
   const auto totalMsgSize = size();
   const auto& numOfMessagesInBatch = msgBody()->numOfMessagesInBatch;
   if (!numOfMessagesInBatch || (numOfMessagesInBatch > MAX_BATCH_SIZE)) {
-    LOG_ERROR(logger(), KVLOG(numOfMessagesInBatch));
+    LOG_WARN(logger(), KVLOG(numOfMessagesInBatch));
     return false;
   }
   char* dataPosition = body() + sizeof(Header) + msgBody()->cidLength;
@@ -74,13 +74,13 @@ bool PreProcessBatchRequestMsg::checkElements() const {
     auto expectedSigLen = (isClientTransactionSigningEnabled ? sigManager->getSigLength(clientId) : 0);
     if ((expectedSigLen != singleMsgHeader.reqSignatureLength) || (totalMsgSize < singleMsgHeader.requestLength) ||
         (totalMsgSize < singleMsgHeader.cidLength)) {
-      LOG_ERROR(logger(),
-                KVLOG(clientId,
-                      totalMsgSize,
-                      expectedSigLen,
-                      singleMsgHeader.reqSignatureLength,
-                      singleMsgHeader.requestLength,
-                      singleMsgHeader.cidLength));
+      LOG_WARN(logger(),
+               KVLOG(clientId,
+                     totalMsgSize,
+                     expectedSigLen,
+                     singleMsgHeader.reqSignatureLength,
+                     singleMsgHeader.requestLength,
+                     singleMsgHeader.cidLength));
       return false;
     }
     dataPosition += sizeof(PreProcessRequestMsg::Header) + singleMsgHeader.spanContextSize +

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.cpp
@@ -58,13 +58,13 @@ void PreProcessReplyMsg::validate(const ReplicasInfo& repInfo) const {
   if (size() < headerSize || size() < headerSize + msgBody()->replyLength) throw runtime_error(__PRETTY_FUNCTION__);
 
   if (type() != MsgCode::PreProcessReply) {
-    LOG_ERROR(logger(), "Message type is incorrect" << KVLOG(type()));
+    LOG_WARN(logger(), "Message type is incorrect" << KVLOG(type()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 
   auto& msgHeader = *msgBody();
   if (msgHeader.senderId == repInfo.myId()) {
-    LOG_ERROR(logger(), "Message sender is invalid" << KVLOG(senderId()));
+    LOG_WARN(logger(), "Message sender is invalid" << KVLOG(senderId()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 
@@ -72,9 +72,9 @@ void PreProcessReplyMsg::validate(const ReplicasInfo& repInfo) const {
   uint16_t sigLen = sigManager->getSigLength(msgHeader.senderId);
   if (msgHeader.status == STATUS_GOOD) {
     if (size() < (sizeof(Header) + sigLen)) {
-      LOG_ERROR(logger(),
-                "Message size is too small" << KVLOG(
-                    msgHeader.senderId, msgHeader.clientId, msgHeader.reqSeqNum, size(), sizeof(Header) + sigLen));
+      LOG_WARN(logger(),
+               "Message size is too small" << KVLOG(
+                   msgHeader.senderId, msgHeader.clientId, msgHeader.reqSeqNum, size(), sizeof(Header) + sigLen));
       throw runtime_error(__PRETTY_FUNCTION__ + string(": Message size is too small"));
     }
     concord::diagnostics::TimeRecorder scoped_timer(*preProcessorHistograms_->verifyPreProcessReplySig);

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -84,12 +84,12 @@ void PreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {
   if (size() != expectedMsgSize) throw std::runtime_error(__PRETTY_FUNCTION__);
 
   if (type() != MsgCode::PreProcessRequest) {
-    LOG_ERROR(logger(), "Message type is incorrect" << KVLOG(type()));
+    LOG_WARN(logger(), "Message type is incorrect" << KVLOG(type()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 
   if (senderId() == repInfo.myId()) {
-    LOG_ERROR(logger(), "Message sender is ivalid" << KVLOG(senderId(), repInfo.myId()));
+    LOG_WARN(logger(), "Message sender is ivalid" << KVLOG(senderId(), repInfo.myId()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 
@@ -98,8 +98,8 @@ void PreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {
     if (!sigManager->verifySig(
             header->clientId, requestBuf(), header->requestLength, requestSignature, header->reqSignatureLength)) {
       std::stringstream msg;
-      LOG_ERROR(logger(),
-                "Signature verification failed for " << KVLOG(header->reqSeqNum, header->clientId, this->senderId()));
+      LOG_WARN(logger(),
+               "Signature verification failed for " << KVLOG(header->reqSeqNum, header->clientId, this->senderId()));
       msg << "Signature verification failed for: "
           << KVLOG(header->clientId, header->reqSeqNum, header->requestLength, header->reqSignatureLength);
       throw std::runtime_error(msg.str());

--- a/client/reconfiguration/src/poll_based_state_client.cpp
+++ b/client/reconfiguration/src/poll_based_state_client.cpp
@@ -36,7 +36,7 @@ concord::messages::ReconfigurationResponse PollBasedStateClient::sendReconfigura
     }
     concord::messages::deserialize(rep.matched_data, rres);
   } catch (std::exception& e) {
-    LOG_ERROR(getLogger(), "error while initiating bft request " << e.what());
+    LOG_WARN(getLogger(), "error while initiating bft request " << e.what());
     rres.success = false;
     return rres;
   }

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -74,9 +74,9 @@ void AsyncTlsConnection::readMsgSizeHeader(std::optional<size_t> bytes_already_r
             } else {
               // The message size header was read completely.
               if (getReadMsgSize() > config_.bufferLength) {
-                LOG_ERROR(logger_,
-                          "Message Size: " << getReadMsgSize() << " exceeds maximum: " << config_.bufferLength
-                                           << " for node " << peer_id_.value());
+                LOG_WARN(logger_,
+                         "Message Size: " << getReadMsgSize() << " exceeds maximum: " << config_.bufferLength
+                                          << " for node " << peer_id_.value());
                 return dispose();
               }
               if (!bytes_already_read) {
@@ -113,9 +113,9 @@ void AsyncTlsConnection::readMsg() {
           }
           // Remove the connection as it is no longer valid, and then close it, cancelling any ongoing
           // operations.
-          LOG_ERROR(logger_,
-                    "Reading message of size <<" << getReadMsgSize() << " failed for node " << peer_id_.value() << ": "
-                                                 << error_code.message());
+          LOG_WARN(logger_,
+                   "Reading message of size <<" << getReadMsgSize() << " failed for node " << peer_id_.value() << ": "
+                                                << error_code.message());
           return dispose();
         }
 
@@ -371,7 +371,7 @@ bool AsyncTlsConnection::verifyCertificateClient(asio::ssl::verify_context& ctx,
   std::string subject(256, 0);
   X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
   if (!cert) {
-    LOG_ERROR(logger_, "No certificate from server at node " << expected_dest_id);
+    LOG_WARN(logger_, "No certificate from server at node " << expected_dest_id);
     return false;
   }
   X509_NAME_oneline(X509_get_subject_name(cert), subject.data(), 256);
@@ -388,7 +388,7 @@ bool AsyncTlsConnection::verifyCertificateServer(asio::ssl::verify_context& ctx)
   std::string subject(SIZE, 0);
   X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
   if (!cert) {
-    LOG_ERROR(logger_, "No certificate from client");
+    LOG_WARN(logger_, "No certificate from client");
     return false;
   }
   X509_NAME_oneline(X509_get_subject_name(cert), subject.data(), SIZE);
@@ -413,13 +413,13 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* receivedCert
   std::smatch sm;
   regex_search(subject, sm, r);
   if (sm.length() <= peerIdPrefixLength) {
-    LOG_ERROR(logger_, "OU not found or empty: " << subject);
+    LOG_WARN(logger_, "OU not found or empty: " << subject);
     return std::make_pair(false, 0);
   }
 
   auto remPeer = sm.str().substr(peerIdPrefixLength, sm.str().length() - peerIdPrefixLength);
   if (0 == remPeer.length()) {
-    LOG_ERROR(logger_, "OU empty " << subject);
+    LOG_WARN(logger_, "OU empty " << subject);
     return std::make_pair(false, 0);
   }
 
@@ -427,17 +427,17 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* receivedCert
   try {
     remotePeerId = stoul(remPeer, nullptr);
   } catch (const std::invalid_argument& ia) {
-    LOG_ERROR(logger_, "cannot convert OU, " << subject << ", " << ia.what());
+    LOG_WARN(logger_, "cannot convert OU, " << subject << ", " << ia.what());
     return std::make_pair(false, 0);
   } catch (const std::out_of_range& e) {
-    LOG_ERROR(logger_, "cannot convert OU, " << subject << ", " << e.what());
+    LOG_WARN(logger_, "cannot convert OU, " << subject << ", " << e.what());
     return std::make_pair(false, 0);
   }
 
   // If the server has been verified, check that the peers match.
   if (expectedPeerId) {
     if (remotePeerId != expectedPeerId) {
-      LOG_ERROR(logger_, "Peers don't match, expected: " << expectedPeerId.value() << ", received: " << remPeer);
+      LOG_WARN(logger_, "Peers don't match, expected: " << expectedPeerId.value() << ", received: " << remPeer);
       return std::make_pair(false, remotePeerId);
     }
   }
@@ -477,9 +477,9 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* receivedCert
     // Instead we log in onXXXHandshakeComplete callbacks it TlsTcpImpl.
     return std::make_pair(true, remotePeerId);
   }
-  LOG_ERROR(logger_,
-            "X509_cmp failed at node: " << config_.selfId << ", type: " << connectionType << ", peer: " << remotePeerId
-                                        << " res=" << res);
+  LOG_WARN(logger_,
+           "X509_cmp failed at node: " << config_.selfId << ", type: " << connectionType << ", peer: " << remotePeerId
+                                       << " res=" << res);
   return std::make_pair(false, remotePeerId);
 }
 

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -282,7 +282,7 @@ class PlainUDPCommunication::PlainUdpImpl {
     if (res == addr2nodes.end()) {
       // IG: if we don't know the sender we just ignore this message and
       // continue.
-      LOG_ERROR(_logger, "Unknown sender, address: " << key);
+      LOG_WARN(_logger, "Unknown sender, address: " << key);
       return NodeAddressResolveResult({0, false, key});
     }
 

--- a/communication/src/TlsConnectionManager.cpp
+++ b/communication/src/TlsConnectionManager.cpp
@@ -213,7 +213,7 @@ void ConnectionManager::onServerHandshakeComplete(const asio::error_code& ec, si
   status_->num_accepted_waiting_for_handshake = accepted_waiting_for_handshake_.size();
   if (ec) {
     auto peer_str = conn->getPeerId().has_value() ? std::to_string(conn->getPeerId().value()) : "Unknown";
-    LOG_ERROR(logger_, "Server handshake failed for peer " << peer_str << ": " << ec.message());
+    LOG_WARN(logger_, "Server handshake failed for peer " << peer_str << ": " << ec.message());
     return closeConnection(std::move(conn));
   }
   LOG_INFO(logger_, "Server handshake succeeded for peer " << conn->getPeerId().value());
@@ -225,7 +225,7 @@ void ConnectionManager::onClientHandshakeComplete(const asio::error_code& ec, No
   connected_waiting_for_handshake_.erase(destination);
   status_->num_connected_waiting_for_handshake = connected_waiting_for_handshake_.size();
   if (ec) {
-    LOG_ERROR(logger_, "Client handshake failed for peer " << conn->getPeerId().value() << ": " << ec.message());
+    LOG_WARN(logger_, "Client handshake failed for peer " << conn->getPeerId().value() << ": " << ec.message());
     return closeConnection(std::move(conn));
   }
   status_->total_connect_attempts_completed++;

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -673,9 +673,9 @@ void DBAdapter::getLastKnownReconfigurationCmdBlock(std::string &outBlockData) c
       if (Status s = mdtGet(lastKnownReconfigCmdBlockIdKey, val); s.isOK())
         outBlockData = val.toString();
       else
-        LOG_ERROR(logger_, "Error in getting Latest known reconfig block ");
+        LOG_WARN(logger_, "Error in getting Latest known reconfig block ");
     } catch (std::exception &e) {
-      LOG_ERROR(logger_, "Error in getting Latest known reconfig block" << e.what());
+      LOG_WARN(logger_, "Error in getting Latest known reconfig block" << e.what());
     }
   }
 }

--- a/kvbc/src/direct_kv_db_adapter.cpp
+++ b/kvbc/src/direct_kv_db_adapter.cpp
@@ -673,9 +673,9 @@ void DBAdapter::getLastKnownReconfigurationCmdBlock(std::string &outBlockData) c
       if (Status s = mdtGet(lastKnownReconfigCmdBlockIdKey, val); s.isOK())
         outBlockData = val.toString();
       else
-        LOG_WARN(logger_, "Error in getting Latest known reconfig block ");
+        LOG_WARN(logger_, "Unable to get the last known reconfig block");
     } catch (std::exception &e) {
-      LOG_WARN(logger_, "Error in getting Latest known reconfig block" << e.what());
+      LOG_WARN(logger_, "Unable to get the last known reconfig block: " << e.what());
     }
   }
 }

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -172,7 +172,7 @@ bool ReconfigurationHandler::handle(const concord::messages::InstallCommand& cmd
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ReconfigurationErrorMsg error_msg;
   if (cmd.version.empty()) {
-    LOG_ERROR(getLogger(), "InstallCommand received with empty version string at seq_num " << sequence_num);
+    LOG_WARN(getLogger(), "InstallCommand received with empty version string at seq_num " << sequence_num);
     return false;
   }
   LOG_INFO(getLogger(), "InstallCommand instructs replica to stop at seq_num " << KVLOG(sequence_num, cmd.version));
@@ -209,7 +209,7 @@ BftReconfigurationHandler::BftReconfigurationHandler() {
   std::ifstream key_content;
   key_content.open(operatorPubKeyPath);
   if (!key_content) {
-    LOG_ERROR(getLogger(), "unable to read the operator public key file");
+    LOG_WARN(getLogger(), "unable to read the operator public key file");
     return;
   }
   auto key_str = std::string{};

--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -112,7 +112,6 @@ Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
     _outValue = Sliver::copy(reinterpret_cast<const char*>(cbData.data), cbData.readLength);
     return Status::OK();
   } else {
-    LOG_ERROR(logger_, "get status: " << S3_get_status_name(cbData.status) << " (" << cbData.errorMessage << ")");
     if (cbData.status == S3Status::S3StatusHttpErrorNotFound || cbData.status == S3Status::S3StatusErrorNoSuchBucket ||
         cbData.status == S3Status::S3StatusErrorNoSuchKey)
       return Status::NotFound("Status: " + std::string(S3_get_status_name(cbData.status)) +

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -123,7 +123,7 @@ void InternalCommandsHandler::execute(InternalCommandsHandler::ExecutionRequests
                                 merkleUpdates);
     }
 
-    if (!res) LOG_ERROR(m_logger, "Command execution failed!");
+    if (!res) LOG_WARN(m_logger, "Command execution failed!");
     req.outExecutionStatus = res ? 0 : -1;
   }
 
@@ -427,7 +427,7 @@ bool InternalCommandsHandler::executeGetBlockDataCommand(const SKVBCGetBlockData
   auto block_id = request.block_id;
   const auto updates = getBlockUpdates(block_id);
   if (!updates) {
-    LOG_ERROR(m_logger, "GetBlockData: Failed to retrieve block ID " << block_id);
+    LOG_WARN(m_logger, "GetBlockData: Failed to retrieve block ID " << block_id);
     return false;
   }
 
@@ -554,7 +554,7 @@ bool InternalCommandsHandler::executeReadOnlyCommand(uint32_t requestSize,
         std::get<SKVBCGetBlockDataRequest>(deserialized_request.request), maxReplySize, outReply, outReplySize);
   } else {
     outReplySize = 0;
-    LOG_ERROR(m_logger, "Received read-only request of unrecognized message type.");
+    LOG_WARN(m_logger, "Received read-only request of unrecognized message type.");
     return false;
   }
 }

--- a/util/src/MetricsServer.cpp
+++ b/util/src/MetricsServer.cpp
@@ -137,7 +137,7 @@ void Server::sendError(sockaddr_in* cliaddr, socklen_t addrlen) {
   memcpy(buf_ + sizeof(Header), msg, msglen);
   auto len = sendto(sock_, buf_, msglen + sizeof(Header), 0, (const struct sockaddr*)cliaddr, addrlen);
   if (len < 0) {
-    LOG_ERROR(logger_, "Failed to send error msg: " << concordUtils::errnoString(errno));
+    LOG_WARN(logger_, "Failed to send error msg: " << concordUtils::errnoString(errno));
   }
 }
 

--- a/util/src/MetricsServer.cpp
+++ b/util/src/MetricsServer.cpp
@@ -137,7 +137,7 @@ void Server::sendError(sockaddr_in* cliaddr, socklen_t addrlen) {
   memcpy(buf_ + sizeof(Header), msg, msglen);
   auto len = sendto(sock_, buf_, msglen + sizeof(Header), 0, (const struct sockaddr*)cliaddr, addrlen);
   if (len < 0) {
-    LOG_WARN(logger_, "Failed to send error msg: " << concordUtils::errnoString(errno));
+    LOG_ERROR(logger_, "Failed to send error msg: " << concordUtils::errnoString(errno));
   }
 }
 


### PR DESCRIPTION
Most of the changes in PR #2000 are preserved except two cases where the error log level is kept as is:
* SigManager should log an unrecognized pid as an error to remind
that invalid pids from messages should be sanitized earlier.
* MetricsServer sendError should log an error instead of
a warning - the fix for the error is in PR #2016
And one minor addition:
* Added more suitable wording for the warning
in getLastKnownReconfigurationCmdBlock.