### PR TITLE
Initial implementation for byzantine_behavior (faulty) replica.

### DIFF
--- a/docs/sbft-formal-model/cluster_config.s.dfy
+++ b/docs/sbft-formal-model/cluster_config.s.dfy
@@ -55,6 +55,20 @@ module ClusterConfig {
       2 * F() + 1
     }
 
+    predicate IsHonestReplica(id:HostId)
+      requires WF()
+    {
+      && ValidHostId(id)
+      && F() <= id < N()
+    }
+
+    predicate IsFaultyReplica(id:HostId)
+      requires WF()
+    {
+      && ValidHostId(id)
+      && 0 <= id < F()
+    }
+
     predicate IsReplica(id:HostId)
       requires WF()
     {

--- a/docs/sbft-formal-model/distributed_system.s.dfy
+++ b/docs/sbft-formal-model/distributed_system.s.dfy
@@ -61,8 +61,8 @@ module DistributedSystem {
       && c.WF()
       && |hosts| == |c.hosts|
       && (forall id | c.clusterConfig.IsHonestReplica(id) :: hosts[id].Replica? && hosts[id].replicaVariables.WF(c.hosts[id].replicaConstants))
-      && (forall id | c.clusterConfig.IsClient(id) :: hosts[id].Client? && hosts[id].clientVariables.WF(c.hosts[id].clientConstants)
-      && (forall id | c.clusterConfig.IsFaultyReplica(id) :: hosts[id].FaultyReplica?))
+      && (forall id | c.clusterConfig.IsClient(id) :: hosts[id].Client? && hosts[id].clientVariables.WF(c.hosts[id].clientConstants))
+      && (forall id | c.clusterConfig.IsFaultyReplica(id) :: hosts[id].FaultyReplica?)
     }
   }
 

--- a/docs/sbft-formal-model/distributed_system.s.dfy
+++ b/docs/sbft-formal-model/distributed_system.s.dfy
@@ -13,6 +13,7 @@ include "replica.i.dfy"
 include "client.i.dfy"
 include "cluster_config.s.dfy"
 include "messages.dfy"
+include "faulty_replica.i.dfy"
 
 // Before we get here, caller must define a type Message that we'll
 // use to instantiate network.s.dfy.
