### PR TITLE
Setting db-checkpoint feature disable by default.

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -222,7 +222,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                false,
                "If true, replicas will publish their master key on startup");
   // Db checkpoint
-  CONFIG_PARAM(dbCheckpointFeatureEnabled, bool, true, "Feature flag for rocksDb checkpoints");
+  CONFIG_PARAM(dbCheckpointFeatureEnabled, bool, false, "Feature flag for rocksDb checkpoints");
   CONFIG_PARAM(maxNumberOfDbCheckpoints, uint32_t, 2u, "Max number of db checkpoints to be created");
   CONFIG_PARAM(dbCheckPointWindowSize, uint32_t, 30000u, "Db checkpoint window size in bft sequence number");
   CONFIG_PARAM(dbCheckpointDirPath, std::string, "", "Db checkpoint directory path");


### PR DESCRIPTION
* **Problem Overview**  
  To fix the code coverage timeout issue, turn off the db checkpoint
  option by default. Because of dbCheckpointMonitorIntervalSeconds,
  all apollo test suits run with dbcheckpoint when the feature is enabled,
  which causes all tests to run for a longer period of time.
* **Testing Done**  
  Testing is done after running a codecoverage CI job on the above changes.
  https://github.com/itsmeakashgoyal/concord-bft/actions/runs/2376518694