### PR TITLE
Remove span argument from send(). In future use ReadConfig or WriteConfig Hierarchy

### DIFF
--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -74,12 +74,12 @@ Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_req
     bft::client::ReadConfig config;
     config.request = req_config;
     auto span = opentracing::Tracer::Global()->StartSpan("send_ro", {});
-    client_->send(config, std::move(msg), span, callback);
+    client_->send(config, std::move(msg), callback);
   } else {
     bft::client::WriteConfig config;
     config.request = req_config;
     auto span = opentracing::Tracer::Global()->StartSpan("send", {});
-    client_->send(config, std::move(msg), span, callback);
+    client_->send(config, std::move(msg), callback);
   }
 
   return status_future.get();

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -131,11 +131,9 @@ class ConcordClient {
   // Register a callback that gets invoked once the handling BFT client returns.
   void send(const bft::client::WriteConfig& config,
             bft::client::Msg&& msg,
-            const std::unique_ptr<opentracing::Span>& parent_span,
             const std::function<void(SendResult&&)>& callback);
   void send(const bft::client::ReadConfig& config,
             bft::client::Msg&& msg,
-            const std::unique_ptr<opentracing::Span>& parent_span,
             const std::function<void(SendResult&&)>& callback);
 
   // Subscribe to events which are pushed into the given update queue.

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -102,7 +102,6 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
 
 void ConcordClient::send(const bft::client::ReadConfig& config,
                          bft::client::Msg&& msg,
-                         const std::unique_ptr<opentracing::Span>& parent_span,
                          const std::function<void(SendResult&&)>& callback) {
   LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
   client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
@@ -110,7 +109,6 @@ void ConcordClient::send(const bft::client::ReadConfig& config,
 
 void ConcordClient::send(const bft::client::WriteConfig& config,
                          bft::client::Msg&& msg,
-                         const std::unique_ptr<opentracing::Span>& parent_span,
                          const std::function<void(SendResult&&)>& callback) {
   client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
 }


### PR DESCRIPTION
Remove span_context argument from send() function as it is not used to pass span context to call hierarchy.  send() function takes either bft::client::ReadConfig or 'bft::client::WriteConfig' as argument. In both the config hierarchy, need to populate 'request.span_context' to enable Opentracing.