### PR TITLE
Downgrade LOG level for isUpdatePruned

### DIFF
--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -581,7 +581,7 @@ class ThinReplicaImpl {
       if (request->events().block_id() < first_block_id) {
         msg << "Block ID " << request->events().block_id() << " has been pruned."
             << " First block_id is " << first_block_id;
-        LOG_ERROR(logger_, msg.str());
+        LOG_WARN(logger_, msg.str());
         return true;
       }
     } else {
@@ -591,7 +591,7 @@ class ThinReplicaImpl {
       if (request->event_groups().event_group_id() < first_eg_id || (last_eg_id && !first_eg_id)) {
         msg << "Event group ID " << request->event_groups().event_group_id() << " has been pruned."
             << " First event_group_id is " << first_eg_id;
-        LOG_ERROR(logger_, msg.str());
+        LOG_WARN(logger_, msg.str());
         return true;
       }
     }


### PR DESCRIPTION
* **Problem Overview**  
This PR downgrades the log level on concord for the scenario wherein a client app tries to subscribe to an already pruned event group ID. Throwing a `NOT_FOUND` error via clientservice is sufficient in this scenario because it is erroneous on the clientservice consumer's part that they are subscribing to a non-existent event group ID and thus, it is not a concord/TRS issue.

* **Testing Done**  
 This change just downgrades the log level, hence, no testing is required.
