### PR TITLE
Create verifiers if keys paths are set in config (even with tx signing disabled)

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -235,6 +235,9 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     if (auto it = config_params_.find(param); it != config_params_.end()) return concord::util::to<T>(it->second);
     return defaultValue;
   }
+  inline std::set<std::pair<const std::string, std::set<uint16_t>>>* getPublicKeysOfClients() {
+    return (clientTransactionSigningEnabled || !clientsKeysPrefix.empty()) ? &publicKeysOfClients : nullptr;
+  }
 
  protected:
   ReplicaConfig() = default;

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -60,7 +60,7 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
                    config_.replicaPrivateKey,
                    config_.publicKeysOfReplicas,
                    concord::util::crypto::KeyFormat::HexaDecimalStrippedFormat,
-                   config_.clientTransactionSigningEnabled ? &config_.publicKeysOfClients : nullptr,
+                   ReplicaConfig::instance().getPublicKeysOfClients(),
                    concord::util::crypto::KeyFormat::PemFormat,
                    *repsInfo);
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4271,7 +4271,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
                                        config_.replicaPrivateKey,
                                        config_.publicKeysOfReplicas,
                                        concord::util::crypto::KeyFormat::HexaDecimalStrippedFormat,
-                                       config_.clientTransactionSigningEnabled ? &config_.publicKeysOfClients : nullptr,
+                                       ReplicaConfig::instance().getPublicKeysOfClients(),
                                        concord::util::crypto::KeyFormat::PemFormat,
                                        *repsInfo));
     viewsManager = new ViewsManager(repsInfo);

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -53,7 +53,7 @@ ReplicaLoader::ErrorCode loadConfig(LoadedReplicaData &ld) {
                                    config.replicaPrivateKey,
                                    config.publicKeysOfReplicas,
                                    concord::util::crypto::KeyFormat::HexaDecimalStrippedFormat,
-                                   config.clientTransactionSigningEnabled ? &config.publicKeysOfClients : nullptr,
+                                   ReplicaConfig::instance().getPublicKeysOfClients(),
                                    concord::util::crypto::KeyFormat::PemFormat,
                                    *ld.repsInfo);
 

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include "keys_and_signatures.cmf.hpp"
+#include "ReplicaConfig.hpp"
 
 using namespace std;
 
@@ -80,13 +81,14 @@ SigManager* SigManager::initImpl(ReplicaId myId,
   }
 
   LOG_INFO(GL, "Done Compute Start ctor for SigManager with " << KVLOG(publickeys.size(), publicKeysMapping.size()));
