### PR TITLE
Consider client service id in the client manager and signature manager

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -30,22 +30,25 @@ namespace bftEngine::impl {
 ClientsManager::ClientsManager(std::shared_ptr<PersistentStorage> ps,
                                const std::set<NodeIdType>& proxyClients,
                                const std::set<NodeIdType>& externalClients,
+                               const std::set<NodeIdType>& clientServices,
                                const std::set<NodeIdType>& internalClients,
                                concordMetrics::Component& metrics)
-    : ClientsManager{proxyClients, externalClients, internalClients, metrics} {
-  rsiManager_.reset(new RsiDataManager(proxyClients.size() + externalClients.size() + internalClients.size() +
-                                           ReplicaConfig::instance().numOfClientServices,
-                                       maxNumOfReqsPerClient_,
-                                       ps));
+    : ClientsManager{proxyClients, externalClients, clientServices, internalClients, metrics} {
+  rsiManager_.reset(
+      new RsiDataManager(proxyClients.size() + externalClients.size() + internalClients.size() + clientServices.size(),
+                         maxNumOfReqsPerClient_,
+                         ps));
 }
 ClientsManager::ClientsManager(const std::set<NodeIdType>& proxyClients,
                                const std::set<NodeIdType>& externalClients,
+                               const std::set<NodeIdType>& clientServices,
                                const std::set<NodeIdType>& internalClients,
                                concordMetrics::Component& metrics)
     : myId_(ReplicaConfig::instance().replicaId),
       scratchPage_(sizeOfReservedPage(), 0),
       proxyClients_{proxyClients},
       externalClients_{externalClients},
+      clientServices_{clientServices},
       internalClients_{internalClients},
       maxReplySize_(ReplicaConfig::instance().getmaxReplyMessageSize()),
       maxNumOfReqsPerClient_(
@@ -59,6 +62,7 @@ ClientsManager::ClientsManager(const std::set<NodeIdType>& proxyClients,
   }
   clientIds_.insert(proxyClients_.begin(), proxyClients_.end());
   clientIds_.insert(externalClients_.begin(), externalClients_.end());
+  clientIds_.insert(clientServices_.begin(), clientServices_.end());
   clientIds_.insert(internalClients_.begin(), internalClients_.end());
   ConcordAssert(clientIds_.size() >= 1);
   uint32_t rpage = 0;

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -52,11 +52,13 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   //   - The global logger CL_MNGR is destroyed.
   ClientsManager(const std::set<NodeIdType>& proxyClients,
                  const std::set<NodeIdType>& externalClients,
+                 const std::set<NodeIdType>& clientServices,
                  const std::set<NodeIdType>& internalClients,
                  concordMetrics::Component& metrics);
   ClientsManager(std::shared_ptr<PersistentStorage> ps,
                  const std::set<NodeIdType>& proxyClients,
                  const std::set<NodeIdType>& externalClients,
+                 const std::set<NodeIdType>& clientServices,
                  const std::set<NodeIdType>& internalClients,
                  concordMetrics::Component& metrics);
 
@@ -224,6 +226,7 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
 
   std::set<NodeIdType> proxyClients_;
   std::set<NodeIdType> externalClients_;
+  std::set<NodeIdType> clientServices_;
   std::set<NodeIdType> internalClients_;
   std::set<NodeIdType> clientIds_;
   std::map<NodeIdType, uint32_t> clientIdsToReservedPages_;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4690,8 +4690,12 @@ ReplicaImp::ReplicaImp(bool firstTime,
   bft::communication::StateControl::instance().setGetPeerPubKeyMethod(
       [&](uint32_t id) { return sigManager_->getPublicKeyOfVerifier(id); });
 
-  clientsManager = std::make_shared<ClientsManager>(
-      ps, repsInfo->idsOfClientProxies(), repsInfo->idsOfExternalClients(), repsInfo->idsOfInternalClients(), metrics_);
+  clientsManager = std::make_shared<ClientsManager>(ps,
+                                                    repsInfo->idsOfClientProxies(),
+                                                    repsInfo->idsOfExternalClients(),
+                                                    repsInfo->idsOfIClientServices(),
+                                                    repsInfo->idsOfInternalClients(),
+                                                    metrics_);
   internalBFTClient_.reset(
       new InternalBFTClient(*(repsInfo->idsOfInternalClients()).cbegin() + config_.getreplicaId(), msgsCommunicator_));
 

--- a/bftengine/src/bftengine/ReplicasInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasInfo.hpp
@@ -40,13 +40,14 @@ class ReplicasInfo {
   bool isIdOfInternalClient(PrincipalId id) const {
     return _idsOfInternalClients.find(id) != _idsOfInternalClients.end();
   }
-
+  bool isIdOfClientService(NodeIdType id) { return _idsOfClientServices.find(id) != _idsOfClientServices.end(); }
   bool isValidPrincipalId(PrincipalId id) const { return id <= _maxValidPrincipalId; }
   const std::set<ReplicaId>& idsOfPeerReplicas() const { return _idsOfPeerReplicas; }
   const std::set<ReplicaId>& idsOfPeerROReplicas() const { return _idsOfPeerROReplicas; }
   const std::set<PrincipalId>& idsOfClientProxies() const { return _idsOfClientProxies; }
   const std::set<PrincipalId>& idsOfExternalClients() const { return _idsOfExternalClients; }
   const std::set<PrincipalId>& idsOfInternalClients() const { return _idsOfInternalClients; }
+  const std::set<PrincipalId>& idsOfIClientServices() const { return _idsOfClientServices; }
 
   ReplicaId primaryOfView(ViewNum view) const { return (view % _numberOfReplicas); }
 

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -248,7 +248,7 @@ uint16_t SigManager::getMySigLength() const { return (uint16_t)mySigner_->signat
 
 void SigManager::setClientPublicKey(const std::string& key, PrincipalId id, concord::util::crypto::KeyFormat format) {
   LOG_INFO(KEY_EX_LOG, "client: " << id << " key: " << key << " format: " << (uint16_t)format);
-  if (replicasInfo_.isIdOfExternalClient(id)) {
+  if (replicasInfo_.isIdOfExternalClient(id) || replicasInfo_.isIdOfClientService(id)) {
     try {
       std::unique_lock lock(mutex_);
       verifiers_.insert_or_assign(id, std::make_shared<concord::util::crypto::RSAVerifier>(key.c_str(), format));


### PR DESCRIPTION
Currently, the client service id is part of the client group when transaction singing is enabled, but this fact is not reflected in the code.
This PR is to fix this problem in master