@@ -22,11 +23,17 @@ module DistributedSystem {
   import opened Messages
   import ClusterConfig
   import Replica
+  import FaultyReplica
   import Client
   import Network
 
-  datatype HostConstants = Replica(replicaConstants:Replica.Constants) | Client(clientConstants:Client.Constants)
-  datatype HostVariables = Replica(replicaVariables:Replica.Variables) | Client(clientVariables:Client.Variables)
+  datatype HostConstants = | Replica(replicaConstants:Replica.Constants)
+                           | FaultyReplica(faultyReplicaConstants:FaultyReplica.Constants)
+                           | Client(clientConstants:Client.Constants)
+
+  datatype HostVariables = | Replica(replicaVariables:Replica.Variables)
+                           | FaultyReplica(faultyReplicaVariables:FaultyReplica.Variables)
+                           | Client(clientVariables:Client.Variables)
 
   datatype Constants = Constants(
     hosts:seq<HostConstants>,
@@ -37,8 +44,12 @@ module DistributedSystem {
       && clusterConfig.WF()
       && clusterConfig.ClusterSize() == NumHosts()
       && |hosts| == NumHosts()
-      && (forall id | clusterConfig.IsReplica(id) :: hosts[id] == HostConstants.Replica(Replica.Constants(id, clusterConfig)))
-      && (forall id | clusterConfig.IsClient(id) :: hosts[id] == HostConstants.Client(Client.Constants(id, clusterConfig)))
+      && (forall id | clusterConfig.IsHonestReplica(id) :: && hosts[id] == HostConstants.Replica(Replica.Constants(id, clusterConfig))
+                                                           && hosts[id].replicaConstants.Configure(id, clusterConfig))
+      && (forall id | clusterConfig.IsFaultyReplica(id) :: && hosts[id] == HostConstants.FaultyReplica(FaultyReplica.Constants(id, clusterConfig))
+                                                           && hosts[id].faultyReplicaConstants.Configure(id, clusterConfig))
+      && (forall id | clusterConfig.IsClient(id) :: && hosts[id] == HostConstants.Client(Client.Constants(id, clusterConfig))
+                                                    && hosts[id].clientConstants.Configure(id, clusterConfig))
     }
   }
 
@@ -49,24 +60,24 @@ module DistributedSystem {
     predicate WF(c: Constants) {
       && c.WF()
       && |hosts| == |c.hosts|
-      && (forall id | c.clusterConfig.IsReplica(id) :: hosts[id].Replica? && hosts[id].replicaVariables.WF(c.hosts[id].replicaConstants))
+      && (forall id | c.clusterConfig.IsHonestReplica(id) :: hosts[id].Replica? && hosts[id].replicaVariables.WF(c.hosts[id].replicaConstants))
       && (forall id | c.clusterConfig.IsClient(id) :: hosts[id].Client? && hosts[id].clientVariables.WF(c.hosts[id].clientConstants))
     }
   }
 
   predicate IsCommitted(c:Constants, v:Variables, view:nat, seqID:SequenceID) {
     && v.WF(c)
-    && var ReplicasCommitted := set replicaID | && 0 <= replicaID < c.clusterConfig.N()
+    && var ReplicasCommitted := set replicaID | && c.clusterConfig.F() <= replicaID < c.clusterConfig.N()
                                                 && Replica.QuorumOfPrepares(c.hosts[replicaID].replicaConstants,
                                                                             v.hosts[replicaID].replicaVariables,
                                                                             seqID);
     //TODO: Implement check for hasPrePrepare
-    && |ReplicasCommitted| >= c.clusterConfig.ByzantineSafeQuorum()
+    && |ReplicasCommitted| >= c.clusterConfig.AgreementQuorum()
   }
 
   predicate Init(c:Constants, v:Variables) {
     && v.WF(c)
-    && (forall id | && c.clusterConfig.IsReplica(id) 
+    && (forall id | && c.clusterConfig.IsHonestReplica(id) 
                     :: Replica.Init(c.hosts[id].replicaConstants, v.hosts[id].replicaVariables))
     && (forall id | && c.clusterConfig.IsClient(id)
                     :: Client.Init(c.hosts[id].clientConstants, v.hosts[id].clientVariables))
@@ -79,8 +90,15 @@ module DistributedSystem {
   predicate ReplicaStep(c:Constants, v:Variables, v':Variables, step: Step) {
       && v.WF(c)
       && v'.WF(c)
-      && c.clusterConfig.IsReplica(step.id)
+      && c.clusterConfig.IsHonestReplica(step.id)
       && Replica.Next(c.hosts[step.id].replicaConstants, v.hosts[step.id].replicaVariables, v'.hosts[step.id].replicaVariables, step.msgOps)
+  }
+
+  predicate FaultyReplicaStep(c:Constants, v:Variables, v':Variables, step: Step) {
+      && v.WF(c)
+      && v'.WF(c)
+      && c.clusterConfig.IsFaultyReplica(step.id)
+      && FaultyReplica.Next(c.hosts[step.id].faultyReplicaConstants, v.hosts[step.id].faultyReplicaVariables, v'.hosts[step.id].faultyReplicaVariables, step.msgOps)
   }
 
   predicate ClientStep(c:Constants, v:Variables, v':Variables, step: Step) {

--- a/docs/sbft-formal-model/distributed_system.s.dfy
+++ b/docs/sbft-formal-model/distributed_system.s.dfy
@@ -61,7 +61,8 @@ module DistributedSystem {
       && c.WF()
       && |hosts| == |c.hosts|
       && (forall id | c.clusterConfig.IsHonestReplica(id) :: hosts[id].Replica? && hosts[id].replicaVariables.WF(c.hosts[id].replicaConstants))
-      && (forall id | c.clusterConfig.IsClient(id) :: hosts[id].Client? && hosts[id].clientVariables.WF(c.hosts[id].clientConstants))
+      && (forall id | c.clusterConfig.IsClient(id) :: hosts[id].Client? && hosts[id].clientVariables.WF(c.hosts[id].clientConstants)
+      && (forall id | c.clusterConfig.IsFaultyReplica(id) :: hosts[id].FaultyReplica?))
     }
   }
 
@@ -98,6 +99,7 @@ module DistributedSystem {
       && v.WF(c)
       && v'.WF(c)
       && c.clusterConfig.IsFaultyReplica(step.id)
+      && assert v.hosts[step.id].FaultyReplica?; true
       && FaultyReplica.Next(c.hosts[step.id].faultyReplicaConstants, v.hosts[step.id].faultyReplicaVariables, v'.hosts[step.id].faultyReplicaVariables, step.msgOps)
   }
 

--- a/docs/sbft-formal-model/faulty_replica.i.dfy
+++ b/docs/sbft-formal-model/faulty_replica.i.dfy
@@ -1,0 +1,45 @@
+//#title Host protocol
+//#desc Define the host state machine here: message type, state machine for executing one
+//#desc host's part of the protocol.
+
+// See exercise01.dfy for an English design of the protocol.
+
+include "network.s.dfy"
+include "cluster_config.s.dfy"
+include "messages.dfy"
+
+module FaultyReplica {
+  import opened Library
+  import opened HostIdentifiers
+  import opened Messages
+  import Network
+  import ClusterConfig
+
+  datatype Constants = Constants(myId:HostId, clusterConfig:ClusterConfig.Constants) {
+    predicate Configure(id:HostId, clusterConf:ClusterConfig.Constants) {
+      && myId == id
+      && clusterConfig == clusterConf
+    }
+  }
+
+  datatype Variables = Variables()
+
+
+  // JayNF
+  datatype Step =
+    | ArbitraryBehaviorStep()
+
+  predicate ArbitraryBehavior(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>)
+  {
+    true
+  }
+
+  predicate NextStep(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>, step: Step) {
+    match step
+       case ArbitraryBehaviorStep() => ArbitraryBehavior(c, v, v', msgOps)
+  }
+
+  predicate Next(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>) {
+    exists step :: NextStep(c, v, v', msgOps, step)
+  }
+}

--- a/docs/sbft-formal-model/proof.dfy
+++ b/docs/sbft-formal-model/proof.dfy
@@ -365,7 +365,7 @@ module Proof {
 
   lemma CountHonestReplicas(c: Constants)
     requires c.WF()
-    ensures |HonestReplicas(c)| == c.clusterConfig.AgreementQuorum()
+    ensures |HonestReplicas(c)| >= c.clusterConfig.AgreementQuorum()
   {
     var count := 0;
     var f := c.clusterConfig.F();

--- a/docs/sbft-formal-model/proof.dfy
+++ b/docs/sbft-formal-model/proof.dfy
@@ -32,7 +32,7 @@ module Proof {
   predicate IsHonestReplica(c:Constants, hostId:HostId) 
   {
     && c.WF()
-    && c.clusterConfig.IsReplica(hostId)
+    && c.clusterConfig.IsHonestReplica(hostId)
   }
 
   // Here's a predicate that will be very useful in constructing invariant conjuncts.
@@ -220,7 +220,7 @@ module Proof {
 
   predicate AllReplicasLiteInv (c: Constants, v:Variables) {
     && v.WF(c)
-    && (forall replicaIdx | 0 <= replicaIdx < |c.hosts| && c.clusterConfig.IsReplica(replicaIdx)
+    && (forall replicaIdx | 0 <= replicaIdx < |c.hosts| && c.clusterConfig.IsHonestReplica(replicaIdx)
                             :: Replica.LiteInv(c.hosts[replicaIdx].replicaConstants, v.hosts[replicaIdx].replicaVariables))
   }
 
@@ -338,7 +338,6 @@ module Proof {
         < |senders1| + |senders2| - |senders1*senders2|;
         == |senders1 + senders2|; 
         <= {
-          assert senders1 + senders2 <= getAllReplicas(c);
           Library.SubsetCardinality(senders1 + senders2, getAllReplicas(c));
         }
         n;
@@ -347,12 +346,42 @@ module Proof {
     }
     assert f + 1 <= |commonSenders|;
 
-    var honestReplicas := set sender | 0 <= sender < n && IsHonestReplica(c, sender);
-    var commonHonest := commonSenders * honestReplicas;
-    assert 1 <= |commonHonest|;
+    var commonHonest := commonSenders * HonestReplicas(c);
+    CountHonestReplicas(c);
+    if(|commonHonest| == 0) {
+      Library.SubsetCardinality(commonSenders + HonestReplicas(c), getAllReplicas(c));
+      assert false; //Proof by contradiction
+    }
 
     var result :| result in commonHonest;
     common := result;
+  }
+
+  function HonestReplicas(c: Constants) : (honest:set<HostId>) 
+    requires c.WF()
+  {
+    set sender | 0 <= sender < c.clusterConfig.N() && IsHonestReplica(c, sender)
+  }
+
+  lemma CountHonestReplicas(c: Constants)
+    requires c.WF()
+    ensures |HonestReplicas(c)| == c.clusterConfig.AgreementQuorum()
+  {
+    var count := 0;
+    var f := c.clusterConfig.F();
+    var n := c.clusterConfig.N();
+    while(count < n)
+      invariant count <= n
+      invariant |set sender | 0 <= sender < count && IsHonestReplica(c, sender)| == if count < f then 0
+                                                                                      else count - f
+      {
+        var oldSet := set sender | 0 <= sender < count && IsHonestReplica(c, sender);
+        var newSet := set sender | 0 <= sender < count + 1 && IsHonestReplica(c, sender);
+        if(count >= f) {
+          assert newSet == oldSet + {count};
+        }
+        count := count + 1;
+      }
   }
 
   lemma ProofCommitMsgsFromHonestSendersAgree(c: Constants, v:Variables, v':Variables, step:Step)

--- a/docs/sbft-formal-model/replica.i.dfy
+++ b/docs/sbft-formal-model/replica.i.dfy
@@ -508,9 +508,9 @@ module Replica {
   predicate NextStep(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>, step: Step) {
     match step
        case SendPrePrepareStep() => SendPrePrepare(c, v, v', msgOps)
-       case RecvPrePrepareStep => RecvPrePrepare(c, v, v', msgOps)
+       case RecvPrePrepareStep() => RecvPrePrepare(c, v, v', msgOps)
        case SendPrepareStep(seqID) => SendPrepare(c, v, v', msgOps, seqID)
-       case RecvPrepareStep => RecvPrepare(c, v, v', msgOps)
+       case RecvPrepareStep() => RecvPrepare(c, v, v', msgOps)
        case SendCommitStep(seqID) => SendCommit(c, v, v', msgOps, seqID)
        case RecvCommitStep() => RecvCommit(c, v, v', msgOps)
        case DoCommitStep(seqID) => DoCommit(c, v, v', msgOps, seqID)


### PR DESCRIPTION
In this implementation we instantiate the faulty replicas at the
creation of our distributed system. Even though the distributed system
is aware who are the faulty nodes, the replicas themselves don't have
access to this knowledge.