### PR TITLE
Add state transfer callback for publish client key request

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -41,7 +41,9 @@ class KeyExchangeManager {
   void registerForNotification(IKeyExchanger* ke) { registryToExchange_.push_back(ke); }
   // Called at the end of state transfer
   void loadPublicKeys();
+  void loadClientPublicKeys();
   // whether initial key exchange has occurred
+
   bool exchanged() const {
     uint32_t liveClusterSize = ReplicaConfig::instance().waitForFullCommOnStartup ? clusterSize_ : quorumSize_;
     bool exchange_self_keys = publicKeys_.keyExists(ReplicaConfig::instance().replicaId);

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -142,6 +142,11 @@ void KeyExchangeManager::loadPublicKeys() {
   notifyRegistry();
 }
 
+void KeyExchangeManager::loadClientPublicKeys() {
+  // after State Transfer public keys for all clients are expected to exist
+  clientsPublicKeys_.checkAndSetState();
+}
+
 void KeyExchangeManager::exchangeTlsKeys(const std::string& type, const SeqNum& bft_sn) {
   auto keys = concord::util::crypto::Crypto::instance().generateECDSAKeyPair(
       concord::util::crypto::KeyFormat::PemFormat, concord::util::crypto::CurveType::secp384r1);

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3350,6 +3350,7 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
   clientsManager->loadInfoFromReservedPages();
 
   KeyExchangeManager::instance().loadPublicKeys();
+  KeyExchangeManager::instance().loadClientPublicKeys();
 
   if (config_.timeServiceEnabled) {
     time_service_manager_->load();


### PR DESCRIPTION
* **Problem Overview**  
  When a lagged replica has done with state transfer it needs to update the published client keys such that it won't execute the request (executing the request may cause a deviation in the reserved pages hash).
This PR is about adding a state transfer callback for this request
* **Testing Done**  
  GHA tests
