### PR TITLE
Allow batch cancellation only when completed

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -207,18 +207,39 @@ void RequestsBatch::releaseReqsAndSendBatchedReplyIfCompleted(PreProcessReplyMsg
 }
 
 // On a primary replica
+void RequestsBatch::cancelRequestAndBatchIfCompleted(const string &reqBatchCid,
+                                                     uint16_t reqOffsetInBatch,
+                                                     PreProcessingResult status) {
+  const lock_guard<mutex> lock(batchMutex_);
+  if (batchCid_ != reqBatchCid) {
+    LOG_INFO(preProcessor_.logger(),
+             "The batch has been cancelled/completed earlier; do nothing" << KVLOG(clientId_, reqBatchCid, batchCid_));
+    return;
+  }
+  const auto &reqEntry = requestsMap_[reqOffsetInBatch];
+  if (reqEntry) {
+    if (status == CANCEL) preProcessor_.preProcessorMetrics_.preProcConsensusNotReached++;
+    preProcessor_.releaseClientPreProcessRequestSafe(clientId_, reqEntry, status);
+    finalizeBatchIfCompleted();
+  }
+}
+
+// On a primary replica
+void RequestsBatch::finalizeBatchIfCompletedSafe() {
+  const lock_guard<mutex> lock(batchMutex_);
+  finalizeBatchIfCompleted();
+}
+
+// On a primary replica; unsafe
 void RequestsBatch::finalizeBatchIfCompleted() {
   string batchCid;
   atomic_uint32_t batchSize = 0;
   uint32_t numOfCompletedReqs = 0;
-  {
-    const lock_guard<mutex> lock(batchMutex_);
-    if (numOfCompletedReqs_ < batchSize_) return;
-    batchCid = batchCid_;
-    batchSize = batchSize_;
-    numOfCompletedReqs = numOfCompletedReqs_;
-    resetBatchParams();
-  }
+  if (numOfCompletedReqs_ < batchSize_) return;
+  batchCid = batchCid_;
+  batchSize = batchSize_;
+  numOfCompletedReqs = numOfCompletedReqs_;
+  resetBatchParams();
   LOG_INFO(preProcessor_.logger(),
            "The batch has been released" << KVLOG(clientId_, batchCid, numOfCompletedReqs, batchSize));
 }
@@ -1287,7 +1308,7 @@ void PreProcessor::handlePreProcessReplyMsg(const string &reqCid,
 
 void PreProcessor::cancelPreProcessing(NodeIdType clientId, const string &batchCid, uint16_t reqOffsetInBatch) {
   if (clientBatchingEnabled_)
-    ongoingReqBatches_[clientId]->cancelBatchAndReleaseRequests(batchCid, CANCEL);
+    ongoingReqBatches_[clientId]->cancelRequestAndBatchIfCompleted(batchCid, reqOffsetInBatch, CANCEL);
   else {
     preProcessorMetrics_.preProcConsensusNotReached++;
     SeqNum reqSeqNum = 0;
@@ -1371,7 +1392,7 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
                "Pre-processing completed for" << KVLOG(batchCid, reqSeqNum, reqCid, clientId, reqOffsetInBatch));
     }
   }
-  if (batchedPreProcessEnabled_) batchEntry->finalizeBatchIfCompleted();
+  if (batchedPreProcessEnabled_) batchEntry->finalizeBatchIfCompletedSafe();
 }
 
 uint16_t PreProcessor::numOfRequiredReplies() { return myReplica_.getReplicaConfig().fVal + 1; }
@@ -1813,6 +1834,7 @@ void PreProcessor::handleReqPreProcessedByPrimary(const PreProcessRequestMsgShar
                                                   OperationResult preProcessResult) {
   const uint16_t &reqOffsetInBatch = preProcessReqMsg->reqOffsetInBatch();
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.handlePreProcessedReqByPrimary);
+  setPreprocessingRightNow(clientId, reqOffsetInBatch, false);
   const PreProcessingResult result =
       handlePreProcessedReqByPrimaryAndGetConsensusResult(clientId, reqOffsetInBatch, resultBufLen, preProcessResult);
   if (result != NONE)

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -84,8 +84,11 @@ class RequestsBatch {
   RequestStateSharedPtr &getRequestState(uint16_t reqOffsetInBatch);
   const std::string getBatchCid() const;
   void cancelBatchAndReleaseRequests(const std::string &batchCid, PreProcessingResult status);
+  void cancelRequestAndBatchIfCompleted(const std::string &reqBatchCid,
+                                        uint16_t reqOffsetInBatch,
+                                        PreProcessingResult status);
   void releaseReqsAndSendBatchedReplyIfCompleted(PreProcessReplyMsgSharedPtr replyMsg);
-  void finalizeBatchIfCompleted();
+  void finalizeBatchIfCompletedSafe();
   void handlePossiblyExpiredRequests();
   void sendCancelBatchedPreProcessingMsgToNonPrimaries(const ClientMsgsList &clientMsgs, NodeIdType destId);
   uint64_t getBlockId() const;
@@ -93,6 +96,7 @@ class RequestsBatch {
  private:
   void setBatchParameters(const std::string &batchCid, uint32_t batchSize);
   void resetBatchParams();
+  void finalizeBatchIfCompleted();
 
  private:
   PreProcessor &preProcessor_;

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -27,7 +27,7 @@ uint16_t RequestProcessingState::numOfRequiredEqualReplies_ = 0;
 PreProcessorRecorder *RequestProcessingState::preProcessorHistograms_ = nullptr;
 
 void RequestProcessingState::init(uint16_t numOfRequiredReplies, PreProcessorRecorder *histograms) {
-  LOG_INFO(logger(), "RequestProcessingstate init:" << KVLOG(numOfRequiredReplies));
+  LOG_INFO(logger(), "RequestProcessingState init:" << KVLOG(numOfRequiredReplies));
   numOfRequiredEqualReplies_ = numOfRequiredReplies;
   preProcessorHistograms_ = histograms;
 }
@@ -89,7 +89,6 @@ void RequestProcessingState::updatePreProcessResultData(OperationResult preProce
 void RequestProcessingState::handlePrimaryPreProcessed(const char *preProcessResultData,
                                                        uint32_t preProcessResultLen,
                                                        OperationResult preProcessResult) {
-  preprocessingRightNow_ = false;
   primaryPreProcessResult_ = preProcessResult;
   if (preProcessResult != OperationResult::UNKNOWN) {
     primaryPreProcessResultData_ = preProcessResultData;


### PR DESCRIPTION
* **Problem Overview**  
  In case one of the requests in the batch has not reached the pre-execution consensus, we cancel the whole batch.
  It is a good approach because we can succeed only in case all the requests in the batch are completed successfully. 
  But when one of the batch requests is in the middle of pre-processing, the buffer allocated for it from the memory pool
  could not be released, otherwise, concord will crash. I've changed the approach. Now we wait until all requests complete 
  pre-processing and only then cancel the batch.
* **Testing Done**  
  Ran a one-day test on a reserved system.
