### PR TITLE
Fix races between pruning, execution and main thread

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -44,6 +44,7 @@
 #include <ccron/ticks_generator.hpp>
 #include "EpochManager.hpp"
 #include "PerfMetrics.hpp"
+#include "ControlStateManager.hpp"
 
 namespace preprocessor {
 class PreProcessResultMsg;
@@ -647,6 +648,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
     virtual void release() override { delete this; }
 
     virtual void execute() override {
+      bftEngine::ControlStateManager::instance().waitForPruningIfNeeded();
       MDC_PUT(MDC_REPLICA_ID_KEY, std::to_string(parent_.config_.replicaId));
       MDC_PUT(MDC_THREAD_KEY, "post-execution-thread");
       SCOPED_MDC_SEQ_NUM(std::to_string(ppMsg_->seqNumber()));


### PR DESCRIPTION
* **Problem Overview**  
  In case we run in async pruning mode and we have a prePrepare message that contains pruning request + regular post-execution request we can hit the following scenario:
  1. The pruning thread starts working
  2. The main thread schedule the regular request for execution in the post-execution thread
  3. The post-execution thread adds block while pruning (causing a state deviation between the replicas)

The solution provided before (see https://github.com/vmware/concord-bft/blob/master/bftengine/src/bftengine/RequestHandler.cpp#L175) was to return from execution if we had a pruning request in the prePrepeare message. This solution won't work when we have a separated thread for post-execution because pruning is executed in synchronous mode as part of the execution of the special requests. 
On the other hand, we cannot simply abort the execution in case async pruning is running because pruning is a local operation in the replica.
(If you notice carefully, this solution is not even correct in the regular case, because pruning may take different time in different replicas)

The solution suggested in this PR is to use a mutex to block the post-execution thread in case pruning has started. 
__Correctness__: When we have a pruning request in a prePrepare message we first execute it synchronously in the main thread as part of the special requests. Hence, every "regular" request will be executed after pruning has started.
On the other hand, in case of pruning was not done when the regular request was scheduled for execution, the post-execution thread will simply wait for pruning to be finished.
This means that all replicas will execute the other requests in the prePrepare only after the pruning thread releases the lock and hence the state will be identical.
__Efficiency__: As long as there is no contention, grabbing modern mutex is cheap as testAndSet operation. Hence, this should not affect performance (see https://preshing.com/20111118/locks-arent-slow-lock-contention-is/)
* **Testing Done**  
  CI tests (unable to reproduce as this is a non-deterministic test) 
