### PR TITLE
TRS: Fix pruned event group transition

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -205,6 +205,10 @@ class KvbAppFilter {
 
   kvbc::categorization::EventGroup getEventGroup(kvbc::EventGroupId event_group_id, std::string &cid);
 
+  // Return the oldest global event group id.
+  // If no event group can be found then 0 (invalid group id) is returned.
+  uint64_t getOldestEventGroupId();
+
   // Return the block number of the very first global event group.
   // Optional because during start-up there might be no block/event group written yet.
   std::optional<BlockId> getOldestEventGroupBlockId();

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -49,8 +49,10 @@ using concord::util::openssl_utils::kExpectedSHA256HashLengthInBytes;
 namespace concord {
 namespace kvbc {
 
+uint64_t KvbAppFilter::getOldestEventGroupId() { return getValueFromLatestTable(kGlobalEgIdKeyOldest); }
+
 optional<BlockId> KvbAppFilter::getOldestEventGroupBlockId() {
-  uint64_t global_eg_id_oldest = getValueFromLatestTable(kGlobalEgIdKeyOldest);
+  uint64_t global_eg_id_oldest = getOldestEventGroupId();
   const auto opt = rostorage_->getLatestVersion(concord::kvbc::categorization::kExecutionEventGroupDataCategory,
                                                 concordUtils::toBigEndianStringBuffer(global_eg_id_oldest));
   if (not opt.has_value()) {

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -388,9 +388,10 @@ class ThinReplicaImpl {
       ConcordAssert(request->has_events());
       // We assume that the caller wants updates but we cannot determine the event group id the caller is looking for.
       // Therefore, we start at the beginning.
-      // TODO: Doesn't work with pruning - use "global_event_group_id_oldest" once it is supported
-      event_group_id = 1;
-      LOG_INFO(logger_, "Legacy event request will receive event groups");
+      event_group_id = kvb_filter->getOldestEventGroupId();
+      // If an event group transition is happening then we already confirmed that event groups are available.
+      ConcordAssertNE(event_group_id, 0);
+      LOG_INFO(logger_, "Legacy event request will receive event groups starting at id " << event_group_id);
     } else {
       ConcordAssert(request->has_event_groups());
       event_group_id = request->event_groups().event_group_id();


### PR DESCRIPTION
The code assumed that we would always have event group 1 available which is not
true with pruning enabled. Hence, we need to query the oldest available event
group id.