### PR TITLE
Reduce gcc test matrix

### DIFF
--- a/.github/workflows/build_and_test_gcc_debug.yml
+++ b/.github/workflows/build_and_test_gcc_debug.yml
@@ -16,7 +16,6 @@ jobs:
                 - "-DCMAKE_BUILD_TYPE=DEBUG -DBUILD_COMM_TCP_TLS=FALSE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
-                - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
         - name: Cleanup pre-installed tools
           run: |

--- a/.github/workflows/build_and_test_gcc_release.yml
+++ b/.github/workflows/build_and_test_gcc_release.yml
@@ -13,11 +13,9 @@ jobs:
             compiler:
                 - "CONCORD_BFT_CONTAINER_CC=gcc CONCORD_BFT_CONTAINER_CXX=g++"
             ci_build_type:
-                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=FALSE"
                 - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=TRUE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
-                - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
         - name: Cleanup pre-installed tools
           run: |


### PR DESCRIPTION
Disable redundant builds to save on worker time.