### PR TITLE
Apollo: slow down ST by adding a DelayStateTransferMsgStrategy

### DIFF
--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -46,6 +46,18 @@ def start_replica_cmd(builddir, replica_id):
             "-v", viewChangeTimeoutMilli 
             ]
 
+def start_replica_cmd_with_slowdown(builddir, replica_id):
+    statusTimerMilli = "500"
+    viewChangeTimeoutMilli = "10000"
+
+    path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
+    return [path,
+            "-k", KEY_FILE_PREFIX,
+            "-i", str(replica_id),
+            "-s", statusTimerMilli,
+            "-v", viewChangeTimeoutMilli,
+            "--delay-state-transfer-messages-millisec", '10'
+            ]
 
 class SkvbcPersistenceTest(ApolloTest):
 
@@ -189,7 +201,7 @@ class SkvbcPersistenceTest(ApolloTest):
         await skvbc.read_your_writes()
 
     @with_trio
-    @with_bft_network(start_replica_cmd)
+    @with_bft_network(start_replica_cmd=start_replica_cmd_with_slowdown)
     @verify_linearizability()
     async def test_st_when_fetcher_crashes(self, bft_network, tracker):
         """

--- a/tests/simpleKVBC/TesterReplica/strategy/DelayStateTransferMsgStrategy.hpp
+++ b/tests/simpleKVBC/TesterReplica/strategy/DelayStateTransferMsgStrategy.hpp
@@ -1,0 +1,42 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include "Logger.hpp"
+#include "TesterReplica/strategy/ByzantineStrategy.hpp"
+
+namespace concord::kvbc::strategy {
+
+// This strategy is used to add a delay between all State Transfer nessages sent between replicas
+// TODO - in practice, it would have been better to have a generel way to delay one of many/few of
+// many/all messages. But currently, IByzantineStrategy supports only single message code per strategy.
+class DelayStateTransferMsgStrategy : public IByzantineStrategy {
+ public:
+  std::string getStrategyName() override { return CLASSNAME(DelayStateTransferMsgStrategy); }
+  uint16_t getMessageCode() override { return static_cast<uint16_t>(MsgCode::StateTransfer); }
+  bool changeMessage(std::shared_ptr<bftEngine::impl::MessageBase>& msg) override {
+    if (delayMillisec_ > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(delayMillisec_));
+    }
+    return false;
+  }
+  explicit DelayStateTransferMsgStrategy(logging::Logger& logger, size_t delayMillisec)
+      : logger_(logger), delayMillisec_(delayMillisec) {}
+  virtual ~DelayStateTransferMsgStrategy() = default;
+
+ private:
+  logging::Logger logger_;
+  size_t delayMillisec_;
+};
+
+}  // namespace concord::kvbc::strategy


### PR DESCRIPTION
New command line parameter added to TesterReplica, long-form only:
--delay-state-transfer-messages-millisec MS, while MS is the time in ms
to delay each sent ST message.

To be able to monitor ST better, we add a delay in 3 test suites which
use ST extensively:
test_skvbc_persistence,test_skvbc_reconfiguration
and test_skvbc_state_transfer.

Reduce all tests which open 10 checkpoints gap of 10 into 4, due to
the fact that this was initially done to slow down the ST cycle.