### PR TITLE
Fix unstable skvbc_reply tc

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -253,7 +253,7 @@ std::unique_ptr<ClientReplyMsg> ClientsManager::allocateReplyFromSavedOne(NodeId
     sizeLastPage = replyMsgSize % sizeOfReservedPage();
   }
   LOG_DEBUG(CL_MNGR, KVLOG(clientId, numOfPages, sizeLastPage));
-  auto r = std::make_unique<ClientReplyMsg>(myId_, replyHeader->replyLength);
+  auto r = std::make_unique<ClientReplyMsg>(myId_, replyHeader->replyLength, replyHeader->result);
 
   // load reply message from reserved pages
   for (uint32_t i = 0; i < numOfPages; i++) {

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.cpp
@@ -30,9 +30,9 @@ ClientReplyMsg::ClientReplyMsg(
   memcpy(body() + sizeof(ClientReplyMsgHeader), reply, replyLength);
 }
 
-ClientReplyMsg::ClientReplyMsg(ReplicaId replicaId, uint32_t replyLength)
+ClientReplyMsg::ClientReplyMsg(ReplicaId replicaId, uint32_t replyLength, uint32_t executionResult)
     : MessageBase(replicaId, MsgCode::ClientReply, sizeof(ClientReplyMsgHeader) + replyLength) {
-  setHeaderParameters(0, 0, replyLength, 0);
+  setHeaderParameters(0, 0, replyLength, executionResult);
 }
 
 // Reply with no data; returns an error to the client

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
@@ -34,7 +34,7 @@ class ClientReplyMsg : public MessageBase {
 
   ClientReplyMsg(ReplicaId primaryId, ReqId reqSeqNum, ReplicaId replicaId, uint32_t result);
 
-  ClientReplyMsg(ReplicaId replicaId, uint32_t replyLength);
+  ClientReplyMsg(ReplicaId replicaId, uint32_t replyLength, uint32_t executionResult = 0);
 
   uint32_t maxReplyLength() const { return internalStorageSize() - sizeof(ClientReplyMsgHeader); }
 


### PR DESCRIPTION
Fixed the below issues:
1. The reply length was zero, causing fatal error when debugging was enabled.
2. The client was not accepting the reply as reply data was different from different replicas.