### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -5,54 +5,11 @@ on:
 
 jobs:
   build:
-    name: asan
+    name: dummy
     runs-on: ubuntu-18.04
     strategy:
         fail-fast: false
     steps:
-        - name: Cleanup pre-installed tools
+        - name: dummy
           run: |
-            # This is a fix for https://github.com/actions/virtual-environments/issues/1918
-            sudo rm -rf /usr/share/dotnet
-            sudo rm -rf /opt/ghc
-            sudo rm -rf "/usr/local/share/boost"
-            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Create artifact directory
-          run: mkdir -p ${{ github.workspace }}/artifact
-        # Uncomment the step below to enable core dump collection
-        #- name: Configure core dump location
-        #  run: |
-            # echo "/concord-bft/build/cores/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
-        # Uncomment the step below if you want to log into the running session.
-        # Please note that the build will block on this step.
-        # Refer to https://github.com/marketplace/actions/debugging-with-tmate
-        #- name: Setup tmate session
-        #  uses: mxschmitt/action-tmate@v2
-        - name: Build and test
-          run: |
-              script -q -e -c "make pull"
-              sudo df -h
-              script -q -e -c "CONCORD_BFT_CMAKE_OMIT_TEST_OUTPUT=TRUE CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE CONCORD_BFT_CMAKE_ASAN=TRUE CONCORD_BFT_CMAKE_USE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE make build" \
-              && script -q -e -c "make test"
-        - name: Check if ASAN passed
-          if: always()
-          run: |
-              chmod +x "./.github/fail_action_if_sanitizer_reports_exist.sh"
-              ./.github/fail_action_if_sanitizer_reports_exist.sh ./build/asan_logs
-        - name: Prepare artifacts
-          if: always()
-          run: |
-            sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            #tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs # Do not attempt to archive because CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE
-            tar -czvf ${{ github.workspace }}/artifact/asan.logs.tar.gz ./build/asan_logs
-            du -h ${{ github.workspace }}/artifact
-            sudo df -h
-        - name: Upload artifacts
-          uses: actions/upload-artifact@v2
-          if: always()
-          with:
-            name: artifacts-${{ github.sha }}
-            path: ${{ github.workspace }}/artifact/
-
+            echo "done"

--- a/.github/workflows/build_and_test_clang_debug.yml
+++ b/.github/workflows/build_and_test_clang_debug.yml
@@ -3,102 +3,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build
+    name: dummy
     runs-on: ubuntu-18.04
-    outputs:
-      err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:
         fail-fast: false
-        matrix:
-            compiler:
-                - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
-            ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=DEBUG -DBUILD_COMM_TCP_TLS=FALSE"
-            use_s3_obj_store:
-                - "-DUSE_S3_OBJECT_STORE=ON"
-                - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
         - name: Cleanup pre-installed tools
           run: |
