### PR TITLE
Fix misleading/disordered logs

### DIFF
--- a/bftengine/src/bftengine/ReplicasInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasInfo.hpp
@@ -105,8 +105,8 @@ class ReplicasInfo {
   const std::set<ReplicaId> _idsOfPeerROReplicas;
   const std::set<PrincipalId> _idsOfClientProxies;
   const std::set<PrincipalId> _idsOfExternalClients;
-  const std::set<PrincipalId> _idsOfInternalClients;
   const std::set<PrincipalId> _idsOfClientServices;
+  const std::set<PrincipalId> _idsOfInternalClients;
 };
 }  // namespace impl
 }  // namespace bftEngine


### PR DESCRIPTION
Organize comments and the logs related to the order of principle-ids.