### PR TITLE
Pass ClientRequest cid to ExecutionRequest instead of the PrePrepareMsg cid

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4857,7 +4857,7 @@ void ReplicaImp::executeRequests(PrePrepareMsg *ppMsg, Bitmap &requestSet, Times
     pAccumulatedRequests->push_back(IRequestsHandler::ExecutionRequest{
         clientId,
         static_cast<uint64_t>(lastExecutedSeqNum + 1),
-        ppMsg->getCid(),
+        req.getCid(),
         req.flags(),
         req.requestLength(),
         req.requestBuf(),


### PR DESCRIPTION
We're setting the cid on all ExecutionRequests to the PrePrepareMsg cid. We need the actual client request cid to be passed in instead for use in some execution implementations.