### PR TITLE
Introduce a Raw Memory Pool for PreProcessor

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -29,7 +29,7 @@ using namespace std;
 using namespace std::placeholders;
 using namespace concordUtil;
 
-uint8_t RequestState::reqProcessingHistoryHeight = 10;
+uint8_t RequestState::reqProcessingHistoryHeight = 1;
 
 //**************** Class RequestsBatch ****************//
 
@@ -301,10 +301,13 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       requestsHandler_(requestsHandler),
       myReplica_(myReplica),
       myReplicaId_(myReplica.getReplicaConfig().replicaId),
-      maxPreExecResultSize_(myReplica.getReplicaConfig().maxExternalMessageSize),
+      // YS TBD: remove memory allocated for the block-id after Eran fixes for conflict detection optimization
+      maxPreExecResultSize_(myReplica.getReplicaConfig().maxExternalMessageSize + sizeof(uint64_t)),
       numOfReplicas_(myReplica.getReplicaConfig().numReplicas + myReplica.getReplicaConfig().numRoReplicas),
       numOfInternalClients_(myReplica.getReplicaConfig().numOfClientProxies),
       clientBatchingEnabled_(myReplica.getReplicaConfig().clientBatchingEnabled),
+      // YS TBD: remove memory allocated for the block-id after Eran fixes for conflict detection optimization
+      memoryPool_(maxPreExecResultSize_, timers),
       metricsComponent_{concordMetrics::Component("preProcessor", std::make_shared<concordMetrics::Aggregator>())},
       metricsLastDumpTime_(0),
       metricsDumpIntervalInSec_{myReplica_.getReplicaConfig().metricsDumpIntervalSeconds},
@@ -336,8 +339,10 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   const uint16_t numOfReqEntries = numOfExternalClients * clientMaxBatchSize_;
   for (uint16_t i = 0; i < numOfReqEntries; i++) {
     // Placeholders for all clients including batches
-    preProcessResultBuffers_.emplace_back(std::make_pair(false, Sliver()));
+    preProcessResultBuffers_.emplace_back(make_shared<SafeResultBuffer>());
   }
+  // Initially, allocate a memory for all batches of one client (clientMaxBatchSize_)
+  memoryPool_.allocatePool(clientMaxBatchSize_, numOfReqEntries);
   const uint16_t firstClientId = numOfReplicas_ + numOfInternalClients_;
   for (uint16_t i = 0; i < numOfExternalClients; i++) {
     // Placeholders for all client batches
@@ -1345,6 +1350,7 @@ void PreProcessor::releaseClientPreProcessRequest(const RequestStateSharedPtr &r
     if (!myReplica_.isCurrentPrimary()) {
       preProcessorMetrics_.preProcInFlyRequestsNum--;
     }
+    releasePreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
   }
 }
 
@@ -1458,30 +1464,34 @@ void PreProcessor::registerAndHandleClientPreProcessReqOnNonPrimary(const string
   }
 }
 
