### PR TITLE
Persist quorum of complaints

### DIFF
--- a/bftengine/src/bftengine/DebugPersistentStorage.cpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.cpp
@@ -122,8 +122,13 @@ void DebugPersistentStorage::setDescriptorOfLastExitFromView(const DescriptorOfL
   if (descriptorOfLastExitFromView_.myViewChangeMsg != nullptr) delete descriptorOfLastExitFromView_.myViewChangeMsg;
 
   hasDescriptorOfLastExitFromView_ = true;
-  descriptorOfLastExitFromView_ = DescriptorOfLastExitFromView{
-      d.view, d.lastStable, d.lastExecuted, clonedElements, clonedViewChangeMsg, d.stableLowerBoundWhenEnteredToView};
+  descriptorOfLastExitFromView_ = DescriptorOfLastExitFromView{d.view,
+                                                               d.lastStable,
+                                                               d.lastExecuted,
+                                                               clonedElements,
+                                                               clonedViewChangeMsg,
+                                                               d.stableLowerBoundWhenEnteredToView,
+                                                               d.complaints};
 }
 
 void DebugPersistentStorage::setDescriptorOfLastNewView(const DescriptorOfLastNewView &d) {
@@ -332,7 +337,7 @@ DescriptorOfLastExitFromView DebugPersistentStorage::getAndAllocateDescriptorOfL
   if (d.myViewChangeMsg != nullptr) myVCMsg = (ViewChangeMsg *)d.myViewChangeMsg->cloneObjAndMsg();
 
   DescriptorOfLastExitFromView retVal{
-      d.view, d.lastStable, d.lastExecuted, elements, myVCMsg, d.stableLowerBoundWhenEnteredToView};
+      d.view, d.lastStable, d.lastExecuted, elements, myVCMsg, d.stableLowerBoundWhenEnteredToView, d.complaints};
 
   return retVal;
 }

