### PR TITLE
Fix max message size

### DIFF
--- a/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
@@ -151,12 +151,13 @@ PrePrepareMsg::PrePrepareMsg(ReplicaId sender,
                              const concordUtils::SpanContext& spanContext,
                              const std::string& batchCid,
                              size_t size)
-    : MessageBase(sender,
-                  MsgCode::PrePrepare,
-                  spanContext.data().size(),
-                  (((size + sizeof(Header) + batchCid.size()) < maxMessageSize<PrePrepareMsg>())
-                       ? (size + sizeof(Header) + batchCid.size())
-                       : maxMessageSize<PrePrepareMsg>() - spanContext.data().size())) {
+    : MessageBase(
+          sender,
+          MsgCode::PrePrepare,
+          spanContext.data().size(),
+          (((size + sizeof(Header) + batchCid.size()) + spanContext.data().size() < maxMessageSize<PrePrepareMsg>())
+               ? (size + sizeof(Header) + batchCid.size())
+               : maxMessageSize<PrePrepareMsg>() - spanContext.data().size())) {
   bool ready = size == 0;  // if null, then message is ready
   if (!ready) {
     b()->digestOfRequests.makeZero();

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -155,7 +155,7 @@ class RequestsIterator {
 
 template <>
 inline MsgSize maxMessageSize<PrePrepareMsg>() {
-  return ReplicaConfig::instance().getmaxExternalMessageSize() + MessageBase::SPAN_CONTEXT_MAX_SIZE;
+  return ReplicaConfig::instance().getmaxExternalMessageSize();
 }
 
 }  // namespace impl


### PR DESCRIPTION
* **Problem Overview**  
MessageBase considers the span size outside of the regular "size" parameter. Hence, in some cases, we may end up letting a message be larger than the allowed size.  For example, if a prePrepare message span size is smaller than the max span size, we may end up with a message that exceeds a bit from the maximal size. This change is for fixing this issue
* **Testing Done**  
  CI tests
