### PR TITLE
Infra for replicas main public key exchange

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -31,6 +31,8 @@ class KeyExchangeManager {
   void exchangeTlsKeys(const SeqNum& bft_sn);
   // Generates and publish key to consensus
   void sendKeyExchange(const SeqNum&);
+  // Send the current main public key of the replica to consensus
+  void sendMainPublicKey();
   // Generates and publish the first replica's key,
   void sendInitialKey(uint32_t prim = 0, const SeqNum& = 0);
   // The execution handler implementation that is called when a key exchange msg has passed consensus.

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -215,7 +215,10 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                60,
                "timeout we ready to wait for primary to be ready on the system first startup");
   CONFIG_PARAM(waitForFullCommOnStartup, bool, false, "whether to wait for n/n communication on startup");
-
+  CONFIG_PARAM(publishReplicasMasterKeyOnStartup,
+               bool,
+               false,
+               "If true, replicas will publish their master key on startup");
   // Db checkpoint
   CONFIG_PARAM(dbCheckpointFeatureEnabled, bool, false, "Feature flag for rocksDb checkpoints");
   CONFIG_PARAM(maxNumberOfDbCheckpoints, uint32_t, 0u, "Max number of db checkpoints to be created");
@@ -234,6 +237,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                true,
                "When set to true this parameter will cause endWriteTran to block until "
                "the transaction is persisted every time we update the metadata.");
+
+  // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters
   // Example of usage:
   // repclicaConfig.set(someTimeout, 6000);
@@ -336,6 +341,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, threadbagConcurrencyLevel2);
     serialize(outStream, timeoutForPrimaryOnStartupSeconds);
     serialize(outStream, waitForFullCommOnStartup);
+    serialize(outStream, publishReplicasMasterKeyOnStartup);
     serialize(outStream, dbCheckpointFeatureEnabled);
     serialize(outStream, maxNumberOfDbCheckpoints);
     serialize(outStream, dbCheckPointWindowSize);
@@ -421,6 +427,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, threadbagConcurrencyLevel2);
     deserialize(inStream, timeoutForPrimaryOnStartupSeconds);
     deserialize(inStream, waitForFullCommOnStartup);
+    deserialize(inStream, publishReplicasMasterKeyOnStartup);
     deserialize(inStream, dbCheckpointFeatureEnabled);
     deserialize(inStream, maxNumberOfDbCheckpoints);
     deserialize(inStream, dbCheckPointWindowSize);

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -108,7 +108,9 @@ std::string KeyExchangeManager::onKeyExchange(const KeyExchangeMsg& kemsg,
              "Exchanged [" << publicKeys_.numOfExchangedReplicas() << "] out of [" << liveQuorumSize << "]");
   if (!initial_exchange_ && exchanged()) {
     initial_exchange_ = true;
-    if (ReplicaConfig::instance().getkeyExchangeOnStart()) sendMainPublicKey();
+    if (ReplicaConfig::instance().getkeyExchangeOnStart() &&
+        ReplicaConfig::instance().publishReplicasMasterKeyOnStartup)
+      sendMainPublicKey();
   }
   return "ok";
 }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4466,7 +4466,7 @@ void ReplicaImp::start() {
     KeyExchangeManager::instance().sendInitialKey(currentPrimary());
   } else {
     // If key exchange is disabled, first publish the replica's main (rsa) key to clients
-    KeyExchangeManager::instance().sendMainPublicKey();
+    if (ReplicaConfig::instance().publishReplicasMasterKeyOnStartup) KeyExchangeManager::instance().sendMainPublicKey();
   }
   KeyExchangeManager::instance().sendInitialClientsKeys(SigManager::instance()->getClientsPublicKeys());
 }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4464,6 +4464,9 @@ void ReplicaImp::start() {
 
   if (ReplicaConfig::instance().getkeyExchangeOnStart() && !KeyExchangeManager::instance().exchanged()) {
     KeyExchangeManager::instance().sendInitialKey(currentPrimary());
+  } else {
+    // If key exchange is disabled, first publish the replica's main (rsa) key to clients
+    KeyExchangeManager::instance().sendMainPublicKey();
   }
   KeyExchangeManager::instance().sendInitialClientsKeys(SigManager::instance()->getClientsPublicKeys());
 }

