### PR TITLE
Pass batch cid to the functions where it is missing

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -584,9 +584,9 @@ void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequest
   const auto &reqTimeoutMilli = clientMsg->requestTimeoutMilli();
   SCOPED_MDC_CID(cid);
   LOG_DEBUG(logger(), "Received ClientPreProcessRequestMsg" << KVLOG(reqSeqNum, clientId, senderId, reqTimeoutMilli));
-  if (!checkClientMsgCorrectness(reqSeqNum, cid, clientMsg->isReadOnly(), clientId, senderId)) return;
+  if (!checkClientMsgCorrectness(reqSeqNum, cid, clientMsg->isReadOnly(), clientId, senderId, "")) return;
   PreProcessRequestMsgSharedPtr preProcessRequestMsg;
-  handleSingleClientRequestMessage(move(clientMsg), senderId, false, 0, preProcessRequestMsg);
+  handleSingleClientRequestMessage(move(clientMsg), senderId, false, 0, preProcessRequestMsg, "", 1);
 }
 
 // Should be called under reqEntry->mutex lock
@@ -668,12 +668,12 @@ bool PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
       if (!batchedPreProcessEnabled_ && (senderId != clientId))
         // Send 'cancel' request to non-primary replicas to release them from waiting to a 'real' PreProcessRequestMsg,
         // which will not arrive in this case. Doing this to avoid request from being timed out on non-primary replicas.
-        cancelPreProcessingOnNonPrimary(clientMsg, senderId, reqOffsetInBatch, (reqEntry->reqRetryId)++);
+        cancelPreProcessingOnNonPrimary(clientMsg, senderId, reqOffsetInBatch, (reqEntry->reqRetryId)++, batchCid);
       return false;
     }
     if (myReplica_.isReplyAlreadySentToClient(clientId, reqSeqNum)) {
       if (!batchedPreProcessEnabled_ && (senderId != clientId))
-        cancelPreProcessingOnNonPrimary(clientMsg, senderId, reqOffsetInBatch, (reqEntry->reqRetryId)++);
+        cancelPreProcessingOnNonPrimary(clientMsg, senderId, reqOffsetInBatch, (reqEntry->reqRetryId)++, batchCid);
       LOG_INFO(logger(),
                "Request has already been executed - let replica decide how to proceed further"
                    << KVLOG(batchCid, batchSize, reqSeqNum, clientId, senderId));
@@ -947,7 +947,7 @@ void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *message
             "Received PreProcessRequestMsg" << KVLOG(
                 reqType, msg->reqSeqNum(), msg->getCid(), msg->senderId(), msg->clientId(), msg->reqOffsetInBatch()));
   if (checkPreProcessRequestMsgCorrectness(msg)) {
-    handleSinglePreProcessRequestMsg(msg);
+    handleSinglePreProcessRequestMsg(msg, "", 1);
   }
 }
 
@@ -1012,7 +1012,7 @@ void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *message) {
             "Received PreProcessReplyMsg"
                 << KVLOG(msg->reqSeqNum(), msg->senderId(), msg->clientId(), msg->reqOffsetInBatch(), replyStatus));
   if (checkPreProcessReplyMsgCorrectness(msg)) {
-    handleSinglePreProcessReplyMsg(msg);
+    handleSinglePreProcessReplyMsg(msg, "");
   }
 }
 
@@ -1738,7 +1738,7 @@ void PreProcessor::handlePreProcessedReqPrimaryRetry(NodeIdType clientId,
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.handlePreProcessedReqPrimaryRetry);
   if (handlePreProcessedReqByPrimaryAndGetConsensusResult(clientId, reqOffsetInBatch, resultBufLen, preProcessResult) ==
       COMPLETE)
-    finalizePreProcessing(clientId, reqOffsetInBatch);
+    finalizePreProcessing(clientId, reqOffsetInBatch, batchCid);
   else
     cancelPreProcessing(clientId, batchCid, reqOffsetInBatch);
 }
