### PR TITLE
Add sequence number to BatchRequestProcessingJob log message on complete

### DIFF
--- a/client/client_pool/src/external_client.cpp
+++ b/client/client_pool/src/external_client.cpp
@@ -204,7 +204,11 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
           pending_reply.cb(move(response));
           LOG_INFO(logger_,
                    "Request processing completed; return response through the callback"
-                       << KVLOG(client_id_, batch_cid, pending_reply.cid, received_reply_entry.second.result));
+                       << KVLOG(client_id_,
+                                batch_cid,
+                                received_reply_seq_num,
+                                pending_reply.cid,
+                                received_reply_entry.second.result));
         } else {
           // Used for testing only
           if (data_size > pending_reply.lengthOfReplyBuffer) {
@@ -216,8 +220,11 @@ std::pair<int32_t, ConcordClient::PendingReplies> ConcordClient::SendPendingRequ
           pending_reply.actualReplyLength = data_size;
           pending_reply.opResult = static_cast<bftEngine::OperationResult>(received_reply_entry.second.result);
           LOG_INFO(logger_,
-                   "Request processing completed"
-                       << KVLOG(client_id_, batch_cid, pending_reply.cid, received_reply_entry.second.result));
+                   "Request processing completed" << KVLOG(client_id_,
+                                                           batch_cid,
+                                                           received_reply_seq_num,
+                                                           pending_reply.cid,
+                                                           received_reply_entry.second.result));
         }
       }
     }


### PR DESCRIPTION
Add sequence number to "Request processing completed" log message of BatchRequestProcessingJob.
(same message of SingleRequestProcessingJob already contains sequence number)

**Problem Overview:**
BFT Client completed log message doesn't have sequence number

**Testing Done:**
Local docker-compose. Logs were reviewed&approved by Priyadharshan Reddy Seelam


