### PR TITLE
Enable test_remove_nodes Testcase and run multiple times

### DIFF
--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1328,7 +1328,6 @@ class SkvbcReconfigurationTest(ApolloTest):
         crashed_replicas = set(range(replica_count - 2, replica_count))
         await self.send_restart_with_params(bft_network, bft=True, restart=True, faulty_replica_ids=crashed_replicas)
 
-    @unittest.skip("Unstable test - BC-19690")
     @with_trio
     @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True, publish_master_keys=True)
     async def test_remove_nodes(self, bft_network):


### PR DESCRIPTION
* **Problem Overview**  
  test_remove_nodes tescase of skvbc_reconfiguration was failing intermittently. So Enabled the testcase in this PR.
* **Testing Done**  
  After adding the logs, ran the tc multiple times, it never failed. So raised PR and will run this multiple times before merging.
