### PR TITLE
ConcordClient: Self-contained API

### DIFF
--- a/bftclient/CMakeLists.txt
+++ b/bftclient/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(bftclient_new PUBLIC
     util
 )
 
+add_library(bftclient_new-interface INTERFACE)
+target_include_directories(bftclient_new-interface INTERFACE include)
+
 if (BUILD_TESTING)
     add_subdirectory(test)
 endif()

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -116,7 +116,8 @@ target_link_libraries(corebft PUBLIC
   db_checkpoint_msg
   cre
   stdc++fs
-  )
+  concordclient-interface
+)
 
 
 target_include_directories(bftclient PUBLIC include/bftengine)
@@ -124,7 +125,11 @@ target_include_directories(bftclient PUBLIC src/bftengine)
 target_include_directories(bftclient PUBLIC src/preprocessor)
 target_include_directories(bftclient PUBLIC ${perf_include})
 target_include_directories(bftclient PUBLIC ${kvbc_include})
-target_link_libraries(bftclient PUBLIC bftcommunication diagnostics)
+target_link_libraries(bftclient PUBLIC
+  bftcommunication
+  diagnostics
+  concordclient-interface
+)
 
 target_include_directories(bftclient_shared PUBLIC include/bftengine)
 target_include_directories(bftclient_shared PUBLIC src/bftengine)
@@ -132,7 +137,11 @@ target_include_directories(bftclient_shared PUBLIC src/preprocessor)
 target_include_directories(bftclient_shared PUBLIC ${perf_include})
 target_include_directories(bftclient_shared PUBLIC ${kvbc_include})
 
-target_link_libraries(bftclient_shared PUBLIC bftcommunication_shared diagnostics)
+target_link_libraries(bftclient_shared PUBLIC
+  bftcommunication_shared
+  diagnostics
+  concordclient-interface
+)
 install (TARGETS bftclient_shared DESTINATION lib${LIB_SUFFIX})
 
 install(DIRECTORY include/bftengine DESTINATION include)

--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -116,7 +116,6 @@ target_link_libraries(corebft PUBLIC
   db_checkpoint_msg
   cre
   stdc++fs
-  concordclient-interface
 )
 
 
@@ -128,7 +127,6 @@ target_include_directories(bftclient PUBLIC ${kvbc_include})
 target_link_libraries(bftclient PUBLIC
   bftcommunication
   diagnostics
-  concordclient-interface
 )
 
 target_include_directories(bftclient_shared PUBLIC include/bftengine)
@@ -140,7 +138,6 @@ target_include_directories(bftclient_shared PUBLIC ${kvbc_include})
 target_link_libraries(bftclient_shared PUBLIC
   bftcommunication_shared
   diagnostics
-  concordclient-interface
 )
 install (TARGETS bftclient_shared DESTINATION lib${LIB_SUFFIX})
 

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -19,7 +19,6 @@
 #include <memory>
 
 #include "Metrics.hpp"
-#include "client/concordclient/send_callback.hpp"
 #include "communication/ICommunication.hpp"
 #include "PerformanceManager.hpp"
 #include "SharedTypes.hpp"
