### PR TITLE
Add debug logs to RawMemoryPool and correct numOfAvailableChunks_ counter

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -306,7 +306,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       myReplicaId_(myReplica.getReplicaConfig().replicaId),
       maxPreExecResultSize_(myReplica.getReplicaConfig().maxExternalMessageSize - sizeof(uint64_t)),
       numOfReplicas_(myReplica.getReplicaConfig().numReplicas + myReplica.getReplicaConfig().numRoReplicas),
-      numOfInternalClients_(myReplica.getReplicaConfig().numOfClientProxies),
+      numOfClientProxies_(myReplica.getReplicaConfig().numOfClientProxies),
       clientBatchingEnabled_(myReplica.getReplicaConfig().clientBatchingEnabled),
       memoryPool_(myReplica.getReplicaConfig().maxExternalMessageSize, timers),
       metricsComponent_{concordMetrics::Component("preProcessor", std::make_shared<concordMetrics::Aggregator>())},
@@ -344,7 +344,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   }
   // Initially, allocate a memory for all batches of one client (clientMaxBatchSize_)
   memoryPool_.allocatePool(clientMaxBatchSize_, numOfReqEntries);
-  const uint16_t firstClientId = numOfReplicas_ + numOfInternalClients_;
+  const uint16_t firstClientId = numOfReplicas_ + numOfClientProxies_;
   for (uint16_t i = 0; i < numOfExternalClients; i++) {
     // Placeholders for all client batches
     const uint16_t clientId = firstClientId + i;
@@ -364,7 +364,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   LOG_INFO(logger(),
            "PreProcessor initialization:" << KVLOG(numOfReplicas_,
                                                    numOfExternalClients,
-                                                   numOfInternalClients_,
+                                                   numOfClientProxies_,
                                                    numOfReqEntries,
                                                    firstClientId,
                                                    clientBatchingEnabled_,
@@ -1517,8 +1517,11 @@ void PreProcessor::registerAndHandleClientPreProcessReqOnNonPrimary(const string
 }
 
 uint32_t PreProcessor::getBufferOffset(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const {
-  ConcordAssertGE(clientId - numOfReplicas_ - numOfInternalClients_, 0);
-  return (clientId - numOfReplicas_ - numOfInternalClients_) * clientMaxBatchSize_ + reqOffsetInBatch;
+  const auto clientIndex = clientId - numOfReplicas_ - numOfClientProxies_;
+  ConcordAssertGE(clientIndex, 0);
+  const auto reqOffset = clientIndex * clientMaxBatchSize_ + reqOffsetInBatch;
+  LOG_DEBUG(logger(), KVLOG(clientId, reqSeqNum, clientIndex, reqOffsetInBatch));
+  return reqOffset;
 }
 
 const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) {

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -323,7 +323,7 @@ class PreProcessor {
   const ReplicaId myReplicaId_;
   const uint32_t maxPreExecResultSize_;
   const uint16_t numOfReplicas_;
-  const uint16_t numOfInternalClients_;
+  const uint16_t numOfClientProxies_;
   const bool clientBatchingEnabled_;
   inline static uint16_t clientMaxBatchSize_ = 0;
   concord::util::SimpleThreadPool threadPool_;

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -343,7 +343,7 @@ class ThinReplicaImpl {
       if (request->events().block_id() == last_block_id + 1) {
         while (not live_updates->waitUntilNonEmpty(kWaitForUpdateTimeout)) {
           if (context->IsCancelled()) {
-            LOG_INFO(logger_, "StreamCancelled while waiting for the next live update.");
+            LOG_DEBUG(logger_, "StreamCancelled while waiting for the next live update.");
             CLEANUP_SUBSCRIPTION();
             return grpc::Status::CANCELLED;
           }


### PR DESCRIPTION
1. Added DEBUG logs printing memory chunk addresses to allow debugging of RawMemoryPool issues.
2. Increase and decrease numOfAvailableChunks_ only in case the chunk gets allocated/returned from/to the pool.