### PR TITLE
Fix for data race in ClientsManager.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1519,8 +1519,8 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
     return finishExecutePrePrepareMsg(t->prePrepareMsg, t->pAccumulatedRequests);
   }
 
-  if (auto *t = std::get_if<RemovePendingForExecutionRequest>(&msg)) {
-    clientsManager->removePendingForExecutionRequest(t->clientProxyId, t->requestSeqNum);
+  if (auto *rpferMsg = std::get_if<RemovePendingForExecutionRequest>(&msg)) {
+    clientsManager->removePendingForExecutionRequest(rpferMsg->clientProxyId, rpferMsg->requestSeqNum);
     return;
   }
 

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1519,6 +1519,11 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
     return finishExecutePrePrepareMsg(t->prePrepareMsg, t->pAccumulatedRequests);
   }
 
+  if (auto *t = std::get_if<RemovePendingForExecutionRequest>(&msg)) {
+    clientsManager->removePendingForExecutionRequest(t->clientProxyId, t->requestSeqNum);
+    return;
+  }
+
   // Handle vaidated messages
   if (auto *vldMsg = std::get_if<CarrierMesssage *>(&msg)) {
     return onCarrierMessage(*vldMsg);
@@ -4989,7 +4994,8 @@ void ReplicaImp::executeRequests(PrePrepareMsg *ppMsg, Bitmap &requestSet, Times
     ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
 
     if (!requestSet.get(tmp) || req.requestLength() == 0) {
-      clientsManager->removePendingForExecutionRequest(req.clientProxyId(), req.requestSeqNum());
+      InternalMessage im = RemovePendingForExecutionRequest{req.clientProxyId(), req.requestSeqNum()};
+      getIncomingMsgsStorage().pushInternalMsg(std::move(im));
       continue;
     }
 

--- a/bftengine/src/bftengine/messages/InternalMessage.hpp
+++ b/bftengine/src/bftengine/messages/InternalMessage.hpp
@@ -24,6 +24,7 @@
 #include "messages/PrePrepareCarrierInternalMsg.hpp"
 #include "messages/ValidatedMessageCarrierInternalMsg.hpp"
 #include "messages/FinishPrePrepareExecutionInternalMsg.hpp"
+#include "messages/RemovePendingForExecutionRequest.hpp"
 #include "IRequestHandler.hpp"
 
 namespace bftEngine::impl {
@@ -85,6 +86,7 @@ using InternalMessage = std::variant<FullCommitProofMsg*,
                                      // post execution defer related
                                      OnStateTransferCompleteMsg,
 
-                                     FinishPrePrepareExecutionInternalMsg>;
+                                     FinishPrePrepareExecutionInternalMsg,
+                                     RemovePendingForExecutionRequest>;
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/messages/RemovePendingForExecutionRequest.hpp
+++ b/bftengine/src/bftengine/messages/RemovePendingForExecutionRequest.hpp
@@ -1,0 +1,25 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <cstdint>
+#include "IRequestHandler.hpp"
+
+namespace bftEngine::impl {
+
+struct RemovePendingForExecutionRequest {
+  uint16_t clientProxyId;
+  ReqId requestSeqNum;
+  RemovePendingForExecutionRequest(uint16_t cpid, ReqId rsn) : clientProxyId{cpid}, requestSeqNum{rsn} {}
+};
+
+}  // namespace bftEngine::impl


### PR DESCRIPTION
executeRequests method is now being called from threads
different than the message processing thread. This causes
multi threaded read/write access to the requestsInfo data
structures in ClientsManager, which eventually leads to
data corruption.
The proposed fix posts an internal message to the message
processing thread to clean up the given client request
thus maintaining the read/write access to 1 thread.