### PR TITLE
Cherry-pick: Change default concord.storage.s3.save_kv_pairs_separately to false

### DIFF
--- a/kvbc/src/direct_kv_storage_factory.cpp
+++ b/kvbc/src/direct_kv_storage_factory.cpp
@@ -86,7 +86,7 @@ IStorageFactory::DatabaseSet S3StorageFactory::newDatabaseSet() const {
       ret.dataDBClient,
       std::move(dataKeyGenerator),
       true /* use_mdt */,
-      bftEngine::ReplicaConfig::instance().get<bool>("concord.storage.s3.save_kv_pairs_separately", true));
+      bftEngine::ReplicaConfig::instance().get<bool>("concord.storage.s3.save_kv_pairs_separately", false));
 
   return ret;
 }


### PR DESCRIPTION

This flag controls whether to store keys separately in S3 Object Store.