### PR TITLE
Support state snapshot public keys count estimate

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -156,6 +156,8 @@ class Replica : public IReplica,
     return nullptr;
   }
 
+  std::optional<categorization::KeyValueBlockchain> &kvBlockchain() { return m_kvBlockchain; }
+
   ~Replica() override;
 
  protected:

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -188,6 +188,12 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
 
+  bool handle(const concord::messages::StateSnapshotRequest&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
+
   bool handle(const concord::messages::SignedPublicStateHashRequest&,
               uint64_t,
               uint32_t,

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -285,6 +285,11 @@ Msg StateSnapshotData 66 {
 
   # The event group ID at which the state snapshot with `snapshot_id` was taken.
   uint64 event_group_id
+
+  # An estimate (with reasonable accuracy) of the count of key-values contained
+  # in the state snapshot. Please note that this is an estimation and *not* the
+  # actual count.
+  uint64 key_value_count_estimate
 }
 
 # The response to a `StateSnapshotRequest`. Sent by the replicas to Clientservice.

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -81,12 +81,6 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
               const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
 
-  bool handle(const concord::messages::StateSnapshotRequest &,
-              uint64_t,
-              uint32_t,
-              const std::optional<bftEngine::Timestamp> &,
-              concord::messages::ReconfigurationResponse &) override;
-
  private:
   void handleWedgeCommands(
       bool bft_support, bool remove_metadata, bool restart, bool unwedge, bool blockNewConnections);

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -136,7 +136,13 @@ void run_replica(int argc, char** argv) {
 
   if (!setup->GetReplicaConfig().isReadOnly) replica->setReplicaStateSync(new ReplicaStateSyncImp(blockMetadata));
 
-  auto cmdHandler = std::make_shared<InternalCommandsHandler>(replica.get(), replica.get(), blockMetadata, logger);
+  auto cmdHandler =
+      std::make_shared<InternalCommandsHandler>(replica.get(),
+                                                replica.get(),
+                                                blockMetadata,
+                                                logger,
+                                                setup->AddAllKeysAsPublic(),
+                                                replica->kvBlockchain() ? &replica->kvBlockchain().value() : nullptr);
   replica->set_command_handler(cmdHandler);
   replica->start();
   if (setup->GetReplicaConfig().isReadOnly)

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -85,6 +85,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::optional<std::uint32_t> cronEntryNumberOfExecutes;
     std::string byzantineStrategies;
     bool is_separate_communication_mode = false;
+    int addAllKeysAsPublic = 0;
 
     static struct option longOptions[] = {
         {"replica-id", required_argument, 0, 'i'},
@@ -115,6 +116,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
         {"pre-exec-result-auth", no_argument, 0, 'x'},
         {"enable-db-checkpoint", required_argument, 0, 'h'},
         {"publish-master-key-on-startup", no_argument, (int*)&replicaConfig.publishReplicasMasterKeyOnStartup, 1},
+        {"add-all-keys-as-public", no_argument, &addAllKeysAsPublic, 1},
         {0, 0, 0, 0}};
     int o = 0;
     int optionIndex = 0;
@@ -317,7 +319,8 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                               persistMode == PersistencyMode::RocksDB,
                               s3ConfigFile,
                               logPropsFile,
-                              cronEntryNumberOfExecutes));
+                              cronEntryNumberOfExecutes,
+                              addAllKeysAsPublic != 0));
     setup->sm_ = sm_;
     return setup;
 

--- a/tests/simpleKVBC/TesterReplica/setup.hpp
+++ b/tests/simpleKVBC/TesterReplica/setup.hpp
@@ -46,6 +46,7 @@ class TestSetup {
   std::string getLogPropertiesFile() { return logPropsFile_; }
   std::shared_ptr<concord::performance::PerformanceManager> GetPerformanceManager() { return pm_; }
   std::optional<std::uint32_t> GetCronEntryNumberOfExecutes() const { return cronEntryNumberOfExecutes_; }
+  bool AddAllKeysAsPublic() const { return addAllKeysAsPublic_; }
 
   static inline constexpr auto kCronTableComponentId = 42;
   static inline constexpr auto kTickGeneratorPeriod = std::chrono::seconds{1};
@@ -58,7 +59,8 @@ class TestSetup {
             bool usePersistentStorage,
             const std::string& s3ConfigFile,
             const std::string& logPropsFile,
-            const std::optional<std::uint32_t>& cronEntryNumberOfExecutes)
+            const std::optional<std::uint32_t>& cronEntryNumberOfExecutes,
+            bool addAllKeysAsPublic)
       : replicaConfig_(config),
         communication_(std::move(comm)),
         logger_(logger),
@@ -67,7 +69,8 @@ class TestSetup {
         s3ConfigFile_(s3ConfigFile),
         logPropsFile_(logPropsFile),
         pm_{std::make_shared<concord::performance::PerformanceManager>()},
-        cronEntryNumberOfExecutes_{cronEntryNumberOfExecutes} {}
+        cronEntryNumberOfExecutes_{cronEntryNumberOfExecutes},
+        addAllKeysAsPublic_{addAllKeysAsPublic} {}
 
   TestSetup() = delete;
 
@@ -87,6 +90,7 @@ class TestSetup {
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
   std::optional<std::uint32_t> cronEntryNumberOfExecutes_;
   std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
+  bool addAllKeysAsPublic_{false};
 };
 
 }  // namespace concord::kvbc


### PR DESCRIPTION
Add the CMF StateSnapshotData.key_value_count_estimate field that
provides an estimate (with reasonable accuracy) of the count of
key-values contained in the state snapshot. If we are using an existing
snapshot at the time of the StateSnapshotRequest, use the actual public
key-value count in the snapshot. If creating a snapshot asynchronously
at the time of the request, use the current public key-value count in
the blockchain. In order to achieve it, move StateSnapshotRequest
handling to the KVBC reconfiguration handler instead of the generic one
that doesn't have access to KVBC.

Augment the Apollo tests such that we test all scenarios - with and
without a snapshot and with and without public keys. To achieve that,
add support for the --add-all-keys-as-public TesterReplica option that
allows us to add (or not) public keys.