### PR TITLE
Fix RSI indexing v0.14

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -167,13 +167,13 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
   uint16_t numOfObjects = 0;
   bool isNewStorage = true;
   if (metadataStorage != nullptr) {
-    persistentStoragePtr.reset(new impl::PersistentStorageImp(replicaConfig.numReplicas,
-                                                              replicaConfig.fVal,
-                                                              replicaConfig.cVal,
-                                                              replicaConfig.numReplicas + replicaConfig.numRoReplicas +
-                                                                  replicaConfig.numOfClientProxies +
-                                                                  replicaConfig.numOfExternalClients,
-                                                              replicaConfig.clientBatchingMaxMsgsNbr));
+    persistentStoragePtr.reset(new impl::PersistentStorageImp(
+        replicaConfig.numReplicas,
+        replicaConfig.fVal,
+        replicaConfig.cVal,
+        replicaConfig.numReplicas + replicaConfig.numRoReplicas + replicaConfig.numOfClientProxies +
+            replicaConfig.numOfExternalClients + replicaConfig.numOfClientServices + replicaConfig.numReplicas,
+        replicaConfig.clientBatchingMaxMsgsNbr));
     unique_ptr<MetadataStorage> metadataStoragePtr(metadataStorage);
     auto objectDescriptors =
         ((PersistentStorageImp *)persistentStoragePtr.get())->getDefaultMetadataObjectDescriptors(numOfObjects);

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -18,6 +18,7 @@
 #include "bftengine/KeyExchangeManager.hpp"
 #include "Serializable.h"
 #include "PersistentStorageImp.hpp"
+#include "ReplicasInfo.hpp"
 
 #include <chrono>
 using namespace std::chrono;
@@ -32,8 +33,10 @@ ClientsManager::ClientsManager(std::shared_ptr<PersistentStorage> ps,
                                const std::set<NodeIdType>& internalClients,
                                concordMetrics::Component& metrics)
     : ClientsManager{proxyClients, externalClients, internalClients, metrics} {
-  rsiManager_.reset(new RsiDataManager(
-      proxyClients.size() + externalClients.size() + internalClients.size(), maxNumOfReqsPerClient_, ps));
+  rsiManager_.reset(new RsiDataManager(proxyClients.size() + externalClients.size() + internalClients.size() +
+                                           ReplicaConfig::instance().numOfClientServices,
+                                       maxNumOfReqsPerClient_,
+                                       ps));
 }
 ClientsManager::ClientsManager(const std::set<NodeIdType>& proxyClients,
                                const std::set<NodeIdType>& externalClients,

--- a/bftengine/src/bftengine/ReplicaSpecificInfoManager.hpp
+++ b/bftengine/src/bftengine/ReplicaSpecificInfoManager.hpp
@@ -49,7 +49,6 @@ class RsiDataManager {
 
  private:
   void init();
-
   uint32_t num_of_principles_;
   uint32_t max_client_batch_size_;
   std::shared_ptr<PersistentStorage> ps_;


### PR DESCRIPTION
RSI manager assumes order on the external client ids. Now that we have clientservice ids added, we need to adapt this index
In this PR we simply add the clientservice ids into account