+uint32_t PreProcessor::getBufferOffset(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const {
+  return (clientId - numOfReplicas_ - numOfInternalClients_) * clientMaxBatchSize_ + reqOffsetInBatch;
+}
+
 const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) {
-  // Allocate on first use buffers scheme:
+  // Buffers structure scheme:
   // |first client's first buffer|...|first client's last buffer|......
   // |last client's first buffer|...|last client's last buffer|
   // First client id starts after the last replica id.
   // First buffer offset = numOfReplicas_ * batchSize_
   // The number of buffers per client comes from the configuration parameter clientBatchingMaxMsgsNbr.
-  const auto bufferOffset =
-      (clientId - numOfReplicas_ - numOfInternalClients_) * clientMaxBatchSize_ + reqOffsetInBatch;
-  LOG_TRACE(logger(), KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset, reqSeqNum));
-  char *buf = nullptr;
-  if (!preProcessResultBuffers_[bufferOffset].first) {
-    // sizeof(uint64_t) -> block id of conflict detection optimization
-    buf = new char[maxPreExecResultSize_ + sizeof(uint64_t)];
-    {
-      std::unique_lock lock(resultBufferLock_);
-      if (!preProcessResultBuffers_[bufferOffset].first) {
-        preProcessResultBuffers_[bufferOffset].second = Sliver(buf, maxPreExecResultSize_);
-        preProcessResultBuffers_[bufferOffset].first = true;
-      } else
-        delete[] buf;
-    }
+  const auto bufferOffset = getBufferOffset(clientId, reqSeqNum, reqOffsetInBatch);
+  std::unique_lock lock(preProcessResultBuffers_[bufferOffset]->mutex);
+  if (!preProcessResultBuffers_[bufferOffset]->buffer) {
+    preProcessResultBuffers_[bufferOffset]->buffer = memoryPool_.getChunk();
+    LOG_TRACE(logger(), "Allocate memory from the pool" << KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
   }
-  return preProcessResultBuffers_[bufferOffset].second.data();
+  return preProcessResultBuffers_[bufferOffset]->buffer;
+}
+
+void PreProcessor::releasePreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) {
+  const auto bufferOffset = getBufferOffset(clientId, reqSeqNum, reqOffsetInBatch);
+  std::unique_lock lock(preProcessResultBuffers_[bufferOffset]->mutex);
+  if (preProcessResultBuffers_[bufferOffset]->buffer) {
+    memoryPool_.returnChunk(preProcessResultBuffers_[bufferOffset]->buffer);
+    preProcessResultBuffers_[bufferOffset]->buffer = nullptr;
+    LOG_TRACE(logger(), "Returned memory to the pool" << KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
+  }
 }
 
 // Primary replica: ask all replicas to pre-process the request

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -11,7 +11,8 @@ set(util_source_files
     src/hex_tools.cpp
     src/OpenTracing.cpp
     src/throughput.cpp
-    src/crypto_utils.cpp)
+    src/crypto_utils.cpp
+    src/RawMemoryPool.cpp)
 
 
 add_library(util        STATIC ${util_source_files})

--- a/util/include/MemoryPool.hpp
+++ b/util/include/MemoryPool.hpp
@@ -1,0 +1,54 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "Logger.hpp"
+
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <boost/lockfree/queue.hpp>
+
+namespace concordUtils {
+
+class MemoryPool {
+ public:
+  MemoryPool(uint32_t chunkSize) : chunkSize_(chunkSize) {}
+  virtual ~MemoryPool();
+
+  void allocatePool(int32_t minChunks, int32_t maxChunks);
+  char* getChunk();
+  void returnChunk(char*);
+
+  MemoryPool(const MemoryPool&) = delete;
+  MemoryPool& operator=(const MemoryPool&) = delete;
+  MemoryPool(MemoryPool&&) = delete;
+  MemoryPool&& operator=(MemoryPool&&) = delete;
+
+  static logging::Logger& logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.memory.pool");
+    return logger_;
+  }
+
+ private:
+  const uint32_t WAIT_TIMEOUT_MILLI = 5;
+  const uint32_t chunkSize_;
+  int32_t minChunksNum_ = 0;
+  int32_t maxChunksNum_ = 0;
+  std::shared_ptr<boost::lockfree::queue<char*, boost::lockfree::fixed_sized<true>>> pool_;
+  std::atomic_int numOfAvailableChunks_{0};
+  std::atomic_bool stopWorking_{false};
+  std::condition_variable waitForChunkCond_;
+  std::mutex waitForChunkLock_;
+};
+
+}  // namespace concordUtils

