### PR TITLE
Sync on update of metadata

### DIFF
--- a/bftengine/include/bftengine/DbMetadataStorage.hpp
+++ b/bftengine/include/bftengine/DbMetadataStorage.hpp
@@ -45,7 +45,7 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
   void atomicWriteArbitraryObject(const std::string &key, const char *data, uint32_t dataLength) override;
   void beginAtomicWriteOnlyBatch() override;
   void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) override;
-  void commitAtomicWriteOnlyBatch(bool sync=false) override;
+  void commitAtomicWriteOnlyBatch(bool sync = false) override;
   concordUtils::Status multiDel(const ObjectIdsVector &objectIds);
   bool isNewStorage() override;
   void eraseData() override;

--- a/bftengine/include/bftengine/DbMetadataStorage.hpp
+++ b/bftengine/include/bftengine/DbMetadataStorage.hpp
@@ -45,7 +45,7 @@ class DBMetadataStorage : public bftEngine::MetadataStorage {
   void atomicWriteArbitraryObject(const std::string &key, const char *data, uint32_t dataLength) override;
   void beginAtomicWriteOnlyBatch() override;
   void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) override;
-  void commitAtomicWriteOnlyBatch() override;
+  void commitAtomicWriteOnlyBatch(bool sync=false) override;
   concordUtils::Status multiDel(const ObjectIdsVector &objectIds);
   bool isNewStorage() override;
   void eraseData() override;

--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -47,7 +47,7 @@ class MetadataStorage {
   // Atomic write-only transactions
   virtual void beginAtomicWriteOnlyBatch() = 0;
   virtual void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) = 0;
-  virtual void commitAtomicWriteOnlyBatch() = 0;
+  virtual void commitAtomicWriteOnlyBatch(bool sync=false) = 0;
 
   // In some cases, we would like to load a new metadata after a crash (for example, on reconfiguration actions).
   virtual void eraseData() = 0;

--- a/bftengine/include/bftengine/MetadataStorage.hpp
+++ b/bftengine/include/bftengine/MetadataStorage.hpp
@@ -47,7 +47,7 @@ class MetadataStorage {
   // Atomic write-only transactions
   virtual void beginAtomicWriteOnlyBatch() = 0;
   virtual void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) = 0;
-  virtual void commitAtomicWriteOnlyBatch(bool sync=false) = 0;
+  virtual void commitAtomicWriteOnlyBatch(bool sync = false) = 0;
 
   // In some cases, we would like to load a new metadata after a crash (for example, on reconfiguration actions).
   virtual void eraseData() = 0;

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -227,6 +227,12 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   // Post-execution separation feature flag
   CONFIG_PARAM(enablePostExecutionSeparation, bool, true, "Post-execution separation feature flag");
 
+  // Parameter to enable/disable waiting for transaction data to be persisted.
+  CONFIG_PARAM(syncOnUpdateOfMetadata,
+               bool,
+               true,
+               "When set to true this parameter will cause endWriteTran to block until "
+               "the transaction is persisted every time we update the metadata.");
   // Not predefined configuration parameters
   // Example of usage:
   // repclicaConfig.set(someTimeout, 6000);

--- a/bftengine/src/bftengine/DbMetadataStorage.cpp
+++ b/bftengine/src/bftengine/DbMetadataStorage.cpp
@@ -135,14 +135,14 @@ void DBMetadataStorage::writeInBatch(uint32_t objectId, const char *data, uint32
   batch_->insert(KeyValuePair(metadataKeyManipulator_->generateMetadataKey(objectId), copy));
 }
 
