### PR TITLE
Adjust remaining window size while building PPM

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <type_traits>
 #include <bitset>
+#include <limits>
 
 #include "ReplicaImp.hpp"
 #include "Timers.hpp"
@@ -564,29 +565,30 @@ bool ReplicaImp::checkSendPrePrepareMsgPrerequisites() {
     return false;
   }
 
-  if (isSeqNumToStopAt(primaryLastUsedSeqNum + 1)) {
+  if (isSeqNumToStopAt(primaryLastUsedSeqNum + numOfTransientPreprepareMsgs_ + 1)) {
     LOG_INFO(GL,
              "Not sending PrePrepareMsg because system is stopped at checkpoint pending control state operation "
              "(upgrade, etc...)");
     return false;
   }
 
-  if (primaryLastUsedSeqNum + 1 > lastStableSeqNum + kWorkWindowSize) {
+  if (primaryLastUsedSeqNum + numOfTransientPreprepareMsgs_ + 1 > lastStableSeqNum + kWorkWindowSize) {
     LOG_INFO(GL,
              "Will not send PrePrepare since next sequence number ["
-                 << primaryLastUsedSeqNum + 1 << "] exceeds window threshold [" << lastStableSeqNum + kWorkWindowSize
-                 << "]");
+                 << primaryLastUsedSeqNum + numOfTransientPreprepareMsgs_ + 1 << "] exceeds window threshold ["
+                 << lastStableSeqNum + kWorkWindowSize << "]");
     return false;
   }
 
-  if (primaryLastUsedSeqNum + 1 > lastExecutedSeqNum + config_.getconcurrencyLevel() + activeExecutions_) {
+  if (primaryLastUsedSeqNum + numOfTransientPreprepareMsgs_ + 1 >
+      lastExecutedSeqNum + config_.getconcurrencyLevel() + activeExecutions_) {
     LOG_INFO(GL,
              "Will not send PrePrepare since next sequence number ["
-                 << primaryLastUsedSeqNum + 1 << "] exceeds concurrency threshold ["
-                 << lastExecutedSeqNum + config_.getconcurrencyLevel() << "]");
+                 << primaryLastUsedSeqNum + numOfTransientPreprepareMsgs_ + 1 << "] exceeds concurrency threshold ["
+                 << lastExecutedSeqNum + config_.getconcurrencyLevel() + activeExecutions_ << "]");
     return false;
   }
-  metric_concurrency_level_.Get().Set(primaryLastUsedSeqNum + 1 - lastExecutedSeqNum);
+  metric_concurrency_level_.Get().Set(primaryLastUsedSeqNum + numOfTransientPreprepareMsgs_ + 1 - lastExecutedSeqNum);
   ConcordAssertGE(primaryLastUsedSeqNum, lastExecutedSeqNum + activeExecutions_);
   // Because maxConcurrentAgreementsByPrimary <  MaxConcurrentFastPaths
   ConcordAssertLE((primaryLastUsedSeqNum + 1), lastExecutedSeqNum + MaxConcurrentFastPaths + activeExecutions_);
@@ -754,6 +756,17 @@ std::pair<PrePrepareMsg *, bool> ReplicaImp::finishAddingRequestsToPrePrepareMsg
       // by dispatcher will not allow multiple threads together.
       try {
         static auto &threadPool = RequestThreadPool::getThreadPool(RequestThreadPool::PoolLevel::STARTING);
+        // The UINT16 MAX is the upper bound of numOfTransientPreprepareMsgs_
+        // This upper limit should never be reached and thus this check is
+        // added. We cannot do ConcordAssert here, since there is a way to
+        // move forward if we stop just before touching this upper bound.
+        if ((numOfTransientPreprepareMsgs_ + 1) < std::numeric_limits<decltype(numOfTransientPreprepareMsgs_)>::max()) {
+          numOfTransientPreprepareMsgs_++;
+        } else {
+          LOG_ERROR(GL, "The number of transient preprepare messages are very large so they will have to be retried.");
+          delete prePrepareMsg;
+          return std::make_pair(nullptr, false);
+        }
         threadPool.async(
             [](auto *ppm, auto *iq, auto *hist) {
               {
@@ -1551,6 +1564,16 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
 
   // Handle a pre prepare sent by self
   if (auto *ppm = std::get_if<PrePrepareMsg *>(&msg)) {
+    // This if is guarding the numOfTransientPreprepareMsgs_ variable.
+    // This condition will always be true but keeping this to ensure that
+    // we never decrement this variable when it is at its lower bound.
+    // Why we donot use ConcordAssert here?
+    // Ans: 0 is a correct value for this variable, as this is unsigned,
+    // it will never become negative. So check for lower bound and
+    // then decrement is the correct idiom for this case.
+    if (numOfTransientPreprepareMsgs_ > 0) {
+      numOfTransientPreprepareMsgs_--;
+    }
     if (isCollectingState() || bftEngine::ControlStateManager::instance().getPruningProcessStatus()) {
       LOG_INFO(GL, "Received PrePrepareMsg while pruning or state transfer, so ignoring the message");
       delete *ppm;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -120,8 +120,17 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   size_t NonPrimaryCombinedReqSize = 1000;
   //
   const std::thread::id MAIN_THREAD_ID;
+  // A preprepare message which is still building is called transient preprepare.
+  // activeTransientPreprepare_ represents the number of preprepare messages that are
+  // currently getting build in a separate thread.
+  // This should not be thread safe because its used only in the main thread
+  // This should start with 0, since by default we will assume that a preprepare is taken
+  // to be added to main log. And this will solely represent those preprepares which are
+  // to be added to main log, but are not added as yet.
+  uint16_t numOfTransientPreprepareMsgs_ = 0;
+
   // represents the number of running executions at this moment.
-  // This shoukd not be thread safe because its been changed in 3 places:
+  // This should not be thread safe because its been changed in 3 places:
   // 1) startPrePrepareMsgExecution - when we are getting empty PP its simbulize that we should push
   // FinishPrePrepareExecutionInternalMsg which can happen only on the main thread. 2) executeAllPrePreparedRequests -
   // just before we insert the job to execution thread which means we are in the main thread. 3)

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
@@ -213,7 +213,11 @@ void PrePrepareMsg::finishAddingRequests() {
   b()->flags |= 0x2;
   ConcordAssert(isReady());
 
-  calculateDigestOfRequests(b()->digestOfRequests);
+  try {
+    calculateDigestOfRequests(b()->digestOfRequests);
+  } catch (std::runtime_error& ex) {
+    ConcordAssert(false);
+  }
 
   // size
   setMsgSize(b()->endLocationOfLastRequest);


### PR DESCRIPTION
As we know the preprepare creation is now happening in parallel. The threadpool can schedule atmost 64 (this is configurable) preprepare building together. When we try building the preprepare message, we check if "main log" (this is a local rough notebook to keep track of built and in-flight preprepare message), can hold new preprepare or not. If we bypass this check then during actual allocation, we terminate. The check for available space in main log and actual assignment of a place in log for preprepare message is separated, since building of preprepare message is an elaborate process.
But the check and assignment should be in sync and this should also happen for inflight messages.
When the preprepare message was built completely and checked in the same thread, this was little easier. But when it became asynchronous, we have to add a best effort based check which can assure that a place for the fully-built preprepare will always be guaranteed.

So the fix for this issue, is to keep a track of the number of preprepare messages who are not yet built. We are calling such a pre prepare message as active transient preprepare message. This count of active transient preprepare messages will help us to get the instantaneous upper bound of the number of message that will require a place in the main log.