### PR TITLE
Make deferred messages queues configurable

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -230,6 +230,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                "Interval time to create db snapshot in seconds");
   // Post-execution separation feature flag
   CONFIG_PARAM(enablePostExecutionSeparation, bool, true, "Post-execution separation feature flag");
+  CONFIG_PARAM(postExecutionQueuesSize, uint16_t, 50, "Post-execution deferred message queues size");
 
   // Parameter to enable/disable waiting for transaction data to be persisted.
   CONFIG_PARAM(syncOnUpdateOfMetadata,
@@ -348,6 +349,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, dbCheckpointDirPath);
     serialize(outStream, dbSnapshotIntervalSeconds);
     serialize(outStream, enablePostExecutionSeparation);
+    serialize(outStream, postExecutionQueuesSize);
     serialize(outStream, config_params_);
   }
   void deserializeDataMembers(std::istream& inStream) {
@@ -434,6 +436,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, dbCheckpointDirPath);
     deserialize(inStream, dbSnapshotIntervalSeconds);
     deserialize(inStream, enablePostExecutionSeparation);
+    deserialize(inStream, postExecutionQueuesSize);
     deserialize(inStream, config_params_);
   }
 
@@ -509,6 +512,7 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.threadbagConcurrencyLevel1,
               rc.threadbagConcurrencyLevel2,
               rc.enablePostExecutionSeparation,
