### PR TITLE
Added new ConcordClientRequest/ConcordClientResponse for passing client information

### DIFF
--- a/client/concordclient/proto/concord_client_request/v1/concord_client_request.proto
+++ b/client/concordclient/proto/concord_client_request/v1/concord_client_request.proto
@@ -1,0 +1,28 @@
+// Copyright 2022 VMware, all rights reserved
+//
+// Concordclient's request service
+
+syntax = "proto3";
+package vmware.concord.client.concord_client_request.v1;
+
+import "google/protobuf/any.proto";
+
+option java_package = "com.vmware.concord.client.concord_client_request.v1";
+
+// ConcordClientRequest is used to send application request along
+// with clientservice specific information to the blockchain network.
+
+message ConcordClientRequest {
+  // Required application request which gets evaluated by the execution engine.
+  google.protobuf.Any application_request = 1;
+  
+  // Client service ID or thin replica client's subscription ID 
+  // used for filtering events for this client.
+  string client_service_id = 2;
+}
+
+message ConcordClientResponse {
+  // Required application response which is returned by the execution engine.
+  google.protobuf.Any application_response = 1;
+}
+

--- a/client/proto/CMakeLists.txt
+++ b/client/proto/CMakeLists.txt
@@ -7,11 +7,13 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   request/v1/request.proto
   event/v1/event.proto
   state_snapshot/v1/state_snapshot.proto
+  ../concordclient/proto/concord_client_request/v1/concord_client_request.proto
 )
 grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   request/v1/request.proto
   event/v1/event.proto
   state_snapshot/v1/state_snapshot.proto
+  ../concordclient/proto/concord_client_request/v1/concord_client_request.proto
 )
 
 add_library(clientservice-proto STATIC ${PROTO_SRCS} ${GRPC_SRCS})


### PR DESCRIPTION
Added new ConcordClientRequest/ConcordClientResponse for passing client information which currently includes the actual application request and the client service id necessary for the execution engine to evaluate the request.