### PR TITLE
Change log level in getDirectorySize api

### DIFF
--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -158,7 +158,7 @@ uint64_t DbCheckpointManager::directorySize(const _fs::path& directory, const bo
       }
     }
   } catch (std::exception& e) {
-    LOG_ERROR(getLogger(), "Failed to find size of the checkpoint dir: " << e.what());
+    LOG_WARN(getLogger(), "Failed to find size of the checkpoint dir: " << e.what());
   }
   return size;
 }


### PR DESCRIPTION
Disk space monitoring thread tracks size of the database,
we use boost::filesystem::recursive_directory_iterator for this.
It enumerates all the files in folder and then calculate size.
If rocksdb delete a sst files in between for compaction then we may see an error
Changing log level of this event to WARN