### PR TITLE
Refactor time service logic

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -165,10 +165,11 @@ void ReplicaImp::registerMsgHandlers() {
 template <typename T>
 void ReplicaImp::messageHandler(MessageBase *msg) {
   T *trueTypeObj = new T(msg);
-  validateMessage(trueTypeObj);
   if (isCollectingState()) {
     // Extract only required information and handover to ST thread
-    peekConsensusMessage<T>(msg);
+    if (validateMessage(trueTypeObj)) {
+      peekConsensusMessage<T>(msg);
+    }
   }
   delete msg;
 
@@ -639,7 +640,7 @@ std::pair<PrePrepareMsg *, bool> ReplicaImp::buildPrePrepareMsgBatchByOverallSiz
 std::pair<PrePrepareMsg *, bool> ReplicaImp::buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
   ConcordAssertGT(requiredRequestsNum, 0);
 
-  if (requestsQueueOfPrimary.size()) {
+  if (requestsQueueOfPrimary.size() < requiredRequestsNum) {
     LOG_DEBUG(GL,
               "Not enough messages in the primary replica queue to fill a batch"
                   << KVLOG(requestsQueueOfPrimary.size(), requiredRequestsNum));
@@ -697,16 +698,6 @@ PrePrepareMsg *ReplicaImp::createPrePrepareMessage() {
     controller->onSendingPrePrepare((primaryLastUsedSeqNum + 1), firstPath);
   }
 
-  if (config_.timeServiceEnabled) {
-    // If time-service is enabled, the first client request will be time request
-    auto pp = new PrePrepareMsg(config_.getreplicaId(),
-                                getCurrentView(),
-                                (primaryLastUsedSeqNum + 1),
-                                firstPath,
-                                requestsQueueOfPrimary.front()->spanContext<ClientRequestMsg>(),
-                                primaryCombinedReqSize);
-    return pp;
-  }
   return new PrePrepareMsg(config_.getreplicaId(),
                            getCurrentView(),
                            (primaryLastUsedSeqNum + 1),
@@ -877,7 +868,10 @@ void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp) {
 void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp, bool isCreatedEarlier) {
   if (!isCurrentPrimary()) return;
   TimeRecorder scoped_timer(*histograms_.startConsensusProcess);
-  pp->setTime(time_service_manager_->getTimePoint());
+  if (getReplicaConfig().timeServiceEnabled) {
+    pp->setTime(time_service_manager_->getClockTimePoint());
+  }
+
   auto firstPath = pp->firstPath();
   if (config_.getdebugStatisticsEnabled()) {
     DebugStatistics::onSendPrePrepareMessage(pp->numberOfRequests(), requestsQueueOfPrimary.size());
@@ -1098,13 +1092,14 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
 
     bool time_is_ok = true;
     if (config_.timeServiceEnabled) {
-      if (msg->getTime() == 0) {
-        LOG_WARN(CNSUS, "No timePoint in the prePrepare, PrePrepare will be ignored");
+      auto ppmTime = msg->getTime();
+      if (ppmTime <= 0) {
+        LOG_WARN(CNSUS, "No timePoint in the prePrepare, PrePrepare will be ignored" << KVLOG(ppmTime));
         delete msg;
         return;
       }
       if (msgSeqNum > maxSeqNumTransferredFromPrevViews /* not transferred from the previous view*/) {
-        time_is_ok = time_service_manager_->isPrimarysTimeWithinBounds(msg->getTime());
+        time_is_ok = time_service_manager_->isPrimarysTimeWithinBounds(ppmTime);
       }
     }
     // For MDC it doesn't matter which type of fast path

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -638,9 +638,8 @@ std::pair<PrePrepareMsg *, bool> ReplicaImp::buildPrePrepareMsgBatchByOverallSiz
 // So, the second value of the pair provides the real indication of success of failure.
 std::pair<PrePrepareMsg *, bool> ReplicaImp::buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
   ConcordAssertGT(requiredRequestsNum, 0);
-  // DD: To make sure that time service does not affect sending messages
-  uint32_t timeServiceBatchSizeAdjustment = config_.timeServiceEnabled ? 1 : 0;
-  if (requestsQueueOfPrimary.size() < requiredRequestsNum - timeServiceBatchSizeAdjustment) {
+
+  if (requestsQueueOfPrimary.size()) {
     LOG_DEBUG(GL,
               "Not enough messages in the primary replica queue to fill a batch"
                   << KVLOG(requestsQueueOfPrimary.size(), requiredRequestsNum));
@@ -700,15 +699,12 @@ PrePrepareMsg *ReplicaImp::createPrePrepareMessage() {
 
   if (config_.timeServiceEnabled) {
     // If time-service is enabled, the first client request will be time request
-    auto timeServiceMsg = time_service_manager_->createClientRequestMsg();
     auto pp = new PrePrepareMsg(config_.getreplicaId(),
                                 getCurrentView(),
                                 (primaryLastUsedSeqNum + 1),
                                 firstPath,
                                 requestsQueueOfPrimary.front()->spanContext<ClientRequestMsg>(),
-                                primaryCombinedReqSize + timeServiceMsg->size());
-    // add time-Service request as first message in pre-prepare message
-    pp->addRequest(timeServiceMsg->body(), timeServiceMsg->size());
+                                primaryCombinedReqSize);
     return pp;
   }
   return new PrePrepareMsg(config_.getreplicaId(),
@@ -881,6 +877,7 @@ void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp) {
 void ReplicaImp::startConsensusProcess(PrePrepareMsg *pp, bool isCreatedEarlier) {
   if (!isCurrentPrimary()) return;
   TimeRecorder scoped_timer(*histograms_.startConsensusProcess);
+  pp->setTime(time_service_manager_->getTimePoint());
   auto firstPath = pp->firstPath();
   if (config_.getdebugStatisticsEnabled()) {
     DebugStatistics::onSendPrePrepareMessage(pp->numberOfRequests(), requestsQueueOfPrimary.size());
@@ -1100,14 +1097,14 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
     const bool slowStarted = (msg->firstPath() == CommitPath::SLOW || seqNumInfo.slowPathStarted());
 
     bool time_is_ok = true;
-    if (config_.timeServiceEnabled && msg->numberOfRequests() > 0) {
-      if (!time_service_manager_->hasTimeRequest(*msg)) {
-        LOG_WARN(CNSUS, "PrePrepare will be ignored");
+    if (config_.timeServiceEnabled) {
+      if (msg->getTime() == 0) {
+        LOG_WARN(CNSUS, "No timePoint in the prePrepare, PrePrepare will be ignored");
         delete msg;
         return;
       }
       if (msgSeqNum > maxSeqNumTransferredFromPrevViews /* not transferred from the previous view*/) {
-        time_is_ok = time_service_manager_->isPrimarysTimeWithinBounds(*msg);
+        time_is_ok = time_service_manager_->isPrimarysTimeWithinBounds(msg->getTime());
       }
     }
     // For MDC it doesn't matter which type of fast path
@@ -1121,7 +1118,6 @@ void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
       char *requestBody = nullptr;
       while (reqIter.getAndGoToNext(requestBody)) {
         ClientRequestMsg req(reinterpret_cast<ClientRequestMsgHeader *>(requestBody));
-        if (config_.timeServiceEnabled && req.flags() & MsgFlag::TIME_SERVICE_FLAG) continue;
         if (!clientsManager->isValidClient(req.clientProxyId())) continue;
         clientsManager->removeRequestsOutOfBatchBounds(req.clientProxyId(), req.requestSeqNum());
         if (clientsManager->canBecomePending(req.clientProxyId(), req.requestSeqNum()))
@@ -5106,7 +5102,6 @@ void ReplicaImp::tryToRemovePendingRequestsForSeqNum(SeqNum seqNum) {
   char *requestBody = nullptr;
   while (reqIter.getAndGoToNext(requestBody)) {
     ClientRequestMsg req((ClientRequestMsgHeader *)requestBody);
-    if (config_.timeServiceEnabled && req.flags() & MsgFlag::TIME_SERVICE_FLAG) continue;
     if (!clientsManager->isValidClient(req.clientProxyId())) continue;
     auto clientId = req.clientProxyId();
     LOG_DEBUG(GL, "removing pending requests for client" << KVLOG(clientId));

--- a/bftengine/src/bftengine/TimeServiceManager.hpp
+++ b/bftengine/src/bftengine/TimeServiceManager.hpp
@@ -81,56 +81,12 @@ class TimeServiceManager {
     return last_timestamp;
   }
 
-  // Returns a client request message with timestamp (current system clock time)
-  [[nodiscard]] std::unique_ptr<impl::ClientRequestMsg> createClientRequestMsg() const {
-    const auto& config = ReplicaConfig::instance();
-    const auto now = std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch());
-    const auto& serialized = concord::util::serialize(now);
-    return std::make_unique<impl::ClientRequestMsg>(config.replicaId,
-                                                    MsgFlag::TIME_SERVICE_FLAG,
-                                                    0U,
-                                                    serialized.size(),
-                                                    serialized.data(),
-                                                    std::numeric_limits<uint64_t>::max(),
-                                                    "TIME_SERVICE");
+  [[nodiscard]] ConsensusTickRep getTimePoint() {
+    return std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch()).count();
   }
 
-  [[nodiscard]] bool hasTimeRequest(const impl::PrePrepareMsg& msg) const {
-    if (msg.numberOfRequests() < 2) {
-      LOG_WARN(TS_MNGR, "PrePrepare with Time Service on, cannot have less than 2 messages");
-      ill_formed_preprepare_++;
-      metrics_component_.UpdateAggregator();
-      return false;
-    }
-    auto it = impl::RequestsIterator(&msg);
-    char* requestBody = nullptr;
-    ConcordAssertEQ(it.getCurrent(requestBody), true);
-
-    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
-    if (req.flags() != MsgFlag::TIME_SERVICE_FLAG) {
-      LOG_WARN(GL, "Time Service is on but first CR in PrePrepare is not TS request");
-      ill_formed_preprepare_++;
-      metrics_component_.UpdateAggregator();
-      return false;
-    }
-    return true;
-  }
-
-  [[nodiscard]] bool isPrimarysTimeWithinBounds(const impl::PrePrepareMsg& msg) const {
-    ConcordAssertGE(msg.numberOfRequests(), 1);
-
-    auto it = impl::RequestsIterator(&msg);
-    char* requestBody = nullptr;
-    ConcordAssertEQ(it.getCurrent(requestBody), true);
-
-    ClientRequestMsg req((ClientRequestMsgHeader*)requestBody);
-    return isPrimarysTimeWithinBounds(req);
-  }
-
-  [[nodiscard]] bool isPrimarysTimeWithinBounds(impl::ClientRequestMsg& msg) const {
-    ConcordAssert((msg.flags() & MsgFlag::TIME_SERVICE_FLAG) != 0 &&
-                  "TimeServiceManager supports only messages with TIME_SERVICE_FLAG");
-    const auto t = concord::util::deserialize<ConsensusTime>(msg.requestBuf(), msg.requestBuf() + msg.requestLength());
+  [[nodiscard]] bool isPrimarysTimeWithinBounds(ConsensusTickRep timePoint) const {
+    const ConsensusTime t(timePoint);
     const auto now = std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch());
 
     const auto& config = ReplicaConfig::instance();

--- a/bftengine/src/bftengine/TimeServiceManager.hpp
+++ b/bftengine/src/bftengine/TimeServiceManager.hpp
@@ -81,7 +81,7 @@ class TimeServiceManager {
     return last_timestamp;
   }
 
-  [[nodiscard]] ConsensusTickRep getTimePoint() {
+  [[nodiscard]] ConsensusTickRep getClockTimePoint() {
     return std::chrono::duration_cast<ConsensusTime>(ClockT::now().time_since_epoch()).count();
   }
 

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
@@ -170,6 +170,7 @@ PrePrepareMsg::PrePrepareMsg(ReplicaId sender,
   b()->seqNum = s;
   b()->epochNum = EpochManager::instance().getSelfEpochNumber();
   b()->viewNum = v;
+  b()->time = 0;
 
   char* position = body() + sizeof(Header);
   memcpy(position, spanContext.data().data(), b()->header.spanContextSize);

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -38,6 +38,7 @@ class PrePrepareMsg : public MessageBase {
     EpochNum epochNum;
     uint16_t flags;
     uint64_t batchCidLength;
+    int64_t time;
     Digest digestOfRequests;
 
     uint16_t numberOfRequests;
@@ -50,7 +51,7 @@ class PrePrepareMsg : public MessageBase {
     // 10 = SLOW) bits 4-15: zero
   };
 #pragma pack(pop)
-  static_assert(sizeof(Header) == (6 + 8 + 8 + 8 + 2 + DIGEST_SIZE + 2 + 4 + 8), "Header is 78B");
+  static_assert(sizeof(Header) == (6 + 8 + 8 + 8 + 2 + 8 + DIGEST_SIZE + 2 + 4 + 8), "Header is 86B");
 
   static const size_t prePrepareHeaderPrefix =
       sizeof(Header) - sizeof(Header::numberOfRequests) - sizeof(Header::endLocationOfLastRequest);
@@ -98,7 +99,8 @@ class PrePrepareMsg : public MessageBase {
 
   SeqNum seqNumber() const { return b()->seqNum; }
   void setSeqNumber(SeqNum s) { b()->seqNum = s; }
-
+  int64_t getTime() const { return b()->time; }
+  void setTime(int64_t time) { b()->time = time; }
   std::string getCid() const;
   void setCid(SeqNum s);
 

--- a/bftengine/tests/timeServiceManager/TimeServiceManager_test.cpp
+++ b/bftengine/tests/timeServiceManager/TimeServiceManager_test.cpp
@@ -66,7 +66,7 @@ TEST(TimeServiceManager, TimeWithinLimits) {
 
   auto aggregator = std::make_shared<concordMetrics::Aggregator>();
   auto manager = TimeServiceManager<FakeClock>{aggregator};
-  const auto time = manager.getTimePoint();
+  const auto time = manager.getClockTimePoint();
 
   EXPECT_TRUE(manager.isPrimarysTimeWithinBounds(time));
   EXPECT_EQ(aggregator->GetCounter("time_service", "hard_limit_reached_counter").Get(), 0);
@@ -88,7 +88,7 @@ TEST(TimeServiceManager, TimeOutOfHardLimits) {
 
   auto aggregator = std::make_shared<concordMetrics::Aggregator>();
   auto manager = TimeServiceManager<FakeClock>{aggregator};
-  const auto time = manager.getTimePoint();
+  const auto time = manager.getClockTimePoint();
 
   FakeClock::current_time = now + config.timeServiceHardLimitMillis + std::chrono::milliseconds{1};
   EXPECT_FALSE(manager.isPrimarysTimeWithinBounds(time));
@@ -114,7 +114,7 @@ TEST(TimeServiceManager, TimeOnTheEdgeOfHardLimits) {
 
   auto aggregator = std::make_shared<concordMetrics::Aggregator>();
   auto manager = TimeServiceManager<FakeClock>{aggregator};
-  const auto time = manager.getTimePoint();
+  const auto time = manager.getClockTimePoint();
 
   FakeClock::current_time = now + config.timeServiceHardLimitMillis;
   EXPECT_TRUE(manager.isPrimarysTimeWithinBounds(time));
@@ -141,7 +141,7 @@ TEST(TimeServiceManager, TimeOutOfSoftLimits) {
 
   auto aggregator = std::make_shared<concordMetrics::Aggregator>();
   auto manager = TimeServiceManager<FakeClock>{aggregator};
-  const auto time = manager.getTimePoint();
+  const auto time = manager.getClockTimePoint();
 
   FakeClock::current_time = now + config.timeServiceSoftLimitMillis + std::chrono::milliseconds{1};
   EXPECT_TRUE(manager.isPrimarysTimeWithinBounds(time));
@@ -168,7 +168,7 @@ TEST(TimeServiceManager, TimeOnTheEdgeOfSoftLimits) {
 
   auto aggregator = std::make_shared<concordMetrics::Aggregator>();
   auto manager = TimeServiceManager<FakeClock>{aggregator};
-  const auto time = manager.getTimePoint();
+  const auto time = manager.getClockTimePoint();
 
   FakeClock::current_time = now + config.timeServiceSoftLimitMillis;
   EXPECT_TRUE(manager.isPrimarysTimeWithinBounds(time));

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -52,11 +52,10 @@ def start_replica_cmd(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -84,11 +83,11 @@ def start_replica_cmd_with_high_db_window_size(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -116,11 +115,11 @@ def start_replica_cmd_db_snapshot_disabled(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -147,11 +146,11 @@ def start_replica_cmd_with_operator_and_public_keys(builddir, replica_id):
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
-        batch_size = "2"
         time_service_enabled = "1"
     else:
-        batch_size = "1"
         time_service_enabled = "0"
+
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -42,11 +42,11 @@ def start_replica_cmd_with_object_store(builddir, replica_id, config):
     """
     ret = start_replica_cmd_prefix(builddir, replica_id, config)
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+    
+    batch_size = "1"
     ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-o", builddir + "/operator_pub.pem"])
     return ret
 
@@ -59,11 +59,11 @@ def start_replica_cmd_with_object_store_and_ke(builddir, replica_id, config):
     """
     ret = start_replica_cmd_prefix(builddir, replica_id, config)
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+        
+    batch_size = "1"
     ret.extend(["-f", time_service_enabled, "-b", "2", "-q", batch_size, "-e", str(True), "-o", builddir + "/operator_pub.pem", "--publish-master-key-on-startup"])
     return ret
 
@@ -78,11 +78,11 @@ def start_replica_cmd(builddir, replica_id):
     viewChangeTimeoutMilli = "10000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+        
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
@@ -107,11 +107,11 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
     viewChangeTimeoutMilli = "10000"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
-        batch_size = "2"
         time_service_enabled = "1"
     else :
-        batch_size = "1"
         time_service_enabled = "0"
+    
+    batch_size = "1"
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),


### PR DESCRIPTION
Instead of having the time request as a client request inside the prePrepare message, we add it as a metadata in the prePrepare message