### PR TITLE
Decoupling kv blockchain and its usage

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -272,6 +272,8 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                true,
                "A flag to specify whether to use a memory pool in PreProcessor or not");
 
+  CONFIG_PARAM(kvBlockchainVersion, std::uint32_t, 1u, "Default version of KV blockchain for this replica");
+
   // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters
   // Example of usage:
@@ -394,6 +396,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, enableMultiplexChannel);
     serialize(outStream, enableEventGroups);
     serialize(outStream, enablePreProcessorMemoryPool);
+    serialize(outStream, kvBlockchainVersion);
   }
   void deserializeDataMembers(std::istream& inStream) {
     deserialize(inStream, isReadOnly);
@@ -491,6 +494,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, enableMultiplexChannel);
     deserialize(inStream, enableEventGroups);
     deserialize(inStream, enablePreProcessorMemoryPool);
+    deserialize(inStream, kvBlockchainVersion);
   }
 
  private:
@@ -581,7 +585,8 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.enableMultiplexChannel,
               rc.enableEventGroups,
               rc.operatorEnabled_,
-              rc.enablePreProcessorMemoryPool);
+              rc.enablePreProcessorMemoryPool,
+              rc.kvBlockchainVersion);
   os << ", ";
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -34,6 +34,9 @@ add_library(kvbc  src/ClientImp.cpp
     src/resources-manager/ReplicaResources.cpp
     src/resources-manager/AdaptivePruningManager.cpp
     src/resources-manager/IntervalMappingResourceManager.cpp
+
+    src/kvbc_adapter/state_snapshot_adapter.cpp
+    src/kvbc_adapter/kv_blockchain_adapter.cpp
 )
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/benchmark/kvbcbench/pre_execution.h
+++ b/kvbc/benchmark/kvbcbench/pre_execution.h
@@ -18,7 +18,7 @@
 
 #include "assertUtils.hpp"
 #include "categorization/block_merkle_category.h"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "input.h"
 
 namespace concord::kvbc::bench {
@@ -46,7 +46,7 @@ class PreExecutionSimulator {
   PreExecutionSimulator(const PreExecConfig& config,
                         const ReadKeys& merkle_read_keys,
                         const ReadKeys& versioned_read_keys,
-                        categorization::KeyValueBlockchain& kvbc)
+                        adapter::KeyValueBlockchain& kvbc)
       : config_(config), merkle_read_keys_(merkle_read_keys), versioned_read_keys_(versioned_read_keys), kvbc_(kvbc) {}
 
   void start() {
@@ -106,7 +106,7 @@ class PreExecutionSimulator {
   const ReadKeys& merkle_read_keys_;
   const ReadKeys& versioned_read_keys_;
 
-  categorization::KeyValueBlockchain& kvbc_;
+  adapter::KeyValueBlockchain& kvbc_;
 };
 
 }  // namespace concord::kvbc::bench

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -11,7 +11,7 @@
 
 #include "st_reconfiguraion_sm.hpp"
 #include "OpenTracing.hpp"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "categorization/db_categories.h"
 #include "communication/ICommunication.hpp"
 #include "communication/CommFactory.hpp"
@@ -167,11 +167,9 @@ class Replica : public IReplica,
     return nullptr;
   }
 
-  std::optional<categorization::KeyValueBlockchain> &kvBlockchain() { return m_kvBlockchain; }
+  std::optional<adapter::KeyValueBlockchain> &kvBlockchain() { return m_kvBlockchain; }
 
-  void setStateSnapshotValueConverter(const categorization::KeyValueBlockchain::Converter &c) {
-    m_stateSnapshotValueConverter = c;
-  }
+  void setStateSnapshotValueConverter(const categorization::Converter &c) { m_stateSnapshotValueConverter = c; }
 
   void setLastApplicationTransactionTimeCallback(const LastApplicationTransactionTimeCallback &cb) {
     m_lastAppTxnCallback = cb;
@@ -228,8 +226,8 @@ class Replica : public IReplica,
 
   concord::kvbc::IStorageFactory::DatabaseSet m_dbSet;
   // The categorization KeyValueBlockchain is used for a normal read-write replica.
-  std::optional<categorization::KeyValueBlockchain> m_kvBlockchain;
-  categorization::KeyValueBlockchain::Converter m_stateSnapshotValueConverter{concord::kvbc::valueFromKvbcProto};
+  std::optional<adapter::KeyValueBlockchain> m_kvBlockchain;
+  categorization::Converter m_stateSnapshotValueConverter{concord::kvbc::valueFromKvbcProto};
   kvbc::LastApplicationTransactionTimeCallback m_lastAppTxnCallback{newestPublicEventGroupRecordTime};
   // The IdbAdapter instance is used for a read-only replica.
   std::unique_ptr<IDbAdapter> m_bcDbAdapter;

--- a/kvbc/include/blockchain_type.hpp
+++ b/kvbc/include/blockchain_type.hpp
@@ -1,0 +1,26 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <variant>
+#include <optional>
+#include <memory>
+#include "categorization/kv_blockchain.h"
+
+namespace concord::kvbc {
+enum BLOCKCHAIN_VERSION { CATEGORIZED_BLOCKCHAIN = 1, NATURAL_BLOCKCHAIN = 4 };
+using CatBCimpl = std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain>;
+
+using KVBlockChain = std::variant<CatBCimpl>;
+}  // end namespace concord::kvbc

--- a/kvbc/include/categorization/base_types.h
+++ b/kvbc/include/categorization/base_types.h
@@ -130,4 +130,8 @@ inline std::string categoryStringType(CATEGORY_TYPE t) {
   }
 }
 
