### PR TITLE
Do not rethrow same exception everytime upon pop() and tryPop() call

### DIFF
--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -127,8 +127,10 @@ int main(int argc, char** argv) {
   try {
     auto yaml = YAML::LoadFile(opts["config"].as<std::string>());
     parseConfigFile(config, yaml);
-    const std::optional<std::string>& secrets_url =
-        opts.count("secrets-url") ? opts["secrets-url"].as<std::optional<std::string>>() : std::nullopt;
+    std::optional<std::string> secrets_url = std::nullopt;
+    if (opts.count("secrets-url")) {
+      secrets_url = {opts["secrets-url"].as<std::string>()};
+    }
     configureSubscription(config,
                           opts["tr-id"].as<std::string>(),
                           opts["tr-insecure"].as<bool>(),

--- a/client/concordclient/src/event_update_queue.cpp
+++ b/client/concordclient/src/event_update_queue.cpp
@@ -53,7 +53,9 @@ unique_ptr<EventVariant> BasicUpdateQueue::pop() {
     condition_.wait(lock);
   }
   if (exception_) {
-    std::rethrow_exception(exception_);
+    auto e = exception_;
+    exception_ = nullptr;
+    std::rethrow_exception(e);
   }
   if (release_consumers_) {
     return unique_ptr<EventVariant>(nullptr);
@@ -67,7 +69,9 @@ unique_ptr<EventVariant> BasicUpdateQueue::pop() {
 unique_ptr<EventVariant> BasicUpdateQueue::tryPop() {
   lock_guard<mutex> lock(mutex_);
   if (exception_) {
-    std::rethrow_exception(exception_);
+    auto e = exception_;
+    exception_ = nullptr;
+    std::rethrow_exception(e);
   }
   if (queue_data_.size() > 0) {
     unique_ptr<EventVariant> ret = move(queue_data_.front());

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -1053,36 +1053,6 @@ class ThinReplicaImpl {
       LOG_ERROR(logger_, msg.str());
       return {grpc::Status(grpc::StatusCode::INTERNAL, msg.str()), live_updates};
     }
-    if (request->has_events()) {
-      LOG_DEBUG(logger_, "subscribeToLiveUpdates events (client id " << client_id << ")");
-      auto last_block_id = (config_->rostorage)->getLastBlockId();
-      if (request->events().block_id() > last_block_id) {
-        config_->subscriber_list.removeBuffer(live_updates);
-        live_updates->removeAllUpdates();
-        std::stringstream msg;
-        msg << "Block " << request->events().block_id() << " doesn't exist yet "
-            << " latest block is " << last_block_id;
-        LOG_DEBUG(logger_, msg.str());
-        return {grpc::Status(grpc::StatusCode::OUT_OF_RANGE, msg.str()), live_updates};
-      }
-    } else {
-      LOG_DEBUG(logger_, "subscribeToLiveUpdates event groups (client id " << client_id << ")");
-
-      auto last_eg_id = kvb_filter->newestTagSpecificPublicEventGroupId();
-      LOG_DEBUG(
-          logger_,
-          "subscribeToLiveUpdates (eg vs last) " << request->event_groups().event_group_id() << " > " << last_eg_id);
-      if (request->event_groups().event_group_id() > last_eg_id) {
-        config_->subscriber_list.removeBuffer(live_updates);
-        live_updates->removeAllEventGroupUpdates();
-        std::stringstream msg;
-        msg << "Event group ID " << request->event_groups().event_group_id() << " doesn't exist yet "
-            << " latest event_group_id is " << last_eg_id;
-        LOG_DEBUG(logger_, msg.str());
-        return {grpc::Status(grpc::StatusCode::OUT_OF_RANGE, msg.str()), live_updates};
-      }
-    }
-
     return {grpc::Status::OK, live_updates};
   }
 

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -482,7 +482,7 @@ class ThinReplicaImpl {
       if (request->events().block_id() > last_block_id) {
         msg << "Block " << request->events().block_id() << " doesn't exist yet "
             << " latest block is " << last_block_id;
-        LOG_DEBUG(logger_, msg.str());
+        LOG_WARN(logger_, msg.str());
         return true;
       }
     } else {
@@ -491,7 +491,7 @@ class ThinReplicaImpl {
       if (request->event_groups().event_group_id() > last_eg_id) {
         msg << "Event group ID " << request->event_groups().event_group_id() << " doesn't exist yet."
             << " Latest event_group_id is " << last_eg_id;
-        LOG_DEBUG(logger_, msg.str());
+        LOG_WARN(logger_, msg.str());
         return true;
       }
     }
@@ -506,7 +506,7 @@ class ThinReplicaImpl {
       if (request->events().block_id() < first_block_id) {
         msg << "Block ID " << request->events().block_id() << " has been pruned."
             << " First block_id is " << first_block_id;
-        LOG_DEBUG(logger_, msg.str());
+        LOG_ERROR(logger_, msg.str());
         return true;
       }
     } else {
@@ -516,7 +516,7 @@ class ThinReplicaImpl {
       if (request->event_groups().event_group_id() < first_eg_id || (last_eg_id && !first_eg_id)) {
         msg << "Event group ID " << request->event_groups().event_group_id() << " has been pruned."
             << " First event_group_id is " << first_eg_id;
-        LOG_DEBUG(logger_, msg.str());
+        LOG_ERROR(logger_, msg.str());
         return true;
       }
     }


### PR DESCRIPTION
This commit clears the BasicUpdateQueue exception_ptr when an exception is caught during update_queue pop() and tryPop(). If exception_ptr is not reset to nullptr, after the first time an exception is caught and set, we keep on throwing the same exception every time pop()/tryPop() is called.

This commit also includes a configuration fix and some refactoring, see individual commits for more detail.
