### PR TITLE
Read event groups from live update queue correctly

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -131,8 +131,7 @@ class KvbAppFilter {
   KvbFilteredUpdate filterUpdate(const KvbUpdate &update);
 
   // Filter event groups
-  std::optional<KvbFilteredEventGroupUpdate> filterEventGroupUpdate(const EgUpdate &update,
-                                                                    const uint64_t next_ext_eg_id);
+  std::optional<KvbFilteredEventGroupUpdate> filterEventGroupUpdate(const EgUpdate &update);
   KvbFilteredEventGroupUpdate::EventGroup filterEventsInEventGroup(kvbc::EventGroupId event_group_id,
                                                                    const kvbc::categorization::EventGroup &event_group);
   // Compute hash for the given update
@@ -178,9 +177,9 @@ class KvbAppFilter {
 
   TagTableValue getValueFromTagTable(const std::string &key) const;
 
-  uint64_t oldestExternalTagSpecificEventGroupId() const;
+  uint64_t oldestExternalEventGroupId() const;
 
-  uint64_t newestExternalTagSpecificEventGroupId() const;
+  uint64_t newestExternalEventGroupId() const;
 
   // Given a tag-specific public (external) event group id, return the corresponding global event group id
   // Precondition: We expect that the requested external event group id exists in storage
@@ -204,17 +203,13 @@ class KvbAppFilter {
   // Optional because during start-up there might be no block/event group written yet.
   std::optional<BlockId> getOldestEventGroupBlockId();
 
-  // set external event group ID to start reading from
   void setNextExternalEgIdToRead(uint64_t ext_eg_id);
 
-  // get external event group ID to start reading from
   uint64_t getNextExternalEgIdToRead() const;
 
-  // set last global event group ID read
-  void setLastGlobalEgIdRead(uint64_t global_eg_id);
+  void setLastGlobalEgIdReadForClient(uint64_t global_eg_id);
 
-  // get last global event group ID read
-  uint64_t getLastGlobalEgIdRead() const;
+  uint64_t getLastGlobalEgIdReadForClient() const;
 
  public:
   static inline const std::string kGlobalEgIdKeyOldest{"_global_eg_id_oldest"};

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -131,7 +131,8 @@ class KvbAppFilter {
   KvbFilteredUpdate filterUpdate(const KvbUpdate &update);
 
   // Filter event groups
-  KvbFilteredEventGroupUpdate filterEventGroupUpdate(const EgUpdate &update);
+  std::optional<KvbFilteredEventGroupUpdate> filterEventGroupUpdate(const EgUpdate &update,
+                                                                    const uint64_t next_ext_eg_id);
   KvbFilteredEventGroupUpdate::EventGroup filterEventsInEventGroup(kvbc::EventGroupId event_group_id,
                                                                    const kvbc::categorization::EventGroup &event_group);
   // Compute hash for the given update
@@ -189,7 +190,7 @@ class KvbAppFilter {
 
   // Return the oldest global event group id.
   // If no event group can be found then 0 (invalid group id) is returned.
-  uint64_t getOldestEventGroupId() const;
+  uint64_t getOldestGlobalEventGroupId() const;
 
   // Return the ID of the newest public event group.
   // If no event group can be found, then 0 is returned.
@@ -203,8 +204,21 @@ class KvbAppFilter {
   // Optional because during start-up there might be no block/event group written yet.
   std::optional<BlockId> getOldestEventGroupBlockId();
 
+  // set external event group ID to start reading from
+  void setNextExternalEgIdToRead(uint64_t ext_eg_id);
+
+  // get external event group ID to start reading from
+  uint64_t getNextExternalEgIdToRead() const;
+
+  // set last global event group ID read
+  void setLastGlobalEgIdRead(uint64_t global_eg_id);
+
+  // get last global event group ID read
+  uint64_t getLastGlobalEgIdRead() const;
+
  public:
   static inline const std::string kGlobalEgIdKeyOldest{"_global_eg_id_oldest"};
+  static inline const std::string kGlobalEgIdKeyNewest{"_global_eg_id_newest"};
   static inline const std::string kPublicEgIdKeyOldest{"_public_eg_id_oldest"};
   static inline const std::string kPublicEgIdKeyNewest{"_public_eg_id_newest"};
   static inline const std::string kPublicEgId{"_public_eg_id"};
@@ -217,6 +231,11 @@ class KvbAppFilter {
   logging::Logger logger_;
   const concord::kvbc::IReader *rostorage_{nullptr};
   const std::string client_id_;
+
+  // next external event group ID to be read
+  uint64_t next_ext_eg_id_to_read_{0};
+  // last global event group ID read
+  uint64_t last_global_eg_id_read_{0};
 };
 
 }  // namespace kvbc

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -177,9 +177,9 @@ class KvbAppFilter {
 
   TagTableValue getValueFromTagTable(const std::string &key) const;
 
-  uint64_t oldestTagSpecificPublicEventGroupId() const;
+  uint64_t oldestExternalTagSpecificEventGroupId() const;
 
-  uint64_t newestTagSpecificPublicEventGroupId() const;
+  uint64_t newestExternalTagSpecificEventGroupId() const;
 
   // Given a tag-specific public (external) event group id, return the corresponding global event group id
   // Precondition: We expect that the requested external event group id exists in storage

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -334,7 +334,7 @@ TagTableValue KvbAppFilter::getValueFromTagTable(const std::string &key) const {
 
 // This function returns the oldest tag-specific public event group id that the user can request.
 // Due to pruning, it depends on the oldest public event group and the oldest tag-specific event group available.
-uint64_t KvbAppFilter::oldestTagSpecificPublicEventGroupId() const {
+uint64_t KvbAppFilter::oldestExternalTagSpecificEventGroupId() const {
   uint64_t public_oldest = getValueFromLatestTable(kPublicEgIdKeyOldest);
   uint64_t private_oldest = getValueFromLatestTable(client_id_ + "_oldest");
   if (!public_oldest && !private_oldest) return 0;
@@ -348,7 +348,7 @@ uint64_t KvbAppFilter::oldestTagSpecificPublicEventGroupId() const {
 
 // This function returns the newest tag-specific public event group id that the user can request.
 // Note that newest tag-specific event group ids will not be updated by pruning
-uint64_t KvbAppFilter::newestTagSpecificPublicEventGroupId() const {
+uint64_t KvbAppFilter::newestExternalTagSpecificEventGroupId() const {
   uint64_t public_newest = getValueFromLatestTable(kPublicEgIdKeyNewest);
   uint64_t private_newest = getValueFromLatestTable(client_id_ + "_newest");
   return public_newest + private_newest;

--- a/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
+++ b/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
@@ -601,7 +601,7 @@ TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pvt) {
   auto kvb_filter = KvbAppFilter(&storage, client_id);
   size_t num_event_groups_to_fill = 5;
   storage.fillWithEventGroupData(num_event_groups_to_fill, client_id);
-  EXPECT_EQ(kvb_filter.oldestTagSpecificPublicEventGroupId(), 1);
+  EXPECT_EQ(kvb_filter.oldestExternalTagSpecificEventGroupId(), 1);
 }
 
 TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pub) {
@@ -610,7 +610,7 @@ TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pub) {
   auto kvb_filter = KvbAppFilter(&storage, client_id);
   size_t num_event_groups_to_fill = 5;
   storage.fillWithEventGroupData(num_event_groups_to_fill, kPublicEgIdKey);
-  EXPECT_EQ(kvb_filter.oldestTagSpecificPublicEventGroupId(), 1);
+  EXPECT_EQ(kvb_filter.oldestExternalTagSpecificEventGroupId(), 1);
 }
 
 TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pvt_pub) {
@@ -620,7 +620,7 @@ TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pvt_pub) {
   size_t num_event_groups_to_fill = 5;
   storage.fillWithEventGroupData(num_event_groups_to_fill, client_id);
   storage.fillWithEventGroupData(num_event_groups_to_fill, kPublicEgIdKey);
-  EXPECT_EQ(kvb_filter.oldestTagSpecificPublicEventGroupId(), 1);
+  EXPECT_EQ(kvb_filter.oldestExternalTagSpecificEventGroupId(), 1);
 }
 
 TEST(kvbc_filter_test, kvbfilter_start_block_greater_then_end_block) {

--- a/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
+++ b/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
@@ -336,12 +336,13 @@ TEST(kvbc_filter_test, kvbfilter_update_success_eg) {
   event2.tags = {"0"};
   event_group.events.emplace_back(event1);
   event_group.events.emplace_back(event2);
+  const auto next_ext_eg_id = EventGroupId{1};
+  const auto &filtered = kvb_filter.filterEventGroupUpdate({eg_id, event_group}, next_ext_eg_id);
 
-  const auto &filtered = kvb_filter.filterEventGroupUpdate({eg_id, event_group});
-
-  EXPECT_EQ(filtered.event_group_id, eg_id);
-  EXPECT_EQ(filtered.event_group.events.size(), 1);
-  EXPECT_EQ(filtered.event_group.events[0].data, "TridVal1");
+  EXPECT_TRUE(filtered.has_value());
+  EXPECT_EQ(filtered.value().event_group_id, eg_id);
+  EXPECT_EQ(filtered.value().event_group.events.size(), 1);
+  EXPECT_EQ(filtered.value().event_group.events[0].data, "TridVal1");
 }
 
 TEST(kvbc_filter_test, kvbfilter_update_message_empty_prefix) {
@@ -819,13 +820,14 @@ TEST(kvbc_filter_test, kvbfilter_success_hash_of_event_group) {
   EventGroupId eg_id_start = 1;
 
   auto hash_value = kvb_filter.readEventGroupHash(eg_id_start);
-  const auto &[eg_id, filtered] = kvb_filter.filterEventGroupUpdate(storage.eg_data_[0]);
-
-  EXPECT_EQ(eg_id, 1);
+  const auto next_ext_eg_id = EventGroupId{1};
+  const auto &filtered = kvb_filter.filterEventGroupUpdate(storage.eg_data_[0], next_ext_eg_id);
+  EXPECT_TRUE(filtered.has_value());
+  EXPECT_EQ(filtered.value().event_group_id, 1);
   std::string concatenated_entry_hashes;
-  concatenated_entry_hashes += blockIdToByteStringLittleEndian(eg_id);
+  concatenated_entry_hashes += blockIdToByteStringLittleEndian(filtered.value().event_group_id);
   std::set<std::string> entry_hashes;
-  for (const auto &event : filtered.events) {
+  for (const auto &event : filtered.value().event_group.events) {
     entry_hashes.emplace(computeSHA256Hash(event.data));
   }
   for (const auto &event_hash : entry_hashes) {

--- a/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
+++ b/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
@@ -336,8 +336,7 @@ TEST(kvbc_filter_test, kvbfilter_update_success_eg) {
   event2.tags = {"0"};
   event_group.events.emplace_back(event1);
   event_group.events.emplace_back(event2);
-  const auto next_ext_eg_id = EventGroupId{1};
-  const auto &filtered = kvb_filter.filterEventGroupUpdate({eg_id, event_group}, next_ext_eg_id);
+  const auto &filtered = kvb_filter.filterEventGroupUpdate({eg_id, event_group});
 
   EXPECT_TRUE(filtered.has_value());
   EXPECT_EQ(filtered.value().event_group_id, eg_id);
@@ -602,7 +601,7 @@ TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pvt) {
   auto kvb_filter = KvbAppFilter(&storage, client_id);
   size_t num_event_groups_to_fill = 5;
   storage.fillWithEventGroupData(num_event_groups_to_fill, client_id);
-  EXPECT_EQ(kvb_filter.oldestExternalTagSpecificEventGroupId(), 1);
+  EXPECT_EQ(kvb_filter.oldestExternalEventGroupId(), 1);
 }
 
 TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pub) {
@@ -611,7 +610,7 @@ TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pub) {
   auto kvb_filter = KvbAppFilter(&storage, client_id);
   size_t num_event_groups_to_fill = 5;
   storage.fillWithEventGroupData(num_event_groups_to_fill, kPublicEgIdKey);
-  EXPECT_EQ(kvb_filter.oldestExternalTagSpecificEventGroupId(), 1);
+  EXPECT_EQ(kvb_filter.oldestExternalEventGroupId(), 1);
 }
 
 TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pvt_pub) {
@@ -621,7 +620,7 @@ TEST(kvbc_filter_test, kvbfilter_get_oldest_tag_specific_eg_id_pvt_pub) {
   size_t num_event_groups_to_fill = 5;
   storage.fillWithEventGroupData(num_event_groups_to_fill, client_id);
   storage.fillWithEventGroupData(num_event_groups_to_fill, kPublicEgIdKey);
-  EXPECT_EQ(kvb_filter.oldestExternalTagSpecificEventGroupId(), 1);
+  EXPECT_EQ(kvb_filter.oldestExternalEventGroupId(), 1);
 }
 
 TEST(kvbc_filter_test, kvbfilter_start_block_greater_then_end_block) {
@@ -820,8 +819,7 @@ TEST(kvbc_filter_test, kvbfilter_success_hash_of_event_group) {
   EventGroupId eg_id_start = 1;
 
   auto hash_value = kvb_filter.readEventGroupHash(eg_id_start);
-  const auto next_ext_eg_id = EventGroupId{1};
-  const auto &filtered = kvb_filter.filterEventGroupUpdate(storage.eg_data_[0], next_ext_eg_id);
+  const auto &filtered = kvb_filter.filterEventGroupUpdate(storage.eg_data_[0]);
   EXPECT_TRUE(filtered.has_value());
   EXPECT_EQ(filtered.value().event_group_id, 1);
   std::string concatenated_entry_hashes;

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -308,7 +308,7 @@ class ThinReplicaImpl {
     if (is_event_group_transition) {
       // For an event group transition we need to check if the first/oldest tag-specific event group is available. If
       // not then we wait because it is similar to waiting for X+1 whereby X is 0.
-      auto oldest_eg_id = kvb_filter->oldestExternalTagSpecificEventGroupId();
+      auto oldest_eg_id = kvb_filter->oldestExternalEventGroupId();
       while (not oldest_eg_id) {
         auto has_update = live_updates->waitForEventGroupUntilNonEmpty(kWaitForUpdateTimeout);
         if (context->IsCancelled()) {
@@ -318,12 +318,12 @@ class ThinReplicaImpl {
         }
         if (has_update) {
           // If there was an update for us then we must have updated storage
-          oldest_eg_id = kvb_filter->oldestExternalTagSpecificEventGroupId();
+          oldest_eg_id = kvb_filter->oldestExternalEventGroupId();
         }
       }
     } else if (request->has_event_groups()) {
       auto requested_eg_id = request->event_groups().event_group_id();
-      auto newest_eg_id = kvb_filter->newestExternalTagSpecificEventGroupId();
+      auto newest_eg_id = kvb_filter->newestExternalEventGroupId();
       // We already know that the request is valid hence the requested id can only be newest + 1 or less
       while (newest_eg_id < requested_eg_id) {
         auto has_update = live_updates->waitForEventGroupUntilNonEmpty(kWaitForUpdateTimeout);
@@ -334,7 +334,7 @@ class ThinReplicaImpl {
         }
         if (has_update) {
           // If there was an update for us then we must have updated storage
-          newest_eg_id = kvb_filter->newestExternalTagSpecificEventGroupId();
+          newest_eg_id = kvb_filter->newestExternalEventGroupId();
         }
       }
     } else {
@@ -432,7 +432,7 @@ class ThinReplicaImpl {
       ConcordAssert(request->has_events());
       // We assume that the caller wants updates but we cannot determine the event group id the caller is looking for.
       // Therefore, we start at the beginning.
-      event_group_id = kvb_filter->oldestExternalTagSpecificEventGroupId();
+      event_group_id = kvb_filter->oldestExternalEventGroupId();
       // If an event group transition is happening then we already confirmed that event groups are available.
       ConcordAssertNE(event_group_id, 0);
       LOG_INFO(logger_, "Legacy event request will receive event groups starting at id " << event_group_id);
@@ -470,20 +470,21 @@ class ThinReplicaImpl {
         if (not is_update_available) {
           continue;
         }
-        auto last_global_eg_id_read = kvb_filter->getLastGlobalEgIdRead();
-        if (sub_eg_update.event_group_id <= last_global_eg_id_read) {
-          continue;
-        }
+        auto last_global_eg_id_read = kvb_filter->getLastGlobalEgIdReadForClient();
+        // Event group read from live update queue should always be greater than last global event group ID read and
+        // sent
+        ConcordAssertGT(sub_eg_update.event_group_id, last_global_eg_id_read);
 
         auto eg_update = kvbc::EgUpdate{sub_eg_update.event_group_id, std::move(sub_eg_update.event_group)};
 
         auto next_ext_eg_id = kvb_filter->getNextExternalEgIdToRead();
-        const auto& filtered_eg_update = kvb_filter->filterEventGroupUpdate(eg_update, next_ext_eg_id);
+        auto filtered_eg_update = kvb_filter->filterEventGroupUpdate(eg_update);
         if (!filtered_eg_update) {
           continue;
         }
-        kvb_filter->setNextExternalEgIdToRead(++next_ext_eg_id);
-        kvb_filter->setLastGlobalEgIdRead(sub_eg_update.event_group_id);
+        // Overwrite event group ID in the filtered update to external event group ID
+        // We don't want to expose the global event group ID to the client
+        filtered_eg_update.value().event_group_id = next_ext_eg_id;
 
         if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
           //  auto correlation_id = filtered_update.correlation_id; (TODO (Shruti) - Get correlation ID)
@@ -493,6 +494,10 @@ class ThinReplicaImpl {
                              filtered_eg_update.value().event_group_id,
                              kvb_filter->hashEventGroupUpdate(filtered_eg_update.value()));
         }
+
+        kvb_filter->setNextExternalEgIdToRead(++next_ext_eg_id);
+        kvb_filter->setLastGlobalEgIdReadForClient(sub_eg_update.event_group_id);
+
         metrics_.last_sent_event_group_id.Get().Set(filtered_eg_update.value().event_group_id);
         if (++update_aggregator_counter == config_->update_metrics_aggregator_thresh) {
           metrics_.updateAggregator();
@@ -536,7 +541,7 @@ class ThinReplicaImpl {
       }
     } else {
       // Determine latest event group available
-      auto last_eg_id = kvb_filter->newestExternalTagSpecificEventGroupId();
+      auto last_eg_id = kvb_filter->newestExternalEventGroupId();
       if (request->event_groups().event_group_id() > last_eg_id + 1) {
         return true;
       }
@@ -557,8 +562,8 @@ class ThinReplicaImpl {
       }
     } else {
       // Determine oldest event group available (pruning)
-      auto first_eg_id = kvb_filter->oldestExternalTagSpecificEventGroupId();
-      auto last_eg_id = kvb_filter->newestExternalTagSpecificEventGroupId();
+      auto first_eg_id = kvb_filter->oldestExternalEventGroupId();
+      auto last_eg_id = kvb_filter->newestExternalEventGroupId();
       if (request->event_groups().event_group_id() < first_eg_id || (last_eg_id && !first_eg_id)) {
         msg << "Event group ID " << request->event_groups().event_group_id() << " has been pruned."
             << " First event_group_id is " << first_eg_id;
@@ -906,8 +911,8 @@ class ThinReplicaImpl {
                               std::shared_ptr<SubUpdateBuffer>& live_updates,
                               ServerWriterT* stream,
                               std::shared_ptr<kvbc::KvbAppFilter>& kvb_filter) {
-    auto first_eg_id = kvb_filter->oldestExternalTagSpecificEventGroupId();
-    auto end = kvb_filter->newestExternalTagSpecificEventGroupId();
+    auto first_eg_id = kvb_filter->oldestExternalEventGroupId();
+    auto end = kvb_filter->newestExternalEventGroupId();
     if (start < first_eg_id || (end && !first_eg_id)) {
       std::stringstream msg;
       msg << "Requested event group ID: " << start
@@ -928,8 +933,8 @@ class ThinReplicaImpl {
     LOG_INFO(logger_, "Sync reading event groups from KVB [" << start << ", " << end << "]");
     readAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(logger_, context, stream, start, end, kvb_filter);
 
-    auto last_global_eg_id_read = kvb_filter->getLastGlobalEgIdRead();
-    auto newest_eg_id = kvb_filter->newestExternalTagSpecificEventGroupId();
+    auto last_global_eg_id_read = kvb_filter->getLastGlobalEgIdReadForClient();
+    uint64_t newest_eg_id = 0;
     // Let's wait until we have at least one live update for the requesting client
     bool is_update_available = false;
     while (not is_update_available) {
@@ -938,10 +943,9 @@ class ThinReplicaImpl {
         throw StreamCancelled("StreamCancelled while waiting for the first live update");
       }
       if (is_update_available) {
-        newest_eg_id = kvb_filter->newestExternalTagSpecificEventGroupId();
+        newest_eg_id = kvb_filter->newestExternalEventGroupId();
         // There are two scenarios in which updates will be dropped from the live-update-queue
-        // 1. If the oldest global-eg-id on the live-update-queue is less than the next global-eg-id to be read
-        // (corresponds to external-eg-id `end+1`)
+        // 1. If the oldest global-eg-id on the live-update-queue is less than last_global_eg_id_read + 1
         // 2. If the update available on the live-update-queue is for another client (i.e., newest_eg_id in storage is
         // less than the next expected external-eg-id)
         if (live_updates->oldestEventGroupId() < last_global_eg_id_read + 1 || (newest_eg_id < end + 1)) {
@@ -954,6 +958,15 @@ class ThinReplicaImpl {
     ConcordAssertGE(newest_eg_id, end + 1);
     ConcordAssertGT(live_updates->oldestEventGroupId(), last_global_eg_id_read);
     auto global_eg_id_to_read = kvb_filter->findGlobalEventGroupId(end + 1).global_id;
+    while (live_updates->oldestEventGroupId() < global_eg_id_to_read) {
+      // Drop updates from the live-update-queue if the oldest global-eg-id on the live-update-queue is less than the
+      // next global-eg-id to be read (corresponds to external-eg-id `end+1`)
+      SubEventGroupUpdate sub_eg_update;
+      live_updates->PopEventGroup(sub_eg_update);
+      if (live_updates->EmptyEventGroupQueue()) {
+        is_update_available = live_updates->waitForEventGroupUntilNonEmpty(kWaitForUpdateTimeout);
+      }
+    }
     // We are in sync already if the oldest event global-eg-id on live_updates is same as next global_eg_id_to_read
     if (live_updates->oldestEventGroupId() == global_eg_id_to_read) {
       ConcordAssertGE(global_eg_id_to_read, live_updates->oldestEventGroupId());
@@ -968,15 +981,15 @@ class ThinReplicaImpl {
     // create an overlap between what we read from KVB and what is currently in
     // the live updates.
     if (live_updates->oldestEventGroupId() > global_eg_id_to_read) {
-      ConcordAssertGT(kvb_filter->newestExternalTagSpecificEventGroupId(), end + 1);
+      ConcordAssertGT(kvb_filter->newestExternalEventGroupId(), end + 1);
       start = end + 1;
-      end = kvb_filter->newestExternalTagSpecificEventGroupId();
+      end = kvb_filter->newestExternalEventGroupId();
 
       LOG_INFO(logger_, "Sync filling gap [" << start << ", " << end << "]");
       readAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(logger_, context, stream, start, end, kvb_filter);
     }
 
-    last_global_eg_id_read = kvb_filter->getLastGlobalEgIdRead();
+    last_global_eg_id_read = kvb_filter->getLastGlobalEgIdReadForClient();
     // Overlap:
     // If we read updates from KVB that were added to the live updates already
     // then we just need to drop the overlap and return

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -753,9 +753,8 @@ TEST(thin_replica_server_test, SubscribeToUpdatesAlreadySynced) {
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesAlreadySynced) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -797,9 +796,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesAlreadySynced)
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesAlreadySyncedTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -843,9 +841,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesAlreadySyncedT
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesAlreadySynced) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -887,9 +884,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesAlreadySynced) 
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesAlreadySyncedTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -933,9 +929,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesAlreadySyncedTw
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesAlreadySynced) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -977,9 +972,8 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesAlrea
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesAlreadySyncedTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -1047,9 +1041,8 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGap) {
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGap) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -1091,9 +1084,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGap) {
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGapTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -1142,9 +1134,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGapTwoClie
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGap) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -1186,9 +1177,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGap) {
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGapTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -1237,9 +1227,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGapTwoClien
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithGap) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -1281,9 +1270,8 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithG
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithGapTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
@@ -1356,9 +1344,8 @@ TEST(thin_replica_server_test, SubscribeToUpdatesWithGapFromTheMiddleBlock) {
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGapFromTheMiddleBlock) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId);
-  TestStateMachine<Data> state_machine{storage, live_updates, 3, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 3, true};
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
 
@@ -1401,9 +1388,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGapFromThe
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGapFromTheMiddleBlock) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId);
-  TestStateMachine<Data> state_machine{storage, live_updates, 3, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 3, true};
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
 
@@ -1446,9 +1432,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGapFromTheM
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithGapFromTheMiddleBlock) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId);
-  TestStateMachine<Data> state_machine{storage, live_updates, 3, true};
+  TestStateMachine<Data> state_machine{storage, storage_egs, 3, true};
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};
 
@@ -1515,9 +1500,8 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesAlreadySynced) {
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesAlreadySynced) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1559,9 +1543,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesAlreadySy
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesAlreadySyncedTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1605,9 +1588,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesAlreadySy
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesAlreadySynced) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1649,9 +1631,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesAlreadySyn
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesAlreadySyncedTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1695,9 +1676,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesAlreadySyn
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashesAlreadySynced) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1739,9 +1719,8 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashes
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashesAlreadySyncedTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1809,9 +1788,8 @@ TEST(thin_replica_server_test, SubscribeToUpdateHashesWithGap) {
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesWithGap) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1853,9 +1831,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesWithGap) 
 TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesWithGapTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1904,9 +1881,8 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesWithGapTw
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesWithGap) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1948,9 +1924,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesWithGap) {
 TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesWithGapTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicEventGroupsOnly;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -1999,9 +1974,8 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesWithGapTwo
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashesWithGap) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -2043,9 +2017,8 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashes
 TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashesWithGapTwoClients) {
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 5, EventGroupType::PublicAndPrivateEventGroups));
   auto storage_egs = storage.getEventGroups();
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 5);
-  TestStateMachine<Hash> state_machine{storage, live_updates, 1, true};
+  TestStateMachine<Hash> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PublicAndPrivateEventGroups;
   TestSubBufferList<Hash> buffer{state_machine};
   TestServerWriter<Hash> stream{state_machine};
@@ -2504,11 +2477,10 @@ TEST(thin_replica_server_test, SubscribeToUpdatesLegacyRequestEventGroups) {
   // Storage contains event groups only
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId + 10, EventGroupType::PrivateEventGroupsOnly));
   auto storage_egs = storage.getEventGroups();
-  // Live updates can contain event groups only
-  EventGroupMap live_updates = storage_egs;
   EXPECT_EQ(storage.getLastEventGroupId(), kLastEventGroupId + 10);
   EXPECT_EQ(storage.getOldestEventGroupBlockId(), 1);
-  TestStateMachine<Data> state_machine{storage, live_updates, 1, true};
+  // Live updates can contain event groups only (storage_egs = live_updates)
+  TestStateMachine<Data> state_machine{storage, storage_egs, 1, true};
   state_machine.current_eg_type = EventGroupType::PrivateEventGroupsOnly;
   TestSubBufferList<Data> buffer{state_machine};
   TestServerWriter<Data> stream{state_machine};


### PR DESCRIPTION
Previously, event groups consumed from live_updates were relayed to the client with the global event group ID instead of
external event group ID. Also, in sync and send event groups, to identify if live_updates had synced with storage, we were
incorrectly comparing global event group IDs with external event group IDs. This PR fixes these issues, and updates the unit tests to reflect the updated code.
Please see individual commits for more detail.