### PR TITLE
Add TRC/TRS fixes

### DIFF
--- a/client/proto/event/v1/event.proto
+++ b/client/proto/event/v1/event.proto
@@ -38,7 +38,7 @@ service EventService {
 
 // Events come in two formats - Events (old API) and EventGroups (new API).
 // An EventsRequest will result in a stream of EventGroups or a stream of Events which turns into a stream of EventGroups.
-// If the block requested by EventsRequest contains EventGroups only then the stream will start at EventGroup id 1.
+// If the block requested by EventsRequest contains EventGroups only then the stream will start at the first EventGroup.
 // An EventGroupsRequest will result in a stream of EventGroups.
 // If you don't know about Events then use EventGroupsRequest.
 message SubscribeRequest {

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -367,7 +367,9 @@ class ThinReplicaImpl {
     }
 
     if (request->has_events() && !is_event_group_transition) {
-      // Requested block ID must always be greater than 0
+      // Requested block ID received by the TRS must always be greater than zero.
+      // Currently TRS expects TRC to take care of requests with block ID zero
+      // TODO: Replace the assert with INVALID_ARGUMENT error thrown when block ID zero is requested
       ConcordAssertGT(start_block_id, 0);
       try {
         syncAndSend<ServerContextT, ServerWriterT, DataT>(context, start_block_id, live_updates, stream, kvb_filter);

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -367,6 +367,8 @@ class ThinReplicaImpl {
     }
 
     if (request->has_events() && !is_event_group_transition) {
+      // Requested block ID must always be greater than 0
+      ConcordAssertGT(start_block_id, 0);
       try {
         syncAndSend<ServerContextT, ServerWriterT, DataT>(context, start_block_id, live_updates, stream, kvb_filter);
       } catch (concord::kvbc::NoLegacyEvents& error) {
@@ -460,6 +462,8 @@ class ThinReplicaImpl {
       event_group_id = request->event_groups().event_group_id();
     }
 
+    // Requested event group ID must always be greater than 0
+    ConcordAssertGT(event_group_id, 0);
     try {
       syncAndSendEventGroups<ServerContextT, ServerWriterT, DataT>(
           context, event_group_id, live_updates, stream, kvb_filter, metrics);

--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -676,7 +676,7 @@ void addMoreEventGroups(const EventGroupId start,
                         FakeStorage& storage,
                         TestStateMachine<T>& state_machine,
                         TestSubBufferList<T>& buffer,
-                        const std::string trid = kClientId1) {
+                        const std::string& trid = kClientId1) {
   auto more_live_updates = generateEventGroupMap(start, end, type, trid);
   storage.addEventGroups(more_live_updates);
   storage.updateEventGroupStorageMaps(more_live_updates);


### PR DESCRIPTION
This PR adds the following changes -
1. Adds missing asserts in thin_replica_impl.hpp
2. Fixes handling of requests for pruned event groups
3. Adds unit tests for pruning scenarios
4. Fixes a bug in findGlobalEventGroupID for a pruning scenario, identified via the unit tests.

Please see individual commits for more detail.