### PR TITLE
Fix issues of SimpleTest

### DIFF
--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -170,7 +170,8 @@ class SimpleTestReplica {
                                          metaDataStorage,
                                          std::make_shared<concord::performance::PerformanceManager>(),
                                          nullptr /*SecretsManagerEnc*/,
-                                         nullptr);  // call back
+                                         [](bool) {});  // call back
+    replica->SetAggregator(std::make_shared<concordMetrics::Aggregator>());
   }
 
   ~SimpleTestReplica() {


### PR DESCRIPTION
Issue 1: viewChangeCallback should be passed as an empty function wrapper rather than than nullptr as this function is called as no-op later in the code

Issue 2: aggregator has to be set for ReplicaBase at the time of Replica creation in SimpleTest Replica creation code 