### PR TITLE
Adjust remaining window size while building PPM

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -114,6 +114,15 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   std::queue<ClientRequestMsg*> requestsQueueOfPrimary;  // only used by the primary
   size_t primaryCombinedReqSize = 0;                     // only used by the primary
 
+  // A preprepare message which is still building is called transient preprepare.
+  // activeTransientPreprepare_ represents the number of preprepare messages that are
+  // currently getting build in a separate thread.
+  // This should not be thread safe because its used only in the main thread
+  // This should start with 0, since by default we will assume that a preprepare is taken
+  // to be added to main log. And this will solely represent those preprepares which are
+  // to be added to main log, but are not added as yet.
+  uint16_t numOfTransientPreprepareMsgs_ = 0;
+
   // bounded log used to store information about SeqNums in the range (lastStableSeqNum,lastStableSeqNum +
   // kWorkWindowSize]
   typedef SequenceWithActiveWindow<kWorkWindowSize, 1, SeqNum, SeqNumInfo, SeqNumInfo, 1, false> WindowOfSeqNumInfo;


### PR DESCRIPTION
As we know the preprepare creation is now happening in parallel. The threadpool can schedule atmost 64 (this is configurable) preprepare building together. When we try building the preprepare message, we check if "main log" (this is a local rough notebook to keep track of built and in-flight preprepare message), can hold new preprepare or not. If we bypass this check then during actual allocation, we terminate. The check for available space in main log and actual assignment of a place in log for preprepare message is separated, since building of preprepare message is an elaborate process.
But the check and assignment should be in sync and this should also happen for inflight messages. When the preprepare message was built completely and checked in the same thread, this was little easier. But when it became asynchronous, we have to add a best effort based check which can assure that a place for the fully-built preprepare will always be guaranteed.
So the fix for this issue, is to keep a track of the number of preprepare messages who are not yet built. We are calling such a pre prepare message as active transient preprepare message. This count of active transient preprepare messages will help us to get the instantaneous upper bound of the number of message that will require a place in the main log.