### PR TITLE
WIP: Health status for ClientService and child services

### DIFF
--- a/client/client_pool/CMakeLists.txt
+++ b/client/client_pool/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries(concord_client_pool PUBLIC
         bftclient
         bftclient_new
         corebft
-        concordclient-event-api
         concordclient-health
       	)
 

--- a/client/client_pool/CMakeLists.txt
+++ b/client/client_pool/CMakeLists.txt
@@ -11,6 +11,8 @@ target_link_libraries(concord_client_pool PUBLIC
         bftclient
         bftclient_new
         corebft
+        concordclient-event-api
+        concordclient-health
       	)
 
 install (TARGETS concord_client_pool DESTINATION lib${LIB_SUFFIX})

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -26,6 +26,7 @@
 #include "bftclient/quorums.h"
 #include "client_pool_timer.hpp"
 #include "external_client.hpp"
+#include "client/concordclient/client_health.hpp"
 
 namespace concord {
 namespace external_client {
@@ -153,6 +154,8 @@ class ConcordClientPool {
 
   PoolStatus HealthStatus();
 
+  client::concordclient::ClientHealth getClientHealth();
+
   inline bool IsBatchingEnabled() { return client_batching_enabled_; }
 
   bftEngine::OperationResult getClientError();
@@ -207,6 +210,11 @@ class ConcordClientPool {
   bftEngine::impl::RollingAvgAndVar average_cid_receive_dur_;
   bftEngine::impl::RollingAvgAndVar average_cid_close_dur_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> cid_arrival_map_;
+  // number of requests received while periodically seeing if we're overloaded.
+  std::atomic_uint request_counter_for_overloaded_ = 0;
+  // number of requests rejected due to being overloaded in current request count period.
+  std::atomic_uint overloaded_counter_ = 0;
+  std::atomic_bool unhealthy_due_to_overload_ = false;
 };
 
 class BatchRequestProcessingJob : public concord::util::SimpleThreadPool::Job {

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -154,11 +154,16 @@ class ConcordClientPool {
 
   PoolStatus HealthStatus();
 
+  void setHealthCheckEnabled(bool is_enabled);
   client::concordclient::ClientHealth getClientHealth();
+  void setClientHealth(concord::client::concordclient::ClientHealth health);
 
   inline bool IsBatchingEnabled() { return client_batching_enabled_; }
 
   bftEngine::OperationResult getClientError();
+
+  void updateRequestCounter();
+  void updateOverloadCounter();
 
  private:
   void setUpClientParams(bftEngine::SimpleClientParams& client_params,
@@ -211,10 +216,11 @@ class ConcordClientPool {
   bftEngine::impl::RollingAvgAndVar average_cid_close_dur_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> cid_arrival_map_;
   // number of requests received while periodically seeing if we're overloaded.
-  std::atomic_uint request_counter_for_overloaded_ = 0;
+  bool health_check_enabled_ = false;
+  std::atomic_uint request_counter_ = 0;
   // number of requests rejected due to being overloaded in current request count period.
-  std::atomic_uint overloaded_counter_ = 0;
-  std::atomic_bool unhealthy_due_to_overload_ = false;
+  std::atomic_uint overload_counter_ = 0;
+  std::atomic_bool unhealthy_ = false;
 };
 
 class BatchRequestProcessingJob : public concord::util::SimpleThreadPool::Job {

--- a/client/clientservice/CMakeLists.txt
+++ b/client/clientservice/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories(clientservice-lib PUBLIC include)
 target_link_libraries(clientservice-lib PUBLIC
   clientservice-proto
   concordclient
+  concordclient-health
   gRPC::grpc++
   gRPC::grpc++_reflection
   logging

--- a/client/clientservice/include/client/clientservice/client_service.hpp
+++ b/client/clientservice/include/client/clientservice/client_service.hpp
@@ -18,6 +18,7 @@
 #include "request_service.hpp"
 #include "state_snapshot_service.hpp"
 #include "Logger.hpp"
+#include "client/concordclient/client_health.hpp"
 #include "client/concordclient/concord_client.hpp"
 
 namespace concord::client::clientservice {
@@ -50,6 +51,8 @@ class ClientService {
  private:
   // Handler for asynchronous services
   void handleRpcs(unsigned thread_idx);
+
+  void setAllServingStatus(bool status);
 
   logging::Logger logger_;
   std::shared_ptr<concord::client::concordclient::ConcordClient> client_;

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -94,6 +94,9 @@ void parseConfigFile(ConcordClientConfig& config, const YAML::Node& yaml) {
   readYamlField(yaml, "client_batching_flush_timeout_ms", config.topology.client_batching_flush_timeout_ms);
   readYamlField(yaml, "replicas_master_key_path", config.topology.path_to_replicas_master_key, false);
 
+  config.health_check_enabled = false;
+  readYamlField(yaml, "health_check_enabled", config.health_check_enabled, false);
+
   parseConfigFileForStateSnapshot(config.state_snapshot_config, yaml);
 
   ConcordAssert(yaml["node"].IsSequence());

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -66,7 +66,8 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
   auto status = grpc::Status::OK;
 
   if (client_->getClientHealth() == cc::ClientHealth::Unhealthy) {
-    status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "Unavailable");
+    // TODO(scramer): is this the right error code to return?
+    status = grpc::Status(grpc::StatusCode::INTERNAL, "Internal error");
     client_->unsubscribe();
     return status;
   }

--- a/client/concordclient/CMakeLists.txt
+++ b/client/concordclient/CMakeLists.txt
@@ -1,3 +1,7 @@
+# header-only library target
+add_library(concordclient-health INTERFACE)
+target_include_directories(concordclient-health INTERFACE include)
+
 add_library(concordclient "src/concord_client.cpp")
 target_include_directories(concordclient PUBLIC include)
 # TODO: Mark libraries as PRIVATE once the interface is selfcontained

--- a/client/concordclient/include/client/concordclient/client_health.hpp
+++ b/client/concordclient/include/client/concordclient/client_health.hpp
@@ -1,0 +1,21 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+#pragma once
+
+namespace concord::client::concordclient {
+
+// The health of a client (subsidiary compenents) that makes up ConcordClient,
+// e.g. ConcordClientPool.
+enum ClientHealth { Healthy, Unhealthy };
+
+}  // namespace concord::client::concordclient

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -26,6 +26,7 @@
 #include "bftclient/bft_client.h"
 #include "client/thin-replica-client/thin_replica_client.hpp"
 #include "client/client_pool/concord_client_pool.hpp"
+#include "client/concordclient/client_health.hpp"
 #include "client/concordclient/event_update.hpp"
 #include "client/concordclient/snapshot_update.hpp"
 #include "client/concordclient/concord_client_exceptions.hpp"
@@ -176,6 +177,9 @@ class ConcordClient {
 
   // Get subscription id.
   std::string getSubscriptionId() const { return config_.subscribe_config.id; }
+
+  // Health of ConcordClient.
+  ClientHealth getClientHealth();
 
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -127,6 +127,7 @@ struct ConcordClientConfig {
   // Configuration for subscribe requests
   SubscribeConfig subscribe_config;
   StateSnapshotConfig state_snapshot_config;
+  bool health_check_enabled;
 };
 
 struct StateSnapshotRequest {
@@ -180,6 +181,7 @@ class ConcordClient {
 
   // Health of ConcordClient.
   ClientHealth getClientHealth();
+  void setClientHealth(ClientHealth health);
 
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
@@ -192,6 +194,7 @@ class ConcordClient {
 
   // TODO: Allow multiple subscriptions
   std::atomic_bool active_subscription_{false};
+  bool health_check_enabled_ = false;
 
   std::vector<std::shared_ptr<::client::concordclient::GrpcConnection>> grpc_connections_;
   std::unique_ptr<::client::thin_replica_client::ThinReplicaClient> trc_;

--- a/client/thin-replica-client/CMakeLists.txt
+++ b/client/thin-replica-client/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(thin_replica_client_lib
   thin-replica-proto
   replica-state-snapshot-proto
   concordclient-event-api
+  concordclient-health
 )
 
 # Unit tests

--- a/client/thin-replica-client/include/client/thin-replica-client/replica_state_snapshot_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/replica_state_snapshot_client.hpp
@@ -28,6 +28,7 @@
 #include "Metrics.hpp"
 
 #include "Logger.hpp"
+#include "client/concordclient/client_health.hpp"
 #include "client/concordclient/snapshot_update.hpp"
 #include "client/thin-replica-client/grpc_connection.hpp"
 
@@ -59,9 +60,12 @@ class ReplicaStateSnapshotClient {
       : logger_(logging::getLogger("concord.client.replica_stream_snapshot")),
         config_(std::move(config)),
         threadpool_(config_->concurrency_level),
-        count_of_concurrent_request_{0} {}
+        count_of_concurrent_request_{0},
+        is_serving_{false} {}
   void readSnapshotStream(const SnapshotRequest& request,
                           std::shared_ptr<concord::client::concordclient::SnapshotQueue> remote_queue);
+
+  concord::client::concordclient::ClientHealth getClientHealth();
 
  private:
   // Thread function to start subscription_thread_ with snapshot.
@@ -78,5 +82,6 @@ class ReplicaStateSnapshotClient {
   std::unique_ptr<ReplicaStateSnapshotClientConfig> config_;
   concord::util::ThreadPool threadpool_;
   std::atomic_uint32_t count_of_concurrent_request_;
+  bool is_serving_;
 };
 }  // namespace client::replica_state_snapshot_client

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -50,6 +50,7 @@
 #include "Logger.hpp"
 #include "client/concordclient/event_update.hpp"
 #include "client/concordclient/concord_client_exceptions.hpp"
+#include "client/concordclient/client_health.hpp"
 
 namespace client::thin_replica_client {
 
@@ -197,6 +198,12 @@ class ThinReplicaClient final {
   std::unique_ptr<std::thread> subscription_thread_;
   std::atomic_bool stop_subscription_thread_;
 
+  // Is the thinRepliaClient able to server requests?
+  bool is_serving_;
+
+  // Is there a subscriber?
+  bool has_subscriber_;
+
   // Thread function to start subscription_thread_ with.
   void receiveUpdates();
 
@@ -312,7 +319,9 @@ class ThinReplicaClient final {
         latest_verified_event_group_id_(0),
         is_subscription_successful_(false),
         subscription_thread_(),
-        stop_subscription_thread_(false) {
+        stop_subscription_thread_(false),
+        is_serving_(false),
+        has_subscriber_(false) {
     metrics_.setAggregator(aggregator);
     if (config_->trs_conns.size() < (3 * (size_t)config_->max_faulty + 1)) {
       size_t num_servers = config_->trs_conns.size();
@@ -435,6 +444,8 @@ class ThinReplicaClient final {
 
   // Register the callback to update external metrics
   void setMetricsCallback(const std::function<void(const ThinReplicaClientMetrics&)>& exposeAndSetMetrics);
+
+  concord::client::concordclient::ClientHealth getClientHealth();
 };
 
 }  // namespace client::thin_replica_client

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -204,6 +204,16 @@ class ThinReplicaClient final {
   // Is there a subscriber?
   bool has_subscriber_;
 
+  bool health_check_enabled_;
+  // number of read requests received while periodically seeing if we're healthy
+  std::atomic_uint read_counter_for_health_ = 0;
+  // number of read requests with errors in current request count period.
+  std::atomic_uint read_error_counter_for_health_ = 0;
+  bool unhealthy_ = false;
+
+  void updateReadErrorCounter();
+  void updateReadCounter();
+
   // Thread function to start subscription_thread_ with.
   void receiveUpdates();
 
@@ -321,7 +331,8 @@ class ThinReplicaClient final {
         subscription_thread_(),
         stop_subscription_thread_(false),
         is_serving_(false),
-        has_subscriber_(false) {
+        has_subscriber_(false),
+        health_check_enabled_(false) {
     metrics_.setAggregator(aggregator);
     if (config_->trs_conns.size() < (3 * (size_t)config_->max_faulty + 1)) {
       size_t num_servers = config_->trs_conns.size();
@@ -445,7 +456,10 @@ class ThinReplicaClient final {
   // Register the callback to update external metrics
   void setMetricsCallback(const std::function<void(const ThinReplicaClientMetrics&)>& exposeAndSetMetrics);
 
+  bool isServing() { return is_serving_; }
+  void setHealthCheckEnabled(bool is_enabled);
   concord::client::concordclient::ClientHealth getClientHealth();
+  void setClientHealth(concord::client::concordclient::ClientHealth health);
 };
 
 }  // namespace client::thin_replica_client


### PR DESCRIPTION
This MR is created for early, superficial review only.

**These changes provide for health status for ClientService and its child services**  
Each child service (ConcordClientPool, ThinReplicaClient and StateSnapshotClient) have operation and error counters.  When the number of errors exceeds 25% of the operations, we consider the service to be unhealthy.  The ConcordClient is considered to be unhealthy if one or more "child service" is unhealthy.

Additional interfaces are introduced for testing purposes.

**Testing Done**  
No testing done yet.  Still trying to figure that out.
