### PR TITLE
Object Store Integrity

### DIFF
--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -52,7 +52,8 @@ class IStateTransfer : public IReservedPages {
   virtual void getDigestOfCheckpoint(uint64_t checkpointNumber,
                                      uint16_t sizeOfDigestBuffer,
                                      uint64_t &outBlockId,
-                                     char *outDigestBuffer) = 0;
+                                     char *outStateDigest,
+                                     char *outOtherDigest) = 0;
 
   // state
   virtual void startCollectingState() = 0;

--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -51,6 +51,9 @@ class MetadataStorage {
 
   // In some cases, we would like to load a new metadata after a crash (for example, on reconfiguration actions).
   virtual void eraseData() = 0;
+
+  //
+  virtual void atomicWriteArbitraryObject(const std::string &key, const char *data, uint32_t dataLength) = 0;
 };
 
 }  // namespace bftEngine

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -104,7 +104,8 @@ class IReplica {
   static IReplicaPtr createNewRoReplica(const ReplicaConfig &,
                                         std::shared_ptr<IRequestsHandler>,
                                         IStateTransfer *,
-                                        bft::communication::ICommunication *);
+                                        bft::communication::ICommunication *,
+                                        MetadataStorage *);
 
   virtual ~IReplica() = default;
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -73,7 +73,7 @@ IStateTransfer *create(const Config &config,
 
   impl::DataStore *ds = nullptr;
 
-  if (dynamic_cast<concord::storage::memorydb::Client *>(dbc.get()))
+  if (dynamic_cast<concord::storage::memorydb::Client *>(dbc.get()) || config.isReadOnly)
     ds = new impl::InMemoryDataStore(config.sizeOfReservedPage);
   else
     ds = new impl::DBDataStore(dbc, config.sizeOfReservedPage, stKeyManipulator, config.enableReservedPages);
@@ -572,7 +572,8 @@ void BCStateTran::markCheckpointAsStable(uint64_t checkpointNumber) {
 void BCStateTran::getDigestOfCheckpoint(uint64_t checkpointNumber,
                                         uint16_t sizeOfDigestBuffer,
                                         uint64_t &outBlockId,
-                                        char *outDigestBuffer) {
+                                        char *outStateDigest,
+                                        char *outOtherDigest) {
   ConcordAssert(running_);
   ConcordAssertGE(sizeOfDigestBuffer, sizeof(STDigest));
   ConcordAssertGT(checkpointNumber, 0);
@@ -581,18 +582,16 @@ void BCStateTran::getDigestOfCheckpoint(uint64_t checkpointNumber,
   ConcordAssert(psd_->hasCheckpointDesc(checkpointNumber));
 
   DataStore::CheckpointDesc desc = psd_->getCheckpointDesc(checkpointNumber);
-  STDigest checkpointDigest;
-  DigestContext c;
-  c.update(reinterpret_cast<char *>(&desc), sizeof(desc));
-  c.writeDigest(checkpointDigest.getForUpdate());
-
-  LOG_INFO(logger_,
-           KVLOG(desc.checkpointNum, desc.digestOfLastBlock, desc.digestOfResPagesDescriptor, checkpointDigest));
+  LOG_INFO(logger_, KVLOG(desc.checkpointNum, desc.lastBlock, desc.digestOfLastBlock, desc.digestOfResPagesDescriptor));
 
   uint16_t s = std::min((uint16_t)sizeof(STDigest), sizeOfDigestBuffer);
-  memcpy(outDigestBuffer, checkpointDigest.get(), s);
+  memcpy(outStateDigest, desc.digestOfLastBlock.get(), s);
   if (s < sizeOfDigestBuffer) {
-    memset(outDigestBuffer + s, 0, sizeOfDigestBuffer - s);
+    memset(outStateDigest + s, 0, sizeOfDigestBuffer - s);
+  }
+  memcpy(outOtherDigest, desc.digestOfResPagesDescriptor.get(), s);
+  if (s < sizeOfDigestBuffer) {
+    memset(outOtherDigest + s, 0, sizeOfDigestBuffer - s);
   }
   outBlockId = desc.lastBlock;
 }

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -92,7 +92,8 @@ class BCStateTran : public IStateTransfer {
   void getDigestOfCheckpoint(uint64_t checkpointNumber,
                              uint16_t sizeOfDigestBuffer,
                              uint64_t& outBlockId,
-                             char* outDigestBuffer) override;
+                             char* outStateDigest,
+                             char* outFullStateDigest) override;
 
   static void computeDigestOfBlockImpl(const uint64_t blockNum,
                                        const char* block,

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -251,7 +251,8 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
 IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaConfig,
                                                    std::shared_ptr<IRequestsHandler> requestsHandler,
                                                    IStateTransfer *stateTransfer,
-                                                   bft::communication::ICommunication *communication) {
+                                                   bft::communication::ICommunication *communication,
+                                                   MetadataStorage *metadataStorage) {
   auto replicaInternal = std::make_unique<ReplicaInternal>();
   auto msgHandlers = std::make_shared<MsgHandlersRegistrator>();
   auto incomingMsgsStorageImpPtr =
@@ -261,7 +262,7 @@ IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaC
   auto msgReceiver = std::make_shared<MsgReceiver>(incomingMsgsStorage);
   auto msgsCommunicator = std::make_shared<MsgsCommunicator>(communication, incomingMsgsStorage, msgReceiver);
   replicaInternal->replica_ = std::make_unique<ReadOnlyReplica>(
-      replicaConfig, requestsHandler, stateTransfer, msgsCommunicator, msgHandlers, timers);
+      replicaConfig, requestsHandler, stateTransfer, msgsCommunicator, msgHandlers, timers, metadataStorage);
   return replicaInternal;
 }
 

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -92,6 +92,24 @@ void DBMetadataStorage::atomicWrite(uint32_t objectId, const char *data, uint32_
   }
 }
 
+void DBMetadataStorageUnbounded::atomicWriteArbitraryObject(const std::string &key,
+                                                            const char *data,
+                                                            uint32_t dataLength) {
+  Sliver k = Sliver::copy(key.data(), key.length());
+  Sliver v = Sliver::copy(data, dataLength);
+  lock_guard<mutex> lock(ioMutex_);
+  LOG_DEBUG(logger_, "key: " << key);
+  Status status = dbClient_->put(metadataKeyManipulator_->generateMetadataKey(k), v);
+  if (!status.isOK()) {
+    throw runtime_error("DBClient put operation failed");
+  }
+}
+
+void DBMetadataStorage::atomicWriteArbitraryObject(const std::string &key, const char *data, uint32_t dataLength) {
+  LOG_ERROR(GL, "shouldn't have been called. key: " << key);
+  throw runtime_error("DBMetadataStorage::atomicWriteArbitraryObject() shouldn't have been called.");
+}
+
 void DBMetadataStorage::beginAtomicWriteOnlyBatch() {
   lock_guard<mutex> lock(ioMutex_);
   LOG_DEBUG(logger_, "Begin atomic transaction");

--- a/bftengine/src/bftengine/NullStateTransfer.cpp
+++ b/bftengine/src/bftengine/NullStateTransfer.cpp
@@ -55,17 +55,18 @@ void NullStateTransfer::markCheckpointAsStable(uint64_t checkpointNumber) {}
 void NullStateTransfer::getDigestOfCheckpoint(uint64_t checkpointNumber,
                                               uint16_t sizeOfDigestBuffer,
                                               uint64_t& outBlockId,
-                                              char* outDigestBuffer) {
+                                              char* outStateDigest,
+                                              char* outFullStateDigest) {
   ConcordAssert(sizeOfDigestBuffer >= sizeof(Digest));
   LOG_WARN(GL, "State digest is only based on sequence number (because state transfer module has not been loaded)");
 
-  memset(outDigestBuffer, 0, sizeOfDigestBuffer);
-
   Digest d;
-
   DigestUtil::compute((char*)&checkpointNumber, sizeof(checkpointNumber), (char*)&d, sizeof(d));
 
-  memcpy(outDigestBuffer, d.content(), sizeof(d));
+  memset(outStateDigest, 0, sizeOfDigestBuffer);
+  memset(outFullStateDigest, 0, sizeOfDigestBuffer);
+  memcpy(outStateDigest, d.content(), sizeof(d));
+  memcpy(outFullStateDigest, d.content(), sizeof(d));
 }
 
 void NullStateTransfer::startCollectingState() {

--- a/bftengine/src/bftengine/NullStateTransfer.hpp
+++ b/bftengine/src/bftengine/NullStateTransfer.hpp
@@ -29,7 +29,8 @@ class NullStateTransfer : public IStateTransfer {
   virtual void getDigestOfCheckpoint(uint64_t checkpointNumber,
                                      uint16_t sizeOfDigestBuffer,
                                      uint64_t& outBlockId,
-                                     char* outDigestBuffer) override;
+                                     char* outStateDigest,
+                                     char* outFullStateDigest) override;
 
   virtual void startCollectingState() override;
   virtual bool isCollectingState() const override;

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -336,10 +336,7 @@ bool DescriptorOfLastStableCheckpoint::equals(const DescriptorOfLastStableCheckp
     return false;
   }
   for (size_t i = 0; i < checkpointMsgs.size(); i++) {
-    if (other.checkpointMsgs[i] == nullptr ||
-        checkpointMsgs[i]->idOfGeneratedReplica() != other.checkpointMsgs[i]->idOfGeneratedReplica() ||
-        checkpointMsgs[i]->seqNumber() != other.checkpointMsgs[i]->seqNumber() ||
-        checkpointMsgs[i]->digestOfState() != other.checkpointMsgs[i]->digestOfState()) {
+    if (other.checkpointMsgs[i] == nullptr || !CheckpointMsg::equivalent(checkpointMsgs[i], other.checkpointMsgs[i])) {
       return false;
     }
   }

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -18,7 +18,6 @@
 #include "messages/AskForCheckpointMsg.hpp"
 #include "messages/ClientRequestMsg.hpp"
 #include "messages/ClientReplyMsg.hpp"
-#include "CheckpointInfo.hpp"
 #include "Logger.hpp"
 #include "kvstream.h"
 #include "PersistentStorage.hpp"
@@ -36,12 +35,14 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                                  IStateTransfer *stateTransfer,
                                  std::shared_ptr<MsgsCommunicator> msgComm,
                                  std::shared_ptr<MsgHandlersRegistrator> msgHandlerReg,
-                                 concordUtil::Timers &timers)
+                                 concordUtil::Timers &timers,
+                                 MetadataStorage *metadataStorage)
     : ReplicaForStateTransfer(config, requestsHandler, stateTransfer, msgComm, msgHandlerReg, true, timers),
       ro_metrics_{metrics_.RegisterCounter("receivedCheckpointMsgs"),
                   metrics_.RegisterCounter("sentAskForCheckpointMsgs"),
                   metrics_.RegisterCounter("receivedInvalidMsgs"),
-                  metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)} {
+                  metrics_.RegisterGauge("lastExecutedSeqNum", lastExecutedSeqNum)},
+      metadataStorage_{metadataStorage} {
   LOG_INFO(GL, "Initialising ReadOnly Replica");
   repsInfo = new ReplicasInfo(config, dynamicCollectorForPartialProofs, dynamicCollectorForExecutionProofs);
   msgHandlers_->registerMsgHandler(
@@ -112,8 +113,9 @@ void ReadOnlyReplica::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
                  msg->epochNumber(),
                  msg->size(),
                  msg->isStableState(),
-                 msg->state())
-               << ", state digest: " << msg->digestOfState().toString());
+                 msg->state(),
+                 msg->digestOfState(),
+                 msg->otherDigest()));
 
   // Reconfiguration cmd block is synced to RO replica via reserved pages
   EpochNum replicasLastKnownEpochVal = 0;
