### PR TITLE
Clientpool should use the reply message size with fix for callback

### DIFF
--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -237,6 +237,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
                              std::vector<uint8_t>&& request,
                              bftEngine::ClientMsgFlag flags,
                              std::chrono::milliseconds timeout_ms,
+                             uint32_t max_reply_size,
                              std::string correlation_id,
                              uint64_t seq_num,
                              std::string span_context,
@@ -245,6 +246,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
         request_(std::move(request)),
         flags_{flags},
         timeout_ms_{timeout_ms},
+        max_reply_size_{max_reply_size},
         correlation_id_{std::move(correlation_id)},
         span_context_{std::move(span_context)},
         seq_num_{seq_num},
@@ -256,6 +258,7 @@ class SingleRequestProcessingJob : public BatchRequestProcessingJob {
   std::vector<uint8_t> request_;
   bftEngine::ClientMsgFlag flags_;
   std::chrono::milliseconds timeout_ms_;
+  uint32_t max_reply_size_;
   const std::string correlation_id_;
   std::string span_context_;
   uint64_t seq_num_;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -49,7 +49,6 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
     callback(bftEngine::SendResult{static_cast<uint32_t>(OperationResult::INVALID_REQUEST)});
     return SubmitResult::Overloaded;
   }
-  externalRequest external_request;
   std::unique_lock<std::mutex> lock(clients_queue_lock_);
   metricsComponent_.UpdateAggregator();
   auto serving_candidates = clients_.size();
@@ -146,8 +145,10 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
     }
   }
 
