### PR TITLE
Allow s3 integrity checker to recieve only required public keys configuration

### DIFF
--- a/bftengine/src/bftengine/SigManager.cpp
+++ b/bftengine/src/bftengine/SigManager.cpp
@@ -134,7 +134,8 @@ SigManager::SigManager(PrincipalId myId,
   size_t numPublickeys = publickeys.size();
 
   ConcordAssert(publicKeysMapping.size() >= numPublickeys);
-  mySigner_.reset(new concord::util::crypto::RSASigner(mySigPrivateKey.first.c_str(), mySigPrivateKey.second));
+  if (!mySigPrivateKey.first.empty())
+    mySigner_.reset(new concord::util::crypto::RSASigner(mySigPrivateKey.first.c_str(), mySigPrivateKey.second));
   for (const auto& p : publicKeysMapping) {
     ConcordAssert(verifiers_.count(p.first) == 0);
     ConcordAssert(p.second < numPublickeys);

--- a/kvbc/tools/db_integrity_check/integrity_checker.hpp
+++ b/kvbc/tools/db_integrity_check/integrity_checker.hpp
@@ -102,7 +102,7 @@ class IntegrityChecker {
   /** Calculate block digest
    * @return block digest
    */
-  Digest computeBlockDigest(const BlockId&, const std::string_view& block) const;
+  Digest computeBlockDigest(const BlockId&, const std::string_view block) const;
 
   /** Print block content */
   void printBlockContent(const BlockId&, const concord::kvbc::categorization::RawBlock&) const;

--- a/kvbc/tools/db_restore/db_restore.cpp
+++ b/kvbc/tools/db_restore/db_restore.cpp
@@ -53,17 +53,18 @@ void DBRestore::initRocksDB(const fs::path& rocksdb_path) {
   LOG_DEBUG(logger_, rocksdb_path);
   rocksdb_dataset_ = std::make_unique<v2MerkleTree::RocksDBStorageFactory>(rocksdb_path)->newDatabaseSet();
   const auto linkStChain = true;
-  auto kvbc_categories = std::map<std::string, categorization::CATEGORY_TYPE>{
-      {categorization::kExecutionProvableCategory, categorization::CATEGORY_TYPE::block_merkle},
-      {categorization::kExecutionPrivateCategory, categorization::CATEGORY_TYPE::versioned_kv},
-      {categorization::kExecutionEventsCategory, categorization::CATEGORY_TYPE::immutable},
-      {categorization::kRequestsRecord, categorization::CATEGORY_TYPE::immutable},
-      {categorization::kExecutionEventGroupDataCategory, categorization::CATEGORY_TYPE::immutable},
-      {categorization::kExecutionEventGroupTagCategory, categorization::CATEGORY_TYPE::immutable},
+  // clang-format off
+  auto kvbc_categories = std::map<std::string,             categorization::CATEGORY_TYPE>{
+      {categorization::kExecutionProvableCategory,         categorization::CATEGORY_TYPE::block_merkle},
+      {categorization::kExecutionPrivateCategory,          categorization::CATEGORY_TYPE::versioned_kv},
+      {categorization::kExecutionEventsCategory,           categorization::CATEGORY_TYPE::immutable},
+      {categorization::kRequestsRecord,                    categorization::CATEGORY_TYPE::immutable},
+      {categorization::kExecutionEventGroupDataCategory,   categorization::CATEGORY_TYPE::immutable},
+      {categorization::kExecutionEventGroupTagCategory,    categorization::CATEGORY_TYPE::immutable},
       {categorization::kExecutionEventGroupLatestCategory, categorization::CATEGORY_TYPE::versioned_kv},
-      {categorization::kConcordInternalCategoryId, categorization::CATEGORY_TYPE::versioned_kv},
-      {categorization::kConcordReconfigurationCategoryId, categorization::CATEGORY_TYPE::versioned_kv}};
-
+      {categorization::kConcordInternalCategoryId,         categorization::CATEGORY_TYPE::versioned_kv},
+      {categorization::kConcordReconfigurationCategoryId,  categorization::CATEGORY_TYPE::versioned_kv}};
+  // clang-format on
   kv_blockchain_ = std::make_unique<categorization::KeyValueBlockchain>(
       storage::rocksdb::NativeClient::fromIDBClient(rocksdb_dataset_.dataDBClient), linkStChain, kvbc_categories);
 }

--- a/storage/include/s3/config_parser.hpp
+++ b/storage/include/s3/config_parser.hpp
@@ -30,23 +30,6 @@ class ConfigFileParser {
   StoreConfig parse();
 
  protected:
-  template <typename T>
-  T get_optional_value(const std::string& key, const T& defaultValue) {
-    std::vector<std::string> v = parser_.GetValues(key);
-    if (v.size())
-      return concord::util::to<T>(v[0]);
-    else
-      return defaultValue;
-  }
-  template <typename T>
-  T get_value(const std::string& key) {
-    std::vector<std::string> v = parser_.GetValues(key);
-    if (v.size())
-      return concord::util::to<T>(v[0]);
-    else
-      throw std::runtime_error("failed to parse " + parser_.getConfigFileName() + ": " + key + " is not set.");
-  }
-
   logging::Logger logger_ = logging::getLogger("concord.storage.s3");
   util::ConfigFileParser parser_;
 };

--- a/storage/src/s3/config_parser.cpp
+++ b/storage/src/s3/config_parser.cpp
@@ -22,16 +22,16 @@ using std::string;
 namespace concord::storage::s3 {
 
 concord::storage::s3::StoreConfig ConfigFileParser::parse() {
-  if (!parser_.Parse()) throw std::runtime_error("failed to parse" + parser_.getConfigFileName());
+  parser_.parse();
 
   concord::storage::s3::StoreConfig config;
-  config.bucketName = get_value<string>("s3-bucket-name");
-  config.accessKey = get_value<string>("s3-access-key");
-  config.protocol = get_value<string>("s3-protocol");
-  config.url = get_value<string>("s3-url");
-  config.secretKey = get_value<string>("s3-secret-key");
-  config.pathPrefix = get_optional_value<string>("s3-path-prefix", "");
-  config.operationTimeout = get_optional_value<std::uint32_t>("s3-operation-timeout", 60000);
+  config.bucketName = parser_.get_value<string>("s3-bucket-name");
+  config.accessKey = parser_.get_value<string>("s3-access-key");
+  config.protocol = parser_.get_value<string>("s3-protocol");
+  config.url = parser_.get_value<string>("s3-url");
+  config.secretKey = parser_.get_value<string>("s3-secret-key");
+  config.pathPrefix = parser_.get_optional_value<string>("s3-path-prefix", "");
+  config.operationTimeout = parser_.get_optional_value<std::uint32_t>("s3-operation-timeout", 60000);
   LOG_INFO(logger_, config);
   return config;
 }

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -69,12 +69,14 @@ std::unordered_map<NodeNum, NodeInfo> TestCommConfig::SetUpConfiguredNodes(bool 
                                                                            uint16_t& num_of_clients,
                                                                            uint16_t& num_of_replicas) {
   concord::util::ConfigFileParser config_file_parser(logger_, config_file_name);
-  if (!config_file_parser.Parse()) {
-    LOG_FATAL(logger_, "Failed to parse configuration file: " << config_file_name);
+  try {
+    config_file_parser.parse();
+  } catch (const std::exception& e) {
+    LOG_FATAL(logger_, e.what());
     exit(-1);
   }
-  num_of_clients = static_cast<uint16_t>(config_file_parser.Count(CLIENTS_CONFIG));
-  num_of_replicas = static_cast<uint16_t>(config_file_parser.Count(REPLICAS_CONFIG));
+  num_of_clients = static_cast<uint16_t>(config_file_parser.count(CLIENTS_CONFIG));
+  num_of_replicas = static_cast<uint16_t>(config_file_parser.count(REPLICAS_CONFIG));
   if ((is_replica && (node_id + 1 > num_of_replicas)) ||
       (!is_replica && (node_id + 1 > num_of_clients + num_of_replicas))) {
     LOG_FATAL(logger_,
@@ -82,8 +84,8 @@ std::unordered_map<NodeNum, NodeInfo> TestCommConfig::SetUpConfiguredNodes(bool 
                   << "numOfClients=" << num_of_clients << ", numOfReplicas=" << num_of_replicas);
     exit(-1);
   }
-  vector<string> replicas = config_file_parser.GetValues(REPLICAS_CONFIG);
-  vector<string> clients = config_file_parser.GetValues(CLIENTS_CONFIG);
+  auto replicas = config_file_parser.get_values<std::string>(REPLICAS_CONFIG);
+  auto clients = config_file_parser.get_values<std::string>(CLIENTS_CONFIG);
   std::unordered_map<NodeNum, NodeInfo> nodes;
   int k = 0;
   for (int i = 0; i < (num_of_replicas + num_of_clients); i++) {
@@ -93,7 +95,7 @@ std::unordered_map<NodeNum, NodeInfo> TestCommConfig::SetUpConfiguredNodes(bool 
       current_vector = clients;
       k = 0;
     }
-    vector<string> ip_port_pair = config_file_parser.SplitValue(current_vector[k++], ip_port_delimiter_);
+    vector<string> ip_port_pair = config_file_parser.splitValue(current_vector[k++], ip_port_delimiter_);
     LOG_INFO(logger_,
              "setUpConfiguredNodes() node_id: " << node_id << ", k: " << k - 1
                                                 << ", port:" << (uint16_t)(std::stoi(ip_port_pair[1])));

--- a/tests/simpleTest/config_file_parser_test.cpp
+++ b/tests/simpleTest/config_file_parser_test.cpp
@@ -9,7 +9,7 @@ using std::cin;
 using std::string;
 using std::vector;
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   cout << "Enter configuration file name with a full/relative path,"
        << " or 'd' for a default:\n";
 
@@ -32,17 +32,22 @@ int main(int argc, char **argv) {
   if (given_config_file != use_default_config_file) config_file = given_config_file;
   logging::Logger logger = logging::getLogger("simpletest.test");
   concord::util::ConfigFileParser parser(logger, config_file);
-  if (!parser.Parse()) return 1;
 
+  try {
+    parser.parse();
+  } catch (const std::exception& e) {
+    cout << e.what() << "\n";
+    return 1;
+  }
   cout << "\n";
-  size_t replicas_num = parser.Count("replicas_config");
-  vector<string> replicas = parser.GetValues("replicas_config");
+  size_t replicas_num = parser.count("replicas_config");
+  auto replicas = parser.get_values<std::string>("replicas_config");
 
-  size_t clients_num = parser.Count("clients_config");
-  vector<string> clients = parser.GetValues("clients_config");
+  size_t clients_num = parser.count("clients_config");
+  auto clients = parser.get_values<std::string>("clients_config");
   parser.printAll();
 
-  vector<std::string> split_values_vector = parser.SplitValue(values_to_split, values_to_split_delimiter.c_str());
+  vector<std::string> split_values_vector = parser.splitValue(values_to_split, values_to_split_delimiter.c_str());
 
   if (config_file == default_config_file) {
     ConcordAssert(replicas_num == expected_replicas_num);

--- a/util/src/config_file_parser.cpp
+++ b/util/src/config_file_parser.cpp
@@ -11,18 +11,6 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 //
-// This file provides functionality for configuration (.ini) file parsing.
-// Supported format (YAML like):
-//
-// # Sample configuration file for creation of a testing environment.
-// replicas_config:
-// - 127.0.0.1:3410
-// - 127.0.0.1:3420
-// - 127.0.0.1:3430
-// - 127.0.0.1:3440
-//
-// clients_config: 127.0.0.1:4444
-
 #include "config_file_parser.hpp"
 
 #include <fstream>
@@ -37,87 +25,82 @@ using std::vector;
 
 namespace concord::util {
 
-bool ConfigFileParser::Parse() {
-  ifstream stream(file_name_, std::ios::binary);
-  if (!stream.is_open()) {
-    LOG_FATAL(logger_, "Failed to open file: " << file_name_);
-    return false;
-  }
+void ConfigFileParser::parse() {
+  ifstream stream(file_, std::ios::binary);
+  if (!stream.is_open()) throw std::runtime_error("failed to open file: " + file_.string());
+
   string key;
+  std::uint16_t line_no = 0;
   while (stream) {
-    string value, tmp;
-    getline(stream, tmp, end_of_line_);
+    string value, line;
+    line_no++;
+    getline(stream, line, end_of_line_);
     // get rid of leading and trailing spaces
-    concord::util::trim_inplace(tmp);
-    if (tmp[0] == comment_delimiter_)  // Ignore comments.
+    concord::util::trim_inplace(line);
+    if (line[0] == comment_delimiter_) {
+      LOG_TRACE(logger_, "line:" << line_no << " COMMENT");
       continue;
+    }
 
-    if (tmp.empty())  // Skip empty lines.
+    if (line.empty()) {
+      LOG_TRACE(logger_, "line:" << line_no << " EMPTY LINE");
       continue;
+    }
 
-    if (tmp[0] == value_delimiter_) {  // of the form '- value'
-      value = tmp.substr(tmp[1]);
-      concord::util::ltrim_inplace(tmp);
+    if (line[0] == value_delimiter_) {  // of the form '- value'
+      LOG_TRACE(logger_, "line:" << line_no << " VALUE_DELIMETER");
+      value = line.substr(1);
+      concord::util::ltrim_inplace(value);
+      LOG_TRACE(logger_, "line:" << line_no << " value: " << value);
       if (!key.empty())
         parameters_map_.insert(pair<string, string>(key, value));
-      else {
-        LOG_FATAL(logger_, "not found key for value " << value);
-        return false;
-      }
+      else
+        throw ParseError(*this, line_no, "not found key for value: " + value);
+      continue;
     }
-    size_t keyDelimiterPos = tmp.find_first_of(key_delimiter_);
+    size_t keyDelimiterPos = line.find_first_of(key_delimiter_);
     if (keyDelimiterPos != string::npos) {
-      key = tmp.substr(0, keyDelimiterPos);
-      if (tmp.size() > key.size() + 1) {
-        // Handle simple key-value pair.
-        value = tmp.substr(keyDelimiterPos + 1);
+      LOG_TRACE(logger_, "line:" << line_no << " KEY_DELIMETER");
+      key = line.substr(0, keyDelimiterPos);
+      LOG_TRACE(logger_, "line:" << line_no << " key: " << key);
+      if (line.size() > key.size() + 1) {  // simple key-value pair.
+        value = line.substr(keyDelimiterPos + 1);
         concord::util::rtrim_inplace(key);
         concord::util::ltrim_inplace(value);
+        LOG_TRACE(logger_, "line:" << line_no << " value: " << value);
         parameters_map_.insert(pair<string, string>(key, value));
+        key = "";
       }
       continue;
     }
+    throw ParseError(*this, line_no, "unrecognized format: " + line);
   }
   stream.close();
-  LOG_DEBUG(logger_, "File: " << file_name_ << " successfully parsed.");
-  return true;
+  LOG_INFO(logger_, "File: " << file_ << " successfully parsed.");
 }
 
-size_t ConfigFileParser::Count(const string& key) {
+size_t ConfigFileParser::count(const string& key) {
   size_t res = parameters_map_.count(key);
   LOG_INFO(logger_, "count() returns: " << res << " for key: " << key);
   return res;
 }
 
-vector<string> ConfigFileParser::GetValues(const string& key) {
-  vector<string> values;
-  pair<ParamsMultiMapIt, ParamsMultiMapIt> range = parameters_map_.equal_range(key);
-  LOG_DEBUG(logger_, "getValues() for key: " << key);
-  if (range.first != parameters_map_.end()) {
-    for (auto it = range.first; it != range.second; ++it) {
-      values.push_back(it->second);
-      LOG_DEBUG(logger_, "value: " << it->second);
-    }
-  }
-  return values;
-}
-
-std::vector<std::string> ConfigFileParser::SplitValue(const std::string& value_to_split, const char* delimiter) {
-  LOG_DEBUG(logger_, "valueToSplit: " << value_to_split << ", delimiter: " << delimiter);
+std::vector<std::string> ConfigFileParser::splitValue(const std::string& value_to_split, const char* delimiter) {
+  LOG_TRACE(logger_, "valueToSplit: " << value_to_split << ", delimiter: " << delimiter);
   char* rest = (char*)value_to_split.c_str();
   char* token;
   std::vector<std::string> values;
   while ((token = strtok_r(rest, delimiter, &rest))) {
     values.emplace_back(token);
-    LOG_DEBUG(logger_, "Value after split: " << token);
+    LOG_TRACE(logger_, "Value after split: " << token);
   }
   return values;
 }
 
 void ConfigFileParser::printAll() {
-  LOG_DEBUG(logger_, "\nKey/value pairs:");
+  LOG_TRACE(logger_, "\nKey/value pairs:");
   for (const auto& it : parameters_map_) {
-    LOG_DEBUG(logger_, it.first << ", " << it.second);
+    LOG_TRACE(logger_, it.first << ", " << it.second);
   }
 }
 


### PR DESCRIPTION
* **Problem Overview**  
 Previously, due to code reuse, keys configuration file should have matched the one of the RO replica,
which included private key.
Now only replicas public keys are required.

- enhance yaml config file parser
- minor changes related to passing string_view by value.
 
* **Testing Done**  
- integrity apollo tests
- manual tests 
