### PR TITLE
Fixes for data races reported from Apollo TSAN run.

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -231,8 +231,8 @@ BCStateTran::BCStateTran(const Config &config, IAppState *const stateApi, DataSt
 
                metrics_component_.RegisterAtomicCounter("create_checkpoint"),
                metrics_component_.RegisterCounter("mark_checkpoint_as_stable"),
-               metrics_component_.RegisterCounter("load_reserved_page"),
-               metrics_component_.RegisterCounter("load_reserved_page_from_pending"),
+               metrics_component_.RegisterAtomicCounter("load_reserved_page"),
+               metrics_component_.RegisterAtomicCounter("load_reserved_page_from_pending"),
                metrics_component_.RegisterAtomicCounter("load_reserved_page_from_checkpoint"),
                metrics_component_.RegisterAtomicCounter("save_reserved_page"),
                metrics_component_.RegisterCounter("zero_reserved_page"),

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -502,8 +502,8 @@ class BCStateTran : public IStateTransfer {
 
     AtomicCounterHandle create_checkpoint_;
     CounterHandle mark_checkpoint_as_stable_;
-    CounterHandle load_reserved_page_;
-    CounterHandle load_reserved_page_from_pending_;
+    AtomicCounterHandle load_reserved_page_;
+    AtomicCounterHandle load_reserved_page_from_pending_;
     AtomicCounterHandle load_reserved_page_from_checkpoint_;
     AtomicCounterHandle save_reserved_page_;
     CounterHandle zero_reserved_page_;

--- a/bftengine/src/bftengine/DebugStatistics.hpp
+++ b/bftengine/src/bftengine/DebugStatistics.hpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <stdint.h>
 #include "TimeUtils.hpp"
+#include <atomic>
 
 namespace bftEngine {
 namespace impl {
@@ -44,7 +45,7 @@ class DebugStatistics {
     Time lastCycleTime;
 
     size_t receivedMessages;
-    size_t sendMessages;
+    std::atomic<size_t> sendMessages;
     size_t completedReadOnlyRequests;
     size_t completedReadWriteRequests;
     size_t numberOfReceivedSTMessages;


### PR DESCRIPTION
Because of concurrent access to the counters we need
to make them atomic.