-  return new SigManager(myId,
-                        numReplicas,
-                        make_pair(mySigPrivateKey, replicasKeysFormat),
-                        publickeys,
-                        publicKeysMapping,
-                        (publicKeysOfClients != nullptr),
-                        replicasInfo);
+  return new SigManager(
+      myId,
+      numReplicas,
+      make_pair(mySigPrivateKey, replicasKeysFormat),
+      publickeys,
+      publicKeysMapping,
+      ((ReplicaConfig::instance().clientTransactionSigningEnabled) && (publicKeysOfClients != nullptr)),
+      replicasInfo);
 }
 
 SigManager* SigManager::init(ReplicaId myId,

--- a/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
+++ b/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
@@ -23,13 +23,16 @@ using namespace bftEngine::impl;
 using namespace bftEngine;
 using namespace preprocessor;
 
-bftEngine::ReplicaConfig& createReplicaConfigWithExtClient(uint16_t fVal, uint16_t cVal) {
+bftEngine::ReplicaConfig& createReplicaConfigWithExtClient(uint16_t fVal,
+                                                           uint16_t cVal,
+                                                           bool transactionSigningEnabled) {
   auto& config = createReplicaConfig(fVal, cVal);
   config.numOfExternalClients = 1;
   config.numOfClientProxies = 1;
 
   auto clientPrincipalIds = std::set<uint16_t>{uint16_t(config.numReplicas + 1)};
   config.publicKeysOfClients.insert(make_pair(config.publicKeysOfReplicas.begin()->second, clientPrincipalIds));
+  config.clientTransactionSigningEnabled = transactionSigningEnabled;
   return config;
 }
 
@@ -59,11 +62,48 @@ struct MsgParams {
   const char rawSpanContext[14] = {"span_\0context"};  // make clnag-tidy happy
   const std::string spanContext{rawSpanContext};
 };
+std::pair<std::string, std::vector<char>> getProcessResultSigBuff(const std::unique_ptr<SigManager>& sigManager,
+                                                                  const MsgParams& p,
+                                                                  const int sigCount,
+                                                                  bool duplicateSigs) {
+  auto msgSigSize = sigManager->getMySigLength();
+  std::vector<char> msgSig(msgSigSize, 0);
+  auto hash = concord::util::SHA3_256().digest(p.result, sizeof(p.result));
+  sigManager->sign(reinterpret_cast<const char*>(hash.data()), hash.size(), msgSig.data(), msgSigSize);
 
+  // for simplicity, copy the same signatures
+  std::list<PreProcessResultSignature> resultSigs;
+  for (int i = 0; i < sigCount; i++) {
+    resultSigs.emplace_back(std::vector<char>(msgSig), duplicateSigs ? 0 : i);
+  }
+  return std::make_pair(PreProcessResultSignature::serializeResultSignatureList(resultSigs), msgSig);
+}
+void checkMessageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& m,
+                             MsgParams& p,
+                             const ReplicasInfo& repInfo,
+                             bool transactionSigningEnabled) {
+  EXPECT_EQ(m->clientProxyId(), p.senderId);
+  EXPECT_EQ(m->flags(), MsgFlag::HAS_PRE_PROCESSED_FLAG);
+  EXPECT_EQ(m->requestSeqNum(), p.reqSeqNum);
+  EXPECT_EQ(m->requestLength(), sizeof(p.result));
+  if (transactionSigningEnabled) {
+    EXPECT_NE(m->requestSignatureLength(), 0);
+    EXPECT_NE(m->requestSignature(), nullptr);
+  } else {
+    EXPECT_EQ(m->requestSignatureLength(), 0);
+    EXPECT_EQ(m->requestSignature(), nullptr);
+  }
+  EXPECT_NE(m->requestBuf(), p.result);
+  EXPECT_TRUE(std::memcmp(m->requestBuf(), p.result, sizeof(p.result)) == 0u);
+  EXPECT_EQ(m->getCid(), p.correlationId);
+  EXPECT_EQ(m->spanContext<ClientRequestMsg>().data(), p.spanContext);
+  EXPECT_EQ(m->requestTimeoutMilli(), p.requestTimeoutMilli);
+  EXPECT_NO_THROW(m->validate(repInfo));
+}
 class PreProcessResultMsgTestFixture : public testing::Test {
  protected:
   PreProcessResultMsgTestFixture()
-      : config{createReplicaConfigWithExtClient(1, 0)},
+      : config{createReplicaConfigWithExtClient(1, 0, true)},
         replicaInfo{config, false, false},
         sigManager(createSigManagerWithSigning(config.replicaId,
                                                config.replicaPrivateKey,
@@ -77,17 +117,7 @@ class PreProcessResultMsgTestFixture : public testing::Test {
   std::unique_ptr<SigManager> sigManager;
 
   std::unique_ptr<PreProcessResultMsg> createMessage(const MsgParams& p, const int sigCount, bool duplicateSigs) {
-    auto msgSigSize = sigManager->getMySigLength();
-    std::vector<char> msgSig(msgSigSize, 0);
-    auto hash = concord::util::SHA3_256().digest(p.result, sizeof(p.result));
-    sigManager->sign(reinterpret_cast<const char*>(hash.data()), hash.size(), msgSig.data(), msgSigSize);
-
-    // for simplicity, copy the same signatures
-    std::list<PreProcessResultSignature> resultSigs;
-    for (int i = 0; i < sigCount; i++) {
-      resultSigs.emplace_back(std::vector<char>(msgSig), duplicateSigs ? 0 : i);
-    }
-    auto resultSigsBuf = PreProcessResultSignature::serializeResultSignatureList(resultSigs);
+    auto resultSigsBuf = getProcessResultSigBuff(sigManager, p, sigCount, duplicateSigs);
 
     return std::make_unique<PreProcessResultMsg>(p.senderId,
                                                  p.reqSeqNum,
@@ -96,22 +126,48 @@ class PreProcessResultMsgTestFixture : public testing::Test {
                                                  p.requestTimeoutMilli,
                                                  p.correlationId,
                                                  concordUtils::SpanContext{p.spanContext},
-                                                 msgSig.data(),
-                                                 msgSig.size(),
-                                                 resultSigsBuf);
+                                                 resultSigsBuf.second.data(),
+                                                 resultSigsBuf.second.size(),
+                                                 resultSigsBuf.first);
   }
 
   void messageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& m, MsgParams& p) {
-    EXPECT_EQ(m->clientProxyId(), p.senderId);
-    EXPECT_EQ(m->flags(), MsgFlag::HAS_PRE_PROCESSED_FLAG);
-    EXPECT_EQ(m->requestSeqNum(), p.reqSeqNum);
-    EXPECT_EQ(m->requestLength(), sizeof(p.result));
-    EXPECT_NE(m->requestBuf(), p.result);
-    EXPECT_TRUE(std::memcmp(m->requestBuf(), p.result, sizeof(p.result)) == 0u);
-    EXPECT_EQ(m->getCid(), p.correlationId);
-    EXPECT_EQ(m->spanContext<ClientRequestMsg>().data(), p.spanContext);
-    EXPECT_EQ(m->requestTimeoutMilli(), p.requestTimeoutMilli);
-    EXPECT_NO_THROW(m->validate(replicaInfo));
+    checkMessageSanityCheck(m, p, replicaInfo, config.clientTransactionSigningEnabled);
+  }
+};
+
+class PreProcessResultMsgTxSigningOffTestFixture : public testing::Test {
+ protected:
+  PreProcessResultMsgTxSigningOffTestFixture()
+      : config{createReplicaConfigWithExtClient(1, 0, false)},
+        replicaInfo{config, false, false},
+        sigManager(createSigManagerWithSigning(config.replicaId,
+                                               config.replicaPrivateKey,
+                                               concord::util::crypto::KeyFormat::HexaDecimalStrippedFormat,
+                                               config.publicKeysOfReplicas,
+                                               &config.publicKeysOfClients,
+                                               replicaInfo)) {}
+
+  ReplicaConfig& config;
+  ReplicasInfo replicaInfo;
+  std::unique_ptr<SigManager> sigManager;
+
+  std::unique_ptr<PreProcessResultMsg> createMessage(const MsgParams& p, const int sigCount, bool duplicateSigs) {
+    auto resultSigsBuf = getProcessResultSigBuff(sigManager, p, sigCount, duplicateSigs);
+
+    return std::make_unique<PreProcessResultMsg>(p.senderId,
+                                                 p.reqSeqNum,
+                                                 sizeof(p.result),
+                                                 p.result,
+                                                 p.requestTimeoutMilli,
+                                                 p.correlationId,
+                                                 concordUtils::SpanContext{p.spanContext},
+                                                 nullptr,
+                                                 0,
+                                                 resultSigsBuf.first);
+  }
+  void messageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& m, MsgParams& p) {
+    checkMessageSanityCheck(m, p, replicaInfo, config.clientTransactionSigningEnabled);
   }
 };
 
@@ -228,4 +284,37 @@ TEST_F(PreProcessResultMsgTestFixture, MsgWithDuplicatedSigs) {
   EXPECT_TRUE(res->find(ss.str()) != std::string::npos);
 }
 
+TEST_F(PreProcessResultMsgTxSigningOffTestFixture, ClientRequestMsgSanityChecks) {
+  MsgParams p;
+  auto m = createMessage(p, replicaInfo.getNumberOfReplicas(), false /* duplicateSigs */);
+  messageSanityCheck(m, p);
+
+  // check message type
+  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
+  EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
+}
+
+TEST_F(PreProcessResultMsgTxSigningOffTestFixture, MsgWithTooMuchSigs) {
+  MsgParams p;
+  auto serialised = createMessage(p, config.fVal, false /* duplicateSigs */);
+
+  auto m = std::make_unique<PreProcessResultMsg>((MessageBase*)serialised.get());
+  auto res = m->validatePreProcessResultSignatures(config.replicaId, config.fVal);
+
+  std::stringstream ss;
+  ss << "unexpected number of signatures received. Expected " << config.fVal + 1 << " got " << config.fVal;
+  EXPECT_TRUE(res && res->find(ss.str()) != std::string::npos);
+}
+TEST_F(PreProcessResultMsgTxSigningOffTestFixture, MsgWithDuplicatedSigs) {
+  MsgParams p;
+  auto serialised = createMessage(p, config.fVal + 1, true /* duplicateSigs */);
+
+  auto m = std::make_unique<PreProcessResultMsg>((MessageBase*)serialised.get());
+  auto res = m->validatePreProcessResultSignatures(config.replicaId, config.fVal);
+
+  std::stringstream ss;
+  ss << "got more than one signatures with the same sender id";
+  EXPECT_TRUE(res);
+  EXPECT_TRUE(res->find(ss.str()) != std::string::npos);
+}
 }  // namespace


### PR DESCRIPTION
when transaction siging is not enabled, sigmanager does not create verifiers for client pub keys. To validate the requests from cre, we need the verifiers in sig_manager This PR adds changes to create the verifier if keys path is set