### PR TITLE
Add FAILED_PRECONDITION as error for StreamSnapshot

### DIFF
--- a/client/proto/state_snapshot/v1/state_snapshot.proto
+++ b/client/proto/state_snapshot/v1/state_snapshot.proto
@@ -32,6 +32,9 @@ service StateSnapshot {
   // INVALID_ARGUMENT: if resuming a stream using `from_key` and that key is not part of the
   //                   state snapshot.
   // UNAVAILABLE: if Concord Client is not ready yet to process requests.
+  // FAILED_PRECONDITION: if a precondition in Concord Client is not satisfied. For example,
+  //                      the state might be corrupted or invalid and, in that case, there
+  //                      would be no point in proceeding with streaming.
   // UNKNOWN: exact cause is unknown.
   rpc StreamSnapshot(StreamSnapshotRequest) returns (stream StreamSnapshotResponse);
 


### PR DESCRIPTION
Rationale is that we might return it if Concord Client cannot verify the
state from the replicas (i.e. the signatures don't match). It can be
used in different scenarios too.