### PR TITLE
create an order on the clientIds

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -147,6 +147,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
   // Reconfiguration credentials
   CONFIG_PARAM(pathToOperatorPublicKey_, std::string, "", "Path to the operator public key pem file");
+  CONFIG_PARAM(operatorEnabled_, bool, true, "true if operator is enabled");
   // Pruning parameters
   CONFIG_PARAM(pruningEnabled_, bool, false, "Enable pruning");
   CONFIG_PARAM(numBlocksToKeep_, uint64_t, 0, "how much blocks to keep while pruning");
@@ -343,6 +344,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, thresholdVerificationKeys_);
 
     serialize(outStream, pathToOperatorPublicKey_);
+    serialize(outStream, operatorEnabled_);
     serialize(outStream, pruningEnabled_);
     serialize(outStream, numBlocksToKeep_);
 
@@ -438,6 +440,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, thresholdVerificationKeys_);
 
     deserialize(inStream, pathToOperatorPublicKey_);
+    deserialize(inStream, operatorEnabled_);
     deserialize(inStream, pruningEnabled_);
     deserialize(inStream, numBlocksToKeep_);
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4392,20 +4392,11 @@ ReplicaImp::ReplicaImp(bool firstTime,
   }
   bft::communication::StateControl::instance().setGetPeerPubKeyMethod(
       [&](uint32_t id) { return sigManager_->getPublicKeyOfVerifier(id); });
-  // clients ids are assigned as follows:
-  // - client proxies starting at a subsequent id of the last (ro-)replica
-  // - external clients
-  // - internal replicas' client ids
-  std::set<NodeIdType> proxyClients;
-  std::set<NodeIdType> externalClients;
-  std::set<NodeIdType> internalClients;
-  uint16_t clientId = config_.getnumReplicas() + config_.getnumRoReplicas();
-  for (int i = 0; i < config_.getnumOfClientProxies(); ++i) proxyClients.insert(clientId++);
-  for (int i = 0; i < config_.getnumOfExternalClients(); ++i) externalClients.insert(clientId++);
-  for (int i = 0; i < config_.getnumReplicas(); ++i) internalClients.insert(clientId++);
-  clientsManager = std::make_shared<ClientsManager>(ps, proxyClients, externalClients, internalClients, metrics_);
+
+  clientsManager = std::make_shared<ClientsManager>(
+      ps, repsInfo->idsOfClientProxies(), repsInfo->idsOfExternalClients(), repsInfo->idsOfInternalClients(), metrics_);
   internalBFTClient_.reset(
-      new InternalBFTClient(*internalClients.cbegin() + config_.getreplicaId(), msgsCommunicator_));
+      new InternalBFTClient(*(repsInfo->idsOfInternalClients()).cbegin() + config_.getreplicaId(), msgsCommunicator_));
 
   // autoPrimaryRotationEnabled implies viewChangeProtocolEnabled
   // Note: "p=>q" is equivalent to "not p or q"

--- a/bftengine/src/bftengine/ReplicasInfo.cpp
+++ b/bftengine/src/bftengine/ReplicasInfo.cpp
@@ -63,6 +63,11 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
       _dynamicCollectorForPartialProofs{dynamicCollectorForPartialProofs},
       _dynamicCollectorForExecutionProofs{dynamicCollectorForExecutionProofs},
 
+      /*
+       * Ids order is: [replicas, ro-replicas, clientProxies, client-service external clients, client-service ID,
+       * operator, internal-clients]. Notice, that in case we have an operator, it is included in numOfExternalClients,
+       * so no need in any special handling.
+       */
       _idsOfPeerReplicas{[&config]() {
         std::set<ReplicaId> ret;
         for (auto i = 0; i < config.numReplicas; ++i)
@@ -100,17 +105,22 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
         std::set<ReplicaId> ret;
         auto start = config.numReplicas + config.numRoReplicas + config.numOfClientProxies;
         auto end = start + config.numOfExternalClients;
-        for (auto i = start; i < end; ++i) {
+        for (auto i = start; i < (end - ((uint16_t)config.operatorEnabled_)); ++i) {
           ret.insert(i);
         }
-        if (start != end) LOG_INFO(GL, "Principal ids in _idsOfExternalClients: " << start << " to " << end - 1);
+        ret.insert(end + config.numOfClientServices - 1);
+        if (start != end)
+          LOG_INFO(GL,
+                   "Principal ids in _idsOfExternalClients: " << start << " to "
+                                                              << end - 1 - ((uint16_t)config.operatorEnabled_));
+        if (config.operatorEnabled_) LOG_INFO(GL, "Operator id: " << end + config.numOfClientServices - 1);
         return ret;
       }()},
 
       _idsOfInternalClients{[&config]() {
         std::set<ReplicaId> ret;
-        auto start =
-            config.numReplicas + config.numRoReplicas + config.numOfClientProxies + config.numOfExternalClients;
+        auto start = config.numReplicas + config.numRoReplicas + config.numOfClientProxies +
+                     config.numOfExternalClients + config.numOfClientServices;
         auto end = start + config.numReplicas;
         for (auto i = start; i < end; ++i) {
           ret.insert(i);
@@ -121,13 +131,16 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
 
       _idsOfClientServices{[&config]() {
         std::set<ReplicaId> ret;
-        auto start = config.numReplicas + config.numRoReplicas + config.numOfClientProxies +
-                     config.numOfExternalClients + config.numReplicas;
+        auto start =
+            config.numReplicas + config.numRoReplicas + config.numOfClientProxies + config.numOfExternalClients;
         auto end = start + config.numOfClientServices;
-        for (auto i = start; i < end; ++i) {
+        for (auto i = start; i < (end - ((uint16_t)config.operatorEnabled_)); ++i) {
           ret.insert(i);
         }
-        if (start != end) LOG_INFO(GL, "Principal ids in _idsOfClientServices: " << start << " to " << end - 1);
+        if (start != end)
+          LOG_INFO(GL,
+                   "Principal ids in _idsOfClientServices: " << start << " to "
+                                                             << end - 1 - ((uint16_t)config.operatorEnabled_));
         return ret;
       }()} {
   ConcordAssert(_numberOfReplicas == (3 * _fVal + 2 * _cVal + 1));

--- a/bftengine/src/bftengine/ReplicasInfo.cpp
+++ b/bftengine/src/bftengine/ReplicasInfo.cpp
@@ -64,9 +64,9 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
       _dynamicCollectorForExecutionProofs{dynamicCollectorForExecutionProofs},
 
       /*
-       * Ids order is: [replicas, ro-replicas, clientProxies, client-service external clients, client-service ID,
-       * operator, internal-clients]. Notice, that in case we have an operator, it is included in numOfExternalClients,
-       * so no need in any special handling.
+       * Ids order is: [replicas, ro-replicas, clientProxies, client-service clients (aka external clients) including
+       * cre, client-service ID, operator, internal-clients]. Notice, that in case we have an operator, it is included
+       * in numOfExternalClients, so no need in any special handling.
        */
       _idsOfPeerReplicas{[&config]() {
         std::set<ReplicaId> ret;


### PR DESCRIPTION
In this PR we create an order on the client's ids in concordbft.
The order is: [replicas, read-only replica, proxies clients, external clients, clientservice, operator, internal clients]