### PR TITLE
Fix a race between primary replica request retry and its cancellation

### DIFF
--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -283,7 +283,7 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
                    << KVLOG(static_cast<uint32_t>(agreedPreProcessResult_)) << ", we are done");
       return COMPLETE;
     }
-    if (primaryPreProcessResultLen_ != 0 && !retrying_) {
+    if (primaryPreProcessResultLen_ != 0) {
       // A known scenario that can cause a mismatch, is due to rejection of the block id sent by the primary.
       // In this case the difference should be only the last 64 bits that encodes the `0` as the rejection value.
       if (primaryPreProcessResult_ == OperationResult::SUCCESS) {
@@ -294,8 +294,7 @@ PreProcessingResult RequestProcessingState::definePreProcessingConsensusResult()
         }
       }
       reportNonEqualHashes(itOfChosenHash->first.data(), itOfChosenHash->first.size());
-      retrying_ = true;
-      return RETRY_PRIMARY;
+      return CANCEL;
     }
     LOG_INFO(logger(), "Primary replica did not complete pre-processing yet, continue waiting" << KVLOG(reqSeqNum_));
     return CONTINUE;
@@ -331,7 +330,6 @@ const std::set<PreProcessResultSignature> &RequestProcessingState::getPreProcess
                                                                              reqOffsetInBatch_,
                                                                              preProcessingResultHashes_.size(),
                                                                              preprocessingRightNow_,
-                                                                             retrying_,
                                                                              (int)agreedPreProcessResult_,
                                                                              (int)primaryPreProcessResult_,
                                                                              numOfReceivedReplies_));

--- a/bftengine/src/preprocessor/RequestProcessingState.hpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.hpp
@@ -27,16 +27,7 @@ namespace preprocessor {
 
 // This class collects and stores data relevant to the processing of one specific client request by all replicas.
 
-typedef enum {
-  NONE,
-  CONTINUE,
-  COMPLETE,
-  CANCEL,
-  EXPIRED,
-  FAILED,
-  CANCELLED_BY_PRIMARY,
-  RETRY_PRIMARY
-} PreProcessingResult;
+typedef enum { NONE, CONTINUE, COMPLETE, CANCEL, EXPIRED, FAILED, CANCELLED_BY_PRIMARY } PreProcessingResult;
 
 using ReplicaIdsList = std::vector<ReplicaId>;
 
@@ -146,7 +137,6 @@ class RequestProcessingState {
   // Maps result hash to a list of replica signatures sent for this hash. This also implicitly gives the number of
   // replicas returning a specific hash.
   std::map<concord::util::SHA3_256::Digest, std::set<PreProcessResultSignature>> preProcessingResultHashes_;
-  bool retrying_ = false;
   bool preprocessingRightNow_ = false;
   uint64_t reqRetryId_ = 0;
 };

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -536,51 +536,6 @@ TEST(requestPreprocessingState_test, enoughSameRepliesReceived) {
   clearDiagnosticsHandlers();
 }
 
-TEST(requestPreprocessingState_test, primaryReplicaPreProcessingRetrySucceeds) {
-  RequestProcessingState reqState(replicaConfig.replicaId,
-                                  replicaConfig.numReplicas,
-                                  "",
-                                  clientId,
-                                  0,
-                                  cid,
-                                  reqSeqNum,
-                                  ClientPreProcessReqMsgUniquePtr(),
-                                  PreProcessRequestMsgSharedPtr());
-  bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
-  memset(buf, '5', bufLen);
-  reqState.handlePrimaryPreProcessed(buf, bufLen, OperationResult::SUCCESS);
-  for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != replicaConfig.numReplicas - 1) ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), CONTINUE);
-    memset(buf, '4', bufLen);
-    reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo, STATUS_GOOD, OperationResult::SUCCESS));
-  }
-  ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), RETRY_PRIMARY);
-  memset(buf, '4', bufLen);
-  reqState.handlePrimaryPreProcessed(buf, bufLen, OperationResult::SUCCESS);
-  ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), COMPLETE);
-}
-
-TEST(requestPreprocessingState_test, primaryFailedWhileNonPrimariesSucceeded_SuccessfulRetry) {
-  RequestProcessingState reqState(replicaConfig.replicaId,
-                                  replicaConfig.numReplicas,
-                                  "",
-                                  clientId,
-                                  0,
-                                  cid,
-                                  reqSeqNum,
-                                  ClientPreProcessReqMsgUniquePtr(),
-                                  PreProcessRequestMsgSharedPtr());
-  bftEngine::impl::ReplicasInfo repInfo(replicaConfig, true, true);
-  reqState.handlePrimaryPreProcessed(buf, bufLen, OperationResult::EXEC_DATA_EMPTY);
-  for (auto i = 1; i <= numOfRequiredReplies; i++) {
-    if (i != replicaConfig.numReplicas - 1) ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), CONTINUE);
-    reqState.handlePreProcessReplyMsg(preProcessNonPrimary(i, repInfo, STATUS_GOOD, OperationResult::SUCCESS));
-  }
-  ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), RETRY_PRIMARY);
-  reqState.handlePrimaryPreProcessed(buf, bufLen, OperationResult::SUCCESS);
-  ConcordAssertEQ(reqState.definePreProcessingConsensusResult(), COMPLETE);
-}
-
 TEST(requestPreprocessingState_test, enoughSameErrorRepliesReceived) {
   RequestProcessingState reqState(replicaConfig.replicaId,
                                   replicaConfig.numReplicas,


### PR DESCRIPTION
In case the primary replica pre-execution result hash is different from that non-primaries agreed on, it retries the pre-execution. Practically it never helps as the blockchain state changes all the time and the primary most probably will generate different results than others. I think the better approach is to cancel the request and wait for a client retry to give another chance for all replicas to re-generate the result.
