### PR TITLE
final TLS rotation fixes

### DIFF
--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -128,7 +128,7 @@ class FakeCommunication : public bft::communication::ICommunication {
 
   void setReceiver(NodeNum id, IReceiver* receiver) override { receiver_ = receiver; }
 
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
 
  private:
   IReceiver* receiver_;

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -63,7 +63,7 @@ class Communication : public ICommunication {
     return ret;
   }
   void setReceiver(NodeNum receiverNum, IReceiver* receiver) override { receiver_ = receiver; }
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
 
  private:
   std::shared_ptr<MsgsCommunicator> msgsCommunicator_;

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -134,7 +134,7 @@ class PlainUDPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  void dispose(NodeNum i) override{};
+  void restartCommunication(NodeNum i) override{};
   ~PlainUDPCommunication() override;
 
  private:
@@ -161,7 +161,7 @@ class PlainTCPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
   ~PlainTCPCommunication() override;
 
  private:
@@ -190,7 +190,7 @@ class TlsTCPCommunication : public ICommunication {
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
-  void dispose(NodeNum i) override;
+  void restartCommunication(NodeNum i) override;
   ~TlsTCPCommunication() override;
 
  private:

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -67,7 +67,7 @@ class ICommunication {
 
   virtual void setReceiver(NodeNum receiverNum, IReceiver* receiver) = 0;
 
-  virtual void dispose(NodeNum i) = 0;
+  virtual void restartCommunication(NodeNum i) = 0;
   virtual ~ICommunication() = default;
 };
 }  // namespace bft::communication

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -505,5 +505,11 @@ const std::string AsyncTlsConnection::decryptPrivateKey(const boost::filesystem:
 
   return *decBuf;
 }
+void AsyncTlsConnection::close() {
+  std::lock_guard<std::mutex> lock(shutdown_lock_);
+  if (closed_) return;
+  socket_->lowest_layer().close();
+  closed_ = true;
+}
 
 }  // namespace bft::communication::tls

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -142,6 +142,8 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Clean up the connection
   void dispose(bool close_connection = true);
 
+  void close();
+
  private:
   // We know the size of the message and that a message should be forthcoming. We start a timer and
   // ensure we read all remaining bytes within a given timeout. If we read the full message we
@@ -217,6 +219,8 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   TlsStatus& status_;
   Recorders& histograms_;
   WriteQueue write_queue_;
+  std::mutex shutdown_lock_;
+  bool closed_ = false;
 };
 
 }  // namespace bft::communication::tls

--- a/communication/src/TlsConnectionManager.h
+++ b/communication/src/TlsConnectionManager.h
@@ -45,7 +45,6 @@ class ConnectionManager {
   void send(const NodeNum destination, const std::shared_ptr<OutgoingMsg> &msg);
   void send(const std::set<NodeNum> &destinations, const std::shared_ptr<OutgoingMsg> &msg);
   int getMaxMessageSize() const;
-  void dispose(NodeNum i);
 
  private:
   void start();
@@ -154,6 +153,7 @@ class ConnectionManager {
   // Diagnostics
   std::shared_ptr<TlsStatus> status_;
   Recorders histograms_;
+  std::atomic_bool stopped_ = false;
 };
 
 }  // namespace bft::communication::tls

--- a/communication/src/TlsRunner.cpp
+++ b/communication/src/TlsRunner.cpp
@@ -30,6 +30,7 @@ void Runner::start() {
   std::lock_guard<std::mutex> lock(start_stop_mutex);
   ConcordAssert(io_threads_.empty());
   LOG_INFO(logger_, "Starting TLS Runner");
+  io_context_.restart();
 
   // Give the io_context work to do.
   for (auto& [_, conn_mgr] : principals_) {

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -99,7 +99,9 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
 }
 
 void TlsTCPCommunication::restartCommunication(NodeNum i) {
-  runner_->stop();
-  runner_->start();
+  if (i == config_.selfId) {
+    runner_->stop();
+    runner_->start();
+  }
 }
 }  // namespace bft::communication

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -98,15 +98,8 @@ void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) {
   }
 }
 
