### PR TITLE
kvbc/Replica: Expose native db client

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -151,6 +151,11 @@ class Replica : public IReplica,
   std::shared_ptr<cron::TicksGenerator> ticksGenerator() const { return m_replicaPtr->ticksGenerator(); }
   void registerStBasedReconfigurationHandler(std::shared_ptr<concord::client::reconfiguration::IStateHandler>);
 
+  std::shared_ptr<concord::storage::rocksdb::NativeClient> nativeDbClient() {
+    if (m_kvBlockchain) return m_kvBlockchain->db();
+    return nullptr;
+  }
+
   ~Replica() override;
 
  protected:


### PR DESCRIPTION
When adjusting event group counters at pruning we need the ability of the
native client to iterate over the kv-store efficiently.