### PR TITLE
Adding the EDBKeyType for Migration

### DIFF
--- a/kvbc/src/merkle_tree_key_manipulator.cpp
+++ b/kvbc/src/merkle_tree_key_manipulator.cpp
@@ -155,6 +155,8 @@ EDBKeyType DBKeyManipulator::getDBKeyType(const Sliver &s) {
       return EDBKeyType::Key;
     case toChar(EDBKeyType::BFT):
       return EDBKeyType::BFT;
+    case toChar(EDBKeyType::Migration):
+      return EDBKeyType::Migration;
   }
   ConcordAssert(false);
 


### PR DESCRIPTION
This will handle the case of EDBKeyType for the block merkel lastest
key version column family.