### PR TITLE
Fix preProcInFlyRequestsNum Metric For Primary

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1326,7 +1326,9 @@ void PreProcessor::releaseClientPreProcessRequest(const RequestStateSharedPtr &r
       givenReq.reset();
     }
     if (batchedPreProcessEnabled_) ongoingReqBatches_[clientId]->increaseNumOfCompletedReqs();
-    preProcessorMetrics_.preProcInFlyRequestsNum--;
+    if (!myReplica_.isCurrentPrimary()) {
+      preProcessorMetrics_.preProcInFlyRequestsNum--;
+    }
   }
 }
 


### PR DESCRIPTION
In the primary, the value for this metric was defect (18E).
This metric was never incremented when the replica is the primary but this check was not conducted when we decremented it.