### PR TITLE
Asynchronous Incoming External Message validation

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <utility>
+
 #include "ReplicaForStateTransfer.hpp"
 #include "CollectorOfThresholdSignatures.hpp"
 #include "SeqNumInfo.hpp"
@@ -340,6 +341,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   template <typename T>
   void messageHandler(MessageBase* msg);
 
+  template <typename T>
+  void validatedMessageHandler(CarrierMesssage* msg);
+
   void send(MessageBase*, NodeIdType) override;
   void sendAndIncrementMetric(MessageBase*, NodeIdType, CounterHandle&);
 
@@ -398,6 +402,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   std::pair<PrePrepareMsg*, bool> buildPrePrepareMessageByBatchSize(uint32_t requiredBatchSizeInBytes);
 
   void validatePrePrepareMsg(PrePrepareMsg*& ppm);
+
+  template <typename MSG>
+  void asyncValidateMessage(MSG* msg);
 
   void removeDuplicatedRequestsFromRequestsQueue();
 
@@ -486,6 +493,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqNum,
                                           const ViewNum relatedViewNumber,
                                           const std::forward_list<RetSuggestion>& suggestedRetransmissions);
+
+  void onCarrierMessage(CarrierMesssage* msg);
 
  private:
   void addTimers();

--- a/bftengine/src/bftengine/messages/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.hpp
@@ -48,6 +48,8 @@ class CheckpointMsg : public MessageBase {
 
   void validate(const ReplicasInfo& repInfo) const override;
 
+  bool shouldValidateAsync() const override { return true; }
+
   void sign();
 
   void setSenderId(NodeIdType id) { sender_ = id; }

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -71,6 +71,8 @@ class ClientRequestMsg : public MessageBase {
 
   void validate(const ReplicasInfo& repInfo) const override { validateImp(repInfo); }
 
+  bool shouldValidateAsync() const override;
+
  protected:
   ClientRequestMsgHeader* msgBody() const { return ((ClientRequestMsgHeader*)msgBody_); }
 

--- a/bftengine/src/bftengine/messages/InternalMessage.hpp
+++ b/bftengine/src/bftengine/messages/InternalMessage.hpp
@@ -18,9 +18,10 @@
 #include "messages/RetranProcResultInternalMsg.hpp"
 #include "messages/TickInternalMsg.hpp"
 #include "messages/PrePrepareMsg.hpp"
-#include "SignatureInternalMsgs.hpp"
-#include "ViewChangeIndicatorInternalMsg.hpp"
-#include "PrePrepareCarrierInternalMsg.hpp"
+#include "messages/SignatureInternalMsgs.hpp"
+#include "messages/ViewChangeIndicatorInternalMsg.hpp"
+#include "messages/PrePrepareCarrierInternalMsg.hpp"
+#include "messages/ValidatedMessageCarrierInternalMsg.hpp"
 
 namespace bftEngine::impl {
 
@@ -62,6 +63,10 @@ using InternalMessage = std::variant<FullCommitProofMsg*,
 
                                      // Carries PrePrepare message after validation.
                                      PrePrepareCarrierInternalMsg,
+
+                                     // Add Carriers of messages which will encapsulate
+                                     // Incoming External messages to Internal message.
+                                     CarrierMesssage*,
 
                                      // Retransmission manager related
                                      RetranProcResultInternalMsg,

--- a/bftengine/src/bftengine/messages/MessageBase.cpp
+++ b/bftengine/src/bftengine/messages/MessageBase.cpp
@@ -129,6 +129,7 @@ void MessageBase::validate(const ReplicasInfo &) const {
   LOG_DEBUG(GL, "Calling MessageBase::validate on a message of type " << type());
 }
 
+bool MessageBase::shouldValidateAsync() const { return false; }
 void MessageBase::setMsgSize(MsgSize size) {
   ConcordAssert((msgBody_ != nullptr));
   ConcordAssert(size <= storageSize_);

--- a/bftengine/src/bftengine/messages/MessageBase.hpp
+++ b/bftengine/src/bftengine/messages/MessageBase.hpp
@@ -50,6 +50,9 @@ class MessageBase {
 
   virtual void validate(const ReplicasInfo &) const;
 
+  // This function will tell whether async validation of a message is enabled or not.
+  virtual bool shouldValidateAsync() const;
+
   bool equals(const MessageBase &other) const;
 
   static size_t serializeMsg(char *&buf, const MessageBase *msg);

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -60,6 +60,8 @@ class PrePrepareMsg : public MessageBase {
 
   void validate(const ReplicasInfo&) const override;
 
+  bool shouldValidateAsync() const override { return true; }
+
   // size - total size of all requests that will be added
   PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath firstPath, size_t size);
 

--- a/bftengine/src/bftengine/messages/ReplicaAsksToLeaveViewMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReplicaAsksToLeaveViewMsg.hpp
@@ -16,7 +16,6 @@
 #include "assertUtils.hpp"
 #include "Digest.hpp"
 #include "ReplicaConfig.hpp"
-
 #include "MessageBase.hpp"
 #include "OpenTracing.hpp"
 
@@ -51,6 +50,8 @@ class ReplicaAsksToLeaveViewMsg : public MessageBase {
                                            const concordUtils::SpanContext& spanContext = {});
 
   void validate(const ReplicasInfo&) const override;
+
+  bool shouldValidateAsync() const override { return true; }
 
  protected:
   template <typename MessageT>

--- a/bftengine/src/bftengine/messages/ReplicaRestartReadyMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReplicaRestartReadyMsg.hpp
@@ -56,6 +56,8 @@ class ReplicaRestartReadyMsg : public MessageBase {
 
   void validate(const ReplicasInfo&) const override;
 
+  bool shouldValidateAsync() const override { return true; }
+
   static uint32_t sizeOfHeader() { return sizeof(Header); }
 
  protected:

--- a/bftengine/src/bftengine/messages/ReplicasRestartReadyProofMsg.cpp
+++ b/bftengine/src/bftengine/messages/ReplicasRestartReadyProofMsg.cpp
@@ -9,6 +9,7 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 #include <cstring>
+
 #include "OpenTracing.hpp"
 #include "ReplicasRestartReadyProofMsg.hpp"
 #include "SysConsts.hpp"

--- a/bftengine/src/bftengine/messages/ReplicasRestartReadyProofMsg.hpp
+++ b/bftengine/src/bftengine/messages/ReplicasRestartReadyProofMsg.hpp
@@ -49,6 +49,8 @@ class ReplicasRestartReadyProofMsg : public MessageBase {
 
   void validate(const ReplicasInfo&) const override;
 
+  bool shouldValidateAsync() const override { return true; }
+
   bool checkElements(const ReplicasInfo& repInfo, uint16_t sigSize) const;
 
  protected:

--- a/bftengine/src/bftengine/messages/ValidatedMessageCarrierInternalMsg.hpp
+++ b/bftengine/src/bftengine/messages/ValidatedMessageCarrierInternalMsg.hpp
@@ -1,0 +1,61 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <type_traits>
+
+#include "MessageBase.hpp"
+
+namespace bftEngine {
+namespace impl {
+
+// Any Incoming message is external and can be translated into internal message.
+// CarrierMesssage class will contain the knowledge of type of the translated message that
+// Carried from internal message into external message
+class CarrierMesssage {
+ public:
+  CarrierMesssage(MsgType msgType) : msgType_(msgType) {}
+  virtual ~CarrierMesssage() {}
+  MsgType getMsgType() const { return msgType_; }
+
+ private:
+  MsgType msgType_;
+};
+
+// One use case of translation of message is doing validation in a separate thread and then
+// use the validated message as an internal message. This message is encapsulated by
+// ValidatedMessageCarrierInternalMsg<T> class.
+// This class assumes that the translated message is a subclass of MessageBase
+template <typename MSG, typename = std::enable_if_t<std::is_base_of_v<MessageBase, MSG>>>
+class ValidatedMessageCarrierInternalMsg : public CarrierMesssage {
+ public:
+  // This ctor will get a ptr to message and it is not responsible to allocate or deallocation of the message
+  // It just carries the message.
+  ValidatedMessageCarrierInternalMsg(MSG*& msg) : CarrierMesssage(msg->type()), msg_(std::move(msg)) {}
+
+  // Once the message is returned to the owner of the message, it will never be taken by anyone or
+  // given to anyone.
+  // This is a onetime transaction. Subsequent call to this function will be nullptr.
+  MSG* returnMessageToOwner() {
+    MSG* retMsg = msg_;
+    msg_ = nullptr;
+    return retMsg;
+  }
+  ~ValidatedMessageCarrierInternalMsg() { msg_ = nullptr; }
+  typedef MSG type;
+
+ private:
+  MSG* msg_ = nullptr;
+};
+
+}  // namespace impl
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
+++ b/bftengine/src/bftengine/messages/ViewChangeMsg.hpp
@@ -82,6 +82,8 @@ class ViewChangeMsg : public MessageBase {
 
   void validate(const ReplicasInfo&) const override;
 
+  bool shouldValidateAsync() const override { return true; }
+
   class ElementsIterator {
    public:
     // this ctor assumes that m is a legal ViewChangeMsg message (as defined by checkElements() )

--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -217,7 +217,6 @@ class SkvbcBatchPreExecutionTest(unittest.TestCase):
         try:
             with trio.move_on_after(seconds=INDEFINITE_BATCH_WRITES_TIMEOUT):
                 await skvbc.send_indefinite_batch_writes(BATCH_SIZE)
-
         except trio.TooSlowError:
             pass
         finally:

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -318,7 +318,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
             await bft_network.wait_for_view(replica_id=random.choice(bft_network.all_replicas(without={0})),
                                             expected=lambda v: v == expected_next_primary,
                                             err_msg="Make sure view change has been triggered.")
-            await skvbc.send_write_kv_set(client, max_set_size=2)
+            await skvbc.send_write_kv_set(client, max_set_size=2, raise_slowErrorIfAny=False)
 
     @with_trio
     @with_bft_network(start_replica_cmd)


### PR DESCRIPTION
The message validation for various message involves
many time consuming tasks. Such tasks leads to slower
validation of messages. If the entire process of
validation happens asynchronously then the throughput
of our system will improve. This PR is achieving this
by the following step:
If the message requires asynchronous validation
then the validation happens in a separate thread;
     After validation, the message is translated
     into an internal message and pushed into the
     internal message queue.
     The internal message is handled by the replica
Criteria for async message validation:
If for a message the validation require any time consuming
operation, like signature verification, then only such message's
validation will happen asynchronously.
List of messages chosen in this PR are as below:
1) CheckpointMsg
2) ClientRequestMsg
3) PrePrepareMsg (This message is handled separately)
4) ReplicaRestartReadyMsg
5) ReplicasRestartReadyProofMsg
6) ViewChangeMsg
Adding existing message for Async validation is simple:
step1: Review if the validation can happen in a separate
thread
step2: Add bool canValidateAsync() const override { 
return true; 
}
In the message as public member function.
Adding a new message for Async validation require the
following extra step:
step3: Register the validated message callback in
MsgHandlersRegistrator.