### PR TITLE
Refactor time service logic

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -635,7 +635,7 @@ std::pair<PrePrepareMsg *, bool> ReplicaImp::buildPrePrepareMsgBatchByOverallSiz
 std::pair<PrePrepareMsg *, bool> ReplicaImp::buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
   ConcordAssertGT(requiredRequestsNum, 0);
 
-  if (requestsQueueOfPrimary.size()) {
+  if (requestsQueueOfPrimary.size() < requiredRequestsNum) {
     LOG_DEBUG(GL,
               "Not enough messages in the primary replica queue to fill a batch"
                   << KVLOG(requestsQueueOfPrimary.size(), requiredRequestsNum));
@@ -693,16 +693,6 @@ PrePrepareMsg *ReplicaImp::createPrePrepareMessage() {
     controller->onSendingPrePrepare((primaryLastUsedSeqNum + 1), firstPath);
   }
 
-  if (config_.timeServiceEnabled) {
-    // If time-service is enabled, the first client request will be time request
-    auto pp = new PrePrepareMsg(config_.getreplicaId(),
-                                getCurrentView(),
-                                (primaryLastUsedSeqNum + 1),
-                                firstPath,
-                                requestsQueueOfPrimary.front()->spanContext<ClientRequestMsg>(),
-                                primaryCombinedReqSize);
-    return pp;
-  }
   return new PrePrepareMsg(config_.getreplicaId(),
                            getCurrentView(),
                            (primaryLastUsedSeqNum + 1),

--- a/bftengine/src/bftengine/TimeServiceManager.hpp
+++ b/bftengine/src/bftengine/TimeServiceManager.hpp
@@ -81,56 +81,12 @@ class TimeServiceManager {
     return last_timestamp;
   }
 
-  // Returns a client request message with timestamp (current system clock time)
-  [[nodiscard]] std::unique_ptr<impl::ClientRequestMsg> createClientRequestMsg() const {
-    const auto& config = ReplicaConfig::instance();
-    const auto now = std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch());
-    const auto& serialized = concord::util::serialize(now);
-    return std::make_unique<impl::ClientRequestMsg>(config.replicaId,
-                                                    MsgFlag::TIME_SERVICE_FLAG,
-                                                    0U,
-                                                    serialized.size(),
-                                                    serialized.data(),
-                                                    std::numeric_limits<uint64_t>::max(),
-                                                    "TIME_SERVICE");
+  [[nodiscard]] ConsensusTickRep getTimePoint() {
+    return std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch()).count();
   }
 
-  [[nodiscard]] bool hasTimeRequest(const impl::PrePrepareMsg& msg) const {
-    if (msg.numberOfRequests() < 2) {
-      LOG_WARN(TS_MNGR, "PrePrepare with Time Service on, cannot have less than 2 messages");
-      ill_formed_preprepare_++;
-      metrics_component_.UpdateAggregator();
-      return false;
-    }
-    auto it = impl::RequestsIterator(&msg);
-    char* requestBody = nullptr;
-    ConcordAssertEQ(it.getCurrent(requestBody), true);
-
-    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
-    if (req.flags() != MsgFlag::TIME_SERVICE_FLAG) {
-      LOG_WARN(GL, "Time Service is on but first CR in PrePrepare is not TS request");
-      ill_formed_preprepare_++;
-      metrics_component_.UpdateAggregator();
-      return false;
-    }
-    return true;
-  }
-
-  [[nodiscard]] bool isPrimarysTimeWithinBounds(const impl::PrePrepareMsg& msg) const {
-    ConcordAssertGE(msg.numberOfRequests(), 1);
-
-    auto it = impl::RequestsIterator(&msg);
-    char* requestBody = nullptr;
-    ConcordAssertEQ(it.getCurrent(requestBody), true);
-
-    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
-    return isPrimarysTimeWithinBounds(req);
-  }
-
-  [[nodiscard]] bool isPrimarysTimeWithinBounds(impl::ClientRequestMsg& msg) const {
-    ConcordAssert((msg.flags() & MsgFlag::TIME_SERVICE_FLAG) != 0 &&
-                  "TimeServiceManager supports only messages with TIME_SERVICE_FLAG");
-    const auto t = concord::util::deserialize<ConsensusTime>(msg.requestBuf(), msg.requestBuf() + msg.requestLength());
+  [[nodiscard]] bool isPrimarysTimeWithinBounds(ConsensusTickRep timePoint) const {
+    const ConsensusTime t(timePoint);
     const auto now = std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch());
 
     const auto& config = ReplicaConfig::instance();

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -36,6 +36,7 @@ class PrePrepareMsg : public MessageBase {
     EpochNum epochNum;
     uint16_t flags;
     uint64_t batchCidLength;
+    int64_t time;
     Digest digestOfRequests;
 
     uint16_t numberOfRequests;
@@ -48,7 +49,7 @@ class PrePrepareMsg : public MessageBase {
     // 10 = SLOW) bits 4-15: zero
   };
 #pragma pack(pop)
-  static_assert(sizeof(Header) == (6 + 8 + 8 + 8 + 2 + DIGEST_SIZE + 2 + 4 + 8), "Header is 78B");
+  static_assert(sizeof(Header) == (6 + 8 + 8 + 8 + 2 + 8 + DIGEST_SIZE + 2 + 4 + 8), "Header is 86B");
 
   static const size_t prePrepareHeaderPrefix =
       sizeof(Header) - sizeof(Header::numberOfRequests) - sizeof(Header::endLocationOfLastRequest);
@@ -96,7 +97,8 @@ class PrePrepareMsg : public MessageBase {
 
   SeqNum seqNumber() const { return b()->seqNum; }
   void setSeqNumber(SeqNum s) { b()->seqNum = s; }
-
+  int64_t getTime() const { return b()->time; }
+  void setTime(int64_t time) { b()->time = time; }
   std::string getCid() const;
   void setCid(SeqNum s);
 

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -47,11 +47,10 @@ def start_replica_cmd(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -79,11 +78,11 @@ def start_replica_cmd_with_high_db_window_size(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -111,11 +110,11 @@ def start_replica_cmd_db_snapshot_disabled(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -142,11 +141,11 @@ def start_replica_cmd_with_operator_and_public_keys(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -39,11 +39,11 @@ def start_replica_cmd_with_object_store(builddir, replica_id, config):
     """
     ret = start_replica_cmd_prefix(builddir, replica_id, config)
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+    
+    batch_size = "1"
     ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem"])
     return ret
 
@@ -56,11 +56,11 @@ def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
     """
     ret = start_replica_cmd_prefix(builddir, replica_id, config)
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+        
+    batch_size = "1"
     ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem", "--publish-master-key-on-startup"])
     return ret
 
@@ -75,11 +75,11 @@ def start_replica_cmd(builddir, replica_id):
     viewChangeTimeoutMilli = "10000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+        
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -104,11 +104,11 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
     viewChangeTimeoutMilli = "10000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+    
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),


### PR DESCRIPTION
Instead of having the time request as a client request inside the prePrepare message, we add it as a metadata in the prePrepare message