### PR TITLE
TS: Fix an issue with time check

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1297,7 +1297,7 @@ void ReplicaImp::onMessage<StartSlowCommitMsg>(StartSlowCommitMsg *msg) {
 
     SeqNumInfo &seqNumInfo = mainLog->get(msgSeqNum);
 
-    if (!seqNumInfo.slowPathStarted() && !seqNumInfo.isPrepared() && seqNumInfo.isTimeCorrect()) {
+    if (!seqNumInfo.slowPathStarted() && !seqNumInfo.isPrepared()) {
       LOG_INFO(CNSUS, "Start slow path.");
 
       seqNumInfo.startSlowPath();


### PR DESCRIPTION
Removes the check  seqNumInfo.isTimeCorrect() during arrival of StartSlowCommitMsg. Because of it the replica will not be able to quickly recover from a temporary time difference, and it may lead to unnecessary view changes.