### PR TITLE
Unify_certs: Changes to enable the certs flag

### DIFF
--- a/client/client_pool/include/client/client_pool/client_pool_config.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_config.hpp
@@ -62,6 +62,7 @@ typedef struct ConcordClientPoolConfig {
   std::string file_name;
   bool client_batching_enabled = false;
   bool enable_multiplex_channel = false;
+  bool use_unified_certificates = false;
   size_t client_batching_max_messages_nbr = 20;
   std::uint64_t client_batching_flush_timeout_ms = 100;
   bool encrypted_config_enabled = false;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -365,6 +365,7 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
                                     config.clients_per_participant_node,
                                     config.client_batching_enabled,
                                     config.enable_multiplex_channel,
+                                    config.use_unified_certificates,
                                     config.client_batching_max_messages_nbr,
                                     config.encrypted_config_enabled,
                                     config.transaction_signing_enabled,
@@ -400,6 +401,7 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
                                                 config.participant_nodes[0].principal_id,
                                                 config.tls_certificates_folder_path,
                                                 config.tls_cipher_suite_list,
+                                                config.use_unified_certificates,
                                                 endpointIdToNodeIdMap,
                                                 nullptr,
                                                 secretData);

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -259,6 +259,7 @@ BaseCommConfig* ConcordClient::CreateCommConfig() const {
                           selfId,
                           pool_config_.tls_certificates_folder_path,
                           pool_config_.tls_cipher_suite_list,
+                          pool_config_.use_unified_certificates,
                           nullptr,
                           secretData};
 }

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -247,7 +247,6 @@ void configureTransport(concord::client::concordclient::ConcordClientConfig& con
       // concatentation of the certificates of all known servers
       readCert(server_cert_path, config.transport.event_pem_certs);
     }
-    LOG_INFO(logger, "Certificate chain: " << config.transport.event_pem_certs);
   }
 }
 

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -101,6 +101,7 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
                                        ? "Invalid"
                                        : config.transport.comm_type == TransportConfig::TlsTcp ? "tls" : "udp";
   client_pool_config.enable_multiplex_channel = config.transport.enable_multiplex_channel;
+  client_pool_config.use_unified_certificates = config.transport.use_unified_certs;
   client_pool_config.concord_bft_communication_buffer_length = std::to_string(config.transport.buffer_length);
   client_pool_config.tls_certificates_folder_path = config.transport.tls_cert_root_path;
   client_pool_config.tls_cipher_suite_list = config.transport.tls_cipher_suite;

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -135,11 +135,13 @@ class TlsTcpConfig : public PlainTcpConfig {
                NodeNum selfId,
                const std::string &certRootPath,
                const std::string &cipherSuite,
+               bool useUnifiedCerts,
                UPDATE_CONNECTIVITY_FN statusCallback = nullptr,
                std::optional<concord::secretsmanager::SecretData> decryptionSecretData = std::nullopt)
       : PlainTcpConfig(host, port, bufLength, nodes, maxServerId, selfId, std::move(statusCallback)),
         certificatesRootPath_{certRootPath},
         cipherSuite_{cipherSuite},
+        useUnifiedCertificates_{useUnifiedCerts},
         secretData_{std::move(decryptionSecretData)} {
     commType_ = CommType::TlsTcp;
   }
@@ -147,6 +149,7 @@ class TlsTcpConfig : public PlainTcpConfig {
  public:
   std::string certificatesRootPath_;
   std::string cipherSuite_;
+  bool useUnifiedCertificates_;
   std::optional<concord::secretsmanager::SecretData> secretData_;
 };
 
@@ -160,6 +163,7 @@ class TlsMultiplexConfig : public TlsTcpConfig {
                      NodeNum selfId,
                      const std::string &certRootPath,
                      const std::string &cipherSuite,
+                     bool useUnifiedCerts,
                      std::unordered_map<NodeNum, NodeNum> &endpointIdToNodeIdMap,
                      UPDATE_CONNECTIVITY_FN statusCallback = nullptr,
                      std::optional<concord::secretsmanager::SecretData> secretData = std::nullopt)
