### PR TITLE
Tls fix in 1.5

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2356,6 +2356,7 @@ void ReplicaImp::startExecution(SeqNum seqNumber,
                                 bool askForMissingInfoAboutCommittedItems) {
   consensus_times_.end(seqNumber);
   tryToRemovePendingRequestsForSeqNum(seqNumber);  // TODO(LG) Should verify if needed
+  LOG_INFO(CNSUS, "Starting execution of seqNumber:" << seqNumber);
   if (config_.enablePostExecutionSeparation) {
     tryToStartOrFinishExecution(askForMissingInfoAboutCommittedItems);
   } else {
@@ -4952,7 +4953,7 @@ void ReplicaImp::finishExecutePrePrepareMsg(PrePrepareMsg *ppMsg,
     sendResponses(ppMsg, *pAccumulatedRequests);
     delete pAccumulatedRequests;
   }
-
+  LOG_INFO(CNSUS, "Finished execution of request seqNum:" << ppMsg->seqNumber());
   uint64_t checkpointNum{};
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {
     checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -603,6 +603,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
       MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(parent_.config_.replicaId));
       MDC_PUT(MDC_THREAD_KEY, "post-execution-thread");
       SCOPED_MDC_SEQ_NUM(std::to_string(ppMsg_->seqNumber()));
+      LOG_INFO(CNSUS, "Starting post-execution for seqNumber:" << ppMsg_->seqNumber());
       parent_.executeRequests(ppMsg_, requestSet_, time_);
     }
   };

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -209,14 +209,21 @@ void AsyncTlsConnection::send(std::shared_ptr<OutgoingMsg>&& msg) {
 void AsyncTlsConnection::write(std::shared_ptr<OutgoingMsg> msg) {
   if (disposed_ || !msg) return;
 
+  bool expected = true;
   // There is already an in-flight msg
-  if (write_msg_) {
+  if (write_msg_used_.compare_exchange_weak(expected, true)) {
     write_queue_.push(std::move(msg));
     return;
   }
-
+  expected = false;
   // Set the in-flight msg
-  write_msg_ = std::move(msg);
+  if (write_msg_used_.compare_exchange_weak(expected, true)) {
+    write_msg_ = std::move(msg);
+  } else {
+    write_queue_.push(std::move(msg));
+    LOG_ERROR(logger_, "write_msg_ already in use by other thread, msg pushed to the write queue.");
+    return;
+  }
   LOG_DEBUG(logger_, "Writing" << KVLOG(write_msg_->msg.size()));
 
   // We don't want to include tcp transmission time.
@@ -246,6 +253,7 @@ void AsyncTlsConnection::write(std::shared_ptr<OutgoingMsg> msg) {
         write_timer_.cancel();
         histograms_.sent_msg_size->recordAtomic(static_cast<int64_t>(write_msg_->msg.size()));
         write_msg_ = nullptr;
+        write_msg_used_ = false;
         write(write_queue_.pop());
       }));
   startWriteTimer();

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -213,6 +213,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   std::vector<char> read_msg_;
 
   // Message being currently written.
+  std::atomic_bool write_msg_used_{false};
   std::shared_ptr<OutgoingMsg> write_msg_;
 
   TlsTcpConfig& config_;

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -14,7 +14,7 @@
 #include "TlsRunner.h"
 
 // TODO: Make this configurable
-static constexpr size_t NUM_THREADS = 2;
+static constexpr size_t NUM_THREADS = 1;
 
 namespace bft::communication {
 


### PR DESCRIPTION
This PR insert:
1) On TLS code we find that in some situations the write_msg_ could be overridden by 2 different threads and cause the disappearing of messages.