### PR TITLE
Send prePreapre as response to RFMD even from non-primary replica

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3408,14 +3408,14 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
   if ((currentViewIsActive()) && (mainLog->insideActiveWindow(msgSeqNum) || mainLog->isPressentInHistory(msgSeqNum))) {
     SeqNumInfo &seqNumInfo = mainLog->getFromActiveWindowOrHistory(msgSeqNum);
 
-    if (config_.getreplicaId() == currentPrimary()) {
-      PrePrepareMsg *pp = seqNumInfo.getSelfPrePrepareMsg();
-      if (msg->getPrePrepareIsMissing()) {
-        if (pp != nullptr) {
-          sendAndIncrementMetric(pp, msgSender, metric_sent_preprepare_msg_due_to_reqMissingData_);
-        }
+    PrePrepareMsg *pp = seqNumInfo.getSelfPrePrepareMsg();
+    if (msg->getPrePrepareIsMissing()) {
+      if (pp != nullptr) {
+        sendAndIncrementMetric(pp, msgSender, metric_sent_preprepare_msg_due_to_reqMissingData_);
       }
+    }
 
+    if (config_.getreplicaId() == currentPrimary()) {
       if (seqNumInfo.slowPathStarted() && !msg->getSlowPathHasStarted()) {
         StartSlowCommitMsg startSlowMsg(config_.getreplicaId(), getCurrentView(), msgSeqNum);
         sendAndIncrementMetric(&startSlowMsg, msgSender, metric_sent_startSlowPath_msg_due_to_reqMissingData_);


### PR DESCRIPTION
Until now, when a replica requests a prePreapre message in RFMD message, only the primary was answering.
This is not good for two reasons:
1. It implies the primary is the only one responsible for distributing missing prePreapre messages - more job to do for the primary
2. In case a replica X is not able to talk with the primary (for example, due to TLS key rotation) it won't be able to execute the request (as it will never get the prePrepare message)

Recall that all of the replicas have the prePrepare messages, so why not let them help the late replica?
This PR fixes this issue