### PR TITLE
Add prune stop message + implement basic KVBC reconfiguration handlers…

### DIFF
--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -33,6 +33,14 @@ static const char reconfiguration_rep_main_key = 0x32;
 static const std::string genesis_block_key(1, 0x32);
 static const std::string state_public_key_set(1, 0x33);
 
+enum PRUNING_COMMAND_TYPES : uint16_t {
+  PRUNING_START = 0x0,
+  BACKWARD_COMP = 0x1,
+  TICKS_CHANGE_REQUEST = 0x2,
+  SWITCH_MODE_REQUEST = 0x3,
+  STOP_REQUEST = 0x4,
+  PRUNING_END
+};
 enum CLIENT_COMMAND_TYPES : uint8_t {
   start_ = 0x0,
   PUBLIC_KEY_EXCHANGE = 0x1,             // identifier of public key exchange request by client

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -193,6 +193,24 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
+
+  bool handle(const concord::messages::PruneTicksChangeRequest&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
+
+  bool handle(const concord::messages::PruneSwitchModeRequest&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
+
+  bool handle(const concord::messages::PruneStopRequest&,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp>&,
+              concord::messages::ReconfigurationResponse&) override;
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -849,6 +849,60 @@ bool ReconfigurationHandler::handle(const concord::messages::SignedPublicStateHa
   return true;
 }
 
+bool ReconfigurationHandler::handle(const concord::messages::PruneTicksChangeRequest& command,
+                                    uint64_t bft_seq_num,
+                                    uint32_t sender_id,
+                                    const std::optional<bftEngine::Timestamp>& ts,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(
+      serialized_command,
+      bft_seq_num,
+      std::string{kvbc::keyTypes::reconfiguration_pruning_key,
+                  static_cast<char>(kvbc::keyTypes::PRUNING_COMMAND_TYPES::TICKS_CHANGE_REQUEST)},
+      ts,
+      false);
+  LOG_INFO(getLogger(), "block id: " << KVLOG(blockId, sender_id));
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::PruneSwitchModeRequest& command,
+                                    uint64_t bft_seq_num,
+                                    uint32_t sender_id,
+                                    const std::optional<bftEngine::Timestamp>& ts,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId = persistReconfigurationBlock(
+      serialized_command,
+      bft_seq_num,
+      std::string{kvbc::keyTypes::reconfiguration_pruning_key,
+                  static_cast<char>(kvbc::keyTypes::PRUNING_COMMAND_TYPES::SWITCH_MODE_REQUEST)},
+      ts,
+      false);
+  LOG_INFO(getLogger(), "block id: " << KVLOG(blockId, sender_id));
+  return true;
+}
+
+bool ReconfigurationHandler::handle(const concord::messages::PruneStopRequest& command,
+                                    uint64_t bft_seq_num,
+                                    uint32_t sender_id,
+                                    const std::optional<bftEngine::Timestamp>& ts,
+                                    concord::messages::ReconfigurationResponse&) {
+  std::vector<uint8_t> serialized_command;
+  concord::messages::serialize(serialized_command, command);
+  auto blockId =
+      persistReconfigurationBlock(serialized_command,
+                                  bft_seq_num,
+                                  std::string{kvbc::keyTypes::reconfiguration_pruning_key,
+                                              static_cast<char>(kvbc::keyTypes::PRUNING_COMMAND_TYPES::STOP_REQUEST)},
+                                  ts,
+                                  false);
+  LOG_INFO(getLogger(), "block id: " << KVLOG(blockId, sender_id));
+  return true;
+}
+
 bool InternalKvReconfigurationHandler::verifySignature(uint32_t sender_id,
                                                        const std::string& data,
                                                        const std::string& signature) const {

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -376,6 +376,10 @@ Msg PruneTicksChangeRequest 74 {
     uint64 batch_blocks_num
 }
 
+Msg PruneStopRequest 75 {
+    uint64 sender_id
+}
+
 Msg ReconfigurationRequest 1 {
   uint64 sender
   bytes signature
@@ -411,6 +415,7 @@ Msg ReconfigurationRequest 1 {
     ClientsRestartStatus
     ClientsRestartUpdate
     PruneSwitchModeRequest
+    PruneStopRequest
     GetDbCheckpointInfoRequest
     CreateDbCheckpointCommand
     ReplicaMainKeyUpdate

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -292,6 +292,14 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::PruneStopRequest &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const = 0;


### PR DESCRIPTION
… for the existing commands

In this PR we add a PruneStop CMF message to handle the prune-stop request.
In addition, we also added a basic implementation for the KVBC reconfiguration handler (writing the new pruning commands to the blockchain)