### PR TITLE
Don't create replies for internal clients

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -93,6 +93,7 @@ uint32_t ClientsManager::reservedPagesPerClient(const uint32_t& sizeOfReservedPa
 // * remove pending request if loaded reply is newer
 void ClientsManager::loadInfoFromReservedPages() {
   for (auto const& clientId : clientIds_) {
+    if (internalClients_.find(clientId) != internalClients_.end()) continue;
     if (loadReservedPage(getKeyPageId(clientId), sizeOfReservedPage(), scratchPage_.data())) {
       auto& info = clientsInfo_[clientId];
       std::istringstream iss(scratchPage_);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -5636,6 +5636,8 @@ void ReplicaImp::sendResponses(PrePrepareMsg *ppMsg, IRequestsHandler::Execution
     auto executionResult = req.outExecutionStatus;
     std::unique_ptr<ClientReplyMsg> replyMsg;
 
+    // Internal clients don't expect to be answered
+    if (repsInfo->isIdOfInternalClient(req.clientId)) continue;
     if (executionResult != 0) {
       LOG_WARN(GL,
                "Request execution failed: " << KVLOG(req.clientId,

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -5637,7 +5637,10 @@ void ReplicaImp::sendResponses(PrePrepareMsg *ppMsg, IRequestsHandler::Execution
     std::unique_ptr<ClientReplyMsg> replyMsg;
 
     // Internal clients don't expect to be answered
-    if (repsInfo->isIdOfInternalClient(req.clientId)) continue;
+    if (repsInfo->isIdOfInternalClient(req.clientId)) {
+      clientsManager->removePendingForExecutionRequest(req.clientId, req.requestSequenceNum);
+      continue;
+    }
     if (executionResult != 0) {
       LOG_WARN(GL,
                "Request execution failed: " << KVLOG(req.clientId,

--- a/bftengine/tests/clientsManager/ClientsManager_test.cpp
+++ b/bftengine/tests/clientsManager/ClientsManager_test.cpp
@@ -304,14 +304,13 @@ TEST(ClientsManager, numberOfRequiredReservedPagesSucceeds) {
 }
 
 TEST(ClientsManager, loadInfoFromReservedPagesLoadsCorrectInfo) {
-  set<NodeIdType> client_ids{1, 2, 3, 4, 5, 6};
+  set<NodeIdType> client_ids{1, 2, 3, 4};
   set<NodeIdType> proxy_client_ids{1, 2, 3};
   set<NodeIdType> external_client_ids{4};
-  set<NodeIdType> internal_client_ids{5, 6};
+  set<NodeIdType> internal_client_ids{};
 
   map<NodeIdType, pair<string, string>> client_keys;
   client_keys[2] = Crypto::instance().generateRsaKeyPair(kRSASigLengthForTesting, kKeyFormatForTesting);
-  client_keys[5] = Crypto::instance().generateRsaKeyPair(kRSASigLengthForTesting, kKeyFormatForTesting);
 
   map<NodeIdType, pair<ReqId, string>> client_replies;
   client_replies[2] = {9, "reply 9 to client 2"};
@@ -455,10 +454,10 @@ TEST(ClientsManager, loadInfoFromReservedPagesHandlesSingleClientClientsManager)
 }
 
 TEST(ClientsManager, loadInfoFromReservedPagesCorrectlyDeletesOldReplies) {
-  set<NodeIdType> client_ids{1, 2, 3, 4, 5, 6};
+  set<NodeIdType> client_ids{1, 2, 3, 4};
   set<NodeIdType> proxy_client_ids{1, 2, 3};
   set<NodeIdType> external_client_ids{4};
-  set<NodeIdType> internal_client_ids{5, 6};
+  set<NodeIdType> internal_client_ids{};
 
   map<NodeIdType, pair<ReqId, string>> client_replies;
   client_replies[2] = {9, "reply 9 to client 2"};
@@ -1311,16 +1310,13 @@ TEST(ClientsManager, setClientPublicKey) {
   pair<string, string> client_7_key =
       Crypto::instance().generateRsaKeyPair(kRSASigLengthForTesting, kKeyFormatForTesting);
 
-  unique_ptr<ClientsManager> cm(new ClientsManager({}, {4, 5, 7}, {2}, metrics));
-  cm->setClientPublicKey(2, client_2_key.second, kKeyFormatForTesting);
+  unique_ptr<ClientsManager> cm(new ClientsManager({}, {4, 5, 7}, {}, metrics));
   cm->setClientPublicKey(7, client_7_key.second, kKeyFormatForTesting);
 
   clearClientPublicKeysLoadedToKEM();
-  cm.reset(new ClientsManager({}, {4, 5, 7}, {2}, metrics));
+  cm.reset(new ClientsManager({}, {4, 5, 7}, {}, metrics));
   cm->loadInfoFromReservedPages();
 
-  EXPECT_TRUE(verifyClientPublicKeyLoadedToKEM(2, client_2_key))
-      << "ClientsManager::setClientPublicKey failed to correctly write the given public key to the reserved pages.";
   EXPECT_TRUE(verifyClientPublicKeyLoadedToKEM(7, client_7_key))
       << "ClientsManager::setClientPublicKey failed to correctly write the given public key to the reserved pages.";
   EXPECT_TRUE(verifyNoClientPublicKeyLoadedToKEM(4))

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -78,6 +78,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.set("concord.bft.st.runInSeparateThread", true);
     replicaConfig.set("concord.bft.keyExchage.clientKeysEnabled", false);
     replicaConfig.preExecutionResultAuthEnabled = false;
+    replicaConfig.numOfClientServices = 1;
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
     std::string commConfigFile;


### PR DESCRIPTION
(1) add clientservice to tests (to make sure we don't have bugs)
(2) don't create replies for internal clients