### PR TITLE
Perform scale cmd restart after db-checkpoint is created

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -131,6 +131,9 @@ class DbCheckpointManager {
     if (ReplicaConfig::instance().dbCheckpointFeatureEnabled)
       createDbCheckpointAsync(seqNum, std::nullopt, std::nullopt);
   }
+  void addOnDbCheckpointCreatedCb(std::function<void(SeqNum)> cb) {
+    if (cb) onDbCheckpointCreated_.push_back(cb);
+  }
   inline auto getLastDbCheckpointSeqNum() const { return lastCheckpointSeqNum_; }
 
  private:
@@ -171,7 +174,7 @@ class DbCheckpointManager {
   InternalBftClient* client_{nullptr};
   std::atomic<bool> stopped_ = false;
   DbCheckpointMetadata dbCheckptMetadata_;
-  std::map<CheckpointId, std::future<void> > dbCreateCheckPtFuture_;
+  std::map<CheckpointId, std::future<void>> dbCreateCheckPtFuture_;
   std::future<void> cleanUpFuture_;
   std::shared_ptr<concord::storage::IDBClient> dbClient_;
   std::shared_ptr<bftEngine::impl::PersistentStorage> ps_;
@@ -189,6 +192,7 @@ class DbCheckpointManager {
   std::chrono::seconds lastCheckpointCreationTime_{duration_cast<Seconds>(SystemClock::now().time_since_epoch())};
   std::function<void(SeqNum)> onStableSeqNumCb_;
   std::function<SeqNum()> getLastStableSeqNumCb_;
+  std::vector<std::function<void(SeqNum)>> onDbCheckpointCreated_;
   std::string dbCheckPointDirPath_;
   concordMetrics::Component metrics_;
   concordMetrics::GaugeHandle maxDbCheckpointCreationTimeMsec_;

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -76,6 +76,9 @@ Status DbCheckpointManager::createDbCheckpoint(const CheckpointId& checkPointId,
     while (dbCheckptMetadata_.dbCheckPoints_.size() > maxNumOfCheckpoints_) {
       removeOldestDbCheckpoint();
     }
+    for (auto& cb : onDbCheckpointCreated_) {
+      if (cb) cb(seqNum);
+    }
   }
   updateMetrics();
   return Status::OK();

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -82,8 +82,12 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
               concord::messages::ReconfigurationResponse &) override;
 
  private:
-  void handleWedgeCommands(
-      bool bft_support, bool remove_metadata, bool restart, bool unwedge, bool blockNewConnections);
+  void handleWedgeCommands(bool bft_support,
+                           bool remove_metadata,
+                           bool restart,
+                           bool unwedge,
+                           bool blockNewConnections,
+                           bool createDbCheckpoint);
   void addCreateDbSnapshotCbOnWedge(bool bft_support);
 };
 


### PR DESCRIPTION
Create db checkpoint is an async operation. We need to wait for it to complete before restarting replica if scale operation was done with restart option true. This PR addresses this issue