### PR TITLE
BCStateTran: memset BlockIOContext::blockData to claim ownership

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -464,7 +464,9 @@ class BCStateTran : public IStateTransfer {
     static size_t sizeOfBlockData;
     BlockIOContext() {
       ConcordAssert(sizeOfBlockData != 0);
-      blockData.reset(new char[sizeOfBlockData]);
+      auto buff = new char[sizeOfBlockData];
+      memset(buff, 0, sizeOfBlockData);
+      blockData.reset(buff);
     }
     uint64_t blockId = 0;
     uint32_t actualBlockSize = 0;


### PR DESCRIPTION
When allocating only, memory is not marked as used, and other processed
might capture it later on. Some time can pass until replica may enter
into St as a source or as a destination. We would like to make sure the
memory is owned on startup, since the amount of memory acquired here
is very large. Failing in allocation on startup is better then failing
later on.
Solution: memset all memory in BlockIOContext::blockData immediately
after allocation in order marked it by OS as used and reserved for ST.