### PR TITLE
Call findGlobalEventGroupId() only once per subscription

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -203,13 +203,10 @@ class KvbAppFilter {
   // Optional because during start-up there might be no block/event group written yet.
   std::optional<BlockId> getOldestEventGroupBlockId();
 
-  void setNextExternalEgIdToRead(uint64_t ext_eg_id);
+  void setLastEgIdsRead(uint64_t last_ext_eg_id_read, uint64_t last_global_eg_id_read);
 
-  uint64_t getNextExternalEgIdToRead() const;
-
-  void setLastGlobalEgIdReadForClient(uint64_t global_eg_id);
-
-  uint64_t getLastGlobalEgIdReadForClient() const;
+  // Return the pair {last_ext_eg_id_read, last_global_eg_id_read}
+  std::pair<uint64_t, uint64_t> getLastEgIdsRead();
 
  public:
   static inline const std::string kGlobalEgIdKeyOldest{"_global_eg_id_oldest"};
@@ -227,10 +224,7 @@ class KvbAppFilter {
   const concord::kvbc::IReader *rostorage_{nullptr};
   const std::string client_id_;
 
-  // next external event group ID to be read
-  uint64_t next_ext_eg_id_to_read_{0};
-  // last global event group ID read
-  uint64_t last_global_eg_id_read_{0};
+  std::pair<uint64_t, uint64_t> last_ext_and_global_eg_id_read_{0, 0};
 };
 
 }  // namespace kvbc

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -539,8 +539,7 @@ void KvbAppFilter::readEventGroups(EventGroupId external_eg_id_start,
     }
     ext_eg_id += 1;
   }
-  setNextExternalEgIdToRead(++ext_eg_id);
-  setLastGlobalEgIdReadForClient(global_eg_id);
+  setLastEgIdsRead(ext_eg_id, global_eg_id);
 }
 
 void KvbAppFilter::readEventGroupRange(EventGroupId external_eg_id_start,
@@ -599,8 +598,7 @@ string KvbAppFilter::readEventGroupHash(EventGroupId external_eg_id) {
     throw KvbReadError(msg.str());
   }
   KvbFilteredEventGroupUpdate filtered_update{external_eg_id, filterEventsInEventGroup(result.global_id, event_group)};
-  setLastGlobalEgIdReadForClient(result.global_id);
-  setNextExternalEgIdToRead(++external_eg_id);
+  setLastEgIdsRead(external_eg_id, result.global_id);
   return hashEventGroupUpdate(filtered_update);
 }
 
@@ -690,13 +688,11 @@ kvbc::categorization::EventGroup KvbAppFilter::getEventGroup(kvbc::EventGroupId 
   return event_group_out;
 }
 
-void KvbAppFilter::setNextExternalEgIdToRead(uint64_t ext_eg_id) { next_ext_eg_id_to_read_ = ext_eg_id; }
+void KvbAppFilter::setLastEgIdsRead(uint64_t last_ext_eg_id_read, uint64_t last_global_eg_id_read) {
+  last_ext_and_global_eg_id_read_ = std::make_pair(last_ext_eg_id_read, last_global_eg_id_read);
+}
 
-uint64_t KvbAppFilter::getNextExternalEgIdToRead() const { return next_ext_eg_id_to_read_; }
-
-void KvbAppFilter::setLastGlobalEgIdReadForClient(uint64_t global_eg_id) { last_global_eg_id_read_ = global_eg_id; }
-
-uint64_t KvbAppFilter::getLastGlobalEgIdReadForClient() const { return last_global_eg_id_read_; }
+std::pair<uint64_t, uint64_t> KvbAppFilter::getLastEgIdsRead() { return last_ext_and_global_eg_id_read_; }
 
 }  // namespace kvbc
 }  // namespace concord

--- a/thin-replica-server/include/thin-replica-server/subscription_buffer.hpp
+++ b/thin-replica-server/include/thin-replica-server/subscription_buffer.hpp
@@ -234,6 +234,14 @@ class SubUpdateBuffer {
     return eg_queue_.front().event_group_id;
   }
 
