### PR TITLE
Add last app-level txn time in StateSnapshotResponse

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -160,8 +160,13 @@ class Replica : public IReplica,
   }
 
   std::optional<categorization::KeyValueBlockchain> &kvBlockchain() { return m_kvBlockchain; }
+
   void setStateSnapshotValueConverter(const categorization::KeyValueBlockchain::Converter &c) {
     m_stateSnapshotValueConverter = c;
+  }
+
+  void setLastApplicationTransactionTimeCallback(const LastApplicationTransactionTimeCallback &cb) {
+    m_lastAppTxnCallback = cb;
   }
 
   ~Replica() override;
@@ -217,6 +222,7 @@ class Replica : public IReplica,
   // The categorization KeyValueBlockchain is used for a normal read-write replica.
   std::optional<categorization::KeyValueBlockchain> m_kvBlockchain;
   categorization::KeyValueBlockchain::Converter m_stateSnapshotValueConverter{concord::kvbc::valueFromKvbcProto};
+  kvbc::LastApplicationTransactionTimeCallback m_lastAppTxnCallback{kvbc::epochLastApplicationTransactionTime};
   // The IdbAdapter instance is used for a read-only replica.
   std::unique_ptr<IDbAdapter> m_bcDbAdapter;
   std::shared_ptr<storage::IDBClient> m_metadataDBClient;

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -9,6 +9,8 @@
 #include "categorization/base_types.h"
 #include "categorization/updates.h"
 
+#include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -96,5 +98,11 @@ class IBlocksDeleter {
 
   virtual ~IBlocksDeleter() = default;
 };
+
+// Given an IReader, return the time of the last application-level transaction stored in the blockchain in the form of
+// seconds since epoch.
+using LastApplicationTransactionTimeCallback = std::function<std::uint64_t(const IReader &)>;
+
+inline std::uint64_t epochLastApplicationTransactionTime(const kvbc::IReader &) { return 0; }
 
 }  // namespace concord::kvbc

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -54,8 +54,11 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
  public:
   StateSnapshotReconfigurationHandler(kvbc::IBlockAdder& block_adder,
                                       kvbc::IReader& ro_storage,
-                                      const categorization::KeyValueBlockchain::Converter& state_value_converter)
-      : ReconfigurationBlockTools{block_adder, ro_storage}, state_value_converter_{state_value_converter} {}
+                                      const categorization::KeyValueBlockchain::Converter& state_value_converter,
+                                      const kvbc::LastApplicationTransactionTimeCallback& last_app_txn_time_cb_)
+      : ReconfigurationBlockTools{block_adder, ro_storage},
+        state_value_converter_{state_value_converter},
+        last_app_txn_time_cb_{last_app_txn_time_cb_} {}
 
   bool handle(const concord::messages::StateSnapshotRequest&,
               uint64_t,
@@ -87,6 +90,10 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
   // Allows users to convert state values to any format that is appropriate.
   // The default converter extracts the value from the ValueWithTrids protobuf type.
   categorization::KeyValueBlockchain::Converter state_value_converter_{valueFromKvbcProto};
+
+  // Returns the time of the last application-level transaction stored in the blockchain in the form of seconds since
+  // epoch. The default callback returns epoch (0).
+  kvbc::LastApplicationTransactionTimeCallback last_app_txn_time_cb_{kvbc::epochLastApplicationTransactionTime};
 
   const concord::reconfiguration::BftReconfigurationHandler bft_reconf_handler_;
   const concord::reconfiguration::ClientReconfigurationHandler client_reconf_handler_;

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -172,7 +172,7 @@ void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IReques
                                             concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::StateSnapshotReconfigurationHandler>(
-          *this, *this, m_stateSnapshotValueConverter),
+          *this, *this, m_stateSnapshotValueConverter, m_lastAppTxnCallback),
       concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(
                                                 *this, *this, this->AdaptivePruningManager_),

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -201,6 +201,7 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
     } else {
       resp.data->key_value_count_estimate = public_state->keys.size();
     }
+    resp.data->last_application_transaction_time = last_app_txn_time_cb_(reader);
     LOG_INFO(getLogger(),
              "StateSnapshotRequest(participant ID = " << cmd.participant_id << "): using existing last checkpoint ID: "
                                                       << last_checkpoint_desc->checkPointId_);
@@ -226,6 +227,7 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
         ConcordAssertNE(val, nullptr);
         categorization::detail::deserialize(val->data, public_state);
         resp.data->key_value_count_estimate = public_state.keys.size();
+        resp.data->last_application_transaction_time = last_app_txn_time_cb_(ro_storage_);
       }
       LOG_INFO(getLogger(),
                "StateSnapshotRequest(participant ID = " << cmd.participant_id

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -293,6 +293,10 @@ Msg StateSnapshotData 66 {
   # in the state snapshot. Please note that this is an estimation and *not* the
   # actual count.
   uint64 key_value_count_estimate
+
+  # The time of the last application-level transaction in the given snapshot
+  # in the form of seconds since epoch.
+  uint64 last_application_transaction_time
 }
 
 # The response to a `StateSnapshotRequest`. Sent by the replicas to Clientservice.


### PR DESCRIPTION
Add the `StateSnapshotData.last_application_transaction_time` field
that contains the time of the last application-level transaction in the
snapshot in the form of seconds since epoch.

Additionally, since getting the time of the latest application-level
transaction is specific to the application, add a callback that knows
how to return it. The default callback returns the epoch (0).