### PR TITLE
New tls certificates scheme with verification

### DIFF
--- a/scripts/linux/create_tls_certs.sh
+++ b/scripts/linux/create_tls_certs.sh
@@ -36,28 +36,17 @@ i=$start_node_id
 last_node_id=$((i + $1 - 1))
 while [ $i -le $last_node_id ]; do
    echo "processing replica $i/$last_node_id"
-   clientDir=$dir/$i/client
-   serverDir=$dir/$i/server
+   certDir=$dir/$i
 
-   mkdir -p $clientDir
-   mkdir -p $serverDir
+   mkdir -p $certDir
 
-   openssl ecparam -name secp384r1 -genkey -noout -out $serverDir/pk.pem
-   openssl ecparam -name secp384r1 -genkey -noout -out $clientDir/pk.pem
+   openssl ecparam -name secp384r1 -genkey -noout -out $certDir/pk.pem
 
-   openssl req -new -key $serverDir/pk.pem -nodes -days 365 -x509 \
-        -subj "/C=NA/ST=NA/L=NA/O=NA/OU=${i}/CN=node${i}ser" -out $serverDir/server.cert
+   openssl req -new -key $certDir/pk.pem -nodes -days 365 -x509 \
+        -subj "/C=NA/ST=NA/L=NA/O=concord${i}/OU=${i}/CN=node${i}" -out $certDir/tls.cert
 
-   openssl req -new -key $clientDir/pk.pem -nodes -days 365 -x509 \
-        -subj "/C=NA/ST=NA/L=NA/O=NA/OU=${i}/CN=node${i}cli" -out $clientDir/client.cert
-
-   openssl enc -base64 -aes-256-cbc -e -in  $serverDir/pk.pem -K ${KEY} -iv ${IV}  \
-         -p -out $serverDir/pk.pem.enc 2>/dev/null
-   openssl enc -base64 -aes-256-cbc -e -in $clientDir/pk.pem -K ${KEY} -iv ${IV}  \
-         -p -out $clientDir/pk.pem.enc 2>/dev/null
-
-   # rm $serverDir/pk.pem
-   # rm $clientDir/pk.pem
+   openssl enc -base64 -aes-256-cbc -e -in $certDir/pk.pem -K ${KEY} -iv ${IV}  \
+         -p -out $certDir/pk.pem.enc 2>/dev/null
 
    (( i=i+1 ))
 done

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -32,10 +32,7 @@ class CertificateUtils {
                                             const std::string& pub_key,
                                             const std::string& signing_key);
   static bool verifyCertificate(X509* cert, const std::string& pub_key);
-  static bool verifyCertificate(X509* cert_to_verify,
-                                const std::string& cert_root_directory,
-                                uint32_t& remote_peer_id,
-                                std::string& conn_type);
+  static bool verifyCertificate(X509* cert_to_verify, const std::string& cert_root_directory, uint32_t& remote_peer_id);
 };
 class IVerifier {
  public:

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -436,7 +436,7 @@ class TcpTlsClient(BftClient):
     """
     # In create_tls_certs.sh - openssl command line utility uses CN(certificate name) in the subj field.
     # This is the host name (domain name) to be verified.
-    CERT_DOMAIN_FORMAT="node%dser"
+    CERT_DOMAIN_FORMAT="node%d"
     # Taken from TlsTCPCommunication.cpp (we prefer hard-code and not to parse the file)
     MSG_LEN_SIZE = 4
     ENDPOINT_SIZE = 8
@@ -457,19 +457,15 @@ class TcpTlsClient(BftClient):
 
     def _get_private_key_path(self, replica_id, *, is_client):
         """
-        Private key is under <certificate root path>/replica_id/<node type>/pk.pem,
-        where node type is "server" or "client".
+        Private key is under <certificate root path>/replica_id/pk.pem
         """
-        cert_type = "client" if is_client else "server"
-        return os.path.join(self.config.certs_path, str(replica_id), cert_type, "pk.pem")
+        return os.path.join(self.config.certs_path, str(replica_id), "pk.pem")
 
     def _get_cert_path(self, replica_id, *, is_client):
         """
-        Certificate is under <certificate root path>/replica_id/<node type>/cert.pem,
-        where node type is "server" or "client".
+        Certificate is under <certificate root path>/replica_id/tls.cert
         """
-        cert_type = "client" if is_client else "server"
-        return os.path.join(self.config.certs_path, str(replica_id), cert_type, cert_type + ".cert")
+        return os.path.join(self.config.certs_path, str(replica_id),"tls.cert")
 
     async def _close_ssl_stream(self, dest_addr):
         """ Delete and close SSL stream from self.ssl_streams """


### PR DESCRIPTION
This PR handles:
1. Replica & Bft Client new certificate generation scheme
2. Code modification to verify the new scheme
3. Directory structure changed from <Replica_id>/<node_type>/<node_type>.cert where node_type can be "client" or "server"
     to <Replica_id>/tls.cert
4. Modification in apollo infra to handle new scheme and directory structure of certificates.