### PR TITLE
Persist the lastBlockId in metadata on unwedge

### DIFF
--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -23,6 +23,7 @@
 #include "OpenTracing.hpp"
 #include "TimeService.hpp"
 #include "ISystemResourceEntity.hpp"
+#include "PersistentStorageImp.hpp"
 
 namespace concord::reconfiguration {
 class IReconfigurationHandler;
@@ -79,6 +80,7 @@ class IRequestsHandler {
                                              static_cast<concord::reconfiguration::ReconfigurationHandlerType>(1)) {
     reconfig_handler_.push_back(rh);
   }
+  virtual void setPersistentStorage(const std::shared_ptr<bftEngine::impl::PersistentStorage> &persistent_storage) {}
 
   virtual ~IRequestsHandler() = default;
 

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -200,4 +200,11 @@ void RequestHandler::preExecute(IRequestsHandler::ExecutionRequest& req,
                                 concordUtils::SpanWrapper& parent_span) {
   if (userRequestsHandler_) return userRequestsHandler_->preExecute(req, timestamp, batchCid, parent_span);
 }
+
+void RequestHandler::setPersistentStorage(
+    const std::shared_ptr<bftEngine::impl::PersistentStorage>& persistent_storage) {
+  for (auto& rh : reconfig_handler_) {
+    rh->setPersistentStorage(persistent_storage);
+  }
+}
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -59,14 +59,16 @@ class RequestHandler : public IRequestsHandler {
   void setReconfigurationHandler(std::shared_ptr<concord::reconfiguration::IReconfigurationHandler> rh,
                                  concord::reconfiguration::ReconfigurationHandlerType type =
                                      concord::reconfiguration::ReconfigurationHandlerType::REGULAR) override {
+    IRequestsHandler::setReconfigurationHandler(rh, type);
     reconfig_dispatcher_.addReconfigurationHandler(rh, type);
   }
 
   void setCronTableRegistry(const std::shared_ptr<concord::cron::CronTableRegistry> &reg) {
     cron_table_registry_ = reg;
   }
-
+  void setPersistentStorage(const std::shared_ptr<bftEngine::impl::PersistentStorage> &persistent_storage) override;
   void onFinishExecutingReadWriteRequests() override { userRequestsHandler_->onFinishExecutingReadWriteRequests(); }
+  std::shared_ptr<IRequestsHandler> getUserHandler() { return userRequestsHandler_; }
 
  private:
   std::shared_ptr<IRequestsHandler> userRequestsHandler_;

--- a/kvbc/include/metadata_block_id.h
+++ b/kvbc/include/metadata_block_id.h
@@ -35,6 +35,17 @@ void persistLastBlockIdInMetadata(const categorization::KeyValueBlockchain &bloc
   }
 }
 
+template <bool in_transaction>
+void persistLastBlockIdInMetadata(const BlockId bid,
+                                  const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
+  const auto user_data = concordUtils::toBigEndianArrayBuffer(bid);
+  if constexpr (in_transaction) {
+    metadata->setUserDataInTransaction(user_data.data(), user_data.size());
+  } else {
+    metadata->setUserDataAtomically(user_data.data(), user_data.size());
+  }
+}
+
 inline std::optional<BlockId> getLastBlockIdFromMetadata(
     const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
   const auto ud = metadata->getUserData();

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -25,6 +25,7 @@
 #include "AdaptivePruningManager.hpp"
 #include "IntervalMappingResourceManager.hpp"
 #include "newest_public_event_group_record_time.h"
+#include "bftengine/PersistentStorageImp.hpp"
 #include <functional>
 #include <string>
 #include <utility>
@@ -293,10 +294,14 @@ class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurati
               uint32_t,
               const std::optional<bftEngine::Timestamp>&,
               concord::messages::ReconfigurationResponse&) override;
+  void setPersistentStorage(const std::shared_ptr<bftEngine::impl::PersistentStorage>& persistent_storage) override {
+    persistent_storage_ = persistent_storage;
+  }
 
  private:
   concord::performance::AdaptivePruningManager& apm_;
   concord::performance::ISystemResourceEntity& replicaResources_;
+  std::shared_ptr<bftEngine::impl::PersistentStorage> persistent_storage_;
 };
 /**
  * This component is reposnsible for logging internal reconfiguration requests to the blockchain (such as noop

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -143,7 +143,11 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
     persistLastBlockIdInMetadata<in_transaction>(blockchain_, persistent_storage_);
   }
 
-  void setPersistentStorage(const std::shared_ptr<bftEngine::impl::PersistentStorage> &persistent_storage) {
+  void setPersistentStorage(const std::shared_ptr<bftEngine::impl::PersistentStorage> &persistent_storage) override {
+    getUserHandler()->setPersistentStorage(persistent_storage);
+    for (auto &rh : reconfig_handler_) {
+      rh->setPersistentStorage(persistent_storage);
+    }
     persistent_storage_ = persistent_storage;
   }
 

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -27,6 +27,7 @@
 #include "categorization/db_categories.h"
 #include "categorization/details.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
+#include "metadata_block_id.h"
 #include <chrono>
 #include <algorithm>
 #include <memory>
@@ -1001,7 +1002,8 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
   bool can_unwedge = (valid_sigs >= quorum_size);
   if (can_unwedge) {
     if (!cmd.restart) {
-      persistNewEpochBlock(bft_seq_num);
+      auto bid = persistNewEpochBlock(bft_seq_num);
+      persistLastBlockIdInMetadata<false>(bid, persistent_storage_);
       bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(0);
       bftEngine::ControlStateManager::instance().unwedge();
       bftEngine::IControlHandler::instance()->resetState();

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -17,6 +17,7 @@
 #include "kv_types.hpp"
 #include "Replica.hpp"
 #include "bftengine/TimeService.hpp"
+#include "bftengine/PersistentStorageImp.hpp"
 
 namespace concord::reconfiguration {
 enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
@@ -318,6 +319,7 @@ class IReconfigurationHandler {
 
   // The verification method is pure virtual as all subclasses has to define how they verify the reconfiguration
   // requests.
+  virtual void setPersistentStorage(const std::shared_ptr<bftEngine::impl::PersistentStorage> &persistent_storage) {}
   virtual bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const = 0;
   virtual ~IReconfigurationHandler() = default;
 

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -786,7 +786,10 @@ class SkvbcReconfigurationTest(ApolloTest):
         await self.verify_last_executed_seq_num(bft_network, checkpoint_before)
         await self.validate_stop_on_super_stable_checkpoint(bft_network, skvbc)
         await op.unwedge()
-
+        await self.validate_start_on_unwedge(bft_network,skvbc,fullWedge=True)
+        # To make sure that revocery doesn't remove the new epoch block, lets manually restart the replicas
+        bft_network.stop_all_replicas()
+        bft_network.start_all_replicas()
         protocol = kvbc.SimpleKVBCProtocol(bft_network)
 
         key = protocol.random_key()

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -50,7 +50,7 @@ using Hash = Hasher::Digest;
 const uint64_t LONG_EXEC_CMD_TIME_IN_SEC = 11;
 
 template <typename Span>
-static Hash hash(const Span &span) {
+static Hash createHash(const Span &span) {
   return Hasher{}.digest(span.data(), span.size());
 }
 
@@ -63,7 +63,7 @@ static const std::string &keyHashToCategory(const Hash &keyHash) {
   return BLOCK_MERKLE_CAT_ID;
 }
 
-static const std::string &keyToCategory(const std::string &key) { return keyHashToCategory(hash(key)); }
+static const std::string &keyToCategory(const std::string &key) { return keyHashToCategory(createHash(key)); }
 
 void InternalCommandsHandler::add(std::string &&key,
                                   std::string &&value,


### PR DESCRIPTION
* **Problem Overview**  
  For recovery, we persist the last reachable block id after every execution. However, on unwedge (without restart) we add a block due to a **read request**, hence we do not persist the last reachable block id. If we do restart right after the wedge, the recovery mechanism will delete the new epoch block and the system will be stayed wedged.
The solution is to write the latest reachable block id to the metadata after successful unwedge.

* **Testing Done**  
The test_unwedge_command Apollo test was modified a bit to also test that we are not wedged even if we restart the replicas after the wedge
