### PR TITLE
Downgrade hash stream closed message to WARN from ERROR

### DIFF
--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -364,6 +364,10 @@ class ThinReplicaImpl {
         LOG_WARN(logger_, "Requested update pruned in syncAndSend: " << error.what());
         CLEANUP_SUBSCRIPTION();
         return grpc::Status(grpc::StatusCode::NOT_FOUND, error.what());
+      } catch (StreamClosed& error) {
+        LOG_INFO(logger_, "StreamClosed in syncAndSend: " << error.what());
+        CLEANUP_SUBSCRIPTION();
+        return grpc::Status(grpc::StatusCode::CANCELLED, error.what());
       } catch (std::exception& error) {
         LOG_ERROR(logger_, error.what());
         CLEANUP_SUBSCRIPTION();
@@ -452,6 +456,10 @@ class ThinReplicaImpl {
       LOG_WARN(logger_, "Requested update pruned in syncAndSendEventGroups: " << error.what());
       CLEANUP_SUBSCRIPTION();
       return grpc::Status(grpc::StatusCode::NOT_FOUND, error.what());
+    } catch (StreamClosed& error) {
+      LOG_INFO(logger_, "StreamClosed in syncAndSendEventGroups: " << error.what());
+      CLEANUP_SUBSCRIPTION();
+      return grpc::Status(grpc::StatusCode::CANCELLED, error.what());
     } catch (std::exception& error) {
       LOG_ERROR(logger_, "Exception in syncAndSendEventGroups: " << error.what());
       CLEANUP_SUBSCRIPTION();


### PR DESCRIPTION
When TRC forces resubscription on one of the f+1 open streams
to not miss an update while receiving updates, it closes all
hash streams, this doesn't warrant an ERROR message on the TRS,
hence downgrading to WARN.