### PR TITLE
Replace boost::filysytem by std::filesystem

### DIFF
--- a/bftclient/test/CMakeLists.txt
+++ b/bftclient/test/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(bft_client_test PRIVATE
   bftclient_new
   threshsign
   secretsmanager
+  stdc++fs
 )
 
 add_executable(bft_client_api_tests bft_client_api_tests.cpp)

--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -32,8 +32,8 @@
 #include "Metrics.hpp"
 #include "InternalBFTClient.hpp"
 #include "storage/db_interface.h"
-#include <boost/filesystem.hpp>
-namespace _fs = boost::filesystem;
+#include "util/filesystem.hpp"
+namespace _fs = fs;
 namespace bftEngine::impl {
 using std::chrono::duration_cast;
 using Status = concordUtils::Status;

--- a/communication/CMakeLists.txt
+++ b/communication/CMakeLists.txt
@@ -37,6 +37,8 @@ if(BUILD_COMM_TCP_TLS)
     target_link_libraries(bftcommunication_shared PUBLIC secretsmanager_shared)
 endif()
 
+target_link_libraries(bftcommunication PRIVATE stdc++fs)
+target_link_libraries(bftcommunication_shared PRIVATE stdc++fs)
 set(Boost_USE_STATIC_LIBS OFF) # find all kind of libs
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -11,6 +11,8 @@
 // LICENSE file.
 
 #include <asio/bind_executor.hpp>
+#include <boost/system/system_error.hpp>
+#include <fstream>
 #include <regex>
 
 #include <arpa/inet.h>
@@ -280,7 +282,6 @@ void AsyncTlsConnection::initClientSSLContext(NodeNum destination) {
   auto self = std::weak_ptr(shared_from_this());
   ssl_context_.set_verify_mode(asio::ssl::verify_peer);
 
-  namespace fs = boost::filesystem;
   fs::path path;
   try {
     path = fs::path(config_.certificatesRootPath_) / fs::path(std::to_string(config_.selfId_)) / "client";
@@ -340,7 +341,6 @@ void AsyncTlsConnection::initServerSSLContext() {
     ConcordAssert(false);
   }
 
-  namespace fs = boost::filesystem;
   fs::path path;
   try {
     path = fs::path(config_.certificatesRootPath_) / fs::path(std::to_string(config_.selfId_)) / fs::path("server");
@@ -458,8 +458,7 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* received_cer
 
 using namespace concord::secretsmanager;
 
-const std::string AsyncTlsConnection::decryptPrivateKey(const boost::filesystem::path& path) {
-  namespace fs = boost::filesystem;
+const std::string AsyncTlsConnection::decryptPrivateKey(const fs::path& path) {
   std::string pkpath;
 
   std::unique_ptr<ISecretsManagerImpl> secrets_manager;

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -18,7 +18,7 @@
 
 #include <asio.hpp>
 #include <asio/ssl.hpp>
-#include <boost/filesystem.hpp>
+#include "util/filesystem.hpp"
 
 #include "communication/CommDefs.hpp"
 #include "Logger.hpp"
@@ -176,7 +176,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
   // Return true along with the actual node id if verification succeeds, (false, 0) if not.
   std::pair<bool, NodeNum> checkCertificate(X509* received_cert, std::optional<NodeNum> expected_peer_id);
 
-  const std::string decryptPrivateKey(const boost::filesystem::path& path);
+  const std::string decryptPrivateKey(const fs::path& path);
 
   logging::Logger logger_;
   asio::io_context& io_context_;

--- a/communication/src/TlsConnectionManager.cpp
+++ b/communication/src/TlsConnectionManager.cpp
@@ -10,7 +10,6 @@
 // subcomponent's license, as noted in the LICENSE file.
 
 #include <asio/bind_executor.hpp>
-#include <boost/filesystem.hpp>
 #include <cstdint>
 #include <future>
 #include <string>

--- a/kvbc/src/migrations/block_merkle_latest_ver_cf_migration.cpp
+++ b/kvbc/src/migrations/block_merkle_latest_ver_cf_migration.cpp
@@ -24,7 +24,7 @@
 #include <stdexcept>
 #include <vector>
 
-#include <boost/filesystem.hpp>
+#include "util/filesystem.hpp"
 #include <rocksdb/options.h>
 
 namespace concord::kvbc::migrations {
@@ -62,7 +62,7 @@ BlockMerkleLatestVerCfMigration::BlockMerkleLatestVerCfMigration(const std::stri
   db_ = NativeClient::newClient(db_path, read_only, NativeClient::DefaultOptions{});
 }
 
-void BlockMerkleLatestVerCfMigration::removeExportDir() { boost::filesystem::remove_all(export_path_); }
+void BlockMerkleLatestVerCfMigration::removeExportDir() { fs::remove_all(export_path_); }
 
 void BlockMerkleLatestVerCfMigration::checkpointDB() {
   Checkpoint* checkpoint{nullptr};

--- a/kvbc/test/migrations/block_merkle_latest_ver_cf_migration_test.cpp
+++ b/kvbc/test/migrations/block_merkle_latest_ver_cf_migration_test.cpp
@@ -22,7 +22,7 @@
 #include "sha_hash.hpp"
 #include "storage/test/storage_test_common.h"
 
-#include <boost/filesystem.hpp>
+#include "util/filesystem.hpp"
 
 #include <iostream>
 #include <map>
@@ -200,7 +200,7 @@ class block_merkle_latest_ver_cf_migration_test : public Test {
 
     createKvbc();
 
-    ASSERT_FALSE(boost::filesystem::exists(rocksDbPath(export_path_id_)));
+    ASSERT_FALSE(fs::exists(rocksDbPath(export_path_id_)));
     ASSERT_FALSE(db_->hasColumnFamily(BlockMerkleLatestVerCfMigration::temporaryColumnFamily()));
     const auto state = db_->get(BlockMerkleLatestVerCfMigration::migrationKey());
     ASSERT_TRUE(state.has_value());

--- a/kvbc/tools/db_editor/include/db_editor_common.hpp
+++ b/kvbc/tools/db_editor/include/db_editor_common.hpp
@@ -18,16 +18,7 @@
 #include "merkle_tree_block.h"
 #include "storage/db_types.h"
 #include "rocksdb/client.h"
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error "Missing filesystem support"
-#endif
+#include "util/filesystem.hpp"
 
 namespace concord::kvbc::tools::db_editor {
 

--- a/kvbc/tools/migrations/block_merkle_latest_ver_cf_migration_tool.cpp
+++ b/kvbc/tools/migrations/block_merkle_latest_ver_cf_migration_tool.cpp
@@ -1,6 +1,6 @@
 #include "migrations/block_merkle_latest_ver_cf_migration.h"
 
-#include <boost/filesystem.hpp>
+#include "util/filesystem.hpp"
 #include <boost/program_options.hpp>
 #include <boost/program_options/errors.hpp>
 #include <boost/program_options/value_semantic.hpp>
@@ -14,7 +14,6 @@
 namespace {
 
 namespace po = boost::program_options;
-namespace fs = boost::filesystem;
 
 std::pair<po::options_description, po::variables_map> parseArgs(int argc, char* argv[]) {
   auto desc = po::options_description(

--- a/storage/include/storage/test/storage_test_common.h
+++ b/storage/include/storage/test/storage_test_common.h
@@ -20,6 +20,7 @@
 #include "rocksdb/native_client.h"
 #include "sliver.hpp"
 #include "storage/db_interface.h"
+#include "util/filesystem.hpp"
 
 #include <unistd.h>
 
@@ -28,16 +29,6 @@
 #include <sstream>
 #include <string>
 #include <thread>
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error "Missing filesystem support"
-#endif
 
 inline constexpr auto defaultDbId = std::size_t{0};
 

--- a/storage/src/rocksdb_client.cpp
+++ b/storage/src/rocksdb_client.cpp
@@ -14,15 +14,8 @@
 #include <rocksdb/db.h>
 #include <rocksdb/options.h>
 #include <stdexcept>
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error "Missing filesystem support"
-#endif
+#include "util/filesystem.hpp"
+
 #ifdef USE_ROCKSDB
 
 #include <rocksdb/client.h>

--- a/util/include/util/filesystem.hpp
+++ b/util/include/util/filesystem.hpp
@@ -1,0 +1,22 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing filesystem support"
+#endif


### PR DESCRIPTION
Since std::filesystem became a standard, we want to replace all existing boost::filesystem usages by std::filesystem.
This will also allow not to build boost::filesystem library 