### PR TITLE
Correctly propagate exceptions from the TRC to the event service

### DIFF
--- a/client/concordclient/include/client/concordclient/event_update_queue.hpp
+++ b/client/concordclient/include/client/concordclient/event_update_queue.hpp
@@ -17,6 +17,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <exception>
 
 #include "client/concordclient/event_update.hpp"
 
@@ -73,6 +74,8 @@ class UpdateQueue {
   virtual std::unique_ptr<EventVariant> tryPop() = 0;
 
   virtual uint64_t size() = 0;
+
+  virtual void setException(std::exception_ptr e) = 0;
 };
 
 // Basic UpdateQueue implementation provided by this library. This class can be expected to adhere to the UpdateQueue
@@ -85,6 +88,7 @@ class BasicUpdateQueue : public UpdateQueue {
   std::mutex mutex_;
   std::condition_variable condition_;
   bool release_consumers_;
+  std::exception_ptr exception;
 
  public:
   // Construct a BasicUpdateQueue.
@@ -107,6 +111,7 @@ class BasicUpdateQueue : public UpdateQueue {
   virtual std::unique_ptr<EventVariant> pop() override;
   virtual std::unique_ptr<EventVariant> tryPop() override;
   virtual uint64_t size() override;
+  virtual void setException(std::exception_ptr e) override;
 };
 
 }  // namespace concord::client::concordclient

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -147,25 +147,9 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
   if (std::holds_alternative<EventGroupRequest>(sub_req.request)) {
     ::client::thin_replica_client::SubscribeRequest trc_request;
     trc_request.event_group_id = std::get<EventGroupRequest>(sub_req.request).event_group_id;
-    try {
-      trc_->Subscribe(trc_request);
-    } catch (UpdateNotFound& e) {
-      throw;
-    } catch (OutOfRangeSubscriptionRequest& e) {
-      throw;
-    } catch (InternalError& e) {
-      throw;
-    }
+    trc_->Subscribe(trc_request);
   } else if (std::holds_alternative<LegacyEventRequest>(sub_req.request)) {
-    try {
-      trc_->Subscribe(std::get<LegacyEventRequest>(sub_req.request).block_id);
-    } catch (UpdateNotFound& e) {
-      throw;
-    } catch (OutOfRangeSubscriptionRequest& e) {
-      throw;
-    } catch (InternalError& e) {
-      throw;
-    }
+    trc_->Subscribe(std::get<LegacyEventRequest>(sub_req.request).block_id);
   } else {
     ConcordAssert(false);
   }

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -200,6 +200,9 @@ class ThinReplicaClient final {
   // Thread function to start subscription_thread_ with.
   void receiveUpdates();
 
+  // wrapper around receiveUpdates to set exceptions_ptr in update_queue
+  void receiveUpdatesWrapper();
+
   // Store call to the function that exposes and updates internal TRC metrics
   // to the user of the TRC library
   std::function<void(const ThinReplicaClientMetrics&)> onSetMetricsCallbackFunc;


### PR DESCRIPTION
This PR adds changes to propagate exceptions correctly from the TRC to the client service. Please see individual commits for more detail.