### PR TITLE
Fix warning from address sanitizer.

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1481,8 +1481,12 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
     if (!psd_->hasCheckpointDesc(i)) continue;
 
     DataStore::CheckpointDesc cpDesc = psd_->getCheckpointDesc(i);
-    std::unique_ptr<CheckpointSummaryMsg> msg =
-        std::unique_ptr<CheckpointSummaryMsg>(CheckpointSummaryMsg::create(cpDesc.rvbData.size()));
+    auto deleter = [](CheckpointSummaryMsg *msg) {
+      char *bytes = reinterpret_cast<char *>(msg);
+      delete[] bytes;
+    };
+    auto msg = std::unique_ptr<CheckpointSummaryMsg, decltype(deleter)>(
+        CheckpointSummaryMsg::create(cpDesc.rvbData.size()), deleter);
 
     msg->checkpointNum = i;
     msg->maxBlockId = cpDesc.maxBlockId;


### PR DESCRIPTION
We have a report from address sanitizer that we get to a situation
of a new/delete mismatch. In the problematic situation we allocate
an array of chars to store a CheckpointSummaryMsg and later deallocate
it as a pointer to CheckpointSummaryMsg, which is undefined behavior.

* **Problem Overview**  
  During development of restart recovery test for View Change with F crashed replicas with ASAN build we got a report for new/delete mismatch as follows:
`=================================================================
==90790==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x608000064320
    #0 0x13bc7cd in operator delete(void*) (/concord-bft/build/tests/simpleKVBC/TesterReplica/skvbc_replica+0x13bc7cd)
    #1 0x1d79fea in std::default_delete<bftEngine::bcst::impl::CheckpointSummaryMsg>::operator()(bftEngine::bcst::impl::CheckpointSummaryMsg*) const /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/unique_ptr.h:78:2
    #2 0x1ceffee in std::unique_ptr<bftEngine::bcst::impl::CheckpointSummaryMsg, std::default_delete<bftEngine::bcst::impl::CheckpointSummaryMsg> >::~unique_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/unique_ptr.h:263:4
    #3 0x1c7a380 in bftEngine::bcst::impl::BCStateTran::onMessage(bftEngine::bcst::impl::AskForCheckpointSummariesMsg const*, unsigned int, unsigned short) /concord-bft/bftengine/src/bcstatetransfer/BCStateTran.cpp:1507:3
...
`
* **Testing Done**  
  The Apollo test that initiated the log form ASAN was ran after the fix to verify the error is corrected and no further undefined behavior is reported.
