### PR TITLE
KvbAppFilter: Get TagTableValue from tag table

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -40,6 +40,8 @@ typedef size_t KvbStateHash;
 
 typedef BlockUpdate KvbUpdate;
 typedef EventGroupUpdate EgUpdate;
+// global_event_group_id, external_tag_event_group_id
+typedef std::pair<uint64_t, uint64_t> TagTableValue;
 
 struct KvbFilteredUpdate {
   using OrderedKVPairs = std::vector<std::pair<std::string, std::string>>;
@@ -219,7 +221,7 @@ class KvbAppFilter {
 
   uint64_t getValueFromLatestTable(const std::string &key) const;
 
-  uint64_t getValueFromTagTable(const std::string &key) const;
+  TagTableValue getValueFromTagTable(const std::string &key) const;
 
   uint64_t oldestTagSpecificPublicEventGroupId() const;
 


### PR DESCRIPTION
A value in the tag table is now of the form -
<global_eg_id> + kTagTableSeparator + <external_tag_eg_id>.
Where external_tag_eg_id is the eg ID from participant's
perspective. The change is required to allow for a more
scalable read path solution for consumption of event groups.
This commit updates the KvbAppFilter to read the updated
value from the tag table.