### PR TITLE
RVBManager: fix a bug in updateRvbDataDuringCheckpoint

### DIFF
--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -213,6 +213,7 @@ class TestAppState : public IAppState, public IBlocksDeleter {
     }
   }
 
+  // until is the 1st block which is not deleted.
   BlockId deleteBlocksUntil(BlockId until) override {
     if (genesis_block_id_ == 0) {
       throw std::logic_error{"Cannot delete a block range from an empty blockchain"};


### PR DESCRIPTION
* **Problem Overview** 
RVB failed on assertion while didn't find a block digest during real deployment. The search range given to the RVB during updateRvbDataDuringCheckpoint was incorrect due to multiple pruning commands.

1) Reverse order of RVT update: first prune the blocks, then add blocks.
both are optional of course. The reason is that the whole logic checks
the RVT min/max which should be most updated before adding blocks (
  in rare cases) for the most simplified code. Therefore, we would like
  to first trim the RVT.
2) Calculate add_range_min_block_id while taking into consideration
the pruned_blocks_digests_. We never want to define a range for blocks
that were already pruned.

* **Testing Done***
test bkpCheckpointingWithPruning is added as a unit test to
reproduce the exact scenario for this fix. After the fix is applied,
the test won't fail.

