### PR TITLE
Removing the external_queue of requests from client pool

### DIFF
--- a/client/client_pool/include/client/client_pool/client_pool_config.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_config.hpp
@@ -57,7 +57,6 @@ typedef struct ConcordClientPoolConfig {
   std::string tls_certificates_folder_path = "/concord/tls_certs";
   std::string tls_cipher_suite_list = "ECDHE-ECDSA-AES256-GCM-SHA384";
   std::string signing_key_path = "resources/signing_keys";
-  std::uint32_t external_requests_queue_size = 0;
   std::uint32_t trace_sampling_rate = 0;
   std::string file_name;
   bool client_batching_enabled = false;

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -118,7 +118,7 @@ class ConcordClientPool {
                            std::uint32_t max_reply_size,
                            uint64_t seq_num,
                            std::string correlation_id = {},
-                           std::string span_context = std::string(),
+                           const std::string& span_context = std::string(),
                            const bftEngine::RequestCallBack& callback = {});
 
   // This method is responsible to get write requests with the new client
@@ -133,8 +133,8 @@ class ConcordClientPool {
                            bft::client::Msg&& request,
                            const bftEngine::RequestCallBack& callback = {});
 
-  void InsertClientToQueue(std::shared_ptr<concord::external_client::ConcordClient>& client,
-                           std::pair<int8_t, external_client::ConcordClient::PendingReplies>&& replies);
+  void processReplies(std::shared_ptr<concord::external_client::ConcordClient>& client,
+                      std::pair<int8_t, external_client::ConcordClient::PendingReplies>&& replies);
 
   // For batching jobs
   void assignJobToClient(const ClientPtr& client);
@@ -173,8 +173,7 @@ class ConcordClientPool {
 
   // Clients that are available for use (i.e. not already in use).
   std::deque<ClientPtr> clients_;
-  // The queue holds the jobs that no client was available to get.
-  std::deque<externalRequest> external_requests_queue_;
+
   // Thread pool, on each thread on client will run
   concord::util::SimpleThreadPool jobs_thread_pool_;
   // Clients queue mutex
@@ -201,7 +200,6 @@ class ConcordClientPool {
   // Logger
   logging::Logger logger_;
   std::atomic_bool is_overloaded_ = false;
-  uint32_t jobs_queue_max_size_ = 0;
   using Timer_t = ::concord_client_pool::Timer<ClientPtr>;
   std::unique_ptr<Timer_t> batch_timer_;
   bftEngine::impl::RollingAvgAndVar average_req_dur_;

--- a/client/clientservice/test/example_config.hpp
+++ b/client/clientservice/test/example_config.hpp
@@ -36,7 +36,6 @@ comm_to_use: tls
 concord-bft_communication_buffer_length: 16777216
 enable_mock_comm: false
 encrypted_config_enabled: false
-external_requests_queue_size: 0
 f_val: 1
 num_replicas: 4
 num_ro_replicas: 1

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -60,7 +60,6 @@ struct BftTopology {
   std::uint16_t client_sends_request_to_all_replicas_period_thresh;
   std::uint32_t client_proxies_per_replica;
   std::string signing_key_path;
-  std::uint32_t external_requests_queue_size;
   bool encrypted_config_enabled;
   bool transaction_signing_enabled;
   bool with_cre;

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -89,7 +89,6 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
   client_pool_config.num_replicas = config.topology.replicas.size();
   client_pool_config.client_proxies_per_replica = config.topology.client_proxies_per_replica;
   client_pool_config.signing_key_path = config.topology.signing_key_path;
-  client_pool_config.external_requests_queue_size = config.topology.external_requests_queue_size;
   client_pool_config.encrypted_config_enabled = config.topology.encrypted_config_enabled;
   client_pool_config.transaction_signing_enabled = config.topology.transaction_signing_enabled;
   client_pool_config.with_cre = config.topology.with_cre;


### PR DESCRIPTION
Client Pool (CP) batches the requests till batch size or batch timeout in a pending request queue inside a client in the pool. Either of these conditions (timer off or size overflow) leads to creation of a batch job which sends the requests and then fills the client with some requests which were in the external request queue. This client will then wait till it fills up or timeout and then the process repeats.

During the SendRequest if there are no serving clients or available clients then the request is dumped into the external request queue (ERQ).

As we can see this is a good mechanism if batching is not available. But if batching is available, we should deprecate the ERQ and this PR is doing the same.