### PR TITLE
Return reply data from the client pool to the client service when operation succeeds

### DIFF
--- a/bftengine/include/bftengine/SharedTypes.hpp
+++ b/bftengine/include/bftengine/SharedTypes.hpp
@@ -24,6 +24,8 @@ enum class OperationResult : uint32_t {
   EXEC_DATA_TOO_LARGE,
   EXEC_DATA_EMPTY,
   CONFLICT_DETECTED,
+  OVERLOADED,
+  ACKNOWLEDGED,
   INTERNAL_ERROR
 };
 

--- a/bftengine/include/bftengine/SharedTypes.hpp
+++ b/bftengine/include/bftengine/SharedTypes.hpp
@@ -25,7 +25,6 @@ enum class OperationResult : uint32_t {
   EXEC_DATA_EMPTY,
   CONFLICT_DETECTED,
   OVERLOADED,
-  ACKNOWLEDGED,
   INTERNAL_ERROR
 };
 

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -39,17 +39,6 @@ namespace concord_client_pool {
 
 using TextMap = std::unordered_map<std::string, std::string>;
 
-// Represents the answer that the DAML Ledger API could get when sending a
-// request
-enum SubmitResult {
-  Acknowledged,  // The request has been queued for submission
-  Overloaded,    // There is no available client to the moment to process the
-  // request
-  InvalidArgument,
-  TimedOut,
-  ClientUnavailable,  // There are clients in the queue but none of them are connected to enough replicas
-};
-
 // An internal error has occurred. Reason is recorded in logs.
 class InternalError : public std::exception {
  public:
@@ -116,27 +105,27 @@ class ConcordClientPool {
   // response.
   // max_reply_size - holds the size of reply_buffer.
   // seq_num - sequence number for the request
-  SubmitResult SendRequest(std::vector<uint8_t>&& request,
-                           bftEngine::ClientMsgFlag flags,
-                           std::chrono::milliseconds timeout_ms,
-                           char* reply_buffer,
-                           std::uint32_t max_reply_size,
-                           uint64_t seq_num,
-                           std::string correlation_id = {},
-                           std::string span_context = std::string(),
-                           const bftEngine::RequestCallBack& callback = {});
+  bftEngine::OperationResult SendRequest(std::vector<uint8_t>&& request,
+                                         bftEngine::ClientMsgFlag flags,
+                                         std::chrono::milliseconds timeout_ms,
+                                         char* reply_buffer,
+                                         std::uint32_t max_reply_size,
+                                         uint64_t seq_num,
+                                         std::string correlation_id = {},
+                                         std::string span_context = std::string(),
+                                         const bftEngine::RequestCallBack& callback = {});
 
   // This method is responsible to get write requests with the new client
   // paramters and parse it to the old SimpleClient interface.
-  SubmitResult SendRequest(const bft::client::WriteConfig& config,
-                           bft::client::Msg&& request,
-                           const bftEngine::RequestCallBack& callback = {});
+  bftEngine::OperationResult SendRequest(const bft::client::WriteConfig& config,
+                                         bft::client::Msg&& request,
+                                         const bftEngine::RequestCallBack& callback = {});
 
   // This method is responsible to get read requests with the new client
   // paramters and parse it to the old SimpleClient interface.
-  SubmitResult SendRequest(const bft::client::ReadConfig& config,
-                           bft::client::Msg&& request,
-                           const bftEngine::RequestCallBack& callback = {});
+  bftEngine::OperationResult SendRequest(const bft::client::ReadConfig& config,
+                                         bft::client::Msg&& request,
+                                         const bftEngine::RequestCallBack& callback = {});
 
   void InsertClientToQueue(std::shared_ptr<concord::external_client::ConcordClient>& client,
                            std::pair<int8_t, external_client::ConcordClient::PendingReplies>&& replies);

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -93,7 +93,7 @@ class ConcordClient {
                          uint32_t max_reply_size,
                          size_t batch_size);
   static void setDelayFlagForTest(bool delay);
-  bftEngine::OperationResult getClientRequestError();
+  bftEngine::OperationResult getRequestExecutionResult();
   ConcordClient(ConcordClient&& t) = delete;
 
  private:
@@ -124,7 +124,7 @@ class ConcordClient {
   PendingReplies pending_replies_;
   size_t batching_buffer_reply_offset_ = 0UL;
   static bool delayed_behaviour_;
-  bftEngine::OperationResult clientRequestError_;
+  bftEngine::OperationResult clientRequestExecutionResult_;
 };
 
 }  // namespace external_client

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -34,18 +34,18 @@ static auto IsGoodForBatching(ClientMsgFlag flags, bool client_batching_enabled)
   return flags & ClientMsgFlag::PRE_PROCESS_REQ && client_batching_enabled;
 }
 
-SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
-                                            ClientMsgFlag flags,
-                                            std::chrono::milliseconds timeout_ms,
-                                            char *reply_buffer,
-                                            std::uint32_t max_reply_size,
-                                            uint64_t seq_num,
-                                            std::string correlation_id,
-                                            std::string span_context,
-                                            const bftEngine::RequestCallBack &callback) {
+bftEngine::OperationResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
+                                                          ClientMsgFlag flags,
+                                                          std::chrono::milliseconds timeout_ms,
+                                                          char *reply_buffer,
+                                                          std::uint32_t max_reply_size,
+                                                          uint64_t seq_num,
+                                                          std::string correlation_id,
+                                                          std::string span_context,
+                                                          const bftEngine::RequestCallBack &callback) {
   if (callback && timeout_ms.count() == 0) {
-    callback(bftEngine::SendResult{SubmitResult::InvalidArgument});
-    return SubmitResult::Overloaded;
+    callback(bftEngine::SendResult{static_cast<uint32_t>(bftEngine::OperationResult::INVALID_REQUEST)});
+    return bftEngine::OperationResult::OVERLOADED;
   }
   externalRequest external_request;
   std::unique_lock<std::mutex> lock(clients_queue_lock_);
@@ -104,7 +104,7 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
         assignJobToClient(client);
       }
       LOG_DEBUG(logger_, "Request Acknowledged (batch)" << KVLOG(client_id, correlation_id, seq_num, flags));