-  // Request hasn't been processed yet
-  if (external_requests_queue_.size() < jobs_queue_max_size_) {
+  // Request hasn't been processed yet and this is not a reconfiguration request then only allow the request to wait in
+  // the external request queue. Reconfigution requests are unbatched and in general require immediate response. So
+  // waiting is not acceptable.
+  if ((external_requests_queue_.size() < jobs_queue_max_size_) && (!(flags & ClientMsgFlag::RECONFIG_FLAG_REQ))) {
     LOG_DEBUG(logger_, "Request has been inserted to the wait queue" << KVLOG(correlation_id, seq_num));
     external_requests_queue_.emplace_back(externalRequest{std::move(request),
                                                           flags,
@@ -196,13 +197,22 @@ void ConcordClientPool::assignJobToClient(const ClientPtr &client,
                                           const std::string &span_context,
                                           const bftEngine::RequestCallBack &callback) {
   LOG_INFO(logger_,
-           "client_id=" << client->getClientId() << " starts handling reqSeqNum=" << seq_num << " cid="
-                        << correlation_id << " span_context exists=" << !span_context.empty() << " flags=" << flags
-                        << " request_size=" << request.size() << " timeout_ms=" << timeout_ms.count());
+           "client_id=" << client->getClientId() << " starts handling reqSeqNum=" << seq_num
+                        << " cid=" << correlation_id << " span_context exists=" << !span_context.empty()
+                        << " flags=" << flags << " request_size=" << request.size()
+                        << " timeout_ms=" << timeout_ms.count() << " max_reply_size = " << max_reply_size);
 
   client->setStartRequestTime();
-  auto *job = new SingleRequestProcessingJob(
-      *this, client, std::move(request), flags, timeout_ms, correlation_id, seq_num, span_context, callback);
+  auto *job = new SingleRequestProcessingJob(*this,
+                                             client,
+                                             std::move(request),
+                                             flags,
+                                             timeout_ms,
+                                             max_reply_size,
+                                             correlation_id,
+                                             seq_num,
+                                             span_context,
+                                             callback);
   ClientPoolMetrics_.requests_counter++;
   ClientPoolMetrics_.clients_gauge.Get().Set(clients_.size());
   jobs_thread_pool_.add(job);
@@ -223,7 +233,7 @@ SubmitResult ConcordClientPool::SendRequest(const bft::client::WriteConfig &conf
                      request_flag,
                      config.request.timeout,
                      nullptr,
-                     0,
+                     config.request.max_reply_size,
                      config.request.sequence_number,
                      config.request.correlation_id,
                      config.request.span_context,
@@ -244,7 +254,7 @@ SubmitResult ConcordClientPool::SendRequest(const bft::client::ReadConfig &confi
                      request_flag,
                      config.request.timeout,
                      nullptr,
-                     0,
+                     config.request.max_reply_size,
                      config.request.sequence_number,
                      config.request.correlation_id,
                      config.request.span_context,
@@ -466,6 +476,9 @@ void SingleRequestProcessingJob::execute() {
     read_config_.request.sequence_number = seq_num_;
     read_config_.request.correlation_id = correlation_id_;
     read_config_.request.span_context = span_context_;
+    if (max_reply_size_ > 0) {
+      read_config_.request.max_reply_size = max_reply_size_;
+    }
     read_config_.request.reconfiguration = flags_ & RECONFIG_FLAG_REQ;
     res = processing_client_->SendRequest(read_config_, std::move(request_));
   } else {
@@ -473,6 +486,9 @@ void SingleRequestProcessingJob::execute() {
     write_config_.request.sequence_number = seq_num_;
     write_config_.request.correlation_id = correlation_id_;
     write_config_.request.span_context = span_context_;
+    if (max_reply_size_ > 0) {
+      write_config_.request.max_reply_size = max_reply_size_;
+    }
     write_config_.request.reconfiguration = flags_ & RECONFIG_FLAG_REQ;
     write_config_.request.pre_execute = flags_ & PRE_PROCESS_REQ;
     res = processing_client_->SendRequest(write_config_, std::move(request_));

--- a/client/clientservice/src/state_snapshot_service.cpp
+++ b/client/clientservice/src/state_snapshot_service.cpp
@@ -194,6 +194,10 @@ static void getResponseSetStatus(concord::client::concordclient::SendResult&& se
   }
 }
 
+static std::shared_ptr<bftEngine::RequestCallBack> getCallbackLambda(const bftEngine::RequestCallBack& callback) {
+  return std::make_shared<bftEngine::RequestCallBack>(callback);
+}
+
 Status StateSnapshotServiceImpl::GetRecentSnapshot(ServerContext* context,
                                                    const GetRecentSnapshotRequest* proto_request,
                                                    GetRecentSnapshotResponse* response) {
@@ -209,27 +213,28 @@ Status StateSnapshotServiceImpl::GetRecentSnapshot(ServerContext* context,
 
   LOG_INFO(logger_, "Received a GetRecentSnapshotRequest with timeout : " << timeout.count() << "ms");
 
-  WriteConfig write_config{RequestConfig{false, 0, 1024 * 1024, timeout, "snapshotreq", "", false, true},
-                           bft::client::LinearizableQuorum{}};
-  StateSnapshotResponse snapshot_response;
-  grpc::Status return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Timeout");
-  std::condition_variable wait_for_me;
-  bool reply_available = false;
-  auto callback = [&snapshot_response, &return_status, &write_config, &wait_for_me, &reply_available](
-                      concord::client::concordclient::SendResult&& send_result) {
+  auto write_config = std::shared_ptr<WriteConfig>(
+      new WriteConfig{RequestConfig{false, 0, 1024 * 1024, timeout, "snapshotreq", "", false, true},
+                      bft::client::LinearizableQuorum{}});
+  auto snapshot_response = std::make_shared<StateSnapshotResponse>();
+  auto return_status = std::make_shared<grpc::Status>(grpc::StatusCode::UNAVAILABLE, "Timeout");
+  auto wait_for_me = std::make_shared<std::condition_variable>();
+  auto reply_available = std::make_shared<bool>(false);
+  auto callback = getCallbackLambda([snapshot_response, return_status, write_config, wait_for_me, reply_available](
+                                        concord::client::concordclient::SendResult&& send_result) {
     ResponseType<StateSnapshotResponse> reponse;
     getResponseSetStatus(std::move(send_result),
                          reponse,
-                         return_status,
-                         write_config.request.correlation_id,
+                         *return_status,
+                         (write_config->request).correlation_id,
                          false,
                          "concord.client.clientservice.state_snapshot_service.getrecentsnapshot.callback");
-    if (return_status.ok()) {
-      snapshot_response = std::get<StateSnapshotResponse>(reponse.response);
+    if (return_status->ok()) {
+      *snapshot_response = std::get<StateSnapshotResponse>(reponse.response);
     }
-    reply_available = true;
-    wait_for_me.notify_one();
-  };
+    *reply_available = true;
+    wait_for_me->notify_one();
+  });
 
   ReconfigurationRequest rreq;
   StateSnapshotRequest cmd;
@@ -238,36 +243,37 @@ Status StateSnapshotServiceImpl::GetRecentSnapshot(ServerContext* context,
   rreq.command = cmd;
   bft::client::Msg message;
   concord::messages::serialize(message, rreq);
-  client_->send(write_config, std::move(message), callback);
+  client_->send(*write_config, std::move(message), *callback);
   bool response_available = false;
   {
     std::mutex mtx;
     std::unique_lock<std::mutex> lck(mtx);
-    response_available = wait_for_me.wait_for(lck, timeout, [&reply_available]() { return reply_available; });
+    response_available = wait_for_me->wait_for(lck, timeout, [reply_available]() { return *reply_available; });
   }
 
   if (!response_available) {
+    clearAllPrevDoneCallbacksAndAdd(reply_available, callback);
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "Timeout");
   }
 
-  if (return_status.ok() && snapshot_response.data.has_value()) {
-    response->set_snapshot_id(snapshot_response.data->snapshot_id);
-    switch (snapshot_response.data->blockchain_height_type) {
+  if (return_status->ok() && snapshot_response->data.has_value()) {
+    response->set_snapshot_id(snapshot_response->data->snapshot_id);
+    switch (snapshot_response->data->blockchain_height_type) {
       case concord::messages::BlockchainHeightType::EventGroupId:
-        response->set_event_group_id(snapshot_response.data->blockchain_height);
+        response->set_event_group_id(snapshot_response->data->blockchain_height);
         break;
       case concord::messages::BlockchainHeightType::BlockId:
-        response->set_block_id(snapshot_response.data->blockchain_height);
+        response->set_block_id(snapshot_response->data->blockchain_height);
         break;
     }
-    response->set_key_value_count_estimate(snapshot_response.data->key_value_count_estimate);
+    response->set_key_value_count_estimate(snapshot_response->data->key_value_count_estimate);
     auto* ledger_time = response->mutable_ledger_time();
-    if (!google::protobuf::util::TimeUtil::FromString(snapshot_response.data->last_application_transaction_time,
+    if (!google::protobuf::util::TimeUtil::FromString(snapshot_response->data->last_application_transaction_time,
                                                       ledger_time)) {
       *ledger_time = google::protobuf::util::TimeUtil::GetEpoch();
     }
   }
-  return return_status;
+  return *return_status;
 }
 
 Status StateSnapshotServiceImpl::StreamSnapshot(ServerContext* context,
@@ -350,28 +356,31 @@ Status StateSnapshotServiceImpl::StreamSnapshot(ServerContext* context,
 void StateSnapshotServiceImpl::isHashValid(uint64_t snapshot_id,
                                            const concord::util::SHA3_256::Digest& final_hash,
                                            const std::chrono::milliseconds& timeout,
-                                           Status& return_status) const {
-  ReadConfig read_config{RequestConfig{false, 0, 1024 * 1024, timeout, "signedHashReq", "", false, true},
-                         bft::client::ByzantineSafeQuorum{}};
-  std::condition_variable wait_for_me;
-  bool reply_available = false;
-  std::vector<std::unique_ptr<SignedPublicStateHashResponse>> signed_hash_responses;
-  auto callback = [&signed_hash_responses, &return_status, &read_config, &wait_for_me, &reply_available](
-                      concord::client::concordclient::SendResult&& send_result) {
-    ResponseType<SignedPublicStateHashResponse> reponse;
-    getResponseSetStatus(std::move(send_result),
-                         reponse,
-                         return_status,
-                         read_config.request.correlation_id,
-                         true,
-                         "concord.client.clientservice.state_snapshot_service.signedhash.callback");
-    if (return_status.ok()) {
-      signed_hash_responses =
-          std::get<std::vector<std::unique_ptr<SignedPublicStateHashResponse>>>(std::move(reponse.response));
-    }
-    reply_available = true;
-    wait_for_me.notify_one();
-  };
+                                           Status& return_status) {
+  auto read_config = std::shared_ptr<ReadConfig>(
+      new ReadConfig{RequestConfig{false, 0, 1024 * 1024, timeout, "signedHashReq", "", false, true},
+                     bft::client::ByzantineSafeQuorum{}});
+  auto wait_for_me = std::make_shared<std::condition_variable>();
+  auto reply_available = std::make_shared<bool>(false);
+  auto hash_valid_return_status = std::make_shared<grpc::Status>(grpc::StatusCode::UNAVAILABLE, "Timeout");
+  auto signed_hash_responses = std::make_shared<std::vector<std::unique_ptr<SignedPublicStateHashResponse>>>();
+  auto callback =
+      getCallbackLambda([signed_hash_responses, hash_valid_return_status, read_config, wait_for_me, reply_available](
+                            concord::client::concordclient::SendResult&& send_result) {
+        ResponseType<SignedPublicStateHashResponse> reponse;
+        getResponseSetStatus(std::move(send_result),
+                             reponse,
+                             *hash_valid_return_status,
+                             (read_config->request).correlation_id,
+                             true,
+                             "concord.client.clientservice.state_snapshot_service.signedhash.callback");
+        if (hash_valid_return_status->ok()) {
+          *signed_hash_responses =
+              std::get<std::vector<std::unique_ptr<SignedPublicStateHashResponse>>>(std::move(reponse.response));
+        }
+        *reply_available = true;
+        wait_for_me->notify_one();
+      });
 
   ReconfigurationRequest rreq;
   SignedPublicStateHashRequest cmd;
@@ -380,21 +389,26 @@ void StateSnapshotServiceImpl::isHashValid(uint64_t snapshot_id,
   rreq.command = cmd;
   bft::client::Msg message;
   concord::messages::serialize(message, rreq);
-  client_->send(read_config, std::move(message), callback);
+  client_->send(*read_config, std::move(message), *callback);
 
   bool response_available = false;
   {
     std::mutex mtx;
     std::unique_lock<std::mutex> lck(mtx);
-    response_available = wait_for_me.wait_for(lck, timeout, [&reply_available]() { return reply_available; });
+    response_available = wait_for_me->wait_for(lck, timeout, [reply_available]() { return *reply_available; });
   }
 
   if (!response_available) {
+    clearAllPrevDoneCallbacksAndAdd(reply_available, callback);
     return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Timeout");
     return;
   }
 
-  for (const auto& res : signed_hash_responses) {
+  if (response_available) {
+    return_status = *hash_valid_return_status;
+  }
+
+  for (const auto& res : *signed_hash_responses) {
     if (return_status.ok()) {
       switch (res->status) {
         case SnapshotResponseStatus::InternalError:
@@ -478,29 +492,30 @@ Status StateSnapshotServiceImpl::ReadAsOf(ServerContext* context,
 
   LOG_INFO(logger_, "Received a ReadAsOfRequest with timeout : " << timeout.count() << "ms");
 
-  ReadConfig read_config{RequestConfig{false, 0, 1024 * 1024, timeout, "readasofreq", "", false, true},
-                         bft::client::ByzantineSafeQuorum{}};
-
-  std::vector<std::unique_ptr<StateSnapshotReadAsOfResponse>> read_as_of_responses;
-  std::condition_variable wait_for_me;
-  bool reply_available = false;
-  grpc::Status return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Timeout");
-  auto callback = [&read_as_of_responses, &return_status, &read_config, &wait_for_me, &reply_available](
-                      concord::client::concordclient::SendResult&& send_result) {
+  auto read_config = std::shared_ptr<ReadConfig>(
+      new ReadConfig{RequestConfig{false, 0, 1024 * 1024, timeout, "readasofreq", "", false, true},
+                     bft::client::ByzantineSafeQuorum{}});
+  auto signed_hash_responses = std::make_shared<std::vector<std::unique_ptr<SignedPublicStateHashResponse>>>();
+  auto read_as_of_responses = std::make_shared<std::vector<std::unique_ptr<StateSnapshotReadAsOfResponse>>>();
+  auto wait_for_me = std::make_shared<std::condition_variable>();
+  auto reply_available = std::make_shared<bool>(false);
+  auto return_status = std::make_shared<grpc::Status>(grpc::StatusCode::UNAVAILABLE, "Timeout");
+  auto callback = getCallbackLambda([read_as_of_responses, return_status, read_config, wait_for_me, reply_available](
+                                        concord::client::concordclient::SendResult&& send_result) {
     ResponseType<StateSnapshotReadAsOfResponse> reponse;
     getResponseSetStatus(std::move(send_result),
                          reponse,
-                         return_status,
-                         read_config.request.correlation_id,
+                         *return_status,
+                         (read_config->request).correlation_id,
                          true,
                          "concord.client.clientservice.state_snapshot_service.readasof.callback");
-    if (return_status.ok()) {
-      read_as_of_responses =
+    if (return_status->ok()) {
+      *read_as_of_responses =
           std::get<std::vector<std::unique_ptr<StateSnapshotReadAsOfResponse>>>(std::move(reponse.response));
     }
-    reply_available = true;
-    wait_for_me.notify_one();
-  };
+    *reply_available = true;
+    wait_for_me->notify_one();
+  });
 
   ConcordAssertNE(proto_request, nullptr);
   ReconfigurationRequest rreq;
@@ -513,42 +528,61 @@ Status StateSnapshotServiceImpl::ReadAsOf(ServerContext* context,
   rreq.command = cmd;
   bft::client::Msg message;
   concord::messages::serialize(message, rreq);
-  client_->send(read_config, std::move(message), callback);
+  client_->send(*read_config, std::move(message), *callback);
   bool response_available = false;
   {
     std::mutex mtx;
     std::unique_lock<std::mutex> lck(mtx);
-    response_available = wait_for_me.wait_for(lck, timeout, [&reply_available]() { return reply_available; });
+    response_available = wait_for_me->wait_for(lck, timeout, [reply_available]() { return *reply_available; });
   }
 
   if (!response_available) {
+    clearAllPrevDoneCallbacksAndAdd(reply_available, callback);
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "Timeout");
   }
 
-  for (const auto& res : read_as_of_responses) {
-    if (!return_status.ok()) {
+  for (const auto& res : *read_as_of_responses) {
+    if (!return_status->ok()) {
       break;
     }
 
     switch (res->status) {
       case SnapshotResponseStatus::InternalError:
-        return_status = grpc::Status(grpc::StatusCode::UNKNOWN, "Internal error");
+        *return_status = grpc::Status(grpc::StatusCode::UNKNOWN, "Internal error");
         break;
       case SnapshotResponseStatus::SnapshotNonExistent:
-        return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Snapshot doesn't exist");
+        *return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Snapshot doesn't exist");
         break;
       case SnapshotResponseStatus::SnapshotPending:
-        return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Snapshot not ready");
+        *return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Snapshot not ready");
         break;
       case SnapshotResponseStatus::Success:
-        compareWithRsiAndSetReadAsOfResponse(res, proto_request, response, return_status);
+        compareWithRsiAndSetReadAsOfResponse(res, proto_request, response, *return_status);
         break;
       default:
         ConcordAssert(false);
         break;
     }
   }
-  return return_status;
+  return *return_status;
+}
+
+void StateSnapshotServiceImpl::clearAllPrevDoneCallbacksAndAdd(std::shared_ptr<bool> condition,
+                                                               std::shared_ptr<bftEngine::RequestCallBack> callback) {
+  std::unique_lock<std::mutex> cleanup_lck(cleanup_mutex_);
+  bool got_value = false;
+  do {
+    got_value = false;
+    for (auto it = callbacks_for_cleanup_.begin(); it != callbacks_for_cleanup_.end(); ++it) {
+      if (*(it->first)) {
+        // We can delete this callback
+        got_value = true;
+        callbacks_for_cleanup_.erase(it);
+        break;
+      }
+    }
+  } while (got_value);
+  callbacks_for_cleanup_.emplace(condition, callback);
 }
 
 }  // namespace concord::client::clientservice


### PR DESCRIPTION
Client service uses client pool to send the BFT request using BFT client. But after receiving the request the client pool ignores the reply size and calls the bft client with the default reply size (which is 64KB). This may not be correct for all clients of the client pool and as the max_reply_buffe_size is available in the request config, the client pool is expected to honor the same. Any API like ReadAsOf, which might return a bigger size response will get a timeout operation result. So in this PR, we are making sure that the client pool uses the max reply message buffer from the request config.

This is however not taken care of in case of batch requests. The batch request will ignore the request config's the max reply buffer size. It will use the same message size for each message in a batch as it's happening now.

Along with this, the requests that are kept in the external queue are not keeping the callback function. In this PR the callback is added if available.