### PR TITLE
Removing stable state check in checkpoint messgae validation

### DIFF
--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -1052,8 +1052,7 @@ struct VerifyDbCheckpoint {
     return !st.isZero() && (sizeof(d) == sizeof(st)) && !std::memcmp(d.content(), st.get(), sizeof(st));
   }
   bool verify(const CheckpointMsg &msg, const CheckpointDesc &desc) const {
-    return (msg.isStableState() && isSame(msg.digestOfState(), desc.digestOfLastBlock) &&
-            (msg.state() == desc.lastBlock));
+    return (isSame(msg.digestOfState(), desc.digestOfLastBlock) && (msg.state() == desc.lastBlock));
   }
   BlockDigest getBlockDigest(const KeyValueBlockchain &adapter, const uint64_t &blockId) const {
     using bftEngine::bcst::computeBlockDigest;


### PR DESCRIPTION
Replicas mark checkpoint to be stable when it receives 2f+1 checkpoint messages. Some of the messages may have stable flag set to 0. Removing this check in checkpoint message validation rocksdb checkpoints