### PR TITLE
Remove Static Reply Buffer In Client Pool

### DIFF
--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -96,15 +96,6 @@ class ConcordClient {
   bftEngine::OperationResult getClientRequestError();
   ConcordClient(ConcordClient&& t) = delete;
 
-  // this buffer is fully owned by external application who may set it
-  // via the setExternalReplyBuffer() function.
-  // this memory is used when the callback is called and probably
-  // will be used ONLY in conjunction with external callback.
-  // the better solution is to pass it via the Send function but due to the time
-  // constraints we are not changing the interface now.
-  void setReplyBuffer(char* buf, uint32_t size);
-  void unsetReplyBuffer();
-
  private:
   void CreateClient(concord::config_pool::ConcordClientPoolConfig&, const bftEngine::SimpleClientParams& client_params);
 
@@ -128,14 +119,6 @@ class ConcordClient {
   // is not important
   static std::shared_ptr<std::vector<char>> reply_;
 
-  // this buffer is fully owned by external application who may set it
-  // via the setExternalReplyBuffer() function.
-  // this memory is used when the callback is called and probably
-  // will be used ONLY in conjunction with external callback.
-  // the better solution is to pass it via the Send function but due to the time
-  // constraints we are not changing the interface now.
-  char* externalReplyBuffer = nullptr;
-  uint32_t externalReplyBufferSize = 0;
   using PendingRequests = std::deque<bftEngine::ClientRequest>;
   PendingRequests pending_requests_;
   PendingReplies pending_replies_;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -183,8 +183,6 @@ void ConcordClientPool::assignJobToClient(const ClientPtr &client,
                                           const std::string &correlation_id,
                                           const std::string &span_context,
                                           const bftEngine::RequestCallBack &callback) {
-  if (max_reply_size) client->setReplyBuffer(reply_buffer, max_reply_size);
-
   LOG_INFO(logger_,
            "client_id=" << client->getClientId() << " starts handling reqSeqNum=" << seq_num << " cid="
                         << correlation_id << " span_context exists=" << !span_context.empty() << " flags=" << flags
@@ -461,7 +459,6 @@ void ConcordClientPool::InsertClientToQueue(
   ClientPoolMetrics_.average_req_dur_gauge.Get().Set((uint64_t)average_req_dur_.avg());
   if (average_req_dur_.numOfElements() == 1000) average_req_dur_.reset();  // reset the average every 1000 samples
   ClientPoolMetrics_.executed_requests_counter++;
-  client->unsetReplyBuffer();
   {
     std::unique_lock<std::mutex> lock(clients_queue_lock_);
     metricsComponent_.UpdateAggregator();

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -60,9 +60,6 @@ bft::client::Reply ConcordClient::SendRequest(const bft::client::WriteConfig& co
   LOG_DEBUG(logger_,
             "Request has completed processing"
                 << KVLOG(client_id_, config.request.sequence_number, config.request.correlation_id));
-  if (externalReplyBuffer) {
-    memcpy(externalReplyBuffer, res.matched_data.data(), res.matched_data.size());
-  }
   return res;
 }
 
@@ -84,10 +81,6 @@ bft::client::Reply ConcordClient::SendRequest(const bft::client::ReadConfig& con
   LOG_DEBUG(logger_,
             "Request has completed processing"
                 << KVLOG(client_id_, config.request.sequence_number, config.request.correlation_id));
-  if (externalReplyBuffer) {
-    memcpy(externalReplyBuffer, res.matched_data.data(), res.matched_data.size());
-  }
-
   return res;
 }
 
@@ -316,16 +309,6 @@ void ConcordClient::setStatics(uint16_t required_num_of_replicas,
   ConcordClient::reply_->resize((batch_size) ? batch_size * max_reply_size : max_reply_size_);
   ConcordClient::required_num_of_replicas_ = required_num_of_replicas;
   ConcordClient::num_of_replicas_ = num_of_replicas;
-}
-
-void ConcordClient::setReplyBuffer(char* buf, uint32_t size) {
-  externalReplyBuffer = buf;
-  externalReplyBufferSize = size;
-}
-
-void ConcordClient::unsetReplyBuffer() {
-  externalReplyBuffer = nullptr;
-  externalReplyBufferSize = 0;
 }
 
 void ConcordClient::setDelayFlagForTest(bool delay) { ConcordClient::delayed_behaviour_ = delay; }


### PR DESCRIPTION
In the current BFT client pool implementation, we allocate one static buffer for all clients in the pool (per request in the batch) and use it as a trash can for reply messages. 
There is no need for that anymore.