### PR TITLE
concord apollo tests failure fix

### DIFF
--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -98,6 +98,9 @@ Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool rea
   header->requestLength = request.size();
   header->timeoutMilli = config.timeout.count();
   header->cidLength = config.correlation_id.size();
+  header->result = 1;  // UNKNOWN
+  header->reqSignatureLength = 0;
+  header->extraDataLength = 0;
 
   auto* position = msg.data() + header_size;
 

--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -35,7 +35,7 @@ struct ClientRequestMsgHeader {
   uint32_t spanContextSize = 0u;
   uint16_t idOfClientProxy = 0;  // TODO - rename - now used mostly as id of external client
   uint64_t flags = 0;            // bit 0 == isReadOnly, bit 1 = preProcess ...
-  uint32_t result = 0;           // SUCCESS
+  uint32_t result = 1;           // UNKNOWN
   uint64_t reqSeqNum = 0;
   uint32_t requestLength = 0;
   uint64_t timeoutMilli = 0;


### PR DESCRIPTION
Apollo tests were failing as the response size was 0. The req.outExecution status was passed as success from client. As the value was already success, the request was not executed, hence sending reply size zero, causing test failure.