### PR TITLE
Pass batch cid to the functions where it is missing

### DIFF
--- a/bftclient/test/bft_client_test.cpp
+++ b/bftclient/test/bft_client_test.cpp
@@ -33,6 +33,7 @@ TEST(msg_receiver_tests, unmatched_replies_returned_no_rsi) {
   header->reqSeqNum = 100;
   header->replyLength = data_len;
   header->replicaSpecificInfoLength = 0;
+  header->result = 7;
 
   // Handle the message
   auto source = 1;
@@ -159,12 +160,14 @@ TEST(matcher_tests, wait_for_1_out_of_1) {
   auto rsi = ReplicaSpecificInfo{source, {'r', 's', 'i'}};
 
   ReplicaId primary{1};
-  UnmatchedReply reply{ReplyMetadata{primary, seq_num}, msg, rsi};
+  uint32_t result = 7;
+  UnmatchedReply reply{ReplyMetadata{primary, seq_num, result}, msg, rsi};
   auto match = matcher.onReply(std::move(reply));
   ASSERT_TRUE(match.has_value());
   ASSERT_EQ(match.value().reply.matched_data, msg);
   ASSERT_EQ(match.value().reply.rsi[source], rsi.data);
   ASSERT_EQ(match.value().primary.value(), primary);
+  ASSERT_EQ(match.value().reply.result, result);
 }
 
 TEST(matcher_tests, wait_for_3_out_of_4) {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -5648,13 +5648,10 @@ void ReplicaImp::sendResponses(PrePrepareMsg *ppMsg, IRequestsHandler::Execution
       continue;
     }
     if (executionResult != 0) {
-      LOG_WARN(GL,
-               "Request execution failed: " << KVLOG(req.clientId,
-                                                     req.requestSequenceNum,
-                                                     ppMsg->getCid(),
-                                                     req.outExecutionStatus,
-                                                     req.outReply,
-                                                     req.outActualReplySize));
+      LOG_WARN(
+          GL,
+          "Request execution failed: " << KVLOG(
+              req.clientId, req.requestSequenceNum, ppMsg->getCid(), req.outExecutionStatus, req.outActualReplySize));
     } else {
       if (req.flags & HAS_PRE_PROCESSED_FLAG) metric_total_preexec_requests_executed_++;
       if (req.outActualReplySize != 0) {

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -179,7 +179,7 @@ class PreProcessor {
                                  bool isReadOnly,
                                  uint16_t clientId,
                                  NodeIdType senderId,
-                                 const std::string &batchCid = "") const;
+                                 const std::string &batchCid) const;
   bool checkClientBatchMsgCorrectness(const ClientBatchRequestMsgUniquePtr &clientBatchReqMsg);
   bool checkPreProcessReqPrerequisites(SeqNum reqSeqNum,
                                        const std::string &cid,
@@ -220,7 +220,7 @@ class PreProcessor {
                                        NodeIdType destId,
                                        uint16_t reqOffsetInBatch,
                                        uint64_t reqRetryId,
-                                       const std::string &batchCid = "");
+                                       const std::string &batchCid);
   uint32_t getBufferOffset(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
   const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
   void releasePreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
@@ -252,7 +252,7 @@ class PreProcessor {
                                          uint32_t resultBufLen,
                                          const std::string &batchCid,
                                          bftEngine::OperationResult preProcessResult);
-  void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch, const std::string &batchCid = "");
+  void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch, const std::string &batchCid);
   void cancelPreProcessing(NodeIdType clientId, const std::string &batchCid, uint16_t reqOffsetInBatch);
   void setPreprocessingRightNow(uint16_t clientId, uint16_t reqOffsetInBatch, bool set);
   PreProcessingResult handlePreProcessedReqByPrimaryAndGetConsensusResult(uint16_t clientId,
@@ -264,7 +264,7 @@ class PreProcessor {
                                 NodeIdType clientId,
                                 uint16_t reqOffsetInBatch,
                                 SeqNum reqSeqNum,
-                                const std::string &batchCid = "");
+                                const std::string &batchCid);
   void updateAggregatorAndDumpMetrics();
   void addTimers();
   void cancelTimers();
@@ -274,12 +274,12 @@ class PreProcessor {
                                         bool arrivedInBatch,
                                         uint16_t msgOffsetInBatch,
                                         PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
-                                        const std::string &batchCid = "",
-                                        uint32_t batchSize = 1);
+                                        const std::string &batchCif,
+                                        uint32_t batchSize);
   void handleSinglePreProcessRequestMsg(PreProcessRequestMsgSharedPtr preProcessReqMsg,
-                                        const std::string &batchCid = "",
-                                        uint32_t batchSize = 1);
-  void handleSinglePreProcessReplyMsg(PreProcessReplyMsgSharedPtr preProcessReplyMsg, const std::string &batchCid = "");
+                                        const std::string &batchCid,
+                                        uint32_t batchSize);
+  void handleSinglePreProcessReplyMsg(PreProcessReplyMsgSharedPtr preProcessReplyMsg, const std::string &batchCid);
   bool isRequestPreProcessingRightNow(const RequestStateSharedPtr &reqEntry,
                                       ReqId reqSeqNum,
                                       NodeIdType clientId,

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -66,7 +66,7 @@ ConcordClient::~ConcordClient() noexcept = default;
 bft::client::Reply ConcordClient::SendRequest(const bft::client::WriteConfig& config, bft::client::Msg&& request) {
   LOG_INFO(
       logger_,
-      "Start request processing" << KVLOG(client_id_, config.request.sequence_number, config.request.correlation_id));
+      "Request processing started" << KVLOG(client_id_, config.request.sequence_number, config.request.correlation_id));
   bft::client::Reply res;
   clientRequestExecutionResult_ = OperationResult::SUCCESS;
   try {
@@ -84,17 +84,17 @@ bft::client::Reply ConcordClient::SendRequest(const bft::client::WriteConfig& co
   if (res.result != static_cast<uint32_t>(OperationResult::SUCCESS))
     clientRequestExecutionResult_ = static_cast<OperationResult>(res.result);
   LOG_INFO(logger_,
-           "Request has completed processing" << KVLOG(client_id_,
-                                                       config.request.sequence_number,
-                                                       config.request.correlation_id,
-                                                       static_cast<uint32_t>(clientRequestExecutionResult_)));
+           "Request processing completed" << KVLOG(client_id_,
+                                                   config.request.sequence_number,
+                                                   config.request.correlation_id,
+                                                   static_cast<uint32_t>(clientRequestExecutionResult_)));
   return res;
 }
 
 bft::client::Reply ConcordClient::SendRequest(const bft::client::ReadConfig& config, bft::client::Msg&& request) {
   LOG_INFO(
       logger_,
-      "Start request processing" << KVLOG(client_id_, config.request.sequence_number, config.request.correlation_id));
+      "Request processing started" << KVLOG(client_id_, config.request.sequence_number, config.request.correlation_id));
   bft::client::Reply res;
   clientRequestExecutionResult_ = OperationResult::SUCCESS;
   try {
@@ -112,10 +112,10 @@ bft::client::Reply ConcordClient::SendRequest(const bft::client::ReadConfig& con
   if (res.result != static_cast<uint32_t>(OperationResult::SUCCESS))
     clientRequestExecutionResult_ = static_cast<OperationResult>(res.result);
   LOG_INFO(logger_,
-           "Request has completed processing" << KVLOG(client_id_,
-                                                       config.request.sequence_number,
-                                                       config.request.correlation_id,
-                                                       static_cast<uint32_t>(clientRequestExecutionResult_)));
+           "Request processing completed" << KVLOG(client_id_,
+                                                   config.request.sequence_number,
+                                                   config.request.correlation_id,
+                                                   static_cast<uint32_t>(clientRequestExecutionResult_)));
   return res;
 }
 
@@ -177,25 +177,41 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
     request_queue.push_back(bft::client::WriteRequest{single_config, std::move(req.request)});
   }
   try {
-    auto res = new_client_->sendBatch(request_queue, batch_cid);
-    for (const auto& rep : res) {
-      auto cid = seq_num_to_cid.find(rep.first)->second;
-      auto data_size = rep.second.matched_data.size();
-      for (auto& reply : pending_replies_) {
-        if (reply.cid != cid) continue;
-        if (reply.cb) {
-          auto result = bftEngine::SendResult{rep.second};
-          reply.cb(std::move(result));
-          LOG_DEBUG(logger_, "Request processing via callback completed " << KVLOG(client_id_, batch_cid, reply.cid));
+    LOG_INFO(logger_, "Batch processing started" << KVLOG(client_id_, batch_cid));
+    auto received_replies_map = new_client_->sendBatch(request_queue, batch_cid);
+    for (const auto& received_reply_entry : received_replies_map) {
+      const auto received_reply_seq_num = received_reply_entry.first;
+      const auto& pending_seq_num_to_cid_entry = seq_num_to_cid.find(received_reply_seq_num);
+      if (pending_seq_num_to_cid_entry == seq_num_to_cid.end()) {
+        LOG_ERROR(logger_,
+                  "Received reply for a non pending for reply request"
+                      << KVLOG(client_id_, batch_cid, received_reply_seq_num));
+        continue;
+      }
+      auto cid = pending_seq_num_to_cid_entry->second;
+      auto data_size = received_reply_entry.second.matched_data.size();
+      for (auto& pending_reply : pending_replies_) {
+        if (pending_reply.cid != cid) continue;
+        auto response = received_reply_entry.second.result ? bftEngine::SendResult{received_reply_entry.second.result}
+                                                           : bftEngine::SendResult{received_reply_entry.second};
+        if (pending_reply.cb) {
+          pending_reply.cb(move(response));
+          LOG_INFO(logger_,
+                   "Request processing completed; return response through the callback"
+                       << KVLOG(client_id_, batch_cid, pending_reply.cid, received_reply_entry.second.result));
         } else {
-          // TODO: Used for testing only
-          if (data_size > reply.lengthOfReplyBuffer) {
-            LOG_WARN(logger_, "Reply too big " << KVLOG(client_id_, cid, reply.lengthOfReplyBuffer, data_size));
+          // Used for testing only
+          if (data_size > pending_reply.lengthOfReplyBuffer) {
+            LOG_WARN(logger_,
+                     "Reply is too big" << KVLOG(client_id_, cid, pending_reply.lengthOfReplyBuffer, data_size));
             continue;
           }
-          memcpy(reply.replyBuffer, rep.second.matched_data.data(), data_size);
-          reply.actualReplyLength = data_size;
-          LOG_DEBUG(logger_, "Request processing completed " << KVLOG(client_id_, batch_cid, reply.cid));
+          memcpy(pending_reply.replyBuffer, received_reply_entry.second.matched_data.data(), data_size);
+          pending_reply.actualReplyLength = data_size;
+          pending_reply.opResult = static_cast<bftEngine::OperationResult>(received_reply_entry.second.result);
+          LOG_INFO(logger_,
+                   "Request processing completed"
+                       << KVLOG(client_id_, batch_cid, pending_reply.cid, received_reply_entry.second.result));
         }
       }
     }
@@ -204,6 +220,7 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
     LOG_ERROR(logger_, "Batch cid =" << batch_cid << " has failed to invoke, timeout has been reached");
     ret = OperationResult::TIMEOUT;
   }
+  LOG_INFO(logger_, "Batch processing completed" << KVLOG(client_id_, batch_cid));
   batching_buffer_reply_offset_ = 0UL;
   pending_requests_.clear();
   return {static_cast<uint32_t>(ret), std::move(pending_replies_)};


### PR DESCRIPTION
Correct batch cid is a condition for the batch object to be released. In case it is empty, the batch does not get released and the client gets stuck with it forether.