### PR TITLE
Potential fix for a replica crash in case of incorrect memory release

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -88,7 +88,6 @@ class RequestsBatch {
   void finalizeBatchIfCompleted();
   void handlePossiblyExpiredRequests();
   void sendCancelBatchedPreProcessingMsgToNonPrimaries(const ClientMsgsList &clientMsgs, NodeIdType destId);
-  void updateRegisteredBatchIfNeeded(const std::string &batchCid, const PreProcessReqMsgsList &preProcessReqs);
   uint64_t getBlockId() const { return cidToBlockid_.second; }
 
  private:


### PR DESCRIPTION
cherry-pick for 123e9ca1552356975ba4b5bbd213c850d7e9b704
In the case of batch retransmission, the primary could identify that some of the batched requests have been pre-processed already and are in process in ReplicaImp. In this case, it removes them from the original batch and sends to the non-primaries decreased number of requests to pre-process again.
In case some non-primary replica is still processing the batch sent the first time, we should give it to complete processing, otherwise, we have a mess between old and new requests.
What’s for sure is that we cannot release requests that are not a part of a new primary batch request, but are in progress, as this causes replica to crash. The fix is to ignore a newly arrived batch on a non-primary replica when it has not completed the original batch yet.