### PR TITLE
Expose state snapshot reconf commands to clients

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -159,6 +159,9 @@ class Replica : public IReplica,
   }
 
   std::optional<categorization::KeyValueBlockchain> &kvBlockchain() { return m_kvBlockchain; }
+  void setStateSnapshotValueConverter(const categorization::KeyValueBlockchain::Converter &c) {
+    m_stateSnapshotValueConverter = c;
+  }
 
   ~Replica() override;
 
@@ -212,6 +215,8 @@ class Replica : public IReplica,
   concord::kvbc::IStorageFactory::DatabaseSet m_dbSet;
   // The categorization KeyValueBlockchain is used for a normal read-write replica.
   std::optional<categorization::KeyValueBlockchain> m_kvBlockchain;
+  categorization::KeyValueBlockchain::Converter m_stateSnapshotValueConverter{
+      categorization::KeyValueBlockchain::kNoopConverter};
   // The IdbAdapter instance is used for a read-only replica.
   std::unique_ptr<IDbAdapter> m_bcDbAdapter;
   std::shared_ptr<storage::IDBClient> m_metadataDBClient;

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -44,13 +44,15 @@ class KeyValueBlockchain {
   // Allows users to convert keys or values to any format that is appropriate.
   using Converter = std::function<std::string(std::string&&)>;
 
+  // The noop converter returns the input string as is, without modifying it.
+  static const Converter kNoopConverter;
+
  public:
   // Creates a key-value blockchain.
   // If `category_types` is nullopt, the persisted categories in storage will be used.
-  // If `category_types` has a value, it should contain all persisted categories in storage at a minimum. New ones will
-  // be created and persisted.
-  // Users are required to pass a value for `category_types` on first construction (i.e. a new blockchain) in order to
-  // specify the categories in use. Failure to do so will generate an exception.
+  // If `category_types` has a value, it should contain all persisted categories in storage at a minimum. New ones
+  // will be created and persisted. Users are required to pass a value for `category_types` on first construction
+  // (i.e. a new blockchain) in order to specify the categories in use. Failure to do so will generate an exception.
   KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client,
                      bool link_st_chain,
                      const std::optional<std::map<std::string, CATEGORY_TYPE>>& category_types = std::nullopt);
@@ -144,7 +146,7 @@ class KeyValueBlockchain {
   //
   // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
   // Precondition: The current KeyValueBlockchain instance points to a DB snapshot.
-  void computeAndPersistPublicStateHash(BlockId checkpoint_block_id);
+  void computeAndPersistPublicStateHash(BlockId checkpoint_block_id, const Converter& value_converter = kNoopConverter);
 
   // Returns the public state keys as of the current point in the blockchain's history.
   // Returns std::nullopt if no public keys have been persisted.

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -88,6 +88,7 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
 };
 
 class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
+ public:
   bool handle(const concord::messages::ClientExchangePublicKey &,
               uint64_t,
               uint32_t,


### PR DESCRIPTION
Introduce the `StateSnapshotReconfigurationHandler` class and move state
snapshot handle() methods to it. Furthermore, override the
verifySignature() method such that it allows requests from the
Operator (via a `BftReconfigurationHandler` instance) and from Clients
(via a `ClientReconfigurationHandler` instance).

We choose composition over inheritance for the handlers, because:
 *  we'd like to avoid complex multiple virtual inheritance
 * `ClientReconfigurationHandler` has a handle() method that would be
   called multiple times if we inherited from it

Finally, add support for state snapshot value conversion in
`kvbc::Replica` and `KeyValueBlockchain`.