--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -99,7 +99,7 @@ class DebugPersistentStorage : public PersistentStorage {
 
   bool hasDescriptorOfLastExitFromView_ = false;
   DescriptorOfLastExitFromView descriptorOfLastExitFromView_ =
-      DescriptorOfLastExitFromView{0, 0, 0, std::vector<ViewsManager::PrevViewInfo>(0), 0, 0};
+      DescriptorOfLastExitFromView{0, 0, 0, std::vector<ViewsManager::PrevViewInfo>(0), 0, 0, {}};
   bool hasDescriptorOfLastNewView_ = false;
   DescriptorOfLastNewView descriptorOfLastNewView_ =
       DescriptorOfLastNewView{0, nullptr, std::vector<ViewChangeMsg*>(0), nullptr, 0, 0};

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -195,7 +195,7 @@ void DescriptorOfLastExitFromView::deserializeComplaint(uint32_t id, char *buf, 
   {
     std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, msgSize));
     if (baseMsg) {
-      replicaAsksToLeaveViewMsg = make_unique<ReplicaAsksToLeaveViewMsg>(ReplicaAsksToLeaveViewMsg(baseMsg.get()));
+      replicaAsksToLeaveViewMsg = make_unique<ReplicaAsksToLeaveViewMsg>(baseMsg.get());
     }
   }
 

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -35,12 +35,18 @@ bool DescriptorOfLastExitFromView::equals(const DescriptorOfLastExitFromView &ot
 
   if (other.elements.size() != elements.size()) return false;
 
+  if (other.complaints.size() != complaints.size()) return false;
+
   if ((other.myViewChangeMsg && !myViewChangeMsg) || (!other.myViewChangeMsg && myViewChangeMsg)) return false;
   bool res = myViewChangeMsg ? (other.myViewChangeMsg->equals(*myViewChangeMsg)) : true;
   if (!res) return false;
 
   for (uint32_t i = 0; i < elements.size(); ++i)
     if (!elements[i].equals(other.elements[i])) return false;
+
+  for (uint32_t i = 0; i < complaints.size(); ++i)
+    if (!complaints[i]->equals(*other.complaints[i])) return false;
+
   return (other.view == view && other.lastStable == lastStable && other.lastExecuted == lastExecuted &&
           other.stableLowerBoundWhenEnteredToView == stableLowerBoundWhenEnteredToView);
 }

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.cpp
@@ -73,9 +73,15 @@ void DescriptorOfLastExitFromView::serializeSimpleParams(char *buf, size_t bufLe
   uint32_t elementsNum = elements.size();
   size_t elementsNumSize = sizeof(elementsNum);
   memcpy(buf, &elementsNum, elementsNumSize);
+  buf += elementsNumSize;
+
+  uint32_t complaintsNum = complaints.size();
+  size_t complaintsNumSize = sizeof(complaintsNum);
+  memcpy(buf, &complaintsNum, complaintsNumSize);
+  buf += complaintsNumSize;
 
   actualSize = isDefaultSize + viewSize + lastStableSize + lastExecutedSize + stableLowerBoundWhenEnteredToViewSize +
-               myViewChangeMsgSize + elementsNumSize;
+               myViewChangeMsgSize + elementsNumSize + complaintsNumSize;
 }
 
 void DescriptorOfLastExitFromView::serializeElement(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) const {
@@ -92,6 +98,14 @@ void DescriptorOfLastExitFromView::serializeElement(uint32_t id, char *buf, size
   size_t hasAllRequestsSize = sizeof(elements[id].hasAllRequests);
   memcpy(buf, &elements[id].hasAllRequests, hasAllRequestsSize);
   actualSize += hasAllRequestsSize;
+}
+
+void DescriptorOfLastExitFromView::serializeComplaint(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) const {
+  actualSize = 0;
+  ConcordAssert(id < complaints.size());
+  ConcordAssert(bufLen >= maxComplaintSize());
+
+  actualSize += MessageBase::serializeMsg(buf, complaints[id].get());
 }
 
 void DescriptorOfLastExitFromView::deserializeSimpleParams(char *buf, size_t bufLen, uint32_t &actualSize) {
@@ -127,11 +141,19 @@ void DescriptorOfLastExitFromView::deserializeSimpleParams(char *buf, size_t buf
   uint32_t elementsNum;
   size_t elementsNumSize = sizeof(elementsNum);
   memcpy(&elementsNum, buf, elementsNumSize);
+  buf += elementsNumSize;
 
   if (elementsNum) elements.resize(elementsNum);
 
+  uint32_t complaintsNum;
+  size_t complaintsNumSize = sizeof(complaintsNum);
+  memcpy(&complaintsNum, buf, complaintsNumSize);
+  buf += complaintsNumSize;
+
+  if (complaintsNum) complaints.resize(complaintsNum);
+
   actualSize = isDefaultSize + viewSize + lastStableSize + lastExecutedSize + stableLowerBoundWhenEnteredToViewSize +
-               actualMsgSize + elementsNumSize;
+               complaintsNumSize + actualMsgSize + elementsNumSize;
 }
 
 void DescriptorOfLastExitFromView::deserializeElement(uint32_t id, char *buf, size_t bufLen, uint32_t &actualSize) {
@@ -164,6 +186,25 @@ void DescriptorOfLastExitFromView::deserializeElement(uint32_t id, char *buf, si
   actualSize = msgSize1 + msgSize2 + hasAllRequestsSize;
 }
 
+void DescriptorOfLastExitFromView::deserializeComplaint(uint32_t id, char *buf, size_t bufLen, uint32_t &actualSize) {
+  actualSize = 0;
+  size_t msgSize = 0;
+
+  std::unique_ptr<ReplicaAsksToLeaveViewMsg> replicaAsksToLeaveViewMsg;
+
+  {
+    std::unique_ptr<MessageBase> baseMsg(MessageBase::deserializeMsg(buf, bufLen, msgSize));
+    if (baseMsg) {
+      replicaAsksToLeaveViewMsg = make_unique<ReplicaAsksToLeaveViewMsg>(ReplicaAsksToLeaveViewMsg(baseMsg.get()));
+    }
+  }
+
+  ConcordAssert(complaints[id] == nullptr);
+
+  complaints[id] = move(replicaAsksToLeaveViewMsg);
+
+  actualSize = msgSize;
+}
 /***** DescriptorOfLastNewView *****/
 
 // This static variable is needed for an initial values population.

--- a/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
+++ b/bftengine/src/bftengine/PersistentStorageDescriptors.hpp
@@ -22,6 +22,7 @@
 #include "messages/NewViewMsg.hpp"
 #include "messages/FullCommitProofMsg.hpp"
 #include "messages/CheckpointMsg.hpp"
+#include "messages/ReplicaAsksToLeaveViewMsg.hpp"
 #include "SysConsts.hpp"
 #include "TimeService.hpp"
 
@@ -40,33 +41,40 @@ struct DescriptorOfLastExitFromView {
                                SeqNum execNum,
                                PrevViewInfoElements elements,
                                ViewChangeMsg *viewChangeMsg,
-                               SeqNum stableLowerBound)
+                               SeqNum stableLowerBound,
+                               SequenceOfComplaints complaints)
       : isDefault(false),
         view(viewNum),
         lastStable(stableNum),
         lastExecuted(execNum),
         stableLowerBoundWhenEnteredToView(stableLowerBound),
         myViewChangeMsg(viewChangeMsg),
-        elements(move(elements)) {}
+        elements(move(elements)),
+        complaints(move(complaints)) {}
 
   DescriptorOfLastExitFromView() : isDefault(true){};
 
   void clean();
   void serializeSimpleParams(char *buf, size_t bufLen, size_t &actualSize) const;
   void serializeElement(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) const;
+  void serializeComplaint(uint32_t id, char *buf, size_t bufLen, size_t &actualSize) const;
 
   void deserializeSimpleParams(char *buf, size_t bufLen, uint32_t &actualSize);
   void deserializeElement(uint32_t id, char *buf, size_t bufLen, uint32_t &actualSize);
+  void deserializeComplaint(uint32_t id, char *buf, size_t bufLen, uint32_t &actualSize);
 
   bool equals(const DescriptorOfLastExitFromView &other) const;
 
   static uint32_t simpleParamsSize() {
     uint32_t elementsNum;
+    uint32_t complaintsNum;
     uint8_t msgFilledFlag;
     return (sizeof(isDefault) + sizeof(view) + sizeof(lastStable) + sizeof(lastExecuted) +
             sizeof(stableLowerBoundWhenEnteredToView) + sizeof(msgFilledFlag) +
-            maxMessageSizeInLocalBuffer<ViewChangeMsg>() + sizeof(elementsNum));
+            maxMessageSizeInLocalBuffer<ViewChangeMsg>() + sizeof(elementsNum) + sizeof(complaintsNum));
   }
+
+  static uint32_t maxComplaintSize() { return (maxMessageSizeInLocalBuffer<ReplicaAsksToLeaveViewMsg>()); }
 
   static uint32_t maxElementSize() {
     uint8_t msgFilledFlag;
@@ -99,6 +107,9 @@ struct DescriptorOfLastExitFromView {
 
   // elements.size() <= kWorkWindowSize; the messages in elements[i] may be null
   PrevViewInfoElements elements;
+
+  // ReplicaAsksToLeaveViewMsg-s (Complaints) stored as proof we need to exit the View.
+  SequenceOfComplaints complaints;
 };
 
 /***** DescriptorOfLastNewView *****/

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -237,11 +237,11 @@ void PersistentStorageImp::saveDescriptorOfLastExitFromView(const DescriptorOfLa
   uint32_t maxComplaintSize = DescriptorOfLastExitFromView::maxComplaintSize();
   UniquePtrToChar complaintBuf(new char[maxComplaintSize]);
   for (size_t i = 0; i < complaintsNum; ++i) {
-    newDesc.serializeComplaint(i, elementBuf.get(), maxComplaintSize, actualComplaintSize);
+    newDesc.serializeComplaint(i, complaintBuf.get(), maxComplaintSize, actualComplaintSize);
     ConcordAssertNE(actualComplaintSize, 0);
     uint32_t itemId = LAST_COMPLAINTS_DESC + i;
     ConcordAssertLT(itemId, LAST_EXEC_DESC);
-    metadataStorage_->writeInBatch(itemId, elementBuf.get(), actualComplaintSize);
+    metadataStorage_->writeInBatch(itemId, complaintBuf.get(), actualComplaintSize);
   }
 }
 

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -119,6 +119,9 @@ ObjectDescMap PersistentStorageImp::getDefaultMetadataObjectDescriptors(uint16_t
         CheckWindow::maxElementSize();
 
   metadataObjectsArray[LAST_EXIT_FROM_VIEW_DESC].maxSize = DescriptorOfLastExitFromView::simpleParamsSize();
+  for (uint32_t i = 0; i < reservedComplaintsNum; ++i) {
+    metadataObjectsArray[LAST_COMPLAINTS_DESC + i].maxSize = DescriptorOfLastExitFromView::maxComplaintSize();
+  }
   metadataObjectsArray[LAST_EXEC_DESC].maxSize = DescriptorOfLastExecution::maxSize();
   metadataObjectsArray[LAST_NEW_VIEW_DESC].maxSize = DescriptorOfLastNewView::simpleParamsSize();
   metadataObjectsArray[LAST_STABLE_CHECKPOINT_DESC].maxSize = DescriptorOfLastStableCheckpoint::maxSize(numReplicas_);
@@ -225,8 +228,20 @@ void PersistentStorageImp::saveDescriptorOfLastExitFromView(const DescriptorOfLa
     newDesc.serializeElement(i, elementBuf.get(), maxElementSize, actualElementSize);
     ConcordAssertNE(actualElementSize, 0);
     uint32_t itemId = LAST_EXIT_FROM_VIEW_DESC + 1 + i;
-    ConcordAssertLT(itemId, LAST_EXEC_DESC);
+    ConcordAssertLT(itemId, LAST_COMPLAINTS_DESC);
     metadataStorage_->writeInBatch(itemId, elementBuf.get(), actualElementSize);
+  }
+
+  size_t actualComplaintSize = 0;
+  uint32_t complaintsNum = newDesc.complaints.size();
+  uint32_t maxComplaintSize = DescriptorOfLastExitFromView::maxComplaintSize();
+  UniquePtrToChar complaintBuf(new char[maxComplaintSize]);
+  for (size_t i = 0; i < complaintsNum; ++i) {
+    newDesc.serializeComplaint(i, elementBuf.get(), maxComplaintSize, actualComplaintSize);
+    ConcordAssertNE(actualComplaintSize, 0);
+    uint32_t itemId = LAST_COMPLAINTS_DESC + i;
+    ConcordAssertLT(itemId, LAST_EXEC_DESC);
+    metadataStorage_->writeInBatch(itemId, elementBuf.get(), actualComplaintSize);
   }
 }
 
@@ -616,11 +631,24 @@ DescriptorOfLastExitFromView PersistentStorageImp::getAndAllocateDescriptorOfLas
   uint32_t elementsNum = dbDesc.elements.size();
   for (uint32_t i = 0; i < elementsNum; ++i) {
     uint32_t itemId = LAST_EXIT_FROM_VIEW_DESC + 1 + i;
-    ConcordAssertLT(itemId, LAST_EXEC_DESC);
+    ConcordAssertLT(itemId, LAST_COMPLAINTS_DESC);
     metadataStorage_->read(itemId, maxElementSize, elementBuf.get(), actualSize);
     dbDesc.deserializeElement(i, elementBuf.get(), actualSize, actualElementSize);
     ConcordAssertNE(actualElementSize, 0);
   }
+
+  const size_t maxComplaintSize = DescriptorOfLastExitFromView::maxComplaintSize();
+  UniquePtrToChar complaintBuf(new char[maxComplaintSize]);
+  uint32_t actualComplaintSize = 0;
+  uint32_t complaintsNum = dbDesc.complaints.size();
+  for (uint32_t i = 0; i < complaintsNum; ++i) {
+    uint32_t itemId = LAST_COMPLAINTS_DESC + i;
+    ConcordAssertLT(itemId, LAST_EXEC_DESC);
+    metadataStorage_->read(itemId, maxComplaintSize, complaintBuf.get(), actualSize);
+    dbDesc.deserializeComplaint(i, complaintBuf.get(), actualSize, actualComplaintSize);
+    ConcordAssertNE(actualComplaintSize, 0);
+  }
+
   return dbDesc;
 }
 

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -51,6 +51,7 @@ namespace impl {
 // Make a reservation for future params
 const uint16_t reservedSimpleParamsNum = 499;
 const uint16_t reservedWindowParamsNum = 3000;
+const uint16_t reservedComplaintsNum = 300;
 
 const uint16_t MAX_METADATA_PARAMS_NUM = 10000;
 
@@ -94,7 +95,8 @@ const uint16_t numOfLastExitFromViewDescObjs = kWorkWindowSize + 1;
 // objects plus one - for simple descriptor parameters.
 enum DescMetadataParameterIds {
   LAST_EXIT_FROM_VIEW_DESC = WIN_PARAMETERS_NUM + reservedWindowParamsNum,
-  LAST_EXEC_DESC = LAST_EXIT_FROM_VIEW_DESC + numOfLastExitFromViewDescObjs,
+  LAST_COMPLAINTS_DESC = LAST_EXIT_FROM_VIEW_DESC + numOfLastExitFromViewDescObjs,
+  LAST_EXEC_DESC = LAST_COMPLAINTS_DESC + reservedComplaintsNum + 1,
   LAST_STABLE_CHECKPOINT_DESC,
   LAST_NEW_VIEW_DESC
 };

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3029,6 +3029,8 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
       }
     }
 
