### PR TITLE
Pass failed pre-execution result through ReplicaImp consensus.

### DIFF
--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -33,11 +33,12 @@ struct ClientBatchRequestMsgHeader {
 struct ClientRequestMsgHeader {
   uint16_t msgType;  // always == REQUEST_MSG_TYPE
   uint32_t spanContextSize = 0u;
-  uint16_t idOfClientProxy;  // TODO - rename - now used mostly as id of external client
-  uint64_t flags;            // bit 0 == isReadOnly, bit 1 = preProcess, bits 2-7 are reserved
-  uint64_t reqSeqNum;
-  uint32_t requestLength;
-  uint64_t timeoutMilli;
+  uint16_t idOfClientProxy = 0;  // TODO - rename - now used mostly as id of external client
+  uint64_t flags = 0;            // bit 0 == isReadOnly, bit 1 = preProcess ...
+  uint64_t opResult = 0;
+  uint64_t reqSeqNum = 0;
+  uint32_t requestLength = 0;
+  uint64_t timeoutMilli = 0;
   uint32_t cidLength = 0;
   uint16_t reqSignatureLength = 0;
   uint32_t extraDataLength = 0;

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -54,15 +54,15 @@ enum MsgFlag : uint64_t {
 
 // The IControlHandler is a group of methods that enables the userRequestHandler to perform infrastructure
 // changes in the system.
-// For example, assuming we want to upgrade the system to new software version, then:
+// For example, assuming we want to upgrade the system to a new software version, then:
 // 1. We need to bring the system to a stable state (bft responsibility)
 // 2. We need to perform the actual upgrade process (the platform responsibility)
-// Thus, once the bft brings the system to the desired stable state, it needs to invoke the a callback of the user to
-// perform the actual upgrade.
+// Once the bft brings the system to the desired stable state, it needs to invoke a user callback to perform the actual
+// upgrade.
 // More possible scenarios would be:
 // 1. Adding/removing node
 // 2. Key exchange
-// 3. Change DB scheme
+// 3. DB scheme change
 // and basically any management action that is handled by the layer that uses concord-bft.
 class IControlHandler {
  public:

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -344,7 +344,7 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
   if (isPreProcessRequired)
     reqMsg = new ClientPreProcessRequestMsg(clientId_, reqSeqNum, lenOfRequest, request, reqTimeoutMilli, msgCid, ctx);
   else
-    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lenOfRequest, request, reqTimeoutMilli, msgCid, ctx);
+    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lenOfRequest, request, reqTimeoutMilli, msgCid, 0, ctx);
   {
     std::unique_lock<std::mutex> mlock(lock_);
     pendingRequests_.push_back(reqMsg);
@@ -452,6 +452,7 @@ OperationResult SimpleClientImp::preparePendingRequestsFromBatch(const deque<Cli
                                   (char*)req.request.data(),
                                   req.timeoutMilli,
                                   cid,
+                                  0,
                                   ctx);
     {
       unique_lock<std::mutex> mlock(lock_);

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -15,7 +15,6 @@
 #include "ReplicaConfig.hpp"
 #include "SigManager.hpp"
 #include "Replica.hpp"
-
 #include <cstring>
 
 namespace bftEngine::impl {
@@ -43,6 +42,7 @@ ClientRequestMsg::ClientRequestMsg(NodeIdType sender,
                                    const char* request,
                                    uint64_t reqTimeoutMilli,
                                    const std::string& cid,
+                                   uint64_t opResult,
                                    const concordUtils::SpanContext& spanContext,
                                    const char* requestSignature,
                                    uint32_t requestSignatureLen,
@@ -54,7 +54,7 @@ ClientRequestMsg::ClientRequestMsg(NodeIdType sender,
   // logical XOR - if requestSignatureLen is zero requestSignature must be null and vise versa
   ConcordAssert((requestSignature == nullptr) == (requestSignatureLen == 0));
   // set header
-  setParams(sender, reqSeqNum, requestLength, flags, reqTimeoutMilli, cid, requestSignatureLen, extraBufSize);
+  setParams(sender, reqSeqNum, requestLength, flags, reqTimeoutMilli, opResult, cid, requestSignatureLen, extraBufSize);
 
   // set span context
   char* position = body() + sizeof(ClientRequestMsgHeader);
@@ -86,11 +86,9 @@ ClientRequestMsg::ClientRequestMsg(ClientRequestMsgHeader* body)
 bool ClientRequestMsg::isReadOnly() const { return (msgBody()->flags & READ_ONLY_REQ) != 0; }
 
 bool ClientRequestMsg::shouldValidateAsync() const {
-  // Reconfiguration messages are validated in their own handler
-  // so we should not do its validtion in asynchronous manner
-  // as that will lead to overhead.
-  // Similarly key exchanges should happen rarely and thus we
-  // should validate as quick as possible, in sync.
+  // Reconfiguration messages are validated in their own handler, so we should not do its validation in an asynchronous
+  // manner, as that will lead to overhead. Similarly, key exchanges should happen rarely, and thus we should validate
+  // as quick as possible, in sync.
   const auto* header = msgBody();
   if (((header->flags & RECONFIG_FLAG) != 0) || ((header->flags & KEY_EXCHANGE_FLAG) != 0)) {
     return false;
@@ -129,8 +127,8 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
   }
   if (isIdOfExternalClient) {
     if ((header->flags & RECONFIG_FLAG) != 0) {
-      // This message arrived from operator/cre - no need at this stage to verifiy the request, since operator/cre
-      // verifies it's own signatures on requests in the reconfiguration handler
+      // This message arrived from operator/cre - no need at this stage to verify the request, since operator/cre
+      // verifies its own signatures on requests in the reconfiguration handler.
       expectedSigLen = header->reqSignatureLength;
       doSigVerify = false;
     } else if (isClientTransactionSigningEnabled) {
@@ -142,7 +140,7 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
       } else {
         expectedSigLen = sigManager->getSigLength(clientId);
         if (0 == expectedSigLen) {
-          msg << "Invalid expectedSigLen " << KVLOG(clientId, this->senderId());
+          msg << "Invalid expectedSigLen" << KVLOG(clientId, this->senderId());
           LOG_ERROR(GL, msg.str());
           throw std::runtime_error(msg.str());
         }
@@ -152,9 +150,8 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
       }
     }
   }
-
   if (expectedSigLen != header->reqSignatureLength) {
-    msg << "Unexpected request signature length: "
+    msg << "Unexpected request signature length:"
         << KVLOG(clientId,
                  this->senderId(),
                  header->reqSeqNum,
@@ -162,22 +159,31 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
                  header->reqSignatureLength,
                  isIdOfExternalClient,
                  isClientTransactionSigningEnabled);
-    LOG_WARN(CNSUS, msg.str());
+    LOG_ERROR(CNSUS, msg.str());
     throw std::runtime_error(msg.str());
   }
   auto expectedMsgSize = sizeof(ClientRequestMsgHeader) + header->requestLength + header->cidLength +
                          spanContextSize() + expectedSigLen + header->extraDataLength;
 
   if ((msgSize < minMsgSize) || (msgSize != expectedMsgSize)) {
-    msg << "Invalid msgSize: " << KVLOG(msgSize, minMsgSize, expectedMsgSize);
-    LOG_WARN(CNSUS, msg.str());
+    msg << "Invalid msgSize:"
+        << KVLOG(msgSize,
+                 minMsgSize,
+                 expectedMsgSize,
+                 sizeof(ClientRequestMsgHeader),
+                 header->requestLength,
+                 header->cidLength,
+                 expectedSigLen,
+                 spanContextSize(),
+                 header->extraDataLength);
+    LOG_ERROR(CNSUS, msg.str());
     throw std::runtime_error(msg.str());
   }
   if (doSigVerify) {
     if (!sigManager->verifySig(
             clientId, requestBuf(), header->requestLength, requestSignature(), header->reqSignatureLength)) {
       std::stringstream msg;
-      LOG_WARN(CNSUS, "Signature verification failed for " << KVLOG(header->reqSeqNum, this->senderId(), clientId));
+      LOG_WARN(CNSUS, "Signature verification failed for" << KVLOG(header->reqSeqNum, this->senderId(), clientId));
       msg << "Signature verification failed for: "
           << KVLOG(clientId,
                    this->senderId(),
@@ -188,7 +194,7 @@ void ClientRequestMsg::validateImp(const ReplicasInfo& repInfo) const {
                    this->senderId());
       throw std::runtime_error(msg.str());
     }
-    LOG_TRACE(CNSUS, "Signature verified for " << KVLOG(header->reqSeqNum, this->senderId(), clientId));
+    LOG_TRACE(CNSUS, "Signature verified for" << KVLOG(header->reqSeqNum, this->senderId(), clientId));
   }
 }
 
@@ -197,6 +203,7 @@ void ClientRequestMsg::setParams(NodeIdType sender,
                                  uint32_t requestLength,
                                  uint64_t flags,
                                  uint64_t reqTimeoutMilli,
+                                 uint64_t opResult,
                                  const std::string& cid,
                                  uint32_t requestSignatureLen,
                                  uint32_t extraBufSize) {
@@ -206,6 +213,7 @@ void ClientRequestMsg::setParams(NodeIdType sender,
   header->reqSeqNum = reqSeqNum;
   header->requestLength = requestLength;
   header->flags = flags;
+  header->opResult = opResult;
   header->cidLength = cid.size();
   header->reqSignatureLength = requestSignatureLen;
   header->extraDataLength = extraBufSize;

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -26,7 +26,7 @@ class ClientRequestMsg : public MessageBase {
   static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header::msgType), "");
   static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
   static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
-  static_assert(sizeof(ClientRequestMsgHeader) == 46, "ClientRequestMsgHeader size is 46B");
+  static_assert(sizeof(ClientRequestMsgHeader) == 54, "ClientRequestMsgHeader size is 54B");
   static concord::diagnostics::Recorder sigNatureVerificationRecorder;
   // TODO(GG): more asserts
 
@@ -38,6 +38,7 @@ class ClientRequestMsg : public MessageBase {
                    const char* request,
                    uint64_t reqTimeoutMilli,
                    const std::string& cid = "",
+                   uint64_t opResult = 0,
                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{},
                    const char* requestSignature = nullptr,
                    uint32_t requestSignatureLen = 0,
@@ -54,6 +55,8 @@ class ClientRequestMsg : public MessageBase {
   bool isReadOnly() const;
 
   uint64_t flags() const { return msgBody()->flags; }
+
+  uint64_t opResult() const { return msgBody()->opResult; }
 
   ReqId requestSeqNum() const { return msgBody()->reqSeqNum; }
 
@@ -89,6 +92,7 @@ class ClientRequestMsg : public MessageBase {
                  uint32_t requestLength,
                  uint64_t flags,
                  uint64_t reqTimeoutMilli,
+                 uint64_t opResult,
                  const std::string& cid,
                  uint32_t requestSignatureLen,
                  uint32_t extraBufSize);

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1164,14 +1164,16 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
       const auto &span_context = preProcessReqMsg->spanContext<PreProcessRequestMsgSharedPtr::element_type>();
       // Copy of the message body is unavoidable here, as we need to create a new message type which lifetime is
       // controlled by the replica while all PreProcessReply messages get released here.
+      const auto preProcessResult = static_cast<uint64_t>(reqProcessingStatePtr->getAgreedPreProcessResult());
       if (ReplicaConfig::instance().preExecutionResultAuthEnabled) {
         auto sigsList = reqProcessingStatePtr->getPreProcessResultSignatures();
         sigsList.resize(numOfRequiredReplies());
         auto sigsBuf = PreProcessResultSignature::serializeResultSignatureList(sigsList);
         preProcessMsg = make_unique<PreProcessResultMsg>(clientId,
+                                                         preProcessResult,
                                                          reqSeqNum,
                                                          reqProcessingStatePtr->getPrimaryPreProcessedResultLen(),
-                                                         reqProcessingStatePtr->getPrimaryPreProcessedResult(),
+                                                         reqProcessingStatePtr->getPrimaryPreProcessedResultData(),
                                                          reqProcessingStatePtr->getReqTimeoutMilli(),
                                                          cid,
                                                          span_context,
@@ -1186,9 +1188,10 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
                                                       HAS_PRE_PROCESSED_FLAG,
                                                       reqSeqNum,
                                                       reqProcessingStatePtr->getPrimaryPreProcessedResultLen(),
-                                                      reqProcessingStatePtr->getPrimaryPreProcessedResult(),
+                                                      reqProcessingStatePtr->getPrimaryPreProcessedResultData(),
                                                       reqProcessingStatePtr->getReqTimeoutMilli(),
                                                       cid,
+                                                      preProcessResult,
                                                       span_context,
                                                       reqProcessingStatePtr->getReqSignature(),
                                                       reqProcessingStatePtr->getReqSignatureLength());

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -65,14 +65,13 @@ class RequestProcessingState {
   const auto getReqOffsetInBatch() const { return reqOffsetInBatch_; }
   const SeqNum getReqSeqNum() const { return reqSeqNum_; }
   PreProcessingResult definePreProcessingConsensusResult();
-  const char* getPrimaryPreProcessedResult() const { return primaryPreProcessResultData_; }
+  const char* getPrimaryPreProcessedResultData() const { return primaryPreProcessResultData_; }
   uint32_t getPrimaryPreProcessedResultLen() const { return primaryPreProcessResultLen_; }
   bool isReqTimedOut() const;
   const uint64_t reqRetryId() const { return reqRetryId_; }
   uint64_t getReqTimeoutMilli() const {
     return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->requestTimeoutMilli() : 0;
   }
-
   const char* getReqSignature() const {
     if (!clientRequestSignature_.empty()) {
       return clientRequestSignature_.data();
@@ -80,7 +79,6 @@ class RequestProcessingState {
     return nullptr;
   }
   uint32_t getReqSignatureLength() const { return clientRequestSignature_.size(); }
-
   const std::string getReqCid() const { return clientPreProcessReqMsg_ ? clientPreProcessReqMsg_->getCid() : ""; }
   const std::string& getBatchCid() const { return batchCid_; }
   void detectNonDeterministicPreProcessing(const uint8_t* newHash, NodeIdType newSenderId, uint64_t reqRetryId) const;
@@ -89,6 +87,8 @@ class RequestProcessingState {
   void resetRejectedReplicasList() { rejectedReplicaIds_.clear(); }
   void setPreprocessingRightNow(bool set) { preprocessingRightNow_ = set; }
   const std::list<PreProcessResultSignature>& getPreProcessResultSignatures();
+  const concord::util::SHA3_256::Digest& getResultHash() { return primaryPreProcessResultHash_; };
+  const bftEngine::OperationResult getAgreedPreProcessResult() const { return agreedPreProcessResult_; }
 
   static void init(uint16_t numOfRequiredReplies, preprocessor::PreProcessorRecorder* histograms);
   static concord::util::SHA3_256::Digest createPreProcessResultHash(const char* preProcessResultData,
@@ -96,7 +96,6 @@ class RequestProcessingState {
                                                                     bftEngine::OperationResult preProcessResult,
                                                                     uint16_t clientId,
                                                                     ReqId reqSeqNum);
-  const concord::util::SHA3_256::Digest& getResultHash() { return primaryPreProcessResultHash_; };
 
  private:
   static concord::util::SHA3_256::Digest convertToArray(
@@ -110,7 +109,6 @@ class RequestProcessingState {
   void detectNonDeterministicPreProcessing(const concord::util::SHA3_256::Digest& newHash,
                                            NodeIdType newSenderId,
                                            uint64_t reqRetryId) const;
-  const bftEngine::OperationResult getAgreedPreProcessResult() const { return agreedPreProcessResult_; }
 
   // Detect if a hash is different from the input parameter because of the appended block id.
   std::pair<std::string, concord::util::SHA3_256::Digest> detectFailureDueToBlockID(

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -33,6 +33,7 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
                        request,
                        reqTimeoutMilli,
                        cid,
+                       0,
                        spanContext,
                        requestSignature,
                        requestSignatureLen) {
@@ -48,6 +49,7 @@ unique_ptr<MessageBase> ClientPreProcessRequestMsg::convertToClientRequestMsg(bo
                                                                            requestBuf(),
                                                                            requestTimeoutMilli(),
                                                                            getCid(),
+                                                                           opResult(),
                                                                            spanContext<ClientRequestMsg>(),
                                                                            emptyReq ? nullptr : requestSignature(),
                                                                            emptyReq ? 0 : requestSignatureLength());

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -28,7 +28,7 @@ PreProcessRequestMsg::PreProcessRequestMsg(RequestType reqType,
                                            const std::string& cid,
                                            const char* requestSignature,
                                            uint16_t requestSignatureLength,
-                                           uint64_t blockid,
+                                           uint64_t blockId,
                                            const concordUtils::SpanContext& span_context)
     : MessageBase(senderId,
                   MsgCode::PreProcessRequest,
@@ -45,7 +45,7 @@ PreProcessRequestMsg::PreProcessRequestMsg(RequestType reqType,
             reqRetryId,
             reqLength,
             requestSignatureLength,
-            blockid);
+            blockId);
   auto position = body() + sizeof(Header);
   memcpy(position, span_context.data().data(), span_context.data().size());
   position += span_context.data().size();
@@ -70,7 +70,7 @@ PreProcessRequestMsg::PreProcessRequestMsg(RequestType reqType,
                   span_context.data().size(),
                   requestSignatureLength,
                   msgLength,
-                  blockid));
+                  blockId));
 }
 
 void PreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
@@ -20,9 +20,10 @@ namespace preprocessor {
 using namespace bftEngine;
 
 PreProcessResultMsg::PreProcessResultMsg(NodeIdType sender,
+                                         uint64_t preProcessResult,
                                          uint64_t reqSeqNum,
                                          uint32_t resultLength,
-                                         const char* result,
+                                         const char* resultBuf,
                                          uint64_t reqTimeoutMilli,
                                          const std::string& cid,
                                          const concordUtils::SpanContext& spanContext,
@@ -33,9 +34,10 @@ PreProcessResultMsg::PreProcessResultMsg(NodeIdType sender,
                        HAS_PRE_PROCESSED_FLAG,
                        reqSeqNum,
                        resultLength,  // check the comment in the header to
-                       result,        // understand why result is passed as request here
+                       resultBuf,     // understand why result is passed as request here
                        reqTimeoutMilli,
                        cid,
+                       preProcessResult,
                        spanContext,
                        messageSignature,
                        messageSignatureLen,

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
@@ -39,9 +39,10 @@ class PreProcessResultMsg : public ClientRequestMsg {
   using ErrorMessage = std::optional<std::string>;
 
   PreProcessResultMsg(NodeIdType sender,
+                      uint64_t preProcessResult,
                       uint64_t reqSeqNum,
                       uint32_t resultLength,
-                      const char* result,
+                      const char* resultBuf,
                       uint64_t reqTimeoutMilli,
                       const std::string& cid = "",
                       const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{},

--- a/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
+++ b/bftengine/src/preprocessor/tests/messages/PreProcessResultMsg_test.cpp
@@ -135,6 +135,7 @@ class PreProcessResultMsgTestFixture : public testing::Test {
       resultSigs.emplace_back(std::vector<char>(msgSig), duplicateSigs ? 0 : i, bftEngine::SUCCESS);
     }
     return std::make_unique<PreProcessResultMsg>(params.senderId,
+                                                 0,
                                                  params.reqSeqNum,
                                                  sizeof(params.result),
                                                  params.result,
@@ -169,8 +170,8 @@ class PreProcessResultMsgTxSigningOffTestFixture : public testing::Test {
 
   std::unique_ptr<PreProcessResultMsg> createMessage(const MsgParams& params, const int sigCount, bool duplicateSigs) {
     auto resultSigsBuf = getProcessResultSigBuff(sigManager, params, sigCount, duplicateSigs);
-
     return std::make_unique<PreProcessResultMsg>(params.senderId,
+                                                 0,
                                                  params.reqSeqNum,
                                                  sizeof(params.result),
                                                  params.result,

--- a/bftengine/tests/messages/ClientRequestMsg_test.cpp
+++ b/bftengine/tests/messages/ClientRequestMsg_test.cpp
@@ -56,6 +56,7 @@ TEST_F(ClientRequestMsgTestFixture, create_and_compare) {
                        request,
                        requestTimeoutMilli,
                        correlationId,
+                       0,
                        concordUtils::SpanContext{spanContext});
 
   EXPECT_EQ(msg.clientProxyId(), senderId);
@@ -86,6 +87,7 @@ TEST_F(ClientRequestMsgTestFixture, create_and_compare_with_empty_span) {
                        request,
                        requestTimeoutMilli,
                        correlationId,
+                       0,
                        concordUtils::SpanContext{spanContext});
 
   EXPECT_EQ(msg.clientProxyId(), senderId);
@@ -115,6 +117,7 @@ TEST_F(ClientRequestMsgTestFixture, create_and_compare_with_empty_cid) {
                        request,
                        requestTimeoutMilli,
                        correlationId,
+                       0,
                        concordUtils::SpanContext{spanContext});
 
   EXPECT_EQ(msg.clientProxyId(), senderId);
@@ -145,6 +148,7 @@ TEST_F(ClientRequestMsgTestFixture, create_from_buffer) {
                                request,
                                requestTimeoutMilli,
                                correlationId,
+                               0,
                                concordUtils::SpanContext{spanContext});
 
   ClientRequestMsg copy_msg((ClientRequestMsgHeader*)originalMsg.body());
@@ -178,6 +182,7 @@ TEST_F(ClientRequestMsgTestFixture, test_with_timestamp) {
                                request.data(),
                                requestTimeoutMilli,
                                correlationId,
+                               0,
                                concordUtils::SpanContext{spanContext});
 
   ClientRequestMsg copy_msg((ClientRequestMsgHeader*)originalMsg.body());
@@ -214,6 +219,7 @@ TEST_F(ClientRequestMsgTestFixture, base_methods) {
                        request,
                        requestTimeoutMilli,
                        correlationId,
+                       0,
                        concordUtils::SpanContext{spanContext});
   EXPECT_NO_THROW(msg.validate(replicaInfo));
   testMessageBaseMethods(msg, MsgCode::ClientRequest, senderId, spanContext);
@@ -240,6 +246,7 @@ TEST_F(ClientRequestMsgTestFixture, extra_buffer) {
                            request,
                            reqTimeoutMilli,
                            cid,
+                           0,
                            spanContext,
                            requestSignature,
                            requestSignatureLen,

--- a/bftengine/tests/messages/PrePrepareMsg_test.cpp
+++ b/bftengine/tests/messages/PrePrepareMsg_test.cpp
@@ -45,6 +45,7 @@ ClientRequestMsg create_client_request() {
                           request,
                           requestTimeoutMilli,
                           correlationId,
+                          0,
                           concordUtils::SpanContext{spanContext});
 }
 
@@ -84,6 +85,7 @@ void create_random_client_requests(std::vector<std::shared_ptr<ClientRequestMsg>
                                                                           request.c_str(),
                                                                           requestTimeoutMilli,
                                                                           correlationId,
+                                                                          0,
                                                                           concordUtils::SpanContext{spanContext})});
     numMsgs--;
   }

--- a/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
+++ b/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
@@ -45,21 +45,18 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
            "-v", view_change_timeout_milli,
            "-x"
            ]
-    if(replica_id == 0) :
+    if replica_id == 0 :
         cmd.extend(["-g", "MangledPreProcessResultMsgStrategy"])
 
     return cmd
 
-def start_replica_cmd_assymetric_communication(builddir, replica_id, view_change_timeout_milli="10000"):
+def start_replica_cmd_asymmetric_communication(builddir, replica_id, view_change_timeout_milli="10000"):
     """
-    Return a command that starts an skvbc replica when passed to
-    subprocess.Popen.
-    The replica is started with a short view change timeout.
-    Note each arguments is an element in a list.
-    The primary replica is started with a Byzantine Strategy, so it
-    will exhibit Byzantine behaviours. Alongwith this it will also
-    send different message to different backup replicas. This primary
-    will try to mess-up the consensus and confuse all the other replicas.
+    Return a command that starts a skvbc replica when passed to subprocess.
+    The replica is started with a short view change timeout. Note each argument is an element in a list.
+    The primary replica is started with a Byzantine Strategy, so it will exhibit Byzantine behaviours.
+    Along with this it will also send different message to different backup replicas. This primary
+    will try to mess up the consensus and confuse all the other replicas.
     """
 
     status_timer_milli = "500"
@@ -72,7 +69,7 @@ def start_replica_cmd_assymetric_communication(builddir, replica_id, view_change
            "-v", view_change_timeout_milli,
            "-x"
            ]
-    if(replica_id == 0) :
+    if replica_id == 0 :
         cmd.extend(["-d", "-g", "MangledPreProcessResultMsgStrategy"])
 
     return cmd
@@ -91,11 +88,11 @@ class SkvbcPrimaryByzantinePreExecutionTest(unittest.TestCase):
         They immediately should request for view change by sending ReplicaAsksToLeaveViewMsg.
         After that if a quorum of replica feels that new primary should be elected, a view change
         will be triggered in the system.
-        If clients donot send any message, no one will know if any Byzantine replica is present
+        If clients do not send any message, no one will know if any Byzantine replica is present
         in the system.
         This function should be called after clients start sending message.
         This function will wait for a view change. After the view change it will check the new primary
-        and then initialize the preexecution counts for the new primary and returns the new primary.
+        and then initialize the pre-execution counts for the new primary and returns the new primary.
         """
         try:
             with trio.move_on_after(seconds=4*viewchange_timeout_secs):
@@ -140,9 +137,9 @@ class SkvbcPrimaryByzantinePreExecutionTest(unittest.TestCase):
         await bft_network.assert_successful_pre_executions_count(new_primary, NUM_OF_SEQ_WRITES * BATCH_SIZE)
 
     @with_trio
-    @with_bft_network(start_replica_cmd_assymetric_communication, selected_configs=lambda n, f, c: f >= 2)
+    @with_bft_network(start_replica_cmd_asymmetric_communication, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
-    async def test_byzantine_behavior_with_assymetric_comm(self, bft_network, tracker):
+    async def test_byzantine_behavior_with_asymmetric_comm(self, bft_network, tracker):
         """
         Use a random client to launch one batch pre-process request at a time.
         As there is a Byzantine Primary in the replica cluster, which sends different messages

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -183,8 +183,8 @@ class BftClient(ABC):
             if corrupt_params:
                 msg, signature, client_id = self._corrupt_signing_params(msg, signature, client_id, corrupt_params)
 
-        data = bft_msgs.pack_request(client_id, seq_num, read_only, self.config.req_timeout_milli, cid, msg,
-                                    pre_process, reconfiguration=reconfiguration, signature=signature)
+        data = bft_msgs.pack_request(client_id, seq_num, read_only, self.config.req_timeout_milli, cid, msg, 0,
+                                     pre_process, reconfiguration=reconfiguration, signature=signature)
 
         if m_of_n_quorum is None:
             m_of_n_quorum = MofNQuorum.LinearizableQuorum(self.config, [r.id for r in self.replicas])
@@ -230,11 +230,10 @@ class BftClient(ABC):
                     msg, signature, client_id = self._corrupt_signing_params(msg, signature, client_id, corrupt_params)
 
             msg_data = b''.join([msg_data, bft_msgs.pack_request(
-                self.client_id, msg_seq_num, False, self.config.req_timeout_milli, msg_cid, msg, True,
+                self.client_id, msg_seq_num, False, self.config.req_timeout_milli, msg_cid, msg, 0, True,
                 reconfiguration=False, span_context=b'', signature=signature)])
 
-        data = bft_msgs.pack_batch_request(
-            self.client_id, batch_size, msg_data, cid)
+        data = bft_msgs.pack_batch_request(self.client_id, batch_size, msg_data, cid)
 
         if m_of_n_quorum is None:
             m_of_n_quorum = MofNQuorum.LinearizableQuorum(self.config, [r.id for r in self.replicas])

--- a/util/pyclient/test_msgs.py
+++ b/util/pyclient/test_msgs.py
@@ -148,10 +148,11 @@ class TestPackUnpack(unittest.TestCase):
         timeout_milli = 5000
         span_context = b'span context'
         msg = b'hello'
+        op_result = 5
         cid = str(req_seq_num)
 
-        packed = bft_msgs.pack_request(client_id, req_seq_num, read_only,
-                                       timeout_milli, cid, msg, pre_process=False, span_context=span_context)
+        packed = bft_msgs.pack_request(client_id, req_seq_num, read_only, timeout_milli, cid, msg, op_result,
+                                       pre_process=False, span_context=span_context)
         header, unpacked_span_context, unpacked_msg, unpacked_cid = bft_msgs.unpack_request(packed)
 
         self.assertEqual(len(span_context), header.span_context_size)
@@ -161,6 +162,7 @@ class TestPackUnpack(unittest.TestCase):
         self.assertEqual(len(msg), header.length)
         self.assertEqual(timeout_milli, header.timeout_milli)
         self.assertEqual(len(cid), header.cid)
+        self.assertEqual(op_result, header.op_result)
 
         self.assertEqual(span_context, unpacked_span_context)
         self.assertEqual(msg, unpacked_msg)


### PR DESCRIPTION
Sign pre-execution failure result and pass it through the ReplicaImp consensus. Add opResult to ClientRequestMsgHeader to send it later to the client (not a part of this MR).