### PR TITLE
Sleep in async execution until pruning is completed

### DIFF
--- a/bftengine/include/bftengine/ControlStateManager.hpp
+++ b/bftengine/include/bftengine/ControlStateManager.hpp
@@ -20,6 +20,7 @@
 #include "Serializable.h"
 #include "SysConsts.hpp"
 #include "callback_registry.hpp"
+#include "assertUtils.hpp"
 
 namespace bftEngine {
 class ControlStateManager {
@@ -36,6 +37,7 @@ class ControlStateManager {
   void unwedge() { wedged = false; }
   void markRemoveMetadata(bool include_st = true) { removeMetadataCbRegistry_.invokeAll(include_st); }
   void setPruningProcess(bool onPruningProcess) {
+    ConcordAssert(!(onPruningProcess_ && onPruningProcess));
     onPruningProcess ? pruningLock_.lock() : pruningLock_.unlock();
     onPruningProcess_ = onPruningProcess;
   }

--- a/bftengine/src/bftengine/ExecutionEngine.cpp
+++ b/bftengine/src/bftengine/ExecutionEngine.cpp
@@ -191,6 +191,11 @@ void ExecutionEngine::addPostExecCallBack(
 }
 void ExecutionEngine::execute(std::deque<IRequestsHandler::ExecutionRequest>& accumulatedRequests,
                               Timestamp& timestamp) {
+  if (bftEngine::ControlStateManager::instance().getPruningProcessStatus()) {
+    // This can be happen only if we run in a async execution mode and then the execution thread will sleep until
+    // pruning is done. In the case of sync execution, we will never get to this point.
+    bftEngine::ControlStateManager::instance().sleepUntilPruningIsDone();
+  }
   const std::string cid = accumulatedRequests.back().cid;
   const auto sn = accumulatedRequests.front().executionSequenceNum;
   concordUtils::SpanWrapper span_wrapper{};


### PR DESCRIPTION
This is to fix the following bug with async execution.
Assume two replicas, r1, r2, and assume 2 sequence numbers s1 and s2.
Also, let's assume that one of s1's requests is a pruning request and that pruning is happening in an async mode.
The following inconsistency can happen:
1. r1, schedule s1 and s2 for execution
2. s1 is executed and s2 is rejected (here https://github.com/vmware/concord-bft/blob/master/bftengine/src/bftengine/RequestHandler.cpp#L175)

In the meantime, r2 does the following:
1. schedule s1 for execution
2. execute s1
3. schedule s2 for execution
In r2 case, s2 will be executed once we did with pruning.
The end result is that s2 was executed in r2 but not in r1.

To fix the above, we let the execution thread sleep in the sequence number that is scheduled right after the pruning request (s2 in our case) instead of ignoring it.