### PR TITLE
Fix race condition between receiveUpdates and updates_queue Pop

### DIFF
--- a/client/concordclient/src/event_update_queue.cpp
+++ b/client/concordclient/src/event_update_queue.cpp
@@ -49,11 +49,11 @@ void BasicUpdateQueue::push(unique_ptr<EventVariant> update) {
 
 unique_ptr<EventVariant> BasicUpdateQueue::pop() {
   unique_lock<mutex> lock(mutex_);
+  while (!(exception || release_consumers_ || (queue_data_.size() > 0))) {
+    condition_.wait(lock);
+  }
   if (exception) {
     std::rethrow_exception(exception);
-  }
-  while (!(release_consumers_ || (queue_data_.size() > 0))) {
-    condition_.wait(lock);
   }
   if (release_consumers_) {
     return unique_ptr<EventVariant>(nullptr);
@@ -84,8 +84,11 @@ uint64_t BasicUpdateQueue::size() {
 }
 
 void BasicUpdateQueue::setException(std::exception_ptr e) {
-  lock_guard<mutex> lock(mutex_);
-  exception = e;
+  {
+    lock_guard<mutex> lock(mutex_);
+    exception = e;
+  }
+  condition_.notify_all();
 }
 
 }  // namespace concord::client::concordclient

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -958,6 +958,7 @@ void ThinReplicaClient::Subscribe(uint64_t block_id) {
     subscription_thread_.reset();
   }
 
+  LOG_INFO(logger_, "Subscribing to block ID: " << block_id);
   config_->update_queue->clear();
   latest_verified_block_id_ = block_id > 0 ? block_id - 1 : block_id;
   latest_verified_event_group_id_ = 0;
@@ -983,6 +984,7 @@ void ThinReplicaClient::Subscribe(const SubscribeRequest& req) {
     subscription_thread_.reset();
   }
 
+  LOG_INFO(logger_, "Subscribing to update ID: " << req.event_group_id);
   config_->update_queue->clear();
   // We assume that the latest known event group for the caller is the event group prior to the requested one.
   latest_verified_event_group_id_ = req.event_group_id > 0 ? req.event_group_id - 1 : req.event_group_id;


### PR DESCRIPTION
Currently BasicUpdateQueue::pop() waits in an endless while loop until the queue is no longer empty or release_consumers_ has been set. If receiveUpdates throws an exception while pop() is waiting, it will not catch the exception. 
This commit updates BasicUpdateQueue::pop() s.t., it breaks from the while loop  when an exception is set by receiveUpdatesWrapper, so that the exception can be rethrown.

