### PR TITLE
Limit on the number of request that RSC will accept

### DIFF
--- a/client/clientservice/src/state_snapshot_service.cpp
+++ b/client/clientservice/src/state_snapshot_service.cpp
@@ -50,6 +50,7 @@ using concord::client::concordclient::OutOfRangeSubscriptionRequest;
 using concord::client::concordclient::StreamUnavailable;
 using concord::client::concordclient::InternalError;
 using concord::client::concordclient::EndOfStream;
+using concord::client::concordclient::RequestOverload;
 
 namespace concord::client::clientservice {
 
@@ -306,6 +307,9 @@ Status StateSnapshotServiceImpl::StreamSnapshot(ServerContext* context,
       status = grpc::Status(grpc::StatusCode::UNKNOWN, e.what());
       break;
     } catch (const StreamUnavailable& e) {
+      status = grpc::Status(grpc::StatusCode::UNAVAILABLE, e.what());
+      break;
+    } catch (const RequestOverload& e) {
       status = grpc::Status(grpc::StatusCode::UNAVAILABLE, e.what());
       break;
     } catch (const EndOfStream& e) {

--- a/client/concordclient/include/client/concordclient/concord_client_exceptions.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client_exceptions.hpp
@@ -53,4 +53,10 @@ class StreamUnavailable : public std::runtime_error {
   StreamUnavailable() : std::runtime_error("Stream is not available"){};
 };
 
+// An internal error may occur due to service unavailability.
+class RequestOverload : public std::runtime_error {
+ public:
+  RequestOverload() : std::runtime_error("Server overloaded with requests"){};
+};
+
 }  // namespace concord::client::concordclient


### PR DESCRIPTION
Currently the RSC is created as a concurrent receiver of requests from
Applications. In one of the experiment when for an idle server 1000
concurrent requests were sent the clientservice choked and it took lot
of time to recover. This definitely result into loss of service by the
RSS. But the service loss should be gracefully handled. This commit is
to make sure that service loss is gracefully handled and in case an
avalanche of requests are bombarded to the server, it will gracefully
reject extra requests and will accept them when added later. Server will
accept and service (supply the stream of public states) till it receives
certain requests and then it rejects any other client till it free up
some space.