### PR TITLE
KvbAppFilter: Downgrade log level in getValueFromTagTable

### DIFF
--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -314,7 +314,7 @@ TagTableValue KvbAppFilter::getValueFromTagTable(const std::string &tag, uint64_
   if (not opt) {
     std::stringstream msg;
     msg << "Failed to get event group id from tag table for key " << key;
-    LOG_ERROR(logger_, msg.str());
+    LOG_WARN(logger_, msg.str());
     throw std::runtime_error(msg.str());
   }
   const auto val = std::get_if<concord::kvbc::categorization::ImmutableValue>(&(opt.value()));


### PR DESCRIPTION
When reading event groups TRS tries to calculate next global
and external event group IDs to read via call to `getValueFromTagTable`.
It is expected that the corresponding values have not yet been
populated in the tag table, wherein `getValueFromTagTable` would
throw and log an error. While the error is now re-thrown in the
caller `readEventGroups` method, we must also not log an ERROR
as the behavior is expected. This commit therefore downgrades the log to
WARN.
