### PR TITLE
Make RequestsBatch class more thread-safe

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -45,18 +45,38 @@ void RequestsBatch::addReply(PreProcessReplyMsgSharedPtr replyMsg) {
   repliesList_.push_back(replyMsg);
 }
 
+bool RequestsBatch::isBatchRegistered() const {
+  const std::lock_guard<std::mutex> lock(batchMutex_);
+  return batchRegistered_;
+}
+
+bool RequestsBatch::isBatchInProcess() const {
+  const std::lock_guard<std::mutex> lock(batchMutex_);
+  return batchInProcess_;
+}
+
+void RequestsBatch::increaseNumOfCompletedReqs() {
+  const std::lock_guard<std::mutex> lock(batchMutex_);
+  numOfCompletedReqs_++;
+}
+
+uint64_t RequestsBatch::getBlockId() const {
+  const std::lock_guard<std::mutex> lock(batchMutex_);
+  return cidToBlockId_.second;
+}
+
 // Should be called under batchMutex_
 void RequestsBatch::setBatchParameters(const std::string &cid, uint32_t batchSize) {
   cid_ = cid;
   batchSize_ = batchSize;
-  // We want to preserve blockid between retries, therefore cidToBlockid_ is not being part of the reset,
+  // We want to preserve block-id between retries, therefore cidToBlockId_ is not being part of the reset,
   // And is being set only if cid is new.
-  if (cidToBlockid_.first != cid_) {
+  if (cidToBlockId_.first != cid_) {
     LOG_DEBUG(preProcessor_.logger(),
-              "resetting batch block id, old cid: " << cidToBlockid_.first << " to: " << cid_ << ", old block id: "
-                                                    << cidToBlockid_.second << " to: " << GlobalData::current_block_id);
-    cidToBlockid_.first = cid_;
-    cidToBlockid_.second = GlobalData::current_block_id;
+              "resetting batch block id, old cid: " << cidToBlockId_.first << " to: " << cid_ << ", old block id: "
+                                                    << cidToBlockId_.second << " to: " << GlobalData::current_block_id);
+    cidToBlockId_.first = cid_;
+    cidToBlockId_.second = GlobalData::current_block_id;
   }
 }
 
@@ -119,7 +139,7 @@ void RequestsBatch::handlePossiblyExpiredRequests() {
     const std::lock_guard<std::mutex> lock(batchMutex_);
     if (batchSize_ && reqsExpired && (numOfCompletedReqs_ >= batchSize_)) {
       cid = cid_;
-      batchSize = batchSize_.load();
+      batchSize = batchSize_;
       resetBatchParams();
       batchCancelled = true;
     }
@@ -142,7 +162,7 @@ void RequestsBatch::cancelBatchAndReleaseRequests(const string &batchCid, PrePro
       if (status == CANCEL) preProcessor_.preProcessorMetrics_.preProcConsensusNotReached++;
       if (reqEntry.second) preProcessor_.releaseClientPreProcessRequestSafe(clientId_, reqEntry.second, status);
     }
-    batchSize = batchSize_.load();
+    batchSize = batchSize_;
     resetBatchParams();
   }
   LOG_INFO(preProcessor_.logger(), "The batch has been cancelled" << KVLOG(clientId_, batchCid, batchSize));
