### PR TITLE
Unify_certs: New certificate generation scheme with verification

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -255,6 +255,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
   CONFIG_PARAM(enableMultiplexChannel, bool, false, "whether multiplex communication channel is enabled")
 
+  CONFIG_PARAM(useUnifiedCertificates, bool, false, "A flag to use unified Certificates");
+
   CONFIG_PARAM(adaptivePruningIntervalDuration,
                std::chrono::milliseconds,
                std::chrono::milliseconds{20000},
@@ -401,6 +403,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, enableEventGroups);
     serialize(outStream, enablePreProcessorMemoryPool);
     serialize(outStream, diagnosticsServerPort);
+    serialize(outStream, useUnifiedCertificates);
   }
   void deserializeDataMembers(std::istream& inStream) {
     deserialize(inStream, isReadOnly);
@@ -499,6 +502,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, enableEventGroups);
     deserialize(inStream, enablePreProcessorMemoryPool);
     deserialize(inStream, diagnosticsServerPort);
+    deserialize(inStream, useUnifiedCertificates);
   }
 
  private:
@@ -590,7 +594,8 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.enableEventGroups,
               rc.operatorEnabled_,
               rc.enablePreProcessorMemoryPool,
-              rc.diagnosticsServerPort);
+              rc.diagnosticsServerPort,
+              rc.useUnifiedCertificates);
   os << ", ";
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;

--- a/communication/CMakeLists.txt
+++ b/communication/CMakeLists.txt
@@ -22,11 +22,13 @@ add_library(bftcommunication ${bftcommunication_src})
 add_library(bftcommunication_shared SHARED ${bftcommunication_src})
 set_property(TARGET bftcommunication_shared PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+target_include_directories(bftcommunication PUBLIC ../bftengine/include/bftengine)
 target_include_directories(bftcommunication PUBLIC include)
 target_include_directories(bftcommunication PUBLIC ${util}/include)
 target_include_directories(bftcommunication PUBLIC ../secretsmanager/include)
 target_link_libraries(bftcommunication PUBLIC util)
 
+target_include_directories(bftcommunication_shared PUBLIC ../bftengine/include/bftengine)
 target_include_directories(bftcommunication_shared PUBLIC include)
 target_include_directories(bftcommunication_shared PUBLIC ${util}/include)
 target_include_directories(bftcommunication_shared PUBLIC ../secretsmanager/include)

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -25,6 +25,7 @@
 #include "TlsConnectionManager.h"
 #include "TlsDiagnostics.h"
 #include "TlsWriteQueue.h"
+#include "ReplicaConfig.hpp"
 
 namespace bft::communication::tls {
 
@@ -34,6 +35,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
  public:
   static constexpr std::chrono::seconds READ_TIMEOUT = std::chrono::seconds(10);
   static constexpr std::chrono::seconds WRITE_TIMEOUT = READ_TIMEOUT;
+  static bool useUnifiedCertificates_;
 
   // We require a factory function because we can't call shared_from_this() in the constructor.
   //
@@ -48,6 +50,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                                     TlsStatus& status,
                                                     Recorders& histograms) {
     auto conn = std::make_shared<AsyncTlsConnection>(io_context, receiver, conn_mgr, config, status, histograms);
+    useUnifiedCertificates_ = bftEngine::ReplicaConfig::instance().useUnifiedCertificates;
     conn->initServerSSLContext();
     conn->createSSLSocket(std::move(socket));
     return conn;
@@ -63,6 +66,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                                     Recorders& histograms) {
     auto conn =
         std::make_shared<AsyncTlsConnection>(io_context, receiver, conn_mgr, destination, config, status, histograms);
+    useUnifiedCertificates_ = bftEngine::ReplicaConfig::instance().useUnifiedCertificates;
     conn->initClientSSLContext(destination);
     conn->createSSLSocket(std::move(socket));
     return conn;

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     std::string keysFilePrefix;
     std::string commConfigFile;
     std::string s3ConfigFile;
-    std::string certRootPath = "certs";
+    std::string certRootPath = (replicaConfig.useUnifiedCertificates) ? "tls_certs" : "certs";
     std::string logPropsFile = "logging.properties";
     std::string principalsMapping;
     std::string txnSigningKeysPath;

--- a/util/include/crypto_utils.hpp
+++ b/util/include/crypto_utils.hpp
@@ -35,7 +35,8 @@ class CertificateUtils {
   static bool verifyCertificate(X509* cert_to_verify,
                                 const std::string& cert_root_directory,
                                 uint32_t& remote_peer_id,
-                                std::string& conn_type);
+                                std::string& conn_type,
+                                bool use_unified_certs);
 };
 class IVerifier {
  public:

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -276,7 +276,8 @@ Crypto::~Crypto() = default;
 bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
                                          const std::string& cert_root_directory,
                                          uint32_t& remote_peer_id,
-                                         std::string& conn_type) {
+                                         std::string& conn_type,
+                                         bool use_unified_certs) {
   // First get the source ID
   static constexpr size_t SIZE = 512;
   std::string subject(SIZE, 0);
@@ -317,7 +318,9 @@ bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
 
   // Get the local stored certificate for this peer
   std::string local_cert_path =
-      cert_root_directory + "/" + std::to_string(remotePeerId) + "/" + cert_type + "/" + cert_type + ".cert";
+      (use_unified_certs)
+          ? cert_root_directory + "/" + std::to_string(remotePeerId) + "/" + "node.cert"
+          : cert_root_directory + "/" + std::to_string(remotePeerId) + "/" + cert_type + "/" + cert_type + ".cert";
   auto deleter = [](FILE* fp) {
     if (fp) fclose(fp);
   };


### PR DESCRIPTION
This PR handles:

1. Replica & Bft Client new certificate generation scheme
2. Code modification to verify the new scheme
3. Directory structure changed from <Replica_id>/<node_type>/<node_type>.cert where node_type can be "client" or "server" to <Replica_id>/tls.cert
4. Flag useUnifiedCertificates added for unification of certificates.