### PR TITLE
[WIP] Handle new Any request in request.proto

### DIFF
--- a/client/clientservice/include/client/clientservice/client_service.hpp
+++ b/client/clientservice/include/client/clientservice/client_service.hpp
@@ -32,7 +32,7 @@ class ClientService {
 
   void start(const std::string& addr, unsigned num_async_threads, uint64_t max_receive_msg_size);
 
-  const std::string kRequestService{"vmware.concord.client.request.v1.RequestService"};
+  const std::string kRequestService{"vmware.concord.client.request.v2.RequestService"};
   const std::string kEventService{"vmware.concord.client.event.v1.EventService"};
   const std::string kStateSnapshotService{"vmware.concord.client.statesnapshot.v1.StateSnapshotService"};
 
@@ -48,7 +48,7 @@ class ClientService {
   std::unique_ptr<StateSnapshotServiceImpl> state_snapshot_service_;
 
   // Asynchronous services
-  vmware::concord::client::request::v1::RequestService::AsyncService request_service_;
+  vmware::concord::client::request::v2::RequestService::AsyncService request_service_;
 
   std::vector<std::unique_ptr<grpc::ServerCompletionQueue>> cqs_;
   std::vector<std::thread> server_threads_;

--- a/client/clientservice/include/client/clientservice/request_service.hpp
+++ b/client/clientservice/include/client/clientservice/request_service.hpp
@@ -29,7 +29,7 @@ namespace requestservice {
 // FINISH - clean-up
 class RequestServiceCallData {
  public:
-  RequestServiceCallData(vmware::concord::client::request::v1::RequestService::AsyncService* service,
+  RequestServiceCallData(vmware::concord::client::request::v2::RequestService::AsyncService* service,
                          grpc::ServerCompletionQueue* cq,
                          std::shared_ptr<concord::client::concordclient::ConcordClient> client)
       : logger_(logging::getLogger("concord.client.clientservice.requestservice")),
@@ -51,16 +51,16 @@ class RequestServiceCallData {
  private:
   logging::Logger logger_;
 
-  vmware::concord::client::request::v1::RequestService::AsyncService* service_;
+  vmware::concord::client::request::v2::RequestService::AsyncService* service_;
   grpc::ServerCompletionQueue* cq_;
   grpc::ServerContext ctx_;
-  grpc::ServerAsyncResponseWriter<vmware::concord::client::request::v1::Response> responder_;
+  grpc::ServerAsyncResponseWriter<vmware::concord::client::request::v2::Response> responder_;
 
   grpc::Alarm callback_alarm_;
   grpc::Status return_status_;
 
-  vmware::concord::client::request::v1::Request request_;
-  vmware::concord::client::request::v1::Response response_;
+  vmware::concord::client::request::v2::Request request_;
+  vmware::concord::client::request::v2::Response response_;
 
   enum RpcState { CREATE, SEND_TO_CONCORDCLIENT, PROCESS_CALLBACK_RESULT, FINISH };
   RpcState state_;

--- a/client/proto/CMakeLists.txt
+++ b/client/proto/CMakeLists.txt
@@ -4,12 +4,12 @@ find_package(GRPC REQUIRED)
 include_directories(${GRPC_INCLUDE_DIR})
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
-  request/v1/request.proto
+  request/v2/request.proto
   event/v1/event.proto
   state_snapshot/v1/state_snapshot.proto
 )
 grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
-  request/v1/request.proto
+  request/v2/request.proto
   event/v1/event.proto
   state_snapshot/v1/state_snapshot.proto
 )

--- a/client/proto/request/v2/request.proto
+++ b/client/proto/request/v2/request.proto
@@ -1,0 +1,76 @@
+// Copyright 2021 VMware, all rights reserved
+//
+// Concordclient's request service
+
+syntax = "proto3";
+package vmware.concord.client.request.v2;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/any.proto";
+
+// Specifies Java package name, using the standard prefix "com."
+option java_package = "com.vmware.concord.client.request.v2";
+
+// Service error handling
+// Each service method will return a gRPC status object.
+// All errors are mapped to the common gRPC error codes defined here: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+// See each method for concrete explanations below.
+
+// The RequestService allows the caller to submit requests to the blockchain
+// network, and receive the result of the request in a synchronous response.
+//
+// You can use the EventService below for asynchronously consuming the
+// events of submitted requests.
+service RequestService {
+  // Send a single request via the Concord Client to the blockchain network.
+  // Errors:
+  // DEADLINE_EXCEEDED: if the request couldn't be processed before the given timeout expired.
+  // INVALID_ARGUMENT: if a required field is not set.
+  // RESOURCE_EXHAUSTED: if Concord Client is overloaded. The caller should retry with a backoff.
+  // UNAVAILABLE: if Concord Client is currently unable to process any requests. The caller should retry with a backoff.
+  // ABORTED: if Concord has a contention between concurrently running requests. The caller should retry.
+  // INTERNAL: if Concord Client cannot progress independent of the request.
+  rpc Send(Request) returns (Response);
+}
+
+message Request {
+  // Required application request which gets evaluated by the execution engine.
+  bytes request = 1;
+
+  // Required timeout which defines the maximum amount of time the caller is
+  // willing to wait for the request to be processed by a quorum of replicas.
+  // Returns DEADLINE_EXCEEDED if the request times out.
+  // Returns INVALID_ARGUMENT if the timeout is zero.
+  google.protobuf.Duration timeout = 2;
+
+  // Optional flag to mark the request as read-only.
+  // A read-only request doesn't go through consensus.
+  // Concord Client makes sure it receives matching replies from a quorum of replicas.
+  // `read_only` and `pre_execute` are mutually exclusive.
+  // INVALID_ARGUMENT if read_only and pre_execute are set.
+  optional bool read_only = 3;
+
+  // Optional flag to enable request pre-execution.
+  // Pre-execution evaluates the request before consensus as opposed to after.
+  // If pre-execution is successful and no conflicts are detected during the
+  // execution phase then consensus will speed up for all requests in the system.
+  // `read_only` and `pre_execute` are mutually exclusive.
+  // INVALID_ARGUMENT if `read_only` and `pre_execute` are set.
+  optional bool pre_execute = 4;
+
+  // Optional request identifier. At runtime, Concord Client maps the
+  // `correlation_id` to a sequence number which can be used to track the request
+  // in log messages in the blockchain network.
+  optional string correlation_id = 5;
+  
+  //This will be the new application request which will co-exist with request during transition
+  optional google.protobuf.Any new_request = 6;
+}
+
+message Response {
+  // Application data returned by the execution engine.
+  bytes response = 1;
+  
+  //This will be the new application data returned which will co-exist with response during transition
+  optional google.protobuf.Any new_response = 2;
+}


### PR DESCRIPTION
This commit consists of introducing google.protobuf.Any request/response for application request/response. 
The current bytes request/response will co-exist for the time being to support both types.
Additional changes have been added to serialize and deserialize google.protobuf.Any request and response in clientservice.