### PR TITLE
Make ValueWithTrids the default state snapshot value format

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -34,6 +34,7 @@
 #include <ccron/ticks_generator.hpp>
 #include "ReplicaResources.h"
 #include "AdaptivePruningManager.hpp"
+#include "kvbc_app_filter/value_from_kvbc_proto.h"
 
 namespace concord::kvbc {
 
@@ -215,8 +216,7 @@ class Replica : public IReplica,
   concord::kvbc::IStorageFactory::DatabaseSet m_dbSet;
   // The categorization KeyValueBlockchain is used for a normal read-write replica.
   std::optional<categorization::KeyValueBlockchain> m_kvBlockchain;
-  categorization::KeyValueBlockchain::Converter m_stateSnapshotValueConverter{
-      categorization::KeyValueBlockchain::kNoopConverter};
+  categorization::KeyValueBlockchain::Converter m_stateSnapshotValueConverter{concord::kvbc::valueFromKvbcProto};
   // The IdbAdapter instance is used for a read-only replica.
   std::unique_ptr<IDbAdapter> m_bcDbAdapter;
   std::shared_ptr<storage::IDBClient> m_metadataDBClient;

--- a/kvbc/include/kvbc_app_filter/value_from_kvbc_proto.h
+++ b/kvbc/include/kvbc_app_filter/value_from_kvbc_proto.h
@@ -1,0 +1,41 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "concord_kvbc.pb.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace concord::kvbc {
+
+inline std::string valueFromKvbcProto(std::string&& in) {
+  using com::vmware::concord::kvbc::ValueWithTrids;
+
+  auto proto = ValueWithTrids{};
+  if (!proto.ParseFromArray(in.data(), in.size())) {
+    throw std::runtime_error{"Parsing of ValueWithTrids failed"};
+  }
+
+  if (!proto.has_value()) {
+    return std::string{};
+  }
+
+  auto value = std::unique_ptr<std::string>(proto.release_value());
+  return std::move(*value);
+}
+
+}  // namespace concord::kvbc

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -171,7 +171,8 @@ void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IReques
                                                 *this, *this, this->AdaptivePruningManager_, this->replicaResources_),
                                             concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(
-      std::make_shared<kvbc::reconfiguration::StateSnapshotReconfigurationHandler>(*this, *this),
+      std::make_shared<kvbc::reconfiguration::StateSnapshotReconfigurationHandler>(
+          *this, *this, m_stateSnapshotValueConverter),
       concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(
                                                 *this, *this, this->AdaptivePruningManager_),

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -144,6 +144,7 @@ void run_replica(int argc, char** argv) {
                                                 setup->AddAllKeysAsPublic(),
                                                 replica->kvBlockchain() ? &replica->kvBlockchain().value() : nullptr);
   replica->set_command_handler(cmdHandler);
+  replica->setStateSnapshotValueConverter(categorization::KeyValueBlockchain::kNoopConverter);
   replica->start();
   if (setup->GetReplicaConfig().isReadOnly)
     replica->registerStBasedReconfigurationHandler(std::make_shared<STAddRemoveHandlerTest>());

--- a/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
@@ -17,12 +17,16 @@
 
 #include "bftengine/DbCheckpointManager.hpp"
 #include "categorization/kv_blockchain.h"
+#include "kvbc_app_filter/value_from_kvbc_proto.h"
 
 #include <optional>
 #include <string>
 
 namespace concord::thin_replica {
 
+// A service that streams state snapshot key-values. By default, `kvbc` values are assumed to be in a
+// `com::vmware::concord::kvbc::ValueWithTrids` format and the value is extracted from it. Users can specify different
+// convertors, if needed.
 class ReplicaStateSnapshotServiceImpl
     : public vmware::concord::replicastatesnapshot::ReplicaStateSnapshotService::Service {
  public:
@@ -49,9 +53,9 @@ class ReplicaStateSnapshotServiceImpl
   std::optional<std::string> overriden_path_for_test_;
   std::optional<bftEngine::impl::DbCheckpointManager::CheckpointState> overriden_checkpoint_state_for_test_;
   bool throw_exception_for_test_{false};
-  // The default converter returns the input string as is, without modifying it.
-  kvbc::categorization::KeyValueBlockchain::Converter state_value_converter_{
-      [](std::string&& v) -> std::string { return std::move(v); }};
+  // Allows users to convert state values to any format that is appropriate.
+  // The default converter extracts the value from the ValueWithTrids protobuf type.
+  kvbc::categorization::KeyValueBlockchain::Converter state_value_converter_{kvbc::valueFromKvbcProto};
 };
 
 }  // namespace concord::thin_replica

--- a/thin-replica-server/test/replica_state_snapshot_service_test.cpp
+++ b/thin-replica-server/test/replica_state_snapshot_service_test.cpp
@@ -53,6 +53,7 @@ using vmware::concord::replicastatesnapshot::StreamSnapshotResponse;
 class replica_state_snapshot_service_test : public Test {
   void SetUp() override {
     destroyDb();
+    service_.setStateValueConverter(KeyValueBlockchain::kNoopConverter);
     db_ = TestRocksDb::createNative();
     const auto link_st_chain = false;
     kvbc_ = std::make_unique<KeyValueBlockchain>(


### PR DESCRIPTION
Change the default state snapshot converter from the noop one (that
doesn't change the value) to one that parses a ValueWithTrids protobuf
type and extracts the value from it. Make it default for:
 * StateSnapshotReconfigurationHandler - when we execute ReadAsOf
 * computeAndPersistPublicStateHash() - when we compute the public state
   hash
 * ReplicaStateSnapshotServiceImpl - when we stream state

Make sure tests still use the noop converter, for simplicity.