### PR TITLE
Set gRPC max receive message size for clientservice

### DIFF
--- a/client/clientservice/include/client/clientservice/client_service.hpp
+++ b/client/clientservice/include/client/clientservice/client_service.hpp
@@ -27,7 +27,7 @@ class ClientService {
         event_service_(std::make_unique<EventServiceImpl>(client_)),
         request_service_(std::make_unique<RequestServiceImpl>(client_)){};
 
-  void start(const std::string& addr);
+  void start(const std::string& addr, uint64_t max_receive_msg_size);
 
   const std::string kRequestService{"vmware.concord.client.request.v1.RequestService"};
   const std::string kEventService{"vmware.concord.client.event.v1.EventService"};

--- a/client/clientservice/src/client_service.cpp
+++ b/client/clientservice/src/client_service.cpp
@@ -15,11 +15,12 @@
 
 namespace concord::client::clientservice {
 
-void ClientService::start(const std::string& addr) {
+void ClientService::start(const std::string& addr, uint64_t max_receive_msg_size) {
   grpc::EnableDefaultHealthCheckService(true);
 
   grpc::ServerBuilder builder;
   builder.AddListeningPort(addr, grpc::InsecureServerCredentials());
+  builder.SetMaxReceiveMessageSize(max_receive_msg_size);
   builder.RegisterService(request_service_.get());
   builder.RegisterService(event_service_.get());
 

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -58,6 +58,7 @@ po::variables_map parseCmdLine(int argc, char** argv) {
     ("metrics-port", po::value<int>()->default_value(9891), "Prometheus port to query clientservice metrics")
     ("secrets-url", po::value<std::string>(), "URL to decrypt private keys")
     ("jaeger", po::value<std::string>(), "Push trace data to this Jaeger Agent")
+    ("max-receive-msg-size", po::value<int>()->default_value(4194304), "Clientservice max receive message size in bytes")
   ;
   // clang-format on
   po::variables_map opts;
@@ -164,7 +165,7 @@ int main(int argc, char** argv) {
 
   auto server_addr = opts["host"].as<std::string>() + ":" + std::to_string(opts["port"].as<int>());
   LOG_INFO(logger, "Starting clientservice at " << server_addr);
-  service.start(server_addr);
+  service.start(server_addr, opts["max-receive-msg-size"].as<int>());
 
   return 0;
 }


### PR DESCRIPTION
The default value for gRPC max receive message size is 4MiB
(see GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH). This commit
adds a `max-receive-msg-size` commandline argument and sets it
a default value of 4MiB. The parameter can be configured at
runtime to a higher value to avoid gRPC RESOURCE_EXHAUSTED errors.