### PR TITLE
Client key exchange support for unified certificates

### DIFF
--- a/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
@@ -39,9 +39,12 @@ class ClientTlsKeyExchangeHandler : public IStateHandler {
                               const std::string& cert_folder,
                               bool enc,
                               const std::vector<uint32_t>& bft_clients,
+                              uint16_t clientservice_pid,
+                              bool use_unified_certificates,
                               std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm);
   bool validate(const State&) const override;
   bool execute(const State&, WriteState&) override;
+  void exchangeTlsKeys(const std::string& pkey_path, const std::string& cert_path, const uint64_t blockid);
 
  private:
   logging::Logger getLogger() {
@@ -53,6 +56,8 @@ class ClientTlsKeyExchangeHandler : public IStateHandler {
   bool enc_;
   std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
   std::vector<uint32_t> bft_clients_;
+  uint16_t clientservice_pid_;
+  bool use_unified_certificates_;
   uint64_t init_last_tls_update_block_;
   concord::secretsmanager::SecretsManagerPlain psm_;
   std::string version_path_;

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -253,6 +253,8 @@ int main(int argc, char** argv) {
       creParams.certFolder,
       enc,
       bft_clients,
+      creParams.bftConfig.id.val,
+      false,
       sm_));
   cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientMasterKeyExchangeHandler>(
       creParams.CreConfig.id_,

--- a/util/src/crypto_utils.cpp
+++ b/util/src/crypto_utils.cpp
@@ -288,7 +288,7 @@ bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
   std::smatch sm;
   regex_search(subject, sm, r);
 
-  LOG_DEBUG(GL, "Subject from certificate " << subject);
+  LOG_DEBUG(GL, "Subject from certificate " << subject.data());
   if (sm.length() <= peerIdPrefixLength) {
     LOG_ERROR(GL, "OU not found or empty: " << subject);
     return false;
@@ -316,7 +316,7 @@ bool CertificateUtils::verifyCertificate(X509* cert_to_verify,
   CN.resize(SIZE);
   X509_NAME_get_text_by_NID(X509_get_subject_name(cert_to_verify), NID_commonName, CN.data(), SIZE);
 
-  LOG_INFO(GL, "Field CN: " << CN);
+  LOG_INFO(GL, "Field CN: " << CN.data());
   std::string cert_type = "server";
   if (CN.find("cli") != std::string::npos) cert_type = "client";
   conn_type = cert_type;


### PR DESCRIPTION
* **Problem Overview**  
Earlier we had certificates same as the number of bfs-clients, thus needed to exchange those many client certificates.
With unified certificates, we have single certificate for communication i.e of clientservice. These changes will exchange single certificate.
**Unified certificates is disabled in master.**
* **Testing Done**  
 Testing done with Hermes CI. Key-exchange passed in deployment setup with flags enabled.
