### PR TITLE
Remove RSIs of the source replica on metadata reset

### DIFF
--- a/bftengine/src/bftengine/ReplicaSpecificInfoManager.cpp
+++ b/bftengine/src/bftengine/ReplicaSpecificInfoManager.cpp
@@ -64,7 +64,9 @@ void RsiDataManager::init() {
     for (uint32_t offset = 0; offset < max_client_batch_size_; offset++) {
       std::vector<uint8_t> data = ps_->getReplicaSpecificInfo(clientId * max_client_batch_size_ + offset);
       if (data.empty()) continue;
-      clientRsiData.emplace_back(RsiItem::deserialize(data));
+      auto rsi_item = RsiItem::deserialize(data);
+      if (rsi_item.data().empty()) continue;
+      clientRsiData.emplace_back(rsi_item);
     }
     std::sort(clientRsiData.begin(), clientRsiData.end(), [](auto& data1, auto& data2) {
       return data1.index() < data2.index();

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -30,6 +30,7 @@
 #include "bftengine/DbMetadataStorage.hpp"
 #include "crypto_utils.hpp"
 #include "json_output.hpp"
+#include "bftengine/ReplicaSpecificInfoManager.hpp"
 
 #include <unordered_map>
 
@@ -870,13 +871,22 @@ struct ResetMetadata {
   std::string description() const {
     return "resetMetadata REPLICA_ID\n"
            "  resets BFT and State Transfer metadata for live replica restore"
-           "  REPLICA_ID - of the target replica";
+           "  REPLICA_ID - of the target replica"
+           "  F - the value of f in the original blockchain"
+           "  C - the value of c in the original blockchain"
+           "  principles - the number of principles in the original blockchain."
+           "  MAX_CLIENT_BATCH_SIZE - the maximal client's batch size in the original blockchain"
+           "  Note that if latest 4 parameters is not provided, RSIs won't be removed from the metadata";
   }
 
   std::string execute(const KeyValueBlockchain &adapter, const CommandArguments &args) const {
     if (args.values.empty()) throw std::invalid_argument{"Missing REPLICA_ID argument"};
     std::uint16_t repId = concord::util::to<std::uint16_t>(args.values.front());
-
+    bool removeRsis = args.values.size() == 5;
+    uint32_t fVal = removeRsis ? concord::util::to<std::uint32_t>(args.values[1]) : 1;
+    uint32_t cVal = removeRsis ? concord::util::to<std::uint32_t>(args.values[2]) : 0;
+    uint32_t principles = removeRsis ? concord::util::to<std::uint32_t>(args.values[3]) : 0;
+    uint32_t maxClientBatchSize = removeRsis ? concord::util::to<std::uint32_t>(args.values[4]) : 0;
     std::map<std::string, std::string> result;
     // Update/reset ST metadata
     using namespace concord::storage;
@@ -903,8 +913,9 @@ struct ResetMetadata {
     std::unique_ptr<MetadataStorage> mdtStorage(
         new DBMetadataStorage(adapter.db()->asIDBClient().get(), std::make_unique<MetadataKeyManipulator>()));
     // in this case n, f and c have no use
-    shared_ptr<bftEngine::impl::PersistentStorage> p(
-        new bftEngine::impl::PersistentStorageImp(4, 1, 0, 0, 0));  // TODO: add here rsi reset
+    uint32_t nVal = removeRsis ? 3 * fVal + 2 * cVal + 1 : 4;
+    shared_ptr<bftEngine::impl::PersistentStorage> p(new bftEngine::impl::PersistentStorageImp(
+        nVal, fVal, cVal, principles, maxClientBatchSize));  // TODO: add here rsi reset
     uint16_t numOfObjects = 0;
     auto objectDescriptors = ((PersistentStorageImp *)p.get())->getDefaultMetadataObjectDescriptors(numOfObjects);
     bool isNewStorage = mdtStorage->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);
@@ -920,6 +931,15 @@ struct ResetMetadata {
       result["stable seq num"] = std::to_string(stableSeqNum);
     }
     p->setPrimaryLastUsedSeqNum(lastExecutedSn);
+    if (removeRsis) {
+      for (uint32_t principle = 0; principle < nVal + principles; principle++) {
+        uint32_t baseIndex = principle * maxClientBatchSize;
+        for (uint32_t index = 0; index < maxClientBatchSize; index++) {
+          bftEngine::impl::RsiItem rsi_item(0, 0, std::string());
+          p->setReplicaSpecificInfo(baseIndex + index, rsi_item.serialize());
+        }
+      }
+    }
     p->endWriteTran();
     return toJson(result);
   }


### PR DESCRIPTION
Following https://github.com/vmware/concord-bft/pull/2127, on metadata reset we also need to remove the source RSIs (because they are not generated by the restored replica).
We present 4 new parameters one needs to pass to the `resetMetadata` for removing the RSIs - 
F - the fVal of the original blockchain
C - the cVal of the original blockchain
principles - the number of principles in the original blockchain (including, replicas, read-only replicas and bft clients)
MAX_CLIENT_BATCH_SIZE - the client's ma batch size in the original blockchain.

In order not to break the current API, if one of the latest 4 parameters is missing, we won't remove the RSI at all.