### PR TITLE
Return the last public event group ID on StateSnapshotRequest

### DIFF
--- a/client/thin-replica-client/test/trc_hash_test.cpp
+++ b/client/thin-replica-client/test/trc_hash_test.cpp
@@ -55,8 +55,6 @@ TEST(trc_hash, hash_data) {
 }
 
 TEST(trc_hash, trs_trc_legacy) {
-  concord::kvbc::KvbAppFilter kvb_app_filter(nullptr, "");
-
   // Data created on the TRS
   concord::kvbc::KvbFilteredUpdate kvb_update;
   kvb_update.block_id = 1337;
@@ -72,12 +70,10 @@ TEST(trc_hash, trs_trc_legacy) {
     data->set_value(kv.second);
   }
 
-  EXPECT_EQ(kvb_app_filter.hashUpdate(kvb_update), hashUpdate(data_update));
+  EXPECT_EQ(concord::kvbc::KvbAppFilter::hashUpdate(kvb_update), hashUpdate(data_update));
 }
 
 TEST(trc_hash, trs_trc_event_group) {
-  concord::kvbc::KvbAppFilter kvb_app_filter(nullptr, "");
-
   // Data created on the TRS
   concord::kvbc::KvbFilteredEventGroupUpdate kvb_update;
   kvb_update.event_group_id = 1337;
@@ -91,7 +87,7 @@ TEST(trc_hash, trs_trc_event_group) {
     *data_update.mutable_event_group()->add_events() = event.data;
   }
 
-  EXPECT_EQ(kvb_app_filter.hashEventGroupUpdate(kvb_update), hashUpdate(data_update));
+  EXPECT_EQ(concord::kvbc::KvbAppFilter::hashEventGroupUpdate(kvb_update), hashUpdate(data_update));
 }
 
 }  // anonymous namespace