+  // The caller needs to make sure that the queue is not empty when calling
+  SubEventGroupUpdate oldestEventGroup() {
+    std::unique_lock<std::mutex> lock(eg_mutex_);
+    // Undefined behavior if the queue is empty
+    ConcordAssertGT(eg_queue_.read_available(), 0);
+    return eg_queue_.front();
+  }
+
   bool Empty() {
     std::unique_lock<std::mutex> lock(mutex_);
     return !queue_.read_available();

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -842,7 +842,7 @@ class ThinReplicaImpl {
   // returns when the next update can be taken from the given live updates.
   // We assume that the Commands handler is already filling the queue. Also, we
   // don't care if the queue fills up. In that case, the caller won't be able to
-  // use the queue as soon as he consumes it.
+  // use the queue as soon as they consume it.
   template <typename ServerContextT, typename ServerWriterT, typename DataT>
   void syncAndSend(ServerContextT* context,
                    kvbc::BlockId start,
@@ -912,7 +912,7 @@ class ThinReplicaImpl {
   // returns when the next update can be taken from the given live updates.
   // We assume that the Commands handler is already filling the queue. Also, we
   // don't care if the queue fills up. In that case, the caller won't be able to
-  // use the queue as soon as he consumes it.
+  // use the queue as soon as they consume it.
   template <typename ServerContextT, typename ServerWriterT, typename DataT>
   void syncAndSendEventGroups(ServerContextT* context,
                               kvbc::EventGroupId start,
@@ -941,72 +941,84 @@ class ThinReplicaImpl {
     LOG_INFO(logger_, "Sync reading event groups from KVB [" << start << ", " << end << "]");
     readAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(logger_, context, stream, start, end, kvb_filter);
 
-    auto last_global_eg_id_read = kvb_filter->getLastGlobalEgIdReadForClient();
-    uint64_t newest_eg_id = 0;
-    // Let's wait until we have at least one live update for the requesting client
     bool is_update_available = false;
+    int num_updates_filtered_out = 0;
+    auto next_global_eg_id_to_read = kvb_filter->getLastGlobalEgIdReadForClient() + 1;
     while (not is_update_available) {
       is_update_available = live_updates->waitForEventGroupUntilNonEmpty(kWaitForUpdateTimeout);
       if (context->IsCancelled()) {
         throw StreamCancelled("StreamCancelled while waiting for the first live update");
       }
-      if (is_update_available) {
-        newest_eg_id = kvb_filter->newestExternalEventGroupId();
-        // There are two scenarios in which updates will be dropped from the live-update-queue
-        // 1. If the oldest global-eg-id on the live-update-queue is less than last_global_eg_id_read + 1
-        // 2. If the update available on the live-update-queue is for another client (i.e., newest_eg_id in storage is
-        // less than the next expected external-eg-id)
-        if (live_updates->oldestEventGroupId() < last_global_eg_id_read + 1 || (newest_eg_id < end + 1)) {
+      if (not is_update_available) continue;
+
+      // Drop all live updates with global_eg_id < next_global_eg_id_to_read, because TRS has already read and sent
+      // these updates from storage
+      if (live_updates->oldestEventGroupId() < next_global_eg_id_to_read) {
+        SubEventGroupUpdate sub_eg_update;
+        live_updates->PopEventGroup(sub_eg_update);
+        LOG_INFO(logger_, "Sync dropping " << sub_eg_update.event_group_id);
+        is_update_available = false;
+        continue;
+      }
+
+      auto ext_eg_id = end + 1;  // next external event group ID to be read
+
+      // live_updates in sync with KVB i.e., event group ID associated with the oldest live update is the
+      // next_global_eg_id_to_read.
+      if (live_updates->oldestEventGroupId() == next_global_eg_id_to_read) {
+        auto filtered_eg_update = kvb_filter->filterEventGroupUpdate(live_updates->oldestEventGroup());
+        // If the oldest live update is not for the requesting client, keep reading from the live update queue
+        // until the first relevant live update is reached. Drop all non-relevant live updates read along the way.
+        if (!filtered_eg_update) {
           SubEventGroupUpdate sub_eg_update;
           live_updates->PopEventGroup(sub_eg_update);
+          LOG_INFO(logger_, "Sync dropping upon filtering " << sub_eg_update.event_group_id);
+          num_updates_filtered_out++;
           is_update_available = false;
+          next_global_eg_id_to_read += 1;
+          continue;
+        }
+        break;
+      }
+
+      // fill the gap
+      LOG_INFO(logger_,
+               "Sync filling gap [" << next_global_eg_id_to_read << ", " << live_updates->oldestEventGroupId() << "]");
+      while (live_updates->oldestEventGroupId() > next_global_eg_id_to_read) {
+        // gap exists between next_global_eg_id_to_read and live_updates->oldestEventGroupId()
+        // Let's read from data table directly, filter and send updates, until next_global_eg_id_to_read equals
+        // live_updates->oldestEventGroupId()
+        auto event_group = kvb_filter->getEventGroup(next_global_eg_id_to_read);
+        if (event_group.events.empty()) {
+          std::stringstream msg;
+          msg << "EventGroup empty/doesn't exist for global event group " << next_global_eg_id_to_read;
+          throw kvbc::KvbReadError(msg.str());
+        }
+        auto eg_update_from_storage = kvbc::EgUpdate{event_group.id, std::move(event_group)};
+        auto filtered_eg_update = kvb_filter->filterEventGroupUpdate(eg_update_from_storage);
+        if (!filtered_eg_update) {
+          next_global_eg_id_to_read++;
+          continue;
+        }
+        // Overwrite event group ID in the filtered update to external event group ID
+        // We don't want to expose the global event group ID to the client
+        filtered_eg_update.value().event_group_id = ext_eg_id;
+
+        kvb_filter->setNextExternalEgIdToRead(++ext_eg_id);
+        kvb_filter->setLastGlobalEgIdReadForClient(next_global_eg_id_to_read++);
+
+        // send update
+        if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
+          //  auto correlation_id = filtered_update.correlation_id; (TODO (Shruti) - Get correlation ID)
+          sendEventGroupData(stream, filtered_eg_update.value());
+        } else if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Hash>()) {
+          sendEventGroupHash(stream,
+                             filtered_eg_update.value().event_group_id,
+                             kvb_filter->hashEventGroupUpdate(filtered_eg_update.value()));
         }
       }
     }
-    ConcordAssertGE(newest_eg_id, end + 1);
-    ConcordAssertGT(live_updates->oldestEventGroupId(), last_global_eg_id_read);
-    auto global_eg_id_to_read = kvb_filter->findGlobalEventGroupId(end + 1).global_id;
-    while (live_updates->oldestEventGroupId() < global_eg_id_to_read) {
-      // Drop updates from the live-update-queue if the oldest global-eg-id on the live-update-queue is less than the
-      // next global-eg-id to be read (corresponds to external-eg-id `end+1`)
-      SubEventGroupUpdate sub_eg_update;
-      live_updates->PopEventGroup(sub_eg_update);
-      if (live_updates->EmptyEventGroupQueue()) {
-        is_update_available = live_updates->waitForEventGroupUntilNonEmpty(kWaitForUpdateTimeout);
-      }
-    }
-    // We are in sync already if the oldest event global-eg-id on live_updates is same as next global_eg_id_to_read
-    if (live_updates->oldestEventGroupId() == global_eg_id_to_read) {
-      ConcordAssertGE(global_eg_id_to_read, live_updates->oldestEventGroupId());
-      ConcordAssertLE(global_eg_id_to_read, live_updates->newestEventGroupId());
-      return;
-    }
-
-    // Gap:
-    // If the first live update is not the follow-up to the last read event group from
-    // KVB then we need to fill the gap. Let's read from KVB starting at end + 1
-    // up to updates that are part of the live updates already. Thereby, we
-    // create an overlap between what we read from KVB and what is currently in
-    // the live updates.
-    if (live_updates->oldestEventGroupId() > global_eg_id_to_read) {
-      ConcordAssertGT(kvb_filter->newestExternalEventGroupId(), end + 1);
-      start = end + 1;
-      end = kvb_filter->newestExternalEventGroupId();
-
-      LOG_INFO(logger_, "Sync filling gap [" << start << ", " << end << "]");
-      readAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(logger_, context, stream, start, end, kvb_filter);
-    }
-
-    last_global_eg_id_read = kvb_filter->getLastGlobalEgIdReadForClient();
-    // Overlap:
-    // If we read updates from KVB that were added to the live updates already
-    // then we just need to drop the overlap and return
-    ConcordAssert(live_updates->oldestEventGroupId() <= last_global_eg_id_read);
-    SubEventGroupUpdate update;
-    do {
-      live_updates->PopEventGroup(update);
-      LOG_INFO(logger_, "Sync dropping " << update.event_group_id);
-    } while (update.event_group_id < last_global_eg_id_read);
+    ConcordAssertEQ(next_global_eg_id_to_read, live_updates->oldestEventGroupId());
   }
 
   // Send* prepares the response object and puts it on the stream


### PR DESCRIPTION
This PR updates syncAndSendEventGroups method s.t.,
computation heavy method findGlobalEventGroupId() is no longer used
to get the global event group ID corresponding to the requested
external event group ID when syncing live update queue with storage.
Instead we calculate global event group ID corresponding to
global event group ID of the first live update to be read by the
client on the fly.