### PR TITLE
TRS: Wait for last_block_id + 1 live update in SubscribeToUpdates

### DIFF
--- a/client/concordclient/include/client/concordclient/thread_safe_queue.ipp
+++ b/client/concordclient/include/client/concordclient/thread_safe_queue.ipp
@@ -59,7 +59,7 @@ std::unique_ptr<T> BasicThreadSafeQueue<T>::pop() {
   if (release_consumers_) {
     return std::unique_ptr<T>(nullptr);
   }
-  ConcordAssert(queue_data_.size() > 0);
+  ConcordAssertGT(queue_data_.size(), 0);
   std::unique_ptr<T> ret = move(queue_data_.front());
   queue_data_.pop_front();
   return ret;
@@ -83,7 +83,7 @@ std::unique_ptr<T> BasicThreadSafeQueue<T>::popTill(std::chrono::milliseconds ti
   if (release_consumers_) {
     return std::unique_ptr<T>(nullptr);
   }
-  ConcordAssert(queue_data_.size() > 0);
+  ConcordAssertGT(queue_data_.size(), 0);
   std::unique_ptr<T> ret = move(queue_data_.front());
   queue_data_.pop_front();
   return ret;

--- a/client/thin-replica-client/src/grpc_connection.cpp
+++ b/client/thin-replica-client/src/grpc_connection.cpp
@@ -141,7 +141,7 @@ GrpcConnection::Result GrpcConnection::openDataStream(const SubscriptionRequest&
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   data_stream_ = stream.get();
   if (data_stream_) return Result::kSuccess;
 
@@ -179,7 +179,7 @@ GrpcConnection::Result GrpcConnection::readData(Data* data) {
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   if (result.get()) return Result::kSuccess;
 
   auto grpc_status = data_stream_->Finish();
@@ -215,7 +215,7 @@ GrpcConnection::Result GrpcConnection::openStateStream(const ReadStateRequest& r
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   state_stream_ = stream.get();
   if (!state_stream_) {
     state_context_.reset();
@@ -253,7 +253,7 @@ GrpcConnection::Result GrpcConnection::closeStateStream() {
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   state_context_.reset();
   state_stream_.reset();
   Status finish_reported_status = result.get();
@@ -284,7 +284,7 @@ GrpcConnection::Result GrpcConnection::readState(Data* data) {
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   return result.get() ? Result::kSuccess : Result::kFailure;
 }
 
@@ -305,7 +305,7 @@ GrpcConnection::Result GrpcConnection::readStateHash(const ReadStateHashRequest&
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   Status call_grpc_status = result.get();
   if (!call_grpc_status.ok()) {
     LOG_WARN(logger_,
@@ -347,7 +347,7 @@ GrpcConnection::Result GrpcConnection::openHashStream(SubscriptionRequest& reque
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   hash_stream_ = stream.get();
   if (hash_stream_) return Result::kSuccess;
 
@@ -385,7 +385,7 @@ GrpcConnection::Result GrpcConnection::readHash(Hash* hash) {
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   if (result.get()) return Result::kSuccess;
 
   auto grpc_status = hash_stream_->Finish();
@@ -425,7 +425,7 @@ GrpcConnection::Result GrpcConnection::openStateSnapshotStream(
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   snapshot_stream = stream.get();
   if (snapshot_stream) {
     WriteLock write_lock(rss_streams_mutex_);
@@ -517,7 +517,7 @@ GrpcConnection::Result GrpcConnection::readStateSnapshot(
     return Result::kTimeout;
   }
 
-  ConcordAssert(status == future_status::ready);
+  ConcordAssertEQ(status, future_status::ready);
   if (result.get()) {
     return Result::kSuccess;
   }

--- a/client/thin-replica-client/src/replica_state_snapshot_client.cpp
+++ b/client/thin-replica-client/src/replica_state_snapshot_client.cpp
@@ -48,7 +48,7 @@ void ReplicaStateSnapshotClient::readSnapshotStream(const SnapshotRequest& reque
 
 void ReplicaStateSnapshotClient::receiveSnapshot(const SnapshotRequest& request,
                                                  std::shared_ptr<SnapshotQueue> remote_queue) {
-  ConcordAssert(config_->rss_conns.size() > 0);
+  ConcordAssertGT(config_->rss_conns.size(), 0);
   uint16_t replica_id = 0;
   GrpcConnection::Result result = GrpcConnection::Result::kUnknown;
   std::string last_read_key("");

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -433,7 +433,7 @@ FindGlobalEgIdResult KvbAppFilter::findGlobalEventGroupId(uint64_t external_even
     return {global_eg_id, true, current_pvt_eg_id - 1, pub_eg_id};
   }
 
-  ConcordAssert(external_event_group_id > current_ext_eg_id);
+  ConcordAssertGT(external_event_group_id, current_ext_eg_id);
   if (current_pvt_eg_id == private_end) {
     auto num_pub_egs = current_ext_eg_id - current_pvt_eg_id;
     auto pub_eg_id = num_pub_egs + (external_event_group_id - current_ext_eg_id);

--- a/thin-replica-server/include/thin-replica-server/subscription_buffer.hpp
+++ b/thin-replica-server/include/thin-replica-server/subscription_buffer.hpp
@@ -314,7 +314,7 @@ class SubBufferList {
   virtual void removeBuffer(std::shared_ptr<SubUpdateBuffer> elem) {
     std::lock_guard<std::mutex> lock(mutex_);
     // If the assert fires then there is a logic error somewhere
-    ConcordAssert(subscriber_.erase(elem) == 1);
+    ConcordAssertEQ(subscriber_.erase(elem), 1);
   }
 
   // Populate updates to all subscribers

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -341,11 +341,26 @@ class ThinReplicaImpl {
       ConcordAssert(request->has_events());
       auto last_block_id = (config_->rostorage)->getLastBlockId();
       if (request->events().block_id() == last_block_id + 1) {
-        while (not live_updates->waitUntilNonEmpty(kWaitForUpdateTimeout)) {
+        // `last_block_id + 1` is an acceptable requested block ID (not flagged with OUT_OF_RANGE exception),
+        // even though it can not have been written to storage at the time of the request.
+        // To ensure TRS doesn't try to read a non-existent block ID from storage, it must wait on the
+        // live update queue until a block with ID greater than or equal to last_block_id + 1 gets added.
+        // Note that, before a block gets pushed to the live update queue, it must be written to storage.
+        bool is_update_available = false;
+        while (not is_update_available) {
           if (context->IsCancelled()) {
             LOG_DEBUG(logger_, "StreamCancelled while waiting for the next live update.");
             CLEANUP_SUBSCRIPTION();
             return grpc::Status::CANCELLED;
+          }
+          is_update_available = live_updates->waitUntilNonEmpty(kWaitForUpdateTimeout);
+          if (is_update_available && live_updates->oldestBlockId() < last_block_id + 1) {
+            SubUpdate update;
+            live_updates->Pop(update);
+            LOG_DEBUG(logger_,
+                      "Dropping block ID: " << update.block_id << " from live_updates, requested block ID: "
+                                            << request->events().block_id());
+            is_update_available = false;
           }
         }
       }

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -874,7 +874,7 @@ class ThinReplicaImpl {
       throw UpdatePruned(msg.str());
     }
     kvbc::BlockId end = (config_->rostorage)->getLastBlockId();
-    ConcordAssert(start <= end);
+    ConcordAssertLE(start, end);
 
     // Let's not wait for a live update yet due to there might be lots of
     // history we have to catch up with first
@@ -917,7 +917,7 @@ class ThinReplicaImpl {
     // Overlap:
     // If we read updates from KVB that were added to the live updates already
     // then we just need to drop the overlap and return
-    ConcordAssert(live_updates->oldestBlockId() <= end);
+    ConcordAssertLE(live_updates->oldestBlockId(), end);
     SubUpdate update;
     do {
       live_updates->Pop(update);
@@ -950,8 +950,8 @@ class ThinReplicaImpl {
       msg << "No event group exists in KVB yet for client: " << getClientId(context);
       LOG_ERROR(logger_, msg.str());
     }
-    ConcordAssert(start_ext_storage_eg_id <= end_ext_storage_eg_id);
-    ConcordAssert(start <= end_ext_storage_eg_id);
+    ConcordAssertLE(start_ext_storage_eg_id, end_ext_storage_eg_id);
+    ConcordAssertLE(start, end_ext_storage_eg_id);
 
     // Let's not wait for a live update yet as there might be lots of
     // history we have to catch up with first


### PR DESCRIPTION
This commit fixes a bug in TRS, and adds minor refactoring.