### PR TITLE
Initial Key-exchange for lagged replicas on completing ST

### DIFF
--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -82,6 +82,9 @@ class IStateTransfer : public IReservedPages {
       std::function<void(uint64_t)>,
       StateTransferCallBacksPriorities priority = StateTransferCallBacksPriorities::DEFAULT) = 0;
 
+  // Registers a function that is called every time fetching state changes
+  virtual void addOnFetchingStateChangeCallback(std::function<void(uint64_t)>) = 0;
+
   virtual void setEraseMetadataFlag() = 0;
 
   virtual void setReconfigurationEngine(

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -32,9 +32,9 @@ class KeyExchangeManager {
   // Generates and publish key to consensus
   void sendKeyExchange(const SeqNum&);
   // Generates and publish the first replica's key,
-  void sendInitialKey(uint32_t prim = 0);
+  void sendInitialKey(uint32_t prim = 0, const SeqNum& = 0);
   // The execution handler implementation that is called when a key exchange msg has passed consensus.
-  std::string onKeyExchange(const KeyExchangeMsg& kemsg, const SeqNum& sn, const std::string& cid);
+  std::string onKeyExchange(const KeyExchangeMsg& kemsg, const SeqNum& req_sn, const std::string& cid);
   // Register a IKeyExchanger to notification when keys are rotated.
   void registerForNotification(IKeyExchanger* ke) { registryToExchange_.push_back(ke); }
   // Called at the end of state transfer

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -126,6 +126,8 @@ class BCStateTran : public IStateTransfer {
       std::function<void(uint64_t)>,
       StateTransferCallBacksPriorities priority = StateTransferCallBacksPriorities::DEFAULT) override;
 
+  void addOnFetchingStateChangeCallback(std::function<void(uint64_t)>) override;
+
   void setEraseMetadataFlag() override { psd_->setEraseDataStoreFlag(); }
   void setReconfigurationEngine(
       std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> cre) override {
@@ -531,6 +533,7 @@ class BCStateTran : public IStateTransfer {
   mutable Metrics metrics_;
 
   std::map<uint64_t, concord::util::CallbackRegistry<uint64_t>> on_transferring_complete_cb_registry_;
+  concord::util::CallbackRegistry<uint64_t> on_fetching_state_change_cb_registry_;
 
  protected:
   //////////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/NullStateTransfer.hpp
+++ b/bftengine/src/bftengine/NullStateTransfer.hpp
@@ -46,6 +46,7 @@ class NullStateTransfer : public IStateTransfer {
 
   void addOnTransferringCompleteCallback(std::function<void(uint64_t)>,
                                          StateTransferCallBacksPriorities priority) override{};
+  void addOnFetchingStateChangeCallback(std::function<void(uint64_t)>) override {}
   void setEraseMetadataFlag() override {}
   void setReconfigurationEngine(
       std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine>) override {}

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -37,7 +37,6 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   void onTransferringComplete(uint64_t checkpointNumberOfNewState) override;
   void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) override;
   Timers::Handle addOneShotTimer(uint32_t timeoutMilli) override;
-
   bool isCollectingState() const { return stateTransfer->isCollectingState(); }
 
   void start() override;

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -33,7 +33,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
     if (req.flags & KEY_EXCHANGE_FLAG) {
       KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(req.request, req.requestSize);
       LOG_INFO(KEY_EX_LOG, "BFT handler received KEY_EXCHANGE msg " << ke.toString());
-      auto resp = impl::KeyExchangeManager::instance().onKeyExchange(ke, ke.generated_sn, req.cid);
+      auto resp = impl::KeyExchangeManager::instance().onKeyExchange(ke, req.executionSequenceNum, req.cid);
       if (resp.size() <= req.maxReplySize) {
         std::copy(resp.begin(), resp.end(), req.outReply);
         req.outActualReplySize = resp.size();

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -86,6 +86,8 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
   void addOnTransferringCompleteCallback(std::function<void(uint64_t)>,
                                          StateTransferCallBacksPriorities priority) override {}
 
+  void addOnFetchingStateChangeCallback(std::function<void(uint64_t)>) override {}
+
   //////////////////////////////////////////////////////////////////////////
   // ISimpleInMemoryStateTransfer methods
   //////////////////////////////////////////////////////////////////////////

--- a/bftengine/tests/keyManager/KeyManager_test.cpp
+++ b/bftengine/tests/keyManager/KeyManager_test.cpp
@@ -356,18 +356,21 @@ TEST(KeyExchangeManager, initialKeyExchange) {
   KeyExchangeMsg kem;
   kem.pubkey = "a";
   kem.repID = 0;
+  kem.generated_sn = 2;
   test.km_.onKeyExchange(kem, 2);
 
   // set public of replica 1
   KeyExchangeMsg kem2;
   kem2.pubkey = "b";
   kem2.repID = 1;
+  kem2.generated_sn = 3;
   test.km_.onKeyExchange(kem2, 3);
 
   // set public of replica 3 and promote its private
   KeyExchangeMsg kem4;
   kem4.pubkey = "public";
   kem4.repID = 3;
+  kem4.generated_sn = 5;
   test.km_.onKeyExchange(kem4, 5);
 
   // will return true to slow path and will ignore this msg
@@ -375,6 +378,7 @@ TEST(KeyExchangeManager, initialKeyExchange) {
   // set to fast path
   kem3.pubkey = "c";
   kem3.repID = 2;
+  kem3.generated_sn = 5;
   test.km_.onKeyExchange(kem3, 5);
   ASSERT_EQ(test.getKeyExchangedOnStartCounter(), 4);
   ASSERT_EQ(test.km_.keysExchanged, true);
@@ -415,24 +419,28 @@ TEST(KeyExchangeManager, endToEnd) {
   KeyExchangeMsg kem;
   kem.pubkey = "a";
   kem.repID = 0;
+  kem.generated_sn = 2;
   test.km_.onKeyExchange(kem, 2);
 
   // set public of replica 1
   KeyExchangeMsg kem2;
   kem2.pubkey = "b";
   kem2.repID = 1;
+  kem2.generated_sn = 3;
   test.km_.onKeyExchange(kem2, 3);
 
   // set public of replica 2 and promote private
   KeyExchangeMsg kem3;
   kem3.pubkey = "public";
   kem3.repID = 2;
+  kem3.generated_sn = 4;
   test.km_.onKeyExchange(kem3, 4);
 
   // set public of replica 3
   KeyExchangeMsg kem4;
   kem4.pubkey = "d";
   kem4.repID = 3;
+  kem4.generated_sn = 5;
   ASSERT_EQ(test.km_.keysExchanged, false);
   test.km_.onKeyExchange(kem4, 5);
   ASSERT_EQ(test.km_.keysExchanged, true);
@@ -464,18 +472,21 @@ TEST(KeyExchangeManager, endToEnd) {
   KeyExchangeMsg kem5;
   kem5.pubkey = "aaaa";
   kem5.repID = 0;
+  kem5.generated_sn = 22;
   test.km_.onKeyExchange(kem5, 22);
 
   // rotation candidate for replica 1
   KeyExchangeMsg kem6;
   kem6.pubkey = "bbbb";
   kem6.repID = 1;
+  kem6.generated_sn = 33;
   test.km_.onKeyExchange(kem6, 33);
 
   // rotation candidate for replica 2 promote private
   KeyExchangeMsg kem7;
   kem7.pubkey = "public2";
   kem7.repID = 2;
+  kem7.generated_sn = 34;
   test.km_.onKeyExchange(kem7, 34);
   // Checkpoint too close, should not rotate
   test.km_.onCheckpoint(1);
@@ -495,6 +506,7 @@ TEST(KeyExchangeManager, endToEnd) {
   KeyExchangeMsg kem8;
   kem8.pubkey = "ddddd";
   kem8.repID = 3;
+  kem8.generated_sn = 180;
   test.km_.onKeyExchange(kem8, 180);
 
   // now should rotate 0,1,2


### PR DESCRIPTION
With (n-f) initial key exchange support, we do initial key exchange for live replicas only. Lagged replicas get the public keys of peer replicas from reserved pages. But, we also need to generate key pair and perform key-exchange for lagged replicas as well. this PR addresses this issue.