### PR TITLE
Implement the SignedPublicStateHashRequest command

### DIFF
--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -187,6 +187,12 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
+
+  bool handle(const concord::messages::SignedPublicStateHashRequest&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -58,34 +58,6 @@ Msg PruneStatus 18 {
     string configuration_json
 }
 
-Msg PruneConfigurationMax 60 {
-    uint32 dbMaxRate
-    uint32 consensusEngineMaxRate
-}
-
-Msg PruneConfigurationMap 61 {
-   list kvpair uint64 uint64 mapConsensusRateToPruningRate
-}
-
-Msg PruneSwitchModeRequest 50 {
-    uint64 sender_id
-    uint8 mode
-    oneof {
-        PruneConfigurationMap
-        PruneConfigurationMax
-    }
-    configuration
-}
-
-Msg PruneTicksChangeRequest 68 {
-    uint64 sender_id
-    # TicksGenerator period in seconds.
-    uint32 tick_period_seconds
-
-    # The number of blocks in a pruning batch.
-    uint64 batch_blocks_num
-}
-
 Msg GetVersionCommand 19 {
   bytes place_holder
 }
@@ -322,6 +294,88 @@ Msg StateSnapshotResponse 67 {
   optional StateSnapshotData data
 }
 
+# Sent by Clientservice to request the signed hash of the public state at `snapshot_id`.
+Msg SignedPublicStateHashRequest 68 {
+  # Unique identifier of the DB snapshot at which the signed public state hash is requested.
+  uint64 snapshot_id
+
+  # The participant ID that requested the signed public state hash.
+  string participant_id
+}
+
+Msg SignedPublicStateHashData 69 {
+  # The ID of the snapshot for which the signed public state hash was requested.
+  uint64 snapshot_id
+
+  # The ID of the responding replica.
+  uint64 replica_id
+
+  # The block ID at which the public state hash is computed.
+  uint64 block_id
+
+  # The SHA3-256 hash of the public state at `snapshot_id`.
+  fixedlist uint8 32 hash
+}
+
+# Represents the status of a `SignedPublicStateHashResponse`.
+Enum SignedPublicStateHashStatus {
+  # Successful response.
+  Success,
+
+  # The snapshot with the given ID is valid, but is still pending creation.
+  # Clientservice is advised to retry.
+  SnapshotPending,
+
+  # A snapshot with the given ID is non-existent.
+  # Clientservice must request a new snapshot ID.
+  SnapshotNonExistent,
+
+  # An internal error has occurred. Clientservice might either retry
+  # or request a new snapshot ID.
+  InternalError
+}
+
+# Returned as replica-specific-information (RSI).
+Msg SignedPublicStateHashResponse 70 {
+  # The status of the response.
+  # Note that `data` and `signature` are only relevant if status is `Success`.
+  SignedPublicStateHashStatus status
+
+  # The public state hash data.
+  SignedPublicStateHashData data
+
+  # An RSA signature from the responding replica on the serialization of `data`.
+  bytes signature
+}
+
+Msg PruneConfigurationMax 71 {
+    uint32 dbMaxRate
+    uint32 consensusEngineMaxRate
+}
+
+Msg PruneConfigurationMap 72 {
+   list kvpair uint64 uint64 mapConsensusRateToPruningRate
+}
+
+Msg PruneSwitchModeRequest 73 {
+    uint64 sender_id
+    uint8 mode
+    oneof {
+        PruneConfigurationMap
+        PruneConfigurationMax
+    }
+    configuration
+}
+
+Msg PruneTicksChangeRequest 74 {
+    uint64 sender_id
+    # TicksGenerator period in seconds.
+    uint32 tick_period_seconds
+
+    # The number of blocks in a pruning batch.
+    uint64 batch_blocks_num
+}
+
 Msg ReconfigurationRequest 1 {
   uint64 sender
   bytes signature
@@ -361,6 +415,7 @@ Msg ReconfigurationRequest 1 {
     CreateDbCheckpointCommand
     ReplicaMainKeyUpdate
     StateSnapshotRequest
+    SignedPublicStateHashRequest
   } command
   bytes additional_data
 }
@@ -385,6 +440,7 @@ Msg ReconfigurationResponse 2 {
     ClientsRestartStatusResponse
     GetDbCheckpointInfoStatusResponse
     StateSnapshotResponse
+    SignedPublicStateHashResponse
   } response
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -284,6 +284,14 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::SignedPublicStateHashRequest &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const = 0;

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -177,6 +177,12 @@ class Operator:
         cp_command.sender_id = 1000
         return self._construct_basic_reconfiguration_request(cp_command)
 
+    def _construct_reconfiguration_signed_public_state_hash_req(self, snapshot_id):
+        req = cmf_msgs.SignedPublicStateHashRequest()
+        req.snapshot_id = snapshot_id
+        req.participant_id = 'apollo_test_participant_id'
+        return self._construct_basic_reconfiguration_request(req)
+
     def _construct_reconfiguration_state_snapshot_req(self):
         req = cmf_msgs.StateSnapshotRequest()
         req.checkpoint_kv_count = 0
@@ -311,3 +317,8 @@ class Operator:
     async def state_snapshot_req(self):
         req = self._construct_reconfiguration_state_snapshot_req()
         return await self.client.write(req.serialize(), reconfiguration=True)
+
+    async def signed_public_state_hash_req(self, snapshot_id):
+        req = self._construct_reconfiguration_signed_public_state_hash_req(snapshot_id)
+        return await self.client.read(req.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config,
+                                        [r for r in range(self.config.n)]), reconfiguration=True)


### PR DESCRIPTION
`SignedPublicStateHashRequest` is a read-only command that Clientservice
can send to request signatures from replicas on the public state hash at
a given snapshot ID. The responses are returned as replica-specific
information (RSI).

Add an Apollo test to verify the behaviour.