--- a/client/reconfiguration/CMakeLists.txt
+++ b/client/reconfiguration/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(cre
         src/client_reconfiguration_engine.cpp
         src/poll_based_state_client.cpp
         src/st_based_reconfiguration_client.cpp
+        src/default_handlers.cpp
         )
 
 target_include_directories(cre PUBLIC include)

--- a/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
@@ -15,7 +15,7 @@
 #include "secrets_manager_plain.h"
 
 namespace concord::client::reconfiguration::handlers {
-class ReplicaMainKeyPublicationHandler : IStateHandler {
+class ReplicaMainKeyPublicationHandler : public IStateHandler {
  public:
   ReplicaMainKeyPublicationHandler(const std::string& output_dir) : output_dir_{output_dir} {}
   bool validate(const State&) const override;

--- a/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
@@ -1,0 +1,29 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "cre_interfaces.hpp"
+#include "secrets_manager_plain.h"
+
+namespace concord::client::reconfiguration::handlers {
+class ReplicaMainKeyPublicationHandler : IStateHandler {
+ public:
+  ReplicaMainKeyPublicationHandler(const std::string& output_dir) : output_dir_{output_dir} {}
+  bool validate(const State&) const override;
+  bool execute(const State&, WriteState&) override;
+
+ private:
+  std::string output_dir_;
+  concord::secretsmanager::SecretsManagerPlain file_handler_;
+  uint32_t latest_known_update_{0};
+};
+}  // namespace concord::client::reconfiguration::handlers

--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -1,0 +1,48 @@
+// Concord
+//
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client/reconfiguration/default_handlers.hpp"
+#include "concord.cmf.hpp"
+
+#include <variant>
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+
+namespace concord::client::reconfiguration::handlers {
+
+template <typename T>
+bool validateInputState(const State& state) {
+  concord::messages::ClientStateReply crep;
+  concord::messages::deserialize(state.data, crep);
+  return std::holds_alternative<T>(crep.response);
+}
+
+template <typename T>
+T getCmdFromInputState(const State& state) {
+  concord::messages::ClientStateReply crep;
+  concord::messages::deserialize(state.data, crep);
+  return std::get<T>(crep.response);
+}
+bool ReplicaMainKeyPublicationHandler::validate(const State& state) const {
+  return validateInputState<concord::messages::ReplicaMainKeyUpdate>(state);
+}
+bool ReplicaMainKeyPublicationHandler::execute(const State& state, WriteState&) {
+  auto cmd = getCmdFromInputState<concord::messages::ReplicaMainKeyUpdate>(state);
+  fs::path path = fs::path(output_dir_) / std::to_string(cmd.sender_id);
+  auto curr_key = file_handler_.decryptFile((path / "pub_key").string()).value_or("");
+  if (curr_key != cmd.key) {
+    if (!fs::exists(path)) fs::create_directories(path);
+    file_handler_.encryptFile((path / "pub_key").string(), cmd.key);
+  }
+  latest_known_update_ = state.blockid;
+  return true;
+}
+}  // namespace concord::client::reconfiguration::handlers

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -29,6 +29,7 @@ static const char reconfiguration_tls_exchange_key = 0x2e;
 
 static const char reconfiguration_restart_key = 0x30;
 static const char reconfiguration_ts_key = 0x31;
+static const char reconfiguration_rep_main_key = 0x32;
 static const std::string genesis_block_key(1, 0x32);
 
 enum CLIENT_COMMAND_TYPES : uint8_t {

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -209,6 +209,11 @@ class InternalKvReconfigurationHandler : public concord::reconfiguration::IRecon
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
+  bool handle(const concord::messages::ReplicaMainKeyUpdate&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
 };
 
 class InternalPostKvReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -785,6 +785,19 @@ bool InternalKvReconfigurationHandler::verifySignature(uint32_t sender_id,
       sender_id, data.data(), data.size(), signature.data(), signature.size());
 }
 
+bool InternalKvReconfigurationHandler::handle(const concord::messages::ReplicaMainKeyUpdate& command,
+                                              uint64_t bft_seq_num,
+                                              uint32_t,
+                                              const std::optional<bftEngine::Timestamp>& ts,
+                                              concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+
+  auto blockId = persistReconfigurationBlock(
+      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_rep_main_key}, ts, false);
+  LOG_INFO(getLogger(), "received ReplicaMainKeyUpdate" << KVLOG(command.sender_id, bft_seq_num, blockId));
+  return true;
+}
 bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,
                                               uint64_t bft_seq_num,
                                               uint32_t,

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -167,6 +167,10 @@ concord::messages::ClientStateReply KvbcClientReconfigurationHandler::buildRepli
             concord::messages::ClientsAddRemoveExecuteCommand cmd;
             concord::messages::deserialize(data_buf, cmd);
             creply.response = cmd;
+          } else if (command_type == std::string{kvbc::keyTypes::reconfiguration_rep_main_key}) {
+            concord::messages::ReplicaMainKeyUpdate cmd;
+            concord::messages::deserialize(data_buf, cmd);
+            creply.response = cmd;
           }
           auto epoch_data = ro_storage_.get(concord::kvbc::categorization::kConcordReconfigurationCategoryId,
                                             std::string{kvbc::keyTypes::reconfiguration_epoch_key},
@@ -199,6 +203,10 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
     }
     for (uint16_t i = 0; i < first_client_id; i++) {
       auto ke_csrep = buildReplicaStateReply(std::string{kvbc::keyTypes::reconfiguration_tls_exchange_key}, i);
+      if (ke_csrep.block_id > 0) rep.states.push_back(ke_csrep);
+    }
+    for (uint16_t i = 0; i < first_client_id; i++) {
+      auto ke_csrep = buildReplicaStateReply(std::string{kvbc::keyTypes::reconfiguration_rep_main_key}, i);
       if (ke_csrep.block_id > 0) rep.states.push_back(ke_csrep);
     }
   } else {

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -787,15 +787,19 @@ bool InternalKvReconfigurationHandler::verifySignature(uint32_t sender_id,
 
 bool InternalKvReconfigurationHandler::handle(const concord::messages::ReplicaMainKeyUpdate& command,
                                               uint64_t bft_seq_num,
-                                              uint32_t,
+                                              uint32_t sender_id,
                                               const std::optional<bftEngine::Timestamp>& ts,
                                               concord::messages::ReconfigurationResponse&) {
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
 
-  auto blockId = persistReconfigurationBlock(
-      serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_rep_main_key}, ts, false);
-  LOG_INFO(getLogger(), "received ReplicaMainKeyUpdate" << KVLOG(command.sender_id, bft_seq_num, blockId));
+  auto blockId =
+      persistReconfigurationBlock(serialized_command,
+                                  bft_seq_num,
+                                  std::string{kvbc::keyTypes::reconfiguration_rep_main_key} + std::to_string(sender_id),
+                                  ts,
+                                  false);
+  LOG_INFO(getLogger(), "received ReplicaMainKeyUpdate" << KVLOG(sender_id, bft_seq_num, blockId));
   return true;
 }
 bool InternalKvReconfigurationHandler::handle(const concord::messages::WedgeCommand& command,

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -244,7 +244,7 @@ Msg ReplicaTlsExchangeKey 57 {
     string cert
 }
 
-Msg ReplicaMainKeyUpdate 58 {
+Msg ReplicaMainKeyUpdate 64 {
     uint64 sender_id
     string key
     string format

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -322,6 +322,7 @@ Msg ReconfigurationRequest 1 {
     PruneSwitchModeRequest
     GetDbCheckpointInfoRequest
     CreateDbCheckpointCommand
+    ReplicaMainKeyUpdate
   } command
   bytes additional_data
 }

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -244,6 +244,12 @@ Msg ReplicaTlsExchangeKey 57 {
     string cert
 }
 
+Msg ReplicaMainKeyUpdate 58 {
+    uint64 sender_id
+    string key
+    string format
+}
+
 Msg ClientStateReply 39 {
     uint64 block_id
     oneof {
@@ -253,6 +259,7 @@ Msg ClientStateReply 39 {
         ClientsAddRemoveUpdateCommand
         ClientsRestartCommand
         ReplicaTlsExchangeKey
+        ReplicaMainKeyUpdate
       } response
     uint64 epoch
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -245,6 +245,14 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::ReplicaMainKeyUpdate &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
   virtual bool handle(const concord::messages::GetDbCheckpointInfoRequest &,
                       uint64_t,
                       uint32_t,

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -42,7 +42,7 @@ def start_replica_cmd_with_object_store(builddir, replica_id, config):
     else :
         batch_size = "1"
         time_service_enabled = "0"
-    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem", "--publish-master-key-on-startup"])
+    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem"])
     return ret
 
 def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
@@ -59,7 +59,7 @@ def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
     else :
         batch_size = "1"
         time_service_enabled = "0"
-    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem", "--publish-master-key-on-startup"])
+    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem"])
     return ret
 
 def start_replica_cmd(builddir, replica_id):
@@ -87,8 +87,7 @@ def start_replica_cmd(builddir, replica_id):
             "-f", time_service_enabled,
             "-b", "2",
             "-q", batch_size,
-            "-o", builddir + "/operator_pub.pem",
-            "--publish-master-key-on-startup"]
+            "-o", builddir + "/operator_pub.pem"]
 
 
 def start_replica_cmd_with_key_exchange(builddir, replica_id):
@@ -117,8 +116,7 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
             "-b", "2",
             "-q", batch_size,
             "-e", str(True),
-            "-o", builddir + "/operator_pub.pem",
-            "--publish-master-key-on-startup"]
+            "-o", builddir + "/operator_pub.pem"]
 
 class SkvbcReconfigurationTest(unittest.TestCase):
     @classmethod

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -42,7 +42,7 @@ def start_replica_cmd_with_object_store(builddir, replica_id, config):
     else :
         batch_size = "1"
         time_service_enabled = "0"
-    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem"])
+    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem", "-K"])
     return ret
 
 def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
@@ -59,7 +59,7 @@ def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
     else :
         batch_size = "1"
         time_service_enabled = "0"
-    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem"])
+    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem", "-K"])
     return ret
 
 def start_replica_cmd(builddir, replica_id):
@@ -87,7 +87,8 @@ def start_replica_cmd(builddir, replica_id):
             "-f", time_service_enabled,
             "-b", "2",
             "-q", batch_size,
-            "-o", builddir + "/operator_pub.pem"]
+            "-o", builddir + "/operator_pub.pem"
+            "-K"]
 
 
 def start_replica_cmd_with_key_exchange(builddir, replica_id):
