### PR TITLE
Add State Streaming Interface b/w TRC/S and placeholder methods for assoc. methods

### DIFF
--- a/client/clientservice/include/client/clientservice/client_service.hpp
+++ b/client/clientservice/include/client/clientservice/client_service.hpp
@@ -9,6 +9,8 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#pragma once
+
 #include <memory>
 #include <string>
 

--- a/client/clientservice/include/client/clientservice/client_service.hpp
+++ b/client/clientservice/include/client/clientservice/client_service.hpp
@@ -14,6 +14,7 @@
 
 #include "event_service.hpp"
 #include "request_service.hpp"
+#include "state_snapshot_service.hpp"
 #include "Logger.hpp"
 #include "client/concordclient/concord_client.hpp"
 
@@ -25,18 +26,21 @@ class ClientService {
       : logger_(logging::getLogger("concord.client.clientservice")),
         client_(std::move(client)),
         event_service_(std::make_unique<EventServiceImpl>(client_)),
-        request_service_(std::make_unique<RequestServiceImpl>(client_)){};
+        request_service_(std::make_unique<RequestServiceImpl>(client_)),
+        state_snapshot_service_(std::make_unique<StateSnapshotServiceImpl>(client_)){};
 
   void start(const std::string& addr, uint64_t max_receive_msg_size);
 
   const std::string kRequestService{"vmware.concord.client.request.v1.RequestService"};
   const std::string kEventService{"vmware.concord.client.event.v1.EventService"};
+  const std::string kStateSnapshotService{"vmware.concord.client.statesnapshot.v1.StateSnapshotService"};
 
  private:
   logging::Logger logger_;
   std::shared_ptr<concord::client::concordclient::ConcordClient> client_;
   std::unique_ptr<EventServiceImpl> event_service_;
   std::unique_ptr<RequestServiceImpl> request_service_;
+  std::unique_ptr<StateSnapshotServiceImpl> state_snapshot_service_;
 };
 
 }  // namespace concord::client::clientservice

--- a/client/clientservice/include/client/clientservice/state_snapshot_service.hpp
+++ b/client/clientservice/include/client/clientservice/state_snapshot_service.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -8,6 +8,8 @@
 // This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
+
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 #include "state_snapshot.grpc.pb.h"

