### PR TITLE
Apollo test. View change when primary is behind

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -501,7 +501,7 @@ class BftTestNetwork:
 
     def _generate_operator_keys(self):
         if self.builddir is None:
-            return 
+            return
         with open(self.builddir + "/operator_pub.pem", 'w') as f:
             f.write("-----BEGIN PUBLIC KEY-----\n"
                     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENEMHcbJgnnYxfa1zDlIF7lzp/Ioa"
@@ -607,7 +607,7 @@ class BftTestNetwork:
             self.txn_signing_keys_base_path = tempfile.mkdtemp()
             self.principals_mapping, self.principals_to_participant_map = self.create_principals_mapping()
             self.generate_txn_signing_keys(self.txn_signing_keys_base_path)
-            
+
     def generate_txn_signing_keys(self, keys_path):
         """ Generates num_participants number of key pairs """
         script_path = "/concord-bft/scripts/linux/create_concord_clients_transaction_signing_keys.sh"
@@ -616,9 +616,9 @@ class BftTestNetwork:
 
     def create_principals_mapping(self):
         """
-        If client principal ids range from 11-20, for example, this method splits them into groups based on 
+        If client principal ids range from 11-20, for example, this method splits them into groups based on
         NUM_PARTICIPANTS and self.num_participants.
-        Client ids in each group will be space separated, and each group will be semicolon separated. 
+        Client ids in each group will be space separated, and each group will be semicolon separated.
         E.g. "11 12;13 14;15 16;17 18;19 20" for 10 client ids divided into 5 participants.
         If there are reserved clients, they are added at the end of the group in round robin manner.
         Thus, if there are 2 reserved client, with ids 21 and 22, the final string would look like:
@@ -1094,7 +1094,7 @@ class BftTestNetwork:
 
                 if view is not None and expected(view):
                     return view
-                
+
             last_agreed_view = await self.wait_for(the_last_agreed_view, 45, 1)
             action.add_success_fields(last_agreed_view=last_agreed_view)
             return last_agreed_view
@@ -1176,7 +1176,7 @@ class BftTestNetwork:
                 if is_fetching:
                     action.add_success_fields(source_replica_id=source_replica_id)
                     return source_replica_id
-                
+
             return await self.wait_for(replica_to_be_in_fetching_state, 10, .5)
 
     async def is_fetching(self, replica_id):
@@ -1288,7 +1288,7 @@ class BftTestNetwork:
                     last_n = -1
                     while True:
                         with trio.move_on_after(.5): # seconds
-                            metrics = await self.metrics.get_all(stale_node)                           
+                            metrics = await self.metrics.get_all(stale_node)
                             try:
                                 n = self.metrics.get_local(metrics, *key)
                                 # If seq_num is not moving send the new message to advance it
@@ -1329,13 +1329,13 @@ class BftTestNetwork:
         """
         with log.start_action(action_type="wait_for_replicas_rvt_root_values", replica_ids=replica_ids, timeout=timeout):
             root_values = [None] * len(replica_ids)
-            
+
             with trio.fail_after(timeout): # seconds
                 while True:
                     async with trio.open_nursery() as nursery:
                         for replica_id in replica_ids:
                             nursery.start_soon(self.wait_for_rvt_root_value, replica_id, root_values, timeout)
-                    
+
                     print(root_values)
                     # At this point all replicas' root values are collected
                     if root_values.count(root_values[0]) == len(root_values) and len(root_values[0]) > 0:
@@ -1348,16 +1348,16 @@ class BftTestNetwork:
         Wait for a single replica to return the current value of the root of its Range validation tree.
         Check every .5 seconds and fail after `timeout` seconds.
         """
-        with log.start_action(action_type="wait_for_rvt_root_value", replica=replica_id, timeout=timeout) as action:            
+        with log.start_action(action_type="wait_for_rvt_root_value", replica=replica_id, timeout=timeout) as action:
             async def rvt_root_value_to_be_returned():
                 key = ['bc_state_transfer', 'Statuses', 'current_rvb_data_state']
                 rvb_data_state = await self.retrieve_metric(replica_id, *key)
                 if (rvb_data_state is not None):
-                    action.log(f"Replica {replica_id}'s current rvb_data_state is: \"{rvb_data_state}\".")                   
+                    action.log(f"Replica {replica_id}'s current rvb_data_state is: \"{rvb_data_state}\".")
                     root_values[replica_id] = rvb_data_state
                     return rvb_data_state
-        
-        return await self.wait_for(rvt_root_value_to_be_returned, timeout, .5)        
+
+        return await self.wait_for(rvt_root_value_to_be_returned, timeout, .5)
 
     async def wait_for_replicas_to_checkpoint(self, replica_ids, expected_checkpoint_num=None):
         """
@@ -1384,11 +1384,11 @@ class BftTestNetwork:
 
                 last_stored_checkpoint = await self.retrieve_metric(replica_id, *key)
                 action.log(message_type=f'[checkpoint] #{last_stored_checkpoint}, replica=#{replica_id}')
-    
+
                 if last_stored_checkpoint is not None and expected_checkpoint_num(last_stored_checkpoint):
                     action.add_success_fields(last_stored_checkpoint=last_stored_checkpoint)
                     return last_stored_checkpoint
-                
+
         return await self.wait_for(expected_checkpoint_to_be_reached, 30, .5)
 
     async def wait_for_fast_path_to_be_prevalent(self, run_ops, threshold, replica_id=0):
@@ -1486,7 +1486,7 @@ class BftTestNetwork:
 
                 if last_executed_seq_num is not None and last_executed_seq_num >= expected:
                     return last_executed_seq_num
-            
+
             return await self.wait_for(expected_seq_num_to_be_reached, 30, .5)
 
     async def assert_state_transfer_not_started_all_up_nodes(self, up_replica_ids):
@@ -1735,8 +1735,8 @@ class BftTestNetwork:
         """
         with log.start_action(action_type="wait_for_replica_asks_to_leave_view_msg", replica=replica_id,
                               previous_asks_to_leave_view_msg_count=previous_asks_to_leave_view_msg_count) as action:
-        
-            async def the_replica_to_ask_for_view_change(): 
+
+            async def the_replica_to_ask_for_view_change():
                 key = ['replica', 'Gauges', 'sentReplicaAsksToLeaveViewMsg']
                 replica_asks_to_leave_view_msg_count = await self.retrieve_metric(replica_id, *key)
 
@@ -1756,7 +1756,17 @@ class BftTestNetwork:
                 async with trio.open_nursery() as nursery:
                     for replica_id in replicas_ids:
                         nursery.start_soon(self.wait_for_replica_to_reach_view, replica_id, expected_view)
-            
+
+    async def wait_for_replicas_to_reach_at_least_view(self, replicas_ids, expected_view, timeout=30):
+        """
+        Wait for all replicas to reach the expected view.
+        """
+        with log.start_action(action_type="wait_for_replicas_to_reach_view", replicas_ids=replicas_ids, expected_view=expected_view) as action:
+            with trio.fail_after(seconds=timeout):
+                async with trio.open_nursery() as nursery:
+                    for replica_id in replicas_ids:
+                        nursery.start_soon(self.wait_for_replica_to_reach_at_least_view, replica_id, expected_view)
+
     async def wait_for_replica_to_reach_view(self, replica_id, expected_view):
         """
         Wait for a single replica to reach the expected view.
@@ -1771,6 +1781,20 @@ class BftTestNetwork:
                     return replica_view
 
         return await self.wait_for(expected_view_to_be_reached, 30, .5)
+
+    async def wait_for_replica_to_reach_at_least_view(self, replica_id, expected_view):
+        """
+        Wait for a single replica to reach the expected view.
+        """
+        with log.start_action(action_type="wait_for_replica_to_reach_at_least_view", replica=replica_id,
+                              expected_view=expected_view) as action:
+            async def expected_view_to_be_reached():
+                key = ['replica', 'Gauges', 'view']
+                replica_view = await self.retrieve_metric(replica_id, *key)
+
+                if replica_view is not None and replica_view >= expected_view:
+                    return replica_view
+
 
     @staticmethod
     @lru_cache(maxsize=None)

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -55,7 +55,7 @@ class SimpleKVBCProtocol:
         as bft_network, and optionally an SkvbcTracker to use as tracker and a
         Boolean value specifying whether to enable pre execution on all requests
         as pre_exec_all.
-        
+
         Note pre_exec_all defaults to False if no tracker is given and to the
         tracker's value for pre_exec_all if a tracker is given, so passing an
         explicit value for pre_exec_all is unnecessary if a tracker is in use.
@@ -283,7 +283,7 @@ class SimpleKVBCProtocol:
                 val = self.random_value()
                 reply = await self.send_write_kv_set(client, [(key, val)])
                 assert reply.success
-            
+
             await self.bft_network.wait_for_replicas_to_collect_stable_checkpoint(
                 initial_nodes, checkpoint_before + num_of_checkpoints_to_add)
 
@@ -292,7 +292,7 @@ class SimpleKVBCProtocol:
                 expected_checkpoint_num=lambda ecn: ecn == checkpoint_before + num_of_checkpoints_to_add,
                 verify_checkpoint_persistency=verify_checkpoint_persistency,
                 assert_state_transfer_not_started=assert_state_transfer_not_started)
