### PR TITLE
Add support for the StateSnapshotRequest

### DIFF
--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -329,9 +329,9 @@ void Replica::createReplicaAndSyncState() {
       m_replicaPtr->persistentStorage(),
       aggregator_,
       [this]() -> uint64_t { return getLastBlockId(); },
-      [](BlockId blockIdAtCheckpoint, const std::string &path) {
-        if (blockIdAtCheckpoint < INITIAL_GENESIS_BLOCK_ID) {
-          LOG_INFO(GL, "DB checkpoint done at block ID = " << blockIdAtCheckpoint << ", no need to prepare it");
+      [](BlockId block_id_at_checkpoint, const std::string &path) {
+        if (block_id_at_checkpoint < INITIAL_GENESIS_BLOCK_ID) {
+          LOG_INFO(GL, "DB checkpoint done at block ID = " << block_id_at_checkpoint << ", no need to prepare it");
           return;
         }
         const auto read_only = false;
@@ -339,7 +339,7 @@ void Replica::createReplicaAndSyncState() {
         auto db = storage::rocksdb::NativeClient::newClient(
             path, read_only, storage::rocksdb::NativeClient::DefaultOptions{});
         auto kvbc = categorization::KeyValueBlockchain{db, link_st_chain};
-        while (blockIdAtCheckpoint < kvbc.getLastReachableBlockId()) {
+        while (block_id_at_checkpoint < kvbc.getLastReachableBlockId()) {
           LOG_INFO(
               GL, "Deleting last reachable block = " << kvbc.getLastReachableBlockId() << ", DB checkpoint = " << path);
           kvbc.deleteLastReachableBlock();

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -325,8 +325,25 @@ void Replica::createReplicaAndSyncState() {
   handleNewEpochEvent();
   handleWedgeEvent();
   bftEngine::impl::DbCheckpointManager::instance().initializeDbCheckpointManager(
-      m_dbSet.dataDBClient, m_replicaPtr->persistentStorage(), aggregator_, [this]() -> uint64_t {
-        return getLastBlockId();
+      m_dbSet.dataDBClient,
+      m_replicaPtr->persistentStorage(),
+      aggregator_,
+      [this]() -> uint64_t { return getLastBlockId(); },
+      [](BlockId blockIdAtCheckpoint, const std::string &path) {
+        if (blockIdAtCheckpoint < INITIAL_GENESIS_BLOCK_ID) {
+          LOG_INFO(GL, "DB checkpoint done at block ID = " << blockIdAtCheckpoint << ", no need to prepare it");
+          return;
+        }
+        const auto read_only = false;
+        const auto link_st_chain = false;
+        auto db = storage::rocksdb::NativeClient::newClient(
+            path, read_only, storage::rocksdb::NativeClient::DefaultOptions{});
+        auto kvbc = categorization::KeyValueBlockchain{db, link_st_chain};
+        while (blockIdAtCheckpoint < kvbc.getLastReachableBlockId()) {
+          LOG_INFO(
+              GL, "Deleting last reachable block = " << kvbc.getLastReachableBlockId() << ", DB checkpoint = " << path);
+          kvbc.deleteLastReachableBlock();
+        }
       });
 }
 

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -286,6 +286,33 @@ Msg CreateDbCheckpointCommand 63 {
     uint64 sender_id
 }
 
+# Sent by Clientservice to the replicas to request a DB snapshot.
+Msg StateSnapshotRequest 65 {
+  # Checkpoint the state every `checkpoint_kv_count` key-value pairs.
+  # Note: Ignored in this version of the protocol as it only supports state snapshot
+  # for new participant IDs (meaning we will only stream a relatively small amount of public state
+  # and, therefore, we don't need multiple checkpoints).
+  uint64 checkpoint_kv_count
+
+  # The participant ID that requested a snapshot.
+  string participant_id
+}
+
+Msg StateSnapshotData 66 {
+  # Unique identifier of the DB snapshot.
+  uint64 snapshot_id
+
+  # The event group ID at which the state snapshot with `snapshot_id` was taken.
+  uint64 event_group_id
+}
+
+# The response to a `StateSnapshotRequest`. Sent by the replicas to Clientservice.
+Msg StateSnapshotResponse 67 {
+  # If `data` is not set, it means that state snapshot is being created at the moment.
+  # The user is required to retry the request after some *random* amount of time has elapsed.
+  optional StateSnapshotData data
+}
+
 Msg ReconfigurationRequest 1 {
   uint64 sender
   bytes signature
@@ -323,6 +350,7 @@ Msg ReconfigurationRequest 1 {
     GetDbCheckpointInfoRequest
     CreateDbCheckpointCommand
     ReplicaMainKeyUpdate
+    StateSnapshotRequest
   } command
   bytes additional_data
 }
@@ -346,6 +374,7 @@ Msg ReconfigurationResponse 2 {
     ClientKeyExchangeStatusResponse
     ClientsRestartStatusResponse
     GetDbCheckpointInfoStatusResponse
+    StateSnapshotResponse
   } response
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -269,6 +269,14 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::StateSnapshotRequest &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const = 0;

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -81,6 +81,12 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
               const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
 
+  bool handle(const concord::messages::StateSnapshotRequest &,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
+
  private:
   void handleWedgeCommands(
       bool bft_support, bool remove_metadata, bool restart, bool unwedge, bool blockNewConnections);

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -236,7 +236,8 @@ bool ReconfigurationHandler::handle(const concord::messages::StateSnapshotReques
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>& timestamp,
                                     concord::messages::ReconfigurationResponse& rres) {
-  if (!bftEngine::ReplicaConfig::instance().dbCheckpointFeatureEnabled) {
+  if (!bftEngine::ReplicaConfig::instance().dbCheckpointFeatureEnabled ||
+      bftEngine::ReplicaConfig::instance().maxNumberOfDbCheckpoints == 0) {
     const auto err = "StateSnapshotRequest(participant ID = " + cmd.participant_id +
                      "): failed, the DB checkpoint feature is disabled";
     LOG_WARN(getLogger(), err);

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -231,6 +231,52 @@ bool ReconfigurationHandler::handle(const concord::messages::CreateDbCheckpointC
   }
 }
 
+bool ReconfigurationHandler::handle(const concord::messages::StateSnapshotRequest& cmd,
+                                    uint64_t sequence_number,
+                                    uint32_t,
+                                    const std::optional<bftEngine::Timestamp>& timestamp,
+                                    concord::messages::ReconfigurationResponse& rres) {
+  if (!bftEngine::ReplicaConfig::instance().dbCheckpointFeatureEnabled) {
+    const auto err = "StateSnapshotRequest(participant ID = " + cmd.participant_id +
+                     "): failed, the DB checkpoint feature is disabled";
+    LOG_WARN(getLogger(), err);
+    rres.response = concord::messages::ReconfigurationErrorMsg{err};
+    return false;
+  }
+
+  auto resp = StateSnapshotResponse{};
+  const auto last_checkpoint_desc = DbCheckpointManager::instance().getLastCreatedDbCheckpointMetadata();
+  // TODO: We currently only support new participants and, therefore, the event group ID will always be the one before
+  // the first one, namely 0.
+  if (last_checkpoint_desc) {
+    resp.data.emplace();
+    resp.data->snapshot_id = last_checkpoint_desc->checkPointId_;
+    resp.data->event_group_id = 0;
+    LOG_INFO(getLogger(),
+             "StateSnapshotRequest(participant ID = " << cmd.participant_id << "): using existing last checkpoint ID: "
+                                                      << last_checkpoint_desc->checkPointId_);
+  } else {
+    const auto checkpoint_id = DbCheckpointManager::instance().createDbCheckpointAsync(sequence_number, timestamp);
+    if (checkpoint_id) {
+      resp.data.emplace();
+      resp.data->snapshot_id = *checkpoint_id;
+      resp.data->event_group_id = 0;
+      LOG_INFO(getLogger(),
+               "StateSnapshotRequest(participant ID = " << cmd.participant_id
+                                                        << "): creating checkpoint with ID: " << *checkpoint_id);
+    } else {
+      // If we couldn't create a DB checkpoint and there is no last one created, we just leave `resp.data`
+      // nullopt, indicating to the client that it should retry.
+      LOG_INFO(getLogger(),
+               "StateSnapshotRequest(participant ID = "
+                   << cmd.participant_id
+                   << "): cannot create a checkpoint and there is no existing one, client must retry");
+    }
+  }
+  rres.response = std::move(resp);
+  return true;
+}
+
 BftReconfigurationHandler::BftReconfigurationHandler() {
   auto operatorPubKeyPath = bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_;
   if (operatorPubKeyPath.empty()) {

--- a/storage/include/rocksdb/client.h
+++ b/storage/include/rocksdb/client.h
@@ -107,6 +107,7 @@ class Client : public concord::storage::IDBClient {
   std::string getPath() const override { return m_dbPath; }
   void setCheckpointPath(const std::string& path) override { dbCheckpointPath_ = path; }
   std::string getCheckpointPath() const override { return dbCheckpointPath_; }
+  std::string getPathForCheckpoint(std::uint64_t checkpointId) const override;
   concordUtils::Status createCheckpoint(const uint64_t& checkPointId) override;
   std::vector<uint64_t> getListOfCreatedCheckpoints() const override;
   void removeCheckpoint(const uint64_t& checkPointId) const override;

--- a/storage/include/storage/db_interface.h
+++ b/storage/include/storage/db_interface.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "assertUtils.hpp"
 #include "sliver.hpp"
 #include "status.hpp"
 #include <unordered_map>
@@ -76,6 +77,7 @@ class IDBClient {
   virtual std::string getPath() const { return ""; };
   virtual void setCheckpointPath(const std::string&){};
   virtual std::string getCheckpointPath() const { return "NotSupported"; };
+  virtual std::string getPathForCheckpoint(std::uint64_t checkpointId) const { ConcordAssert(false); };
   virtual std::vector<uint64_t> getListOfCreatedCheckpoints() const { return {}; }
   virtual void removeCheckpoint(const uint64_t&) const {}
   virtual void removeAllCheckpoints() const {};

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -578,6 +578,10 @@ Status Client::rangeDel(const Sliver &_beginKey, const Sliver &_endKey) {
   return Status::OK();
 }
 
+std::string Client::getPathForCheckpoint(std::uint64_t checkpointId) const {
+  return (fs::path{dbCheckpointPath_} / std::to_string(checkpointId)).string();
+}
+
 Status Client::createCheckpoint(const uint64_t &checkPointId) {
   if (!dbCheckPoint_.get()) return Status::GeneralError("Checkpoint instance is not initialized");
   // create dir(remove if already exist)
@@ -592,7 +596,7 @@ Status Client::createCheckpoint(const uint64_t &checkPointId) {
     if (!fs::exists(path)) {
       fs::create_directory(path);
     }
-    fs::path chkptDirPath = path / std::to_string(checkPointId);
+    fs::path chkptDirPath = getPathForCheckpoint(checkPointId);
     // rocksDb create the dir for the checkpoint
     if (fs::exists(chkptDirPath)) fs::remove_all(chkptDirPath);
 

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -133,7 +133,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
             await skvbc.send_write_kv_set()
         await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 150)
         num_of_db_snapshots =  await bft_network.get_metric(0, bft_network, "Counters", "numOfDbCheckpointsCreated", component="rocksdbCheckpoint")
-        assert num_of_db_snapshots == 1
+        self.assertEqual(num_of_db_snapshots, 1)
         last_blockId =  await bft_network.get_metric(0, bft_network, "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
         for replica_id in range(len(bft_network.all_replicas())):
             self.verify_snapshot_is_available(bft_network, replica_id, last_blockId)
@@ -149,7 +149,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
             await skvbc.send_write_kv_set()
         await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 150)
         num_of_db_snapshots =  await bft_network.get_metric(0, bft_network, "Counters", "numOfDbCheckpointsCreated", component="rocksdbCheckpoint")
-        assert num_of_db_snapshots == 1
+        self.assertEqual(num_of_db_snapshots, 1)
         snapshot_id = await bft_network.get_metric(0, bft_network, "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
         for replica_id in range(len(bft_network.all_replicas())):
             self.verify_snapshot_is_available(bft_network, replica_id, snapshot_id)
@@ -186,7 +186,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
             await skvbc.send_write_kv_set()
         await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 300)
         num_of_db_snapshots =  await bft_network.get_metric(0, bft_network, "Counters", "numOfDbCheckpointsCreated", component="rocksdbCheckpoint")
-        assert num_of_db_snapshots == 0
+        self.assertEqual(num_of_db_snapshots, 0)
     
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7)
@@ -211,7 +211,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
         self.assertGreaterEqual(checkpoint_before + 1, checkpoint_after_1)
         await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), checkpoint_after_1*150)
         num_of_db_snapshots =  await bft_network.get_metric(0, bft_network, "Counters", "numOfDbCheckpointsCreated", component="rocksdbCheckpoint")
-        assert num_of_db_snapshots == 1
+        self.assertEqual(num_of_db_snapshots, 1)
         old_snapshot_id = await bft_network.get_metric(0, bft_network, "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
         self.verify_snapshot_is_available(bft_network, 0, old_snapshot_id)
         await skvbc.fill_and_wait_for_checkpoint(
@@ -224,7 +224,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
         self.assertGreaterEqual(checkpoint_after_1 + 3, checkpoint_after_2)
         await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), checkpoint_after_2*150)
         num_of_db_snapshots =  await bft_network.get_metric(0, bft_network, "Counters", "numOfDbCheckpointsCreated", component="rocksdbCheckpoint")
-        assert num_of_db_snapshots == 4
+        self.assertEqual(num_of_db_snapshots, 4)
         for replica_id in range(len(bft_network.all_replicas())):
             self.verify_snapshot_is_available(bft_network, replica_id, old_snapshot_id, isPresent=False)
 
@@ -244,19 +244,19 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
         op = operator.Operator(bft_network.config, client, bft_network.builddir)
         rep = await op.create_dbcheckpoint_cmd()
         data = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
-        assert(data.success == True)
+        self.assertTrue(data.success)
 
         await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 300)
 
         getrep = await op.get_dbcheckpoint_info_request()
         rsi_rep = client.get_rsi_replies()
         data = cmf_msgs.ReconfigurationResponse.deserialize(getrep)[0]
-        assert(data.success == True)
+        self.assertTrue(data.success)
         for r in rsi_rep.values():
             res = cmf_msgs.ReconfigurationResponse.deserialize(r)
-            assert(len(res[0].response.db_checkpoint_info) == 1)
+            self.assertEqual(len(res[0].response.db_checkpoint_info), 1)
             dbcheckpoint_info_list = res[0].response.db_checkpoint_info
-            assert(any(dbcheckpoint_info.seq_num == 300 for dbcheckpoint_info in dbcheckpoint_info_list))
+            self.assertTrue(any(dbcheckpoint_info.seq_num == 300 for dbcheckpoint_info in dbcheckpoint_info_list))
         last_blockId =  await bft_network.get_metric(0, bft_network, "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
         for replica_id in range(len(bft_network.all_replicas())):
             self.verify_snapshot_is_available(bft_network, replica_id, last_blockId)
@@ -276,19 +276,19 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
         # There will be 2 dbcheckpoints created on stable seq num 150 and 300.
         await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 300)
         num_of_db_snapshots =  await bft_network.get_metric(0, bft_network, "Counters", "numOfDbCheckpointsCreated", component="rocksdbCheckpoint")
-        assert num_of_db_snapshots == 2
+        self.assertEqual(num_of_db_snapshots, 2)
         
         op = operator.Operator(bft_network.config, client, bft_network.builddir)
         rep = await op.get_dbcheckpoint_info_request()
         rsi_rep = client.get_rsi_replies()
         data = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
-        assert(data.success == True)
+        self.assertTrue(data.success)
         for r in rsi_rep.values():
             res = cmf_msgs.ReconfigurationResponse.deserialize(r)
-            assert(len(res[0].response.db_checkpoint_info) == 2)
+            self.assertEqual(len(res[0].response.db_checkpoint_info), 2)
             dbcheckpoint_info_list = res[0].response.db_checkpoint_info
-            assert(any(dbcheckpoint_info.seq_num == 150 for dbcheckpoint_info in dbcheckpoint_info_list))
-            assert(any(dbcheckpoint_info.seq_num == 300 for dbcheckpoint_info in dbcheckpoint_info_list))
+            self.assertTrue(any(dbcheckpoint_info.seq_num == 150 for dbcheckpoint_info in dbcheckpoint_info_list))
+            self.assertTrue(any(dbcheckpoint_info.seq_num == 300 for dbcheckpoint_info in dbcheckpoint_info_list))
         last_blockId =  await bft_network.get_metric(0, bft_network, "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
         for replica_id in range(len(bft_network.all_replicas())):
             self.verify_snapshot_is_available(bft_network, replica_id, last_blockId)
@@ -377,7 +377,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
             if isPresent == True:
                 self.assertTrue(self.snapshot_exists(bft_network, replica_id, snapshot_id))
             else:
-                assert (os.path.exists(snapshot_db_dir) == False)
+                self.assertFalse(os.path.exists(snapshot_db_dir))
 
     def snapshot_exists(self, bft_network, replica_id, snapshot_id=None):
       with log.start_action(action_type="snapshot_exists()"):

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -176,6 +176,12 @@ class Operator:
         cp_command = cmf_msgs.CreateDbCheckpointCommand()
         cp_command.sender_id = 1000
         return self._construct_basic_reconfiguration_request(cp_command)
+
+    def _construct_reconfiguration_state_snapshot_req(self):
+        req = cmf_msgs.StateSnapshotRequest()
+        req.checkpoint_kv_count = 0
+        req.participant_id = 'apollo_test_participant_id'
+        return self._construct_basic_reconfiguration_request(req)
     
     def get_rsi_replies(self):
         return self.client.get_rsi_replies()
@@ -297,3 +303,7 @@ class Operator:
     async def create_dbcheckpoint_cmd(self):
         cp = self._construct_reconfiguration_create_dbcheckpoint_command()
         return await self.client.write(cp.serialize(), reconfiguration=True)
+
+    async def state_snapshot_req(self):
+        req = self._construct_reconfiguration_state_snapshot_req()
+        return await self.client.write(req.serialize(), reconfiguration=True)


### PR DESCRIPTION
The StateSnapshotRequest is sent by Clientservice to the replicas to
create a state snapshot and get:
 * the snapshot identifier
 * the event group ID at which the state snapshot is created

On receiving StateSnapshotRequest, we first check if there is an
existing checkpoint. If yes, we use it. If not, we create a new one
asynchronously.

When creating a checkpoint asynchronously, the StateSnapshotRequest
might arrive at block ID = P. However, since the snapshot is done in a
separate thread, the actual block ID might be block ID = Q, where Q > P.
In order to make the snapshots equivalent on all replicas, we introduce
a callback in DbCheckpointManager that prepares the checkpoint for use.
In that case, it will delete all last reachable blocks from Q back to P,
leaving all replicas' checkpoints with last reachable block ID = P.

Currently, we only support snapshots for new participants, meaning that
we will only focus on streaming public state.