@@ -131,10 +133,30 @@ void ReadOnlyReplica::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
   checkpointsInfo[msg->seqNumber()].addCheckpointMsg(msg, msg->idOfGeneratedReplica());
   // if enough - invoke state transfer
   if (checkpointsInfo[msg->seqNumber()].isCheckpointCertificateComplete()) {
+    persistCheckpointDescriptor(msg->seqNumber(), checkpointsInfo[msg->seqNumber()]);
     checkpointsInfo.clear();
     LOG_INFO(GL, "call to startCollectingState()");
     stateTransfer->startCollectingState();
   }
+}
+
+void ReadOnlyReplica::persistCheckpointDescriptor(const SeqNum &seqnum, const CheckpointInfo<false> &chckpinfo) {
+  std::vector<CheckpointMsg *> msgs;
+  msgs.reserve(chckpinfo.getAllCheckpointMsgs().size());
+  for (const auto &m : chckpinfo.getAllCheckpointMsgs()) msgs.push_back(m.second);
+  DescriptorOfLastStableCheckpoint desc(ReplicaConfig::instance().getnumReplicas(), msgs);
+  const size_t bufLen = DescriptorOfLastStableCheckpoint::maxSize(ReplicaConfig::instance().getnumReplicas());
+  concord::serialize::UniquePtrToChar descBuf(new char[bufLen]);
+  char *descBufPtr = descBuf.get();
+  size_t actualSize = 0;
+  desc.serialize(descBufPtr, bufLen, actualSize);
+  ConcordAssertNE(actualSize, 0);
+
+  // TODO [TK] S3KeyGenerator
+  // checkpoints/<SeqNum>/<BlockId>/<RepId>
+  std::ostringstream oss;
+  oss << "checkpoints/" << seqnum << "/" << msgs[0]->state() << "/" << config_.replicaId;
+  metadataStorage_->atomicWriteArbitraryObject(oss.str(), descBuf.get(), actualSize);
 }
 
 template <>

