### PR TITLE
Change Github workflow so clang debug builds use s3 storage only.

### DIFF
--- a/.github/workflows/build_and_test_clang_debug.yml
+++ b/.github/workflows/build_and_test_clang_debug.yml
@@ -16,7 +16,6 @@ jobs:
                 - "-DCMAKE_BUILD_TYPE=DEBUG -DBUILD_COMM_TCP_TLS=FALSE"
             use_s3_obj_store:
                 - "-DUSE_S3_OBJECT_STORE=ON"
-                - "-DUSE_S3_OBJECT_STORE=OFF"
     steps:
         - name: Cleanup pre-installed tools
           run: |


### PR DESCRIPTION
This is done to reduce the CI workload by omitting building and testing with the option turned off.