-    
+
     async def network_wait_for_checkpoint(
             self, initial_nodes,
             expected_checkpoint_num=lambda ecn: ecn == 2,
@@ -306,7 +306,7 @@ class SimpleKVBCProtocol:
             # Wait for initial replicas to take checkpoints (exhausting
             # the full window)
             await self.bft_network.wait_for_replicas_to_checkpoint(initial_nodes, expected_checkpoint_num)
-            
+
             if expected_checkpoint_num is None:
                 expected_checkpoint_num = await self.bft_network.wait_for_checkpoint(
                 replica_id=random.choice(initial_nodes))
@@ -542,28 +542,28 @@ class SimpleKVBCProtocol:
                                     for client in clients:
                                         nursery.start_soon(self.send_kv_set, client, readset, writeset, read_version, False, False, False)
                         await self.bft_network.wait_for_replicas_to_checkpoint(initial_nodes)
-                        
+
     async def send_concurrent_ops(
-            self, 
-            exit_factor, 
-            max_concurrency, 
-            max_size, 
-            write_weight, 
-            create_conflicts=False, 
+            self,
+            exit_factor,
+            max_concurrency,
+            max_size,
+            write_weight,
+            create_conflicts=False,
             exit_policy=ExitPolicy.COUNT):
         """
         exit_factor should be number of seconds to run if exit_policy is TIME
         and number of times to run if exit_policy is COUNT
-        """ 
+        """
         max_read_set_size = max_size
         if self.tracker is not None:
             max_read_set_size = 0 if self.tracker.no_conflicts else max_size
         sent = 0
         write_count = 0
         read_count = 0
-        total_run_duration = 0 
+        total_run_duration = 0
         if exit_policy is ExitPolicy.TIME:
-            total_run_duration = time.time() + exit_factor  
+            total_run_duration = time.time() + exit_factor
         clients = self.bft_network.random_clients(max_concurrency)
 
         def exit_predicate():
@@ -641,7 +641,7 @@ class SimpleKVBCProtocol:
             batch_seq_nums.append(seq_num)
             if self.tracker is not None:
                 self.tracker.send_write(client_id, seq_num, readset, dict(writeset), read_version)
-        
+
         with log.start_action(action_type="send_tracked_kv_set_batch"):
             try:
                 replies = await client.write_batch(msg_batch, batch_seq_nums)


### PR DESCRIPTION
The Apollo test, which should be part of the test_skvbc_restart_recovery suite needs to implement the following steps:

Start all Replicas.
Stop the expected next Primary.
Advance the system 5 Checkpoints.
Stop the current Primary.
Send Client operations in order to trigger View Change.
Bring back up all the previously stopped replicas.
Verify View Change was successful.
Goto Step 2.