--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -13,6 +13,7 @@
 
 #include "ReplicaForStateTransfer.hpp"
 #include "Timers.hpp"
+#include "CheckpointInfo.hpp"
 
 namespace bftEngine::impl {
 
@@ -27,7 +28,8 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
                   IStateTransfer*,
                   std::shared_ptr<MsgsCommunicator>,
                   std::shared_ptr<MsgHandlersRegistrator>,
-                  concordUtil::Timers& timers);
+                  concordUtil::Timers& timers,
+                  MetadataStorage* metadataStorage);
 
   void start() override;
   void stop() override;
@@ -52,6 +54,9 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
   template <class T>
   void onMessage(T*);
 
+  void executeReadOnlyRequest(concordUtils::SpanWrapper& parent_span, const ClientRequestMsg& m);
+  void persistCheckpointDescriptor(const SeqNum&, const CheckpointInfo<false>&);
+
  protected:
   concordUtil::Timers::Handle askForCheckpointMsgTimer_;
 
@@ -62,7 +67,7 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
     concordMetrics::GaugeHandle last_executed_seq_num_;
   } ro_metrics_;
 
-  void executeReadOnlyRequest(concordUtils::SpanWrapper& parent_span, const ClientRequestMsg& m);
+  std::unique_ptr<MetadataStorage> metadataStorage_;
   std::atomic<SeqNum> last_executed_seq_num_;
 
  private:

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1946,12 +1946,20 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
   const SeqNum msgSeqNum = msg->seqNumber();
   const EpochNum msgEpochNum = msg->epochNumber();
   const CheckpointMsg::State msgState = msg->state();
