### PR TITLE
Clientservice: Async request service

### DIFF
--- a/client/clientservice/include/client/clientservice/request_service.hpp
+++ b/client/clientservice/include/client/clientservice/request_service.hpp
@@ -9,6 +9,7 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
+#include <grpcpp/alarm.h>
 #include <grpcpp/grpcpp.h>
 #include <request.grpc.pb.h>
 #include <memory>
@@ -18,17 +19,55 @@
 
 namespace concord::client::clientservice {
 
-class RequestServiceImpl final : public vmware::concord::client::request::v1::RequestService::Service {
+namespace requestservice {
+
+// Every `Send` request is represented by this class.
+// It follows a simple state machine `RpcState`:
+// CREATE - Register to handle incoming `Send` requests
+// SEND_TO_CONCORDCLIENT - forward request to concord client
+// PROCESS_CALLBACK_RESULT - respond to caller
+// FINISH - clean-up
+class RequestServiceCallData {
  public:
-  RequestServiceImpl(std::shared_ptr<concord::client::concordclient::ConcordClient> client)
-      : logger_(logging::getLogger("concord.client.clientservice.request")), client_(client){};
-  grpc::Status Send(grpc::ServerContext* context,
-                    const vmware::concord::client::request::v1::Request* request,
-                    vmware::concord::client::request::v1::Response* response) override;
+  RequestServiceCallData(vmware::concord::client::request::v1::RequestService::AsyncService* service,
+                         grpc::ServerCompletionQueue* cq,
+                         std::shared_ptr<concord::client::concordclient::ConcordClient> client)
+      : logger_(logging::getLogger("concord.client.clientservice.requestservice")),
+        service_(service),
+        cq_(cq),
+        responder_(&ctx_),
+        state_(CREATE),
+        client_(client) {
+    proceed();
+  }
+
+  // Walk through the state machine
+  void proceed();
+  // Callback invoked by concord client after request processing is done
+  void populateResult(grpc::Status);
+  // Forward request to concord client
+  void sendToConcordClient();
 
  private:
   logging::Logger logger_;
+
+  vmware::concord::client::request::v1::RequestService::AsyncService* service_;
+  grpc::ServerCompletionQueue* cq_;
+  grpc::ServerContext ctx_;
+  grpc::ServerAsyncResponseWriter<vmware::concord::client::request::v1::Response> responder_;
+
+  grpc::Alarm callback_alarm_;
+  grpc::Status return_status_;
+
+  vmware::concord::client::request::v1::Request request_;
+  vmware::concord::client::request::v1::Response response_;
+
+  enum RpcState { CREATE, SEND_TO_CONCORDCLIENT, PROCESS_CALLBACK_RESULT, FINISH };
+  RpcState state_;
+
   std::shared_ptr<concord::client::concordclient::ConcordClient> client_;
 };
+
+}  // namespace requestservice
 
 }  // namespace concord::client::clientservice

--- a/client/clientservice/src/client_service.cpp
+++ b/client/clientservice/src/client_service.cpp
@@ -15,22 +15,66 @@
 
 namespace concord::client::clientservice {
 
-void ClientService::start(const std::string& addr, uint64_t max_receive_msg_size) {
+void ClientService::start(const std::string& addr, int num_async_threads, uint64_t max_receive_msg_size) {
   grpc::EnableDefaultHealthCheckService(true);
 
   grpc::ServerBuilder builder;
   builder.AddListeningPort(addr, grpc::InsecureServerCredentials());
   builder.SetMaxReceiveMessageSize(max_receive_msg_size);
-  builder.RegisterService(request_service_.get());
+
+  // Register synchronous services
   builder.RegisterService(event_service_.get());
 
+  // Register asynchronous services
+  builder.RegisterService(&request_service_);
+
+  for (int i = 0; i < num_async_threads; ++i) {
+    cqs_.emplace_back(builder.AddCompletionQueue());
+  }
+
   auto clientservice_server = std::unique_ptr<grpc::Server>(builder.BuildAndStart());
+
+  // From the "C++ Performance Notes" in the gRPC documentation:
+  // "Right now, the best performance trade-off is having numcpu's threads and one completion queue per thread."
+  for (int i = 0; i < num_async_threads; ++i) {
+    server_threads_.emplace_back(std::thread([this, i] { this->handleRpcs(i); }));
+  }
 
   auto health = clientservice_server->GetHealthCheckService();
   health->SetServingStatus(kRequestService, true);
   health->SetServingStatus(kEventService, true);
 
   clientservice_server->Wait();
+
+  LOG_INFO(logger_, "Wait for async gRPC threads to finish");
+  for (auto& t : server_threads_) {
+    t.join();
+  }
+}
+
+void ClientService::handleRpcs(int thread_idx) {
+  // Note: Memory is freed in `proceed`
+  new requestservice::RequestServiceCallData(&request_service_, cqs_[thread_idx].get(), client_);
+
+  void* tag;  // uniquely identifies a request.
+  bool ok = false;
+  while (true) {
+    // Block waiting to read the next event from the completion queue. The
+    // event is uniquely identified by its tag, which in this case is the
+    // memory address of a RequestServiceCallData instance (see `proceed`).
+    // The return value of Next should always be checked. This return value
+    // tells us whether there is any kind of event or cqs_ is shutting down.
+    if (not cqs_[thread_idx]->Next(&tag, &ok)) {
+      // The queue is drained and shutdown, no need to stay around.
+      LOG_INFO(logger_, "Completion queue drained and shutdown, stop processing.");
+      return;
+    }
+    // We expect a successful event or an alarm to be expired (alarm cancelled is false)
+    if (not ok) {
+      LOG_WARN(logger_, "Got unsuccessful event from completion queue with tag " << tag);
+    }
+    static_cast<requestservice::RequestServiceCallData*>(tag)->proceed();
+  }
 }
 
 }  // namespace concord::client::clientservice

--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -14,7 +14,6 @@
 #include <string>
 #include <vector>
 #include <chrono>
-#include <grpcpp/grpcpp.h>
 #include <boost/program_options.hpp>
 #include <yaml-cpp/yaml.h>
 
@@ -51,6 +50,7 @@ po::variables_map parseCmdLine(int argc, char** argv) {
     ("config", po::value<std::string>()->required(), "YAML configuration file for the RequestService")
     ("host", po::value<std::string>()->default_value("0.0.0.0"), "Clientservice gRPC service host")
     ("port", po::value<int>()->default_value(50505), "Clientservice gRPC service port")
+    ("num-async-threads", po::value<int>()->default_value(1), "Number of threads for async gRPC services")
     ("tr-id", po::value<std::string>()->required(), "ID used to subscribe to replicas for data/hashes")
     ("tr-insecure", po::value<bool>()->default_value(false), "Testing only: Allow insecure connection with TRS on replicas")
     ("tr-tls-path", po::value<std::string>()->default_value(""), "Path to thin replica TLS certificates")
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
 
   auto server_addr = opts["host"].as<std::string>() + ":" + std::to_string(opts["port"].as<int>());
   LOG_INFO(logger, "Starting clientservice at " << server_addr);
-  service.start(server_addr, opts["max-receive-msg-size"].as<int>());
+  service.start(server_addr, opts["num-async-threads"].as<int>(), opts["max-receive-msg-size"].as<int>());
 
   return 0;
 }

--- a/cmake/FindGRPC.cmake
+++ b/cmake/FindGRPC.cmake
@@ -4,10 +4,13 @@
 # Adds the following targets:
 #
 #  gRPC::grpc - gRPC library
+#  gRPC::gpr - GPR library
 #  gRPC::grpc++ - gRPC C++ library
 #  gRPC::grpc++_reflection - gRPC C++ reflection library
 #  gRPC::grpc_cpp_plugin - C++ generator plugin for Protocol Buffers
 #
+
+include_guard()
 
 #
 # Generates C++ sources from the .proto files
@@ -83,6 +86,15 @@ endif()
 find_path(GRPC_INCLUDE_DIR grpc/grpc.h)
 mark_as_advanced(GRPC_INCLUDE_DIR)
 
+# Find gRPC gpr (Google Portable Runtime)
+find_library(GRPC_GPR_LIBRARY NAMES gpr)
+mark_as_advanced(GRPC_GPR_LIBRARY)
+add_library(gRPC::gpr UNKNOWN IMPORTED)
+set_target_properties(gRPC::gpr PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${GRPC_INCLUDE_DIR}
+    IMPORTED_LOCATION ${GRPC_GPR_LIBRARY}
+)
+
 # Find gRPC library
 find_library(GRPC_LIBRARY NAMES grpc)
 mark_as_advanced(GRPC_LIBRARY)
@@ -99,7 +111,7 @@ mark_as_advanced(GRPC_GRPC++_LIBRARY)
 add_library(gRPC::grpc++ UNKNOWN IMPORTED)
 set_target_properties(gRPC::grpc++ PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${GRPC_INCLUDE_DIR}
-    INTERFACE_LINK_LIBRARIES gRPC::grpc
+    INTERFACE_LINK_LIBRARIES "gRPC::grpc;gRPC::gpr"
     IMPORTED_LOCATION ${GRPC_GRPC++_LIBRARY}
 )
 


### PR DESCRIPTION
This change converts the request service handling from synchronous to
asynchronous. Meaning, instead of relying on the gRPC thread pool to handle
each incoming request synchronously, we now have each thread handle multiple
requests concurrently.
Each executing thread listens on its own "completion queue" which the gRPC
server fills with events - an incoming `Send` request is such an event. Each
request will walk through a state machine whereby the handling of each state is
triggered by an event from the completion queue. In between each state, the
executing thread will listen for further events and is thereby able to work on
multiple requests concurrently. Based on the gRPC documentation, one thread
handles exactly one completion queue. With more than one thread (which is
configurable) we can handle multiple requests in parallel.