### PR TITLE
Fix path transition test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,12 @@ CONCORD_BFT_USER_GROUP?=--user `id -u`:`id -g`
 CONCORD_BFT_CORE_DIR?=${CONCORD_BFT_TARGET_SOURCE_PATH}/${CONCORD_BFT_BUILD_DIR}/cores
 
 CONCORD_BFT_ADDITIONAL_RUN_PARAMS?=
+APOLLO_CTEST_RUN_PARAMS?=
+
+ifneq (${APOLLO_LOG_STDOUT},)
+	CONCORD_BFT_ADDITIONAL_RUN_PARAMS+=--env APOLLO_LOG_STDOUT=TRUE
+    CONCORD_BFT_ADDITIONAL_CTEST_RUN_PARAMS+=-V
+endif
 
 BASIC_RUN_PARAMS?=-it --init --rm --privileged=true \
 					  --memory-swap -1 \
@@ -170,7 +176,7 @@ test-range: ## Run all tests in the range [START,END], inclusive: `make test-ran
 			${CONCORD_BFT_CONTAINER_SHELL} -c \
 			"mkdir -p ${CONCORD_BFT_CORE_DIR} && \
 			cd ${CONCORD_BFT_BUILD_DIR} && \
-			ctest -I ${START},${END}"
+			ctest ${CONCORD_BFT_ADDITIONAL_CTEST_RUN_PARAMS} -I ${START},${END}"
 
 .PHONY: format
 format: gen_cmake ## Format Concord-BFT source with clang-format
@@ -208,7 +214,7 @@ test: ## Run all tests
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"mkdir -p ${CONCORD_BFT_CORE_DIR} && \
 		cd ${CONCORD_BFT_BUILD_DIR} && \
-		ctest --timeout ${CONCORD_BFT_CTEST_TIMEOUT} --output-on-failure"
+		ctest ${CONCORD_BFT_ADDITIONAL_CTEST_RUN_PARAMS} --timeout ${CONCORD_BFT_CTEST_TIMEOUT} --output-on-failure"
 
 .PHONY: list-tests
 list-tests: gen_cmake ## List all tests. This one is helpful to choose which test to run when calling `make single-test TEST_NAME=<test name>`
@@ -223,7 +229,7 @@ single-test: ## Run a single test `make single-test TEST_NAME=<test name>`
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"mkdir -p ${CONCORD_BFT_CORE_DIR} && \
 		cd ${CONCORD_BFT_BUILD_DIR} && \
-		ctest -V -R ${TEST_NAME} --timeout ${CONCORD_BFT_CTEST_TIMEOUT} --output-on-failure"
+		ctest ${CONCORD_BFT_ADDITIONAL_CTEST_RUN_PARAMS} -V -R ${TEST_NAME} --timeout ${CONCORD_BFT_CTEST_TIMEOUT} --output-on-failure"
 
 .PHONY: clean
 clean: ## Clean Concord-BFT build directory

--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,15 @@ CONCORD_BFT_CORE_DIR?=${CONCORD_BFT_TARGET_SOURCE_PATH}/${CONCORD_BFT_BUILD_DIR}
 
 CONCORD_BFT_ADDITIONAL_RUN_PARAMS?=
 APOLLO_CTEST_RUN_PARAMS?=
+CONCORD_BFT_FORMAT_CMD=make format-check &&
 
 ifneq (${APOLLO_LOG_STDOUT},)
 	CONCORD_BFT_ADDITIONAL_RUN_PARAMS+=--env APOLLO_LOG_STDOUT=TRUE
     CONCORD_BFT_ADDITIONAL_CTEST_RUN_PARAMS+=-V
+endif
+
+ifneq (${SKIP_FORMAT},)
+	CONCORD_BFT_FORMAT_CMD=
 endif
 
 BASIC_RUN_PARAMS?=-it --init --rm --privileged=true \
