### PR TITLE
Collect preprocess signatures in a set instead of list

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1152,9 +1152,8 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
       // Copy of the message body is unavoidable here, as we need to create a new message type which lifetime is
       // controlled by the replica while all PreProcessReply messages get released here.
       if (ReplicaConfig::instance().preExecutionResultAuthEnabled) {
-        auto sigsList = reqProcessingStatePtr->getPreProcessResultSignatures();
-        sigsList.resize(numOfRequiredReplies());
-        auto sigsBuf = PreProcessResultSignature::serializeResultSignatureList(sigsList);
+        const auto &sigsSet = reqProcessingStatePtr->getPreProcessResultSignatures();
+        auto sigsBuf = PreProcessResultSignature::serializeResultSignatures(sigsSet, numOfRequiredReplies());
         preProcessMsg = make_unique<PreProcessResultMsg>(clientId,
                                                          reqSeqNum,
                                                          reqProcessingStatePtr->getPrimaryPreProcessedResultLen(),

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -76,7 +76,7 @@ class RequestProcessingState {
   ReplicaIdsList getRejectedReplicasList() { return rejectedReplicaIds_; }
   void resetRejectedReplicasList() { rejectedReplicaIds_.clear(); }
   void setPreprocessingRightNow(bool set) { preprocessingRightNow_ = set; }
-  const std::list<PreProcessResultSignature>& getPreProcessResultSignatures();
+  const std::set<PreProcessResultSignature>& getPreProcessResultSignatures();
 
   static void init(uint16_t numOfRequiredReplies, preprocessor::PreProcessorRecorder* histograms);
   const concord::util::SHA3_256::Digest& getResultHash() { return primaryPreProcessResultHash_; };
@@ -128,8 +128,7 @@ class RequestProcessingState {
   concord::util::SHA3_256::Digest primaryPreProcessResultHash_ = {};
   // Maps result hash to a list of replica signatures sent for this hash. Implcitly this also gives the number of
   // replicas returning a specific hash.
-  std::map<concord::util::SHA3_256::Digest, std::list<PreProcessResultSignature>> preProcessingResultHashes_;
-  std::map<concord::util::SHA3_256::Digest, std::unordered_set<bftEngine::impl::NodeIdType>> seenSenders_;
+  std::map<concord::util::SHA3_256::Digest, std::set<PreProcessResultSignature>> preProcessingResultHashes_;
   bool retrying_ = false;
   bool preprocessingRightNow_ = false;
   uint64_t reqRetryId_ = 0;

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
@@ -70,8 +70,11 @@ struct PreProcessResultSignature {
     return signature == rhs.signature && sender_replica == rhs.sender_replica;
   }
 
-  static std::string serializeResultSignatureList(const std::list<PreProcessResultSignature>& signatures);
-  static std::list<PreProcessResultSignature> deserializeResultSignatureList(const char* buf, size_t len);
+  bool operator<(const PreProcessResultSignature& rhs) const { return sender_replica < rhs.sender_replica; }
+
+  static std::string serializeResultSignatures(const std::set<PreProcessResultSignature>& signatures,
+                                               uint16_t numOfRequiredSignatures);
+  static std::set<PreProcessResultSignature> deserializeResultSignatures(const char* buf, size_t len);
 };
 
 }  // namespace preprocessor


### PR DESCRIPTION
In order to eliminate duplicate signatures from the same sender ID in the preprocess result.