### PR TITLE
 Introduce TlsMultiplexCommunication

### DIFF
--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -113,12 +113,12 @@ class FakeCommunication : public bft::communication::ICommunication {
   bool isRunning() const override { return true; }
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override { return ConnectionStatus::Connected; }
 
-  int send(NodeNum destNode, std::vector<uint8_t>&& msg) override {
+  int send(NodeNum destNode, std::vector<uint8_t>&& msg, NodeNum endpointNum) override {
     runner_.send(MsgFromClient{ReplicaId{(uint16_t)destNode}, std::move(msg)});
     return 0;
   }
 
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg, NodeNum endpointNum) override {
     for (auto& d : dests) {
       // This is a class used for unit testing, so a copy is passed for simplicity
       runner_.send(MsgFromClient{ReplicaId{(uint16_t)d}, msg});  // a copy is made here!
@@ -157,7 +157,7 @@ inline std::vector<uint8_t> createReply(const MsgFromClient& msg, std::vector<ui
   return reply;
 }
 
-inline void immideateBehaviour(const MsgFromClient& msg, IReceiver* client_receiver) {
+inline void immediateBehaviour(const MsgFromClient& msg, IReceiver* client_receiver) {
   std::vector<uint8_t> reply = createReply(msg);
   client_receiver->onNewMessage(msg.destination.val, reinterpret_cast<const char*>(reply.data()), reply.size());
 }

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -224,13 +224,13 @@ Reply Client::send(const MatchConfig& match_config,
   while (std::chrono::steady_clock::now() < end) {
     bft::client::Msg msg(orig_msg);  // create copy here due to the loop
     if (primary_ && !read_only) {
-      communication_->send(primary_.value().val, std::move(msg));
+      communication_->send(primary_.value().val, std::move(msg), config_.id.val);
     } else {
       std::set<bft::communication::NodeNum> dests;
       for (const auto& d : match_config.quorum.destinations) {
         dests.emplace(d.val);
       }
-      communication_->send(dests, std::move(msg));
+      communication_->send(dests, std::move(msg), config_.id.val);
     }
 
     if (auto reply = wait()) {
@@ -257,13 +257,13 @@ SeqNumToReplyMap Client::sendBatch(std::deque<WriteRequest>& write_requests, con
   while (std::chrono::steady_clock::now() < end && replies.size() != pending_requests_.size()) {
     bft::client::Msg msg(batch_msg);  // create copy here due to the loop
     if (primary_) {
-      communication_->send(primary_.value().val, std::move(msg));
+      communication_->send(primary_.value().val, std::move(msg), config_.id.val);
     } else {
       std::set<bft::communication::NodeNum> dests;
       for (const auto& d : match_config.quorum.destinations) {
         dests.emplace(d.val);
       }
-      communication_->send(dests, std::move(msg));
+      communication_->send(dests, std::move(msg), config_.id.val);
     }
 
     wait(replies);

--- a/bftclient/src/msg_receiver.cpp
+++ b/bftclient/src/msg_receiver.cpp
@@ -39,7 +39,10 @@ void UnmatchedReplyQueue::clear() {
   msgs_.clear();
 }
 
-void MsgReceiver::onNewMessage(bft::communication::NodeNum source, const char* const message, size_t msg_len) {
+void MsgReceiver::onNewMessage(bft::communication::NodeNum source,
+                               const char* const message,
+                               size_t msg_len,
+                               bft::communication::NodeNum endpointNum) {
   auto max_reply_size = max_reply_size_.load();
   if (max_reply_size == 0) {
     // There are no outstanding requests, so any replies are stale.

--- a/bftclient/src/msg_receiver.h
+++ b/bftclient/src/msg_receiver.h
@@ -83,7 +83,10 @@ class MsgReceiver : public bft::communication::IReceiver {
  public:
   // IReceiver methods
   // These are called from the ASIO thread when a new message is received.
-  void onNewMessage(bft::communication::NodeNum sourceNode, const char* const message, size_t messageLength) override;
+  void onNewMessage(bft::communication::NodeNum sourceNode,
+                    const char* const message,
+                    size_t messageLength,
+                    bft::communication::NodeNum endpointNum = bft::communication::MAX_ENDPOINT_NUM) override;
 
   void onConnectionStatusChanged(bft::communication::NodeNum node,
                                  bft::communication::ConnectionStatus newStatus) override {}

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -247,6 +247,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                std::uint32_t,
                30u,
                "Amount of keys to get at once via multiGet when iterating state");
+               
+  CONFIG_PARAM(enableMultiplexChannel, bool, false, "whether multiplex channel communication is enabled")
 
   // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters
@@ -361,6 +363,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, enablePostExecutionSeparation);
     serialize(outStream, postExecutionQueuesSize);
     serialize(outStream, config_params_);
+    serialize(outStream, enableMultiplexChannel);
   }
   void deserializeDataMembers(std::istream& inStream) {
     deserialize(inStream, isReadOnly);
@@ -449,6 +452,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, enablePostExecutionSeparation);
     deserialize(inStream, postExecutionQueuesSize);
     deserialize(inStream, config_params_);
+    deserialize(inStream, enableMultiplexChannel);
   }
 
  private:
@@ -529,7 +533,8 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.dbCheckPointWindowSize,
               rc.dbCheckpointDirPath,
               rc.dbSnapshotIntervalSeconds.count(),
-              rc.dbCheckpointMonitorIntervalSeconds.count());
+              rc.dbCheckpointMonitorIntervalSeconds.count(),
+              rc.enableMultiplexChannel);
 
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -247,8 +247,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                std::uint32_t,
                30u,
                "Amount of keys to get at once via multiGet when iterating state");
-               
-  CONFIG_PARAM(enableMultiplexChannel, bool, false, "whether multiplex channel communication is enabled")
+
+  CONFIG_PARAM(enableMultiplexChannel, bool, false, "whether multiplex communication channel is enabled")
 
   // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters

--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -48,13 +48,13 @@ class Communication : public ICommunication {
     if (!is_running_) return ConnectionStatus::Disconnected;
     return ConnectionStatus::Connected;
   }
-  int send(NodeNum destNode, std::vector<uint8_t>&& msg) override {
+  int send(NodeNum destNode, std::vector<uint8_t>&& msg, NodeNum endpointNum) override {
     if (destNode == repId_) {
       return msg.size();
     }
     return msgsCommunicator_->sendAsyncMessage(destNode, reinterpret_cast<char*>(msg.data()), msg.size());
   }
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg) override {
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg, NodeNum endpointNum) override {
     auto ret = dests;
     if (dests.find(repId_) != dests.end()) {
       dests.erase(repId_);

--- a/bftengine/src/bftengine/MsgReceiver.cpp
+++ b/bftengine/src/bftengine/MsgReceiver.cpp
@@ -21,7 +21,10 @@ using namespace bft::communication;
 
 MsgReceiver::MsgReceiver(std::shared_ptr<IncomingMsgsStorage> &storage) : incomingMsgsStorage_(storage) {}
 
-void MsgReceiver::onNewMessage(NodeNum sourceNode, const char *const message, size_t messageLength) {
+void MsgReceiver::onNewMessage(NodeNum sourceNode,
+                               const char *const message,
+                               size_t messageLength,
+                               NodeNum endpointNum) {
   if (messageLength > ReplicaConfig::instance().getmaxExternalMessageSize()) {
     LOG_WARN(GL, "Msg exceeds allowed max msg size, size " << messageLength << " source " << sourceNode);
     return;

--- a/bftengine/src/bftengine/MsgReceiver.hpp
+++ b/bftengine/src/bftengine/MsgReceiver.hpp
@@ -22,7 +22,10 @@ class MsgReceiver : public bft::communication::IReceiver {
   explicit MsgReceiver(std::shared_ptr<IncomingMsgsStorage>& storage);
   virtual ~MsgReceiver() = default;
 
-  void onNewMessage(bft::communication::NodeNum sourceNode, const char* const message, size_t messageLength) override;
+  void onNewMessage(bft::communication::NodeNum sourceNode,
+                    const char* const message,
+                    size_t messageLength,
+                    bft::communication::NodeNum endpointNum) override;
   void onConnectionStatusChanged(const bft::communication::NodeNum node,
                                  const bft::communication::ConnectionStatus newStatus) override;
 

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -87,7 +87,10 @@ class DummyReceiver : public IReceiver {
  public:
   virtual ~DummyReceiver() = default;
 
-  void onNewMessage(const NodeNum sourceNode, const char* const message, const size_t messageLength) override {}
+  void onNewMessage(const NodeNum sourceNode,
+                    const char* const message,
+                    const size_t messageLength,
+                    NodeNum endpointNum) override {}
   void onConnectionStatusChanged(const NodeNum node, const ConnectionStatus newStatus) override {}
 };
 

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -246,7 +246,7 @@ void ConcordClient::CreateClient(ConcordClientPoolConfig& config, const SimpleCl
       std::unique_ptr<FakeCommunication> fakecomm(new FakeCommunication(delayedBehaviour));
       comm_ = std::move(fakecomm);
     } else {
-      std::unique_ptr<FakeCommunication> fakecomm(new FakeCommunication(immideateBehaviour));
+      std::unique_ptr<FakeCommunication> fakecomm(new FakeCommunication(immediateBehaviour));
       comm_ = std::move(fakecomm);
     }
   } else {

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -28,13 +28,18 @@
 
 namespace bft::communication {
 typedef struct sockaddr_in Addr;
-
 struct NodeInfo {
   std::string host;
   std::uint16_t port;
   bool isReplica;
 };
-
+#pragma pack(push, 1)
+struct Header {
+  uint32_t msg_size;
+  NodeNum endpoint_num;
+};
+#pragma pack(pop)
+static constexpr size_t MSG_HEADER_SIZE = sizeof(Header);
 typedef std::unordered_map<NodeNum, NodeInfo> NodeMap;
 
 enum CommType { PlainUdp, SimpleAuthUdp, PlainTcp, SimpleAuthTcp, TlsTcp };
@@ -133,8 +138,8 @@ class PlainUDPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int send(NodeNum destNode, std::vector<uint8_t> &&msg) override;
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
+  int send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
@@ -160,8 +165,8 @@ class PlainTCPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int send(NodeNum destNode, std::vector<uint8_t> &&msg) override;
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
+  int send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 
@@ -189,8 +194,8 @@ class TlsTCPCommunication : public ICommunication {
   bool isRunning() const override;
   ConnectionStatus getCurrentConnectionStatus(NodeNum node) override;
 
-  int send(NodeNum destNode, std::vector<uint8_t> &&msg) override;
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
+  int send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override;
 

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -19,6 +19,7 @@
 namespace bft::communication {
 
 typedef uint64_t NodeNum;
+const NodeNum MAX_ENDPOINT_NUM = 0xFFFFFFFFFFFFFFFF;
 
 enum class ConnectionStatus { Unknown = 0, Connected, Disconnected };
 
@@ -27,7 +28,10 @@ class IReceiver {
   // Invoked when a new message is received
   // Notice that the memory pointed by message may be freed immediately
   // after the execution of this method.
-  virtual void onNewMessage(NodeNum sourceNode, const char* const message, size_t messageLength) = 0;
+  virtual void onNewMessage(NodeNum sourceNode,
+                            const char* const message,
+                            size_t messageLength,
+                            NodeNum endpointNum = MAX_ENDPOINT_NUM) = 0;
 
   // Invoked when the known status of a connection is changed.
   // For each NodeNum, this method will never be concurrently
@@ -56,14 +60,16 @@ class ICommunication {
   // destination node. Asynchronous (non-blocking) method.
   // The function takes ownership of the buffer provided.
   // Returns 0 on success.
-  virtual int send(NodeNum destNode, std::vector<uint8_t>&& msg) = 0;
+  virtual int send(NodeNum destNode, std::vector<uint8_t>&& msg, NodeNum endpointNum = MAX_ENDPOINT_NUM) = 0;
 
   // Sends a message to all nodes in dests set.
   // The function takes ownership of the buffer provided.
   // The return value is a set<NodeNum>.
   //    On success the set is empty.
   //    On failure it contains the NodeNum-s of the destinations for which the message sending has failed.
-  virtual std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg) = 0;
+  virtual std::set<NodeNum> send(std::set<NodeNum> dests,
+                                 std::vector<uint8_t>&& msg,
+                                 NodeNum endpointNum = MAX_ENDPOINT_NUM) = 0;
 
   virtual void setReceiver(NodeNum receiverNum, IReceiver* receiver) = 0;
 

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -153,6 +153,9 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Return the recently read size header as an integer. Assume network byte order.
   uint32_t getReadMsgSize();
 
+  // Return the recently read endpoint number from header as an integer. Assume network byte order
+  NodeNum getReadMsgEndpointNum() const;
+
   void startReadTimer();
   void startWriteTimer();
 

--- a/communication/src/PlainTcpCommunication.cpp
+++ b/communication/src/PlainTcpCommunication.cpp
@@ -847,11 +847,13 @@ ConnectionStatus PlainTCPCommunication::getCurrentConnectionStatus(const NodeNum
   return ptrImpl_->getCurrentConnectionStatus(node);
 }
 
-int PlainTCPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg) {
+int PlainTCPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum) {
   return ptrImpl_->sendAsyncMessage(destNode, (char *)msg.data(), msg.size());
 }
 
-std::set<NodeNum> PlainTCPCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
+std::set<NodeNum> PlainTCPCommunication::send(std::set<NodeNum> dests,
+                                              std::vector<uint8_t> &&msg,
+                                              NodeNum endpointNum) {
   std::set<NodeNum> failed_nodes;
   for (auto &d : dests) {
     if (ptrImpl_->sendAsyncMessage(d, (char *)msg.data(), msg.size()) != 0) {

--- a/communication/src/PlainUDPCommunication.cpp
+++ b/communication/src/PlainUDPCommunication.cpp
@@ -364,12 +364,14 @@ ConnectionStatus PlainUDPCommunication::getCurrentConnectionStatus(NodeNum node)
   return ptrImpl_->getCurrentConnectionStatus(node);
 }
 
-int PlainUDPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg) {
+int PlainUDPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum) {
   auto m = std::make_shared<std::vector<uint8_t>>(std::move(msg));
   return ptrImpl_->sendAsyncMessage(destNode, m);
 }
 
-std::set<NodeNum> PlainUDPCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
+std::set<NodeNum> PlainUDPCommunication::send(std::set<NodeNum> dests,
+                                              std::vector<uint8_t> &&msg,
+                                              NodeNum endpointNum) {
   std::set<NodeNum> failed_nodes;
   auto m = std::make_shared<std::vector<uint8_t>>(std::move(msg));
   for (auto &d : dests) {

--- a/communication/src/TlsConnectionManager.h
+++ b/communication/src/TlsConnectionManager.h
@@ -28,7 +28,6 @@ class AsyncTlsConnection;
 //
 // Peers with higher ids connect to peers with lower ids.
 class ConnectionManager {
-  static constexpr size_t MSG_HEADER_SIZE = 4;
   static constexpr std::chrono::seconds CONNECT_TICK = std::chrono::seconds(1);
   friend class Runner;
   friend class AsyncTlsConnection;

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -51,15 +51,15 @@ ConnectionStatus TlsTCPCommunication::getCurrentConnectionStatus(const NodeNum n
   return runner_->getCurrentConnectionStatus(node);
 }
 
-int TlsTCPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg) {
-  auto outgoingMsg = std::make_shared<tls::OutgoingMsg>(std::move(msg));
+int TlsTCPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum) {
+  auto outgoingMsg = std::make_shared<tls::OutgoingMsg>(std::move(msg), endpointNum);
   runner_->send(destNode, outgoingMsg);
   return 0;
 }
 
-std::set<NodeNum> TlsTCPCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) {
+std::set<NodeNum> TlsTCPCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum endpointNum) {
   std::set<NodeNum> failed_nodes;
-  auto outgoingMsg = std::make_shared<tls::OutgoingMsg>(std::move(msg));
+  auto outgoingMsg = std::make_shared<tls::OutgoingMsg>(std::move(msg), endpointNum);
   runner_->send(dests, outgoingMsg);
   return failed_nodes;
 }

--- a/communication/src/TlsWriteQueue.h
+++ b/communication/src/TlsWriteQueue.h
@@ -26,26 +26,18 @@
 #include "communication/CommDefs.hpp"
 #include "Logger.hpp"
 #include "TlsDiagnostics.h"
-
+#include "endianness.hpp"
 namespace bft::communication::tls {
-#pragma pack(push, 1)
-struct Header {
-  uint32_t msg_size;
-  NodeNum endpoint_num;
-};
-#pragma pack(pop)
 // Any message attempted to be put on the queue that causes the total size of the queue to exceed
 // this value will be dropped. This is to prevent indefinite backups and useless stale messages.
 // The number is very large right now so as not to affect current setups. In the future we will
 // have better admission control.
 static constexpr size_t MAX_QUEUE_SIZE_IN_BYTES = 1024 * 1024 * 1024;  // 1 GB
-static constexpr size_t MSG_HEADER_SIZE = sizeof(Header);
-
 struct OutgoingMsg {
   OutgoingMsg(std::vector<uint8_t>&& raw_msg, NodeNum endpointNum)
       : msg(raw_msg.size() + MSG_HEADER_SIZE), send_time(std::chrono::steady_clock::now()) {
-    uint32_t msg_size = htonl(static_cast<uint32_t>(raw_msg.size()) + MSG_HEADER_SIZE);
-    auto const endpoint = htonl(endpointNum);
+    uint32_t msg_size = htonl(static_cast<uint32_t>(raw_msg.size()));
+    auto const endpoint = concordUtils::hostToNet<NodeNum>(endpointNum);
     const Header header{msg_size, endpoint};
     std::memcpy(msg.data(), &header, MSG_HEADER_SIZE);
     std::memcpy(msg.data() + MSG_HEADER_SIZE, raw_msg.data(), raw_msg.size());

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.cpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.cpp
@@ -25,18 +25,18 @@ using bftEngine::ReplicaConfig;
 
 std::map<uint16_t, std::shared_ptr<IByzantineStrategy>> WrapCommunication::changeStrategy;
 
-int WrapCommunication::send(NodeNum destNode, std::vector<uint8_t>&& msg) {
+int WrapCommunication::send(NodeNum destNode, std::vector<uint8_t>&& msg, NodeNum endpointNum) {
   std::shared_ptr<MessageBase> newMsg;
   if (changeMesssage(msg, newMsg) && newMsg) {
     std::vector<uint8_t> chgMsg(newMsg->body(), newMsg->body() + newMsg->size());
     LOG_INFO(logger_, "Sending the changed message to destNode : " << destNode);
-    return communication_->send(destNode, std::move(chgMsg));
+    return communication_->send(destNode, std::move(chgMsg), endpointNum);
   } else {
-    return communication_->send(destNode, std::move(msg));
+    return communication_->send(destNode, std::move(msg), endpointNum);
   }
 }
 
-std::set<NodeNum> WrapCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg) {
+std::set<NodeNum> WrapCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg, NodeNum endpointNum) {
   if (separate_communication_) {
     std::set<NodeNum> failedNodes;
     for (auto dst : dests) {

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
@@ -37,8 +37,8 @@ class WrapCommunication : public ICommunication {
     return communication_->getCurrentConnectionStatus(node);
   }
 
-  int send(NodeNum destNode, std::vector<uint8_t> &&msg) override;
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg) override;
+  int send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum = MAX_ENDPOINT_NUM) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override {
     communication_->setReceiver(receiverNum, receiver);


### PR DESCRIPTION
We introduce a new communication class - TlsMultiplexCommunication, which will replace TlsTcpCommunication for the BFT clients pool and replicas.
This PR adds feature flag to support multiplex communication channel and adds endpoint number as an extra field in message header in order to distinguish between endpoints.
As result of this we change send and onNewMessage APIs to have support for extra field i.e. end_point_number.
More details in each commit.