### PR TITLE
Revert commit: [Client pool] Push client to the top of the queue

### DIFF
--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -515,7 +515,7 @@ void ConcordClientPool::InsertClientToQueue(
           client->setStartWaitingTime();
         }
         LOG_TRACE(logger_, "Return client with pending jobs to the queue" << KVLOG(client_id));
-        clients_.push_front(client);
+        clients_.push_back(client);
       }
     } else {
       if (!external_requests_queue_.empty()) {
@@ -533,7 +533,7 @@ void ConcordClientPool::InsertClientToQueue(
                           req.span_context,
                           nullptr);
       } else {
-        clients_.push_front(client);
+        clients_.push_back(client);
       }
     }
   }


### PR DESCRIPTION
Revert commit 22e9bb6741bb534f11ac7d2acd4838f565632ea4 as it causes BFT client pool to loose application requests in some cases.