### PR TITLE
Enabling db-checkpoint feature by default

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -222,9 +222,9 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                false,
                "If true, replicas will publish their master key on startup");
   // Db checkpoint
-  CONFIG_PARAM(dbCheckpointFeatureEnabled, bool, false, "Feature flag for rocksDb checkpoints");
-  CONFIG_PARAM(maxNumberOfDbCheckpoints, uint32_t, 0u, "Max number of db checkpoints to be created");
-  CONFIG_PARAM(dbCheckPointWindowSize, uint32_t, 300u, "Db checkpoint window size in bft sequence number");
+  CONFIG_PARAM(dbCheckpointFeatureEnabled, bool, true, "Feature flag for rocksDb checkpoints");
+  CONFIG_PARAM(maxNumberOfDbCheckpoints, uint32_t, 2u, "Max number of db checkpoints to be created");
+  CONFIG_PARAM(dbCheckPointWindowSize, uint32_t, 30000u, "Db checkpoint window size in bft sequence number");
   CONFIG_PARAM(dbCheckpointDirPath, std::string, "", "Db checkpoint directory path");
   CONFIG_PARAM(dbSnapshotIntervalSeconds,
                std::chrono::seconds,


### PR DESCRIPTION

* **Problem Overview**  
  Setting db-checkpoint feature to be default enabled. Updating config
for creating maximum number of d-cbeckpoint to 2 and db-checkpoint
window size to 30000
* **Testing Done**  
  Tested in db-checkpoint apollo test suite
