### PR TITLE
Present num of client service parameter

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -551,11 +551,10 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.dbCheckPointWindowSize,
               rc.dbCheckpointDirPath,
               rc.adaptivePruningIntervalDuration.count(),
-              rc.adaptivePruningIntervalPeriod,
-              rc.dbSnapshotIntervalSeconds.count(),
-              rc.dbCheckpointMonitorIntervalSeconds.count(),
-              rc.enableMultiplexChannel);
-
+              rc.adaptivePruningIntervalPeriod);
+  os << ",";
+  os << KVLOG(
+      rc.dbSnapshotIntervalSeconds.count(), rc.dbCheckpointMonitorIntervalSeconds.count(), rc.enableMultiplexChannel);
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;
 }

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -58,6 +58,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                "replicaId should also represent this replica in ICommunication.");
   CONFIG_PARAM(numOfClientProxies, uint16_t, 0, "number of objects that represent clients, numOfClientProxies >= 1");
   CONFIG_PARAM(numOfExternalClients, uint16_t, 0, "number of objects that represent external clients");
+  CONFIG_PARAM(numOfClientServices, uint16_t, 0, "number of objects that represent client services");
   CONFIG_PARAM(sizeOfInternalThreadPool, uint16_t, 8, "number of threads in the internal replica thread pool");
   CONFIG_PARAM(statusReportTimerMillisec, uint16_t, 0, "how often the replica sends a status report to other replicas");
   CONFIG_PARAM(clientRequestRetransmissionTimerMilli,
@@ -295,6 +296,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, replicaId);
     serialize(outStream, numOfClientProxies);
     serialize(outStream, numOfExternalClients);
+    serialize(outStream, numOfClientServices);
     serialize(outStream, statusReportTimerMillisec);
     serialize(outStream, concurrencyLevel);
     serialize(outStream, numWorkerThreadsForBlockIO);
@@ -386,6 +388,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, replicaId);
     deserialize(inStream, numOfClientProxies);
     deserialize(inStream, numOfExternalClients);
+    deserialize(inStream, numOfClientServices);
     deserialize(inStream, statusReportTimerMillisec);
     deserialize(inStream, concurrencyLevel);
     deserialize(inStream, numWorkerThreadsForBlockIO);
@@ -542,6 +545,7 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.threadbagConcurrencyLevel2,
               rc.enablePostExecutionSeparation,
               rc.postExecutionQueuesSize,
+              rc.numOfClientServices,
               rc.dbCheckpointFeatureEnabled,
               rc.maxNumberOfDbCheckpoints,
               rc.dbCheckPointWindowSize,

--- a/bftengine/src/bftengine/ReplicasInfo.cpp
+++ b/bftengine/src/bftengine/ReplicasInfo.cpp
@@ -35,9 +35,15 @@ namespace impl {
 //  [numReplicas+numRoReplicas+numOfClientProxies+numOfExternalClients-1,
 //  numReplicas+numRoReplicas+numOfClientProxies+numOfExternalClients+numOfInternalClients-1] inclusive
 //
+// Client services address range:
+//  [numReplicas+numRoReplicas+numOfClientProxies+numOfExternalClients+numOfInternalClients-1,
+//  numReplicas+numRoReplicas+numOfClientProxies+numOfExternalClients+numOfInternalClients+numOfClientServices-1]
+//  inclusive
+//
 // Example:
-//  numReplicas = 7, numRoReplicas = 1, numOfClientProxies=14, numOfExternalClients=100, numOfInternalClients=7
-//  address range in this order: [0,6], [7,7], [8,21] , [22,121], [122,128] - total 129 participants
+//  numReplicas = 7, numRoReplicas = 1, numOfClientProxies=14, numOfExternalClients=100, numOfInternalClients=7,
+//  numOfClientServices=2 address range in this order: [0,6], [7,7], [8,21] , [22,121], [122,128], [129,130] - total 130
+//  participants
 //
 ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
                            bool dynamicCollectorForPartialProofs,
@@ -47,9 +53,11 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
       _numberOfRoReplicas{config.numRoReplicas},
       _numOfClientProxies{config.numOfClientProxies},
       _numberOfExternalClients{config.numOfExternalClients},
+      _numberOfClientServices{config.numOfClientServices},
       _numberOfInternalClients{config.numReplicas},
       _maxValidPrincipalId{static_cast<uint16_t>(config.numReplicas + config.numRoReplicas + config.numOfClientProxies +
-                                                 config.numOfExternalClients + _numberOfInternalClients - 1)},
+                                                 config.numOfExternalClients + _numberOfInternalClients +
+                                                 _numberOfClientServices - 1)},
       _fVal{config.fVal},
       _cVal{config.cVal},
       _dynamicCollectorForPartialProofs{dynamicCollectorForPartialProofs},