@@ -116,7 +117,8 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
             "-b", "2",
             "-q", batch_size,
             "-e", str(True),
-            "-o", builddir + "/operator_pub.pem"]
+            "-o", builddir + "/operator_pub.pem"
+            "-K"]
 
 class SkvbcReconfigurationTest(unittest.TestCase):
     @classmethod

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -42,7 +42,7 @@ def start_replica_cmd_with_object_store(builddir, replica_id, config):
     else :
         batch_size = "1"
         time_service_enabled = "0"
-    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem", "-K"])
+    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem", "--publish-master-key-on-startup"])
     return ret
 
 def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
@@ -59,7 +59,7 @@ def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
     else :
         batch_size = "1"
         time_service_enabled = "0"
-    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem", "-K"])
+    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem", "--publish-master-key-on-startup"])
     return ret
 
 def start_replica_cmd(builddir, replica_id):
@@ -88,7 +88,7 @@ def start_replica_cmd(builddir, replica_id):
             "-b", "2",
             "-q", batch_size,
             "-o", builddir + "/operator_pub.pem",
-            "-K"]
+            "--publish-master-key-on-startup"]
 
 
 def start_replica_cmd_with_key_exchange(builddir, replica_id):
@@ -118,7 +118,7 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
             "-q", batch_size,
             "-e", str(True),
             "-o", builddir + "/operator_pub.pem",
