### PR TITLE
[Example fix] Set correct pruning mode on ST

### DIFF
--- a/kvbc/src/st_reconfiguration_sm.cpp
+++ b/kvbc/src/st_reconfiguration_sm.cpp
@@ -166,6 +166,9 @@ bool StReconfigurationHandler::handle(const concord::messages::PruneSwitchModeRe
                             false);
     apm_.switchMode(concord::performance::PruningMode::ADAPTIVE);
   }
+  for (auto &rec : orig_reconf_handlers_) {
+    rec->switchPruningSM(command.mode);
+  }
   return true;
 }
 bool StReconfigurationHandler::handle(const concord::messages::InstallCommand &cmd,

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -308,6 +308,8 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool switchPruningSM(int mode) { return true; }
+
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
   virtual bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const = 0;


### PR DESCRIPTION
In a very rare edge case, a replica may crash after receiving a PruneSwitchModeRequest but before persisting the new mode in reserved pages.  
This change fixes this by setting the pruning mode during ST.