@@ -158,10 +178,14 @@ void RequestsBatch::releaseReqsAndSendBatchedReplyIfCompleted() {
   PreProcessBatchReplyMsgSharedPtr batchReplyMsg;
   {
     const lock_guard<mutex> lock(batchMutex_);
-    if (repliesList_.size() != batchSize_) return;
+    if (repliesList_.size() != batchSize_) {
+      LOG_DEBUG(preProcessor_.logger(),
+                "Not all replies collected" << KVLOG(senderId, clientId_, cid, repliesList_.size(), batchSize_));
+      return;
+    }
 
     cid = cid_;
-    batchSize = batchSize_.load();
+    batchSize = batchSize_;
     // The last batch request has pre-processed => send batched reply message
     for (auto const &replyMsg : repliesList_) {
       replyMsgsSize += replyMsg->size();
@@ -183,7 +207,7 @@ void RequestsBatch::finalizeBatchIfCompleted() {
   {
     const lock_guard<mutex> lock(batchMutex_);
     cid = cid_;
-    batchSize = batchSize_.load();
+    batchSize = batchSize_;
     if (numOfCompletedReqs_ != batchSize_) return;
     resetBatchParams();
   }
@@ -1247,8 +1271,8 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
       releaseClientPreProcessRequest(reqEntry, COMPLETE);
       LOG_INFO(logger(), "Pre-processing completed for" << KVLOG(cid, batchCid, reqSeqNum, clientId, reqOffsetInBatch));
     }
+    if (batchedPreProcessEnabled_) batchEntry->finalizeBatchIfCompleted();
   }
-  if (batchedPreProcessEnabled_) batchEntry->finalizeBatchIfCompleted();
 }
 
 uint16_t PreProcessor::numOfRequiredReplies() { return myReplica_.getReplicaConfig().fVal + 1; }

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -78,9 +78,9 @@ class RequestsBatch {
   void startBatch(const std::string &cid, uint32_t batchSize);
   void addReply(PreProcessReplyMsgSharedPtr replyMsg);
   void updateBatchSize(uint32_t batchSize);
-  bool isBatchRegistered() const { return batchRegistered_; }
-  bool isBatchInProcess() const { return batchInProcess_; }
-  void increaseNumOfCompletedReqs() { numOfCompletedReqs_++; }
+  bool isBatchRegistered() const;
+  bool isBatchInProcess() const;
+  void increaseNumOfCompletedReqs();
   RequestStateSharedPtr &getRequestState(uint16_t reqOffsetInBatch);
   const std::string getCid() const;
   void cancelBatchAndReleaseRequests(const std::string &batchCid, PreProcessingResult status);
@@ -88,7 +88,7 @@ class RequestsBatch {
   void finalizeBatchIfCompleted();
   void handlePossiblyExpiredRequests();
   void sendCancelBatchedPreProcessingMsgToNonPrimaries(const ClientMsgsList &clientMsgs, NodeIdType destId);
-  uint64_t getBlockId() const { return cidToBlockid_.second; }
+  uint64_t getBlockId() const;
 
  private:
   void setBatchParameters(const std::string &cid, uint32_t batchSize);
@@ -98,11 +98,11 @@ class RequestsBatch {
   PreProcessor &preProcessor_;
   const uint16_t clientId_;
   std::string cid_;
-  std::pair<std::string, uint64_t> cidToBlockid_;
-  std::atomic_uint32_t batchSize_ = 0;
-  std::atomic_bool batchRegistered_ = false;
-  std::atomic_bool batchInProcess_ = false;
-  std::atomic_uint32_t numOfCompletedReqs_ = 0;
+  std::pair<std::string, uint64_t> cidToBlockId_;
+  uint32_t batchSize_ = 0;
+  bool batchRegistered_ = false;
+  bool batchInProcess_ = false;
+  uint32_t numOfCompletedReqs_ = 0;
   // Pre-allocated map: request offset in batch -> request state
   std::map<uint16_t, RequestStateSharedPtr> requestsMap_;
   mutable std::mutex batchMutex_;

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -322,8 +322,20 @@ unique_ptr<MessageBase> RequestProcessingState::buildClientRequestMsg(bool empty
 
 const std::set<PreProcessResultSignature> &RequestProcessingState::getPreProcessResultSignatures() {
   const auto &r = preProcessingResultHashes_.find(primaryPreProcessResultHash_);
-  ConcordAssert(r != preProcessingResultHashes_.end());
-  return r->second;
+  if (r != preProcessingResultHashes_.end()) return r->second;
+  LOG_FATAL(logger(),
+            "Primary replica pre-processing has not been completed" << KVLOG(batchCid_,
+                                                                             reqSeqNum_,
+                                                                             clientId_,
+                                                                             cid_,
+                                                                             reqOffsetInBatch_,
+                                                                             preProcessingResultHashes_.size(),
+                                                                             preprocessingRightNow_,
+                                                                             retrying_,
+                                                                             (int)agreedPreProcessResult_,
+                                                                             (int)primaryPreProcessResult_,
+                                                                             numOfReceivedReplies_));
+  ConcordAssert(false);
 }
 
 }  // namespace preprocessor


### PR DESCRIPTION
Check for atomic variables is not thread-safe in case we need to modify a few of them atomically.