+    auto complaints = viewsManager->getSeqOfComplaintsSortedByIssuerID();
+
     if (ps_) {
       ViewChangeMsg *myVC = (getCurrentView() == 0 ? nullptr : viewsManager->getMyLatestViewChangeMsg());
       SeqNum stableLowerBoundWhenEnteredToView = viewsManager->stableLowerBoundWhenEnteredToView();
@@ -3037,7 +3039,8 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
                                               lastExecutedSeqNum,
                                               prevViewInfo,
                                               myVC,
-                                              stableLowerBoundWhenEnteredToView};
+                                              stableLowerBoundWhenEnteredToView,
+                                              std::move(complaints)};
       ps_->beginWriteTran();
       ps_->setDescriptorOfLastExitFromView(desc);
       ps_->clearSeqNumWindow();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -2812,9 +2812,9 @@ void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
   /////////////////////////////////////////////////////////////////////////
 
   if (msg->getViewNumber() == getCurrentView()) {
-    for (const auto &i : viewsManager->getAllMsgsFromComplainedReplicas()) {
-      if (!msg->hasComplaintFromReplica(i.first)) {
-        sendAndIncrementMetric(i.second.get(), msgSenderId, metric_sent_replica_asks_to_leave_view_msg_due_to_status_);
+    for (const auto &it : viewsManager->getAllMsgsFromComplainedReplicas()) {
+      if (!msg->hasComplaintFromReplica(it->idOfGeneratedReplica())) {
+        sendAndIncrementMetric(it.get(), msgSenderId, metric_sent_replica_asks_to_leave_view_msg_due_to_status_);
       }
     }
   }
@@ -3029,7 +3029,7 @@ void ReplicaImp::MoveToHigherView(ViewNum nextView) {
       }
     }
 
-    auto complaints = viewsManager->getSeqOfComplaintsSortedByIssuerID();
+    auto complaints = viewsManager->getAllMsgsFromComplainedReplicas(true);
 
     if (ps_) {
       ViewChangeMsg *myVC = (getCurrentView() == 0 ? nullptr : viewsManager->getMyLatestViewChangeMsg());
@@ -3994,6 +3994,7 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
     ViewChangeMsg *t = ld.viewsManager->getMyLatestViewChangeMsg();
     ConcordAssert(t != nullptr);
     ConcordAssert(t->newView() == getCurrentView());
+    viewsManager->insertStoredComplaintsIntoVCMsg(t);
     t->finalizeMessage();  // needed to initialize the VC message
   }
 

--- a/bftengine/src/bftengine/ReplicaLoader.cpp
+++ b/bftengine/src/bftengine/ReplicaLoader.cpp
@@ -118,7 +118,8 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
                                                    descriptorOfLastExitFromView.lastExecuted,
                                                    descriptorOfLastExitFromView.stableLowerBoundWhenEnteredToView,
                                                    descriptorOfLastExitFromView.myViewChangeMsg,
-                                                   descriptorOfLastExitFromView.elements);
+                                                   descriptorOfLastExitFromView.elements,
+                                                   descriptorOfLastExitFromView.complaints);
 
     Verify((viewsManager->latestActiveView() == 0), InconsistentErr);
     Verify((!viewsManager->viewIsActive(0)), InconsistentErr);
