### PR TITLE
Add another metric to TRS and allow tags for counter metrics

### DIFF
--- a/thin-replica-server/include/thin-replica-server/trs_metrics.hpp
+++ b/thin-replica-server/include/thin-replica-server/trs_metrics.hpp
@@ -27,7 +27,9 @@ struct ThinReplicaServerMetrics {
         last_sent_block_id{metrics_component_.RegisterGauge(
             "last_sent_block_id", 0, {{"stream_type", stream_type}, {"client_id", client_id}})},
         last_sent_event_group_id{metrics_component_.RegisterGauge(
-            "last_sent_event_group_id", 0, {{"stream_type", stream_type}, {"client_id", client_id}})} {
+            "last_sent_event_group_id", 0, {{"stream_type", stream_type}, {"client_id", client_id}})},
+        num_skipped_event_groups{metrics_component_.RegisterCounter(
+            "num_skipped_event_groups", 0, {{"stream_type", stream_type}, {"client_id", client_id}})} {
     metrics_component_.Register();
   }
 
@@ -49,6 +51,8 @@ struct ThinReplicaServerMetrics {
   concordMetrics::GaugeHandle last_sent_block_id;
   // last sent event group id
   concordMetrics::GaugeHandle last_sent_event_group_id;
+  // number of event groups skipped after filtering
+  concordMetrics::CounterHandle num_skipped_event_groups;
 };
 }  // namespace thin_replica
 }  // namespace concord

--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -262,6 +262,9 @@ class Component {
                               const std::unordered_map<std::string, std::string>& tag_map);
   Handle<Status> RegisterStatus(const std::string& name, const std::string& val);
   Handle<Counter> RegisterCounter(const std::string& name, const uint64_t val);
+  Handle<Counter> RegisterCounter(const std::string& name,
+                                  const uint64_t val,
+                                  const std::unordered_map<std::string, std::string>& tag_map);
   Handle<Counter> RegisterCounter(const std::string& name) { return RegisterCounter(name, 0); }
   Handle<AtomicCounter> RegisterAtomicCounter(const std::string& name, const uint64_t val);
   Handle<AtomicCounter> RegisterAtomicCounter(const std::string& name) { return RegisterAtomicCounter(name, 0); }

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -66,6 +66,15 @@ Component::Handle<Counter> Component::RegisterCounter(const string& name, const 
   return Component::Handle<Counter>(values_.counters_, values_.counters_.size() - 1, metricsEnabled_);
 }
 
+Component::Handle<Counter> Component::RegisterCounter(const string& name,
+                                                      const uint64_t val,
+                                                      const std::unordered_map<std::string, std::string>& tag_map) {
+  names_.counter_names_.emplace_back(name);
+  tags_.counter_tags_.emplace_back(tag_map);
+  values_.counters_.emplace_back(Counter(val));
+  return Component::Handle<Counter>(values_.counters_, values_.counters_.size() - 1, metricsEnabled_);
+}
+
 Component::Handle<AtomicCounter> Component::RegisterAtomicCounter(const std::string& name, const uint64_t val) {
   names_.atomic_counter_names_.emplace_back(name);
   values_.atomic_counters_.emplace_back(AtomicCounter(val));
@@ -99,7 +108,11 @@ std::list<Metric> Component::CollectCounters() {
   if (!metricsEnabled_) return list<Metric>();
   std::list<Metric> ret;
   for (size_t i = 0; i < names_.counter_names_.size(); i++) {
-    ret.emplace_back(Metric{name_, names_.counter_names_[i], values_.counters_[i]});
+    if (tags_.counter_tags_.size() > i) {
+      ret.emplace_back(Metric{name_, names_.counter_names_[i], values_.counters_[i], tags_.counter_tags_[i]});
+    } else {
+      ret.emplace_back(Metric{name_, names_.counter_names_[i], values_.counters_[i]});
+    }
   }
   for (std::size_t i = 0; i < names_.atomic_counter_names_.size(); i++) {
     ret.emplace_back(Metric{name_, names_.atomic_counter_names_[i], Counter(values_.atomic_counters_[i].Get())});


### PR DESCRIPTION
This PR makes the following changes -
1. Metrics: Update counter metrics to allow for tags
2. TRS: Add num_skipped_event_groups metric and refactor
Please see individual commits for more detail.