### PR TITLE
Allow s3 integrity checker to receive only required public keys configuration

### DIFF
--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -134,7 +134,8 @@ SigManager::SigManager(PrincipalId myId,
   size_t numPublickeys = publickeys.size();
 
   ConcordAssert(publicKeysMapping.size() >= numPublickeys);
-  mySigner_.reset(new concord::util::crypto::RSASigner(mySigPrivateKey.first.c_str(), mySigPrivateKey.second));
+  if (!mySigPrivateKey.first.empty())
+    mySigner_.reset(new concord::util::crypto::RSASigner(mySigPrivateKey.first.c_str(), mySigPrivateKey.second));
   for (const auto& p : publicKeysMapping) {
     ConcordAssert(verifiers_.count(p.first) == 0);
     ConcordAssert(p.second < numPublickeys);

--- a/kvbc/tools/db_integrity_check/integrity_checker.cpp
+++ b/kvbc/tools/db_integrity_check/integrity_checker.cpp
@@ -69,8 +69,8 @@ void IntegrityChecker::parseCLIArgs(int argc, char** argv) {
 void IntegrityChecker::initKeysConfig(const fs::path& keys_file) {
   LOG_DEBUG(logger_, keys_file);
   auto& config = bftEngine::ReplicaConfig::instance();
-  auto sys = inputReplicaKeyfileMultisig(keys_file, config);
-  (void)sys;  // currently for ro replica cryptosys is null
+  inputReplicasPublicConfig(keys_file, config);
+  config.replicaId = config.numReplicas;  // "my" replica id shouldn't match one of the regular replicas
   repsInfo_ = new ReplicasInfo(config, true, false);
 
   bftEngine::impl::SigManager::init(config.replicaId,
@@ -223,7 +223,7 @@ concord::kvbc::categorization::RawBlock IntegrityChecker::getBlock(const BlockId
   return kvbc::categorization::RawBlock::deserialize(rawBlockSer);
 }
 
-Digest IntegrityChecker::computeBlockDigest(const BlockId& block_id, const std::string_view& block) const {
+Digest IntegrityChecker::computeBlockDigest(const BlockId& block_id, const std::string_view block) const {
   Digest calcDigest;
   BCStateTran::computeDigestOfBlock(block_id, block.data(), block.size(), &calcDigest);
 

--- a/kvbc/tools/db_integrity_check/integrity_checker.hpp
+++ b/kvbc/tools/db_integrity_check/integrity_checker.hpp
@@ -102,7 +102,7 @@ class IntegrityChecker {
   /** Calculate block digest
    * @return block digest
    */
-  Digest computeBlockDigest(const BlockId&, const std::string_view& block) const;
+  Digest computeBlockDigest(const BlockId&, const std::string_view block) const;
 
   /** Print block content */
   void printBlockContent(const BlockId&, const concord::kvbc::categorization::RawBlock&) const;

--- a/kvbc/tools/db_restore/db_restore.cpp
+++ b/kvbc/tools/db_restore/db_restore.cpp
@@ -53,17 +53,18 @@ void DBRestore::initRocksDB(const fs::path& rocksdb_path) {
   LOG_DEBUG(logger_, rocksdb_path);
   rocksdb_dataset_ = std::make_unique<v2MerkleTree::RocksDBStorageFactory>(rocksdb_path)->newDatabaseSet();
   const auto linkStChain = true;
-  auto kvbc_categories = std::map<std::string, categorization::CATEGORY_TYPE>{
-      {categorization::kExecutionProvableCategory, categorization::CATEGORY_TYPE::block_merkle},
-      {categorization::kExecutionPrivateCategory, categorization::CATEGORY_TYPE::versioned_kv},
-      {categorization::kExecutionEventsCategory, categorization::CATEGORY_TYPE::immutable},
-      {categorization::kRequestsRecord, categorization::CATEGORY_TYPE::immutable},
-      {categorization::kExecutionEventGroupDataCategory, categorization::CATEGORY_TYPE::immutable},
-      {categorization::kExecutionEventGroupTagCategory, categorization::CATEGORY_TYPE::immutable},
+  // clang-format off
+  auto kvbc_categories = std::map<std::string,             categorization::CATEGORY_TYPE>{
+      {categorization::kExecutionProvableCategory,         categorization::CATEGORY_TYPE::block_merkle},
+      {categorization::kExecutionPrivateCategory,          categorization::CATEGORY_TYPE::versioned_kv},
+      {categorization::kExecutionEventsCategory,           categorization::CATEGORY_TYPE::immutable},
+      {categorization::kRequestsRecord,                    categorization::CATEGORY_TYPE::immutable},
+      {categorization::kExecutionEventGroupDataCategory,   categorization::CATEGORY_TYPE::immutable},
+      {categorization::kExecutionEventGroupTagCategory,    categorization::CATEGORY_TYPE::immutable},
       {categorization::kExecutionEventGroupLatestCategory, categorization::CATEGORY_TYPE::versioned_kv},
-      {categorization::kConcordInternalCategoryId, categorization::CATEGORY_TYPE::versioned_kv},
-      {categorization::kConcordReconfigurationCategoryId, categorization::CATEGORY_TYPE::versioned_kv}};
-
+      {categorization::kConcordInternalCategoryId,         categorization::CATEGORY_TYPE::versioned_kv},
+      {categorization::kConcordReconfigurationCategoryId,  categorization::CATEGORY_TYPE::versioned_kv}};
+  // clang-format on
   kv_blockchain_ = std::make_unique<categorization::KeyValueBlockchain>(
       storage::rocksdb::NativeClient::fromIDBClient(rocksdb_dataset_.dataDBClient), linkStChain, kvbc_categories);
 }

--- a/tools/KeyfileIOUtils.hpp
+++ b/tools/KeyfileIOUtils.hpp
@@ -67,6 +67,12 @@ void outputReplicaKeyfile(uint16_t numReplicas,
  */
 Cryptosystem* inputReplicaKeyfileMultisig(const std::string& inputFilename, bftEngine::ReplicaConfig& config);
 
+/**
+ * Read public keys configuration only.
+ * Used by integrity/restore tools.
+ */
+void inputReplicasPublicConfig(const std::string& filename, bftEngine::ReplicaConfig& config);
+
 template <typename T>
 T parse(const std::string& str, const std::string& name) {
   try {


### PR DESCRIPTION
* **Problem Overview**  
Previously, due to code reuse, keys configuration file should have matched the one of the RO replica,
which included private key.
Some minor changes related to passing string_view by value.

* **Testing Done**  
Tested new configuration with db integrity and restore tools.  
