### PR TITLE
Persist time and recover from it if needed

### DIFF
--- a/bftengine/include/bftengine/TimeService.hpp
+++ b/bftengine/include/bftengine/TimeService.hpp
@@ -14,7 +14,8 @@
 #include <chrono>
 
 namespace bftEngine {
-using ConsensusTime = std::chrono::milliseconds;
+using ConsensusTickRep = std::int64_t;
+using ConsensusTime = std::chrono::duration<ConsensusTickRep, std::milli>;
 
 struct Timestamp {
   ConsensusTime time_since_epoch = ConsensusTime::min();

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -196,7 +196,7 @@ void DebugPersistentStorage::setDescriptorOfLastExecution(const DescriptorOfLast
   ConcordAssert(d.validRequests.numOfBits() <= maxNumOfRequestsInBatch);
 
   hasDescriptorOfLastExecution_ = true;
-  descriptorOfLastExecution_ = DescriptorOfLastExecution{d.executedSeqNum, d.validRequests};
+  descriptorOfLastExecution_ = DescriptorOfLastExecution{d.executedSeqNum, d.validRequests, d.timeInTicks};
 }
 
 void DebugPersistentStorage::setDescriptorOfLastStableCheckpoint(
@@ -376,7 +376,7 @@ DescriptorOfLastExecution DebugPersistentStorage::getDescriptorOfLastExecution()
 
   DescriptorOfLastExecution &d = descriptorOfLastExecution_;
 
-  return DescriptorOfLastExecution{d.executedSeqNum, d.validRequests};
+  return DescriptorOfLastExecution{d.executedSeqNum, d.validRequests, d.timeInTicks};
 }
 
 DescriptorOfLastStableCheckpoint DebugPersistentStorage::getDescriptorOfLastStableCheckpoint() {

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -100,7 +100,7 @@ class DebugPersistentStorage : public PersistentStorage {
   DescriptorOfLastNewView descriptorOfLastNewView_ =
       DescriptorOfLastNewView{0, nullptr, std::vector<ViewChangeMsg*>(0), nullptr, 0, 0};
   bool hasDescriptorOfLastExecution_ = false;
-  DescriptorOfLastExecution descriptorOfLastExecution_ = DescriptorOfLastExecution{0, Bitmap()};
+  DescriptorOfLastExecution descriptorOfLastExecution_ = DescriptorOfLastExecution{0, Bitmap(), 0};
 
   SeqNum lastStableSeqNum_ = 0;
 

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
@@ -23,6 +23,7 @@
 #include "messages/FullCommitProofMsg.hpp"
 #include "messages/CheckpointMsg.hpp"
 #include "SysConsts.hpp"
+#include "TimeService.hpp"
 
 #include <vector>
 
@@ -182,7 +183,8 @@ struct DescriptorOfLastNewView {
 /***** DescriptorOfLastExecution *****/
 
 struct DescriptorOfLastExecution {
-  DescriptorOfLastExecution(SeqNum seqNum, const Bitmap &requests) : executedSeqNum(seqNum), validRequests(requests) {}
+  DescriptorOfLastExecution(SeqNum seqNum, const Bitmap &requests, const ConsensusTickRep &ticks)
+      : executedSeqNum(seqNum), validRequests(requests), timeInTicks(ticks) {}
 
   DescriptorOfLastExecution() = default;
 
@@ -192,7 +194,8 @@ struct DescriptorOfLastExecution {
   void deserialize(char *buf, size_t bufLen, uint32_t &actualSize);
 
   static uint32_t maxSize() {
-    return (sizeof(executedSeqNum) + Bitmap::maxSizeNeededToStoreInBuffer(maxNumOfRequestsInBatch));
+    return (sizeof(executedSeqNum) + Bitmap::maxSizeNeededToStoreInBuffer(maxNumOfRequestsInBatch) +
+            sizeof(ConsensusTickRep));
   };
 
   // executedSeqNum >= 1
@@ -200,6 +203,8 @@ struct DescriptorOfLastExecution {
 
   // 1 <= validRequests.numOfBits() <= maxNumOfRequestsInBatch
   Bitmap validRequests;
+
+  ConsensusTickRep timeInTicks = 0;
 };
 
 /***** DescriptorOfLastStableCheckpoint *****/

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -312,7 +312,7 @@ void PersistentStorageImp::initDescriptorOfLastStableCheckpoint() {
 void PersistentStorageImp::setDescriptorOfLastExecution(const DescriptorOfLastExecution &desc) {
   setDescriptorOfLastExecution(desc, false);
   hasDescriptorOfLastExecution_ = true;
-  descriptorOfLastExecution_ = DescriptorOfLastExecution{desc.executedSeqNum, desc.validRequests};
+  descriptorOfLastExecution_ = DescriptorOfLastExecution{desc.executedSeqNum, desc.validRequests, desc.timeInTicks};
 }
 
 /***** Windows handling *****/

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -257,7 +257,7 @@ class PersistentStorageImp : public PersistentStorage {
   bool hasDescriptorOfLastNewView_ = false;
   bool hasDescriptorOfLastExecution_ = false;
 
-  const DescriptorOfLastExecution emptyDescriptorOfLastExecution_ = DescriptorOfLastExecution{0, Bitmap()};
+  const DescriptorOfLastExecution emptyDescriptorOfLastExecution_ = DescriptorOfLastExecution{0, Bitmap(), 0};
   DescriptorOfLastExecution descriptorOfLastExecution_ = emptyDescriptorOfLastExecution_;
 
   // Parameters to be saved persistently

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -220,6 +220,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   bool recoveringFromExecutionOfRequests = false;
   Bitmap mapOfRecoveredRequests;
+  ConsensusTickRep recoveredTime = 0;
 
   shared_ptr<concord::performance::PerformanceManager> pm_;
 

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -291,6 +291,7 @@ ReplicaLoader::ErrorCode loadReplicaData(shared_ptr<PersistentStorage> p, Loaded
 
       ld.isExecuting = true;
       ld.validRequestsThatAreBeingExecuted = d.validRequests;
+      ld.timeInTicks = d.timeInTicks;
     }
   }
   const auto &desc = p->getDescriptorOfLastStableCheckpoint();

--- a/bftengine/src/bftengine/ReplicaLoader.hpp
+++ b/bftengine/src/bftengine/ReplicaLoader.hpp
@@ -53,6 +53,7 @@ struct LoadedReplicaData {
 
   bool isExecuting = false;
   Bitmap validRequestsThatAreBeingExecuted;
+  ConsensusTickRep timeInTicks = 0;
 };
 
 class ReplicaLoader {

--- a/bftengine/src/bftengine/TimeServiceManager.hpp
+++ b/bftengine/src/bftengine/TimeServiceManager.hpp
@@ -48,6 +48,17 @@ class TimeServiceManager {
     LOG_INFO(TS_MNGR, "Loaded time data from reserved pages");
   }
 
+  // Used on recovery to restore the time prior the request that is about to be re-executed.
+  // In order to suport a correct behaviour of the compareAndUpdate method.
+  void recoverTime(const ConsensusTickRep& recovered_time) {
+    auto last_timestamp = client_.getLastTimestamp().count();
+    ConcordAssertLE(recovered_time, last_timestamp);
+    client_.setTimestampFromTicks(recovered_time);
+    LOG_INFO(
+        TS_MNGR,
+        "Recovering time: time before recovery [" << last_timestamp << "], after recovery [" << recovered_time << "]");
+  }
+
   // Checks if the new time is less or equal to the one reserved pages,
   // if this is the case, returns reserved pages time + epsilon
   // otherwise, returns the new time

--- a/bftengine/src/bftengine/TimeServiceResPageClient.cpp
+++ b/bftengine/src/bftengine/TimeServiceResPageClient.cpp
@@ -26,14 +26,20 @@ TimeServiceResPageClient::TimeServiceResPageClient() {
 
 void TimeServiceResPageClient::setLastTimestamp(ConsensusTime timestamp) {
   auto raw_value = timestamp.count();
-  saveReservedPage(RESERVED_PAGE_ID, sizeof(ConsensusTime::rep), reinterpret_cast<char*>(&raw_value));
+  saveReservedPage(RESERVED_PAGE_ID, sizeof(ConsensusTickRep), reinterpret_cast<char*>(&raw_value));
   last_timestamp_ = timestamp;
   LOG_DEBUG(TS_MNGR, "Saved ts: " << last_timestamp_.count());
 }
 
+void TimeServiceResPageClient::setTimestampFromTicks(ConsensusTickRep ticks) {
+  saveReservedPage(RESERVED_PAGE_ID, sizeof(ConsensusTickRep), reinterpret_cast<char*>(&ticks));
+  last_timestamp_ = ConsensusTime(ticks);
+  LOG_DEBUG(TS_MNGR, "Saved ts from ticks: " << ticks);
+}
+
 void TimeServiceResPageClient::load() {
-  auto raw_value = ConsensusTime::rep{0};
-  if (loadReservedPage(RESERVED_PAGE_ID, sizeof(ConsensusTime::rep), reinterpret_cast<char*>(&raw_value))) {
+  auto raw_value = ConsensusTickRep{0};
+  if (loadReservedPage(RESERVED_PAGE_ID, sizeof(ConsensusTickRep), reinterpret_cast<char*>(&raw_value))) {
     last_timestamp_ = ConsensusTime{raw_value};
     LOG_DEBUG(TS_MNGR, "Loaded ts: " << last_timestamp_.count());
   } else {

--- a/bftengine/src/bftengine/TimeServiceResPageClient.hpp
+++ b/bftengine/src/bftengine/TimeServiceResPageClient.hpp
@@ -25,6 +25,8 @@ class TimeServiceResPageClient : private ResPagesClient<TimeServiceResPageClient
 
   // saves the timestamp in reserved pages
   void setLastTimestamp(ConsensusTime timestamp);
+  // saves the timestamp in reserved pages from ticks
+  void setTimestampFromTicks(ConsensusTickRep ticks);
 
   // loads the timestamp from reserved pages, to be called on ST completed
   void load();

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -250,7 +250,8 @@ void testSetDescriptors(bool toSet) {
   bftEngine::ReservedPagesClientBase::setReservedPages(&res_pages_mock_);
   SeqNum lastExecutionSeqNum = 33;
   Bitmap requests(100);
-  DescriptorOfLastExecution lastExecutionDesc(lastExecutionSeqNum, requests);
+  ConsensusTickRep timeInTicks = 1638860598;
+  DescriptorOfLastExecution lastExecutionDesc(lastExecutionSeqNum, requests, timeInTicks);
   ViewNum viewNum = 0;
   SeqNum lastExitExecNum = 65;
   PrevViewInfoElements elements;


### PR DESCRIPTION
Cherry pick of 92784efbad2fc0d75a82c2853f6ccfcfd9900779

If we have a crash during execution, we recover by reverting any byproduct of the faulty execution and re-executing
the request.
The data needed for the recovery is saved in a struct DescriptorOfLastExecution that is being filled and persists prior to the execution of the request.
Time service V2 has a mechanism that adds an epsilon to the timestamp in case it's identical to the stored timestamp.
This mechanism's current behavior is faulty during the recovery process since it adds an epsilon to the time of the recovered request, if that request already visited its compareAndUpdate method prior to the crash.

The addition of the epsilon creates deviation of the state of the crashed replica from the other replicas as its time for the recovered request is different.

This PR solves it by recovering the time that was prior to the execution of the crashed request.
By persisting the time in the DescriptorOfLastExecution and setting the time in case we recover from a crash.