-            # This is a fix for https://github.com/actions/virtual-environments/issues/1918
-            sudo rm -rf /usr/share/dotnet
-            sudo rm -rf /opt/ghc
-            sudo rm -rf "/usr/local/share/boost"
-            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Create artifact directory
-          run: mkdir -p ${{ github.workspace }}/artifact
-        #- name: Configure core dump location
-        #  run: |
-            # Uncomment the line below to enable core dump collection
-            # echo "/concord-bft/build/cores/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
-            # Uncomment this is you want to login into the running session.
-            # Please note that the build will block on this step.
-            # Refer to https://github.com/marketplace/actions/debugging-with-tmate
-        #- name: Setup tmate session
-        #  uses: mxschmitt/action-tmate@v2
-        - name: Build and test
-          run: |
-              script -q -e -c "make pull"
-              sudo df -h
-              script -q -e -c "make build \
-                              ${{ matrix.compiler}} \
-                              CONCORD_BFT_CMAKE_FLAGS=\"\
-                              ${{ matrix.ci_build_type }} \
-                              -DBUILD_TESTING=ON \
-                              -DBUILD_COMM_TCP_PLAIN=FALSE \
-                              -DCMAKE_CXX_FLAGS_RELEASE='-O3 -g' \
-                              -DUSE_LOG4CPP=TRUE \
-                              -DBUILD_ROCKSDB_STORAGE=TRUE \
-                              ${{ matrix.use_s3_obj_store }} \
-                              -DUSE_OPENTRACING=ON \
-                              -DOMIT_TEST_OUTPUT=OFF\
-                              -DKEEP_APOLLO_LOGS=TRUE\
-                              -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
-              && script -q -e -c "make test"
-        - name: Prepare artifacts
-          if: failure()
-          run: |
-            sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
-            du -h ${{ github.workspace }}/artifact
-            sudo df -h
-        - name: Upload artifacts
-          uses: actions/upload-artifact@v2
-          if: failure()
-          with:
-            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
-            path: ${{ github.workspace }}/artifact/
-        - name: Check ERROR/FATAL logs
-          if: always()
-          run: |
-            ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
-            echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
-        - name: Prepare error artifacts
-          id: prepare_err_artifacts
-          if: ${{ env.file_count > 0 }}
-          run: |
-            sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
-            du -h ${{ github.workspace }}/artifact
-            sudo df -h
-            echo "::set-output name=test::success"
-        - name: Upload error artifacts
-          uses: actions/upload-artifact@v2
-          if: ${{ env.file_count > 0 }}
-          with:
-            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
-            path: ${{ github.workspace }}/artifact/
-  testlog:
-    name: Check ERROR/ FATAL logs(Apollo)
-    runs-on: ubuntu-18.04
-    continue-on-error: true
-    needs: build
-    steps:
-        - name: Check ERROR/FATAL logs in apollo
-          if: needs.build.outputs.err_output == 'success'
-          run: |
-            echo "Errors exist in replica logs. Please check Artifacts"
-            exit 1
-   
+            echo "done"

--- a/.github/workflows/build_and_test_clang_release.yml
+++ b/.github/workflows/build_and_test_clang_release.yml
@@ -13,11 +13,9 @@ jobs:
             compiler:
                 - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
             ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=FALSE"
                 - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=TRUE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
-                - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
         - name: Cleanup pre-installed tools
           run: |
@@ -57,7 +55,8 @@ jobs:
                               -DOMIT_TEST_OUTPUT=OFF\
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
-              && script -q -e -c "make test"
+              && script -q -e -c \
+              "make single-test TEST_NAME=\"bcstatetransfer_tests\|source_selector_test\|skvbc_reconfiguration\|skvbc_state_transfer_tests\|skvbc_persistence_tests\|skvbc_network_partitioning_tests\|skvbc_backup_restore\|skvbc_ro_replica_tests\|skvbc_basic_tests\|skvbc_chaotic_startup\" "
         - name: Prepare artifacts
           if: failure()
           run: |

--- a/.github/workflows/build_and_test_gcc_debug.yml
+++ b/.github/workflows/build_and_test_gcc_debug.yml
@@ -15,7 +15,6 @@ jobs:
             ci_build_type:
                 - "-DCMAKE_BUILD_TYPE=DEBUG -DBUILD_COMM_TCP_TLS=FALSE"
             use_s3_obj_store:
-                - "-DUSE_S3_OBJECT_STORE=ON"
                 - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
         - name: Cleanup pre-installed tools
@@ -57,7 +56,8 @@ jobs:
                               -DKEEP_APOLLO_LOGS=TRUE\
                               -DRUN_APOLLO_TESTS=FALSE\
                               -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
-              && script -q -e -c "make test"
+              && script -q -e -c \
+              "make single-test TEST_NAME=\"bcstatetransfer_tests\|source_selector_test\|skvbc_reconfiguration\|skvbc_state_transfer_tests\|skvbc_persistence_tests\|skvbc_network_partitioning_tests\|skvbc_backup_restore\|skvbc_ro_replica_tests\|skvbc_basic_tests\|skvbc_chaotic_startup\" "
         - name: Prepare artifacts
           if: failure()
           run: |

--- a/.github/workflows/build_and_test_gcc_release.yml
+++ b/.github/workflows/build_and_test_gcc_release.yml
@@ -1,105 +1,15 @@
 name: Release build (gcc)
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: "0 12 * * 6" # Every Saturday at 12PM UTC
 
 jobs:
   build:
