### PR TITLE
Fixing issues during TRC integration test

### DIFF
--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -143,13 +143,20 @@ void ConcordClient::createGrpcConnections() {
 }
 
 void ConcordClient::checkAndReConnectGrpcConnections() {
+  bool need_reconnection = false;
   for (size_t con_offset = 0; con_offset < config_.topology.replicas.size(); ++con_offset) {
     if (!(grpc_connections_[con_offset])->isConnected()) {
+      need_reconnection = true;
+      break;
+    }
+  }
+  if (need_reconnection) {
+    for (size_t con_offset = 0; con_offset < config_.topology.replicas.size(); ++con_offset) {
       auto trsc_config = std::make_unique<GrpcConnectionConfig>(config_.subscribe_config.use_tls,
                                                                 config_.subscribe_config.pem_private_key,
                                                                 config_.subscribe_config.pem_cert_chain,
                                                                 config_.transport.event_pem_certs);
-      (grpc_connections_[con_offset])->reConnect(trsc_config);
+      (grpc_connections_[con_offset])->checkAndReConnect(trsc_config);
     }
   }
 }


### PR DESCRIPTION
The reconnection use-case of GRPC Connection was not thread-safe. When we raised the number of parallel connections and stopped the replicas, reconnection happened and it was stopping the client service abruptly. So adding the changes to create a thread-safe and performant GrpcConnection abstraction.