### PR TITLE
Add preformance duration metrics for 6 segments of a request flow

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -43,6 +43,7 @@
 #include "FakeClock.hpp"
 #include <ccron/ticks_generator.hpp>
 #include "EpochManager.hpp"
+#include "PerfMetrics.hpp"
 
 namespace preprocessor {
 class PreProcessResultMsg;
@@ -311,6 +312,9 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   CounterHandle metric_total_preexec_requests_executed_;
   CounterHandle metric_received_restart_ready_;
   CounterHandle metric_received_restart_proof_;
+  PerfMetric<uint64_t> metric_consensus_duration_;
+  PerfMetric<uint64_t> metric_post_exe_duration_;
+  PerfMetric<std::string> metric_primary_batching_duration_;
   //*****************************************************
   RollingAvgAndVar consensus_time_;
   RollingAvgAndVar accumulating_batch_time_;

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -309,6 +309,7 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
                            metricsComponent_.RegisterAtomicGauge("preProcessingTimeAvg", 0),
                            metricsComponent_.RegisterAtomicGauge("launchAsyncPreProcessJobTimeAvg", 0),
                            metricsComponent_.RegisterAtomicGauge("PreProcInFlyRequestsNum", 0)},
+      metric_pre_exe_duration_{metricsComponent_, "metric_pre_exe_duration_", 10000, true},
       totalPreProcessingTime_(true),
       launchAsyncJobTimeAvg_(true),
       preExecReqStatusCheckPeriodMilli_(myReplica_.getReplicaConfig().preExecReqStatusCheckTimerMillisec),
@@ -1299,6 +1300,11 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
       incomingMsgsStorage_->pushExternalMsg(move(preProcessMsg));
 
       releaseClientPreProcessRequest(reqEntry, COMPLETE);
+
+      if (myReplica_.isCurrentPrimary()) {
+        metric_pre_exe_duration_.finishMeasurement(cid);
+      }
+
       LOG_INFO(logger(), "Pre-processing completed for" << KVLOG(cid, batchCid, reqSeqNum, clientId, reqOffsetInBatch));
     }
   }
@@ -1472,6 +1478,10 @@ bool PreProcessor::registerRequestOnPrimaryReplica(const string &batchCid,
                                                    PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
                                                    uint16_t reqOffsetInBatch,
                                                    RequestStateSharedPtr reqEntry) {
+  if (myReplica_.isCurrentPrimary()) {
+    metric_pre_exe_duration_.addStartTimeStamp(clientReqMsg->getCid());
+  }
+
   (reqEntry->reqRetryId)++;
   countRetriedRequests(clientReqMsg, reqEntry);
   const auto reqSeqNum = clientReqMsg->requestSeqNum();
@@ -1500,7 +1510,7 @@ bool PreProcessor::registerRequestOnPrimaryReplica(const string &batchCid,
                                         clientReqMsg->result());
   const auto registerSucceeded =
       registerRequest(batchCid, batchSize, move(clientReqMsg), preProcessRequestMsg, reqOffsetInBatch);
-  if (registerSucceeded)
+  if (registerSucceeded) {
     LOG_INFO(logger(),
              "Start request processing by a primary replica" << KVLOG(reqSeqNum,
                                                                       batchCid,
@@ -1510,6 +1520,11 @@ bool PreProcessor::registerRequestOnPrimaryReplica(const string &batchCid,
                                                                       senderId,
                                                                       requestTimeoutMilli,
                                                                       blockId));
+  } else {
+    // delete this cid from time stamp map cause registration failed
+    metric_pre_exe_duration_.deleteSingleEntry(clientReqMsg->getCid());
+  }
+
   return registerSucceeded;
 }
 

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1478,8 +1478,11 @@ bool PreProcessor::registerRequestOnPrimaryReplica(const string &batchCid,
                                                    PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
                                                    uint16_t reqOffsetInBatch,
                                                    RequestStateSharedPtr reqEntry) {
+  // save in local var cause we might use it (for metrics) after clientReqMsg obj is moved
+  const std::string reqCid = clientReqMsg->getCid();
+
   if (myReplica_.isCurrentPrimary()) {
-    metric_pre_exe_duration_.addStartTimeStamp(clientReqMsg->getCid());
+    metric_pre_exe_duration_.addStartTimeStamp(reqCid);
   }
 
   (reqEntry->reqRetryId)++;
@@ -1522,7 +1525,7 @@ bool PreProcessor::registerRequestOnPrimaryReplica(const string &batchCid,
                                                                       blockId));
   } else {
     // delete this cid from time stamp map cause registration failed
-    metric_pre_exe_duration_.deleteSingleEntry(clientReqMsg->getCid());
+    metric_pre_exe_duration_.deleteSingleEntry(reqCid);
   }
 
   return registerSucceeded;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -33,6 +33,7 @@
 #include "SharedTypes.hpp"
 #include "RawMemoryPool.hpp"
 #include "GlobalData.hpp"
