### PR TITLE
Bayarcher/client service trace tags

### DIFF
--- a/client/clientservice/src/main.cpp
+++ b/client/clientservice/src/main.cpp
@@ -88,7 +88,7 @@ class JaegerLogger : public jaegertracing::logging::Logger {
   void info(const std::string& message) override { LOG_INFO(logger, message); }
 };
 
-void initJaeger(const std::string& addr, const std::string& id) {
+void initJaeger(const std::string& addr) {
   // No sampling for now - report all traces
   jaegertracing::samplers::Config sampler_config(jaegertracing::kSamplerTypeConst, 1.0);
   jaegertracing::reporters::Config reporter_config(jaegertracing::reporters::Config::kDefaultQueueSize,
@@ -100,7 +100,7 @@ void initJaeger(const std::string& addr, const std::string& id) {
                                                            jaegertracing::kTraceContextHeaderName,
                                                            jaegertracing::kTraceBaggageHeaderPrefix);
   jaegertracing::baggage::RestrictionsConfig baggage_restrictions(false, "", std::chrono::steady_clock::duration());
-  std::string trace_proc_name = "clientservice-" + id;
+  std::string trace_proc_name = "clientservice";
   jaegertracing::Config config(false,
                                false,
                                sampler_config,
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
   // Tracing
   if (opts.count("jaeger")) {
     auto jaeger_addr = opts["jaeger"].as<std::string>();
-    initJaeger(jaeger_addr, opts["tr-id"].as<std::string>());
+    initJaeger(jaeger_addr);
     LOG_INFO(logger, "Sending trace data to Jaeger Agent at " << jaeger_addr);
   } else {
     LOG_INFO(logger, "No Jaeger Agent address provided");

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -24,6 +24,8 @@ namespace concord::client::clientservice {
 
 namespace requestservice {
 
+const std::string kClientInstanceId = "client_instance_id";
+
 void RequestServiceCallData::proceed() {
   if (state_ == FINISH) {
     delete this;
@@ -182,6 +184,9 @@ void RequestServiceCallData::sendToConcordClient() {
     bft::client::ReadConfig config;
     config.request = req_config;
     auto span = opentracing::Tracer::Global()->StartSpan("send_ro", {opentracing::ChildOf(parent_span.get())});
+    if (span) {
+      span->SetTag(kClientInstanceId, client_->getSubscriptionId());
+    }
     std::ostringstream carrier;
     opentracing::Tracer::Global()->Inject(span->context(), carrier);
     config.request.span_context = carrier.str();
@@ -190,6 +195,9 @@ void RequestServiceCallData::sendToConcordClient() {
     bft::client::WriteConfig config;
     config.request = req_config;
     auto span = opentracing::Tracer::Global()->StartSpan("send", {opentracing::ChildOf(parent_span.get())});
+    if (span) {
+      span->SetTag(kClientInstanceId, client_->getSubscriptionId());
+    }
     std::ostringstream carrier;
     opentracing::Tracer::Global()->Inject(span->context(), carrier);
     config.request.span_context = carrier.str();


### PR DESCRIPTION
Remove ClientService instance ID from application name in OpenTracing traces and add the Instance ID as Tags
