### PR TITLE
Fix malformed JSON with nested objects produced in various places

### DIFF
--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -273,15 +273,17 @@ void ReadOnlyReplica::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_s
 void ReadOnlyReplica::registerStatusHandlers() {
   auto h = concord::diagnostics::StatusHandler(
       "replica", "Last executed sequence number of the read-only replica", [this]() {
-        std::ostringstream oss;
-        std::unordered_map<std::string, std::string> result, nested_data;
+        concordUtils::BuildJson bj;
 
-        nested_data.insert(concordUtils::toPair("lastExecutedSeqNum", last_executed_seq_num_));
-        result.insert(concordUtils::toPair(
-            "sequenceNumbers ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+        bj.startJson();
+        bj.startNested("sequenceNumbers");
+        bj.addKv("lastExecutedSeqNum", last_executed_seq_num_);
+        bj.endNested();
+        bj.endJson();
 
-        oss << concordUtils::kContainerToJson(result);
-        return oss.str();
+        char *cstr = new char[bj.getJson().length() + 1];
+        std::strcpy(cstr, bj.getJson().c_str());
+        return cstr;
       });
   concord::diagnostics::RegistrarSingleton::getInstance().status.registerHandler(h);
 }

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -67,7 +67,6 @@
 #define getName(var) #var
 
 using concordUtil::Timers;
-using concordUtils::toPair;
 using namespace std;
 using namespace std::chrono;
 using namespace std::placeholders;
@@ -1645,59 +1644,55 @@ std::string ReplicaImp::getReplicaLastStableSeqNum() const {
 
 std::string ReplicaImp::getReplicaState() const {
   auto primary = getReplicasInfo().primaryOfView(getCurrentView());
-  std::ostringstream oss;
-  std::unordered_map<std::string, std::string> result, nested_data;
+  concordUtils::BuildJson bj;
 
-  result.insert(toPair("replicaID", std::to_string(getReplicasInfo().myId())));
+  bj.startJson();
 
-  result.insert(toPair("primary", std::to_string(primary)));
+  bj.addKv("replicaID", std::to_string(getReplicasInfo().myId()));
+  bj.addKv("primary", std::to_string(primary));
 
-  nested_data.insert(toPair(getName(viewChangeProtocolEnabled), viewChangeProtocolEnabled));
-  nested_data.insert(toPair(getName(autoPrimaryRotationEnabled), autoPrimaryRotationEnabled));
-  nested_data.insert(toPair("curView", getCurrentView()));
-  nested_data.insert(toPair(getName(timeOfLastViewEntrance), utcstr(timeOfLastViewEntrance)));
-  nested_data.insert(toPair(getName(lastAgreedView), lastAgreedView));
-  nested_data.insert(toPair(getName(timeOfLastAgreedView), utcstr(timeOfLastAgreedView)));
-  nested_data.insert(toPair(getName(viewChangeTimerMilli), viewChangeTimerMilli));
-  nested_data.insert(toPair(getName(autoPrimaryRotationTimerMilli), autoPrimaryRotationTimerMilli));
-  result.insert(
-      toPair("viewChange", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
-  nested_data.clear();
+  bj.startNested("viewChange");
+  bj.addKv(getName(viewChangeProtocolEnabled), viewChangeProtocolEnabled);
+  bj.addKv(getName(autoPrimaryRotationEnabled), autoPrimaryRotationEnabled);
+  bj.addKv("curView", getCurrentView());
+  bj.addKv(getName(timeOfLastViewEntrance), utcstr(timeOfLastViewEntrance));
+  bj.addKv(getName(lastAgreedView), lastAgreedView);
+  bj.addKv(getName(timeOfLastAgreedView), utcstr(timeOfLastAgreedView));
+  bj.addKv(getName(viewChangeTimerMilli), viewChangeTimerMilli);
+  bj.addKv(getName(autoPrimaryRotationTimerMilli), autoPrimaryRotationTimerMilli);
+  bj.endNested();
 
-  nested_data.insert(toPair(getName(primaryLastUsedSeqNum), primaryLastUsedSeqNum));
-  nested_data.insert(toPair(getName(lastStableSeqNum), lastStableSeqNum));
-  nested_data.insert(toPair("lastStableCheckpoint", lastStableSeqNum / checkpointWindowSize));
-  nested_data.insert(toPair(getName(strictLowerBoundOfSeqNums), strictLowerBoundOfSeqNums));
-  nested_data.insert(toPair(getName(maxSeqNumTransferredFromPrevViews), maxSeqNumTransferredFromPrevViews));
-  nested_data.insert(toPair(getName(mainLog->currentActiveWindow().first), mainLog->currentActiveWindow().first));
-  nested_data.insert(toPair(getName(mainLog->currentActiveWindow().second), mainLog->currentActiveWindow().second));
-  nested_data.insert(
-      toPair(getName(lastViewThatTransferredSeqNumbersFullyExecuted), lastViewThatTransferredSeqNumbersFullyExecuted));
-  result.insert(
-      toPair("sequenceNumbers", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
-  nested_data.clear();
+  bj.startNested("sequenceNumbers");
+  bj.addKv(getName(primaryLastUsedSeqNum), primaryLastUsedSeqNum);
+  bj.addKv(getName(lastStableSeqNum), lastStableSeqNum);
+  bj.addKv("lastStableCheckpoint", lastStableSeqNum / checkpointWindowSize);
+  bj.addKv(getName(strictLowerBoundOfSeqNums), strictLowerBoundOfSeqNums);
+  bj.addKv(getName(maxSeqNumTransferredFromPrevViews), maxSeqNumTransferredFromPrevViews);
+  bj.addKv(getName(mainLog->currentActiveWindow().first), mainLog->currentActiveWindow().first);
+  bj.addKv(getName(mainLog->currentActiveWindow().second), mainLog->currentActiveWindow().second);
+  bj.addKv(getName(lastViewThatTransferredSeqNumbersFullyExecuted), lastViewThatTransferredSeqNumbersFullyExecuted);
+  bj.endNested();
 
-  nested_data.insert(toPair(getName(restarted_), restarted_));
-  nested_data.insert(toPair(getName(requestsQueueOfPrimary.size()), requestsQueueOfPrimary.size()));
-  nested_data.insert(toPair(getName(requestsBatcg312her_->getMaxNumberOfPendingRequestsInRecentHistory()),
-                            reqBatchingLogic_.getMaxNumberOfPendingRequestsInRecentHistory()));
-  nested_data.insert(toPair(getName(reqBatchingLogic_->getBatchingFactor()), reqBatchingLogic_.getBatchingFactor()));
-  nested_data.insert(toPair(getName(lastTimeThisReplicaSentStatusReportMsgToAllPeerReplicas),
-                            utcstr(lastTimeThisReplicaSentStatusReportMsgToAllPeerReplicas)));
-  nested_data.insert(toPair(getName(timeOfLastStateSynch), utcstr(timeOfLastStateSynch)));
-  nested_data.insert(toPair(getName(recoveringFromExecutionOfRequests), recoveringFromExecutionOfRequests));
-  nested_data.insert(
-      toPair(getName(checkpointsLog->currentActiveWindow().first), checkpointsLog->currentActiveWindow().first));
-  nested_data.insert(
-      toPair(getName(checkpointsLog->currentActiveWindow().second), checkpointsLog->currentActiveWindow().second));
-  nested_data.insert(toPair(getName(clientsManager->numberOfRequiredReservedPages()),
-                            clientsManager->numberOfRequiredReservedPages()));
-  nested_data.insert(toPair(getName(numInvalidClients), numInvalidClients));
-  nested_data.insert(toPair(getName(numValidNoOps), numValidNoOps));
-  result.insert(toPair("Other ", concordUtils::kvContainerToJson(nested_data, [](const auto &arg) { return arg; })));
+  bj.startNested("Other");
+  bj.addKv(getName(restarted_), restarted_);
+  bj.addKv(getName(requestsQueueOfPrimary.size()), requestsQueueOfPrimary.size());
+  bj.addKv(getName(requestsBatcg312her_->getMaxNumberOfPendingRequestsInRecentHistory()),
+           reqBatchingLogic_.getMaxNumberOfPendingRequestsInRecentHistory());
+  bj.addKv(getName(reqBatchingLogic_->getBatchingFactor()), reqBatchingLogic_.getBatchingFactor());
+  bj.addKv(getName(lastTimeThisReplicaSentStatusReportMsgToAllPeerReplicas),
+           utcstr(lastTimeThisReplicaSentStatusReportMsgToAllPeerReplicas));
+  bj.addKv(getName(timeOfLastStateSynch), utcstr(timeOfLastStateSynch));
+  bj.addKv(getName(recoveringFromExecutionOfRequests), recoveringFromExecutionOfRequests);
+  bj.addKv(getName(checkpointsLog->currentActiveWindow().first), checkpointsLog->currentActiveWindow().first);
+  bj.addKv(getName(checkpointsLog->currentActiveWindow().second), checkpointsLog->currentActiveWindow().second);
+  bj.addKv(getName(clientsManager->numberOfRequiredReservedPages()), clientsManager->numberOfRequiredReservedPages());
+  bj.addKv(getName(numInvalidClients), numInvalidClients);
+  bj.addKv(getName(numValidNoOps), numValidNoOps);
+  bj.endNested();
 
-  oss << concordUtils::kContainerToJson(result);
-  return oss.str();
+  bj.endJson();
+
+  return bj.getJson();
 }
 
 void ReplicaImp::onInternalMsg(GetStatus &status) const {

--- a/util/include/json_output.hpp
+++ b/util/include/json_output.hpp
@@ -22,6 +22,8 @@
 
 namespace concordUtils {
 
+// Note: these templated functions are deprecated.  Use the BuildJson class below for new code.
+
 template <typename KVContainer, typename Encoder>
 inline std::string kvContainerToJson(const KVContainer &kv, const Encoder &enc) {
   auto out = std::string{"{\n"};
@@ -77,5 +79,57 @@ inline std::pair<std::string, std::string> toPair(const std::string &key, const 
 inline std::pair<std::string, std::string> toPair(const std::string &key, const std::string &value) {
   return std::make_pair(key, value);
 }
+
+// Build a JSON object.  Supports nested objects.
+class BuildJson {
+ public:
+  inline BuildJson() {}
+
+  // Start a root JSON object.
+  inline void startJson() { str += "\n{\n"; }
+
+  // End the root JSON object.
+  inline void endJson() {
+    if (str.size() >= 2 && str[str.size() - 2] == ',') {
+      str.erase(str.size() - 2, 1);
+    }
+    str += "\n}\n";
+  }
+
+  // Start a nested JSON object.
+  inline void startNested(const std::string &key) { str += "\"" + key + "\" : {\n"; }
+
+  // End a nested JSON object.
+  inline void endNested() {
+    if (str.size() >= 2 && str[str.size() - 2] == ',') {
+      str.erase(str.size() - 2, 1);
+    }
+    str += "\n},\n";
+  }
+
+  // Add a key and a string value to the current object.
+  inline void addKv(const std::string &key, const std::string &value) {
+    str += "\"" + key + "\" : \"" + value + "\",\n";
+  }
+
+  // Add a key and a non-string value to the current object.
+  template <typename T>
+  inline void addKv(const std::string &key, const T &value) {
+    str += "\"" + key + "\" : \"" + std::to_string(value) + "\",\n";
+  }
+
+  // Add a nested JSON object.  The "json" parameter is expected to be a
+  // quoted JSON object in braces with no key prefix.
+  inline void addNestedJson(const std::string &key, const std::string &json) {
+    str += "\"" + key + "\" : ";
+    str += json + ",\n";
+  }
+
+  // Return the generated JSON.  Should be called after endJson().
+  inline std::string getJson() { return str; }
+
+ private:
+  std::string str;
+};
 
 }  // namespace concordUtils


### PR DESCRIPTION
BC-16805

Adds a `BuildJson` class which correctly composes JSON for nested objects.  The existing functions in `json-output.hpp` produce malformed JSON for nested object.

Testing:
- ran `echo "status get -replica-state | nc localhost 6888 | jq -S`
- ran `echo "status get state-transfer" | nc localhost  6888 | jq -S`
- compared the output of both commands to the output produced by the same commands run on master
- I needed to manually fix the output from master by removing the extraneous quotes around curly brackets, 
   since `jq` refuses to process invalid JSON
- compared the output produced by my fix with the output produced by master

I still need to figure out how to test `status get-replica-state` against a read-only replica; I had some trouble setting up a configuration which includes a read-only replica.  However the change in this case is trivial and I'm pretty confident I got it right.

Also, there should be unit tests for these cases.  I plan to include such tests in a future MR.