### PR TITLE
Assert because of two transactions on checkpoint

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -563,6 +563,13 @@ void BCStateTran::createCheckpointOfCurrentState(uint64_t checkpointNumber) {
   ConcordAssert(running_);
   ConcordAssert(!isFetching());
   ConcordAssertGT(checkpointNumber, 0);
+  if (checkpointNumber == lastStoredCheckpointNumber) {
+    // We persist the lastStoredCheckpointNumber in a separate transaction from the actual
+    // update of the lastExecutedSeqNum. Since we have no mechanism to batch the 2 transactions
+    // together we need to handle this rare recovery situation.
+    LOG_WARN(logger_, "checkpointNumber == lastStoredCheckpointNumber" << KVLOG(checkpointNumber));
+    return;
+  }
   ConcordAssertGT(checkpointNumber, lastStoredCheckpointNumber);
 
   metrics_.create_checkpoint_++;


### PR DESCRIPTION
* **Problem Overview**  
 Because we store the checkpoint in one transaction and update 
the sequence ID in another we can potentially recover in a situation 
where we have already created a checkpoint for the current sequence ID.
This is something that can only happen due to restarts.
We need to resolve the situation in the recovery procedure, because
the storage mechanisms used in ReplicaImp and State Transfer are different
in order to improve decoupling and stacking the 2 transactions in 1 is not
feasible. This bug was found by the Apollo's restart recovery suite test
test_restarting_replica_with_client_load.
* **Testing Done**  
Apollo's test test_restarting_replica_with_client_load was used to both discover this problem and to verify correct recovery after the fix.