--- a/util/include/RawMemoryPool.hpp
+++ b/util/include/RawMemoryPool.hpp
@@ -1,0 +1,100 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "Timers.hpp"
+#include "Logger.hpp"
+#include "Metrics.hpp"
+
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <boost/lockfree/queue.hpp>
+
+// This thread-safe memory pool implementation is intended for the raw memory chunks operations. During the pool
+// initialization, a pre-defined number (minChunksNum_) of raw memory chunks of size chunkSize_ gets allocated.
+// In case there is no available chunk, a new one gets dynamically allocated - up to a maximum number (maxChunksNum_).
+// No support for different memory sizes provided.
+
+namespace concordUtil {
+
+class RawMemoryPoolMetrics {
+ public:
+  RawMemoryPoolMetrics(Timers& timers)
+      : component_{"memoryPoolMetrics", std::make_shared<concordMetrics::Aggregator>()},
+        availableChunks_{component_.RegisterGauge("availableChunks", 0)},
+        allocatedChunks_{component_.RegisterGauge("allocatedChunks", 0)},
+        timers_(timers) {
+    component_.Register();
+    const std::chrono::milliseconds period{100};
+    metricsTimer_ = timers_.add(period, Timers::Timer::RECURRING, [this](Timers::Handle h) { updateAggregator(); });
+  }
+
+  ~RawMemoryPoolMetrics() { timers_.cancel(metricsTimer_); }
+
+  void setAggregator(const std::shared_ptr<concordMetrics::Aggregator>& aggregator) {
+    component_.SetAggregator(aggregator);
+  }
+
+  void increaseAvailableChunksNum() { availableChunks_++; }
+  void decreaseAvailableChunksNum() { availableChunks_--; }
+  void increaseAllocatedChunksNum() { allocatedChunks_++; }
+  void decreaseAllocatedChunksNum() { allocatedChunks_--; }
+
+  void updateAggregator() { component_.UpdateAggregator(); }
+
+ private:
+  concordMetrics::Component component_;
+  concordMetrics::GaugeHandle availableChunks_;
+  concordMetrics::GaugeHandle allocatedChunks_;
+  Timers& timers_;
+  Timers::Handle metricsTimer_;
+};
+
+class RawMemoryPool {
+ public:
+  RawMemoryPool(uint32_t chunkSize, Timers& timers);
+  virtual ~RawMemoryPool();
+
+  void allocatePool(int32_t minChunks, int32_t maxChunks);
+  int32_t getNumOfAvailableChunks() const { return numOfAvailableChunks_; }
+  int32_t getNumOfAllocatedChunks() const { return numOfAllocatedChunks_; }
+  bool isPoolFull() const { return numOfAllocatedChunks_ == maxChunksNum_; }
+  char* getChunk();
+  void returnChunk(char*);
+  void stopPool() { stopWorking_ = true; }
+
+  RawMemoryPool(const RawMemoryPool&) = delete;
+  RawMemoryPool& operator=(const RawMemoryPool&) = delete;
+  RawMemoryPool(RawMemoryPool&&) = delete;
+  RawMemoryPool&& operator=(RawMemoryPool&&) = delete;
+
+  static logging::Logger& logger() {
+    static logging::Logger logger_ = logging::getLogger("concord.memory.pool");
+    return logger_;
+  }
+
+ private:
+  const uint32_t WAIT_TIMEOUT_MILLI = 5;
+  const uint32_t chunkSize_;
+  int32_t minChunksNum_ = 0;
+  int32_t maxChunksNum_ = 0;
+  std::shared_ptr<boost::lockfree::queue<char*, boost::lockfree::fixed_sized<true>>> pool_;
+  std::atomic_int numOfAvailableChunks_{0};
+  std::atomic_int numOfAllocatedChunks_{0};
+  std::atomic_bool stopWorking_{false};
+  std::condition_variable waitForAvailChunkCond_;
+  std::mutex waitForAvailChunkLock_;
+  RawMemoryPoolMetrics metrics_;
+};
+
+}  // namespace concordUtil

