### PR TITLE
Add support for legacy events in StateSnapshotService

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -260,6 +260,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                20,
                "Resetting the measurements and starting again after polling X times");
 
+  CONFIG_PARAM(enableEventGroups, bool, false, "A flag to specify whether event groups are enabled or not.");
+
   // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters
   // Example of usage:
@@ -373,10 +375,12 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, dbCheckpointMonitorIntervalSeconds);
     serialize(outStream, enablePostExecutionSeparation);
     serialize(outStream, postExecutionQueuesSize);
+    serialize(outStream, stateIterationMultiGetBatchSize);
     serialize(outStream, adaptivePruningIntervalDuration);
     serialize(outStream, adaptivePruningIntervalPeriod);
     serialize(outStream, config_params_);
     serialize(outStream, enableMultiplexChannel);
+    serialize(outStream, enableEventGroups);
   }
   void deserializeDataMembers(std::istream& inStream) {
     deserialize(inStream, isReadOnly);
@@ -465,10 +469,12 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, dbCheckpointMonitorIntervalSeconds);
     deserialize(inStream, enablePostExecutionSeparation);
     deserialize(inStream, postExecutionQueuesSize);
+    deserialize(inStream, stateIterationMultiGetBatchSize);
     deserialize(inStream, adaptivePruningIntervalDuration);
     deserialize(inStream, adaptivePruningIntervalPeriod);
     deserialize(inStream, config_params_);
     deserialize(inStream, enableMultiplexChannel);
+    deserialize(inStream, enableEventGroups);
   }
 
  private:
@@ -544,6 +550,7 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.threadbagConcurrencyLevel2,
               rc.enablePostExecutionSeparation,
               rc.postExecutionQueuesSize,
+              rc.stateIterationMultiGetBatchSize,
               rc.numOfClientServices,
               rc.dbCheckpointFeatureEnabled,
               rc.maxNumberOfDbCheckpoints,
@@ -552,8 +559,10 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.adaptivePruningIntervalDuration.count(),
               rc.adaptivePruningIntervalPeriod);
   os << ",";
-  os << KVLOG(
-      rc.dbSnapshotIntervalSeconds.count(), rc.dbCheckpointMonitorIntervalSeconds.count(), rc.enableMultiplexChannel);
+  os << KVLOG(rc.dbSnapshotIntervalSeconds.count(),
+              rc.dbCheckpointMonitorIntervalSeconds.count(),
+              rc.enableMultiplexChannel,
+              rc.enableEventGroups);
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;
 }

--- a/client/clientservice/src/state_snapshot_service.cpp
+++ b/client/clientservice/src/state_snapshot_service.cpp
@@ -251,7 +251,14 @@ Status StateSnapshotServiceImpl::GetRecentSnapshot(ServerContext* context,
 
   if (return_status.ok() && snapshot_response.data.has_value()) {
     response->set_snapshot_id(snapshot_response.data->snapshot_id);
-    response->set_event_group_id(snapshot_response.data->event_group_id);
+    switch (snapshot_response.data->blockchain_height_type) {
+      case concord::messages::BlockchainHeightType::EventGroupId:
+        response->set_event_group_id(snapshot_response.data->blockchain_height);
+        break;
+      case concord::messages::BlockchainHeightType::BlockId:
+        response->set_block_id(snapshot_response.data->blockchain_height);
+        break;
+    }
     response->set_key_value_count_estimate(snapshot_response.data->key_value_count_estimate);
     auto* ledger_time = response->mutable_ledger_time();
     if (!google::protobuf::util::TimeUtil::FromString(snapshot_response.data->last_application_transaction_time,

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -282,12 +282,20 @@ Msg StateSnapshotRequest 65 {
   string participant_id
 }
 
+Enum BlockchainHeightType {
+  EventGroupId,
+  BlockId
+}
+
 Msg StateSnapshotData 66 {
   # Unique identifier of the DB snapshot.
   uint64 snapshot_id
 
-  # The event group ID at which the state snapshot with `snapshot_id` was taken.
-  uint64 event_group_id
+  # The blockchain height at which the state snapshot with `snapshot_id` was taken.
+  uint64 blockchain_height
+
+  # The type of the blockchain height in the `blockchain_height` field.
+  BlockchainHeightType blockchain_height_type
 
   # An estimate (with reasonable accuracy) of the count of key-values contained
   # in the state snapshot. Please note that this is an estimation and *not* the

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -494,15 +494,16 @@ class SkvbcDbSnapshotTest(ApolloTest):
             self.assertEqual(last_block_id, 600)
             await self.wait_for_snapshot(bft_network, replica_id, last_block_id)
 
-        # Send a StateSnapshotRequest and make sure we get the already existing checkpoint/snapshot ID of 600
-        # and an event group ID of 0.
+        # Send a StateSnapshotRequest and make sure we get the already existing checkpoint/snapshot ID of 600.
         op = operator.Operator(bft_network.config, client, bft_network.builddir)
         rep = await op.state_snapshot_req()
         resp = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
         self.assertTrue(resp.success)
         self.assertIsNotNone(resp.response.data)
         self.assertEqual(resp.response.data.snapshot_id, 600)
-        self.assertEqual(resp.response.data.event_group_id, 0)
+        # TODO: add test for BlockchainHeightType.EventGroupId here (including support for it in TesterReplica).
+        self.assertEqual(resp.response.data.blockchain_height, 600)
+        self.assertEqual(resp.response.data.blockchain_height_type, cmf_msgs.BlockchainHeightType.BlockId)
         self.assertEqual(resp.response.data.key_value_count_estimate, expected_key_value_count_estimate)
 
     @with_trio
@@ -531,14 +532,15 @@ class SkvbcDbSnapshotTest(ApolloTest):
             self.assertFalse(self.snapshot_exists(bft_network, replica_id))
 
         # Send a StateSnapshotRequest and make sure a new checkpoint/snapshot ID of 100 is created.
-        # Expect an event group ID of 0.
         op = operator.Operator(bft_network.config, client, bft_network.builddir)
         rep = await op.state_snapshot_req()
         resp = cmf_msgs.ReconfigurationResponse.deserialize(rep)[0]
         self.assertTrue(resp.success)
         self.assertIsNotNone(resp.response.data)
         self.assertEqual(resp.response.data.snapshot_id, 100)
-        self.assertEqual(resp.response.data.event_group_id, 0)
+        self.assertEqual(resp.response.data.blockchain_height, 100)
+        # TODO: add test for BlockchainHeightType.EventGroupId here (including support for it in TesterReplica).
+        self.assertEqual(resp.response.data.blockchain_height_type, cmf_msgs.BlockchainHeightType.BlockId)
         self.assertEqual(resp.response.data.key_value_count_estimate, expected_key_value_count_estimate)
 
         # Expect that a snapshot/checkpoint with an ID of 100 is available. For that, we assume that the snapshot/checkpoint ID


### PR DESCRIPTION
Add support for legacy events in StateSnapshotService by introducing the
StateSnapshotData.blockchain_height field. The blockchain height can be
either:
 * EventGroupId for when event groups are enabled
 * BlockId for when legacy events are used

Introduce the ReplicaConfig.enableEventGroups option that specifies
whether event groups are enabled or not. If event groups are enabled,
return the newest public event group ID in the StateSnapshotResponse
message. If event groups are disabled, return the last block ID.

Change the Apollo test to accommodate the new fields.