@@ -158,7 +163,7 @@ build: gen_cmake ## Build Concord-BFT source. In order to build a specific targe
 	docker run ${CONCORD_BFT_USER_GROUP} ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"cd ${CONCORD_BFT_BUILD_DIR} && \
-		make format-check && \
+		${CONCORD_BFT_FORMAT_CMD} \
 		make -j $$(nproc) ${TARGET}"
 	@echo
 	@echo "Build finished. The binaries are in ${CURDIR}/${CONCORD_BFT_BUILD_DIR}"

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -232,8 +232,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                std::chrono::seconds,
                std::chrono::seconds{60},
                "Time interval in seconds to monitor disk usage by db checkpoints");
-  // Post-execution separation feature flag
-  CONFIG_PARAM(enablePostExecutionSeparation, bool, true, "Post-execution separation feature flag");
+  CONFIG_PARAM(enablePostExecutionSeparation, bool, true, "Post-execution thread separation feature flag");
   CONFIG_PARAM(postExecutionQueuesSize, uint16_t, 50, "Post-execution deferred message queues size");
 
   // Parameter to enable/disable waiting for transaction data to be persisted.

--- a/bftengine/src/bftengine/PrimitiveTypes.hpp
+++ b/bftengine/src/bftengine/PrimitiveTypes.hpp
@@ -39,7 +39,7 @@ typedef uint32_t MsgSize;
 typedef uint16_t MsgType;
 typedef uint32_t SpanContextSize;
 
-enum class CommitPath { NA = -1, OPTIMISTIC_FAST = 0, FAST_WITH_THRESHOLD = 1, SLOW = 2 };
+enum class CommitPath : int8_t { NA = -1, OPTIMISTIC_FAST = 0, FAST_WITH_THRESHOLD = 1, SLOW = 2 };
 
 std::string CommitPathToStr(CommitPath path);
 std::string CommitPathToMDCString(CommitPath path);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -131,7 +131,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // represents the number of running executions at this moment.
   // This should not be thread safe because its been changed in 3 places:
-  // 1) startPrePrepareMsgExecution - when we are getting empty PP its simbulize that we should push
+  // 1) startPrePrepareMsgExecution - when we are getting empty PP its symbolize that we should push
   // FinishPrePrepareExecutionInternalMsg which can happen only on the main thread. 2) executeAllPrePreparedRequests -
   // just before we insert the job to execution thread which means we are in the main thread. 3)
   // finishExecutePrePrepareMsg   - which can be called only when we fetch FinishPrePrepareExecutionInternalMsg from the
@@ -257,16 +257,25 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   GaugeHandle deferredMessagesMetric_;
   // The first commit path being attempted for a new request.
   StatusHandle metric_first_commit_path_;
-
   CounterHandle batch_closed_on_logic_off_;
   CounterHandle batch_closed_on_logic_on_;
   CounterHandle metric_indicator_of_non_determinism_;
   CounterHandle metric_total_committed_sn_;
-  CounterHandle metric_slow_path_count_;
+  /// Executed slow consensuses
+  CounterHandle metric_total_slowPath_;
+  /// Inner requests in slow executions
+  CounterHandle metric_total_slowPath_requests_;
+  /// StartSlowCommitMsg received
+  CounterHandle metric_received_start_slow_commits_;
+  /// Executed FAST_WITH_THRESHOLD consensuses
+  CounterHandle metric_fast_threshold_path_count_;
+  /// Executed fast consensuses
+  CounterHandle metric_total_fastPath_;
+  /// Inner requests in fast executions
+  CounterHandle metric_total_fastPath_requests_;
   CounterHandle metric_received_internal_msgs_;
   CounterHandle metric_received_client_requests_;
   CounterHandle metric_received_pre_prepares_;
-  CounterHandle metric_received_start_slow_commits_;
   CounterHandle metric_received_partial_commit_proofs_;
   CounterHandle metric_received_full_commit_proofs_;
   CounterHandle metric_received_prepare_partials_;
@@ -295,10 +304,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_sent_commitFull_msg_due_to_reqMissingData_;
   CounterHandle metric_sent_fullCommitProof_msg_due_to_reqMissingData_;
   CounterHandle metric_total_finished_consensuses_;
-  CounterHandle metric_total_slowPath_;
-  CounterHandle metric_total_fastPath_;
-  CounterHandle metric_total_slowPath_requests_;
-  CounterHandle metric_total_fastPath_requests_;
   CounterHandle metric_total_preexec_requests_executed_;
   CounterHandle metric_received_restart_ready_;
   CounterHandle metric_received_restart_proof_;