@@ -1754,7 +1754,7 @@ void PreProcessor::handleReqPreProcessedByPrimary(const PreProcessRequestMsgShar
       handlePreProcessedReqByPrimaryAndGetConsensusResult(clientId, reqOffsetInBatch, resultBufLen, preProcessResult);
   if (result != NONE)
     handlePreProcessReplyMsg(
-        preProcessReqMsg->getCid(), result, clientId, reqOffsetInBatch, preProcessReqMsg->reqSeqNum());
+        preProcessReqMsg->getCid(), result, clientId, reqOffsetInBatch, preProcessReqMsg->reqSeqNum(), batchCid);
 }
 
 void PreProcessor::releaseReqAndSendReplyMsg(PreProcessReplyMsgSharedPtr replyMsg) {

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -186,7 +186,7 @@ class PreProcessor {
                                  bool isReadOnly,
                                  uint16_t clientId,
                                  NodeIdType senderId,
-                                 const std::string &batchCid = "") const;
+                                 const std::string &batchCid) const;
   bool checkClientBatchMsgCorrectness(const ClientBatchRequestMsgUniquePtr &clientBatchReqMsg);
   bool checkPreProcessReqPrerequisites(SeqNum reqSeqNum,
                                        const std::string &cid,
@@ -225,7 +225,7 @@ class PreProcessor {
                                        NodeIdType destId,
                                        uint16_t reqOffsetInBatch,
                                        uint64_t reqRetryId,
-                                       const std::string &batchCid = "");
+                                       const std::string &batchCid);
   uint32_t getBufferOffset(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
   const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
   void releasePreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
@@ -257,7 +257,7 @@ class PreProcessor {
                                          uint32_t resultBufLen,
                                          const std::string &batchCid,
                                          bftEngine::OperationResult preProcessResult);
-  void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch, const std::string &batchCid = "");
+  void finalizePreProcessing(NodeIdType clientId, uint16_t reqOffsetInBatch, const std::string &batchCid);
   void cancelPreProcessing(NodeIdType clientId, const std::string &batchCid, uint16_t reqOffsetInBatch);
   void setPreprocessingRightNow(uint16_t clientId, uint16_t reqOffsetInBatch, bool set);
   PreProcessingResult handlePreProcessedReqByPrimaryAndGetConsensusResult(uint16_t clientId,
@@ -269,7 +269,7 @@ class PreProcessor {
                                 NodeIdType clientId,
                                 uint16_t reqOffsetInBatch,
                                 SeqNum reqSeqNum,
-                                const std::string &batchCid = "");
+                                const std::string &batchCid);
   void updateAggregatorAndDumpMetrics();
   void addTimers();
   void cancelTimers();
@@ -279,12 +279,12 @@ class PreProcessor {
                                         bool arrivedInBatch,
                                         uint16_t msgOffsetInBatch,
                                         PreProcessRequestMsgSharedPtr &preProcessRequestMsg,
-                                        const std::string &batchCid = "",
-                                        uint32_t batchSize = 1);
+                                        const std::string &batchCid,
+                                        uint32_t batchSize);
   void handleSinglePreProcessRequestMsg(PreProcessRequestMsgSharedPtr preProcessReqMsg,
-                                        const std::string &batchCid = "",
-                                        uint32_t batchSize = 1);
-  void handleSinglePreProcessReplyMsg(PreProcessReplyMsgSharedPtr preProcessReplyMsg, const std::string &batchCid = "");
+                                        const std::string &batchCid,
+                                        uint32_t batchSize);
+  void handleSinglePreProcessReplyMsg(PreProcessReplyMsgSharedPtr preProcessReplyMsg, const std::string &batchCid);
   bool isRequestPreProcessingRightNow(const RequestStateSharedPtr &reqEntry,
                                       ReqId reqSeqNum,
                                       NodeIdType clientId,


### PR DESCRIPTION
Cherry-pick for 8f3d53a11647ce5a036df0aafd2b9e0d618ce5bb
Correct batch cid is a condition for the batch object to be released. In case it is empty, the batch does not get released and the client gets stuck with it forever.