### PR TITLE
Unskip test_fast_path_is_default because it's used internally

### DIFF
--- a/tests/apollo/test_skvbc_commit_path.py
+++ b/tests/apollo/test_skvbc_commit_path.py
@@ -44,7 +44,6 @@ class SkvbcCommitPathTest(unittest.TestCase):
 
     __test__ = False  # so that PyTest ignores this test scenario
 
-    @unittest.skip("This is the initial state covered in test_commit_path_transitions and is kept as a manual testing option.")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6, rotate_keys=True)
     @verify_linearizability()


### PR DESCRIPTION
This test should be running by default since it's needed by internal testing.