-            "-K"]
+            "--publish-master-key-on-startup"]
 
 class SkvbcReconfigurationTest(unittest.TestCase):
     @classmethod

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -87,7 +87,7 @@ def start_replica_cmd(builddir, replica_id):
             "-f", time_service_enabled,
             "-b", "2",
             "-q", batch_size,
-            "-o", builddir + "/operator_pub.pem"
+            "-o", builddir + "/operator_pub.pem",
             "-K"]
 
 
@@ -117,7 +117,7 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
             "-b", "2",
             "-q", batch_size,
             "-e", str(True),
-            "-o", builddir + "/operator_pub.pem"
+            "-o", builddir + "/operator_pub.pem",
             "-K"]
 
 class SkvbcReconfigurationTest(unittest.TestCase):

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -113,12 +113,14 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                           {"time_service", optional_argument, 0, 'f'},
                                           {"pre-exec-result-auth", no_argument, 0, 'x'},
                                           {"enable-db-checkpoint", required_argument, 0, 'h'},
+                                          {"publish replicas master key on startup", optional_argument, 0, 'K'},
                                           {0, 0, 0, 0}};
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
     while ((o = getopt_long(
-                argc, argv, "i:k:n:s:v:a:3:l:e:w:c:b:m:q:z:y:udp:t:o:r:g:xf:h:j:", longOptions, &optionIndex)) != -1) {
+                argc, argv, "i:k:n:s:v:a:3:l:e:w:c:b:m:q:z:y:udp:t:o:r:g:xf:h:K:j:", longOptions, &optionIndex)) !=
+           -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -235,6 +237,9 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           dbSnapshotPath << BasicRandomTests::DB_FILE_PREFIX << "snapshot_" << replicaConfig.replicaId;
           replicaConfig.dbCheckpointDirPath = dbSnapshotPath.str();
           break;