@@ -376,7 +381,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void finalizeExecution();
   void updateLimitsAndMetrics(PrePrepareMsg* ppMsg);
   void finishExecutePrePrepareMsg(PrePrepareMsg* pp, IRequestsHandler::ExecutionRequestsQueue* pAccumulatedRequests);
-  void executeRequests(PrePrepareMsg* pp, Bitmap& requestSet, Timestamp time);
+  /// This functions is mostly called through the separate thread execution flow
+  void executeRequests(PrePrepareMsg* ppMsg, Bitmap& requestSet, Timestamp time);
   void executeSpecialRequests(PrePrepareMsg* ppMsg,
                               uint16_t numOfSpecialReqs,
                               bool recoverFromErrorInRequestsExecution,
@@ -500,6 +506,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   void executeReadOnlyRequest(concordUtils::SpanWrapper& parent_span, ClientRequestMsg* m);
 
+  /// Single threaded execution only
   void executeNextCommittedRequests(concordUtils::SpanWrapper& parent_span, bool requestMissingInfo = false);
 
   void executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper& parent_span,
@@ -599,6 +606,12 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   EpochNum getSelfEpochNumber() { return static_cast<EpochNum>(EpochManager::instance().getSelfEpochNumber()); }
 
   void setConflictDetectionBlockId(const ClientRequestMsg&, IRequestsHandler::ExecutionRequest&);
+  /**
+   * Updates execution related metrics
+   * @param executionPath - The consensus path type
+   * @param numOfRequests - The number of executed requests
+   */
+  void updateExecutedPathMetrics(const CommitPath executionPath, uint16_t numOfRequests);
 
   class PostExecJob : public concord::util::SimpleThreadPool::Job {
    private:

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -100,6 +100,7 @@ class PrePrepareMsg : public MessageBase {
   std::string getCid() const;
   void setCid(SeqNum s);
 
+  /// This is actually the final commit path of the request
   CommitPath firstPath() const;
 
   bool isNull() const { return ((b()->flags & 0x1) == 0); }

--- a/bftengine/src/preprocessor/GlobalData.cpp
+++ b/bftengine/src/preprocessor/GlobalData.cpp
@@ -4,7 +4,4 @@ namespace preprocessor {
 
 std::atomic_uint64_t GlobalData::current_block_id = 0;
 std::atomic_uint64_t GlobalData::block_delta = 0;
-std::atomic_uint64_t GlobalData::delta_factor = 60;
-std::atomic_bool GlobalData::increment_step = false;
-std::atomic_bool GlobalData::decrement_step = false;
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/GlobalData.hpp
+++ b/bftengine/src/preprocessor/GlobalData.hpp
@@ -6,9 +6,6 @@ struct GlobalData {
   // Used for the conflict detection optimization.
   static std::atomic_uint64_t current_block_id;
   static std::atomic_uint64_t block_delta;
-  static std::atomic_uint64_t delta_factor;
-  static std::atomic_bool increment_step;
-  static std::atomic_bool decrement_step;
   const static uint8_t step = 10;
 };
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1605,7 +1605,6 @@ OperationResult PreProcessor::launchReqPreProcessing(const PreProcessRequestMsgS
              "Primary block [" << preProcessReqMsg->primaryBlockId()
                                << "] is too advanced for conflict detection optimization, replica block id ["
                                << GlobalData::current_block_id << "] delta [" << GlobalData::block_delta << "]");
-    GlobalData::increment_step = true;
   }
   auto preProcessResultBuffer = (char *)getPreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
   IRequestsHandler::ExecutionRequest request = bftEngine::IRequestsHandler::ExecutionRequest{

--- a/tests/apollo/test_skvbc.py
+++ b/tests/apollo/test_skvbc.py
@@ -16,6 +16,7 @@ from os import environ
 
 import trio
 
+from util.test_base import ApolloTest
 from util import blinking_replica
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
@@ -40,7 +41,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcTest(unittest.TestCase):
+class SkvbcTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_auto_view_change.py
+++ b/tests/apollo/test_skvbc_auto_view_change.py
@@ -15,6 +15,7 @@ import random
 import unittest
 from os import environ
 
+from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
@@ -38,7 +39,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcAutoViewChangeTest(unittest.TestCase):
+class SkvbcAutoViewChangeTest(ApolloTest):
 
     @with_trio
     @with_bft_network(start_replica_cmd)

--- a/tests/apollo/test_skvbc_backup_restore.py
+++ b/tests/apollo/test_skvbc_backup_restore.py
@@ -15,6 +15,7 @@ import unittest
 
 import trio
 
+from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, with_constant_load, KEY_FILE_PREFIX
 from util import eliot_logging as log
@@ -43,7 +44,7 @@ def start_replica_cmd_with_vc_timeout(vc_timeout):
     return wrapper
 
 
-class SkvbcBackupRestoreTest(unittest.TestCase):
+class SkvbcBackupRestoreTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -15,6 +15,7 @@ import unittest
 import trio
 import random
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load
 from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
@@ -55,7 +56,7 @@ def start_replica_cmd_with_vc_timeout(vc_timeout):
     return wrapper
 
 
-class SkvbcBatchPreExecutionTest(unittest.TestCase):
+class SkvbcBatchPreExecutionTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_block_accumulation.py
+++ b/tests/apollo/test_skvbc_block_accumulation.py
@@ -15,6 +15,7 @@ import unittest
 import trio
 import random
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load
 from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
@@ -51,7 +52,7 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
             "-u", str(True)
             ]
 
-class SkvbcBlockAccumulationTest(unittest.TestCase):
+class SkvbcBlockAccumulationTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
+++ b/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
@@ -16,6 +16,7 @@ from os import environ
 
 import trio
 
+from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load
 from util.skvbc_history_tracker import verify_linearizability
@@ -75,7 +76,7 @@ def start_replica_cmd_asymmetric_communication(builddir, replica_id, view_change
     return cmd
 
 
-class SkvbcPrimaryByzantinePreExecutionTest(unittest.TestCase):
+class SkvbcPrimaryByzantinePreExecutionTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -18,6 +18,7 @@ from os import environ
 
 import trio
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, with_constant_load, KEY_FILE_PREFIX, skip_for_tls
 from util import bft_network_partitioning as net
 from util import eliot_logging as log
@@ -46,7 +47,7 @@ def start_replica_cmd_with_vc_timeout(vc_timeout):
     return wrapper
 
 
-class SkvbcChaoticStartupTest(unittest.TestCase):
+class SkvbcChaoticStartupTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -15,6 +15,7 @@ import unittest
 
 import trio
 
+from util.test_base import ApolloTest
 from util import bft_network_partitioning as net
 
 from util import skvbc as kvbc
@@ -38,7 +39,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcCheckpointTest(unittest.TestCase):
+class SkvbcCheckpointTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_client_transaction_signing.py
+++ b/tests/apollo/test_skvbc_client_transaction_signing.py
@@ -17,6 +17,7 @@ from os import environ
 
 import trio
 
+from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 
@@ -46,7 +47,7 @@ def start_replica_cmd(builddir, replica_id):
             "-e", str(True)
             ]
 
-class SkvbcTestClientTxnSigning(unittest.TestCase):
+class SkvbcTestClientTxnSigning(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_commit_path.py
+++ b/tests/apollo/test_skvbc_commit_path.py
@@ -15,6 +15,7 @@ import random
 import unittest
 import trio
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
@@ -40,7 +41,7 @@ def start_replica_cmd(builddir, replica_id):
             "-e", str(True)
             ]
 
-class SkvbcCommitPathTest(unittest.TestCase):
+class SkvbcCommitPathTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_consensus_batching.py
+++ b/tests/apollo/test_skvbc_consensus_batching.py
@@ -13,6 +13,7 @@
 import os.path
 import unittest
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
@@ -48,7 +49,7 @@ def start_replica_cmd(builddir, replica_id):
             "-z", BATCH_FLUSH_PERIOD
             ]
 
-class SkvbcConsensusBatchingPoliciesTest(unittest.TestCase):
+class SkvbcConsensusBatchingPoliciesTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_cron.py
+++ b/tests/apollo/test_skvbc_cron.py
@@ -13,6 +13,7 @@
 import os.path
 import unittest
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 
 expected_number_of_executes = 3
@@ -36,7 +37,7 @@ def start_replica_cmd(builddir, replica_id):
             "-r", str(expected_number_of_executes)
             ]
 
-class SkvbcTestCron(unittest.TestCase):
+class SkvbcTestCron(ApolloTest):
     __test__ = False  # so that PyTest ignores this test scenario
 
     expected_component_id = "42"

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -19,6 +19,7 @@ import difflib
 import subprocess
 import shutil
 import tempfile
+from util.test_base import ApolloTest
 from util import bft
 from util import skvbc as kvbc
 from util.skvbc import SimpleKVBCProtocol
@@ -161,7 +162,7 @@ def start_replica_cmd_with_operator_and_public_keys(builddir, replica_id):
             "-o", builddir + "/operator_pub.pem",
             "--add-all-keys-as-public"]
 