--- a/kvbc/include/categorization/categorized_reader.h
+++ b/kvbc/include/categorization/categorized_reader.h
@@ -1,0 +1,81 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "assertUtils.hpp"
+#include "db_interfaces.h"
+#include "kv_blockchain.h"
+
+#include <memory>
+
+namespace concord::kvbc::categorization {
+
+// A utility that adapts a KeyValueBlockchain instance to an IReader.
+class CategorizedReader : public IReader {
+ public:
+  // Constructs a CategorizedReader from a non-null KeyValueBlockchain pointer.
+  // Precondition: kvbc != nullptr
+  CategorizedReader(const std::shared_ptr<const KeyValueBlockchain> &kvbc) : kvbc_{kvbc} {
+    ConcordAssertNE(kvbc, nullptr);
+  }
+
+ public:
+  std::optional<categorization::Value> get(const std::string &category_id,
+                                           const std::string &key,
+                                           BlockId block_id) const override {
+    return kvbc_->get(category_id, key, block_id);
+  }
+
+  std::optional<categorization::Value> getLatest(const std::string &category_id,
+                                                 const std::string &key) const override {
+    return kvbc_->getLatest(category_id, key);
+  }
+
+  void multiGet(const std::string &category_id,
+                const std::vector<std::string> &keys,
+                const std::vector<BlockId> &versions,
+                std::vector<std::optional<categorization::Value>> &values) const override {
+    kvbc_->multiGet(category_id, keys, versions, values);
+  }
+
+  void multiGetLatest(const std::string &category_id,
+                      const std::vector<std::string> &keys,
+                      std::vector<std::optional<categorization::Value>> &values) const override {
+    kvbc_->multiGetLatest(category_id, keys, values);
+  }
+
+  std::optional<categorization::TaggedVersion> getLatestVersion(const std::string &category_id,
+                                                                const std::string &key) const override {
+    return kvbc_->getLatestVersion(category_id, key);
+  }
+
+  void multiGetLatestVersion(const std::string &category_id,
+                             const std::vector<std::string> &keys,
+                             std::vector<std::optional<categorization::TaggedVersion>> &versions) const override {
+    kvbc_->multiGetLatestVersion(category_id, keys, versions);
+  }
+
+  std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const override {
+    return kvbc_->getBlockUpdates(block_id);
+  }
+
+  BlockId getGenesisBlockId() const override { return kvbc_->getGenesisBlockId(); }
+
+  BlockId getLastBlockId() const override { return kvbc_->getLastReachableBlockId(); }
+
+ private:
+  const std::shared_ptr<const KeyValueBlockchain> kvbc_;
+};
+
+}  // namespace concord::kvbc::categorization

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -49,7 +49,9 @@ using concord::util::openssl_utils::kExpectedSHA256HashLengthInBytes;
 namespace concord {
 namespace kvbc {
 
-uint64_t KvbAppFilter::getOldestEventGroupId() { return getValueFromLatestTable(kGlobalEgIdKeyOldest); }
+uint64_t KvbAppFilter::getOldestEventGroupId() const { return getValueFromLatestTable(kGlobalEgIdKeyOldest); }
+
+uint64_t KvbAppFilter::getNewestPublicEventGroupId() const { return getValueFromLatestTable(kPublicEgIdKeyNewest); }
 
 optional<BlockId> KvbAppFilter::getOldestEventGroupBlockId() {
   uint64_t global_eg_id_oldest = getOldestEventGroupId();
@@ -274,7 +276,7 @@ void KvbAppFilter::readBlockRange(BlockId block_id_start,
   }
 }
 
-uint64_t KvbAppFilter::getValueFromLatestTable(const std::string &key) {
+uint64_t KvbAppFilter::getValueFromLatestTable(const std::string &key) const {
   const auto opt = rostorage_->getLatest(kvbc::categorization::kExecutionEventGroupLatestCategory, key);
   if (not opt) {
     LOG_DEBUG(logger_, "Tag-specific event group ID for key \"" << key << "\" doesn't exist yet");
@@ -291,7 +293,7 @@ uint64_t KvbAppFilter::getValueFromLatestTable(const std::string &key) {
   return concordUtils::fromBigEndianBuffer<uint64_t>(val->data.data());
 }
 
-uint64_t KvbAppFilter::getValueFromTagTable(const std::string &key) {
+uint64_t KvbAppFilter::getValueFromTagTable(const std::string &key) const {
   const auto opt = rostorage_->getLatest(concord::kvbc::categorization::kExecutionEventGroupTagCategory, key);
   if (not opt) {
     std::stringstream msg;
@@ -317,7 +319,7 @@ uint64_t KvbAppFilter::getValueFromTagTable(const std::string &key) {
 
 // This function returns the oldest tag-specific public event group id that the user can request.
 // Due to pruning, it depends on the oldest public event group and the oldest tag-specific event group available.
-uint64_t KvbAppFilter::oldestTagSpecificPublicEventGroupId() {
+uint64_t KvbAppFilter::oldestTagSpecificPublicEventGroupId() const {
   uint64_t public_oldest = getValueFromLatestTable(kPublicEgIdKeyOldest);
   uint64_t private_oldest = getValueFromLatestTable(client_id_ + "_oldest");
   if (!public_oldest && !private_oldest) return 0;
@@ -331,7 +333,7 @@ uint64_t KvbAppFilter::oldestTagSpecificPublicEventGroupId() {
 
 // This function returns the newest tag-specific public event group id that the user can request.
 // Note that newest tag-specific event group ids will not be updated by pruning
-uint64_t KvbAppFilter::newestTagSpecificPublicEventGroupId() {
+uint64_t KvbAppFilter::newestTagSpecificPublicEventGroupId() const {
   uint64_t public_newest = getValueFromLatestTable(kPublicEgIdKeyNewest);
   uint64_t private_newest = getValueFromLatestTable(client_id_ + "_newest");
   return public_newest + private_newest;


### PR DESCRIPTION
Instead of using a hardcoded 0, return the last (newest) public event
group ID on StateSnapshotRequest.

In order to adapt to KvbAppFilter, introduce the CategorizedReader
utility that allows a KeyValueBlockchain instance to be used as an
IReader.

Improve const-correctness in KvbAppFilter.

Introduce KvbAppFilter::getNewestPublicEventGroupId().