### PR TITLE
Fix handling of encrypted private keys

### DIFF
--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -26,14 +26,14 @@ void parseConfigFile(concord::client::concordclient::ConcordClientConfig&, const
 void configureSubscription(concord::client::concordclient::ConcordClientConfig&,
                            const std::string& tr_id,
                            bool insecure,
-                           const std::string& tls_path,
-                           const std::optional<std::string>& secrets_url);
+                           const std::string& tls_path);
 
 void configureTransport(concord::client::concordclient::ConcordClientConfig& config,
                         bool is_insecure,
                         const std::string& tls_path);
 
-const std::string decryptPrivateKey(const std::optional<std::string>& secrets_url, const std::string& path);
+const std::string decryptPrivateKey(const std::optional<secretsmanager::SecretData>& secret_data,
+                                    const std::string& path);
 
 // This method reads certificates from file
 void readCert(const std::string& input_filename, std::string& out_data);

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -145,8 +145,7 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
 void configureSubscription(concord::client::concordclient::ConcordClientConfig& config,
                            const std::string& tr_id,
                            bool is_insecure,
-                           const std::string& tls_path,
-                           const std::optional<std::string>& secrets_url) {
+                           const std::string& tls_path) {
   config.subscribe_config.id = tr_id;
   config.subscribe_config.use_tls = not is_insecure;
 
@@ -156,7 +155,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
 
     readCert(client_cert_path, config.subscribe_config.pem_cert_chain);
 
-    config.subscribe_config.pem_private_key = decryptPrivateKey(secrets_url, tls_path);
+    config.subscribe_config.pem_private_key = decryptPrivateKey(config.transport.secret_data, tls_path);
 
     std::string cert_client_id = getClientIdFromClientCert(client_cert_path);
     // The client cert must have the client ID in the OU field, because the TRS obtains
@@ -196,13 +195,13 @@ void configureTransport(concord::client::concordclient::ConcordClientConfig& con
   }
 }
 
-const std::string decryptPrivateKey(const std::optional<std::string>& secrets_url, const std::string& path) {
+const std::string decryptPrivateKey(const std::optional<secretsmanager::SecretData>& secret_data,
+                                    const std::string& path) {
   std::string pkpath;
   std::unique_ptr<concord::secretsmanager::ISecretsManagerImpl> secrets_manager;
-  if (secrets_url) {
-    auto secret_data = concord::secretsmanager::secretretriever::retrieveSecret(*secrets_url);
+  if (secret_data.has_value()) {
     pkpath = path + "/pk.pem.enc";
-    secrets_manager.reset(new concord::secretsmanager::SecretsManagerEnc(secret_data));
+    secrets_manager.reset(new concord::secretsmanager::SecretsManagerEnc(secret_data.value()));
   } else {
     pkpath = path + "/pk.pem";
     secrets_manager.reset(new concord::secretsmanager::SecretsManagerPlain());

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv) {
     auto yaml = YAML::LoadFile(opts["config"].as<std::string>());
     parseConfigFile(config, yaml);
     std::optional<std::string> secrets_url = std::nullopt;
-    if (opts.count("secrets-url")) {
+    if (opts.count("secrets-url") && config.topology.encrypted_config_enabled) {
       secrets_url = {opts["secrets-url"].as<std::string>()};
     }
     configureSubscription(config,

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -23,6 +23,7 @@
 #include "client/concordclient/concord_client.hpp"
 #include "Logger.hpp"
 #include "Metrics.hpp"
+#include "secret_retriever.hpp"
 #include <jaegertracing/Tracer.h>
 
 using concord::client::clientservice::ClientService;
@@ -129,6 +130,9 @@ int main(int argc, char** argv) {
     std::optional<std::string> secrets_url = std::nullopt;
     if (opts.count("secrets-url") && config.topology.encrypted_config_enabled) {
       secrets_url = {opts["secrets-url"].as<std::string>()};
+      if (secrets_url) {
+        config.transport.secret_data = concord::secretsmanager::secretretriever::retrieveSecret(*secrets_url);
+      }
     }
     configureSubscription(config,
                           opts["tr-id"].as<std::string>(),

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -134,11 +134,8 @@ int main(int argc, char** argv) {
         config.transport.secret_data = concord::secretsmanager::secretretriever::retrieveSecret(*secrets_url);
       }
     }
-    configureSubscription(config,
-                          opts["tr-id"].as<std::string>(),
-                          opts["tr-insecure"].as<bool>(),
-                          opts["tr-tls-path"].as<std::string>(),
-                          secrets_url);
+    configureSubscription(
+        config, opts["tr-id"].as<std::string>(), opts["tr-insecure"].as<bool>(), opts["tr-tls-path"].as<std::string>());
     configureTransport(config, opts["tr-insecure"].as<bool>(), opts["tr-tls-path"].as<std::string>());
   } catch (std::exception& e) {
     LOG_ERROR(logger, "Failed to configure ConcordClient: " << e.what());

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -81,6 +81,7 @@ struct TransportConfig {
   // TLS settings ignored if comm_type is not TlsTcp
   std::string tls_cert_root_path;
   std::string tls_cipher_suite;
+  concord::secretsmanager::SecretData secret_data;
   // Buffer with the servers' PEM encoded certificates for the event port
   std::string event_pem_certs;
 };

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -96,6 +96,7 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
   client_pool_config.tls_certificates_folder_path = config.transport.tls_cert_root_path;
   client_pool_config.tls_cipher_suite_list = config.transport.tls_cipher_suite;
   client_pool_config.enable_mock_comm = config.transport.enable_mock_comm;
+  client_pool_config.secret_data = config.transport.secret_data;
 
   return client_pool_config;
 }


### PR DESCRIPTION
This PR fixes two issues -
1. If encrypted_config_enabled is disabled, but secrets_url was non-empty, concord client still tried to decrypt non-existent encrypted private keys. 
2. secret_data in client pool config was not being configured via the secrets_url value in ConcordClientConfig.
Please see individual commits for more detail.