### PR TITLE
Enable concurrent delete of categories when deleting a block

### DIFF
--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -159,17 +159,17 @@ class KeyValueBlockchain {
   void deleteGenesisBlock(BlockId block_id,
                           const std::string& category_id,
                           const ImmutableOutput& updates_info,
-                          storage::rocksdb::NativeWriteBatch&);
+                          detail::LocalWriteBatch&);
 
   void deleteGenesisBlock(BlockId block_id,
                           const std::string& category_id,
                           const VersionedOutput& updates_info,
-                          storage::rocksdb::NativeWriteBatch&);
+                          detail::LocalWriteBatch&);
 
   void deleteGenesisBlock(BlockId block_id,
                           const std::string& category_id,
                           const BlockMerkleOutput& updates_info,
-                          storage::rocksdb::NativeWriteBatch&);
+                          detail::LocalWriteBatch&);
 
   void deleteLastReachableBlock(BlockId block_id,
                                 const std::string& category_id,
@@ -220,6 +220,8 @@ class KeyValueBlockchain {
 
   // currently we are operating with single thread
   util::ThreadPool thread_pool_{1};
+  // For concurrent deletion of the categories inside a block.
+  util::ThreadPool prunning_thread_pool_{2};
 
   // metrics
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -27,6 +27,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+#include "details.h"
 
 namespace concord::kvbc::categorization::detail {
 
@@ -50,7 +51,7 @@ class VersionedKeyValueCategory {
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
   // Return the number of deleted keys from the DB.
-  std::size_t deleteGenesisBlock(BlockId, const VersionedOutput &, storage::rocksdb::NativeWriteBatch &);
+  std::size_t deleteGenesisBlock(BlockId, const VersionedOutput &, detail::LocalWriteBatch &);
 
   // Delete the given block ID as a last reachable one.
   // Precondition: The given block ID must be the last reachable one.

--- a/kvbc/src/categorization/immutable_kv_category.cpp
+++ b/kvbc/src/categorization/immutable_kv_category.cpp
@@ -133,7 +133,7 @@ std::vector<std::string> ImmutableKeyValueCategory::getBlockStaleKeys(BlockId,
 
 size_t ImmutableKeyValueCategory::deleteGenesisBlock(BlockId,
                                                      const ImmutableOutput &updates_info,
-                                                     storage::rocksdb::NativeWriteBatch &batch) {
+                                                     detail::LocalWriteBatch &batch) {
   deleteBlock(updates_info, batch);
   return updates_info.tagged_keys.size();
 }
@@ -142,13 +142,6 @@ void ImmutableKeyValueCategory::deleteLastReachableBlock(BlockId,
                                                          const ImmutableOutput &updates_info,
                                                          storage::rocksdb::NativeWriteBatch &batch) {
   deleteBlock(updates_info, batch);
-}
-
-void ImmutableKeyValueCategory::deleteBlock(const ImmutableOutput &updates_info,
-                                            storage::rocksdb::NativeWriteBatch &batch) {
-  for (const auto &kv : updates_info.tagged_keys) {
-    batch.del(cf_, kv.first);
-  }
 }
 
 std::optional<Value> ImmutableKeyValueCategory::get(const std::string &key, BlockId block_id) const {

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -453,6 +453,9 @@ void KeyValueBlockchain::deleteStateTransferBlock(const BlockId block_id) {
 void KeyValueBlockchain::deleteGenesisBlock() {
   // We assume there are blocks in the system.
   auto genesis_id = block_chain_.getGenesisBlockId();
+  // If a versioned/Merkle category contains more keys than concurrent_threshold
+  // It will be executed in a separate thread.
+  const auto concurrent_threshold = 10;
   ConcordAssertGE(genesis_id, INITIAL_GENESIS_BLOCK_ID);
   // And we assume this is not the only block in the blockchain. That excludes ST temporary blocks as they are not yet
   // part of the blockchain.
@@ -470,13 +473,55 @@ void KeyValueBlockchain::deleteGenesisBlock() {
 
   // Iterate over groups and call corresponding deleteGenesisBlock,
   // Each group is responsible to fill its deltetes to the batch
+  const auto start = std::chrono::steady_clock::now();
+  std::vector<std::future<void>> futures;
+  futures.reserve((*block).data.categories_updates_info.size());
+  std::vector<detail::LocalWriteBatch> write_batches;
+  write_batches.reserve((*block).data.categories_updates_info.size());
   for (auto&& [category_id, update_info] : (*block).data.categories_updates_info) {
-    std::visit([&genesis_id, category_id = category_id, &write_batch, this](
-                   const auto& update_info) { deleteGenesisBlock(genesis_id, category_id, update_info, write_batch); },
-               update_info);
+    uint64_t num_of_keys = 0;
+    // Decide whether to perform the deletion on a separate thread based on the number of keys
+    // Immutable category, should always be sequential as its deletion is fast.
+    if (std::holds_alternative<VersionedOutput>(update_info)) {
+      num_of_keys = std::get<VersionedOutput>(update_info).keys.size();
+    } else if (std::holds_alternative<BlockMerkleOutput>(update_info)) {
+      num_of_keys = std::get<BlockMerkleOutput>(update_info).keys.size();
+    }
+    std::visit(
+        [genesis_id, category_id = category_id, &write_batches, &futures, &num_of_keys, this](const auto& update_info) {
+          write_batches.push_back(detail::LocalWriteBatch());
+          if (num_of_keys > concurrent_threshold) {
+            futures.push_back(prunning_thread_pool_.async(
+                [&](BlockId genesis_id,
+                    std::string category_id,
+                    const auto& update_info,
+                    detail::LocalWriteBatch& write_batch) {
+                  LOG_DEBUG(CAT_BLOCK_LOG, "Deletion of " << category_id << " will be performed in a seperate thread");
+                  deleteGenesisBlock(genesis_id, category_id, update_info, write_batch);
+                },
+                genesis_id,
+                category_id,
+                std::ref(update_info),
+                std::ref(write_batches.back())));
+
+          } else {
+            deleteGenesisBlock(genesis_id, category_id, update_info, write_batches.back());
+          }
+        },
+        update_info);
+  }
+  for (auto& future : futures) {
+    future.get();
+  }
+  for (auto& write_batche : write_batches) {
+    write_batche.moveToBatch(write_batch);
   }
 
   native_client_->write(std::move(write_batch));
+
+  auto jobDuration =
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count();
+  LOG_INFO(CAT_BLOCK_LOG, "CONC_DEL deleteGenesisBlock took " << jobDuration << " micro, block " << genesis_id);
   // Increment the genesis block ID cache.
   block_chain_.setGenesisBlockId(genesis_id + 1);
 }
@@ -552,28 +597,25 @@ std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
 void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const ImmutableOutput& updates_info,
-                                            storage::rocksdb::NativeWriteBatch& batch) {
-  auto num_of_deletes = std::get<detail::ImmutableKeyValueCategory>(getCategoryRef(category_id))
-                            .deleteGenesisBlock(block_id, updates_info, batch);
-  immutable_num_of_deleted_keys_ += num_of_deletes;
+                                            detail::LocalWriteBatch& batch) {
+  immutable_num_of_deleted_keys_ += std::get<detail::ImmutableKeyValueCategory>(getCategoryRef(category_id))
+                                        .deleteGenesisBlock(block_id, updates_info, batch);
 }
 
 void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const VersionedOutput& updates_info,
-                                            storage::rocksdb::NativeWriteBatch& batch) {
-  auto num_of_deletes = std::get<detail::VersionedKeyValueCategory>(getCategoryRef(category_id))
-                            .deleteGenesisBlock(block_id, updates_info, batch);
-  versioned_num_of_deletes_keys_ += num_of_deletes;
+                                            detail::LocalWriteBatch& batch) {
+  versioned_num_of_deletes_keys_ += std::get<detail::VersionedKeyValueCategory>(getCategoryRef(category_id))
+                                        .deleteGenesisBlock(block_id, updates_info, batch);
 }
 
 void KeyValueBlockchain::deleteGenesisBlock(BlockId block_id,
                                             const std::string& category_id,
                                             const BlockMerkleOutput& updates_info,
-                                            storage::rocksdb::NativeWriteBatch& batch) {
-  auto num_of_deletes = std::get<detail::BlockMerkleCategory>(getCategoryRef(category_id))
-                            .deleteGenesisBlock(block_id, updates_info, batch);
-  merkle_num_of_deleted_keys_ += num_of_deletes;
+                                            detail::LocalWriteBatch& batch) {
+  merkle_num_of_deleted_keys_ += std::get<detail::BlockMerkleCategory>(getCategoryRef(category_id))
+                                     .deleteGenesisBlock(block_id, updates_info, batch);
 }
 
 void KeyValueBlockchain::deleteLastReachableBlock(BlockId block_id,

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -194,7 +194,7 @@ std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId bl
 
 std::size_t VersionedKeyValueCategory::deleteGenesisBlock(BlockId block_id,
                                                           const VersionedOutput &out,
-                                                          storage::rocksdb::NativeWriteBatch &batch) {
+                                                          detail::LocalWriteBatch &batch) {
   auto number_of_deletes = std::size_t{0};
 
   // Delete active keys from previously pruned genesis blocks.

--- a/kvbc/test/categorization/block_merkle_category_unit_test.cpp
+++ b/kvbc/test/categorization/block_merkle_category_unit_test.cpp
@@ -160,7 +160,9 @@ class block_merkle_category : public Test {
 
   void deleteGenesisBlock(BlockId block_id, const BlockMerkleOutput &out) {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(block_id, out, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(block_id, out, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 

--- a/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
+++ b/kvbc/test/categorization/versioned_kv_category_unit_test.cpp
@@ -590,7 +590,9 @@ TEST_F(versioned_kv_category, delete_genesis_with_update) {
   // Delete genesis block 1.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(1, out1, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(1, out1, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
@@ -684,7 +686,9 @@ TEST_F(versioned_kv_category, delete_genesis_with_deletes) {
   // Delete genesis block 1.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(1, out, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(1, out, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
@@ -724,14 +728,18 @@ TEST_F(versioned_kv_category, delete_genesis_with_update_and_delete_afterwards) 
   // Delete genesis block 1.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(1, out1, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(1, out1, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
   // Delete genesis block 2.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(2, out2, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(2, out2, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
@@ -780,14 +788,18 @@ TEST_F(versioned_kv_category, delete_genesis_with_delete_and_update_afterwards) 
   // Delete genesis block 1.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(1, out1, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(1, out1, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
   // Delete genesis block 2.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(2, out2, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(2, out2, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
@@ -820,7 +832,9 @@ TEST_F(versioned_kv_category, delete_genesis_with_active_keys) {
   // Delete genesis block 1 with active keys inside.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(1, out1, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(1, out1, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
@@ -851,7 +865,9 @@ TEST_F(versioned_kv_category, delete_genesis_with_active_keys) {
   // anymore and can be deleted.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(2, out2, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(2, out2, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
@@ -888,7 +904,9 @@ TEST_F(versioned_kv_category, delete_genesis_with_active_keys_and_previous_activ
   // Delete genesis block 1 with active keys inside.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(1, out1, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(1, out1, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 
@@ -910,7 +928,9 @@ TEST_F(versioned_kv_category, delete_genesis_with_active_keys_and_previous_activ
   // active key column family.
   {
     auto batch = db->getBatch();
-    cat.deleteGenesisBlock(2, out2, batch);
+    concord::kvbc::categorization::detail::LocalWriteBatch loc_batch;
+    cat.deleteGenesisBlock(2, out2, loc_batch);
+    loc_batch.moveToBatch(batch);
     db->write(std::move(batch));
   }
 

--- a/storage/include/rocksdb/native_write_batch.ipp
+++ b/storage/include/rocksdb/native_write_batch.ipp
@@ -55,6 +55,12 @@ void NativeWriteBatch::del(const std::string &cFamily, const KeySpan &key) {
   detail::throwOnError("batch del failed"sv, std::move(s));
 }
 
+template <>
+inline void NativeWriteBatch::del<::rocksdb::Slice>(const std::string &cFamily, const ::rocksdb::Slice &key) {
+  auto s = batch_.Delete(client_->columnFamilyHandle(cFamily), key);
+  detail::throwOnError("batch del failed"sv, std::move(s));
+}
+
 template <typename KeySpan>
 void NativeWriteBatch::del(const KeySpan &key) {
   del(NativeClient::defaultColumnFamily(), key);


### PR DESCRIPTION
A block is composed of several categories, where each category writes to its own set of column families.
Deleting a block iterates over those categories, and per-category performs the dedicated logic that deletes a block for that category.

The Merkle and the Versioned category perform some non-trivial operations that make the deletion of a block a slow operation.

An important observation is that deleting a category is a local event i.e., each category is isolated, and its set of updates 
affects only its column families. Therefore we can concurrently perform the internal category deletion.

Since the NativeWriteSet is not thread-safe, this PR introduces a LocalWriteSet, that has the same put and delete interface as the NativeWriteSet, it knows to keep the order of the operations and can be instantiated per category and then merged into the single NativeWriteSet that eventually performs the write to storage.

When deleting a genesis block, if the Merkle or Version categories have some amount of keys that exceed a threshold, their deletion will be executed as a job on a dedicated thread pool. 

Measurements show that, on average, it improves the deletion by 15%. 