### PR TITLE
Batch size 0 as stop pruning fix

### DIFF
--- a/kvbc/include/resources-manager/AdaptivePruningManager.hpp
+++ b/kvbc/include/resources-manager/AdaptivePruningManager.hpp
@@ -80,7 +80,7 @@ class AdaptivePruningManager {
   uint32_t current_pruning_pace_;
   uint64_t current_batch_size_;
   concordMetrics::Component metricComponent;
-  concordMetrics::Component::Handle<concordMetrics::AtomicGauge> ticksPerSecondMetric, batchSizeMetric,
+  concordMetrics::Component::Handle<concordMetrics::AtomicGauge> intervalBetweenTicksSecondsMetric, batchSizeMetric,
       transactionsPerSecondMetric, postExecUtilizationMetric, pruningAvgTimeMicroMetric, pruningUtilizationMetric;
 };
 }  // namespace concord::performance

--- a/kvbc/include/resources-manager/AdaptivePruningManager.hpp
+++ b/kvbc/include/resources-manager/AdaptivePruningManager.hpp
@@ -80,7 +80,7 @@ class AdaptivePruningManager {
   uint32_t current_pruning_pace_;
   uint64_t current_batch_size_;
   concordMetrics::Component metricComponent;
-  concordMetrics::Component::Handle<concordMetrics::AtomicGauge> intervalBetweenTicksSecondsMetric, batchSizeMetric,
+  concordMetrics::Component::Handle<concordMetrics::AtomicGauge> blocksPerSecondMetric, batchSizeMetric,
       transactionsPerSecondMetric, postExecUtilizationMetric, pruningAvgTimeMicroMetric, pruningUtilizationMetric;
 };
 }  // namespace concord::performance

