### PR TITLE
Complete TLS exchange improvements

### DIFF
--- a/bftclient/include/bftclient/StateControl.hpp
+++ b/bftclient/include/bftclient/StateControl.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.

--- a/bftclient/include/bftclient/StateControl.hpp
+++ b/bftclient/include/bftclient/StateControl.hpp
@@ -1,0 +1,30 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include "callback_registry.hpp"
+#include <functional>
+namespace bft::client {
+class StateControl {
+ public:
+  static StateControl& instance() {
+    static StateControl sc;
+    return sc;
+  }
+
+  void setRestartFunc(const std::function<void()>& f) { restart_registry_.add(f); }
+
+  void restart() { restart_registry_.invokeAll(); }
+
+ private:
+  concord::util::CallbackRegistry<> restart_registry_;
+};
+}  // namespace bft::client

--- a/bftclient/include/bftclient/config.h
+++ b/bftclient/include/bftclient/config.h
@@ -68,6 +68,7 @@ struct ClientConfig {
   RetryTimeoutConfig retry_timeout_config;
   std::optional<std::string> transaction_signing_private_key_file_path = std::nullopt;
   std::optional<concord::secretsmanager::SecretData> secrets_manager_config = std::nullopt;
+  std::string replicas_master_key_folder_path = "./replicas_rsa_keys";
 };
 
 // Generic per-request configuration shared by reads and writes.

--- a/bftclient/include/bftclient/config.h
+++ b/bftclient/include/bftclient/config.h
@@ -68,7 +68,7 @@ struct ClientConfig {
   RetryTimeoutConfig retry_timeout_config;
   std::optional<std::string> transaction_signing_private_key_file_path = std::nullopt;
   std::optional<concord::secretsmanager::SecretData> secrets_manager_config = std::nullopt;
-  std::string replicas_master_key_folder_path = "./replicas_rsa_keys";
+  std::optional<std::string> replicas_master_key_folder_path = "./replicas_rsa_keys";
 };
 
 // Generic per-request configuration shared by reads and writes.

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -58,11 +58,13 @@ Client::Client(std::unique_ptr<bft::communication::ICommunication> comm, const C
   }
   communication_->setReceiver(config_.id.val, &receiver_);
   communication_->start();