+// Key or value converter interface.
+// Allows users to convert keys or values to any format that is appropriate.
+using Converter = std::function<std::string(std::string &&)>;
+
 }  // namespace concord::kvbc::categorization

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -40,14 +40,6 @@ class KeyValueBlockchain {
   using VersionedRawBlock = std::pair<BlockId, std::optional<categorization::RawBlockData>>;
 
  public:
-  // Key or value converter interface.
-  // Allows users to convert keys or values to any format that is appropriate.
-  using Converter = std::function<std::string(std::string&&)>;
-
-  // The noop converter returns the input string as is, without modifying it.
-  static const Converter kNoopConverter;
-
- public:
   // Creates a key-value blockchain.
   // If `category_types` is nullopt, the persisted categories in storage will be used.
   // If `category_types` has a value, it should contain all persisted categories in storage at a minimum. New ones
@@ -152,7 +144,9 @@ class KeyValueBlockchain {
   //
   // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
   // Precondition: The current KeyValueBlockchain instance points to a DB snapshot.
-  void computeAndPersistPublicStateHash(BlockId checkpoint_block_id, const Converter& value_converter = kNoopConverter);
+  void computeAndPersistPublicStateHash(
+      BlockId checkpoint_block_id,
+      const Converter& value_converter = [](std::string&& v) -> std::string { return std::move(v); });
 
   // Returns the public state keys as of the current point in the blockchain's history.
   // Returns std::nullopt if no public keys have been persisted.

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -235,6 +235,8 @@ struct Updates {
 
   const CategoryInput& categoryUpdates() const { return category_updates_; }
 
+  CategoryInput&& categoryUpdates() { return std::move(category_updates_); }
+
   // Appends a key-value of an `Update` type to already existing key-values for that category.
   // Precondition: The given `category_id` is of the same type as the passed updates.
   // Returns true on success or false if the given `category_id` doesn't exist.
@@ -264,7 +266,6 @@ struct Updates {
 
  private:
   friend bool operator==(const Updates&, const Updates&);
-  friend class KeyValueBlockchain;
   CategoryInput category_updates_;
 };
 

--- a/kvbc/include/kvbc_adapter/idempotent_reader.h
+++ b/kvbc/include/kvbc_adapter/idempotent_reader.h
@@ -15,18 +15,18 @@
 
 #include "assertUtils.hpp"
 #include "db_interfaces.h"
-#include "kv_blockchain.h"
+#include "kv_blockchain_adapter.hpp"
 
 #include <memory>
 
-namespace concord::kvbc::categorization {
+namespace concord::kvbc::adapter {
 
 // A utility that adapts a KeyValueBlockchain instance to an IReader.
-class CategorizedReader : public IReader {
+class IdempotentReader : public IReader {
  public:
-  // Constructs a CategorizedReader from a non-null KeyValueBlockchain pointer.
+  // Constructs a IdempotentReader from a non-null KeyValueBlockchain pointer.
   // Precondition: kvbc != nullptr
-  CategorizedReader(const std::shared_ptr<const KeyValueBlockchain> &kvbc) : kvbc_{kvbc} {
+  IdempotentReader(const std::shared_ptr<const KeyValueBlockchain> &kvbc) : kvbc_{kvbc} {
     ConcordAssertNE(kvbc, nullptr);
   }
 
@@ -78,4 +78,4 @@ class CategorizedReader : public IReader {
   const std::shared_ptr<const KeyValueBlockchain> kvbc_;
 };
 
-}  // namespace concord::kvbc::categorization
+}  // namespace concord::kvbc::adapter

--- a/kvbc/include/kvbc_adapter/kv_blockchain_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/kv_blockchain_adapter.hpp
@@ -1,0 +1,158 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "categorization/base_types.h"
+#include "categorization/updates.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "blockchain_type.hpp"
+#include "ReplicaConfig.hpp"
+
+using concord::storage::rocksdb::NativeClient;
+
+namespace concord::kvbc::adapter {
+class KeyValueBlockchain {
+ public:
+  template <typename OPTIONS,
+            typename = std::enable_if_t<std::is_same_v<OPTIONS, NativeClient::DefaultOptions> ||
+                                        std::is_same_v<OPTIONS, NativeClient::ExistingOptions> ||
+                                        std::is_same_v<OPTIONS, NativeClient::UserOptions>>>
+  [[maybe_unused]] explicit KeyValueBlockchain(const std::string& db_path,
+                                               bool read_only,
+                                               bool link_st_chain,
+                                               const OPTIONS& options) {
+    // The logic of choosing type of block chain will happen here.
+    if (bftEngine::ReplicaConfig::instance().kvBlockchainVersion == BLOCKCHAIN_VERSION::CATEGORIZED_BLOCKCHAIN) {
+      auto kv = std::make_shared<CatBCimpl::element_type>(NativeClient::newClient(db_path, read_only, options),
+                                                          link_st_chain);
+      kvbc_.emplace<CatBCimpl>(kv);
+    }
+  }
+
+  // Creates a key-value blockchain.
+  // If `category_types` is nullopt, the persisted categories in storage will be used.
+  // If `category_types` has a value, it should contain all persisted categories in storage at a minimum. New ones
+  // will be created and persisted. Users are required to pass a value for `category_types` on first construction
+  // (i.e. a new blockchain) in order to specify the categories in use. Failure to do so will generate an exception.
+  explicit KeyValueBlockchain(
+      const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client,
+      bool link_st_chain,
+      const std::optional<std::map<std::string, categorization::CATEGORY_TYPE>>& category_types = std::nullopt) {
+    if (bftEngine::ReplicaConfig::instance().kvBlockchainVersion == BLOCKCHAIN_VERSION::CATEGORIZED_BLOCKCHAIN) {
+      auto kv = std::make_shared<CatBCimpl::element_type>(native_client, link_st_chain, category_types);
+      kvbc_.emplace<CatBCimpl>(kv);
+    }
+  }
+
+  // The noop converter returns the input string as is, without modifying it.
+  static const categorization::Converter kNoopConverter;
+
+  /////////////////////// Add Block ///////////////////////
+
+  BlockId addBlock(categorization::Updates&& updates);
+
+  /////////////////////// Delete block ///////////////////////
+
+  bool deleteBlock(const BlockId& blockId);
+  void deleteLastReachableBlock();
+
+  /////////////////////// Raw Blocks ///////////////////////
+
+  // Adds raw block and tries to link the state transfer blockchain to the main blockchain
+  // If linkSTChainFrom is true, try to remove blocks form the state transfer chain to the blockchain
+  void addRawBlock(const categorization::RawBlock& block, const BlockId& block_id, bool lastBlock = true);
+  std::optional<categorization::RawBlock> getRawBlock(const BlockId& block_id) const;
+
+  /////////////////////// Info ///////////////////////
+  BlockId getGenesisBlockId() const;
+  BlockId getLastReachableBlockId() const;
+  std::optional<BlockId> getLastStatetransferBlockId() const;
+
+  std::optional<categorization::Hash> parentDigest(BlockId block_id) const;
+  bool hasBlock(BlockId block_id) const;
+
+  std::vector<std::string> getStaleKeys(BlockId block_id,
+                                        const std::string& category_id,
+                                        const categorization::ImmutableOutput& updates_info) const;
+
+  std::vector<std::string> getStaleKeys(BlockId block_id,
+                                        const std::string& category_id,
+                                        const categorization::VersionedOutput& updates_info) const;
+
+  std::vector<std::string> getStaleKeys(BlockId block_id,
+                                        const std::string& category_id,
+                                        const categorization::BlockMerkleOutput& updates_info) const;
+
+  /////////////////////// Read interface ///////////////////////
+
+  // Gets the value of a key by the exact blockVersion.
+  std::optional<categorization::Value> get(const std::string& category_id,
+                                           const std::string& key,
+                                           BlockId block_id) const;
+
+  std::optional<categorization::Value> getLatest(const std::string& category_id, const std::string& key) const;
+
+  void multiGet(const std::string& category_id,
+                const std::vector<std::string>& keys,
+                const std::vector<BlockId>& versions,
+                std::vector<std::optional<categorization::Value>>& values) const;
+
+  void multiGetLatest(const std::string& category_id,
+                      const std::vector<std::string>& keys,
+                      std::vector<std::optional<categorization::Value>>& values) const;
+
+  std::optional<categorization::TaggedVersion> getLatestVersion(const std::string& category_id,
+                                                                const std::string& key) const;
+
+  void multiGetLatestVersion(const std::string& category_id,
+                             const std::vector<std::string>& keys,
+                             std::vector<std::optional<categorization::TaggedVersion>>& versions) const;
+
+  // Get the updates that were used to create `block_id`.
+  std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const;
+
+  // Get a map of category_id and stale keys for `block_id`
+  std::map<std::string, std::vector<std::string>> getBlockStaleKeys(BlockId block_id) const;
+
+  // Get a map from category ID -> type for all known categories in the blockchain.
+  const std::map<std::string, categorization::CATEGORY_TYPE>& blockchainCategories() const;
+
+  // from_block_id is given as a hint, as supposed to be the next block after the last reachable block.
+  // until_block_id is the maximum block ID to be linked. If there are blocks with a block ID larger than
+  // until_block_id, they can be linked on future calls.
+  // returns the number of blocks connected
+  size_t linkUntilBlockId(BlockId from_block_id, BlockId until_block_id);
+
+  std::shared_ptr<concord::storage::rocksdb::NativeClient> db();
+  std::shared_ptr<const concord::storage::rocksdb::NativeClient> db() const;
+
+  //////// Extra functions ////////
+  std::string getPruningStatus();
+
+  void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator);
+
+  // The key used in the default column family for persisting the current public state hash.
+  static std::string publicStateHashKey();
+
+ private:
+  KVBlockChain kvbc_;
+};
+
+}  // namespace concord::kvbc::adapter

--- a/kvbc/include/kvbc_adapter/state_snapshot_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/state_snapshot_adapter.hpp
@@ -1,0 +1,73 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+#include "state_snapshot_interface.hpp"
+#include "categorization/kv_blockchain.h"
+#include "rocksdb/native_client.h"
+#include "blockchain_type.hpp"
+#include "ReplicaConfig.hpp"
+
+using concord::storage::rocksdb::NativeClient;
+using concord::kvbc::IKVBCStateSnapshot;
+using concord::kvbc::KVBlockChain;
+using concord::kvbc::categorization::Converter;
+
+namespace concord::kvbc::statesnapshot {
+class KVBCStateSnapshot : public IKVBCStateSnapshot {
+ public:
+  template <typename OPTIONS,
+            typename = std::enable_if_t<std::is_same_v<OPTIONS, NativeClient::DefaultOptions> ||
+                                        std::is_same_v<OPTIONS, NativeClient::ExistingOptions> ||
+                                        std::is_same_v<OPTIONS, NativeClient::UserOptions>>>
+  [[maybe_unused]] explicit KVBCStateSnapshot(const std::string& db_path, bool read_only, const OPTIONS& options) {
+    const auto link_st_chain = false;
+    // The logic of choosing type of block chain will happen here.
+    if (bftEngine::ReplicaConfig::instance().kvBlockchainVersion == BLOCKCHAIN_VERSION::CATEGORIZED_BLOCKCHAIN) {
+      auto kv = std::make_shared<CatBCimpl::element_type>(NativeClient::newClient(db_path, read_only, options),
+                                                          link_st_chain);
+      kvbc_.emplace<CatBCimpl>(kv);
+    }
+  }
+
+  explicit KVBCStateSnapshot(
+      const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client,
+      const std::optional<std::map<std::string, categorization::CATEGORY_TYPE>>& category_types = std::nullopt) {
+    const auto link_st_chain = false;
+    if (bftEngine::ReplicaConfig::instance().kvBlockchainVersion == BLOCKCHAIN_VERSION::CATEGORIZED_BLOCKCHAIN) {
+      auto kv = std::make_shared<CatBCimpl::element_type>(native_client, link_st_chain, category_types);
+      kvbc_.emplace<CatBCimpl>(kv);
+    }
+  }
+
+  virtual void computeAndPersistPublicStateHash(
+      BlockId checkpoint_block_id,
+      const Converter& value_converter = [](std::string&& s) -> std::string { return std::move(s); }) override;
+
+  virtual std::optional<PublicStateKeys> getPublicStateKeys() const override;
+
+  virtual void iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f) const override;
+
+  virtual bool iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f,
+                                           const std::string& after_key) const override;
+
+  virtual ~KVBCStateSnapshot() {}
+
+ private:
+  KVBlockChain kvbc_;
+};
+}  // end of namespace concord::kvbc::statesnapshot

--- a/kvbc/include/metadata_block_id.h
+++ b/kvbc/include/metadata_block_id.h
@@ -13,7 +13,7 @@
 #pragma once
 
 #include "assertUtils.hpp"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "endianness.hpp"
 #include "kv_types.hpp"
 #include "PersistentStorage.hpp"
@@ -25,7 +25,7 @@ namespace concord::kvbc {
 
 // Persist the last KVBC block ID in big-endian in metadata's user data field.
 template <bool in_transaction>
-void persistLastBlockIdInMetadata(const categorization::KeyValueBlockchain &blockchain,
+void persistLastBlockIdInMetadata(const adapter::KeyValueBlockchain &blockchain,
                                   const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
   const auto user_data = concordUtils::toBigEndianArrayBuffer(blockchain.getLastReachableBlockId());
   if constexpr (in_transaction) {

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -20,7 +20,6 @@
 #include "kvbc_key_types.hpp"
 #include "SigManager.hpp"
 #include "reconfiguration/reconfiguration_handler.hpp"
-#include "categorization/kv_blockchain.h"
 #include "kvbc_app_filter/value_from_kvbc_proto.h"
 #include "AdaptivePruningManager.hpp"
 #include "IntervalMappingResourceManager.hpp"
@@ -56,7 +55,7 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
  public:
   StateSnapshotReconfigurationHandler(kvbc::IBlockAdder& block_adder,
                                       kvbc::IReader& ro_storage,
-                                      const categorization::KeyValueBlockchain::Converter& state_value_converter,
+                                      const categorization::Converter& state_value_converter,
                                       const kvbc::LastApplicationTransactionTimeCallback& last_app_txn_time_cb_)
       : ReconfigurationBlockTools{block_adder, ro_storage},
         state_value_converter_{state_value_converter},
@@ -97,7 +96,7 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
  private:
   // Allows users to convert state values to any format that is appropriate.
   // The default converter extracts the value from the ValueWithTrids protobuf type.
-  categorization::KeyValueBlockchain::Converter state_value_converter_{valueFromKvbcProto};
+  categorization::Converter state_value_converter_{valueFromKvbcProto};
 
   // Return the time of the last application-level transaction stored in the blockchain.
   // The result must be a string that can be parsed via google::protobuf::util::TimeUtil::FromString().

--- a/kvbc/include/replica_state_sync.h
+++ b/kvbc/include/replica_state_sync.h
@@ -18,7 +18,7 @@
 #include "storage/db_types.h"
 #include "Logger.hpp"
 #include "db_adapter_interface.h"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "PersistentStorage.hpp"
 
 #include <memory>
@@ -33,7 +33,7 @@ class ReplicaStateSync {
 
   // Synchronizes replica state and returns a number of deleted blocks.
   virtual uint64_t execute(logging::Logger& logger,
-                           categorization::KeyValueBlockchain& blockchain,
+                           adapter::KeyValueBlockchain& blockchain,
                            const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                            uint64_t lastExecutedSeqNum,
                            uint32_t maxNumOfBlocksToDelete) = 0;

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -26,18 +26,18 @@ class ReplicaStateSyncImp : public ReplicaStateSync {
   ~ReplicaStateSyncImp() override = default;
 
   uint64_t execute(logging::Logger& logger,
-                   categorization::KeyValueBlockchain& blockchain,
+                   adapter::KeyValueBlockchain& blockchain,
                    const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                    uint64_t lastExecutedSeqNum,
                    uint32_t maxNumOfBlocksToDelete) override;
 
   uint64_t executeBasedOnBftSeqNum(logging::Logger& logger,
-                                   categorization::KeyValueBlockchain& blockchain,
+                                   adapter::KeyValueBlockchain& blockchain,
                                    uint64_t lastExecutedSeqNum,
                                    uint32_t maxNumOfBlocksToDelete);
 
   uint64_t executeBasedOnBlockId(logging::Logger& logger,
-                                 categorization::KeyValueBlockchain& blockchain,
+                                 adapter::KeyValueBlockchain& blockchain,
                                  const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                                  uint32_t maxNumOfBlocksToDelete);
 

--- a/kvbc/include/state_snapshot_interface.hpp
+++ b/kvbc/include/state_snapshot_interface.hpp
@@ -1,0 +1,76 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <optional>
+#include <functional>
+#include <string>
+
+#include "kv_types.hpp"
+#include "categorization/base_types.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+using concord::kvbc::categorization::PublicStateKeys;
+
+namespace concord::kvbc {
+
+class IDBCheckpoint {
+ public:
+  // Trims the DB snapshot such that its last reachable block is equal to `block_id_at_checkpoint`.
+  // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
+  // Precondition1: The current KeyValueBlockchain instance points to a DB snapshot.
+  // Precondition2: `block_id_at_checkpoint` >= INITIAL_GENESIS_BLOCK_ID
+  // Precondition3: `block_id_at_checkpoint` <= getLastReachableBlockId()
+  virtual void trimBlocksFromCheckpoint(BlockId block_id_at_checkpoint) = 0;
+
+  virtual ~IDBCheckpoint() = default;
+};
+
+// State snapshot support.
+class IKVBCStateSnapshot {
+ public:
+  // Computes and persists the public state hash by:
+  //  h0 = hash("")
+  //  h1 = hash(h0 || hash(k1) || v1)
+  //  h2 = hash(h1 || hash(k2) || v2)
+  //  ...
+  //  hN = hash(hN-1 || hash(kN) || vN)
+  //
+  // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
+  // Precondition: The current KeyValueBlockchain instance points to a DB snapshot.
+  virtual void computeAndPersistPublicStateHash(BlockId checkpoint_block_id,
+                                                const categorization::Converter& value_converter) = 0;
+
+  // Returns the public state keys as of the current point in the blockchain's history.
+  // Returns std::nullopt if no public keys have been persisted.
+  virtual std::optional<PublicStateKeys> getPublicStateKeys() const = 0;
+
+  // Iterate over all public key values, calling the given function multiple times with two parameters:
+  // * key
+  // * value
+  virtual void iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f) const = 0;
+
+  // Iterate over public key values from the key after `after_key`, calling the given function multiple times with two
+  // parameters:
+  // * key
+  // * value
+  //
+  // If `after_key` is not a public key, false is returned and no iteration is done (no calls to `f`). Else, iteration
+  // is done and the returned value is true, even if there are 0 public keys to actually iterate.
+  virtual bool iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f,
+                                           const std::string& after_key) const = 0;
+
+  virtual ~IKVBCStateSnapshot() = default;
+};
+
+}  // namespace concord::kvbc

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -127,7 +127,7 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
   static std::shared_ptr<KvbcRequestHandler> create(
       const std::shared_ptr<IRequestsHandler> &user_req_handler,
       const std::shared_ptr<concord::cron::CronTableRegistry> &cron_table_registry,
-      categorization::KeyValueBlockchain &blockchain,
+      adapter::KeyValueBlockchain &blockchain,
       std::shared_ptr<concordMetrics::Aggregator> aggregator_,
       ISystemResourceEntity &resourceEntity) {
     return std::shared_ptr<KvbcRequestHandler>{
@@ -149,7 +149,7 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
  private:
   KvbcRequestHandler(const std::shared_ptr<IRequestsHandler> &user_req_handler,
                      const std::shared_ptr<concord::cron::CronTableRegistry> &cron_table_registry,
-                     categorization::KeyValueBlockchain &blockchain,
+                     adapter::KeyValueBlockchain &blockchain,
                      std::shared_ptr<concordMetrics::Aggregator> aggregator_,
                      ISystemResourceEntity &resourceEntity)
       : bftEngine::RequestHandler(resourceEntity, aggregator_), blockchain_{blockchain} {
@@ -164,7 +164,7 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
 
  private:
   std::shared_ptr<bftEngine::impl::PersistentStorage> persistent_storage_;
-  categorization::KeyValueBlockchain &blockchain_;
+  adapter::KeyValueBlockchain &blockchain_;
 };
 void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler) {
   requestHandler->setReconfigurationHandler(std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -40,10 +40,6 @@ void nullopts(std::vector<std::optional<T>>& vec, std::size_t count) {
   vec.resize(count, std::nullopt);
 }
 
-const KeyValueBlockchain::Converter KeyValueBlockchain::kNoopConverter = [](std::string&& v) -> std::string {
-  return std::move(v);
-};
-
 KeyValueBlockchain::Recorders KeyValueBlockchain::histograms_;
 
 KeyValueBlockchain::KeyValueBlockchain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>& native_client,
@@ -188,7 +184,7 @@ BlockId KeyValueBlockchain::addBlock(Updates&& updates) {
   // Use new client batch and column families
   auto write_batch = native_client_->getBatch();
   addGenesisBlockKey(updates);
-  auto block_id = addBlock(std::move(updates.category_updates_), write_batch);
+  auto block_id = addBlock(updates.categoryUpdates(), write_batch);
   native_client_->write(std::move(write_batch));
   block_chain_.setAddedBlockId(block_id);
   return block_id;

--- a/kvbc/src/kvbc_adapter/kv_blockchain_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/kv_blockchain_adapter.cpp
@@ -1,0 +1,243 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
+#include "assertUtils.hpp"
+
+namespace concord::kvbc::adapter {
+
+const categorization::Converter KeyValueBlockchain::kNoopConverter = [](std::string&& v) -> std::string {
+  return std::move(v);
+};
+
+BlockId KeyValueBlockchain::addBlock(categorization::Updates&& updates) {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->addBlock(std::move(updates));
+  }
+  ConcordAssert(false);
+}
+
+bool KeyValueBlockchain::deleteBlock(const BlockId& blockId) {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->deleteBlock(blockId);
+  }
+  ConcordAssert(false);
+}
+void KeyValueBlockchain::deleteLastReachableBlock() {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->deleteLastReachableBlock();
+    return;
+  }
+  ConcordAssert(false);
+}
+
+void KeyValueBlockchain::addRawBlock(const categorization::RawBlock& block, const BlockId& block_id, bool lastBlock) {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->addRawBlock(block, block_id, lastBlock);
+    return;
+  }
+  ConcordAssert(false);
+}
+std::optional<categorization::RawBlock> KeyValueBlockchain::getRawBlock(const BlockId& block_id) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getRawBlock(block_id);
+  }
+  ConcordAssert(false);
+}
+
+BlockId KeyValueBlockchain::getGenesisBlockId() const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getGenesisBlockId();
+  }
+  ConcordAssert(false);
+}
+BlockId KeyValueBlockchain::getLastReachableBlockId() const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getLastReachableBlockId();
+  }
+  ConcordAssert(false);
+}
+std::optional<BlockId> KeyValueBlockchain::getLastStatetransferBlockId() const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getLastStatetransferBlockId();
+  }
+  ConcordAssert(false);
+}
+
+std::optional<categorization::Hash> KeyValueBlockchain::parentDigest(BlockId block_id) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->parentDigest(block_id);
+  }
+  ConcordAssert(false);
+}
+bool KeyValueBlockchain::hasBlock(BlockId block_id) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->hasBlock(block_id);
+  }
+  ConcordAssert(false);
+}
+
+std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
+                                                          const std::string& category_id,
+                                                          const categorization::ImmutableOutput& updates_info) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getStaleKeys(block_id, category_id, updates_info);
+  }
+  ConcordAssert(false);
+}
+
+std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
+                                                          const std::string& category_id,
+                                                          const categorization::VersionedOutput& updates_info) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getStaleKeys(block_id, category_id, updates_info);
+  }
+  ConcordAssert(false);
+}
+
+std::vector<std::string> KeyValueBlockchain::getStaleKeys(BlockId block_id,
+                                                          const std::string& category_id,
+                                                          const categorization::BlockMerkleOutput& updates_info) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getStaleKeys(block_id, category_id, updates_info);
+  }
+  ConcordAssert(false);
+}
+
+std::optional<categorization::Value> KeyValueBlockchain::get(const std::string& category_id,
+                                                             const std::string& key,
+                                                             BlockId block_id) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->get(category_id, key, block_id);
+  }
+  ConcordAssert(false);
+}
+
+std::optional<categorization::Value> KeyValueBlockchain::getLatest(const std::string& category_id,
+                                                                   const std::string& key) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getLatest(category_id, key);
+  }
+  ConcordAssert(false);
+}
+
+void KeyValueBlockchain::multiGet(const std::string& category_id,
+                                  const std::vector<std::string>& keys,
+                                  const std::vector<BlockId>& versions,
+                                  std::vector<std::optional<categorization::Value>>& values) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->multiGet(category_id, keys, versions, values);
+    return;
+  }
+  ConcordAssert(false);
+}
+
+void KeyValueBlockchain::multiGetLatest(const std::string& category_id,
+                                        const std::vector<std::string>& keys,
+                                        std::vector<std::optional<categorization::Value>>& values) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->multiGetLatest(category_id, keys, values);
+    return;
+  }
+  ConcordAssert(false);
+}
+
+std::optional<categorization::TaggedVersion> KeyValueBlockchain::getLatestVersion(const std::string& category_id,
+                                                                                  const std::string& key) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getLatestVersion(category_id, key);
+  }
+  ConcordAssert(false);
+}
+
+void KeyValueBlockchain::multiGetLatestVersion(
+    const std::string& category_id,
+    const std::vector<std::string>& keys,
+    std::vector<std::optional<categorization::TaggedVersion>>& versions) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->multiGetLatestVersion(category_id, keys, versions);
+    return;
+  }
+  ConcordAssert(false);
+}
+
+// Get the updates that were used to create `block_id`.
+std::optional<categorization::Updates> KeyValueBlockchain::getBlockUpdates(BlockId block_id) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getBlockUpdates(block_id);
+  }
+  ConcordAssert(false);
+}
+
+// Get a map of category_id and stale keys for `block_id`
+std::map<std::string, std::vector<std::string>> KeyValueBlockchain::getBlockStaleKeys(BlockId block_id) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getBlockStaleKeys(block_id);
+  }
+  ConcordAssert(false);
+}
+
+// Get a map from category ID -> type for all known categories in the blockchain.
+const std::map<std::string, categorization::CATEGORY_TYPE>& KeyValueBlockchain::blockchainCategories() const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->blockchainCategories();
+  }
+  ConcordAssert(false);
+}
+
+// from_block_id is given as a hint, as supposed to be the next block after the last reachable block.
+// until_block_id is the maximum block ID to be linked. If there are blocks with a block ID larger than
+// until_block_id, they can be linked on future calls.
+// returns the number of blocks connected
+size_t KeyValueBlockchain::linkUntilBlockId(BlockId from_block_id, BlockId until_block_id) {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->linkUntilBlockId(from_block_id, until_block_id);
+  }
+  ConcordAssert(false);
+}
+
+std::shared_ptr<concord::storage::rocksdb::NativeClient> KeyValueBlockchain::db() {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->db();
+  }
+  ConcordAssert(false);
+}
+std::shared_ptr<const concord::storage::rocksdb::NativeClient> KeyValueBlockchain::db() const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->db();
+  }
+  ConcordAssert(false);
+}
+
+std::string KeyValueBlockchain::getPruningStatus() {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getPruningStatus();
+  }
+  ConcordAssert(false);
+}
+
+void KeyValueBlockchain::setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->setAggregator(aggregator);
+    return;
+  }
+  ConcordAssert(false);
+}
+
+// The key used in the default column family for persisting the current public state hash.
+// TODO: ARC: Remove this static function
+std::string KeyValueBlockchain::publicStateHashKey() {
+  return concord::kvbc::categorization::KeyValueBlockchain::publicStateHashKey();
+}
+
+}  // namespace concord::kvbc::adapter

