### PR TITLE
Sign unique request fields along with PrePrepareResult

### DIFF
--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -46,7 +46,7 @@ enum ClientMsgFlag : uint8_t {
   EMPTY_CLIENT_REQ = 0x10,
 };
 
-enum OperationResult : uint32_t { SUCCESS, INVALID_REQUEST, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL, EMPTY_EXEC_RESULT };
+enum OperationResult : uint32_t { SUCCESS, INVALID_REQUEST, NOT_READY, TIMEOUT, BUFFER_TOO_SMALL, EMPTY_EXEC_DATA };
 // Call back for request - at this point we know for sure that a client is handling the request, so we can assure that
 // we will have reply. This callback will be attached to the client reply struct and whenever we get the reply from,
 // the bft client we will activate the callback.

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -29,6 +29,7 @@
 #include "PreProcessorRecorder.hpp"
 #include "diagnostics.h"
 #include "PerformanceManager.hpp"
+#include "SimpleClient.hpp"
 #include <RollingAvgAndVar.hpp>
 #include "GlobalData.hpp"
 
@@ -215,7 +216,8 @@ class PreProcessor {
                                       bool isPrimary,
                                       bool isRetry,
                                       TimeRecorder &&totalPreExecDurationRecorder = TimeRecorder());
-  uint32_t launchReqPreProcessing(const PreProcessRequestMsgSharedPtr &preProcessReqMsg);
+  bftEngine::OperationResult launchReqPreProcessing(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
+                                                    uint32_t &resultLen);
   void handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                  const std::string &batchCid,
                                  bool isPrimary,
