### PR TITLE
dbcheckpoint apollo test improvement

### DIFF
--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -233,7 +233,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
           replicaConfig.dbCheckpointFeatureEnabled = false;
           replicaConfig.dbCheckPointWindowSize = 150;
           replicaConfig.dbSnapshotIntervalSeconds = std::chrono::seconds{0};
-          replicaConfig.dbCheckpointMonitorIntervalSeconds = std::chrono::seconds{5};
+          replicaConfig.dbCheckpointMonitorIntervalSeconds = std::chrono::seconds{1};
           replicaConfig.maxNumberOfDbCheckpoints = concord::util::to<std::uint32_t>(std::string(optarg));
           if (replicaConfig.maxNumberOfDbCheckpoints) replicaConfig.dbCheckpointFeatureEnabled = true;
           std::stringstream dbSnapshotPath;


### PR DESCRIPTION
This PR fixes all of the issues that cause clang workflow CI actions for the dbSnapshot apollo test to fail.
It also includes a fix for codecoverage workflow CI job timeout concerns.