### PR TITLE
Make the number of objects dynamic in the metadata storage

### DIFF
--- a/bftengine/include/bftengine/DbMetadataStorage.hpp
+++ b/bftengine/include/bftengine/DbMetadataStorage.hpp
@@ -39,7 +39,8 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
     objectIdToSizeMap_[objectsNumParameterId_] = sizeof(objectsNum_);
   }
 
-  bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) override;
+  bool initMaxSizeOfObjects(const std::map<uint32_t, ObjectDesc> &metadataObjectsArray,
+                            uint32_t metadataObjectsArrayLength) override;
   void read(uint32_t objectId, uint32_t bufferSize, char *outBufferForObject, uint32_t &outActualObjectSize) override;
   void atomicWrite(uint32_t objectId, const char *data, uint32_t dataLength) override;
   void atomicWriteArbitraryObject(const std::string &key, const char *data, uint32_t dataLength) override;

--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <map>
 
 namespace bftEngine {
 
@@ -30,7 +31,8 @@ class MetadataStorage {
   // Initialize the storage before the first time used. In case storage is already initialized, do nothing.
   // Return 'true' in case DB was virgin (not initialized) before a call to this function
   // (the IDs and their maximal size are known in advance).
-  virtual bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) = 0;
+  virtual bool initMaxSizeOfObjects(const std::map<uint32_t, ObjectDesc> &metadataObjectsArray,
+                                    uint32_t metadataObjectsArrayLength) = 0;
 
   // Return 'true' in case DB is virgin (not initialized).
   virtual bool isNewStorage() = 0;

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -166,8 +166,7 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
     unique_ptr<MetadataStorage> metadataStoragePtr(metadataStorage);
     auto objectDescriptors =
         ((PersistentStorageImp *)persistentStoragePtr.get())->getDefaultMetadataObjectDescriptors(numOfObjects);
-    isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);
-
+    isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors, numOfObjects);
     // Check if we need to remove the metadata or start a new epoch
     bool erasedMetaData = false;
     uint32_t actualObjectSize = 0;
