### PR TITLE
Changes to support separate error for out of time bound requests

### DIFF
--- a/bftengine/include/bftengine/SharedTypes.hpp
+++ b/bftengine/include/bftengine/SharedTypes.hpp
@@ -25,6 +25,7 @@ enum class OperationResult : uint32_t {
   EXEC_DATA_EMPTY,
   CONFLICT_DETECTED,
   OVERLOADED,
+  EXEC_ENGINE_REJECT_ERROR,
   INTERNAL_ERROR
 };
 

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -99,39 +99,55 @@ void RequestServiceCallData::sendToConcordClient() {
       switch (std::get<uint32_t>(send_result)) {
         case (static_cast<uint32_t>(bftEngine::OperationResult::INVALID_REQUEST)):
           LOG_INFO(logger, "Request failed with INVALID_ARGUMENT error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid argument");
+          status = grpc::Status(
+              grpc::StatusCode::INVALID_ARGUMENT,
+              ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_INVALID_REQUEST));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::NOT_READY)):
           LOG_INFO(logger, "Request failed with NOT_READY error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "No clients connected to the replicas");
+          status =
+              grpc::Status(grpc::StatusCode::UNAVAILABLE,
+                           ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_NOT_READY));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::TIMEOUT)):
           LOG_INFO(logger, "Request failed with TIMEOUT error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED, "Timeout");
+          status = grpc::Status(grpc::StatusCode::DEADLINE_EXCEEDED,
+                                ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_TIMEOUT));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_DATA_TOO_LARGE)):
           LOG_INFO(logger, "Request failed with EXEC_DATA_TOO_LARGE error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::INTERNAL, "Execution data too large");
+          status = grpc::Status(
+              grpc::StatusCode::INTERNAL,
+              ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_EXEC_DATA_TOO_LARGE));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_DATA_EMPTY)):
           LOG_INFO(logger, "Request failed with EXEC_DATA_EMPTY error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::INTERNAL, "Execution data is empty");
+          status = grpc::Status(
+              grpc::StatusCode::INTERNAL,
+              ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_EXEC_DATA_EMPTY));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::CONFLICT_DETECTED)):
           LOG_INFO(logger, "Request failed with CONFLICT_DETECTED error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::ABORTED, "Aborted due to conflict detected");
+          status = grpc::Status(
+              grpc::StatusCode::ABORTED,
+              ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_CONFLICT_DETECTED));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::OVERLOADED)):
           LOG_INFO(logger, "Request failed with OVERLOADED error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "All clients occupied");
+          status =
+              grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                           ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_OVERLOADED));
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_ENGINE_REJECT_ERROR)):
           LOG_INFO(logger, "Request failed with EXEC_ENGINE_REJECT_ERROR error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::ABORTED, "Aborted due to request rejected error");
+          status = grpc::Status(
+              grpc::StatusCode::ABORTED,
+              ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_EXECUTION_ENGINE_REJECTED));
           break;
         default:
           LOG_INFO(logger, "Request failed with INTERNAL error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::INTERNAL, "Internal error");
+          status = grpc::Status(grpc::StatusCode::INTERNAL,
+                                ConcordErrorMessage_Name(vmware::concord::client::request::v1::CONCORD_ERROR_INTERNAL));
           break;
       }
       this->populateResult(status);

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -119,11 +119,15 @@ void RequestServiceCallData::sendToConcordClient() {
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::CONFLICT_DETECTED)):
           LOG_INFO(logger, "Request failed with CONFLICT_DETECTED error for cid=" << req_config.correlation_id);
-          status = grpc::Status(grpc::StatusCode::ABORTED, "Aborted");
+          status = grpc::Status(grpc::StatusCode::ABORTED, "Aborted due to conflict detected");
           break;
         case (static_cast<uint32_t>(bftEngine::OperationResult::OVERLOADED)):
           LOG_INFO(logger, "Request failed with OVERLOADED error for cid=" << req_config.correlation_id);
           status = grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "All clients occupied");
+          break;
+        case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_ENGINE_REJECT_ERROR)):
+          LOG_INFO(logger, "Request failed with EXEC_ENGINE_REJECT_ERROR error for cid=" << req_config.correlation_id);
+          status = grpc::Status(grpc::StatusCode::ABORTED, "Aborted due to request rejected error");
           break;
         default:
           LOG_INFO(logger, "Request failed with INTERNAL error for cid=" << req_config.correlation_id);

