### PR TITLE
Stabilize reconfiguration tests v0.13.x

### DIFF
--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -215,6 +215,7 @@ class KeyExchangeCommandHandler : public IStateHandler {
                fs::copy(enc_path, old_path, fs::copy_options::update_existing);
                fs::copy(enc_file_path, enc_path, fs::copy_options::update_existing);
                fs::remove(old_path);
+               fs::remove(enc_file_path);
                LOG_INFO(this->getLogger(), "exchanged transaction signing keys (encrypted)");
              }
              if (non_enc) {
@@ -223,6 +224,7 @@ class KeyExchangeCommandHandler : public IStateHandler {
                fs::copy(this->key_path_, old_path, fs::copy_options::update_existing);
                fs::copy(new_key_path, this->key_path_, fs::copy_options::update_existing);
                fs::remove(old_path);
+               fs::remove(new_key_path);
                LOG_INFO(this->getLogger(), "exchanged transaction signing keys (non encrypted)");
              }
            }};


### PR DESCRIPTION
To validate the client key exchange, we compared the ".new" file and the old file after the key exchange.
However, this was not good for 2 reasons:

leaving the ".new" fine in the directory
When having two key exchange phases in a row (as in the tests) and CRE is not fast enough, we may restart the clients before even exchanging the keys.
The fix is to remove the ".new" file once we have done with the exchange and compare the actual key before & after the key exchange command