### PR TITLE
Modified the logic of db-checkpoint window size check

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -131,6 +131,7 @@ class DbCheckpointManager {
     if (ReplicaConfig::instance().dbCheckpointFeatureEnabled)
       createDbCheckpointAsync(seqNum, std::nullopt, std::nullopt);
   }
+  inline auto getLastDbCheckpointSeqNum() const { return lastCheckpointSeqNum_; }
 
  private:
   logging::Logger getLogger() {

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -175,6 +175,11 @@ void DbCheckpointManager::initializeDbCheckpointManager(std::shared_ptr<concord:
   if (getLastBlockIdCb) getLastBlockIdCb_ = getLastBlockIdCb;
   prepareCheckpointCb_ = prepareCheckpointCb;
   if (ReplicaConfig::instance().dbCheckpointFeatureEnabled) {
+    // in case of upgrade, we need to set the lastStableCheckpointSeqNum from persistence
+    // instead of 0. if there is a db checkpoint metatdata present in persistence
+    // then this gets overriden by the lastCheckpointSeqNum loaded from persistence
+    if (getLastStableSeqNumCb_) lastCheckpointSeqNum_ = getLastStableSeqNumCb_();
+
     init();
   } else {
     // db checkpoint is disabled. Cleanup metadata and checkpoints created if any

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4463,8 +4463,9 @@ ReplicaImp::ReplicaImp(bool firstTime,
       auto timeSinceLastSnapshot = (std::chrono::duration_cast<std::chrono::seconds>(currTime) -
                                     DbCheckpointManager::instance().getLastCheckpointCreationTime())
                                        .count();
+      auto seqNumsExecutedSinceLastDbCheckPt = seqNum - DbCheckpointManager::instance().getLastDbCheckpointSeqNum();
       if (getReplicaConfig().dbCheckpointFeatureEnabled && seqNum && isCurrentPrimary() &&
-          !(seqNum % getReplicaConfig().dbCheckPointWindowSize) &&
+          (seqNumsExecutedSinceLastDbCheckPt >= getReplicaConfig().dbCheckPointWindowSize) &&
           (timeSinceLastSnapshot >= getReplicaConfig().dbSnapshotIntervalSeconds.count())) {
         DbCheckpointManager::instance().sendInternalCreateDbCheckpointMsg(seqNum, false);
         LOG_INFO(GL, "send msg to create Db Checkpoint:" << KVLOG(seqNum));

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -603,9 +603,9 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
         for r in bft_network.all_replicas():
             epoch = await bft_network.get_metric(r, bft_network, "Gauges", "epoch_number", component="epoch_manager")
             self.assertEqual(epoch, 1)
-        for i in range(300):
+        for i in range(600):
             await skvbc.send_write_kv_set()
-        await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 600)
+        await self.wait_for_stable_checkpoint(bft_network, bft_network.all_replicas(), 900)
         await self.wait_for_created_snapshots_metric(bft_network, bft_network.all_replicas(), 2)
         for replica_id in bft_network.all_replicas():
             last_block_id = await bft_network.get_metric(replica_id, bft_network,
@@ -622,7 +622,7 @@ class SkvbcDbSnapshotTest(unittest.TestCase):
             self.assertTrue(any(dbcheckpoint_info.seq_num ==
                             300 for dbcheckpoint_info in dbcheckpoint_info_list))
             self.assertTrue(any(dbcheckpoint_info.seq_num ==
-                            600 for dbcheckpoint_info in dbcheckpoint_info_list))
+                            900 for dbcheckpoint_info in dbcheckpoint_info_list))
 
     @with_trio
     @with_bft_network(start_replica_cmd_with_high_db_window_size, selected_configs=lambda n, f, c: n == 7)


### PR DESCRIPTION
At present, we only check for db checkpoint create condition on the seqNum window size boundary. It may happen that, we complete the time interval required to create next db checkpoint much before reaching next window size boundary, This PR addresses this, now on every stable sequence number, we check if seqNum executed since last db checkpoint creation is greater or equal to the window size and time interval between two db checkpoints is expired.