### PR TITLE
Deactivate some thin_replica_server_test.cpp cases

### DIFF
--- a/thin-replica-server/test/thin_replica_server_test.cpp
+++ b/thin-replica-server/test/thin_replica_server_test.cpp
@@ -1296,7 +1296,9 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGap) {
   EXPECT_EQ(state_machine.numEventGroupsReceived(), total_event_groups);
 }
 
-TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdatesWithGapTwoClients) {
+// Disabled due to instability in order to unblock master for other fixes to improve its stability.
+// TODO (Alex): Develop a propper fix and re-enable this test.
+TEST(thin_replica_server_test, DISABLED_SubscribeToPrivateEventGroupUpdatesWithGapTwoClients) {
   // Initialize storage and live update queue
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PrivateEventGroupsOnly, kClientId1));
   auto client2_egs = generateEventGroupMap(
@@ -1427,7 +1429,9 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGap) {
   EXPECT_EQ(state_machine.numEventGroupsReceived(), total_event_groups);
 }
 
-TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdatesWithGapTwoClients) {
+// Disabled due to instability in order to unblock master for other fixes to improve its stability.
+// TODO (Alex): Develop a propper fix and re-enable this test.
+TEST(thin_replica_server_test, DISABLED_SubscribeToPublicEventGroupUpdatesWithGapTwoClients) {
   // Initialize storage and live update queue with public event groups and private event groups for kClientId2
   // Initialize storage and live update queue
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PublicEventGroupsOnly));
@@ -1557,7 +1561,9 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithG
   EXPECT_EQ(state_machine.numEventGroupsReceived(), total_event_groups);
 }
 
-TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdatesWithGapTwoClients) {
+// Disabled due to instability in order to unblock master for other fixes to improve its stability.
+// TODO (Alex): Develop a propper fix and re-enable this test.
+TEST(thin_replica_server_test, DISABLED_SubscribeToPublicAndPrivateEventGroupUpdatesWithGapTwoClients) {
   // Initialize storage and live update queue
   FakeStorage storage(
       generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PublicAndPrivateEventGroups, kClientId1));
@@ -2245,7 +2251,9 @@ TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesWithGap) 
   EXPECT_EQ(state_machine.numEventGroupsReceived(), total_event_groups);
 }
 
-TEST(thin_replica_server_test, SubscribeToPrivateEventGroupUpdateHashesWithGapTwoClients) {
+// Disabled due to instability in order to unblock master for other fixes to improve its stability.
+// TODO (Alex): Develop a propper fix and re-enable this test.
+TEST(thin_replica_server_test, DISABLED_SubscribeToPrivateEventGroupUpdateHashesWithGapTwoClients) {
   // Initialize storage and live update queue
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PrivateEventGroupsOnly, kClientId1));
   auto client2_egs = generateEventGroupMap(
@@ -2374,7 +2382,9 @@ TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesWithGap) {
   EXPECT_EQ(state_machine.numEventGroupsReceived(), total_event_groups);
 }
 
-TEST(thin_replica_server_test, SubscribeToPublicEventGroupUpdateHashesWithGapTwoClients) {
+// Disabled due to instability in order to unblock master for other fixes to improve its stability.
+// TODO (Alex): Develop a propper fix and re-enable this test.
+TEST(thin_replica_server_test, DISABLED_SubscribeToPublicEventGroupUpdateHashesWithGapTwoClients) {
   // Initialize storage and live update queue
   FakeStorage storage(generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PublicEventGroupsOnly));
   auto client2_egs = generateEventGroupMap(
@@ -2503,7 +2513,9 @@ TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashes
   EXPECT_EQ(state_machine.numEventGroupsReceived(), total_event_groups);
 }
 
-TEST(thin_replica_server_test, SubscribeToPublicAndPrivateEventGroupUpdateHashesWithGapTwoClients) {
+// Disabled due to instability in order to unblock master for other fixes to improve its stability.
+// TODO (Alex): Develop a propper fix and re-enable this test.
+TEST(thin_replica_server_test, DISABLED_SubscribeToPublicAndPrivateEventGroupUpdateHashesWithGapTwoClients) {
   // Initialize storage and live update queue
   FakeStorage storage(
       generateEventGroupMap(1, kLastEventGroupId, EventGroupType::PublicAndPrivateEventGroups, kClientId1));


### PR DESCRIPTION
This commit deactivates certain test cases in `thin-replica-server/test/thin_replica_server_test.cpp` known to be unstable. This is intended to be a temporary measure in order to prevent these failures from blocking other merges, especially others intended to improve stability. The intention is to reactivate these test cases in the near future once a better fix for them can be provided.

* **Problem Overview**  
Several test cases with names of the form `SubscribeTo*EventGroupUpdate*WithGapTwoClients` have been observed to fail intermittently on `master`. These failures have been observed to be significantly more common for builds with `DCMAKE_BUILD_TYPE=DEBUG`. These failures are interfering with the ability of developers to merge changes to `master`, including other changes intended to stabilize the branch.
* **Testing Done**  
 I have tried building with these changes and with `DCMAKE_BUILD_TYPE=DEBUG` and running the `thin_replica_server_test` suite built from `thin-replica-server/test/thin_replica_server_test.cpp`. This suite has not failed since I reached the current set of deactivated test cases included in this PR, and I have run the suite with these changes and the `DEBUG` build at least several dozen times (I wanted to have a script run it at least a couple hundred times, but decided I'd probably run the tests enough times after a couple hours with no failures). I've also tried running the suite with a build with the default parameters (i.e. without explicitly providing `DCMAKE_BUILD_TYPE=DEBUG`) with these changes 32 times, and all of them passed with no failures.