@@ -65,7 +64,6 @@ struct ClientReply {
   bftEngine::OperationResult opResult = bftEngine::OperationResult::SUCCESS;
   std::string cid;
   std::string span_context;
-  concord::client::concordclient::SendCallback cb = {};
 };
 
 class SimpleClient {

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "Metrics.hpp"
+#include "client/concordclient/send_callback.hpp"
 #include "communication/ICommunication.hpp"
 #include "PerformanceManager.hpp"
 #include "SharedTypes.hpp"
@@ -47,12 +48,6 @@ enum ClientMsgFlag : uint8_t {
   EMPTY_CLIENT_REQ = 0x10,
 };
 
-// Call back for request - at this point we know for sure that a client is handling the request, so we can assure that
-// we will have reply. This callback will be attached to the client reply struct and whenever we get the reply from,
-// the bft client we will activate the callback.
-typedef std::variant<uint32_t, bft::client::Reply> SendResult;
-typedef std::function<void(SendResult&&)> RequestCallBack;
-
 struct ClientRequest {
   uint8_t flags = 0;
   std::vector<uint8_t> request;
@@ -70,7 +65,7 @@ struct ClientReply {
   bftEngine::OperationResult opResult = bftEngine::OperationResult::SUCCESS;
   std::string cid;
   std::string span_context;
-  RequestCallBack cb = {};
+  concord::client::concordclient::SendCallback cb = {};
 };
 
 class SimpleClient {

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -27,7 +27,6 @@ target_include_directories(preprocessor PUBLIC ${perf_include} ${util_include} $
 
 target_link_libraries(preprocessor PUBLIC
   bftcommunication
-  concordclient-interface
   diagnostics
   threshsign
   util

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -25,15 +25,17 @@ get_property(util_include GLOBAL PROPERTY UTIL_INCLUDE_DIR)
 get_property(kvbc_include GLOBAL PROPERTY KVBC_INCLUDE_DIR)
 target_include_directories(preprocessor PUBLIC ${perf_include} ${util_include} ${kvbc_include})
 
-target_link_libraries(preprocessor PUBLIC diagnostics)
+target_link_libraries(preprocessor PUBLIC
+  bftcommunication
+  concordclient-interface
+  diagnostics
+  threshsign
+  util
+)
 
 if(BUILD_SLOWDOWN)
     target_compile_definitions(preprocessor PUBLIC USE_SLOWDOWN)
 endif()
-
-target_link_libraries(preprocessor PUBLIC util)
-target_link_libraries(preprocessor PUBLIC threshsign)
-target_link_libraries(preprocessor PUBLIC bftcommunication)
 
 if (BUILD_TESTING)
     add_subdirectory(tests)

--- a/client/client_pool/CMakeLists.txt
+++ b/client/client_pool/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(concord_client_pool PUBLIC include)
 target_link_libraries(concord_client_pool PUBLIC
         bftclient
         bftclient_new
+        concordclient-interface
         corebft
       	)
 

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -26,6 +26,7 @@
 #include "bftclient/quorums.h"
 #include "client_pool_timer.hpp"
 #include "external_client.hpp"
+#include "client/concordclient/send_callback.hpp"
 
 // the parameters are sequence number and cid
 typedef std::function<void(const std::string /* cid */, uint32_t /*reply_size*/)> EXT_DONE_CALLBACK;
@@ -124,19 +125,19 @@ class ConcordClientPool {
                            uint64_t seq_num,
                            std::string correlation_id = {},
                            std::string span_context = std::string(),
-                           const bftEngine::RequestCallBack& callback = {});
+                           const concord::client::concordclient::SendCallback& callback = {});
 
   // This method is responsible to get write requests with the new client
   // paramters and parse it to the old SimpleClient interface.
   SubmitResult SendRequest(const bft::client::WriteConfig& config,
                            bft::client::Msg&& request,
-                           const bftEngine::RequestCallBack& callback = {});
+                           const concord::client::concordclient::SendCallback& callback = {});
 
   // This method is responsible to get read requests with the new client
   // paramters and parse it to the old SimpleClient interface.
   SubmitResult SendRequest(const bft::client::ReadConfig& config,
                            bft::client::Msg&& request,
-                           const bftEngine::RequestCallBack& callback = {});
+                           const concord::client::concordclient::SendCallback& callback = {});
 
   void InsertClientToQueue(std::shared_ptr<concord::external_client::ConcordClient>& client,
                            std::pair<int8_t, external_client::ConcordClient::PendingReplies>&& replies);
@@ -154,7 +155,7 @@ class ConcordClientPool {
                          uint64_t seq_num,
                          const std::string& correlation_id,
                          const std::string& span_context,
-                         const bftEngine::RequestCallBack& callback);
+                         const concord::client::concordclient::SendCallback& callback);
 
   PoolStatus HealthStatus();
 
@@ -240,7 +241,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
                              std::string correlation_id,
                              uint64_t seq_num,
                              std::string span_context,
-                             const bftEngine::RequestCallBack& callback)
+                             const concord::client::concordclient::SendCallback& callback)
       : BatchRequestProcessingJob(clients, std::move(client)),
         request_(std::move(request)),
         flags_{flags},
@@ -261,7 +262,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
   uint64_t seq_num_;
   bft::client::WriteConfig write_config_;
   bft::client::ReadConfig read_config_;
