### PR TITLE
ThinReplica: Reduce TRS log spam

### DIFF
--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -577,7 +577,12 @@ void ThinReplicaClient::receiveUpdates() {
         throw InternalError();
       }
       // print the warning every minute to avoid flooding with logs
-      std::string no_update_msg = "No new update from replicas";
+      std::string no_update_msg = "Waiting for ";
+      if (is_event_group_request_) {
+        no_update_msg += "event group " + std::to_string(latest_verified_event_group_id_ + 1);
+      } else {
+        no_update_msg += "block " + std::to_string(latest_verified_block_id_ + 1);
+      }
       auto current_time = std::chrono::steady_clock::now();
       if (!last_non_agreement_time.has_value()) {
         LOG_WARN(logger_, no_update_msg);

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -482,7 +482,7 @@ class ThinReplicaImpl {
       if (request->events().block_id() > last_block_id) {
         msg << "Block " << request->events().block_id() << " doesn't exist yet "
             << " latest block is " << last_block_id;
-        LOG_WARN(logger_, msg.str());
+        LOG_DEBUG(logger_, msg.str());
         return true;
       }
     } else {
@@ -491,7 +491,7 @@ class ThinReplicaImpl {
       if (request->event_groups().event_group_id() > last_eg_id) {
         msg << "Event group ID " << request->event_groups().event_group_id() << " doesn't exist yet."
             << " Latest event_group_id is " << last_eg_id;
-        LOG_WARN(logger_, msg.str());
+        LOG_DEBUG(logger_, msg.str());
         return true;
       }
     }


### PR DESCRIPTION
The TRS rejects any subscriptions that are made for future blocks/event groups.
Every time such a request is made we log a warning message. In practice, this
leads to log flodding because all TRCs in the system keep retrying with the
anticipation that "the future is now". The TRS does not accept future requests
due to it doesn't know anything about workload of the system and accepting
malicious (far into the future) requests can lead to resource exhaustion.
Therefore, we keep the behavior but reduce the log level on the server side.
In order to not loose the information from that message in non-debug mode, this
change adds the block/event group id to the TRC message which is a throttled
log message already.