--- a/kvbc/src/pruning_reserved_pages_client.cpp
+++ b/kvbc/src/pruning_reserved_pages_client.cpp
@@ -23,7 +23,7 @@ static char* data(std::vector<std::uint8_t>& v) { return reinterpret_cast<char*>
 static const char* cdata(const std::vector<std::uint8_t>& v) { return reinterpret_cast<const char*>(v.data()); }
 
 static std::uint32_t toSecondsCount(const std::chrono::seconds& s) {
-  if (s.count() <= 0 || s.count() > std::numeric_limits<std::uint32_t>::max()) {
+  if (s.count() > std::numeric_limits<std::uint32_t>::max()) {
     throw std::invalid_argument{"Invalid tick period (seconds) value"};
   }
   return static_cast<std::uint32_t>(s.count());
@@ -32,7 +32,7 @@ static std::uint32_t toSecondsCount(const std::chrono::seconds& s) {
 Agreement createAgreement(const std::chrono::seconds& tick_period,
                           std::uint64_t batch_blocks_num,
                           BlockId last_agreed_prunable_block_id) {
-  if (batch_blocks_num == 0 || last_agreed_prunable_block_id < INITIAL_GENESIS_BLOCK_ID) {
+  if (last_agreed_prunable_block_id < INITIAL_GENESIS_BLOCK_ID) {
     throw std::invalid_argument{"Invalid pruning agreement paramteres"};
   }
   return Agreement{toSecondsCount(tick_period), batch_blocks_num, last_agreed_prunable_block_id};

--- a/kvbc/src/resources-manager/AdaptivePruningManager.cpp
+++ b/kvbc/src/resources-manager/AdaptivePruningManager.cpp
@@ -21,7 +21,7 @@ AdaptivePruningManager::AdaptivePruningManager(
       interval(interval),
       ro_storage_(ro_storage),
       metricComponent(std::string("Adaptive Pruning"), aggregator),
-      intervalBetweenTicksSecondsMetric(metricComponent.RegisterAtomicGauge(std::string("interval_between_ticks"), 0)),
+      blocksPerSecondMetric(metricComponent.RegisterAtomicGauge(std::string("blocks_per_second"), 0)),
       batchSizeMetric(metricComponent.RegisterAtomicGauge("batch_size", 0)),
       transactionsPerSecondMetric(metricComponent.RegisterAtomicGauge("transactions_per_second", 0)),
       postExecUtilizationMetric(metricComponent.RegisterAtomicGauge("post_exec_utilization", 0)),
@@ -47,7 +47,7 @@ void AdaptivePruningManager::notifyReplicas(const PruneInfo &pruneInfo) {
   pruneRequest.batch_blocks_num = pruneInfo.blocksPerSecond / bftEngine::ReplicaConfig::instance().numReplicas;
 
   // Is this going to register all send values or just update current
-  intervalBetweenTicksSecondsMetric.Get().Set(pruneRequest.batch_blocks_num);
+  blocksPerSecondMetric.Get().Set(pruneInfo.blocksPerSecond);
   batchSizeMetric.Get().Set(pruneInfo.batchSize);
   transactionsPerSecondMetric.Get().Set(pruneInfo.transactionsPerSecond);
   postExecUtilizationMetric.Get().Set(pruneInfo.postExecUtilization);

--- a/kvbc/src/resources-manager/AdaptivePruningManager.cpp
+++ b/kvbc/src/resources-manager/AdaptivePruningManager.cpp
@@ -21,7 +21,7 @@ AdaptivePruningManager::AdaptivePruningManager(
       interval(interval),
       ro_storage_(ro_storage),
       metricComponent(std::string("Adaptive Pruning"), aggregator),
-      ticksPerSecondMetric(metricComponent.RegisterAtomicGauge(std::string("ticks_per_second"), 0)),
+      intervalBetweenTicksSecondsMetric(metricComponent.RegisterAtomicGauge(std::string("interval_between_ticks"), 0)),
       batchSizeMetric(metricComponent.RegisterAtomicGauge("batch_size", 0)),
       transactionsPerSecondMetric(metricComponent.RegisterAtomicGauge("transactions_per_second", 0)),
       postExecUtilizationMetric(metricComponent.RegisterAtomicGauge("post_exec_utilization", 0)),
@@ -47,7 +47,7 @@ void AdaptivePruningManager::notifyReplicas(const PruneInfo &pruneInfo) {
   pruneRequest.batch_blocks_num = pruneInfo.blocksPerSecond / bftEngine::ReplicaConfig::instance().numReplicas;
 
   // Is this going to register all send values or just update current
-  ticksPerSecondMetric.Get().Set(pruneRequest.batch_blocks_num);
+  intervalBetweenTicksSecondsMetric.Get().Set(pruneRequest.batch_blocks_num);
   batchSizeMetric.Get().Set(pruneInfo.batchSize);
   transactionsPerSecondMetric.Get().Set(pruneInfo.transactionsPerSecond);
   postExecUtilizationMetric.Get().Set(pruneInfo.postExecUtilization);
@@ -93,6 +93,7 @@ const concord::messages::PruneSwitchModeRequest &AdaptivePruningManager::getLate
   return latestConfiguration_;
   // TODO: Add log line that describes the given stored configuration
 }
+
 void AdaptivePruningManager::threadFunction() {
   while (isRunning.load()) {
     {

--- a/kvbc/test/pruning_reserved_pages_client_test.cpp
+++ b/kvbc/test/pruning_reserved_pages_client_test.cpp
@@ -49,14 +49,6 @@ TEST_F(pruning_reserved_pages_client_test, create_valid_agreement) {
   ASSERT_EQ(agreement.last_agreed_prunable_block_id, last_agreed_prunable_block_id_);
 }
 
-TEST_F(pruning_reserved_pages_client_test, create_agreement_with_0s_tick_period) {
-  ASSERT_THROW(createAgreement(0s, batch_blocks_num_, last_agreed_prunable_block_id_), std::invalid_argument);
-}
-
-TEST_F(pruning_reserved_pages_client_test, create_agreement_with_0_batch_blocks_num) {
-  ASSERT_THROW(createAgreement(tick_period_, 0, last_agreed_prunable_block_id_), std::invalid_argument);
-}
-
 TEST_F(pruning_reserved_pages_client_test, create_agreement_with_invalid_last_agreed) {
   ASSERT_THROW(
       createAgreement(tick_period_, batch_blocks_num_, INITIAL_GENESIS_BLOCK_ID > 0 ? INITIAL_GENESIS_BLOCK_ID - 1 : 0),


### PR DESCRIPTION
Stop command has batch size set to 0 which earlier was disallowed. COndition on throw runtime exception is removed. 