### PR TITLE
[WIP] Introduce a new method to exchange TLS certificates

### DIFF
--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -128,7 +128,7 @@ class FakeCommunication : public bft::communication::ICommunication {
 
   void setReceiver(NodeNum id, IReceiver* receiver) override { receiver_ = receiver; }
 
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
 
  private:
   IReceiver* receiver_;

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -28,7 +28,7 @@ typedef int64_t SeqNum;  // TODO [TK] redefinition
 
 class KeyExchangeManager {
  public:
-  void exchangeTlsKeys(const SeqNum&);
+  void exchangeTlsKeys(uint64_t bftSn);
   // Generates and publish key to consensus
   void sendKeyExchange(const SeqNum&);
   // Generates and publish the first replica's key,
@@ -180,6 +180,7 @@ class KeyExchangeManager {
   std::string generateCid(std::string);
   // build cryptosystem
   void notifyRegistry();
+  void exchangeTlsKeys(const std::string& type, uint64_t bftSn);
   /**
    * Samples periodically how many connections the replica has with other replicas.
    * returns when num of connections is (clusterSize - 1) i.e. full communication.

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -187,7 +187,10 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                std::chrono::milliseconds,
                std::chrono::milliseconds{1},
                "time provided to execution is max(consensus_time, last_time + timeServiceEpsilonMillis)");
-
+  CONFIG_PARAM(rotatingCertificatesTimeoutSeconds,
+               uint64_t,
+               300,
+               "specifies the amount of time we wait after TLS key rotation before start using the new certificate");
   // Ticks Generator
   CONFIG_PARAM(ticksGeneratorPollPeriod,
                std::chrono::seconds,
@@ -301,6 +304,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, timeServiceHardLimitMillis);
     serialize(outStream, timeServiceSoftLimitMillis);
     serialize(outStream, timeServiceEpsilonMillis);
+    serialize(outStream, rotatingCertificatesTimeoutSeconds);
     serialize(outStream, ticksGeneratorPollPeriod);
     serialize(outStream, preExecutionResultAuthEnabled);
     serialize(outStream, prePrepareFinalizeAsyncEnabled);
@@ -379,6 +383,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, timeServiceHardLimitMillis);
     deserialize(inStream, timeServiceSoftLimitMillis);
     deserialize(inStream, timeServiceEpsilonMillis);
+    deserialize(inStream, rotatingCertificatesTimeoutSeconds);
     deserialize(inStream, ticksGeneratorPollPeriod);
     deserialize(inStream, preExecutionResultAuthEnabled);
     deserialize(inStream, prePrepareFinalizeAsyncEnabled);

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -63,7 +63,7 @@ class Communication : public ICommunication {
     return ret;
   }
   void setReceiver(NodeNum receiverNum, IReceiver* receiver) override { receiver_ = receiver; }
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
 
  private:
   std::shared_ptr<MsgsCommunicator> msgsCommunicator_;

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -127,24 +127,39 @@ void KeyExchangeManager::loadPublicKeys() {
   notifyRegistry();
 }
 
-void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
-  auto repId = bftEngine::ReplicaConfig::instance().replicaId;
+void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bftSn) {
+  std::string tmp_suffix = type == "client" ? std::string() : ".latest";
   auto keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
       concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);
-  auto cert = concord::util::crypto::Crypto::instance().generateSelfSignedCertificate(
-      keys, "node" + std::to_string(repId) + "ser", repId);
-  std::string pk_path =
-      bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" + std::to_string(repId) + "/server/pk.pem";
-  concord::secretsmanager::SecretsManagerPlain psm_;
+  std::string root_path =
+      bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" + std::to_string(repID_) + "/" + type;
+
+  std::string cert_path = root_path + "/" + type + ".cert";
+  std::string prev_key_pem = concord::util::crypto::Crypto::instance()
+                                 .RsaHexToPem(std::make_pair(SigManager::instance()->getSelfPrivKey(), ""))
+                                 .first;
+  auto cert = concord::util::crypto::CertificateUtils::generateSelfSignedCert(cert_path, keys.second, prev_key_pem);
+  // Now that we have generated new key pair and certificate, lets do the actual exchange on this replica
+  std::string pk_path = root_path + "/pk.pem";
   std::fstream nec_f(pk_path);
-  if (nec_f.good()) {
-    secretsMgr_->encryptFile(pk_path + ".tmp", keys.first);
-  }
   std::fstream ec_f(pk_path + ".enc");
+
+  // 1. exchange private key
+  if (nec_f.good()) {
+    secretsMgr_->encryptFile(pk_path + tmp_suffix, keys.first);
+    nec_f.close();
+  }
   if (ec_f.good()) {
-    secretsMgr_->encryptFile(pk_path + ".enc.tmp", keys.first);
+    secretsMgr_->encryptFile(pk_path + ".enc" + tmp_suffix, keys.first);
+    ec_f.close();
   }
 
+  concord::secretsmanager::SecretsManagerPlain psm_;
+  // 2. exchange the certificate itself
+  psm_.encryptFile(cert_path + tmp_suffix, cert);
+
+  if (type == "client") return;
+  auto repId = bftEngine::ReplicaConfig::instance().replicaId;
   concord::messages::ReconfigurationRequest req;
   req.sender = repId;
   req.command = concord::messages::ReplicaTlsExchangeKey{repId, cert};
@@ -158,8 +173,13 @@ void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
   data_vec.clear();
   concord::messages::serialize(data_vec, req);
   std::string strMsg(data_vec.begin(), data_vec.end());
-  std::string cid = "replicaTlsKeyExchange_" + std::to_string(bft_sn) + "_" + std::to_string(repId);
+  std::string cid = "replicaTlsKeyExchange_" + std::to_string(bftSn) + "_" + std::to_string(repId);
   client_->sendRequest(RECONFIG_FLAG, strMsg.size(), strMsg.c_str(), cid);
+}
+
+void KeyExchangeManager::exchangeTlsKeys(uint64_t bftSn) {
+  exchangeTlsKeys("server", bftSn);
+  exchangeTlsKeys("client", bftSn);
   metrics_->tls_key_exchange_requests_++;
   LOG_INFO(KEY_EX_LOG, "Replica has generated a new tls keys");
 }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -56,6 +56,7 @@
 #include <string>
 #include <type_traits>
 #include <bitset>
+#include "communication/StateControl.hpp"
 
 #define getName(var) #var
 
@@ -3954,6 +3955,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
     sigManager_.reset(sigManager);
     viewsManager = viewsMgr;
   }
+  bft::communication::StateControl::instance().setGetPeerPubKeyMethod(
+      [&](uint32_t id) { return sigManager_->getPublicKeyOfVerifier(id); });
   // clients ids are assigned as follows:
   // - client proxies starting at a subsequent id of the last (ro-)replica
   // - external clients

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -73,6 +73,11 @@ class SigManager {
   SigManager& operator=(SigManager&&) = delete;
 
   std::string getClientsPublicKeys();
+  std::string getPublicKeyOfVerifier(uint32_t id) const {
+    if (!verifiers_.count(id)) return std::string();
+    return verifiers_.at(id)->getPubKey();
+  }
+  std::string getSelfPrivKey() const { return mySigner_->getPrivKey(); }
 
  protected:
   static constexpr uint16_t updateMetricsAggregatorThresh = 1000;

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -134,7 +134,7 @@ class PlainUDPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  void dispose(NodeNum i) override{};
+  void restartCommunication(NodeNum i) override{};
   ~PlainUDPCommunication() override;
 
  private:
@@ -161,7 +161,7 @@ class PlainTCPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
   ~PlainTCPCommunication() override;
 
  private:
@@ -190,7 +190,7 @@ class TlsTCPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  void dispose(NodeNum i) override;
+  void restartCommunication(NodeNum i) override;
   ~TlsTCPCommunication() override;
 
  private:

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -67,7 +67,7 @@ class ICommunication {
 
   virtual void setReceiver(NodeNum receiverNum, IReceiver* receiver) = 0;
 
-  virtual void dispose(NodeNum i) = 0;
+  virtual void restartCommunication(NodeNum i) = 0;
   virtual ~ICommunication() = default;
 };
 }  // namespace bft::communication

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 #include <functional>
+#include <utility>
 #include "callback_registry.hpp"
 namespace bft::communication {
 class StateControl {
@@ -29,9 +30,15 @@ class StateControl {
   }
 
   void restartComm(uint32_t id) { comm_restart_cb_registry_.invokeAll(id); }
+  void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { getPeerPubKey_ = std::move(m); }
+  std::string getPeerPubKey(uint32_t id) {
+    if (getPeerPubKey_) return getPeerPubKey_(id);
+    return std::string();
+  }
 
  private:
   std::mutex lock_comm_;
   concord::util::CallbackRegistry<uint32_t> comm_restart_cb_registry_;
+  std::function<std::string(uint32_t)> getPeerPubKey_;
 };
 }  // namespace bft::communication

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -22,6 +22,8 @@
 #include "TlsWriteQueue.h"
 #include "secrets_manager_enc.h"
 #include "secrets_manager_plain.h"
+#include "crypto_utils.hpp"
+#include "communication/StateControl.hpp"
 
 namespace bft::communication::tls {
 
@@ -374,8 +376,7 @@ bool AsyncTlsConnection::verifyCertificateClient(asio::ssl::verify_context& ctx,
     LOG_ERROR(logger_, "No certificate from server at node " << expected_dest_id);
     return false;
   }
-  X509_NAME_oneline(X509_get_subject_name(cert), subject.data(), 256);
-  auto [valid, _] = checkCertificate(cert, "server", subject, expected_dest_id);
+  auto [valid, _] = checkCertificate(cert, expected_dest_id);
   (void)_;  // unused variable hack
   return valid;
 }
@@ -384,103 +385,74 @@ bool AsyncTlsConnection::verifyCertificateServer(asio::ssl::verify_context& ctx)
   if (X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT != X509_STORE_CTX_get_error(ctx.native_handle())) {
     return false;
   }
-  static constexpr size_t SIZE = 512;
-  std::string subject(SIZE, 0);
   X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
   if (!cert) {
     LOG_ERROR(logger_, "No certificate from client");
     return false;
   }
-  X509_NAME_oneline(X509_get_subject_name(cert), subject.data(), SIZE);
-  auto [valid, peer_id] = checkCertificate(cert, "client", std::string(subject), std::nullopt);
+  auto [valid, peer_id] = checkCertificate(cert, std::nullopt);
   peer_id_ = peer_id;
   return valid;
 }
 
 std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* receivedCert,
-                                                              std::string connectionType,
-                                                              const std::string& subject,
                                                               std::optional<NodeNum> expectedPeerId) {
-  // First, perform a basic sanity test, in order to eliminate a disk read if the certificate is
-  // unknown.
-  //
-  // The certificate must have a node id, as we put it in `OU` field on creation.
-  //
-  // Since we use pinning we must know who the remote peer is.
-  // `peerIdPrefixLength` stands for the length of 'OU=' substring
-  int peerIdPrefixLength = 3;
-  std::regex r("OU=\\d*", std::regex_constants::icase);
-  std::smatch sm;
-  regex_search(subject, sm, r);
-  if (sm.length() <= peerIdPrefixLength) {
-    LOG_ERROR(logger_, "OU not found or empty: " << subject);
-    return std::make_pair(false, 0);
-  }
+  uint32_t peerId = UINT32_MAX;
+  std::string conn_type;
+  bool res = concord::util::crypto::CertificateUtils::verifyCertificate(
+      receivedCert, config_.certificatesRootPath, peerId, conn_type);
+  LOG_INFO(GL, "*** :" << KVLOG(res, expectedPeerId.has_value()));
+  if (expectedPeerId.has_value() && peerId != expectedPeerId.value()) return std::make_pair(false, peerId);
+  if (!res) {
+    std::string pem_pub_key = StateControl::instance().getPeerPubKey(peerId);
+    if (concord::util::crypto::Crypto::instance().getFormat(pem_pub_key) !=
+        concord::util::crypto::KeyFormat::PemFormat) {
+      pem_pub_key = concord::util::crypto::Crypto::instance()
+                        .RsaHexToPem(std::make_pair("", StateControl::instance().getPeerPubKey(peerId)))
+                        .second;
+    }
+    res = concord::util::crypto::CertificateUtils::verifyCertificate(receivedCert, pem_pub_key);
+    if (!res) {
+      auto latest_cert = config_.certificatesRootPath + "/" + std::to_string(peerId) + "/server/server.cert.latest";
+      auto deleter = [](FILE* fp) {
+        if (fp) fclose(fp);
+      };
+      std::unique_ptr<FILE, decltype(deleter)> fp(fopen(latest_cert.c_str(), "r"), deleter);
+      if (!fp) {
+        LOG_ERROR(GL, "Certificate file not found, path: " << latest_cert);
+        return std::make_pair(false, peerId);
+      }
 
-  auto remPeer = sm.str().substr(peerIdPrefixLength, sm.str().length() - peerIdPrefixLength);
-  if (0 == remPeer.length()) {
-    LOG_ERROR(logger_, "OU empty " << subject);
-    return std::make_pair(false, 0);
-  }
+      X509* cert = PEM_read_X509(fp.get(), NULL, NULL, NULL);
+      if (!cert) {
+        LOG_ERROR(GL, "Cannot parse certificate, path: " << latest_cert);
+        return std::make_pair(false, peerId);
+      }
+      res = (X509_cmp(receivedCert, cert) == 0);
+    }
 
-  NodeNum remotePeerId;
-  try {
-    remotePeerId = stoul(remPeer, nullptr);
-  } catch (const std::invalid_argument& ia) {
-    LOG_ERROR(logger_, "cannot convert OU, " << subject << ", " << ia.what());
-    return std::make_pair(false, 0);
-  } catch (const std::out_of_range& e) {
-    LOG_ERROR(logger_, "cannot convert OU, " << subject << ", " << e.what());
-    return std::make_pair(false, 0);
-  }
-
-  // If the server has been verified, check that the peers match.
-  if (expectedPeerId) {
-    if (remotePeerId != expectedPeerId) {
-      LOG_ERROR(logger_, "Peers don't match, expected: " << expectedPeerId.value() << ", received: " << remPeer);
-      return std::make_pair(false, remotePeerId);
+    if (res) {
+      BIO* outbio = BIO_new(BIO_s_mem());
+      if (!PEM_write_bio_X509(outbio, receivedCert)) {
+        BIO_free(outbio);
+        return std::make_pair(false, peerId);
+      }
+      std::string local_cert_path =
+          config_.certificatesRootPath + "/" + std::to_string(peerId) + "/" + conn_type + "/" + conn_type + ".cert";
+      std::string certStr;
+      int certLen = BIO_pending(outbio);
+      certStr.resize(certLen);
+      BIO_read(outbio, (void*)&(certStr.front()), certLen);
+      std::ofstream out(local_cert_path.data());
+      out << certStr;
+      out.close();
+      BIO_free(outbio);
+      LOG_INFO(logger_, "new certificate has been updated on local storage, peer: " << peerId);
+    } else {
+      std::make_pair(false, peerId);
     }
   }
-
-  // the actual pinning - read the correct certificate from the disk and
-  // compare it to the received one
-  namespace fs = boost::filesystem;
-  fs::path path;
-  try {
-    path = fs::path(config_.certificatesRootPath) / std::to_string(remotePeerId) / connectionType /
-           std::string(connectionType + ".cert");
-  } catch (std::exception& e) {
-    LOG_FATAL(logger_, "Failed to construct filesystem path: " << e.what());
-    ConcordAssert(false);
-  }
-
-  auto deleter = [](FILE* fp) {
-    if (fp) fclose(fp);
-  };
-  std::unique_ptr<FILE, decltype(deleter)> fp(fopen(path.c_str(), "r"), deleter);
-  if (!fp) {
-    LOG_ERROR(logger_, "Certificate file not found, path: " << path);
-    return std::make_pair(false, remotePeerId);
-  }
-
-  X509* localCert = PEM_read_X509(fp.get(), NULL, NULL, NULL);
-  if (!localCert) {
-    LOG_ERROR(logger_, "Cannot parse certificate, path: " << path);
-    return std::make_pair(false, remotePeerId);
-  }
-
-  // this is actual comparison, compares hash of 2 certs
-  int res = X509_cmp(receivedCert, localCert);
-  X509_free(localCert);
-  if (res == 0) {
-    // We don't put a log message here, because it will be called for each cert in the chain, resulting in duplicates.
-    // Instead we log in onXXXHandshakeComplete callbacks it TlsTcpImpl.
-    return std::make_pair(true, remotePeerId);
-  }
-  LOG_ERROR(logger_,
-            "X509_cmp failed at node: " << config_.selfId << ", type: " << connectionType << ", peer: " << remotePeerId
-                                        << " res=" << res);
-  return std::make_pair(false, remotePeerId);
+  return std::make_pair(res, peerId);
 }
 
 using namespace concord::secretsmanager;
@@ -504,6 +476,12 @@ const std::string AsyncTlsConnection::decryptPrivateKey(const boost::filesystem:
   }
 
   return *decBuf;
+}
+void AsyncTlsConnection::close() {
+  std::lock_guard<std::mutex> lock(shutdown_lock_);
+  if (closed_) return;
+  socket_->lowest_layer().close();
+  closed_ = true;
 }
 
 }  // namespace bft::communication::tls

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -142,6 +142,8 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Clean up the connection
   void dispose(bool close_connection = true);
 
+  void close();
+
  private:
   // We know the size of the message and that a message should be forthcoming. We start a timer and
   // ensure we read all remaining bytes within a given timeout. If we read the full message we
@@ -169,10 +171,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Check for a specific certificate and do not rely on chain authentication.
   //
   // Return true along with the actual node id if verification succeeds, (false, 0) if not.
-  std::pair<bool, NodeNum> checkCertificate(X509* cert,
-                                            std::string connectionType,
-                                            const std::string& subject,
-                                            std::optional<NodeNum> expected_peer_id);
+  std::pair<bool, NodeNum> checkCertificate(X509* cert, std::optional<NodeNum> expected_peer_id);
 
   const std::string decryptPrivateKey(const boost::filesystem::path& path);
 
@@ -217,6 +216,8 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   TlsStatus& status_;
   Recorders& histograms_;
   WriteQueue write_queue_;
+  std::mutex shutdown_lock_;
+  bool closed_ = false;
 };
 
 }  // namespace bft::communication::tls

--- a/communication/src/TlsConnectionManager.cpp
+++ b/communication/src/TlsConnectionManager.cpp
@@ -42,7 +42,7 @@ ConnectionManager::ConnectionManager(const TlsTcpConfig& config, asio::io_contex
 
 void ConnectionManager::start() {
   LOG_INFO(logger_, "Starting connection manager for " << config_.selfId);
-
+  stopped_ = false;
   if (isReplica()) {
     listen();
     accept();
@@ -54,8 +54,8 @@ void ConnectionManager::start() {
 
 void ConnectionManager::stop() {
   LOG_INFO(logger_, "Stopping connection manager for " << config_.selfId);
+  stopped_ = true;
   status_->reset();
-
   acceptor_.close();
   for (auto& [_, sock] : connecting_) {
     (void)_;  // unused variable hack
@@ -75,6 +75,7 @@ void ConnectionManager::stop() {
     LOG_DEBUG(logger_, "Closing connection from: " << config_.selfId << ", to: " << id);
     syncCloseConnection(conn);
   }
+  connect_timer_.wait();
 }
 
 void ConnectionManager::setReceiver(NodeNum, IReceiver* receiver) { receiver_ = receiver; }
@@ -98,13 +99,12 @@ void ConnectionManager::listen() {
 void ConnectionManager::startConnectTimer() {
   connect_timer_.expires_from_now(CONNECT_TICK);
   connect_timer_.async_wait(asio::bind_executor(strand_, [this](const asio::error_code& ec) {
+    if (stopped_) {
+      return;
+    }
     if (ec) {
-      if (ec == asio::error::operation_aborted) {
-        // We are shutting down the system. Just return.
-        return;
-      }
-      LOG_FATAL(logger_, "Connect timer wait failure: " << ec.message());
-      abort();
+      LOG_ERROR(logger_, "Connect timer wait failure: " << ec.message());
+      return;
     }
     connect();
     startConnectTimer();
@@ -177,18 +177,16 @@ void ConnectionManager::remoteCloseConnection(NodeNum id) {
     auto conn = std::move(connections_.at(id));
     connections_.erase(id);
     status_->num_connections = connections_.size();
-    conn->getSocket().lowest_layer().close();
+    conn->close();
   });
 }
 
 void ConnectionManager::closeConnection(std::shared_ptr<AsyncTlsConnection> conn) {
   conn->remoteDispose();
-  conn->getSocket().lowest_layer().close();
+  conn->close();
 }
 
-void ConnectionManager::syncCloseConnection(std::shared_ptr<AsyncTlsConnection>& conn) {
-  conn->getSocket().lowest_layer().close();
-}
+void ConnectionManager::syncCloseConnection(std::shared_ptr<AsyncTlsConnection>& conn) { conn->close(); }
 
 void ConnectionManager::onConnectionAuthenticated(std::shared_ptr<AsyncTlsConnection> conn) {
   // Move the connection into the accepted connections map. If there is an existing connection
@@ -258,6 +256,7 @@ void ConnectionManager::startClientSSLHandshake(asio::ip::tcp::socket&& socket, 
 
 void ConnectionManager::accept() {
   acceptor_.async_accept(asio::bind_executor(strand_, [this](asio::error_code ec, asio::ip::tcp::socket sock) {
+    if (stopped_) return;
     if (!StateControl::instance().tryLockComm()) {
       LOG_WARN(logger_, "incoming comm is blocked");
       return;
@@ -267,7 +266,10 @@ void ConnectionManager::accept() {
       // When io_service is stopped, the handlers are destroyed and when the
       // io_service dtor runs they will be invoked with operation_aborted error.
       // In this case we dont want to accept again.
-      if (ec == asio::error::operation_aborted) return;
+      if (ec == asio::error::operation_aborted) {
+        StateControl::instance().unlockComm();
+        return;
+      }
     } else {
       total_accepted_connections_++;
       status_->total_accepted_connections = total_accepted_connections_;
@@ -354,9 +356,4 @@ ConnectionStatus ConnectionManager::getCurrentConnectionStatus(const NodeNum id)
   }
   return ConnectionStatus::Disconnected;
 }
-void ConnectionManager::dispose(NodeNum i) {
-  if (connections_.find(i) == connections_.end()) return;
-  connections_.at(i)->dispose(true);
-}
-
 }  // namespace bft::communication::tls

--- a/communication/src/TlsConnectionManager.h
+++ b/communication/src/TlsConnectionManager.h
@@ -45,7 +45,6 @@ class ConnectionManager {
   void send(const NodeNum destination, const std::shared_ptr<OutgoingMsg> &msg);
   void send(const std::set<NodeNum> &destinations, const std::shared_ptr<OutgoingMsg> &msg);
   int getMaxMessageSize() const;
-  void dispose(NodeNum i);
 
  private:
   void start();
@@ -154,6 +153,7 @@ class ConnectionManager {
   // Diagnostics
   std::shared_ptr<TlsStatus> status_;
   Recorders histograms_;
+  std::atomic_bool stopped_ = false;
 };
 
 }  // namespace bft::communication::tls

--- a/communication/src/TlsRunner.cpp
+++ b/communication/src/TlsRunner.cpp
@@ -30,6 +30,7 @@ void Runner::start() {
   std::lock_guard<std::mutex> lock(start_stop_mutex);
   ConcordAssert(io_threads_.empty());
   LOG_INFO(logger_, "Starting TLS Runner");
+  io_context_.restart();
 
   // Give the io_context work to do.
   for (auto& [_, conn_mgr] : principals_) {

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -98,7 +98,7 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
   }
 }
 
-void TlsTCPCommunication::dispose(NodeNum i) {
+void TlsTCPCommunication::restartCommunication(NodeNum i) {
   auto &connMgr = runner_->principals().at(config_.selfId);
   if (i == config_.selfId) {
     auto end = std::min<size_t>(config_.selfId, config_.maxServerId + 1);

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -99,14 +99,7 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
 }
 
 void TlsTCPCommunication::restartCommunication(NodeNum i) {
-  auto &connMgr = runner_->principals().at(config_.selfId);
-  if (i == config_.selfId) {
-    auto end = std::min<size_t>(config_.selfId, config_.maxServerId + 1);
-    for (auto rep = 0u; rep < end; rep++) {
-      connMgr.dispose(rep);
-    }
-  } else if (i < config_.selfId) {
-    connMgr.dispose(i);
-  }
+  runner_->stop();
+  runner_->start();
 }
 }  // namespace bft::communication

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -33,14 +33,13 @@ static const std::string genesis_block_key(1, 0x32);
 
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
-  PUBLIC_KEY_EXCHANGE = 0x1,              // identifier of public key exchange request by client
-  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,      // identifier of client key exchange request by operator
-  CLIENT_SCALING_COMMAND = 0x3,           // identifier of client scaling request by operator
-  CLIENT_SCALING_COMMAND_STATUS = 0X4,    // identifier of client update request after successful scaling
-  CLIENT_SCALING_EXECUTE_COMMAND = 0x5,   // identifier of client scaling execute request by operator
-  CLIENT_TLS_KEY_EXCHANGE_COMMAND = 0x6,  // identifier of tls key exchange request by client
-  CLIENT_RESTART_COMMAND = 0x7,           // identifier of client restart command by operator
-  CLIENT_RESTART_STATUS = 0x8,            // identifier of client restart status
+  PUBLIC_KEY_EXCHANGE = 0x1,             // identifier of public key exchange request by client
+  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,     // identifier of client key exchange request by operator
+  CLIENT_SCALING_COMMAND = 0x3,          // identifier of client scaling request by operator
+  CLIENT_SCALING_COMMAND_STATUS = 0X4,   // identifier of client update request after successful scaling
+  CLIENT_SCALING_EXECUTE_COMMAND = 0x5,  // identifier of client scaling execute request by operator
+  CLIENT_RESTART_COMMAND = 0x7,          // identifier of client restart command by operator
+  CLIENT_RESTART_STATUS = 0x8,           // identifier of client restart status
   end_
 };
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -209,6 +209,11 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::ReplicaTlsExchangeKey&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
 };
 
 class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler,
@@ -225,11 +230,5 @@ class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IR
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
-
-  bool handle(const concord::messages::ReplicaTlsExchangeKey&,
-              uint64_t,
-              uint32_t,
-              const std::optional<bftEngine::Timestamp>&,
-              concord::messages::ReconfigurationResponse&) override;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -64,11 +64,6 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
-  bool handle(const concord::messages::ClientTlsExchangeKey&,
-              uint64_t,
-              uint32_t,
-              const std::optional<bftEngine::Timestamp>&,
-              concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsRestartUpdate&,
               uint64_t,
               uint32_t,

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -68,7 +68,6 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::RestartCommand&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::InstallCommand&, uint64_t, uint64_t, uint64_t);
-  bool handle(const concord::messages::ClientTlsExchangeKey&, uint64_t, uint64_t, uint64_t);
 
   kvbc::IReader& ro_storage_;
   BlockMetadata block_metadata_;

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -443,20 +443,8 @@ Replica::Replica(ICommunication *comm,
       secretsManager_{secretsManager},
       blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
                                                                           : std::thread::hardware_concurrency()) {
-  bft::communication::StateControl::instance().setCommRestartCallBack([this](uint32_t i) {
-    m_ptrComm->dispose(i);
-    // Now wait for a live quorum before continue running
-    uint32_t live_replicas = 1;
-    uint32_t minQuorumSize = 2 * replicaConfig_.fVal + replicaConfig_.cVal + 1;
-    while (live_replicas < minQuorumSize) {
-      live_replicas = 1;
-      for (uint32_t r = 0; r < replicaConfig_.numReplicas; r++) {
-        if (r == replicaConfig_.replicaId) continue;
-        live_replicas += (m_ptrComm->getCurrentConnectionStatus(r) == bft::communication::ConnectionStatus::Connected);
-      }
-    }
-    LOG_INFO(GL, "post communication restart: resuming running after getting " << live_replicas << " connected");
-  });
+  bft::communication::StateControl::instance().setCommRestartCallBack(
+      [this](uint32_t i) { m_ptrComm->restartCommunication(i); });
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {
     replicaConfig_.replicaId,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -433,12 +433,6 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& rres) {
-  if (command.tls && command.target_replicas.size() > bftEngine::ReplicaConfig::instance().fVal) {
-    concord::messages::ReconfigurationErrorMsg error_msg{
-        "Unable to perform tls key exchange for more than f replicas at once"};
-    rres.response = error_msg;
-    return false;
-  }
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -130,12 +130,6 @@ concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildClien
               creply.response = cmd;
               break;
             }
-            case kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_TLS_KEY_EXCHANGE_COMMAND: {
-              concord::messages::ClientTlsExchangeKey cmd;
-              concord::messages::deserialize(data_buf, cmd);
-              creply.response = cmd;
-              break;
-            }
             case kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_RESTART_COMMAND: {
               concord::messages::ClientsRestartCommand cmd;
               concord::messages::deserialize(data_buf, cmd);
@@ -251,38 +245,6 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientExc
   return true;
 }
 
-bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientTlsExchangeKey& command,
-                                              uint64_t bft_seq_num,
-                                              uint32_t sender_id,
-                                              const std::optional<bftEngine::Timestamp>& ts,
-                                              concord::messages::ReconfigurationResponse& response) {
-  if (command.sender_id != sender_id) {
-    concord::messages::ReconfigurationErrorMsg error_msg;
-    error_msg.error_msg = "sender_id of the message does not match the real sender id";
-    response.response = error_msg;
-    return false;
-  }
-  std::vector<uint8_t> serialized_command;
-  concord::messages::serialize(serialized_command, command);
-  auto blockId = persistReconfigurationBlock(
-      serialized_command,
-      bft_seq_num,
-      std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
-                  static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_TLS_KEY_EXCHANGE_COMMAND)} +
-          std::to_string(sender_id),
-      ts,
-      false);
-  LOG_INFO(getLogger(), "block id: " << blockId);
-  std::string bft_clients_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath;
-  secretsmanager::SecretsManagerPlain sm;
-  for (const auto& [cid, cert] : command.clients_certificates) {
-    std::string cert_path = bft_clients_cert_path + "/" + std::to_string(cid) + "/client/client.cert";
-    sm.encryptFile(cert_path, cert);
-    LOG_INFO(getLogger(), cert_path + " is updated on the disk");
-  }
-  return true;
-}
-
 bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveUpdateCommand& command,
                                               uint64_t bft_seq_num,
                                               uint32_t sender_id,
@@ -336,16 +298,19 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeSt
                                     const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& rres) {
   concord::messages::ClientKeyExchangeStatusResponse stats;
+  concord::secretsmanager::SecretsManagerPlain psm;
   for (const auto& gr : bftEngine::ReplicaConfig::instance().clientGroups) {
     for (auto cid : gr.second) {
+      if (command.tls) {
+        std::string client_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" +
+                                       std::to_string(cid) + "/client/client.cert";
+        auto cert = psm.decryptFile(client_cert_path).value_or("invalid client id");
+        stats.clients_data.push_back(std::make_pair(cid, cert));
+        continue;
+      }
       std::string key = std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
                                     static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::PUBLIC_KEY_EXCHANGE)} +
                         std::to_string(cid);
-      if (command.tls) {
-        key = std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
-                          static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_TLS_KEY_EXCHANGE_COMMAND)} +
-              std::to_string(cid);
-      }
       auto bid = ro_storage_.getLatestVersion(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key);
       if (bid.has_value()) {
         auto saved_ts = ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
@@ -355,39 +320,25 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeSt
         if (saved_ts.has_value()) {
           auto strval = std::visit([](auto&& arg) { return arg.data; }, *saved_ts);
           numeric_ts = concordUtils::fromBigEndianBuffer<uint64_t>(strval.data());
-          if (!command.tls) {
-            stats.timestamps.push_back(std::make_pair(cid, numeric_ts));
-          }
+          stats.timestamps.push_back(std::make_pair(cid, numeric_ts));
         }
         auto res =
             ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId, key, bid.value().version);
         if (res.has_value()) {
           auto strval = std::visit([](auto&& arg) { return arg.data; }, *res);
-          if (!command.tls) {
-            concord::messages::ClientExchangePublicKey cmd;
-            std::vector<uint8_t> bytesval(strval.begin(), strval.end());
-            concord::messages::deserialize(bytesval, cmd);
+          concord::messages::ClientExchangePublicKey cmd;
+          std::vector<uint8_t> bytesval(strval.begin(), strval.end());
+          concord::messages::deserialize(bytesval, cmd);
 
-            LOG_INFO(getLogger(), "found transactions public key exchange status for client" << KVLOG(cid));
-            stats.clients_data.push_back(std::make_pair(cid, cmd.pub_key));
-          } else {
-            concord::messages::ClientTlsExchangeKey cmd;
-            std::vector<uint8_t> bytesval(strval.begin(), strval.end());
-            concord::messages::deserialize(bytesval, cmd);
-
-            LOG_INFO(getLogger(), "found tls certificate exchange status for client" << KVLOG(cid));
-            for (const auto& [icid, cert] : cmd.clients_certificates) {
-              stats.clients_data.push_back(std::make_pair(icid, cert));
-              stats.timestamps.push_back(std::make_pair(icid, numeric_ts));
-            }
-          }
+          LOG_INFO(getLogger(), "found transactions public key exchange status for client" << KVLOG(cid));
+          stats.clients_data.push_back(std::make_pair(cid, cmd.pub_key));
         }
       }
     }
   }
   rres.response = stats;
   return true;
-}
+}  // namespace concord::kvbc::reconfiguration
 
 bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                     uint64_t bft_seq_num,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -19,8 +19,7 @@
 #include "concord.cmf.hpp"
 #include "secrets_manager_plain.h"
 #include "communication/StateControl.hpp"
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
+
 namespace concord::kvbc::reconfiguration {
 
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -204,11 +204,6 @@ Msg ClientsAddRemoveExecuteCommand 51 {
     bool restart
 }
 
-Msg ClientTlsExchangeKey 52 {
-    uint64 sender_id
-    list kvpair uint32 string clients_certificates
-}
-
 Msg ClientsRestartCommand 53 {
     uint64 sender_id
     string data
@@ -236,7 +231,6 @@ Msg ClientStateReply 39 {
         ClientKeyExchangeCommand
         ClientsAddRemoveExecuteCommand
         ClientsAddRemoveUpdateCommand
-        ClientTlsExchangeKey
         ClientsRestartCommand
         ReplicaTlsExchangeKey
       } response
@@ -271,7 +265,6 @@ Msg ReconfigurationRequest 1 {
     ClientKeyExchangeCommand
     ClientReconfigurationStateRequest
     ClientExchangePublicKey
-    ClientTlsExchangeKey
     RestartCommand
     ReplicaTlsExchangeKey
     ClientsAddRemoveCommand

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -208,13 +208,6 @@ class IReconfigurationHandler {
     return true;
   }
 
-  virtual bool handle(const concord::messages::ClientTlsExchangeKey &,
-                      uint64_t,
-                      uint32_t,
-                      const std::optional<bftEngine::Timestamp> &,
-                      concord::messages::ReconfigurationResponse &) {
-    return true;
-  }
   virtual bool handle(const concord::messages::ClientsRestartCommand &,
                       uint64_t,
                       uint32_t,

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -19,6 +19,11 @@
 #include "OpenTracing.hpp"
 #include "SigManager.hpp"
 #include "crypto_utils.hpp"
+#include "SimpleThreadPool.hpp"
+#include "communication/StateControl.hpp"
+#include "secrets_manager_plain.h"
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 
 namespace concord::reconfiguration {
 class BftReconfigurationHandler : public IReconfigurationHandler {
@@ -30,7 +35,8 @@ class BftReconfigurationHandler : public IReconfigurationHandler {
 };
 class ReconfigurationHandler : public BftReconfigurationHandler {
  public:
-  ReconfigurationHandler() {}
+  ReconfigurationHandler() { executor_.start(); }
+  ~ReconfigurationHandler() { executor_.stop(); }
   bool handle(const concord::messages::WedgeCommand &,
               uint64_t,
               uint32_t,
@@ -72,6 +78,7 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
  private:
   void handleWedgeCommands(
       bool bft_support, bool remove_metadata, bool restart, bool unwedge, bool blockNewConnections);
+  concord::util::SimpleThreadPool executor_;
 };
 
 class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -261,16 +261,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             for i in range(100):
                 await skvbc.send_write_kv_set()
             await self.run_client_tls_key_exchange_cycle(bft_network)
-            cert_a, ts_a = await self.get_last_client_keys_data(bft_network, bft_network.cre_id, tls=True)
-            assert cert_a is not None
-            assert ts_a is not None
-            await self.run_client_tls_key_exchange_cycle(bft_network, cert_a, ts_a)
-            cert_b, ts_b = await self.get_last_client_keys_data(bft_network, bft_network.cre_id, tls=True)
-            assert cert_b is not None
-            assert ts_b is not None
-
-            assert cert_a != cert_b
-            assert ts_a < ts_b
+            await self.run_client_tls_key_exchange_cycle(bft_network)
 
             for i in range(100):
                 await skvbc.send_write_kv_set()
@@ -291,10 +282,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             next_primary = 1
             bft_network.stop_replica(next_primary)
             await self.run_client_tls_key_exchange_cycle(bft_network)
-            cert_a, ts_a = await self.get_last_client_keys_data(bft_network, bft_network.cre_id, tls=True)
-            assert cert_a is not None
-            assert ts_a is not None
-
             for i in range(500):
                 await skvbc.send_write_kv_set()
             current_view = await bft_network.wait_for_view(0)
@@ -315,13 +302,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
             # Now lets run another Client TLS key exchange and make sure the new primary is able
             # to communicate with the client after its state transfer
-            await self.run_client_tls_key_exchange_cycle(bft_network, cert_a, ts_a)
-            cert_b, ts_b = await self.get_last_client_keys_data(bft_network, bft_network.cre_id, tls=True)
-            assert cert_b is not None
-            assert ts_b is not None
-
-            assert cert_a != cert_b
-            assert ts_a < ts_b
+            await self.run_client_tls_key_exchange_cycle(bft_network)
 
             for i in range(100):
                 await skvbc.send_write_kv_set()
@@ -356,56 +337,45 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         rep = await op.client_key_exchange_command([bft_network.cre_id], tls=tls)
         rep = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
         assert rep.success is True
-        log.log_message(message_type=f"block_id {rep.response.block_id}")
+
+    async def run_client_tls_key_exchange_cycle(self, bft_network):
+        effected = list(bft_network.all_replicas()) + [bft_network.cre_id]
+        client_cert_path = os.path.join(bft_network.certdir, str(bft_network.cre_id), str(bft_network.cre_id),"client", "client.cert")
+        certs_in_effected = {}
+        for p in effected:
+            with open(client_cert_path) as orig_cert:
+                orig_cert_text = orig_cert.read()
+                certs_in_effected[p] = orig_cert_text
+        await self.run_client_ke_command(bft_network, True)
         with trio.fail_after(60):
             succ = False
-            while succ is False:
-                succ = True
-                data, ts = await self.get_last_client_keys_data(bft_network, bft_network.cre_id, tls=tls)
-                if data is None or ts is None or data == prev_data or ts <= prev_ts:
-                    succ = False
-
-    async def run_client_tls_key_exchange_cycle(self, bft_network, prev_cert="", prev_ts=0):
-        await self.run_client_ke_command(bft_network, True, prev_cert, prev_ts)
-        with trio.fail_after(30):
-            succ = False
             while not succ:
-                await trio.sleep(1)
                 succ = True
-                priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem")
-                new_priv_path = priv_key_path + ".new"
+                await trio.sleep(1)
+                with open(client_cert_path) as orig_cert:
+                    orig_cert_text = orig_cert.read()
+                    diff = difflib.unified_diff(certs_in_effected[bft_network.cre_id], orig_cert_text, fromfile=client_cert_path, tofile=client_cert_path, lineterm='')
+                    lines = sum(1 for l in diff)
+                    if lines == 0:
+                        succ = False
 
-                enc_priv_key_path = os.path.join(bft_network.certdir, str(bft_network.cre_id), str(bft_network.cre_id),"client", "pk.pem.enc")
-                enc_new_priv_path = enc_priv_key_path + ".new"
-                if os.path.isfile(priv_key_path):
-                    if not os.path.isfile(new_priv_path):
-                        succ = False
-                    continue
-                    with open(priv_key_path) as orig_key:
-                        orig_key_text = orig_key.readlines()
-                    with open(new_priv_path) as new_key:
-                        new_key_text = new_key.readlines()
-                    diff = difflib.unified_diff(orig_key_text, new_key_text, fromfile=priv_key_path, tofile=new_priv_path, lineterm='')
-                    for line in diff:
-                        succ = False
-                    if not succ:
-                        continue
-
-                if os.path.isfile(enc_priv_key_path):
-                    if not os.path.isfile(enc_new_priv_path):
-                        succ = False
-                    continue
-                    with open(enc_priv_key_path) as orig_key:
-                        orig_key_text = orig_key.readlines()
-                    with open(enc_new_priv_path) as new_key:
-                        new_key_text = new_key.readlines()
-                    diff = difflib.unified_diff(orig_key_text, new_key_text, fromfile=enc_priv_key_path, tofile=enc_new_priv_path, lineterm='')
-                    for line in diff:
-                        succ = False
-                    if not succ:
-                        continue
         bft_network.stop_cre()
         bft_network.start_cre()
+
+        with trio.fail_after(60):
+            succ = False
+            while not succ:
+                succ = True
+                for p in effected:
+                    await trio.sleep(1)
+                    with open(client_cert_path) as orig_cert:
+                        orig_cert_text = orig_cert.read()
+                        diff = difflib.unified_diff(certs_in_effected[p], orig_cert_text, fromfile=client_cert_path, tofile=client_cert_path, lineterm='')
+                    lines = sum(1 for l in diff)
+                    if lines == 0:
+                        succ = False
+                        break
+
 
     async def get_last_client_keys_data(self, bft_network, client_id, tls):
         client = bft_network.random_client()
@@ -459,7 +429,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
-    async def test_replicas_tls_key_exchange_command_without_primary(self, bft_network):
+    async def test_replicas_tls_key_exchange_command_all_nodes(self, bft_network):
         """
             Operator sends client key exchange command for f replicas
         """
@@ -467,7 +437,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             bft_network.start_all_replicas()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             initial_prim = 0
-            exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f, {initial_prim}))
+            exchanged_replicas = list(bft_network.all_replicas())
             for i in range(100):
                 await skvbc.send_write_kv_set()
             fast_paths = {}
@@ -475,8 +445,37 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
                 fast_paths[r] = nb_fast_path
             await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas)
-            # Manually copy the new certs from one of the replicas to clients and restart clients
-            bft_network.copy_certs_from_server_to_clients(1)
+            # Manually copy the new certs from the last replica of the replicas to clients and restart clients
+            bft_network.copy_certs_from_server_to_clients(6)
+            bft_network.restart_clients(False, False)
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+            for i in range(100):
+                await skvbc.send_write_kv_set()
+            for r in bft_network.all_replicas():
+                nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
+                self.assertGreater(nb_fast_path, fast_paths[r])
+
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
+    async def test_replicas_tls_key_exchange_command_all_nodes_with_cre(self, bft_network):
+        """
+            Operator sends client key exchange command for f replicas
+        """
+        with log.start_action(action_type="test_replica_key_exchange_command_with_cre"):
+            bft_network.start_all_replicas()
+            bft_network.start_cre()
+            skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+            initial_prim = 0
+            exchanged_replicas = list(bft_network.all_replicas())
+            for i in range(100):
+                await skvbc.send_write_kv_set()
+            fast_paths = {}
+            for r in bft_network.all_replicas():
+                nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
+                fast_paths[r] = nb_fast_path
+            await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, exchanged_replicas + [bft_network.cre_id])
+            # Manually copy the new certs from the last replica of the replicas to clients and restart clients
+            bft_network.copy_certs_from_server_to_clients(6)
             bft_network.restart_clients(False, False)
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             for i in range(100):
@@ -510,7 +509,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             live_replicas =  bft_network.all_replicas(without=set(crashed_replica))
             await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, live_replicas)
             # Manually copy the new certs from one of the replicas to clients and restart clients
-            bft_network.copy_certs_from_server_to_clients(live_replicas[0])
+            bft_network.copy_certs_from_server_to_clients(max(live_replicas))
             bft_network.restart_clients(False, False)
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             for i in range(700):
@@ -568,6 +567,9 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         # Now, lets exchange another replica key, to make sure the read only replica is able to exchange the keys
         exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f, without=set(exchanged_replicas)))
         await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, affected_replicas=[r for r in range(bft_network.config.n + 1)])
+        bft_network.copy_certs_from_server_to_clients(7)
+        bft_network.restart_clients(False, False)
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         # Make sure that the read only replica is able to complete another state transfer
         for i in range(500): # Produce 500 new blocks
             await skvbc.send_write_kv_set()
@@ -582,32 +584,47 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         for rep in affected_replicas:
             reps_data[rep] = {}
             for r in replicas:
-                cert_path = os.path.join(bft_network.certdir + "/" + str(r), str(r),"server", "server.cert")
+                val = []
+                cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "server", "server.cert")
                 with open(cert_path) as orig_key:
                     cert_text = orig_key.readlines()
-                    reps_data[rep][r] = cert_text
+                    val += [cert_text]
+                cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "client", "client.cert")
+                with open(cert_path) as orig_key:
+                    cert_text = orig_key.readlines()
+                    val += [cert_text]
+                reps_data[rep][r] = val
         client = bft_network.random_client()
         op = operator.Operator(bft_network.config, client, bft_network.builddir)
-        rep = await op.key_exchange(replicas, tls=True)
-        rep = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
-        assert rep.success is True
 
-        with trio.fail_after(30):
+        try:
+            await op.key_exchange(replicas, tls=True)
+        except trio.TooSlowError:
+            # As we rotate the TLS keys immediately, the call may return with timeout
+            pass
+        with trio.fail_after(60):
             succ = False
             while not succ:
                 await trio.sleep(1)
                 succ = True
                 for rep in affected_replicas:
                     for r in replicas:
-                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r),"server", "server.cert")
-                        cert_text = []
+                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "server", "server.cert")
                         with open(cert_path) as orig_key:
                             cert_text = orig_key.readlines()
-                        diff = difflib.unified_diff(reps_data[rep][r], cert_text, fromfile="new", tofile="old", lineterm='')
-                        lines = sum(1 for l in diff)
-                        if lines == 0:
-                            succ = False
-                            continue
+                            diff = difflib.unified_diff(reps_data[rep][r][0], cert_text, fromfile="new", tofile="old", lineterm='')
+                            lines = sum(1 for l in diff)
+                            if lines > 0:
+                                continue
+                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "client", "client.cert")
+                        with open(cert_path) as orig_key:
+                            cert_text = orig_key.readlines()
+                            diff = difflib.unified_diff(reps_data[rep][r][1], cert_text, fromfile="new", tofile="old", lineterm='')
+                            lines = sum(1 for l in diff)
+                            if lines > 0:
+                                continue
+                        succ = False
+                        break
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
@@ -44,7 +44,7 @@ class WrapCommunication : public ICommunication {
     communication_->setReceiver(receiverNum, receiver);
   }
 
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
   static void addStrategies(
       std::string const &strategies,
       char delim,

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -73,6 +73,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.set("concord.bft.st.runInSeparateThread", true);
     replicaConfig.set("concord.bft.keyExchage.clientKeysEnabled", false);
     replicaConfig.preExecutionResultAuthEnabled = false;
+    replicaConfig.rotatingCertificatesTimeoutSeconds = 10;
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
     std::string commConfigFile;

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -15,14 +15,34 @@
 #include <utility>
 #include <string>
 #include <memory>
+
+#include <openssl/bio.h>
+#include <openssl/ec.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+
 namespace concord::util::crypto {
 enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
 enum class CurveType : std::uint16_t { secp256k1, secp384r1 };
+
+class CertificateUtils {
+ public:
+  static std::string generateSelfSignedCert(const std::string& origin_cert_path,
+                                            const std::string& pub_key,
+                                            const std::string& signing_key);
+  static bool verifyCertificate(X509* cert, const std::string& pub_key);
+  static bool verifyCertificate(X509* cert_to_verify,
+                                const std::string& cert_root_directory,
+                                uint32_t& remote_peer_id,
+                                std::string& conn_type);
+};
 class IVerifier {
  public:
   virtual bool verify(const std::string& data, const std::string& sig) const = 0;
   virtual uint32_t signatureLength() const = 0;
   virtual ~IVerifier() = default;
+  virtual std::string getPubKey() const = 0;
 };
 
 class ISigner {
@@ -30,6 +50,7 @@ class ISigner {
   virtual std::string sign(const std::string& data) = 0;
   virtual uint32_t signatureLength() const = 0;
   virtual ~ISigner() = default;
+  virtual std::string getPrivKey() const = 0;
 };
 
 class ECDSAVerifier : public IVerifier {
@@ -37,34 +58,40 @@ class ECDSAVerifier : public IVerifier {
   ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) const override;
   uint32_t signatureLength() const override;
+  std::string getPubKey() const override { return key_str_; }
   ~ECDSAVerifier();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 
 class ECDSASigner : public ISigner {
  public:
-  ECDSASigner(const std::string& str_pub_key, KeyFormat fmt);
+  ECDSASigner(const std::string& str_priv_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
   uint32_t signatureLength() const override;
+  std::string getPrivKey() const override { return key_str_; }
   ~ECDSASigner();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 class RSAVerifier : public IVerifier {
  public:
   RSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) const override;
   uint32_t signatureLength() const override;
+  std::string getPubKey() const override { return key_str_; }
   ~RSAVerifier();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 
 class RSASigner : public ISigner {
@@ -72,11 +99,13 @@ class RSASigner : public ISigner {
   RSASigner(const std::string& str_priv_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
   uint32_t signatureLength() const override;
+  std::string getPrivKey() const override { return key_str_; }
   ~RSASigner();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 
 class Crypto {
@@ -93,6 +122,7 @@ class Crypto {
                                                            CurveType curve_type = CurveType::secp256k1) const;
   std::pair<std::string, std::string> RsaHexToPem(const std::pair<std::string, std::string>& key_pair) const;
   std::pair<std::string, std::string> ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) const;
+  KeyFormat getFormat(const std::string& key_str) const;
   std::string generateSelfSignedCertificate(const std::pair<std::string, std::string>& keyPair_pem,
                                             const std::string& host,
                                             uint32_t node_id);

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -123,9 +123,6 @@ class Crypto {
   std::pair<std::string, std::string> RsaHexToPem(const std::pair<std::string, std::string>& key_pair) const;
   std::pair<std::string, std::string> ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) const;
   KeyFormat getFormat(const std::string& key_str) const;
-  std::string generateSelfSignedCertificate(const std::pair<std::string, std::string>& keyPair_pem,
-                                            const std::string& host,
-                                            uint32_t node_id);
 
  private:
   class Impl;

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -26,8 +26,9 @@
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/evp.h>
-
+#include <regex>
 #include "Logger.hpp"
+
 using namespace CryptoPP;
 namespace concord::util::crypto {
 class ECDSAVerifier::Impl {
@@ -48,7 +49,7 @@ class ECDSAVerifier::Impl {
   uint32_t signatureLength() const { return verifier_->SignatureLength(); }
 };
 bool ECDSAVerifier::verify(const std::string& data, const std::string& sig) const { return impl_->verify(data, sig); }
-ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
+ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) : key_str_{str_pub_key} {
   ECDSA<ECP, CryptoPP::SHA256>::PublicKey publicKey;
   if (fmt == KeyFormat::PemFormat) {
     StringSource s(str_pub_key, true);
@@ -83,13 +84,13 @@ class ECDSASigner::Impl {
 };
 
 std::string ECDSASigner::sign(const std::string& data) { return impl_->sign(data); }
-ECDSASigner::ECDSASigner(const std::string& str_pub_key, KeyFormat fmt) {
+ECDSASigner::ECDSASigner(const std::string& str_priv_key, KeyFormat fmt) : key_str_{str_priv_key} {
   ECDSA<ECP, CryptoPP::SHA256>::PrivateKey privateKey;
   if (fmt == KeyFormat::PemFormat) {
-    StringSource s(str_pub_key, true);
+    StringSource s(str_priv_key, true);
     PEM_Load(s, privateKey);
   } else {
-    StringSource s(str_pub_key, true, new HexDecoder());
+    StringSource s(str_priv_key, true, new HexDecoder());
     privateKey.Load(s);
   }
   impl_.reset(new Impl(privateKey));
@@ -135,7 +136,7 @@ class RSASigner::Impl {
   AutoSeededRandomPool prng_;
 };
 
-RSASigner::RSASigner(const std::string& str_priv_key, KeyFormat fmt) {
+RSASigner::RSASigner(const std::string& str_priv_key, KeyFormat fmt) : key_str_{str_priv_key} {
   CryptoPP::RSA::PrivateKey private_key;
   if (fmt == KeyFormat::PemFormat) {
     StringSource s(str_priv_key, true);
@@ -151,7 +152,7 @@ std::string RSASigner::sign(const std::string& data) { return impl_->sign(data);
 uint32_t RSASigner::signatureLength() const { return impl_->signatureLength(); }
 RSASigner::~RSASigner() = default;
 
-RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
+RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) : key_str_{str_pub_key} {
   CryptoPP::RSA::PublicKey public_key;
   if (fmt == KeyFormat::PemFormat) {
     StringSource s(str_pub_key, true);
@@ -342,8 +343,168 @@ std::string Crypto::generateSelfSignedCertificate(const std::pair<std::string, s
                                                   uint32_t node_id) {
   return impl_->generateSelfSignedCert(keyPair_pem, host, node_id);
 }
+KeyFormat Crypto::getFormat(const std::string& key) const {
+  return key.find("BEGIN") != std::string::npos ? KeyFormat::PemFormat : KeyFormat::HexaDecimalStrippedFormat;
+}
 
 Crypto::Crypto() : impl_{new Impl()} {}
 
 Crypto::~Crypto() = default;
+
+bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
+                                         const std::string& cert_root_directory,
+                                         uint32_t& remote_peer_id,
+                                         std::string& conn_type) {
+  // First get the source ID
+  static constexpr size_t SIZE = 512;
+  std::string subject(SIZE, 0);
+  X509_NAME_oneline(X509_get_subject_name(cert_to_verify), subject.data(), SIZE);
+
+  int peerIdPrefixLength = 3;
+  std::regex r("OU=\\d*", std::regex_constants::icase);
+  std::smatch sm;
+  regex_search(subject, sm, r);
+  if (sm.length() <= peerIdPrefixLength) {
+    LOG_ERROR(GL, "OU not found or empty: " << subject);
+    return false;
+  }
+
+  auto remPeer = sm.str().substr(peerIdPrefixLength, sm.str().length() - peerIdPrefixLength);
+  if (0 == remPeer.length()) {
+    LOG_ERROR(GL, "OU empty " << subject);
+    return false;
+  }
+
+  uint32_t remotePeerId;
+  try {
+    remotePeerId = stoul(remPeer, nullptr);
+  } catch (const std::invalid_argument& ia) {
+    LOG_ERROR(GL, "cannot convert OU, " << subject << ", " << ia.what());
+    return false;
+  } catch (const std::out_of_range& e) {
+    LOG_ERROR(GL, "cannot convert OU, " << subject << ", " << e.what());
+    return false;
+  }
+  remote_peer_id = remotePeerId;
+  std::string CN;
+  CN.resize(SIZE);
+  X509_NAME_get_text_by_NID(X509_get_subject_name(cert_to_verify), NID_commonName, CN.data(), SIZE);
+  std::string cert_type = "server";
+  if (CN.find("cli") != std::string::npos) cert_type = "client";
+  conn_type = cert_type;
+
+  // Get the local stored certificate for this peer
+  std::string local_cert_path =
+      cert_root_directory + "/" + std::to_string(remotePeerId) + "/" + cert_type + "/" + cert_type + ".cert";
+  auto deleter = [](FILE* fp) {
+    if (fp) fclose(fp);
+  };
+  std::unique_ptr<FILE, decltype(deleter)> fp(fopen(local_cert_path.c_str(), "r"), deleter);
+  if (!fp) {
+    LOG_ERROR(GL, "Certificate file not found, path: " << local_cert_path);
+    return false;
+  }
+
+  X509* localCert = PEM_read_X509(fp.get(), NULL, NULL, NULL);
+  if (!localCert) {
+    LOG_ERROR(GL, "Cannot parse certificate, path: " << local_cert_path);
+    return false;
+  }
+
+  // this is actual comparison, compares hash of 2 certs
+  bool res = (X509_cmp(cert_to_verify, localCert) == 0);
+  X509_free(localCert);
+  return res;
+}
+std::string CertificateUtils::generateSelfSignedCert(const std::string& origin_cert_path,
+                                                     const std::string& public_key,
+                                                     const std::string& signing_key) {
+  auto deleter = [](FILE* fp) {
+    if (fp) fclose(fp);
+  };
+  std::unique_ptr<FILE, decltype(deleter)> fp(fopen(origin_cert_path.c_str(), "r"), deleter);
+  if (!fp) {
+    LOG_ERROR(GL, "Certificate file not found, path: " << origin_cert_path);
+    return std::string();
+  }
+
+  X509* cert = PEM_read_X509(fp.get(), NULL, NULL, NULL);
+  if (!cert) {
+    LOG_ERROR(GL, "Cannot parse certificate, path: " << origin_cert_path);
+    return std::string();
+  }
+
+  EVP_PKEY* priv_key = EVP_PKEY_new();
+  BIO* priv_bio = BIO_new(BIO_s_mem());
+  std::string priv_key_pem = signing_key;
+  int priv_bio_write_ret = BIO_write(priv_bio, static_cast<const char*>(priv_key_pem.c_str()), priv_key_pem.size());
+  if (priv_bio_write_ret <= 0) {
+    EVP_PKEY_free(priv_key);
+    BIO_free(priv_bio);
+    return std::string();
+  }
+  if (!PEM_read_bio_PrivateKey(priv_bio, &priv_key, NULL, NULL)) {
+    EVP_PKEY_free(priv_key);
+    BIO_free(priv_bio);
+    return std::string();
+  }
+  std::string pub_key_pem = public_key;
+  EVP_PKEY* pub_key = EVP_PKEY_new();
+  BIO* pub_bio = BIO_new(BIO_s_mem());
+  int pub_bio_write_ret = BIO_write(pub_bio, static_cast<const char*>(pub_key_pem.c_str()), pub_key_pem.size());
+  if (pub_bio_write_ret <= 0) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    return std::string();
+  }
+  if (!PEM_read_bio_PUBKEY(pub_bio, &pub_key, NULL, NULL)) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    return std::string();
+  }
+
+  X509_set_pubkey(cert, pub_key);
+  X509_sign(cert, priv_key, EVP_sha256());
+
+  BIO* outbio = BIO_new(BIO_s_mem());
+  if (!PEM_write_bio_X509(outbio, cert)) {
+    BIO_free(outbio);
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    X509_free(cert);
+    return std::string();
+  }
+  std::string certStr;
+  int certLen = BIO_pending(outbio);
+  certStr.resize(certLen);
+  BIO_read(outbio, (void*)&(certStr.front()), certLen);
+  // free all pointers
+  BIO_free(outbio);
+  EVP_PKEY_free(priv_key);
+  BIO_free(priv_bio);
+  EVP_PKEY_free(pub_key);
+  BIO_free(pub_bio);
+  X509_free(cert);
+  return certStr;
+}
+bool CertificateUtils::verifyCertificate(X509* cert, const std::string& public_key) {
+  EVP_PKEY* pub_key = EVP_PKEY_new();
+  BIO* pub_bio = BIO_new(BIO_s_mem());
+  int pub_bio_write_ret = BIO_write(pub_bio, static_cast<const char*>(public_key.c_str()), public_key.size());
+  if (pub_bio_write_ret <= 0) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    return false;
+  }
+  if (!PEM_read_bio_PUBKEY(pub_bio, &pub_key, NULL, NULL)) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    return false;
+  }
+  int r = X509_verify(cert, pub_key);
+  EVP_PKEY_free(pub_key);
+  return (bool)r;
+}
 }  // namespace concord::util::crypto

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -358,8 +358,7 @@ std::string CertificateUtils::generateSelfSignedCert(const std::string& origin_c
 
   EVP_PKEY* priv_key = EVP_PKEY_new();
   BIO* priv_bio = BIO_new(BIO_s_mem());
-  std::string priv_key_pem = signing_key;
-  int priv_bio_write_ret = BIO_write(priv_bio, static_cast<const char*>(priv_key_pem.c_str()), priv_key_pem.size());
+  int priv_bio_write_ret = BIO_write(priv_bio, static_cast<const char*>(signing_key.c_str()), signing_key.size());
   if (priv_bio_write_ret <= 0) {
     EVP_PKEY_free(priv_key);
     BIO_free(priv_bio);
@@ -370,10 +369,9 @@ std::string CertificateUtils::generateSelfSignedCert(const std::string& origin_c
     BIO_free(priv_bio);
     return std::string();
   }
-  std::string pub_key_pem = public_key;
   EVP_PKEY* pub_key = EVP_PKEY_new();
   BIO* pub_bio = BIO_new(BIO_s_mem());
-  int pub_bio_write_ret = BIO_write(pub_bio, static_cast<const char*>(pub_key_pem.c_str()), pub_key_pem.size());
+  int pub_bio_write_ret = BIO_write(pub_bio, static_cast<const char*>(public_key.c_str()), public_key.size());
   if (pub_bio_write_ret <= 0) {
     EVP_PKEY_free(pub_key);
     BIO_free(pub_bio);

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -362,11 +362,13 @@ std::string CertificateUtils::generateSelfSignedCert(const std::string& origin_c
   if (priv_bio_write_ret <= 0) {
     EVP_PKEY_free(priv_key);
     BIO_free(priv_bio);
+    LOG_ERROR(GL, "Unable to create private key object");
     return std::string();
   }
   if (!PEM_read_bio_PrivateKey(priv_bio, &priv_key, NULL, NULL)) {
     EVP_PKEY_free(priv_key);
     BIO_free(priv_bio);
+    LOG_ERROR(GL, "Unable to create private key object");
     return std::string();
   }
   EVP_PKEY* pub_key = EVP_PKEY_new();
@@ -375,11 +377,13 @@ std::string CertificateUtils::generateSelfSignedCert(const std::string& origin_c
   if (pub_bio_write_ret <= 0) {
     EVP_PKEY_free(pub_key);
     BIO_free(pub_bio);
+    LOG_ERROR(GL, "Unable to create public key object");
     return std::string();
   }
   if (!PEM_read_bio_PUBKEY(pub_bio, &pub_key, NULL, NULL)) {
     EVP_PKEY_free(pub_key);
     BIO_free(pub_bio);
+    LOG_ERROR(GL, "Unable to create public key object");
     return std::string();
   }
 
@@ -394,6 +398,7 @@ std::string CertificateUtils::generateSelfSignedCert(const std::string& origin_c
     EVP_PKEY_free(pub_key);
     BIO_free(pub_bio);
     X509_free(cert);
+    LOG_ERROR(GL, "Unable to create certificate object");
     return std::string();
   }
   std::string certStr;


### PR DESCRIPTION
In this PR we introduce a new method to exchange TLS certificates.
The current method involves two phases:
1. publish the exchange command
2. each exchanged component (replica or client) publish its new certificate on the chain
The above method has a basic limit that prevents us from exchanging more than f replicas at once (otherwise we may lose the channel themselves before we are able to update the new certificates).

The new validation method relies on the fact that the certificate is published in the TLS handshake procedure itself. 
1. We sign the new certificate with the current component RSA key (as we assume that the certificate private key has been exposed)
2. On the validation itself, we try three different validations:
(a) compare with the current certificate
(b) validate against the sender RSA keys
(c) compare to the "latest" known certificate (this may happen on clients node that got an update through the CRE)

In addition, we improved the tests and stabilized them

