### PR TITLE
Introduce TlsMultiplexCommunication class

### DIFF
--- a/bftclient/include/bftclient/bft_client.h
+++ b/bftclient/include/bftclient/bft_client.h
@@ -31,10 +31,11 @@
 namespace bft::client {
 
 typedef std::unordered_map<uint64_t, Reply> SeqNumToReplyMap;
+typedef std::shared_ptr<bft::communication::ICommunication> SharedCommPtr;
 
 class Client {
  public:
-  Client(std::unique_ptr<bft::communication::ICommunication> comm, const ClientConfig& config);
+  Client(SharedCommPtr comm, const ClientConfig& config);
 
   void setAggregator(const std::shared_ptr<concordMetrics::Aggregator>& aggregator) {
     metrics_.setAggregator(aggregator);
@@ -99,7 +100,7 @@ class Client {
 
   MsgReceiver receiver_;
 
-  std::unique_ptr<bft::communication::ICommunication> communication_;
+  SharedCommPtr communication_;
   ClientConfig config_;
   logging::Logger logger_ = logging::getLogger("bftclient");
   std::deque<Msg> pending_requests_;
@@ -139,7 +140,7 @@ class Client {
       registrar.perf.unRegisterComponent(component_name_);
     }
 
-    const std::string& getComponenetName() { return component_name_; }
+    const std::string& getComponentName() { return component_name_; }
 
    private:
     std::string component_name_;

--- a/bftclient/include/bftclient/fake_comm.h
+++ b/bftclient/include/bftclient/fake_comm.h
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the 'License").
 // You may not use this product except in compliance with the Apache 2.0 License.
@@ -118,7 +118,7 @@ class FakeCommunication : public bft::communication::ICommunication {
     return 0;
   }
 
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg, NodeNum endpointNum) override {
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg, NodeNum srcEndpointNum) override {
     for (auto& d : dests) {
       // This is a class used for unit testing, so a copy is passed for simplicity
       runner_.send(MsgFromClient{ReplicaId{(uint16_t)d}, msg});  // a copy is made here!

--- a/bftclient/src/bft_client.cpp
+++ b/bftclient/src/bft_client.cpp
@@ -23,7 +23,7 @@ using namespace bftEngine::impl;
 
 namespace bft::client {
 
-Client::Client(std::unique_ptr<bft::communication::ICommunication> comm, const ClientConfig& config)
+Client::Client(SharedCommPtr comm, const ClientConfig& config)
     : communication_(std::move(comm)),
       config_(config),
       quorum_converter_(config_.all_replicas, config.ro_replicas, config.f_val, config_.c_val),
@@ -134,7 +134,7 @@ Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool rea
     metrics_.transactionSigning++;
     if ((metrics_.transactionSigning.Get().Get() % count_between_snapshots) == 0) {
       auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      auto& name = histograms_->getComponenetName();
+      auto& name = histograms_->getComponentName();
       registrar.perf.snapshot(name);
       LOG_DEBUG(logger_,
                 "Signing stats snapshot #" << snapshot_index_ << " for " << name << std::endl

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -14,7 +14,6 @@
 #include "PreProcessor.hpp"
 #include "OpenTracing.hpp"
 #include "Timers.hpp"
-#include "messages/FullCommitProofMsg.hpp"
 #include "messages/PreProcessBatchRequestMsg.hpp"
 #include "InternalReplicaApi.hpp"
 #include "communication/CommFactory.hpp"
@@ -348,7 +347,7 @@ void setUpCommunication() {
   unordered_map<NodeNum, NodeInfo> nodes;
 
   NodeInfo nodeInfo{"128.0.0.1", 4321, true};
-  nodes[1] = nodeInfo;
+  nodes[0] = nodeInfo;
 
   PlainUdpConfig configuration("128.0.0.1", 1234, 4096, nodes, replicaConfig.replicaId);
   communicatorPtr.reset(CommFactory::create(configuration), [](ICommunication* c) {

--- a/client/client_pool/include/client/client_pool/client_pool_config.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_config.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -31,14 +31,9 @@ typedef struct ExternalClient {
 
 typedef struct ParticipantNode {
   std::string participant_node_host;
+  std::uint16_t principal_id;
   std::unordered_map<uint16_t, ExternalClient> externalClients;
 } ParticipantNode;
-
-typedef struct Replica {
-  bft::communication::NodeNum principal_id;
-  std::string replica_host;
-  std::uint32_t replica_port;
-} Replica;
 
 typedef struct ConcordClientPoolConfig {
   std::uint16_t c_val = 0;
@@ -66,13 +61,14 @@ typedef struct ConcordClientPoolConfig {
   std::uint32_t trace_sampling_rate = 0;
   std::string file_name;
   bool client_batching_enabled = false;
+  bool enable_multiplex_channel = false;
   size_t client_batching_max_messages_nbr = 20;
   std::uint64_t client_batching_flush_timeout_ms = 100;
   bool encrypted_config_enabled = false;
   bool transaction_signing_enabled = false;
   bool with_cre = false;
   std::string secrets_url;
-  std::unordered_map<bft::communication::NodeNum, Replica> node;
+  bft::communication::NodeMap replicas;
   std::deque<ParticipantNode> participant_nodes;
   secretsmanager::SecretData secret_data;
   std::string path_to_replicas_master_key = std::string();
@@ -116,6 +112,7 @@ class ClientPoolConfig {
   const std::string TRANSACTION_SIGNING_ENABLED = "transaction_signing_enabled";
   const std::string TRANSACTION_SIGNING_KEY_PATH = "signing_key_path";
   const std::string CLIENT_BATCHING_ENABLED = "client_batching_enabled";
+  const std::string MULTIPLEX_CHANNEL_ENABLED = "enable_multiplex_channel";
   const std::string CLIENT_BATCHING_MAX_MSG_NUM = "client_batching_max_messages_nbr";
   const std::string CLIENT_BATCHING_TIMEOUT_MILLI = "client_batching_flush_timeout_ms";
   const std::string TRACE_SAMPLING_RATE = "trace_sampling_rate";

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -315,36 +315,41 @@ void ConcordClientPool::setUpClientParams(SimpleClientParams &client_params,
       struct_config.client_sends_request_to_all_replicas_period_thresh;
   client_params.clientPeriodicResetThresh = struct_config.client_periodic_reset_thresh;
   LOG_INFO(logger_,
-           "clientInitialRetryTimeoutMilli="
-               << client_params.clientInitialRetryTimeoutMilli
-               << " clientMinRetryTimeoutMilli=" << client_params.clientMinRetryTimeoutMilli
-               << " clientMaxRetryTimeoutMilli=" << client_params.clientMaxRetryTimeoutMilli
-               << " numberOfStandardDeviationsToTolerate=" << client_params.numberOfStandardDeviationsToTolerate
-               << " samplesPerEvaluation=" << client_params.samplesPerEvaluation << " samplesUntilReset="
-               << client_params.samplesUntilReset << " clientSendsRequestToAllReplicasFirstThresh="
-               << client_params.clientSendsRequestToAllReplicasFirstThresh
-               << " clientSendsRequestToAllReplicasPeriodThresh="
-               << client_params.clientSendsRequestToAllReplicasPeriodThresh
-               << " clientPeriodicResetThresh=" << client_params.clientPeriodicResetThresh);
+           "Client configuration parameters" << KVLOG(client_params.clientInitialRetryTimeoutMilli,
+                                                      client_params.clientMinRetryTimeoutMilli,
+                                                      client_params.numberOfStandardDeviationsToTolerate,
+                                                      client_params.samplesPerEvaluation,
+                                                      client_params.clientSendsRequestToAllReplicasFirstThresh,
+                                                      client_params.clientSendsRequestToAllReplicasPeriodThresh,
+                                                      client_params.clientPeriodicResetThresh));
 }
 
 void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig &config) {
   auto num_clients = config.clients_per_participant_node - (int)config.with_cre;
-  LOG_INFO(logger_, "Creating pool" << KVLOG(num_clients));
   auto f_val = config.f_val;
   auto c_val = config.c_val;
   auto max_buf_size = stol(config.concord_bft_communication_buffer_length);
   const auto num_replicas = 3 * f_val + 2 * c_val + 1;
   const auto required_num_of_replicas = 2 * f_val + 1;
-
+  LOG_INFO(logger_,
+           "Creating pool" << KVLOG(c_val,
+                                    f_val,
+                                    config.clients_per_participant_node,
+                                    config.comm_to_use,
+                                    config.concord_bft_communication_buffer_length,
+                                    config.num_replicas,
+                                    config.clients_per_participant_node,
+                                    config.client_batching_enabled,
+                                    config.enable_multiplex_channel,
+                                    config.client_batching_max_messages_nbr,
+                                    config.encrypted_config_enabled,
+                                    config.transaction_signing_enabled,
+                                    config.with_cre));
   auto timeout = std::chrono::milliseconds{0UL};
   if (config.client_batching_enabled) {
     batch_size_ = config.client_batching_max_messages_nbr;
     timeout = std::chrono::milliseconds(config.client_batching_flush_timeout_ms);
     client_batching_enabled_ = true;
-    LOG_INFO(logger_, "Batching for client pool is enabled" << KVLOG(timeout.count(), batch_size_));
-  } else {
-    LOG_INFO(logger_, "Batching for client pool is disabled");
   }
   batch_timer_ =
       std::make_unique<Timer_t>(timeout, [this](ClientPtr client) -> void { OnBatchingTimeout(std::move(client)); });
@@ -357,6 +362,7 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
     auto const secretData = config.encrypted_config_enabled
                                 ? std::optional<concord::secretsmanager::SecretData>(config.secret_data)
                                 : std::nullopt;
+    LOG_INFO(logger_, "Create TLS Multiplex configuration");
     tlsMultiplexConfig = new TlsMultiplexConfig("tls_multiplex_channel",
                                                 0,
                                                 std::stoul(config.concord_bft_communication_buffer_length),
@@ -368,14 +374,13 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
                                                 endpointIdToNodeIdMap,
                                                 nullptr,
                                                 secretData);
-    LOG_INFO(logger_, "Create TLS Multiplex channel");
   }
-  external_client::ConcordClient::setStatics(
-      required_num_of_replicas, num_replicas, max_buf_size, batch_size_, tlsMultiplexConfig);
   bftEngine::SimpleClientParams clientParams;
   setUpClientParams(clientParams, config);
+  external_client::ConcordClient::setStatics(
+      required_num_of_replicas, num_replicas, max_buf_size, batch_size_, config, clientParams, tlsMultiplexConfig);
   for (int i = 0; i < num_clients; i++) {
-    clients_.push_back(std::make_shared<external_client::ConcordClient>(i, config, clientParams));
+    clients_.push_back(std::make_shared<external_client::ConcordClient>(i));
     ClientPoolMetrics_.clients_gauge++;
   }
   jobs_thread_pool_.start(num_clients);
@@ -406,7 +411,6 @@ ConcordClientPool::~ConcordClientPool() {
     client->stopClientComm();
   }
   clients_.clear();
-  LOG_INFO(logger_, "Clients cleanup complete");
 }
 
 void ConcordClientPool::SetDoneCallback(EXT_DONE_CALLBACK cb) { done_callback_ = std::move(cb); }

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -29,15 +29,36 @@ uint16_t ConcordClient::required_num_of_replicas_ = 0;
 uint16_t ConcordClient::num_of_replicas_ = 0;
 size_t ConcordClient::max_reply_size_ = 0;
 bool ConcordClient::delayed_behaviour_ = false;
+std::set<ReplicaId> ConcordClient::all_replicas_;
+config_pool::ConcordClientPoolConfig ConcordClient::pool_config_;
+bftEngine::SimpleClientParams ConcordClient::client_params_;
 BaseCommConfig* ConcordClient::multiplexConfig_ = nullptr;
+bft::client::SharedCommPtr ConcordClient::multiplex_comm_channel_;
 
-ConcordClient::ConcordClient(int client_id,
-                             ConcordClientPoolConfig& struct_config,
-                             const SimpleClientParams& client_params)
+void ConcordClient::setStatics(uint16_t required_num_of_replicas,
+                               uint16_t num_of_replicas,
+                               uint32_t max_reply_size,
+                               size_t batch_size,
+                               ConcordClientPoolConfig& pool_config,
+                               SimpleClientParams& client_params,
+                               BaseCommConfig* multiplexConfig) {
+  ConcordClient::max_reply_size_ = max_reply_size;
+  ConcordClient::reply_->resize((batch_size) ? batch_size * max_reply_size : max_reply_size_);
+  ConcordClient::required_num_of_replicas_ = required_num_of_replicas;
+  ConcordClient::num_of_replicas_ = num_of_replicas;
+  pool_config_ = pool_config;
+  client_params_ = client_params;
+  multiplexConfig_ = multiplexConfig;
+  for (const auto& replica : pool_config.replicas) {
+    all_replicas_.insert(ReplicaId{static_cast<uint16_t>(replica.first)});
+  }
+}
+
+ConcordClient::ConcordClient(int client_id)
     : logger_(logging::getLogger("concord.client.client_pool.external_client")),
       clientRequestExecutionResult_(OperationResult::SUCCESS) {
   client_id_ = client_id;
-  CreateClient(struct_config, client_params);
+  CreateClient();
 }
 
 ConcordClient::~ConcordClient() noexcept = default;
@@ -173,104 +194,123 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
   return {static_cast<uint32_t>(ret), std::move(pending_replies_)};
 }
 
-bft::communication::BaseCommConfig* ConcordClient::CreateCommConfig(int num_replicas,
-                                                                    const ConcordClientPoolConfig& config) const {
-  const auto& client_conf = config.participant_nodes.at(0).externalClients.at(client_id_);
+BaseCommConfig* ConcordClient::CreateCommConfig() const {
+  const auto& client_conf = pool_config_.participant_nodes.at(0).externalClients.at(client_id_);
   const auto commType =
-      config.comm_to_use == "tls"
+      pool_config_.comm_to_use == "tls"
           ? TlsTcp
-          : config.comm_to_use == "tcp" ? PlainTcp : config.comm_to_use == "udp" ? PlainUdp : SimpleAuthTcp;
+          : pool_config_.comm_to_use == "tcp" ? PlainTcp : pool_config_.comm_to_use == "udp" ? PlainUdp : SimpleAuthTcp;
   const auto listenPort = client_conf.client_port;
-  const auto bufferLength = std::stoul(config.concord_bft_communication_buffer_length);
+  const auto bufferLength = std::stoul(pool_config_.concord_bft_communication_buffer_length);
   const auto selfId = client_conf.principal_id;
   if (commType == PlainTcp)
     return new PlainTcpConfig{"external_client",
                               listenPort,
                               static_cast<uint32_t>(bufferLength),
-                              config.replicas,
-                              static_cast<int32_t>(num_replicas - 1),
+                              pool_config_.replicas,
+                              static_cast<int32_t>(pool_config_.num_replicas - 1),
                               selfId};
-  auto const secretData = config.encrypted_config_enabled
-                              ? std::optional<concord::secretsmanager::SecretData>(config.secret_data)
+  auto const secretData = pool_config_.encrypted_config_enabled
+                              ? std::optional<concord::secretsmanager::SecretData>(pool_config_.secret_data)
                               : std::nullopt;
   return new TlsTcpConfig{"external_client",
                           listenPort,
                           static_cast<uint32_t>(bufferLength),
-                          config.replicas,
-                          static_cast<std::int32_t>(num_replicas - 1),
+                          pool_config_.replicas,
+                          static_cast<std::int32_t>(pool_config_.num_replicas - 1),
                           selfId,
-                          config.tls_certificates_folder_path,
-                          config.tls_cipher_suite_list,
+                          pool_config_.tls_certificates_folder_path,
+                          pool_config_.tls_cipher_suite_list,
                           nullptr,
                           secretData};
 }
 
-void ConcordClient::CreateClient(ConcordClientPoolConfig& config, const SimpleClientParams& client_params) {
-  const auto num_replicas = config.num_replicas;
-  const auto& nodes = std::move(config.participant_nodes);
-  const auto& node = nodes.at(0);
-  const auto& external_clients_conf = node.externalClients;
-  const auto& client_conf = external_clients_conf.at(client_id_);
-  auto fVal = config.f_val;
-  auto cVal = config.c_val;
-  auto clientId = client_conf.principal_id;
-  enable_mock_comm_ = config.enable_mock_comm;
-  BaseCommConfig* comm_config = CreateCommConfig(num_replicas, config);
-  client_id_ = clientId;
-  std::set<ReplicaId> all_replicas;
-  for (const auto& replica : config.replicas) {
-    const auto replica_id = replica.first;
-    comm_config->nodes_[replica_id] = replica.second;
-    all_replicas.insert(ReplicaId{static_cast<uint16_t>(replica_id)});
+SharedCommPtr ConcordClient::ToCommunication(const BaseCommConfig& comm_config) {
+  if (comm_config.commType_ == TlsTcp) {
+    return SharedCommPtr{CommFactory::create(comm_config)};
+  } else if (comm_config.commType_ == PlainUdp) {
+    const auto udp_config = PlainUdpConfig{comm_config.listenHost_,
+                                           comm_config.listenPort_,
+                                           comm_config.bufferLength_,
+                                           comm_config.nodes_,
+                                           comm_config.selfId_,
+                                           comm_config.statusCallback_};
+    return SharedCommPtr{CommFactory::create(udp_config)};
   }
-  // Ensure exception safety by creating local pointers and only moving to
-  // object members if construction and startup haven't thrown.
-  LOG_DEBUG(logger_, "Client_id=" << client_id_ << " Creating communication module");
-  if (enable_mock_comm_) {
-    if (delayed_behaviour_) {
-      std::unique_ptr<FakeCommunication> fakecomm(new FakeCommunication(delayedBehaviour));
-      comm_ = std::move(fakecomm);
-    } else {
-      std::unique_ptr<FakeCommunication> fakecomm(new FakeCommunication(immediateBehaviour));
-      comm_ = std::move(fakecomm);
+  throw std::invalid_argument{"Unknown communication module type=" + std::to_string(comm_config.commType_)};
+}
+
+std::tuple<BaseCommConfig*, SharedCommPtr> ConcordClient::CreateCommConfigAndCommChannel() {
+  const auto& nodes = std::move(pool_config_.participant_nodes);
+  const auto& client_conf = nodes.at(0).externalClients.at(client_id_);
+  BaseCommConfig* comm_config = nullptr;
+  SharedCommPtr comm_layer;
+  if (multiplexConfig_)
+    comm_config = multiplexConfig_;
+  else {
+    comm_config = CreateCommConfig();
+    for (const auto& replica : pool_config_.replicas) {
+      comm_config->nodes_[replica.first] = replica.second;
     }
-  } else {
-    auto comm = ToCommunication(*comm_config);
-    comm_ = std::move(comm);
+    enable_mock_comm_ = pool_config_.enable_mock_comm;
+    if (enable_mock_comm_) {
+      const auto behaviour = delayed_behaviour_ ? delayedBehaviour : immediateBehaviour;
+      comm_layer = std::make_shared<FakeCommunication>(behaviour);
+    }
   }
+  client_id_ = client_conf.principal_id;
+  LOG_DEBUG(logger_, "Creating communication module" << KVLOG(client_id_));
+  if (!enable_mock_comm_) {
+    if (multiplexConfig_) {
+      if (!multiplex_comm_channel_) {
+        multiplex_comm_channel_ = SharedCommPtr{CommFactory::create(*multiplexConfig_)};
+      }
+      comm_layer = multiplex_comm_channel_;
+    } else
+      comm_layer = ToCommunication(*comm_config);
+  }
+  return {comm_config, comm_layer};
+}
+
+void ConcordClient::CreateClientConfig(BaseCommConfig* comm_config, ClientConfig& client_config) {
   static constexpr char transaction_signing_plain_file_name[] = "transaction_signing_priv.pem";
   static constexpr char transaction_signing_enc_file_name[] = "transaction_signing_priv.pem.enc";
-
-  LOG_DEBUG(logger_, "Client_id=" << client_id_ << " starting communication and creating new bft client instance");
-  ClientConfig cfg;
-  cfg.all_replicas = all_replicas;
-  cfg.c_val = cVal;
-  cfg.f_val = fVal;
-  cfg.id = ClientId{clientId};
-  cfg.retry_timeout_config = RetryTimeoutConfig{std::chrono::milliseconds(client_params.clientInitialRetryTimeoutMilli),
-                                                std::chrono::milliseconds(client_params.clientMinRetryTimeoutMilli),
-                                                std::chrono::milliseconds(client_params.clientMaxRetryTimeoutMilli),
-                                                client_params.numberOfStandardDeviationsToTolerate,
-                                                client_params.samplesPerEvaluation,
-                                                static_cast<int16_t>(client_params.samplesUntilReset)};
-  if (!config.path_to_replicas_master_key.empty())
-    cfg.replicas_master_key_folder_path = config.path_to_replicas_master_key;
-  bool transaction_signing_enabled = config.transaction_signing_enabled;
+  client_config.all_replicas = all_replicas_;
+  client_config.c_val = pool_config_.c_val;
+  client_config.f_val = pool_config_.f_val;
+  client_config.id = ClientId{static_cast<uint16_t>(client_id_)};
+  client_config.retry_timeout_config =
+      RetryTimeoutConfig{std::chrono::milliseconds(client_params_.clientInitialRetryTimeoutMilli),
+                         std::chrono::milliseconds(client_params_.clientMinRetryTimeoutMilli),
+                         std::chrono::milliseconds(client_params_.clientMaxRetryTimeoutMilli),
+                         client_params_.numberOfStandardDeviationsToTolerate,
+                         client_params_.samplesPerEvaluation,
+                         static_cast<int16_t>(client_params_.samplesUntilReset)};
+  if (!pool_config_.path_to_replicas_master_key.empty())
+    client_config.replicas_master_key_folder_path = pool_config_.path_to_replicas_master_key;
+  bool transaction_signing_enabled = pool_config_.transaction_signing_enabled;
+  auto tls_config = dynamic_cast<TlsTcpConfig*>(comm_config);
   if (transaction_signing_enabled) {
-    std::string priv_key_path = config.signing_key_path;
+    std::string priv_key_path = pool_config_.signing_key_path;
     const char* transaction_signing_file_name = transaction_signing_plain_file_name;
-
-    auto tls_config = dynamic_cast<TlsTcpConfig*>(comm_config);
     if (tls_config->secretData_) {
       transaction_signing_file_name = transaction_signing_enc_file_name;
-      cfg.secrets_manager_config = tls_config->secretData_;
+      client_config.secrets_manager_config = tls_config->secretData_;
     }
-    cfg.transaction_signing_private_key_file_path = priv_key_path + std::string("/") + transaction_signing_file_name;
+    client_config.transaction_signing_private_key_file_path =
+        priv_key_path + std::string("/") + transaction_signing_file_name;
   }
-  auto new_client = std::unique_ptr<bft::client::Client>{new bft::client::Client(std::move(comm_), cfg)};
+}
+
+void ConcordClient::CreateClient() {
+  ClientConfig client_config;
+  auto [comm_config, comm_layer] = CreateCommConfigAndCommChannel();
+  CreateClientConfig(comm_config, client_config);
+  LOG_DEBUG(logger_, "Creating new bft-client instance" << KVLOG(client_id_));
+  auto new_client = std::unique_ptr<bft::client::Client>{new bft::client::Client(comm_layer, client_config)};
   new_client_ = std::move(new_client);
   seqGen_ = bftEngine::SeqNumberGeneratorForClientRequests::createSeqNumberGeneratorForClientRequests();
-  LOG_INFO(logger_, "client_id=" << client_id_ << " creation succeeded");
+  LOG_INFO(logger_, "Client creation succeeded" << KVLOG(client_id_));
 }
 
 int ConcordClient::getClientId() const { return client_id_; }
@@ -287,37 +327,10 @@ std::chrono::steady_clock::time_point ConcordClient::getWaitingTime() const { re
 
 bool ConcordClient::isServing() const { return new_client_->isServing(num_of_replicas_, required_num_of_replicas_); }
 
-void ConcordClient::setStatics(uint16_t required_num_of_replicas,
-                               uint16_t num_of_replicas,
-                               uint32_t max_reply_size,
-                               size_t batch_size,
-                               BaseCommConfig* multiplexConfig) {
-  ConcordClient::max_reply_size_ = max_reply_size;
-  ConcordClient::reply_->resize((batch_size) ? batch_size * max_reply_size : max_reply_size_);
-  ConcordClient::required_num_of_replicas_ = required_num_of_replicas;
-  ConcordClient::num_of_replicas_ = num_of_replicas;
-  multiplexConfig_ = multiplexConfig;
-}
-
 void ConcordClient::setDelayFlagForTest(bool delay) { ConcordClient::delayed_behaviour_ = delay; }
 
 OperationResult ConcordClient::getRequestExecutionResult() { return clientRequestExecutionResult_; }
 
 void ConcordClient::stopClientComm() { new_client_->stop(); }
-
-std::unique_ptr<bft::communication::ICommunication> ConcordClient::ToCommunication(const BaseCommConfig& comm_config) {
-  if (comm_config.commType_ == TlsTcp) {
-    return std::unique_ptr<ICommunication>{CommFactory::create(comm_config)};
-  } else if (comm_config.commType_ == PlainUdp) {
-    const auto udp_config = PlainUdpConfig{comm_config.listenHost_,
-                                           comm_config.listenPort_,
-                                           comm_config.bufferLength_,
-                                           comm_config.nodes_,
-                                           comm_config.selfId_,
-                                           comm_config.statusCallback_};
-    return std::unique_ptr<ICommunication>{CommFactory::create(udp_config)};
-  }
-  throw std::invalid_argument{"Unknown communication module type=" + std::to_string(comm_config.commType_)};
-}
 
 }  // namespace concord::external_client

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
 // compliance with the Apache 2.0 License.
@@ -35,7 +35,7 @@ static void readYamlField(const YAML::Node& yaml, const std::string& index, T& o
     out = yaml[index].as<T>();
   } catch (const std::exception& e) {
     if (value_required) {
-      // We ignore the YAML excpetions because they aren't useful
+      // We ignore the YAML exceptions because they aren't useful
       std::ostringstream msg;
       msg << "Failed to read \"" << index << "\"";
       throw std::runtime_error(msg.str().data());
@@ -52,7 +52,7 @@ static void readYamlField(const YAML::Node& yaml,
     out = std::chrono::milliseconds(yaml[index].as<uint64_t>());
   } catch (const std::exception& e) {
     if (value_required) {
-      // We ignore the YAML excpetions because they aren't useful
+      // We ignore the YAML exceptions because they aren't useful
       std::ostringstream msg;
       msg << "Failed to read milliseconds \"" << index << "\"";
       throw std::runtime_error(msg.str().data());
@@ -104,10 +104,9 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
                 "client_number_of_standard_deviations_to_tolerate",
                 config.topology.client_retry_config.number_of_standard_deviations_to_tolerate);
   readYamlField(yaml, "client_samples_until_reset", config.topology.client_retry_config.samples_until_reset);
+  readYamlField(yaml, "enable_multiplex_channel", config.transport.enable_multiplex_channel);
   readYamlField(yaml, "enable_mock_comm", config.transport.enable_mock_comm);
-
   readYamlField(yaml, "concord-bft_communication_buffer_length", config.transport.buffer_length);
-
   concord::client::concordclient::TransportConfig::CommunicationType comm_type;
   std::string comm;
   readYamlField(yaml, "comm_to_use", comm);
@@ -127,6 +126,10 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
   ConcordAssert(node["participant_node"].IsSequence());
   ConcordAssert(node["participant_node"][0].IsMap());
   ConcordAssert(node["participant_node"][0]["external_clients"].IsSequence());
+
+  readYamlField(node["participant_node"][0], "participant_node_host", config.client_service.host);
+  readYamlField(node["participant_node"][0], "principal_id", config.client_service.id.val);
+
   for (const auto& item : node["participant_node"][0]["external_clients"]) {
     ConcordAssert(item.IsMap());
     ConcordAssert(item["client"].IsSequence());
@@ -136,7 +139,6 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
     concord::client::concordclient::BftClientInfo ci;
     readYamlField(client, "principal_id", ci.id.val);
     readYamlField(client, "client_port", ci.port);
-    readYamlField(node["participant_node"][0], "participant_node_host", ci.host);
     config.bft_clients.push_back(ci);
   }
 

--- a/client/clientservice/test/example_config.hpp
+++ b/client/clientservice/test/example_config.hpp
@@ -48,6 +48,7 @@ tls_certificates_folder_path: /clientservice/bft_certs
 tls_cipher_suite_list: ECDHE-ECDSA-AES256-GCM-SHA384
 tls_1_3_cipher_suite_list: TLS_AES_256_GCM_SHA384
 transaction_signing_enabled: true
+enable_multiplex_channel: false
 with_cre: false
 node:
   - replica:
@@ -73,6 +74,7 @@ node:
 participant_nodes:
   - participant_node:
       - participant_node_host: 0.0.0.0
+        principal_id: 55
         external_clients:
           - client:
               - client_port: 3502

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -1,4 +1,6 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Concord
+//
+// Copyright (c) 2021-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -66,16 +68,21 @@ struct BftTopology {
   std::string path_to_replicas_master_key = std::string();
 };
 
+struct ClientServiceInfo {
+  bft::client::ClientId id;
+  std::string host;
+};
+
 struct BftClientInfo {
   // ID needs to match the values set in Concord's configuration
   bft::client::ClientId id;
   uint16_t port;
-  std::string host;
 };
 
 struct TransportConfig {
   enum CommunicationType { Invalid, TlsTcp, PlainUdp };
   CommunicationType comm_type;
+  bool enable_multiplex_channel;
   // for testing purposes
   bool enable_mock_comm;
   // Communication buffer length
@@ -105,6 +112,7 @@ struct ConcordClientConfig {
   // Communication layer configuration
   TransportConfig transport;
   // BFT client descriptors
+  ClientServiceInfo client_service;
   std::vector<BftClientInfo> bft_clients;
   std::uint16_t num_of_used_bft_clients;
   // Configuration for subscribe requests

--- a/communication/CMakeLists.txt
+++ b/communication/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 if(BUILD_COMM_TCP_TLS)
     set(bftcommunication_src ${bftcommunication_src}
         src/TlsTCPCommunication.cpp
+        src/TlsMultiplexCommunication.cpp
         src/TlsRunner.cpp
         src/TlsConnectionManager.cpp
         src/AsyncTlsConnection.cpp
@@ -20,12 +21,16 @@ endif()
 add_library(bftcommunication ${bftcommunication_src})
 add_library(bftcommunication_shared SHARED ${bftcommunication_src})
 set_property(TARGET bftcommunication_shared PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(bftcommunication PUBLIC include)
-target_link_libraries(bftcommunication PUBLIC util)
-target_include_directories(bftcommunication_shared PUBLIC include)
-target_link_libraries(bftcommunication_shared PUBLIC util_shared)
+target_include_directories(bftcommunication PUBLIC ${util}/include)
 target_include_directories(bftcommunication PUBLIC ../secretsmanager/include)
+target_link_libraries(bftcommunication PUBLIC util)
+
+target_include_directories(bftcommunication_shared PUBLIC include)
+target_include_directories(bftcommunication_shared PUBLIC ${util}/include)
 target_include_directories(bftcommunication_shared PUBLIC ../secretsmanager/include)
+target_link_libraries(bftcommunication_shared PUBLIC util_shared)
 
 if(BUILD_COMM_TCP_TLS)
     target_link_libraries(bftcommunication PUBLIC secretsmanager)

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -62,17 +62,16 @@ class BaseCommConfig {
         bufferLength_{bufLength},
         nodes_{std::move(nodes)},
         statusCallback_{std::move(statusCallback)},
-        selfId_{selfId},
-        logger_(logging::getLogger("concord-bft.tls.basecommconfig")) {
+        selfId_{selfId} {
     const auto myNode = nodes_.find(selfId_);
-    ConcordAssertNE(myNode, nodes_.end());
-    amIReplica_ = myNode->second.isReplica;
+    // A replica node is always a part of the configuration. A client node is presented only in replicas' configuration.
+    if (myNode != nodes_.end()) amIReplica_ = myNode->second.isReplica;
   }
 
   bool isClient(NodeNum nodeNum) const {
     const auto node = nodes_.find(nodeNum);
     if (node != nodes_.end()) return !(node->second.isReplica);
-    LOG_ERROR(logger_, "The node " << nodeNum << " has not been found");
+    // A client node is presented only in replicas' configuration.
     return false;
   }
   virtual ~BaseCommConfig() = default;
@@ -85,8 +84,7 @@ class BaseCommConfig {
   NodeMap nodes_;
   UPDATE_CONNECTIVITY_FN statusCallback_;
   NodeNum selfId_;
-  bool amIReplica_;
-  logging::Logger logger_;
+  bool amIReplica_ = false;
 };
 
 class PlainUdpConfig : public BaseCommConfig {

--- a/communication/include/communication/CommFactory.hpp
+++ b/communication/include/communication/CommFactory.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0

--- a/communication/include/communication/ICommunication.hpp
+++ b/communication/include/communication/ICommunication.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0 License.
@@ -66,10 +66,10 @@ class ICommunication {
   // The function takes ownership of the buffer provided.
   // The return value is a set<NodeNum>.
   //    On success the set is empty.
-  //    On failure it contains the NodeNum-s of the destinations for which the message sending has failed.
+  //    On failure, it contains the NodeNum-s of the destinations for which the message sending has failed.
   virtual std::set<NodeNum> send(std::set<NodeNum> dests,
                                  std::vector<uint8_t>&& msg,
-                                 NodeNum endpointNum = MAX_ENDPOINT_NUM) = 0;
+                                 NodeNum srcEndpointNum = MAX_ENDPOINT_NUM) = 0;
 
   virtual void setReceiver(NodeNum receiverNum, IReceiver* receiver) = 0;
 

--- a/communication/src/CommFactory.cpp
+++ b/communication/src/CommFactory.cpp
@@ -48,6 +48,15 @@ ICommunication *CommFactory::create(const BaseCommConfig &config) {
                "Using TlsTCP: "
                    << "Host=" << config.listenHost_ << ", Port=" << config.listenPort_);
       res = TlsTCPCommunication::create(dynamic_cast<const TlsTcpConfig &>(config));
+      break;
+#endif
+      break;
+    case CommType::TlsMultiplex:
+#ifdef USE_COMM_TLS_TCP
+      LOG_INFO(_logger,
+               "Using TlsMultiplex: "
+                   << "Host=" << config.listenHost_ << ", Port=" << config.listenPort_);
+      res = TlsMultiplexCommunication::create(dynamic_cast<const TlsMultiplexConfig &>(config));
 #endif
       break;
   }

--- a/communication/src/TlsMultiplexCommunication.cpp
+++ b/communication/src/TlsMultiplexCommunication.cpp
@@ -44,7 +44,7 @@ void TlsMultiplexCommunication::TlsMultiplexReceiver::onNewMessage(NodeNum sourc
     LOG_DEBUG(logger_, "Receiver found for" << KVLOG(receiverId, endpointNum, sourceNode));
     return;
   }
-  LOG_WARN(logger_, "Receiver not found for" << KVLOG(receiverId, endpointNum, sourceNode));
+  LOG_ERROR(logger_, "Receiver not found for" << KVLOG(receiverId, endpointNum, sourceNode));
 }
 
 void TlsMultiplexCommunication::TlsMultiplexReceiver::onConnectionStatusChanged(NodeNum node,
@@ -82,13 +82,14 @@ int TlsMultiplexCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg
   // replica1 -> replica2: endpointNum = destNode = replica2
   if (endpointNum == MAX_ENDPOINT_NUM) endpointNum = destNode;
 
-  // Find connection-id to be used to reach specified endpoint entity
+  // Find connection-id to be used to reach specified endpoint entity.
+  // clientservice connection to be used to reach clients, replicas' connection - to reach replicas.
   const auto &connectionId = config_->endpointIdToNodeIdMap_.find(endpointNum);
   if (connectionId != config_->endpointIdToNodeIdMap_.end()) {
     LOG_DEBUG(logger_, "Connection found:" << KVLOG(destNode, connectionId->second));
     return TlsTCPCommunication::send(connectionId->second, move(msg), endpointNum);
   }
-  LOG_WARN(logger_, "Connection not found for destination endpoint" << KVLOG(destNode));
+  LOG_ERROR(logger_, "Connection not found for destination endpoint" << KVLOG(destNode));
   return 1;
 }
 

--- a/communication/src/TlsMultiplexCommunication.cpp
+++ b/communication/src/TlsMultiplexCommunication.cpp
@@ -1,0 +1,106 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include "communication/CommDefs.hpp"
+#include "TlsRunner.h"
+
+using namespace std;
+
+namespace bft::communication {
+
+//********************** Class TlsMultiplexReceiver **********************
+
+void TlsMultiplexCommunication::TlsMultiplexReceiver::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
+  receiversMap_.insert_or_assign(receiverNum, receiver);
+}
+
+void TlsMultiplexCommunication::TlsMultiplexReceiver::onNewMessage(NodeNum sourceNode,
+                                                                   const char *const message,
+                                                                   size_t messageLength,
+                                                                   NodeNum endpointNum) {
+  // client -> replica: endpointNum = clientId
+  // replica -> client: endpointNum = clientId
+  // replica1 -> replica2: endpointNum = destNode = replica2
+  NodeNum receiverId = MAX_ENDPOINT_NUM;
+  if (config_.amIReplica_) {
+    receiverId = config_.selfId_;
+    if (config_.isClient(endpointNum))
+      sourceNode = endpointNum;  // Replica received client message => set correct source node
+  } else
+    receiverId = endpointNum;
+
+  const auto &receiver = receiversMap_.find(receiverId);
+  if (receiver != receiversMap_.end()) {
+    receiver->second->onNewMessage(sourceNode, message, messageLength);
+    LOG_DEBUG(logger_, "Receiver found for" << KVLOG(receiverId, endpointNum, sourceNode));
+    return;
+  }
+  LOG_WARN(logger_, "Receiver not found for" << KVLOG(receiverId, endpointNum, sourceNode));
+}
+
+void TlsMultiplexCommunication::TlsMultiplexReceiver::onConnectionStatusChanged(NodeNum node,
+                                                                                ConnectionStatus newStatus) {}
+
+//********************** Class TlsMultiplexCommunication **********************
+
+TlsMultiplexCommunication::TlsMultiplexCommunication(const TlsMultiplexConfig &config)
+    : TlsTCPCommunication(config), logger_(logging::getLogger("concord-bft.tls.multiplex")) {
+  ownReceiver_ = new TlsMultiplexReceiver(config);
+  config_ = static_cast<TlsMultiplexConfig *>(config_);
+}
+
+TlsMultiplexCommunication *TlsMultiplexCommunication::create(const TlsMultiplexConfig &config) {
+  return new TlsMultiplexCommunication(config);
+}
+
+TlsMultiplexCommunication::~TlsMultiplexCommunication() { delete ownReceiver_; }
+
+int TlsMultiplexCommunication::start() {
+  auto const result = TlsTCPCommunication::start();
+  if (!result) runner_->setReceiver(config_->selfId_, ownReceiver_);
+  return result;
+}
+
+void TlsMultiplexCommunication::setReceiver(NodeNum receiverNum, IReceiver *receiver) {
+  // For a replica: the same receiver object serves all endpoint clients.
+  // For a client: one receiver object serves one endpoint client.
+  ownReceiver_->setReceiver(receiverNum, receiver);
+}
+
+int TlsMultiplexCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum) {
+  // client -> replica: endpointNum = clientId
+  // replica -> client: endpointNum = clientId
+  // replica1 -> replica2: endpointNum = destNode = replica2
+  if (endpointNum == MAX_ENDPOINT_NUM) endpointNum = destNode;
+
+  // Find connection-id to be used to reach specified endpoint entity
+  const auto &connectionId = config_->endpointIdToNodeIdMap_.find(endpointNum);
+  if (connectionId != config_->endpointIdToNodeIdMap_.end()) {
+    LOG_DEBUG(logger_, "Connection found:" << KVLOG(destNode, connectionId->second));
+    return TlsTCPCommunication::send(connectionId->second, move(msg), endpointNum);
+  }
+  LOG_WARN(logger_, "Connection not found for destination endpoint" << KVLOG(destNode));
+  return 1;
+}
+
+ConnectionStatus TlsMultiplexCommunication::getCurrentConnectionStatus(NodeNum endpointNum) {
+  auto const nodeEntryIt = config_->endpointIdToNodeIdMap_.find(endpointNum);
+  if (nodeEntryIt != config_->endpointIdToNodeIdMap_.end()) {
+    const auto connectionStatus = runner_->getCurrentConnectionStatus(nodeEntryIt->second);
+    LOG_DEBUG(logger_, "Connection status:" << KVLOG(endpointNum, static_cast<int>(connectionStatus)));
+    return connectionStatus;
+  }
+  LOG_WARN(logger_, "An active connection not found for node" << KVLOG(endpointNum));
+  return ConnectionStatus::Unknown;
+}
+
+}  // namespace bft::communication

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -58,9 +58,11 @@ int TlsTCPCommunication::send(NodeNum destNode, std::vector<uint8_t> &&msg, Node
   return 0;
 }
 
-std::set<NodeNum> TlsTCPCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum endpointNum) {
+std::set<NodeNum> TlsTCPCommunication::send(std::set<NodeNum> dests,
+                                            std::vector<uint8_t> &&msg,
+                                            NodeNum srcEndpointNum) {
   std::set<NodeNum> failed_nodes;
-  auto outgoingMsg = std::make_shared<tls::OutgoingMsg>(std::move(msg), endpointNum);
+  auto outgoingMsg = std::make_shared<tls::OutgoingMsg>(std::move(msg), srcEndpointNum);
   runner_->send(dests, outgoingMsg);
   return failed_nodes;
 }

--- a/communication/src/TlsTCPCommunication.cpp
+++ b/communication/src/TlsTCPCommunication.cpp
@@ -19,14 +19,15 @@ static constexpr size_t NUM_THREADS = 1;
 namespace bft::communication {
 
 // This is the public interface to this library. TlsTcpCommunication implements ICommunication.
-TlsTCPCommunication::TlsTCPCommunication(const TlsTcpConfig &config) : config_(config) {
+TlsTCPCommunication::TlsTCPCommunication(const TlsTcpConfig &config) {
+  config_ = new TlsTcpConfig(config);
   if (config.selfId_ > static_cast<uint64_t>(config.maxServerId_))
     runner_.reset(new tls::Runner(config, 1));
   else
     runner_.reset(new tls::Runner(config, NUM_THREADS));
 }
 
-TlsTCPCommunication::~TlsTCPCommunication() {}
+TlsTCPCommunication::~TlsTCPCommunication() { delete config_; }
 
 TlsTCPCommunication *TlsTCPCommunication::create(const TlsTcpConfig &config) { return new TlsTCPCommunication(config); }
 
@@ -67,7 +68,7 @@ std::set<NodeNum> TlsTCPCommunication::send(std::set<NodeNum> dests, std::vector
 void TlsTCPCommunication::setReceiver(NodeNum id, IReceiver *receiver) { runner_->setReceiver(id, receiver); }
 
 void TlsTCPCommunication::restartCommunication(NodeNum i) {
-  if (i == config_.selfId_) {
+  if (i == config_->selfId_) {
     runner_->stop();
     runner_->start();
   }

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.cpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.cpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0
@@ -36,7 +36,7 @@ int WrapCommunication::send(NodeNum destNode, std::vector<uint8_t>&& msg, NodeNu
   }
 }
 
-std::set<NodeNum> WrapCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg, NodeNum endpointNum) {
+std::set<NodeNum> WrapCommunication::send(std::set<NodeNum> dests, std::vector<uint8_t>&& msg, NodeNum srcEndpointNum) {
   if (separate_communication_) {
     std::set<NodeNum> failedNodes;
     for (auto dst : dests) {

--- a/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
+++ b/tests/simpleKVBC/TesterReplica/WrapCommunication.hpp
@@ -1,6 +1,6 @@
 // Concord
 //
-// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0 License.
@@ -38,7 +38,7 @@ class WrapCommunication : public ICommunication {
   }
 
   int send(NodeNum destNode, std::vector<uint8_t> &&msg, NodeNum endpointNum = MAX_ENDPOINT_NUM) override;
-  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum endpointNum) override;
+  std::set<NodeNum> send(std::set<NodeNum> dests, std::vector<uint8_t> &&msg, NodeNum srcEndpointNum) override;
 
   void setReceiver(NodeNum receiverNum, IReceiver *receiver) override {
     communication_->setReceiver(receiverNum, receiver);


### PR DESCRIPTION
As a part of a client pool refactoring task, we introduce TlsMultiplexCommunication class, which allows all clients in the pool to share the same communication channel. The feature is enabled through enableMultiplexChannel flag, which is set to 'false' by default.