### PR TITLE
 TLS key-exchange improvements (replica-replica and client-replica)

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -28,7 +28,7 @@ typedef int64_t SeqNum;  // TODO [TK] redefinition
 
 class KeyExchangeManager {
  public:
-  void exchangeTlsKeys(uint64_t bft_sn);
+  void exchangeTlsKeys(const SeqNum& bft_sn);
   // Generates and publish key to consensus
   void sendKeyExchange(const SeqNum&);
   // Generates and publish the first replica's key,
@@ -180,7 +180,7 @@ class KeyExchangeManager {
   std::string generateCid(std::string);
   // build cryptosystem
   void notifyRegistry();
-  void exchangeTlsKeys(const std::string& type, uint64_t bft_sn);
+  void exchangeTlsKeys(const std::string& type, const SeqNum& bft_sn);
   /**
    * Samples periodically how many connections the replica has with other replicas.
    * returns when num of connections is (clusterSize - 1) i.e. full communication.

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -28,7 +28,7 @@ typedef int64_t SeqNum;  // TODO [TK] redefinition
 
 class KeyExchangeManager {
  public:
-  void exchangeTlsKeys(const SeqNum&);
+  void exchangeTlsKeys(uint64_t bftSn);
   // Generates and publish key to consensus
   void sendKeyExchange(const SeqNum&);
   // Generates and publish the first replica's key,
@@ -180,6 +180,7 @@ class KeyExchangeManager {
   std::string generateCid(std::string);
   // build cryptosystem
   void notifyRegistry();
+  void exchangeTlsKeys(const std::string& type, uint64_t bftSn);
   /**
    * Samples periodically how many connections the replica has with other replicas.
    * returns when num of connections is (clusterSize - 1) i.e. full communication.

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -28,7 +28,7 @@ typedef int64_t SeqNum;  // TODO [TK] redefinition
 
 class KeyExchangeManager {
  public:
-  void exchangeTlsKeys(uint64_t bftSn);
+  void exchangeTlsKeys(uint64_t bft_sn);
   // Generates and publish key to consensus
   void sendKeyExchange(const SeqNum&);
   // Generates and publish the first replica's key,
@@ -180,7 +180,7 @@ class KeyExchangeManager {
   std::string generateCid(std::string);
   // build cryptosystem
   void notifyRegistry();
-  void exchangeTlsKeys(const std::string& type, uint64_t bftSn);
+  void exchangeTlsKeys(const std::string& type, uint64_t bft_sn);
   /**
    * Samples periodically how many connections the replica has with other replicas.
    * returns when num of connections is (clusterSize - 1) i.e. full communication.

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -117,6 +117,7 @@ class InternalSigner : public concord::util::crypto::ISigner {
     return out;
   }
   uint32_t signatureLength() const override { return bftEngine::impl::SigManager::instance()->getMySigLength(); }
+  std::string getPrivKey() const override { return ""; }
 };
 
 class ScalingReplicaHandler : public IStateHandler {

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -101,7 +101,6 @@ class ReplicaTLSKeyExchangeHandler : public IStateHandler {
                              std::to_string(sender_id) + "/client/client.cert";
     sm_.encryptFile(bft_replicas_cert_path, cert);
     LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
-    StateControl::instance().restartComm(sender_id);
     return succ;
   }
 
@@ -197,7 +196,8 @@ std::shared_ptr<ClientReconfigurationEngine> CreFactory::create(std::shared_ptr<
   IStateClient* pbc = new PollBasedStateClient(bftClient, cre_config.interval_timeout_ms_, 0, cre_config.id_);
   auto cre =
       std::make_shared<ClientReconfigurationEngine>(cre_config, pbc, std::make_shared<concordMetrics::Aggregator>());
-  cre->registerHandler(std::make_shared<ReplicaTLSKeyExchangeHandler>());
+  if (bftEngine::ReplicaConfig::instance().isReadOnly)
+    cre->registerHandler(std::make_shared<ReplicaTLSKeyExchangeHandler>());
   if (!bftEngine::ReplicaConfig::instance().isReadOnly) cre->registerHandler(std::make_shared<ScalingReplicaHandler>());
   return cre;
 }

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -136,7 +136,7 @@ void KeyExchangeManager::loadPublicKeys() {
   notifyRegistry();
 }
 
-void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bft_sn) {
+void KeyExchangeManager::exchangeTlsKeys(const std::string& type, const SeqNum& bft_sn) {
   auto keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
       concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);
   std::string root_path =
@@ -185,7 +185,7 @@ void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bft_s
   client_->sendRequest(RECONFIG_FLAG, strMsg.size(), strMsg.c_str(), cid);
 }
 
-void KeyExchangeManager::exchangeTlsKeys(uint64_t bft_sn) {
+void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
   exchangeTlsKeys("server", bft_sn);
   exchangeTlsKeys("client", bft_sn);
   metrics_->tls_key_exchange_requests_++;

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -136,7 +136,7 @@ void KeyExchangeManager::loadPublicKeys() {
   notifyRegistry();
 }
 
-void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bftSn) {
+void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bft_sn) {
   auto keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
       concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);
   std::string root_path =
@@ -181,13 +181,13 @@ void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bftSn
   data_vec.clear();
   concord::messages::serialize(data_vec, req);
   std::string strMsg(data_vec.begin(), data_vec.end());
-  std::string cid = "replicaTlsKeyExchange_" + std::to_string(bftSn) + "_" + std::to_string(repId);
+  std::string cid = "replicaTlsKeyExchange_" + std::to_string(bft_sn) + "_" + std::to_string(repId);
   client_->sendRequest(RECONFIG_FLAG, strMsg.size(), strMsg.c_str(), cid);
 }
 
-void KeyExchangeManager::exchangeTlsKeys(uint64_t bftSn) {
-  exchangeTlsKeys("server", bftSn);
-  exchangeTlsKeys("client", bftSn);
+void KeyExchangeManager::exchangeTlsKeys(uint64_t bft_sn) {
+  exchangeTlsKeys("server", bft_sn);
+  exchangeTlsKeys("client", bft_sn);
   metrics_->tls_key_exchange_requests_++;
   bft::communication::StateControl::instance().restartComm(repID_);
   LOG_INFO(KEY_EX_LOG, "Replica has generated a new tls keys");

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -162,9 +162,9 @@ void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bft_s
     ec_f.close();
   }
 
-  concord::secretsmanager::SecretsManagerPlain psm_;
+  concord::secretsmanager::SecretsManagerPlain psm;
   // 2. exchange the certificate itself
-  psm_.encryptFile(cert_path, cert);
+  psm.encryptFile(cert_path, cert);
 
   if (type == "client") return;
   auto repId = bftEngine::ReplicaConfig::instance().replicaId;

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -18,6 +18,7 @@
 #include "secrets_manager_plain.h"
 #include "concord.cmf.hpp"
 #include "bftengine/EpochManager.hpp"
+#include "communication/StateControl.hpp"
 
 namespace bftEngine::impl {
 
@@ -135,15 +136,38 @@ void KeyExchangeManager::loadPublicKeys() {
   notifyRegistry();
 }
 
-void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
-  auto repId = bftEngine::ReplicaConfig::instance().replicaId;
+void KeyExchangeManager::exchangeTlsKeys(const std::string& type, uint64_t bftSn) {
   auto keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
       concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);
-  auto cert = concord::util::crypto::Crypto::instance().generateSelfSignedCertificate(
-      keys, "node" + std::to_string(repId) + "ser", repId);
-  std::string pk_tmp_file = bftEngine::ReplicaConfig::instance().keyViewFilePath + "/pk.pem." + std::to_string(repId);
-  secretsMgr_->encryptFile(pk_tmp_file, keys.first);
+  std::string root_path =
+      bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" + std::to_string(repID_) + "/" + type;
 
+  std::string cert_path = root_path + "/" + type + ".cert";
+  std::string prev_key_pem = concord::util::crypto::Crypto::instance()
+                                 .RsaHexToPem(std::make_pair(SigManager::instance()->getSelfPrivKey(), ""))
+                                 .first;
+  auto cert = concord::util::crypto::CertificateUtils::generateSelfSignedCert(cert_path, keys.second, prev_key_pem);
+  // Now that we have generated new key pair and certificate, lets do the actual exchange on this replica
+  std::string pk_path = root_path + "/pk.pem";
+  std::fstream nec_f(pk_path);
+  std::fstream ec_f(pk_path + ".enc");
+
+  // 1. exchange private key
+  if (nec_f.good()) {
+    secretsMgr_->encryptFile(pk_path, keys.first);
+    nec_f.close();
+  }
+  if (ec_f.good()) {
+    secretsMgr_->encryptFile(pk_path + ".enc", keys.first);
+    ec_f.close();
+  }
+
+  concord::secretsmanager::SecretsManagerPlain psm_;
+  // 2. exchange the certificate itself
+  psm_.encryptFile(cert_path, cert);
+
+  if (type == "client") return;
+  auto repId = bftEngine::ReplicaConfig::instance().replicaId;
   concord::messages::ReconfigurationRequest req;
   req.sender = repId;
   req.command = concord::messages::ReplicaTlsExchangeKey{repId, cert};
@@ -157,9 +181,15 @@ void KeyExchangeManager::exchangeTlsKeys(const SeqNum& bft_sn) {
   data_vec.clear();
   concord::messages::serialize(data_vec, req);
   std::string strMsg(data_vec.begin(), data_vec.end());
-  std::string cid = "replicaTlsKeyExchange_" + std::to_string(bft_sn) + "_" + std::to_string(repId);
+  std::string cid = "replicaTlsKeyExchange_" + std::to_string(bftSn) + "_" + std::to_string(repId);
   client_->sendRequest(RECONFIG_FLAG, strMsg.size(), strMsg.c_str(), cid);
+}
+
+void KeyExchangeManager::exchangeTlsKeys(uint64_t bftSn) {
+  exchangeTlsKeys("server", bftSn);
+  exchangeTlsKeys("client", bftSn);
   metrics_->tls_key_exchange_requests_++;
+  bft::communication::StateControl::instance().restartComm(repID_);
   LOG_INFO(KEY_EX_LOG, "Replica has generated a new tls keys");
 }
 void KeyExchangeManager::sendKeyExchange(const SeqNum& sn) {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -61,6 +61,7 @@
 #include "bftengine/EpochManager.hpp"
 #include "RequestThreadPool.hpp"
 #include "DbCheckpointManager.hpp"
+#include "communication/StateControl.hpp"
 
 #define getName(var) #var
 
@@ -4274,6 +4275,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
     sigManager_.reset(sigManager);
     viewsManager = viewsMgr;
   }
+  bft::communication::StateControl::instance().setGetPeerPubKeyMethod(
+      [&](uint32_t id) { return sigManager_->getPublicKeyOfVerifier(id); });
   // clients ids are assigned as follows:
   // - client proxies starting at a subsequent id of the last (ro-)replica
   // - external clients

--- a/bftengine/src/bftengine/SigManager.hpp
+++ b/bftengine/src/bftengine/SigManager.hpp
@@ -73,6 +73,11 @@ class SigManager {
   SigManager& operator=(SigManager&&) = delete;
 
   std::string getClientsPublicKeys();
+  std::string getPublicKeyOfVerifier(uint32_t id) const {
+    if (!verifiers_.count(id)) return std::string();
+    return verifiers_.at(id)->getPubKey();
+  }
+  std::string getSelfPrivKey() const { return mySigner_->getPrivKey(); }
 
  protected:
   static constexpr uint16_t updateMetricsAggregatorThresh = 1000;

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -30,15 +30,15 @@ class StateControl {
   }
 
   void restartComm(uint32_t id) { comm_restart_cb_registry_.invokeAll(id); }
-  void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { getPeerPubKey_ = std::move(m); }
+  void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { get_peer_pub_key_ = std::move(m); }
   std::string getPeerPubKey(uint32_t id) {
-    if (getPeerPubKey_) return getPeerPubKey_(id);
+    if (get_peer_pub_key_) return get_peer_pub_key_(id);
     return std::string();
   }
 
  private:
   std::mutex lock_comm_;
   concord::util::CallbackRegistry<uint32_t> comm_restart_cb_registry_;
-  std::function<std::string(uint32_t)> getPeerPubKey_;
+  std::function<std::string(uint32_t)> get_peer_pub_key_;
 };
 }  // namespace bft::communication

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 #include <functional>
+#include <utility>
 #include "callback_registry.hpp"
 namespace bft::communication {
 class StateControl {
@@ -29,9 +30,15 @@ class StateControl {
   }
 
   void restartComm(uint32_t id) { comm_restart_cb_registry_.invokeAll(id); }
+  void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { getPeerPubKey_ = std::move(m); }
+  std::string getPeerPubKey(uint32_t id) {
+    if (getPeerPubKey_) return getPeerPubKey_(id);
+    return std::string();
+  }
 
  private:
   std::mutex lock_comm_;
   concord::util::CallbackRegistry<uint32_t> comm_restart_cb_registry_;
+  std::function<std::string(uint32_t)> getPeerPubKey_;
 };
 }  // namespace bft::communication

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -22,6 +22,8 @@
 #include "TlsWriteQueue.h"
 #include "secrets_manager_enc.h"
 #include "secrets_manager_plain.h"
+#include "crypto_utils.hpp"
+#include "communication/StateControl.hpp"
 
 namespace bft::communication::tls {
 
@@ -374,8 +376,7 @@ bool AsyncTlsConnection::verifyCertificateClient(asio::ssl::verify_context& ctx,
     LOG_WARN(logger_, "No certificate from server at node " << expected_dest_id);
     return false;
   }
-  X509_NAME_oneline(X509_get_subject_name(cert), subject.data(), 256);
-  auto [valid, _] = checkCertificate(cert, "server", subject, expected_dest_id);
+  auto [valid, _] = checkCertificate(cert, expected_dest_id);
   (void)_;  // unused variable hack
   return valid;
 }
@@ -384,103 +385,60 @@ bool AsyncTlsConnection::verifyCertificateServer(asio::ssl::verify_context& ctx)
   if (X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT != X509_STORE_CTX_get_error(ctx.native_handle())) {
     return false;
   }
-  static constexpr size_t SIZE = 512;
-  std::string subject(SIZE, 0);
   X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
   if (!cert) {
     LOG_WARN(logger_, "No certificate from client");
     return false;
   }
-  X509_NAME_oneline(X509_get_subject_name(cert), subject.data(), SIZE);
-  auto [valid, peer_id] = checkCertificate(cert, "client", std::string(subject), std::nullopt);
+  auto [valid, peer_id] = checkCertificate(cert, std::nullopt);
   peer_id_ = peer_id;
   return valid;
 }
 
 std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* receivedCert,
-                                                              std::string connectionType,
-                                                              const std::string& subject,
                                                               std::optional<NodeNum> expectedPeerId) {
-  // First, perform a basic sanity test, in order to eliminate a disk read if the certificate is
-  // unknown.
-  //
-  // The certificate must have a node id, as we put it in `OU` field on creation.
-  //
-  // Since we use pinning we must know who the remote peer is.
-  // `peerIdPrefixLength` stands for the length of 'OU=' substring
-  int peerIdPrefixLength = 3;
-  std::regex r("OU=\\d*", std::regex_constants::icase);
-  std::smatch sm;
-  regex_search(subject, sm, r);
-  if (sm.length() <= peerIdPrefixLength) {
-    LOG_WARN(logger_, "OU not found or empty: " << subject);
-    return std::make_pair(false, 0);
-  }
-
-  auto remPeer = sm.str().substr(peerIdPrefixLength, sm.str().length() - peerIdPrefixLength);
-  if (0 == remPeer.length()) {
-    LOG_WARN(logger_, "OU empty " << subject);
-    return std::make_pair(false, 0);
-  }
-
-  NodeNum remotePeerId;
-  try {
-    remotePeerId = stoul(remPeer, nullptr);
-  } catch (const std::invalid_argument& ia) {
-    LOG_WARN(logger_, "cannot convert OU, " << subject << ", " << ia.what());
-    return std::make_pair(false, 0);
-  } catch (const std::out_of_range& e) {
-    LOG_WARN(logger_, "cannot convert OU, " << subject << ", " << e.what());
-    return std::make_pair(false, 0);
-  }
-
-  // If the server has been verified, check that the peers match.
-  if (expectedPeerId) {
-    if (remotePeerId != expectedPeerId) {
-      LOG_WARN(logger_, "Peers don't match, expected: " << expectedPeerId.value() << ", received: " << remPeer);
-      return std::make_pair(false, remotePeerId);
+  uint32_t peerId = UINT32_MAX;
+  std::string conn_type;
+  bool res = concord::util::crypto::CertificateUtils::verifyCertificate(
+      receivedCert, config_.certificatesRootPath, peerId, conn_type);
+  if (expectedPeerId.has_value() && peerId != expectedPeerId.value()) return std::make_pair(false, peerId);
+  if (!res) {
+    LOG_INFO(logger_,
+             "Unable to validate certificate against the local storage, falling back to validate against the RSA "
+             "public key");
+    std::string pem_pub_key = StateControl::instance().getPeerPubKey(peerId);
+    if (!pem_pub_key.empty()) {
+      if (concord::util::crypto::Crypto::instance().getFormat(pem_pub_key) !=
+          concord::util::crypto::KeyFormat::PemFormat) {
+        pem_pub_key = concord::util::crypto::Crypto::instance()
+                          .RsaHexToPem(std::make_pair("", StateControl::instance().getPeerPubKey(peerId)))
+                          .second;
+      }
+      res = concord::util::crypto::CertificateUtils::verifyCertificate(receivedCert, pem_pub_key);
+    }
+    if (res) {
+      // Exchanging the stored certificate
+      BIO* outbio = BIO_new(BIO_s_mem());
+      if (!PEM_write_bio_X509(outbio, receivedCert)) {
+        BIO_free(outbio);
+        return std::make_pair(false, peerId);
+      }
+      std::string local_cert_path =
+          config_.certificatesRootPath + "/" + std::to_string(peerId) + "/" + conn_type + "/" + conn_type + ".cert";
+      std::string certStr;
+      int certLen = BIO_pending(outbio);
+      certStr.resize(certLen);
+      BIO_read(outbio, (void*)&(certStr.front()), certLen);
+      std::ofstream out(local_cert_path.data());
+      out << certStr;
+      out.close();
+      BIO_free(outbio);
+      LOG_INFO(logger_, "new certificate has been updated on local storage, peer: " << peerId);
+    } else {
+      std::make_pair(false, peerId);
     }
   }
-
-  // the actual pinning - read the correct certificate from the disk and
-  // compare it to the received one
-  namespace fs = boost::filesystem;
-  fs::path path;
-  try {
-    path = fs::path(config_.certificatesRootPath) / std::to_string(remotePeerId) / connectionType /
-           std::string(connectionType + ".cert");
-  } catch (std::exception& e) {
-    LOG_FATAL(logger_, "Failed to construct filesystem path: " << e.what());
-    ConcordAssert(false);
-  }
-
-  auto deleter = [](FILE* fp) {
-    if (fp) fclose(fp);
-  };
-  std::unique_ptr<FILE, decltype(deleter)> fp(fopen(path.c_str(), "r"), deleter);
-  if (!fp) {
-    LOG_ERROR(logger_, "Certificate file not found, path: " << path);
-    return std::make_pair(false, remotePeerId);
-  }
-
-  X509* localCert = PEM_read_X509(fp.get(), NULL, NULL, NULL);
-  if (!localCert) {
-    LOG_ERROR(logger_, "Cannot parse certificate, path: " << path);
-    return std::make_pair(false, remotePeerId);
-  }
-
-  // this is actual comparison, compares hash of 2 certs
-  int res = X509_cmp(receivedCert, localCert);
-  X509_free(localCert);
-  if (res == 0) {
-    // We don't put a log message here, because it will be called for each cert in the chain, resulting in duplicates.
-    // Instead we log in onXXXHandshakeComplete callbacks it TlsTcpImpl.
-    return std::make_pair(true, remotePeerId);
-  }
-  LOG_WARN(logger_,
-           "X509_cmp failed at node: " << config_.selfId << ", type: " << connectionType << ", peer: " << remotePeerId
-                                       << " res=" << res);
-  return std::make_pair(false, remotePeerId);
+  return std::make_pair(res, peerId);
 }
 
 using namespace concord::secretsmanager;

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -171,10 +171,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Check for a specific certificate and do not rely on chain authentication.
   //
   // Return true along with the actual node id if verification succeeds, (false, 0) if not.
-  std::pair<bool, NodeNum> checkCertificate(X509* cert,
-                                            std::string connectionType,
-                                            const std::string& subject,
-                                            std::optional<NodeNum> expected_peer_id);
+  std::pair<bool, NodeNum> checkCertificate(X509* cert, std::optional<NodeNum> expected_peer_id);
 
   const std::string decryptPrivateKey(const boost::filesystem::path& path);
 

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -171,7 +171,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Check for a specific certificate and do not rely on chain authentication.
   //
   // Return true along with the actual node id if verification succeeds, (false, 0) if not.
-  std::pair<bool, NodeNum> checkCertificate(X509* cert, std::optional<NodeNum> expected_peer_id);
+  std::pair<bool, NodeNum> checkCertificate(X509* received_cert, std::optional<NodeNum> expected_peer_id);
 
   const std::string decryptPrivateKey(const boost::filesystem::path& path);
 

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -33,14 +33,13 @@ static const std::string genesis_block_key(1, 0x32);
 
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
-  PUBLIC_KEY_EXCHANGE = 0x1,              // identifier of public key exchange request by client
-  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,      // identifier of client key exchange request by operator
-  CLIENT_SCALING_COMMAND = 0x3,           // identifier of client scaling request by operator
-  CLIENT_SCALING_COMMAND_STATUS = 0X4,    // identifier of client update request after successful scaling
-  CLIENT_SCALING_EXECUTE_COMMAND = 0x5,   // identifier of client scaling execute request by operator
-  CLIENT_TLS_KEY_EXCHANGE_COMMAND = 0x6,  // identifier of tls key exchange request by client
-  CLIENT_RESTART_COMMAND = 0x7,           // identifier of client restart command by operator
-  CLIENT_RESTART_STATUS = 0x8,            // identifier of client restart status
+  PUBLIC_KEY_EXCHANGE = 0x1,             // identifier of public key exchange request by client
+  CLIENT_KEY_EXCHANGE_COMMAND = 0x2,     // identifier of client key exchange request by operator
+  CLIENT_SCALING_COMMAND = 0x3,          // identifier of client scaling request by operator
+  CLIENT_SCALING_COMMAND_STATUS = 0X4,   // identifier of client update request after successful scaling
+  CLIENT_SCALING_EXECUTE_COMMAND = 0x5,  // identifier of client scaling execute request by operator
+  CLIENT_RESTART_COMMAND = 0x7,          // identifier of client restart command by operator
+  CLIENT_RESTART_STATUS = 0x8,           // identifier of client restart status
   end_
 };
 }  // namespace concord::kvbc::keyTypes

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -64,11 +64,6 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
-  bool handle(const concord::messages::ClientTlsExchangeKey&,
-              uint64_t,
-              uint32_t,
-              const std::optional<bftEngine::Timestamp>&,
-              concord::messages::ReconfigurationResponse&) override;
   bool handle(const concord::messages::ClientsRestartUpdate&,
               uint64_t,
               uint32_t,
@@ -209,6 +204,11 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::ReplicaTlsExchangeKey&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
 };
 
 class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler,
@@ -225,11 +225,5 @@ class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IR
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse& response) override;
-
-  bool handle(const concord::messages::ReplicaTlsExchangeKey&,
-              uint64_t,
-              uint32_t,
-              const std::optional<bftEngine::Timestamp>&,
-              concord::messages::ReconfigurationResponse&) override;
 };
 }  // namespace concord::kvbc::reconfiguration

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -68,7 +68,6 @@ class StReconfigurationHandler {
   bool handle(const concord::messages::RestartCommand&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::PruneRequest&, uint64_t, uint64_t, uint64_t);
   bool handle(const concord::messages::InstallCommand&, uint64_t, uint64_t, uint64_t);
-  bool handle(const concord::messages::ClientTlsExchangeKey&, uint64_t, uint64_t, uint64_t);
 
   kvbc::IReader& ro_storage_;
   BlockMetadata block_metadata_;

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -337,7 +337,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeSt
   }
   rres.response = stats;
   return true;
-}  // namespace concord::kvbc::reconfiguration
+}
 
 bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                     uint64_t bft_seq_num,

--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -71,17 +71,6 @@ void StReconfigurationHandler::stCallBack(uint64_t current_cp_num) {
                                                        current_cp_num);
   handleStoredCommand<concord::messages::InstallCommand>(std::string{kvbc::keyTypes::reconfiguration_install_key},
                                                          current_cp_num);
-
-  auto &rep_info = bftEngine::ReplicaConfig::instance();
-  auto first_external_client_id = rep_info.numReplicas + rep_info.numRoReplicas + rep_info.numOfClientProxies;
-  // Check for every client if we have an update for TLS key exchange
-  for (auto i = first_external_client_id; i < first_external_client_id + rep_info.numOfExternalClients; i++) {
-    std::string client_key =
-        std::string{kvbc::keyTypes::reconfiguration_client_data_prefix,
-                    static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_TLS_KEY_EXCHANGE_COMMAND)} +
-        std::to_string(i);
-    handleStoredCommand<concord::messages::ClientTlsExchangeKey>(client_key, current_cp_num);
-  }
 }
 
 void StReconfigurationHandler::pruneOnStartup() {
@@ -257,24 +246,4 @@ bool StReconfigurationHandler::handle(const concord::messages::PruneRequest &com
   }
   return succ;
 }
-
-bool StReconfigurationHandler::handle(const concord::messages::ClientTlsExchangeKey &command,
-                                      uint64_t bft_seq_num,
-                                      uint64_t,
-                                      uint64_t) {
-  bool succ = true;
-  concord::messages::ReconfigurationResponse response;
-  for (const auto &[cid, cert] : command.clients_certificates) {
-    std::string bft_clients_cert_path =
-        bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" + std::to_string(cid) + "/client/client.cert";
-    auto current_rep_cert = sm_.decryptFile(bft_clients_cert_path);
-    if (current_rep_cert == cert) continue;
-    LOG_INFO(GL, "execute client's TLS key exchange after state transfer" << KVLOG(cid));
-    std::string cert_path = bft_clients_cert_path + "/" + std::to_string(cid) + "/client/client.cert";
-    sm_.encryptFile(bft_clients_cert_path, cert);
-    LOG_INFO(GL, bft_clients_cert_path + " is updated on the disk");
-  }
-  return succ;
-}
-
 }  // namespace concord::kvbc

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -224,11 +224,6 @@ Msg ClientsAddRemoveExecuteCommand 51 {
     bool restart
 }
 
-Msg ClientTlsExchangeKey 52 {
-    uint64 sender_id
-    list kvpair uint32 string clients_certificates
-}
-
 Msg ClientsRestartCommand 53 {
     uint64 sender_id
     string data
@@ -256,7 +251,6 @@ Msg ClientStateReply 39 {
         ClientKeyExchangeCommand
         ClientsAddRemoveExecuteCommand
         ClientsAddRemoveUpdateCommand
-        ClientTlsExchangeKey
         ClientsRestartCommand
         ReplicaTlsExchangeKey
       } response
@@ -291,7 +285,6 @@ Msg ReconfigurationRequest 1 {
     ClientKeyExchangeCommand
     ClientReconfigurationStateRequest
     ClientExchangePublicKey
-    ClientTlsExchangeKey
     RestartCommand
     ReplicaTlsExchangeKey
     ClientsAddRemoveCommand

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -215,13 +215,6 @@ class IReconfigurationHandler {
     return true;
   }
 
-  virtual bool handle(const concord::messages::ClientTlsExchangeKey &,
-                      uint64_t,
-                      uint32_t,
-                      const std::optional<bftEngine::Timestamp> &,
-                      concord::messages::ReconfigurationResponse &) {
-    return true;
-  }
   virtual bool handle(const concord::messages::ClientsRestartCommand &,
                       uint64_t,
                       uint32_t,

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -141,7 +141,9 @@ class KeyExchangeCommandHandler : public IStateHandler {
                             std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm)
       : clientId_{clientId}, key_path_{key_path}, tls_key_path_{certFolder}, sm_{sm} {
     init_last_update_block_ = init_update_block;
-    init_last_tls_update_block_ = init_tls_update_block;
+    init_last_tls_update_block_ = std::stol(
+        plain_sm_.decryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert.version").string())
+            .value_or("0"));
   }
   bool validate(const State& state) const {
     concord::messages::ClientStateReply crep;
@@ -149,8 +151,8 @@ class KeyExchangeCommandHandler : public IStateHandler {
     if (std::holds_alternative<concord::messages::ClientKeyExchangeCommand>(crep.response)) {
       concord::messages::ClientKeyExchangeCommand command =
           std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
-      if (command.tls && state.blockid >= init_last_tls_update_block_) return true;
-      if (!command.tls && state.blockid >= init_last_update_block_) return true;
+      if (command.tls && state.blockid > init_last_tls_update_block_) return true;
+      if (!command.tls && state.blockid > init_last_update_block_) return true;
     }
     return false;
   };
@@ -160,7 +162,7 @@ class KeyExchangeCommandHandler : public IStateHandler {
     concord::messages::ClientKeyExchangeCommand command =
         std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
     if (!command.tls) return executeTransactionSigningKeyExchange(out);
-    if (command.tls) return executeTlsKeyExchange(out);
+    if (command.tls) return executeTlsKeyExchange(state.blockid, out);
     return false;
   }
 
@@ -228,63 +230,48 @@ class KeyExchangeCommandHandler : public IStateHandler {
     return true;
   }
 
-  bool executeTlsKeyExchange(WriteState& out) {
+  bool executeTlsKeyExchange(uint32_t version, WriteState& out) {
     LOG_INFO(getLogger(), "execute tls key exchange request");
     // Generate new key pair
-    auto keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
+    auto new_cert_keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
         concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);
-    auto cert = concord::util::crypto::Crypto::instance().generateSelfSignedCertificate(
-        keys, "node" + std::to_string(clientId_) + "cli", clientId_);
-
-    concord::messages::ReconfigurationRequest rreq;
-    concord::messages::ClientTlsExchangeKey creq;
-    fs::path orig_pk_path = tls_key_path_ / std::to_string(clientId_) / "client" / "pk.pem";
-    fs::path enc_file_path = orig_pk_path;
+    fs::path enc_file_path = key_path_;
     enc_file_path += ".enc";
-    bool enc = false;
+    std::string private_key_str;
     std::fstream f(enc_file_path.string());
     if (f.good()) {
-      enc_file_path += ".new";
-      enc = true;
-      sm_->encryptFile(enc_file_path.string(), keys.first);
+      private_key_str = sm_->decryptFile(enc_file_path.string()).value_or("");
+      f.close();
     }
-    bool non_encrypted = false;
-    std::fstream f2(orig_pk_path.string());
-    fs::path new_key_path = orig_pk_path;
-    if (f2.good()) {
-      new_key_path += ".new";
-      plain_sm_.encryptFile(new_key_path.string(), keys.first);
-      non_encrypted = true;
+    if (private_key_str.empty()) {
+      fs::path new_key_path = key_path_;
+      std::fstream f2(new_key_path);
+      if (f2.good()) {
+        private_key_str = plain_sm_.decryptFile(new_key_path.string()).value_or("");
+        f2.close();
+      }
     }
-
-    creq.sender_id = clientId_;
-    creq.clients_certificates.emplace_back(std::make_pair(clientId_, cert));
-    rreq.command = creq;
-    std::vector<uint8_t> req_buf;
-    concord::messages::serialize(req_buf, rreq);
-    out = {req_buf, [this, non_encrypted, new_key_path, orig_pk_path, enc, enc_file_path, cert]() {
-             if (enc) {
-               fs::path orig_enc_key_path = orig_pk_path;
-               orig_enc_key_path += ".enc";
-               fs::path old_pk_path = orig_enc_key_path;
-               old_pk_path += ".old";
-               fs::copy(orig_enc_key_path, old_pk_path, fs::copy_options::update_existing);
-               fs::copy(enc_file_path, orig_enc_key_path, fs::copy_options::update_existing);
-               fs::remove(old_pk_path);
-               LOG_INFO(this->getLogger(), "exchanged tls keys (encrypted)");
-             }
-             if (non_encrypted) {
-               fs::path old_pk_path = orig_pk_path;
-               old_pk_path += ".old";
-               fs::copy(orig_pk_path, old_pk_path, fs::copy_options::update_existing);
-               fs::copy(new_key_path, orig_pk_path, fs::copy_options::update_existing);
-               fs::remove(old_pk_path);
-               LOG_INFO(this->getLogger(), "exchanged tls keys (non encrypted)");
-             }
-             plain_sm_.encryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert").string(),
-                                   cert);
-             LOG_INFO(this->getLogger(), "exchanged tls certificate");
-           }};
+    if (private_key_str.empty()) LOG_FATAL(logger, "private key does not exist");
+    auto current_cert_path = (tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert").string();
+    fs::path cert_priv_key_path = tls_key_path_ / std::to_string(clientId_) / "client" / "pk.pem";
+    std::string cert_enc_priv_key_path = cert_priv_key_path.string() + ".enc";
+    std::ifstream f3(cert_enc_priv_key_path);
+    if (f3.good()) {
+      sm_->encryptFile(cert_enc_priv_key_path, new_cert_keys.first);
+      f3.close();
+    }
+    std::ifstream f4(cert_priv_key_path);
+    if (f4.good()) {
+      plain_sm_.encryptFile(cert_priv_key_path.string(), new_cert_keys.first);
+      f4.close();
+    }
+    auto cert = concord::util::crypto::CertificateUtils::generateSelfSignedCert(
+        current_cert_path, new_cert_keys.second, private_key_str);
+    plain_sm_.encryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert").string(), cert);
+    auto curr_version = std::to_string(version);
+    plain_sm_.encryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert.version").string(),
+                          curr_version);
+    LOG_INFO(this->getLogger(), "exchanged tls certificate");
     return true;
   }
   uint16_t clientId_;
@@ -417,7 +404,6 @@ int main(int argc, char** argv) {
   // First, lets find the latest update per action
   uint64_t last_pk_status{0};
   uint64_t last_scaling_status{0};
-  uint64_t last_tls_status{0};
   uint64_t last_resatrt_status{0};
   bool succ = false;
   auto states = pollBasedClient->getStateUpdate(succ);
@@ -433,9 +419,6 @@ int main(int argc, char** argv) {
     if (std::holds_alternative<concord::messages::ClientsAddRemoveUpdateCommand>(csp.response)) {
       last_scaling_status = s.blockid;
     }
-    if (std::holds_alternative<concord::messages::ClientTlsExchangeKey>(csp.response)) {
-      last_tls_status = s.blockid;
-    }
     if (std::holds_alternative<concord::messages::ClientsRestartCommand>(csp.response)) {
       last_resatrt_status = s.blockid;
     }
@@ -446,7 +429,7 @@ int main(int argc, char** argv) {
                                                   creParams.bftConfig.transaction_signing_private_key_file_path.value(),
                                                   creParams.certFolder,
                                                   last_pk_status,
-                                                  last_tls_status,
+                                                  0,
                                                   sm_));
   cre.registerHandler(std::make_shared<ClientsAddRemoveHandler>(last_scaling_status));
   cre.registerHandler(std::make_shared<ClientsRestartHandler>(last_resatrt_status, creParams.CreConfig.id_));

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -15,14 +15,34 @@
 #include <utility>
 #include <string>
 #include <memory>
+
+#include <openssl/bio.h>
+#include <openssl/ec.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+
 namespace concord::util::crypto {
 enum class KeyFormat : std::uint16_t { HexaDecimalStrippedFormat, PemFormat };
 enum class CurveType : std::uint16_t { secp256k1, secp384r1 };
+
+class CertificateUtils {
+ public:
+  static std::string generateSelfSignedCert(const std::string& origin_cert_path,
+                                            const std::string& pub_key,
+                                            const std::string& signing_key);
+  static bool verifyCertificate(X509* cert, const std::string& pub_key);
+  static bool verifyCertificate(X509* cert_to_verify,
+                                const std::string& cert_root_directory,
+                                uint32_t& remote_peer_id,
+                                std::string& conn_type);
+};
 class IVerifier {
  public:
   virtual bool verify(const std::string& data, const std::string& sig) const = 0;
   virtual uint32_t signatureLength() const = 0;
   virtual ~IVerifier() = default;
+  virtual std::string getPubKey() const = 0;
 };
 
 class ISigner {
@@ -30,6 +50,7 @@ class ISigner {
   virtual std::string sign(const std::string& data) = 0;
   virtual uint32_t signatureLength() const = 0;
   virtual ~ISigner() = default;
+  virtual std::string getPrivKey() const = 0;
 };
 
 class ECDSAVerifier : public IVerifier {
@@ -37,34 +58,40 @@ class ECDSAVerifier : public IVerifier {
   ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) const override;
   uint32_t signatureLength() const override;
+  std::string getPubKey() const override { return key_str_; }
   ~ECDSAVerifier();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 
 class ECDSASigner : public ISigner {
  public:
-  ECDSASigner(const std::string& str_pub_key, KeyFormat fmt);
+  ECDSASigner(const std::string& str_priv_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
   uint32_t signatureLength() const override;
+  std::string getPrivKey() const override { return key_str_; }
   ~ECDSASigner();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 class RSAVerifier : public IVerifier {
  public:
   RSAVerifier(const std::string& str_pub_key, KeyFormat fmt);
   bool verify(const std::string& data, const std::string& sig) const override;
   uint32_t signatureLength() const override;
+  std::string getPubKey() const override { return key_str_; }
   ~RSAVerifier();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 
 class RSASigner : public ISigner {
@@ -72,11 +99,13 @@ class RSASigner : public ISigner {
   RSASigner(const std::string& str_priv_key, KeyFormat fmt);
   std::string sign(const std::string& data) override;
   uint32_t signatureLength() const override;
+  std::string getPrivKey() const override { return key_str_; }
   ~RSASigner();
 
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;
+  std::string key_str_;
 };
 
 class Crypto {
@@ -93,9 +122,7 @@ class Crypto {
                                                            CurveType curve_type = CurveType::secp256k1) const;
   std::pair<std::string, std::string> RsaHexToPem(const std::pair<std::string, std::string>& key_pair) const;
   std::pair<std::string, std::string> ECDSAHexToPem(const std::pair<std::string, std::string>& key_pair) const;
-  std::string generateSelfSignedCertificate(const std::pair<std::string, std::string>& keyPair_pem,
-                                            const std::string& host,
-                                            uint32_t node_id);
+  KeyFormat getFormat(const std::string& key_str) const;
 
  private:
   class Impl;

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -26,8 +26,9 @@
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/evp.h>
-
+#include <regex>
 #include "Logger.hpp"
+
 using namespace CryptoPP;
 namespace concord::util::crypto {
 class ECDSAVerifier::Impl {
@@ -48,7 +49,7 @@ class ECDSAVerifier::Impl {
   uint32_t signatureLength() const { return verifier_->SignatureLength(); }
 };
 bool ECDSAVerifier::verify(const std::string& data, const std::string& sig) const { return impl_->verify(data, sig); }
-ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
+ECDSAVerifier::ECDSAVerifier(const std::string& str_pub_key, KeyFormat fmt) : key_str_{str_pub_key} {
   ECDSA<ECP, CryptoPP::SHA256>::PublicKey publicKey;
   if (fmt == KeyFormat::PemFormat) {
     StringSource s(str_pub_key, true);
@@ -83,13 +84,13 @@ class ECDSASigner::Impl {
 };
 
 std::string ECDSASigner::sign(const std::string& data) { return impl_->sign(data); }
-ECDSASigner::ECDSASigner(const std::string& str_pub_key, KeyFormat fmt) {
+ECDSASigner::ECDSASigner(const std::string& str_priv_key, KeyFormat fmt) : key_str_{str_priv_key} {
   ECDSA<ECP, CryptoPP::SHA256>::PrivateKey privateKey;
   if (fmt == KeyFormat::PemFormat) {
-    StringSource s(str_pub_key, true);
+    StringSource s(str_priv_key, true);
     PEM_Load(s, privateKey);
   } else {
-    StringSource s(str_pub_key, true, new HexDecoder());
+    StringSource s(str_priv_key, true, new HexDecoder());
     privateKey.Load(s);
   }
   impl_.reset(new Impl(privateKey));
@@ -135,7 +136,7 @@ class RSASigner::Impl {
   AutoSeededRandomPool prng_;
 };
 
-RSASigner::RSASigner(const std::string& str_priv_key, KeyFormat fmt) {
+RSASigner::RSASigner(const std::string& str_priv_key, KeyFormat fmt) : key_str_{str_priv_key} {
   CryptoPP::RSA::PrivateKey private_key;
   if (fmt == KeyFormat::PemFormat) {
     StringSource s(str_priv_key, true);
@@ -151,7 +152,7 @@ std::string RSASigner::sign(const std::string& data) { return impl_->sign(data);
 uint32_t RSASigner::signatureLength() const { return impl_->signatureLength(); }
 RSASigner::~RSASigner() = default;
 
-RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) {
+RSAVerifier::RSAVerifier(const std::string& str_pub_key, KeyFormat fmt) : key_str_{str_pub_key} {
   CryptoPP::RSA::PublicKey public_key;
   if (fmt == KeyFormat::PemFormat) {
     StringSource s(str_pub_key, true);
@@ -245,79 +246,6 @@ class Crypto::Impl {
     return keyPair;
   }
 
-  std::string generateSelfSignedCert(const std::pair<std::string, std::string>& keyPair_pem,
-                                     const std::string& host,
-                                     uint32_t node_id) {
-    EVP_PKEY* priv_key = EVP_PKEY_new();
-    BIO* priv_bio = BIO_new(BIO_s_mem());
-    std::string priv_key_pem = keyPair_pem.first;
-    int priv_bio_write_ret = BIO_write(priv_bio, static_cast<const char*>(priv_key_pem.c_str()), priv_key_pem.size());
-    if (priv_bio_write_ret <= 0) {
-      EVP_PKEY_free(priv_key);
-      BIO_free(priv_bio);
-      return std::string();
-    }
-    if (!PEM_read_bio_PrivateKey(priv_bio, &priv_key, NULL, NULL)) {
-      EVP_PKEY_free(priv_key);
-      BIO_free(priv_bio);
-      return std::string();
-    }
-    std::string pub_key_pem = keyPair_pem.second;
-    EVP_PKEY* pub_key = EVP_PKEY_new();
-    BIO* pub_bio = BIO_new(BIO_s_mem());
-    int pub_bio_write_ret = BIO_write(pub_bio, static_cast<const char*>(pub_key_pem.c_str()), pub_key_pem.size());
-    if (pub_bio_write_ret <= 0) {
-      EVP_PKEY_free(pub_key);
-      BIO_free(pub_bio);
-      return std::string();
-    }
-    if (!PEM_read_bio_PUBKEY(pub_bio, &pub_key, NULL, NULL)) {
-      EVP_PKEY_free(pub_key);
-      BIO_free(pub_bio);
-      return std::string();
-    }
-    X509* x509;
-    x509 = X509_new();
-
-    ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
-    X509_gmtime_adj(X509_get_notBefore(x509), 0);
-    X509_gmtime_adj(X509_get_notAfter(x509), 31536000L);
-
-    X509_set_pubkey(x509, pub_key);
-
-    X509_NAME* name;
-    name = X509_get_subject_name(x509);
-
-    X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC, (unsigned char*)"NA", -1, -1, 0);
-    X509_NAME_add_entry_by_txt(name, "ST", MBSTRING_ASC, (unsigned char*)"NA", -1, -1, 0);
-    X509_NAME_add_entry_by_txt(name, "L", MBSTRING_ASC, (unsigned char*)"NA", -1, -1, 0);
-    X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, (unsigned char*)"NA", -1, -1, 0);
-    X509_NAME_add_entry_by_txt(name, "OU", MBSTRING_ASC, (unsigned char*)std::to_string(node_id).c_str(), -1, -1, 0);
-    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char*)host.c_str(), -1, -1, 0);
-    X509_set_issuer_name(x509, name);
-    X509_sign(x509, priv_key, EVP_sha256());
-
-    BIO* outbio = BIO_new(BIO_s_mem());
-    if (!PEM_write_bio_X509(outbio, x509)) {
-      BIO_free(outbio);
-      EVP_PKEY_free(pub_key);
-      BIO_free(pub_bio);
-      EVP_PKEY_free(pub_key);
-      BIO_free(pub_bio);
-      return std::string();
-    }
-    std::string certStr;
-    int certLen = BIO_pending(outbio);
-    certStr.resize(certLen);
-    BIO_read(outbio, (void*)&(certStr.front()), certLen);
-    // free all pointers
-    BIO_free(outbio);
-    EVP_PKEY_free(priv_key);
-    BIO_free(priv_bio);
-    EVP_PKEY_free(pub_key);
-    BIO_free(pub_bio);
-    return certStr;
-  }
   ~Impl() = default;
 };
 
@@ -337,13 +265,171 @@ std::pair<std::string, std::string> Crypto::ECDSAHexToPem(const std::pair<std::s
   return impl_->ECDSAHexToPem(key_pair);
 }
 
-std::string Crypto::generateSelfSignedCertificate(const std::pair<std::string, std::string>& keyPair_pem,
-                                                  const std::string& host,
-                                                  uint32_t node_id) {
-  return impl_->generateSelfSignedCert(keyPair_pem, host, node_id);
+KeyFormat Crypto::getFormat(const std::string& key) const {
+  return key.find("BEGIN") != std::string::npos ? KeyFormat::PemFormat : KeyFormat::HexaDecimalStrippedFormat;
 }
 
 Crypto::Crypto() : impl_{new Impl()} {}
 
 Crypto::~Crypto() = default;
+
+bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
+                                         const std::string& cert_root_directory,
+                                         uint32_t& remote_peer_id,
+                                         std::string& conn_type) {
+  // First get the source ID
+  static constexpr size_t SIZE = 512;
+  std::string subject(SIZE, 0);
+  X509_NAME_oneline(X509_get_subject_name(cert_to_verify), subject.data(), SIZE);
+
+  int peerIdPrefixLength = 3;
+  std::regex r("OU=\\d*", std::regex_constants::icase);
+  std::smatch sm;
+  regex_search(subject, sm, r);
+  if (sm.length() <= peerIdPrefixLength) {
+    LOG_ERROR(GL, "OU not found or empty: " << subject);
+    return false;
+  }
+
+  auto remPeer = sm.str().substr(peerIdPrefixLength, sm.str().length() - peerIdPrefixLength);
+  if (0 == remPeer.length()) {
+    LOG_ERROR(GL, "OU empty " << subject);
+    return false;
+  }
+
+  uint32_t remotePeerId;
+  try {
+    remotePeerId = stoul(remPeer, nullptr);
+  } catch (const std::invalid_argument& ia) {
+    LOG_ERROR(GL, "cannot convert OU, " << subject << ", " << ia.what());
+    return false;
+  } catch (const std::out_of_range& e) {
+    LOG_ERROR(GL, "cannot convert OU, " << subject << ", " << e.what());
+    return false;
+  }
+  remote_peer_id = remotePeerId;
+  std::string CN;
+  CN.resize(SIZE);
+  X509_NAME_get_text_by_NID(X509_get_subject_name(cert_to_verify), NID_commonName, CN.data(), SIZE);
+  std::string cert_type = "server";
+  if (CN.find("cli") != std::string::npos) cert_type = "client";
+  conn_type = cert_type;
+
+  // Get the local stored certificate for this peer
+  std::string local_cert_path =
+      cert_root_directory + "/" + std::to_string(remotePeerId) + "/" + cert_type + "/" + cert_type + ".cert";
+  auto deleter = [](FILE* fp) {
+    if (fp) fclose(fp);
+  };
+  std::unique_ptr<FILE, decltype(deleter)> fp(fopen(local_cert_path.c_str(), "r"), deleter);
+  if (!fp) {
+    LOG_ERROR(GL, "Certificate file not found, path: " << local_cert_path);
+    return false;
+  }
+
+  X509* localCert = PEM_read_X509(fp.get(), NULL, NULL, NULL);
+  if (!localCert) {
+    LOG_ERROR(GL, "Cannot parse certificate, path: " << local_cert_path);
+    return false;
+  }
+
+  // this is actual comparison, compares hash of 2 certs
+  bool res = (X509_cmp(cert_to_verify, localCert) == 0);
+  X509_free(localCert);
+  return res;
+}
+std::string CertificateUtils::generateSelfSignedCert(const std::string& origin_cert_path,
+                                                     const std::string& public_key,
+                                                     const std::string& signing_key) {
+  auto deleter = [](FILE* fp) {
+    if (fp) fclose(fp);
+  };
+  std::unique_ptr<FILE, decltype(deleter)> fp(fopen(origin_cert_path.c_str(), "r"), deleter);
+  if (!fp) {
+    LOG_ERROR(GL, "Certificate file not found, path: " << origin_cert_path);
+    return std::string();
+  }
+
+  X509* cert = PEM_read_X509(fp.get(), NULL, NULL, NULL);
+  if (!cert) {
+    LOG_ERROR(GL, "Cannot parse certificate, path: " << origin_cert_path);
+    return std::string();
+  }
+
+  EVP_PKEY* priv_key = EVP_PKEY_new();
+  BIO* priv_bio = BIO_new(BIO_s_mem());
+  int priv_bio_write_ret = BIO_write(priv_bio, static_cast<const char*>(signing_key.c_str()), signing_key.size());
+  if (priv_bio_write_ret <= 0) {
+    EVP_PKEY_free(priv_key);
+    BIO_free(priv_bio);
+    LOG_ERROR(GL, "Unable to create private key object");
+    return std::string();
+  }
+  if (!PEM_read_bio_PrivateKey(priv_bio, &priv_key, NULL, NULL)) {
+    EVP_PKEY_free(priv_key);
+    BIO_free(priv_bio);
+    LOG_ERROR(GL, "Unable to create private key object");
+    return std::string();
+  }
+  EVP_PKEY* pub_key = EVP_PKEY_new();
+  BIO* pub_bio = BIO_new(BIO_s_mem());
+  int pub_bio_write_ret = BIO_write(pub_bio, static_cast<const char*>(public_key.c_str()), public_key.size());
+  if (pub_bio_write_ret <= 0) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    LOG_ERROR(GL, "Unable to create public key object");
+    return std::string();
+  }
+  if (!PEM_read_bio_PUBKEY(pub_bio, &pub_key, NULL, NULL)) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    LOG_ERROR(GL, "Unable to create public key object");
+    return std::string();
+  }
+
+  X509_set_pubkey(cert, pub_key);
+  X509_sign(cert, priv_key, EVP_sha256());
+
+  BIO* outbio = BIO_new(BIO_s_mem());
+  if (!PEM_write_bio_X509(outbio, cert)) {
+    BIO_free(outbio);
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    X509_free(cert);
+    LOG_ERROR(GL, "Unable to create certificate object");
+    return std::string();
+  }
+  std::string certStr;
+  int certLen = BIO_pending(outbio);
+  certStr.resize(certLen);
+  BIO_read(outbio, (void*)&(certStr.front()), certLen);
+  // free all pointers
+  BIO_free(outbio);
+  EVP_PKEY_free(priv_key);
+  BIO_free(priv_bio);
+  EVP_PKEY_free(pub_key);
+  BIO_free(pub_bio);
+  X509_free(cert);
+  return certStr;
+}
+bool CertificateUtils::verifyCertificate(X509* cert, const std::string& public_key) {
+  EVP_PKEY* pub_key = EVP_PKEY_new();
+  BIO* pub_bio = BIO_new(BIO_s_mem());
+  int pub_bio_write_ret = BIO_write(pub_bio, static_cast<const char*>(public_key.c_str()), public_key.size());
+  if (pub_bio_write_ret <= 0) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    return false;
+  }
+  if (!PEM_read_bio_PUBKEY(pub_bio, &pub_key, NULL, NULL)) {
+    EVP_PKEY_free(pub_key);
+    BIO_free(pub_bio);
+    return false;
+  }
+  int r = X509_verify(cert, pub_key);
+  EVP_PKEY_free(pub_key);
+  return (bool)r;
+}
 }  // namespace concord::util::crypto


### PR DESCRIPTION
In this PR we introduce the first stage of the TLS key rotation improvements.
Until now, on TLS key exchange, the exchanged component created a key-pair and a self-signed certificate (signed by the new generated private key). Then, the replica published the certificate on the blockchain and all other components had to read it from the blockchain itself.

In this PR we introduce a different method. Instead of generating a self-signed certificate with the new private key, the replica signs the new certificate with its current TLS key. This way, other replicas can validate the certificate against the replica's RSA key, instead of reading it from the blockchain.

This PR is for the replicas' side only (meaning, not for replica-client exchange), but once we complete this change for the replica-client exchange also, we will get rid of the limitation of not exchanging more than f replicas at once.
