### PR TITLE
Create db snapshot on replicas wedge with apollo tests

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -101,6 +101,11 @@ class DbCheckpointManager {
     if (monitorThread_.joinable()) monitorThread_.join();
   }
   void sendInternalCreateDbCheckpointMsg(const SeqNum& seqNum, bool noop);
+  SeqNum getLastStableSeqNum() const;
+  void setOnStableSeqNumCb_(std::function<void(SeqNum)> cb) { onStableSeqNumCb_ = cb; }
+  void onStableSeqNum(SeqNum s) {
+    if (onStableSeqNumCb_) onStableSeqNumCb_(s);
+  }
 
  private:
   logging::Logger getLogger() {
@@ -156,6 +161,7 @@ class DbCheckpointManager {
   std::optional<DbCheckpointMetadata::DbCheckPointDescriptor> lastCreatedCheckpointMetadata_{std::nullopt};
   std::optional<SeqNum> nextSeqNumToCreateCheckPt_{std::nullopt};
   std::chrono::seconds lastCheckpointCreationTime_{duration_cast<Seconds>(SystemClock::now().time_since_epoch())};
+  std::function<void(SeqNum)> onStableSeqNumCb_;
   std::string dbCheckPointDirPath_;
   concordMetrics::Component metrics_;
   concordMetrics::GaugeHandle maxDbCheckpointCreationTimeMsec_;

--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -46,22 +46,31 @@ class DbCheckpointManager {
  public:
   /***************************************************
    *@Input parameter1: Request sequnce number
-   *@Input parameter2: Request timestamp
+   *@Input parameter2: Optional request timestamp
+   *@Input parameter3: Optional snapshotId
    *@Description: Creates rocksdb checkpoint asynchronously if database has new state.
-   *              If we already have a checkpoint with same state as lastBlock in the DB, we reject the request.
-   *              Creating another db checkpoint with the same state as the previous one has no use.
-   *              Note1: if ReplicaConfig::maxNumberOfDbCheckpoints is set to zero, then also we do not create rocksDb
-   *              and return std::nullopt in that case
-   *              Note2: if there is no state in the blockchain, we don't create a snapshot and return std::nullopt.
+   *  If we already have a checkpoint with same state as lastBlock in the DB, we reject the request.
+   *  Creating another db checkpoint with the same state as the previous one has no use.
+   *  Note1: if ReplicaConfig::maxNumberOfDbCheckpoints is set to zero, then also we do not create rocksDb
+   *  and return std::nullopt in that case
+   *  Note2: if there is no state in the blockchain, we don't create a snapshot and return std::nullopt.
+   *  Note3: We create db-snapshot only on stable seq number. But, we need same snapshot id for all
+   *  replicas. All replicas handle db-snapshot create request at same seq num and snapshot id is equal to
+   *  the last reachable block number at that time. Some replicas may not have reached stable sequence number while
+   *  handling the request, in that case it waits to reach the sable sequence number before creating snapshot. In
+   *  such a case, we pass snapshot id as input paramter, and it is used to trim extra blocks that might be present in
+   *  the db snapshot if required.
    *@Return: returns a unique db checkpoint id. Else return std::nullopt
    ***************************************************/
-  std::optional<CheckpointId> createDbCheckpointAsync(const SeqNum& seqNum, const std::optional<Timestamp>& timestamp);
+  std::optional<CheckpointId> createDbCheckpointAsync(const SeqNum& seqNum,
+                                                      const std::optional<Timestamp>& timestamp,
+                                                      const std::optional<DbCheckpointId>& snapshotId);
 
   /***************************************************
    *@Description: Returns last created db checkpoint metadata. If there is no db-checkpoint created then it returns
    *nullopt
    *@Return: returns the metadata of last created checkpoint. Else return std::nullopt
-   *         Note: if ReplicaConfig::maxNumberOfDbCheckpoints is set to zero, then also this api retrun std::nullopt
+   *  Note: if ReplicaConfig::maxNumberOfDbCheckpoints is set to zero, then also this api retrun std::nullopt
    ***************************************************/
   std::optional<DbCheckpointMetadata::DbCheckPointDescriptor> getLastCreatedDbCheckpointMetadata();
 
@@ -115,6 +124,7 @@ class DbCheckpointManager {
     if (monitorThread_.joinable()) monitorThread_.join();
   }
   void sendInternalCreateDbCheckpointMsg(const SeqNum& seqNum, bool noop);
+  BlockId getLastReachableBlock() const;
   SeqNum getLastStableSeqNum() const;
   void setOnStableSeqNumCb_(std::function<void(SeqNum)> cb) { onStableSeqNumCb_ = cb; }
   void onStableSeqNum(SeqNum s) {

--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -120,6 +120,7 @@ class DbCheckpointManager {
   void onStableSeqNum(SeqNum s) {
     if (onStableSeqNumCb_) onStableSeqNumCb_(s);
   }
+  void setGetLastStableSeqNumCb(std::function<SeqNum()> cb) { getLastStableSeqNumCb_ = cb; }
 
  private:
   logging::Logger getLogger() {
@@ -176,6 +177,7 @@ class DbCheckpointManager {
   std::optional<SeqNum> nextSeqNumToCreateCheckPt_{std::nullopt};
   std::chrono::seconds lastCheckpointCreationTime_{duration_cast<Seconds>(SystemClock::now().time_since_epoch())};
   std::function<void(SeqNum)> onStableSeqNumCb_;
+  std::function<SeqNum()> getLastStableSeqNumCb_;
   std::string dbCheckPointDirPath_;
   concordMetrics::Component metrics_;
   concordMetrics::GaugeHandle maxDbCheckpointCreationTimeMsec_;

--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -47,7 +47,7 @@ class DbCheckpointManager {
   /***************************************************
    *@Input parameter1: Request sequnce number
    *@Input parameter2: Optional request timestamp
-   *@Input parameter3: Optional snapshotId
+   *@Input parameter3: Optional blockId
    *@Description: Creates rocksdb checkpoint asynchronously if database has new state.
    *  If we already have a checkpoint with same state as lastBlock in the DB, we reject the request.
    *  Creating another db checkpoint with the same state as the previous one has no use.
@@ -58,13 +58,13 @@ class DbCheckpointManager {
    *  replicas. All replicas handle db-snapshot create request at same seq num and snapshot id is equal to
    *  the last reachable block number at that time. Some replicas may not have reached stable sequence number while
    *  handling the request, in that case it waits to reach the sable sequence number before creating snapshot. In
-   *  such a case, we pass snapshot id as input paramter, and it is used to trim extra blocks that might be present in
+   *  such a case, we pass block id as input paramter, and it is used to trim extra blocks that might be present in
    *  the db snapshot if required.
    *@Return: returns a unique db checkpoint id. Else return std::nullopt
    ***************************************************/
   std::optional<CheckpointId> createDbCheckpointAsync(const SeqNum& seqNum,
                                                       const std::optional<Timestamp>& timestamp,
-                                                      const std::optional<DbCheckpointId>& snapshotId);
+                                                      const std::optional<DbCheckpointId>& blockId);
 
   /***************************************************
    *@Description: Returns last created db checkpoint metadata. If there is no db-checkpoint created then it returns

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -205,8 +205,9 @@ DbCheckpointManager::CheckpointState DbCheckpointManager::getCheckpointState(Che
   return CheckpointState::kNonExistent;
 }
 
-std::optional<CheckpointId> DbCheckpointManager::createDbCheckpointAsync(
-    const SeqNum& seqNum, const std::optional<Timestamp>& timestamp, const std::optional<DbCheckpointId>& snapshotId) {
+std::optional<CheckpointId> DbCheckpointManager::createDbCheckpointAsync(const SeqNum& seqNum,
+                                                                         const std::optional<Timestamp>& timestamp,
+                                                                         const std::optional<DbCheckpointId>& blockId) {
   if (seqNum <= lastCheckpointSeqNum_) {
     LOG_ERROR(getLogger(), "createDb checkpoint failed." << KVLOG(seqNum, lastCheckpointSeqNum_));
     return std::nullopt;
@@ -225,8 +226,8 @@ std::optional<CheckpointId> DbCheckpointManager::createDbCheckpointAsync(
   }
   // Get last blockId from rocksDb
   auto lastBlockid = BlockId{0};
-  if (snapshotId.has_value()) {
-    lastBlockid = snapshotId.value();
+  if (blockId.has_value()) {
+    lastBlockid = blockId.value();
   } else {
     lastBlockid = getLastBlockIdCb_();
   }

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -320,4 +320,8 @@ void DbCheckpointManager::updateLastCmdInfo(const SeqNum& seqNum, const std::opt
     updateDbCheckpointMetadata();
   }
 }
+SeqNum DbCheckpointManager::getLastStableSeqNum() const {
+  ConcordAssert(ps_.get() != nullptr);
+  return ps_->getLastStableSeqNum();
+}
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -345,7 +345,7 @@ void DbCheckpointManager::updateLastCmdInfo(const SeqNum& seqNum, const std::opt
   }
 }
 SeqNum DbCheckpointManager::getLastStableSeqNum() const {
-  ConcordAssert(ps_.get() != nullptr);
-  return ps_->getLastStableSeqNum();
+  if (getLastStableSeqNumCb_) return getLastStableSeqNumCb_();
+  return 0;
 }
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3525,7 +3525,7 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     // reason: wedge is performed for some maintainance, scaling, reconfiguration etc.
     // so, we create a snapshot of the database, when we stop the replicas
     if (getReplicaConfig().dbCheckpointFeatureEnabled)
-      DbCheckpointManager::instance().createDbCheckpointAsync(seq_num_to_stop_at.value(), std::nullopt);
+      DbCheckpointManager::instance().createDbCheckpointAsync(seq_num_to_stop_at.value(), std::nullopt, std::nullopt);
   }
   onSeqNumIsStableCallbacks_.invokeAll(newStableSeqNum);
 }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4461,6 +4461,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
       }
       DbCheckpointManager::instance().onStableSeqNum(seqNum);
     });
+    DbCheckpointManager::instance().setGetLastStableSeqNumCb([this]() -> SeqNum { return lastStableSeqNum; });
   }
   LOG_INFO(GL, "ReplicaConfig parameters: " << config);
   auto numThreads = 8;

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -127,11 +127,10 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
           // seq num because checkpoint msg certificate is stored on stable seq num and is used for intergrity
           // check of db snapshots
           const auto& seqNumToCreateSanpshot = createDbChkPtMsg.seqNum;
-          std::optional snapshotId(DbCheckpointManager::instance().getLastReachableBlock());
-          DbCheckpointManager::instance().setOnStableSeqNumCb_([seqNumToCreateSanpshot, timestamp, snapshotId](
-                                                                   SeqNum s) {
+          std::optional blockId(DbCheckpointManager::instance().getLastReachableBlock());
+          DbCheckpointManager::instance().setOnStableSeqNumCb_([seqNumToCreateSanpshot, timestamp, blockId](SeqNum s) {
             if (s == static_cast<SeqNum>(seqNumToCreateSanpshot))
-              DbCheckpointManager::instance().createDbCheckpointAsync(seqNumToCreateSanpshot, timestamp, snapshotId);
+              DbCheckpointManager::instance().createDbCheckpointAsync(seqNumToCreateSanpshot, timestamp, blockId);
           });
         }
       }

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -117,8 +117,22 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
       concord::messages::db_checkpoint_msg::CreateDbCheckpoint createDbChkPtMsg;
       concord::messages::db_checkpoint_msg::deserialize(
           std::vector<std::uint8_t>(req.request, req.request + req.requestSize), createDbChkPtMsg);
-      if (!createDbChkPtMsg.noop)
-        DbCheckpointManager::instance().createDbCheckpointAsync(createDbChkPtMsg.seqNum, timestamp);
+      if (!createDbChkPtMsg.noop) {
+        const auto& lastStableSeqNum = DbCheckpointManager::instance().getLastStableSeqNum();
+        if (lastStableSeqNum == static_cast<SeqNum>(createDbChkPtMsg.seqNum)) {
+          DbCheckpointManager::instance().createDbCheckpointAsync(createDbChkPtMsg.seqNum, timestamp);
+        } else {
+          // this replica has not reached stable seqNum yet to create snapshot at requested seqNum
+          // add a callback to be called when seqNum is stable. We need to create snapshot on stable
+          // seq num because checkpoint msg certificate is stored on stable seq num and is used for intergrity
+          // check of db snapshots
+          const auto& seqNumToCreateSanpshot = createDbChkPtMsg.seqNum;
+          DbCheckpointManager::instance().setOnStableSeqNumCb_([seqNumToCreateSanpshot, timestamp](SeqNum s) {
+            if (s == static_cast<SeqNum>(seqNumToCreateSanpshot))
+              DbCheckpointManager::instance().createDbCheckpointAsync(seqNumToCreateSanpshot, timestamp);
+          });
+        }
+      }
       req.outExecutionStatus = static_cast<uint32_t>(OperationResult::SUCCESS);
       req.outReply[0] = '1';
       req.outActualReplySize = 1;

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -1038,7 +1038,7 @@ struct VerifyDbCheckpoint {
         << " optionally it verifies N number of blocks from the block added"
         << " on last stable checkpoint in reverse order"
         << " and optionally verifies signature of bft-checkpoint messages\n"
-        << " N - Number of blocks to verify\n"
+        << " N - Number of additional blocks to verify from the block added on last stable checkpoint\n"
         << " Usage: verifyDbCheckpoint [N] [true/false]\n";
     return oss.str();
   }
@@ -1230,6 +1230,7 @@ struct VerifyDbCheckpoint {
           verifyBlockChain(adapter, (checkPtDesc.lastBlock - numOfBlocksToVerify - 1), checkPtDesc.lastBlock) ? "Ok"
                                                                                                               : "Fail";
     }
+    result["NumOfBlocksVerifiedFromLastStableCheckPtBlock"] = std::to_string(numOfBlocksToVerify);
     return concordUtils::toJson(result);
   }
 };

--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -266,7 +266,8 @@ bool ReconfigurationHandler::handle(const concord::messages::StateSnapshotReques
              "StateSnapshotRequest(participant ID = " << cmd.participant_id << "): using existing last checkpoint ID: "
                                                       << last_checkpoint_desc->checkPointId_);
   } else {
-    const auto checkpoint_id = DbCheckpointManager::instance().createDbCheckpointAsync(sequence_number, timestamp);
+    const auto checkpoint_id =
+        DbCheckpointManager::instance().createDbCheckpointAsync(sequence_number, timestamp, std::nullopt);
     if (checkpoint_id) {
       resp.data.emplace();
       resp.data->snapshot_id = *checkpoint_id;

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -64,7 +64,7 @@ def start_replica_cmd(builddir, replica_id):
             "-o", builddir + "/operator_pub.pem"]
 
 
-def start_replica_cmd_with_operator(builddir, replica_id):
+def start_replica_cmd_for_manual_db_snapshot_creation(builddir, replica_id):
     """
     Return a command with operator that starts an skvbc replica when passed to
     subprocess.Popen.
@@ -237,7 +237,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
             self.verify_snapshot_is_available(bft_network, replica_id, old_snapshot_id, isPresent=False)
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_operator, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_for_manual_db_snapshot_creation, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability()
     async def test_create_dbcheckpoint_cmd(self, bft_network, tracker):
         """
@@ -273,7 +273,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
             self.verify_snapshot_is_available(bft_network, replica_id, last_blockId)
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_operator, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_for_manual_db_snapshot_creation, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability()
     async def test_create_dbcheckpoint_with_parallel_client_requests(self, bft_network, tracker):
         """
@@ -428,7 +428,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
                          "StateSnapshotRequest(participant ID = apollo_test_participant_id): failed, the DB checkpoint feature is disabled")
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_operator, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_for_manual_db_snapshot_creation, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability()
     async def test_state_snapshot_req_existing_checkpoint(self, bft_network, tracker):
         bft_network.start_all_replicas()
@@ -458,7 +458,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
         self.assertEqual(resp.response.data.event_group_id, 0)
 
     @with_trio
-    @with_bft_network(start_replica_cmd_with_operator, selected_configs=lambda n, f, c: n == 7)
+    @with_bft_network(start_replica_cmd_for_manual_db_snapshot_creation, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability()
     async def test_state_snapshot_req_non_existent_checkpoint(self, bft_network, tracker):
         bft_network.start_all_replicas()
@@ -486,6 +486,128 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
         last_block_id = 100
         for replica_id in bft_network.all_replicas():
             await self.wait_for_snapshot(bft_network, replica_id, last_block_id)
+
+    @with_trio
+    @with_bft_network(start_replica_cmd_for_manual_db_snapshot_creation, selected_configs=lambda n, f, c: n == 7)
+    async def test_db_checkpoint_creation_with_wedge(self, bft_network):
+        """
+            We create a db-snapshot when we wedge the replicas.
+            Steps performed in this test:
+            1. Configure replicas to create db-snapshot with bft-sequence number window sz = 600
+            2. Send a wedge command to wedge replicas at seq number 300
+            3. Verify replicas are wedged
+            4. Verify db-checkpoints are created on stable sequence number
+            5. Unwedge replicas
+            6. Write kv requests.
+            7. Verify that 2nd db-checkpoint is created at seqNum 600 as a result of configured policy
+         """
+        bft_network.start_all_replicas()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        client = bft_network.random_client()
+        # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
+        client.config._replace(req_timeout_milli=10000)
+        checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)
+        op = operator.Operator(
+            bft_network.config, client,  bft_network.builddir)
+        await op.wedge()
+        await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), (checkpoint_before+2)*150)
+        await self.validate_stop_on_wedge_point(bft_network, skvbc=skvbc, fullWedge=True)
+        #verify that snapshot is created on wedge point
+        await self.wait_for_created_snapshots_metric(bft_network, bft_network.all_replicas(), 1)
+        for replica_id in range(len(bft_network.all_replicas())):
+            last_block_id = await bft_network.get_metric(replica_id, bft_network,
+                                                         "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
+            await self.wait_for_snapshot(bft_network, replica_id, last_block_id)
+        #verify from operatore get db snapshot status command
+        rep = await op.get_dbcheckpoint_info_request(bft=False)
+        data = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
+        self.assertTrue(data.success)
+        for r in client.get_rsi_replies().values():
+            res = cmf_msgs.ReconfigurationResponse.deserialize(r)
+            self.assertEqual(len(res[0].response.db_checkpoint_info), 1)
+            dbcheckpoint_info_list = res[0].response.db_checkpoint_info
+            self.assertTrue(any(dbcheckpoint_info.seq_num ==
+                            300 for dbcheckpoint_info in dbcheckpoint_info_list))
+        #unwedge replicas
+        await op.unwedge()
+        protocol = kvbc.SimpleKVBCProtocol(bft_network)
+        key = protocol.random_key()
+        value = protocol.random_value()
+        kv_pair = [(key, value)]
+        await client.write(protocol.write_req([], kv_pair, 0))
+        read_result = await client.read(protocol.read_req([key]))
+        value_read = (protocol.parse_reply(read_result))[key]
+        #verify that un-wedge was successfull
+        self.assertEqual(value, value_read, "A BFT Client failed to read a key-value pair from a "
+                         "SimpleKVBC cluster matching the key-value pair it wrote "
+                         "immediately prior to the read.")
+        for r in bft_network.all_replicas():
+            epoch = await bft_network.get_metric(r, bft_network, "Gauges", "epoch_number", component="epoch_manager")
+            self.assertEqual(epoch, 1)
+        for i in range(300):
+            await skvbc.send_write_kv_set()
+        await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 600)
+        await self.wait_for_created_snapshots_metric(bft_network, bft_network.all_replicas(), 2)
+        for replica_id in range(len(bft_network.all_replicas())):
+            last_block_id = await bft_network.get_metric(replica_id, bft_network,
+                                                         "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
+            await self.wait_for_snapshot(bft_network, replica_id, last_block_id)
+        #verify from operatore get db snapshot status command
+        rep = await op.get_dbcheckpoint_info_request(bft=False)
+        data = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
+        self.assertTrue(data.success)
+        for r in client.get_rsi_replies().values():
+            res = cmf_msgs.ReconfigurationResponse.deserialize(r)
+            self.assertEqual(len(res[0].response.db_checkpoint_info), 2)
+            dbcheckpoint_info_list = res[0].response.db_checkpoint_info
+            self.assertTrue(any(dbcheckpoint_info.seq_num ==
+                            300 for dbcheckpoint_info in dbcheckpoint_info_list))
+            self.assertTrue(any(dbcheckpoint_info.seq_num ==
+                            600 for dbcheckpoint_info in dbcheckpoint_info_list))
+        
+    
+    @with_trio
+    @with_bft_network(start_replica_cmd_for_manual_db_snapshot_creation, selected_configs=lambda n, f, c: n == 7)
+    async def test_scale_and_restart_blockchain_with_db_snapshot(self, bft_network):
+        """
+             Sends a scale replica command and checks that new configuration is written to blockchain.
+             Note that in this test we assume no failures and synchronized network.
+             The test does the following:
+             1. A client sends a scale replica command which will also wedge the system on next next checkpoint
+             2. Validate that all replicas have stopped
+             3. Replicas create db snapshot at wedge point
+             4. Use db snapshot to restart blockchain
+             This test is equivalent to starting a new blockchain with db snapshot
+         """
+        bft_network.start_all_replicas()
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        for i in range(100):
+            await skvbc.send_write_kv_set()
+        key, val = await skvbc.send_write_kv_set()
+        client = bft_network.random_client()
+        client.config._replace(req_timeout_milli=10000)
+        op = operator.Operator(bft_network.config, client,  bft_network.builddir)
+        test_config = 'new_configuration'
+        await op.add_remove_with_wedge(test_config, bft=False)  
+    
+        #verify that snapshot is created on wedge point
+        await self.wait_for_created_snapshots_metric(bft_network, bft_network.all_replicas(), 1)
+        last_block_id = await bft_network.get_metric(0, bft_network,
+                                                         "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
+        for replica_id in range(len(bft_network.all_replicas())):
+            await self.wait_for_snapshot(bft_network, replica_id, last_block_id)
+        bft_network.stop_all_replicas()
+        for r in bft_network.all_replicas():
+            #restore all replicas using snapshot created in replica id=0
+            self.restore_form_older_snapshot(bft_network, 0, last_block_id)
+        #replicas will clean metadata and start a new blockchain
+        bft_network.start_all_replicas()
+        for i in range(100):
+            await skvbc.send_write_kv_set()
+        for r in bft_network.all_replicas():
+            nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
+            self.assertGreater(nb_fast_path, 0)
+    
 
     def verify_snapshot_is_available(self, bft_network, replica_id, snapshot_id, isPresent=True):
         with log.start_action(action_type="verify snapshot db files"):
@@ -569,3 +691,27 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
                   await trio.sleep(0.5)
               else:
                   break
+    
+
+    async def validate_stop_on_wedge_point(self, bft_network, skvbc, fullWedge=False):
+        with log.start_action(action_type="validate_stop_on_stable_checkpoint") as action:
+            with trio.fail_after(seconds=90):
+                client = bft_network.random_client()
+                client.config._replace(req_timeout_milli=10000)
+                op = operator.Operator(bft_network.config, client,  bft_network.builddir)
+                done = False
+                quorum = None if fullWedge is True else bft_client.MofNQuorum.LinearizableQuorum(bft_network.config, [r.id for r in bft_network.replicas])
+                while done is False:
+                    stopped_replicas = 0
+                    await op.wedge_status(quorum=quorum, fullWedge=fullWedge)
+                    rsi_rep = client.get_rsi_replies()
+                    done = True
+                    for r in rsi_rep.values():
+                        res = cmf_msgs.ReconfigurationResponse.deserialize(r)
+                        status = res[0].response.stopped
+                        if status:
+                            stopped_replicas += 1
+                    stop_condition = bft_network.config.n if fullWedge is True else (bft_network.config.n - bft_network.config.f)
+                    if stopped_replicas < stop_condition:
+                        done = False
+


### PR DESCRIPTION
There are two changes in this PR:
1. We create a db-snapshot when we wedge the replicas. Reason: wedge is performed for some maintainance, scaling, reconfiguration etc. So, we create a snapshot of the database, when we stop/wedge the replicas

2. On stable checkpoint, primary replicas send internal bft request to create db-checkpoint. However, other replicas may not have reached stable checkpoint when they get the request from primary. So, if a replica is yet to reach the sable checkpoint, it just adds a callback to create db-checkpoint on stable sequence number, This ensures that, we capture bft proof of n-f checkpoint messages in the rocksdb checkpoint