### PR TITLE
Add validation for max client batch size

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -486,6 +486,16 @@ bool PreProcessor::checkClientBatchMsgCorrectness(const ClientBatchRequestMsgUni
     preProcessorMetrics_.preProcReqIgnored++;
     return false;
   }
+
+  const auto numMsgsInBatch = clientBatchReqMsg->numOfMessagesInBatch();
+  if (numMsgsInBatch > clientMaxBatchSize_) {
+    LOG_WARN(logger(),
+             "Ignoring client batch that exceeds max number of requests ("
+                 << numMsgsInBatch << " > " << clientMaxBatchSize_ << ")"
+                 << KVLOG(clientBatchReqMsg->clientId(), clientBatchReqMsg->senderId(), clientBatchReqMsg->getCid()));
+    return false;
+  }
+
   const auto &clientRequestMsgs = clientBatchReqMsg->getClientPreProcessRequestMsgs();
   bool valid = true;
   for (const auto &msg : clientRequestMsgs) {


### PR DESCRIPTION
Add validation for max client batch size when receiving ClientBatchRequestMsg, otherwise a faulty client will be able to bring down a replica by triggering later assertions predicated on the correct size of the accepted batch.