-  const bftEngine::RequestCallBack callback_;
+  const concord::client::concordclient::SendCallback& callback_;
 };
 }  // namespace concord_client_pool
 

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -30,6 +30,12 @@ class ConcordConfiguration;
 }
 
 namespace external_client {
+
+struct ExtClientReply {
+  bftEngine::ClientReply reply;
+  concord::client::concordclient::SendCallback callback = {};
+};
+
 // Represents a Concord BFT client. The purpose of this class is to be easy to
 // use for external users. This is achieved by:
 //  * providing a simple public interface
@@ -39,7 +45,7 @@ namespace external_client {
 //  client
 class ConcordClient {
  public:
-  using PendingReplies = std::deque<bftEngine::ClientReply>;
+  using PendingReplies = std::deque<ExtClientReply>;
   // Constructs the client by passing concord configuration
   // object and a client_id to get the specific values for this client.
   // Construction executes all needed steps to provide a ready-to-use

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 #include "client_pool_config.hpp"
+#include "client/concordclient/send_callback.hpp"
 #include "communication/StatusInfo.h"
 #include "external_client_exception.hpp"
 
@@ -63,7 +64,7 @@ class ConcordClient {
                          uint64_t seq_num,
                          const std::string& correlation_id = {},
                          const std::string& span_context = {},
-                         bftEngine::RequestCallBack callback = {});
+                         concord::client::concordclient::SendCallback callback = {});
 
   size_t PendingRequestsCount() const { return pending_requests_.size(); }
 

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -25,6 +25,9 @@ using namespace bftEngine;
 
 using namespace bft::communication;
 
+using concord::client::concordclient::SendCallback;
+using concord::client::concordclient::SendResult;
+
 std::shared_ptr<std::vector<char>> ConcordClient::reply_ = std::make_shared<std::vector<char>>(0);
 uint16_t ConcordClient::required_num_of_replicas_ = 0;
 uint16_t ConcordClient::num_of_replicas_ = 0;
@@ -92,7 +95,7 @@ void ConcordClient::AddPendingRequest(std::vector<uint8_t>&& request,
                                       uint64_t seq_num,
                                       const std::string& correlation_id,
                                       const std::string& span_context,
-                                      RequestCallBack callback) {
+                                      SendCallback callback) {
   bftEngine::ClientRequest pending_request;
   pending_request.lengthOfRequest = request.size();
   pending_request.request = std::move(request);

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -106,23 +106,23 @@ void ConcordClient::AddPendingRequest(std::vector<uint8_t>&& request,
   pending_request.span_context = span_context;
   pending_requests_.push_back(std::move(pending_request));
 
-  bftEngine::ClientReply pending_reply;
+  ExtClientReply pending;
   if (reply_size) {
-    pending_reply.replyBuffer = reply_buffer;
-    pending_reply.lengthOfReplyBuffer = reply_size;
+    pending.reply.replyBuffer = reply_buffer;
+    pending.reply.lengthOfReplyBuffer = reply_size;
   } else {
-    pending_reply.replyBuffer = reply_->data() + batching_buffer_reply_offset_ * max_reply_size_;
+    pending.reply.replyBuffer = reply_->data() + batching_buffer_reply_offset_ * max_reply_size_;
     LOG_DEBUG(logger_,
               "Given reply size is 0, setting internal buffer with offset="
                   << (batching_buffer_reply_offset_ * max_reply_size_));
     ++batching_buffer_reply_offset_;
-    pending_reply.lengthOfReplyBuffer = max_reply_size_;
+    pending.reply.lengthOfReplyBuffer = max_reply_size_;
   }
-  pending_reply.actualReplyLength = 0UL;
-  pending_reply.cid = correlation_id;
-  pending_reply.span_context = span_context;
-  pending_reply.cb = std::move(callback);
-  pending_replies_.push_back(std::move(pending_reply));
+  pending.reply.actualReplyLength = 0UL;
+  pending.reply.cid = correlation_id;
+  pending.reply.span_context = span_context;
+  pending.callback = std::move(callback);
+  pending_replies_.push_back(std::move(pending));
 }
 
 std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequests() {

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -13,7 +13,7 @@
 
 #include <chrono>
 #include <string>
-#include <sstream>
+#include <fstream>
 
 #include "assertUtils.hpp"
 #include "secret_retriever.hpp"

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -45,17 +45,17 @@ Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_req
   auto callback = [&](cc::SendResult&& send_result) {
     if (not std::holds_alternative<bft::client::Reply>(send_result)) {
       LOG_INFO(logger_, "Send returned error");
-      switch (std::get<uint32_t>(send_result)) {
-        case (concord_client_pool::Overloaded):
+      switch (std::get<cc::SendError>(send_result)) {
+        case (cc::SendError::Overloaded):
           status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "All clients occupied"));
           break;
-        case (concord_client_pool::InvalidArgument):
+        case (cc::SendError::InvalidArgument):
           status.set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid argument"));
           break;
-        case (concord_client_pool::TimedOut):
+        case (cc::SendError::TimedOut):
           status.set_value(grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "Timeout"));
           break;
-        case (concord_client_pool::ClientUnavailable):
+        case (cc::SendError::ClientUnavailable):
           status.set_value(grpc::Status(grpc::StatusCode::UNAVAILABLE, "No clients connected to the replicas"));
           break;
         default:

--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -10,6 +10,11 @@ PRIVATE
   thin_replica_client_lib
 )
 
+# Provide type definitions in a separate library
+add_library(concordclient-interface INTERFACE)
+target_include_directories(concordclient-interface INTERFACE include)
+target_link_libraries(concordclient-interface INTERFACE bftclient_new-interface)
+
 find_package(Protobuf REQUIRED)
 add_library(concordclient-event-api STATIC "src/event_update_queue.cpp")
 target_include_directories(concordclient-event-api PUBLIC include)

--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -1,11 +1,13 @@
-add_library(concordclient "src/concord_client.cpp")
+add_library(concordclient STATIC "src/concord_client.cpp")
 target_include_directories(concordclient PUBLIC include)
-# TODO: Mark libraries as PRIVATE once the interface is selfcontained
-target_link_libraries(concordclient PUBLIC
-  thin_replica_client_lib
-  concord_client_pool
+target_link_libraries(concordclient
+PUBLIC
+  bftclient_new
   concordclient-event-api
   util
+PRIVATE
+  concord_client_pool
+  thin_replica_client_lib
 )
 
 find_package(Protobuf REQUIRED)

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <functional>
 #include <opentracing/span.h>
 #include <memory>
@@ -22,8 +21,6 @@
 
 #include "bftclient/base_types.h"
 #include "bftclient/bft_client.h"
-#include "client/thin-replica-client/thin_replica_client.hpp"
-#include "client/client_pool/concord_client_pool.hpp"
 #include "client/concordclient/event_update_queue.hpp"
 #include "client/concordclient/concord_client_exceptions.hpp"
 #include "Metrics.hpp"
@@ -128,7 +125,7 @@ struct SubscribeRequest {
 class ConcordClient {
  public:
   ConcordClient(const ConcordClientConfig&, std::shared_ptr<concordMetrics::Aggregator>);
-  ~ConcordClient() { unsubscribe(); }
+  ~ConcordClient();
 
   // Register a callback that gets invoked once the handling BFT client returns.
   void send(const bft::client::WriteConfig& config,
@@ -148,18 +145,8 @@ class ConcordClient {
   void unsubscribe();
 
  private:
-  config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
-
-  logging::Logger logger_;
-  const ConcordClientConfig& config_;
-  std::shared_ptr<concordMetrics::Aggregator> metrics_;
-
-  // TODO: Allow multiple subscriptions
-  std::atomic_bool active_subscription_{false};
-
-  std::shared_ptr<BasicUpdateQueue> trc_queue_;
-  std::unique_ptr<::client::thin_replica_client::ThinReplicaClient> trc_;
-  std::unique_ptr<concord::concord_client_pool::ConcordClientPool> client_pool_;
+  class Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace concord::client::concordclient

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -22,20 +22,11 @@
 #include "bftclient/base_types.h"
 #include "bftclient/bft_client.h"
 #include "client/concordclient/event_update_queue.hpp"
+#include "client/concordclient/send_callback.hpp"
 #include "client/concordclient/concord_client_exceptions.hpp"
 #include "Metrics.hpp"
 
 namespace concord::client::concordclient {
-
-struct SendError {
-  std::string msg;
-  enum ErrorType {
-    ClientsBusy  // All clients are busy and cannot accept new requests
-  };
-  ErrorType type;
-};
-
-typedef std::variant<uint32_t, bft::client::Reply> SendResult;
 
 struct ReplicaInfo {
   bft::client::ReplicaId id;
@@ -130,10 +121,10 @@ class ConcordClient {
   // Register a callback that gets invoked once the handling BFT client returns.
   void send(const bft::client::WriteConfig& config,
             bft::client::Msg&& msg,
-            const std::function<void(SendResult&&)>& callback);
+            const SendCallback& callback);
   void send(const bft::client::ReadConfig& config,
             bft::client::Msg&& msg,
-            const std::function<void(SendResult&&)>& callback);
+            const SendCallback& callback);
 
   // Subscribe to events which are pushed into the given update queue.
   void subscribe(const SubscribeRequest& request,

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -119,12 +119,8 @@ class ConcordClient {
   ~ConcordClient();
 
   // Register a callback that gets invoked once the handling BFT client returns.
-  void send(const bft::client::WriteConfig& config,
-            bft::client::Msg&& msg,
-            const SendCallback& callback);
-  void send(const bft::client::ReadConfig& config,
-            bft::client::Msg&& msg,
-            const SendCallback& callback);
+  void send(const bft::client::WriteConfig& config, bft::client::Msg&& msg, const SendCallback& callback);
+  void send(const bft::client::ReadConfig& config, bft::client::Msg&& msg, const SendCallback& callback);
 
   // Subscribe to events which are pushed into the given update queue.
   void subscribe(const SubscribeRequest& request,
@@ -136,8 +132,8 @@ class ConcordClient {
   void unsubscribe();
 
  private:
-  class Impl;
-  std::unique_ptr<Impl> impl_;
+  class ConcordClientImpl;
+  std::unique_ptr<ConcordClientImpl> impl_;
 };
 
 }  // namespace concord::client::concordclient

--- a/client/concordclient/include/client/concordclient/send_callback.hpp
+++ b/client/concordclient/include/client/concordclient/send_callback.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <functional>
+#include <variant>
+
+#include "bftclient/base_types.h"
+
+namespace concord::client::concordclient {
+
+enum SendError {
+  ClientUnavailable,  // Clients have trouble connecting, retry with backoff
+  InvalidArgument,
+  Overloaded,  // All internal clients are busy, retry with backoff
+  TimedOut,
+};
+typedef std::variant<SendError, bft::client::Reply> SendResult;
+typedef std::function<void(SendResult&&)> SendCallback;
+
+}  // namespace concord::client::concordclient

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -28,9 +28,9 @@ using ::client::thin_replica_client::TrsConnectionConfig;
 
 namespace concord::client::concordclient {
 
-class ConcordClient::Impl {
+class ConcordClient::ConcordClientImpl {
  public:
-  Impl(const ConcordClientConfig& config, std::shared_ptr<concordMetrics::Aggregator> aggregator)
+  ConcordClientImpl(const ConcordClientConfig& config, std::shared_ptr<concordMetrics::Aggregator> aggregator)
       : logger_(logging::getLogger("concord.client.concordclient")), config_(config), metrics_(aggregator) {
     ConcordClientPoolConfig client_pool_config = createClientPoolStruct(config);
     client_pool_ = std::make_unique<concord::concord_client_pool::ConcordClientPool>(client_pool_config, metrics_);
@@ -181,7 +181,7 @@ class ConcordClient::Impl {
 
 ConcordClient::ConcordClient(const ConcordClientConfig& config,
                              std::shared_ptr<concordMetrics::Aggregator> aggregator) {
-  impl_.reset(new Impl(config, aggregator));
+  impl_.reset(new ConcordClientImpl(config, aggregator));
 }
 ConcordClient::~ConcordClient() { unsubscribe(); }
 

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -15,6 +15,7 @@
 #include "assertUtils.hpp"
 #include "client/concordclient/concord_client.hpp"
 #include "client/thin-replica-client/thin_replica_client.hpp"
+#include "client/client_pool/concord_client_pool.hpp"
 
 using ::client::thin_replica_client::ThinReplicaClient;
 using ::client::thin_replica_client::ThinReplicaClientConfig;
@@ -27,143 +28,181 @@ using ::client::thin_replica_client::TrsConnectionConfig;
 
 namespace concord::client::concordclient {
 
-ConcordClient::ConcordClient(const ConcordClientConfig& config, std::shared_ptr<concordMetrics::Aggregator> aggregator)
-    : logger_(logging::getLogger("concord.client.concordclient")), config_(config), metrics_(aggregator) {
-  ConcordClientPoolConfig client_pool_config = createClientPoolStruct(config);
-  client_pool_ = std::make_unique<concord::concord_client_pool::ConcordClientPool>(client_pool_config, metrics_);
-  while (client_pool_->HealthStatus() == concord::concord_client_pool::PoolStatus::NotServing) {
-    LOG_INFO(logger_, "Waiting for client pool to connect");
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+class ConcordClient::Impl {
+ public:
+  Impl(const ConcordClientConfig& config, std::shared_ptr<concordMetrics::Aggregator> aggregator)
+      : logger_(logging::getLogger("concord.client.concordclient")), config_(config), metrics_(aggregator) {
+    ConcordClientPoolConfig client_pool_config = createClientPoolStruct(config);
+    client_pool_ = std::make_unique<concord::concord_client_pool::ConcordClientPool>(client_pool_config, metrics_);
+    while (client_pool_->HealthStatus() == concord::concord_client_pool::PoolStatus::NotServing) {
+      LOG_INFO(logger_, "Waiting for client pool to connect");
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+    }
   }
+
+  ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config) {
+    ConcordClientPoolConfig client_pool_config;
+    int id = 0;
+    for (const auto& replica : config_.topology.replicas) {
+      Replica client_pool_replica;
+      auto replica_id = replica.id.val;
+      client_pool_replica.principal_id = replica_id;
+      client_pool_replica.replica_host = replica.host;
+      client_pool_replica.replica_port = replica.bft_port;
+      client_pool_config.node[id] = client_pool_replica;
+      id++;
+    }
+
+    ParticipantNode client_pool_pn;
+    id = 0;
+    for (const auto& bft_client : config_.bft_clients) {
+      ExternalClient client_pool_ec;
+      auto external_client_id = bft_client.id.val;
+      client_pool_ec.principal_id = external_client_id;
+      client_pool_ec.client_port = bft_client.port;
+      client_pool_pn.externalClients[id] = client_pool_ec;
+      id++;
+    }
+    client_pool_pn.participant_node_host = config_.bft_clients[0].host;
+    client_pool_config.participant_nodes.push_back(client_pool_pn);
+    client_pool_config.clients_per_participant_node = config_.num_of_used_bft_clients;
+
+    client_pool_config.f_val = config.topology.f_val;
+    client_pool_config.c_val = config.topology.c_val;
+    client_pool_config.client_initial_retry_timeout_milli =
+        config.topology.client_retry_config.initial_retry_timeout.count();
+    client_pool_config.client_min_retry_timeout_milli = config.topology.client_retry_config.min_retry_timeout.count();
+    client_pool_config.client_max_retry_timeout_milli = config.topology.client_retry_config.max_retry_timeout.count();
+    client_pool_config.client_number_of_standard_deviations_to_tolerate =
+        config.topology.client_retry_config.number_of_standard_deviations_to_tolerate;
+    client_pool_config.client_samples_per_evaluation = config.topology.client_retry_config.samples_per_evaluation;
+    client_pool_config.client_samples_until_reset = config.topology.client_retry_config.samples_until_reset;
+    client_pool_config.client_sends_request_to_all_replicas_first_thresh =
+        config.topology.client_sends_request_to_all_replicas_first_thresh;
+    client_pool_config.client_sends_request_to_all_replicas_period_thresh =
+        config.topology.client_sends_request_to_all_replicas_period_thresh;
+    client_pool_config.num_replicas = config.topology.replicas.size();
+    client_pool_config.client_proxies_per_replica = config.topology.client_proxies_per_replica;
+    client_pool_config.signing_key_path = config.topology.signing_key_path;
+    client_pool_config.external_requests_queue_size = config.topology.external_requests_queue_size;
+    client_pool_config.encrypted_config_enabled = config.topology.encrypted_config_enabled;
+    client_pool_config.transaction_signing_enabled = config.topology.transaction_signing_enabled;
+    client_pool_config.with_cre = config.topology.with_cre;
+    client_pool_config.client_batching_enabled = config.topology.client_batching_enabled;
+    client_pool_config.client_batching_max_messages_nbr = config.topology.client_batching_max_messages_nbr;
+    client_pool_config.client_batching_flush_timeout_ms = config.topology.client_batching_flush_timeout_ms;
+
+    client_pool_config.comm_to_use = config.transport.comm_type == TransportConfig::Invalid
+                                         ? "Invalid"
+                                         : config.transport.comm_type == TransportConfig::TlsTcp ? "tls" : "udp";
+    client_pool_config.concord_bft_communication_buffer_length = std::to_string(config.transport.buffer_length);
+    client_pool_config.tls_certificates_folder_path = config.transport.tls_cert_root_path;
+    client_pool_config.tls_cipher_suite_list = config.transport.tls_cipher_suite;
+    client_pool_config.enable_mock_comm = config.transport.enable_mock_comm;
+
+    return client_pool_config;
+  }
+
+  void send(const bft::client::ReadConfig& config,
+            bft::client::Msg&& msg,
+            const std::function<void(SendResult&&)>& callback) {
+    LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
+    client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
+  }
+
+  void send(const bft::client::WriteConfig& config,
+            bft::client::Msg&& msg,
+            const std::function<void(SendResult&&)>& callback) {
+    client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
+  }
+
+  void subscribe(const SubscribeRequest& sub_req,
+                 std::shared_ptr<UpdateQueue>& queue,
+                 const std::unique_ptr<opentracing::Span>& parent_span) {
+    bool expected = false;
+    if (!active_subscription_.compare_exchange_weak(expected, true)) {
+      LOG_ERROR(logger_, "subscription already in progress - unsubscribe first");
+      throw SubscriptionExists();
+    }
+
+    std::vector<std::unique_ptr<::client::thin_replica_client::TrsConnection>> trs_connections;
+    std::unique_ptr<TrsConnectionConfig> trsc_config;
+    for (const auto& replica : config_.topology.replicas) {
+      auto addr = replica.host + ":" + std::to_string(replica.event_port);
+      auto trsc = std::make_unique<TrsConnection>(addr, config_.subscribe_config.id, /* TODO */ 3, /* TODO */ 3);
+
+      // TODO: Adapt TRC API to support PEM buffers
+      auto trsc_config = std::make_unique<TrsConnectionConfig>(config_.subscribe_config.use_tls,
+                                                               config_.subscribe_config.pem_private_key,
+                                                               config_.subscribe_config.pem_cert_chain,
+                                                               config_.transport.event_pem_certs);
+
+      trsc->connect(trsc_config);
+      trs_connections.push_back(std::move(trsc));
+    }
+
+    auto trc_config = std::make_unique<ThinReplicaClientConfig>(
+        config_.subscribe_config.id, queue, config_.topology.f_val, std::move(trs_connections));
+    trc_ = std::make_unique<ThinReplicaClient>(std::move(trc_config), metrics_);
+
+    if (std::holds_alternative<EventGroupRequest>(sub_req.request)) {
+      ::client::thin_replica_client::SubscribeRequest trc_request;
+      trc_request.event_group_id = std::get<EventGroupRequest>(sub_req.request).event_group_id;
+      trc_->Subscribe(trc_request);
+    } else if (std::holds_alternative<LegacyEventRequest>(sub_req.request)) {
+      trc_->Subscribe(std::get<LegacyEventRequest>(sub_req.request).block_id);
+    } else {
+      ConcordAssert(false);
+    }
+  }
+
+  void unsubscribe() {
+    if (active_subscription_) {
+      LOG_INFO(logger_, "Closing subscription. Waiting for subscriber to finish.");
+      trc_->Unsubscribe();
+      trc_.reset();
+      active_subscription_ = false;
+      LOG_INFO(logger_, "Subscriber finished.");
+    }
+  }
+
+ private:
+  logging::Logger logger_;
+  const ConcordClientConfig& config_;
+  std::shared_ptr<concordMetrics::Aggregator> metrics_;
+
+  // TODO: Allow multiple subscriptions
+  std::atomic_bool active_subscription_{false};
+
+  std::shared_ptr<BasicUpdateQueue> trc_queue_;
+  std::unique_ptr<::client::thin_replica_client::ThinReplicaClient> trc_;
+  std::unique_ptr<concord::concord_client_pool::ConcordClientPool> client_pool_;
+};
+
+ConcordClient::ConcordClient(const ConcordClientConfig& config,
+                             std::shared_ptr<concordMetrics::Aggregator> aggregator) {
+  impl_.reset(new Impl(config, aggregator));
 }
-
-ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClientConfig& config) {
-  ConcordClientPoolConfig client_pool_config;
-  int id = 0;
-  for (const auto& replica : config_.topology.replicas) {
-    Replica client_pool_replica;
-    auto replica_id = replica.id.val;
-    client_pool_replica.principal_id = replica_id;
-    client_pool_replica.replica_host = replica.host;
-    client_pool_replica.replica_port = replica.bft_port;
-    client_pool_config.node[id] = client_pool_replica;
-    id++;
-  }
-
-  ParticipantNode client_pool_pn;
-  id = 0;
-  for (const auto& bft_client : config_.bft_clients) {
-    ExternalClient client_pool_ec;
-    auto external_client_id = bft_client.id.val;
-    client_pool_ec.principal_id = external_client_id;
-    client_pool_ec.client_port = bft_client.port;
-    client_pool_pn.externalClients[id] = client_pool_ec;
-    id++;
-  }
-  client_pool_pn.participant_node_host = config_.bft_clients[0].host;
-  client_pool_config.participant_nodes.push_back(client_pool_pn);
-  client_pool_config.clients_per_participant_node = config_.num_of_used_bft_clients;
-
-  client_pool_config.f_val = config.topology.f_val;
-  client_pool_config.c_val = config.topology.c_val;
-  client_pool_config.client_initial_retry_timeout_milli =
-      config.topology.client_retry_config.initial_retry_timeout.count();
-  client_pool_config.client_min_retry_timeout_milli = config.topology.client_retry_config.min_retry_timeout.count();
-  client_pool_config.client_max_retry_timeout_milli = config.topology.client_retry_config.max_retry_timeout.count();
-  client_pool_config.client_number_of_standard_deviations_to_tolerate =
-      config.topology.client_retry_config.number_of_standard_deviations_to_tolerate;
-  client_pool_config.client_samples_per_evaluation = config.topology.client_retry_config.samples_per_evaluation;
-  client_pool_config.client_samples_until_reset = config.topology.client_retry_config.samples_until_reset;
-  client_pool_config.client_sends_request_to_all_replicas_first_thresh =
-      config.topology.client_sends_request_to_all_replicas_first_thresh;
-  client_pool_config.client_sends_request_to_all_replicas_period_thresh =
-      config.topology.client_sends_request_to_all_replicas_period_thresh;
-  client_pool_config.num_replicas = config.topology.replicas.size();
-  client_pool_config.client_proxies_per_replica = config.topology.client_proxies_per_replica;
-  client_pool_config.signing_key_path = config.topology.signing_key_path;
-  client_pool_config.external_requests_queue_size = config.topology.external_requests_queue_size;
-  client_pool_config.encrypted_config_enabled = config.topology.encrypted_config_enabled;
-  client_pool_config.transaction_signing_enabled = config.topology.transaction_signing_enabled;
-  client_pool_config.with_cre = config.topology.with_cre;
-  client_pool_config.client_batching_enabled = config.topology.client_batching_enabled;
-  client_pool_config.client_batching_max_messages_nbr = config.topology.client_batching_max_messages_nbr;
-  client_pool_config.client_batching_flush_timeout_ms = config.topology.client_batching_flush_timeout_ms;
-
-  client_pool_config.comm_to_use = config.transport.comm_type == TransportConfig::Invalid
-                                       ? "Invalid"
-                                       : config.transport.comm_type == TransportConfig::TlsTcp ? "tls" : "udp";
-  client_pool_config.concord_bft_communication_buffer_length = std::to_string(config.transport.buffer_length);
-  client_pool_config.tls_certificates_folder_path = config.transport.tls_cert_root_path;
-  client_pool_config.tls_cipher_suite_list = config.transport.tls_cipher_suite;
-  client_pool_config.enable_mock_comm = config.transport.enable_mock_comm;
-  if (config.transport.secret_data.has_value()) {
-    client_pool_config.secret_data = config.transport.secret_data.value();
-  }
-
-  return client_pool_config;
-}
+ConcordClient::~ConcordClient() { unsubscribe(); }
 
 void ConcordClient::send(const bft::client::ReadConfig& config,
                          bft::client::Msg&& msg,
                          const std::function<void(SendResult&&)>& callback) {
-  LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
-  client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
+  impl_->send(config, std::move(msg), callback);
 }
 
 void ConcordClient::send(const bft::client::WriteConfig& config,
                          bft::client::Msg&& msg,
                          const std::function<void(SendResult&&)>& callback) {
-  client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
+  impl_->send(config, std::move(msg), callback);
 }
 
 void ConcordClient::subscribe(const SubscribeRequest& sub_req,
                               std::shared_ptr<UpdateQueue>& queue,
                               const std::unique_ptr<opentracing::Span>& parent_span) {
-  bool expected = false;
-  if (!active_subscription_.compare_exchange_weak(expected, true)) {
-    LOG_ERROR(logger_, "subscription already in progress - unsubscribe first");
-    throw SubscriptionExists();
-  }
-
-  std::vector<std::unique_ptr<::client::thin_replica_client::TrsConnection>> trs_connections;
-  std::unique_ptr<TrsConnectionConfig> trsc_config;
-  for (const auto& replica : config_.topology.replicas) {
-    auto addr = replica.host + ":" + std::to_string(replica.event_port);
-    auto trsc = std::make_unique<TrsConnection>(addr, config_.subscribe_config.id, /* TODO */ 3, /* TODO */ 3);
-
-    // TODO: Adapt TRC API to support PEM buffers
-    auto trsc_config = std::make_unique<TrsConnectionConfig>(config_.subscribe_config.use_tls,
-                                                             config_.subscribe_config.pem_private_key,
-                                                             config_.subscribe_config.pem_cert_chain,
-                                                             config_.transport.event_pem_certs);
-
-    trsc->connect(trsc_config);
-    trs_connections.push_back(std::move(trsc));
-  }
-
-  auto trc_config = std::make_unique<ThinReplicaClientConfig>(
-      config_.subscribe_config.id, queue, config_.topology.f_val, std::move(trs_connections));
-  trc_ = std::make_unique<ThinReplicaClient>(std::move(trc_config), metrics_);
-
-  if (std::holds_alternative<EventGroupRequest>(sub_req.request)) {
-    ::client::thin_replica_client::SubscribeRequest trc_request;
-    trc_request.event_group_id = std::get<EventGroupRequest>(sub_req.request).event_group_id;
-    trc_->Subscribe(trc_request);
-  } else if (std::holds_alternative<LegacyEventRequest>(sub_req.request)) {
-    trc_->Subscribe(std::get<LegacyEventRequest>(sub_req.request).block_id);
-  } else {
-    ConcordAssert(false);
-  }
+  impl_->subscribe(sub_req, queue, parent_span);
 }
 
-void ConcordClient::unsubscribe() {
-  if (active_subscription_) {
-    LOG_INFO(logger_, "Closing subscription. Waiting for subscriber to finish.");
-    trc_->Unsubscribe();
-    trc_.reset();
-    active_subscription_ = false;
-    LOG_INFO(logger_, "Subscriber finished.");
-  }
-}
+void ConcordClient::unsubscribe() { impl_->unsubscribe(); }
 
 }  // namespace concord::client::concordclient


### PR DESCRIPTION
This PR breaks the dependency between request service and concord client pool.
In order to keep the separation between our public client interface (bft client, concord client, clientservice) clean, users should not need to depend on implementation details such as the client pool or the thin replica client.

Please take a look at the individual commit messages for more details.