### PR TITLE
Stability improvement for apollo test_skvbc_fast_path

### DIFF
--- a/tests/apollo/test_skvbc_multi_sig.py
+++ b/tests/apollo/test_skvbc_multi_sig.py
@@ -42,9 +42,6 @@ class SkvbcMultiSig(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    def setUp(self):
-        self.evaluation_period_seq_num = 64
-
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, rotate_keys=True )
     async def test_happy_initial_key_exchange(self, bft_network):

--- a/tests/apollo/test_skvbc_slow_path.py
+++ b/tests/apollo/test_skvbc_slow_path.py
@@ -44,12 +44,6 @@ class SkvbcSlowPathTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    def setUp(self):
-        # Whenever a replica goes down, all messages initially go via the slow path.
-        # However, when an "evaluation period" elapses (set at 64 sequence numbers),
-        # the system should return to the fast path.
-        self.evaluation_period_seq_num = 64
-
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: c == 0 and n >= 6, rotate_keys=True)

--- a/tests/apollo/test_skvbc_time_service.py
+++ b/tests/apollo/test_skvbc_time_service.py
@@ -55,12 +55,6 @@ class SkvbcTimeServiceTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    def setUp(self):
-        # Whenever a replica goes down, all messages initially go via the slow path.
-        # However, when an "evaluation period" elapses (set at 64 sequence numbers),
-        # the system should return to the fast path.
-        self.evaluation_period_seq_num = 64
-
     @with_trio
     @with_bft_network(start_replica_cmd, rotate_keys=True)
     @verify_linearizability()


### PR DESCRIPTION
* Fix test_fast_to_slow_path_transition to crash C+1 replicas instead of 1 replica to test the transition to slow path.
* test_fast_path_resilience_to_crashes doesn't need to test for the slow path to be prevalent as an intermediate step - the fast/slow path controller doesn't switch logically to the slow path but uses the slow path as a mechanism to downgrade from optimistic fast (n of n replicas) to fast with threshold commit path. This might be improved in the future and should not be captured by a test if it's not needed. 
* Remove dead code in test_skvbc_fast_path that was copy-pasted around in other tests.