-  const Digest msgDigest = msg->digestOfState();
+  const Digest stateDigest = msg->digestOfState();
+  const Digest otherDigest = msg->otherDigest();
   const bool msgIsStable = msg->isStableState();
   SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   LOG_INFO(GL,
-           "Received checkpoint message from node. " << KVLOG(
-               msgSenderId, msgGenReplicaId, msgSeqNum, msgEpochNum, msg->size(), msgIsStable, msgState, msgDigest));
+           "Received checkpoint message from node. " << KVLOG(msgSenderId,
+                                                              msgGenReplicaId,
+                                                              msgSeqNum,
+                                                              msgEpochNum,
+                                                              msg->size(),
+                                                              msgIsStable,
+                                                              msgState,
+                                                              stateDigest,
+                                                              otherDigest));
   LOG_INFO(GL, "My " << KVLOG(lastStableSeqNum, lastExecutedSeqNum, getSelfEpochNumber()));
   auto span = concordUtils::startChildSpanFromContext(msg->spanContext<std::remove_pointer<decltype(msg)>::type>(),
                                                       "bft_handle_checkpoint_msg");
@@ -1993,18 +2001,18 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
       // <= to allow repeating checkpoint message since state transfer may not kick in when we are inside active
       // window
       if (pos != tableOfStableCheckpoints.end()) delete pos->second;
