### PR TITLE
TPS snowball drop due to pruning mitigation

### DIFF
--- a/kvbc/include/resources-manager/AdaptivePruningManager.hpp
+++ b/kvbc/include/resources-manager/AdaptivePruningManager.hpp
@@ -32,7 +32,7 @@ class AdaptivePruningManager {
   }
   PruningMode getCurrentMode() { return mode.load(); }
 
-  void setPrimay(bool isPrimary) {
+  void setPrimary(bool isPrimary) {
     LOG_INFO(ADPTV_PRUNING, "am I the new primary? " << isPrimary);
     if (isPrimary) {
       amIPrimary = true;

--- a/kvbc/include/resources-manager/IntervalMappingResourceManager.hpp
+++ b/kvbc/include/resources-manager/IntervalMappingResourceManager.hpp
@@ -19,6 +19,11 @@
 #include <vector>
 #include <algorithm>
 
+struct IntervalMappingResourceManagerConfiguration {
+  uint16_t limitMaximumPruningTimeUtilizationPercentage{60};
+  uint16_t pruningTimeUlizationTPSInterferenceLimitPercentage{20};
+};
+
 namespace concord::performance {
 class IntervalMappingResourceManager : public IResourceManager {
  public:
@@ -32,17 +37,23 @@ class IntervalMappingResourceManager : public IResourceManager {
   virtual PruneInfo getPruneInfo() override;
 
   static std::unique_ptr<IntervalMappingResourceManager> createIntervalMappingResourceManager(
-      ISystemResourceEntity &replicaResources, std::vector<std::pair<uint64_t, uint64_t>> &&intervalMapping) {
+      ISystemResourceEntity &replicaResources,
+      std::vector<std::pair<uint64_t, uint64_t>> &&intervalMapping,
+      const IntervalMappingResourceManagerConfiguration &configuration =
+          IntervalMappingResourceManagerConfiguration{}) {
+    sort(intervalMapping.begin(), intervalMapping.end());
     intervalMapping.push_back(std::make_pair(UINT64_MAX, 0));
     return std::unique_ptr<IntervalMappingResourceManager>(
-        new IntervalMappingResourceManager(replicaResources, std::move(intervalMapping)));
+        new IntervalMappingResourceManager(replicaResources, std::move(intervalMapping), configuration));
   }
-
-  IntervalMappingResourceManager(ISystemResourceEntity &replicaResources,
-                                 std::vector<std::pair<uint64_t, uint64_t>> &&intervalMapping);
 
   std::uint64_t getDurationFromLastCallSec();
   virtual void setPeriod(std::uint64_t interval) override { periodicInterval_ = interval; }
+
+ protected:
+  IntervalMappingResourceManager(ISystemResourceEntity &replicaResources,
+                                 std::vector<std::pair<uint64_t, uint64_t>> &&intervalMapping,
+                                 const IntervalMappingResourceManagerConfiguration &configuration);
 
  private:
   ISystemResourceEntity &replicaResources_;
@@ -51,5 +62,6 @@ class IntervalMappingResourceManager : public IResourceManager {
   std::uint64_t period_{0};
   std::uint64_t periodicInterval_{20};  // config
   std::uint64_t lastTPS_{0};
+  IntervalMappingResourceManagerConfiguration configuration;
 };
 }  // namespace concord::performance

--- a/kvbc/include/resources-manager/IntervalMappingResourceManager.hpp
+++ b/kvbc/include/resources-manager/IntervalMappingResourceManager.hpp
@@ -50,5 +50,6 @@ class IntervalMappingResourceManager : public IResourceManager {
   std::uint64_t lastInvocationTime_{0};
   std::uint64_t period_{0};
   std::uint64_t periodicInterval_{20};  // config
+  std::uint64_t lastTPS_{0};
 };
 }  // namespace concord::performance

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -315,7 +315,7 @@ void Replica::createReplicaAndSyncState() {
       m_metadataStorage,
       pm_,
       secretsManager_,
-      std::bind(&AdaptivePruningManager::setPrimay, &AdaptivePruningManager_, std::placeholders::_1));
+      std::bind(&AdaptivePruningManager::setPrimary, &AdaptivePruningManager_, std::placeholders::_1));
   requestHandler->setPersistentStorage(m_replicaPtr->persistentStorage());
   AdaptivePruningManager_.initBFTClient(m_replicaPtr->internalClient());
 

--- a/kvbc/src/resources-manager/AdaptivePruningManager.cpp
+++ b/kvbc/src/resources-manager/AdaptivePruningManager.cpp
@@ -44,7 +44,7 @@ void AdaptivePruningManager::notifyReplicas(const PruneInfo &pruneInfo) {
   pruneRequest.sender_id = bftEngine::ReplicaConfig::instance().replicaId;
   pruneRequest.interval_between_ticks_seconds = bftEngine::ReplicaConfig::instance().numReplicas;
 
-  pruneRequest.batch_blocks_num = pruneInfo.blocksPerSecond / bftEngine::ReplicaConfig::instance().numReplicas;
+  pruneRequest.batch_blocks_num = pruneInfo.blocksPerSecond;
 
   // Is this going to register all send values or just update current
   blocksPerSecondMetric.Get().Set(pruneInfo.blocksPerSecond);

--- a/kvbc/src/resources-manager/IntervalMappingResourceManager.cpp
+++ b/kvbc/src/resources-manager/IntervalMappingResourceManager.cpp
@@ -62,9 +62,9 @@ PruneInfo IntervalMappingResourceManager::getPruneInfo() {
   PruneInfo ret;
   if (it != intervalMapping_.end()) {
     // 0.9 reflects maximum allowed 10% drop in perfomance.
-    double adjust = 1;
+    long double adjust = 1;
     if (lastTPS_ * 0.9 > tps && pruningUtilization > configuration.limitMaximumPruningTimeUtilizationPercentage) {
-      adjust = (100 - pruningUtilization) / 100.0;
+      adjust = (100 - (long double)pruningUtilization) / 100.0;
       LOG_WARN(ADPTV_PRUNING, "Pruning consumes too much resources at the cost of TPS. Adjusting by " << adjust);
 
       // pruningTimeUlizationTPSInterferenceLimit of percentage where it can be assumed that tps fall is not caused by

--- a/kvbc/src/resources-manager/ReplicaResources.cpp
+++ b/kvbc/src/resources-manager/ReplicaResources.cpp
@@ -88,7 +88,9 @@ void ReplicaResourceEntity::start() { is_stopped = false; }
 void ReplicaResourceEntity::reset() {
   mutex_.lock();
   pruning_utilization.restart();
+  pruning_utilization.addMarker();
   post_exec_utilization.restart();
+  post_exec_utilization.addMarker();
   pruned_blocks = 0;
   pruning_accumulated_time = 0;
   num_of_consensus = 0;

--- a/kvbc/test/resources-manager/ResourceManagerTest.cpp
+++ b/kvbc/test/resources-manager/ResourceManagerTest.cpp
@@ -20,19 +20,29 @@ using namespace std::chrono_literals;
 
 namespace {
 
+const double MaxToleratedError = 0.5;
+
 using namespace concord::performance;
 
 class ResourceEntityMock : public ISystemResourceEntity {
  public:
   virtual ~ResourceEntityMock() = default;
   virtual int64_t getAvailableResources() const override { return availableResources; }
-  virtual uint64_t getMeasurement(const type type) const override { return measurements; }
+  virtual uint64_t getMeasurement(const type type) const override {
+    switch (type) {
+      case type::pruning_utilization:
+        return cpuMeasurements;
+      default:
+        return measurements;
+    }
+  }
 
   virtual const std::string getResourceName() const override { return "MOCK"; }
 
   virtual void reset() override {
     availableResources = 0;
     measurements = 0;
+    cpuMeasurements = 0;
   }
 
   virtual void stop() override {}
@@ -42,24 +52,26 @@ class ResourceEntityMock : public ISystemResourceEntity {
 
   int64_t availableResources;
   uint64_t measurements;
+  uint64_t cpuMeasurements;
 };  // namespace
 
 TEST(IntervalMappingResourceManager_test, duration) {
   std::vector<std::pair<uint64_t, uint64_t>> mapping{{200, 100}, {600, 10}, {1000, 5}};
   auto consensusEngineResourceMonitor = ResourceEntityMock{};
 
-  auto interval_mapping = IntervalMappingResourceManager(consensusEngineResourceMonitor, std::move(mapping));
-  auto first_duration = interval_mapping.getDurationFromLastCallSec();
+  auto interval_mapping = IntervalMappingResourceManager::createIntervalMappingResourceManager(
+      consensusEngineResourceMonitor, std::move(mapping), IntervalMappingResourceManagerConfiguration{});
+  auto first_duration = interval_mapping->getDurationFromLastCallSec();
   // First duration is 0
   ASSERT_EQ(first_duration, 0);
   // Second duration, short interval, should be rounded up to 1
   {
-    auto duration = interval_mapping.getDurationFromLastCallSec();
+    auto duration = interval_mapping->getDurationFromLastCallSec();
     ASSERT_EQ(duration, 1);
   }
   {
     std::this_thread::sleep_for(2s);
-    auto duration = interval_mapping.getDurationFromLastCallSec();
+    auto duration = interval_mapping->getDurationFromLastCallSec();
     ASSERT_EQ(duration, 2);
   }
 }
@@ -67,43 +79,44 @@ TEST(IntervalMappingResourceManager_test, duration) {
 TEST(IntervalMappingResourceManager_test, prune_info) {
   std::vector<std::pair<uint64_t, uint64_t>> mapping{{60, 40}, {100, 30}, {300, 20}, {500, 10}};
   auto consensusEngineResourceMonitor = ResourceEntityMock{};
-  auto interval_mapping = IntervalMappingResourceManager(consensusEngineResourceMonitor, std::move(mapping));
+  auto interval_mapping = IntervalMappingResourceManager::createIntervalMappingResourceManager(
+      consensusEngineResourceMonitor, std::move(mapping), IntervalMappingResourceManagerConfiguration{});
   // First prune info is 0
   consensusEngineResourceMonitor.measurements = 110;
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 0);
   }
   consensusEngineResourceMonitor.measurements = 110;
   // second prune gets rate of 110tps
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 20);
   }
   // tps is now will be devided by two i.e. 119/2 = 59
   consensusEngineResourceMonitor.measurements = 119;
   {
     std::this_thread::sleep_for(2s);
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 40);
   }
   // duration 1 -> 600 tps
   consensusEngineResourceMonitor.measurements = 600;
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 0);
   }
   // duration 4 -> 150 tps
   consensusEngineResourceMonitor.measurements = 600;
   {
     std::this_thread::sleep_for(4s);
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 20);
   }
   // duration 1 -> 300 tps
   consensusEngineResourceMonitor.measurements = 300;
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 20);
   }
 }
