### PR TITLE
ClientPoolTimer: Fix busy-wait loop

### DIFF
--- a/client/client_pool/CMakeLists.txt
+++ b/client/client_pool/CMakeLists.txt
@@ -14,3 +14,7 @@ target_link_libraries(concord_client_pool PUBLIC
       	)
 
 install (TARGETS concord_client_pool DESTINATION lib${LIB_SUFFIX})
+
+if (BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/client/client_pool/include/client/client_pool/client_pool_timer.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_timer.hpp
@@ -22,6 +22,8 @@
 #include "Logger.hpp"
 
 namespace concord_client_pool {
+
+// Note oddity: ClientT has to implement `operator<<`
 template <typename ClientT>
 class Timer {
  public:
@@ -48,6 +50,7 @@ class Timer {
 
   void start(const ClientT& client) {
     if (timeout_.count() == 0 || not timer_thread_future_.valid() || io_context_.stopped()) {
+      LOG_WARN(logger_, "Timer cannot start for client " << client_);
       return;
     }
     client_ = client;
@@ -68,7 +71,7 @@ class Timer {
       return timeout_;
     }
     timer_.cancel();
-    LOG_DEBUG(logger_, "Timer canceled for client " << client_);
+    LOG_DEBUG(logger_, "Timer cancelled for client " << client_);
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_timer_);
   }
 

--- a/client/client_pool/include/client/client_pool/client_pool_timer.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_timer.hpp
@@ -47,7 +47,7 @@ class Timer {
   }
 
   void start(const ClientT& client) {
-    if (timeout_.count() == 0) {
+    if (timeout_.count() == 0 || not timer_thread_future_.valid() || io_context_.stopped()) {
       return;
     }
     client_ = client;

--- a/client/client_pool/include/client/client_pool/client_pool_timer.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_timer.hpp
@@ -51,16 +51,16 @@ class Timer {
       return;
     }
     client_ = client;
-    start_timer_ = std::chrono::steady_clock::now();
-    std::chrono::milliseconds timeout(timeout_.count());
-    timer_.expires_from_now(timeout);
     auto handler = [this](const asio::error_code& error) {
       if (error != asio::error::operation_aborted) {
         on_timeout_(std::move(client_));
       }
     };
-    LOG_INFO(logger_, "Timer set for client " << client_);
+
+    start_timer_ = std::chrono::steady_clock::now();
+    timer_.expires_at(start_timer_ + timeout_);
     timer_.async_wait(handler);
+    LOG_DEBUG(logger_, "Timer set for client " << client_);
   }
 
   std::chrono::milliseconds cancel() {
@@ -68,7 +68,7 @@ class Timer {
       return timeout_;
     }
     timer_.cancel();
-    LOG_INFO(logger_, "Timer canceled for client " << client_);
+    LOG_DEBUG(logger_, "Timer canceled for client " << client_);
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_timer_);
   }
 

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -78,7 +78,7 @@ SubmitResult ConcordClientPool::SendRequest(std::vector<uint8_t> &&request,
     if (IsGoodForBatching(flags, client_batching_enabled_)) {
       if (0 == client->PendingRequestsCount()) {
         LOG_TRACE(logger_, "Set batching timer" << KVLOG(client_id));
-        batch_timer_->set(client);
+        batch_timer_->start(client);
       }
 
       if (flags & ClientMsgFlag::RECONFIG_FLAG_REQ) {
@@ -439,7 +439,7 @@ void ConcordClientPool::OnBatchingTimeout(std::shared_ptr<concord::external_clie
 }
 
 ConcordClientPool::~ConcordClientPool() {
-  batch_timer_->stop();
+  batch_timer_->stopTimerThread();
   jobs_thread_pool_.stop(true);
   std::unique_lock<std::mutex> clients_lock(clients_queue_lock_);
   for (auto &client : clients_) {

--- a/client/client_pool/test/CMakeLists.txt
+++ b/client/client_pool/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+find_package(GTest REQUIRED)
+
+add_executable(client-pool-timer-test client_pool_timer_test.cpp)
+target_link_libraries(client-pool-timer-test PUBLIC
+  GTest::Main
+  concord_client_pool
+)
+add_test(client-pool-timer-test client-pool-timer-test)

--- a/client/client_pool/test/client_pool_timer_test.cpp
+++ b/client/client_pool/test/client_pool_timer_test.cpp
@@ -1,0 +1,72 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <chrono>
+#include <thread>
+
+#include "client/client_pool/client_pool_timer.hpp"
+#include "gtest/gtest.h"
+
+using concord_client_pool::Timer;
+
+using namespace std::chrono_literals;
+
+struct TestClient {};
+
+TEST(client_pool_timer, work_items) {
+  uint16_t num_times_called = 0;
+  std::chrono::milliseconds timeout = 1ms;
+  auto timer = Timer<TestClient>(timeout, [&num_times_called](TestClient&& c) -> void { num_times_called++; });
+
+  // Wait for timeout
+  TestClient client1;
+  timer.start(client1);
+  std::this_thread::sleep_for(timeout * 2);
+  ASSERT_EQ(num_times_called, 1);
+
+  // Cancel timeout
+  TestClient client2;
+  timer.start(client2);
+  timer.cancel();
+  ASSERT_EQ(num_times_called, 1);
+
+  // Wait for timeout
+  TestClient client3;
+  timer.start(client3);
+  std::this_thread::sleep_for(timeout * 2);
+  ASSERT_EQ(num_times_called, 2);
+
+  // Wait for timeout
+  TestClient client4;
+  timer.start(client4);
+  std::this_thread::sleep_for(timeout * 2);
+  ASSERT_EQ(num_times_called, 3);
+
+  // Stop timer thread
+  TestClient client5;
+  timer.start(client5);
+  timer.stopTimerThread();
+  ASSERT_EQ(num_times_called, 3);
+
+  // Starting new timer won't work because the thread is stopped
+  TestClient client6;
+  timer.start(client6);
+  std::this_thread::sleep_for(timeout * 2);
+  ASSERT_EQ(num_times_called, 3);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int res = RUN_ALL_TESTS();
+  return res;
+}

--- a/client/client_pool/test/client_pool_timer_test.cpp
+++ b/client/client_pool/test/client_pool_timer_test.cpp
@@ -21,7 +21,7 @@ using concord_client_pool::Timer;
 
 using namespace std::chrono_literals;
 
-struct TestClient {};
+using TestClient = std::shared_ptr<void>;
 
 TEST(client_pool_timer, work_items) {
   uint16_t num_times_called = 0;


### PR DESCRIPTION
When there are no timeouts that need to be processed then the timer thread spins in a busy-wait loop. This PR is fixing the problem. Please see commit messages for details.