### PR TITLE
Enable test_create_dbcheckpoint_with_parallel_client_requests

### DIFF
--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -305,7 +305,6 @@ class SkvbcDbSnapshotTest(ApolloTest):
             last_blockId = await bft_network.last_db_checkpoint_block_id(replica_id)
             bft_network.verify_db_snapshot_is_available(replica_id, last_blockId)
 
-    @unittest.skip("Disable until fixed. Unstable test because of BC-17338")
     @with_trio
     @with_bft_network(start_replica_cmd_with_high_db_window_size, selected_configs=lambda n, f, c: n == 7)
     @verify_linearizability()


### PR DESCRIPTION
Problem Overview
test_create_dbcheckpoint_with_parallel_client_requests tescase of skvbc_dbsnapshot was failing. So Enabled the testcase in this PR as fix for it was added : https://github.com/vmware/concord-bft/pull/2252

Testing Done
Ran the test case 20 times locally to verify the stability.
Ran the test 50 times in CI/CD.