@@ -185,7 +184,7 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
     LOG_INFO(GL, "erasedMetaData flag = " << erasedMetaData);
     if (erasedMetaData) {
       metadataStoragePtr->eraseData();
-      isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);
+      isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors, numOfObjects);
       auto secFileDir = ReplicaConfig::instance().getkeyViewFilePath();
       LOG_INFO(GL, "removing " << secFileDir << " files if exist");
       try {

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -46,12 +46,14 @@ bool DBMetadataStorage::isNewStorage() {
   return (outActualObjectSize == 0);
 }
 
-bool DBMetadataStorage::initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) {
+bool DBMetadataStorage::initMaxSizeOfObjects(const std::map<uint32_t, ObjectDesc> &metadataObjectsArray,
+                                             uint32_t metadataObjectsArrayLength) {
   for (uint32_t i = objectsNumParameterId_ + 1; i < metadataObjectsArrayLength; ++i) {
-    objectIdToSizeMap_[i] = metadataObjectsArray[i].maxSize;
-    LOG_TRACE(logger_,
-              "initMaxSizeOfObjects i=" << i << " object data: id=" << metadataObjectsArray[i].id
-                                        << ", maxSize=" << metadataObjectsArray[i].maxSize);
+    const auto objectData = metadataObjectsArray.at(i);
+    objectIdToSizeMap_[i] = objectData.maxSize;
+    LOG_TRACE(
+        logger_,
+        "initMaxSizeOfObjects i=" << i << " object data: id=" << objectData.id << ", maxSize=" << objectData.maxSize);
   }
   // Metadata object with id=1 is used to indicate storage initialization state
   // (number of specified metadata objects).

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -106,7 +106,7 @@ enum ReplicaSpecificInfoParameterIds {
 
 const uint32_t replicaSpecificInfoMaxSize = 1024 * 1024;  // 1MB
 
-typedef unique_ptr<MetadataStorage::ObjectDesc[]> ObjectDescUniquePtr;
+typedef std::map<uint32_t, MetadataStorage::ObjectDesc> ObjectDescMap;
 
 class PersistentStorageImp : public PersistentStorage {
  public:
@@ -142,7 +142,7 @@ class PersistentStorageImp : public PersistentStorage {
   void setCheckpointMsgInCheckWindow(SeqNum seqNum, CheckpointMsg *msg) override;
   void setCompletedMarkInCheckWindow(SeqNum seqNum, bool completed) override;
   void clearSeqNumWindow() override;
-  ObjectDescUniquePtr getDefaultMetadataObjectDescriptors(uint16_t &numOfObjects) const;
+  ObjectDescMap getDefaultMetadataObjectDescriptors(uint16_t &numOfObjects) const;
 
   void setUserDataAtomically(const void *data, std::size_t numberOfBytes) override;
   void setUserDataInTransaction(const void *data, std::size_t numberOfBytes) override;

--- a/bftengine/tests/metadataStorage/metadataStorage_test.cpp
+++ b/bftengine/tests/metadataStorage/metadataStorage_test.cpp
@@ -62,7 +62,7 @@ DBMetadataStorage *initiateMetadataStorage(Client *dbClient, const std::string &
   }
   DBMetadataStorage *metadataStorage_ =
       new DBMetadataStorage(dbClient, std::make_unique<concord::storage::v1DirectKeyValue::MetadataKeyManipulator>());
-  bftEngine::MetadataStorage::ObjectDesc objectDesc[objectsNum];
+  std::map<uint32_t, bftEngine::MetadataStorage::ObjectDesc> objectDesc;
   for (uint32_t id = initialObjectId; id < objectsNum; ++id) {
     objectDesc[id].id = id;
     objectDesc[id].maxSize = maxObjDataSize;

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -111,7 +111,8 @@ void FileStorage::write(
 
 bool FileStorage::isNewStorage() { return (objectsMetadata_ == nullptr); }
 
-bool FileStorage::initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) {
+bool FileStorage::initMaxSizeOfObjects(const std::map<uint32_t, ObjectDesc> &metadataObjectsArray,
+                                       uint32_t metadataObjectsArrayLength) {
   if (!isNewStorage()) {
     LOG_WARN(logger_, "FileStorage::initMaxSizeOfObjects Storage file already initialized; ignoring");
     return false;
@@ -124,9 +125,9 @@ bool FileStorage::initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_
   // Metadata object with id=0 is used to indicate storage initialization state (not used by FileStorage).
   for (uint32_t i = initializedObjectId_ + 1; i < metadataObjectsArrayLength; i++) {
     MetadataObjectInfo objectInfo(
-        metadataObjectsArray[i].id, objMetaOffset, objOffset, metadataObjectsArray[i].maxSize);
+        metadataObjectsArray.at(i).id, objMetaOffset, objOffset, metadataObjectsArray.at(i).maxSize);
     objMetaOffset += sizeof(objectInfo);
-    objOffset += metadataObjectsArray[i].maxSize;
+    objOffset += metadataObjectsArray.at(i).maxSize;
     objectsMetadata_->setObjectInfo(objectInfo);
   }
   const uint64_t maxObjectsSize = objOffset - fileMetadataSize;

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -29,7 +29,8 @@ class FileStorage : public MetadataStorage {
 
   ~FileStorage() override;
 
-  bool initMaxSizeOfObjects(ObjectDesc *metadataObjectsArray, uint32_t metadataObjectsArrayLength) override;
+  bool initMaxSizeOfObjects(const std::map<uint32_t, ObjectDesc> &metadataObjectsArray,
+                            uint32_t metadataObjectsArrayLength) override;
 
   bool isNewStorage() override;
 

--- a/bftengine/tests/simpleStorage/main.cpp
+++ b/bftengine/tests/simpleStorage/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     remove(dbFile.c_str());
     auto *fileStorage = new FileStorage(logger, dbFile);
     const uint32_t objNum = 6;
-    FileStorage::ObjectDesc objects[objNum];
+    std::map<uint32_t, FileStorage::ObjectDesc> objects;
     // Metadata object with id=1 is used to indicate storage initialization state
     for (uint32_t i = 2; i < objNum; i++) {
       objects[i].id = i;

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -403,8 +403,8 @@ int main() {
   PersistentStorageImp persistentStorage(numReplicas, fVal, cVal, numReplicas + clientsNum, batchSize);
   metadataStorage.reset(new FileStorage(logger, dbFile));
   uint16_t numOfObjects = 0;
-  ObjectDescUniquePtr objectDescArray = persistentStorage.getDefaultMetadataObjectDescriptors(numOfObjects);
-  metadataStorage->initMaxSizeOfObjects(objectDescArray.get(), numOfObjects);
+  ObjectDescMap objectDescArray = persistentStorage.getDefaultMetadataObjectDescriptors(numOfObjects);
+  metadataStorage->initMaxSizeOfObjects(objectDescArray, numOfObjects);
   persistentStorageImp->init(move(metadataStorage));
 
   testInit();
@@ -415,7 +415,7 @@ int main() {
       // Re-open existing DB file
       metadataStorage.reset();
       metadataStorage.reset(new FileStorage(logger, dbFile));
-      metadataStorage->initMaxSizeOfObjects(objectDescArray.get(), numOfObjects);
+      metadataStorage->initMaxSizeOfObjects(objectDescArray, numOfObjects);
       persistentStorageImp->init(move(metadataStorage));
     }
     testSetSimpleParams(init);

--- a/kvbc/test/replica_state_sync_test.cpp
+++ b/kvbc/test/replica_state_sync_test.cpp
@@ -67,7 +67,7 @@ class replica_state_sync_test : public Test, public IReader {
     auto obj_descriptors = metadata_->getDefaultMetadataObjectDescriptors(num_of_objects);
     auto db_metadata_storage =
         std::make_unique<DBMetadataStorage>(db_->asIDBClient().get(), std::make_unique<MetadataKeyManipulator>());
-    db_metadata_storage->initMaxSizeOfObjects(obj_descriptors.get(), num_of_objects);
+    db_metadata_storage->initMaxSizeOfObjects(obj_descriptors, num_of_objects);
     metadata_->init(std::move(db_metadata_storage));
   }
 

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -907,7 +907,7 @@ struct ResetMetadata {
         new bftEngine::impl::PersistentStorageImp(4, 1, 0, 0, 0));  // TODO: add here rsi reset
     uint16_t numOfObjects = 0;
     auto objectDescriptors = ((PersistentStorageImp *)p.get())->getDefaultMetadataObjectDescriptors(numOfObjects);
-    bool isNewStorage = mdtStorage->initMaxSizeOfObjects(objectDescriptors.get(), numOfObjects);
+    bool isNewStorage = mdtStorage->initMaxSizeOfObjects(objectDescriptors, numOfObjects);
     ((PersistentStorageImp *)p.get())->init(move(mdtStorage));
     SeqNum stableSeqNum = p->getLastStableSeqNum();
     CheckpointMsg *cpm = p->getAndAllocateCheckpointMsgInCheckWindow(stableSeqNum);

--- a/tools/DBEditor.cpp
+++ b/tools/DBEditor.cpp
@@ -107,7 +107,7 @@ void setupDBEditorParams(int argc, char **argv) {
 }
 
 void setupMetadataStorage() {
-  MetadataStorage::ObjectDesc objectsDesc[MAX_OBJECT_ID];
+  std::map<uint32_t, MetadataStorage::ObjectDesc> objectsDesc;
   MetadataStorage::ObjectDesc objectDesc = {0, MAX_OBJECT_SIZE};
   for (uint32_t i = firstObjId; i < MAX_OBJECT_ID; i++) {
     objectDesc.id = i;


### PR DESCRIPTION
Now that we save RSI in the persistent storage, we may end up with the default number of object descriptors not matching the actual number of objects. In case we have x bft clients and batch size of y we need at least x*y objects in the persistent storage objects map.
This number may exceed the hardcoded 10000 number.
In this PR we introduced a dynamic way to initiate and determine the number of objects depending on the numbers x and y