@@ -171,6 +175,7 @@ class TlsMultiplexConfig : public TlsTcpConfig {
                      selfId,
                      certRootPath,
                      cipherSuite,
+                     useUnifiedCerts,
                      std::move(statusCallback),
                      secretData),
         endpointIdToNodeIdMap_(endpointIdToNodeIdMap) {

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -30,8 +30,6 @@
 
 namespace bft::communication::tls {
 
-bool AsyncTlsConnection::useUnifiedCertificates_ = false;
-
 void AsyncTlsConnection::startReading() {
   auto self = shared_from_this();
   asio::post(strand_, [this, self] { readMsgSizeHeader(); });
@@ -289,7 +287,7 @@ void AsyncTlsConnection::initClientSSLContext(NodeNum destination) {
   fs::path cert_path;
   try {
     path = fs::path(config_.certificatesRootPath_) / fs::path(std::to_string(config_.selfId_));
-    if (!useUnifiedCertificates_) path = path / fs::path("client");
+    if (!config_.useUnifiedCertificates_) path = path / fs::path("client");
   } catch (std::exception& e) {
     LOG_FATAL(logger_, "Failed to construct filesystem path: " << e.what());
     ConcordAssert(false);
@@ -308,8 +306,9 @@ void AsyncTlsConnection::initClientSSLContext(NodeNum destination) {
   }
 
   try {
-    cert_path =
-        (useUnifiedCertificates_) ? path / fs::path("node.cert").string() : path / fs::path("client.cert").string();
+    cert_path = (config_.useUnifiedCertificates_) ? path / fs::path("node.cert").string()
+                                                  : path / fs::path("client.cert").string();
+    LOG_INFO(logger_, "Certificates Path: " << cert_path);
     ssl_context_.use_certificate_chain_file(cert_path);
     const std::string pk = decryptPrivateKey(path);
     ssl_context_.use_private_key(asio::const_buffer(pk.c_str(), pk.size()), asio::ssl::context::pem);
@@ -352,15 +351,16 @@ void AsyncTlsConnection::initServerSSLContext() {
   fs::path cert_path;
   try {
     path = fs::path(config_.certificatesRootPath_) / fs::path(std::to_string(config_.selfId_));
-    if (!useUnifiedCertificates_) path = path / fs::path("server");
+    if (!config_.useUnifiedCertificates_) path = path / fs::path("server");
   } catch (std::exception& e) {
     LOG_FATAL(logger_, "Failed to construct filesystem path: " << e.what());
     ConcordAssert(false);
   }
 
   try {
-    cert_path =
-        (useUnifiedCertificates_) ? path / fs::path("node.cert").string() : path / fs::path("server.cert").string();
+    cert_path = (config_.useUnifiedCertificates_) ? path / fs::path("node.cert").string()
+                                                  : path / fs::path("server.cert").string();
+    LOG_INFO(logger_, "Server Certificates Path: " << cert_path);
     ssl_context_.use_certificate_chain_file(cert_path);
     const std::string pk = decryptPrivateKey(path);
     ssl_context_.use_private_key(asio::const_buffer(pk.c_str(), pk.size()), asio::ssl::context::pem);
@@ -430,7 +430,7 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* received_cer
   std::string conn_type;
   // (1) First, try to verify the certificate against the latest saved certificate
   bool res = concord::util::crypto::CertificateUtils::verifyCertificate(
-      received_cert, config_.certificatesRootPath_, peerId, conn_type, useUnifiedCertificates_);
+      received_cert, config_.certificatesRootPath_, peerId, conn_type, config_.useUnifiedCertificates_);
   if (expected_peer_id.has_value() && peerId != expected_peer_id.value()) return std::make_pair(false, peerId);
   if (res) return std::make_pair(res, peerId);
   LOG_INFO(logger_,
@@ -454,7 +454,7 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* received_cer
     return std::make_pair(false, peerId);
   }
   std::string local_cert_path =
-      (useUnifiedCertificates_)
+      (config_.useUnifiedCertificates_)
           ? config_.certificatesRootPath_ + "/" + std::to_string(peerId) + "/" + "node.cert"
           : config_.certificatesRootPath_ + "/" + std::to_string(peerId) + "/" + conn_type + "/" + conn_type + ".cert";
   std::string certStr;

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -35,7 +35,6 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
  public:
   static constexpr std::chrono::seconds READ_TIMEOUT = std::chrono::seconds(10);
   static constexpr std::chrono::seconds WRITE_TIMEOUT = READ_TIMEOUT;
-  static bool useUnifiedCertificates_;
 
   // We require a factory function because we can't call shared_from_this() in the constructor.
   //
@@ -50,7 +49,6 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                                     TlsStatus& status,
                                                     Recorders& histograms) {
     auto conn = std::make_shared<AsyncTlsConnection>(io_context, receiver, conn_mgr, config, status, histograms);
-    useUnifiedCertificates_ = bftEngine::ReplicaConfig::instance().useUnifiedCertificates;
     conn->initServerSSLContext();
     conn->createSSLSocket(std::move(socket));
     return conn;
@@ -66,7 +64,6 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                                     Recorders& histograms) {
     auto conn =
         std::make_shared<AsyncTlsConnection>(io_context, receiver, conn_mgr, destination, config, status, histograms);
-    useUnifiedCertificates_ = bftEngine::ReplicaConfig::instance().useUnifiedCertificates;
     conn->initClientSSLContext(destination);
     conn->createSSLSocket(std::move(socket));
     return conn;

--- a/communication/tests/multiplex_comm_test.cpp
+++ b/communication/tests/multiplex_comm_test.cpp
@@ -66,7 +66,7 @@ void setUpCommunicationOnReplica(NodeNum selfId, shared_ptr<IReceiver> receiver)
     endpointIdToNodeIdMap[i] = clientServiceNum;
   }
   auto configuration = TlsMultiplexConfig(
-      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, endpointIdToNodeIdMap);
+      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, false, endpointIdToNodeIdMap);
   ASSERT_TRUE(configuration.amIReplica_);
   int clients = 0;
   int replicas = 0;
@@ -89,7 +89,7 @@ void setUpCommunicationOnClient(NodeNum selfId, shared_ptr<IReceiver> receiver) 
   delete communicatorPtr;
   auto [nodes, endpointIdToNodeIdMap] = createClientNodesConfig();
   auto configuration = TlsMultiplexConfig(
-      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, endpointIdToNodeIdMap);
+      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, false, endpointIdToNodeIdMap);
   for (auto const& node : configuration.nodes_) ASSERT_TRUE(node.second.isReplica);
   ASSERT_FALSE(configuration.amIReplica_);
   communicatorPtr = dynamic_cast<TlsMultiplexCommunication*>(CommFactory::create(configuration));

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -200,6 +200,7 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
                       id,
                       cert_root_path,
                       "TLS_AES_256_GCM_SHA384",
+                      false,
                       nullptr,
                       secretData);
   return retVal;

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -309,6 +309,7 @@ bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
     return false;
   }
   remote_peer_id = remotePeerId;
+  LOG_INFO(GL, "Peer: " << remote_peer_id);
   std::string CN;
   CN.resize(SIZE);
   X509_NAME_get_text_by_NID(X509_get_subject_name(cert_to_verify), NID_commonName, CN.data(), SIZE);


### PR DESCRIPTION
This PR handles:
1. Addition of log to debug new certificates path
2. To fix clientservice crash while initiating client connection when flags enable_multiplex_channel and use_unified_certificates is enabled.

Testing:
Thin_replica_server_tests are passing with the new changes.