### PR TITLE
TRC ID needs to be populated irrespective of in(secure) TRC-TRS connection.

### DIFF
--- a/client/clientservice/src/configuration.cpp
+++ b/client/clientservice/src/configuration.cpp
@@ -171,6 +171,7 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
                            const std::string& tr_id,
                            bool is_insecure,
                            const std::string& tls_path) {
+  config.subscribe_config.id = tr_id;
   config.subscribe_config.use_tls = not is_insecure;
   std::string cert_client_id;
   std::string client_cert_path;
@@ -193,7 +194,6 @@ void configureSubscription(concord::client::concordclient::ConcordClientConfig& 
       LOG_INFO(logger, " Certificates path" << tls_path);
       base_path = tls_path;
       client_cert_path = tls_path + "/client.cert";
-      config.subscribe_config.id = tr_id;
     }
 
     readCert(client_cert_path, config.subscribe_config.pem_cert_chain);


### PR DESCRIPTION
The bug was introduced in https://github.com/vmware/concord-bft/pull/2613, with the introduction of unify_certificates flag. TRC ID was not being populated if TRC-TRS connection was insecure, this change fixes this issue.