### PR TITLE
Implement ReplicaStateSnapshotService::StreamSnapshot

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -243,10 +243,10 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                "When set to true this parameter will cause endWriteTran to block until "
                "the transaction is persisted every time we update the metadata.");
 
-  CONFIG_PARAM(hashStateMultiGetBatchSize,
+  CONFIG_PARAM(stateIterationMultiGetBatchSize,
                std::uint32_t,
                30u,
-               "Amount of keys to get at once via multiGet when hashing state");
+               "Amount of keys to get at once via multiGet when iterating state");
 
   // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters

--- a/client/thin-replica-client/CMakeLists.txt
+++ b/client/thin-replica-client/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(thin_replica_client_lib
   opentracing
   util
   thin-replica-proto
-  state-snapshot-proto
+  replica-state-snapshot-proto
   concordclient-event-api
 )
 

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -22,10 +22,11 @@
 #include "endianness.hpp"
 #include "migrations/block_merkle_latest_ver_cf_migration.h"
 #include "storage/merkle_tree_key_manipulator.h"
-#include "categorized_kvbc_msgs.cmf.hpp"
 #include "categorization/details.h"
 #include "ReplicaConfig.hpp"
 
+#include <algorithm>
+#include <iterator>
 #include <stdexcept>
 
 namespace concord::kvbc::categorization {
@@ -396,58 +397,87 @@ static const auto kPublicStateHashKey = concord::storage::v2MerkleTree::detail::
 
 std::string KeyValueBlockchain::publicStateHashKey() { return kPublicStateHashKey; }
 
-static const auto kInitialHash = detail::hash(std::string{});
-
-void KeyValueBlockchain::computeAndPersistPublicStateHash(BlockId checkpoint_block_id) {
-  auto hash = kInitialHash;
-
-  auto persist = [&, this]() {
-    native_client_->put(kPublicStateHashKey, detail::serialize(StateHash{checkpoint_block_id, hash}));
-  };
-
+std::optional<PublicStateKeys> KeyValueBlockchain::getPublicStateKeys() const {
   const auto opt_val = getLatest(kConcordInternalCategoryId, keyTypes::state_public_key_set);
   if (!opt_val) {
-    // No public state keys - persist the hash of the empty string as a result.
-    persist();
-    return;
+    return std::nullopt;
   }
   auto public_state = PublicStateKeys{};
   const auto val = std::get_if<VersionedValue>(&opt_val.value());
   ConcordAssertNE(val, nullptr);
   detail::deserialize(val->data, public_state);
+  return std::make_optional(std::move(public_state));
+}
+
+void KeyValueBlockchain::iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f) const {
+  const auto ret = iteratePublicStateKeyValuesImpl(f, std::nullopt);
+  ConcordAssert(ret);
+}
+
+bool KeyValueBlockchain::iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f,
+                                                     const std::string& after_key) const {
+  return iteratePublicStateKeyValuesImpl(f, after_key);
+}
+
+bool KeyValueBlockchain::iteratePublicStateKeyValuesImpl(const std::function<void(std::string&&, std::string&&)>& f,
+                                                         const std::optional<std::string>& after_key) const {
+  const auto public_state = getPublicStateKeys();
+  if (!public_state) {
+    return true;
+  }
 
   auto idx = 0ull;
+  if (after_key) {
+    auto it = std::lower_bound(public_state->keys.cbegin(), public_state->keys.cend(), *after_key);
+    if (it == public_state->keys.cend() || *it != *after_key) {
+      return false;
+    }
+    // Start from the key after `after_key`.
+    idx = std::distance(public_state->keys.cbegin(), it) + 1;
+  }
+
+  const auto batch_size = bftEngine::ReplicaConfig::instance().stateIterationMultiGetBatchSize;
   auto keys_batch = std::vector<std::string>{};
-  keys_batch.reserve(bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize);
-  auto values = std::vector<std::optional<Value>>{};
-  values.reserve(bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize);
-  while (idx < public_state.keys.size()) {
+  keys_batch.reserve(batch_size);
+  auto opt_values = std::vector<std::optional<Value>>{};
+  opt_values.reserve(batch_size);
+  while (idx < public_state->keys.size()) {
     keys_batch.clear();
-    values.clear();
-    while (keys_batch.size() < bftEngine::ReplicaConfig::instance().hashStateMultiGetBatchSize) {
-      if (idx == public_state.keys.size()) {
+    opt_values.clear();
+    while (keys_batch.size() < batch_size) {
+      if (idx == public_state->keys.size()) {
         break;
       }
-      keys_batch.push_back(public_state.keys[idx]);
+      keys_batch.push_back(public_state->keys[idx]);
       ++idx;
     }
-    multiGetLatest(kExecutionProvableCategory, keys_batch, values);
-    ConcordAssertEQ(keys_batch.size(), values.size());
-
+    multiGetLatest(kExecutionProvableCategory, keys_batch, opt_values);
+    ConcordAssertEQ(keys_batch.size(), opt_values.size());
     for (auto i = 0ull; i < keys_batch.size(); ++i) {
-      auto hasher = Hasher{};
-      hasher.init();
-      hasher.update(hash.data(), hash.size());
-      const auto key_hash = detail::hash(keys_batch[i]);
-      hasher.update(key_hash.data(), key_hash.size());
-      ConcordAssert(values[i].has_value());
-      const auto val = std::get_if<MerkleValue>(&values[i].value());
-      ConcordAssertNE(val, nullptr);
-      hasher.update(val->data.data(), val->data.size());
-      hash = hasher.finish();
+      auto& opt_value = opt_values[i];
+      ConcordAssert(opt_value.has_value());
+      auto value = std::get_if<MerkleValue>(&opt_value.value());
+      ConcordAssertNE(value, nullptr);
+      f(std::move(keys_batch[i]), std::move(value->data));
     }
   }
-  persist();
+  return true;
+}
+
+static const auto kInitialHash = detail::hash(std::string{});
+
+void KeyValueBlockchain::computeAndPersistPublicStateHash(BlockId checkpoint_block_id) {
+  auto hash = kInitialHash;
+  iteratePublicStateKeyValues([&](const std::string& key, const std::string& value) {
+    auto hasher = Hasher{};
+    hasher.init();
+    hasher.update(hash.data(), hash.size());
+    const auto key_hash = detail::hash(key);
+    hasher.update(key_hash.data(), key_hash.size());
+    hasher.update(value.data(), value.size());
+    hash = hasher.finish();
+  });
+  native_client_->put(kPublicStateHashKey, detail::serialize(StateHash{checkpoint_block_id, hash}));
 }
 
 /////////////////////// Delete block ///////////////////////

--- a/logging/include/Logger.hpp
+++ b/logging/include/Logger.hpp
@@ -37,6 +37,7 @@ extern logging::Logger ST_DST_LOG;
 extern logging::Logger MSGS;
 extern logging::Logger CL_MNGR;
 extern logging::Logger TS_MNGR;
+extern logging::Logger STATE_SNAPSHOT;
 
 namespace logging {
 

--- a/logging/src/Logger.cpp
+++ b/logging/src/Logger.cpp
@@ -34,3 +34,4 @@ logging::Logger ST_SRC_LOG = logging::getLogger("concord.bft.st.src");
 logging::Logger MSGS = logging::getLogger("concord.bft.msgs");
 logging::Logger CL_MNGR = logging::getLogger("concord.bft.client-manager");
 logging::Logger TS_MNGR = logging::getLogger("concord.bft.time-service-manager");
+logging::Logger STATE_SNAPSHOT = logging::getLogger("concord.thin_replica.replica-state-snapshot");

--- a/thin-replica-server/CMakeLists.txt
+++ b/thin-replica-server/CMakeLists.txt
@@ -2,7 +2,7 @@ project("Thin Replica Server")
 
 add_subdirectory("proto")
 
-file(GLOB thin_replica_server_src "src/grpc_services.cpp")
+file(GLOB thin_replica_server_src "src/grpc_services.cpp" "src/replica_state_snapshot_service_impl.cpp")
 
 add_library(thin_replica_server ${thin_replica_server_src})
 target_include_directories(thin_replica_server PUBLIC include)
@@ -17,6 +17,7 @@ endif()
 target_link_libraries(thin_replica_server PUBLIC
   concord_block_update
   thin-replica-proto
+  replica-state-snapshot-proto
   kvbc
   logging
   util

--- a/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
@@ -1,0 +1,48 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "replica_state_snapshot.grpc.pb.h"
+
+#include "bftengine/DbCheckpointManager.hpp"
+
+#include <optional>
+#include <string>
+
+namespace concord::thin_replica {
+
+class ReplicaStateSnapshotServiceImpl
+    : public vmware::concord::replicastatesnapshot::ReplicaStateSnapshotService::Service {
+ public:
+  // Streams the state snapshot requested in `request` in the form of a finite stream of key-values.
+  // See `replica_state_snapshot.proto` for the possible return values and the data structures.
+  ::grpc::Status StreamSnapshot(
+      ::grpc::ServerContext* context,
+      const ::vmware::concord::replicastatesnapshot::StreamSnapshotRequest* request,
+      ::grpc::ServerWriter< ::vmware::concord::replicastatesnapshot::StreamSnapshotResponse>* writer) override;
+
+  // Following methods are used for testing only. Please do not use in production.
+  void overrideCheckpointPathForTest(const std::string& path) { overriden_path_for_test_ = path; }
+  void overrideCheckpointStateForTest(bftEngine::impl::DbCheckpointManager::CheckpointState state) {
+    overriden_checkpoint_state_for_test_ = state;
+  }
+  void throwExceptionForTest() { throw_exception_for_test_ = true; }
+
+ private:
+  std::optional<std::string> overriden_path_for_test_;
+  std::optional<bftEngine::impl::DbCheckpointManager::CheckpointState> overriden_checkpoint_state_for_test_;
+  bool throw_exception_for_test_{false};
+};
+
+}  // namespace concord::thin_replica

--- a/thin-replica-server/proto/CMakeLists.txt
+++ b/thin-replica-server/proto/CMakeLists.txt
@@ -11,10 +11,10 @@ grpc_generate_cpp(THIN_REPLICA_GRPC_SRCS THIN_REPLICA_GRPC_HDRS ${CMAKE_CURRENT_
 )
 message(STATUS "Thin replica gRPC/protobuf generated - see " ${CMAKE_CURRENT_BINARY_DIR})
 
-protobuf_generate_cpp(STATE_SNAPSHOT_PROTO_SRCS STATE_SNAPSHOT_PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+protobuf_generate_cpp(REPLICA_STATE_SNAPSHOT_PROTO_SRCS REPLICA_STATE_SNAPSHOT_PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   replica_state_snapshot.proto
 )
-grpc_generate_cpp(STATE_SNAPSHOT_GRPC_SRCS STATE_SNAPSHOT_GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+grpc_generate_cpp(REPLICA_STATE_SNAPSHOT_GRPC_SRCS REPLICA_STATE_SNAPSHOT_GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   replica_state_snapshot.proto
 )
 message(STATUS "State snapshot gRPC/protobuf generated - see " ${CMAKE_CURRENT_BINARY_DIR})
@@ -24,7 +24,7 @@ add_library(thin-replica-proto STATIC ${THIN_REPLICA_PROTO_SRCS} ${THIN_REPLICA_
 target_link_libraries(thin-replica-proto protobuf::libprotobuf gRPC::grpc++)
 target_include_directories(thin-replica-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
-add_library(state-snapshot-proto STATIC ${STATE_SNAPSHOT_PROTO_SRCS} ${STATE_SNAPSHOT_PROTO_HDRS} 
-            ${STATE_SNAPSHOT_GRPC_SRCS} ${STATE_SNAPSHOT_GRPC_HDRS})
-target_link_libraries(state-snapshot-proto protobuf::libprotobuf gRPC::grpc++)
-target_include_directories(state-snapshot-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+add_library(replica-state-snapshot-proto STATIC ${REPLICA_STATE_SNAPSHOT_PROTO_SRCS} ${REPLICA_STATE_SNAPSHOT_PROTO_HDRS} 
+            ${REPLICA_STATE_SNAPSHOT_GRPC_SRCS} ${REPLICA_STATE_SNAPSHOT_GRPC_HDRS})
+target_link_libraries(replica-state-snapshot-proto protobuf::libprotobuf gRPC::grpc++)
+target_include_directories(replica-state-snapshot-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/thin-replica-server/src/replica_state_snapshot_service_impl.cpp
+++ b/thin-replica-server/src/replica_state_snapshot_service_impl.cpp
@@ -1,0 +1,106 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "thin-replica-server/replica_state_snapshot_service_impl.hpp"
+
+#include "categorization/kv_blockchain.h"
+#include "Logger.hpp"
+#include "rocksdb/native_client.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace concord::thin_replica {
+
+using vmware::concord::replicastatesnapshot::StreamSnapshotRequest;
+using vmware::concord::replicastatesnapshot::StreamSnapshotResponse;
+
+using bftEngine::impl::DbCheckpointManager;
+using kvbc::categorization::KeyValueBlockchain;
+using storage::rocksdb::NativeClient;
+
+grpc::Status ReplicaStateSnapshotServiceImpl::StreamSnapshot(grpc::ServerContext* context,
+                                                             const StreamSnapshotRequest* request,
+                                                             grpc::ServerWriter<StreamSnapshotResponse>* writer) {
+  const auto snapshot_id_str = std::to_string(request->snapshot_id());
+  if (!overriden_path_for_test_.has_value()) {
+    const auto checkpoint_state = overriden_checkpoint_state_for_test_.has_value()
+                                      ? *overriden_checkpoint_state_for_test_
+                                      : DbCheckpointManager::instance().getCheckpointState(request->snapshot_id());
+    switch (checkpoint_state) {
+      case DbCheckpointManager::CheckpointState::kNonExistent: {
+        const auto msg = "State Snapshot ID = " + snapshot_id_str + " doesn't exist";
+        LOG_INFO(STATE_SNAPSHOT, msg);
+        return grpc::Status{grpc::StatusCode::NOT_FOUND, msg};
+      }
+      case DbCheckpointManager::CheckpointState::kPending: {
+        const auto msg = "State Snapshot ID = " + snapshot_id_str + " is pending creation";
+        LOG_INFO(STATE_SNAPSHOT, msg);
+        return grpc::Status{grpc::StatusCode::UNAVAILABLE, msg};
+      }
+      case DbCheckpointManager::CheckpointState::kCreated:
+        LOG_INFO(STATE_SNAPSHOT, "Starting streaming of State Snapshot ID = " + snapshot_id_str);
+        break;
+    }
+  }
+
+  try {
+    if (throw_exception_for_test_) {
+      throw std::runtime_error{"test exception - only thrown in tests"};
+    }
+
+    const auto snapshot_path = overriden_path_for_test_.has_value()
+                                   ? *overriden_path_for_test_
+                                   : DbCheckpointManager::instance().getPathForCheckpoint(request->snapshot_id());
+    const auto link_st_chain = false;
+    const auto read_only = true;
+    auto db = NativeClient::newClient(snapshot_path, read_only, NativeClient::DefaultOptions{});
+    const auto kvbc = KeyValueBlockchain{db, link_st_chain};
+
+    const auto iterate = [&](std::string&& key, std::string&& value) {
+      auto resp = StreamSnapshotResponse{};
+      auto kv = resp.mutable_key_value();
+      auto resp_key = kv->mutable_key();
+      auto resp_value = kv->mutable_value();
+      *resp_key = std::move(key);
+      *resp_value = std::move(value);
+      if (!writer->Write(resp)) {
+        const auto err =
+            "Streaming of State Snapshot ID = " + snapshot_id_str + " failed, reason = gRPC:Write() failure";
+        LOG_ERROR(STATE_SNAPSHOT, err);
+        throw std::runtime_error{err};
+      }
+    };
+
+    if (request->has_last_received_key()) {
+      if (!kvbc.iteratePublicStateKeyValues(iterate, request->last_received_key())) {
+        const auto msg =
+            "Streaming of State Snapshot ID = " + snapshot_id_str + " failed, reason = last_received_key not found";
+        LOG_INFO(STATE_SNAPSHOT, msg);
+        return grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, msg};
+      }
+    } else {
+      kvbc.iteratePublicStateKeyValues(iterate);
+    }
+  } catch (const std::exception& e) {
+    const auto err = "Streaming of State Snapshot ID = " + snapshot_id_str + " failed, reason = " + e.what();
+    LOG_ERROR(STATE_SNAPSHOT, err);
+    return grpc::Status{grpc::StatusCode::UNKNOWN, err};
+  }
+
+  const auto success_msg = "Streaming of State Snapshot ID = " + snapshot_id_str + " succeeded";
+  LOG_INFO(STATE_SNAPSHOT, success_msg);
+  return grpc::Status{grpc::StatusCode::OK, success_msg};
+}
+
+}  // namespace concord::thin_replica

--- a/thin-replica-server/test/CMakeLists.txt
+++ b/thin-replica-server/test/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(Boost ${MIN_BOOST_VERSION} COMPONENTS program_options REQUIRED)
 
 add_test(NAME thin_replica_server_test COMMAND thin_replica_server_test)
 add_test(NAME trs_sub_buffer_test COMMAND trs_sub_buffer_test)
+add_test(NAME replica_state_snapshot_service_test COMMAND replica_state_snapshot_service_test)
 
 add_executable(thin_replica_server_test
         thin_replica_server_test.cpp)
@@ -23,6 +24,15 @@ target_link_libraries(trs_sub_buffer_test
         GTest::Main
         GTest::GTest
         categorized_kvbc_msgs
+        thin_replica_server
+        logging)
+
+add_executable(replica_state_snapshot_service_test replica_state_snapshot_service_test.cpp)
+target_link_libraries(replica_state_snapshot_service_test
+        ${Boost_LIBRARIES}
+        GTest::Main
+        GTest::GTest
+        kvbc
         thin_replica_server
         logging)
 

--- a/thin-replica-server/test/replica_state_snapshot_service_test.cpp
+++ b/thin-replica-server/test/replica_state_snapshot_service_test.cpp
@@ -1,0 +1,246 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "categorization/db_categories.h"
+#include "categorization/kv_blockchain.h"
+#include "kvbc_key_types.hpp"
+#include "storage/test/storage_test_common.h"
+#include "thin-replica-server/replica_state_snapshot_service_impl.hpp"
+
+#include <grpcpp/channel.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace ::testing;
+using namespace concord::kvbc;
+using namespace concord::kvbc::categorization;
+using namespace concord::thin_replica;
+using bftEngine::impl::DbCheckpointManager;
+using concord::storage::rocksdb::NativeClient;
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::ClientReader;
+using grpc::CreateChannel;
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::StatusCode;
+using vmware::concord::replicastatesnapshot::ReplicaStateSnapshotService;
+using vmware::concord::replicastatesnapshot::StreamSnapshotRequest;
+using vmware::concord::replicastatesnapshot::StreamSnapshotResponse;
+
+class replica_state_snapshot_service_test : public Test {
+  void SetUp() override {
+    destroyDb();
+    db_ = TestRocksDb::createNative();
+    const auto link_st_chain = false;
+    kvbc_ = std::make_unique<KeyValueBlockchain>(
+        db_,
+        link_st_chain,
+        std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                             {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}});
+  }
+
+  void TearDown() override {
+    destroyDb();
+    shutdownServer();
+  }
+
+ protected:
+  void destroyDb() {
+    db_.reset();
+    ASSERT_EQ(0, db_.use_count());
+    cleanup();
+  }
+
+  void startServer() {
+    builder_.AddListeningPort(grpc_uri_, grpc::InsecureServerCredentials());
+    builder_.RegisterService(&service_);
+    server_ = builder_.BuildAndStart();
+  }
+
+  void shutdownServer() {
+    server_->Shutdown();
+    server_->Wait();
+  }
+
+  void addPublicState() {
+    auto updates = Updates{};
+    auto merkle = BlockMerkleUpdates{};
+    merkle.addUpdate("a", "va");
+    merkle.addUpdate("b", "vb");
+    merkle.addUpdate("c", "vc");
+    merkle.addUpdate("d", "vd");
+    auto versioned = VersionedUpdates{};
+    const auto public_state = PublicStateKeys{std::vector<std::string>{"a", "b", "c", "d"}};
+    const auto ser_public_state = detail::serialize(public_state);
+    versioned.addUpdate(std::string{keyTypes::state_public_key_set},
+                        std::string{ser_public_state.cbegin(), ser_public_state.cend()});
+    updates.add(kExecutionProvableCategory, std::move(merkle));
+    updates.add(kConcordInternalCategoryId, std::move(versioned));
+    ASSERT_EQ(kvbc_->addBlock(std::move(updates)), 1);
+  }
+
+ protected:
+  const std::string grpc_uri_{"127.0.0.1:50051"};
+  std::shared_ptr<NativeClient> db_;
+  ServerBuilder builder_;
+  ReplicaStateSnapshotServiceImpl service_;
+  std::unique_ptr<Server> server_;
+  std::shared_ptr<Channel> channel_ = grpc::CreateChannel(grpc_uri_, grpc::InsecureChannelCredentials());
+  std::unique_ptr<ReplicaStateSnapshotService::Stub> stub_ = ReplicaStateSnapshotService::NewStub(channel_);
+  std::unique_ptr<KeyValueBlockchain> kvbc_;
+};
+
+TEST_F(replica_state_snapshot_service_test, non_existent_snapshot_id) {
+  startServer();
+  auto context = ClientContext{};
+  auto request = StreamSnapshotRequest{};
+  request.set_snapshot_id(42);
+  auto response = StreamSnapshotResponse{};
+  auto reader = std::unique_ptr<ClientReader<StreamSnapshotResponse>>{stub_->StreamSnapshot(&context, request)};
+  auto kvs = std::vector<std::pair<std::string, std::string>>{};
+  while (reader->Read(&response)) {
+    kvs.push_back(std::make_pair(response.key_value().key(), response.key_value().value()));
+  }
+  const auto status = reader->Finish();
+  ASSERT_EQ(status.error_code(), StatusCode::NOT_FOUND);
+  ASSERT_TRUE(kvs.empty());
+}
+
+TEST_F(replica_state_snapshot_service_test, no_last_received_key) {
+  addPublicState();
+  service_.overrideCheckpointPathForTest(db_->path());
+  startServer();
+  auto context = ClientContext{};
+  auto request = StreamSnapshotRequest{};
+  request.set_snapshot_id(42);  // ignored, because we override the DB path and, hence, the DbCheckpointManager
+  auto response = StreamSnapshotResponse{};
+  auto reader = std::unique_ptr<ClientReader<StreamSnapshotResponse>>{stub_->StreamSnapshot(&context, request)};
+  auto kvs = std::vector<std::pair<std::string, std::string>>{};
+  while (reader->Read(&response)) {
+    kvs.push_back(std::make_pair(response.key_value().key(), response.key_value().value()));
+  }
+  const auto status = reader->Finish();
+  ASSERT_EQ(status.error_code(), StatusCode::OK);
+  ASSERT_THAT(kvs,
+              ContainerEq(std::vector<std::pair<std::string, std::string>>{
+                  {"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"d", "vd"}}));
+}
+
+TEST_F(replica_state_snapshot_service_test, valid_last_received_key) {
+  addPublicState();
+  service_.overrideCheckpointPathForTest(db_->path());
+  startServer();
+  auto context = ClientContext{};
+  auto request = StreamSnapshotRequest{};
+  request.set_snapshot_id(42);  // ignored, because we override the DB path and, hence, the DbCheckpointManager
+  request.set_last_received_key("b");
+  auto response = StreamSnapshotResponse{};
+  auto reader = std::unique_ptr<ClientReader<StreamSnapshotResponse>>{stub_->StreamSnapshot(&context, request)};
+  auto kvs = std::vector<std::pair<std::string, std::string>>{};
+  while (reader->Read(&response)) {
+    kvs.push_back(std::make_pair(response.key_value().key(), response.key_value().value()));
+  }
+  const auto status = reader->Finish();
+  ASSERT_EQ(status.error_code(), StatusCode::OK);
+  ASSERT_THAT(kvs, ContainerEq(std::vector<std::pair<std::string, std::string>>{{"c", "vc"}, {"d", "vd"}}));
+}
+
+TEST_F(replica_state_snapshot_service_test, last_key_as_last_received_key) {
+  addPublicState();
+  service_.overrideCheckpointPathForTest(db_->path());
+  startServer();
+  auto context = ClientContext{};
+  auto request = StreamSnapshotRequest{};
+  request.set_snapshot_id(42);  // ignored, because we override the DB path and, hence, the DbCheckpointManager
+  request.set_last_received_key("d");
+  auto response = StreamSnapshotResponse{};
+  auto reader = std::unique_ptr<ClientReader<StreamSnapshotResponse>>{stub_->StreamSnapshot(&context, request)};
+  auto kvs = std::vector<std::pair<std::string, std::string>>{};
+  while (reader->Read(&response)) {
+    kvs.push_back(std::make_pair(response.key_value().key(), response.key_value().value()));
+  }
+  const auto status = reader->Finish();
+  ASSERT_EQ(status.error_code(), StatusCode::OK);
+  ASSERT_TRUE(kvs.empty());
+}
+
+TEST_F(replica_state_snapshot_service_test, invalid_last_received_key) {
+  addPublicState();
+  service_.overrideCheckpointPathForTest(db_->path());
+  startServer();
+  auto context = ClientContext{};
+  auto request = StreamSnapshotRequest{};
+  request.set_snapshot_id(42);  // ignored, because we override the DB path and, hence, the DbCheckpointManager
+  request.set_last_received_key("e");
+  auto response = StreamSnapshotResponse{};
+  auto reader = std::unique_ptr<ClientReader<StreamSnapshotResponse>>{stub_->StreamSnapshot(&context, request)};
+  auto kvs = std::vector<std::pair<std::string, std::string>>{};
+  while (reader->Read(&response)) {
+    kvs.push_back(std::make_pair(response.key_value().key(), response.key_value().value()));
+  }
+  const auto status = reader->Finish();
+  ASSERT_EQ(status.error_code(), StatusCode::INVALID_ARGUMENT);
+  ASSERT_TRUE(kvs.empty());
+}
+
+TEST_F(replica_state_snapshot_service_test, pending_checkpoint_creation) {
+  addPublicState();
+  service_.overrideCheckpointStateForTest(DbCheckpointManager::CheckpointState::kPending);
+  startServer();
+  auto context = ClientContext{};
+  auto request = StreamSnapshotRequest{};
+  request.set_snapshot_id(42);  // ignored, because we override the checkpoint state
+  auto response = StreamSnapshotResponse{};
+  auto reader = std::unique_ptr<ClientReader<StreamSnapshotResponse>>{stub_->StreamSnapshot(&context, request)};
+  auto kvs = std::vector<std::pair<std::string, std::string>>{};
+  while (reader->Read(&response)) {
+    kvs.push_back(std::make_pair(response.key_value().key(), response.key_value().value()));
+  }
+  const auto status = reader->Finish();
+  ASSERT_EQ(status.error_code(), StatusCode::UNAVAILABLE);
+  ASSERT_TRUE(kvs.empty());
+}
+
+TEST_F(replica_state_snapshot_service_test, exception_thrown_while_streaming) {
+  addPublicState();
+  service_.overrideCheckpointPathForTest(db_->path());
+  service_.throwExceptionForTest();
+  startServer();
+  auto context = ClientContext{};
+  auto request = StreamSnapshotRequest{};
+  request.set_snapshot_id(42);  // ignored, because we override the DB path and, hence, the DbCheckpointManager
+  auto response = StreamSnapshotResponse{};
+  auto reader = std::unique_ptr<ClientReader<StreamSnapshotResponse>>{stub_->StreamSnapshot(&context, request)};
+  auto kvs = std::vector<std::pair<std::string, std::string>>{};
+  while (reader->Read(&response)) {
+    kvs.push_back(std::make_pair(response.key_value().key(), response.key_value().value()));
+  }
+  const auto status = reader->Finish();
+  ASSERT_EQ(status.error_code(), StatusCode::UNKNOWN);
+  ASSERT_TRUE(kvs.empty());
+}
+
+}  // namespace


### PR DESCRIPTION
Implement streaming state in replicas by introducing the
`KeyValueBlockchain::iteratePublicStateKeyValues()` method that accepts a
callback to be called on every iterated key-value. This callback
directly writes to the gRPC state snapshot stream.

Add support for resumption of state streaming from the
`last_received_key`.

Add an unit test to verify the newly-introduced behaviours.