+#include "PerfMetrics.hpp"
 
 // TODO[TK] till boost upgrade
 #pragma GCC diagnostic push
@@ -353,6 +354,9 @@ class PreProcessor {
     concordMetrics::AtomicGaugeHandle launchAsyncPreProcessJobTimeAvg;
     concordMetrics::AtomicGaugeHandle preProcInFlyRequestsNum;
   } preProcessorMetrics_;
+
+  PerfMetric<std::string> metric_pre_exe_duration_;
+
   bftEngine::impl::RollingAvgAndVar totalPreProcessingTime_;
   bftEngine::impl::RollingAvgAndVar launchAsyncJobTimeAvg_;
   concordUtil::Timers::Handle requestsStatusCheckTimer_;

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -200,6 +200,8 @@ class ConcordClientPool {
     concordMetrics::GaugeHandle last_request_time_gauge;
     concordMetrics::GaugeHandle average_req_dur_gauge;
     concordMetrics::GaugeHandle average_batch_agg_dur_gauge;
+    concordMetrics::GaugeHandle average_cid_rcv_dur_gauge;
+    concordMetrics::GaugeHandle average_cid_finish_dur_gauge;
   } ClientPoolMetrics_;
 
   // Logger
@@ -211,6 +213,9 @@ class ConcordClientPool {
   std::unique_ptr<Timer_t> batch_timer_;
   bftEngine::impl::RollingAvgAndVar average_req_dur_;
   bftEngine::impl::RollingAvgAndVar batch_agg_dur_;
+  bftEngine::impl::RollingAvgAndVar average_cid_receive_dur_;
+  bftEngine::impl::RollingAvgAndVar average_cid_close_dur_;
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point> cid_arrival_map_;
 };
 
 class BatchRequestProcessingJob : public concord::util::SimpleThreadPool::Job {

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -74,6 +74,10 @@ class ConcordClient {
 
   std::chrono::steady_clock::time_point getStartRequestTime() const;
 
+  std::chrono::steady_clock::time_point getAndDeleteCidBeforeSendTime(const std::string& cid);
+
+  std::chrono::steady_clock::time_point getAndDeleteCidResponseTime(const std::string& cid);
+
   void setStartWaitingTime();
 
   std::chrono::steady_clock::time_point getWaitingTime() const;
@@ -134,6 +138,8 @@ class ConcordClient {
   PendingReplies pending_replies_;
   size_t batching_buffer_reply_offset_ = 0UL;
   bftEngine::OperationResult clientRequestExecutionResult_;
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point> cid_before_send_map_;
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point> cid_response_map_;
 };
 
 }  // namespace external_client

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -67,7 +67,9 @@ bft::client::Reply ConcordClient::SendRequest(const bft::client::WriteConfig& co
   bft::client::Reply res;
   clientRequestExecutionResult_ = OperationResult::SUCCESS;
   try {
+    cid_before_send_map_[config.request.correlation_id] = std::chrono::steady_clock::now();
     res = new_client_->send(config, std::move(request));
+    cid_response_map_[config.request.correlation_id] = std::chrono::steady_clock::now();
   } catch (const BadQuorumConfigException& e) {
     clientRequestExecutionResult_ = OperationResult::INVALID_REQUEST;
     LOG_ERROR(logger_, "Invalid write config: " << e.what());
@@ -88,7 +90,9 @@ bft::client::Reply ConcordClient::SendRequest(const bft::client::ReadConfig& con
   bft::client::Reply res;
   clientRequestExecutionResult_ = OperationResult::SUCCESS;
   try {
+    cid_before_send_map_[config.request.correlation_id] = std::chrono::steady_clock::now();
     res = new_client_->send(config, std::move(request));
+    cid_response_map_[config.request.correlation_id] = std::chrono::steady_clock::now();
   } catch (const BadQuorumConfigException& e) {
     clientRequestExecutionResult_ = OperationResult::INVALID_REQUEST;
     LOG_ERROR(logger_, "Invalid read config: " << e.what());
@@ -161,11 +165,13 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
     single_config.request.reconfiguration = req.flags & bftEngine::RECONFIG_FLAG_REQ;
     single_config.request.pre_execute = req.flags & bftEngine::PRE_PROCESS_REQ;
     request_queue.push_back(bft::client::WriteRequest{single_config, std::move(req.request)});
+    cid_before_send_map_[req.cid] = std::chrono::steady_clock::now();
   }
   try {
     auto res = new_client_->sendBatch(request_queue, batch_cid);
     for (const auto& rep : res) {
       auto cid = seq_num_to_cid.find(rep.first)->second;
+      cid_response_map_[cid] = std::chrono::steady_clock::now();
       auto data_size = rep.second.matched_data.size();
       for (auto& reply : pending_replies_) {
         if (reply.cid != cid) continue;
@@ -321,6 +327,18 @@ uint64_t ConcordClient::generateClientSeqNum() { return seqGen_->generateUniqueS
 void ConcordClient::setStartRequestTime() { start_job_time_ = std::chrono::steady_clock::now(); }
 
 std::chrono::steady_clock::time_point ConcordClient::getStartRequestTime() const { return start_job_time_; }
+
+std::chrono::steady_clock::time_point ConcordClient::getAndDeleteCidBeforeSendTime(const std::string& cid) {
+  auto time = cid_before_send_map_[cid];
+  cid_before_send_map_.erase(cid);
+  return time;
+}
+
+std::chrono::steady_clock::time_point ConcordClient::getAndDeleteCidResponseTime(const std::string& cid) {
+  auto time = cid_response_map_[cid];
+  cid_response_map_.erase(cid);
+  return time;
+}
 
 void ConcordClient::setStartWaitingTime() { waiting_job_time_ = std::chrono::steady_clock::now(); }
 

--- a/util/include/PerfMetrics.hpp
+++ b/util/include/PerfMetrics.hpp
@@ -1,0 +1,112 @@
+// Concord
+//
+// Copyright (c) 2019-2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <chrono>
+#include <variant>
+#include <mutex>
+
+#include "RollingAvgAndVar.hpp"
+#include "Metrics.hpp"
+#include "Logger.hpp"
+
+#define getMonotonicTime std::chrono::steady_clock::now
+
+using namespace std;
+using concordMetrics::GaugeHandle;
+using concordMetrics::AtomicGaugeHandle;
+using concordMetrics::Component;
+
+template <typename T>
+class PerfMetric {
+ public:
+  PerfMetric(Component& component, string name, uint64_t num_map_entries_for_reset, bool isThreadSafe)
+      : num_map_entries_for_reset_(num_map_entries_for_reset),
+        is_thread_safe_(isThreadSafe),
+        name_(name),
+        avg_{component.RegisterGauge(name + "Avg", 0)},
+        variance_{component.RegisterGauge(name + "Variance", 0)} {}
+
+  void addStartTimeStamp(const T& key) {
+    if (is_thread_safe_) {
+      lock_guard<mutex> lock(mutex_);
+      addStartTimeStampUnSafe(key);
+    } else {
+      addStartTimeStampUnSafe(key);
+    }
+  }
+
+  void finishMeasurement(const T& key) {
+    if (is_thread_safe_) {
+      lock_guard<mutex> lock(mutex_);
+      finishMeasurementUnSafe(key);
+    } else {
+      finishMeasurementUnSafe(key);
+    }
+  }
+
+  void deleteSingleEntry(const T& key) {
+    if (is_thread_safe_) {
+      lock_guard<mutex> lock(mutex_);
+      deleteSingleEntryUnSafe(key);
+    } else {
+      deleteSingleEntryUnSafe(key);
+    }
+  }
+
+  void reset() {
+    if (is_thread_safe_) {
+      lock_guard<mutex> lock(mutex_);
+      entries_.clear();
+    } else {
+      entries_.clear();
+    }
+  }
+
+ private:
+  void addStartTimeStampUnSafe(const T& key) {
+    if (entries_.count(key) == 0) {
+      entries_[key] = getMonotonicTime();
+    }
+  }
+  void finishMeasurementUnSafe(const T& key) {
+    if (entries_.count(key) != 0) {
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(getMonotonicTime() - entries_[key]).count();
+
+      avg_and_variance_.add(static_cast<double>(duration));
+
+      avg_.Get().Set(static_cast<uint64_t>(avg_and_variance_.avg()));
+      variance_.Get().Set(static_cast<uint64_t>(avg_and_variance_.var()));
+      entries_.erase(key);
+    }
+
+    if (entries_.size() > num_map_entries_for_reset_) {
+      reset();
+    }
+  }
+  void deleteSingleEntryUnSafe(const T& key) {
+    if (entries_.count(key) != 0) {
+      entries_.erase(key);
+    }
+  }
+
+  mutex mutex_;
+  uint64_t num_map_entries_for_reset_;
+  bool is_thread_safe_;
+  string name_;
+  bftEngine::impl::RollingAvgAndVar avg_and_variance_;
+  unordered_map<T, chrono::time_point<std::chrono::steady_clock>> entries_;
+  GaugeHandle avg_;
+  GaugeHandle variance_;
+};


### PR DESCRIPTION
6 duration measurements:

1. client processing before sending to replicas
2. pre exe
3. primary batching
4. consensus
5. post exe
6. client reply handling 