@@ -134,7 +135,8 @@ ReplicaLoader::ErrorCode loadViewInfo(shared_ptr<PersistentStorage> &p, LoadedRe
                                                    descriptorOfLastExitFromView.lastExecuted,
                                                    descriptorOfLastExitFromView.stableLowerBoundWhenEnteredToView,
                                                    descriptorOfLastExitFromView.myViewChangeMsg,
-                                                   descriptorOfLastExitFromView.elements);
+                                                   descriptorOfLastExitFromView.elements,
+                                                   descriptorOfLastExitFromView.complaints);
 
     Verify((viewsManager->latestActiveView() == descriptorOfLastExitFromView.view), InconsistentErr);
     Verify((!viewsManager->viewIsActive(descriptorOfLastExitFromView.view)), InconsistentErr);

--- a/bftengine/src/bftengine/ReplicasAskedToLeaveViewInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasAskedToLeaveViewInfo.hpp
@@ -46,20 +46,6 @@ class ReplicasAskedToLeaveViewInfo {
     }
   }
 
-  SequenceOfComplaints getSeqOfComplaintsSortedByIssuerID() {
-    SequenceOfComplaints retval;
-    for (auto& msg : msgs) {
-      retval.emplace_back(msg.second);
-    }
-    std::sort(retval.begin(),
-              retval.end(),
-              [](const std::shared_ptr<ReplicaAsksToLeaveViewMsg>& lhs,
-                 const std::shared_ptr<ReplicaAsksToLeaveViewMsg>& rhs) {
-                return lhs->idOfGeneratedReplica() < rhs->idOfGeneratedReplica();
-              });
-    return retval;
-  }
-
   void clear() { msgs.clear(); }
 
   bool empty() const { return msgs.empty(); }
