### PR TITLE
Revert "Reduce memory footprint of persistent storage component"

### DIFF
--- a/bftengine/src/bftengine/PersistentStorageImp.cpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.cpp
@@ -15,7 +15,6 @@
 #include "bftengine/EpochManager.hpp"
 #include "bftengine/DbCheckpointMetadata.hpp"
 #include "bftengine/ReplicaSpecificInfoManager.hpp"
-#include "bftengine/ReplicaConfig.hpp"
 #include <list>
 #include <sstream>
 #include <stdexcept>
@@ -34,18 +33,7 @@ PersistentStorageImp::PersistentStorageImp(
       cVal_(cVal),
       numPrinciples_(numOfPrinciples + numReplicas),  // numReplicas is for the internal clients
       maxClientBatchSize_(maxClientBatchSize),
-      version_(METADATA_PARAMS_VERSION),
-      pre_allocated_mem_buffers_{UniquePtrToChar(new char[DescriptorOfLastExitFromView::simpleParamsSize()]),
-                                 UniquePtrToChar(new char[DescriptorOfLastExitFromView::maxElementSize()]),
-                                 UniquePtrToChar(new char[DescriptorOfLastExitFromView::maxComplaintSize()]),
-                                 UniquePtrToChar(new char[DescriptorOfLastNewView::simpleParamsSize()]),
-                                 UniquePtrToChar(new char[DescriptorOfLastNewView::maxElementSize()]),
-                                 UniquePtrToChar(new char[DescriptorOfLastExecution::maxSize()]),
-                                 UniquePtrToChar(new char[DescriptorOfLastStableCheckpoint::maxSize(numReplicas_)]),
-                                 UniquePtrToChar(new char[CheckData::maxSize()]),
-                                 UniquePtrToChar(new char[bftEngine::ReplicaConfig::instance().maxExternalMessageSize]),
-                                 UniquePtrToChar(new char[CheckData::maxSize()]),
-                                 UniquePtrToChar(new char[SeqNumWindow::maxElementSize()])} {
+      version_(METADATA_PARAMS_VERSION) {
   DescriptorOfLastNewView::setViewChangeMsgsNum(fVal, cVal);
 }
 
@@ -226,38 +214,34 @@ void PersistentStorageImp::setLastViewThatTransferredSeqNumbersFullyExecuted(Vie
 
 void PersistentStorageImp::saveDescriptorOfLastExitFromView(const DescriptorOfLastExitFromView &newDesc) {
   const size_t simpleParamsSize = DescriptorOfLastExitFromView::simpleParamsSize();
-  memset(pre_allocated_mem_buffers_.last_exit_from_view_simple_element_buf.get(), 0, simpleParamsSize);
+  UniquePtrToChar simpleParamsBuf(new char[simpleParamsSize]);
+  memset(simpleParamsBuf.get(), 0, simpleParamsSize);
   size_t actualSize = 0;
-  newDesc.serializeSimpleParams(
-      pre_allocated_mem_buffers_.last_exit_from_view_simple_element_buf.get(), simpleParamsSize, actualSize);
-  metadataStorage_->writeInBatch(LAST_EXIT_FROM_VIEW_DESC,
-                                 pre_allocated_mem_buffers_.last_exit_from_view_simple_element_buf.get(),
-                                 simpleParamsSize);
+  newDesc.serializeSimpleParams(simpleParamsBuf.get(), simpleParamsSize, actualSize);
+  metadataStorage_->writeInBatch(LAST_EXIT_FROM_VIEW_DESC, simpleParamsBuf.get(), simpleParamsSize);
 
   size_t actualElementSize = 0;
   uint32_t elementsNum = newDesc.elements.size();
   uint32_t maxElementSize = DescriptorOfLastExitFromView::maxElementSize();
+  UniquePtrToChar elementBuf(new char[maxElementSize]);
   for (size_t i = 0; i < elementsNum; ++i) {
-    newDesc.serializeElement(
-        i, pre_allocated_mem_buffers_.last_exit_fron_view_element_buf.get(), maxElementSize, actualElementSize);
+    newDesc.serializeElement(i, elementBuf.get(), maxElementSize, actualElementSize);
     ConcordAssertNE(actualElementSize, 0);
     uint32_t itemId = LAST_EXIT_FROM_VIEW_DESC + 1 + i;
     ConcordAssertLT(itemId, LAST_COMPLAINTS_DESC);
-    metadataStorage_->writeInBatch(
-        itemId, pre_allocated_mem_buffers_.last_exit_fron_view_element_buf.get(), actualElementSize);
+    metadataStorage_->writeInBatch(itemId, elementBuf.get(), actualElementSize);
   }
 
   size_t actualComplaintSize = 0;
   uint32_t complaintsNum = newDesc.complaints.size();
   uint32_t maxComplaintSize = DescriptorOfLastExitFromView::maxComplaintSize();
+  UniquePtrToChar complaintBuf(new char[maxComplaintSize]);
   for (size_t i = 0; i < complaintsNum; ++i) {
-    newDesc.serializeComplaint(
-        i, pre_allocated_mem_buffers_.last_exit_from_view_complaint_buf.get(), maxComplaintSize, actualComplaintSize);
+    newDesc.serializeComplaint(i, complaintBuf.get(), maxComplaintSize, actualComplaintSize);
     ConcordAssertNE(actualComplaintSize, 0);
     uint32_t itemId = LAST_COMPLAINTS_DESC + i;
     ConcordAssertLT(itemId, LAST_EXEC_DESC);
-    metadataStorage_->writeInBatch(
-        itemId, pre_allocated_mem_buffers_.last_exit_from_view_complaint_buf.get(), actualComplaintSize);
+    metadataStorage_->writeInBatch(itemId, complaintBuf.get(), actualComplaintSize);
   }
 }
 
@@ -281,21 +265,19 @@ void PersistentStorageImp::initDescriptorOfLastExitFromView() {
 
 void PersistentStorageImp::saveDescriptorOfLastNewView(const DescriptorOfLastNewView &newDesc) {
   const size_t simpleParamsSize = DescriptorOfLastNewView::simpleParamsSize();
+  UniquePtrToChar simpleParamsBuf(new char[simpleParamsSize]);
   size_t actualSize = 0;
-  newDesc.serializeSimpleParams(
-      pre_allocated_mem_buffers_.last_new_view_simple_element_buf.get(), simpleParamsSize, actualSize);
-  metadataStorage_->writeInBatch(
-      LAST_NEW_VIEW_DESC, pre_allocated_mem_buffers_.last_new_view_simple_element_buf.get(), actualSize);
+  newDesc.serializeSimpleParams(simpleParamsBuf.get(), simpleParamsSize, actualSize);
+  metadataStorage_->writeInBatch(LAST_NEW_VIEW_DESC, simpleParamsBuf.get(), actualSize);
 
   size_t actualElementSize = 0;
   uint32_t numOfMessages = DescriptorOfLastNewView::getViewChangeMsgsNum();
   uint32_t maxElementSize = DescriptorOfLastNewView::maxElementSize();
+  UniquePtrToChar elementBuf(new char[maxElementSize]);
   for (uint32_t i = 0; i < numOfMessages; ++i) {
-    newDesc.serializeElement(
-        i, pre_allocated_mem_buffers_.last_new_view_element_buf.get(), maxElementSize, actualElementSize);
+    newDesc.serializeElement(i, elementBuf.get(), maxElementSize, actualElementSize);
     ConcordAssertNE(actualElementSize, 0);
-    metadataStorage_->writeInBatch(
-        LAST_NEW_VIEW_DESC + 1 + i, pre_allocated_mem_buffers_.last_new_view_element_buf.get(), actualElementSize);
+    metadataStorage_->writeInBatch(LAST_NEW_VIEW_DESC + 1 + i, elementBuf.get(), actualElementSize);
   }
 }
 
@@ -319,12 +301,12 @@ void PersistentStorageImp::initDescriptorOfLastNewView() {
 
 void PersistentStorageImp::saveDescriptorOfLastExecution(const DescriptorOfLastExecution &newDesc) {
   const size_t bufLen = DescriptorOfLastExecution::maxSize();
-  char *descBuf = pre_allocated_mem_buffers_.descriptor_of_last_execution_buf.get();
+  UniquePtrToChar descBuf(new char[bufLen]);
+  char *descBufPtr = descBuf.get();
   size_t actualSize = 0;
-  newDesc.serialize(descBuf, bufLen, actualSize);
+  newDesc.serialize(descBufPtr, bufLen, actualSize);
   ConcordAssertNE(actualSize, 0);
-  metadataStorage_->writeInBatch(
-      LAST_EXEC_DESC, pre_allocated_mem_buffers_.descriptor_of_last_execution_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(LAST_EXEC_DESC, descBuf.get(), actualSize);
 }
 
 void PersistentStorageImp::setDescriptorOfLastExecution(const DescriptorOfLastExecution &desc, bool init) {
@@ -335,12 +317,12 @@ void PersistentStorageImp::setDescriptorOfLastExecution(const DescriptorOfLastEx
 void PersistentStorageImp::setDescriptorOfLastStableCheckpoint(
     const DescriptorOfLastStableCheckpoint &stableCheckDesc) {
   const size_t bufLen = DescriptorOfLastStableCheckpoint::maxSize(numReplicas_);
-  char *descBuf = pre_allocated_mem_buffers_.descriptor_og_last_stable_cp_buf.get();
+  UniquePtrToChar descBuf(new char[bufLen]);
+  char *descBufPtr = descBuf.get();
   size_t actualSize = 0;
-  stableCheckDesc.serialize(descBuf, bufLen, actualSize);
+  stableCheckDesc.serialize(descBufPtr, bufLen, actualSize);
   ConcordAssertNE(actualSize, 0);
-  metadataStorage_->writeInBatch(
-      LAST_STABLE_CHECKPOINT_DESC, pre_allocated_mem_buffers_.descriptor_og_last_stable_cp_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(LAST_STABLE_CHECKPOINT_DESC, descBuf.get(), actualSize);
 }
 
 void PersistentStorageImp::initDescriptorOfLastExecution() {
@@ -370,46 +352,47 @@ void PersistentStorageImp::saveDefaultsInSeqNumWindow() {
 }
 
 void PersistentStorageImp::setSeqNumDataElement(SeqNum index, const SeqNumData &seqNumData) const {
-  char *movablePtr = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  UniquePtrToChar buf(new char[SeqNumData::maxSize()]);
   SeqNum shift = index * numOfSeqNumWinParameters;
+  char *movablePtr = buf.get();
   size_t actualSize = seqNumData.serializePrePrepareMsg(movablePtr);
   uint32_t itemId = BEGINNING_OF_SEQ_NUM_WINDOW + PRE_PREPARE_MSG + shift;
   ConcordAssertLT(itemId, BEGINNING_OF_CHECK_WINDOW);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.seq_num_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
   ConcordAssertNE(actualSize, 0);
 
-  movablePtr = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  movablePtr = buf.get();
   actualSize = seqNumData.serializeFullCommitProofMsg(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + FULL_COMMIT_PROOF_MSG + shift;
   ConcordAssertLT(itemId, BEGINNING_OF_CHECK_WINDOW);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.seq_num_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
   ConcordAssertNE(actualSize, 0);
 
-  movablePtr = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  movablePtr = buf.get();
   actualSize = seqNumData.serializePrepareFullMsg(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + PRE_PREPARE_FULL_MSG + shift;
   ConcordAssertLT(itemId, BEGINNING_OF_CHECK_WINDOW);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.seq_num_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
   ConcordAssertNE(actualSize, 0);
 
-  movablePtr = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  movablePtr = buf.get();
   actualSize = seqNumData.serializeCommitFullMsg(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + COMMIT_FULL_MSG + shift;
   ConcordAssertLT(itemId, BEGINNING_OF_CHECK_WINDOW);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.seq_num_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
   ConcordAssertNE(actualSize, 0);
 
-  movablePtr = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  movablePtr = buf.get();
   actualSize = seqNumData.serializeForceCompleted(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + FORCE_COMPLETED + shift;
   ConcordAssertLT(itemId, BEGINNING_OF_CHECK_WINDOW);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.seq_num_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
 
-  movablePtr = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  movablePtr = buf.get();
   actualSize = seqNumData.serializeSlowStarted(movablePtr);
   itemId = BEGINNING_OF_SEQ_NUM_WINDOW + SLOW_STARTED + shift;
   ConcordAssertLT(itemId, BEGINNING_OF_CHECK_WINDOW);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.seq_num_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
 }
 
 void PersistentStorageImp::saveDefaultsInCheckWindow() {
@@ -419,20 +402,20 @@ void PersistentStorageImp::saveDefaultsInCheckWindow() {
 }
 
 void PersistentStorageImp::setCheckDataElement(SeqNum index, const CheckData &checkData) const {
-  char *movablePtr = pre_allocated_mem_buffers_.check_data_element_buf.get();
+  UniquePtrToChar buf(new char[CheckData::maxSize()]);
+  char *movablePtr = buf.get();
   SeqNum shift = index * numOfCheckWinParameters;
   size_t actualSize = checkData.serializeCheckpointMsg(movablePtr);
 
   uint32_t itemId = BEGINNING_OF_CHECK_WINDOW + CHECK_DATA_FIRST_PARAM + shift;
   ConcordAssertLT(itemId, WIN_PARAMETERS_NUM);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.check_data_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
   ConcordAssertNE(actualSize, 0);
-
-  movablePtr = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  movablePtr = buf.get();
   actualSize = checkData.serializeCompletedMark(movablePtr);
   itemId = BEGINNING_OF_CHECK_WINDOW + COMPLETED_MARK + shift;
   ConcordAssertLT(itemId, WIN_PARAMETERS_NUM);
-  metadataStorage_->writeInBatch(itemId, pre_allocated_mem_buffers_.check_data_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(itemId, buf.get(), actualSize);
 }
 
 void PersistentStorageImp::setDefaultWindowsValues() {
@@ -480,13 +463,14 @@ void PersistentStorageImp::setMsgInSeqNumWindow(SeqNum seqNum,
                                                 SeqNum parameterId,
                                                 MessageBase *msg,
                                                 size_t msgSize) const {
-  char *movablePtr = pre_allocated_mem_buffers_.msg_element_buf.get();
+  UniquePtrToChar buf(new char[msgSize]);
+  char *movablePtr = buf.get();
   const size_t actualSize = SeqNumData::serializeMsg(movablePtr, msg);
   ConcordAssertNE(actualSize, 0);
   const SeqNum convertedIndex = BEGINNING_OF_SEQ_NUM_WINDOW + parameterId + convertSeqNumWindowIndex(seqNum);
   ConcordAssertLT(convertedIndex, BEGINNING_OF_CHECK_WINDOW);
   LOG_DEBUG(GL, "PersistentStorageImp::setMsgInSeqNumWindow convertedIndex=" << convertedIndex);
-  metadataStorage_->writeInBatch(convertedIndex, pre_allocated_mem_buffers_.msg_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(convertedIndex, buf.get(), actualSize);
 }
 
 void PersistentStorageImp::setPrePrepareMsgInSeqNumWindow(SeqNum seqNum, PrePrepareMsg *msg) {
@@ -531,13 +515,15 @@ void PersistentStorageImp::setCompletedMarkInCheckWindow(SeqNum seqNum, bool com
 }
 
 void PersistentStorageImp::setCheckpointMsgInCheckWindow(SeqNum seqNum, CheckpointMsg *msg) {
-  char *movablePtr = pre_allocated_mem_buffers_.check_data_element_buf.get();
+  size_t bufLen = CheckData::maxCheckpointMsgSize();
+  UniquePtrToChar buf(new char[bufLen]);
+  char *movablePtr = buf.get();
   size_t actualSize = CheckData::serializeCheckpointMsg(movablePtr, (CheckpointMsg *)msg);
   ConcordAssertNE(actualSize, 0);
   const SeqNum convertedIndex = BEGINNING_OF_CHECK_WINDOW + CHECKPOINT_MSG + convertCheckWindowIndex(seqNum);
   ConcordAssertLT(convertedIndex, WIN_PARAMETERS_NUM);
   LOG_DEBUG(GL, "PersistentStorageImp::setCheckpointMsgInCheckWindow convertedIndex=" << convertedIndex);
-  metadataStorage_->writeInBatch(convertedIndex, pre_allocated_mem_buffers_.check_data_element_buf.get(), actualSize);
+  metadataStorage_->writeInBatch(convertedIndex, buf.get(), actualSize);
 }
 
 void PersistentStorageImp::setUserDataAtomically(const void *data, std::size_t numberOfBytes) {
@@ -633,38 +619,33 @@ DescriptorOfLastExitFromView PersistentStorageImp::getAndAllocateDescriptorOfLas
   uint32_t sizeInDb = 0;
 
   // Read first simple params.
-  metadataStorage_->read(LAST_EXIT_FROM_VIEW_DESC,
-                         simpleParamsSize,
-                         pre_allocated_mem_buffers_.last_exit_from_view_simple_element_buf.get(),
-                         sizeInDb);
+  UniquePtrToChar simpleParamsBuf(new char[simpleParamsSize]);
+  metadataStorage_->read(LAST_EXIT_FROM_VIEW_DESC, simpleParamsSize, simpleParamsBuf.get(), sizeInDb);
   ConcordAssertEQ(sizeInDb, simpleParamsSize);
   uint32_t actualSize = 0;
-  dbDesc.deserializeSimpleParams(
-      pre_allocated_mem_buffers_.last_exit_from_view_simple_element_buf.get(), simpleParamsSize, actualSize);
+  dbDesc.deserializeSimpleParams(simpleParamsBuf.get(), simpleParamsSize, actualSize);
 
   const size_t maxElementSize = DescriptorOfLastExitFromView::maxElementSize();
+  UniquePtrToChar elementBuf(new char[maxElementSize]);
   uint32_t actualElementSize = 0;
   uint32_t elementsNum = dbDesc.elements.size();
   for (uint32_t i = 0; i < elementsNum; ++i) {
     uint32_t itemId = LAST_EXIT_FROM_VIEW_DESC + 1 + i;
     ConcordAssertLT(itemId, LAST_COMPLAINTS_DESC);
-    metadataStorage_->read(
-        itemId, maxElementSize, pre_allocated_mem_buffers_.last_exit_fron_view_element_buf.get(), actualSize);
-    dbDesc.deserializeElement(
-        i, pre_allocated_mem_buffers_.last_exit_fron_view_element_buf.get(), actualSize, actualElementSize);
+    metadataStorage_->read(itemId, maxElementSize, elementBuf.get(), actualSize);
+    dbDesc.deserializeElement(i, elementBuf.get(), actualSize, actualElementSize);
     ConcordAssertNE(actualElementSize, 0);
   }
 
   const size_t maxComplaintSize = DescriptorOfLastExitFromView::maxComplaintSize();
+  UniquePtrToChar complaintBuf(new char[maxComplaintSize]);
   uint32_t actualComplaintSize = 0;
   uint32_t complaintsNum = dbDesc.complaints.size();
   for (uint32_t i = 0; i < complaintsNum; ++i) {
     uint32_t itemId = LAST_COMPLAINTS_DESC + i;
     ConcordAssertLT(itemId, LAST_EXEC_DESC);
-    metadataStorage_->read(
-        itemId, maxComplaintSize, pre_allocated_mem_buffers_.last_exit_from_view_complaint_buf.get(), actualSize);
-    dbDesc.deserializeComplaint(
-        i, pre_allocated_mem_buffers_.last_exit_from_view_complaint_buf.get(), actualSize, actualComplaintSize);
+    metadataStorage_->read(itemId, maxComplaintSize, complaintBuf.get(), actualSize);
+    dbDesc.deserializeComplaint(i, complaintBuf.get(), actualSize, actualComplaintSize);
     ConcordAssertNE(actualComplaintSize, 0);
   }
 
@@ -677,23 +658,17 @@ DescriptorOfLastNewView PersistentStorageImp::getAndAllocateDescriptorOfLastNewV
   uint32_t actualSize = 0;
 
   // Read first simple params.
-  metadataStorage_->read(LAST_NEW_VIEW_DESC,
-                         simpleParamsSize,
-                         pre_allocated_mem_buffers_.last_new_view_simple_element_buf.get(),
-                         actualSize);
-  dbDesc.deserializeSimpleParams(
-      pre_allocated_mem_buffers_.last_new_view_simple_element_buf.get(), simpleParamsSize, actualSize);
+  UniquePtrToChar simpleParamsBuf(new char[simpleParamsSize]);
+  metadataStorage_->read(LAST_NEW_VIEW_DESC, simpleParamsSize, simpleParamsBuf.get(), actualSize);
+  dbDesc.deserializeSimpleParams(simpleParamsBuf.get(), simpleParamsSize, actualSize);
 
   size_t maxElementSize = DescriptorOfLastNewView::maxElementSize();
+  UniquePtrToChar elementBuf(new char[maxElementSize]);
   size_t actualElementSize = 0;
   uint32_t viewChangeMsgsNum = DescriptorOfLastNewView::getViewChangeMsgsNum();
   for (uint32_t i = 0; i < viewChangeMsgsNum; ++i) {
-    metadataStorage_->read(LAST_NEW_VIEW_DESC + 1 + i,
-                           maxElementSize,
-                           pre_allocated_mem_buffers_.last_new_view_element_buf.get(),
-                           actualSize);
-    dbDesc.deserializeElement(
-        i, pre_allocated_mem_buffers_.last_new_view_element_buf.get(), actualSize, actualElementSize);
+    metadataStorage_->read(LAST_NEW_VIEW_DESC + 1 + i, maxElementSize, elementBuf.get(), actualSize);
+    dbDesc.deserializeElement(i, elementBuf.get(), actualSize, actualElementSize);
     ConcordAssertNE(actualElementSize, 0);
   }
   return dbDesc;
@@ -704,9 +679,9 @@ DescriptorOfLastExecution PersistentStorageImp::getDescriptorOfLastExecution() {
   const size_t maxSize = DescriptorOfLastExecution::maxSize();
   uint32_t actualSize = 0;
 
-  metadataStorage_->read(
-      LAST_EXEC_DESC, maxSize, pre_allocated_mem_buffers_.descriptor_of_last_execution_buf.get(), actualSize);
-  dbDesc.deserialize(pre_allocated_mem_buffers_.descriptor_of_last_execution_buf.get(), maxSize, actualSize);
+  UniquePtrToChar buf(new char[maxSize]);
+  metadataStorage_->read(LAST_EXEC_DESC, maxSize, buf.get(), actualSize);
+  dbDesc.deserialize(buf.get(), maxSize, actualSize);
   ConcordAssertNE(actualSize, 0);
   if (!dbDesc.equals(emptyDescriptorOfLastExecution_)) {
     descriptorOfLastExecution_ = dbDesc;
@@ -721,13 +696,11 @@ DescriptorOfLastStableCheckpoint PersistentStorageImp::getDescriptorOfLastStable
   uint32_t dbDescSize = DescriptorOfLastStableCheckpoint::maxSize(numReplicas_);
   uint32_t sizeInDb = 0;
 
-  metadataStorage_->read(LAST_STABLE_CHECKPOINT_DESC,
-                         dbDescSize,
-                         pre_allocated_mem_buffers_.descriptor_og_last_stable_cp_buf.get(),
-                         sizeInDb);
+  UniquePtrToChar simpleParamsBuf(new char[dbDescSize]);
+  metadataStorage_->read(LAST_STABLE_CHECKPOINT_DESC, dbDescSize, simpleParamsBuf.get(), sizeInDb);
 
   size_t actualSize = 0;
-  dbDesc.deserialize(pre_allocated_mem_buffers_.descriptor_og_last_stable_cp_buf.get(), dbDescSize, actualSize);
+  dbDesc.deserialize(simpleParamsBuf.get(), dbDescSize, actualSize);
 
   return dbDesc;
 }
@@ -759,35 +732,35 @@ bool PersistentStorageImp::hasDescriptorOfLastExecution() { return hasDescriptor
 void PersistentStorageImp::readSeqNumDataElementFromDisk(SeqNum index, const SharedPtrSeqNumWindow &seqNumWindow) {
   uint32_t actualElementSize = 0;
   uint32_t actualParameterSize = 0;
-  char *buf = pre_allocated_mem_buffers_.seq_num_element_buf.get();
+  UniquePtrToChar buf(new char[SeqNumWindow::maxElementSize()]);
   SeqNum shift = index * numOfSeqNumWinParameters;
+  char *movablePtr = buf.get();
   for (auto i = 0; i < numOfSeqNumWinParameters; ++i) {
     uint32_t itemId = BEGINNING_OF_SEQ_NUM_WINDOW + SEQ_NUM_FIRST_PARAM + i + shift;
     ConcordAssertLT(itemId, BEGINNING_OF_CHECK_WINDOW);
-    metadataStorage_->read(itemId, SeqNumData::maxSize(), buf, actualParameterSize);
-    buf += actualParameterSize;
+    metadataStorage_->read(itemId, SeqNumData::maxSize(), movablePtr, actualParameterSize);
+    movablePtr += actualParameterSize;
     actualElementSize += actualParameterSize;
   }
   uint32_t actualSize = 0;
-  seqNumWindow.get()->deserializeElement(
-      index, pre_allocated_mem_buffers_.seq_num_element_buf.get(), actualElementSize, actualSize);
+  seqNumWindow.get()->deserializeElement(index, buf.get(), actualElementSize, actualSize);
 }
 
 void PersistentStorageImp::readCheckDataElementFromDisk(SeqNum index, const SharedPtrCheckWindow &checkWindow) {
   uint32_t actualElementSize = 0;
   uint32_t actualParameterSize = 0;
-  char *buf = pre_allocated_mem_buffers_.check_data_element_buf.get();
+  UniquePtrToChar buf(new char[CheckData::maxSize()]);
+  char *movablePtr = buf.get();
   const SeqNum shift = index * numOfCheckWinParameters;
   for (auto i = 0; i < numOfCheckWinParameters; ++i) {
     uint32_t itemId = BEGINNING_OF_CHECK_WINDOW + CHECK_DATA_FIRST_PARAM + i + shift;
     ConcordAssertLT(itemId, WIN_PARAMETERS_NUM);
-    metadataStorage_->read(itemId, CheckData::maxSize(), buf, actualParameterSize);
-    buf += actualParameterSize;
+    metadataStorage_->read(itemId, CheckData::maxSize(), movablePtr, actualParameterSize);
+    movablePtr += actualParameterSize;
     actualElementSize += actualParameterSize;
   }
   uint32_t actualSize = 0;
-  checkWindow.get()->deserializeElement(
-      index, pre_allocated_mem_buffers_.check_data_element_buf.get(), CheckData::maxSize(), actualSize);
+  checkWindow.get()->deserializeElement(index, buf.get(), CheckData::maxSize(), actualSize);
   ConcordAssertEQ(actualSize, actualElementSize);
 }
 
@@ -809,15 +782,15 @@ uint8_t PersistentStorageImp::readOneByteFromDisk(SeqNum index, SeqNum parameter
 }
 
 MessageBase *PersistentStorageImp::readMsgFromDisk(SeqNum seqNum, SeqNum parameterId, size_t msgSize) const {
-  char *buf = pre_allocated_mem_buffers_.msg_element_buf.get();
+  UniquePtrToChar buf(new char[msgSize]);
   uint32_t actualMsgSize = 0;
   const SeqNum convertedIndex = BEGINNING_OF_SEQ_NUM_WINDOW + parameterId + convertSeqNumWindowIndex(seqNum);
   ConcordAssertLT(convertedIndex, BEGINNING_OF_CHECK_WINDOW);
   LOG_DEBUG(GL, "PersistentStorageImp::readMsgFromDisk seqNum=" << seqNum << " dbIndex=" << convertedIndex);
-  metadataStorage_->read(convertedIndex, msgSize, buf, actualMsgSize);
+  metadataStorage_->read(convertedIndex, msgSize, buf.get(), actualMsgSize);
   size_t actualSize = 0;
-  buf = pre_allocated_mem_buffers_.msg_element_buf.get();
-  auto *msg = SeqNumData::deserializeMsg(buf, msgSize, actualSize);
+  char *movablePtr = buf.get();
+  auto *msg = SeqNumData::deserializeMsg(movablePtr, msgSize, actualSize);
   ConcordAssertEQ(actualSize, actualMsgSize);
   return msg;
 }
@@ -856,15 +829,15 @@ uint8_t PersistentStorageImp::readCompletedMarkFromDisk(SeqNum index) const {
 
 CheckpointMsg *PersistentStorageImp::readCheckpointMsgFromDisk(SeqNum index) const {
   const size_t bufLen = CheckData::maxSize();
-  char *buf = pre_allocated_mem_buffers_.check_data_element_buf.get();
+  UniquePtrToChar buf(new char[bufLen]);
   uint32_t actualMsgSize = 0;
   const SeqNum convertedIndex = BEGINNING_OF_CHECK_WINDOW + CHECKPOINT_MSG + convertCheckWindowIndex(index);
   ConcordAssertLT(convertedIndex, WIN_PARAMETERS_NUM);
   LOG_DEBUG(GL, "PersistentStorageImp::readCheckpointMsgFromDisk convertedIndex=" << convertedIndex);
-  metadataStorage_->read(convertedIndex, bufLen, buf, actualMsgSize);
+  metadataStorage_->read(convertedIndex, bufLen, buf.get(), actualMsgSize);
   size_t actualSize = 0;
-  buf = pre_allocated_mem_buffers_.check_data_element_buf.get();
-  auto *checkpointMsg = CheckData::deserializeCheckpointMsg(buf, bufLen, actualSize);
+  char *movablePtr = buf.get();
+  auto *checkpointMsg = CheckData::deserializeCheckpointMsg(movablePtr, bufLen, actualSize);
   ConcordAssertEQ(actualSize, actualMsgSize);
   return checkpointMsg;
 }

--- a/bftengine/src/bftengine/PersistentStorageImp.hpp
+++ b/bftengine/src/bftengine/PersistentStorageImp.hpp
@@ -288,23 +288,6 @@ class PersistentStorageImp : public PersistentStorage {
   SeqNum strictLowerBoundOfSeqNums_ = 0;
   ViewNum lastViewTransferredSeqNum_ = 0;
   SeqNum lastStableSeqNum_ = 0;
-
-  struct PreAllocataedMemoryBuffers {
-    concord::serialize::UniquePtrToChar last_exit_from_view_simple_element_buf;
-    concord::serialize::UniquePtrToChar last_exit_fron_view_element_buf;
-    concord::serialize::UniquePtrToChar last_exit_from_view_complaint_buf;
-    concord::serialize::UniquePtrToChar last_new_view_simple_element_buf;
-    concord::serialize::UniquePtrToChar last_new_view_element_buf;
-    concord::serialize::UniquePtrToChar descriptor_of_last_execution_buf;
-    concord::serialize::UniquePtrToChar descriptor_og_last_stable_cp_buf;
-    concord::serialize::UniquePtrToChar seq_num_element_buf;
-    concord::serialize::UniquePtrToChar check_data_element_buf;
-    concord::serialize::UniquePtrToChar msg_element_buf;
-    concord::serialize::UniquePtrToChar cp_message_buf;
-    concord::serialize::UniquePtrToChar seq_num_data_buf;
-  };
-
-  mutable PreAllocataedMemoryBuffers pre_allocated_mem_buffers_;
 };
 
 }  // namespace impl

--- a/client/client_pool/include/client/client_pool/client_pool_config.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_config.hpp
@@ -62,7 +62,6 @@ typedef struct ConcordClientPoolConfig {
   std::string file_name;
   bool client_batching_enabled = false;
   bool enable_multiplex_channel = false;
-  bool use_unified_certificates = false;
   size_t client_batching_max_messages_nbr = 20;
   std::uint64_t client_batching_flush_timeout_ms = 100;
   bool encrypted_config_enabled = false;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -365,7 +365,6 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
                                     config.clients_per_participant_node,
                                     config.client_batching_enabled,
                                     config.enable_multiplex_channel,
-                                    config.use_unified_certificates,
                                     config.client_batching_max_messages_nbr,
                                     config.encrypted_config_enabled,
                                     config.transaction_signing_enabled,
@@ -401,7 +400,6 @@ void ConcordClientPool::CreatePool(concord::config_pool::ConcordClientPoolConfig
                                                 config.participant_nodes[0].principal_id,
                                                 config.tls_certificates_folder_path,
                                                 config.tls_cipher_suite_list,
-                                                config.use_unified_certificates,
                                                 endpointIdToNodeIdMap,
                                                 nullptr,
                                                 secretData);

--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -259,7 +259,6 @@ BaseCommConfig* ConcordClient::CreateCommConfig() const {
                           selfId,
                           pool_config_.tls_certificates_folder_path,
                           pool_config_.tls_cipher_suite_list,
-                          pool_config_.use_unified_certificates,
                           nullptr,
                           secretData};
 }

--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -247,6 +247,7 @@ void configureTransport(concord::client::concordclient::ConcordClientConfig& con
       // concatentation of the certificates of all known servers
       readCert(server_cert_path, config.transport.event_pem_certs);
     }
+    LOG_INFO(logger, "Certificate chain: " << config.transport.event_pem_certs);
   }
 }
 

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -101,7 +101,6 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
                                        ? "Invalid"
                                        : config.transport.comm_type == TransportConfig::TlsTcp ? "tls" : "udp";
   client_pool_config.enable_multiplex_channel = config.transport.enable_multiplex_channel;
-  client_pool_config.use_unified_certificates = config.transport.use_unified_certs;
   client_pool_config.concord_bft_communication_buffer_length = std::to_string(config.transport.buffer_length);
   client_pool_config.tls_certificates_folder_path = config.transport.tls_cert_root_path;
   client_pool_config.tls_cipher_suite_list = config.transport.tls_cipher_suite;

--- a/communication/include/communication/CommDefs.hpp
+++ b/communication/include/communication/CommDefs.hpp
@@ -135,13 +135,11 @@ class TlsTcpConfig : public PlainTcpConfig {
                NodeNum selfId,
                const std::string &certRootPath,
                const std::string &cipherSuite,
-               bool useUnifiedCerts,
                UPDATE_CONNECTIVITY_FN statusCallback = nullptr,
                std::optional<concord::secretsmanager::SecretData> decryptionSecretData = std::nullopt)
       : PlainTcpConfig(host, port, bufLength, nodes, maxServerId, selfId, std::move(statusCallback)),
         certificatesRootPath_{certRootPath},
         cipherSuite_{cipherSuite},
-        useUnifiedCertificates_{useUnifiedCerts},
         secretData_{std::move(decryptionSecretData)} {
     commType_ = CommType::TlsTcp;
   }
@@ -149,7 +147,6 @@ class TlsTcpConfig : public PlainTcpConfig {
  public:
   std::string certificatesRootPath_;
   std::string cipherSuite_;
-  bool useUnifiedCertificates_;
   std::optional<concord::secretsmanager::SecretData> secretData_;
 };
 
@@ -163,7 +160,6 @@ class TlsMultiplexConfig : public TlsTcpConfig {
                      NodeNum selfId,
                      const std::string &certRootPath,
                      const std::string &cipherSuite,
-                     bool useUnifiedCerts,
                      std::unordered_map<NodeNum, NodeNum> &endpointIdToNodeIdMap,
                      UPDATE_CONNECTIVITY_FN statusCallback = nullptr,
                      std::optional<concord::secretsmanager::SecretData> secretData = std::nullopt)
@@ -175,7 +171,6 @@ class TlsMultiplexConfig : public TlsTcpConfig {
                      selfId,
                      certRootPath,
                      cipherSuite,
-                     useUnifiedCerts,
                      std::move(statusCallback),
                      secretData),
         endpointIdToNodeIdMap_(endpointIdToNodeIdMap) {

--- a/communication/src/AsyncTlsConnection.h
+++ b/communication/src/AsyncTlsConnection.h
@@ -35,6 +35,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
  public:
   static constexpr std::chrono::seconds READ_TIMEOUT = std::chrono::seconds(10);
   static constexpr std::chrono::seconds WRITE_TIMEOUT = READ_TIMEOUT;
+  static bool useUnifiedCertificates_;
 
   // We require a factory function because we can't call shared_from_this() in the constructor.
   //
@@ -49,6 +50,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                                     TlsStatus& status,
                                                     Recorders& histograms) {
     auto conn = std::make_shared<AsyncTlsConnection>(io_context, receiver, conn_mgr, config, status, histograms);
+    useUnifiedCertificates_ = bftEngine::ReplicaConfig::instance().useUnifiedCertificates;
     conn->initServerSSLContext();
     conn->createSSLSocket(std::move(socket));
     return conn;
@@ -64,6 +66,7 @@ class AsyncTlsConnection : public std::enable_shared_from_this<AsyncTlsConnectio
                                                     Recorders& histograms) {
     auto conn =
         std::make_shared<AsyncTlsConnection>(io_context, receiver, conn_mgr, destination, config, status, histograms);
+    useUnifiedCertificates_ = bftEngine::ReplicaConfig::instance().useUnifiedCertificates;
     conn->initClientSSLContext(destination);
     conn->createSSLSocket(std::move(socket));
     return conn;

--- a/communication/tests/multiplex_comm_test.cpp
+++ b/communication/tests/multiplex_comm_test.cpp
@@ -66,7 +66,7 @@ void setUpCommunicationOnReplica(NodeNum selfId, shared_ptr<IReceiver> receiver)
     endpointIdToNodeIdMap[i] = clientServiceNum;
   }
   auto configuration = TlsMultiplexConfig(
-      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, false, endpointIdToNodeIdMap);
+      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, endpointIdToNodeIdMap);
   ASSERT_TRUE(configuration.amIReplica_);
   int clients = 0;
   int replicas = 0;
@@ -89,7 +89,7 @@ void setUpCommunicationOnClient(NodeNum selfId, shared_ptr<IReceiver> receiver) 
   delete communicatorPtr;
   auto [nodes, endpointIdToNodeIdMap] = createClientNodesConfig();
   auto configuration = TlsMultiplexConfig(
-      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, false, endpointIdToNodeIdMap);
+      host, port, bufLength, nodes, maxServerId, selfId, certRootPath, cipherSuite, endpointIdToNodeIdMap);
   for (auto const& node : configuration.nodes_) ASSERT_TRUE(node.second.isReplica);
   ASSERT_FALSE(configuration.amIReplica_);
   communicatorPtr = dynamic_cast<TlsMultiplexCommunication*>(CommFactory::create(configuration));

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -200,7 +200,6 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
                       id,
                       cert_root_path,
                       "TLS_AES_256_GCM_SHA384",
-                      false,
                       nullptr,
                       secretData);
   return retVal;

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -311,7 +311,6 @@ bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
     return false;
   }
   remote_peer_id = remotePeerId;
-  LOG_INFO(GL, "Peer: " << remote_peer_id);
   std::string CN;
   CN.resize(SIZE);
   X509_NAME_get_text_by_NID(X509_get_subject_name(cert_to_verify), NID_commonName, CN.data(), SIZE);


### PR DESCRIPTION
* **Problem Overview** 
This is a testing PR. Its purpose is to verify performance without the following reverted commits: 
Revert commit cf0c07 that was supposed to reduce memory footprint of the persistent storage component.
Revert commit 480b56 since it is causing incompatibilities, which prevent concord from building.
* **Testing Done**  
N/A
