### PR TITLE
Fix memory leak in deferred requests.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -444,6 +444,8 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         deferredRORequests_.push_back(
             m);  // We should handle span and deleting the message when we handle the deferred message
         deferredRORequestsMetric_++;
+      } else {
+        delete m;
       }
     } else {
       executeReadOnlyRequest(span, m);
@@ -2365,6 +2367,8 @@ void ReplicaImp::pushDeferredMessage(MessageBase *m) {
   if (deferredMessages_.size() < maxQueueSize) {
     deferredMessages_.push_back(m);
     deferredMessagesMetric_++;
+  } else {
+    delete m;
   }
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1051,6 +1051,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
     LOG_INFO(GL,
              "Ignoring PrePrepareMsg because system is stopped at checkpoint pending control state operation (upgrade, "
              "etc...)");
+    // TODO(LG): we should delete the message.
     return;
   }
 
@@ -1086,9 +1087,14 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
 
     return;  // TODO(GG): memory deallocation is confusing .....
   }
+  if (isCurrentPrimary() && (msg->senderId() != getReplicaConfig().replicaId)) {
+    LOG_INFO(GL, "Ignoring PrePrepareMsg since im the current primary");
+    delete msg;
+    return;
+  }
   bool msgAdded = false;
 
-  if (relevantMsgForActiveView(msg) && (msg->senderId() == currentPrimary())) {
+  if (relevantMsgForActiveView(msg)) {
     sendAckIfNeeded(msg, msg->senderId(), msgSeqNum);
     SeqNumInfo &seqNumInfo = mainLog->get(msgSeqNum);
     const bool slowStarted = (msg->firstPath() == CommitPath::SLOW || seqNumInfo.slowPathStarted());


### PR DESCRIPTION
When added post-execution separation we added a defer mechanism.
We defer messages if post-execution is running and push the messages to a bounded queue.

I forgot to delete the message if we already cross the boundary of queue size.