### PR TITLE
TS:Don't allow requests to execute when time is incorrect.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3685,7 +3685,7 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
       sendAndIncrementMetric(fcp, msgSender, metric_sent_fullCommitProof_msg_due_to_reqMissingData_);
     }
 
-    if (msg->getPartialProofIsMissing()) {
+    if (msg->getPartialProofIsMissing() && seqNumInfo.isTimeCorrect()) {
       // TODO(GG): consider not to send if msgSender is not a collector
       PartialCommitProofMsg *pcf = seqNumInfo.getFastPathSelfPartialCommitProofMsg();
 
@@ -3695,7 +3695,7 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
       }
     }
 
-    if (msg->getPartialPrepareIsMissing() && (currentPrimary() == msgSender)) {
+    if (msg->getPartialPrepareIsMissing() && (currentPrimary() == msgSender) && seqNumInfo.isTimeCorrect()) {
       PreparePartialMsg *pr = seqNumInfo.getSelfPreparePartialMsg();
 
       if (pr != nullptr) {
@@ -3713,7 +3713,7 @@ void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
       }
     }
 
-    if (msg->getPartialCommitIsMissing() && (currentPrimary() == msgSender)) {
+    if (msg->getPartialCommitIsMissing() && (currentPrimary() == msgSender) && seqNumInfo.isTimeCorrect()) {
       CommitPartialMsg *c = seqNumInfo.getSelfCommitPartialMsg();
       if (c != nullptr) {
         LOG_INFO(CNSUS, "Sending PartialCommit message as a response of RFMD" << KVLOG(msgSender, msgSeqNum));

--- a/tests/apollo/test_skvbc_time_service.py
+++ b/tests/apollo/test_skvbc_time_service.py
@@ -35,7 +35,7 @@ def start_replica_cmd(builddir, replica_id, time_service_enabled='1'):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
-    viewChangeTimeoutMilli = "3000"
+    viewChangeTimeoutMilli = "10000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path, 
             "-k", KEY_FILE_PREFIX,


### PR DESCRIPTION
When a non-primary detects that a PrePrepare has a timestamp which
exceeds the hard limit, it doesn't continue with consensus.
However as part of RFMD it gets the missing data from other replicas who
themseleves had detected incorrect time in Pre-prepare. Thus the request makes through
consensus despite having wrong time.
We simply make a check to not send consensus messages as part of RFMD if
time was not correct for that sequence number.