### PR TITLE
Add kKvbKeyEthBlockHash

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_key_types.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_key_types.h
@@ -24,6 +24,7 @@ const char kKvbKeyEthBalance = 0x03;
 const char kKvbKeyEthCode = 0x04;
 const char kKvbKeyEthStorage = 0x05;
 const char kKvbKeyEthNonce = 0x06;
+const char kKvbKeyEthBlockHash = 0x07;
 
 // Unused 0x10 - 0x1f
 


### PR DESCRIPTION
* **Problem Overview**  
  Concord product requires a new key type for Ethereum. Both a block number and block hash keys will be stored in the block.
* **Testing Done**  
  N/A
