### PR TITLE
Remove DoneCallback From Client Pool

### DIFF
--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -27,9 +27,6 @@
 #include "client_pool_timer.hpp"
 #include "external_client.hpp"
 
-// the parameters are sequence number and cid
-typedef std::function<void(const std::string /* cid */, uint32_t /*reply_size*/)> EXT_DONE_CALLBACK;
-
 namespace concord {
 namespace external_client {
 class ConcordClient;
@@ -156,9 +153,6 @@ class ConcordClientPool {
 
   PoolStatus HealthStatus();
 
-  void Done(std::pair<int8_t, external_client::ConcordClient::PendingReplies>&& replies);
-  void SetDoneCallback(EXT_DONE_CALLBACK cb);
-
   inline bool IsBatchingEnabled() { return client_batching_enabled_; }
 
   bftEngine::OperationResult getClientError();
@@ -205,7 +199,6 @@ class ConcordClientPool {
   // Logger
   logging::Logger logger_;
   std::atomic_bool is_overloaded_ = false;
-  EXT_DONE_CALLBACK done_callback_ = nullptr;
   uint32_t jobs_queue_max_size_ = 0;
   using Timer_t = ::concord_client_pool::Timer<ClientPtr>;
   std::unique_ptr<Timer_t> batch_timer_;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -443,17 +443,6 @@ ConcordClientPool::~ConcordClientPool() {
   clients_.clear();
 }
 
-void ConcordClientPool::SetDoneCallback(EXT_DONE_CALLBACK cb) { done_callback_ = std::move(cb); }
-
-void ConcordClientPool::Done(std::pair<int8_t, external_client::ConcordClient::PendingReplies> &&replies) {
-  if (done_callback_) {
-    for (const auto &reply : replies.second) {
-      LOG_DEBUG(logger_, "Return client reply to the sender" << KVLOG(reply.cid, reply.actualReplyLength));
-      done_callback_(reply.cid, reply.actualReplyLength);
-    }
-  }
-}
-
 void BatchRequestProcessingJob::execute() {
   clients_pool_.InsertClientToQueue(processing_client_, processing_client_->SendPendingRequests());
 }
@@ -585,7 +574,6 @@ void ConcordClientPool::InsertClientToQueue(
   if (replies.second.front().cb && operation_result != OperationResult::SUCCESS) {
     for (const auto &reply : replies.second) reply.cb(SendResult{static_cast<uint32_t>(operation_result)});
   }
-  Done(std::move(replies));
 }
 
 PoolStatus ConcordClientPool::HealthStatus() {


### PR DESCRIPTION
In the client pool, we now use a different mechanism for the callback(the callback is being passed in every request).
The done callback is no longer needed.