### PR TITLE
Filter duplicate preprocess replies from the same sender

### DIFF
--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <map>
 #include <list>
+#include <unordered_set>
 
 namespace preprocessor {
 
@@ -96,6 +97,7 @@ class RequestProcessingState {
                                                                     bftEngine::OperationResult preProcessResult,
                                                                     uint16_t clientId,
                                                                     ReqId reqSeqNum);
+  uint16_t getNumOfRecievedReplicas() { return numOfReceivedReplies_; };
 
  private:
   static concord::util::SHA3_256::Digest convertToArray(
@@ -144,6 +146,7 @@ class RequestProcessingState {
   // Maps result hash to a list of replica signatures sent for this hash. This also implicitly gives the number of
   // replicas returning a specific hash.
   std::map<concord::util::SHA3_256::Digest, std::list<PreProcessResultSignature>> preProcessingResultHashes_;
+  std::map<concord::util::SHA3_256::Digest, std::unordered_set<bftEngine::impl::NodeIdType>> seenSenders_;
   bool retrying_ = false;
   bool preprocessingRightNow_ = false;
   uint64_t reqRetryId_ = 0;

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
@@ -78,9 +78,8 @@ std::optional<std::string> PreProcessResultMsg::validatePreProcessResultSignatur
 
   std::unordered_set<impl::NodeIdType> seen_signatures;
   for (const auto& sig : sigs) {
-    // Insert returns std::pair<iterator, bool>. The bool indicates if the element was created, or it was already in the
-    // set and no insertion was performed. The latter case indicates that we already have got a signature from this
-    // replica.
+    // logic that filters duplicate signatures exist in the preprocessing phase,
+    // therefore duplication implies that the primary is probably malicious.
     if (!seen_signatures.insert(sig.sender_replica).second) {
       return "PreProcessResult signatures validation failure - got more than one signature with the same sender id";
     }


### PR DESCRIPTION
Before this PR, multiple identical replies from the same sender could have been added to the preprocess result set.
The duplication would have been discovered in the signatures' validation phase, resulting in a view change.

This PR filters the duplications at the preprocessing phase eliminating the possibility for a view change unless the primary is malicious and adds duplications on purpose.

 