### PR TITLE
Update events.proto doc

### DIFF
--- a/client/proto/event/v1/event.proto
+++ b/client/proto/event/v1/event.proto
@@ -38,7 +38,7 @@ service EventService {
 
 // Events come in two formats - Events (old API) and EventGroups (new API).
 // An EventsRequest will result in a stream of EventGroups or a stream of Events which turns into a stream of EventGroups.
-// If the block requested by EventsRequest contains EventGroups only then the stream will start at EventGroup id 0.
+// If the block requested by EventsRequest contains EventGroups only then the stream will start at EventGroup id 1.
 // An EventGroupsRequest will result in a stream of EventGroups.
 // If you don't know about Events then use EventGroupsRequest.
 message SubscribeRequest {


### PR DESCRIPTION
EventGroups start at index 1. Zero is an invalid event group id. This change
updates the documentation accordingly.