--- a/util/src/RawMemoryPool.cpp
+++ b/util/src/RawMemoryPool.cpp
@@ -1,0 +1,93 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "RawMemoryPool.hpp"
+
+#include <thread>
+#include "assertUtils.hpp"
+#include "kvstream.h"
+
+namespace concordUtil {
+
+using namespace std;
+using namespace std::chrono;
+
+RawMemoryPool::RawMemoryPool(uint32_t chunkSize, Timers& timers) : chunkSize_(chunkSize), metrics_(timers) {}
+
+RawMemoryPool::~RawMemoryPool() {
+  stopWorking_ = true;
+  unique_lock<mutex> lock(waitForAvailChunkLock_);
+  this_thread::sleep_for(std::chrono::milliseconds(WAIT_TIMEOUT_MILLI * 2));
+  char* chunk = nullptr;
+  while (pool_->pop(chunk)) delete[] chunk;
+}
+
+void RawMemoryPool::allocatePool(int32_t minChunks, int32_t maxChunks) {
+  if (minChunks > maxChunks || minChunks < 0 || maxChunks < 0) {
+    stringstream err;
+    err << "Wrong parameters specified: minChunks=" << minChunks << ", maxChunks=" << maxChunks;
+    LOG_ERROR(logger(), KVLOG(err.str()));
+    throw std::invalid_argument(__PRETTY_FUNCTION__ + err.str());
+  }
+  minChunksNum_ = minChunks;
+  maxChunksNum_ = maxChunks;
+  pool_ = make_shared<boost::lockfree::queue<char*, boost::lockfree::fixed_sized<true>>>(maxChunksNum_);
+  for (int32_t i = 0; i < minChunksNum_; ++i) {
+    pool_->push(new char[chunkSize_]);
+    metrics_.increaseAvailableChunksNum();
+    metrics_.increaseAllocatedChunksNum();
+  }
+  numOfAvailableChunks_ = minChunksNum_;
+  numOfAllocatedChunks_ = minChunksNum_;
+  LOG_INFO(logger(),
+           "Memory pool allocated" << KVLOG(
+               chunkSize_, minChunksNum_, maxChunksNum_, numOfAllocatedChunks_, numOfAvailableChunks_));
+}
+
+char* RawMemoryPool::getChunk() {
+  ConcordAssert(pool_.get() != nullptr);
+  char* chunk = nullptr;
+  if (!pool_->pop(chunk)) {
+    // No available chunks => allocate a new one, if permitted
+    if (numOfAvailableChunks_ < maxChunksNum_) {
+      chunk = new char[chunkSize_];
+      numOfAllocatedChunks_++;
+      metrics_.increaseAllocatedChunksNum();
+      numOfAvailableChunks_++;
+      metrics_.increaseAvailableChunksNum();
+      LOG_INFO(logger(), "A new chunk has been allocated" << KVLOG(numOfAllocatedChunks_, numOfAvailableChunks_));
+    } else {
+      // Wait until some chunk gets released
+      unique_lock<mutex> lock(waitForAvailChunkLock_);
+      while (!stopWorking_ && !numOfAvailableChunks_)
+        waitForAvailChunkCond_.wait_until(lock, steady_clock::now() + milliseconds(WAIT_TIMEOUT_MILLI));
+    }
+  }
+  if (chunk) numOfAvailableChunks_--;
+  metrics_.decreaseAvailableChunksNum();
+  return chunk;
+}
+
+void RawMemoryPool::returnChunk(char* chunk) {
+  if (numOfAvailableChunks_ >= maxChunksNum_) {
+    stringstream err;
+    err << "The chunk overflows the pool size: numOfAvailableChunks_=" << numOfAvailableChunks_
+        << ", maxChunksNum_=" << maxChunksNum_;
+    LOG_ERROR(logger(), KVLOG(err.str()));
+    throw std::runtime_error(__PRETTY_FUNCTION__ + err.str());
+  }
+  pool_->push(chunk);
+  numOfAvailableChunks_++;
+  metrics_.increaseAvailableChunksNum();
+  waitForAvailChunkCond_.notify_one();
+}
+
+}  // namespace concordUtil

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -71,6 +71,10 @@ add_executable(simple_memory_pool_test simple_memory_pool_test.cpp)
 add_test(simple_memory_pool_test simple_memory_pool_test)
 target_link_libraries(simple_memory_pool_test GTest::Main util)
 
