### PR TITLE
Exclude operator id from sig manager (v0.14.x)

### DIFF
--- a/bftengine/src/bftengine/ReplicasInfo.cpp
+++ b/bftengine/src/bftengine/ReplicasInfo.cpp
@@ -112,7 +112,7 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
         for (auto i = start; i < (end - ((uint16_t)config.operatorEnabled_)); ++i) {
           ret.insert(i);
         }
-        ret.insert(end + config.numOfClientServices - 1);
+        if (config.operatorEnabled_) ret.insert(end + config.numOfClientServices - 1);
         if (start != end)
           LOG_INFO(GL,
                    "Principal ids in _idsOfExternalClients: " << start << " to "
@@ -132,7 +132,16 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
         if (config.operatorEnabled_) LOG_INFO(GL, "Operator id: " << end);
         return ret;
       }()},
-
+      _idsOfOperators{[&config]() {
+        std::set<ReplicaId> ret;
+        if (config.operatorEnabled_) {
+          auto operator_id =
+              config.numReplicas + config.numRoReplicas + config.numOfClientProxies + config.numOfExternalClients - 1;
+          ret.insert(operator_id);
+          LOG_INFO(GL, "Operator id: " << operator_id);
+        }
+        return ret;
+      }()},
       _idsOfInternalClients{[&config]() {
         std::set<ReplicaId> ret;
         auto start = config.numReplicas + config.numRoReplicas + config.numOfClientProxies +
@@ -142,13 +151,6 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
           ret.insert(i);
         }
         if (start != end) LOG_INFO(GL, "Principal ids in _idsOfInternalClients: " << start << " to " << end - 1);
-        return ret;
-      }()},
-      _idsOfOperators{[&config]() {
-        std::set<ReplicaId> ret;
-        if (config.operatorEnabled_)
-          ret.insert(config.numReplicas + config.numRoReplicas + config.numOfClientProxies +
-                     config.numOfExternalClients - 1);
         return ret;
       }()} {
   ConcordAssert(_numberOfReplicas == (3 * _fVal + 2 * _cVal + 1));

--- a/bftengine/src/bftengine/ReplicasInfo.cpp
+++ b/bftengine/src/bftengine/ReplicasInfo.cpp
@@ -129,7 +129,6 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
           ret.insert(i);
         }
         if (start != end) LOG_INFO(GL, "Principal ids in _idsOfClientServices: " << start << " to " << end - 1);
-        if (config.operatorEnabled_) LOG_INFO(GL, "Operator id: " << end);
         return ret;
       }()},
       _idsOfOperators{[&config]() {

--- a/bftengine/src/bftengine/ReplicasInfo.cpp
+++ b/bftengine/src/bftengine/ReplicasInfo.cpp
@@ -143,6 +143,13 @@ ReplicasInfo::ReplicasInfo(const ReplicaConfig& config,
         }
         if (start != end) LOG_INFO(GL, "Principal ids in _idsOfInternalClients: " << start << " to " << end - 1);
         return ret;
+      }()},
+      _idsOfOperators{[&config]() {
+        std::set<ReplicaId> ret;
+        if (config.operatorEnabled_)
+          ret.insert(config.numReplicas + config.numRoReplicas + config.numOfClientProxies +
+                     config.numOfExternalClients - 1);
+        return ret;
       }()} {
   ConcordAssert(_numberOfReplicas == (3 * _fVal + 2 * _cVal + 1));
 }

--- a/bftengine/src/bftengine/ReplicasInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasInfo.hpp
@@ -107,8 +107,8 @@ class ReplicasInfo {
   const std::set<PrincipalId> _idsOfClientProxies;
   const std::set<PrincipalId> _idsOfExternalClients;
   const std::set<PrincipalId> _idsOfClientServices;
-  const std::set<PrincipalId> _idsOfInternalClients;
   const std::set<PrincipalId> _idsOfOperators;
+  const std::set<PrincipalId> _idsOfInternalClients;
 };
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/ReplicasInfo.hpp
+++ b/bftengine/src/bftengine/ReplicasInfo.hpp
@@ -37,6 +37,7 @@ class ReplicasInfo {
   bool isIdOfExternalClient(PrincipalId id) const {
     return _idsOfExternalClients.find(id) != _idsOfExternalClients.end();
   }
+  bool isIdOfOperator(PrincipalId id) const { return _idsOfOperators.find(id) != _idsOfOperators.end(); }
   bool isIdOfInternalClient(PrincipalId id) const {
     return _idsOfInternalClients.find(id) != _idsOfInternalClients.end();
   }
@@ -107,6 +108,7 @@ class ReplicasInfo {
   const std::set<PrincipalId> _idsOfExternalClients;
   const std::set<PrincipalId> _idsOfClientServices;
   const std::set<PrincipalId> _idsOfInternalClients;
+  const std::set<PrincipalId> _idsOfOperators;
 };
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -248,7 +248,8 @@ uint16_t SigManager::getMySigLength() const { return (uint16_t)mySigner_->signat
 
 void SigManager::setClientPublicKey(const std::string& key, PrincipalId id, concord::util::crypto::KeyFormat format) {
   LOG_INFO(KEY_EX_LOG, "client: " << id << " key: " << key << " format: " << (uint16_t)format);
-  if (replicasInfo_.isIdOfExternalClient(id) || replicasInfo_.isIdOfClientService(id)) {
+  if ((replicasInfo_.isIdOfExternalClient(id) || replicasInfo_.isIdOfClientService(id)) &&
+      !replicasInfo_.isIdOfOperator(id)) {
     try {
       std::unique_lock lock(mutex_);
       verifiers_.insert_or_assign(id, std::make_shared<concord::util::crypto::RSAVerifier>(key.c_str(), format));


### PR DESCRIPTION
When transaction signing is enabled, the operator id is not part of any client group but it is still considered as an external client.
This causes the replicas to crash in case transaction signing is enabled.