### PR TITLE
Fix for clang build ci workflow failure

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -227,7 +227,7 @@ class BftTestNetwork:
             self.metrics.__exit__()
             self.stop_all_replicas()
             os.chdir(self.origdir)
-            # shutil.rmtree(self.testdir, ignore_errors=True)
+            shutil.rmtree(self.testdir, ignore_errors=True)
             shutil.rmtree(self.certdir, ignore_errors=True)
             shutil.rmtree(self.txn_signing_keys_base_path, ignore_errors=True)
             if self.test_dir and self.test_start_time:


### PR DESCRIPTION
This PR includes a fix where all clang CI workflows are failing due to Apollo running out of space.