@@ -111,56 +124,119 @@ TEST(IntervalMappingResourceManager_test, prune_info) {
 TEST(IntervalMappingResourceManager_test, periodic_interval) {
   std::vector<std::pair<uint64_t, uint64_t>> mapping{{60, 40}, {100, 30}, {300, 20}, {500, 10}};
   auto consensusEngineResourceMonitor = ResourceEntityMock{};
-  auto interval_mapping = IntervalMappingResourceManager(consensusEngineResourceMonitor, std::move(mapping));
+  auto interval_mapping = IntervalMappingResourceManager::createIntervalMappingResourceManager(
+      consensusEngineResourceMonitor, std::move(mapping));
   // reset every three calls
-  interval_mapping.setPeriod(3);
+  interval_mapping->setPeriod(3);
   // First prune info is 0
   consensusEngineResourceMonitor.measurements = 80;
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 0);
   }
 
   consensusEngineResourceMonitor.measurements = 110;
   // second prune gets rate of 110tps
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 20);
   }
   // tps is now will be devided by two i.e. 119/2 = 59
   consensusEngineResourceMonitor.measurements = 119;
   {
     std::this_thread::sleep_for(2s);
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 40);
   }
   // period should happen
   consensusEngineResourceMonitor.measurements = 110;
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 0);
   }
 
   consensusEngineResourceMonitor.measurements = 310;
   // second prune gets rate of 110tps
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 10);
   }
   // tps is now will be devided by two i.e. 119/2 = 59
   consensusEngineResourceMonitor.measurements = 119;
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 20);
   }
   // period should happen
   consensusEngineResourceMonitor.measurements = 10;
   {
-    auto prune_info = interval_mapping.getPruneInfo();
+    auto prune_info = interval_mapping->getPruneInfo();
     ASSERT_EQ(prune_info.blocksPerSecond, 0);
   }
 }
 
