### PR TITLE
Update pruning metrics when pruning is done after state transfer

### DIFF
--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -967,9 +967,10 @@ void KeyValueBlockchain::pruneOnSTLink(const RawBlock& block) {
   auto key_it = internal_kvs.find(keyTypes::genesis_block_key);
   if (key_it != internal_kvs.cend()) {
     const auto block_genesis_id = concordUtils::fromBigEndianBuffer<BlockId>(key_it->second.data.data());
-    while (getGenesisBlockId() >= INITIAL_GENESIS_BLOCK_ID && getGenesisBlockId() < getLastReachableBlockId() &&
-           block_genesis_id > getGenesisBlockId()) {
-      deleteGenesisBlock();
+    if (getGenesisBlockId() >= INITIAL_GENESIS_BLOCK_ID && getGenesisBlockId() < getLastReachableBlockId()) {
+      for (auto i = getGenesisBlockId(); i < block_genesis_id; i++) {
+        ConcordAssert(deleteBlock(i));
+      }
     }
   }
 }


### PR DESCRIPTION
* **Problem Overview**  
  When pruning is done after state transfer, we use a code path that doesn't update the pruning metrics
This PR is for fixing this bug
* **Testing Done**  
  CI tests + enabling buck the test_pruning_with_failures_test and update it to also test that the lagged replica updates its metrics
