### PR TITLE
Add support to recover prune requests

### DIFF
--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -34,6 +34,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
                              std::optional<Timestamp> timestamp,
                              const std::string& batchCid,
                              concordUtils::SpanWrapper& parent_span) {
+  std::uint64_t tickOrder = 0;
   for (auto& req : requests) {
     if (req.flags & KEY_EXCHANGE_FLAG) {
       KeyExchangeMsg ke = KeyExchangeMsg::deserializeMsg(req.request, req.requestSize);
@@ -109,7 +110,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
         auto payload = ClientReqMsgTickPayload{};
         auto req_ptr = reinterpret_cast<const uint8_t*>(req.request);
         deserialize(req_ptr, req_ptr + req.requestSize, payload);
-        const auto tick = Tick{payload.component_id, req.executionSequenceNum};
+        const auto tick = Tick{payload.component_id, req.executionSequenceNum, std::nullopt, tickOrder++};
         (*cron_table_registry_)[payload.component_id].evaluate(tick);
       } else {
         LOG_WARN(GL, "Received a Tick, but the cron table registry is not initialized");

--- a/ccron/include/ccron/tick.hpp
+++ b/ccron/include/ccron/tick.hpp
@@ -28,11 +28,14 @@ struct Tick {
   // Time that is the same across replicas after being agreed upon.
   // It is optional as the time service that provides agreement across replicas is itself optional.
   std::optional<std::chrono::milliseconds> ms_since_epoch;
+
+  // a sequnce number, may contain several ticks, this field is used in order to order them.
+  std::uint64_t internal_order{};
 };
 
 inline bool operator==(const Tick& l, const Tick& r) {
   return (l.component_id == r.component_id && l.bft_sequence_num == r.bft_sequence_num &&
-          l.ms_since_epoch == r.ms_since_epoch);
+          l.ms_since_epoch == r.ms_since_epoch && l.internal_order == r.internal_order);
 }
 
 }  // namespace concord::cron

--- a/kvbc/cmf/pruning_msgs.cmf
+++ b/kvbc/cmf/pruning_msgs.cmf
@@ -14,4 +14,6 @@ Msg Agreement 1 {
 Msg Batch 2 {
   # The latest block ID to prune in the batch.
   uint64 latest_batch_block_id_to
+  uint64 bft_sn
+  uint64 tick_order
 }

--- a/kvbc/include/pruning_reserved_pages_client.hpp
+++ b/kvbc/include/pruning_reserved_pages_client.hpp
@@ -85,14 +85,18 @@ class ReservedPagesClient {
   void updateExistingAgreement(std::uint64_t batch_blocks_num);
 
   // Saves the `to` block ID of the latest batch. A batch is a range [genesis, to].
-  void saveLatestBatch(BlockId to);
+  void saveLatestBatch(Batch batch);
 
  public:
   // Returns the latest agreement or std::nullopt if no agreement has been reached yet.
   std::optional<Agreement> latestAgreement() const { return latest_agreement_; }
 
   // Returns the `to` block ID of the latest batch or std::nullopt if no batch pruning has started yet.
-  std::optional<BlockId> latestBatchBlockIdTo() const { return latest_batch_block_id_to_; }
+  std::optional<BlockId> latestBatchBlockIdTo() const {
+    return batch_ ? std::optional<BlockId>{batch_->latest_batch_block_id_to} : std::nullopt;
+  }
+
+  std::optional<Batch> recoverInfo() const { return batch_; }
 
  private:
   static constexpr std::uint32_t kLatestAgreementPageId{0};
@@ -100,7 +104,7 @@ class ReservedPagesClient {
 
  private:
   std::optional<Agreement> latest_agreement_;
-  std::optional<BlockId> latest_batch_block_id_to_;
+  std::optional<Batch> batch_;
   ClientType client_;
 };
 

--- a/kvbc/src/pruning_reserved_pages_client.cpp
+++ b/kvbc/src/pruning_reserved_pages_client.cpp
@@ -46,9 +46,8 @@ ReservedPagesClient::ReservedPagesClient() {
   }
 
   if (client_.loadReservedPage(kLatestBatchBlockIdToPageId, in.size(), data(in))) {
-    auto batch = Batch{};
-    deserialize(in, batch);
-    latest_batch_block_id_to_ = batch.latest_batch_block_id_to;
+    batch_.emplace();
+    deserialize(in, *batch_);
   }
 }
 
@@ -81,11 +80,11 @@ void ReservedPagesClient::updateExistingAgreement(std::uint64_t batch_blocks_num
                                 latest_agreement_->last_agreed_prunable_block_id));
 }
 
-void ReservedPagesClient::saveLatestBatch(BlockId to) {
+void ReservedPagesClient::saveLatestBatch(Batch batch) {
   auto out = std::vector<std::uint8_t>{};
-  serialize(out, Batch{to});
+  serialize(out, batch);
   client_.saveReservedPage(kLatestBatchBlockIdToPageId, out.size(), cdata(out));
-  latest_batch_block_id_to_ = to;
+  batch_ = batch;
 }
 
 }  // namespace concord::kvbc::pruning

--- a/kvbc/test/pruning_reserved_pages_client_test.cpp
+++ b/kvbc/test/pruning_reserved_pages_client_test.cpp
@@ -73,12 +73,18 @@ TEST_F(pruning_reserved_pages_client_test, save_agreement) {
 
 TEST_F(pruning_reserved_pages_client_test, save_latest_batch) {
   const auto to = BlockId{42};
-  client_->saveLatestBatch(to);
+  client_->saveLatestBatch({to, 420, 10});
 
   // Verify the batch has been cached properly.
   const auto cached_to = client_->latestBatchBlockIdTo();
   ASSERT_TRUE(cached_to.has_value());
   ASSERT_EQ(*cached_to, to);
+
+  const auto recover = client_->recoverInfo();
+  ASSERT_TRUE(recover.has_value());
+  ASSERT_EQ(recover->latest_batch_block_id_to, to);
+  ASSERT_EQ(recover->bft_sn, 420);
+  ASSERT_EQ(recover->tick_order, 10);
 
   // Create a new client and verify it can load the saved batch.
   client_ = std::make_unique<ReservedPagesClient>();


### PR DESCRIPTION
If a replica terminates while performing pruning, on restart, it will re-execute the requests that were part of the last sequence number that was executed.
Requests that were already executed before the crash should be revered prior to the re-execution or should not have an additional side effect if re-executed.

Concurrent pruning is triggered by tick commands, when those commands are being re-executed, the concurrent pruning handler re-executes them regardless of whether they have been executed before resulting in diverge in state from other replicas as double execution might occur.

This PR will extend the information that is saved in the reserved pages before each invocation to include also the bft sequence number and the internal tick order within the sequence number.
the internal order inside a preprepare msg is deterministic therefore on re-execution the same request must get the same sequence number and internal order.

This information will be used in order to total order the ticks.
A corresponding MR will include this change and will implement the handler logic that checks whether a received tick is newer than the saved tick.
