### PR TITLE
Remove assert condition that checks tx signing key based on secret url

### DIFF
--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -36,8 +36,6 @@ Client::Client(std::unique_ptr<bft::communication::ICommunication> comm, const C
                                config_.retry_timeout_config.max_decreasing_factor),
       metrics_(config.id),
       histograms_(std::unique_ptr<Recorders>(new Recorders(config.id))) {
-  // secrets_manager_config can be set only if transaction_signing_private_key_file_path is set
-  if (config.secrets_manager_config) ConcordAssert(config.transaction_signing_private_key_file_path != std::nullopt);
   if (config.transaction_signing_private_key_file_path) {
     // transaction signing is enabled
     auto file_path = config.transaction_signing_private_key_file_path.value();

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -82,6 +82,7 @@ class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigu
               concord::messages::ReconfigurationResponse &) override;
 
   bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const override {
+    if (!bftEngine::impl::SigManager::instance()->isClientTransactionSigningEnabled()) return true;
     if (!bftEngine::impl::SigManager::instance()->hasVerifier(sender_id)) return false;
     return bftEngine::impl::SigManager::instance()->verifySig(
         sender_id, data.data(), data.size(), signature.data(), signature.size());


### PR DESCRIPTION
Secret manager config does not depend of transaction signing feature. In this PR, we remove the assert that manadates the presence of transaction_signing_key when secret_config is enabled