### PR TITLE
Clientservice: Shutdown gRPC server with deadline

### DIFF
--- a/client/clientservice/src/client_service.cpp
+++ b/client/clientservice/src/client_service.cpp
@@ -11,7 +11,10 @@
 
 #include "client/clientservice/client_service.hpp"
 
+#include <chrono>
 #include <grpcpp/grpcpp.h>
+
+using namespace std::literals::chrono_literals;
 
 namespace concord::client::clientservice {
 
@@ -55,7 +58,7 @@ void ClientService::wait() {
 void ClientService::shutdown() {
   if (clientservice_server_) {
     LOG_INFO(logger_, "Shutting down clientservice");
-    clientservice_server_->Shutdown();
+    clientservice_server_->Shutdown(std::chrono::system_clock::now() + 1s);
 
     LOG_INFO(logger_, "Shutting down and emptying completion queues");
     std::for_each(cqs_.begin(), cqs_.end(), [](auto& cq) { cq->Shutdown(); });


### PR DESCRIPTION
During runtime analysis, we wanted to shut down clientservice gracefully but
the server was hanging on the `Shutdown()` call. Let's not wait forever and
release resources properly. If the deadline is reached, the gRPC server will
cancel all ongoing requests.