### PR TITLE
Lock reserved pages access (on inmemory datastore)

### DIFF
--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -210,7 +210,7 @@ class InMemoryDataStore : public DataStore {
   const map<uint64_t, CheckpointDesc>& getDescMap() const { return descMap; }
   const map<ResPageKey, ResPageVal>& getPagesMap() const { return pages; }
   const map<uint32_t, char*>& getPendingPagesMap() const { return pendingPages; }
-
+  std::mutex reservedPagesLock_;
   void setInitialized(bool init) { wasInit_ = init; }
   logging::Logger& logger() {
     static logging::Logger logger_ = logging::getLogger("concord.bft.st.inmem");


### PR DESCRIPTION
As a result of executing the "special requests" in a separate thread (see https://github.com/vmware/concord-bft/pull/2382) we may access the reserved pages from two different threads - the execution thread and the consensus thread.
To lock the read/write operation (as this is the only contention that can happen), we used mutex on the read/write level which is the inmemory datastore.
Note that in modern cpp, as this contention is very rare, using mutex is cheap as using spinlock with compare&swap.