+TEST(IntervalMappingResourceManager_test, tps_drop_due_to_pruning_mitigation) {
+  std::vector<std::pair<uint64_t, uint64_t>> mapping{{60, 40}, {100, 30}, {300, 20}, {500, 10}};
+  auto consensusEngineResourceMonitor = ResourceEntityMock{};
+  auto interval_mapping = IntervalMappingResourceManager::createIntervalMappingResourceManager(
+      consensusEngineResourceMonitor, std::move(mapping), IntervalMappingResourceManagerConfiguration{});
+
+  // reset every three calls
+  interval_mapping->setPeriod(20);
+  // First prune info is 0
+  consensusEngineResourceMonitor.measurements = 110;
+  consensusEngineResourceMonitor.cpuMeasurements = 0;
+  {
+    auto prune_info = interval_mapping->getPruneInfo();
+    ASSERT_EQ(prune_info.blocksPerSecond, 0);
+  }
+
+  consensusEngineResourceMonitor.measurements = 110;
+  {
+    auto prune_info = interval_mapping->getPruneInfo();
+    ASSERT_EQ(prune_info.blocksPerSecond, 20);
+  }
+
+  consensusEngineResourceMonitor.measurements = 90;
+  consensusEngineResourceMonitor.cpuMeasurements = 80;
+  // Too much tps is lost. Slow down pruning
+  {
+    auto prune_info = interval_mapping->getPruneInfo();
+    ASSERT_LT(abs(prune_info.blocksPerSecond - 6), MaxToleratedError);
+  }
+
+  consensusEngineResourceMonitor.measurements = 400;
+  consensusEngineResourceMonitor.cpuMeasurements = 50;
+  // Tps is growing and pruning ulization is on acceptable level, so mapping to 10
+  {
+    auto prune_info = interval_mapping->getPruneInfo();
+    ASSERT_LT(abs(prune_info.blocksPerSecond - 10), MaxToleratedError);
+  }
+
+  consensusEngineResourceMonitor.measurements = 380;
+  consensusEngineResourceMonitor.cpuMeasurements = 90;
+  // Pruning utlization is high but the loss in the tps is acceptable
+  {
+    auto prune_info = interval_mapping->getPruneInfo();
+    ASSERT_LT(abs(prune_info.blocksPerSecond - 10), MaxToleratedError);
+  }
+
+  consensusEngineResourceMonitor.measurements = 180;
+  consensusEngineResourceMonitor.cpuMeasurements = 90;
+  // tps drops naturally, but for safety adjustment is made
+  {
+    auto prune_info = interval_mapping->getPruneInfo();
+    ASSERT_LT(abs(prune_info.blocksPerSecond - 2), MaxToleratedError);
+  }
+
+  consensusEngineResourceMonitor.measurements = 180;
+  consensusEngineResourceMonitor.cpuMeasurements = 20;
+  // tps stable - resources to prune
+  {
+    auto prune_info = interval_mapping->getPruneInfo();
+    ASSERT_LT(abs(prune_info.blocksPerSecond - 20), MaxToleratedError);
+  }
+}
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {

--- a/util/include/utilization.hpp
+++ b/util/include/utilization.hpp
@@ -36,9 +36,23 @@ class utilization {
     utilization_.push_back(std::move(dur));
   }
 
+  // Convenience method for adding marker measurements.
+  // i.e. start and end
+  void addMarker() {
+    durtionMicro dur;
+    dur.start =
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+    dur.end = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch())
+                  .count();
+    addDuration(std::move(dur));
+    marker_ = true;
+  }
+
   // Calculate the total time and then subtracts the intervals between the operations.
   std::uint64_t getUtilization() const {
-    if (utilization_.size() == 0) return 0;
+    uint64_t init_measurement = marker_ ? 1 : 0;
+    if (utilization_.size() == init_measurement) return 0;
     const auto total_time = utilization_.back().end - utilization_.front().start;
     auto busy_time = total_time;
     for (auto it = utilization_.cbegin(); (it + 1) < utilization_.cend(); it++) {
@@ -54,6 +68,7 @@ class utilization {
 
  private:
   std::vector<durtionMicro> utilization_;
+  bool marker_{false};
 };
 
 }  // namespace concordUtil


### PR DESCRIPTION
**Problem:** When the adaptive pruning starts working with certain TPS, it is observed that pruning operation highjack the cluster resources and TPS drops. After that the adaptive pruning requests even more block to be prune, creating a snowball effect.

**Solution:** when TPS drop is observed with pruning utilization, lower down the blocks per second rate.

**Testing:** unit test to simulate the tps drop due to pruning mitigation