--- a/client/clientservice/src/state_snapshot_service.cpp
+++ b/client/clientservice/src/state_snapshot_service.cpp
@@ -114,7 +114,7 @@ static void getResponseSetStatus(concord::client::concordclient::SendResult&& se
         break;
       case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_ENGINE_REJECT_ERROR)):
         LOG_INFO(logger, "Request failed with EXEC_ENGINE_REJECT_ERROR error for cid=" << correlation_id);
-        return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Aborted");
+        return_status = grpc::Status(grpc::StatusCode::UNKNOWN, "Aborted");
         break;
       case (static_cast<uint32_t>(bftEngine::OperationResult::UNKNOWN)):
         LOG_INFO(logger, "Request failed with UNKNOWN error for cid=" << correlation_id);

--- a/client/clientservice/src/state_snapshot_service.cpp
+++ b/client/clientservice/src/state_snapshot_service.cpp
@@ -112,6 +112,10 @@ static void getResponseSetStatus(concord::client::concordclient::SendResult&& se
         LOG_INFO(logger, "Request failed with OVERLOADED error for cid=" << correlation_id);
         return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "All clients occupied");
         break;
+      case (static_cast<uint32_t>(bftEngine::OperationResult::EXEC_ENGINE_REJECT_ERROR)):
+        LOG_INFO(logger, "Request failed with EXEC_ENGINE_REJECT_ERROR error for cid=" << correlation_id);
+        return_status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Aborted");
+        break;
       case (static_cast<uint32_t>(bftEngine::OperationResult::UNKNOWN)):
         LOG_INFO(logger, "Request failed with UNKNOWN error for cid=" << correlation_id);
         return_status = grpc::Status(grpc::StatusCode::UNKNOWN, "Failure due to unknown reason");

--- a/client/proto/request/v1/request.proto
+++ b/client/proto/request/v1/request.proto
@@ -28,7 +28,7 @@ service RequestService {
   // INVALID_ARGUMENT: if a required field is not set.
   // RESOURCE_EXHAUSTED: if Concord Client is overloaded. The caller should retry with a backoff.
   // UNAVAILABLE: if Concord Client is currently unable to process any requests. The caller should retry with a backoff.
-  // ABORTED: if Concord has a contention between concurrently running requests. The caller should retry.
+  // ABORTED: if Concord has a contention between concurrently running requests or if execution engine has rejected requests. The caller should retry.
   // INTERNAL: if Concord Client cannot progress independent of the request.
   rpc Send(Request) returns (Response);
 }
@@ -74,3 +74,19 @@ message Response {
     google.protobuf.Any typed_response = 6;
   } 
 }
+
+//Error messages corresponding to the error returned by request service. 
+enum ConcordErrorMessage {
+  CONCORD_ERROR_UNSPECIFIED = 0;
+  CONCORD_ERROR_INVALID_REQUEST = 1;            // Invalid request if required field is not set.
+  CONCORD_ERROR_NOT_READY = 2;                  // Concord is unavailable.
+  CONCORD_ERROR_TIMEOUT = 3;                    // Request couldn't be processed before the given timeout expired.
+  CONCORD_ERROR_EXEC_DATA_TOO_LARGE= 4;         // Execution data is too large.
+  CONCORD_ERROR_EXEC_DATA_EMPTY = 5;            // Execution data is empty.
+  CONCORD_ERROR_CONFLICT_DETECTED = 6;          // Concord has a contention between concurrently running requests.
+  CONCORD_ERROR_OVERLOADED = 7;                 // Clients are occupied. 
+  CONCORD_ERROR_EXECUTION_ENGINE_REJECTED = 8;  // Execution Engine rejected request.
+  CONCORD_ERROR_INTERNAL = 9;                   // Internal error.
+}
+
+

--- a/util/pyclient/bft_msgs.py
+++ b/util/pyclient/bft_msgs.py
@@ -74,7 +74,8 @@ class OperationResult(IntEnum):
     EXEC_DATA_EMPTY = 6
     CONFLICT_DETECTED = 7
     OVERLOADED = 8
-    INTERNAL_ERROR = 9
+    EXEC_ENGINE_REJECT_ERROR = 9
+    INTERNAL_ERROR = 10
 
 def pack_request(client_id, req_seq_num, read_only, timeout_milli, cid, msg, op_result = 0, pre_process=False,
                  reconfiguration=False, span_context=b'', signature=b''):


### PR DESCRIPTION
Added changes to support separate error for out of time bound requests to be send back to the application as gRPC error - ABORT.