-      return SubmitResult::Acknowledged;
+      return bftEngine::OperationResult::ACKNOWLEDGED;
     } else {
       clients_.pop_front();
       if (0 != client->PendingRequestsCount()) {
@@ -129,7 +129,7 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
                           span_context,
                           callback);
         LOG_DEBUG(logger_, "Request Acknowledged (single)" << KVLOG(client_id, correlation_id, seq_num, flags));
-        return SubmitResult::Acknowledged;
+        return bftEngine::OperationResult::ACKNOWLEDGED;
       }
     }
   }
@@ -147,19 +147,19 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
                                                           reply_buffer,
                                                           max_reply_size});
     LOG_DEBUG(logger_, "Request Acknowledged (external)" << KVLOG(client_id, correlation_id, seq_num, flags));
-    return SubmitResult::Acknowledged;
+    return bftEngine::OperationResult::ACKNOWLEDGED;
   } else {
     ClientPoolMetrics_.rejected_counter++;
     is_overloaded_ = true;
     LOG_WARN(logger_, "Cannot allocate client for" << KVLOG(correlation_id));
     if (callback) {
       if (serving_candidates == 0 && !clients_.empty()) {
-        callback(bftEngine::SendResult{SubmitResult::ClientUnavailable});
+        callback(bftEngine::SendResult{static_cast<uint32_t>(bftEngine::OperationResult::NOT_READY)});
       } else {
-        callback(bftEngine::SendResult{SubmitResult::Overloaded});
+        callback(bftEngine::SendResult{static_cast<uint32_t>(bftEngine::OperationResult::OVERLOADED)});
       }
     }
-    return SubmitResult::Overloaded;
+    return bftEngine::OperationResult::OVERLOADED;
   }
 }
 
@@ -196,9 +196,9 @@ void ConcordClientPool::assignJobToClient(const ClientPtr &client,
   jobs_thread_pool_.add(job);
 }
 
