### PR TITLE
Stabilize TRC unit test

### DIFF
--- a/client/thin-replica-client/test/thin_replica_client_test.cpp
+++ b/client/thin-replica-client/test/thin_replica_client_test.cpp
@@ -396,14 +396,10 @@ TEST(thin_replica_client_test, test_correct_data_returned_) {
   sleep_for(kBriefDelayDuration);
   EXPECT_FALSE((bool)(update_queue->tryPop())) << "ThinReplicaClient appears to have received an update after "
                                                   "unsubscribing.";
-  *spurious_wakeup_indicator = true;
 
   trc->Subscribe(num_initial_updates);
   for (size_t i = num_initial_updates; i < update_data.size(); ++i) {
-    *spurious_wakeup_indicator = false;
-    delay_condition->notify_one();
     unique_ptr<EventVariant> received_update = update_queue->pop();
-    *spurious_wakeup_indicator = true;
     Data& expected_update = update_data[i];
 
     EXPECT_TRUE((bool)received_update) << "ThinReplicaClient failed to fetch an expected update from an "


### PR DESCRIPTION
In the TRC test `test_correct_data_returned_`, we get stuck in the
while loop in `DelayedMockDataStreamPreparer::DataDelayer::Read`
and we never reach reach the `Read` call outside the while loop in
the following scenario-

-In the second call to Subscribe in the unit test, an async Read
thread is launched, which is mocked by
`DelayedMockDataStreamPreparer::DataDelayer::Read` for this test,
wherein while the `spurious_wakeup_indicator` is set, Read waits on
a condition_variable. In the scenario where the async Read is called
and enters the aforementioned while loop before `spurious_wakeup_indicator`
is set to false, and the test's main thread sets the
`spurious_wakeup_indicator` and notifies the condition_variable before the
the async Read thread while loop actually starts waiting on the
condition variable, we can be stuck in the while loop forever.
Because the main thread would now block on the pop() call
while the Read call is waiting on the condition variable.

Since the goal of the test is not to test that TRC's ability to wait
for updates that aren’t ready yet, we remove delays added past
the second subscribe call to avoid scenarios such as described above.