### PR TITLE
Remove view change desc in resetMetadata

### DIFF
--- a/bftengine/src/bftengine/DebugPersistentStorage.hpp
+++ b/bftengine/src/bftengine/DebugPersistentStorage.hpp
@@ -80,6 +80,9 @@ class DebugPersistentStorage : public PersistentStorage {
   void setNewEpochFlag(bool flag) override {}
   bool getNewEpochFlag() override { return false; };
 
+  void checkAndClearDescriptorOfLastExitFromView() override {}
+  void checkAndClearDescriptorOfLastNewView() override {}
+
  protected:
   bool setIsAllowed() const;
   bool getIsAllowed() const;

--- a/bftengine/src/bftengine/PersistentStorage.hpp
+++ b/bftengine/src/bftengine/PersistentStorage.hpp
@@ -125,6 +125,9 @@ class PersistentStorage {
 
   virtual bool setReplicaSpecificInfo(uint32_t index, const std::vector<uint8_t> &data) = 0;
 
+  virtual void checkAndClearDescriptorOfLastExitFromView() = 0;
+  virtual void checkAndClearDescriptorOfLastNewView() = 0;
+
   //////////////////////////////////////////////////////////////////////////
   // Read methods (should only be used before using write-only transactions)
   //////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -673,6 +673,46 @@ DescriptorOfLastNewView PersistentStorageImp::getAndAllocateDescriptorOfLastNewV
   }
   return dbDesc;
 }
+void PersistentStorageImp::checkAndClearDescriptorOfLastExitFromView() {
+  DescriptorOfLastExitFromView storedDesc;
+  const size_t simpleParamsSize = DescriptorOfLastExitFromView::simpleParamsSize();
+  uint32_t sizeInDb = 0;
+  UniquePtrToChar simpleParamsBuf(new char[simpleParamsSize]);
+  metadataStorage_->read(LAST_EXIT_FROM_VIEW_DESC, simpleParamsSize, simpleParamsBuf.get(), sizeInDb);
+  LOG_INFO(GL, "checkAndClearDescriptorOfLastExitFromView. " << KVLOG(simpleParamsSize, sizeInDb));
+  ConcordAssertGE(simpleParamsSize, sizeInDb);
+  uint32_t actualSize = 0;
+  storedDesc.deserializeSimpleParams(simpleParamsBuf.get(), simpleParamsSize, actualSize);
+  if (!storedDesc.isDefault) {
+    DescriptorOfLastExitFromView defaultDesc;
+    UniquePtrToChar simpleParamsNewBuf(new char[simpleParamsSize]);
+    memset(simpleParamsNewBuf.get(), 0, simpleParamsSize);
+    size_t sz = 0;
+    defaultDesc.serializeSimpleParams(simpleParamsNewBuf.get(), simpleParamsSize, sz);
+    metadataStorage_->writeInBatch(LAST_EXIT_FROM_VIEW_DESC, simpleParamsNewBuf.get(), sizeInDb);
+  }
+  storedDesc.clean();
+}
+void PersistentStorageImp::checkAndClearDescriptorOfLastNewView() {
+  DescriptorOfLastNewView storedDesc;
+  const size_t simpleParamsSize = DescriptorOfLastNewView::simpleParamsSize();
+  uint32_t sizeInDb = 0;
+  UniquePtrToChar simpleParamsBuf(new char[simpleParamsSize]);
+  metadataStorage_->read(LAST_NEW_VIEW_DESC, simpleParamsSize, simpleParamsBuf.get(), sizeInDb);
+  LOG_INFO(GL, "checkAndClearDescriptorOfLastNewView. " << KVLOG(simpleParamsSize, sizeInDb));
+  ConcordAssertGE(simpleParamsSize, sizeInDb);
+  uint32_t actualSize = 0;
+  storedDesc.deserializeSimpleParams(simpleParamsBuf.get(), simpleParamsSize, actualSize);
+  if (!storedDesc.isDefault) {
+    DescriptorOfLastNewView defaultDesc;
+    UniquePtrToChar simpleParamsNewBuf(new char[simpleParamsSize]);
+    size_t sz = 0;
+    defaultDesc.serializeSimpleParams(simpleParamsNewBuf.get(), simpleParamsSize, sz);
+    ConcordAssertLE(sz, sizeInDb);
+    metadataStorage_->writeInBatch(LAST_NEW_VIEW_DESC, simpleParamsNewBuf.get(), sz);
+  }
+  storedDesc.clean();
+}
 
 DescriptorOfLastExecution PersistentStorageImp::getDescriptorOfLastExecution() {
   DescriptorOfLastExecution dbDesc;

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -133,6 +133,8 @@ class PersistentStorageImp : public PersistentStorage {
   void setDescriptorOfLastNewView(const DescriptorOfLastNewView &prevViewDesc) override;
   void setDescriptorOfLastExecution(const DescriptorOfLastExecution &prevViewDesc) override;
   void setDescriptorOfLastStableCheckpoint(const DescriptorOfLastStableCheckpoint &stableCheckDesc) override;
+  void checkAndClearDescriptorOfLastExitFromView() override;
+  void checkAndClearDescriptorOfLastNewView() override;
 
   void setLastStableSeqNum(SeqNum seqNum) override;
   void setPrePrepareMsgInSeqNumWindow(SeqNum seqNum, PrePrepareMsg *msg) override;

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -896,6 +896,11 @@ struct ResetMetadata {
     using storage::v2MerkleTree::STKeyManipulator;
     using storage::v2MerkleTree::MetadataKeyManipulator;
     using bftEngine::MetadataStorage;
+    // Buffer size used to store descriptors for lastExitFromView and lastNewView
+    // is configurable. Here we use a large buffer to read the object from persistence
+    // and get the actual object size in the DB. This actual size is used to
+    // re-write the default descriptors in resetMeatadata
+    bftEngine::ReplicaConfig::instance().setmaxExternalMessageSize(33554432);
     std::unique_ptr<DataStore> ds = std::make_unique<DBDataStore>(
         adapter.db()->asIDBClient(), 1024 * 4, std::make_shared<STKeyManipulator>(), true);
 
@@ -942,6 +947,10 @@ struct ResetMetadata {
         }
       }
     }
+    p->checkAndClearDescriptorOfLastExitFromView();
+    p->checkAndClearDescriptorOfLastNewView();
+    p->setLastViewThatTransferredSeqNumbersFullyExecuted(0);
+    p->clearSeqNumWindow();
     p->endWriteTran();
     return toJson(result);
   }


### PR DESCRIPTION
On resetMetadata - we do not remove these two items: descriptorOfLastExitFromView, descriptorOfLastNewView
in case of cross-node restore, these descriptors are not relevant and can be removed. After restore, replica can sync its view from other replica via ReplicaStatus message