### PR TITLE
Potential fix for a replica crash in case of incorrect memory release

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -102,29 +102,6 @@ const string RequestsBatch::getCid() const {
   return cid_;
 }
 
-// Release not-matching client requests in case PreProcessBatchRequestMsg arrived with fewer messages
-void RequestsBatch::updateRegisteredBatchIfNeeded(const string &batchCid, const PreProcessReqMsgsList &preProcessReqs) {
-  const std::lock_guard<std::mutex> lock(batchMutex_);
-  if (batchRegistered_ && cid_ == batchCid && batchSize_.load() != preProcessReqs.size()) {
-    LOG_INFO(preProcessor_.logger(),
-             "The batch needs to be updated" << KVLOG(clientId_, cid_, batchSize_, preProcessReqs.size()));
-    for (const auto &regReqEntry : requestsMap_) {
-      if (regReqEntry.second && regReqEntry.second->reqProcessingStatePtr) {
-        bool registeredReqFound = false;
-        for (const auto &arrivedReq : preProcessReqs) {
-          if (regReqEntry.second->reqProcessingStatePtr->getReqSeqNum() == arrivedReq->reqSeqNum()) {
-            registeredReqFound = true;
-            break;
-          }
-        }
-        if (!registeredReqFound)
-          preProcessor_.releaseClientPreProcessRequestSafe(clientId_, regReqEntry.second, CANCELLED_BY_PRIMARY);
-      }
-    }
-    batchSize_ = preProcessReqs.size();
-  }
-}
-
 RequestStateSharedPtr &RequestsBatch::getRequestState(uint16_t reqOffsetInBatch) {
   ConcordAssertLE(reqOffsetInBatch, PreProcessor::clientMaxBatchSize_ - 1);
   return requestsMap_[reqOffsetInBatch];
@@ -855,18 +832,21 @@ void PreProcessor::onMessage<PreProcessBatchRequestMsg>(PreProcessBatchRequestMs
   PreProcessReqMsgsList &preProcessReqMsgs = batchMsg->getPreProcessRequestMsgs();
   const auto batchSize = preProcessReqMsgs.size();
 
-  // YS TBD: Support send of batched reject reply message when required
-
-  ongoingReqBatches_[clientId]->updateRegisteredBatchIfNeeded(batchCid, preProcessReqMsgs);
-  for (auto &singleMsg : preProcessReqMsgs) {
-    LOG_DEBUG(logger(),
-              "Start handling single message from the batch:" << KVLOG(
-                  batchCid, singleMsg->reqSeqNum(), singleMsg->getCid(), senderId, clientId, batchSize));
-    handleSinglePreProcessRequestMsg(singleMsg, batchCid, batchSize);
-  }
-  if (batchMsg->reqType() == REQ_TYPE_CANCEL && !ongoingReqBatches_[clientId]->isBatchInProcess())
+  if (batchMsg->reqType() == REQ_TYPE_CANCEL && !ongoingReqBatches_[clientId]->isBatchInProcess()) {
     // Don't cancel the batch if it has received PreProcessBatchRequestMsg before
     ongoingReqBatches_[clientId]->cancelBatchAndReleaseRequests(batchCid, CANCELLED_BY_PRIMARY);
+    return;
+  }
+
+  if (!ongoingReqBatches_[clientId]->isBatchInProcess()) {
+    for (auto &singleMsg : preProcessReqMsgs) {
+      LOG_DEBUG(logger(),
+                "Start handling single message from the batch"
+                    << KVLOG(batchCid, singleMsg->reqSeqNum(), singleMsg->getCid(), senderId, clientId, batchSize));
+      handleSinglePreProcessRequestMsg(singleMsg, batchCid, batchSize);
+    }
+  } else
+    LOG_INFO(logger(), "The batch is in process; ignore the message" << KVLOG(batchCid, senderId, clientId, batchSize));
 }
 
 void PreProcessor::handleSinglePreProcessRequestMsg(PreProcessRequestMsgSharedPtr preProcessReqMsg,

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -88,7 +88,6 @@ class RequestsBatch {
   void finalizeBatchIfCompleted();
   void handlePossiblyExpiredRequests();
   void sendCancelBatchedPreProcessingMsgToNonPrimaries(const ClientMsgsList &clientMsgs, NodeIdType destId);
-  void updateRegisteredBatchIfNeeded(const std::string &batchCid, const PreProcessReqMsgsList &preProcessReqs);
   uint64_t getBlockId() const { return cidToBlockid_.second; }
 
  private:


### PR DESCRIPTION
In the case of batch retransmission, the primary could identify that some of the batched requests have been pre-processed already and are in process in ReplicaImp. In this case, it removes them from the original batch and sends to the non-primaries decreased number of requests to pre-process again.
In case some non-primary replica is still processing the batch sent the first time, we should give it to complete processing, otherwise, we have a mess between old and new requests.
What’s for sure is that we cannot release requests that are not a part of a new primary batch request, but are in progress, as this causes replica to crash. The fix is to ignore a newly arrived batch on a non-primary replica when it has not completed the original batch yet.