+        }
+        case 'K': {
+          replicaConfig.publishReplicasMasterKeyOnStartup = true;
         }
         case 'j': {
           // updating dbCheckPointWindowSize value to test create dbSnapshot operator command

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -86,41 +86,41 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::string byzantineStrategies;
     bool is_separate_communication_mode = false;
 
-    static struct option longOptions[] = {{"replica-id", required_argument, 0, 'i'},
-                                          {"key-file-prefix", required_argument, 0, 'k'},
-                                          {"network-config-file", required_argument, 0, 'n'},
-                                          {"status-report-timeout", required_argument, 0, 's'},
-                                          {"view-change-timeout", required_argument, 0, 'v'},
-                                          {"auto-primary-rotation-timeout", required_argument, 0, 'a'},
-                                          {"s3-config-file", required_argument, 0, '3'},
-                                          {"log-props-file", required_argument, 0, 'l'},
-                                          {"key-exchange-on-start", required_argument, 0, 'e'},
-                                          {"publish-client-keys", required_argument, 0, 'w'},
-                                          {"cert-root-path", required_argument, 0, 'c'},
-                                          {"consensus-batching-policy", required_argument, 0, 'b'},
-                                          {"consensus-batching-max-reqs-size", required_argument, 0, 'm'},
-                                          {"consensus-batching-max-req-num", required_argument, 0, 'q'},
-                                          {"consensus-batching-flush-period", required_argument, 0, 'z'},
-                                          {"consensus-concurrency-level", required_argument, 0, 'y'},
-                                          {"replica-block-accumulation", no_argument, 0, 'u'},
-                                          {"send-different-messages-to-different-replica", no_argument, 0, 'd'},
-                                          {"principals-mapping", optional_argument, 0, 'p'},
-                                          {"txn-signing-key-path", optional_argument, 0, 't'},
-                                          {"operator-public-key-path", optional_argument, 0, 'o'},
-                                          {"cron-entry-number-of-executes", optional_argument, 0, 'r'},
-                                          {"replica-byzantine-strategies", optional_argument, 0, 'g'},
-                                          {"pre-exec-result-auth", no_argument, 0, 'x'},
-                                          {"time_service", optional_argument, 0, 'f'},
-                                          {"pre-exec-result-auth", no_argument, 0, 'x'},
-                                          {"enable-db-checkpoint", required_argument, 0, 'h'},
-                                          {"publish replicas master key on startup", optional_argument, 0, 'K'},
-                                          {0, 0, 0, 0}};
+    static struct option longOptions[] = {
+        {"replica-id", required_argument, 0, 'i'},
+        {"key-file-prefix", required_argument, 0, 'k'},
+        {"network-config-file", required_argument, 0, 'n'},
+        {"status-report-timeout", required_argument, 0, 's'},
+        {"view-change-timeout", required_argument, 0, 'v'},
+        {"auto-primary-rotation-timeout", required_argument, 0, 'a'},
+        {"s3-config-file", required_argument, 0, '3'},
+        {"log-props-file", required_argument, 0, 'l'},
+        {"key-exchange-on-start", required_argument, 0, 'e'},
+        {"publish-client-keys", required_argument, 0, 'w'},
+        {"cert-root-path", required_argument, 0, 'c'},
+        {"consensus-batching-policy", required_argument, 0, 'b'},
+        {"consensus-batching-max-reqs-size", required_argument, 0, 'm'},
+        {"consensus-batching-max-req-num", required_argument, 0, 'q'},
+        {"consensus-batching-flush-period", required_argument, 0, 'z'},
+        {"consensus-concurrency-level", required_argument, 0, 'y'},
+        {"replica-block-accumulation", no_argument, 0, 'u'},
+        {"send-different-messages-to-different-replica", no_argument, 0, 'd'},
+        {"principals-mapping", optional_argument, 0, 'p'},
+        {"txn-signing-key-path", optional_argument, 0, 't'},
+        {"operator-public-key-path", optional_argument, 0, 'o'},
+        {"cron-entry-number-of-executes", optional_argument, 0, 'r'},
+        {"replica-byzantine-strategies", optional_argument, 0, 'g'},
+        {"pre-exec-result-auth", no_argument, 0, 'x'},
+        {"time_service", optional_argument, 0, 'f'},
+        {"pre-exec-result-auth", no_argument, 0, 'x'},
+        {"enable-db-checkpoint", required_argument, 0, 'h'},
+        {"publish-master-key-on-startup", no_argument, (int*)&replicaConfig.publishReplicasMasterKeyOnStartup, 1},
+        {0, 0, 0, 0}};
     int o = 0;
     int optionIndex = 0;
     LOG_INFO(GL, "Command line options:");
     while ((o = getopt_long(
-                argc, argv, "i:k:n:s:v:a:3:l:e:w:c:b:m:q:z:y:udp:t:o:r:g:xf:h:K:j:", longOptions, &optionIndex)) !=
-           -1) {
+                argc, argv, "i:k:n:s:v:a:3:l:e:w:c:b:m:q:z:y:udp:t:o:r:g:xf:h:j:", longOptions, &optionIndex)) != -1) {
       switch (o) {
         case 'i': {
           replicaConfig.replicaId = concord::util::to<std::uint16_t>(std::string(optarg));
@@ -237,9 +237,6 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           dbSnapshotPath << BasicRandomTests::DB_FILE_PREFIX << "snapshot_" << replicaConfig.replicaId;
           replicaConfig.dbCheckpointDirPath = dbSnapshotPath.str();
           break;
-        }
-        case 'K': {
-          replicaConfig.publishReplicasMasterKeyOnStartup = true;
         }
         case 'j': {
           // updating dbCheckPointWindowSize value to test create dbSnapshot operator command


### PR DESCRIPTION
In this PR we introduce the infrastructure for publishing the replicas' main key (currently RSA).
This is done by publishing a special block on the blockchain which contains the replica's public key.

This feature is working independently on the initial key exchange feature