+add_executable(RawMemoryPool_test RawMemoryPool_test.cpp)
+add_test(RawMemoryPool_test RawMemoryPool_test)
+target_link_libraries(RawMemoryPool_test GTest::Main util)
+
 add_executable(crypto_utils_test crypto_utils_test.cpp )
 add_test(crypto_utils_test crypto_utils_test)
 target_link_libraries(crypto_utils_test GTest::Main util)

--- a/util/test/RawMemoryPool_test.cpp
+++ b/util/test/RawMemoryPool_test.cpp
@@ -1,0 +1,91 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "RawMemoryPool.hpp"
+
+namespace {
+using namespace std;
+using namespace concordUtil;
+
+Timers timers;
+const uint32_t chunkSize = 1034;
+const uint32_t minChunks = 10;
+const uint32_t maxChunks = 20;
+
+TEST(RawMemoryPoolTest, checkInput) {
+  RawMemoryPool pool(chunkSize, timers);
+  EXPECT_THROW(pool.allocatePool(maxChunks + 1, maxChunks), std::invalid_argument);
+  EXPECT_THROW(pool.allocatePool(minChunks, -1), std::invalid_argument);
+  EXPECT_THROW(pool.allocatePool(-1, maxChunks), std::invalid_argument);
+  EXPECT_NO_THROW(pool.allocatePool(minChunks, minChunks));
+}
+
+TEST(RawMemoryPoolTest, testAllocFree) {
+  RawMemoryPool pool(chunkSize, timers);
+  pool.allocatePool(minChunks, maxChunks);
+
+  ASSERT_EQ(pool.getNumOfAvailableChunks(), minChunks);
+  ASSERT_EQ(pool.getNumOfAllocatedChunks(), minChunks);
+  ASSERT_FALSE(pool.isPoolFull());
+
+  char* chunk = pool.getChunk();
+  ASSERT_TRUE(chunk);
+  ASSERT_EQ(pool.getNumOfAvailableChunks(), minChunks - 1);
+  ASSERT_EQ(pool.getNumOfAllocatedChunks(), minChunks);
+  ASSERT_FALSE(pool.isPoolFull());
+
+  pool.returnChunk(chunk);
+  ASSERT_EQ(pool.getNumOfAvailableChunks(), minChunks);
+  ASSERT_EQ(pool.getNumOfAllocatedChunks(), minChunks);
+  ASSERT_FALSE(pool.isPoolFull());
+
+  // Allocate all chunks up to maxChunks number through getChunk() function
+  char* chunks[maxChunks];
+  for (uint32_t i = 0; i < minChunks; i++) {
+    chunks[i] = pool.getChunk();
+    ASSERT_TRUE(chunks[i]);
+  }
+  for (uint32_t i = maxChunks - minChunks; i < maxChunks; i++) {
+    chunks[i] = pool.getChunk();
+    ASSERT_TRUE(chunks[i]);
+  }
+  ASSERT_EQ(pool.getNumOfAvailableChunks(), 0);
+  ASSERT_EQ(pool.getNumOfAllocatedChunks(), maxChunks);
+  ASSERT_TRUE(pool.isPoolFull());
+
+  // Return all chunks
+  for (uint32_t i = 0; i < maxChunks; i++) {
+    ASSERT_TRUE(chunks[i]);
+    pool.returnChunk(chunks[i]);
+  }
+  ASSERT_EQ(pool.getNumOfAvailableChunks(), maxChunks);
+  ASSERT_EQ(pool.getNumOfAllocatedChunks(), maxChunks);
+  ASSERT_TRUE(pool.isPoolFull());
+}
+
+TEST(RawMemoryPoolTest, testAllocFreeErrors) {
+  RawMemoryPool pool(chunkSize, timers);
+  pool.allocatePool(maxChunks, maxChunks);
+  ASSERT_TRUE(pool.isPoolFull());
+
+  // Return more chunks than were allocated
+  char chunk[chunkSize];
+  EXPECT_THROW(pool.returnChunk(chunk), std::runtime_error);
+}
+
+}  // namespace


### PR DESCRIPTION
Use memory pool for the PreProcessor reply buffer allocations. Allow allocated chunks sharing among clients/requests.