@@ -72,7 +58,21 @@ class ReplicasAskedToLeaveViewInfo {
     return nullptr;
   }
 
-  const auto& getAllMsgs() const { return msgs; }
+  SequenceOfComplaints getAllMsgs(bool sortedByIssuerID) const {
+    SequenceOfComplaints retval;
+    for (auto& msg : msgs) {
+      retval.emplace_back(msg.second);
+    }
+    if (sortedByIssuerID) {
+      std::sort(retval.begin(),
+                retval.end(),
+                [](const std::shared_ptr<ReplicaAsksToLeaveViewMsg>& lhs,
+                   const std::shared_ptr<ReplicaAsksToLeaveViewMsg>& rhs) {
+                  return lhs->idOfGeneratedReplica() < rhs->idOfGeneratedReplica();
+                });
+    }
+    return retval;
+  }
 
  private:
   const int16_t f_val;

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -123,7 +123,7 @@ ViewsManager* ViewsManager::createOutsideView(const ReplicasInfo* const r,
                                               SeqNum stableLowerBound,
                                               ViewChangeMsg* myLastViewChange,
                                               std::vector<PrevViewInfo>& elementsOfPrevView,
-                                              SequenceOfComplaints complaints) {
+                                              const SequenceOfComplaints& complaints) {
   // check arguments
   ConcordAssert(lastActiveView >= 0);
   ConcordAssert(lastStable >= 0);

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -67,7 +67,8 @@ class ViewsManager {
                                          SeqNum lastExecuted,
                                          SeqNum stableLowerBound,
                                          ViewChangeMsg *myLastViewChange,
-                                         std::vector<PrevViewInfo> &elementsOfPrevView);
+                                         std::vector<PrevViewInfo> &elementsOfPrevView,
+                                         SequenceOfComplaints complaints);
 
   static ViewsManager *createInsideViewZero(const ReplicasInfo *const r);
 
