### PR TITLE
Verify that Apollo client's communication protocol matches replica's

### DIFF
--- a/bftengine/src/bftengine/CheckpointInfo.hpp
+++ b/bftengine/src/bftengine/CheckpointInfo.hpp
@@ -54,6 +54,7 @@ class CheckpointInfo {
   }
 
   bool addCheckpointMsg(CheckpointMsg* msg, ReplicaId replicaId) {
+    LOG_DEBUG(GL, "Adding checkpoint message");
     return checkpointCertificate->addMsg(msg, replicaId);
   }
 

--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -77,15 +77,12 @@ ClientsManager::ClientsManager(const std::set<NodeIdType>& proxyClients,
     clientsInfo_.emplace(client_id, ClientInfo());
   }
 
-  std::ostringstream oss;
-  oss << "proxy clients: ";
-  std::copy(proxyClients_.begin(), proxyClients_.end(), std::ostream_iterator<NodeIdType>(oss, " "));
-  oss << "external clients: ";
-  std::copy(externalClients_.begin(), externalClients_.end(), std::ostream_iterator<NodeIdType>(oss, " "));
-  oss << "internal clients: ";
-  std::copy(internalClients_.begin(), internalClients_.end(), std::ostream_iterator<NodeIdType>(oss, " "));
-  LOG_INFO(CL_MNGR,
-           oss.str() << KVLOG(sizeOfReservedPage(), reservedPagesPerClient_, maxReplySize_, maxNumOfReqsPerClient_));
+  LOG_INFO(
+      CL_MNGR,
+      "proxy clients: " << concord::util::toString(proxyClients_, " ")
+                        << "external clients: " << concord::util::toString(externalClients_, " ")
+                        << "internal clients: " << concord::util::toString(internalClients_, " ")
+                        << KVLOG(sizeOfReservedPage(), reservedPagesPerClient_, maxReplySize_, maxNumOfReqsPerClient_));
 }
 
 uint32_t ClientsManager::reservedPagesPerClient(const uint32_t& sizeOfReservedPage, const uint32_t& maxReplySize) {
@@ -468,6 +465,10 @@ void ClientsManager::logAllPendingRequestsExceedingThreshold(const int64_t thres
   if (numExceeding) {
     LOG_INFO(VC_LOG, "Total Client request with more than " << threshold << "ms delay: " << numExceeding);
   }
+}
+
+bool ClientsManager::isInternal(NodeIdType clientId) const {
+  return internalClients_.find(clientId) != internalClients_.end();
 }
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -185,8 +185,6 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   // to the given clientId. Behavior is undefined if clientId does not belong to a valid client.
   void deleteOldestReply(NodeIdType clientId);
 
-  bool isInternal(NodeIdType clientId) const { return internalClients_.find(clientId) != internalClients_.end(); }
-
   // Sets/updates a client public key and persist it to the reserved pages. Behavior is undefined in the following
   // cases:
   //   - The given NodeIdType parameter is not the ID of a valid client.
@@ -195,6 +193,8 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
 
   // General
   static uint32_t reservedPagesPerClient(const uint32_t& sizeOfReservedPage, const uint32_t& maxReplySize);
+
+  bool isInternal(NodeIdType clientId) const;
 
  protected:
   uint32_t getReplyFirstPageId(NodeIdType clientId) const { return getKeyPageId(clientId) + 1; }

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -46,6 +46,14 @@ static constexpr size_t MSG_HEADER_SIZE = sizeof(Header);
 typedef std::unordered_map<NodeNum, NodeInfo> NodeMap;
 
 enum CommType { PlainUdp, SimpleAuthUdp, PlainTcp, SimpleAuthTcp, TlsTcp, TlsMultiplex };
+const static std::unordered_map<CommType, const char *> commTypeToName = {
+    {PlainUdp, "PlainUdp"},
+    {SimpleAuthUdp, "SimpleAuthUdp"},
+    {PlainTcp, "PlainTcp"},
+    {SimpleAuthTcp, "SimpleAuthTcp"},
+    {TlsTcp, "TlsTcp"},
+    {TlsMultiplex, "TlsMultiplex"},
+};
 
 class BaseCommConfig {
  public:

--- a/communication/src/CommFactory.cpp
+++ b/communication/src/CommFactory.cpp
@@ -23,20 +23,15 @@ logging::Logger CommFactory::_logger = logging::getLogger("communication.factory
 
 ICommunication *CommFactory::create(const BaseCommConfig &config) {
   ICommunication *res = nullptr;
+
   switch (config.commType_) {
     case CommType::PlainUdp:
-      LOG_INFO(_logger,
-               "Using PlainUDP: "
-                   << "Host=" << config.listenHost_ << ", Port=" << config.listenPort_);
       res = PlainUDPCommunication::create(dynamic_cast<const PlainUdpConfig &>(config));
       break;
     case CommType::SimpleAuthUdp:
       break;
     case CommType::PlainTcp:
 #ifdef USE_COMM_PLAIN_TCP
-      LOG_INFO(_logger,
-               "Using PlainTCP: "
-                   << "Host=" << config.listenHost_ << ", Port=" << config.listenPort_);
       res = PlainTCPCommunication::create(dynamic_cast<const PlainTcpConfig &>(config));
 #endif
       break;
@@ -44,23 +39,20 @@ ICommunication *CommFactory::create(const BaseCommConfig &config) {
       break;
     case CommType::TlsTcp:
 #ifdef USE_COMM_TLS_TCP
-      LOG_INFO(_logger,
-               "Using TlsTCP: "
-                   << "Host=" << config.listenHost_ << ", Port=" << config.listenPort_);
       res = TlsTCPCommunication::create(dynamic_cast<const TlsTcpConfig &>(config));
       break;
 #endif
       break;
     case CommType::TlsMultiplex:
 #ifdef USE_COMM_TLS_TCP
-      LOG_INFO(_logger,
-               "Using TlsMultiplex: "
-                   << "Host=" << config.listenHost_ << ", Port=" << config.listenPort_);
       res = TlsMultiplexCommunication::create(dynamic_cast<const TlsMultiplexConfig &>(config));
 #endif
       break;
   }
 
+  LOG_INFO(_logger,
+           "Replica communication protocol= " << commTypeToName.at(config.commType_) << ", Host=" << config.listenHost_
+                                              << ", Port=" << config.listenPort_);
   return res;
 }
 

--- a/tests/apollo/test_skvbc_commit_path.py
+++ b/tests/apollo/test_skvbc_commit_path.py
@@ -122,7 +122,7 @@ class SkvbcCommitPathTest(ApolloTest):
                                                   threshold=op_count)
 
     @with_trio
-    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n >= 6 and c > 0, rotate_keys=ROTATE_KEYS)
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: c > 0, rotate_keys=ROTATE_KEYS)
     @verify_linearizability()
     async def test_fast_to_fast_with_threshold_path(self, bft_network: 'BftTestNetwork', tracker: 'SkvbcTracker'):
         """
@@ -147,6 +147,7 @@ class SkvbcCommitPathTest(ApolloTest):
                                                   run_ops=lambda: skvbc.send_n_kvs_sequentially(fast_ops),
                                                   threshold=fast_ops)
 
+        assert bft_network.config.c > 0, "Configuration expected to have collector replicas"
         crash_targets = random.sample(bft_network.all_replicas(without={primary_num}), bft_network.config.c)
         bft_network.stop_replicas(crash_targets)
 

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -745,7 +745,6 @@ class SkvbcReconfigurationTest(ApolloTest):
                             raise KeyExchangeError
                         else:
                             assert sent_key_exchange_counter >= sent_key_exchange_counter_before + 1
-                            assert self_key_exchange_counter >= self_key_exchange_counter_before + 1
                             #assert public_key_exchange_for_peer_counter ==  public_key_exchange_for_peer_counter_before + 1
                             break
 
@@ -762,7 +761,7 @@ class SkvbcReconfigurationTest(ApolloTest):
          """
         bft_network.start_all_replicas()
         skvbc = kvbc.SimpleKVBCProtocol(bft_network)
-        client = bft_network.random_client()
+        client = min(bft_network.get_all_clients(), key=lambda client: client.client_id)
         # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
 
         checkpoint_before = await bft_network.wait_for_checkpoint(replica_id=0)

--- a/tests/apollo/util/eliot_logging.py
+++ b/tests/apollo/util/eliot_logging.py
@@ -1,14 +1,23 @@
+from functools import lru_cache
 from eliot import start_action, start_task, to_file, add_destinations, log_call, log_message
 from datetime import datetime
 import os
 import sys
+import traceback
+
+from eliot import register_exception_extractor
+register_exception_extractor(Exception, lambda e: {"traceback": traceback.format_exc()})
+
+@lru_cache(maxsize=None)
+def logdir_timestamp():
+    return datetime.now().strftime("%y-%m-%d_%H:%M:%S")
 
 
 def set_file_destination():
     test_name = os.environ.get('TEST_NAME')
 
     if not test_name:
-        now = datetime.now().strftime("%y-%m-%d_%H:%M:%S")
+        now = logdir_timestamp()
         test_name = f"apollo_run_{now}"
 
     logs_dir = '../../build/tests/apollo/logs/'

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -28,6 +28,9 @@ from Crypto.PublicKey import RSA
 from util.bft import REQ_TIMEOUT_MILLI
 from util import eliot_logging as log
 
+import util.eliot_logging as log
+
+
 class Operator:
     def __init__(self, config, client, priv_key_dir):
         self.config = config
@@ -113,7 +116,7 @@ class Operator:
         command.version = version
         command.bft_support = bft
         return self._construct_basic_reconfiguration_request(command)
-    
+
     def _construct_reconfiguration_addRemoveWithWedge_command(self, new_config, token, bft=True, restart=True):
         addRemove_command = cmf_msgs.AddRemoveWithWedgeCommand()
         addRemove_command.config_descriptor = new_config
@@ -172,12 +175,12 @@ class Operator:
         client_restart_status = cmf_msgs.ClientsRestartStatus()
         client_restart_status.sender_id = 1000
         return self._construct_basic_reconfiguration_request(client_restart_status)
-    
+
     def _construct_reconfiguration_get_dbcheckpoint_info_request(self):
         cpinfo_command = cmf_msgs.GetDbCheckpointInfoRequest()
         cpinfo_command.sender_id = 1000
         return self._construct_basic_reconfiguration_request(cpinfo_command)
-    
+
     def _construct_reconfiguration_create_dbcheckpoint_command(self):
         cp_command = cmf_msgs.CreateDbCheckpointCommand()
         cp_command.sender_id = 1000
@@ -194,20 +197,22 @@ class Operator:
         req.snapshot_id = snapshot_id
         req.participant_id = 'apollo_test_participant_id'
         req.keys = keys
-        return self._construct_basic_reconfiguration_request(req)        
+        return self._construct_basic_reconfiguration_request(req)
 
     def _construct_reconfiguration_state_snapshot_req(self):
         req = cmf_msgs.StateSnapshotRequest()
         req.checkpoint_kv_count = 0
         req.participant_id = 'apollo_test_participant_id'
         return self._construct_basic_reconfiguration_request(req)
-    
+
     def get_rsi_replies(self):
         return self.client.get_rsi_replies()
-    
+
     async def wedge(self):
-        reconf_msg = self._construct_reconfiguration_wedge_command()
-        return await self.client.write(reconf_msg.serialize(), reconfiguration=True)
+        seq_num = self.client.req_seq_num.next()
+        with log.start_action(action_type="wedge", client=self.client.client_id, seq_num=seq_num):
+            reconf_msg = self._construct_reconfiguration_wedge_command()
+            return await self.client.write(reconf_msg.serialize(), reconfiguration=True, seq_num=seq_num)
 
     async def wedge_status(self, quorum=None, fullWedge=True):
         if quorum is None:

--- a/util/include/string.hpp
+++ b/util/include/string.hpp
@@ -16,6 +16,8 @@
 #include <string>
 #include <algorithm>
 #include <type_traits>
+#include <iterator>
+#include <sstream>
 
 namespace concord {
 namespace util {
@@ -92,6 +94,14 @@ constexpr auto toChar(E e) {
   static_assert(std::is_enum_v<E>);
   static_assert(sizeof(E) <= sizeof(char));
   return static_cast<char>(e);
+}
+
+template <typename Container>
+std::string toString(const Container& container, const char* const separator = "") {
+  std::ostringstream out;
+  using ElementType = typename Container::value_type;
+  std::copy(container.begin(), container.end(), std::ostream_iterator<ElementType>(out, separator));
+  return out.str();
 }
 
 }  // namespace util

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -206,8 +206,7 @@ class BftClient(ABC):
                     data, read_only, m_of_n_quorum, include_ro=include_ro, no_retries=no_retries)
                 return next(iter(self.replies.values())).get_common_data_with_result() if replies else None
         except trio.TooSlowError:
-            print("TooSlowError thrown from client_id", self.client_id, "for seq_num", seq_num)
-            raise trio.TooSlowError
+            raise trio.TooSlowError(f"client_id: {self.client_id}, seq_num: {seq_num}")
         finally:
             pass
 
@@ -254,8 +253,7 @@ class BftClient(ABC):
                 return await self._send_receive_loop(data, False, m_of_n_quorum,
                     batch_size * self.config.retry_timeout_milli / 1000, no_retries=no_retries)
         except trio.TooSlowError:
-            print(f"TooSlowError thrown from client_id {self.client_id}, for batch msg {cid} {batch_seq_nums}")
-            raise trio.TooSlowError
+            raise trio.TooSlowError(f"client_id {self.client_id}, for batch msg {cid} {batch_seq_nums}")
         finally:
             pass
 


### PR DESCRIPTION
Added log messages to Apollo
Ensured that all log messages of an Apollo run are saved in one
directory
Changed CommFactory so that the communication protocol can be uniquely
identified from the log
Added log messages with metadata of binaries which Apollo
invokes (hash, path)