### PR TITLE
Separate pre-execution from execution workflow

### DIFF
--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -61,6 +61,11 @@ class IRequestsHandler {
                        const std::string &batchCid,
                        concordUtils::SpanWrapper &parent_span) = 0;
 
+  virtual void preExecute(IRequestsHandler::ExecutionRequest &req,
+                          std::optional<Timestamp> timestamp,
+                          const std::string &batchCid,
+                          concordUtils::SpanWrapper &parent_span) = 0;
+
   virtual void onFinishExecutingReadWriteRequests() {}
 
   std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> getReconfigurationHandler() const {

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -167,4 +167,11 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
   if (userRequestsHandler_) return userRequestsHandler_->execute(requests, timestamp, batchCid, parent_span);
   return;
 }
+
+void RequestHandler::preExecute(IRequestsHandler::ExecutionRequest& req,
+                                std::optional<Timestamp> timestamp,
+                                const std::string& batchCid,
+                                concordUtils::SpanWrapper& parent_span) {
+  if (userRequestsHandler_) return userRequestsHandler_->preExecute(req, timestamp, batchCid, parent_span);
+}
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -38,6 +38,11 @@ class RequestHandler : public IRequestsHandler {
                const std::string &batchCid,
                concordUtils::SpanWrapper &) override;
 
+  void preExecute(IRequestsHandler::ExecutionRequest &req,
+                  std::optional<Timestamp> timestamp,
+                  const std::string &batchCid,
+                  concordUtils::SpanWrapper &parent_span) override;
+
   void setUserRequestHandler(std::shared_ptr<IRequestsHandler> userHdlr) {
     if (userHdlr) {
       userRequestsHandler_ = userHdlr;

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1620,7 +1620,9 @@ OperationResult PreProcessor::launchReqPreProcessing(const PreProcessRequestMsgS
       preProcessResultBuffer,
       reqSeqNum,
       preProcessReqMsg->result()});
-  requestsHandler_.execute(accumulatedRequests, std::nullopt, cid, span);
+
+  requestsHandler_.preExecute(accumulatedRequests.front(), std::nullopt, cid, span);
+  // requestsHandler_.execute(accumulatedRequests, std::nullopt, cid, span);
   const IRequestsHandler::ExecutionRequest &request = accumulatedRequests.back();
   auto preProcessResult = static_cast<OperationResult>(request.outExecutionStatus);
   resultLen = request.outActualReplySize;

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -74,6 +74,13 @@ class DummyRequestsHandler : public IRequestsHandler {
       req.outExecutionStatus = static_cast<uint32_t>(OperationResult::SUCCESS);
     }
   }
+  void preExecute(IRequestsHandler::ExecutionRequest& req,
+                  std::optional<Timestamp> timestamp,
+                  const std::string& batchCid,
+                  concordUtils::SpanWrapper& parent_span) override {
+    req.outActualReplySize = 256;
+    req.outExecutionStatus = static_cast<uint32_t>(OperationResult::SUCCESS);
+  }
 };
 
 class DummyReceiver : public IReceiver {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -171,7 +171,9 @@ void InternalCommandsHandler::preExecute(IRequestsHandler::ExecutionRequest &req
   }
   req.outActualReplySize = req.requestSize;
   memcpy(req.outReply, req.request, req.requestSize);
-  req.outExecutionStatus = static_cast<uint32_t>(res);
+  if (req.outExecutionStatus == static_cast<uint32_t>(OperationResult::UNKNOWN)) {
+    req.outExecutionStatus = static_cast<uint32_t>(res);
+  }
 }
 
 void InternalCommandsHandler::addMetadataKeyValue(VersionedUpdates &updates, uint64_t sequenceNum) const {

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -55,6 +55,11 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                const std::string &batchCid,
                concordUtils::SpanWrapper &parent_span) override;
 
+  void preExecute(IRequestsHandler::ExecutionRequest &req,
+                  std::optional<bftEngine::Timestamp> timestamp,
+                  const std::string &batchCid,
+                  concordUtils::SpanWrapper &parent_span) override;
+
   void setPerformanceManager(std::shared_ptr<concord::performance::PerformanceManager> perfManager) override;
 
  private:

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -127,6 +127,11 @@ class SimpleAppState : public IRequestsHandler {
     }
   }
 
+  void preExecute(IRequestsHandler::ExecutionRequest &req,
+                  std::optional<Timestamp> timestamp,
+                  const std::string &batchCid,
+                  concordUtils::SpanWrapper &parent_span) override {}
+
   struct State {
     // Number of modifications made.
     uint64_t stateNum = 0;


### PR DESCRIPTION
This PR separates the pre-execution from execution by introducing a new preExecute method in IRequestsHandler.
The preprocessor starts calling this new method instead of execute