@@ -143,6 +144,9 @@ class ViewsManager {
   bool hasViewChangeMessageForFutureView(uint16_t repId);
 
   const auto &getAllMsgsFromComplainedReplicas() const { return complainedReplicas.getAllMsgs(); }
+  SequenceOfComplaints getSeqOfComplaintsSortedByIssuerID() {
+    return complainedReplicas.getSeqOfComplaintsSortedByIssuerID();
+  }
   void storeComplaint(std::unique_ptr<ReplicaAsksToLeaveViewMsg> &&complaintMessage);
   bool hasQuorumToLeaveView() const { return complainedReplicas.hasQuorumToLeaveView(); }
   std::shared_ptr<ReplicaAsksToLeaveViewMsg> getComplaintFromReplica(ReplicaId replicaId) {

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -68,7 +68,7 @@ class ViewsManager {
                                          SeqNum stableLowerBound,
                                          ViewChangeMsg *myLastViewChange,
                                          std::vector<PrevViewInfo> &elementsOfPrevView,
-                                         SequenceOfComplaints complaints);
+                                         const SequenceOfComplaints &complaints);
 
   static ViewsManager *createInsideViewZero(const ReplicasInfo *const r);
 

--- a/bftengine/src/bftengine/ViewsManager.hpp
+++ b/bftengine/src/bftengine/ViewsManager.hpp
@@ -143,11 +143,11 @@ class ViewsManager {
 
   bool hasViewChangeMessageForFutureView(uint16_t repId);
 
-  const auto &getAllMsgsFromComplainedReplicas() const { return complainedReplicas.getAllMsgs(); }
-  SequenceOfComplaints getSeqOfComplaintsSortedByIssuerID() {
-    return complainedReplicas.getSeqOfComplaintsSortedByIssuerID();
+  auto getAllMsgsFromComplainedReplicas(bool sortedByIssuerID = false) const {
+    return complainedReplicas.getAllMsgs(sortedByIssuerID);
   }
   void storeComplaint(std::unique_ptr<ReplicaAsksToLeaveViewMsg> &&complaintMessage);
+  void insertStoredComplaintsIntoVCMsg(ViewChangeMsg *pVC);
   bool hasQuorumToLeaveView() const { return complainedReplicas.hasQuorumToLeaveView(); }
   std::shared_ptr<ReplicaAsksToLeaveViewMsg> getComplaintFromReplica(ReplicaId replicaId) {
     return complainedReplicas.getComplaintFromReplica(replicaId);

--- a/bftengine/tests/testSerialization/TestSerialization.cpp
+++ b/bftengine/tests/testSerialization/TestSerialization.cpp
@@ -270,7 +270,7 @@ void testSetDescriptors(bool toSet) {
   SeqNum lastStable = 48;
   auto *viewChangeMsg = new ViewChangeMsg(senderId, viewNum + 1, lastStable);
   DescriptorOfLastExitFromView lastExitFromViewDesc(
-      viewNum, lastExitStableNum, lastExitExecNum, elements, viewChangeMsg, lastExitStableLowerBound);
+      viewNum, lastExitStableNum, lastExitExecNum, elements, viewChangeMsg, lastExitStableLowerBound, {});
 
   ViewChangeMsgsVector msgs;
   ViewNum newViewNum = 1;

--- a/bftengine/tests/testViewChange/test_views_manager.cpp
+++ b/bftengine/tests/testViewChange/test_views_manager.cpp
@@ -78,6 +78,7 @@ TEST_F(ViewsManagerTest, store_complaint) {
   }
 
   ASSERT_EQ(viewsManager->getAllMsgsFromComplainedReplicas().size(), 1);
+  ASSERT_EQ(viewsManager->getSeqOfComplaintsSortedByIssuerID().size(), 1);
 }
 
 TEST_F(ViewsManagerTest, form_a_quorum_of_complaints) {
@@ -127,6 +128,9 @@ TEST_F(ViewsManagerTest, status_message_with_complaints) {
 
   for (const auto& i : viewsManager->getAllMsgsFromComplainedReplicas()) {
     ASSERT_TRUE(replicaStatusMessage.hasComplaintFromReplica(i.first));
+  }
+  for (const auto& i : viewsManager->getSeqOfComplaintsSortedByIssuerID()) {
+    ASSERT_TRUE(replicaStatusMessage.hasComplaintFromReplica(i->idOfGeneratedReplica()));
   }
 }
 

--- a/bftengine/tests/testViewChange/test_views_manager.cpp
+++ b/bftengine/tests/testViewChange/test_views_manager.cpp
@@ -78,7 +78,6 @@ TEST_F(ViewsManagerTest, store_complaint) {
   }
 
   ASSERT_EQ(viewsManager->getAllMsgsFromComplainedReplicas().size(), 1);
-  ASSERT_EQ(viewsManager->getSeqOfComplaintsSortedByIssuerID().size(), 1);
 }
 
 TEST_F(ViewsManagerTest, form_a_quorum_of_complaints) {
@@ -127,9 +126,6 @@ TEST_F(ViewsManagerTest, status_message_with_complaints) {
   viewsManager->addComplaintsToStatusMessage(replicaStatusMessage);
 
   for (const auto& i : viewsManager->getAllMsgsFromComplainedReplicas()) {
-    ASSERT_TRUE(replicaStatusMessage.hasComplaintFromReplica(i.first));
-  }
-  for (const auto& i : viewsManager->getSeqOfComplaintsSortedByIssuerID()) {
     ASSERT_TRUE(replicaStatusMessage.hasComplaintFromReplica(i->idOfGeneratedReplica()));
   }
 }


### PR DESCRIPTION
We persist in DescriptorOfLastExitFromView the quorum of complaints
we have accumulated and will later insert in our View Change message
to serve as proof quorum was reached to move to the higher view.
This way after restarts, we are going to recover exactly the same
View Change message as we had prior to the restart.