### PR TITLE
Fixing a bug in create db snapshot flow via opertor cmd

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -103,10 +103,6 @@ class DbCheckpointManager {
   std::map<CheckpointId, DbCheckpointMetadata::DbCheckPointDescriptor> getListOfDbCheckpoints() const {
     return dbCheckptMetadata_.dbCheckPoints_;
   }
-  inline bool isCreateDbCheckPtSeqNumSet(const SeqNum& seqNum) {
-    return (DbCheckpointManager::instance().getNextStableSeqNumToCreateSnapshot().has_value() &&
-            DbCheckpointManager::instance().getNextStableSeqNumToCreateSnapshot().value() >= seqNum);
-  }
 
   /***
    * The operator command uses this function to find the next immediate stable seq number

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -272,7 +272,6 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
                                                         "Gauges", "lastDbCheckpointBlockId", component="rocksdbCheckpoint")
             self.verify_snapshot_is_available(bft_network, replica_id, last_blockId)
 
-    @unittest.skip("Disabled until fixed")
     @with_trio
     @with_bft_network(start_replica_cmd_with_operator, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability()


### PR DESCRIPTION
When last executed sequence number is greater than the seqNum set to create snapshot, snapshots aren't getting created because of a bug in the condition check. This PR addresses this issue.