### PR TITLE
Compute the public state hash on DB checkpoint

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -239,6 +239,11 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                "When set to true this parameter will cause endWriteTran to block until "
                "the transaction is persisted every time we update the metadata.");
 
+  CONFIG_PARAM(hashStateMultiGetBatchSize,
+               std::uint32_t,
+               30u,
+               "Amount of keys to get at once via multiGet when hashing state");
+
   // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters
   // Example of usage:

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -189,16 +189,16 @@ std::optional<DbCheckpointMetadata::DbCheckPointDescriptor> DbCheckpointManager:
 
 DbCheckpointManager::CheckpointState DbCheckpointManager::getCheckpointState(CheckpointId id) const {
   {
-    auto lock = std::scoped_lock{lockDbCheckPtFuture_};
-    if (dbCreateCheckPtFuture_.count(id)) {
-      return CheckpointState::kPending;
+    auto lock = std::scoped_lock{lock_};
+    if (dbCheckptMetadata_.dbCheckPoints_.count(id)) {
+      return CheckpointState::kCreated;
     }
   }
 
   {
-    auto lock = std::scoped_lock{lock_};
-    if (dbCheckptMetadata_.dbCheckPoints_.count(id)) {
-      return CheckpointState::kCreated;
+    auto lock = std::scoped_lock{lockDbCheckPtFuture_};
+    if (dbCreateCheckPtFuture_.count(id)) {
+      return CheckpointState::kPending;
     }
   }
 

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -43,6 +43,12 @@ Msg PublicStateKeys 7 {
     list string keys
 }
 
+# The state hash (public or per participant) at a particular block.
+Msg StateHash 8 {
+    uint64 block_id
+    fixedlist uint8 32 hash
+}
+
 Msg MerkleKeyFlag 1000 {
     bool deleted
 }

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -118,6 +118,27 @@ class KeyValueBlockchain {
   std::shared_ptr<concord::storage::rocksdb::NativeClient> db() { return native_client_; }
   std::shared_ptr<const concord::storage::rocksdb::NativeClient> db() const { return native_client_; }
 
+  // Trims the DB snapshot such that its last reachable block is equal to `block_id_at_checkpoint`.
+  // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
+  // Precondition1: The current KeyValueBlockchain instance points to a DB snapshot.
+  // Precondition2: `block_id_at_checkpoint` >= INITIAL_GENESIS_BLOCK_ID
+  // Precondition3: `block_id_at_checkpoint` <= getLastReachableBlockId()
+  void trimBlocksFromSnapshot(BlockId block_id_at_checkpoint);
+
+  // Computes and persists the public state hash by:
+  //  h0 = hash("")
+  //  h1 = hash(h0 || hash(k1) || v1)
+  //  h2 = hash(h1 || hash(k2) || v2)
+  //  ...
+  //  hN = hash(hN-1 || hash(kN) || vN)
+  //
+  // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
+  // Precondition: The current KeyValueBlockchain instance points to a DB snapshot.
+  void computeAndPersistPublicStateHash(BlockId checkpoint_block_id);
+
+  // The key used in the default column family for persisting the current public state hash.
+  static std::string publicStateHashKey();
+
  private:
   BlockId addBlock(CategoryInput&& category_updates, concord::storage::rocksdb::NativeWriteBatch& write_batch);
 

--- a/kvbc/src/merkle_tree_key_manipulator.cpp
+++ b/kvbc/src/merkle_tree_key_manipulator.cpp
@@ -203,6 +203,8 @@ EBFTSubtype DBKeyManipulator::getBftSubtype(const Sliver &s) {
       return EBFTSubtype::STCheckpointDescriptor;
     case toChar(EBFTSubtype::STTempBlock):
       return EBFTSubtype::STTempBlock;
+    case toChar(EBFTSubtype::PublicStateHashAtDbCheckpoint):
+      return EBFTSubtype::PublicStateHashAtDbCheckpoint;
   }
   ConcordAssert(false);
 

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -12,6 +12,7 @@
 // file.
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "categorization/column_families.h"
 #include "categorization/updates.h"
 #include "categorization/kv_blockchain.h"
@@ -29,10 +30,11 @@ using concord::storage::rocksdb::NativeClient;
 using namespace concord::kvbc::categorization;
 using namespace concord::kvbc::categorization::detail;
 using namespace concord::kvbc;
+using namespace ::testing;
 
 namespace {
 
-class categorized_kvbc : public ::testing::Test {
+class categorized_kvbc : public Test {
  protected:
   void SetUp() override {
     destroyDb();
@@ -45,6 +47,42 @@ class categorized_kvbc : public ::testing::Test {
     db.reset();
     ASSERT_EQ(0, db.use_count());
     cleanup();
+  }
+
+  void addPublicState(KeyValueBlockchain& kvbc) {
+    auto updates = Updates{};
+    auto merkle = BlockMerkleUpdates{};
+    merkle.addUpdate("a", "va");
+    merkle.addUpdate("b", "vb");
+    merkle.addUpdate("c", "vc");
+    merkle.addUpdate("d", "vd");
+    auto versioned = VersionedUpdates{};
+    const auto public_state = PublicStateKeys{std::vector<std::string>{"a", "b", "c", "d"}};
+    const auto ser_public_state = detail::serialize(public_state);
+    versioned.addUpdate(std::string{keyTypes::state_public_key_set},
+                        std::string{ser_public_state.cbegin(), ser_public_state.cend()});
+    updates.add(kExecutionProvableCategory, std::move(merkle));
+    updates.add(kConcordInternalCategoryId, std::move(versioned));
+    ASSERT_EQ(kvbc.addBlock(std::move(updates)), 1);
+  }
+
+  // Public state hash computed via https://emn178.github.io/online-tools/sha3_256.html
+  //
+  // h0 = hash("") = a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
+  // h1 = hash(h0 || hash("a") || "va") = c407fb7c52596d6d0fa0a013798dd72489dcc00607033089a8a09c73fba8bd7c
+  // h2 = hash(h1 || hash("b") || "vb") = 1d911b3b893221358c22f2470fac0864ef145b55eca983d4b17bdc30bf0bda2b
+  // h3 = hash(h2 || hash("c") || "vc") = c6314bdd9c82183d2e4e5cb8869826e1a3ace6a86a7b62ebe5ac77b732d3c792
+  // h4 = hash(h3 || hash("d") || "vd") = fd4c5ea03da18deaf10365fdf001c216055aaaa796b0a98e4db7c756a426ae81
+  void assertPublicStateHash() {
+    const auto state_hash_val = db->get(KeyValueBlockchain::publicStateHashKey());
+    ASSERT_TRUE(state_hash_val.has_value());
+    auto state_hash = StateHash{};
+    detail::deserialize(*state_hash_val, state_hash);
+    ASSERT_EQ(state_hash.block_id, 1);
+    // Expect h4.
+    ASSERT_THAT(state_hash.hash, ContainerEq(Hash{0xfd, 0x4c, 0x5e, 0xa0, 0x3d, 0xa1, 0x8d, 0xea, 0xf1, 0x03, 0x65,
+                                                  0xfd, 0xf0, 0x01, 0xc2, 0x16, 0x05, 0x5a, 0xaa, 0xa7, 0x96, 0xb0,
+                                                  0xa9, 0x8e, 0x4d, 0xb7, 0xc7, 0x56, 0xa4, 0x26, 0xae, 0x81}));
   }
 
  protected:
@@ -2351,9 +2389,152 @@ TEST_F(categorized_kvbc, local_write_batch) {
   ASSERT_EQ(batch.count(), 5);
 }
 
+TEST_F(categorized_kvbc, trim_blocks_from_snapshot) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 1);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 2);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 3);
+  ASSERT_EQ(kvbc.getLastReachableBlockId(), 3);
+  kvbc.trimBlocksFromSnapshot(1);
+  ASSERT_EQ(kvbc.getLastReachableBlockId(), 1);
+}
+
+TEST_F(categorized_kvbc, no_need_to_trim_blocks_from_snapshot) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 1);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 2);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 3);
+  ASSERT_EQ(kvbc.getLastReachableBlockId(), 3);
+  kvbc.trimBlocksFromSnapshot(3);
+  ASSERT_EQ(kvbc.getLastReachableBlockId(), 3);
+}
+
+TEST_F(categorized_kvbc, trim_blocks_from_snapshot_called_with_0) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 1);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 2);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 3);
+  ASSERT_EQ(kvbc.getLastReachableBlockId(), 3);
+  ASSERT_DEATH(kvbc.trimBlocksFromSnapshot(0), "");
+}
+
+TEST_F(categorized_kvbc, trim_blocks_from_snapshot_called_with_bigger_block_id) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 1);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 2);
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 3);
+  ASSERT_EQ(kvbc.getLastReachableBlockId(), 3);
+  ASSERT_DEATH(kvbc.trimBlocksFromSnapshot(4), "");
+}
+
+TEST_F(categorized_kvbc, compute_and_persist_hash_with_no_public_state) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  ASSERT_EQ(kvbc.addBlock(Updates{}), 1);
+  kvbc.computeAndPersistPublicStateHash(1);
+  const auto state_hash_val = db->get(KeyValueBlockchain::publicStateHashKey());
+  ASSERT_TRUE(state_hash_val.has_value());
+  auto state_hash = StateHash{};
+  detail::deserialize(*state_hash_val, state_hash);
+  ASSERT_EQ(state_hash.block_id, 1);
+  // Expect the empty SHA3-256 hash.
+  ASSERT_THAT(state_hash.hash, ContainerEq(Hash{0xa7, 0xff, 0xc6, 0xf8, 0xbf, 0x1e, 0xd7, 0x66, 0x51, 0xc1, 0x47,
+                                                0x56, 0xa0, 0x61, 0xd6, 0x62, 0xf5, 0x80, 0xff, 0x4d, 0xe4, 0x3b,
+                                                0x49, 0xfa, 0x82, 0xd8, 0x0a, 0x4b, 0x80, 0xf8, 0x43, 0x4a}));
+}
+
+TEST_F(categorized_kvbc, compute_and_persist_hash_batch_size_equals_key_count) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  addPublicState(kvbc);
+  bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize = 4;
+  kvbc.computeAndPersistPublicStateHash(1);
+  assertPublicStateHash();
+}
+
+TEST_F(categorized_kvbc, compute_and_persist_hash_batch_size_bigger_than_key_count_uneven) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  addPublicState(kvbc);
+  bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize = 5;
+  kvbc.computeAndPersistPublicStateHash(1);
+  assertPublicStateHash();
+}
+
+TEST_F(categorized_kvbc, compute_and_persist_hash_batch_size_bigger_than_key_count_even) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  addPublicState(kvbc);
+  bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize = 6;
+  kvbc.computeAndPersistPublicStateHash(1);
+  assertPublicStateHash();
+}
+
+TEST_F(categorized_kvbc, compute_and_persist_hash_batch_size_less_than_key_count_uneven) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  addPublicState(kvbc);
+  bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize = 3;
+  kvbc.computeAndPersistPublicStateHash(1);
+  assertPublicStateHash();
+}
+
+TEST_F(categorized_kvbc, compute_and_persist_hash_batch_size_less_than_key_count_even) {
+  const auto link_st_chain = true;
+  auto kvbc = KeyValueBlockchain{
+      db,
+      link_st_chain,
+      std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                           {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
+  addPublicState(kvbc);
+  bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize = 2;
+  kvbc.computeAndPersistPublicStateHash(1);
+  assertPublicStateHash();
+}
+
 }  // end namespace
 
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
+  InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/storage/include/storage/db_types.h
+++ b/storage/include/storage/db_types.h
@@ -61,6 +61,7 @@ enum class EBFTSubtype : std::uint8_t {
   STReservedPageDynamic,
   STCheckpointDescriptor,
   STTempBlock,
+  PublicStateHashAtDbCheckpoint,
 };
 
 enum class EMigrationSubType : std::uint8_t {

--- a/storage/include/storage/merkle_tree_key_manipulator.h
+++ b/storage/include/storage/merkle_tree_key_manipulator.h
@@ -14,6 +14,9 @@
 #pragma once
 
 #include "key_manipulator_interface.h"
+#include "string.hpp"
+
+#include <string>
 
 namespace concord::storage::v2MerkleTree {
 
@@ -30,5 +33,11 @@ class STKeyManipulator : public ISTKeyManipulator {
   concordUtils::Sliver generateSTReservedPageDynamicKey(uint32_t pageId, uint64_t chkpt) const override;
   concordUtils::Sliver getReservedPageKeyPrefix() const override;
 };
+
+namespace detail {
+inline std::string serialize(detail::EBFTSubtype type) {
+  return std::string{concord::util::toChar(detail::EDBKeyType::BFT), concord::util::toChar(type)};
+}
+}  // namespace detail
 
 }  // namespace concord::storage::v2MerkleTree

--- a/storage/src/merkle_tree_key_manipulator.cpp
+++ b/storage/src/merkle_tree_key_manipulator.cpp
@@ -15,17 +15,13 @@
 
 #include "endianness.hpp"
 #include "storage/db_types.h"
-#include "string.hpp"
 
 #include <string>
 
 namespace {
 
 using namespace ::concord::storage::v2MerkleTree::detail;
-using concord::util::toChar;
 using concordUtils::toBigEndianStringBuffer;
-
-std::string serialize(EBFTSubtype type) { return std::string{toChar(EDBKeyType::BFT), toChar(type)}; }
 
 }  // namespace
 


### PR DESCRIPTION
When a DB checkpoint is created, compute the public state hash as part
of its preparation. Do that in the separate checkpoint thread,
sequentially, after the checkpoint itself is created. If it takes too
long, a future commit can change that behaviour such that the checkpoint
is ready before the hash computation.

Add the DbCheckpointManager::getCheckpointState() method that allows
users to check the state of a checkpoint by its ID.

Introduce EBFTSubtype::PublicStateHashAtDbCheckpoint - a key that is
used to persist the current public state hash in the default column
family of the checkpoint.

Move checkpoint preparation code to KeyValueBlockchain and add unit
tests for its behaviour.