+              rc.postExecutionQueuesSize,
               rc.dbCheckpointFeatureEnabled,
               rc.maxNumberOfDbCheckpoints,
               rc.dbCheckPointWindowSize,

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2348,9 +2348,9 @@ void ReplicaImp::onMessage<AskForCheckpointMsg>(AskForCheckpointMsg *msg) {
 void ReplicaImp::startExecution(SeqNum seqNumber,
                                 concordUtils::SpanWrapper &span,
                                 bool askForMissingInfoAboutCommittedItems) {
+  consensus_times_.end(seqNumber);
+  tryToRemovePendingRequestsForSeqNum(seqNumber);  // TODO(LG) Should verify if needed
   if (config_.enablePostExecutionSeparation) {
-    consensus_times_.end(seqNumber);
-    tryToRemovePendingRequestsForSeqNum(seqNumber);  // TODO(LG) Should verify if needed
     tryToStartOrFinishExecution(askForMissingInfoAboutCommittedItems);
   } else {
     executeNextCommittedRequests(span, askForMissingInfoAboutCommittedItems);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2350,6 +2350,7 @@ void ReplicaImp::startExecution(SeqNum seqNumber,
                                 bool askForMissingInfoAboutCommittedItems) {
   consensus_times_.end(seqNumber);
   tryToRemovePendingRequestsForSeqNum(seqNumber);  // TODO(LG) Should verify if needed
+  LOG_INFO(CNSUS, "Starting execution of seqNumber:" << seqNumber);
   if (config_.enablePostExecutionSeparation) {
     tryToStartOrFinishExecution(askForMissingInfoAboutCommittedItems);
   } else {
@@ -4966,7 +4967,7 @@ void ReplicaImp::finishExecutePrePrepareMsg(PrePrepareMsg *ppMsg,
     sendResponses(ppMsg, *pAccumulatedRequests);
     delete pAccumulatedRequests;
   }
-
+  LOG_INFO(CNSUS, "Finished execution of request seqNum:" << ppMsg->seqNumber());
   uint64_t checkpointNum{};
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {
     checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -444,6 +444,8 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         deferredRORequests_.push_back(
             m);  // We should handle span and deleting the message when we handle the deferred message
         deferredRORequestsMetric_++;
+      } else {
+        delete m;
       }
     } else {
       executeReadOnlyRequest(span, m);
@@ -2353,6 +2355,8 @@ void ReplicaImp::pushDeferredMessage(MessageBase *m) {
   if (deferredMessages_.size() < maxQueueSize) {
     deferredMessages_.push_back(m);
     deferredMessagesMetric_++;
+  } else {
+    delete m;
   }
 }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -440,7 +440,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
 
   if (readOnly) {
     if (activeExecutions_ > 0) {
-      if (deferredRORequests_.size() < maxQueueSize) {
+      if (deferredRORequests_.size() < maxQueueSize_) {
         deferredRORequests_.push_back(
             m);  // We should handle span and deleting the message when we handle the deferred message
         deferredRORequestsMetric_++;
@@ -1047,6 +1047,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
     LOG_INFO(GL,
              "Ignoring PrePrepareMsg because system is stopped at checkpoint pending control state operation (upgrade, "
              "etc...)");
+    // TODO(LG): we should delete the message.
     return;
   }
 
@@ -1082,9 +1083,14 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
 
     return;  // TODO(GG): memory deallocation is confusing .....
   }
+  if (isCurrentPrimary() && (msg->senderId() != getReplicaConfig().replicaId)) {
+    LOG_INFO(GL, "Ignoring PrePrepareMsg since im the current primary");
+    delete msg;
+    return;
+  }
   bool msgAdded = false;
 
-  if (relevantMsgForActiveView(msg) && (msg->senderId() == currentPrimary())) {
+  if (relevantMsgForActiveView(msg)) {
     sendAckIfNeeded(msg, msg->senderId(), msgSeqNum);
     SeqNumInfo &seqNumInfo = mainLog->get(msgSeqNum);
     const bool slowStarted = (msg->firstPath() == CommitPath::SLOW || seqNumInfo.slowPathStarted());
@@ -2352,7 +2358,7 @@ void ReplicaImp::startExecution(SeqNum seqNumber,
 }
 
 void ReplicaImp::pushDeferredMessage(MessageBase *m) {
-  if (deferredMessages_.size() < maxQueueSize) {
+  if (deferredMessages_.size() < maxQueueSize_) {
     deferredMessages_.push_back(m);
     deferredMessagesMetric_++;
   } else {
@@ -4255,7 +4261,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   });
   registerMsgHandlers();
   replStatusHandlers_.registerStatusHandlers();
-
+  maxQueueSize_ = config_.postExecutionQueuesSize;
   // Register metrics component with the default aggregator.
   metrics_.Register();
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -5122,7 +5122,8 @@ void ReplicaImp::handleDeferredRequests() {
       tryToGoToNextView();
       shouldTryToGoToNextView_ = false;
     }
-    for (auto &msg : deferredMessages_) {
+    while (!deferredMessages_.empty()) {
+      auto msg = deferredMessages_.front();
       deferredMessages_.pop_front();
       deferredMessagesMetric_--;
       auto msgHandlerCallback = msgHandlers_->getCallback(msg->type());
@@ -5133,7 +5134,8 @@ void ReplicaImp::handleDeferredRequests() {
       }
     }
     // Currently we are avoiding duplicates on deferred RO requests queue
-    for (auto &msg : deferredRORequests_) {
+    while (!deferredRORequests_.empty()) {
+      auto msg = deferredRORequests_.front();
       deferredRORequests_.pop_front();
       deferredRORequestsMetric_--;
       auto msgHandlerCallback = msgHandlers_->getCallback(msg->type());

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -153,7 +153,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // can happen only in main thread since its being called when FinishPrePrepareExecutionInternalMsg fetched m the
   // internal msgs queue.
   std::deque<MessageBase*> deferredMessages_;
-  uint16_t maxQueueSize = 50;
+  uint16_t maxQueueSize_;
   bool shouldTryToGoToNextView_ = false;
   bool shouldGoToNextView_ = false;
   bool isSendCheckpointIfNeeded_ = false;

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -604,6 +604,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
       MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(parent_.config_.replicaId));
       MDC_PUT(MDC_THREAD_KEY, "post-execution-thread");
       SCOPED_MDC_SEQ_NUM(std::to_string(ppMsg_->seqNumber()));
+      LOG_INFO(CNSUS, "Starting post-execution for seqNumber:" << ppMsg_->seqNumber());
       parent_.executeRequests(ppMsg_, requestSet_, time_);
     }
   };

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -600,7 +600,12 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
     virtual void release() override { delete this; }
 
-    virtual void execute() override { parent_.executeRequests(ppMsg_, requestSet_, time_); }
+    virtual void execute() override {
+      MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(parent_.config_.replicaId));
+      MDC_PUT(MDC_THREAD_KEY, "post-execution-thread");
+      SCOPED_MDC_SEQ_NUM(std::to_string(ppMsg_->seqNumber()));
+      parent_.executeRequests(ppMsg_, requestSet_, time_);
+    }
   };
 
   // 5 years

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -210,6 +210,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   std::vector<char> read_msg_;
 
   // Message being currently written.
+  std::atomic_bool write_msg_used_{false};
   std::shared_ptr<OutgoingMsg> write_msg_;
 
   TlsTcpConfig& config_;

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -14,7 +14,7 @@
 #include "TlsRunner.h"
 
 // TODO: Make this configurable
-static constexpr size_t NUM_THREADS = 2;
+static constexpr size_t NUM_THREADS = 1;
 
 namespace bft::communication {
 


### PR DESCRIPTION
This PR inserts 2 main changes:
1) Make the deferred messages queue size configurable.
2) Decrease the num of TLS threads to 1 in order to avoid thread race.
3) Fix Asan heap-use-after-free in post-execution handle of the deferred message.