### PR TITLE
Exclude sub-directory iteration for db size calculation

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -136,6 +136,10 @@ class DbCheckpointManager {
   }
   inline auto getLastDbCheckpointSeqNum() const { return lastCheckpointSeqNum_; }
   std::string getDiskUsageInfo();
+  // return a map of pair<checkpoint_id, size_on_disk>
+  // checkpoint_id = 0 indicates rocksdb size
+  // only used for apollo test
+  std::map<uint64_t, uint64_t> getDbSize();
 
  private:
   logging::Logger getLogger() {

--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -148,7 +148,7 @@ uint64_t DbCheckpointManager::directorySize(const _fs::path& directory, const bo
   uint64_t size{0};
   try {
     if (_fs::exists(directory)) {
-      for (const auto& entry : _fs::recursive_directory_iterator(directory)) {
+      for (const auto& entry : _fs::directory_iterator(directory)) {
         if (_fs::is_regular_file(entry) && !_fs::is_symlink(entry)) {
           if (_fs::hard_link_count(entry) > 1 && excludeHardLinks) continue;
           size += _fs::file_size(entry);
@@ -348,7 +348,8 @@ void DbCheckpointManager::updateMetrics() {
   if (const auto it = dbCheckptMetadata_.dbCheckPoints_.crbegin(); it != dbCheckptMetadata_.dbCheckPoints_.crend()) {
     _fs::path path(checkpointDir);
     _fs::path chkptIdPath = path / std::to_string(it->first);
-    auto lastDbCheckpointSize = directorySize(chkptIdPath, false, true);
+    // db checkpoint directory does not have any sub-directory
+    auto lastDbCheckpointSize = directorySize(chkptIdPath, false, false);
     lastDbCheckpointSizeInMb_.Get().Set(lastDbCheckpointSize / (1024 * 1024));
     metrics_.UpdateAggregator();
     LOG_INFO(getLogger(), "rocksdb check point id:" << it->first << ", size: " << HumanReadable{lastDbCheckpointSize});

--- a/reconfiguration/cmf/concord.cmf
+++ b/reconfiguration/cmf/concord.cmf
@@ -429,6 +429,18 @@ Msg PruneStopRequest 77 {
     uint64 sender_id
 }
 
+Msg DbSizeReadRequest 79 {
+    #this is used only for apollo-test
+    uint64 sender_id
+}
+
+Msg DbSizeReadRequestResponse 80 {
+    #this is used only for apollo-test
+    uint64 replica_id
+    # checkpoint id = 0 is used for rocksdb size
+    list kvpair uint64 uint64 mapCheckpointIdDbSize
+}
+
 Msg ReconfigurationRequest 1 {
   uint64 sender
   bytes signature
@@ -471,6 +483,7 @@ Msg ReconfigurationRequest 1 {
     StateSnapshotRequest
     SignedPublicStateHashRequest
     StateSnapshotReadAsOfRequest
+    DbSizeReadRequest
   } command
   bytes additional_data
 }
@@ -497,6 +510,7 @@ Msg ReconfigurationResponse 2 {
     StateSnapshotResponse
     SignedPublicStateHashResponse
     StateSnapshotReadAsOfResponse
+    DbSizeReadRequestResponse
   } response
   bytes additional_data
 }

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -276,6 +276,14 @@ class IReconfigurationHandler {
     return true;
   }
 
+  virtual bool handle(const concord::messages::DbSizeReadRequest &,
+                      uint64_t,
+                      uint32_t,
+                      const std::optional<bftEngine::Timestamp> &,
+                      concord::messages::ReconfigurationResponse &) {
+    return true;
+  }
+
   virtual bool handle(const concord::messages::StateSnapshotRequest &,
                       uint64_t,
                       uint32_t,

--- a/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration_handler.hpp
@@ -81,6 +81,12 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
               const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
 
+  bool handle(const concord::messages::DbSizeReadRequest &,
+              uint64_t,
+              uint32_t,
+              const std::optional<bftEngine::Timestamp> &,
+              concord::messages::ReconfigurationResponse &) override;
+
  private:
   void handleWedgeCommands(bool bft_support,
                            bool remove_metadata,

--- a/tests/apollo/util/operator.py
+++ b/tests/apollo/util/operator.py
@@ -199,6 +199,11 @@ class Operator:
         req.participant_id = 'apollo_test_participant_id'
         return self._construct_basic_reconfiguration_request(req)
 
+    def _construct_db_size_req(self):
+        req = cmf_msgs.DbSizeReadRequest()
+        req.sender_id = 1000
+        return self._construct_basic_reconfiguration_request(req)
+
     def get_rsi_replies(self):
         return self.client.get_rsi_replies()
 
@@ -340,3 +345,10 @@ class Operator:
         req = self._construct_reconfiguration_state_snapshot_read_as_of_req(snapshot_id, keys)
         return await self.client.read(req.serialize(), m_of_n_quorum=bft_client.MofNQuorum.All(self.client.config,
                                         [r for r in range(self.config.n)]), reconfiguration=True)
+                              
+    async def get_db_size(self):
+        quorum = bft_client.MofNQuorum.All(self.client.config, [r for r in range(self.config.n)])
+        msg = self._construct_db_size_req()
+        return await self.client.read(msg.serialize(), m_of_n_quorum=quorum, reconfiguration=True)
+        
+        


### PR DESCRIPTION
**Problem Overview**
Calculation of rocksdb dir size does not need to include the subdirectories.
rocksdbdata directory also has checkpoint folder for db-checkpoints, and
those should be excluded. To fix this we need to use directory_iterator
instead of recursive_directory_iterator.
Added support to test this apollo
**Testing Done**
Tested in apollo test for SkvbcDbSnapshotTest
