### PR TITLE
TR: Add correlation ID fixes

### DIFF
--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -431,7 +431,7 @@ bool ThinReplicaClient::rotateDataStreamAndVerify(Data& update_in,
     uint64_t update_id;  // Block id or event group id
     if (update_in.has_event_group()) {
       update_id = update_in.event_group().id();
-      correlation_id = to_string(update_id);
+      correlation_id = {};  // Event groups don't include a correlation id
     } else {
       ConcordAssert(update_in.has_events());
       update_id = update_in.events().block_id();

--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -32,6 +32,7 @@
 #include "kv_types.hpp"
 #include "event_group_msgs.cmf.hpp"
 #include "endianness.hpp"
+#include "kvbc_key_types.h"
 
 namespace concord {
 namespace kvbc {
@@ -223,6 +224,7 @@ class KvbAppFilter {
   logging::Logger logger_;
   const concord::kvbc::IReader *rostorage_{nullptr};
   const std::string client_id_;
+  const std::string cid_key_{kKvbKeyCorrelationId};
 
   std::pair<uint64_t, uint64_t> last_ext_and_global_eg_id_read_{0, 0};
 };

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -650,6 +650,15 @@ std::optional<kvbc::categorization::ImmutableInput> KvbAppFilter::getBlockEvents
     LOG_ERROR(logger_, "Couldn't get block updates");
     return {};
   }
+  // get cid
+  const auto &internal_map =
+      std::get<kvbc::categorization::VersionedInput>(
+          updates.value().categoryUpdates(concord::kvbc::categorization::kConcordInternalCategoryId)->get())
+          .kv;
+  auto it = internal_map.find(cid_key_);
+  if (it != internal_map.end()) {
+    cid = it->second.data;
+  }
   // Not all blocks have events.
   auto immutable = updates.value().categoryUpdates(concord::kvbc::categorization::kExecutionEventsCategory);
   if (!immutable) {

--- a/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
+++ b/kvbc/test/kvbc_app_filter/kvbc_filter_test.cpp
@@ -178,6 +178,11 @@ class FakeStorage : public concord::kvbc::IReader {
         immutable.addUpdate(std::move(key), std::move(value));
       }
       updates.add(concord::kvbc::categorization::kExecutionEventsCategory, std::move(immutable));
+      // add cid
+      std::string batch_cid = "temp_batch_cid" + std::to_string(block_id);
+      concord::kvbc::categorization::VersionedUpdates internal;
+      internal.addUpdate(std::string(cid_key_), std::move(batch_cid));
+      updates.add(concord::kvbc::categorization::kConcordInternalCategoryId, std::move(internal));
       return {updates};
     }
     // The actual storage implementation (ReplicaImpl.cpp) expects us to
@@ -255,6 +260,7 @@ class FakeStorage : public concord::kvbc::IReader {
   BlockId blockId_{0};
   BlockId first_event_group_block_id_{0};
   uint64_t latest_global_eg_id_{0};
+  const std::string cid_key_{concord::kvbc::kKvbKeyCorrelationId};
 };
 
 // Helper function to test cases involving computation of expected hash

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -513,7 +513,6 @@ class ThinReplicaImpl {
         filtered_eg_update.value().event_group_id = next_ext_eg_id;
 
         if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
-          //  auto correlation_id = filtered_update.correlation_id; (TODO (Shruti) - Get correlation ID)
           sendEventGroupData(stream, filtered_eg_update.value(), sub_eg_update.parent_span);
         } else if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Hash>()) {
           sendEventGroupHash(stream,
@@ -1027,7 +1026,6 @@ class ThinReplicaImpl {
         kvb_filter->setLastEgIdsRead(ext_eg_id++, next_global_eg_id_to_read++);
 
         if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Data>()) {
-          //  auto correlation_id = filtered_update.correlation_id; (TODO (Shruti) - Get correlation ID)
           sendEventGroupData(stream, filtered_eg_update.value());
         } else if constexpr (std::is_same<DataT, com::vmware::concord::thin_replica::Hash>()) {
           sendEventGroupHash(stream,

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -22,6 +22,7 @@
 #include "concord_kvbc.pb.h"
 
 #include "kv_types.hpp"
+#include "kvbc_app_filter/kvbc_key_types.h"
 #include "thin-replica-server/subscription_buffer.hpp"
 #include "thin-replica-server/thin_replica_impl.hpp"
 
@@ -268,6 +269,11 @@ class FakeStorage : public concord::kvbc::IReader {
         immutable.addUpdate(std::move(key), std::move(value));
       }
       updates.add(concord::kvbc::categorization::kExecutionEventsCategory, std::move(immutable));
+      // add cid
+      std::string batch_cid = "temp_batch_cid" + std::to_string(block_id);
+      concord::kvbc::categorization::VersionedUpdates internal;
+      internal.addUpdate(std::string(cid_key_), std::move(batch_cid));
+      updates.add(concord::kvbc::categorization::kConcordInternalCategoryId, std::move(internal));
       return {updates};
     }
     // The actual storage implementation (ReplicaImpl.cpp) expects us to
@@ -367,6 +373,7 @@ class FakeStorage : public concord::kvbc::IReader {
   std::map<std::string, std::string> latest_table;
   // given trid#<event_group_id> as key, the map returns the global_event_group_id
   std::map<std::string, std::string> tag_table;
+  const std::string cid_key_{concord::kvbc::kKvbKeyCorrelationId};
 };
 
 class TestServerContext {


### PR DESCRIPTION
This PR adds the following changes -
1. Remove references to cid for event groups, since event groups do not contain cid.
2. Read cid via TRS when reading legacy events from storage