-    name: Build
+    name: dummy
     runs-on: ubuntu-18.04
-    outputs:
-      err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:
         fail-fast: false
-        matrix:
-            compiler:
-                - "CONCORD_BFT_CONTAINER_CC=gcc CONCORD_BFT_CONTAINER_CXX=g++"
-            ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=FALSE"
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=TRUE"
-            use_s3_obj_store:
-                - "-DUSE_S3_OBJECT_STORE=ON"
-                - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
-        - name: Cleanup pre-installed tools
+        - name: dummy
           run: |
-            # This is a fix for https://github.com/actions/virtual-environments/issues/1918
-            sudo rm -rf /usr/share/dotnet
-            sudo rm -rf /opt/ghc
-            sudo rm -rf "/usr/local/share/boost"
-            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Create artifact directory
-          run: mkdir -p ${{ github.workspace }}/artifact
-        #- name: Configure core dump location
-        #  run: |
-            # Uncomment the line below to enable core dump collection
-            # echo "/concord-bft/build/cores/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
-            # Uncomment this is you want to login into the running session.
-            # Please note that the build will block on this step.
-            # Refer to https://github.com/marketplace/actions/debugging-with-tmate
-        #- name: Setup tmate session
-        #  uses: mxschmitt/action-tmate@v2
-        - name: Build and test
-          run: |
-              script -q -e -c "make pull"
-              sudo df -h
-              script -q -e -c "make build \
-                              ${{ matrix.compiler}} \
-                              CONCORD_BFT_CMAKE_FLAGS=\"\
-                              ${{ matrix.ci_build_type }} \
-                              -DBUILD_TESTING=ON \
-                              -DBUILD_COMM_TCP_PLAIN=FALSE \
-                              -DCMAKE_CXX_FLAGS_RELEASE='-O3 -g' \
-                              -DUSE_LOG4CPP=TRUE \
-                              -DBUILD_ROCKSDB_STORAGE=TRUE \
-                              ${{ matrix.use_s3_obj_store }} \
-                              -DUSE_OPENTRACING=ON \
-                              -DOMIT_TEST_OUTPUT=OFF\
-                              -DKEEP_APOLLO_LOGS=TRUE\
-                              -DRUN_APOLLO_TESTS=FALSE\
-                              -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
-              && script -q -e -c "make test"
-        - name: Prepare artifacts
-          if: failure()
-          run: |
-            sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
-            du -h ${{ github.workspace }}/artifact
-            sudo df -h
-        - name: Upload artifacts
-          uses: actions/upload-artifact@v2
-          if: failure()
-          with:
-            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
-            path: ${{ github.workspace }}/artifact/
-        - name: Check ERROR/FATAL logs
-          if: always()
-          run: |
-            ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
-            echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
-        - name: Prepare error artifacts
-          id: prepare_err_artifacts
-          if: ${{ env.file_count > 0 }}
-          run: |
-            sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
-            du -h ${{ github.workspace }}/artifact
-            sudo df -h
-            echo "::set-output name=test::success"
-        - name: Upload error artifacts
-          uses: actions/upload-artifact@v2
-          if: ${{ env.file_count > 0 }}
-          with:
-            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
-            path: ${{ github.workspace }}/artifact/
-  testlog:
-    name: Check ERROR/FATAL logs(Apollo)
-    runs-on: ubuntu-18.04
-    continue-on-error: true
-    needs: build
-    steps:
-        - name: Check ERROR/FATAL logs in apollo
-          if: needs.build.outputs.err_output == 'success'
-          run: |
-            echo "Errors exist in replica logs. Please check Artifacts"
-            exit 1
+            echo "done"

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -9,48 +9,8 @@ jobs:
     name: Code coverage for Apollo Tests
     runs-on: ubuntu-18.04
     strategy:
-      fail-fast: false
+        fail-fast: false
     steps:
-      - name: Cleanup pre-installed tools
-        run: |
-          # This is a fix for https://github.com/actions/virtual-environments/issues/1918
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      - name: Checkout repository code
-        uses: actions/checkout@v2
-      - name: Create artifact directory
-        run: mkdir -p ${{ github.workspace }}/artifact
-
-      - name: Build and test
-        id: build_test
-        run: |
-          script -q -e -c "make pull"
-          sudo df -h
-          script -q -e -c "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++ \
-          CONCORD_BFT_CMAKE_CODECOVERAGE=TRUE CONCORD_BFT_CMAKE_TRANSPORT=UDP make build" && script -q -e -c "make test"
-        continue-on-error: true
-
-      - name: Generate code coverage report for apollo tests
-        if: always()
-        run: |
-          script -q -e -c "make codecoverage"
-      - name: Check for coveragereport directory
-        if: always()
-        run: |
-          ./.github/success_action_if_codecoverage_reports_exist.sh ./build/tests/apollo/coveragereport
-          echo "indexfile_count=$(find build/tests/apollo/coveragereport -name index.html | wc -l)" > $GITHUB_ENV
-      - name: Prepare code coverage artifacts
-        if: ${{ env.indexfile_count > 0 }}
-        run: |
-          sudo chown -R ${USER}:${GROUP} ${PWD}/build
-          tar -czvf ${{ github.workspace }}/artifact/apollo-tests-codecoverage.tar.gz ./build/tests/apollo/coveragereport
-          du -h ${{ github.workspace }}/artifact
-          sudo df -h
-      - name: Upload code coverage artifacts
-        uses: actions/upload-artifact@v2
-        if: ${{ env.indexfile_count > 0 }}
-        with:
-          name: artifacts-${{ github.sha }}
-          path: ${{ github.workspace }}/artifact/
+        - name: Cleanup pre-installed tools
+          run: |
+            echo "done"

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -5,55 +5,11 @@ on:
 
 jobs:
   build:
-    name: tsan
+    name: dummy
     runs-on: ubuntu-18.04
     strategy:
         fail-fast: false
     steps:
-        - name: Cleanup pre-installed tools
+        - name: dummy
           run: |
-            # This is a fix for https://github.com/actions/virtual-environments/issues/1918
-            sudo rm -rf /usr/share/dotnet
-            sudo rm -rf /opt/ghc
-            sudo rm -rf "/usr/local/share/boost"
-            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Create artifact directory
-          run: mkdir -p ${{ github.workspace }}/artifact
-        # Uncomment the step below to enable core dump collection
-        #- name: Configure core dump location
-        #  run: |
-            # echo "/concord-bft/build/cores/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
-        # Uncomment the step below if you want to log into the running session.
-        # Please note that the build will block on this step.
-        # Refer to https://github.com/marketplace/actions/debugging-with-tmate
-        #- name: Setup tmate session
-        #  uses: mxschmitt/action-tmate@v2
-        - name: Build and test
-          run: |
-              script -q -e -c "make pull"
-              sudo df -h
-              script -q -e -c "CONCORD_BFT_CMAKE_OMIT_TEST_OUTPUT=TRUE CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE CONCORD_BFT_CMAKE_TSAN=TRUE CONCORD_BFT_CMAKE_USE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE make build" \
-              && script -q -e -c "make test"
-        - name: Check if TSAN passed
-          if: always()
-          run: |
-              chmod +x "./.github/fail_action_if_sanitizer_reports_exist.sh"
-              ./.github/fail_action_if_sanitizer_reports_exist.sh ./build/tsan_logs
-        - name: Prepare artifacts
-          if: always()
-          run: |
-            sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            #tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs # Do not attempt to archive because CONCORD_BFT_CMAKE_KEEP_APOLLO_LOGS=FALSE
-            tar -czvf ${{ github.workspace }}/artifact/tsan.logs.tar.gz ./build/tsan_logs
-            du -h ${{ github.workspace }}/artifact
-            sudo df -h
-        - name: Upload artifacts
-          uses: actions/upload-artifact@v2
-          if: always()
-          with:
-            name: artifacts-${{ github.sha }}
-            path: ${{ github.workspace }}/artifact/
-
-
+            echo "done"


### PR DESCRIPTION
This is a patch on github actions - disabled 5 of 8 workflows.
We shouldn't merge this to master.
The content of the disabled workflows is redundant and should be ignored.
Only 3 left:
1) Two build workflows - once under gcc and one for clang.
2) clang-tidy