### PR TITLE
EventGroups: Add convenient getValueFromTagTable API

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -176,7 +176,7 @@ class KvbAppFilter {
 
   uint64_t getValueFromLatestTable(const std::string &key) const;
 
-  TagTableValue getValueFromTagTable(const std::string &key) const;
+  TagTableValue getValueFromTagTable(const std::string &tag, uint64_t pvt_eg_id) const;
 
   uint64_t oldestExternalEventGroupId() const;
 


### PR DESCRIPTION
This change overloads the `getValueFromTagTable` function so that the caller
doesn't need to care about the separator or the string concatenation. As a
result, the code becomes more readable for the caller.
This is a follow-up from a discussion on #2354 - thanks @dartdart26!