-void DBMetadataStorage::commitAtomicWriteOnlyBatch() {
+void DBMetadataStorage::commitAtomicWriteOnlyBatch(bool sync) {
   lock_guard<mutex> lock(ioMutex_);
   LOG_DEBUG(logger_, "Begin Commit atomic transaction");
   if (!batch_) {
     LOG_FATAL(logger_, WRONG_FLOW);
     throw runtime_error(WRONG_FLOW);
   }
-  Status status = dbClient_->multiPut(*batch_);
+  Status status = dbClient_->multiPut(*batch_, sync);
   LOG_DEBUG(logger_, "End Commit atomic transaction");
   if (!status.isOK()) {
     LOG_FATAL(logger_, "DBClient multiPut operation failed");

--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -27,7 +27,7 @@ DebugPersistentStorage::DebugPersistentStorage(uint16_t fVal, uint16_t cVal)
 
 uint8_t DebugPersistentStorage::beginWriteTran() { return ++numOfNestedTransactions; }
 
-uint8_t DebugPersistentStorage::endWriteTran() {
+uint8_t DebugPersistentStorage::endWriteTran(bool sync) {
   ConcordAssert(numOfNestedTransactions != 0);
   return --numOfNestedTransactions;
 }

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -26,7 +26,7 @@ class DebugPersistentStorage : public PersistentStorage {
 
   // Inherited via PersistentStorage
   uint8_t beginWriteTran() override;
-  uint8_t endWriteTran(bool sync=false) override;
+  uint8_t endWriteTran(bool sync = false) override;
   bool isInWriteTran() const override;
   void setLastExecutedSeqNum(SeqNum seqNum) override;
   void setPrimaryLastUsedSeqNum(SeqNum seqNum) override;

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -26,7 +26,7 @@ class DebugPersistentStorage : public PersistentStorage {
 
   // Inherited via PersistentStorage
   uint8_t beginWriteTran() override;
-  uint8_t endWriteTran() override;
+  uint8_t endWriteTran(bool sync=false) override;
   bool isInWriteTran() const override;
   void setLastExecutedSeqNum(SeqNum seqNum) override;
   void setPrimaryLastUsedSeqNum(SeqNum seqNum) override;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -58,7 +58,7 @@ class PersistentStorage {
 
   // end re-entrant write-only transaction
   // returns the number of remaining nested transactions
-  virtual uint8_t endWriteTran() = 0;
+  virtual uint8_t endWriteTran(bool sync=false) = 0;
 
   // return true IFF write-only transactions are running now
   virtual bool isInWriteTran() const = 0;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -58,7 +58,7 @@ class PersistentStorage {
 
   // end re-entrant write-only transaction
   // returns the number of remaining nested transactions
-  virtual uint8_t endWriteTran(bool sync=false) = 0;
+  virtual uint8_t endWriteTran(bool sync = false) = 0;
 
   // return true IFF write-only transactions are running now
   virtual bool isInWriteTran() const = 0;

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -144,10 +144,10 @@ uint8_t PersistentStorageImp::beginWriteTran() {
   return ++numOfNestedTransactions_;
 }
 
-uint8_t PersistentStorageImp::endWriteTran() {
+uint8_t PersistentStorageImp::endWriteTran(bool sync) {
   ConcordAssertNE(numOfNestedTransactions_, 0);
   if (--numOfNestedTransactions_ == 0) {
-    metadataStorage_->commitAtomicWriteOnlyBatch();
+    metadataStorage_->commitAtomicWriteOnlyBatch(sync);
   }
   return numOfNestedTransactions_;
 }

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -118,7 +118,7 @@ class PersistentStorageImp : public PersistentStorage {
   ~PersistentStorageImp() override = default;
 
   uint8_t beginWriteTran() override;
-  uint8_t endWriteTran() override;
+  uint8_t endWriteTran(bool sync=false) override;
   bool isInWriteTran() const override;
 
   // Setters

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -118,7 +118,7 @@ class PersistentStorageImp : public PersistentStorage {
   ~PersistentStorageImp() override = default;
 
   uint8_t beginWriteTran() override;
-  uint8_t endWriteTran(bool sync=false) override;
+  uint8_t endWriteTran(bool sync = false) override;
   bool isInWriteTran() const override;
 
   // Setters

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -908,7 +908,7 @@ void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp, bool isCreatedEarlier)
     ps_->setPrimaryLastUsedSeqNum(primaryLastUsedSeqNum);
     ps_->setPrePrepareMsgInSeqNumWindow(primaryLastUsedSeqNum, pp);
     if (firstPath == CommitPath::SLOW) ps_->setSlowStartedInSeqNumWindow(primaryLastUsedSeqNum, true);
-    ps_->endWriteTran();
+    ps_->endWriteTran(true);
   }
 
   {
@@ -1122,7 +1122,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
         ps_->beginWriteTran();
         ps_->setPrePrepareMsgInSeqNumWindow(msgSeqNum, msg);
         if (slowStarted) ps_->setSlowStartedInSeqNumWindow(msgSeqNum, true);
-        ps_->endWriteTran();
+        ps_->endWriteTran(true);
       }
       if (!slowStarted)  // TODO(GG): make sure we correctly handle a situation where StartSlowCommitMsg is handled
                          // before PrePrepareMsg
@@ -1194,7 +1194,7 @@ void ReplicaImp::tryToStartSlowPaths() {
     if (ps_) {
       ps_->beginWriteTran();
       ps_->setSlowStartedInSeqNumWindow(i, true);
-      ps_->endWriteTran();
+      ps_->endWriteTran(true);
     }
 
     // send StartSlowCommitMsg to all replicas
@@ -1301,7 +1301,7 @@ void ReplicaImp::onMessage<StartSlowCommitMsg>(StartSlowCommitMsg *msg) {
       if (ps_) {
         ps_->beginWriteTran();
         ps_->setSlowStartedInSeqNumWindow(msgSeqNum, true);
-        ps_->endWriteTran();
+        ps_->endWriteTran(true);
       }
 
       if (seqNumInfo.hasPrePrepareMsg() == false)
@@ -1499,7 +1499,7 @@ void ReplicaImp::onMessage<FullCommitProofMsg>(FullCommitProofMsg *msg) {
         ps_->beginWriteTran();
         ps_->setFullCommitProofMsgInSeqNumWindow(msgSeqNum, msg);
         ps_->setForceCompletedInSeqNumWindow(msgSeqNum, true);
-        ps_->endWriteTran();
+        ps_->endWriteTran(true);
       }
 
       if (msg->senderId() == config_.getreplicaId()) sendToAllOtherReplicas(msg);
@@ -1988,7 +1988,7 @@ void ReplicaImp::onPrepareCombinedSigSucceeded(SeqNum seqNumber,
   if (ps_) {
     ps_->beginWriteTran();
     ps_->setPrepareFullMsgInSeqNumWindow(seqNumber, preFull);
-    ps_->endWriteTran();
+    ps_->endWriteTran(true);
   }
 
   if (!retransmissionsLogicEnabled) {
@@ -2040,7 +2040,7 @@ void ReplicaImp::onPrepareVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view
     ConcordAssertNE(preFull, nullptr);
     ps_->beginWriteTran();
     ps_->setPrepareFullMsgInSeqNumWindow(seqNumber, preFull);
-    ps_->endWriteTran();
+    ps_->endWriteTran(true);
   }
 
   sendCommitPartial(seqNumber);
@@ -2105,7 +2105,7 @@ void ReplicaImp::onCommitCombinedSigSucceeded(SeqNum seqNumber,
   if (ps_) {
     ps_->beginWriteTran();
     ps_->setCommitFullMsgInSeqNumWindow(seqNumber, commitFull);
-    ps_->endWriteTran();
+    ps_->endWriteTran(true);
   }
 
   if (!retransmissionsLogicEnabled) {
@@ -2164,7 +2164,7 @@ void ReplicaImp::onCommitVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view,
   if (ps_) {
     ps_->beginWriteTran();
     ps_->setCommitFullMsgInSeqNumWindow(seqNumber, commitFull);
-    ps_->endWriteTran();
+    ps_->endWriteTran(true);
   }
   LOG_INFO(CNSUS, "Request committed, proceeding to try to execute" << KVLOG(view));
 
@@ -2931,7 +2931,7 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
       ps_->beginWriteTran();
       ps_->setDescriptorOfLastExitFromView(desc);
       ps_->clearSeqNumWindow();
-      ps_->endWriteTran();
+      ps_->endWriteTran(true);
     }
 
     pVC = viewsManager->prepareViewChangeMsgAndSetHigherView(
@@ -3098,7 +3098,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
     metric_slow_path_count_++;
   }
 
-  if (ps_) ps_->endWriteTran();
+  if (ps_) ps_->endWriteTran(true);
 
   clientsManager->clearAllPendingRequests();
 
@@ -3219,7 +3219,7 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   if (newCheckpointSeqNum <= lastExecutedSeqNum) {
     LOG_DEBUG(GL,
               "Executing onTransferringCompleteImp(newStateCheckpoint) where newStateCheckpoint <= lastExecutedSeqNum");
-    if (ps_) ps_->endWriteTran();
+    if (ps_) ps_->endWriteTran(true);
     return;
   }
   lastExecutedSeqNum = newCheckpointSeqNum;
@@ -3269,7 +3269,7 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   if (ps_) {
     ps_->setPrimaryLastUsedSeqNum(primaryLastUsedSeqNum);
     ps_->setCheckpointMsgInCheckWindow(newCheckpointSeqNum, checkpointMsg);
-    ps_->endWriteTran();
+    ps_->endWriteTran(true);
   }
   metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
 
@@ -3398,7 +3398,7 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     ps_->setDescriptorOfLastStableCheckpoint(desc);
   }
 
-  if (ps_) ps_->endWriteTran();
+  if (ps_) ps_->endWriteTran(true);
 
   if (((BatchingPolicy)config_.batchingPolicy == BATCH_SELF_ADJUSTED) && !oldSeqNum && currentViewIsActive() &&
       (currentPrimary() == config_.getreplicaId()) && !isCollectingState()) {
@@ -4765,7 +4765,7 @@ void ReplicaImp::markSpecialRequests(RequestsIterator &reqIter,
     DescriptorOfLastExecution execDesc{lastExecutedSeqNum + 1, requestSet, ticks};
     ps_->beginWriteTran();
     ps_->setDescriptorOfLastExecution(execDesc);
-    ps_->endWriteTran();
+    ps_->endWriteTran(true);
   }
 }
 
@@ -4971,7 +4971,7 @@ void ReplicaImp::finishExecutePrePrepareMsg(PrePrepareMsg *ppMsg,
 
   if (ppMsg->numberOfRequests() > 0) bftRequestsHandler_->onFinishExecutingReadWriteRequests();
 
-  if (ps_) ps_->endWriteTran();
+  if (ps_) ps_->endWriteTran(true);
 
   sendCheckpointIfNeeded();
 
@@ -5262,7 +5262,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
         DescriptorOfLastExecution execDesc{lastExecutedSeqNum + 1, requestSet, ticks};
         ps_->beginWriteTran();
         ps_->setDescriptorOfLastExecution(execDesc);
-        ps_->endWriteTran();
+        ps_->endWriteTran(true);
       }
     } else {
       requestSet = mapOfRecoveredRequests;
@@ -5360,7 +5360,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
 
   if (numOfRequests > 0) bftRequestsHandler_->onFinishExecutingReadWriteRequests();
 
-  if (ps_) ps_->endWriteTran();
+  if (ps_) ps_->endWriteTran(true);
 
   sendCheckpointIfNeeded();
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -908,7 +908,7 @@ void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp, bool isCreatedEarlier)
     ps_->setPrimaryLastUsedSeqNum(primaryLastUsedSeqNum);
     ps_->setPrePrepareMsgInSeqNumWindow(primaryLastUsedSeqNum, pp);
     if (firstPath == CommitPath::SLOW) ps_->setSlowStartedInSeqNumWindow(primaryLastUsedSeqNum, true);
-    ps_->endWriteTran(true);
+    ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
   }
 
   {
@@ -1122,7 +1122,7 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
         ps_->beginWriteTran();
         ps_->setPrePrepareMsgInSeqNumWindow(msgSeqNum, msg);
         if (slowStarted) ps_->setSlowStartedInSeqNumWindow(msgSeqNum, true);
-        ps_->endWriteTran(true);
+        ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
       }
       if (!slowStarted)  // TODO(GG): make sure we correctly handle a situation where StartSlowCommitMsg is handled
                          // before PrePrepareMsg
@@ -1194,7 +1194,7 @@ void ReplicaImp::tryToStartSlowPaths() {
     if (ps_) {
       ps_->beginWriteTran();
       ps_->setSlowStartedInSeqNumWindow(i, true);
-      ps_->endWriteTran(true);
+      ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
     }
 
     // send StartSlowCommitMsg to all replicas
@@ -1301,7 +1301,7 @@ void ReplicaImp::onMessage<StartSlowCommitMsg>(StartSlowCommitMsg *msg) {
       if (ps_) {
         ps_->beginWriteTran();
         ps_->setSlowStartedInSeqNumWindow(msgSeqNum, true);
-        ps_->endWriteTran(true);
+        ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
       }
 
       if (seqNumInfo.hasPrePrepareMsg() == false)
@@ -1499,7 +1499,7 @@ void ReplicaImp::onMessage<FullCommitProofMsg>(FullCommitProofMsg *msg) {
         ps_->beginWriteTran();
         ps_->setFullCommitProofMsgInSeqNumWindow(msgSeqNum, msg);
         ps_->setForceCompletedInSeqNumWindow(msgSeqNum, true);
-        ps_->endWriteTran(true);
+        ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
       }
 
       if (msg->senderId() == config_.getreplicaId()) sendToAllOtherReplicas(msg);
@@ -1988,7 +1988,7 @@ void ReplicaImp::onPrepareCombinedSigSucceeded(SeqNum seqNumber,
   if (ps_) {
     ps_->beginWriteTran();
     ps_->setPrepareFullMsgInSeqNumWindow(seqNumber, preFull);
-    ps_->endWriteTran(true);
+    ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
   }
 
   if (!retransmissionsLogicEnabled) {
@@ -2040,7 +2040,7 @@ void ReplicaImp::onPrepareVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view
     ConcordAssertNE(preFull, nullptr);
     ps_->beginWriteTran();
     ps_->setPrepareFullMsgInSeqNumWindow(seqNumber, preFull);
-    ps_->endWriteTran(true);
+    ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
   }
 
   sendCommitPartial(seqNumber);
@@ -2105,7 +2105,7 @@ void ReplicaImp::onCommitCombinedSigSucceeded(SeqNum seqNumber,
   if (ps_) {
     ps_->beginWriteTran();
     ps_->setCommitFullMsgInSeqNumWindow(seqNumber, commitFull);
-    ps_->endWriteTran(true);
+    ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
   }
 
   if (!retransmissionsLogicEnabled) {
@@ -2164,7 +2164,7 @@ void ReplicaImp::onCommitVerifyCombinedSigResult(SeqNum seqNumber, ViewNum view,
   if (ps_) {
     ps_->beginWriteTran();
     ps_->setCommitFullMsgInSeqNumWindow(seqNumber, commitFull);
-    ps_->endWriteTran(true);
+    ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
   }
   LOG_INFO(CNSUS, "Request committed, proceeding to try to execute" << KVLOG(view));
 
@@ -2931,7 +2931,7 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
       ps_->beginWriteTran();
       ps_->setDescriptorOfLastExitFromView(desc);
       ps_->clearSeqNumWindow();
-      ps_->endWriteTran(true);
+      ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
     }
 
     pVC = viewsManager->prepareViewChangeMsgAndSetHigherView(
@@ -3098,7 +3098,7 @@ void ReplicaImp::onNewView(const std::vector<PrePrepareMsg *> &prePreparesForNew
     metric_slow_path_count_++;
   }
 
-  if (ps_) ps_->endWriteTran(true);
+  if (ps_) ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
 
   clientsManager->clearAllPendingRequests();
 
@@ -3219,7 +3219,7 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   if (newCheckpointSeqNum <= lastExecutedSeqNum) {
     LOG_DEBUG(GL,
               "Executing onTransferringCompleteImp(newStateCheckpoint) where newStateCheckpoint <= lastExecutedSeqNum");
-    if (ps_) ps_->endWriteTran(true);
+    if (ps_) ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
     return;
   }
   lastExecutedSeqNum = newCheckpointSeqNum;
@@ -3269,7 +3269,7 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   if (ps_) {
     ps_->setPrimaryLastUsedSeqNum(primaryLastUsedSeqNum);
     ps_->setCheckpointMsgInCheckWindow(newCheckpointSeqNum, checkpointMsg);
-    ps_->endWriteTran(true);
+    ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
   }
   metric_last_executed_seq_num_.Get().Set(lastExecutedSeqNum);
 
@@ -3398,7 +3398,7 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     ps_->setDescriptorOfLastStableCheckpoint(desc);
   }
 
-  if (ps_) ps_->endWriteTran(true);
+  if (ps_) ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
 
   if (((BatchingPolicy)config_.batchingPolicy == BATCH_SELF_ADJUSTED) && !oldSeqNum && currentViewIsActive() &&
       (currentPrimary() == config_.getreplicaId()) && !isCollectingState()) {
@@ -4765,7 +4765,7 @@ void ReplicaImp::markSpecialRequests(RequestsIterator &reqIter,
     DescriptorOfLastExecution execDesc{lastExecutedSeqNum + 1, requestSet, ticks};
     ps_->beginWriteTran();
     ps_->setDescriptorOfLastExecution(execDesc);
-    ps_->endWriteTran(true);
+    ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
   }
 }
 
@@ -4971,7 +4971,7 @@ void ReplicaImp::finishExecutePrePrepareMsg(PrePrepareMsg *ppMsg,
 
   if (ppMsg->numberOfRequests() > 0) bftRequestsHandler_->onFinishExecutingReadWriteRequests();
 
-  if (ps_) ps_->endWriteTran(true);
+  if (ps_) ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
 
   sendCheckpointIfNeeded();
 
@@ -5262,7 +5262,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
         DescriptorOfLastExecution execDesc{lastExecutedSeqNum + 1, requestSet, ticks};
         ps_->beginWriteTran();
         ps_->setDescriptorOfLastExecution(execDesc);
-        ps_->endWriteTran(true);
+        ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
       }
     } else {
       requestSet = mapOfRecoveredRequests;
@@ -5360,7 +5360,7 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
 
   if (numOfRequests > 0) bftRequestsHandler_->onFinishExecutingReadWriteRequests();
 
-  if (ps_) ps_->endWriteTran(true);
+  if (ps_) ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
 
   sendCheckpointIfNeeded();
 

--- a/bftengine/tests/simpleStorage/FileStorage.cpp
+++ b/bftengine/tests/simpleStorage/FileStorage.cpp
@@ -238,7 +238,7 @@ void FileStorage::writeInBatch(uint32_t objectId, const char *data, uint32_t dat
   transaction_->insert(pair<uint32_t, RequestInfo>(objectId, RequestInfo(data, dataLength)));
 }
 
-void FileStorage::commitAtomicWriteOnlyBatch() {
+void FileStorage::commitAtomicWriteOnlyBatch(bool sync) {
   LOG_DEBUG(logger_, "FileStorage::commitAtomicWriteOnlyBatch");
   lock_guard<mutex> lock(ioMutex_);
   verifyFileMetadataSetup();

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -42,7 +42,7 @@ class FileStorage : public MetadataStorage {
 
   void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) override;
 
-  void commitAtomicWriteOnlyBatch() override;
+  void commitAtomicWriteOnlyBatch(bool sync=false) override;
   void eraseData() override;
 
  private:

--- a/bftengine/tests/simpleStorage/FileStorage.hpp
+++ b/bftengine/tests/simpleStorage/FileStorage.hpp
@@ -42,7 +42,7 @@ class FileStorage : public MetadataStorage {
 
   void writeInBatch(uint32_t objectId, const char *data, uint32_t dataLength) override;
 
-  void commitAtomicWriteOnlyBatch(bool sync=false) override;
+  void commitAtomicWriteOnlyBatch(bool sync = false) override;
   void eraseData() override;
 
  private:

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -80,7 +80,7 @@ class Client : public IDBClient {
   virtual concordUtils::Status put(const Sliver &_key, const Sliver &_value) override;
   virtual concordUtils::Status del(const Sliver &_key) override;
   concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) override;
-  concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap) override;
+  concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap, bool sync=false) override;
   concordUtils::Status multiDel(const KeysVector &_keysVec) override;
   concordUtils::Status rangeDel(const Sliver &_beginKey, const Sliver &_endKey) override;
   bool isNew() override { return true; }

--- a/storage/include/memorydb/client.h
+++ b/storage/include/memorydb/client.h
@@ -80,7 +80,7 @@ class Client : public IDBClient {
   virtual concordUtils::Status put(const Sliver &_key, const Sliver &_value) override;
   virtual concordUtils::Status del(const Sliver &_key) override;
   concordUtils::Status multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec) override;
-  concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap, bool sync=false) override;
+  concordUtils::Status multiPut(const SetOfKeyValuePairs &_keyValueMap, bool sync = false) override;
   concordUtils::Status multiDel(const KeysVector &_keysVec) override;
   concordUtils::Status rangeDel(const Sliver &_beginKey, const Sliver &_endKey) override;
   bool isNew() override { return true; }

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -95,7 +95,7 @@ class Client : public concord::storage::IDBClient {
   concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override;
   concordUtils::Status del(const concordUtils::Sliver& _key) override;
   concordUtils::Status multiGet(const KeysVector& _keysVec, ValuesVector& _valuesVec) override;
-  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override;
+  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync=false) override;
   concordUtils::Status multiDel(const KeysVector& _keysVec) override;
   concordUtils::Status rangeDel(const Sliver& _beginKey, const Sliver& _endKey) override;
   ::rocksdb::Iterator* getNewRocksDbIterator() const;
@@ -138,7 +138,7 @@ class Client : public concord::storage::IDBClient {
   void openRocksDB(bool readOnly,
                    const ::rocksdb::Options& db_options,
                    std::vector<::rocksdb::ColumnFamilyDescriptor>& cf_descs);
-  concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob);
+  concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob, bool sync=false);
   concordUtils::Status get(const concordUtils::Sliver& _key, std::string& _value) const;
   bool keyIsBefore(const concordUtils::Sliver& _lhs, const concordUtils::Sliver& _rhs) const;
   bool columnFamilyIsEmpty(::rocksdb::ColumnFamilyHandle*) const;

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -95,7 +95,7 @@ class Client : public concord::storage::IDBClient {
   concordUtils::Status put(const concordUtils::Sliver& _key, const concordUtils::Sliver& _value) override;
   concordUtils::Status del(const concordUtils::Sliver& _key) override;
   concordUtils::Status multiGet(const KeysVector& _keysVec, ValuesVector& _valuesVec) override;
-  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync=false) override;
+  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync = false) override;
   concordUtils::Status multiDel(const KeysVector& _keysVec) override;
   concordUtils::Status rangeDel(const Sliver& _beginKey, const Sliver& _endKey) override;
   ::rocksdb::Iterator* getNewRocksDbIterator() const;
@@ -138,7 +138,7 @@ class Client : public concord::storage::IDBClient {
   void openRocksDB(bool readOnly,
                    const ::rocksdb::Options& db_options,
                    std::vector<::rocksdb::ColumnFamilyDescriptor>& cf_descs);
-  concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob, bool sync=false);
+  concordUtils::Status launchBatchJob(::rocksdb::WriteBatch& _batchJob, bool sync = false);
   concordUtils::Status get(const concordUtils::Sliver& _key, std::string& _value) const;
   bool keyIsBefore(const concordUtils::Sliver& _lhs, const concordUtils::Sliver& _rhs) const;
   bool columnFamilyIsEmpty(::rocksdb::ColumnFamilyHandle*) const;

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -228,7 +228,7 @@ class Client : public concord::storage::IDBClient {
     return concordUtils::Status::OK();
   }
 
-  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap) override {
+  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync=false) override {
     ITransaction::Guard g(beginTransaction());
     for (auto&& pair : _keyValueMap) g.txn()->put(pair.first, pair.second);
     return concordUtils::Status::OK();

--- a/storage/include/s3/client.hpp
+++ b/storage/include/s3/client.hpp
@@ -228,7 +228,7 @@ class Client : public concord::storage::IDBClient {
     return concordUtils::Status::OK();
   }
 
-  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync=false) override {
+  concordUtils::Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync = false) override {
     ITransaction::Guard g(beginTransaction());
     for (auto&& pair : _keyValueMap) g.txn()->put(pair.first, pair.second);
     return concordUtils::Status::OK();

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -64,7 +64,7 @@ class IDBClient {
   virtual Status put(const Sliver& _key, const Sliver& _value) = 0;
   virtual Status del(const Sliver& _key) = 0;
   virtual Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) = 0;
-  virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync=false) = 0;
+  virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync = false) = 0;
   virtual Status multiDel(const KeysVector& _keysVec) = 0;
   // Delete keys in the [_beginKey, _endKey) range (_beginKey included and _endKey excluded). If an inavlid range has
   // been passed (i.e. _endKey < _beginKey), the behavior is undefined. If _beginKey == _endKey, the call will not have

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -64,7 +64,7 @@ class IDBClient {
   virtual Status put(const Sliver& _key, const Sliver& _value) = 0;
   virtual Status del(const Sliver& _key) = 0;
   virtual Status multiGet(const KeysVector& _keysVec, OUT ValuesVector& _valuesVec) = 0;
-  virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap) = 0;
+  virtual Status multiPut(const SetOfKeyValuePairs& _keyValueMap, bool sync=false) = 0;
   virtual Status multiDel(const KeysVector& _keysVec) = 0;
   // Delete keys in the [_beginKey, _endKey) range (_beginKey included and _endKey excluded). If an inavlid range has
   // been passed (i.e. _endKey < _beginKey), the behavior is undefined. If _beginKey == _endKey, the call will not have

--- a/storage/src/memorydb_client.cpp
+++ b/storage/src/memorydb_client.cpp
@@ -130,7 +130,7 @@ Status Client::multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec
   return status;
 }
 
-Status Client::multiPut(const SetOfKeyValuePairs &_keyValueMap) {
+Status Client::multiPut(const SetOfKeyValuePairs &_keyValueMap, bool sync) {
   Status status = Status::OK();
   for (const auto &it : _keyValueMap) {
     status = put(it.first, it.second);

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -520,9 +520,10 @@ Status Client::multiGet(const KeysVector &_keysVec, OUT ValuesVector &_valuesVec
   return Status::OK();
 }
 
-Status Client::launchBatchJob(::rocksdb::WriteBatch &batch) {
+Status Client::launchBatchJob(::rocksdb::WriteBatch &batch, bool sync) {
   LOG_DEBUG(logger(), "launcBatchJob: batch data size=" << batch.GetDataSize() << " num updates=" << batch.Count());
   ::rocksdb::WriteOptions wOptions = ::rocksdb::WriteOptions();
+  wOptions.sync = sync;
   ::rocksdb::Status status = dbInstance_->Write(wOptions, &batch);
   if (!status.ok()) {
     LOG_ERROR(
@@ -536,14 +537,14 @@ Status Client::launchBatchJob(::rocksdb::WriteBatch &batch) {
   return Status::OK();
 }
 
-Status Client::multiPut(const SetOfKeyValuePairs &keyValueMap) {
+Status Client::multiPut(const SetOfKeyValuePairs &keyValueMap, bool sync) {
   ::rocksdb::WriteBatch batch;
   LOG_DEBUG(logger(), "multiPut: keyValueMap.size() = " << keyValueMap.size());
   for (const auto &it : keyValueMap) {
     batch.Put(toRocksdbSlice(it.first), toRocksdbSlice(it.second));
     LOG_TRACE(logger(), "RocksDB Added entry: key =" << it.first << ", value= " << it.second << " to the batch job");
   }
-  Status status = launchBatchJob(batch);
+  Status status = launchBatchJob(batch, sync);
   if (status.isOK()) LOG_DEBUG(logger(), "Successfully put all entries to the database");
   return status;
 }


### PR DESCRIPTION
Add the possibility for the user to sync at the end of a transaction
in order to be sure the data is correctly persisted before taking
further actions.
Add a config parameter to control this behavior.