### PR TITLE
Add specific message type for latest known epoch

### DIFF
--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -163,6 +163,7 @@ concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildLates
   concord::messages::ClientStateReply creply;
   creply.block_id = 0;
   creply.epoch = 0;
+  creply.response.emplace<concord::messages::LatestEpochData>();
   auto value = ro_storage_.getLatest(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                      std::string{keyTypes::reconfiguration_epoch_key});
   if (value.has_value()) {

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -229,6 +229,9 @@ Msg ReplicaTlsExchangeKey 57 {
     string cert
 }
 
+Msg LatestEpochData 58 {
+}
+
 Msg ClientStateReply 39 {
     uint64 block_id
     oneof {
@@ -239,6 +242,7 @@ Msg ClientStateReply 39 {
         ClientTlsExchangeKey
         ClientsRestartCommand
         ReplicaTlsExchangeKey
+        LatestEpochData
       } response
     uint64 epoch
 }


### PR DESCRIPTION
Apparently, with an empty response, the deserialization set the first class in the variant. Hence we are unable to return a state reply with an empty response. In this PR we add a specific type to the epoch response