### PR TITLE
Reverting column family names on v1.5 release branch.

### DIFF
--- a/kvbc/include/categorization/db_categories.h
+++ b/kvbc/include/categorization/db_categories.h
@@ -21,9 +21,9 @@ inline const auto kExecutionProvableCategory = "execution_provable";
 inline const auto kExecutionPrivateCategory = "execution_private";
 inline const auto kExecutionEventsCategory = "execution_events";
 inline const auto kRequestsRecord = "requests_record";
-inline const auto kExecutionEventGroupDataCategory = "execution_event_group_data";
-inline const auto kExecutionEventGroupTagCategory = "execution_event_group_tag";
-inline const auto kExecutionEventGroupLatestCategory = "execution_event_group_latest";
+inline const auto kExecutionEventGroupDataCategory = "execution_global_event_groups";
+inline const auto kExecutionEventGroupTagCategory = "execution_trid_event_groups";
+inline const auto kExecutionEventGroupLatestCategory = "execution_event_group_ids";
 
 // Concord and Concord-BFT internal category that is used for various kinds of metadata.
 // The type of the internal category is VersionedKeyValueCategory.


### PR DESCRIPTION
Reverting changes done in https://github.com/vmware/concord-bft/commit/1c1a09f608329701b7d344a479edb26ca2e416e9

These changes will be incorporated in an upcoming version release.