-void TlsTCPCommunication::dispose(NodeNum i) {
-  auto &connMgr = runner_->principals().at(config_.selfId);
-  if (i == config_.selfId) {
-    auto end = std::min<size_t>(config_.selfId, config_.maxServerId + 1);
-    for (auto rep = 0u; rep < end; rep++) {
-      connMgr.dispose(rep);
-    }
-  } else if (i < config_.selfId) {
-    connMgr.dispose(i);
-  }
+void TlsTCPCommunication::restartCommunication(NodeNum i) {
+  runner_->stop();
+  runner_->start();
 }
 }  // namespace bft::communication

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -443,20 +443,8 @@ Replica::Replica(ICommunication *comm,
       secretsManager_{secretsManager},
       blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
                                                                           : std::thread::hardware_concurrency()) {
-  bft::communication::StateControl::instance().setCommRestartCallBack([this](uint32_t i) {
-    m_ptrComm->dispose(i);
-    // Now wait for a live quorum before continue running
-    uint32_t live_replicas = 1;
-    uint32_t minQuorumSize = 2 * replicaConfig_.fVal + replicaConfig_.cVal + 1;
-    while (live_replicas < minQuorumSize) {
-      live_replicas = 1;
-      for (uint32_t r = 0; r < replicaConfig_.numReplicas; r++) {
-        if (r == replicaConfig_.replicaId) continue;
-        live_replicas += (m_ptrComm->getCurrentConnectionStatus(r) == bft::communication::ConnectionStatus::Connected);
-      }
-    }
-    LOG_INFO(GL, "post communication restart: resuming running after getting " << live_replicas << " connected");
-  });
+  bft::communication::StateControl::instance().setCommRestartCallBack(
+      [this](uint32_t i) { m_ptrComm->restartCommunication(i); });
   // Populate ST configuration
   bftEngine::bcst::Config stConfig = {
     replicaConfig_.replicaId,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -204,6 +204,10 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
       if (csrep.block_id == 0) continue;
       rep.states.push_back(csrep);
     }
+    for (uint16_t i = 0; i < first_client_id; i++) {
+      auto ke_csrep = buildReplicaStateReply(std::string{kvbc::keyTypes::reconfiguration_tls_exchange_key}, i);
+      if (ke_csrep.block_id > 0) rep.states.push_back(ke_csrep);
+    }
   } else {
     auto scaling_key_prefix =
         std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -524,8 +524,13 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                             if lines > 0:
                                 succ = False
                                 continue
+            await bft_network.wait_for_state_transfer_to_start()
+            for r in crashed_replica:
+                await bft_network.wait_for_state_transfer_to_stop(initial_prim,
+                                                              r,
+                                                              stop_on_stable_seq_num=False)
 
-            for i in range(800):
+            for i in range(500):
                 await skvbc.send_write_kv_set()
             for r in bft_network.all_replicas():
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -525,7 +525,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                                 succ = False
                                 continue
 
-            for i in range(500):
+            for i in range(800):
                 await skvbc.send_write_kv_set()
             for r in bft_network.all_replicas():
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -304,12 +304,10 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
   bool validate(const State& state) const override {
     concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
-    LOG_INFO(GL, "b(1)");
     return std::holds_alternative<concord::messages::ReplicaTlsExchangeKey>(crep.response);
   }
 
   bool execute(const State& state, WriteState& out) override {
-    LOG_INFO(GL, "b(2)");
     bool succ = true;
     concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -304,10 +304,12 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
   bool validate(const State& state) const override {
     concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
+    LOG_INFO(GL, "b(1)");
     return std::holds_alternative<concord::messages::ReplicaTlsExchangeKey>(crep.response);
   }
 
   bool execute(const State& state, WriteState& out) override {
+    LOG_INFO(GL, "b(2)");
     bool succ = true;
     concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
@@ -319,8 +321,8 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
     if (current_rep_cert == command.cert) return succ;
     LOG_INFO(GL, "execute replica TLS key exchange using state transfer cre" << KVLOG(sender_id));
     std::string cert = std::move(command.cert);
-    sm_.encryptFile(bft_replicas_cert_path + ".latest", cert);
-    LOG_INFO(GL, bft_replicas_cert_path + ".latest" + " is updated on the disk");
+    sm_.encryptFile(bft_replicas_cert_path, cert);
+    LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
     return succ;
   }
 

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
@@ -44,7 +44,7 @@ class WrapCommunication : public ICommunication {
     communication_->setReceiver(receiverNum, receiver);
   }
 
-  void dispose(NodeNum i) override {}
+  void restartCommunication(NodeNum i) override {}
   static void addStrategies(
       std::string const &strategies,
       char delim,


### PR DESCRIPTION
In this PR we fix some issues with TLS key exchange as well as adding the handler to tester CRE that handles replicas TLS key exchange (this handler should be implemented in every application-level CRE)
Also, we stabilized some of the reconfiguration Apollo tests. 