### PR TITLE
Percolation Of The Metric Aggregator To BFT Client

### DIFF
--- a/client/bftclient/include/bftclient/bft_client.h
+++ b/client/bftclient/include/bftclient/bft_client.h
@@ -35,7 +35,9 @@ typedef std::shared_ptr<bft::communication::ICommunication> SharedCommPtr;
 
 class Client {
  public:
-  Client(SharedCommPtr comm, const ClientConfig& config);
+  Client(SharedCommPtr comm,
+         const ClientConfig& config,
+         std::shared_ptr<concordMetrics::Aggregator> aggregator = nullptr);
 
   void setAggregator(const std::shared_ptr<concordMetrics::Aggregator>& aggregator) {
     metrics_.setAggregator(aggregator);

--- a/client/bftclient/src/bft_client.cpp
+++ b/client/bftclient/src/bft_client.cpp
@@ -24,7 +24,7 @@ using namespace bftEngine::impl;
 
 namespace bft::client {
 
-Client::Client(SharedCommPtr comm, const ClientConfig& config)
+Client::Client(SharedCommPtr comm, const ClientConfig& config, std::shared_ptr<concordMetrics::Aggregator> aggregator)
     : communication_(std::move(comm)),
       config_(config),
       quorum_converter_(config_.all_replicas, config.ro_replicas, config.f_val, config_.c_val),
@@ -38,6 +38,7 @@ Client::Client(SharedCommPtr comm, const ClientConfig& config)
                                config_.retry_timeout_config.max_decreasing_factor),
       metrics_(config.id),
       histograms_(std::unique_ptr<Recorders>(new Recorders(config.id))) {
+  setAggregator(aggregator);
   // secrets_manager_config can be set only if transaction_signing_private_key_file_path is set
   if (config.secrets_manager_config) ConcordAssert(config.transaction_signing_private_key_file_path != std::nullopt);
   if (config.transaction_signing_private_key_file_path) {

--- a/client/client_pool/include/client/client_pool/concord_client_pool.hpp
+++ b/client/client_pool/include/client/client_pool/concord_client_pool.hpp
@@ -160,7 +160,7 @@ class ConcordClientPool {
  private:
   void setUpClientParams(bftEngine::SimpleClientParams& client_params,
                          const concord::config_pool::ConcordClientPoolConfig&);
-  void CreatePool(concord::config_pool::ConcordClientPoolConfig&);
+  void CreatePool(concord::config_pool::ConcordClientPoolConfig&, std::shared_ptr<concordMetrics::Aggregator>);
 
   void AddSenderAndSignature(std::vector<uint8_t>& request, const ClientPtr& chosenClient);
 

--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -43,7 +43,7 @@ class ConcordClient {
   // object and a client_id to get the specific values for this client.
   // Construction executes all needed steps to provide a ready-to-use
   // object (including starting internal threads, if needed).
-  ConcordClient(int client_id);
+  ConcordClient(int client_id, std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
   // Destructs the client. This includes stopping any internal threads, if needed.
   ~ConcordClient() noexcept;
@@ -105,7 +105,7 @@ class ConcordClient {
   std::string messageSignature(bft::client::Msg&);
 
  private:
-  void CreateClient();
+  void CreateClient(std::shared_ptr<concordMetrics::Aggregator> aggregator);
 
   bft::communication::BaseCommConfig* CreateCommConfig() const;
 

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -275,7 +275,7 @@ ConcordClientPool::ConcordClientPool(config_pool::ConcordClientPoolConfig &confi
   concord::external_client::ConcordClient::setDelayFlagForTest(delay_behavior);
   try {
     metricsComponent_.SetAggregator(aggregator);
-    CreatePool(config);
+    CreatePool(config, aggregator);
   } catch (std::invalid_argument &e) {
     LOG_ERROR(logger_, "Communication protocol=" << config.comm_to_use << " is not supported");
     throw InternalErrorException();
@@ -304,7 +304,7 @@ ConcordClientPool::ConcordClientPool(config_pool::ConcordClientPoolConfig &confi
       logger_(logging::getLogger("com.vmware.external_client_pool")) {
   try {
     metricsComponent_.SetAggregator(aggregator);
-    CreatePool(config);
+    CreatePool(config, aggregator);
   } catch (std::invalid_argument &e) {
     LOG_ERROR(logger_, "Communication protocol=" << config.comm_to_use << " is not supported");
     throw InternalErrorException();
@@ -343,7 +343,8 @@ void ConcordClientPool::setUpClientParams(SimpleClientParams &client_params,
                                                       client_params.clientPeriodicResetThresh));
 }
 
-void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig &config) {
+void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig &config,
+                                   std::shared_ptr<concordMetrics::Aggregator> aggregator) {
   auto num_clients = config.clients_per_participant_node - (int)config.with_cre;
   auto f_val = config.f_val;
   auto c_val = config.c_val;
@@ -404,7 +405,7 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
   external_client::ConcordClient::setStatics(
       required_num_of_replicas, num_replicas, max_buf_size, batch_size_, config, clientParams, tlsMultiplexConfig);
   for (int i = 0; i < num_clients; i++) {
-    clients_.push_back(std::make_shared<external_client::ConcordClient>(i));
+    clients_.push_back(std::make_shared<external_client::ConcordClient>(i, aggregator));
     ClientPoolMetrics_.clients_gauge++;
   }
   jobs_thread_pool_.start(num_clients);


### PR DESCRIPTION
* **Problem Overview**  
The metrics in BFT Client were not shown in the clientservice metrics.
I transferred the metric aggregator to the BFT Client in order to expose those metrics.
* **Testing Done**  
  1. created a clientservice container with my changes
  2. run docker-compose
  3. viewed the container metrics in the browser
  4. run clientservice tests to view changes in those metrics
