### PR TITLE
Fix a race condition between PreProcessor and consensus threads

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -133,6 +133,7 @@ void RequestsBatch::handlePossiblyExpiredRequests() {
   bool batchCancelled = false;
   string batchCid;
   atomic_uint32_t batchSize = 0;
+  auto numOfCompletedReqs = numOfCompletedReqs_.load();
   {
     const std::lock_guard<std::mutex> lock(batchMutex_);
     if (batchSize_ && reqsExpired && (numOfCompletedReqs_ >= batchSize_)) {
@@ -144,7 +145,8 @@ void RequestsBatch::handlePossiblyExpiredRequests() {
   }
   if (batchCancelled)
     LOG_INFO(preProcessor_.logger(),
-             "The batch has been cancelled as expired" << KVLOG(clientId_, batchCid, reqsExpired, batchSize));
+             "The batch has been cancelled as expired"
+                 << KVLOG(clientId_, batchCid, reqsExpired, numOfCompletedReqs, batchSize));
 }
 
 void RequestsBatch::cancelBatchAndReleaseRequests(const string &batchCidToCancel, PreProcessingResult status) {


### PR DESCRIPTION
**Problem Overview**
PreProcessor uses two ClientsManager functions - hasReply and isClientRequestInProcess to determine whether to process or reject client request. As ClientsManager is not thread-safe, we have a race between the consensus thread that modifies required information and the PreProcessor functions that query for.
**Testing Done**
Ran a load of 700 PTS on a reserved system. Gradual performance degradation to 640 TPS has been observed after 5 days of the run; not different from a regular run.
The second commit is a cherry-pick of https://github.com/vmware/concord-bft/pull/2561/commits/c7f351e9b21351c31387903c3f787873ed0544d1