### PR TITLE
Prevent PreProcessor from sending an empty PreProcessBatchReplyMsg

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -40,13 +40,9 @@ void RequestsBatch::init() {
   }
 }
 
-void RequestsBatch::addReply(PreProcessReplyMsgSharedPtr replyMsg) {
+bool RequestsBatch::isBatchRegistered(string &cid) const {
   const std::lock_guard<std::mutex> lock(batchMutex_);
-  repliesList_.push_back(replyMsg);
-}
-
-bool RequestsBatch::isBatchRegistered() const {
-  const std::lock_guard<std::mutex> lock(batchMutex_);
+  cid = cid_;
   return batchRegistered_;
 }
 
@@ -164,7 +160,7 @@ void RequestsBatch::cancelBatchAndReleaseRequests(const string &batchCid, PrePro
 }
 
 // On non-primary replicas
-void RequestsBatch::releaseReqsAndSendBatchedReplyIfCompleted() {
+void RequestsBatch::releaseReqsAndSendBatchedReplyIfCompleted(PreProcessReplyMsgSharedPtr replyMsg) {
   uint32_t replyMsgsSize = 0;
   const auto senderId = preProcessor_.myReplicaId_;
   const auto primaryId = preProcessor_.myReplica_.currentPrimary();
@@ -173,12 +169,16 @@ void RequestsBatch::releaseReqsAndSendBatchedReplyIfCompleted() {
   PreProcessBatchReplyMsgSharedPtr batchReplyMsg;
   {
     const lock_guard<mutex> lock(batchMutex_);
+    if (!batchInProcess_) {
+      LOG_DEBUG(preProcessor_.logger(), "The batch is not in process; ignore");
+      return;
+    }
+    repliesList_.push_back(replyMsg);
     if (repliesList_.size() != batchSize_) {
       LOG_DEBUG(preProcessor_.logger(),
                 "Not all replies collected" << KVLOG(senderId, clientId_, cid, repliesList_.size(), batchSize_));
       return;
     }
-
     cid = cid_;
     batchSize = batchSize_;
     // The last batch request has pre-processed => send batched reply message
@@ -753,8 +753,8 @@ void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) 
   }
   ClientMsgsList &clientMsgs = clientBatchMsg->getClientPreProcessRequestMsgs();
   const auto &batchEntry = ongoingReqBatches_[clientId];
-  if (batchedPreProcessEnabled_ && batchEntry->isBatchRegistered()) {
-    const auto &ongoingBatchCid = batchEntry->getCid();
+  string ongoingBatchCid;
+  if (batchedPreProcessEnabled_ && batchEntry->isBatchRegistered(ongoingBatchCid)) {
     if (batchCid != ongoingBatchCid) {
       LOG_INFO(logger(),
                "Different ClientBatchRequestMsg for this client is in process; ignoring"
@@ -1735,8 +1735,7 @@ void PreProcessor::handleReqPreProcessedByNonPrimary(uint16_t clientId,
                                                   preProcessResult);
   const auto &batchEntry = ongoingReqBatches_[clientId];
   if (batchedPreProcessEnabled_ && batchEntry->isBatchInProcess()) {
-    batchEntry->addReply(replyMsg);
-    batchEntry->releaseReqsAndSendBatchedReplyIfCompleted();
+    batchEntry->releaseReqsAndSendBatchedReplyIfCompleted(replyMsg);
   } else {
     releaseReqAndSendReplyMsg(replyMsg);
   }

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -76,15 +76,14 @@ class RequestsBatch {
   void init();
   void registerBatch(const std::string &cid, uint32_t batchSize);
   void startBatch(const std::string &cid, uint32_t batchSize);
-  void addReply(PreProcessReplyMsgSharedPtr replyMsg);
   void updateBatchSize(uint32_t batchSize);
-  bool isBatchRegistered() const;
+  bool isBatchRegistered(std::string &cid) const;
   bool isBatchInProcess() const;
   void increaseNumOfCompletedReqs() { numOfCompletedReqs_++; }
   RequestStateSharedPtr &getRequestState(uint16_t reqOffsetInBatch);
   const std::string getCid() const;
   void cancelBatchAndReleaseRequests(const std::string &batchCid, PreProcessingResult status);
-  void releaseReqsAndSendBatchedReplyIfCompleted();
+  void releaseReqsAndSendBatchedReplyIfCompleted(PreProcessReplyMsgSharedPtr replyMsg);
   void finalizeBatchIfCompleted();
   void handlePossiblyExpiredRequests();
   void sendCancelBatchedPreProcessingMsgToNonPrimaries(const ClientMsgsList &clientMsgs, NodeIdType destId);

--- a/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.cpp
@@ -56,8 +56,13 @@ void PreProcessBatchReplyMsg::validate(const ReplicasInfo& repInfo) const {
   }
 
   const auto numOfMessagesInBatch = msgBody()->numOfMessagesInBatch;
-  if (!numOfMessagesInBatch || (numOfMessagesInBatch > MAX_BATCH_SIZE)) {
-    LOG_WARN(logger(), "Too many messages in batch" << KVLOG(numOfMessagesInBatch));
+  if (!numOfMessagesInBatch) {
+    LOG_WARN(logger(), "Number of messages in the batch is zero" << KVLOG(msgBody()->senderId, getCid()));
+    throw std::runtime_error(__PRETTY_FUNCTION__);
+  }
+
+  if (numOfMessagesInBatch > MAX_BATCH_SIZE) {
+    LOG_WARN(logger(), "Too many messages in the batch" << KVLOG(numOfMessagesInBatch, msgBody()->senderId, getCid()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 }


### PR DESCRIPTION
Fix a race in the batch completion process when two batch requests could cause sending a good and empty reply to the primary replica.