### PR TITLE
[Client pool] Push client to the top of the queue

### DIFF
--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -515,7 +515,7 @@ void ConcordClientPool::InsertClientToQueue(
           client->setStartWaitingTime();
         }
         LOG_TRACE(logger_, "Return client with pending jobs to the queue" << KVLOG(client_id));
-        clients_.push_back(client);
+        clients_.push_front(client);
       }
     } else {
       if (!external_requests_queue_.empty()) {
@@ -533,7 +533,7 @@ void ConcordClientPool::InsertClientToQueue(
                           req.span_context,
                           nullptr);
       } else {
-        clients_.push_back(client);
+        clients_.push_front(client);
       }
     }
   }

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -227,7 +227,7 @@ class BftTestNetwork:
             self.metrics.__exit__()
             self.stop_all_replicas()
             os.chdir(self.origdir)
-            # shutil.rmtree(self.testdir, ignore_errors=True)
+            shutil.rmtree(self.testdir, ignore_errors=True)
             shutil.rmtree(self.certdir, ignore_errors=True)
             shutil.rmtree(self.txn_signing_keys_base_path, ignore_errors=True)
             if self.test_dir and self.test_start_time:


### PR DESCRIPTION
As of now, when a client finishes handling some work, he returns to the end of the queue to allow the other clients to work.

We are changing it to be pushed to the top of the queue so that we can use as few new clients as possible.


