### PR TITLE
Perf imprv for latest version CF migration tool

### DIFF
--- a/kvbc/include/migrations/block_merkle_latest_ver_cf_migration.h
+++ b/kvbc/include/migrations/block_merkle_latest_ver_cf_migration.h
@@ -30,7 +30,9 @@ namespace concord::kvbc::migrations {
 class BlockMerkleLatestVerCfMigration {
  public:
   // Note: `export_path` must be on the same filesystem as `db_path`.
-  BlockMerkleLatestVerCfMigration(const std::string& db_path, const std::string& export_path);
+  BlockMerkleLatestVerCfMigration(const std::string& db_path,
+                                  const std::string& export_path,
+                                  const size_t iteration_batch_size);
 
  public:
   static const std::string& temporaryColumnFamily();
@@ -69,6 +71,7 @@ class BlockMerkleLatestVerCfMigration {
  private:
   const std::string db_path_;
   const std::string export_path_;
+  const size_t iteration_batch_size_;
   std::shared_ptr<storage::rocksdb::NativeClient> db_;
   std::unique_ptr<::rocksdb::Checkpoint> checkpoint_;
   std::unique_ptr<::rocksdb::ExportImportFilesMetaData> export_metadata_;


### PR DESCRIPTION
We saw that for a 700GB database the latest version CF migration tool, migration is not getting completed even after 12 hours. So in this PR, we are improving the performance by reading in parallel for a batch of blocks. And then do a serialized write. The order of writing is preserved. After the fix, the migration is completed within 2 hours. So this tool will result in a migration time of 2 hours for a DB whose size is around 700 GB
This is cherry-picked into v0.14.x for https://github.com/vmware/concord-bft/pull/2544