### PR TITLE
Enable time service for remaining apollo tests

### DIFF
--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -36,8 +36,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", view_change_timeout_milli,
-            "-f", '0' # disable time service until intermittent failures are fixed for this test
+            "-v", view_change_timeout_milli
             ]
 
 

--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -34,8 +34,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli,
-            "-f", '0' # disable time service until intermittent failures are fixed for this test
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_client_transaction_signing.py
+++ b/tests/apollo/test_skvbc_client_transaction_signing.py
@@ -43,8 +43,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
-            "-e", str(True),
-            "-f", '0'
+            "-e", str(True)
             ]
 
 class SkvbcTestClientTxnSigning(unittest.TestCase):

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -37,8 +37,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli,
-            "-f", '0' # disable time service until intermittent failures are fixed for this test
+            "-v", viewChangeTimeoutMilli
             ]
 
 

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -42,8 +42,7 @@ def start_replica_cmd(builddir, replica_id):
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli,
-            "-f", '0' # disable time service 
+            "-v", viewChangeTimeoutMilli 
             ]
 
 


### PR DESCRIPTION
This PR aims to enable time service for remaining apollo tests(for which TS was disabled) which are following:
test_skvbc_chaotic_startup
test_skvbc_checkpoints
test_skvbc_network_partitioning
test_skvbc_persistence
test_skvbc_transaction_signing