### PR TITLE
RangeValidationTree: change id_to_node_ into a map

### DIFF
--- a/bftengine/src/bcstatetransfer/RangeValidationTree.cpp
+++ b/bftengine/src/bcstatetransfer/RangeValidationTree.cpp
@@ -1122,7 +1122,6 @@ bool RangeValidationTree::setSerializedRvbData(std::istringstream& is) {
   }
 
   // populate id_to_node_ map
-  id_to_node_.reserve(data.total_nodes);
   uint64_t min_rvb_index{std::numeric_limits<uint64_t>::max()}, max_rvb_index{0};
   for (uint64_t i = 0; i < data.total_nodes; i++) {
     auto node = RVTNode::createFromSerialized(is);

--- a/bftengine/src/bcstatetransfer/RangeValidationTree.hpp
+++ b/bftengine/src/bcstatetransfer/RangeValidationTree.hpp
@@ -360,7 +360,7 @@ class RangeValidationTree {
   // level 0 represents RVB node so it would always hold 0x0
   std::array<RVTNodePtr, NodeInfo::kMaxLevels> rightmost_rvt_node_;
   std::array<RVTNodePtr, NodeInfo::kMaxLevels> leftmost_rvt_node_;
-  std::unordered_map<uint64_t, RVTNodePtr> id_to_node_;
+  std::map<uint64_t, RVTNodePtr> id_to_node_;
   RVTNodePtr root_{nullptr};
   uint64_t min_rvb_index_{};  // RVB index is (RVB ID / fetch range size). This is the minimal index in the tree.
   uint64_t max_rvb_index_{};  // RVB index is (RVB ID / fetch range size). This is the maximal index in the tree.


### PR DESCRIPTION
id_to_node_ is an unordered map. This is wrong when trying to serialize,
as the checkpoints, data, and hash representation will all be
mismatched. here we convert it into an ordered map.

* **Problem Overview**  
Ask for checkpoint summary message mismatch. The reason is the use of unordered_map in the RVT. We must use an ordered map.
* **Testing Done**  
Trying to reproduce locally. In addition, RVT conflict detection is committed soon - this should detect such issues much earlier.
