### PR TITLE
Add changes to enable func name in logs using log4cplus macros

### DIFF
--- a/logging/include/Logging4cplus.hpp
+++ b/logging/include/Logging4cplus.hpp
@@ -19,6 +19,9 @@
 
 #ifdef USE_LOG4CPP
 
+#undef LOG4CPLUS_MACRO_FUNCTION
+#define LOG4CPLUS_MACRO_FUNCTION() __FUNCTION__
+
 namespace logging {
 
 typedef log4cplus::Logger Logger;

--- a/logging/include/Logging4cplus.hpp
+++ b/logging/include/Logging4cplus.hpp
@@ -26,14 +26,13 @@ typedef log4cplus::Logger Logger;
 std::string get(const std::string& key);
 
 }  // namespace logging
-#define LOG_FUNC(s) __func__ << "|" << s
 
-#define LOG_TRACE(l, s) LOG4CPLUS_TRACE(l, LOG_FUNC(s))
-#define LOG_DEBUG(l, s) LOG4CPLUS_DEBUG(l, LOG_FUNC(s))
-#define LOG_INFO(l, s) LOG4CPLUS_INFO(l, LOG_FUNC(s))
-#define LOG_WARN(l, s) LOG4CPLUS_WARN(l, LOG_FUNC(s))
-#define LOG_ERROR(l, s) LOG4CPLUS_ERROR(l, LOG_FUNC(s))
-#define LOG_FATAL(l, s) LOG4CPLUS_FATAL(l, LOG_FUNC(s))
+#define LOG_TRACE(l, s) LOG4CPLUS_TRACE(l, s)
+#define LOG_DEBUG(l, s) LOG4CPLUS_DEBUG(l, s)
+#define LOG_INFO(l, s) LOG4CPLUS_INFO(l, s)
+#define LOG_WARN(l, s) LOG4CPLUS_WARN(l, s)
+#define LOG_ERROR(l, s) LOG4CPLUS_ERROR(l, s)
+#define LOG_FATAL(l, s) LOG4CPLUS_FATAL(l, s)
 
 #define MDC_PUT(k, v) log4cplus::getMDC().put(k, v)
 #define MDC_REMOVE(k) log4cplus::getMDC().remove(k)


### PR DESCRIPTION
* **Problem Overview**  
  Revert changes related adding function name to logs as this disables ability to configure the same from properties file
Add changes to use LOG4CPLUS_MACRO_FUNCTION  to explicitly define __FUNCTION__ to avoid pretty function
* **Testing Done**  
Verified logs in apollo tests, sample as below:

022-05-06T04:31:41,067,+0000|INFO |6|concord-bft.tls.connMgr|**main**|||||TlsConnectionManager.cpp:90|listen|TLS server listening at 0.0.0.0:3722 for replica 6
2022-05-06T04:31:41,068,+0000|INFO ||concord-bft.tls.connMgr||||||TlsConnectionManager.cpp:307|**operator()**|Resolved node 0: 127.0.0.1:3710 to 127.0.0.1:3710
2022-05-06T04:31:41,068,+0000|INFO |6|concord.bft|main|||||MsgsCommunicator.cpp:31|**startCommunication**|Communication for replica 6 started
113: static uint32_t bftEngine::ResPagesClient<bftEngine::impl::TimeServiceResPageClient, 1>::calc_my_offset() [T = bftEngine::impl::TimeServiceResPageClient, NumPages = 1] offset: 145
2022-05-06T04:31:41,068,+0000|INFO |6|concord.bft|**main**|||||ReplicaImp.cpp:4581|start|Time Service enabled
113: static uint32_t bftEngine::ResPagesClient<bftEngine::impl::ClientsManager, 0>::calc_my_offset() [T = bftEngine::impl::ClientsManager, NumPages = 0] offset: 3
2022-05-06T04:31:41,068,+0000|INFO |6|concord.bft.client-manager|main|||||ClientsManager.cpp:277|**loadInfoFromReservedPages**|Added/updated reply message clientId: 7, replyHeader->reqSeqNum: 6928199557842993152, res: True


