### PR TITLE
Decrypt private key only if secret_data has value

### DIFF
--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -155,7 +155,9 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
 
     readCert(client_cert_path, config.subscribe_config.pem_cert_chain);
 
-    config.subscribe_config.pem_private_key = decryptPrivateKey(config.transport.secret_data, tls_path);
+    if (config.transport.secret_data.has_value()) {
+      config.subscribe_config.pem_private_key = decryptPrivateKey(config.transport.secret_data, tls_path);
+    }
 
     std::string cert_client_id = getClientIdFromClientCert(client_cert_path);
     // The client cert must have the client ID in the OU field, because the TRS obtains

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -81,7 +81,7 @@ struct TransportConfig {
   // TLS settings ignored if comm_type is not TlsTcp
   std::string tls_cert_root_path;
   std::string tls_cipher_suite;
-  concord::secretsmanager::SecretData secret_data;
+  std::optional<concord::secretsmanager::SecretData> secret_data;
   // Buffer with the servers' PEM encoded certificates for the event port
   std::string event_pem_certs;
 };

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -96,7 +96,9 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
   client_pool_config.tls_certificates_folder_path = config.transport.tls_cert_root_path;
   client_pool_config.tls_cipher_suite_list = config.transport.tls_cipher_suite;
   client_pool_config.enable_mock_comm = config.transport.enable_mock_comm;
-  client_pool_config.secret_data = config.transport.secret_data;
+  if (config.transport.secret_data.has_value()) {
+    client_pool_config.secret_data = config.transport.secret_data.value();
+  }
 
   return client_pool_config;
 }


### PR DESCRIPTION
This PR updates configureSubscription method for the clientservice
to decrypt the private key only if secret_data has value, and it makes
secret_data configuration parameter an optional value in TransportConfig.