### PR TITLE
Adding dbCheckpoint monitor time config flag

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -228,6 +228,10 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                std::chrono::seconds,
                std::chrono::seconds{3600},
                "Interval time to create db snapshot in seconds");
+  CONFIG_PARAM(dbCheckpointMonitorIntervalSeconds,
+               std::chrono::seconds,
+               std::chrono::seconds{60},
+               "Time interval in seconds to monitor disk usage by db checkpoints");
   // Post-execution separation feature flag
   CONFIG_PARAM(enablePostExecutionSeparation, bool, true, "Post-execution separation feature flag");
   CONFIG_PARAM(postExecutionQueuesSize, uint16_t, 50, "Post-execution deferred message queues size");
@@ -353,6 +357,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, dbCheckPointWindowSize);
     serialize(outStream, dbCheckpointDirPath);
     serialize(outStream, dbSnapshotIntervalSeconds);
+    serialize(outStream, dbCheckpointMonitorIntervalSeconds);
     serialize(outStream, enablePostExecutionSeparation);
     serialize(outStream, postExecutionQueuesSize);
     serialize(outStream, config_params_);
@@ -440,6 +445,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, dbCheckPointWindowSize);
     deserialize(inStream, dbCheckpointDirPath);
     deserialize(inStream, dbSnapshotIntervalSeconds);
+    deserialize(inStream, dbCheckpointMonitorIntervalSeconds);
     deserialize(inStream, enablePostExecutionSeparation);
     deserialize(inStream, postExecutionQueuesSize);
     deserialize(inStream, config_params_);
@@ -521,7 +527,9 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.dbCheckpointFeatureEnabled,
               rc.maxNumberOfDbCheckpoints,
               rc.dbCheckPointWindowSize,
-              rc.dbCheckpointDirPath);
+              rc.dbCheckpointDirPath,
+              rc.dbSnapshotIntervalSeconds.count(),
+              rc.dbCheckpointMonitorIntervalSeconds.count());
 
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -121,7 +121,7 @@ void DbCheckpointManager::init() {
   monitorThread_ = std::thread([this]() {
     while (maxNumOfCheckpoints_ && !stopped_) {
       checkAndRemove();
-      std::this_thread::sleep_for(std::chrono::seconds{60});
+      std::this_thread::sleep_for(std::chrono::seconds{ReplicaConfig::instance().dbCheckpointMonitorIntervalSeconds});
     }
   });
 }

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -231,6 +231,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           replicaConfig.dbCheckpointFeatureEnabled = false;
           replicaConfig.dbCheckPointWindowSize = 150;
           replicaConfig.dbSnapshotIntervalSeconds = std::chrono::seconds{0};
+          replicaConfig.dbCheckpointMonitorIntervalSeconds = std::chrono::seconds{5};
           replicaConfig.maxNumberOfDbCheckpoints = concord::util::to<std::uint32_t>(std::string(optarg));
           if (replicaConfig.maxNumberOfDbCheckpoints) replicaConfig.dbCheckpointFeatureEnabled = true;
           std::stringstream dbSnapshotPath;


### PR DESCRIPTION
Adding new deployment config flag to monitor disk space for dbCheckpoints.
Prior to this flag the default value to monitor is 60sec, which makes test_skvbc_dbsnapshot apollo test timeout because it takes more than 3000 sec to complete it.