### PR TITLE
Draft: Support the new certificates generation scheme in the client code

### DIFF
--- a/client/clientservice/include/client/clientservice/configuration.hpp
+++ b/client/clientservice/include/client/clientservice/configuration.hpp
@@ -39,11 +39,17 @@ const std::string decryptPrivateKey(const std::optional<secretsmanager::SecretDa
 // This method reads certificates from file
 void readCert(const std::string& input_filename, std::string& out_data);
 
+// This method gets the subject from the client certificate
+std::string getSubjectFromClientCert(const std::string& client_cert_path);
+
 // This method gets the client_id from the OU field in the client certificate
 std::string getClientIdFromClientCert(const std::string& client_cert_path);
 
 // This method is used by getClientIdFromClientCert to get the client_id from
 // the subject in the client certificate
-std::string parseClientIdFromSubject(const std::string& subject_str);
+std::string parseSubject(const std::string& subject_str, const std::string& delim);
+
+// This method gets the clientservice_host_uuid from the O field in the client certificate
+std::string getClientserviceHostUuidFromClientCert(const std::string& client_cert_path);
 
 }  // namespace concord::client::clientservice

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -97,6 +97,8 @@ struct TransportConfig {
 };
 
 struct SubscribeConfig {
+  // Subscription host ID
+  std::string clientservice_host_uuid;
   // Subscription ID
   std::string id;
   // If set to false then all certificates related to subscription will be ignored


### PR DESCRIPTION
As the certificate generation scheme has changed. New O is field is added. Client side code is added to verify the same.