### PR TITLE
Do not check secret_data's value to decryptPrivateKey

### DIFF
--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -155,9 +155,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
 
     readCert(client_cert_path, config.subscribe_config.pem_cert_chain);
 
-    if (config.transport.secret_data.has_value()) {
-      config.subscribe_config.pem_private_key = decryptPrivateKey(config.transport.secret_data, tls_path);
-    }
+    config.subscribe_config.pem_private_key = decryptPrivateKey(config.transport.secret_data, tls_path);
 
     std::string cert_client_id = getClientIdFromClientCert(client_cert_path);
     // The client cert must have the client ID in the OU field, because the TRS obtains


### PR DESCRIPTION
decryptPrivateKey internally checks the value of secret_data, and based on
that adjusts the filepath of the private key to use. If secret_data
exists, the encrypted private key is used, otherwise plaintext.