### PR TITLE
Avoid replica crash when the system attempts to recover with just a single block on the chain.

### DIFF
--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -24,6 +24,7 @@ from math import inf
 from util.bft import KEY_FILE_PREFIX, with_trio, with_bft_network, skip_for_tls
 from util import eliot_logging as log
 
+from bft_client import MofNQuorum
 
 def start_replica_cmd(builddir, replica_id):
     """
@@ -115,7 +116,17 @@ class SkvbcPersistenceTest(unittest.TestCase):
         """
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
-        (key, val) = await skvbc.send_write_kv_set()
+
+        # Ensure execution happens on all replicas before shutdown
+        # by requiring an N of N quorum of replies.
+        # Since we're creating a single block on the chain we try to 
+        # avoid the state where some replica failed to execute the block
+        # and needs to recover by starting from the genesis block. A recovery with less than 2
+        # total blocks on the chain is unhandled by the system.
+        # For more info see BC-17607.
+
+        full_quorum = MofNQuorum.All(bft_network.config, bft_network.all_replicas())
+        (key, val) = await skvbc.send_write_kv_set(quorum=full_quorum)
 
         bft_network.stop_all_replicas()
         bft_network.start_all_replicas()


### PR DESCRIPTION
As per this PR https://github.com/vmware/concord-bft/pull/1174 the case where a replica needs to recover when only one block has been created on the chain is an unhandled edge case causing termination on the recovering replica.

The persistence test test_read_written_data_after_restart_of_all_nodes writes a single block to the chain but waits for a 2f + c + 1 quorum of replies before shutting down the cluster, this means that f + c replicas race to execute the block concurrently with the shutdown. This may trigger the edge case where some replica failed to write the block and needs to recover but the system has a chain with a single block - the unhandled edge case.

This PR avoids the above situation by forcing an N of N quorum of replies when sending the request to ensure all replicas have executed it before shutdown.