### PR TITLE
Helen tests failure fix

### DIFF
--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -344,7 +344,7 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
   if (isPreProcessRequired)
     reqMsg = new ClientPreProcessRequestMsg(clientId_, reqSeqNum, lenOfRequest, request, reqTimeoutMilli, msgCid, ctx);
   else
-    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lenOfRequest, request, reqTimeoutMilli, msgCid, 0, ctx);
+    reqMsg = new ClientRequestMsg(clientId_, flags, reqSeqNum, lenOfRequest, request, reqTimeoutMilli, msgCid, 1, ctx);
   {
     std::unique_lock<std::mutex> mlock(lock_);
     pendingRequests_.push_back(reqMsg);

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.cpp
@@ -33,7 +33,7 @@ ClientPreProcessRequestMsg::ClientPreProcessRequestMsg(NodeIdType sender,
                        request,
                        reqTimeoutMilli,
                        cid,
-                       0,
+                       1,
                        spanContext,
                        requestSignature,
                        requestSignatureLen) {


### PR DESCRIPTION
HelenapiTests were failing as the test was unable to parse the response.

These tests use kvb_client.cpp. Dueing create of ClientRequestmsg was passed with SUCCESS result variable, hence request was not executed, causing zero size response as in logs.

Passed UNKNOWN during clientRequestMsg creation to fix the issue.