### PR TITLE
Fix a bug where FAST_WITH_THRESHOLD executions weren't counted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,15 @@ CONCORD_BFT_CORE_DIR?=${CONCORD_BFT_TARGET_SOURCE_PATH}/${CONCORD_BFT_BUILD_DIR}
 
 CONCORD_BFT_ADDITIONAL_RUN_PARAMS?=
 APOLLO_CTEST_RUN_PARAMS?=
+CONCORD_BFT_FORMAT_CMD=make format-check &&
 
 ifneq (${APOLLO_LOG_STDOUT},)
 	CONCORD_BFT_ADDITIONAL_RUN_PARAMS+=--env APOLLO_LOG_STDOUT=TRUE
-    CONCORD_BFT_ADDITIONAL_CTEST_RUN_PARAMS+=-V
+	CONCORD_BFT_ADDITIONAL_CTEST_RUN_PARAMS+=-V
+endif
+
+ifneq (${SKIP_FORMAT},)
+	CONCORD_BFT_FORMAT_CMD=
 endif
 
 BASIC_RUN_PARAMS?=-it --init --rm --privileged=true \
@@ -158,7 +163,7 @@ build: gen_cmake ## Build Concord-BFT source. In order to build a specific targe
 	docker run ${CONCORD_BFT_USER_GROUP} ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"cd ${CONCORD_BFT_BUILD_DIR} && \
-		make format-check && \
+		${CONCORD_BFT_FORMAT_CMD} \
 		make -j $$(nproc) ${TARGET}"
 	@echo
 	@echo "Build finished. The binaries are in ${CURDIR}/${CONCORD_BFT_BUILD_DIR}"

--- a/bftengine/src/bftengine/PrimitiveTypes.cpp
+++ b/bftengine/src/bftengine/PrimitiveTypes.cpp
@@ -34,5 +34,7 @@ std::string CommitPathToMDCString(CommitPath path) {
   }
 }
 
+std::ostream& operator<<(std::ostream& os, const CommitPath& path) { return os << CommitPathToStr(path); }
+
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/PrimitiveTypes.hpp
+++ b/bftengine/src/bftengine/PrimitiveTypes.hpp
@@ -41,6 +41,7 @@ typedef uint32_t SpanContextSize;
 
 enum class CommitPath : int8_t { NA = -1, OPTIMISTIC_FAST = 0, FAST_WITH_THRESHOLD = 1, SLOW = 2 };
 
+std::ostream& operator<<(std::ostream& os, const CommitPath& path);
 std::string CommitPathToStr(CommitPath path);
 std::string CommitPathToMDCString(CommitPath path);
 }  // namespace impl

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -401,45 +401,48 @@ class SimpleKVBCProtocol:
             assert kv2 == dict(kv)
             action.log(message_type=f'[READ-YOUR-WRITES] OK.')
 
-    async def send_write_kv_set(self, client=None, kv=None, max_set_size=None, long_exec=False, assert_reply=True, raise_slowErrorIfAny=True):
-        with log.start_action(action_type="send_write_kv_set") as action:
-            readset = set()
-            read_version = 0
+    async def send_write_kv_set(self, client=None, kv=None, max_set_size=None, long_exec=False, assert_reply=True,
+                                raise_slowErrorIfAny=True, description=''):
+        readset = set()
+        read_version = 0
+        kv_input = True
+        if client is None:
+            client = self.bft_network.random_client()
+        if kv is None and max_set_size is None:
+            kv_input = False
+            max_set_size = 0
+            key = self.random_key()
+            val = self.random_value()
+            writeset = [(key, val)]
+        elif kv is not None and max_set_size is None:
+            max_set_size = 0
             kv_input = True
-            if client is None:
-                client = self.bft_network.random_client()
-            if kv is None and max_set_size is None:
-                kv_input = False
-                max_set_size = 0
-                key = self.random_key()
-                val = self.random_value()
-                writeset = [(key, val)]
-            elif kv is not None and max_set_size is None:
-                max_set_size = 0
-                kv_input = True
-                writeset = kv
-            elif kv is None and max_set_size is not None:
-                writeset = self.writeset(max_set_size)
-            if self.tracker is not None:
-                max_read_set_size = 0 if self.tracker.no_conflicts else max_set_size
-                read_version = self.tracker.read_block_id()
-                readset = self.readset(0, max_read_set_size)
-            reply = await self.send_kv_set(client, readset, writeset, read_version, long_exec, assert_reply, raise_slowErrorIfAny)
-            action.log(message_type="[send_write_kv_set] OK")
-            if kv_input is True:
-                return reply
-            else:
-                return writeset[0][0],writeset[0][1]
+            writeset = kv
+        elif kv is None and max_set_size is not None:
+            writeset = self.writeset(max_set_size)
+        if self.tracker is not None:
+            max_read_set_size = 0 if self.tracker.no_conflicts else max_set_size
+            read_version = self.tracker.read_block_id()
+            readset = self.readset(0, max_read_set_size)
+        reply = await self.send_kv_set(client, readset, writeset, read_version, long_exec, assert_reply,
+                                       raise_slowErrorIfAny, description=f'write {description}')
+        if kv_input is True:
+            return reply
+        else:
+            return writeset[0][0], writeset[0][1]
 
-    async def send_kv_set(self, client, readset, writeset, read_version, long_exec=False, reply_assert=True, raise_slowErrorIfAny=True):
-        with log.start_action(action_type="send_kv_set"):
+    async def send_kv_set(self, client, readset, writeset, read_version, long_exec=False, reply_assert=True,
+                          raise_slowErrorIfAny=True, description='send_kv_set'):
+        seq_num = client.req_seq_num.next()
+        with log.start_action(action_type=description, seq=seq_num, client=client.client_id,
+                              readset_size=len(readset), writeset_size=len(writeset)) as action:
             msg = self.write_req(readset, writeset, read_version, long_exec)
-            seq_num = client.req_seq_num.next()
             client_id = client.client_id
             if self.tracker is not None:
                 self.tracker.send_write(client_id, seq_num, readset, dict(writeset), read_version)
             try:
                 serialized_reply = await client.write(msg, seq_num, pre_process=self.pre_exec_all)
+                action.log(message_type=f"received reply", client=client.client_id, seq=client.req_seq_num.val())
                 reply = self.parse_reply(serialized_reply)
                 if reply_assert is True:
                     assert reply.success


### PR DESCRIPTION
Added a new metric for FAST_WITH_THRESHOLD executions
Added apollo support for the new metric
Extracted a function for execution related metric updates
Added an opt-in makefile option to skip format when building via the
SKIP_FORMAT enviroment variable