-  bft::communication::StateControl::instance().setGetPeerPubKeyMethod([&](uint32_t rid) {
-    concord::secretsmanager::SecretsManagerPlain psm_;
-    std::string key_path = config_.replicas_master_key_folder_path + "/" + std::to_string(rid) + "/pub_key";
-    return psm_.decryptFile(key_path).value_or("");
-  });
+  if (config_.replicas_master_key_folder_path.has_value()) {
+    bft::communication::StateControl::instance().setGetPeerPubKeyMethod([&](uint32_t rid) {
+      concord::secretsmanager::SecretsManagerPlain psm_;
+      std::string key_path = config_.replicas_master_key_folder_path.value() + "/" + std::to_string(rid) + "/pub_key";
+      return psm_.decryptFile(key_path).value_or("");
+    });
+  }
 }
 
 Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool read_only, uint16_t client_id) {

--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -211,6 +211,7 @@ class KeyExchangeManager {
   std::vector<IKeyExchanger*> registryToExchange_;
   IMultiSigKeyGenerator* multiSigKeyHdlr_{nullptr};
   IClientPublicKeyStore* clientPublicKeyStore_{nullptr};
+  bool publishedMasterKey = false;
   std::mutex startup_mutex_;
 
   struct Metrics {

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -72,41 +72,6 @@ class Communication : public ICommunication {
   uint16_t repId_;
 };
 
-class ReplicaTLSKeyExchangeHandler : public IStateHandler {
- public:
-  ReplicaTLSKeyExchangeHandler() {}
-
-  bool validate(const State& state) const override {
-    concord::messages::ClientStateReply crep;
-    concord::messages::deserialize(state.data, crep);
-    return std::holds_alternative<concord::messages::ReplicaTlsExchangeKey>(crep.response);
-  }
-
-  bool execute(const State& state, WriteState& out) override {
-    bool succ = true;
-    concord::messages::ClientStateReply crep;
-    concord::messages::deserialize(state.data, crep);
-    auto command = std::get<concord::messages::ReplicaTlsExchangeKey>(crep.response);
-    auto sender_id = command.sender_id;
-    concord::messages::ReconfigurationResponse response;
-    std::string bft_replicas_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" +
-                                         std::to_string(sender_id) + "/server/server.cert";
-    auto current_rep_cert = sm_.decryptFile(bft_replicas_cert_path);
-    if (current_rep_cert == command.cert) return succ;
-    LOG_INFO(GL, "execute replica TLS key exchange using state transfer cre" << KVLOG(sender_id));
-    std::string cert = std::move(command.cert);
-    sm_.encryptFile(bft_replicas_cert_path, cert);
-    LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
-    bft_replicas_cert_path = bftEngine::ReplicaConfig::instance().certificatesRootPath + "/" +
-                             std::to_string(sender_id) + "/client/client.cert";
-    sm_.encryptFile(bft_replicas_cert_path, cert);
-    LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
-    return succ;
-  }
-
- private:
-  concord::secretsmanager::SecretsManagerPlain sm_;
-};
 class InternalSigner : public concord::util::crypto::ISigner {
  public:
   std::string sign(const std::string& data) override {
@@ -197,8 +162,6 @@ std::shared_ptr<ClientReconfigurationEngine> CreFactory::create(std::shared_ptr<
   IStateClient* pbc = new PollBasedStateClient(bftClient, cre_config.interval_timeout_ms_, 0, cre_config.id_);
   auto cre =
       std::make_shared<ClientReconfigurationEngine>(cre_config, pbc, std::make_shared<concordMetrics::Aggregator>());
-  if (bftEngine::ReplicaConfig::instance().isReadOnly)
-    cre->registerHandler(std::make_shared<ReplicaTLSKeyExchangeHandler>());
   if (!bftEngine::ReplicaConfig::instance().isReadOnly) cre->registerHandler(std::make_shared<ScalingReplicaHandler>());
   return cre;
 }

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -187,6 +187,7 @@ std::shared_ptr<ClientReconfigurationEngine> CreFactory::create(std::shared_ptr<
   for (uint16_t i = repConfig.numReplicas; i < repConfig.numReplicas + repConfig.numRoReplicas; i++) {
     bftClientConf.ro_replicas.emplace(bft::client::ReplicaId{i});
   }
+  bftClientConf.replicas_master_key_folder_path = std::nullopt;
   std::unique_ptr<ICommunication> comm = std::make_unique<Communication>(msgsCommunicator, msgHandlers);
   bft::client::Client* bftClient = new bft::client::Client(std::move(comm), bftClientConf);
   bftClient->setTransactionSigner(new InternalSigner());

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -27,6 +27,7 @@
 #include "ReconfigurationCmd.hpp"
 #include "json_output.hpp"
 #include "SharedTypes.hpp"
+#include "communication/StateControl.hpp"
 
 using concordUtil::Timers;
 
@@ -67,6 +68,8 @@ ReadOnlyReplica::ReadOnlyReplica(const ReplicaConfig &config,
 
   // Register status handler for Read-Only replica
   registerStatusHandlers();
+  bft::communication::StateControl::instance().setGetPeerPubKeyMethod(
+      [&](uint32_t id) { return SigManager::instance()->getPublicKeyOfVerifier(id); });
 }
 
 void ReadOnlyReplica::start() {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -410,7 +410,8 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
   // -  in case replica keys haven't been exchanged for all replicas, and it's not a key exchange msg then don't accept
   // the msgs.
   // -  the public keys of the clients haven't been published yet.
-  if (!KeyExchangeManager::instance().exchanged() || !KeyExchangeManager::instance().clientKeysPublished()) {
+  if (!KeyExchangeManager::instance().exchanged() ||
+      (!KeyExchangeManager::instance().clientKeysPublished() && repsInfo->isIdOfClientProxy(senderId))) {
     if (!(flags & KEY_EXCHANGE_FLAG) && !(flags & CLIENTS_PUB_KEYS_FLAG)) {
       LOG_INFO(KEY_EX_LOG, "Didn't complete yet, dropping msg");
       delete m;

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -15,6 +15,7 @@
 #include "reconfiguration/reconfiguration_handler.hpp"
 #include "reconfiguration/dispatcher.hpp"
 #include "IRequestHandler.hpp"
+#include "Metrics.hpp"
 
 #include <ccron/cron_table_registry.hpp>
 #include <optional>
@@ -23,11 +24,13 @@ namespace bftEngine {
 
 class RequestHandler : public IRequestsHandler {
  public:
-  RequestHandler() {
+  RequestHandler(
+      std::shared_ptr<concordMetrics::Aggregator> aggregator_ = std::make_shared<concordMetrics::Aggregator>()) {
     using namespace concord::reconfiguration;
     reconfig_handler_ = std::make_shared<ReconfigurationHandler>();
     reconfig_dispatcher_.addReconfigurationHandler(reconfig_handler_);
     reconfig_dispatcher_.addReconfigurationHandler(std::make_shared<ClientReconfigurationHandler>());
+    reconfig_dispatcher_.setAggregator(aggregator_);
   }
 
   void execute(ExecutionRequestsQueue &requests,

--- a/client/client_pool/include/client/client_pool/client_pool_config.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_config.hpp
@@ -75,6 +75,7 @@ typedef struct ConcordClientPoolConfig {
   std::unordered_map<bft::communication::NodeNum, Replica> node;
   std::deque<ParticipantNode> participant_nodes;
   secretsmanager::SecretData secret_data;
+  std::string path_to_replicas_master_key = std::string();
 } ConcordClientPoolConfig;
 
 class ClientPoolConfig {

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -268,7 +268,8 @@ void ConcordClient::CreateClient(ConcordClientPoolConfig& config, const SimpleCl
                                                 client_params.numberOfStandardDeviationsToTolerate,
                                                 client_params.samplesPerEvaluation,
                                                 static_cast<int16_t>(client_params.samplesUntilReset)};
-
+  if (!config.path_to_replicas_master_key.empty())
+    cfg.replicas_master_key_folder_path = config.path_to_replicas_master_key;
   bool transaction_signing_enabled = config.transaction_signing_enabled;
   if (transaction_signing_enabled) {
     std::string priv_key_path = config.signing_key_path;

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -78,7 +78,7 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
   readYamlField(yaml, "client_batching_enabled", config.topology.client_batching_enabled);
   readYamlField(yaml, "client_batching_max_messages_nbr", config.topology.client_batching_max_messages_nbr);
   readYamlField(yaml, "client_batching_flush_timeout_ms", config.topology.client_batching_flush_timeout_ms);
-  readYamlField(yaml, "path_to_replicas_master_key", config.topology.path_to_replicas_master_key, false);
+  readYamlField(yaml, "replicas_maser_key_path", config.topology.path_to_replicas_master_key, false);
 
   ConcordAssert(yaml["node"].IsSequence());
   for (const auto& node : yaml["node"]) {

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -78,6 +78,7 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
   readYamlField(yaml, "client_batching_enabled", config.topology.client_batching_enabled);
   readYamlField(yaml, "client_batching_max_messages_nbr", config.topology.client_batching_max_messages_nbr);
   readYamlField(yaml, "client_batching_flush_timeout_ms", config.topology.client_batching_flush_timeout_ms);
+  readYamlField(yaml, "path_to_replicas_master_key", config.topology.path_to_replicas_master_key);
 
   ConcordAssert(yaml["node"].IsSequence());
   for (const auto& node : yaml["node"]) {

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -78,7 +78,7 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
   readYamlField(yaml, "client_batching_enabled", config.topology.client_batching_enabled);
   readYamlField(yaml, "client_batching_max_messages_nbr", config.topology.client_batching_max_messages_nbr);
   readYamlField(yaml, "client_batching_flush_timeout_ms", config.topology.client_batching_flush_timeout_ms);
-  readYamlField(yaml, "path_to_replicas_master_key", config.topology.path_to_replicas_master_key);
+  readYamlField(yaml, "path_to_replicas_master_key", config.topology.path_to_replicas_master_key, false);
 
   ConcordAssert(yaml["node"].IsSequence());
   for (const auto& node : yaml["node"]) {

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -78,7 +78,7 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
   readYamlField(yaml, "client_batching_enabled", config.topology.client_batching_enabled);
   readYamlField(yaml, "client_batching_max_messages_nbr", config.topology.client_batching_max_messages_nbr);
   readYamlField(yaml, "client_batching_flush_timeout_ms", config.topology.client_batching_flush_timeout_ms);
-  readYamlField(yaml, "replicas_maser_key_path", config.topology.path_to_replicas_master_key, false);
+  readYamlField(yaml, "replicas_master_key_path", config.topology.path_to_replicas_master_key, false);
 
   ConcordAssert(yaml["node"].IsSequence());
   for (const auto& node : yaml["node"]) {

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -63,6 +63,7 @@ struct BftTopology {
   bool client_batching_enabled;
   size_t client_batching_max_messages_nbr;
   std::uint64_t client_batching_flush_timeout_ms;
+  std::string path_to_replicas_master_key = std::string();
 };
 
 struct BftClientInfo {

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -39,6 +39,7 @@ ConcordClient::ConcordClient(const ConcordClientConfig& config, std::shared_ptr<
 
 ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClientConfig& config) {
   ConcordClientPoolConfig client_pool_config;
+  client_pool_config.path_to_replicas_master_key = config.topology.path_to_replicas_master_key;
   int id = 0;
   for (const auto& replica : config_.topology.replicas) {
     Replica client_pool_replica;

--- a/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
@@ -24,6 +24,11 @@ class ReplicaMainKeyPublicationHandler : public IStateHandler {
   bool execute(const State&, WriteState&) override;
 
  private:
+  logging::Logger getLogger() {
+    static logging::Logger logger_(
+        logging::getLogger("concord.client.reconfiguration.ReplicaMainKeyPublicationHandler"));
+    return logger_;
+  }
   std::string output_dir_;
   concord::secretsmanager::SecretsManagerPlain file_handler_;
 };
@@ -71,6 +76,7 @@ class ClientMasterKeyExchangeHandler : public IStateHandler {
   std::string master_key_path_;
   std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
   uint64_t init_last_update_block_;
+  concord::secretsmanager::SecretsManagerPlain psm_;
 };
 
 class ClientRestartHandler : public IStateHandler {

--- a/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
@@ -38,7 +38,7 @@ class ClientTlsKeyExchangeHandler : public IStateHandler {
   ClientTlsKeyExchangeHandler(const std::string& master_key_path,
                               const std::string& cert_folder,
                               bool enc,
-                              const std::vector<uint32_t> bft_clients,
+                              const std::vector<uint32_t>& bft_clients,
                               std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm);
   bool validate(const State&) const override;
   bool execute(const State&, WriteState&) override;

--- a/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
@@ -14,6 +14,8 @@
 #include "cre_interfaces.hpp"
 #include "secrets_manager_plain.h"
 
+#include <vector>
+
 namespace concord::client::reconfiguration::handlers {
 class ReplicaMainKeyPublicationHandler : public IStateHandler {
  public:
@@ -25,5 +27,29 @@ class ReplicaMainKeyPublicationHandler : public IStateHandler {
   std::string output_dir_;
   concord::secretsmanager::SecretsManagerPlain file_handler_;
   uint32_t latest_known_update_{0};
+class ClientTlsKeyExchangeHandler : public IStateHandler {
+ public:
+  ClientTlsKeyExchangeHandler(const std::string& master_key_path,
+                              const std::string& cert_folder,
+                              bool enc,
+                              const std::vector<uint32_t> bft_clients,
+                              std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm);
+  bool validate(const State&) const override;
+  bool execute(const State&, WriteState&) override;
+
+ private:
+  logging::Logger getLogger() {
+    static logging::Logger logger_(logging::getLogger("concord.client.reconfiguration.ClientTlsKeyExchangeHandler"));
+    return logger_;
+  }
+  std::string master_key_path_;
+  std::string cert_folder_;
+  bool enc_;
+  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
+  std::vector<uint32_t> bft_clients_;
+  uint64_t init_last_tls_update_block_;
+  concord::secretsmanager::SecretsManagerPlain psm_;
+  std::string version_path_;
 };
+
 }  // namespace concord::client::reconfiguration::handlers

--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -10,6 +10,7 @@
 // file.
 
 #include "client/reconfiguration/default_handlers.hpp"
+#include "bftclient/StateControl.hpp"
 #include "concord.cmf.hpp"
 #include "crypto_utils.hpp"
 
@@ -21,9 +22,10 @@ namespace fs = std::experimental::filesystem;
 namespace concord::client::reconfiguration::handlers {
 
 template <typename T>
-bool validateInputState(const State& state) {
+bool validateInputState(const State& state, std::optional<uint64_t> init_block = std::nullopt) {
   concord::messages::ClientStateReply crep;
   concord::messages::deserialize(state.data, crep);
+  if (init_block.has_value() && init_block.value() > crep.block_id) return false;
   return std::holds_alternative<T>(crep.response);
 }
 
@@ -44,7 +46,8 @@ bool ReplicaMainKeyPublicationHandler::execute(const State& state, WriteState&) 
     if (!fs::exists(path)) fs::create_directories(path);
     file_handler_.encryptFile((path / "pub_key").string(), cmd.key);
   }
-  latest_known_update_ = state.blockid;
+  return true;
+}
 bool ClientTlsKeyExchangeHandler::validate(const State& state) const {
   concord::messages::ClientStateReply crep;
   concord::messages::deserialize(state.data, crep);
@@ -80,6 +83,81 @@ bool ClientTlsKeyExchangeHandler::execute(const State& state, WriteState&) {
   LOG_INFO(getLogger(), "done tls exchange");
   LOG_INFO(getLogger(), "restarting the node");
   bft::client::StateControl::instance().restart();
+  return true;
+}
+
+ClientTlsKeyExchangeHandler::ClientTlsKeyExchangeHandler(
+    const std::string& master_key_path,
+    const std::string& cert_folder,
+    bool enc,
+    std::vector<uint32_t> bft_clients,
+    std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm)
+    : master_key_path_{master_key_path}, cert_folder_{cert_folder}, enc_{enc}, sm_{sm}, bft_clients_{bft_clients} {
+  version_path_ = cert_folder + "/version";
+  if (!fs::exists(version_path_)) fs::create_directories(version_path_);
+  version_path_ += "/exchange.version";
+  init_last_tls_update_block_ = std::stol(psm_.decryptFile(version_path_).value_or("0"));
+}
+ClientMasterKeyExchangeHandler::ClientMasterKeyExchangeHandler(
+    uint32_t client_id,
+    const std::string& master_key_path,
+    std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm,
+    uint64_t last_update_block)
+    : client_id_{client_id}, master_key_path_{master_key_path}, sm_{sm}, init_last_update_block_{last_update_block} {}
+bool ClientMasterKeyExchangeHandler::validate(const State& state) const {
+  concord::messages::ClientStateReply crep;
+  concord::messages::deserialize(state.data, crep);
+  if (std::holds_alternative<concord::messages::ClientKeyExchangeCommand>(crep.response)) {
+    concord::messages::ClientKeyExchangeCommand command =
+        std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
+    if (!command.tls && state.blockid > init_last_update_block_) return true;
+  }
+  return false;
+}
+bool ClientMasterKeyExchangeHandler::execute(const State& state, WriteState& out) {
+  LOG_INFO(getLogger(), "execute transaction signing key exchange request");
+  // Generate new key pair
+  auto hex_keys = concord::util::crypto::Crypto::instance().generateRsaKeyPair(
+      2048, concord::util::crypto::KeyFormat::HexaDecimalStrippedFormat);
+  auto pem_keys = concord::util::crypto::Crypto::instance().RsaHexToPem(hex_keys);
+
+  concord::messages::ReconfigurationRequest rreq;
+  concord::messages::ClientExchangePublicKey creq;
+  sm_->encryptFile(master_key_path_ + ".new", pem_keys.first);
+
+  std::string new_pub_key = hex_keys.second;
+  creq.sender_id = client_id_;
+  creq.pub_key = new_pub_key;
+  rreq.command = creq;
+  std::vector<uint8_t> req_buf;
+  concord::messages::serialize(req_buf, rreq);
+  out = {req_buf, [&]() {
+           fs::copy(master_key_path_, master_key_path_ + ".old");
+           fs::copy(master_key_path_ + ".new", master_key_path_, fs::copy_options::update_existing);
+           fs::remove(master_key_path_ + ".new");
+           fs::remove(master_key_path_ + ".old");
+           LOG_INFO(getLogger(), "exchanged transaction signing keys (encrypted)");
+           LOG_INFO(getLogger(), "restarting the node");
+           bft::client::StateControl::instance().restart();
+         }};
+  return true;
+}
+bool ClientRestartHandler::validate(const State& state) const {
+  return validateInputState<concord::messages::ClientsRestartCommand>(state, init_update_block_);
+}
+bool ClientRestartHandler::execute(const State& state, WriteState& out) {
+  LOG_INFO(getLogger(), "executing ClientRestartHandler");
+  auto command = getCmdFromInputState<concord::messages::ClientsRestartCommand>(state);
+  concord::messages::ReconfigurationRequest rreq;
+  concord::messages::ClientsRestartUpdate creq;
+  creq.sender_id = client_id_;
+  rreq.command = creq;
+  std::vector<uint8_t> req_buf;
+  concord::messages::serialize(req_buf, rreq);
+  out = {req_buf, [&, command]() {
+           LOG_INFO(this->getLogger(), "completed client restart command " << client_id_);
+           bft::client::StateControl::instance().restart();
+         }};
   return true;
 }
 }  // namespace concord::client::reconfiguration::handlers

--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -92,7 +92,7 @@ ClientTlsKeyExchangeHandler::ClientTlsKeyExchangeHandler(
     const std::string& master_key_path,
     const std::string& cert_folder,
     bool enc,
-    std::vector<uint32_t> bft_clients,
+    const std::vector<uint32_t>& bft_clients,
     std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm)
     : master_key_path_{master_key_path}, cert_folder_{cert_folder}, enc_{enc}, sm_{sm}, bft_clients_{bft_clients} {
   version_path_ = cert_folder + "/version";

--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -11,9 +11,11 @@
 
 #include "client/reconfiguration/default_handlers.hpp"
 #include "concord.cmf.hpp"
+#include "crypto_utils.hpp"
 
 #include <variant>
 #include <experimental/filesystem>
+#include <fstream>
 namespace fs = std::experimental::filesystem;
 
 namespace concord::client::reconfiguration::handlers {
@@ -43,6 +45,41 @@ bool ReplicaMainKeyPublicationHandler::execute(const State& state, WriteState&) 
     file_handler_.encryptFile((path / "pub_key").string(), cmd.key);
   }
   latest_known_update_ = state.blockid;
+bool ClientTlsKeyExchangeHandler::validate(const State& state) const {
+  concord::messages::ClientStateReply crep;
+  concord::messages::deserialize(state.data, crep);
+  if (std::holds_alternative<concord::messages::ClientKeyExchangeCommand>(crep.response)) {
+    concord::messages::ClientKeyExchangeCommand command =
+        std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
+    if (command.tls && state.blockid > init_last_tls_update_block_) return true;
+  }
+  return false;
+}
+bool ClientTlsKeyExchangeHandler::execute(const State& state, WriteState&) {
+  auto cmd = getCmdFromInputState<concord::messages::ClientKeyExchangeCommand>(state);
+  LOG_INFO(getLogger(), "execute tls key exchange request");
+  // Generate new key pair
+  auto new_cert_keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
+      concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);
+  std::string suffix = enc_ ? ".enc" : "";
+  std::string master_key = sm_->decryptString(master_key_path_).value_or(std::string());
+  if (master_key.empty()) LOG_FATAL(getLogger(), "unable to read the node master key");
+  auto root = fs::path(cert_folder_);
+  for (const auto& c : bft_clients_) {
+    fs::path pkey_path = root / std::to_string(c) / "client" / ("pk.pem" + suffix);
+    fs::path cert_path = root / std::to_string(c) / "client" / "client.cert";
+
+    auto cert =
+        concord::util::crypto::CertificateUtils::generateSelfSignedCert(cert_path, new_cert_keys.second, master_key);
+    sm_->encryptFile(pkey_path.string(), new_cert_keys.first);
+    psm_.encryptFile(cert_path.string(), cert);
+    psm_.encryptFile(version_path_, std::to_string(state.blockid));
+    init_last_tls_update_block_ = state.blockid;
+    LOG_INFO(getLogger(), "exchanged tls certificate for bft client " << c);
+  }
+  LOG_INFO(getLogger(), "done tls exchange");
+  LOG_INFO(getLogger(), "restarting the node");
+  bft::client::StateControl::instance().restart();
   return true;
 }
 }  // namespace concord::client::reconfiguration::handlers

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -202,10 +202,6 @@ bool KvbcClientReconfigurationHandler::handle(const concord::messages::ClientRec
       rep.states.push_back(csrep);
     }
     for (uint16_t i = 0; i < first_client_id; i++) {
-      auto ke_csrep = buildReplicaStateReply(std::string{kvbc::keyTypes::reconfiguration_tls_exchange_key}, i);
-      if (ke_csrep.block_id > 0) rep.states.push_back(ke_csrep);
-    }
-    for (uint16_t i = 0; i < first_client_id; i++) {
       auto ke_csrep = buildReplicaStateReply(std::string{kvbc::keyTypes::reconfiguration_rep_main_key}, i);
       if (ke_csrep.block_id > 0) rep.states.push_back(ke_csrep);
     }

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -387,12 +387,6 @@ bool ReconfigurationHandler::handle(const concord::messages::KeyExchangeCommand&
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse& rres) {
-  if (command.tls && command.target_replicas.size() > bftEngine::ReplicaConfig::instance().fVal) {
-    concord::messages::ReconfigurationErrorMsg error_msg{
-        "Unable to perform tls key exchange for more than f replicas at once"};
-    rres.response = error_msg;
-    return false;
-  }
   std::vector<uint8_t> serialized_command;
   concord::messages::serialize(serialized_command, command);
   auto blockId = persistReconfigurationBlock(

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -16,13 +16,14 @@
 #include "concord.cmf.hpp"
 #include "OpenTracing.hpp"
 #include "Logger.hpp"
+#include "Metrics.hpp"
 
 namespace concord::reconfiguration {
 // The dispatcher forwards all messages to their appropriate handlers.
 // All handled messages are defined in the IReconfigurationHandler interface.
 class Dispatcher {
  public:
-  Dispatcher() = default;
+  Dispatcher();
   // This method is the gate for all reconfiguration actions. It works as
   // follows:
   // 1. Validate the request against the reconfiguration system operator (RSO)
@@ -54,6 +55,11 @@ class Dispatcher {
     }
   }
 
+  void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
+    aggregator_ = aggregator;
+    component_.SetAggregator(aggregator_);
+  }
+
  private:
   logging::Logger getLogger() {
     static logging::Logger logger_(logging::getLogger("concord.reconfiguration"));
@@ -71,6 +77,11 @@ class Dispatcher {
   std::vector<std::shared_ptr<IReconfigurationHandler>> pre_reconfig_handlers_;
   std::vector<std::shared_ptr<IReconfigurationHandler>> reconfig_handlers_;
   std::vector<std::shared_ptr<IReconfigurationHandler>> post_reconfig_handlers_;
+  std::shared_ptr<concordMetrics::Aggregator> aggregator_;
+  concordMetrics::Component component_;
+  concordMetrics::CounterHandle executions_;
+  concordMetrics::CounterHandle failures_;
+  concordMetrics::CounterHandle auth_failures_;
 };
 
 }  // namespace concord::reconfiguration

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -57,12 +57,6 @@ bool ReconfigurationHandler::handle(const KeyExchangeCommand& command,
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>&,
                                     concord::messages::ReconfigurationResponse& rres) {
-  if (command.tls && command.target_replicas.size() > bftEngine::ReplicaConfig::instance().fVal) {
-    concord::messages::ReconfigurationErrorMsg error_msg{
-        "Unable to perform tls key exchange for more than f replicas at once"};
-    rres.response = error_msg;
-    return false;
-  }
   std::ostringstream oss;
   std::copy(command.target_replicas.begin(), command.target_replicas.end(), std::ostream_iterator<int>(oss, " "));
 

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -309,7 +309,7 @@ class SkvbcPreExecutionTest(unittest.TestCase):
         bft_network.stop_replica(initial_primary)
 
         try:
-            with trio.move_on_after(seconds=1):
+            with trio.move_on_after(seconds=10):
                 await skvbc.send_indefinite_ops(write_weight=1)
         except trio.TooSlowError:
             pass

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1512,7 +1512,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             initial_prim = 0
             crashed_replica = bft_network.random_set_of_replicas(1, {initial_prim})
             log.log_message(message_type=f"crashed replica is {crashed_replica}")
-            live_replicas = bft_network.all_replicas(without=crashed_replica)
             bft_network.start_all_replicas()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             await bft_network.check_initial_master_key_publication(bft_network.all_replicas())
@@ -1526,7 +1525,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             with net.ReplicaSubsetIsolatingAdversary(bft_network, crashed_replica) as adversary:
                 adversary.interfere()
 
-                for i in range(601):
+                for i in range(850):
                     await skvbc.send_write_kv_set()
                 client = bft_network.random_client()
                 client.config._replace(req_timeout_milli=10000)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1980,7 +1980,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 succ = True
                 for r in replicas:
                     master_key_path = os.path.join(bft_network.testdir, "replicas_rsa_keys", str(r), "pub_key")
-                    print(master_key_path)
                     if os.path.isfile(master_key_path) is False:
                         succ = False
                         break

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -59,7 +59,7 @@ def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
     else :
         batch_size = "1"
         time_service_enabled = "0"
-    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem"])
+    ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem", "--publish-master-key-on-startup"])
     return ret
 
 def start_replica_cmd(builddir, replica_id):
@@ -87,7 +87,8 @@ def start_replica_cmd(builddir, replica_id):
             "-f", time_service_enabled,
             "-b", "2",
             "-q", batch_size,
-            "-o", builddir + "/operator_pub.pem"]
+            "-o", builddir + "/operator_pub.pem",
+            "--publish-master-key-on-startup"]
 
 
 def start_replica_cmd_with_key_exchange(builddir, replica_id):
@@ -116,7 +117,8 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
             "-b", "2",
             "-q", batch_size,
             "-e", str(True),
-            "-o", builddir + "/operator_pub.pem"]
+            "-o", builddir + "/operator_pub.pem",
+            "--publish-master-key-on-startup"]
 
 class SkvbcReconfigurationTest(unittest.TestCase):
     @classmethod
@@ -128,7 +130,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         pass
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
     async def test_clients_add_remove_cmd(self, bft_network):
         """
             sends a clientsAddRemoveCommand and test the the status for the CRE client is correct
@@ -166,7 +168,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                         assert(v == config_desc)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
     async def test_client_key_exchange_command(self, bft_network):
         """
             Operator sends client key exchange command for all the clients
@@ -174,10 +176,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         with log.start_action(action_type="test_client_key_exchange_command"):
             bft_network.start_all_replicas()
             bft_network.start_cre()
+            await bft_network.check_initial_master_key_publication(bft_network.all_replicas())
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-            for i in range(100):
-                await skvbc.send_write_kv_set()
-
             await self.run_client_key_exchange_cycle(bft_network)
             pub_key_a, ts_a = await self.get_last_client_keys_data(bft_network, bft_network.cre_id, tls=False)
             assert pub_key_a is not None
@@ -196,7 +196,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 await skvbc.send_write_kv_set()
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
     async def test_client_key_exchange_command_with_st(self, bft_network):
         """
             Operator sends client key exchange command for all the clients
@@ -248,12 +248,12 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         bft_network.restart_clients(generate_tx_signing_keys=False, restart_replicas=False)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
-    async def test_client_tls_key_exchange_command(self, bft_network):
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
+    async def test_tls_exchange_client_replica(self, bft_network):
         """
             Operator sends client key exchange command for cre client
         """
-        with log.start_action(action_type="test_client_tls_key_exchange_command"):
+        with log.start_action(action_type="test_tls_exchange_client_replica"):
             bft_network.start_all_replicas()
             bft_network.start_cre()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
@@ -266,12 +266,12 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 await skvbc.send_write_kv_set()
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
-    async def test_client_tls_key_exchange_command_with_st(self, bft_network):
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
+    async def test_tls_exchange_client_replica_with_st(self, bft_network):
         """
             Operator sends client key exchange command for cre client
         """
-        with log.start_action(action_type="test_client_tls_key_exchange_command"):
+        with log.start_action(action_type="test_tls_exchange_client_replica_with_st"):
             bft_network.start_all_replicas()
             bft_network.start_cre()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
@@ -312,7 +312,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 await skvbc.send_write_kv_set()
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
     async def test_client_restart_command(self, bft_network):
         """
             Operator sends client restart command for all the clients
@@ -371,9 +371,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                     lines = sum(1 for l in diff)
                     if lines == 0:
                         succ = False
-
-        bft_network.stop_cre()
-        bft_network.start_cre()
 
         with trio.fail_after(60):
             succ = False
@@ -440,12 +437,12 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         return ts
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True)
-    async def test_replicas_tls_key_exchange_with_f_nodes(self, bft_network):
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
+    async def test_tls_exchange_replicas_replicas_and_replicas_client(self, bft_network):
         """
             Test that tls key exchange where primary is included and make sure CRE is also able to get the update
         """
-        with log.start_action(action_type="test_replicas_tls_key_exchange_with_f_nodes"):
+        with log.start_action(action_type="test_tls_exchange_replicas_replicas_and_replicas_client"):
             bft_network.start_all_replicas()
             bft_network.start_cre()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
@@ -456,7 +453,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             for r in bft_network.all_replicas():
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
                 fast_paths[r] = nb_fast_path
-            exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f))
+            exchanged_replicas = bft_network.all_replicas()
             await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, list(bft_network.all_replicas()) + [bft_network.cre_id])
             # Manually copy the new certs from the last replica of the replicas to clients and restart clients
             bft_network.copy_certs_from_server_to_clients(6)
@@ -469,18 +466,18 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 self.assertGreater(nb_fast_path, fast_paths[r])
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
-    async def test_replicas_tls_key_exchange_command_with_st(self, bft_network):
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, with_cre=True, publish_master_keys=True)
+    async def test_tls_exchange_replicas_replicas_and_replicas_clients_with_st(self, bft_network):
         """
-            Operator sends client key exchange command for f - 1 replicas
+            Operator sends client key exchange command to all replicas
         """
-        with log.start_action(action_type="test_replica_key_exchange_command"):
+        with log.start_action(action_type="test_tls_exchange_replicas_replicas_and_replicas_client_with_st"):
             bft_network.start_all_replicas()
+            bft_network.start_cre()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             initial_prim = 0
             crashed_replica = list(bft_network.random_set_of_replicas(1, {initial_prim}))
-            exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f - 2, {initial_prim, crashed_replica[0]}))
-            exchanged_replicas += [initial_prim]
+            exchanged_replicas = list(bft_network.all_replicas(without={crashed_replica[0]}))
             for i in range(100):
                 await skvbc.send_write_kv_set()
             fast_paths = {}
@@ -491,7 +488,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             bft_network.stop_replicas(crashed_replica)
 
             live_replicas =  bft_network.all_replicas(without=set(crashed_replica))
-            await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, live_replicas)
+            await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, live_replicas + [bft_network.cre_id])
             # Manually copy the new certs from one of the replicas to clients and restart clients
             max_live_replica = max(live_replicas)
             bft_network.copy_certs_from_server_to_clients(max_live_replica)
@@ -501,28 +498,6 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 await skvbc.send_write_kv_set()
 
             bft_network.start_replicas(crashed_replica)
-
-            # Using state transfer CRE means that we don't need to wait for the replica to complete state transfer
-            with trio.fail_after(60):
-                succ = False
-                while not succ:
-                    await trio.sleep(1)
-                    succ = True
-                    for rep in crashed_replica:
-                        for r in exchanged_replicas:
-                            prim_cert_path = os.path.join(bft_network.certdir + "/" + str(max_live_replica), str(r),"server", "server.cert")
-                            st_cert_path =  os.path.join(bft_network.certdir + "/" + str(rep), str(r),"server", "server.cert")
-                            st_cert_data = []
-                            with open(st_cert_path) as st_cert:
-                                st_cert_data = st_cert.readlines()
-                            prim_cert_data = []
-                            with open(prim_cert_path) as orig_key:
-                                prim_cert_data = orig_key.readlines()
-                            diff = difflib.unified_diff(st_cert_data, prim_cert_data, fromfile="new", tofile="old", lineterm='')
-                            lines = sum(1 for l in diff)
-                            if lines > 0:
-                                succ = False
-                                continue
             await bft_network.wait_for_state_transfer_to_start()
             for r in crashed_replica:
                 await bft_network.wait_for_state_transfer_to_stop(initial_prim,
@@ -535,12 +510,12 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                 nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
                 self.assertGreater(nb_fast_path, fast_paths[r])
 
-    @unittest.skip("Unstable scenario")
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
-                      selected_configs=lambda n, f, c: n == 7)
-    async def test_replicas_tls_key_exchange_with_ror(self, bft_network):
+                      selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
+    async def test_tls_exchange_replicas_replicas_with_ror(self, bft_network):
         """
+            Run TLS key exchange and make sure a ror is able to get updates
         """
         bft_network.start_all_replicas()
         ro_replica_id = bft_network.config.n
@@ -548,11 +523,8 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
         for i in range(301): # Produce 301 new blocks
             await skvbc.send_write_kv_set()
-        # Now, lets switch keys to f replicas
-        exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f))
-        await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, affected_replicas=[r for r in range(bft_network.config.n + 1)])
-        # Now, lets exchange another replica key, to make sure the read only replica is able to exchange the keys
-        exchanged_replicas = list(bft_network.random_set_of_replicas(bft_network.config.f, without=set(exchanged_replicas)))
+        # Now, lets switch keys to all replicas
+        exchanged_replicas = bft_network.all_replicas()
         await self.run_replica_tls_key_exchange_cycle(bft_network, exchanged_replicas, affected_replicas=[r for r in range(bft_network.config.n + 1)])
         bft_network.copy_certs_from_server_to_clients(7)
         bft_network.restart_clients(False, False)
@@ -614,7 +586,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                         break
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_key_exchange(self, bft_network):
         """
             No initial key rotation
@@ -634,7 +606,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_key_exchange, 
                       selected_configs=lambda n, f, c: n == 7,
-                      rotate_keys=True)
+                      rotate_keys=True, publish_master_keys=True)
     async def test_key_exchange_with_restart(self, bft_network):
         """
             - With initial key rotation (keys get effective at checkpoint 2)
@@ -677,7 +649,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_key_exchange, 
                       bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}],
-                      rotate_keys=True)
+                      rotate_keys=True, publish_master_keys=True)
     async def test_key_exchange_with_file_backup(self, bft_network):
         """
             - With initial key rotation (keys get effective at checkpoint 2)
@@ -759,7 +731,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                             break
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_wedge_command(self, bft_network):
         """
              Sends a wedge command and checks that the system stops processing new requests.
@@ -782,7 +754,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_unwedge_command(self, bft_network):
         """
              Sends a wedge command and checks that the system stops processing new requests.
@@ -825,7 +797,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertEqual(epoch, 1)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_wedge_command_with_state_transfer(self, bft_network):
         """
             This test checks that even a replica that received the super stable checkpoint via the state transfer mechanism
@@ -866,7 +838,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_unwedge_command_with_state_transfer(self, bft_network):
         """
             This test checks that a replica that is stopped after wedge manages to catch up with the unwedged ones with ST
@@ -928,7 +900,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_unwedge_command_with_f_failures(self, bft_network):
         """
             This test checks that unwedge is executed with f failures
@@ -979,7 +951,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             await skvbc.send_write_kv_set()
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_wedge_status_command(self, bft_network):
         """
              Tests that the wedge command returns correct status after wedge and unwedge
@@ -1011,7 +983,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_get_latest_pruneable_block(self, bft_network):
 
         bft_network.start_all_replicas()
@@ -1053,7 +1025,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         assert min_prunebale_block < min_prunebale_block_b
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_pruning_command(self, bft_network):
         with log.start_action(action_type="test_pruning_command"):
             bft_network.start_all_replicas()
@@ -1080,11 +1052,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             data = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
             pruned_block = int(data.additional_data.decode('utf-8'))
             log.log_message(message_type=f"pruned_block {pruned_block}")
-            assert pruned_block <= 90
+            assert pruned_block <= 97
 
-    @unittest.skip("Disabled till pruning of reconfiguration blocks during state transfer is fixed")
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_pruning_command_with_failures(self, bft_network):
         with log.start_action(action_type="test_pruning_command_with_faliures"):
             bft_network.start_all_replicas()
@@ -1115,7 +1086,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             data = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
             pruned_block = int(data.additional_data.decode('utf-8'))
             log.log_message(message_type=f"pruned_block {pruned_block}")
-            assert pruned_block <= 90
+            assert pruned_block <= 97
 
             # creates 1000 new blocks
             for i in range(1000):
@@ -1138,7 +1109,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
                         status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
                         last_prune_blockid = status.response.last_pruned_block
                         log.log_message(message_type=f"last_prune_blockid {last_prune_blockid}, status.response.sender {status.response.sender}")
-                        if status.response.in_progress is False and last_prune_blockid <= 90 and last_prune_blockid > 0:
+                        if status.response.in_progress is False and last_prune_blockid <= 97 and last_prune_blockid > 0:
                             num_replies += 1
                     if num_replies == bft_network.config.n:
                         break
@@ -1157,7 +1128,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             await self._wait_for_st(bft_network, crashed_replica, 2100)
     
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_pruning_status_command(self, bft_network):
 
         bft_network.start_all_replicas()
@@ -1200,10 +1171,10 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         for r in rsi_rep.values():
             status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
             assert status.response.in_progress is False
-            assert status.response.last_pruned_block <= 90
+            assert status.response.last_pruned_block <= 97
 
     @with_trio
-    @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_pruning_with_ro_replica(self, bft_network):
 
         bft_network.start_all_replicas()
@@ -1249,7 +1220,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
 
     @with_trio
-    @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store, num_ro_replicas=1, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_pruning_with_ro_replica_failure(self, bft_network):
 
         bft_network.start_all_replicas()
@@ -1293,7 +1264,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_restart_command(self, bft_network):
         """
              Send a restart command and verify that replicas have stopped and removed their metadata in two cases
@@ -1337,7 +1308,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             await skvbc.send_write_kv_set()
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True)
+    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True, publish_master_keys=True)
     async def test_remove_nodes(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -1380,7 +1351,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True)
+    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True, publish_master_keys=True)
     async def test_remove_nodes_with_f_failures(self, bft_network):
         """
         In this test we show how a system operator can remove nodes (and thus reduce the cluster) from 7 nodes cluster
@@ -1428,7 +1399,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_remove_nodes_with_unwedge(self, bft_network):
         """
             Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -1473,7 +1444,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         await self.validate_epoch_number(bft_network, 1, bft_network.all_replicas())
 
     @with_trio
-    @with_bft_network(start_replica_cmd, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}])
+    @with_bft_network(start_replica_cmd, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}], publish_master_keys=True)
     async def test_add_nodes(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -1518,7 +1489,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             self.assertGreater(nb_fast_path, 0)
     
     @with_trio
-    @with_bft_network(start_replica_cmd, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}])
+    @with_bft_network(start_replica_cmd, bft_configs=[{'n': 4, 'f': 1, 'c': 0, 'num_clients': 10}], publish_master_keys=True)
     async def test_add_nodes_with_failures(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -1541,17 +1512,11 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             live_replicas = bft_network.all_replicas(without=crashed_replica)
             bft_network.start_all_replicas()
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-            # This is a loop to make sure that all replicas are up before interfering them
-            with trio.fail_after(30):
-                nb_fast_path = await bft_network.get_metric(initial_prim, bft_network, "Counters", "totalFastPaths")
-                while nb_fast_path <= 0:
-                    for i in range(100):
-                        await skvbc.send_write_kv_set()
-                    nb_fast_path = await bft_network.get_metric(initial_prim, bft_network, "Counters", "totalFastPaths")
+            await bft_network.check_initial_master_key_publication(bft_network.all_replicas())
             with net.ReplicaSubsetIsolatingAdversary(bft_network, crashed_replica) as adversary:
                 adversary.interfere()
 
-                for i in range(601):
+                for i in range(1000):
                     await skvbc.send_write_kv_set()
                 client = bft_network.random_client()
                 client.config._replace(req_timeout_milli=10000)
@@ -1632,7 +1597,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
 
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_addRemoveStatusError(self, bft_network):
         """
              Sends a addRemoveStatus command without adding new configuration 
@@ -1657,7 +1622,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
             assert status.success is False
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
-                      selected_configs=lambda n, f, c: n == 7)
+                      selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
     async def test_reconfiguration_with_ror(self, bft_network):
         """
              Sends a addRemove command and checks that new configuration is written to blockchain.
@@ -1758,7 +1723,7 @@ class SkvbcReconfigurationTest(unittest.TestCase):
         self.assertEqual(blockIdRor, blockIdreplica)
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True)
+    @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True, publish_master_keys=True)
     async def test_install_command(self, bft_network):
         """
              Sends a install command and checks that new version is written to blockchain.

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -26,8 +26,6 @@
 #include "secrets_manager_enc.h"
 #include "client/reconfiguration/default_handlers.hpp"
 #include <variant>
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
 
 using namespace bftEngine;
 using namespace bft::communication;

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -138,190 +138,6 @@ ICommunication* createCommunication(const ClientConfig& cc,
   return CommFactory::create(conf);
 }
 
-class KeyExchangeCommandHandler : public IStateHandler {
- public:
-  KeyExchangeCommandHandler(uint16_t clientId,
-                            const std::string& key_path,
-                            const std::string& certFolder,
-                            uint64_t init_update_block,
-                            uint64_t init_tls_update_block,
-                            std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm)
-      : clientId_{clientId}, key_path_{key_path}, tls_key_path_{certFolder}, sm_{sm} {
-    init_last_update_block_ = init_update_block;
-    init_last_tls_update_block_ = std::stol(
-        plain_sm_.decryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert.version").string())
-            .value_or("0"));
-  }
-  bool validate(const State& state) const {
-    concord::messages::ClientStateReply crep;
-    concord::messages::deserialize(state.data, crep);
-    if (std::holds_alternative<concord::messages::ClientKeyExchangeCommand>(crep.response)) {
-      concord::messages::ClientKeyExchangeCommand command =
-          std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
-      if (command.tls && state.blockid > init_last_tls_update_block_) return true;
-      if (!command.tls && state.blockid > init_last_update_block_) return true;
-    }
-    return false;
-  };
-  bool execute(const State& state, WriteState& out) {
-    concord::messages::ClientStateReply crep;
-    concord::messages::deserialize(state.data, crep);
-    concord::messages::ClientKeyExchangeCommand command =
-        std::get<concord::messages::ClientKeyExchangeCommand>(crep.response);
-    if (!command.tls) return executeTransactionSigningKeyExchange(out);
-    if (command.tls) return executeTlsKeyExchange(state.blockid, out);
-    return false;
-  }
-
- private:
-  logging::Logger getLogger() {
-    static logging::Logger logger_(logging::getLogger("concord.client.reconfiguration.testerCre.KeyExchangeHandler"));
-    return logger_;
-  }
-
-  bool executeTransactionSigningKeyExchange(WriteState& out) {
-    LOG_INFO(getLogger(), "execute transaction signing key exchange request");
-    // Generate new key pair
-    auto hex_keys = concord::util::crypto::Crypto::instance().generateRsaKeyPair(
-        2048, concord::util::crypto::KeyFormat::HexaDecimalStrippedFormat);
-    auto pem_keys = concord::util::crypto::Crypto::instance().RsaHexToPem(hex_keys);
-
-    concord::messages::ReconfigurationRequest rreq;
-    concord::messages::ClientExchangePublicKey creq;
-    fs::path enc_file_path = key_path_;
-    enc_file_path += ".enc";
-    bool enc = false;
-    std::fstream f(enc_file_path.string());
-    if (f.good()) {
-      enc_file_path += ".new";
-      enc = true;
-      sm_->encryptFile(enc_file_path.string(), pem_keys.first);
-    }
-    fs::path new_key_path = key_path_;
-    bool non_enc = false;
-    std::fstream f2(new_key_path);
-    if (f2.good()) {
-      new_key_path += ".new";
-      plain_sm_.encryptFile(new_key_path.string(), pem_keys.first);
-      non_enc = true;
-    }
-
-    std::string new_pub_key = hex_keys.second;
-    creq.sender_id = clientId_;
-    creq.pub_key = new_pub_key;
-    rreq.command = creq;
-    std::vector<uint8_t> req_buf;
-    concord::messages::serialize(req_buf, rreq);
-    out = {req_buf, [this, non_enc, new_key_path, enc, enc_file_path]() {
-             if (enc) {
-               fs::path enc_path = this->key_path_;
-               enc_path += ".enc";
-               fs::path old_path = enc_path;
-               old_path += ".old";
-               fs::copy(enc_path, old_path, fs::copy_options::update_existing);
-               fs::copy(enc_file_path, enc_path, fs::copy_options::update_existing);
-               fs::remove(old_path);
-               fs::remove(enc_file_path);
-               LOG_INFO(this->getLogger(), "exchanged transaction signing keys (encrypted)");
-             }
-             if (non_enc) {
-               fs::path old_path = this->key_path_;
-               old_path += ".old";
-               fs::copy(this->key_path_, old_path, fs::copy_options::update_existing);
-               fs::copy(new_key_path, this->key_path_, fs::copy_options::update_existing);
-               fs::remove(old_path);
-               fs::remove(new_key_path);
-               LOG_INFO(this->getLogger(), "exchanged transaction signing keys (non encrypted)");
-             }
-           }};
-    return true;
-  }
-
-  bool executeTlsKeyExchange(uint32_t version, WriteState& out) {
-    LOG_INFO(getLogger(), "execute tls key exchange request");
-    // Generate new key pair
-    auto new_cert_keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
-        concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);
-    fs::path enc_file_path = key_path_;
-    enc_file_path += ".enc";
-    std::string private_key_str;
-    std::fstream f(enc_file_path.string());
-    if (f.good()) {
-      private_key_str = sm_->decryptFile(enc_file_path.string()).value_or("");
-      f.close();
-    }
-    if (private_key_str.empty()) {
-      fs::path new_key_path = key_path_;
-      std::fstream f2(new_key_path);
-      if (f2.good()) {
-        private_key_str = plain_sm_.decryptFile(new_key_path.string()).value_or("");
-        f2.close();
-      }
-    }
-    if (private_key_str.empty()) LOG_FATAL(logger, "private key does not exist");
-    auto current_cert_path = (tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert").string();
-    fs::path cert_priv_key_path = tls_key_path_ / std::to_string(clientId_) / "client" / "pk.pem";
-    std::string cert_enc_priv_key_path = cert_priv_key_path.string() + ".enc";
-    std::ifstream f3(cert_enc_priv_key_path);
-    if (f3.good()) {
-      sm_->encryptFile(cert_enc_priv_key_path, new_cert_keys.first);
-      f3.close();
-    }
-    std::ifstream f4(cert_priv_key_path);
-    if (f4.good()) {
-      plain_sm_.encryptFile(cert_priv_key_path.string(), new_cert_keys.first);
-      f4.close();
-    }
-    auto cert = concord::util::crypto::CertificateUtils::generateSelfSignedCert(
-        current_cert_path, new_cert_keys.second, private_key_str);
-    plain_sm_.encryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert").string(), cert);
-    auto curr_version = std::to_string(version);
-    plain_sm_.encryptFile((tls_key_path_ / std::to_string(clientId_) / "client" / "client.cert.version").string(),
-                          curr_version);
-    LOG_INFO(this->getLogger(), "exchanged tls certificate");
-    return true;
-  }
-  uint16_t clientId_;
-  fs::path key_path_;
-  fs::path tls_key_path_;
-  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
-  concord::secretsmanager::SecretsManagerPlain plain_sm_;
-  uint64_t init_last_update_block_;
-  uint64_t init_last_tls_update_block_;
-};
-
-class ReplicaTLSKeyExchangeHandler : public IStateHandler {
- public:
-  ReplicaTLSKeyExchangeHandler(const std::string& cert_root_path) : cert_root_path_{cert_root_path} {}
-
-  bool validate(const State& state) const override {
-    concord::messages::ClientStateReply crep;
-    concord::messages::deserialize(state.data, crep);
-    return std::holds_alternative<concord::messages::ReplicaTlsExchangeKey>(crep.response);
-  }
-
-  bool execute(const State& state, WriteState& out) override {
-    bool succ = true;
-    concord::messages::ClientStateReply crep;
-    concord::messages::deserialize(state.data, crep);
-    auto command = std::get<concord::messages::ReplicaTlsExchangeKey>(crep.response);
-    auto sender_id = command.sender_id;
-    concord::messages::ReconfigurationResponse response;
-    std::string bft_replicas_cert_path = cert_root_path_ + "/" + std::to_string(sender_id) + "/server/server.cert";
-    auto current_rep_cert = sm_.decryptFile(bft_replicas_cert_path);
-    if (current_rep_cert == command.cert) return succ;
-    LOG_INFO(GL, "execute replica TLS key exchange using state transfer cre" << KVLOG(sender_id));
-    std::string cert = std::move(command.cert);
-    sm_.encryptFile(bft_replicas_cert_path, cert);
-    LOG_INFO(GL, bft_replicas_cert_path + " is updated on the disk");
-    return succ;
-  }
-
- private:
-  concord::secretsmanager::SecretsManagerPlain sm_;
-  std::string cert_root_path_;
-};
-
 class ClientsAddRemoveHandler : public IStateHandler {
  public:
   ClientsAddRemoveHandler(uint64_t init_update_block) : init_last_update_block_{init_update_block} {}
@@ -440,11 +256,17 @@ int main(int argc, char** argv) {
       enc,
       bft_clients,
       sm_));
-  cre.registerHandler(std::make_shared<ClientsAddRemoveHandler>(last_scaling_status));
-  cre.registerHandler(std::make_shared<ClientsRestartHandler>(last_resatrt_status, creParams.CreConfig.id_));
-  cre.registerHandler(std::make_shared<ReplicaTLSKeyExchangeHandler>(creParams.certFolder));
+  cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientMasterKeyExchangeHandler>(
+      creParams.CreConfig.id_,
+      creParams.bftConfig.transaction_signing_private_key_file_path.value(),
+      sm_,
+      last_pk_status));
+  cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientRestartHandler>(
+      last_resatrt_status, creParams.CreConfig.id_));
   cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ReplicaMainKeyPublicationHandler>(
       creParams.replicasKeysFolder));
+  cre.registerHandler(std::make_shared<ClientsAddRemoveHandler>(last_scaling_status));
+
   bft::client::StateControl::instance().setRestartFunc([&cre, argv]() {
     cre.stop();
     execv(argv[0], argv);


### PR DESCRIPTION
In this PR we complete the improvements for TLS exchange procedure

- remove the restriction for no more than f exchanges at once
- allow master key based signed certificates in the client side
- refactor and improve the basic CRE mechanism
- refactor and fix the Apollo tests