### PR TITLE
Attach epoch number per reconfiguration action key

### DIFF
--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -30,18 +30,14 @@ kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
     const std::optional<bftEngine::Timestamp>& timestamp,
     bool include_wedge) {
   concord::kvbc::categorization::VersionedUpdates ver_updates;
-  ver_updates.addUpdate(std::move(key), std::string(data.begin(), data.end()));
-
-  uint64_t epoch = 0;
-  auto value = ro_storage_.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
-                                     std::string{keyTypes::reconfiguration_epoch_key});
-  if (value.has_value()) {
-    const auto& epoch_str = std::get<categorization::VersionedValue>(*value).data;
-    ConcordAssertEQ(epoch_str.size(), sizeof(uint64_t));
-    epoch = concordUtils::fromBigEndianBuffer<uint64_t>(epoch_str.data());
-  }
+  uint64_t epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
   auto current_epoch_buf = concordUtils::toBigEndianStringBuffer(epoch);
-  ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, std::move(current_epoch_buf));
+  // Set the global epoch number
+  ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, concordUtils::toBigEndianStringBuffer(epoch));
+  // Set the epoch number of this action
+  ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key} + key,
+                        concordUtils::toBigEndianStringBuffer(epoch));
+  ver_updates.addUpdate(std::move(key), std::string(data.begin(), data.end()));
   try {
     return persistReconfigurationBlock(ver_updates, bft_seq_num, timestamp, include_wedge);
   } catch (const std::exception& e) {
@@ -146,9 +142,12 @@ concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildClien
               break;
           }
           creply.block_id = arg.block_id;
-          auto epoch_data = ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
-                                            std::string{kvbc::keyTypes::reconfiguration_epoch_key},
-                                            arg.block_id);
+          auto epoch_data = ro_storage_.get(
+              concord::kvbc::categorization::kConcordReconfigurationCategoryId,
+              std::string{kvbc::keyTypes::reconfiguration_epoch_key} +
+                  std::string{kvbc::keyTypes::reconfiguration_client_data_prefix, static_cast<char>(command_type)} +
+                  std::to_string(clientid),
+              arg.block_id);
           ConcordAssert(epoch_data.has_value());
           const auto& epoch_str = std::get<categorization::VersionedValue>(*epoch_data).data;
           ConcordAssertEQ(epoch_str.size(), sizeof(uint64_t));
@@ -198,9 +197,10 @@ concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildRepli
             concord::messages::deserialize(data_buf, cmd);
             creply.response = cmd;
           }
-          auto epoch_data = ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
-                                            std::string{kvbc::keyTypes::reconfiguration_epoch_key},
-                                            arg.block_id);
+          auto epoch_data = ro_storage_.get(
+              concord::kvbc::categorization::kConcordReconfigurationCategoryId,
+              std::string{kvbc::keyTypes::reconfiguration_epoch_key} + command_type + std::to_string(clientid),
+              arg.block_id);
           ConcordAssert(epoch_data.has_value());
           const auto& epoch_str = std::get<categorization::VersionedValue>(*epoch_data).data;
           ConcordAssertEQ(epoch_str.size(), sizeof(uint64_t));
@@ -517,6 +517,8 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
     std::vector<uint8_t> serialized_cmd_data;
     concord::messages::serialize(serialized_cmd_data, cmd);
     // CRE will get this command and execute it
+    ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key} + execute_key_prefix + std::to_string(i),
+                          concordUtils::toBigEndianStringBuffer(epoch));
     ver_updates.addUpdate(execute_key_prefix + std::to_string(i),
                           std::string(serialized_cmd_data.begin(), serialized_cmd_data.end()));
   }
@@ -653,6 +655,8 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientKeyExchangeCo
   ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, concordUtils::toBigEndianStringBuffer(epoch));
   concord::messages::ClientKeyExchangeCommandResponse ckecr;
   for (auto clientid : target_clients) {
+    ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key} + key_prefix + std::to_string(clientid),
+                          concordUtils::toBigEndianStringBuffer(epoch));
     ver_updates.addUpdate(key_prefix + std::to_string(clientid),
                           std::string(serialized_command.begin(), serialized_command.end()));
   }
@@ -687,6 +691,7 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveCom
                   static_cast<char>(kvbc::keyTypes::CLIENT_COMMAND_TYPES::CLIENT_SCALING_EXECUTE_COMMAND)};
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   ver_updates.addUpdate(std::move(key_prefix), std::string(serialized_command.begin(), serialized_command.end()));
+  auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
   for (auto clientid : target_clients) {
     concord::messages::ClientsAddRemoveExecuteCommand cmd;
     cmd.config_descriptor = command.config_descriptor;
@@ -697,8 +702,10 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsAddRemoveCom
     // CRE will get this command and execute it
     ver_updates.addUpdate(execute_key_prefix + std::to_string(clientid),
                           std::string(serialized_cmd_data.begin(), serialized_cmd_data.end()));
+    ver_updates.addUpdate(
+        std::string{keyTypes::reconfiguration_epoch_key} + execute_key_prefix + std::to_string(clientid),
+        concordUtils::toBigEndianStringBuffer(epoch));
   }
-  auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
   ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, concordUtils::toBigEndianStringBuffer(epoch));
   auto block_id = persistReconfigurationBlock(ver_updates, sequence_number, ts, false);
   LOG_INFO(getLogger(), "ClientsAddRemoveCommand block_id is: " << block_id);
@@ -727,6 +734,8 @@ bool ReconfigurationHandler::handle(const concord::messages::ClientsRestartComma
   for (auto clientid : target_clients) {
     ver_updates.addUpdate(key_prefix + std::to_string(clientid),
                           std::string(serialized_command.begin(), serialized_command.end()));
+    ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key} + key_prefix + std::to_string(clientid),
+                          concordUtils::toBigEndianStringBuffer(epoch));
   }
   auto block_id = persistReconfigurationBlock(ver_updates, bft_seq_num, ts, false);
 
@@ -889,6 +898,8 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Clien
   concord::kvbc::categorization::VersionedUpdates ver_updates;
   auto updated_client_keys = SigManager::instance()->getClientsPublicKeys();
   auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
+  ver_updates.addUpdate(std::string(1, concord::kvbc::kClientsPublicKeys),
+                        concordUtils::toBigEndianStringBuffer(epoch));
   ver_updates.addUpdate(std::string{keyTypes::reconfiguration_epoch_key}, concordUtils::toBigEndianStringBuffer(epoch));
   ver_updates.addUpdate(std::string(1, concord::kvbc::kClientsPublicKeys), std::string(updated_client_keys));
   auto id = persistReconfigurationBlock(ver_updates, sequence_number, ts, false);


### PR DESCRIPTION
Until now, we overwrote the epoch number on every new reconfiguration request.
However, in the case of pruning, we may remove the old epoch number and hence lose a command's epoch number.
For example:
1. execute reconfiguration request of replica's scaling the command is written to block X and we have an epoch record on block X
2. execute another request of key exchange and write it to block X + 1 ==> we have a new epoch record on block X+1
3. execute pruning --> the epoch record on block X is stale and hence removed

--> We lost the epoch number of the first scaling command!
This PR is for solving this issue (in v0.13.x). It is solved by writing an epoch record attached to each command key. This way, only if we execute the same command again (and overwrite the first command block) we also overwrite this specific command epoch record.