@@ -225,21 +227,25 @@ class PreProcessor {
                                          ReqId reqSeqNum,
                                          uint64_t reqRetryId,
                                          uint32_t resBufLen,
-                                         const std::string &cid);
+                                         const std::string &cid,
+                                         bftEngine::OperationResult preProcessResult);
   void handleReqPreProcessedByPrimary(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       const std::string &batchCid,
                                       uint16_t clientId,
-                                      uint32_t resultBufLen);
+                                      uint32_t resultBufLen,
+                                      bftEngine::OperationResult preProcessResult);
   void handlePreProcessedReqPrimaryRetry(NodeIdType clientId,
                                          uint16_t reqOffsetInBatch,
                                          uint32_t resultBufLen,
-                                         const std::string &batchCid);
+                                         const std::string &batchCid,
+                                         bftEngine::OperationResult preProcessResult);
   void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch, const std::string &batchCid = "");
   void cancelPreProcessing(NodeIdType clientId, const std::string &batchCid, uint16_t reqOffsetInBatch);
   void setPreprocessingRightNow(uint16_t clientId, uint16_t reqOffsetInBatch, bool set);
   PreProcessingResult handlePreProcessedReqByPrimaryAndGetConsensusResult(uint16_t clientId,
                                                                           uint16_t reqOffsetInBatch,
-                                                                          uint32_t resultBufLen);
+                                                                          uint32_t resultBufLen,
+                                                                          bftEngine::OperationResult preProcessResult);
   void handlePreProcessReplyMsg(const std::string &cid,
                                 PreProcessingResult result,
                                 NodeIdType clientId,
@@ -294,7 +300,7 @@ class PreProcessor {
   std::condition_variable msgLoopSignal_;
   std::atomic_bool msgLoopDone_{false};
 
-  static std::vector<std::shared_ptr<PreProcessor>> preProcessors_;  // The place holder for PreProcessor objects
+  static std::vector<std::shared_ptr<PreProcessor>> preProcessors_;  // The place-holder for PreProcessor objects
 
   std::shared_ptr<MsgsCommunicator> msgsCommunicator_;
   std::shared_ptr<IncomingMsgsStorage> incomingMsgsStorage_;

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -12,10 +12,12 @@
 #include "RequestProcessingState.hpp"
 #include "sparse_merkle/base_types.h"
 #include "SigManager.hpp"
+#include "messages/PreProcessResultHashCreator.hpp"
 
 namespace preprocessor {
 
 using namespace std;
+using namespace bftEngine;
 using namespace chrono;
 using namespace concord::util;
 using namespace concord::kvbc::sparse_merkle;
@@ -71,12 +73,15 @@ void RequestProcessingState::setPreProcessRequest(PreProcessRequestMsgSharedPtr 
   reqRetryId_ = preProcessRequestMsg_->reqRetryId();
 }
 
-void RequestProcessingState::handlePrimaryPreProcessed(const char *preProcessResult, uint32_t preProcessResultLen) {
+void RequestProcessingState::handlePrimaryPreProcessed(const char *preProcessResultData,
+                                                       uint32_t preProcessResultLen,
+                                                       OperationResult preProcessResult) {
   preprocessingRightNow_ = false;
   primaryPreProcessResult_ = preProcessResult;
+  primaryPreProcessResultData_ = preProcessResultData;
   primaryPreProcessResultLen_ = preProcessResultLen;
-  primaryPreProcessResultHash_ =
-      convertToArray(SHA3_256().digest(primaryPreProcessResult_, primaryPreProcessResultLen_).data());
+  primaryPreProcessResultHash_ = PreProcessResultHashCreator::create(
+      preProcessResultData, preProcessResultLen, preProcessResult, clientId_, reqSeqNum_);
 
   auto sm = SigManager::instance();
   std::vector<char> sig(sm->getMySigLength());
@@ -84,9 +89,9 @@ void RequestProcessingState::handlePrimaryPreProcessed(const char *preProcessRes
            primaryPreProcessResultHash_.size(),
            sig.data(),
            sig.size());
-  preProcessingResultHashes_[primaryPreProcessResultHash_].emplace_back(std::move(sig), myReplicaId_);
+  preProcessingResultHashes_[primaryPreProcessResultHash_].emplace_back(std::move(sig), myReplicaId_, preProcessResult);
   // Decision when PreProcessing is complete is made based on the value of received replies. The value should be
-  // increased for the primary hash too.
+  // increased for the primary hash, too.
   numOfReceivedReplies_++;
 }
 
@@ -120,9 +125,10 @@ void RequestProcessingState::handlePreProcessReplyMsg(const PreProcessReplyMsgSh
     numOfReceivedReplies_++;
     const auto &newHashArray = convertToArray(preProcessReplyMsg->resultsHash());
     // Counts equal hashes and saves the signatures with the replica ID. They will be used as a proof that the primary
-    // is sending correct preexecution result to the rest of the replicas.
+    // is sending correct pre-execution result to the rest of the replicas.
     preProcessingResultHashes_[newHashArray].emplace_back(preProcessReplyMsg->getResultHashSignature(),
-                                                          preProcessReplyMsg->senderId());
+                                                          preProcessReplyMsg->senderId(),
+                                                          preProcessReplyMsg->preProcessResult());
     detectNonDeterministicPreProcessing(newHashArray, senderId, preProcessReplyMsg->reqRetryId());
   } else {
     SCOPED_MDC_CID(cid_);
@@ -169,15 +175,16 @@ bool RequestProcessingState::isReqTimedOut() const {
 
 std::pair<std::string, concord::util::SHA3_256::Digest> RequestProcessingState::detectFailureDueToBlockID(
     const concord::util::SHA3_256::Digest &other, uint64_t blockId) {
-  // since this scenario is rare, a new string is allocated for safety.
-  std::string modifiedResult(primaryPreProcessResult_, primaryPreProcessResultLen_);
+  // Since this scenario is rare, a new string is allocated for safety.
+  std::string modifiedResult(primaryPreProcessResultData_, primaryPreProcessResultLen_);
   ConcordAssertGT(modifiedResult.size(), sizeof(uint64_t));
   memcpy(modifiedResult.data() + modifiedResult.size() - sizeof(uint64_t),
          reinterpret_cast<char *>(&blockId),
          sizeof(uint64_t));
-  auto modifiedHash = convertToArray(SHA3_256().digest(modifiedResult.c_str(), modifiedResult.size()).data());
+  auto modifiedHash =
+      PreProcessResultHashCreator::create(modifiedResult.data(), modifiedResult.size(), SUCCESS, clientId_, reqSeqNum_);
   if (other == modifiedHash) {
-    LOG_INFO(logger(), "Primary hash is different from quorum due to mismatch in block id " << KVLOG(reqSeqNum_));
+    LOG_INFO(logger(), "Primary hash is different from quorum due to mismatch in block id" << KVLOG(reqSeqNum_));
     return {modifiedResult, modifiedHash};
   }
   return {"", concord::util::SHA3_256::Digest{}};
@@ -185,7 +192,7 @@ std::pair<std::string, concord::util::SHA3_256::Digest> RequestProcessingState::
 
 void RequestProcessingState::modifyPrimaryResult(
     const std::pair<std::string, concord::util::SHA3_256::Digest> &result) {
-  memcpy(const_cast<char *>(primaryPreProcessResult_), result.first.c_str(), primaryPreProcessResultLen_);
+  memcpy(const_cast<char *>(primaryPreProcessResultData_), result.first.c_str(), primaryPreProcessResultLen_);
   primaryPreProcessResultHash_ = result.second;
   auto sm = SigManager::instance();
   std::vector<char> sig(sm->getMySigLength());
@@ -193,16 +200,17 @@ void RequestProcessingState::modifyPrimaryResult(
            primaryPreProcessResultHash_.size(),
            sig.data(),
            sig.size());
-  preProcessingResultHashes_[primaryPreProcessResultHash_].emplace_back(std::move(sig), myReplicaId_);
+  preProcessingResultHashes_[primaryPreProcessResultHash_].emplace_back(
+      std::move(sig), myReplicaId_, primaryPreProcessResult_);
 }
 
 // The primary replica logic
 PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult() {
   SCOPED_MDC_CID(cid_);
   if (numOfReceivedReplies_ < numOfRequiredEqualReplies_) {
-    LOG_DEBUG(logger(),
-              "Not enough replies received, continue waiting"
-                  << KVLOG(reqSeqNum_, numOfReceivedReplies_, numOfRequiredEqualReplies_));
+    LOG_INFO(logger(),
+             "Not enough replies received, continue waiting"
+                 << KVLOG(reqSeqNum_, numOfReceivedReplies_, numOfRequiredEqualReplies_));
     return CONTINUE;
   }
 
@@ -210,6 +218,14 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
   auto itOfChosenHash = calculateMaxNbrOfEqualHashes(maxNumOfEqualHashes);
   if (maxNumOfEqualHashes >= numOfRequiredEqualReplies_) {
     if (itOfChosenHash->first == primaryPreProcessResultHash_) return COMPLETE;  // Pre-execution consensus reached
+    if (primaryPreProcessResult_ == SUCCESS && itOfChosenHash->second.front().getPreProcessResult() != SUCCESS) {
+      // The pre-execution succeeded on a primary replica while failed on non-primaries. The consensus for an error
+      // execution result has been reached => we are done.
+      agreedPreProcessResult_ = itOfChosenHash->second.front().getPreProcessResult();
+      LOG_INFO(logger(), "The replicas agreed on an error execution result:" << KVLOG(agreedPreProcessResult_));
+      return COMPLETE;
+    }
+
     if (primaryPreProcessResultLen_ != 0 && !retrying_) {
       // A known scenario that can cause a mismatch, is due to rejection of the block id sent by the primary.
       // In this case the difference should be only the last 64 bits that encodes the `0` as the rejection value.
@@ -230,10 +246,10 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
       retrying_ = true;
       return RETRY_PRIMARY;
     }
-    LOG_DEBUG(logger(), "Primary replica did not complete pre-processing yet, continue waiting" << KVLOG(reqSeqNum_));
+    LOG_INFO(logger(), "Primary replica did not complete pre-processing yet, continue waiting" << KVLOG(reqSeqNum_));
     return CONTINUE;
   } else
-    LOG_DEBUG(
+    LOG_INFO(
         logger(),
         "Not enough equal hashes collected yet" << KVLOG(reqSeqNum_, maxNumOfEqualHashes, numOfRequiredEqualReplies_));
 
@@ -243,9 +259,9 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
     LOG_WARN(logger(), "Not enough equal hashes collected, cancel request" << KVLOG(reqSeqNum_));
     return CANCEL;
   }
-  LOG_DEBUG(logger(),
-            "Continue waiting for replies to arrive"
-                << KVLOG(reqSeqNum_, numOfReceivedReplies_, maxNumOfEqualHashes, numOfRequiredEqualReplies_));
+  LOG_INFO(logger(),
+           "Continue waiting for replies to arrive"
+               << KVLOG(reqSeqNum_, numOfReceivedReplies_, maxNumOfEqualHashes, numOfRequiredEqualReplies_));
   return CONTINUE;
 }
 

--- a/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.cpp
@@ -92,7 +92,8 @@ PreProcessReplyMsgsList& PreProcessBatchReplyMsg::getPreProcessReplyMsgs() {
                                                       (const uint8_t*)&singleMsgHeader.resultsHash,
                                                       sigPosition,
                                                       cid,
-                                                      (ReplyStatus)singleMsgHeader.status);
+                                                      singleMsgHeader.status,
+                                                      singleMsgHeader.preProcessResult);
     preProcessReplyMsgsList_.push_back(move(preProcessReplyMsg));
     dataPosition += sizeof(PreProcessReplyMsg::Header) + sigLen + singleMsgHeader.cidLength;
   }

--- a/bftengine/src/preprocessor/messages/PreProcessResultHashCreator.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultHashCreator.hpp
@@ -1,0 +1,35 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "sha_hash.hpp"
+
+namespace preprocessor {
+
+class PreProcessResultHashCreator {
+ public:
+  static concord::util::SHA3_256::Digest create(const char* preProcessResultData,
+                                                uint32_t preProcessResultLen,
+                                                bftEngine::OperationResult preProcessResult,
+                                                uint16_t clientId,
+                                                ReqId reqSeqNum) {
+    auto dataDigest = concord::util::SHA3_256();
+    dataDigest.init();
+    if (preProcessResult == bftEngine::SUCCESS) dataDigest.update(preProcessResultData, preProcessResultLen);
+    dataDigest.update(&preProcessResult, sizeof(preProcessResult));
+    dataDigest.update(&clientId, sizeof(clientId));
+    dataDigest.update(&reqSeqNum, sizeof(reqSeqNum));
+    return dataDigest.finish();
+  }
+};
+
+}  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#include <list>
-
 #include "messages/ClientRequestMsg.hpp"
+#include "SimpleClient.hpp"
+#include <list>
 
 namespace preprocessor {
 
@@ -60,17 +60,21 @@ class PreProcessResultMsg : public ClientRequestMsg {
 struct PreProcessResultSignature {
   std::vector<char> signature;
   NodeIdType sender_replica;
+  bftEngine::OperationResult pre_process_result;
 
   PreProcessResultSignature() = default;
 
-  PreProcessResultSignature(std::vector<char>&& sig, NodeIdType sender)
-      : signature{std::move(sig)}, sender_replica{sender} {}
+  PreProcessResultSignature(std::vector<char>&& sig, NodeIdType sender, bftEngine::OperationResult result)
+      : signature{std::move(sig)}, sender_replica{sender}, pre_process_result{result} {}
 
   bool operator==(const PreProcessResultSignature& rhs) const {
-    return signature == rhs.signature && sender_replica == rhs.sender_replica;
+    return signature == rhs.signature && sender_replica == rhs.sender_replica &&
+           pre_process_result == rhs.pre_process_result;
   }
 
-  static std::string serializeResultSignatureList(const std::list<PreProcessResultSignature>& signatures);
+  const bftEngine::OperationResult getPreProcessResult() const { return pre_process_result; }
+
+  static std::string serializeResultSignatureList(const std::list<PreProcessResultSignature>& sigs);
   static std::list<PreProcessResultSignature> deserializeResultSignatureList(const char* buf, size_t len);
 };
 

--- a/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
+++ b/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
@@ -13,6 +13,7 @@
 #include <gmock/gmock.h>
 #include "PrimitiveTypes.hpp"
 #include "messages/PreProcessResultMsg.hpp"
+#include "messages/PreProcessResultHashCreator.hpp"
 #include "helper.hpp"
 #include "RequestProcessingState.hpp"
 #include "Replica.hpp"
@@ -51,54 +52,59 @@ bftEngine::impl::SigManager* createSigManagerWithSigning(
                           replicasInfo);
 }
 
-// Some default message params used through the test
+// Default message params used in the tests
 struct MsgParams {
   NodeIdType senderId = 5u;
+  const uint16_t clientId = 32;
   uint64_t reqSeqNum = 100u;
   const char result[12] = {"result body"};
   const uint64_t requestTimeoutMilli = 0;
   const std::string correlationId = "correlationId";
-  const char rawSpanContext[14] = {"span_\0context"};  // make clnag-tidy happy
+  const char rawSpanContext[14] = {"span_\0context"};  // make clang-tidy happy
   const std::string spanContext{rawSpanContext};
 };
+
 std::pair<std::string, std::vector<char>> getProcessResultSigBuff(const std::unique_ptr<SigManager>& sigManager,
-                                                                  const MsgParams& p,
+                                                                  const MsgParams& params,
                                                                   const int sigCount,
                                                                   bool duplicateSigs) {
   auto msgSigSize = sigManager->getMySigLength();
   std::vector<char> msgSig(msgSigSize, 0);
-  auto hash = concord::util::SHA3_256().digest(p.result, sizeof(p.result));
+  auto hash = PreProcessResultHashCreator::create(
+      params.result, sizeof(params.result), SUCCESS, params.senderId, params.reqSeqNum);
   sigManager->sign(reinterpret_cast<const char*>(hash.data()), hash.size(), msgSig.data(), msgSigSize);
 
-  // for simplicity, copy the same signatures
+  // For simplicity, copy the same signatures
   std::list<PreProcessResultSignature> resultSigs;
   for (int i = 0; i < sigCount; i++) {
-    resultSigs.emplace_back(std::vector<char>(msgSig), duplicateSigs ? 0 : i);
+    resultSigs.emplace_back(std::vector<char>(msgSig), duplicateSigs ? 0 : i, bftEngine::SUCCESS);
   }
   return std::make_pair(PreProcessResultSignature::serializeResultSignatureList(resultSigs), msgSig);
 }
-void checkMessageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& m,
-                             MsgParams& p,
+
+void checkMessageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& msg,
+                             MsgParams& params,
                              const ReplicasInfo& repInfo,
                              bool transactionSigningEnabled) {
-  EXPECT_EQ(m->clientProxyId(), p.senderId);
-  EXPECT_EQ(m->flags(), MsgFlag::HAS_PRE_PROCESSED_FLAG);
-  EXPECT_EQ(m->requestSeqNum(), p.reqSeqNum);
-  EXPECT_EQ(m->requestLength(), sizeof(p.result));
+  EXPECT_EQ(msg->clientProxyId(), params.senderId);
+  EXPECT_EQ(msg->flags(), MsgFlag::HAS_PRE_PROCESSED_FLAG);
+  EXPECT_EQ(msg->requestSeqNum(), params.reqSeqNum);
+  EXPECT_EQ(msg->requestLength(), sizeof(params.result));
   if (transactionSigningEnabled) {
-    EXPECT_NE(m->requestSignatureLength(), 0);
-    EXPECT_NE(m->requestSignature(), nullptr);
+    EXPECT_NE(msg->requestSignatureLength(), 0);
+    EXPECT_NE(msg->requestSignature(), nullptr);
   } else {
-    EXPECT_EQ(m->requestSignatureLength(), 0);
-    EXPECT_EQ(m->requestSignature(), nullptr);
+    EXPECT_EQ(msg->requestSignatureLength(), 0);
+    EXPECT_EQ(msg->requestSignature(), nullptr);
   }
-  EXPECT_NE(m->requestBuf(), p.result);
-  EXPECT_TRUE(std::memcmp(m->requestBuf(), p.result, sizeof(p.result)) == 0u);
-  EXPECT_EQ(m->getCid(), p.correlationId);
-  EXPECT_EQ(m->spanContext<ClientRequestMsg>().data(), p.spanContext);
-  EXPECT_EQ(m->requestTimeoutMilli(), p.requestTimeoutMilli);
-  EXPECT_NO_THROW(m->validate(repInfo));
+  EXPECT_NE(msg->requestBuf(), params.result);
+  EXPECT_TRUE(std::memcmp(msg->requestBuf(), params.result, sizeof(params.result)) == 0u);
+  EXPECT_EQ(msg->getCid(), params.correlationId);
+  EXPECT_EQ(msg->spanContext<ClientRequestMsg>().data(), params.spanContext);
+  EXPECT_EQ(msg->requestTimeoutMilli(), params.requestTimeoutMilli);
+  EXPECT_NO_THROW(msg->validate(repInfo));
 }
+
 class PreProcessResultMsgTestFixture : public testing::Test {
  protected:
   PreProcessResultMsgTestFixture()
@@ -110,28 +116,38 @@ class PreProcessResultMsgTestFixture : public testing::Test {
                                                config.publicKeysOfReplicas,
                                                &config.publicKeysOfClients,
                                                replicaInfo)) {}
-
   ReplicaConfig& config;
   ReplicasInfo replicaInfo;
   std::unique_ptr<SigManager> sigManager;
 
-  std::unique_ptr<PreProcessResultMsg> createMessage(const MsgParams& p, const int sigCount, bool duplicateSigs) {
-    auto resultSigsBuf = getProcessResultSigBuff(sigManager, p, sigCount, duplicateSigs);
+  std::unique_ptr<PreProcessResultMsg> createMessage(const MsgParams& params, const int sigCount, bool duplicateSigs) {
+    auto resultSigsBuf = getProcessResultSigBuff(sigManager, params, sigCount, duplicateSigs);
+    auto msgSigSize = sigManager->getMySigLength();
+    std::vector<char> msgSig(msgSigSize, 0);
 
-    return std::make_unique<PreProcessResultMsg>(p.senderId,
-                                                 p.reqSeqNum,
-                                                 sizeof(p.result),
-                                                 p.result,
-                                                 p.requestTimeoutMilli,
-                                                 p.correlationId,
-                                                 concordUtils::SpanContext{p.spanContext},
+    auto hash = PreProcessResultHashCreator::create(
+        params.result, sizeof(params.result), SUCCESS, params.senderId, params.reqSeqNum);
+    sigManager->sign(reinterpret_cast<const char*>(hash.data()), hash.size(), msgSig.data(), msgSigSize);
+
+    // For simplicity, copy the same signatures
+    std::list<PreProcessResultSignature> resultSigs;
+    for (int i = 0; i < sigCount; i++) {
+      resultSigs.emplace_back(std::vector<char>(msgSig), duplicateSigs ? 0 : i, bftEngine::SUCCESS);
+    }
+    return std::make_unique<PreProcessResultMsg>(params.senderId,
+                                                 params.reqSeqNum,
+                                                 sizeof(params.result),
+                                                 params.result,
+                                                 params.requestTimeoutMilli,
+                                                 params.correlationId,
+                                                 concordUtils::SpanContext{params.spanContext},
                                                  resultSigsBuf.second.data(),
                                                  resultSigsBuf.second.size(),
                                                  resultSigsBuf.first);
   }
 
-  void messageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& m, MsgParams& p) {
-    checkMessageSanityCheck(m, p, replicaInfo, config.clientTransactionSigningEnabled);
+  void messageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& msg, MsgParams& params) {
+    checkMessageSanityCheck(msg, params, replicaInfo, config.clientTransactionSigningEnabled);
   }
 };
 
@@ -151,41 +167,41 @@ class PreProcessResultMsgTxSigningOffTestFixture : public testing::Test {
   ReplicasInfo replicaInfo;
   std::unique_ptr<SigManager> sigManager;
 
-  std::unique_ptr<PreProcessResultMsg> createMessage(const MsgParams& p, const int sigCount, bool duplicateSigs) {
-    auto resultSigsBuf = getProcessResultSigBuff(sigManager, p, sigCount, duplicateSigs);
+  std::unique_ptr<PreProcessResultMsg> createMessage(const MsgParams& params, const int sigCount, bool duplicateSigs) {
+    auto resultSigsBuf = getProcessResultSigBuff(sigManager, params, sigCount, duplicateSigs);
 
-    return std::make_unique<PreProcessResultMsg>(p.senderId,
-                                                 p.reqSeqNum,
-                                                 sizeof(p.result),
-                                                 p.result,
-                                                 p.requestTimeoutMilli,
-                                                 p.correlationId,
-                                                 concordUtils::SpanContext{p.spanContext},
+    return std::make_unique<PreProcessResultMsg>(params.senderId,
+                                                 params.reqSeqNum,
+                                                 sizeof(params.result),
+                                                 params.result,
+                                                 params.requestTimeoutMilli,
+                                                 params.correlationId,
+                                                 concordUtils::SpanContext{params.spanContext},
                                                  nullptr,
                                                  0,
                                                  resultSigsBuf.first);
   }
-  void messageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& m, MsgParams& p) {
-    checkMessageSanityCheck(m, p, replicaInfo, config.clientTransactionSigningEnabled);
+  void messageSanityCheck(std::unique_ptr<preprocessor::PreProcessResultMsg>& msg, MsgParams& params) {
+    checkMessageSanityCheck(msg, params, replicaInfo, config.clientTransactionSigningEnabled);
   }
 };
 
 TEST_F(PreProcessResultMsgTestFixture, ClientRequestMsgSanityChecks) {
-  MsgParams p;
-  auto m = createMessage(p, replicaInfo.getNumberOfReplicas(), false /* duplicateSigs */);
-  messageSanityCheck(m, p);
+  MsgParams params;
+  auto msg = createMessage(params, replicaInfo.getNumberOfReplicas(), false /* duplicateSigs */);
+  messageSanityCheck(msg, params);
 
   // check message type
-  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
+  MessageBase::Header* hdr = (MessageBase::Header*)msg->body();
   EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
 }
 
-TEST_F(PreProcessResultMsgTestFixture, SignatureDeserialisation) {
+TEST_F(PreProcessResultMsgTestFixture, SignatureDeserialization) {
   std::vector<char> msgSig{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
 
   std::list<PreProcessResultSignature> resultSigs;
   for (int i = 0; i < replicaInfo.getNumberOfReplicas(); i++) {
-    resultSigs.emplace_back(std::vector<char>(msgSig), 0);
+    resultSigs.emplace_back(std::vector<char>(msgSig), 0, bftEngine::SUCCESS);
   }
   auto resultSigsBuf = PreProcessResultSignature::serializeResultSignatureList(resultSigs);
   auto deserialized =
@@ -193,77 +209,78 @@ TEST_F(PreProcessResultMsgTestFixture, SignatureDeserialisation) {
   EXPECT_THAT(resultSigs, deserialized);
 }
 
-TEST_F(PreProcessResultMsgTestFixture, MsgDeserialisation) {
-  MsgParams p;
-  auto serialized = createMessage(p, replicaInfo.getNumberOfReplicas(), true /* duplicateSigs */);
-  auto m = std::make_unique<PreProcessResultMsg>((ClientRequestMsgHeader*)serialized->body());
+TEST_F(PreProcessResultMsgTestFixture, MsgDeserialization) {
+  MsgParams params;
+  auto serialized = createMessage(params, replicaInfo.getNumberOfReplicas(), true /* duplicateSigs */);
+  auto msg = std::make_unique<PreProcessResultMsg>((ClientRequestMsgHeader*)serialized->body());
 
-  messageSanityCheck(m, p);
+  messageSanityCheck(msg, params);
 
   // check message type
-  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
+  MessageBase::Header* hdr = (MessageBase::Header*)msg->body();
   EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
 
   // check the result is correct
-  ASSERT_EQ(sizeof(p.result), m->requestLength());
-  for (int i = 0; i < m->requestLength(); i++) {
-    ASSERT_EQ(p.result[i], m->requestBuf()[i]);
+  ASSERT_EQ(sizeof(params.result), msg->requestLength());
+  for (int i = 0; i < msg->requestLength(); i++) {
+    ASSERT_EQ(params.result[i], msg->requestBuf()[i]);
   }
 
   // Deserialize result signatures
-  auto [sigBuf, sigBufLen] = m->getResultSignaturesBuf();
-  auto sigs = PreProcessResultSignature::deserializeResultSignatureList(sigBuf, sigBufLen);
-
-  // Verify the signatures - SigManager can't veryfy its own signature so first the result
-  // from the message is signed and then it is compared to each signature in the message
-  auto msgSigSize = sigManager->getMySigLength();
-  std::vector<char> msgSig(msgSigSize, 0);
-  auto hash = concord::util::SHA3_256().digest(m->requestBuf(), m->requestLength());
-  sigManager->sign(reinterpret_cast<char*>(hash.data()), hash.size(), msgSig.data(), msgSigSize);
-  for (const auto& s : sigs) {
-    ASSERT_EQ(s.sender_replica, 0);
-    EXPECT_THAT(msgSig, s.signature);
-  }
-}
-
-TEST_F(PreProcessResultMsgTestFixture, MsgDeserialisationFromBase) {
-  MsgParams p;
-  auto serialized = createMessage(p, replicaInfo.getNumberOfReplicas(), true /* duplicateSigs */);
-  auto m = std::make_unique<PreProcessResultMsg>((MessageBase*)serialized.get());
-  messageSanityCheck(m, p);
-
-  // check message type
-  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
-  EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
-
-  // check the result is correct
-  ASSERT_EQ(sizeof(p.result), m->requestLength());
-  for (int i = 0; i < m->requestLength(); i++) {
-    ASSERT_EQ(p.result[i], m->requestBuf()[i]);
-  }
-
-  // Deserialize result signatures
-  auto [sigBuf, sigBufLen] = m->getResultSignaturesBuf();
+  auto [sigBuf, sigBufLen] = msg->getResultSignaturesBuf();
   auto sigs = PreProcessResultSignature::deserializeResultSignatureList(sigBuf, sigBufLen);
 
   // Verify the signatures - SigManager can't verify its own signature so first the result
   // from the message is signed, and then it is compared to each signature in the message
   auto msgSigSize = sigManager->getMySigLength();
   std::vector<char> msgSig(msgSigSize, 0);
-  auto hash = concord::util::SHA3_256().digest(m->requestBuf(), m->requestLength());
+  auto hash = PreProcessResultHashCreator::create(
+      msg->requestBuf(), msg->requestLength(), SUCCESS, params.senderId, params.reqSeqNum);
   sigManager->sign(reinterpret_cast<char*>(hash.data()), hash.size(), msgSig.data(), msgSigSize);
-  for (const auto& s : sigs) {
-    ASSERT_EQ(s.sender_replica, 0);
-    EXPECT_THAT(msgSig, s.signature);
+  for (const auto& sig : sigs) {
+    ASSERT_EQ(sig.sender_replica, 0);
+    EXPECT_THAT(msgSig, sig.signature);
   }
 }
 
-TEST_F(PreProcessResultMsgTestFixture, MsgWithTooMuchSigs) {
-  MsgParams p;
-  auto serialized = createMessage(p, config.fVal, false /* duplicateSigs */);
+TEST_F(PreProcessResultMsgTestFixture, MsgDeserializationFromBase) {
+  MsgParams params;
+  auto serialized = createMessage(params, replicaInfo.getNumberOfReplicas(), true /* duplicateSigs */);
+  auto msg = std::make_unique<PreProcessResultMsg>((MessageBase*)serialized.get());
+  messageSanityCheck(msg, params);
 
-  auto m = std::make_unique<PreProcessResultMsg>((MessageBase*)serialized.get());
-  auto res = m->validatePreProcessResultSignatures(config.replicaId, config.fVal);
+  // check message type
+  MessageBase::Header* hdr = (MessageBase::Header*)msg->body();
+  EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
+
+  // check the result is correct
+  ASSERT_EQ(sizeof(params.result), msg->requestLength());
+  for (int i = 0; i < msg->requestLength(); i++) {
+    ASSERT_EQ(params.result[i], msg->requestBuf()[i]);
+  }
+
+  // Deserialize result signatures
+  auto [sigBuf, sigBufLen] = msg->getResultSignaturesBuf();
+  auto sigs = PreProcessResultSignature::deserializeResultSignatureList(sigBuf, sigBufLen);
+
+  // Verify the signatures - SigManager can't verify its own signature so first the result
+  // from the message is signed, and then it is compared to each signature in the message
+  auto msgSigSize = sigManager->getMySigLength();
+  std::vector<char> msgSig(msgSigSize, 0);
+  auto hash = PreProcessResultHashCreator::create(
+      msg->requestBuf(), msg->requestLength(), SUCCESS, params.senderId, params.reqSeqNum);
+  sigManager->sign(reinterpret_cast<char*>(hash.data()), hash.size(), msgSig.data(), msgSigSize);
+  for (const auto& sig : sigs) {
+    ASSERT_EQ(sig.sender_replica, 0);
+    EXPECT_THAT(msgSig, sig.signature);
+  }
+}
+
+TEST_F(PreProcessResultMsgTestFixture, MsgWithTooManySigs) {
+  MsgParams params;
+  auto serialized = createMessage(params, config.fVal, false /* duplicateSigs */);
+  auto msg = std::make_unique<PreProcessResultMsg>((MessageBase*)serialized.get());
+  auto res = msg->validatePreProcessResultSignatures(config.replicaId, config.fVal);
 
   std::stringstream ss;
   ss << "expectedSignatureCount: " << config.fVal + 1 << ", sigs.size(): " << config.fVal;
@@ -272,11 +289,11 @@ TEST_F(PreProcessResultMsgTestFixture, MsgWithTooMuchSigs) {
 }
 
 TEST_F(PreProcessResultMsgTestFixture, MsgWithDuplicatedSigs) {
-  MsgParams p;
-  auto serialized = createMessage(p, config.fVal + 1, true /* duplicateSigs */);
+  MsgParams params;
+  auto serialized = createMessage(params, config.fVal + 1, true /* duplicateSigs */);
 
-  auto m = std::make_unique<PreProcessResultMsg>((MessageBase*)serialized.get());
-  auto res = m->validatePreProcessResultSignatures(config.replicaId, config.fVal);
+  auto msg = std::make_unique<PreProcessResultMsg>((MessageBase*)serialized.get());
+  auto res = msg->validatePreProcessResultSignatures(config.replicaId, config.fVal);
 
   std::stringstream ss;
   ss << "got more than one signature with the same sender id";
@@ -285,12 +302,12 @@ TEST_F(PreProcessResultMsgTestFixture, MsgWithDuplicatedSigs) {
 }
 
 TEST_F(PreProcessResultMsgTxSigningOffTestFixture, ClientRequestMsgSanityChecks) {
-  MsgParams p;
-  auto m = createMessage(p, replicaInfo.getNumberOfReplicas(), false /* duplicateSigs */);
-  messageSanityCheck(m, p);
+  MsgParams params;
+  auto msg = createMessage(params, replicaInfo.getNumberOfReplicas(), false /* duplicateSigs */);
+  messageSanityCheck(msg, params);
 
   // check message type
-  MessageBase::Header* hdr = (MessageBase::Header*)m->body();
+  MessageBase::Header* hdr = (MessageBase::Header*)msg->body();
   EXPECT_EQ(hdr->msgType, MsgCode::PreProcessResult);
 }
 }  // namespace

--- a/kvbc/src/ClientImp.cpp
+++ b/kvbc/src/ClientImp.cpp
@@ -88,8 +88,8 @@ Status ClientImp::invokeCommandSynch(const char* request,
       return Status::InvalidArgument("Specified output buffer is too small");
     case INVALID_REQUEST:
       return Status::InvalidArgument("Request is invalid");
-    case EMPTY_EXEC_RESULT:
-      return Status::GeneralError("Execution result is empty");
+    case EMPTY_EXEC_DATA:
+      return Status::GeneralError("Execution has not generated the data");
   }
   return Status::GeneralError("Unknown error");
 }


### PR DESCRIPTION
Signing only PrePrepareResult buffer allows a malicious primary replica to make the system fool. Additional request fields should be used in the hash creation process.