### PR TITLE
Log level change for concord metrics dumped in the logs. 

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -716,7 +716,7 @@ void BCStateTran::onTimerImp() {
   auto currTimeForDumping = duration_cast<std::chrono::seconds>(steady_clock::now().time_since_epoch());
   if (currTimeForDumping - last_metrics_dump_time_ >= metrics_dump_interval_in_sec_) {
     last_metrics_dump_time_ = currTimeForDumping;
-    LOG_INFO(logger_, "--BCStateTransfer metrics dump--" + metrics_component_.ToJson());
+    LOG_DEBUG(logger_, "--BCStateTransfer metrics dump--" + metrics_component_.ToJson());
   }
 
   // take a snapshot and log after time passed is approx x2 of fetchRetransmissionTimeoutMs

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -99,7 +99,7 @@ Status DbCheckpointManager::createDbCheckpoint(const CheckpointId& checkPointId,
         metrics_.UpdateAggregator();
         LOG_INFO(getLogger(),
                  "rocksdb check point id:" << it->first << ", size: " << HumanReadable{lastDbCheckpointSize});
-        LOG_INFO(GL, "-- RocksDb checkpoint metrics dump--" + metrics_.ToJson());
+        LOG_DEBUG(GL, "-- RocksDb checkpoint metrics dump--" + metrics_.ToJson());
       }
     });
   }

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -52,7 +52,7 @@ void KeyExchangeManager::initMetrics(std::shared_ptr<concordMetrics::Aggregator>
             std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch());
         if (currTime - metrics_->lastMetricsDumpTime >= metrics_->metricsDumpIntervalInSec) {
           metrics_->lastMetricsDumpTime = currTime;
-          LOG_INFO(KEY_EX_LOG, "-- KeyExchangeManager metrics dump--" + metrics_->component.ToJson());
+          LOG_DEBUG(KEY_EX_LOG, "-- KeyExchangeManager metrics dump--" + metrics_->component.ToJson());
         }
       });
 }

--- a/bftengine/src/bftengine/ReplicaBase.cpp
+++ b/bftengine/src/bftengine/ReplicaBase.cpp
@@ -49,7 +49,7 @@ void ReplicaBase::start() {
         std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch());
     if (currTime - last_metrics_dump_time_ >= metrics_dump_interval_in_sec_) {
       last_metrics_dump_time_ = currTime;
-      LOG_INFO(GL, "-- ReplicaBase metrics dump--" + metrics_.ToJson());
+      LOG_DEBUG(GL, "-- ReplicaBase metrics dump--" + metrics_.ToJson());
     }
   });
   msgsCommunicator_->startCommunication(config_.replicaId);

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -520,7 +520,7 @@ void PreProcessor::updateAggregatorAndDumpMetrics() {
   auto currTime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch());
   if (currTime - metricsLastDumpTime_ >= metricsDumpIntervalInSec_) {
     metricsLastDumpTime_ = currTime;
-    LOG_INFO(logger(), "--preProcessor metrics dump--" + metricsComponent_.ToJson());
+    LOG_DEBUG(logger(), "--preProcessor metrics dump--" + metricsComponent_.ToJson());
   }
 }
 


### PR DESCRIPTION
The metrics dumped in the concord logs are being changed from INFO log level to DEBUG, to reduce unnecessary logging of frequent dumps.
From now onwards to get the metrics dumped in the concord log, change the concord log level to DEBUG.