-SubmitResult ConcordClientPool::SendRequest(const bft::client::WriteConfig &config,
-                                            bft::client::Msg &&request,
-                                            const bftEngine::RequestCallBack &callback) {
+bftEngine::OperationResult ConcordClientPool::SendRequest(const bft::client::WriteConfig &config,
+                                                          bft::client::Msg &&request,
+                                                          const bftEngine::RequestCallBack &callback) {
   LOG_DEBUG(logger_, "Received write request with cid=" << config.request.correlation_id);
   auto request_flag = ClientMsgFlag::EMPTY_FLAGS_REQ;
   if (config.request.pre_execute) request_flag = ClientMsgFlag::PRE_PROCESS_REQ;
@@ -213,13 +213,13 @@ SubmitResult ConcordClientPool::SendRequest(const bft::client::WriteConfig &conf
                      callback);
 }
 
-SubmitResult ConcordClientPool::SendRequest(const bft::client::ReadConfig &config,
-                                            bft::client::Msg &&request,
-                                            const bftEngine::RequestCallBack &callback) {
+bftEngine::OperationResult ConcordClientPool::SendRequest(const bft::client::ReadConfig &config,
+                                                          bft::client::Msg &&request,
+                                                          const bftEngine::RequestCallBack &callback) {
   LOG_INFO(logger_, "Received read request with cid=" << config.request.correlation_id);
   if (callback && config.request.pre_execute) {
-    callback(bftEngine::SendResult{SubmitResult::InvalidArgument});
-    return SubmitResult::Overloaded;
+    callback(bftEngine::SendResult{static_cast<uint32_t>(bftEngine::OperationResult::INVALID_REQUEST)});
+    return bftEngine::OperationResult::OVERLOADED;
   }
   return SendRequest(std::forward<std::vector<uint8_t>>(request),
                      ClientMsgFlag::READ_ONLY_REQ,
@@ -414,10 +414,10 @@ void SingleRequestProcessingJob::execute() {
     res = processing_client_->SendRequest(read_config_, std::move(request_));
     reply_size = res.matched_data.size();
     if (callback_) {
-      if (processing_client_->getClientRequestError() != OperationResult::TIMEOUT) {
-        callback_(bftEngine::SendResult{res});
+      if (processing_client_->getRequestExecutionResult() != OperationResult::TIMEOUT) {
+        callback_(res);
       } else {
-        callback_(bftEngine::SendResult{SubmitResult::TimedOut});
+        callback_(static_cast<uint32_t>(bftEngine::OperationResult::TIMEOUT));
       }
     }
   } else {
@@ -429,12 +429,12 @@ void SingleRequestProcessingJob::execute() {
     res = processing_client_->SendRequest(write_config_, std::move(request_));
     reply_size = res.matched_data.size();
     if (callback_) {
-      if (OperationResult::SUCCESS == processing_client_->getClientRequestError()) {
-        callback_(bftEngine::SendResult{res});
-      } else if (OperationResult::TIMEOUT == processing_client_->getClientRequestError()) {
-        callback_(bftEngine::SendResult{SubmitResult::TimedOut});
+      if (OperationResult::SUCCESS == processing_client_->getRequestExecutionResult()) {
+        callback_(static_cast<uint32_t>(bftEngine::OperationResult::SUCCESS));
+      } else if (OperationResult::TIMEOUT == processing_client_->getRequestExecutionResult()) {
+        callback_(static_cast<uint32_t>(bftEngine::OperationResult::TIMEOUT));
       } else {  // Lets treat as invalid argument request.
-        callback_(bftEngine::SendResult{SubmitResult::InvalidArgument});
+        callback_(static_cast<uint32_t>(bftEngine::OperationResult::INVALID_REQUEST));
       }
     }
   }
@@ -534,13 +534,13 @@ void ConcordClientPool::InsertClientToQueue(
       }
     }
   }
-  if (replies.second.front().cb && client->getClientRequestError() == OperationResult::TIMEOUT) {
+  if (replies.second.front().cb && client->getRequestExecutionResult() == OperationResult::TIMEOUT) {
     for (const auto &reply : replies.second) {
-      reply.cb(SendResult{SubmitResult::TimedOut});
+      reply.cb(SendResult{static_cast<uint32_t>(bftEngine::OperationResult::TIMEOUT)});
     }
-  } else if (replies.second.front().cb && client->getClientRequestError() == OperationResult::INVALID_REQUEST) {
+  } else if (replies.second.front().cb && client->getRequestExecutionResult() == OperationResult::INVALID_REQUEST) {
     for (const auto &reply : replies.second) {
-      reply.cb(SendResult{SubmitResult::InvalidArgument});
+      reply.cb(SendResult{static_cast<uint32_t>(bftEngine::OperationResult::INVALID_REQUEST)});
     }
   }
   Done(std::move(replies));
@@ -588,8 +588,8 @@ bool ConcordClientPool::clusterHasKeys(ClientPtr &cl) {
 
 OperationResult ConcordClientPool::getClientError() {
   for (auto &client : this->clients_) {
-    if (client->getClientRequestError() != OperationResult::SUCCESS) {
-      return client->getClientRequestError();
+    if (client->getRequestExecutionResult() != OperationResult::SUCCESS) {
+      return client->getRequestExecutionResult();
     }
   }
   return OperationResult::SUCCESS;

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -35,7 +35,7 @@ ConcordClient::ConcordClient(int client_id,
                              ConcordClientPoolConfig& struct_config,
                              const SimpleClientParams& client_params)
     : logger_(logging::getLogger("concord.client.client_pool.external_client")),
-      clientRequestError_(OperationResult::SUCCESS) {
+      clientRequestExecutionResult_(OperationResult::SUCCESS) {
   client_id_ = client_id;
   CreateClient(struct_config, client_params);
 }
@@ -44,14 +44,14 @@ ConcordClient::~ConcordClient() noexcept = default;
 
 bft::client::Reply ConcordClient::SendRequest(const bft::client::WriteConfig& config, bft::client::Msg&& request) {
   bft::client::Reply res;
-  clientRequestError_ = OperationResult::SUCCESS;
+  clientRequestExecutionResult_ = OperationResult::SUCCESS;
   try {
     res = new_client_->send(config, std::move(request));
   } catch (const BadQuorumConfigException& e) {
-    clientRequestError_ = OperationResult::INVALID_REQUEST;
+    clientRequestExecutionResult_ = OperationResult::INVALID_REQUEST;
     LOG_ERROR(logger_, "Invalid write config: " << e.what());
   } catch (const TimeoutException& e) {
-    clientRequestError_ = OperationResult::TIMEOUT;
+    clientRequestExecutionResult_ = OperationResult::TIMEOUT;
     LOG_ERROR(logger_,
               "reqSeqNum=" << config.request.sequence_number << " cid=" << config.request.correlation_id
                            << " has failed to invoke, timeout=" << config.request.timeout.count()
@@ -65,14 +65,14 @@ bft::client::Reply ConcordClient::SendRequest(const bft::client::WriteConfig& co
 
 bft::client::Reply ConcordClient::SendRequest(const bft::client::ReadConfig& config, bft::client::Msg&& request) {
   bft::client::Reply res;
-  clientRequestError_ = OperationResult::SUCCESS;
+  clientRequestExecutionResult_ = OperationResult::SUCCESS;
   try {
     res = new_client_->send(config, std::move(request));
   } catch (const BadQuorumConfigException& e) {
-    clientRequestError_ = OperationResult::INVALID_REQUEST;
+    clientRequestExecutionResult_ = OperationResult::INVALID_REQUEST;
     LOG_ERROR(logger_, "Invalid read config: " << e.what());
   } catch (const TimeoutException& e) {
-    clientRequestError_ = OperationResult::TIMEOUT;
+    clientRequestExecutionResult_ = OperationResult::TIMEOUT;
     LOG_ERROR(logger_,
               "reqSeqNum=" << config.request.sequence_number << " cid=" << config.request.correlation_id
                            << " has failed to invoke, timeout=" << config.request.timeout.count()
@@ -126,7 +126,7 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
   const auto& batch_cid =
       std::to_string(client_id_) + "-" + std::to_string(seqGen_->generateUniqueSequenceNumberForRequest());
   OperationResult ret = OperationResult::SUCCESS;
-  clientRequestError_ = OperationResult::SUCCESS;
+  clientRequestExecutionResult_ = OperationResult::SUCCESS;
   std::deque<bft::client::WriteRequest> request_queue;
   std::map<uint64_t, std::string> seq_num_to_cid;
   for (auto req : pending_requests_) {
@@ -164,7 +164,7 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
       }
     }
   } catch (BatchTimeoutException& e) {
-    clientRequestError_ = OperationResult::TIMEOUT;
+    clientRequestExecutionResult_ = OperationResult::TIMEOUT;
     LOG_ERROR(logger_, "Batch cid =" << batch_cid << " has failed to invoke, timeout has been reached");
     ret = OperationResult::TIMEOUT;
   }
@@ -313,7 +313,7 @@ void ConcordClient::setStatics(uint16_t required_num_of_replicas,
 
 void ConcordClient::setDelayFlagForTest(bool delay) { ConcordClient::delayed_behaviour_ = delay; }
 
-OperationResult ConcordClient::getClientRequestError() { return clientRequestError_; }
+OperationResult ConcordClient::getRequestExecutionResult() { return clientRequestExecutionResult_; }
 
 void ConcordClient::stopClientComm() { new_client_->stop(); }
 

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -46,20 +46,32 @@ Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_req
     if (not std::holds_alternative<bft::client::Reply>(send_result)) {
       LOG_INFO(logger_, "Send returned error");
       switch (std::get<uint32_t>(send_result)) {
-        case (concord_client_pool::Overloaded):
+        case (static_cast<uint32_t>(bftEngine::OperationResult::OVERLOADED)):
           status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "All clients occupied"));
           break;
-        case (concord_client_pool::InvalidArgument):
+        case (static_cast<uint32_t>(bftEngine::OperationResult::INVALID_REQUEST)):
           status.set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid argument"));
           break;
-        case (concord_client_pool::TimedOut):
+        case (static_cast<uint32_t>(bftEngine::OperationResult::TIMEOUT)):
           status.set_value(grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "Timeout"));
           break;
-        case (concord_client_pool::ClientUnavailable):
+        case (static_cast<uint32_t>(bftEngine::OperationResult::NOT_READY)):
           status.set_value(grpc::Status(grpc::StatusCode::UNAVAILABLE, "No clients connected to the replicas"));
           break;
-        default:
+        case (static_cast<uint32_t>(bftEngine::OperationResult::INTERNAL_ERROR)):
           status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "Internal error"));
+          break;
+        case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_DATA_TOO_LARGE)):
+          status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "Execution data too large"));
+          break;
+        case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_DATA_EMPTY)):
+          status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "Execution data is empty"));
+          break;
+        case (static_cast<uint32_t>(bftEngine::OperationResult::CONFLICT_DETECTED)):
+          status.set_value(grpc::Status(grpc::StatusCode::ABORTED, "Aborted"));
+          break;
+        default:
+          status.set_value(grpc::Status(grpc::StatusCode::UNKNOWN, "Unknown error"));
           break;
       }
       return;

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -46,23 +46,17 @@ Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_req
     if (not std::holds_alternative<bft::client::Reply>(send_result)) {
       LOG_INFO(logger_, "Send returned error");
       switch (std::get<uint32_t>(send_result)) {
-        case (static_cast<uint32_t>(bftEngine::OperationResult::OVERLOADED)):
-          status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "All clients occupied"));
-          break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::INVALID_REQUEST)):
           status.set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid argument"));
-          break;
-        case (static_cast<uint32_t>(bftEngine::OperationResult::TIMEOUT)):
-          status.set_value(grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "Timeout"));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::NOT_READY)):
           status.set_value(grpc::Status(grpc::StatusCode::UNAVAILABLE, "No clients connected to the replicas"));
           break;
