### PR TITLE
Log format changes in default format

### DIFF
--- a/logging/src/Logging4cplus.cpp
+++ b/logging/src/Logging4cplus.cpp
@@ -24,7 +24,7 @@ using namespace log4cplus;
 
 namespace logging {
 
-static const char* logPattern = "%d{%Y-%m-%dT%H:%M:%S,%qZ}|%-5p|%X{rid}|%c|%X{thread}|%X{cid}|%X{sn}|%b:%L|%M|%m%n";
+static const char* logPattern = "%D{%Y-%m-%dT%H:%M:%S,%q,%z}|%-5p|%X{rid}|%c|%X{thread}|%X{cid}|%X{sn}|%b:%L|%m%n";
 
 void initLogger(const std::string& configFileName) {
   std::ifstream infile(configFileName);


### PR DESCRIPTION
Add changes to default log format in root appender to include Time zone and remove function signature.
Some of the modules like TRC were printing logs without timezone changes and was identified to be using this format.

Old format logs appearing in in TRC:
2021-11-30T09:09:01,741Z|INFO ||thin_replica.facade||||thin_replica_client_facade.cpp:94|std::shared_ptr<concord::utils::PrometheusRegistry> registryInit(logging::Logger)|TRC metrics will expose to 0.0.0.0:9891/metrics

After code change logs from TRC with TimeZone set for testing using new format appears as below:
2021-11-30T02:05:59,710,-0700|INFO ||thin_replica.facade||||thin_replica_client_facade.cpp:94|TRC metrics will expose to 0.0.0.0:9891/metrics