--- a/kvbc/src/kvbc_adapter/state_snapshot_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/state_snapshot_adapter.cpp
@@ -1,0 +1,50 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "assertUtils.hpp"
+#include "kvbc_adapter/state_snapshot_adapter.hpp"
+
+namespace concord::kvbc::statesnapshot {
+
+void KVBCStateSnapshot::computeAndPersistPublicStateHash(BlockId checkpoint_block_id,
+                                                         const Converter& value_converter) {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->computeAndPersistPublicStateHash(checkpoint_block_id, value_converter);
+    return;
+  }
+  ConcordAssert(false);
+}
+
+std::optional<PublicStateKeys> KVBCStateSnapshot::getPublicStateKeys() const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->getPublicStateKeys();
+  }
+  ConcordAssert(false);
+}
+
+void KVBCStateSnapshot::iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    std::get<CatBCimpl>(kvbc_)->iteratePublicStateKeyValues(f);
+    return;
+  }
+  ConcordAssert(false);
+}
+
+bool KVBCStateSnapshot::iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f,
+                                                    const std::string& after_key) const {
+  if (std::holds_alternative<CatBCimpl>(kvbc_)) {
+    return std::get<CatBCimpl>(kvbc_)->iteratePublicStateKeyValues(f, after_key);
+  }
+  ConcordAssert(false);
+}
+}  // End of namespace concord::kvbc::statesnapshot

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -21,9 +21,10 @@
 #include "kvbc_app_filter/kvbc_key_types.h"
 #include "concord.cmf.hpp"
 #include "secrets_manager_plain.h"