--- a/client/clientservice/include/client/clientservice/state_snapshot_service.hpp
+++ b/client/clientservice/include/client/clientservice/state_snapshot_service.hpp
@@ -1,0 +1,42 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <grpcpp/grpcpp.h>
+#include "state_snapshot.grpc.pb.h"
+
+#include "Logger.hpp"
+#include "client/concordclient/concord_client.hpp"
+
+namespace concord::client::clientservice {
+
+class StateSnapshotServiceImpl final
+    : public vmware::concord::client::statesnapshot::v1::StateSnapshotService::Service {
+ public:
+  StateSnapshotServiceImpl(std::shared_ptr<concord::client::concordclient::ConcordClient> client)
+      : logger_(logging::getLogger("concord.client.clientservice.statesnapshot")), client_(client){};
+  grpc::Status GetRecentSnapshot(
+      grpc::ServerContext* context,
+      const vmware::concord::client::statesnapshot::v1::GetRecentSnapshotRequest* request,
+      vmware::concord::client::statesnapshot::v1::GetRecentSnapshotResponse* response) override;
+  grpc::Status StreamSnapshot(
+      grpc::ServerContext* context,
+      const vmware::concord::client::statesnapshot::v1::StreamSnapshotRequest* request,
+      grpc::ServerWriter<vmware::concord::client::statesnapshot::v1::StreamSnapshotResponse>* stream) override;
+  grpc::Status ReadAsOf(grpc::ServerContext* context,
+                        const vmware::concord::client::statesnapshot::v1::ReadAsOfRequest* request,
+                        vmware::concord::client::statesnapshot::v1::ReadAsOfResponse* response) override;
+
+ private:
+  logging::Logger logger_;
+  std::shared_ptr<concord::client::concordclient::ConcordClient> client_;
+};
+
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/state_snapshot_service.cpp
+++ b/client/clientservice/src/state_snapshot_service.cpp
@@ -1,0 +1,48 @@
+// Concord
+//
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client/clientservice/state_snapshot_service.hpp"
+
+using grpc::Status;
+using grpc::ServerContext;
+using grpc::ServerWriter;
+
+using vmware::concord::client::statesnapshot::v1::GetRecentSnapshotRequest;
+using vmware::concord::client::statesnapshot::v1::GetRecentSnapshotResponse;
+using vmware::concord::client::statesnapshot::v1::StreamSnapshotRequest;
+using vmware::concord::client::statesnapshot::v1::StreamSnapshotResponse;
+using vmware::concord::client::statesnapshot::v1::ReadAsOfRequest;
+using vmware::concord::client::statesnapshot::v1::ReadAsOfResponse;
+
+namespace concord::client::clientservice {
+
+Status StateSnapshotServiceImpl::GetRecentSnapshot(ServerContext* context,
+                                                   const GetRecentSnapshotRequest* proto_request,
+                                                   GetRecentSnapshotResponse* response) {
+  // TODO: Add implementation
+  return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "GetRecentSnapshot");
+}
+
+Status StateSnapshotServiceImpl::StreamSnapshot(ServerContext* context,
+                                                const StreamSnapshotRequest* proto_request,
+                                                ServerWriter<StreamSnapshotResponse>* stream) {
+  // TODO: Add implementation
+  return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "StreamSnapshot");
+}
+
+Status StateSnapshotServiceImpl::ReadAsOf(ServerContext* context,
+                                          const ReadAsOfRequest* proto_request,
+                                          ReadAsOfResponse* response) {
+  // TODO: Add implementation
+  return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "ReadAsOf");
+}
+
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/state_snapshot_service.cpp
+++ b/client/clientservice/src/state_snapshot_service.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -122,6 +122,17 @@ struct SubscribeRequest {
   std::variant<EventGroupRequest, LegacyEventRequest> request;
 };
 
+struct GetRecentSnapshotRequest {};
+
+struct StreamSnapshotRequest {
+  uint64_t snapshot_id;
+};
+
+struct ReadAsOfRequest {
+  uint64_t snapshot_id;
+  std::vector<std::string> keys;
+};
+
 // ConcordClient combines two different client functionalities into one interface.
 // On one side, the bft client to send/recieve request/response and on the other, the subscription API to
 // observe events.
@@ -146,6 +157,16 @@ class ConcordClient {
   // Note, if the caller doesn't unsubscribe and no runtime error occurs then resources
   // will be occupied forever.
   void unsubscribe();
+
+  // Get the ID of a recent and available state snapshot
+  void getRecentSnapshot(const GetRecentSnapshotRequest& request);
+
+  // Stream a specific state snapshot in a resumable fashion as a finite stream of key-values.
+  // Key-values are streamed with lexicographic order on keys.
+  void streamSnapshot(const StreamSnapshotRequest& request);
+
+  // Read the values of the given keys as of a specific state snapshot.
+  void readAsOf(const ReadAsOfRequest& request);
 
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);

--- a/client/proto/CMakeLists.txt
+++ b/client/proto/CMakeLists.txt
@@ -6,10 +6,12 @@ include_directories(${GRPC_INCLUDE_DIR})
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   request/v1/request.proto
   event/v1/event.proto
+  state_snapshot/v1/state_snapshot.proto
 )
 grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   request/v1/request.proto
   event/v1/event.proto
+  state_snapshot/v1/state_snapshot.proto
 )
 
 add_library(clientservice-proto STATIC ${PROTO_SRCS} ${GRPC_SRCS})

--- a/client/thin-replica-client/CMakeLists.txt
+++ b/client/thin-replica-client/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(thin_replica_client_lib
   opentracing
   util
   thin-replica-proto
+  state-snapshot-proto
   concordclient-event-api
 )
 