@@ -108,6 +116,18 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
           ret.insert(i);
         }
         if (start != end) LOG_INFO(GL, "Principal ids in _idsOfInternalClients: " << start << " to " << end - 1);
+        return ret;
+      }()},
+
+      _idsOfClientServices{[&config]() {
+        std::set<ReplicaId> ret;
+        auto start = config.numReplicas + config.numRoReplicas + config.numOfClientProxies +
+                     config.numOfExternalClients + config.numReplicas;
+        auto end = start + config.numOfClientServices;
+        for (auto i = start; i < end; ++i) {
+          ret.insert(i);
+        }
+        if (start != end) LOG_INFO(GL, "Principal ids in _idsOfClientServices: " << start << " to " << end - 1);
         return ret;
       }()} {
   ConcordAssert(_numberOfReplicas == (3 * _fVal + 2 * _cVal + 1));

--- a/bftengine/src/bftengine/ReplicasInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasInfo.hpp
@@ -83,6 +83,7 @@ class ReplicasInfo {
   uint16_t getNumOfClientProxies() { return _numOfClientProxies; }
   uint16_t getNumberOfExternalClients() { return _numberOfExternalClients; }
   uint16_t getNumberOfInternalClients() { return _numberOfInternalClients; }
+  uint16_t getNumberOfClientServices() { return _numberOfClientServices; }
 
  protected:
   const ReplicaId _myId = 0;

--- a/bftengine/src/bftengine/ReplicasInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasInfo.hpp
@@ -90,6 +90,7 @@ class ReplicasInfo {
   const uint16_t _numberOfRoReplicas = 0;
   const uint16_t _numOfClientProxies = 0;
   const uint16_t _numberOfExternalClients = 0;
+  const uint16_t _numberOfClientServices = 0;
   const uint16_t _numberOfInternalClients = 0;
   const uint16_t _maxValidPrincipalId = 0;
   const uint16_t _fVal = 0;
@@ -103,6 +104,7 @@ class ReplicasInfo {
   const std::set<PrincipalId> _idsOfClientProxies;
   const std::set<PrincipalId> _idsOfExternalClients;
   const std::set<PrincipalId> _idsOfInternalClients;
+  const std::set<PrincipalId> _idsOfClientServices;
 };
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -45,6 +45,8 @@ SigManager* SigManager::initImpl(ReplicaId myId,
   auto numRoReplicas = replicasInfo.getNumberOfRoReplicas();
   auto numOfClientProxies = replicasInfo.getNumOfClientProxies();
   auto numOfExternalClients = replicasInfo.getNumberOfExternalClients();
+  auto numOfInternalClients = replicasInfo.getNumberOfInternalClients();
+  auto numOfClientServices = replicasInfo.getNumberOfClientServices();
 
   LOG_INFO(
       GL,
@@ -65,7 +67,7 @@ SigManager* SigManager::initImpl(ReplicaId myId,
     // Also, we do not enforce to have all range between [lowBound, highBound] construcred. We might want to have less
     // principal ids mapped to keys than what is stated in the range.
     lowBound = numRoReplicas + numReplicas + numOfClientProxies;
-    highBound = lowBound + numOfExternalClients - 1;
+    highBound = lowBound + numOfExternalClients + numOfInternalClients + numOfClientServices - 1;
     for (const auto& p : (*publicKeysOfClients)) {
       ConcordAssert(!p.first.empty());
       publickeys.push_back(make_pair(p.first, clientsKeysFormat));


### PR DESCRIPTION
As part of our work to unify all client service entities into 1 communication layer, we need to have a unique identity for every client service.
The id of the client service will be after all the other principles in the system.