-#include "communication/StateControl.hpp"
 #include "rocksdb/native_client.h"
-#include "categorization/categorized_reader.h"
+#include "kvbc_adapter/idempotent_reader.h"
+#include "kvbc_adapter/state_snapshot_adapter.hpp"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "categorization/db_categories.h"
 #include "categorization/details.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
@@ -36,10 +37,10 @@ namespace concord::kvbc::reconfiguration {
 using bftEngine::impl::DbCheckpointManager;
 using bftEngine::impl::SigManager;
 using concord::kvbc::KvbAppFilter;
-using concord::kvbc::categorization::CategorizedReader;
-using concord::kvbc::categorization::KeyValueBlockchain;
+using concord::kvbc::adapter::IdempotentReader;
 using concord::messages::SnapshotResponseStatus;
 using concord::storage::rocksdb::NativeClient;
+using concord::kvbc::statesnapshot::KVBCStateSnapshot;
 
 kvbc::BlockId ReconfigurationBlockTools::persistReconfigurationBlock(
     const std::vector<uint8_t>& data,
@@ -196,8 +197,9 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
         read_only,
         NativeClient::DefaultOptions{});
     const auto link_st_chain = false;
-    const auto kvbc = std::make_shared<const KeyValueBlockchain>(db, link_st_chain);
-    const auto reader = CategorizedReader{kvbc};
+    const auto kvbc_state_snapshot = std::make_shared<const KVBCStateSnapshot>(db);
+    const auto idempotent_kvbc = std::make_shared<const adapter::KeyValueBlockchain>(db, link_st_chain);
+    const auto reader = IdempotentReader{idempotent_kvbc};
     const auto filter = KvbAppFilter{&reader, ""};
     if (bftEngine::ReplicaConfig::instance().enableEventGroups) {
       // TODO: We currently only support new participants and, therefore, the event group ID will always be the last
@@ -208,7 +210,7 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
       resp.data->blockchain_height = reader.getLastBlockId();
       resp.data->blockchain_height_type = messages::BlockchainHeightType::BlockId;
     }
-    const auto public_state = kvbc->getPublicStateKeys();
+    const auto public_state = kvbc_state_snapshot->getPublicStateKeys();
     if (!public_state) {
       resp.data->key_value_count_estimate = 0;
     } else {
@@ -295,7 +297,7 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::Signed
       const auto read_only = true;
       try {
         auto db = NativeClient::newClient(snapshot_path, read_only, NativeClient::DefaultOptions{});
-        const auto ser_hash = db->get(KeyValueBlockchain::publicStateHashKey());
+        const auto ser_hash = db->get(adapter::KeyValueBlockchain::publicStateHashKey());
         if (!ser_hash) {
           LOG_ERROR(getLogger(),
                     "SignedPublicStateHashRequest: missing public state hash for snapshot ID = "
@@ -361,8 +363,9 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
       try {
         auto db = NativeClient::newClient(snapshot_path, read_only, NativeClient::DefaultOptions{});
         const auto link_st_chain = false;
-        const auto kvbc = KeyValueBlockchain{db, link_st_chain};
-        const auto public_state = kvbc.getPublicStateKeys();
+        const auto kvbc = adapter::KeyValueBlockchain{db, link_st_chain};
+        const auto kvbc_state_snapshot = KVBCStateSnapshot{db};
+        const auto public_state = kvbc_state_snapshot.getPublicStateKeys();
         auto values = std::vector<std::optional<categorization::Value>>{};
         kvbc.multiGetLatest(categorization::kExecutionProvableCategory, req.keys, values);
         ConcordAssertEQ(req.keys.size(), values.size());
@@ -1234,9 +1237,9 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Clien
   if (!bftEngine::ReplicaConfig::instance().saveClinetKeyFile) return true;
   // Now that keys have exchanged, lets persist the new key in the file system
   uint32_t group_id = 0;
-  for (const auto& [id, cgr] : bftEngine::ReplicaConfig::instance().clientGroups) {
+  for (const auto& [gid, cgr] : bftEngine::ReplicaConfig::instance().clientGroups) {
     if (std::find(cgr.begin(), cgr.end(), sender_id) != cgr.end()) {
-      group_id = id;
+      group_id = gid;
       break;
     }
   }

--- a/kvbc/src/replica_state_sync_imp.cpp
+++ b/kvbc/src/replica_state_sync_imp.cpp
@@ -6,7 +6,19 @@
 // "License").  You may not use this product except in compliance with the
 // Apache 2.0 License.
 //
+// This product may include a // Concord
+//
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
 // This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+// number of subcomponents with separate copyright
 // notices and license terms. Your use of these subcomponents is subject to the
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
@@ -14,7 +26,6 @@
 
 #include "assertUtils.hpp"
 #include "replica_state_sync_imp.hpp"
-#include "bftengine/DbMetadataStorage.hpp"
 #include "block_metadata.hpp"
 #include "kvstream.h"
 #include "metadata_block_id.h"
@@ -28,7 +39,7 @@ namespace concord::kvbc {
 ReplicaStateSyncImp::ReplicaStateSyncImp(IBlockMetadata* blockMetadata) : blockMetadata_(blockMetadata) {}
 
 uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
-                                      categorization::KeyValueBlockchain& blockchain,
+                                      adapter::KeyValueBlockchain& blockchain,
                                       const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                                       uint64_t lastExecutedSeqNum,
                                       uint32_t maxNumOfBlocksToDelete) {
@@ -58,7 +69,7 @@ uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
 }
 
 uint64_t ReplicaStateSyncImp::executeBasedOnBftSeqNum(logging::Logger& logger,
-                                                      categorization::KeyValueBlockchain& blockchain,
+                                                      adapter::KeyValueBlockchain& blockchain,
                                                       uint64_t lastExecutedSeqNum,
                                                       uint32_t maxNumOfBlocksToDelete) {
   if (!lastExecutedSeqNum) {
@@ -98,7 +109,7 @@ uint64_t ReplicaStateSyncImp::executeBasedOnBftSeqNum(logging::Logger& logger,
 }
 
 uint64_t ReplicaStateSyncImp::executeBasedOnBlockId(logging::Logger& logger,
-                                                    categorization::KeyValueBlockchain& blockchain,
+                                                    adapter::KeyValueBlockchain& blockchain,
                                                     const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                                                     uint32_t maxNumOfBlocksToDelete) {
   if (0 == maxNumOfBlocksToDelete) {

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -20,7 +20,6 @@
 #include "categorization/updates.h"
 #include "categorization/kv_blockchain.h"
 #include "categorization/db_categories.h"
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -14,7 +14,7 @@
 #include <bftengine/ControlStateManager.hpp>
 #include <bftengine/ControlStateManager.hpp>
 #include "NullStateTransfer.hpp"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "categorization/updates.h"
 #include "db_interfaces.h"
 #include "endianness.hpp"
@@ -37,6 +37,7 @@ using concord::kvbc::BlockId;
 using namespace concord::kvbc;
 using namespace concord::kvbc::categorization;
 using namespace concord::kvbc::pruning;
+
 namespace {
 const NodeIdType replica_0 = 0;
 const NodeIdType replica_1 = 1;
@@ -444,7 +445,7 @@ class TestStorage : public IReader, public IBlockAdder, public IBlocksDeleter {
   void setGenesisBlockId(BlockId bid) { mockGenesisBlockId = bid; }
 
  private:
-  KeyValueBlockchain bc_;
+  concord::kvbc::adapter::KeyValueBlockchain bc_;
   std::optional<BlockId> mockGenesisBlockId = {};
 };
 

--- a/kvbc/test/replica_state_sync_test.cpp
+++ b/kvbc/test/replica_state_sync_test.cpp
@@ -15,7 +15,7 @@
 #include "DbMetadataStorage.hpp"
 #include "Logger.hpp"
 #include "block_metadata.hpp"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "db_interfaces.h"
 #include "metadata_block_id.h"
 #include "PersistentStorageImp.hpp"
@@ -39,7 +39,7 @@ using concord::kvbc::IReader;
 using concord::kvbc::categorization::kConcordInternalCategoryId;
 using concord::kvbc::ReplicaStateSyncImp;
 using concord::kvbc::categorization::CATEGORY_TYPE;
-using concord::kvbc::categorization::KeyValueBlockchain;
+using concord::kvbc::adapter::KeyValueBlockchain;
 using concord::kvbc::categorization::TaggedVersion;
 using concord::kvbc::categorization::Updates;
 using concord::kvbc::categorization::Value;

--- a/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
@@ -30,7 +30,7 @@ class DbEditorTests : public DbEditorTestsBase {
  public:
   void CreateBlockchain(std::size_t db_id, BlockId blocks, std::optional<BlockId> mismatch_at = std::nullopt) override {
     auto db = TestRocksDb::create(db_id);
-    auto adapter = KeyValueBlockchain{
+    auto adapter = concord::kvbc::adapter::KeyValueBlockchain{
         concord::storage::rocksdb::NativeClient::fromIDBClient(db),
         true,
         std::map<std::string, CATEGORY_TYPE>{
@@ -97,7 +97,7 @@ class DbEditorTests : public DbEditorTestsBase {
 
   void DeleteBlocksUntil(std::size_t db_id, BlockId until_block_id) override {
     auto db = TestRocksDb::createNative(db_id);
-    auto adapter = KeyValueBlockchain{db, true};
+    auto adapter = concord::kvbc::adapter::KeyValueBlockchain{db, true};
 
     for (auto i = 1ull; i < until_block_id; ++i) {
       adapter.deleteBlock(i);

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -18,7 +18,7 @@
 
 #include "kvbc_key_types.hpp"
 #include "db_editor_common.hpp"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "execution_data.cmf.hpp"
 #include "keys_and_signatures.cmf.hpp"
 #include "concord.cmf.hpp"
@@ -42,7 +42,7 @@
 #pragma GCC diagnostic pop
 
 namespace concord::kvbc::tools::db_editor {
-
+using concord::kvbc::adapter::KeyValueBlockchain;
 using namespace categorization;
 
 inline const auto kToolName = "kv_blockchain_db_editor"s;
@@ -678,7 +678,6 @@ struct CompareTo {
       throw std::invalid_argument{"Missing PATH-TO-OTHER-DB argument"};
     }
 
-    const auto read_only = true;
     const auto other_adapter = getAdapter(args.values.front(), read_only);
 
     const auto main_genesis = main_adapter.getGenesisBlockId();

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -347,7 +347,7 @@ void InternalCommandsHandler::addBlock(VersionedUpdates &verUpdates, BlockMerkle
   // Add all key-values in the block merkle category as public ones.
   if (m_addAllKeysAsPublic) {
     ConcordAssertNE(m_kvbc, nullptr);
-    auto public_state = m_kvbc->getPublicStateKeys();
+    auto public_state = m_kvbc_state_snapshot->getPublicStateKeys();
     if (!public_state) {
       public_state = PublicStateKeys{};
     }

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -71,15 +71,15 @@ class STAddRemoveHandlerTest : public concord::client::reconfiguration::IStateHa
   }
 };
 
-void cronSetup(TestSetup& setup, const Replica& replica) {
+void cronSetup(TestSetup& setup, const Replica& main_replica) {
   if (!setup.GetCronEntryNumberOfExecutes()) {
     return;
   }
   const auto numberOfExecutes = *setup.GetCronEntryNumberOfExecutes();
 
   using namespace concord::cron;
-  const auto cronTableRegistry = replica.cronTableRegistry();
-  const auto ticksGenerator = replica.ticksGenerator();
+  const auto cronTableRegistry = main_replica.cronTableRegistry();
+  const auto ticksGenerator = main_replica.ticksGenerator();
 
   auto& cronTable = cronTableRegistry->operator[](TestSetup::kCronTableComponentId);
 
@@ -144,7 +144,7 @@ void run_replica(int argc, char** argv) {
                                                 setup->AddAllKeysAsPublic(),
                                                 replica->kvBlockchain() ? &replica->kvBlockchain().value() : nullptr);
   replica->set_command_handler(cmdHandler);
-  replica->setStateSnapshotValueConverter(categorization::KeyValueBlockchain::kNoopConverter);
+  replica->setStateSnapshotValueConverter(adapter::KeyValueBlockchain::kNoopConverter);
   replica->start();
   if (setup->GetReplicaConfig().isReadOnly)
     replica->registerStBasedReconfigurationHandler(std::make_shared<STAddRemoveHandlerTest>());

--- a/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
@@ -16,11 +16,12 @@
 #include "replica_state_snapshot.grpc.pb.h"
 
 #include "bftengine/DbCheckpointManager.hpp"
-#include "categorization/kv_blockchain.h"
 #include "kvbc_app_filter/value_from_kvbc_proto.h"
+#include "state_snapshot_interface.hpp"
 
 #include <optional>
 #include <string>
+#include <memory>
 
 namespace concord::thin_replica {
 
@@ -38,9 +39,7 @@ class ReplicaStateSnapshotServiceImpl
       ::grpc::ServerWriter< ::vmware::concord::replicastatesnapshot::StreamSnapshotResponse>* writer) override;
 
   // Allows users to convert state values to any format that is appropriate.
-  void setStateValueConverter(const kvbc::categorization::KeyValueBlockchain::Converter& c) {
-    state_value_converter_ = c;
-  }
+  void setStateValueConverter(const kvbc::categorization::Converter& c) { state_value_converter_ = c; }
 
   // Following methods are used for testing only. Please do not use in production.
   void overrideCheckpointPathForTest(const std::string& path) { overriden_path_for_test_ = path; }
@@ -55,7 +54,7 @@ class ReplicaStateSnapshotServiceImpl
   bool throw_exception_for_test_{false};
   // Allows users to convert state values to any format that is appropriate.
   // The default converter extracts the value from the ValueWithTrids protobuf type.
-  kvbc::categorization::KeyValueBlockchain::Converter state_value_converter_{kvbc::valueFromKvbcProto};
+  kvbc::categorization::Converter state_value_converter_{kvbc::valueFromKvbcProto};
 };
 
 }  // namespace concord::thin_replica

--- a/thin-replica-server/src/replica_state_snapshot_service_impl.cpp
+++ b/thin-replica-server/src/replica_state_snapshot_service_impl.cpp
@@ -14,7 +14,7 @@
 #include "thin-replica-server/replica_state_snapshot_service_impl.hpp"
 
 #include "Logger.hpp"
-#include "rocksdb/native_client.h"
+#include "kvbc_adapter/state_snapshot_adapter.hpp"
 
 #include <stdexcept>
 #include <string>
@@ -25,8 +25,8 @@ using vmware::concord::replicastatesnapshot::StreamSnapshotRequest;
 using vmware::concord::replicastatesnapshot::StreamSnapshotResponse;
 
 using bftEngine::impl::DbCheckpointManager;
-using kvbc::categorization::KeyValueBlockchain;
 using storage::rocksdb::NativeClient;
+using kvbc::statesnapshot::KVBCStateSnapshot;
 
 grpc::Status ReplicaStateSnapshotServiceImpl::StreamSnapshot(grpc::ServerContext* context,
                                                              const StreamSnapshotRequest* request,
@@ -61,10 +61,9 @@ grpc::Status ReplicaStateSnapshotServiceImpl::StreamSnapshot(grpc::ServerContext
     const auto snapshot_path = overriden_path_for_test_.has_value()
                                    ? *overriden_path_for_test_
                                    : DbCheckpointManager::instance().getPathForCheckpoint(request->snapshot_id());
-    const auto link_st_chain = false;
     const auto read_only = true;
-    auto db = NativeClient::newClient(snapshot_path, read_only, NativeClient::DefaultOptions{});
-    const auto kvbc = KeyValueBlockchain{db, link_st_chain};
+    std::unique_ptr<kvbc::IKVBCStateSnapshot> kvbc_state_snapshot_ =
+        std::make_unique<KVBCStateSnapshot>(snapshot_path, read_only, NativeClient::DefaultOptions{});
 
     const auto iterate = [&](std::string&& key, std::string&& value) {
       auto resp = StreamSnapshotResponse{};
@@ -82,14 +81,14 @@ grpc::Status ReplicaStateSnapshotServiceImpl::StreamSnapshot(grpc::ServerContext
     };
 
     if (request->has_last_received_key()) {
-      if (!kvbc.iteratePublicStateKeyValues(iterate, request->last_received_key())) {
+      if (!kvbc_state_snapshot_->iteratePublicStateKeyValues(iterate, request->last_received_key())) {
         const auto msg =
             "Streaming of State Snapshot ID = " + snapshot_id_str + " failed, reason = last_received_key not found";
         LOG_INFO(STATE_SNAPSHOT, msg);
         return grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, msg};
       }
     } else {
-      kvbc.iteratePublicStateKeyValues(iterate);
+      kvbc_state_snapshot_->iteratePublicStateKeyValues(iterate);
     }
   } catch (const std::exception& e) {
     const auto err = "Streaming of State Snapshot ID = " + snapshot_id_str + " failed, reason = " + e.what();

--- a/thin-replica-server/test/replica_state_snapshot_service_test.cpp
+++ b/thin-replica-server/test/replica_state_snapshot_service_test.cpp
@@ -15,7 +15,7 @@
 #include "gmock/gmock.h"
 
 #include "categorization/db_categories.h"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
 #include "kvbc_key_types.hpp"
 #include "storage/test/storage_test_common.h"
 #include "thin-replica-server/replica_state_snapshot_service_impl.hpp"
@@ -38,6 +38,7 @@ using namespace concord::kvbc;
 using namespace concord::kvbc::categorization;
 using namespace concord::thin_replica;
 using bftEngine::impl::DbCheckpointManager;
+using concord::kvbc::adapter::KeyValueBlockchain;
 using concord::storage::rocksdb::NativeClient;
 using grpc::Channel;
 using grpc::ClientContext;


### PR DESCRIPTION
This PR adds an adapter layer that can be used to decouple the KV blockchain with the rest of the codebase. Later when the real implementation happens, changing the constructors and functions in the adapter layer can easily help us to choose the correct implementation. Further, this will also help us in doing A/B testing and comparing any improvements in newer versions of the blockchain.