### PR TITLE
Set last app txn time in StateSnapshotResponse

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -35,6 +35,7 @@
 #include "ReplicaResources.h"
 #include "AdaptivePruningManager.hpp"
 #include "kvbc_app_filter/value_from_kvbc_proto.h"
+#include "newest_public_event_group_record_time.h"
 
 namespace concord::kvbc {
 
@@ -222,7 +223,7 @@ class Replica : public IReplica,
   // The categorization KeyValueBlockchain is used for a normal read-write replica.
   std::optional<categorization::KeyValueBlockchain> m_kvBlockchain;
   categorization::KeyValueBlockchain::Converter m_stateSnapshotValueConverter{concord::kvbc::valueFromKvbcProto};
-  kvbc::LastApplicationTransactionTimeCallback m_lastAppTxnCallback{kvbc::epochLastApplicationTransactionTime};
+  kvbc::LastApplicationTransactionTimeCallback m_lastAppTxnCallback{newestPublicEventGroupRecordTime};
   // The IdbAdapter instance is used for a read-only replica.
   std::unique_ptr<IDbAdapter> m_bcDbAdapter;
   std::shared_ptr<storage::IDBClient> m_metadataDBClient;

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -99,10 +99,8 @@ class IBlocksDeleter {
   virtual ~IBlocksDeleter() = default;
 };
 
-// Given an IReader, return the time of the last application-level transaction stored in the blockchain in the form of
-// seconds since epoch.
-using LastApplicationTransactionTimeCallback = std::function<std::uint64_t(const IReader &)>;
-
-inline std::uint64_t epochLastApplicationTransactionTime(const kvbc::IReader &) { return 0; }
+// Given an IReader, return the time of the last application-level transaction stored in the blockchain.
+// The result must be a string that can be parsed via google::protobuf::util::TimeUtil::FromString().
+using LastApplicationTransactionTimeCallback = std::function<std::string(const IReader &)>;
 
 }  // namespace concord::kvbc

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <boost/lockfree/spsc_queue.hpp>
 #include <future>
+#include <optional>
 #include <set>
 #include "Logger.hpp"
 
@@ -231,22 +232,25 @@ class KvbAppFilter {
   // We do not want to process in memory, all the event group ids generated in a pruning window
   std::optional<uint64_t> getNextEventGroupId(std::shared_ptr<EventGroupClientState> &eg_state);
 
-  kvbc::categorization::EventGroup getEventGroup(kvbc::EventGroupId event_group_id, std::string &cid);
+  kvbc::categorization::EventGroup getEventGroup(kvbc::EventGroupId event_group_id) const;
 
   // Return the oldest global event group id.
   // If no event group can be found then 0 (invalid group id) is returned.
   uint64_t getOldestEventGroupId() const;
 
+  // Return the ID of the newest public event group.
+  // If no event group can be found, then 0 is returned.
   uint64_t getNewestPublicEventGroupId() const;
+
+  // Return the newest public event group, if existing. If non-existent, return std::nullopt.
+  // Throws on errors.
+  std::optional<kvbc::categorization::EventGroup> getNewestPublicEventGroup() const;
 
   // Return the block number of the very first global event group.
   // Optional because during start-up there might be no block/event group written yet.
   std::optional<BlockId> getOldestEventGroupBlockId();
 
- private:
-  logging::Logger logger_;
-  const concord::kvbc::IReader *rostorage_{nullptr};
-  const std::string client_id_;
+ public:
   static inline const std::string kGlobalEgIdKeyOldest{"_global_eg_id_oldest"};
   static inline const std::string kPublicEgIdKeyOldest{"_public_eg_id_oldest"};
   static inline const std::string kPublicEgIdKeyNewest{"_public_eg_id_newest"};
@@ -255,6 +259,11 @@ class KvbAppFilter {
   // tag + kTagTableKeySeparator + latest_tag_event_group_id concatenation is used as key for kv-updates of type
   // kExecutionEventGroupTagCategory
   static inline const std::string kTagTableKeySeparator{"#"};
+
+ private:
+  logging::Logger logger_;
+  const concord::kvbc::IReader *rostorage_{nullptr};
+  const std::string client_id_;
 
   // event groups are read in batches from storage, to avoid saving large number of event groups in memory
   // see method definition for getNextEventGroupId()

--- a/kvbc/include/newest_public_event_group_record_time.h
+++ b/kvbc/include/newest_public_event_group_record_time.h
@@ -1,0 +1,37 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "db_interfaces.h"
+#include "kvbc_app_filter/kvbc_app_filter.h"
+
+#include <string>
+
+#include <google/protobuf/util/time_util.h>
+
+namespace concord::kvbc {
+
+inline std::string newestPublicEventGroupRecordTime(const IReader& reader) {
+  using google::protobuf::util::TimeUtil;
+
+  auto filter = KvbAppFilter{&reader, ""};
+  const auto last_public_event_group = filter.getNewestPublicEventGroup();
+  if (!last_public_event_group) {
+    // No public events - return epoch.
+    return TimeUtil::ToString(TimeUtil::GetEpoch());
+  }
+  return last_public_event_group->record_time;
+}
+
+}  // namespace concord::kvbc

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -23,6 +23,7 @@
 #include "kvbc_app_filter/value_from_kvbc_proto.h"
 #include "AdaptivePruningManager.hpp"
 #include "IntervalMappingResourceManager.hpp"
+#include "newest_public_event_group_record_time.h"
 #include <functional>
 #include <string>
 #include <utility>
@@ -91,9 +92,9 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
   // The default converter extracts the value from the ValueWithTrids protobuf type.
   categorization::KeyValueBlockchain::Converter state_value_converter_{valueFromKvbcProto};
 
-  // Returns the time of the last application-level transaction stored in the blockchain in the form of seconds since
-  // epoch. The default callback returns epoch (0).
-  kvbc::LastApplicationTransactionTimeCallback last_app_txn_time_cb_{kvbc::epochLastApplicationTransactionTime};
+  // Return the time of the last application-level transaction stored in the blockchain.
+  // The result must be a string that can be parsed via google::protobuf::util::TimeUtil::FromString().
+  kvbc::LastApplicationTransactionTimeCallback last_app_txn_time_cb_{kvbc::newestPublicEventGroupRecordTime};
 
   const concord::reconfiguration::BftReconfigurationHandler bft_reconf_handler_;
   const concord::reconfiguration::ClientReconfigurationHandler client_reconf_handler_;

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -294,9 +294,9 @@ Msg StateSnapshotData 66 {
   # actual count.
   uint64 key_value_count_estimate
 
-  # The time of the last application-level transaction in the given snapshot
-  # in the form of seconds since epoch.
-  uint64 last_application_transaction_time
+  # The time of the last application-level transaction in the given snapshot.
+  # Can be parsed via google::protobuf::util::TimeUtil::FromString().
+  string last_application_transaction_time
 }
 
 # The response to a `StateSnapshotRequest`. Sent by the replicas to Clientservice.


### PR DESCRIPTION
Return the newest public event group record time as the last
application-specific transaction time in StateSnapshotResponse.

Change the LastApplicationTransactionTimeCallback return type from
std::uint64_t to std::string. Rationale is that we might have a
nanosecond resolution and we might lose it by using an integer.

Introduce KvbAppFilter::getNewestPublicEventGroup() - it returns the
newest public event group, if existing.

Remove the cid parameter from KvbAppFilter::getEventGroup() as it is not
used. Additionally, make this method const.

Add unit tests for the new KvbAppFilter functionalities.