### PR TITLE
test_state_transfer_with_multiple_clients: fix an issue and enable back

### DIFF
--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -84,7 +84,6 @@ class SkvbcStateTransferTest(ApolloTest):
         await bft_network.force_quorum_including_replica(stale_node)
         await skvbc.assert_successful_put_get()
 
-    @unittest.skip("Disable until BC-19686 gets resolved.")
     @with_trio
     @with_bft_network(start_replica_cmd, rotate_keys=True)
     async def test_state_transfer_with_multiple_clients(self, bft_network,exchange_keys=True):
@@ -103,6 +102,10 @@ class SkvbcStateTransferTest(ApolloTest):
 
         # Need to send more than self.STATE_TRANSFER_WINDOW due to batching
         await skvbc.run_concurrent_ops(int(STATE_TRANSFER_WINDOW * 1.5), write_weight=1)
+        
+        # In some very rare cases some replicas need more time to request for missing info, lets wait 2 more seconds
+        await trio.sleep(seconds=2)
+        
         await skvbc.network_wait_for_checkpoint(working_replicas,
                                                 expected_checkpoint_num=lambda checkpoint_num: checkpoint_num >= 2)
 


### PR DESCRIPTION
In some rare cases, after run_concurrent_ops, some replicas need more
time to send RFMI messages and get back into consensus.
We enable test back, and sleep 2 more seconds before calling
network_wait_for_checkpoint.