-class SkvbcDbSnapshotTest(unittest.TestCase):
+class SkvbcDbSnapshotTest(ApolloTest):
     __test__ = False  # so that PyTest ignores this test scenario
 
     @with_trio

--- a/tests/apollo/test_skvbc_history_tracker.py
+++ b/tests/apollo/test_skvbc_history_tracker.py
@@ -11,6 +11,8 @@
 # file.
 
 import unittest
+
+from util.test_base import ApolloTest
 from util import skvbc, skvbc_history_tracker
 
 from util.skvbc_exceptions import(
@@ -21,10 +23,11 @@ from util.skvbc_exceptions import(
     PhantomBlockError
 )
 
-class TestCompleteHistories(unittest.TestCase):
+class TestCompleteHistories(ApolloTest):
     """Test histories where no blocks are unknown"""
 
     def setUp(self):
+        super().setUp()
         self.tracker = skvbc_history_tracker.SkvbcTracker()
 
     def test_sucessful_write(self):
@@ -327,7 +330,7 @@ class TestCompleteHistories(unittest.TestCase):
 
 
 
-class TestPartialHistories(unittest.TestCase):
+class TestPartialHistories(ApolloTest):
     """
     Test histories where some writes don't return replies.
 
@@ -336,6 +339,7 @@ class TestPartialHistories(unittest.TestCase):
     tester informs it of the missing blocks values.
     """
     def setUp(self):
+        super().setUp()
         self.tracker = skvbc_history_tracker.SkvbcTracker()
 
     def test_sucessful_write(self):
@@ -522,7 +526,7 @@ class TestPartialHistories(unittest.TestCase):
         self.assertEqual(1, len(err.exception.matched_blocks))
         self.assertEqual(0, len(err.exception.unmatched_requests))
 
-class TestUnit(unittest.TestCase):
+class TestUnit(ApolloTest):
 
     def test_num_blocks_to_linearize_over(self):
         """

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -17,6 +17,7 @@ from os import environ
 
 import trio
 
+from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.skvbc_history_tracker import verify_linearizability
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
@@ -45,7 +46,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcChaosTest(unittest.TestCase):
+class SkvbcChaosTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_multi_sig.py
+++ b/tests/apollo/test_skvbc_multi_sig.py
@@ -16,6 +16,7 @@ import unittest
 import time
 import trio
 
+from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 
@@ -38,7 +39,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcMultiSig(unittest.TestCase):
+class SkvbcMultiSig(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -16,6 +16,7 @@ import unittest
 
 import trio
 
+from util.test_base import ApolloTest
 from util import bft_network_partitioning as net
 
 from util import skvbc as kvbc
@@ -41,7 +42,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcNetworkPartitioningTest(unittest.TestCase):
+class SkvbcNetworkPartitioningTest(ApolloTest):
 
     from os import environ
     @unittest.skip("Not stable")

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -15,6 +15,7 @@ import trio
 import os.path
 import random
 
+from util.test_base import ApolloTest
 from util import bft
 from util import skvbc as kvbc
 from util.skvbc import SimpleKVBCProtocol
@@ -46,7 +47,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcPersistenceTest(unittest.TestCase):
+class SkvbcPersistenceTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -16,6 +16,7 @@ import unittest
 import trio
 import random
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, with_constant_load, skip_for_tls
 from util.skvbc_history_tracker import verify_linearizability
 from util import skvbc as kvbc
@@ -60,7 +61,7 @@ def start_replica_cmd_with_vc_timeout(vc_timeout):
     return wrapper
 
 
-class SkvbcPreExecutionTest(unittest.TestCase):
+class SkvbcPreExecutionTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_publish_clients_keys.py
+++ b/tests/apollo/test_skvbc_publish_clients_keys.py
@@ -16,6 +16,7 @@ from os import environ
 
 import trio
 
+from util.test_base import ApolloTest
 from util import blinking_replica
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
@@ -40,7 +41,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcPublishClientsKeysTest(unittest.TestCase):
+class SkvbcPublishClientsKeysTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_pyclient.py
+++ b/tests/apollo/test_skvbc_pyclient.py
@@ -26,6 +26,8 @@ import sys
 import trio
 import unittest
 
+from util.test_base import ApolloTest
+
 sys.path.append(os.path.abspath("../../util/pyclient"))
 
 from bft_client import MofNQuorum
@@ -48,7 +50,7 @@ def start_replica_cmd(builddir, replica_id):
             "-s", status_timer_milli,
             ]
 
-class SkvbcPyclientTest(unittest.TestCase):
+class SkvbcPyclientTest(ApolloTest):
 
     
     @with_trio

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -15,6 +15,8 @@ import time
 from shutil import copy2
 import trio
 import difflib
+
+from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, TestConfig
 from util import operator
@@ -120,7 +122,7 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
             "-o", builddir + "/operator_pub.pem",
             "--publish-master-key-on-startup"]
 
-class SkvbcReconfigurationTest(unittest.TestCase):
+class SkvbcReconfigurationTest(ApolloTest):
     @classmethod
     def setUpClass(cls):
         cls.object_store = ObjectStore()

--- a/tests/apollo/test_skvbc_reply.py
+++ b/tests/apollo/test_skvbc_reply.py
@@ -16,6 +16,8 @@ import random
 import unittest
 import trio
 
+from util.test_base import ApolloTest
+
 sys.path.append(os.path.abspath("../../util/pyclient"))
 
 from util import skvbc as kvbc
@@ -40,7 +42,7 @@ def start_replica_cmd(builddir, replica_id):
             "-e", str(True)
             ]
 
-class SkvbcReplyTest(unittest.TestCase):
+class SkvbcReplyTest(ApolloTest):
 
     @unittest.skip("Unstable test - BC-18035")
     @with_trio

--- a/tests/apollo/test_skvbc_ro_replica.py
+++ b/tests/apollo/test_skvbc_ro_replica.py
@@ -19,6 +19,7 @@ import tempfile
 import shutil
 import time
 
+from util.test_base import ApolloTest
 from util import bft
 from util import skvbc as kvbc
 from util.skvbc import SimpleKVBCProtocol
@@ -39,7 +40,7 @@ def start_replica_cmd(builddir, replica_id, config):
     """
     return start_replica_cmd_prefix(builddir, replica_id, config)
 
-class SkvbcReadOnlyReplicaTest(unittest.TestCase):
+class SkvbcReadOnlyReplicaTest(ApolloTest):
     """
     ReadOnlyReplicaTest has got two modes of operation:
         - using external S3 object store (minio)

--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -40,7 +40,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcStateTransferTest(unittest.TestCase):
+class SkvbcStateTransferTest():
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_time_service.py
+++ b/tests/apollo/test_skvbc_time_service.py
@@ -17,6 +17,7 @@ import time
 
 import trio
 
+from util.test_base import ApolloTest
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX
 from util.skvbc_history_tracker import verify_linearizability
 from util import eliot_logging as log
@@ -51,7 +52,7 @@ def start_replica_cmd_without_time_service(disable_time_service):
         return start_replica_cmd(*args, **kwargs, time_service_enabled=disable_time_service)
     return wrapper
 
-class SkvbcTimeServiceTest(unittest.TestCase):
+class SkvbcTimeServiceTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -17,6 +17,7 @@ from os import environ
 
 import trio
 
+from util.test_base import ApolloTest
 from util import bft_network_partitioning as net
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, skip_for_tls
@@ -41,7 +42,7 @@ def start_replica_cmd(builddir, replica_id):
             ]
 
 
-class SkvbcViewChangeTest(unittest.TestCase):
+class SkvbcViewChangeTest(ApolloTest):
 
     __test__ = False  # so that PyTest ignores this test scenario
 

--- a/tests/apollo/util/eliot_logging.py
+++ b/tests/apollo/util/eliot_logging.py
@@ -33,11 +33,26 @@ def set_file_destination():
 
 # Set logs to the console
 def stdout(message):
-    if message is not "":
-        print(message)
+    if message.get("action_status", "") == "succeeded":
+        return
 
+    fields = [datetime.fromtimestamp(message["timestamp"]).strftime("%d/%m/%Y %H:%M:%S.%f"),
+     message.get("message_type", None),
+     message.get("action_type", None),
+     message.get("action_status", None),
+     message.get("result", None),
+     str([(key, val) for key, val in message.items() if key not in
+          ("action_type", "action_status", "result", "task_uuid", "timestamp", "task_level", "message_type")]),
+     message["task_uuid"],
+     ]
+
+    print(f' - '.join([field for field in fields if field]))
+
+
+if os.getenv('APOLLO_LOG_STDOUT', False):
+    add_destinations(stdout)
 
 if os.environ.get('KEEP_APOLLO_LOGS', "").lower() in ["true", "on"]:
     # Uncomment to see logs in console
-    #add_destinations(stdout)
     set_file_destination()
+

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -499,12 +499,12 @@ class SimpleKVBCProtocol:
                             write_count += 1
                     sent += len(clients)
             return write_count
-    
-    async def run_concurrent_ops(self, num_ops, write_weight=.70):
-        with log.start_action(action_type="run_concurrent_ops"):
-            max_concurrency = len(self.bft_network.clients) // 2
-            max_size = len(self.keys) // 2
-            return await self.send_concurrent_ops(num_ops, max_concurrency, max_size, write_weight, create_conflicts=True)
+
+    async def run_concurrent_ops(self, num_ops: int, write_weight: float = .70):
+        return await self.send_concurrent_ops(exit_factor=num_ops,
+                                              max_concurrency=len(self.bft_network.clients) // 2,
+                                              max_size=len(self.keys) // 2,
+                                              write_weight=write_weight, create_conflicts=True)
 
     async def run_concurrent_conflict_ops(self, num_ops, write_weight=.70):
         if self.tracker is not None:

--- a/tests/apollo/util/test_base.py
+++ b/tests/apollo/util/test_base.py
@@ -1,0 +1,29 @@
+# Concord
+#
+# Copyright (c) 2019-2022 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Apache 2.0 license (the "License").
+# You may not use this product except in compliance with the Apache 2.0 License.
+#
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to the
+# terms and conditions of the subcomponent's license, as noted in the LICENSE
+# file.
+
+import os
+import random
+import unittest
+
+
+class ApolloTest(unittest.TestCase):
+
+    _SEED = os.getenv('APOLLO_SEED', random.randint(0, 1 << 32))
+
+    @property
+    def test_seed(self):
+        return self._test_seed
+
+    def setUp(self):
+        self._test_seed = random.randint(0, 1 << 32)
+        random.seed(self._test_seed)
+        print(f'Test seed set to {self._test_seed}')

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -22,7 +22,7 @@
 
 #include "communication/CommFactory.hpp"
 #include "KeyfileIOUtils.hpp"
-#include "config_file_parser.hpp"
+#include "../../util/include/config_file_parser.hpp"
 #include "CryptoManager.hpp"
 
 using bft::communication::PlainUdpConfig;


### PR DESCRIPTION
This branch adds a test for the transition from the FAST_OPTIMISTIC commit path to the FAST_WITH_THRESHOLD path.
It changes the way metrics are counted as they previously did not account for three commit paths.
The full (trinary) path information is not propagated through the consensus protocol, but is propagated through the execution path, and is therefore used.
This branch also adds optional prints and seeded test runs for easier debugging process.