### PR TITLE
Ask prePrepare from non-primary replica in RFMD

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3523,7 +3523,7 @@ void ReplicaImp::tryToSendReqMissingDataMsg(SeqNum seqNumber, bool slowPathOnly,
 
     reqData.resetFlags();
 
-    if (destIsPrimary && missingPrePrepare) reqData.setPrePrepareIsMissing();
+    if (missingPrePrepare) reqData.setPrePrepareIsMissing();
 
     if (missingPartialProof) reqData.setPartialProofIsMissing();
     if (missingPartialPrepare) reqData.setPartialPrepareIsMissing();

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -535,7 +535,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
                 self.assertGreater(nb_fast_path, fast_paths[r])
 
-    @unittest.skip("Unstable scenario")
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
                       selected_configs=lambda n, f, c: n == 7)


### PR DESCRIPTION
Allow late replica to ask prePrepare in RFMD from non-primary replicas