### PR TITLE
S3 path prefix default value. (#2507)

### DIFF
--- a/storage/include/s3/config_parser.hpp
+++ b/storage/include/s3/config_parser.hpp
@@ -47,7 +47,7 @@ class ConfigFileParser {
       throw std::runtime_error("failed to parse " + parser_.getConfigFileName() + ": " + key + " is not set.");
   }
 
-  logging::Logger logger_ = logging::getLogger("concord.tests.config.s3");
+  logging::Logger logger_ = logging::getLogger("concord.storage.s3");
   util::ConfigFileParser parser_;
 };
 }  // namespace concord::storage::s3

--- a/storage/src/s3/config_parser.cpp
+++ b/storage/src/s3/config_parser.cpp
@@ -30,13 +30,9 @@ concord::storage::s3::StoreConfig ConfigFileParser::parse() {
   config.protocol = get_value<string>("s3-protocol");
   config.url = get_value<string>("s3-url");
   config.secretKey = get_value<string>("s3-secret-key");
-  // TesterReplica is used for Apollo tests. Each test is executed against new blockchain, so we need brand new
-  // bucket for the RO replica. To achieve this we use a hack - set the prefix to a unique value so each RO replica
-  // writes in the same bucket but in different directory.
-  // So if s3-path-prefix is NOT SET it is initialized to a unique value based on current time.
-  config.pathPrefix = get_optional_value<string>(
-      "s3-path-prefix", std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+  config.pathPrefix = get_optional_value<string>("s3-path-prefix", "");
   config.operationTimeout = get_optional_value<std::uint32_t>("s3-operation-timeout", 60000);
+  LOG_INFO(logger_, config);
   return config;
 }
 }  // namespace concord::storage::s3

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -26,7 +26,7 @@ from util.skvbc import SimpleKVBCProtocol
 from util.skvbc_history_tracker import verify_linearizability
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, DB_FILE_PREFIX, DB_SNAPSHOT_PREFIX
 from util import bft_metrics, eliot_logging as log
-from util.object_store import ObjectStore, start_replica_cmd_prefix, with_object_store
+from util.object_store import ObjectStore, start_replica_cmd_prefix
 from util import operator
 import concord_msgs as cmf_msgs
 import sys

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -20,7 +20,7 @@ from util.test_base import ApolloTest
 from util import skvbc as kvbc
 from util.bft import with_trio, with_bft_network, KEY_FILE_PREFIX, TestConfig
 from util import operator
-from util.object_store import ObjectStore, start_replica_cmd_prefix, with_object_store
+from util.object_store import ObjectStore, start_replica_cmd_prefix
 import sys
 from util import eliot_logging as log
 import concord_msgs as cmf_msgs

--- a/tests/apollo/util/object_store.py
+++ b/tests/apollo/util/object_store.py
@@ -19,12 +19,6 @@ from util import eliot_logging as log
 from functools import wraps
 from util.bft import KEY_FILE_PREFIX
 
-def with_object_store(async_fn):
-    @wraps(async_fn)
-    async def wrapper(*args, **kwargs):
-        await async_fn(*args, **kwargs, object_store=ObjectStore())
-    return wrapper
-
 MINIO_DATA_DIR="/tmp/concord_bft_minio_datadir"
 def start_replica_cmd_prefix(builddir, replica_id, config):
     """


### PR DESCRIPTION
Change S3 Object Store path prefix default value to an empty string.
Apollo tests generate random value for s3-path-prefix and there's no need to generate a random value in the s3 configuration parsing code.