### PR TITLE
Deleting all dbcheckpoints when dbcheckpoint feature is disable

### DIFF
--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -133,7 +133,7 @@ void DbCheckpointManager::cleanUp() {
   // this gets called when db checkpoint is disabled
   // check if there is chkpt data in persistence
   loadCheckpointDataFromPersistence();
-  if (!maxNumOfCheckpoints_) {
+  if (!ReplicaConfig::instance().dbCheckpointFeatureEnabled || !maxNumOfCheckpoints_) {
     if (!dbCheckptMetadata_.dbCheckPoints_.empty()) {
       dbCheckptMetadata_.dbCheckPoints_.clear();
       updateDbCheckpointMetadata();

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -646,6 +646,7 @@ void Client::removeAllCheckpoints() const {
       for (const auto &entry : fs::directory_iterator(path)) {
         fs::remove_all(entry.path());
       }
+      fs::remove_all(path);
     }
   } catch (std::exception &e) {
     LOG_FATAL(logger(), "Failed remove rocksdb checkpoint: " << e.what());


### PR DESCRIPTION
Cherry-pick commit d4aadfd1598cce9b043645f6ea94601d145ffc35
This PR addresses the issue when customer disable dbcheckpoint feature later in future, than all the old dbcheckpoints will be deleted from disk storage as well as persistence.