### PR TITLE
Fix a race condition between PreProcessor and consensus threads

### DIFF
--- a/bftengine/src/bftengine/ClientsManager.cpp
+++ b/bftengine/src/bftengine/ClientsManager.cpp
@@ -24,6 +24,158 @@
 using namespace std::chrono;
 using namespace concord::serialize;
 namespace bftEngine::impl {
+
+/*************************** Class ClientsManager::RequestsInfo ***************************/
+
+void ClientsManager::RequestsInfo::emplaceSafe(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid) {
+  const lock_guard<mutex> lock(requestsMapMutex_);
+  if (requestsMap_.find(reqSeqNum) != requestsMap_.end()) {
+    LOG_WARN(CL_MNGR, "The request already exists - skip adding" << KVLOG(clientId, reqSeqNum));
+    return;
+  }
+  requestsMap_.emplace(reqSeqNum, RequestInfo{getMonotonicTime(), cid});
+  LOG_DEBUG(CL_MNGR, "Added request" << KVLOG(clientId, reqSeqNum, requestsMap_.size()));
+}
+
+bool ClientsManager::RequestsInfo::findSafe(ReqId reqSeqNum) {
+  const lock_guard<mutex> lock(requestsMapMutex_);
+  return (requestsMap_.find(reqSeqNum) != requestsMap_.end());
+}
+
+bool ClientsManager::RequestsInfo::removeRequestsOutOfBatchBoundsSafe(NodeIdType clientId, ReqId reqSequenceNum) {
+  ReqId maxReqId{0};
+  const lock_guard<mutex> lock(requestsMapMutex_);
+  if (requestsMap_.find(reqSequenceNum) != requestsMap_.end()) return false;
+  for (const auto& reqInfo : requestsMap_)
+    if (reqInfo.first > maxReqId) maxReqId = reqInfo.first;
+
+  if (requestsMap_.size() == maxNumOfRequestsInBatch && maxReqId > reqSequenceNum) {
+    // If we don't have room for the sequence number, and we see that the highest sequence number is greater
+    // than the given one, it means that the highest sequence number is out of the boundaries and can be safely removed
+    requestsMap_.erase(maxReqId);
+    return true;
+  }
+  return false;
+}
+
+void ClientsManager::RequestsInfo::removeOldPendingReqsSafe(NodeIdType clientId, ReqId reqSeqNum) {
+  const lock_guard<mutex> lock(requestsMapMutex_);
+  for (auto it = requestsMap_.begin(); it != requestsMap_.end();) {
+    if (it->first <= reqSeqNum) {
+      it = requestsMap_.erase(it);
+      LOG_INFO(CL_MNGR, "Remove old pending request" << KVLOG(clientId, reqSeqNum));
+    } else
+      it++;
+  }
+}
+
+void ClientsManager::RequestsInfo::removePendingForExecutionRequestSafe(NodeIdType clientId, ReqId reqSeqNum) {
+  const lock_guard<mutex> lock(requestsMapMutex_);
+  const auto& reqIt = requestsMap_.find(reqSeqNum);
+  if (reqIt != requestsMap_.end()) {
+    requestsMap_.erase(reqIt);
+    LOG_DEBUG(CL_MNGR, "Removed request" << KVLOG(clientId, reqSeqNum, requestsMap_.size()));
+  }
+}
+
+void ClientsManager::RequestsInfo::clearSafe() {
+  const std::lock_guard<std::mutex> lock(requestsMapMutex_);
+  requestsMap_.clear();
+}
+
+bool ClientsManager::RequestsInfo::find(ReqId reqSeqNum) const {
+  return (requestsMap_.find(reqSeqNum) != requestsMap_.end());
+}
+
+bool ClientsManager::RequestsInfo::isPending(ReqId reqSeqNum) const {
+  const auto& reqIt = requestsMap_.find(reqSeqNum);
+  if (reqIt != requestsMap_.end() && !reqIt->second.committed) return true;
+  return false;
+}
+
+void ClientsManager::RequestsInfo::markRequestAsCommitted(NodeIdType clientId, ReqId reqSeqNum) {
+  const auto& reqIt = requestsMap_.find(reqSeqNum);
+  if (reqIt != requestsMap_.end()) {
+    reqIt->second.committed = true;
+    LOG_DEBUG(CL_MNGR, "Marked committed" << KVLOG(clientId, reqSeqNum));
+    return;
+  }
+  LOG_DEBUG(CL_MNGR, "Request not found" << KVLOG(clientId, reqSeqNum));
+}
+
+void ClientsManager::RequestsInfo::infoOfEarliestPendingRequest(Time& earliestTime,
+                                                                RequestInfo& earliestPendingReqInfo) const {
+  for (const auto& req : requestsMap_) {
+    // Don't take into account already committed requests
+    if ((req.second.time != MinTime) && (earliestTime > req.second.time) && (!req.second.committed)) {
+      earliestPendingReqInfo = req.second;
+      earliestTime = earliestPendingReqInfo.time;
+    }
+  }
+}
+
+void ClientsManager::RequestsInfo::logAllPendingRequestsExceedingThreshold(const int64_t threshold,
+                                                                           const Time& currTime,
+                                                                           int& numExceeding) const {
+  for (const auto& req : requestsMap_) {
+    // Don't take into account already committed requests
+    if ((req.second.time != MinTime) && (!req.second.committed)) {
+      const auto delayed = duration_cast<milliseconds>(currTime - req.second.time).count();
+      if (delayed > threshold) {
+        LOG_INFO(CL_MNGR, "Request exceeding threshold:" << KVLOG(req.second.cid, delayed));
+        numExceeding++;
+      }
+    }
+  }
+}
+
+/*************************** Class ClientsManager::RepliesInfo ***************************/
+
+void ClientsManager::RepliesInfo::deleteOldestReplyIfNeededSafe(NodeIdType clientId, uint16_t maxNumOfReqsPerClient) {
+  Time earliestTime = MaxTime;
+  ReqId earliestReplyId = 0;
+  const lock_guard<mutex> lock(repliesMapMutex_);
+  if (repliesMap_.size() < maxNumOfReqsPerClient) return;
+  if (repliesMap_.size() > maxNumOfReqsPerClient)
+    LOG_FATAL(CL_MNGR,
+              "More than maxNumOfReqsPerClient_ items in repliesInfo"
+                  << KVLOG(repliesMap_.size(), maxNumOfReqsPerClient, clientId));
+  for (auto& reply : repliesMap_) {
+    if (earliestTime > reply.second) {
+      earliestReplyId = reply.first;
+      earliestTime = reply.second;
+    }
+  }
+  if (earliestReplyId) {
+    repliesMap_.erase(earliestReplyId);
+  } else if (!repliesMap_.empty()) {
+    // Delete reply arrived through ST
+    auto const& reply = repliesMap_.cbegin();
+    earliestReplyId = reply->first;
+    earliestTime = reply->second;
+    repliesMap_.erase(reply);
+  }
+  LOG_DEBUG(CL_MNGR,
+            "Deleted reply message" << KVLOG(
+                clientId, earliestReplyId, earliestTime.time_since_epoch().count(), repliesMap_.size()));
+}
+
+bool ClientsManager::RepliesInfo::insertOrAssignSafe(ReqId reqSeqNum, Time time) {
+  const lock_guard<mutex> lock(repliesMapMutex_);
+  return repliesMap_.insert_or_assign(reqSeqNum, time).second;
+}
+
+bool ClientsManager::RepliesInfo::findSafe(ReqId reqSeqNum) {
+  const lock_guard<mutex> lock(repliesMapMutex_);
+  return (repliesMap_.find(reqSeqNum) != repliesMap_.end());
+}
+
+bool ClientsManager::RepliesInfo::find(ReqId reqSeqNum) const {
+  return (repliesMap_.find(reqSeqNum) != repliesMap_.end());
+}
+
+/*************************** Class ClientsManager ***************************/
+
 // Initialize:
 // * map of client id to indices.
 // * Calculate reserved pages per client.
@@ -70,11 +222,13 @@ ClientsManager::ClientsManager(const std::set<NodeIdType>& proxyClients,
     clientIdsToReservedPages_.emplace(cid, rpage);
     rpage++;
   }
-  // For the benefit of code accessing clientsInfo_, pre-fill cliensInfo_ with a blank entry for each client to reduce
+  // For the benefit of code accessing clientsInfo_, pre-fill clientsInfo_ with a blank entry for each client to reduce
   // ambiguity between invalid client IDs and valid client IDs for which nothing stored in clientsInfo_ has been loaded
   // so far.
   for (const auto& client_id : clientIds_) {
     clientsInfo_.emplace(client_id, ClientInfo());
+    clientsInfo_[client_id].requestsInfo = make_shared<RequestsInfo>();
+    clientsInfo_[client_id].repliesInfo = make_shared<RepliesInfo>();
   }
 
   LOG_INFO(
@@ -117,60 +271,26 @@ void ClientsManager::loadInfoFromReservedPages() {
     ConcordAssert(replyHeader->replyLength >= 0);
     ConcordAssert(replyHeader->replyLength + sizeof(ClientReplyMsgHeader) <= maxReplySize_);
 
-    // YS TBD: Multiple replies for client batching should be sorted by incoming time
-    auto& info = clientsInfo_[clientId];
-    if (info.repliesInfo.size() >= maxNumOfReqsPerClient_) deleteOldestReply(clientId);
-    const auto& res = info.repliesInfo.insert_or_assign(replyHeader->reqSeqNum, MinTime);
-    LOG_INFO(CL_MNGR, "Added/updated reply message" << KVLOG(clientId, replyHeader->reqSeqNum, res.second));
-
-    // Remove old pending requests
-    for (auto it = info.requestsInfo.begin(); it != info.requestsInfo.end();) {
-      if (it->first <= replyHeader->reqSeqNum) {
-        LOG_INFO(CL_MNGR, "Remove old pending request" << KVLOG(clientId, replyHeader->reqSeqNum));
-        it = info.requestsInfo.erase(it);
-      } else
-        it++;
-    }
+    clientsInfo_[clientId].repliesInfo->deleteOldestReplyIfNeededSafe(clientId, maxNumOfReqsPerClient_);
+    const auto& res = clientsInfo_[clientId].repliesInfo->insertOrAssignSafe(replyHeader->reqSeqNum, MinTime);
+    LOG_INFO(CL_MNGR, "Added/updated reply message" << KVLOG(clientId, replyHeader->reqSeqNum, res));
+    clientsInfo_[clientId].requestsInfo->removeOldPendingReqsSafe(clientId, replyHeader->reqSeqNum);
   }
 }
 
-bool ClientsManager::hasReply(NodeIdType clientId, ReqId reqSeqNum) const {
+bool ClientsManager::hasReply(NodeIdType clientId, ReqId reqSeqNum) {
   try {
-    const auto& repliesInfo = clientsInfo_.at(clientId).repliesInfo;
-    const auto& elem = repliesInfo.find(reqSeqNum);
-    const bool found = (elem != repliesInfo.end());
+    const bool found = clientsInfo_.at(clientId).repliesInfo->findSafe(reqSeqNum);
     if (found) LOG_DEBUG(CL_MNGR, "Reply found for" << KVLOG(clientId, reqSeqNum));
     return found;
   } catch (const std::out_of_range& e) {
-    LOG_DEBUG(CL_MNGR, "no info for client: " << clientId);
+    LOG_DEBUG(CL_MNGR, "No info found for client" << KVLOG(clientId, reqSeqNum));
     return false;
   }
 }
 
 void ClientsManager::deleteOldestReply(NodeIdType clientId) {
-  // YS TBD: Once multiple replies for client batching are sorted by incoming time, they could be deleted properly
-  Time earliestTime = MaxTime;
-  ReqId earliestReplyId = 0;
-
-  auto& repliesInfo = clientsInfo_[clientId].repliesInfo;
-  for (const auto& reply : repliesInfo) {
-    if (earliestTime > reply.second) {
-      earliestReplyId = reply.first;
-      earliestTime = reply.second;
-    }
-  }
-  if (earliestReplyId)
-    repliesInfo.erase(earliestReplyId);
-  else if (!repliesInfo.empty()) {
-    // Delete reply arrived through ST
-    auto const& reply = repliesInfo.cbegin();
-    earliestReplyId = reply->first;
-    earliestTime = reply->second;
-    repliesInfo.erase(reply);
-  }
-  LOG_DEBUG(CL_MNGR,
-            "Deleted reply message" << KVLOG(
-                clientId, earliestReplyId, earliestTime.time_since_epoch().count(), repliesInfo.size()));
+  clientsInfo_[clientId].repliesInfo->deleteOldestReplyIfNeededSafe(clientId, maxNumOfReqsPerClient_);
 }
 
 // Reference the ClientInfo of the corresponding client:
@@ -186,15 +306,8 @@ std::unique_ptr<ClientReplyMsg> ClientsManager::allocateNewReplyMsgAndWriteToSto
                                                                                      uint32_t replyLength,
                                                                                      uint32_t rsiLength,
                                                                                      uint32_t executionResult) {
-  ClientInfo& c = clientsInfo_[clientId];
-  if (c.repliesInfo.size() >= maxNumOfReqsPerClient_) deleteOldestReply(clientId);
-  if (c.repliesInfo.size() > maxNumOfReqsPerClient_) {
-    LOG_FATAL(CL_MNGR,
-              "More than maxNumOfReqsPerClient_ items in repliesInfo"
-                  << KVLOG(c.repliesInfo.size(), maxNumOfReqsPerClient_, clientId, requestSeqNum, replyLength));
-  }
-
-  c.repliesInfo.insert_or_assign(requestSeqNum, getMonotonicTime());
+  clientsInfo_[clientId].repliesInfo->deleteOldestReplyIfNeededSafe(clientId, maxNumOfReqsPerClient_);
+  clientsInfo_[clientId].repliesInfo->insertOrAssignSafe(requestSeqNum, getMonotonicTime());
   LOG_DEBUG(CL_MNGR, KVLOG(clientId, requestSeqNum));
   auto r = std::make_unique<ClientReplyMsg>(myId_, requestSeqNum, reply, replyLength - rsiLength, executionResult);
 
@@ -315,116 +428,81 @@ void ClientsManager::setClientPublicKey(NodeIdType clientId,
   saveReservedPage(getKeyPageId(clientId), oss.tellp(), oss.str().data());
 }
 
-bool ClientsManager::isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const {
+bool ClientsManager::isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) {
   try {
-    const auto& info = clientsInfo_.at(clientId);
-    const auto& reqIt = info.requestsInfo.find(reqSeqNum);
-    if (reqIt != info.requestsInfo.end()) {
-      LOG_DEBUG(CL_MNGR, "The request is executing right now" << KVLOG(clientId, reqSeqNum));
-      return true;
-    }
-    return false;
+    const bool found = clientsInfo_.at(clientId).requestsInfo->findSafe(reqSeqNum);
+    if (found) LOG_DEBUG(CL_MNGR, "The request is executing right now" << KVLOG(clientId, reqSeqNum));
+    return found;
   } catch (const std::out_of_range& e) {
-    LOG_DEBUG(CL_MNGR, "no info for client: " << clientId);
+    LOG_DEBUG(CL_MNGR, "No info found for client" << KVLOG(clientId, reqSeqNum));
     return false;
   }
 }
 
 bool ClientsManager::isPending(NodeIdType clientId, ReqId reqSeqNum) const {
   try {
-    const auto& requestsInfo = clientsInfo_.at(clientId).requestsInfo;
-    const auto& reqIt = requestsInfo.find(reqSeqNum);
-    if (reqIt != requestsInfo.end() && !reqIt->second.committed) return true;
-    return false;
+    return clientsInfo_.at(clientId).requestsInfo->isPending(reqSeqNum);
   } catch (const std::out_of_range& e) {
-    LOG_DEBUG(CL_MNGR, "no info for client: " << clientId);
+    LOG_DEBUG(CL_MNGR, "No info found for client" << KVLOG(clientId, reqSeqNum));
     return false;
   }
 }
+
 // Check that:
 // * max number of pending requests not reached for that client.
 // * request seq number is bigger than the last reply seq number.
 bool ClientsManager::canBecomePending(NodeIdType clientId, ReqId reqSeqNum) const {
   try {
-    const auto& info = clientsInfo_.at(clientId);
-    if (info.requestsInfo.size() == maxNumOfReqsPerClient_) {
+    ReqId requestsNum = clientsInfo_.at(clientId).requestsInfo->size();
+    if (requestsNum == maxNumOfReqsPerClient_) {
       LOG_DEBUG(CL_MNGR,
                 "Maximum number of requests per client reached" << KVLOG(maxNumOfReqsPerClient_, clientId, reqSeqNum));
       return false;
     }
-    const auto& reqIt = info.requestsInfo.find(reqSeqNum);
-    if (reqIt != info.requestsInfo.end()) {
+    if (clientsInfo_.at(clientId).requestsInfo->find(reqSeqNum)) {
       LOG_DEBUG(CL_MNGR, "The request is executing right now" << KVLOG(clientId, reqSeqNum));
       return false;
     }
-    const auto& replyIt = info.repliesInfo.find(reqSeqNum);
-    if (replyIt != info.repliesInfo.end()) {
+    if (clientsInfo_.at(clientId).repliesInfo->find(reqSeqNum)) {
       LOG_DEBUG(CL_MNGR, "The request has been already executed" << KVLOG(clientId, reqSeqNum));
       return false;
     }
-    LOG_DEBUG(CL_MNGR, "The request can become pending" << KVLOG(clientId, reqSeqNum, info.requestsInfo.size()));
+    LOG_DEBUG(CL_MNGR, "The request can become pending" << KVLOG(clientId, reqSeqNum, requestsNum));
     return true;
   } catch (const std::out_of_range& e) {
-    LOG_DEBUG(CL_MNGR, "no info for client: " << clientId);
+    LOG_DEBUG(CL_MNGR, "No info found for client" << KVLOG(clientId, reqSeqNum));
     return false;
   }
 }
 
 void ClientsManager::addPendingRequest(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid) {
-  auto& requestsInfo = clientsInfo_[clientId].requestsInfo;
-  if (requestsInfo.find(reqSeqNum) != requestsInfo.end()) {
-    LOG_WARN(CL_MNGR, "The request already exists - skip adding" << KVLOG(clientId, reqSeqNum));
-    return;
-  }
-  requestsInfo.emplace(reqSeqNum, RequestInfo{getMonotonicTime(), cid});
-  LOG_DEBUG(CL_MNGR, "Added request" << KVLOG(clientId, reqSeqNum, requestsInfo.size()));
+  clientsInfo_[clientId].requestsInfo->emplaceSafe(clientId, reqSeqNum, cid);
 }
 
 void ClientsManager::markRequestAsCommitted(NodeIdType clientId, ReqId reqSeqNum) {
-  auto& requestsInfo = clientsInfo_[clientId].requestsInfo;
-  const auto& reqIt = requestsInfo.find(reqSeqNum);
-  if (reqIt != requestsInfo.end()) {
-    reqIt->second.committed = true;
-    LOG_DEBUG(CL_MNGR, "Marked committed" << KVLOG(clientId, reqSeqNum));
-    return;
-  }
-  LOG_DEBUG(CL_MNGR, "Request not found" << KVLOG(clientId, reqSeqNum));
+  clientsInfo_[clientId].requestsInfo->markRequestAsCommitted(clientId, reqSeqNum);
 }
 
 /*
  * We have to keep the following invariant:
  * The client manager cannot hold request that are out of the bounds of a committed sequence number +
- * maxNumOfRequestsInBatch We know that the client sequence number are always ascending. In order to keep this invariant
- * we do the following: Every time we commit or execute a sequence number, we order all of our existing tracked sequence
+ * maxNumOfRequestsInBatch We know that the client sequence number is always ascending. In order to keep this invariant
+ * we do the following: every time we commit or execute a sequence number, we order all of our existing tracked sequence
  * numbers. Then, we count how many bigger sequence number than the given reqSequenceNumber we have. We know for sure
  * that we shouldn't have more than maxNumOfRequestsInBatch. Thus, we can safely remove them from the client manager.
  */
 void ClientsManager::removeRequestsOutOfBatchBounds(NodeIdType clientId, ReqId reqSequenceNum) {
-  auto& requestsInfo = clientsInfo_[clientId].requestsInfo;
-  if (requestsInfo.find(reqSequenceNum) != requestsInfo.end()) return;
-  ReqId maxReqId{0};
-  for (const auto& entry : requestsInfo) {
-    if (entry.first > maxReqId) maxReqId = entry.first;
-  }
-  // If we don't have room for the sequence number and we see that the highest sequence number is greater
-  // than the given one, it means that the highest sequence number is out of the boundries and can be safely removed
-  if (requestsInfo.size() == maxNumOfRequestsInBatch && maxReqId > reqSequenceNum) {
-    requestsInfo.erase(maxReqId);
+  if (clientsInfo_[clientId].requestsInfo->removeRequestsOutOfBatchBoundsSafe(clientId, reqSequenceNum))
     metric_removed_due_to_out_of_boundaries_++;
-  }
 }
+
 void ClientsManager::removePendingForExecutionRequest(NodeIdType clientId, ReqId reqSeqNum) {
   if (!isValidClient(clientId)) return;
-  auto& requestsInfo = clientsInfo_[clientId].requestsInfo;
-  const auto& reqIt = requestsInfo.find(reqSeqNum);
-  if (reqIt != requestsInfo.end()) {
-    requestsInfo.erase(reqIt);
-    LOG_DEBUG(CL_MNGR, "Removed request" << KVLOG(clientId, reqSeqNum, requestsInfo.size()));
-  }
+  clientsInfo_[clientId].requestsInfo->removePendingForExecutionRequestSafe(clientId, reqSeqNum);
 }
 
 void ClientsManager::clearAllPendingRequests() {
-  for (auto& info : clientsInfo_) info.second.requestsInfo.clear();
+  for (auto& clientInfo : clientsInfo_) clientInfo.second.requestsInfo->clearSafe();
   LOG_DEBUG(CL_MNGR, "Cleared pending requests for all clients");
 }
 
@@ -432,15 +510,8 @@ void ClientsManager::clearAllPendingRequests() {
 Time ClientsManager::infoOfEarliestPendingRequest(std::string& cid) const {
   Time earliestTime = MaxTime;
   RequestInfo earliestPendingReqInfo{MaxTime, std::string()};
-  for (const auto& info : clientsInfo_) {
-    for (const auto& req : info.second.requestsInfo) {
-      // Don't take into account already committed requests
-      if ((req.second.time != MinTime) && (earliestTime > req.second.time) && (!req.second.committed)) {
-        earliestPendingReqInfo = req.second;
-        earliestTime = earliestPendingReqInfo.time;
-      }
-    }
-  }
+  for (const auto& clientInfo : clientsInfo_)
+    clientInfo.second.requestsInfo->infoOfEarliestPendingRequest(earliestTime, earliestPendingReqInfo);
   cid = earliestPendingReqInfo.cid;
   if (earliestPendingReqInfo.time != MaxTime) LOG_DEBUG(CL_MNGR, "Earliest pending request: " << KVLOG(cid));
   return earliestPendingReqInfo.time;
@@ -449,21 +520,10 @@ Time ClientsManager::infoOfEarliestPendingRequest(std::string& cid) const {
 // Iterate over all clients and log the ones that have not been committed for more than threshold milliseconds.
 void ClientsManager::logAllPendingRequestsExceedingThreshold(const int64_t threshold, const Time& currTime) const {
   int numExceeding = 0;
-  for (const auto& info : clientsInfo_) {
-    for (const auto& req : info.second.requestsInfo) {
-      // Don't take into account already committed requests
-      if ((req.second.time != MinTime) && (!req.second.committed)) {
-        const auto delayed = duration_cast<milliseconds>(currTime - req.second.time).count();
-        const auto& CID = req.second.cid;
-        if (delayed > threshold) {
-          LOG_INFO(VC_LOG, "Request exceeding threshold:" << KVLOG(CID, delayed));
-          numExceeding++;
-        }
-      }
-    }
-  }
+  for (const auto& clientInfo : clientsInfo_)
+    clientInfo.second.requestsInfo->logAllPendingRequestsExceedingThreshold(threshold, currTime, numExceeding);
   if (numExceeding) {
-    LOG_INFO(VC_LOG, "Total Client request with more than " << threshold << "ms delay: " << numExceeding);
+    LOG_INFO(CL_MNGR, "Total Client request with more than " << threshold << "ms delay: " << numExceeding);
   }
 }
 

--- a/bftengine/src/bftengine/ClientsManager.hpp
+++ b/bftengine/src/bftengine/ClientsManager.hpp
@@ -19,6 +19,7 @@
 #include "bftengine/IKeyExchanger.hpp"
 #include "PersistentStorage.hpp"
 #include "ReplicaSpecificInfoManager.hpp"
+#include <mutex>
 #include <map>
 #include <set>
 #include <unordered_map>
@@ -83,7 +84,7 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   // that client with ID reqSeqNum. Returns false otherwise.
   // TODO(GG): make sure that ReqId is based on time (and ignore requests with time that does
   // not make sense (too high) - this will prevent some potential attacks)
-  bool hasReply(NodeIdType clientId, ReqId reqSeqNum) const;
+  bool hasReply(NodeIdType clientId, ReqId reqSeqNum);
 
   bool isValidClient(NodeIdType clientId) const { return clientIds_.find(clientId) != clientIds_.end(); }
 
@@ -125,7 +126,7 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
 
   // Returns true if there is a valid client with ID clientId and this ClientsManager currently has a recorded request
   // with ID reqSeqNum from that client; otherwise returns false.
-  bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const;
+  bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum);
 
   // Returns true IFF there is no pending requests for clientId, and reqSeqNum can become the new pending request, that
   // is, if all of the following are true:
@@ -218,9 +219,45 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
     bool committed = false;
   };
 
+  class RequestsInfo {
+   public:
+    void emplaceSafe(NodeIdType clientId, ReqId reqSeqNum, const std::string& cid);
+    bool removeRequestsOutOfBatchBoundsSafe(NodeIdType clientId, ReqId reqSequenceNum);
+    bool findSafe(ReqId reqSeqNum);
+    void clearSafe();
+    void removeOldPendingReqsSafe(NodeIdType clientId, ReqId reqSeqNum);
+    void removePendingForExecutionRequestSafe(NodeIdType clientId, ReqId reqSeqNum);
+
+    size_t size() const { return requestsMap_.size(); }
+    bool find(ReqId reqSeqNum) const;
+    bool isPending(ReqId reqSeqNum) const;
+    void markRequestAsCommitted(NodeIdType clientId, ReqId reqSeqNum);
+    void infoOfEarliestPendingRequest(Time& earliestTime, RequestInfo& earliestPendingReqInfo) const;
+    void logAllPendingRequestsExceedingThreshold(const int64_t threshold,
+                                                 const Time& currTime,
+                                                 int& numExceeding) const;
+
+   public:
+    std::mutex requestsMapMutex_;
+    std::map<ReqId, RequestInfo> requestsMap_;
+  };
+
+  class RepliesInfo {
+   public:
+    void deleteOldestReplyIfNeededSafe(NodeIdType clientId, uint16_t maxNumOfReqsPerClient);
+    bool insertOrAssignSafe(ReqId reqSeqNum, Time time);
+    bool findSafe(ReqId reqSeqNum);
+
+    bool find(ReqId reqSeqNum) const;
+
+   public:
+    std::mutex repliesMapMutex_;
+    std::map<ReqId, Time> repliesMap_;
+  };
+
   struct ClientInfo {
-    std::map<ReqId, RequestInfo> requestsInfo;
-    std::map<ReqId, Time> repliesInfo;  // replyId to replyTime
+    std::shared_ptr<RequestsInfo> requestsInfo;
+    std::shared_ptr<RepliesInfo> repliesInfo;
     std::pair<std::string, concord::util::crypto::KeyFormat> pubKey;
   };
 
@@ -237,7 +274,7 @@ class ClientsManager : public ResPagesClient<ClientsManager>, public IPendingReq
   concordMetrics::CounterHandle metric_reply_inconsistency_detected_;
   concordMetrics::CounterHandle metric_removed_due_to_out_of_boundaries_;
   std::unique_ptr<RsiDataManager> rsiManager_;
-};
+};  // namespace impl
 
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -133,6 +133,7 @@ void RequestsBatch::handlePossiblyExpiredRequests() {
   bool batchCancelled = false;
   string batchCid;
   atomic_uint32_t batchSize = 0;
+  auto numOfCompletedReqs = numOfCompletedReqs_.load();
   {
     const std::lock_guard<std::mutex> lock(batchMutex_);
     if (batchSize_ && reqsExpired && (numOfCompletedReqs_ >= batchSize_)) {
@@ -144,7 +145,8 @@ void RequestsBatch::handlePossiblyExpiredRequests() {
   }
   if (batchCancelled)
     LOG_INFO(preProcessor_.logger(),
-             "The batch has been cancelled as expired" << KVLOG(clientId_, batchCid, reqsExpired, batchSize));
+             "The batch has been cancelled as expired"
+                 << KVLOG(clientId_, batchCid, reqsExpired, numOfCompletedReqs, batchSize));
 }
 
 void RequestsBatch::cancelBatchAndReleaseRequests(const string &batchCidToCancel, PreProcessingResult status) {


### PR DESCRIPTION
* **Problem Overview**  
  PreProcessor uses two ClientsManager functions - hasReply and isClientRequestInProcess to determine whether to 
  process or reject client request. As ClientsManager is not thread-safe, we have a race between the consensus thread that 
  modifies required information and the PreProcessor functions that query for.
* **Testing Done**  
  Ran a load of 700 PTS on a reserved system for 1.6. After 4 days of the run, the performance was degraded to 650 TPS; no 
  difference from a regular run.