--- a/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trs_connection.hpp
@@ -11,6 +11,8 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#pragma once
+
 #ifndef THIN_REPLICA_CLIENT_TRS_CONNECTION_HPP_
 #define THIN_REPLICA_CLIENT_TRS_CONNECTION_HPP_
 
@@ -21,6 +23,7 @@
 #include <grpcpp/grpcpp.h>
 #include "assertUtils.hpp"
 #include "thin_replica.grpc.pb.h"
+#include "replica_state_snapshot.grpc.pb.h"
 #include "Logger.hpp"
 
 using namespace std::chrono_literals;
@@ -146,6 +149,20 @@ class TrsConnection {
   // established before).
   virtual Result readStateHash(const com::vmware::concord::thin_replica::ReadStateHashRequest& request,
                                com::vmware::concord::thin_replica::Hash* hash);
+
+  // Open a state snapshot stream (connection has to be established before).
+  // A state snapshot stream will be open after
+  // openStateSnapshotStream returns, if and only if openStateSnapshotStream returns
+  // Result::kSuccess; a stream will not be open in the failure and timeout cases.
+  virtual Result openStateSnapshotStream(const vmware::concord::replicastatesnapshot::StreamSnapshotRequest& request);
+
+  virtual void cancelStateSnapshotStream();
+  virtual bool hasStateSnapshotStream();
+
+  // Read key values from an existing open state snapshot stream. Note readStateSnapshot
+  // will automatically close the open state snapshot stream in the event it has to time
+  // out the read.
+  virtual Result readStateSnapshot(vmware::concord::replicastatesnapshot::KeyValuePair* key_value);
 
   // Helper to print/log connection details
   friend std::ostream& operator<<(std::ostream& os, const TrsConnection& trsc) {

--- a/client/thin-replica-client/src/trs_connection.cpp
+++ b/client/thin-replica-client/src/trs_connection.cpp
@@ -356,4 +356,27 @@ TrsConnection::Result TrsConnection::readHash(Hash* hash) {
   return Result::kFailure;
 }
 
+TrsConnection::Result TrsConnection::openStateSnapshotStream(
+    const vmware::concord::replicastatesnapshot::StreamSnapshotRequest& request) {
+  // TODO: Add implementation
+  ConcordAssert("openStateSnapshotStream should not be called. It is unimplemented." && false);
+  return Result::kFailure;
+}
+
+void TrsConnection::cancelStateSnapshotStream() {
+  // TODO: Add implementation
+  ConcordAssert("cancelStateSnapshotStream should not be called. It is unimplemented." && false);
+  return;
+}
+bool TrsConnection::hasStateSnapshotStream() {
+  // TODO: Add implementation
+  ConcordAssert("hasStateSnapshotStream should not be called. It is unimplemented." && false);
+  return false;
+}
+TrsConnection::Result TrsConnection::readStateSnapshot(vmware::concord::replicastatesnapshot::KeyValuePair* key_value) {
+  // TODO: Add implementation
+  ConcordAssert("readStateSnapshot should not be called. It is unimplemented." && false);
+  return Result::kFailure;
+}
+
 }  // namespace client::thin_replica_client

--- a/thin-replica-server/proto/CMakeLists.txt
+++ b/thin-replica-server/proto/CMakeLists.txt
@@ -11,7 +11,20 @@ grpc_generate_cpp(THIN_REPLICA_GRPC_SRCS THIN_REPLICA_GRPC_HDRS ${CMAKE_CURRENT_
 )
 message(STATUS "Thin replica gRPC/protobuf generated - see " ${CMAKE_CURRENT_BINARY_DIR})
 
+protobuf_generate_cpp(STATE_SNAPSHOT_PROTO_SRCS STATE_SNAPSHOT_PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+  replica_state_snapshot.proto
+)
+grpc_generate_cpp(STATE_SNAPSHOT_GRPC_SRCS STATE_SNAPSHOT_GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+  replica_state_snapshot.proto
+)
+message(STATUS "State snapshot gRPC/protobuf generated - see " ${CMAKE_CURRENT_BINARY_DIR})
+
 add_library(thin-replica-proto STATIC ${THIN_REPLICA_PROTO_SRCS} ${THIN_REPLICA_PROTO_HDRS} 
             ${THIN_REPLICA_GRPC_SRCS} ${THIN_REPLICA_GRPC_HDRS})
 target_link_libraries(thin-replica-proto protobuf::libprotobuf gRPC::grpc++)
 target_include_directories(thin-replica-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+add_library(state-snapshot-proto STATIC ${STATE_SNAPSHOT_PROTO_SRCS} ${STATE_SNAPSHOT_PROTO_HDRS} 
+            ${STATE_SNAPSHOT_GRPC_SRCS} ${STATE_SNAPSHOT_GRPC_HDRS})
+target_link_libraries(state-snapshot-proto protobuf::libprotobuf gRPC::grpc++)
+target_include_directories(state-snapshot-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/thin-replica-server/proto/replica_state_snapshot.proto
+++ b/thin-replica-server/proto/replica_state_snapshot.proto
@@ -1,0 +1,59 @@
+// Concord
+//
+// Copyright 2022 VMware, all rights reserved
+//
+// Concord's StateSnapshotService
+
+// TODO: Rename the file to state_snapshot.proto
+syntax = "proto3";
+package vmware.concord.replicastatesnapshot;
+
+option java_package = "com.vmware.concord.replicastatesnapshot";
+
+// The Concord StateSnapshotService can be used by the concord client to 
+// retrieve state snapshot from a concord cluster
+// See `client/proto/state_snapshot` for definition(s) of state snapshot.
+
+service StateSnapshotService {
+  // Stream a specific state snapshot in a resumable fashion as a finite stream of key-values.
+  // Key-values are streamed with lexicographic order on keys.
+  // Errors:
+  // NOT_FOUND: if a state snapshot with the requested ID is not (or no longer) available.
+  //            Concord client can be directed by the application to retry initialization by 
+  //            fetching a new snapshot ID.
+  // INVALID_ARGUMENT: if resuming a stream using `last_received_key` and that key is not part of the
+  //                   state snapshot.
+  // UNAVAILABLE: if Concord replica is not ready yet to process requests, for e.g., state 
+  //              snapshot is unavailable at the time of the request.
+  // FAILED_PRECONDITION: if a precondition in Concord replica is not satisfied. For example,
+  //                      the state might be corrupted or invalid and, in that case, there
+  //                      would be no point in proceeding with streaming.
+  // UNKNOWN: exact cause is unknown.
+  rpc StreamSnapshot(StreamSnapshotRequest) returns (stream StreamSnapshotResponse);
+}
+
+message StreamSnapshotRequest {  
+  // The ID of the state snapshot to be streamed.
+  uint64 snapshot_id = 1;
+
+  // If set, start streaming from `last_received_key` onwards, excluding
+  // `last_received_key`.
+  // If `last_received_key` is not part of the state snapshot, an INVALID_ARGUMENT
+  // error is returned.
+  //
+  // If not set, start streaming from the first key-value in the state snapshot.
+  //
+  // The empty bytestring is a valid key.
+  //
+  // Key-values are streamed with lexicographic order on keys.
+  optional bytes last_received_key = 2;
+}
+
+message KeyValuePair {
+  bytes key = 1;
+  bytes value = 2;
+}
+
+message StreamSnapshotResponse {
+  KeyValuePair key_value = 1;
+}


### PR DESCRIPTION
This PR adds a state streaming proto file to interface b/w TRC/S to allow gRPC state snapshot streaming. Alongside, placeholder methods have been added in clientservice, concord client and TRC. These methods need to be updated once the implementation is ready to be added.