### PR TITLE
Skip unstable apollo test test_reconfiguration_with_ror

### DIFF
--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1632,6 +1632,8 @@ class SkvbcReconfigurationTest(ApolloTest):
             status = cmf_msgs.ReconfigurationResponse.deserialize(r)[0]
             assert status.response.error_msg == 'key_not_found'
             assert status.success is False
+
+    @unittest.skip("Unstable test - BC-17828")
     @with_trio
     @with_bft_network(start_replica_cmd=start_replica_cmd_with_object_store_and_ke, num_ro_replicas=1, rotate_keys=True,
                       selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)


### PR DESCRIPTION
Failure is linked to previously found instability when testing with RO replicas.