### PR TITLE
WIP: Enable Time-service V2 for Apollo test cases by default

### DIFF
--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -36,7 +36,8 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", view_change_timeout_milli
+            "-v", view_change_timeout_milli,
+            "-f", '0' # disable time service until intermittent failures are fixed for this test
             ]
 
 

--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -34,7 +34,8 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli
+            "-v", viewChangeTimeoutMilli,
+            "-f", '0' # disable time service until intermittent failures are fixed for this test
             ]
 
 

--- a/tests/apollo/test_skvbc_client_transaction_signing.py
+++ b/tests/apollo/test_skvbc_client_transaction_signing.py
@@ -43,7 +43,8 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-e", str(True)
+            "-e", str(True),
+            "-f", '0'
             ]
 
 class SkvbcTestClientTxnSigning(unittest.TestCase):

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -37,7 +37,8 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli
+            "-v", viewChangeTimeoutMilli,
+            "-f", '0' # disable time service until intermittent failures are fixed for this test
             ]
 
 

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -42,7 +42,8 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli
+            "-v", viewChangeTimeoutMilli,
+            "-f", '0' # disable time service 
             ]
 
 

--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -35,7 +35,8 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-e", str(True)
+            "-e", str(True),
+            "-f", '0' # disable time service until intermittent failures are fixed for this test
             ]
 
 

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.pruningEnabled_ = true;
     replicaConfig.numBlocksToKeep_ = 10;
     replicaConfig.batchedPreProcessEnabled = true;
-    replicaConfig.timeServiceEnabled = false;
+    replicaConfig.timeServiceEnabled = true;
     replicaConfig.enablePostExecutionSeparation = true;
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
     replicaConfig.set("concord.bft.st.runInSeparateThread", true);


### PR DESCRIPTION
This PR will enable time-service for all apollo tests except the following:
1. test_skvbc_chaotic_startup
2. test_skvbc_checkpoints
3. test_skvbc_network_partitioning
4. test_skvbc_state_transfer
5. test_skvbc_persistence
6. test_skvbc_client_transaction_signing