### PR TITLE
CMF C++: Allow string as serialization buffer

### DIFF
--- a/messages/compiler/cpp/cppgen.py
+++ b/messages/compiler/cpp/cppgen.py
@@ -18,7 +18,7 @@ from walker import Walker
 def copyright():
     return """// Concord
 //
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
 //
 // This product is licensed to you under the Apache 2.0 license (the "License").
 // You may not use this product except in compliance with the Apache 2.0 License.

--- a/messages/compiler/cpp/test_cppgen.py
+++ b/messages/compiler/cpp/test_cppgen.py
@@ -217,15 +217,20 @@ def testSerializationStr(msg_name):
     s = "void {}() {{\n".format(test_name(msg_name))
     for i in range(0, MAX_SIZE):
         instance = instance_name(msg_name, i)
-        s += """
+        s += f"""
   {{
+    {msg_name} {instance}_computed;
     std::vector<uint8_t> output;
-    serialize(output, {});
-    {} {}_computed;
-    deserialize(output, {}_computed);
-    assert({} == {}_computed);
+    serialize(output, {instance});
+    deserialize(output, {instance}_computed);
+    assert({instance} == {instance}_computed);
+    {msg_name} {instance}_str_computed;
+    std::string output_str;
+    serialize(output_str, {instance});
+    deserialize(output_str, {instance}_str_computed);
+    assert({instance} == {instance}_str_computed);
   }}
-""".format(instance, msg_name, instance, instance, instance, instance)
+"""
     s += "}\n"
     return s
 


### PR DESCRIPTION
This change adds the ability to serialize to and deserialize from `std::string`.
The user should always prefer `std::vector<uint8_t>` over a string because it
more accurately describes serialization and when would we ever need the
terminating NULL-byte?
However, `std::string` can be used to stay compatible with libraries that use
this type for byte buffers. Currently, C++ doesn't allow us to convert between
those types without copying. Therefore, with this change we can use CMF with
those libraries without performance overhead. However, it is considered a
*workaround* because byte buffers should not be strings in the first place.

---

This change introduces new tests (which will be auto generated) to make sure serialization and deserialization still works. In addition, this change has been tested manually with closed source code that takes advantage of CMF.
