### PR TITLE
Don't execute requests from previous epoch on CRE

### DIFF
--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -79,6 +79,7 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
   bool validate(const State& state) const override {
     concord::messages::ClientStateReply crep;
     concord::messages::deserialize(state.data, crep);
+    if (crep.epoch < EpochManager::instance().getSelfEpochNumber()) return false;
     return std::holds_alternative<concord::messages::ReplicaTlsExchangeKey>(crep.response);
   }
 

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -79,6 +79,7 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
   concord::messages::ClientStateReply buildClientStateReply(kvbc::keyTypes::CLIENT_COMMAND_TYPES command_type,
                                                             uint32_t clientid);
   concord::messages::ClientStateReply buildReplicaStateReply(const std::string& command_type, uint32_t clientid);
+  concord::messages::ClientStateReply buildLatestEpochStateReply();
 };
 /**
  * This component is responsible for logging reconfiguration request (issued by an authorized operator) in the


### PR DESCRIPTION
In CRE, executing requests from previous epochs may create problems.
For example, consider the scaling procedure.
On scaling the components may get new TLS certificates from the configuration service.
Now, consider the following scenario:
1. TLS exchange for replica X
2. scale up clients
3. the new client gets the certificate of X using CRE, but X's certificate has already changed due to the reconfiguration procedure.

To conclude, we should not run commands from previous epochs in the CRE