### PR TITLE
Add support for the StateSnapshotReadAsOfRequest

### DIFF
--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -40,6 +40,11 @@ class KeyValueBlockchain {
   using VersionedRawBlock = std::pair<BlockId, std::optional<categorization::RawBlockData>>;
 
  public:
+  // Key or value converter interface.
+  // Allows users to convert keys or values to any format that is appropriate.
+  using Converter = std::function<std::string(std::string&&)>;
+
+ public:
   // Creates a key-value blockchain.
   // If `category_types` is nullopt, the persisted categories in storage will be used.
   // If `category_types` has a value, it should contain all persisted categories in storage at a minimum. New ones will

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -322,8 +322,8 @@ Msg SignedPublicStateHashData 69 {
   fixedlist uint8 32 hash
 }
 
-# Represents the status of a `SignedPublicStateHashResponse`.
-Enum SignedPublicStateHashStatus {
+# Represents the status of a snapshot-related response.
+Enum SnapshotResponseStatus {
   # Successful response.
   Success,
 
@@ -344,7 +344,7 @@ Enum SignedPublicStateHashStatus {
 Msg SignedPublicStateHashResponse 70 {
   # The status of the response.
   # Note that `data` and `signature` are only relevant if status is `Success`.
-  SignedPublicStateHashStatus status
+  SnapshotResponseStatus status
 
   # The public state hash data.
   SignedPublicStateHashData data
@@ -353,16 +353,45 @@ Msg SignedPublicStateHashResponse 70 {
   bytes signature
 }
 
-Msg PruneConfigurationMax 71 {
+Msg StateSnapshotReadAsOfRequest 71 {
+  # The ID of the state snapshot as of which to read the values.
+  uint64 snapshot_id
+
+  # The participant ID that requested the values.
+  string participant_id
+
+  # List of keys for which the values should be returned.
+  list string keys
+}
+
+Msg StateSnapshotReadAsOfResponse 72 {
+  # The status of the response.
+  # Note that `values` is only relevant if status is `Success`.
+  SnapshotResponseStatus status
+
+  # The `values` list contains entries for *all* requested keys
+  # in `StateSnapshotReadAsOfRequest.keys` in the exact same order. `values`
+  # is, therefore, the exact same length as `StateSnapshotReadAsOfRequest.keys`.
+  #
+  # If a key-value is either:
+  #  * deleted
+  #  * never set
+  #  * non-public (TODO: will be removed when we support streaming of non-public state),
+  # the value will not be set. Otherwise, it will
+  # be set to the value's bytes as of the requested state snapshot.
+  list optional string values
+}
+
+Msg PruneConfigurationMax 73 {
     uint32 dbMaxRate
     uint32 consensusEngineMaxRate
 }
 
-Msg PruneConfigurationMap 72 {
+Msg PruneConfigurationMap 74 {
    list kvpair uint64 uint64 mapConsensusRateToPruningRate
 }
 
-Msg PruneSwitchModeRequest 73 {
+Msg PruneSwitchModeRequest 75 {
     uint64 sender_id
     uint8 mode
     oneof {
@@ -372,7 +401,7 @@ Msg PruneSwitchModeRequest 73 {
     configuration
 }
 
-Msg PruneTicksChangeRequest 74 {
+Msg PruneTicksChangeRequest 76 {
     uint64 sender_id
     # TicksGenerator period in seconds.
     uint32 tick_period_seconds
@@ -381,7 +410,7 @@ Msg PruneTicksChangeRequest 74 {
     uint64 batch_blocks_num
 }
 
-Msg PruneStopRequest 75 {
+Msg PruneStopRequest 77 {
     uint64 sender_id
 }
 
@@ -426,6 +455,7 @@ Msg ReconfigurationRequest 1 {
     ReplicaMainKeyUpdate
     StateSnapshotRequest
     SignedPublicStateHashRequest
+    StateSnapshotReadAsOfRequest
   } command
   bytes additional_data
 }
@@ -451,6 +481,7 @@ Msg ReconfigurationResponse 2 {
     GetDbCheckpointInfoStatusResponse
     StateSnapshotResponse
     SignedPublicStateHashResponse
+    StateSnapshotReadAsOfResponse
   } response
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -292,6 +292,14 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::StateSnapshotReadAsOfRequest &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
   virtual bool handle(const concord::messages::PruneStopRequest &,
                       uint64_t,
                       uint32_t,

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -183,6 +183,13 @@ class Operator:
         req.participant_id = 'apollo_test_participant_id'
         return self._construct_basic_reconfiguration_request(req)
 
+    def _construct_reconfiguration_state_snapshot_read_as_of_req(self, snapshot_id, keys):
+        req = cmf_msgs.StateSnapshotReadAsOfRequest()
+        req.snapshot_id = snapshot_id
+        req.participant_id = 'apollo_test_participant_id'
+        req.keys = keys
+        return self._construct_basic_reconfiguration_request(req)        
+
     def _construct_reconfiguration_state_snapshot_req(self):
         req = cmf_msgs.StateSnapshotRequest()
         req.checkpoint_kv_count = 0
@@ -320,5 +327,10 @@ class Operator:
 
     async def signed_public_state_hash_req(self, snapshot_id):
         req = self._construct_reconfiguration_signed_public_state_hash_req(snapshot_id)
+        return await self.client.read(req.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config,
+                                        [r for r in range(self.config.n)]), reconfiguration=True)
+
+    async def state_snapshot_read_as_of_req(self, snapshot_id, keys):
+        req = self._construct_reconfiguration_state_snapshot_read_as_of_req(snapshot_id, keys)
         return await self.client.read(req.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config,
                                         [r for r in range(self.config.n)]), reconfiguration=True)

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -312,8 +312,13 @@ void InternalCommandsHandler::addBlock(VersionedUpdates &verUpdates, BlockMerkle
     }
     for (const auto &[k, _] : merkleUpdates.getData().kv) {
       (void)_;
-      public_state->keys.push_back(k);
+      // We don't allow duplicates.
+      auto it = std::lower_bound(public_state->keys.cbegin(), public_state->keys.cend(), k);
+      if (it != public_state->keys.cend() && *it == k) {
+        continue;
+      }
       // We always persist public state keys in sorted order.
+      public_state->keys.push_back(k);
       std::sort(public_state->keys.begin(), public_state->keys.end());
     }
     const auto public_state_ser = detail::serialize(*public_state);

--- a/thin-replica-server/src/replica_state_snapshot_service_impl.cpp
+++ b/thin-replica-server/src/replica_state_snapshot_service_impl.cpp
@@ -13,7 +13,6 @@
 
 #include "thin-replica-server/replica_state_snapshot_service_impl.hpp"
 
-#include "categorization/kv_blockchain.h"
 #include "Logger.hpp"
 #include "rocksdb/native_client.h"
 
@@ -73,7 +72,7 @@ grpc::Status ReplicaStateSnapshotServiceImpl::StreamSnapshot(grpc::ServerContext
       auto resp_key = kv->mutable_key();
       auto resp_value = kv->mutable_value();
       *resp_key = std::move(key);
-      *resp_value = std::move(value);
+      *resp_value = state_value_converter_(std::move(value));
       if (!writer->Write(resp)) {
         const auto err =
             "Streaming of State Snapshot ID = " + snapshot_id_str + " failed, reason = gRPC:Write() failure";


### PR DESCRIPTION
Introduce the `StateSnapshotReadAsOfRequest` command that allows users
to read a list of state key-values.

Add support for state value conversion by a way of an optional
user-provided converter function. It allows users to convert state
values to any format that is appropriate. The default converter function
doesn't change the state value in any way, just returning it as is.

Fix TesterReplica's behaviour regarding public state - namely, do not
allow duplicate public state keys.

Make sure we add unique keys in DB snapshots tests for which it matters.
In order to do so, use skvbc.unique_random_key() instead of
skvbc.random_key().

Add Apollo tests for the new behaviour.