-      CheckpointMsg *x = new CheckpointMsg(msgGenReplicaId, msgSeqNum, msgState, msgDigest, msgIsStable);
+      CheckpointMsg *x = new CheckpointMsg(msgGenReplicaId, msgSeqNum, msgState, stateDigest, otherDigest, msgIsStable);
       x->setEpochNumber(msgEpochNum);
       tableOfStableCheckpoints[msgGenReplicaId] = x;
       LOG_INFO(GL,
                "Added stable Checkpoint message to tableOfStableCheckpoints: " << KVLOG(msgSenderId, msgGenReplicaId));
       for (auto &[r, cp] : tableOfStableCheckpoints) {
-        if (cp->seqNumber() == msgSeqNum && cp->digestOfState() != x->digestOfState()) {
+        if (cp->seqNumber() == msgSeqNum && cp->otherDigest() != x->otherDigest()) {
           metric_indicator_of_non_determinism_++;
           LOG_ERROR(GL,
                     "Detect non determinism, for checkpoint: "
-                        << msgSeqNum << " [replica: " << r << ", digest: " << cp->digestOfState() << "] Vs [replica: "
-                        << msgGenReplicaId << ", sender: " << msgSenderId << ", digest: " << x->digestOfState() << "]");
+                        << msgSeqNum << " [replica: " << r << ", digest: " << cp->otherDigest() << "] Vs [replica: "
+                        << msgGenReplicaId << ", sender: " << msgSenderId << ", digest: " << x->otherDigest() << "]");
         }
       }
       if ((uint16_t)tableOfStableCheckpoints.size() >= config_.getfVal() + 1) {
@@ -2083,8 +2091,6 @@ void ReplicaImp::onMessage<AskForCheckpointMsg>(AskForCheckpointMsg *msg) {
     // TODO [TK] check if already sent within a configurable time period
     auto destination = m->senderId();
     LOG_INFO(GL, "Sending CheckpointMsg: " << KVLOG(destination));
-
-    if (checkpointMsg->digestOfState().isZero()) LOG_WARN(GL, "Checkpoint digest is zero");
 
     send(checkpointMsg, m->senderId());
   }
@@ -2957,11 +2963,13 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   ConcordAssert(checkpointsLog->insideActiveWindow(newCheckpointSeqNum));
 
   // create and send my checkpoint
-  Digest digestOfNewState;
+  Digest stateDigest;
+  Digest otherDigest;
   CheckpointMsg::State state;
-  stateTransfer->getDigestOfCheckpoint(newStateCheckpoint, sizeof(Digest), state, (char *)&digestOfNewState);
+  stateTransfer->getDigestOfCheckpoint(
+      newStateCheckpoint, sizeof(Digest), state, (char *)&stateDigest, (char *)&otherDigest);
   CheckpointMsg *checkpointMsg =
-      new CheckpointMsg(config_.getreplicaId(), newCheckpointSeqNum, state, digestOfNewState, false);
+      new CheckpointMsg(config_.getreplicaId(), newCheckpointSeqNum, state, stateDigest, otherDigest, false);
   checkpointMsg->sign();
   auto &checkpointInfo = checkpointsLog->get(newCheckpointSeqNum);
   checkpointInfo.addCheckpointMsg(checkpointMsg, config_.getreplicaId());
@@ -3058,11 +3066,14 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     CheckpointMsg *checkpointMsg = checkpointInfo.selfCheckpointMsg();
 
     if (checkpointMsg == nullptr) {
-      Digest digestOfState;
+      Digest stateDigest;
+      Digest otherDigest;
       CheckpointMsg::State state;
       const uint64_t checkpointNum = lastStableSeqNum / checkpointWindowSize;
-      stateTransfer->getDigestOfCheckpoint(checkpointNum, sizeof(Digest), state, (char *)&digestOfState);
-      checkpointMsg = new CheckpointMsg(config_.getreplicaId(), lastStableSeqNum, state, digestOfState, true);
+      stateTransfer->getDigestOfCheckpoint(
+          checkpointNum, sizeof(Digest), state, (char *)&stateDigest, (char *)&otherDigest);
+      checkpointMsg =
+          new CheckpointMsg(config_.getreplicaId(), lastStableSeqNum, state, stateDigest, otherDigest, true);
       checkpointMsg->sign();
       checkpointInfo.addCheckpointMsg(checkpointMsg, config_.getreplicaId());
     } else {
@@ -4364,12 +4375,14 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
     auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
     bftEngine::EpochManager::instance().setSelfEpochNumber(epoch);
     bftEngine::EpochManager::instance().setGlobalEpochNumber(epoch);
-    Digest checkDigest;
-    CheckpointMsg::State checkState;
+    Digest stateDigest;
+    Digest otherDigest;
+    CheckpointMsg::State state;
     const uint64_t checkpointNum = lastExecutedSeqNum / checkpointWindowSize;
-    stateTransfer->getDigestOfCheckpoint(checkpointNum, sizeof(Digest), checkState, (char *)&checkDigest);
+    stateTransfer->getDigestOfCheckpoint(
+        checkpointNum, sizeof(Digest), state, (char *)&stateDigest, (char *)&otherDigest);
     CheckpointMsg *checkMsg =
-        new CheckpointMsg(config_.getreplicaId(), lastExecutedSeqNum, checkState, checkDigest, false);
+        new CheckpointMsg(config_.getreplicaId(), lastExecutedSeqNum, state, stateDigest, otherDigest, false);
     checkMsg->sign();
     auto &checkInfo = checkpointsLog->get(lastExecutedSeqNum);
     checkInfo.addCheckpointMsg(checkMsg, config_.getreplicaId());

--- a/bftengine/src/bftengine/messages/CheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/CheckpointMsg.hpp
@@ -25,6 +25,7 @@ class CheckpointMsg : public MessageBase {
                 SeqNum seqNum,
                 State state,
                 const Digest& stateDigest,
+                const Digest& fullStateDigest,
                 bool stateIsStable,
                 const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{});
 
@@ -37,6 +38,8 @@ class CheckpointMsg : public MessageBase {
   State state() const { return b()->state; }
 
   Digest& digestOfState() const { return b()->stateDigest; }
+
+  Digest& otherDigest() const { return b()->otherDigest; }
 
   uint16_t idOfGeneratedReplica() const { return b()->genReplicaId; }
 
@@ -53,7 +56,7 @@ class CheckpointMsg : public MessageBase {
   void setSenderId(NodeIdType id) { sender_ = id; }
   static bool equivalent(CheckpointMsg* a, CheckpointMsg* b) {
     return (a->seqNumber() == b->seqNumber()) && (a->digestOfState() == b->digestOfState()) &&
-           (a->state() == b->state());
+           (a->otherDigest() == b->otherDigest()) && (a->state() == b->state());
   }
 
  protected:
@@ -67,11 +70,12 @@ class CheckpointMsg : public MessageBase {
     EpochNum epochNum;
     State state;
     Digest stateDigest;
+    Digest otherDigest;
     ReplicaId genReplicaId;  // the replica that originally generated this message
     uint8_t flags;           // followed by a signature (by genReplicaId)
   };
 #pragma pack(pop)
-  static_assert(sizeof(Header) == (6 + 8 + 8 + 8 + DIGEST_SIZE + 2 + 1), "Header is 65B");
+  static_assert(sizeof(Header) == (6 + 8 + 8 + 8 + DIGEST_SIZE + DIGEST_SIZE + 2 + 1), "Header is 97B");
 
   Header* b() const { return (Header*)msgBody_; }
 };

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -62,7 +62,8 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
   void getDigestOfCheckpoint(uint64_t checkpointNumber,
                              uint16_t sizeOfDigestBuffer,
                              uint64_t& outBlockId,
-                             char* outDigestBuffer) override;
+                             char* outStateDigest,
+                             char* outFullStateDigest) override;
 
   void startCollectingState() override;
 
@@ -504,12 +505,14 @@ void SimpleStateTran::markCheckpointAsStable(uint64_t checkpointNumber) {
 void SimpleStateTran::getDigestOfCheckpoint(uint64_t checkpointNumber,
                                             uint16_t sizeOfDigestBuffer,
                                             uint64_t& outBlockId,
-                                            char* outDigestBuffer) {
+                                            char* outStateDigest,
+                                            char* outFullStateDigest) {
   ConcordAssert(isInitialized());
   ConcordAssert(internalST_->isRunning());
   ConcordAssert(checkpointNumber <= lastKnownCheckpoint);
 
-  internalST_->getDigestOfCheckpoint(checkpointNumber, sizeOfDigestBuffer, outBlockId, outDigestBuffer);
+  internalST_->getDigestOfCheckpoint(
+      checkpointNumber, sizeOfDigestBuffer, outBlockId, outStateDigest, outFullStateDigest);
 }
 
 void SimpleStateTran::startCollectingState() {

--- a/bftengine/tests/messages/CheckpointMsg_test.cpp
+++ b/bftengine/tests/messages/CheckpointMsg_test.cpp
@@ -59,7 +59,7 @@ void CheckpointMsgTestsFixture::CheckpointMsgBaseTests(const std::string& spanCo
   Digest digest(digestContext, sizeof(digestContext));
   bool isStable = false;
   const std::string correlationId = "correlationId";
-  CheckpointMsg msg(senderId, reqSeqNum, 0, digest, isStable, concordUtils::SpanContext{spanContext});
+  CheckpointMsg msg(senderId, reqSeqNum, 0, digest, digest, isStable, concordUtils::SpanContext{spanContext});
   EXPECT_EQ(msg.seqNumber(), reqSeqNum);
   EXPECT_EQ(msg.isStableState(), isStable);
   msg.setStateAsStable();

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -36,6 +36,7 @@ class FileStorage : public MetadataStorage {
   void read(uint32_t objectId, uint32_t bufferSize, char *outBufferForObject, uint32_t &outActualObjectSize) override;
 
   void atomicWrite(uint32_t objectId, const char *data, uint32_t dataLength) override;
+  void atomicWriteArbitraryObject(const std::string &key, const char *data, uint32_t dataLength) override {}
 
   void beginAtomicWriteOnlyBatch() override;
 

--- a/bftengine/tests/testMsgsCertificate/msgsCertificate_test.cpp
+++ b/bftengine/tests/testMsgsCertificate/msgsCertificate_test.cpp
@@ -62,7 +62,7 @@ class msgsCertificateTestsFixture : public ::testing::Test {
     MsgsCertificate<CheckpointMsg, true, true, true, CheckpointMsg> replysCertificate(
         numOfReplicas, fval, numOfRequired, selfReplicaId);
 
-    auto selfMsg = new CheckpointMsg(selfReplicaId, 0, 0, Digest(), false);
+    auto selfMsg = new CheckpointMsg(selfReplicaId, 0, 0, Digest(), Digest(), false);
     selfMsg->setEpochNumber(0);
     replysCertificate.addMsg(selfMsg, selfReplicaId);
 

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -110,11 +110,11 @@ void testCheckWindowSetUp(const SeqNum shift, bool toSet) {
   ReplicaId sender = 3;
   Digest stateDigest;
   const bool stateIsStable = true;
-  CheckpointMsg checkpointInitialMsg0(sender, checkpointSeqNum0, 0, stateDigest, stateIsStable);
+  CheckpointMsg checkpointInitialMsg0(sender, checkpointSeqNum0, 0, stateDigest, stateDigest, stateIsStable);
   checkpointInitialMsg0.sign();
-  CheckpointMsg checkpointInitialMsg1(sender, checkpointSeqNum1, 0, stateDigest, stateIsStable);
+  CheckpointMsg checkpointInitialMsg1(sender, checkpointSeqNum1, 0, stateDigest, stateDigest, stateIsStable);
   checkpointInitialMsg1.sign();
-  CheckpointMsg checkpointInitialMsg2(sender, checkpointSeqNum2, 0, stateDigest, stateIsStable);
+  CheckpointMsg checkpointInitialMsg2(sender, checkpointSeqNum2, 0, stateDigest, stateDigest, stateIsStable);
   checkpointInitialMsg2.sign();
 
   const bool completed = true;
@@ -343,11 +343,11 @@ void testCheckDescriptorOfLastStableCheckpoint(bool init) {
   const ReplicaId sender = 3;
   const Digest stateDigest('d');
   const bool stateIsStable = true;
-  CheckpointMsg checkpointInitialMsg0(sender, checkpointSeqNum0, 0, stateDigest, stateIsStable);
+  CheckpointMsg checkpointInitialMsg0(sender, checkpointSeqNum0, 0, stateDigest, stateDigest, stateIsStable);
   checkpointInitialMsg0.sign();
-  CheckpointMsg checkpointInitialMsg1(sender, checkpointSeqNum1, 0, stateDigest, stateIsStable);
+  CheckpointMsg checkpointInitialMsg1(sender, checkpointSeqNum1, 0, stateDigest, stateDigest, stateIsStable);
   checkpointInitialMsg1.sign();
-  CheckpointMsg checkpointInitialMsg2(sender, checkpointSeqNum2, 0, stateDigest, stateIsStable);
+  CheckpointMsg checkpointInitialMsg2(sender, checkpointSeqNum2, 0, stateDigest, stateDigest, stateIsStable);
   checkpointInitialMsg2.sign();
   std::vector<CheckpointMsg *> msgs;
   msgs.push_back(&checkpointInitialMsg0);

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -64,7 +64,8 @@ Status Replica::initInternals() {
     LOG_INFO(logger, "ReadOnly mode");
     auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler, cronTableRegistry_);
     requestHandler->setReconfigurationHandler(std::make_shared<pruning::ReadOnlyReplicaPruningHandler>(*this));
-    m_replicaPtr = bftEngine::IReplica::createNewRoReplica(replicaConfig_, requestHandler, m_stateTransfer, m_ptrComm);
+    m_replicaPtr = bftEngine::IReplica::createNewRoReplica(
+        replicaConfig_, requestHandler, m_stateTransfer, m_ptrComm, m_metadataStorage);
     m_stateTransfer->addOnTransferringCompleteCallback([this](std::uint64_t) {
       std::vector<concord::client::reconfiguration::State> stateFromReservedPages;
       uint64_t wedgePt{0};
@@ -526,9 +527,12 @@ Replica::Replica(ICommunication *comm,
   m_dbSet.metadataDBClient->setAggregator(aggregator);
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
-  m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
   if (!replicaConfig.isReadOnly) {
     stReconfigurationSM_ = std::make_unique<concord::kvbc::StReconfigurationHandler>(*m_stateTransfer, *this);
+    m_metadataStorage = new DBMetadataStorage(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
+  } else {
+    m_metadataStorage =
+        new storage::DBMetadataStorageUnbounded(m_metadataDBClient.get(), storageFactory->newMetadataKeyManipulator());
   }
   // Instantiate IControlHandler.
   // If an application instantiation has already taken a place this will have no effect.

--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -77,10 +77,9 @@ std::unique_ptr<storage::ISTKeyManipulator> MemoryDBStorageFactory::newSTKeyMani
 #if defined(USE_S3_OBJECT_STORE)
 IStorageFactory::DatabaseSet S3StorageFactory::newDatabaseSet() const {
   auto ret = IStorageFactory::DatabaseSet{};
-  const auto comparator = storage::memorydb::KeyComparator{new DBKeyComparator{}};
-  ret.metadataDBClient = std::make_shared<storage::memorydb::Client>(comparator);
   ret.dataDBClient = std::make_shared<storage::s3::Client>(s3Conf_);
   ret.dataDBClient->init();
+  ret.metadataDBClient = ret.dataDBClient;
 
   auto dataKeyGenerator = std::make_unique<S3KeyGenerator>(s3Conf_.pathPrefix);
   ret.dbAdapter = std::make_unique<DBAdapter>(
@@ -90,7 +89,7 @@ IStorageFactory::DatabaseSet S3StorageFactory::newDatabaseSet() const {
 }
 
 std::unique_ptr<storage::IMetadataKeyManipulator> S3StorageFactory::newMetadataKeyManipulator() const {
-  return std::make_unique<storage::v1DirectKeyValue::MetadataKeyManipulator>();
+  return std::make_unique<storage::v1DirectKeyValue::S3MetadataKeyManipulator>(s3Conf_.pathPrefix);
 }
 
 std::unique_ptr<storage::ISTKeyManipulator> S3StorageFactory::newSTKeyManipulator() const {

--- a/storage/include/storage/direct_kv_key_manipulator.h
+++ b/storage/include/storage/direct_kv_key_manipulator.h
@@ -27,6 +27,15 @@ class MetadataKeyManipulator : public DBKeyGeneratorBase, public IMetadataKeyMan
   concordUtils::Sliver generateMetadataKey(ObjectId objectId) const override;
 };
 
+class S3MetadataKeyManipulator : public IMetadataKeyManipulator {
+ public:
+  S3MetadataKeyManipulator(const std::string& prefix = "") : prefix_(prefix.size() ? prefix + std::string("/") : "") {}
+  concordUtils::Sliver generateMetadataKey(const concordUtils::Sliver&) const override;
+
+ protected:
+  std::string prefix_;
+};
+
 class STKeyManipulator : public DBKeyGeneratorBase, public ISTKeyManipulator {
  public:
   concordUtils::Sliver generateStateTransferKey(ObjectId objectId) const override;

--- a/storage/include/storage/key_manipulator_interface.h
+++ b/storage/include/storage/key_manipulator_interface.h
@@ -22,7 +22,8 @@ namespace concord::storage {
 
 class IMetadataKeyManipulator {
  public:
-  virtual concordUtils::Sliver generateMetadataKey(ObjectId objectId) const = 0;
+  virtual concordUtils::Sliver generateMetadataKey(ObjectId objectId) const { return concordUtils::Sliver(); }
+  virtual concordUtils::Sliver generateMetadataKey(const concordUtils::Sliver&) const { return concordUtils::Sliver(); }
   virtual ~IMetadataKeyManipulator() = default;
 };
 

--- a/storage/src/direct_kv_key_manipulator.cpp
+++ b/storage/src/direct_kv_key_manipulator.cpp
@@ -48,6 +48,10 @@ Sliver MetadataKeyManipulator::generateMetadataKey(ObjectId objectId) const {
   copyToAndAdvance(keyBuf, &offset, keySize, (char *)&objectId, sizeof(objectId));
   return Sliver(keyBuf, keySize);
 }
+Sliver S3MetadataKeyManipulator::generateMetadataKey(const concordUtils::Sliver &key) const {
+  return prefix_ + std::string("metadata/") + key.toString();
+}
+
 /*
  * Format : Key Type | Object Id
  */

--- a/storage/src/s3/client.cpp
+++ b/storage/src/s3/client.cpp
@@ -93,7 +93,7 @@ Status Client::del(const Sliver& key) {
 
 Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
   ConcordAssert(init_);
-  LOG_DEBUG(logger_, "get key: " << _key.toString());
+  LOG_DEBUG(logger_, "key: " << _key.toString());
   GetObjectResponseData cbData(kInitialGetBufferSize_);
   S3GetObjectHandler getObjectHandler;
   getObjectHandler.responseHandler = responseHandler;
@@ -124,6 +124,7 @@ Status Client::get_internal(const Sliver& _key, OUT Sliver& _outValue) const {
 
 Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
   ConcordAssert(init_);
+  LOG_DEBUG(logger_, "key: " << _key.toString());
   PutObjectResponseData cbData(_value.data(), _value.length());
   S3PutObjectHandler putObjectHandler;
   putObjectHandler.responseHandler = responseHandler;
@@ -151,7 +152,9 @@ Status Client::put_internal(const Sliver& _key, const Sliver& _value) {
     metrics_.metrics_component.UpdateAggregator();
     return Status::OK();
   } else {
-    LOG_ERROR(logger_, "put status: " << S3_get_status_name(cbData.status) << " (" << cbData.errorMessage << ")");
+    LOG_ERROR(logger_,
+              "key: " << _key.toString() << " status: " << S3_get_status_name(cbData.status) << " ("
+                      << cbData.errorMessage << ")");
     if (cbData.status == S3Status::S3StatusHttpErrorNotFound || cbData.status == S3Status::S3StatusErrorNoSuchBucket)
       return Status::NotFound("Status: " + to_string(cbData.status) + "msg: " + cbData.errorMessage);
 


### PR DESCRIPTION
- ReadOnlyReplica to use MetadataStorage for storing
  CheckpointMsgDescriptor
- CheckpontMsg to include a separate state(block) digest along with an
  additional state digest (which in case of BCStateTransfer is a digest of reserved pages and may include additional info in future)