### PR TITLE
[WIP] Don't save RSI in reserved pages

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -69,6 +69,7 @@ set(corebft_source_files
     src/bftengine/KeyStore.cpp
     src/bftengine/TimeServiceResPageClient.cpp
     src/bftengine/DbCheckpointManager.cpp
+    src/bftengine/ReplicaSpecificInfoManager.cpp
     ../ccron/src/ticks_generator.cpp
     ../ccron/src/periodic_action.cpp
     ../ccron/src/cron_table.cpp

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -156,12 +156,13 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
   uint16_t numOfObjects = 0;
   bool isNewStorage = true;
   if (metadataStorage != nullptr) {
-    persistentStoragePtr.reset(new impl::PersistentStorageImp(
-        replicaConfig.numReplicas,
-        replicaConfig.fVal,
-        replicaConfig.cVal,
-        replicaConfig.numRoReplicas + replicaConfig.numOfClientProxies + replicaConfig.numOfExternalClients,
-        replicaConfig.clientBatchingMaxMsgsNbr));
+    persistentStoragePtr.reset(new impl::PersistentStorageImp(replicaConfig.numReplicas,
+                                                              replicaConfig.fVal,
+                                                              replicaConfig.cVal,
+                                                              replicaConfig.numReplicas + replicaConfig.numRoReplicas +
+                                                                  replicaConfig.numOfClientProxies +
+                                                                  replicaConfig.numOfExternalClients,
+                                                              replicaConfig.clientBatchingMaxMsgsNbr));
     unique_ptr<MetadataStorage> metadataStoragePtr(metadataStorage);
     auto objectDescriptors =
         ((PersistentStorageImp *)persistentStoragePtr.get())->getDefaultMetadataObjectDescriptors(numOfObjects);

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -156,8 +156,12 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
   uint16_t numOfObjects = 0;
   bool isNewStorage = true;
   if (metadataStorage != nullptr) {
-    persistentStoragePtr.reset(
-        new impl::PersistentStorageImp(replicaConfig.numReplicas, replicaConfig.fVal, replicaConfig.cVal));
+    persistentStoragePtr.reset(new impl::PersistentStorageImp(
+        replicaConfig.numReplicas,
+        replicaConfig.fVal,
+        replicaConfig.cVal,
+        replicaConfig.numRoReplicas + replicaConfig.numOfClientProxies + replicaConfig.numOfExternalClients,
+        replicaConfig.clientBatchingMaxMsgsNbr));
     unique_ptr<MetadataStorage> metadataStoragePtr(metadataStorage);
     auto objectDescriptors =
         ((PersistentStorageImp *)persistentStoragePtr.get())->getDefaultMetadataObjectDescriptors(numOfObjects);

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -17,6 +17,7 @@
 #include "ReplicaConfig.hpp"
 #include "bftengine/KeyExchangeManager.hpp"
 #include "Serializable.h"
+#include "PersistentStorageImp.hpp"
 
 #include <chrono>
 using namespace std::chrono;
@@ -25,6 +26,14 @@ namespace bftEngine::impl {
 // Initialize:
 // * map of client id to indices.
 // * Calculate reserved pages per client.
+ClientsManager::ClientsManager(std::shared_ptr<PersistentStorage> ps,
+                               const std::set<NodeIdType>& proxyClients,
+                               const std::set<NodeIdType>& externalClients,
+                               const std::set<NodeIdType>& internalClients,
+                               concordMetrics::Component& metrics)
+    : ClientsManager{proxyClients, externalClients, internalClients, metrics} {
+  ps_ = ps;
+}
 ClientsManager::ClientsManager(const std::set<NodeIdType>& proxyClients,
                                const std::set<NodeIdType>& externalClients,
                                const std::set<NodeIdType>& internalClients,
@@ -152,8 +161,12 @@ void ClientsManager::deleteOldestReply(NodeIdType clientId) {
 // * allocate new ClientReplyMsg
 // * calculate: num of pages, size of last page.
 // * save the reply to the reserved pages.
-std::unique_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToStorage(
-    NodeIdType clientId, ReqId requestSeqNum, uint16_t currentPrimaryId, char* reply, uint32_t replyLength) {
+std::unique_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToStorage(NodeIdType clientId,
+                                                                                     ReqId requestSeqNum,
+                                                                                     uint16_t currentPrimaryId,
+                                                                                     char* reply,
+                                                                                     uint32_t replyLength,
+                                                                                     uint32_t rsiLength) {
   ClientInfo& c = clientsInfo_[clientId];
   if (c.repliesInfo.size() >= maxNumOfReqsPerClient_) deleteOldestReply(clientId);
   if (c.repliesInfo.size() > maxNumOfReqsPerClient_) {
@@ -164,20 +177,22 @@ std::unique_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToSto
 
   c.repliesInfo.insert_or_assign(requestSeqNum, getMonotonicTime());
   LOG_DEBUG(CL_MNGR, KVLOG(clientId, requestSeqNum));
-  auto r = std::make_unique<ClientReplyMsg>(myId_, requestSeqNum, reply, replyLength);
+  auto r = std::make_unique<ClientReplyMsg>(myId_, requestSeqNum, reply, replyLength - rsiLength);
 
-  uint32_t numOfPages = r->size() / sizeOfReservedPage();
+  // At this point, the rsi data is not part of the reply
+  uint32_t commonMsgSize = r->size();
+  uint32_t numOfPages = commonMsgSize / sizeOfReservedPage();
   uint32_t sizeLastPage = sizeOfReservedPage();
   if (numOfPages > reservedPagesPerClient_) {
     LOG_FATAL(CL_MNGR,
-              "Client reply is larger than reservedPagesPerClient_ allows"
-                  << KVLOG(clientId, requestSeqNum, reservedPagesPerClient_ * sizeOfReservedPage(), replyLength));
+              "Client reply is larger than reservedPagesPerClient_ allows" << KVLOG(
+                  clientId, requestSeqNum, reservedPagesPerClient_ * sizeOfReservedPage(), replyLength - rsiLength));
     ConcordAssert(false);
   }
 
-  if (r->size() % sizeOfReservedPage() != 0) {
+  if (commonMsgSize % sizeOfReservedPage() != 0) {
     numOfPages++;
-    sizeLastPage = r->size() % sizeOfReservedPage();
+    sizeLastPage = commonMsgSize % sizeOfReservedPage();
   }
 
   LOG_DEBUG(CL_MNGR, KVLOG(clientId, requestSeqNum, numOfPages, sizeLastPage));
@@ -187,6 +202,17 @@ std::unique_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToSto
     const char* ptrPage = r->body() + i * sizeOfReservedPage();
     const uint32_t sizePage = ((i < numOfPages - 1) ? sizeOfReservedPage() : sizeLastPage);
     saveReservedPage(firstPageId + i, sizePage, ptrPage);
+  }
+
+  // now save the RSI data to the persistent storage
+  if (ps_) {
+    auto commonRepSize = r->replyLength();
+    ps_->setReplicaSpecificInfo(clientId, requestSeqNum, reply + commonRepSize, rsiLength);
+    r->setReplyLength(r->replyLength() + rsiLength);
+    memcpy(r->replyBuf() + commonRepSize, reply + commonRepSize, rsiLength);
+
+    // we cannot set the RSI metadata before saving the reply to the reserved paged, hence save it now.
+    r->setReplicaSpecificInfoLength(rsiLength);
   }
 
   // write currentPrimaryId to message (we don't store the currentPrimaryId in the reserved pages)
@@ -231,6 +257,18 @@ std::unique_ptr<ClientReplyMsg> ClientsManager::allocateReplyFromSavedOne(NodeId
     loadReservedPage(firstPageId + i, sizePage, ptrPage);
   }
 
+  // Load the RSI data from persistent storage
+  if (ps_) {
+    std::string rsiData;
+    size_t rsiSize;
+    ps_->getReplicaSpecificInfo(clientId, requestSeqNum, rsiData.data(), rsiSize);
+    if (rsiSize > 0) {
+      auto commDataLength = r->replyLength();
+      r->setReplyLength(r->replyLength() + rsiSize);
+      memcpy(r->replyBuf() + commDataLength, rsiData.data(), rsiSize);
+      r->setReplicaSpecificInfoLength(rsiSize);
+    }
+  }
   const auto& replySeqNum = r->reqSeqNum();
   if (replySeqNum != requestSeqNum) {
     if (maxNumOfReqsPerClient_ == 1) {

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -242,6 +242,9 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
     // A map that indicates what is current index of each client
     std::unordered_map<uint32_t, uint64_t> clientsIndex_;
     const uint32_t rsiPrefixSize = 3 * sizeof(uint64_t);
+    const uint32_t reqSeqNumSize = sizeof(uint64_t);
+    const uint32_t indexSize = sizeof(uint64_t);
+    const uint32_t dataLengthSize = sizeof(uint64_t);
   };
 
   std::unique_ptr<ClientRsiManager> rsiManager_;

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -18,6 +18,7 @@
 #include "IPendingRequest.hpp"
 #include "bftengine/IKeyExchanger.hpp"
 #include "PersistentStorage.hpp"
+#include "ReplicaSpecificInfoManager.hpp"
 #include <map>
 #include <set>
 #include <unordered_map>
@@ -225,29 +226,7 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   concordMetrics::Component& metrics_;
   concordMetrics::CounterHandle metric_reply_inconsistency_detected_;
   concordMetrics::CounterHandle metric_removed_due_to_out_of_boundaries_;
-
-  class ClientRsiManager {
-   public:
-    ClientRsiManager(uint32_t numOfPrinciples, uint32_t maxClientBatchSize, std::shared_ptr<PersistentStorage> ps);
-    std::string getRsiForClient(uint32_t clientId, uint64_t reqSenNum);
-    void setRsiForClient(uint32_t clientId, uint64_t reqSeqNum, const std::string& rsiData);
-    void init();
-
-   private:
-    uint32_t numOfPrinciples_;
-    uint32_t maxClientBatchSize_;
-    std::shared_ptr<PersistentStorage> ps_;
-    // A map of clientId -> deque<requestSeqNum,rsi>
-    std::unordered_map<uint32_t, std::deque<std::pair<uint64_t, std::string>>> rsiCache_;
-    // A map that indicates what is current index of each client
-    std::unordered_map<uint32_t, uint64_t> clientsIndex_;
-    const uint32_t rsiPrefixSize = 3 * sizeof(uint64_t);
-    const uint32_t reqSeqNumSize = sizeof(uint64_t);
-    const uint32_t indexSize = sizeof(uint64_t);
-    const uint32_t dataLengthSize = sizeof(uint64_t);
-  };
-
-  std::unique_ptr<ClientRsiManager> rsiManager_;
+  std::unique_ptr<RsiDataManager> rsiManager_;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -17,6 +17,7 @@
 #include "Metrics.hpp"
 #include "IPendingRequest.hpp"
 #include "bftengine/IKeyExchanger.hpp"
+#include "PersistentStorage.hpp"
 #include <map>
 #include <set>
 #include <unordered_map>
@@ -48,6 +49,11 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   //   - The concordMetrics::Component object referenced by metrics is destroyed.
   //   - The global logger CL_MNGR is destroyed.
   ClientsManager(const std::set<NodeIdType>& proxyClients,
+                 const std::set<NodeIdType>& externalClients,
+                 const std::set<NodeIdType>& internalClients,
+                 concordMetrics::Component& metrics);
+  ClientsManager(std::shared_ptr<PersistentStorage> ps,
+                 const std::set<NodeIdType>& proxyClients,
                  const std::set<NodeIdType>& externalClients,
                  const std::set<NodeIdType>& internalClients,
                  concordMetrics::Component& metrics);
@@ -85,8 +91,12 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   //   oldest one is deleted.
   // - The size of the allocated reply message exceeds the maximum reply size that was configured at the time of this
   //   ClientsManager's construction.
-  std::unique_ptr<ClientReplyMsg> allocateNewReplyMsgAndWriteToStorage(
-      NodeIdType clientId, ReqId requestSeqNum, uint16_t currentPrimaryId, char* reply, uint32_t replyLength);
+  std::unique_ptr<ClientReplyMsg> allocateNewReplyMsgAndWriteToStorage(NodeIdType clientId,
+                                                                       ReqId requestSeqNum,
+                                                                       uint16_t currentPrimaryId,
+                                                                       char* reply,
+                                                                       uint32_t replyLength,
+                                                                       uint32_t rsiLength);
 
   // Loads a client reply message from the reserved pages, and allocates and returns a ClientReplyMsg containing the
   // loaded message. Returns a null pointer if the configuration recorded at the time of this ClientManager's
@@ -214,6 +224,7 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   concordMetrics::Component& metrics_;
   concordMetrics::CounterHandle metric_reply_inconsistency_detected_;
   concordMetrics::CounterHandle metric_removed_due_to_out_of_boundaries_;
+  std::shared_ptr<PersistentStorage> ps_;
 };
 
 }  // namespace impl

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -273,9 +273,9 @@ void DebugPersistentStorage::setUserDataInTransaction(const void *data, std::siz
   setUserDataAtomically(data, numberOfBytes);
 }
 
-bool DebugPersistentStorage::setReplicaSpecificInfo(uint32_t index, char *data, size_t size) { return true; }
+bool DebugPersistentStorage::setReplicaSpecificInfo(uint32_t index, const std::vector<uint8_t> &data) { return true; }
 
-std::string DebugPersistentStorage::getReplicaSpecificInfo(uint32_t index) { return std::string(); }
+std::vector<uint8_t> DebugPersistentStorage::getReplicaSpecificInfo(uint32_t index) { return {}; }
 
 void DebugPersistentStorage::setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) {
   ConcordAssert(mark == true);

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -273,19 +273,9 @@ void DebugPersistentStorage::setUserDataInTransaction(const void *data, std::siz
   setUserDataAtomically(data, numberOfBytes);
 }
 
-bool DebugPersistentStorage::setReplicaSpecificInfo(uint32_t clientId,
-                                                    uint64_t requestSeqNum,
-                                                    char *rsiData,
-                                                    size_t rsiSize) {
-  return true;
-}
+bool DebugPersistentStorage::setReplicaSpecificInfo(uint32_t index, char *data, size_t size) { return true; }
 
-void DebugPersistentStorage::getReplicaSpecificInfo(uint32_t clientId,
-                                                    uint64_t requestSeqNum,
-                                                    char *rsiData,
-                                                    size_t &rsiSize) {
-  return;
-}
+std::string DebugPersistentStorage::getReplicaSpecificInfo(uint32_t index) { return std::string(); }
 
 void DebugPersistentStorage::setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) {
   ConcordAssert(mark == true);

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -273,6 +273,20 @@ void DebugPersistentStorage::setUserDataInTransaction(const void *data, std::siz
   setUserDataAtomically(data, numberOfBytes);
 }
 
+bool DebugPersistentStorage::setReplicaSpecificInfo(uint32_t clientId,
+                                                    uint64_t requestSeqNum,
+                                                    char *rsiData,
+                                                    size_t rsiSize) {
+  return true;
+}
+
+void DebugPersistentStorage::getReplicaSpecificInfo(uint32_t clientId,
+                                                    uint64_t requestSeqNum,
+                                                    char *rsiData,
+                                                    size_t &rsiSize) {
+  return;
+}
+
 void DebugPersistentStorage::setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) {
   ConcordAssert(mark == true);
   ConcordAssert(checkWindow.insideActiveWindow(seqNum));

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -48,8 +48,8 @@ class DebugPersistentStorage : public PersistentStorage {
   void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) override;
   void setUserDataAtomically(const void* data, std::size_t numberOfBytes) override;
   void setUserDataInTransaction(const void* data, std::size_t numberOfBytes) override;
-  bool setReplicaSpecificInfo(uint32_t index, char* data, size_t size) override;
-  std::string getReplicaSpecificInfo(uint32_t index) override;
+  bool setReplicaSpecificInfo(uint32_t index, const std::vector<uint8_t>& data) override;
+  std::vector<uint8_t> getReplicaSpecificInfo(uint32_t index) override;
   SeqNum getLastExecutedSeqNum() override;
   SeqNum getPrimaryLastUsedSeqNum() override;
   SeqNum getStrictLowerBoundOfSeqNums() override;

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -48,6 +48,8 @@ class DebugPersistentStorage : public PersistentStorage {
   void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) override;
   void setUserDataAtomically(const void* data, std::size_t numberOfBytes) override;
   void setUserDataInTransaction(const void* data, std::size_t numberOfBytes) override;
+  bool setReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char* rsiData, size_t rsiSize) override;
+  void getReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char* rsiData, size_t& rsiSize) override;
   SeqNum getLastExecutedSeqNum() override;
   SeqNum getPrimaryLastUsedSeqNum() override;
   SeqNum getStrictLowerBoundOfSeqNums() override;

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -48,8 +48,8 @@ class DebugPersistentStorage : public PersistentStorage {
   void setCompletedMarkInCheckWindow(SeqNum seqNum, bool mark) override;
   void setUserDataAtomically(const void* data, std::size_t numberOfBytes) override;
   void setUserDataInTransaction(const void* data, std::size_t numberOfBytes) override;
-  bool setReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char* rsiData, size_t rsiSize) override;
-  void getReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char* rsiData, size_t& rsiSize) override;
+  bool setReplicaSpecificInfo(uint32_t index, char* data, size_t size) override;
+  std::string getReplicaSpecificInfo(uint32_t index) override;
   SeqNum getLastExecutedSeqNum() override;
   SeqNum getPrimaryLastUsedSeqNum() override;
   SeqNum getStrictLowerBoundOfSeqNums() override;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -123,10 +123,12 @@ class PersistentStorage {
   virtual void setNewEpochFlag(bool flag) = 0;
   virtual bool getNewEpochFlag() = 0;
 
+  virtual bool setReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char *rsiData, size_t rsiSize) = 0;
+
   //////////////////////////////////////////////////////////////////////////
   // Read methods (should only be used before using write-only transactions)
   //////////////////////////////////////////////////////////////////////////
-
+  virtual void getReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char *rsiData, size_t &rsiSize) = 0;
   virtual SeqNum getLastExecutedSeqNum() = 0;
   virtual SeqNum getPrimaryLastUsedSeqNum() = 0;
   virtual SeqNum getStrictLowerBoundOfSeqNums() = 0;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -123,12 +123,12 @@ class PersistentStorage {
   virtual void setNewEpochFlag(bool flag) = 0;
   virtual bool getNewEpochFlag() = 0;
 
-  virtual bool setReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char *rsiData, size_t rsiSize) = 0;
+  virtual bool setReplicaSpecificInfo(uint32_t index, char *data, size_t size) = 0;
 
   //////////////////////////////////////////////////////////////////////////
   // Read methods (should only be used before using write-only transactions)
   //////////////////////////////////////////////////////////////////////////
-  virtual void getReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char *rsiData, size_t &rsiSize) = 0;
+  virtual std::string getReplicaSpecificInfo(uint32_t index) = 0;
   virtual SeqNum getLastExecutedSeqNum() = 0;
   virtual SeqNum getPrimaryLastUsedSeqNum() = 0;
   virtual SeqNum getStrictLowerBoundOfSeqNums() = 0;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -123,12 +123,12 @@ class PersistentStorage {
   virtual void setNewEpochFlag(bool flag) = 0;
   virtual bool getNewEpochFlag() = 0;
 
-  virtual bool setReplicaSpecificInfo(uint32_t index, char *data, size_t size) = 0;
+  virtual bool setReplicaSpecificInfo(uint32_t index, const std::vector<uint8_t> &data) = 0;
 
   //////////////////////////////////////////////////////////////////////////
   // Read methods (should only be used before using write-only transactions)
   //////////////////////////////////////////////////////////////////////////
-  virtual std::string getReplicaSpecificInfo(uint32_t index) = 0;
+  virtual std::vector<uint8_t> getReplicaSpecificInfo(uint32_t index) = 0;
   virtual SeqNum getLastExecutedSeqNum() = 0;
   virtual SeqNum getPrimaryLastUsedSeqNum() = 0;
   virtual SeqNum getStrictLowerBoundOfSeqNums() = 0;

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -131,7 +131,6 @@ ObjectDescUniquePtr PersistentStorageImp::getDefaultMetadataObjectDescriptors(ui
   for (auto i = 0; i < numReplicas_ + numClients_; i++) {
     uint32_t baseDescNum = clientsDataDescNum + viewChangeMsgsNum + numClientBatch_ * i;
     for (auto j = 0; j < numClientBatch_; j++) {
-      LOG_INFO(GL, "***|" << baseDescNum + j);
       metadataObjectsArray.get()[baseDescNum + j].maxSize =
           (sizeof(size_t) + 2 * sizeof(uint64_t) + replicaSpecificInfoMaxSize);
     }

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -35,7 +35,7 @@ PersistentStorageImp::PersistentStorageImp(
     : numReplicas_(numReplicas),
       fVal_(fVal),
       cVal_(cVal),
-      numPrinciples_(numOfPrinciples),
+      numPrinciples_(numOfPrinciples + numReplicas),  // numReplicas is for the internal clients
       maxClientBatchSize_(maxClientBatchSize),
       version_(METADATA_PARAMS_VERSION) {
   DescriptorOfLastNewView::setViewChangeMsgsNum(fVal, cVal);

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -146,7 +146,7 @@ class PersistentStorageImp : public PersistentStorage {
 
   void setUserDataAtomically(const void *data, std::size_t numberOfBytes) override;
   void setUserDataInTransaction(const void *data, std::size_t numberOfBytes) override;
-  bool setReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char *rsiData, size_t rsiSize) override;
+  bool setReplicaSpecificInfo(uint32_t index, char *data, size_t size) override;
   void setEraseMetadataStorageFlag() override;
   bool getEraseMetadataStorageFlag() override;
   void eraseMetadata() override;
@@ -155,8 +155,7 @@ class PersistentStorageImp : public PersistentStorage {
   bool getNewEpochFlag() override;
 
   // Getters
-  void loadStoredReplicasSpecificInfo();
-  void getReplicaSpecificInfo(uint32_t clientId, uint64_t requestSeqNum, char *rsiData, size_t &rsiSize) override;
+  std::string getReplicaSpecificInfo(uint32_t index) override;
   std::string getStoredVersion();
   std::string getCurrentVersion() const { return version_; }
   SeqNum getLastExecutedSeqNum() override;

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -99,8 +99,12 @@ enum DescMetadataParameterIds {
   LAST_NEW_VIEW_DESC
 };
 
-const uint32_t clientsDataDescNum = LAST_NEW_VIEW_DESC + 1;
-const uint32_t replicaSpecificInfoMaxSize = 64 * 1024;  // 64KB
+enum ReplicaSpecificInfoParameterIds {
+  REPLICA_SPECIFIC_INFO_BASE = LAST_NEW_VIEW_DESC + 1,
+  REPLICA_SPECIFIC_INFO_DESC
+};
+
+const uint32_t replicaSpecificInfoMaxSize = 1024 * 1024;  // 1MB
 
 typedef unique_ptr<MetadataStorage::ObjectDesc[]> ObjectDescUniquePtr;
 
@@ -110,7 +114,7 @@ class PersistentStorageImp : public PersistentStorage {
 
  public:
   PersistentStorageImp(
-      uint16_t numReplicas, uint16_t fVal, uint16_t cVal, uint64_t numClients, uint64_t numOfClientBatch);
+      uint16_t numReplicas, uint16_t fVal, uint16_t cVal, uint64_t numOfPrinciples, uint64_t maxClientBatchSize);
   ~PersistentStorageImp() override = default;
 
   uint8_t beginWriteTran() override;
@@ -256,9 +260,11 @@ class PersistentStorageImp : public PersistentStorage {
   const uint16_t fVal_;
   const uint16_t cVal_;
 
-  const uint16_t numClients_;
-  const uint16_t numClientBatch_;
+  const uint16_t numPrinciples_;
+  const uint16_t maxClientBatchSize_;
+  // The rsi cache is a map of <principle_id, <request_sequence_number, data>>
   std::unordered_map<uint32_t, std::unordered_map<uint64_t, std::string>> rsiCache_;
+  // The rsiLatestIndex is a map of <principle_id, latest_index>
   std::unordered_map<uint32_t, uint64_t> rsiLatestIndex;
 
   uint8_t numOfNestedTransactions_ = 0;

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -146,7 +146,7 @@ class PersistentStorageImp : public PersistentStorage {
 
   void setUserDataAtomically(const void *data, std::size_t numberOfBytes) override;
   void setUserDataInTransaction(const void *data, std::size_t numberOfBytes) override;
-  bool setReplicaSpecificInfo(uint32_t index, char *data, size_t size) override;
+  bool setReplicaSpecificInfo(uint32_t index, const std::vector<uint8_t> &data) override;
   void setEraseMetadataStorageFlag() override;
   bool getEraseMetadataStorageFlag() override;
   void eraseMetadata() override;
@@ -155,7 +155,7 @@ class PersistentStorageImp : public PersistentStorage {
   bool getNewEpochFlag() override;
 
   // Getters
-  std::string getReplicaSpecificInfo(uint32_t index) override;
+  std::vector<uint8_t> getReplicaSpecificInfo(uint32_t index) override;
   std::string getStoredVersion();
   std::string getCurrentVersion() const { return version_; }
   SeqNum getLastExecutedSeqNum() override;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -5475,9 +5475,12 @@ void ReplicaImp::sendResponses(PrePrepareMsg *ppMsg, IRequestsHandler::Execution
     } else {
       if (req.flags & HAS_PRE_PROCESSED_FLAG) metric_total_preexec_requests_executed_++;
       if (req.outActualReplySize != 0) {
-        auto replyMsg = clientsManager->allocateNewReplyMsgAndWriteToStorage(
-            req.clientId, req.requestSequenceNum, currentPrimary(), req.outReply, req.outActualReplySize);
-        replyMsg->setReplicaSpecificInfoLength(req.outReplicaSpecificInfoSize);
+        auto replyMsg = clientsManager->allocateNewReplyMsgAndWriteToStorage(req.clientId,
+                                                                             req.requestSequenceNum,
+                                                                             currentPrimary(),
+                                                                             req.outReply,
+                                                                             req.outActualReplySize,
+                                                                             req.outReplicaSpecificInfoSize);
         send(replyMsg.get(), req.clientId);
       }
     }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3872,7 +3872,8 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
                  msgHandlers,
                  timers,
                  pm,
-                 sm) {
+                 sm,
+                 persistentStorage) {
   LOG_INFO(GL, "Initialising Replica with LoadedReplicaData");
   ConcordAssertNE(persistentStorage, nullptr);
 
@@ -4119,7 +4120,8 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
                  msgHandlers,
                  timers,
                  pm,
-                 sm) {
+                 sm,
+                 persistentStorage) {
   LOG_INFO(GL, "Initialising Replica with ReplicaConfig");
   if (persistentStorage != nullptr) {
     ps_ = persistentStorage;
@@ -4141,7 +4143,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
                        shared_ptr<MsgHandlersRegistrator> msgHandlers,
                        concordUtil::Timers &timers,
                        shared_ptr<concord::performance::PerformanceManager> pm,
-                       shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm)
+                       shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm,
+                       shared_ptr<PersistentStorage> ps)
     : ReplicaForStateTransfer(config, requestsHandler, stateTrans, msgsCommunicator, msgHandlers, firstTime, timers),
       viewChangeProtocolEnabled{config.viewChangeProtocolEnabled},
       autoPrimaryRotationEnabled{config.autoPrimaryRotationEnabled},
@@ -4293,7 +4296,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   for (int i = 0; i < config_.getnumOfClientProxies(); ++i) proxyClients.insert(clientId++);
   for (int i = 0; i < config_.getnumOfExternalClients(); ++i) externalClients.insert(clientId++);
   for (int i = 0; i < config_.getnumReplicas(); ++i) internalClients.insert(clientId++);
-  clientsManager = std::make_shared<ClientsManager>(proxyClients, externalClients, internalClients, metrics_);
+  clientsManager = std::make_shared<ClientsManager>(ps, proxyClients, externalClients, internalClients, metrics_);
   internalBFTClient_.reset(
       new InternalBFTClient(*internalClients.cbegin() + config_.getreplicaId(), msgsCommunicator_));
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -409,7 +409,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
              shared_ptr<MsgHandlersRegistrator>,
              concordUtil::Timers& timers,
              shared_ptr<concord::performance::PerformanceManager> pm,
-             shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm);
+             shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm,
+             shared_ptr<PersistentStorage> ps);
 
   void registerMsgHandlers();
 

--- a/bftengine/src/bftengine/ReplicaSpecificInfoManager.cpp
+++ b/bftengine/src/bftengine/ReplicaSpecificInfoManager.cpp
@@ -1,0 +1,79 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+#include "ReplicaSpecificInfoManager.hpp"
+#include "Serializable.h"
+#include <cstring>
+
+namespace bftEngine {
+namespace impl {
+std::vector<uint8_t> RsiItem::serialize() {
+  // The structure of the RSI in the persistent storage is: [(uint64_t) index | (uint64_t) requestSeqNum | (uint64_t)
+  // dataSize | char* data]
+  std::vector<uint8_t> serialized_data;
+  serialized_data.resize(data_.size() + RSI_DATA_PREFIX_SIZE);
+  memcpy(serialized_data.data(), &index_, RSI_INDEX_SIZE);
+  memcpy(serialized_data.data() + RSI_INDEX_SIZE, &req_seq_num_, RSI_SN_SIZE);
+  auto data_size = data_.size();
+  memcpy(serialized_data.data() + RSI_INDEX_SIZE + RSI_SN_SIZE, &data_size, RSI_DATA_SIZE);
+  memcpy(serialized_data.data() + RSI_DATA_PREFIX_SIZE, data_.data(), data_size);
+  return serialized_data;
+}
+RsiItem RsiItem::deserialize(const std::vector<uint8_t>& data) {
+  RsiItem item;
+  std::memcpy(&item.index_, data.data(), RSI_INDEX_SIZE);
+  std::memcpy(&item.req_seq_num_, data.data() + RSI_INDEX_SIZE, RSI_SN_SIZE);
+  size_t data_size = 0;
+  std::memcpy(&data_size, data.data() + RSI_INDEX_SIZE + RSI_SN_SIZE, RSI_DATA_SIZE);
+  std::memcpy(item.data_.data(), data.data() + RSI_DATA_PREFIX_SIZE, data_size);
+  return item;
+}
+
+RsiItem RsiDataManager::getRsiForClient(uint32_t client_id, uint64_t req_sn) {
+  for (const auto& rsi_item : rsiCache_[client_id]) {
+    if (rsi_item.sequence_number() == req_sn) return rsi_item;
+  }
+  return RsiItem();
+}
+void RsiDataManager::setRsiForClient(uint32_t client_id, uint64_t req_sn, const std::string& data) {
+  // First, compute the correct index for this data
+  uint32_t nextClientIndex = clientsIndex_[client_id];
+  clientsIndex_[client_id]++;
+  uint32_t storageIndex = client_id * max_client_batch_size_ + (nextClientIndex % max_client_batch_size_);
+  RsiItem rsi_item(nextClientIndex, req_sn, data);
+  ps_->beginWriteTran();
+  ps_->setReplicaSpecificInfo(storageIndex, rsi_item.serialize());
+  ps_->endWriteTran();
+  if (rsiCache_[client_id].size() >= max_client_batch_size_) {
+    rsiCache_[client_id].pop_front();
+  }
+  // Add the new record to the cache
+  rsiCache_[client_id].emplace_back(rsi_item);
+}
+void RsiDataManager::init() {
+  for (uint32_t clientId = 0; clientId < num_of_principles_; clientId++) {
+    clientsIndex_[clientId] = 0;
+    std::vector<RsiItem> clientRsiData;
+    for (uint32_t offset = 0; offset < max_client_batch_size_; offset++) {
+      std::vector<uint8_t> data = ps_->getReplicaSpecificInfo(clientId * max_client_batch_size_ + offset);
+      if (data.empty()) continue;
+      clientRsiData.emplace_back(RsiItem::deserialize(data));
+    }
+    std::sort(clientRsiData.begin(), clientRsiData.end(), [](auto& data1, auto& data2) {
+      return data1.index() < data2.index();
+    });
+    for (const auto& rsiItem : clientRsiData) {
+      rsiCache_[clientId].emplace_back(rsiItem);
+    }
+    if (!clientRsiData.empty()) clientsIndex_[clientId] = clientRsiData.back().index();
+  }
+}
+}  // namespace impl
+}  // namespace bftEngine

--- a/bftengine/src/bftengine/ReplicaSpecificInfoManager.hpp
+++ b/bftengine/src/bftengine/ReplicaSpecificInfoManager.hpp
@@ -1,0 +1,62 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include "PersistentStorage.hpp"
+#include <string>
+#include <vector>
+#include <memory>
+namespace bftEngine {
+namespace impl {
+class RsiItem {
+ public:
+  static const uint32_t RSI_INDEX_SIZE = sizeof(uint64_t);
+  static const uint32_t RSI_SN_SIZE = sizeof(uint64_t);
+  static const size_t RSI_DATA_SIZE = sizeof(size_t);
+  static const uint32_t RSI_DATA_PREFIX_SIZE = RSI_INDEX_SIZE + RSI_SN_SIZE + RSI_DATA_SIZE;
+  RsiItem() = default;
+  RsiItem(uint64_t index, uint64_t req_seq_num, const std::string& data)
+      : data_{data}, index_{index}, req_seq_num_{req_seq_num} {};
+  std::vector<uint8_t> serialize();
+  const std::string& data() const { return data_; }
+  uint64_t sequence_number() const { return req_seq_num_; }
+  uint64_t index() const { return index_; }
+
+  static RsiItem deserialize(const std::vector<uint8_t>& data);
+
+ private:
+  std::string data_;
+  uint64_t index_;
+  uint64_t req_seq_num_;
+};
+
+class RsiDataManager {
+ public:
+  RsiDataManager(uint32_t num_of_principles, uint32_t max_client_batch_size, std::shared_ptr<PersistentStorage> ps)
+      : num_of_principles_{num_of_principles}, max_client_batch_size_{max_client_batch_size}, ps_{ps} {
+    init();
+  }
+  RsiItem getRsiForClient(uint32_t client_id, uint64_t req_sn);
+  void setRsiForClient(uint32_t client_id, uint64_t req_sn, const std::string& data);
+
+ private:
+  void init();
+
+  uint32_t num_of_principles_;
+  uint32_t max_client_batch_size_;
+  std::shared_ptr<PersistentStorage> ps_;
+  // A map of clientId -> deque<requestSeqNum,rsi>
+  std::unordered_map<uint32_t, std::deque<RsiItem>> rsiCache_;
+  // A map that indicates what is current index of each client
+  std::unordered_map<uint32_t, uint64_t> clientsIndex_;
+};
+}  // namespace impl
+}  // namespace bftEngine

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -442,14 +442,14 @@ int main() {
   descriptorOfLastNewView = new DescriptorOfLastNewView();
   descriptorOfLastExecution = new DescriptorOfLastExecution();
 
-  persistentStorageImp = new PersistentStorageImp(numReplicas, fVal, cVal, clientsNum, batchSize);
+  persistentStorageImp = new PersistentStorageImp(numReplicas, fVal, cVal, numReplicas + clientsNum, batchSize);
   logging::Logger logger = logging::getLogger("testSerialization.replica");
   // uncomment if needed
   // log4cplus::Logger::getInstance( LOG4CPLUS_TEXT("serializable")).setLogLevel(log4cplus::TRACE_LOG_LEVEL);
   const string dbFile = "testPersistency.txt";
   remove(dbFile.c_str());  // Required for the init testing.
 
-  PersistentStorageImp persistentStorage(numReplicas, fVal, cVal, clientsNum, batchSize);
+  PersistentStorageImp persistentStorage(numReplicas, fVal, cVal, numReplicas + clientsNum, batchSize);
   metadataStorage.reset(new FileStorage(logger, dbFile));
   uint16_t numOfObjects = 0;
   ObjectDescUniquePtr objectDescArray = persistentStorage.getDefaultMetadataObjectDescriptors(numOfObjects);

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -44,6 +44,8 @@ void printRawBuf(const UniquePtrToChar &buf, int64_t bufSize) {
 
 uint16_t fVal = 2;
 uint16_t cVal = 1;
+uint16_t clientsNum = 2;
+uint16_t batchSize = 2;
 uint16_t numReplicas = 3 * fVal + 2 * cVal + 1;
 
 const uint16_t msgsNum = 2 * fVal + 2 * cVal + 1;
@@ -336,6 +338,55 @@ void testSetSimpleParams(bool toSet) {
   ConcordAssert(persistentStorageImp->getLastViewThatTransferredSeqNumbersFullyExecuted() == view);
 }
 
+void testSetAndGetRsiParams(bool init) {
+  std::string rsi1 = "hello1";
+  std::string rsi2 = "hello2";
+  std::string rsi3 = "hello3";
+  std::string rsi4 = "hello4";
+  std::string rsi5 = "hello5";
+  uint32_t firstClientId = numReplicas;
+  uint32_t secondClientId = numReplicas + 1;
+  if (init) {
+    persistentStorageImp->setReplicaSpecificInfo(firstClientId, 1, rsi1.data(), rsi1.size());
+    persistentStorageImp->setReplicaSpecificInfo(firstClientId, 2, rsi2.data(), rsi2.size());
+    persistentStorageImp->setReplicaSpecificInfo(secondClientId, 3, rsi3.data(), rsi3.size());
+    persistentStorageImp->setReplicaSpecificInfo(secondClientId, 4, rsi4.data(), rsi4.size());
+  }
+  char *data = new char[64 * 1024];
+  size_t outSize = 0;
+  if (init) {
+    persistentStorageImp->getReplicaSpecificInfo(firstClientId, 1, data, outSize);
+    ConcordAssert(std::string(data, outSize) == rsi1);
+  } else {
+    persistentStorageImp->getReplicaSpecificInfo(firstClientId, 5, data, outSize);
+    ConcordAssert(std::string(data, outSize) == rsi5);
+    // Here, the result is that the last batch data is being deleted.
+  }
+  if (init) {
+    persistentStorageImp->getReplicaSpecificInfo(firstClientId, 2, data, outSize);
+    ConcordAssert(std::string(data, outSize) == rsi2);
+  } else {
+    persistentStorageImp->getReplicaSpecificInfo(firstClientId, 1, data, outSize);
+    ConcordAssert(outSize == 0);
+    persistentStorageImp->getReplicaSpecificInfo(firstClientId, 5, data, outSize);
+    ConcordAssert(std::string(data, outSize) == rsi5);
+  }
+
+  persistentStorageImp->getReplicaSpecificInfo(secondClientId, 3, data, outSize);
+  ConcordAssert(std::string(data, outSize) == rsi3);
+  persistentStorageImp->getReplicaSpecificInfo(secondClientId, 4, data, outSize);
+  ConcordAssert(std::string(data, outSize) == rsi4);
+
+  if (init) {
+    // Now, set another rsi for client 1 and make sure rsi one is being rotated with the new one
+    persistentStorageImp->setReplicaSpecificInfo(firstClientId, 5, rsi5.data(), rsi5.size());
+    persistentStorageImp->getReplicaSpecificInfo(firstClientId, 5, data, outSize);
+    ConcordAssert(std::string(data, outSize) == rsi5);
+    persistentStorageImp->getReplicaSpecificInfo(firstClientId, 1, data, outSize);
+    ConcordAssert(outSize == 0);
+  }
+}
+
 void testCheckDescriptorOfLastStableCheckpoint(bool init) {
   bftEngine::ReservedPagesClientBase::setReservedPages(&res_pages_mock_);
   const SeqNum checkpointSeqNum0 = 0;
@@ -391,14 +442,14 @@ int main() {
   descriptorOfLastNewView = new DescriptorOfLastNewView();
   descriptorOfLastExecution = new DescriptorOfLastExecution();
 
-  persistentStorageImp = new PersistentStorageImp(numReplicas, fVal, cVal);
+  persistentStorageImp = new PersistentStorageImp(numReplicas, fVal, cVal, clientsNum, batchSize);
   logging::Logger logger = logging::getLogger("testSerialization.replica");
   // uncomment if needed
   // log4cplus::Logger::getInstance( LOG4CPLUS_TEXT("serializable")).setLogLevel(log4cplus::TRACE_LOG_LEVEL);
   const string dbFile = "testPersistency.txt";
   remove(dbFile.c_str());  // Required for the init testing.
 
-  PersistentStorageImp persistentStorage(numReplicas, fVal, cVal);
+  PersistentStorageImp persistentStorage(numReplicas, fVal, cVal, clientsNum, batchSize);
   metadataStorage.reset(new FileStorage(logger, dbFile));
   uint16_t numOfObjects = 0;
   ObjectDescUniquePtr objectDescArray = persistentStorage.getDefaultMetadataObjectDescriptors(numOfObjects);
@@ -421,6 +472,7 @@ int main() {
     testWindows(init);
     testCheckDescriptorOfLastStableCheckpoint(init);
     if (!init) testWindowsAdvance();
+    testSetAndGetRsiParams(init);
     init = false;
   }
 

--- a/kvbc/test/replica_state_sync_test.cpp
+++ b/kvbc/test/replica_state_sync_test.cpp
@@ -62,7 +62,7 @@ class replica_state_sync_test : public Test, public IReader {
         link_st_chain,
         std::map<std::string, CATEGORY_TYPE>{{kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}});
 
-    metadata_ = std::make_shared<PersistentStorageImp>(kNumOfReplicas, kFVal, kCVal);
+    metadata_ = std::make_shared<PersistentStorageImp>(kNumOfReplicas, kFVal, kCVal, 0, 0);
     auto num_of_objects = std::uint16_t{0};
     auto obj_descriptors = metadata_->getDefaultMetadataObjectDescriptors(num_of_objects);
     auto db_metadata_storage =

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -903,7 +903,8 @@ struct ResetMetadata {
     std::unique_ptr<MetadataStorage> mdtStorage(
         new DBMetadataStorage(adapter.db()->asIDBClient().get(), std::make_unique<MetadataKeyManipulator>()));
     // in this case n, f and c have no use
-    shared_ptr<bftEngine::impl::PersistentStorage> p(new bftEngine::impl::PersistentStorageImp(4, 1, 0));
+    shared_ptr<bftEngine::impl::PersistentStorage> p(
+        new bftEngine::impl::PersistentStorageImp(4, 1, 0, 0, 0));  // TODO: add here rsi reset
     uint16_t numOfObjects = 0;
     auto objectDescriptors = ((PersistentStorageImp *)p.get())->getDefaultMetadataObjectDescriptors(numOfObjects);
     bool isNewStorage = mdtStorage->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);


### PR DESCRIPTION
Apparently, we save in the reserved pages the replica's RSI data. 
As this data may be different across the replicas, it means that we may have inconsistency in the hash of the reserved page, resulting in state split.
This PR fixes this issue