### PR TITLE
BCStateTran: initialize session and avoid closing an already closed one

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -3939,6 +3939,10 @@ void BCStateTran::triggerPostProcessing() {
 }
 
 void BCStateTran::SourceSession::close() {
+  if (startTime_ == 0) {
+    LOG_WARN(logger_, "Trying to close a closed session!");
+    return;
+  }
   LOG_INFO(
       logger_,
       "SourceSession: Session closed:" << std::boolalpha << KVLOG(replicaId_, startTime_, activeDuration(), expired()));

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -754,7 +754,7 @@ class BCStateTran : public IStateTransfer {
   struct SourceSession {
    public:
     SourceSession(logging::Logger& logger, uint64_t sourceSessionExpiryDurationMs)
-        : logger_(logger), expiryDurationMs_{sourceSessionExpiryDurationMs} {}
+        : logger_(logger), expiryDurationMs_{sourceSessionExpiryDurationMs}, startTime_{0} {}
     SourceSession() = delete;
     void close();
     // returns a pair of booleans:


### PR DESCRIPTION
startTime_ is initialized in ctor. Print warning if trying to close
and already closed session.

* **Problem Overview**  
This is a minor fix to prevent wrong close nd log print when St starts. There is no actual bug fixed.
* **Testing Done**  
no testing is needed for such a minor fix. We relay on current CI.
