### PR TITLE
Fix race between replica entering ST and reserved page APIs

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -656,10 +656,12 @@ bool BCStateTran::loadReservedPage(uint32_t reservedPageId, uint32_t copyLength,
 
 // TODO(TK) check if this function can have its own transaction(bftimpl)
 void BCStateTran::saveReservedPage(uint32_t reservedPageId, uint32_t copyLength, const char *inReservedPage) {
+  if (psd_->getIsFetchingState()) {
+    LOG_WARN(logger_, "Saving reserved page is not allowed during state transfer" << KVLOG(reservedPageId));
+    return;
+  }
   try {
     LOG_DEBUG(logger_, KVLOG(reservedPageId));
-
-    ConcordAssert(!psd_->getIsFetchingState());
     ConcordAssertLT(reservedPageId, numberOfReservedPages_);
     ConcordAssertLE(copyLength, config_.sizeOfReservedPage);
 
@@ -674,9 +676,12 @@ void BCStateTran::saveReservedPage(uint32_t reservedPageId, uint32_t copyLength,
 
 // TODO(TK) check if this function can have its own transaction(bftimpl)
 void BCStateTran::zeroReservedPage(uint32_t reservedPageId) {
-  LOG_DEBUG(logger_, reservedPageId);
+  if (psd_->getIsFetchingState()) {
+    LOG_WARN(logger_, "Zeroing reserved page is not allowed during state transfer" << KVLOG(reservedPageId));
+    return;
+  }
 
-  ConcordAssert(!psd_->getIsFetchingState());
+  LOG_DEBUG(logger_, KVLOG(reservedPageId));
   ConcordAssertLT(reservedPageId, numberOfReservedPages_);
 
   metrics_.zero_reserved_page_++;


### PR DESCRIPTION
Fix race between replica entering ST and reserved page APIs

Race between replica entering state transfer and replica trying to save reserve page while sending client reply resulted in crash.

We had done runs on our maestro deployment along with apollo runs.