### PR TITLE
Adding the CMF and key for Public State key set

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -37,6 +37,12 @@ Msg CategoryInput 6 {
 
 # Output for category `add`
 
+# Adding sorted list of Public keys
+Msg PublicStateKeys 7 {
+    #These are the state keys which are public, the list contains sorted keys
+    list string keys
+}
+
 Msg MerkleKeyFlag 1000 {
     bool deleted
 }

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -31,6 +31,7 @@ static const char reconfiguration_restart_key = 0x30;
 static const char reconfiguration_ts_key = 0x31;
 static const char reconfiguration_rep_main_key = 0x32;
 static const std::string genesis_block_key(1, 0x32);
+static const std::string state_public_key_set(1, 0x33);
 
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,


### PR DESCRIPTION
The State keys which are categorized with Public will be stored in internal column families