-        case (static_cast<uint32_t>(bftEngine::OperationResult::INTERNAL_ERROR)):
-          status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "Internal error"));
+        case (static_cast<uint32_t>(bftEngine::OperationResult::TIMEOUT)):
+          status.set_value(grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "Timeout"));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_DATA_TOO_LARGE)):
-          status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "Execution data too large"));
+          status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "Execution data too large"));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_DATA_EMPTY)):
           status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "Execution data is empty"));
@@ -70,8 +64,11 @@ Status RequestServiceImpl::Send(ServerContext* context, const Request* proto_req
         case (static_cast<uint32_t>(bftEngine::OperationResult::CONFLICT_DETECTED)):
           status.set_value(grpc::Status(grpc::StatusCode::ABORTED, "Aborted"));
           break;
+        case (static_cast<uint32_t>(bftEngine::OperationResult::OVERLOADED)):
+          status.set_value(grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "All clients occupied"));
+          break;
         default:
-          status.set_value(grpc::Status(grpc::StatusCode::UNKNOWN, "Unknown error"));
+          status.set_value(grpc::Status(grpc::StatusCode::INTERNAL, "Internal error"));
           break;
       }
       return;

--- a/client/proto/request/v1/request.proto
+++ b/client/proto/request/v1/request.proto
@@ -27,6 +27,7 @@ service RequestService {
   // INVALID_ARGUMENT: if a required field is not set.
   // RESOURCE_EXHAUSTED: if Concord Client is overloaded. The caller should retry with a backoff.
   // UNAVAILABLE: if Concord Client is currently unable to process any requests. The caller should retry with a backoff.
+  // ABORTED: if Concord has a contention between concurrently running requests. The caller should retry.
   // INTERNAL: if Concord Client cannot progress independent of the request.
   rpc Send(Request) returns (Response);
 }


### PR DESCRIPTION
The client pool needs to call 'callback_(result_data)' in case of request succeeds and 'callback_(operation_result)' when it fails.