### PR TITLE
Source selector and reject msg fixes

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -374,7 +374,7 @@ void BCStateTran::initImpl(uint64_t maxNumOfRequiredStoredCheckpoints,
         LOG_INFO(logger_, "State Transfer cycle continues");
         startCollectingStats();
         if ((fs == FetchingState::GettingMissingBlocks) || (fs == FetchingState::GettingMissingResPages)) {
-          SetAllReplicasAsPreferred();
+          setAllReplicasAsPreferred();
         }
 
         if (fs == FetchingState::GettingMissingBlocks) {
@@ -2372,7 +2372,7 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
     LOG_DEBUG(logger_, "Adding all peer replicas to preferredReplicas_ (because preferredReplicas_.size()==0)");
 
     // in this case, we will try to use all other replicas (remove current replica)
-    SetAllReplicasAsPreferred();
+    setAllReplicasAsPreferred();
     sourceSelector_.removeCurrentReplica();
     processData();
   } else if (fs == FetchingState::GettingMissingResPages) {
@@ -2873,7 +2873,7 @@ set<uint16_t> BCStateTran::allOtherReplicas() {
   return others;
 }
 
-void BCStateTran::SetAllReplicasAsPreferred() { sourceSelector_.setAllReplicasAsPreferred(); }
+void BCStateTran::setAllReplicasAsPreferred() { sourceSelector_.checkAndRefillPreferredReplicas(); }
 
 void BCStateTran::reportCollectingStatus(const uint32_t actualBlockSize, bool toLog) {
   metrics_.overall_blocks_collected_++;

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1794,15 +1794,19 @@ void BCStateTran::clearIoContexts() {
   ioContexts_.clear();
 }
 
-void BCStateTran::sendRejectFetchingMsg(const char *reason, uint64_t msgSeqNum, uint16_t destReplicaId) {
-  RejectFetchingMsg outMsg;
+void BCStateTran::sendRejectFetchingMsg(const uint16_t rejectionCode,
+                                        uint64_t msgSeqNum,
+                                        uint16_t destReplicaId,
+                                        std::string_view additionalInfo) {
+  RejectFetchingMsg outMsg(rejectionCode, msgSeqNum);
 
   if (sourceSession_.isOpen() && (sourceSession_.ownerDestReplicaId() == destReplicaId)) {
     sourceSession_.close();
   }
-  outMsg.requestMsgSeqNum = msgSeqNum;
   metrics_.sent_reject_fetch_msg_++;
-  LOG_WARN(logger_, "Rejecting msg. Sending RejectFetchingMsg to replica: " << KVLOG(reason, destReplicaId, msgSeqNum));
+  LOG_WARN(logger_,
+           "Rejecting msg. Sending RejectFetchingMsg to replica: " << KVLOG(
+               rejectionCode, outMsg.reasonMessages[rejectionCode], additionalInfo, destReplicaId, msgSeqNum));
   replicaForStateTransfer_->sendStateTransferMessage(
       reinterpret_cast<char *>(&outMsg), sizeof(RejectFetchingMsg), destReplicaId);
 }
@@ -1933,8 +1937,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 
   uint64_t numBlocksRequested = static_cast<uint64_t>(m->maxBlockId - m->minBlockId + 1);
   if (numBlocksRequested > config_.maxNumberOfChunksInBatch) {
-    sendRejectFetchingMsg(
-        "Number of blocks requested exceeds config_.maxNumberOfChunksInBatch", m->msgSeqNum, replicaId);
+    sendRejectFetchingMsg(RejectFetchingMsg::Reason::INVALID_NUMBER_OF_BLOCKS_REQUESTED, m->msgSeqNum, replicaId);
     return false;
   }
 
@@ -1943,18 +1946,22 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 
   // Reject if I'm already in ST (source or destination)
   if (isActiveDestination(fetchingState)) {
-    sendRejectFetchingMsg("In state transfer", m->msgSeqNum, replicaId);
+    sendRejectFetchingMsg(RejectFetchingMsg::Reason::IN_STATE_TRANSFER, m->msgSeqNum, replicaId);
     return false;
   }
   if (m->maxBlockId > lastReachableBlockNum) {
-    sendRejectFetchingMsg("Required blocks range is not present", m->msgSeqNum, replicaId);
+    sendRejectFetchingMsg(RejectFetchingMsg::Reason::BLOCK_RANGE_NOT_FOUND,
+                          m->msgSeqNum,
+                          replicaId,
+                          KVLOG(m->maxBlockId, lastReachableBlockNum));
     return false;
   }
   auto [sessionOpened, otherReplicaSessionClosed] = sourceSession_.tryOpen(replicaId);
   (void)otherReplicaSessionClosed;
   if (sessionOpened == false) {
-    auto reason = "Active session with ownerDestReplicaId=" + std::to_string(sourceSession_.ownerDestReplicaId());
-    sendRejectFetchingMsg(reason.c_str(), m->msgSeqNum, replicaId);
+    auto additionalInfo =
+        "Active session with ownerDestReplicaId=" + std::to_string(sourceSession_.ownerDestReplicaId());
+    sendRejectFetchingMsg(RejectFetchingMsg::Reason::IN_ACTIVE_SESSION, m->msgSeqNum, replicaId, additionalInfo);
     return false;
   }
   // comment: otherReplicaSessionClosed is supposed to mark the need to clear io contexts.
@@ -1963,9 +1970,9 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
   size_t rvbGroupDigestsExpectedSize =
       (m->rvbGroupId != 0) ? rvbm_->getSerializedDigestsOfRvbGroup(m->rvbGroupId, nullptr, 0, true) : 0;
   if ((rvbGroupDigestsExpectedSize == 0) && (m->rvbGroupId != 0)) {
-    // Destination RVB Group request cannot be obtained, reject
-    auto reason = "RVB Group request cannot be obtained, rejecting request:" + KVLOG(m->rvbGroupId);
-    sendRejectFetchingMsg(reason.c_str(), m->msgSeqNum, replicaId);
+    auto additionalInfo = "RVB Group request cannot be fullfiled, rejecting request:" + KVLOG(m->rvbGroupId);
+    sendRejectFetchingMsg(
+        RejectFetchingMsg::Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, m->msgSeqNum, replicaId, additionalInfo);
     sourceSession_.close();
     return false;
   }
@@ -2028,8 +2035,9 @@ void BCStateTran::continueSendBatch() {
         }
         TimeRecorder scoped_timer(*histograms_.src_next_block_wait_duration);
         if (!ctx->future.get()) {
-          auto reason = "Block not found in storage, abort batch:" + KVLOG(ctx->blockId);
-          sendRejectFetchingMsg(reason.c_str(), m->msgSeqNum, sb.destReplicaId);
+          auto additionalInfo = "Block not found in storage, abort batch:" + KVLOG(ctx->blockId);
+          sendRejectFetchingMsg(
+              RejectFetchingMsg::Reason::BLOCK_NOT_FOUND_IN_STORAGE, m->msgSeqNum, sb.destReplicaId, additionalInfo);
           sourceSession_.close();
           sourceBatch_.active = false;
           return;
@@ -2057,9 +2065,12 @@ void BCStateTran::continueSendBatch() {
 
     // if msg is invalid (lastKnownChunkInLastRequiredBlock+1 does not exist)
     if ((sb.numSentChunks == 0) && (sb.nextChunk > numOfChunksInNextBlock)) {
-      auto reason =
+      auto additionalInfo =
           "Msg is invalid (illegal chunk number):" + KVLOG(sb.destReplicaId, sb.nextChunk, numOfChunksInNextBlock);
-      sendRejectFetchingMsg(reason.c_str(), m->msgSeqNum, sb.destReplicaId);
+      sendRejectFetchingMsg(RejectFetchingMsg::Reason::INVALID_NUMBER_OF_BLOCKS_REQUESTED,
+                            m->msgSeqNum,
+                            sb.destReplicaId,
+                            additionalInfo);
       sourceSession_.close();
       sourceBatch_.active = false;
       return;
@@ -2090,10 +2101,11 @@ void BCStateTran::continueSendBatch() {
       size_t rvbGroupDigestsActualSize =
           rvbm_->getSerializedDigestsOfRvbGroup(m->rvbGroupId, outMsg->data, sb.rvbGroupDigestsExpectedSize, false);
       if ((rvbGroupDigestsActualSize == 0) || (sb.rvbGroupDigestsExpectedSize != rvbGroupDigestsActualSize)) {
-        auto reason = "Rejecting message - not holding all requested digests (or some other error)" +
-                      KVLOG(sb.rvbGroupDigestsExpectedSize, rvbGroupDigestsActualSize);
+        auto additionalInfo = "Rejecting message - not holding all requested digests (or some other error)" +
+                              KVLOG(sb.rvbGroupDigestsExpectedSize, rvbGroupDigestsActualSize);
         ItemDataMsg::free(outMsg);
-        sendRejectFetchingMsg(reason.c_str(), m->msgSeqNum, sb.destReplicaId);
+        sendRejectFetchingMsg(
+            RejectFetchingMsg::Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, m->msgSeqNum, sb.destReplicaId, additionalInfo);
         sourceSession_.close();
         sourceBatch_.active = false;
         return;
@@ -2219,9 +2231,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
 
   // if msg should be rejected
   if ((isActiveDestination(fetchingState)) || (!psd_->hasCheckpointDesc(m->requiredCheckpointNum))) {
-    RejectFetchingMsg outMsg;
-    outMsg.requestMsgSeqNum = m->msgSeqNum;
-
+    RejectFetchingMsg outMsg(RejectFetchingMsg::Reason::RES_PAGE_NOT_FOUND, m->msgSeqNum);
     LOG_WARN(logger_,
              "Rejecting msg. Sending RejectFetchingMsg to replica " << KVLOG(replicaId,
                                                                              fetchingState,
@@ -2350,8 +2360,19 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
     return false;
   }
 
+  auto itr = m->reasonMessages.find(m->rejectionCode);
+  if (itr == m->reasonMessages.end()) {
+    LOG_WARN(logger_, "Msg is invalid: " << KVLOG(replicaId, m->rejectionCode));
+    metrics_.invalid_reject_fetching_msg_++;
+    return false;
+  }
+
   // if msg is not relevant
-  if (sourceSelector_.currentReplica() != replicaId || lastMsgSeqNum_ != m->requestMsgSeqNum) {
+  if ((sourceSelector_.currentReplica() != replicaId) || (lastMsgSeqNum_ != m->requestMsgSeqNum) ||
+      ((fs == FetchingState::GettingMissingBlocks) &&
+       (m->rejectionCode == RejectFetchingMsg::Reason::RES_PAGE_NOT_FOUND)) ||
+      ((fs == FetchingState::GettingMissingResPages) &&
+       (m->rejectionCode != RejectFetchingMsg::Reason::RES_PAGE_NOT_FOUND))) {
     LOG_WARN(
         logger_,
         "Msg is irrelevant" << KVLOG(replicaId, sourceSelector_.currentReplica(), lastMsgSeqNum_, m->requestMsgSeqNum));
@@ -2359,27 +2380,23 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
     return false;
   }
 
-  LOG_INFO(logger_, "Received RejectFetchingMsg:" << KVLOG(replicaId, m->requestMsgSeqNum));
-  if (sourceSelector_.isPreferredSourceId(replicaId)) {
-    LOG_WARN(logger_, "Removing replica from preferred replicas: " << KVLOG(replicaId));
+  LOG_INFO(
+      logger_,
+      "Received reject msg" << KVLOG(stateName(fs), m->rejectionCode, itr->second, replicaId, m->requestMsgSeqNum));
+
+  if (fs == FetchingState::GettingMissingResPages) {
+    if (m->rejectionCode == RejectFetchingMsg::Reason::RES_PAGE_NOT_FOUND) {
+      sourceSelector_.reset();
+      // Probably consensus has advanced while destination replica was collecting blocks
+      // and all replicas have already deleted the requested reserved pages
+      // for the target checkpoint so enter new cycle
+      startCollectingStateInternal();
+    }
+  } else {
+    // One of the valid rejection code while getting missing blocks so move on to next source
     sourceSelector_.removeCurrentReplica();
     clearAllPendingItemsData();
-  }
-
-  if (sourceSelector_.hasPreferredReplicas()) {
     processData();
-  } else if (fs == FetchingState::GettingMissingBlocks) {
-    LOG_DEBUG(logger_, "Adding all peer replicas to preferredReplicas_ (because preferredReplicas_.size()==0)");
-
-    // in this case, we will try to use all other replicas (remove current replica)
-    setAllReplicasAsPreferred();
-    sourceSelector_.removeCurrentReplica();
-    processData();
-  } else if (fs == FetchingState::GettingMissingResPages) {
-    // enter new cycle
-    startCollectingStateInternal();
-  } else {
-    ConcordAssert(false);
   }
   return false;
 }

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -475,7 +475,7 @@ class BCStateTran : public IStateTransfer {
   void cycleEndSummary();
   void onGettingMissingBlocksEnd(DataStoreTransaction* txn);
   set<uint16_t> allOtherReplicas();
-  void SetAllReplicasAsPreferred();
+  void setAllReplicasAsPreferred();
 
   ///////////////////////////////////////////////////////////////////////////
   // Helper methods

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -271,7 +271,6 @@ class BCStateTran : public IStateTransfer {
   uint64_t maxNumOfStoredCheckpoints_;
   std::atomic_uint64_t numberOfReservedPages_;
   uint32_t cycleCounter_;
-  uint32_t internalCycleCounter_;
 
   std::atomic<bool> running_;
   IReplicaForStateTransfer* replicaForStateTransfer_;
@@ -640,6 +639,7 @@ class BCStateTran : public IStateTransfer {
     CounterHandle one_shot_timer_;
 
     CounterHandle on_transferring_complete_;
+    CounterHandle internal_cycle_counter;
 
     CounterHandle handle_AskForCheckpointSummaries_msg_;
     CounterHandle handle_CheckpointsSummary_msg_;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -811,7 +811,10 @@ class BCStateTran : public IStateTransfer {
 
   friend std::ostream& operator<<(std::ostream& os, const BCStateTran::SourceBatch& batch);
   void continueSendBatch();
-  void sendRejectFetchingMsg(const char* reason, uint64_t msgSeqNum, uint16_t destReplicaId);
+  void sendRejectFetchingMsg(const uint16_t rejectionCode,
+                             uint64_t msgSeqNum,
+                             uint16_t destReplicaId,
+                             std::string_view additionalInfo = "");
   ///////////////////////////////////////////////////////////////////////////
   // Latency Historgrams (snapshots)
   ///////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -187,12 +187,37 @@ struct FetchResPagesMsg : public BCStateTranBaseMsg {
 };
 
 struct RejectFetchingMsg : public BCStateTranBaseMsg {
-  RejectFetchingMsg() {
+  class Reason {
+   public:
+    enum : uint16_t {
+      RES_PAGE_NOT_FOUND = 1,
+      IN_STATE_TRANSFER = 2,
+      BLOCK_RANGE_NOT_FOUND = 3,
+      IN_ACTIVE_SESSION = 4,
+      INVALID_NUMBER_OF_BLOCKS_REQUESTED = 5,
+      BLOCK_NOT_FOUND_IN_STORAGE = 6,
+      DIGESTS_FOR_RVBGROUP_NOT_FOUND = 7,
+    };
+  };
+  RejectFetchingMsg() = delete;
+  RejectFetchingMsg(uint16_t rejCode, uint64_t reqMsgSeqNum) {
     memset(this, 0, sizeof(RejectFetchingMsg));
     type = MsgType::RejectFetching;
+    rejectionCode = rejCode;
+    requestMsgSeqNum = reqMsgSeqNum;
   }
 
   uint64_t requestMsgSeqNum;
+  uint16_t rejectionCode;
+
+  static inline std::map<uint16_t, const char*> reasonMessages = {
+      {Reason::RES_PAGE_NOT_FOUND, "Reserved page not found"},
+      {Reason::IN_STATE_TRANSFER, "In state transfer"},
+      {Reason::BLOCK_RANGE_NOT_FOUND, "Block range not found"},
+      {Reason::IN_ACTIVE_SESSION, "In active session"},
+      {Reason::INVALID_NUMBER_OF_BLOCKS_REQUESTED, "Invalid number of blocks requested"},
+      {Reason::BLOCK_NOT_FOUND_IN_STORAGE, "Block not found in storage"},
+      {Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, "Digests for RVB group not found"}};
 };
 
 struct ItemDataMsg : public BCStateTranBaseMsg {

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -34,10 +34,20 @@ void SourceSelector::setFetchingTimeStamp(uint64_t currTimeMilli, bool retransmi
 void SourceSelector::removeCurrentReplica() {
   preferredReplicas_.erase(currentReplica_);
   currentReplica_ = NO_REPLICA;
+  checkAndRefillPreferredReplicas();
   receivedValidBlockFromSrc_ = false;
   setSourceSelectionTime(0);
   metrics_.current_source_replica_.Get().Set(currentReplica_);
   metrics_.preferred_replicas_.Get().Set(preferredReplicasToString());
+}
+
+void SourceSelector::removePreferredReplica(uint16_t replicaId) {
+  if (preferredReplicas_.find(replicaId) == preferredReplicas_.end()) {
+    LOG_WARN(logger_, "Not found" << KVLOG(replicaId));
+    return;
+  }
+  preferredReplicas_.erase(replicaId);
+  checkAndRefillPreferredReplicas();
 }
 
 void SourceSelector::onReceivedValidBlockFromSource() {
@@ -47,11 +57,6 @@ void SourceSelector::onReceivedValidBlockFromSource() {
     LOG_INFO(logger_, "Insert source " << currentReplica_ << " into actualSources_");
     actualSources_.push_back(currentReplica_);
   }
-}
-
-void SourceSelector::setAllReplicasAsPreferred() {
-  preferredReplicas_ = allOtherReplicas_;
-  metrics_.preferred_replicas_.Get().Set(preferredReplicasToString());
 }
 
 void SourceSelector::reset() {
@@ -103,17 +108,22 @@ uint64_t SourceSelector::timeSinceSourceSelectedMilli(uint64_t currTimeMilli) co
              : (currTimeMilli - sourceSelectionTimeMilli_);
 }
 
-// Replace the source.
-void SourceSelector::updateSource(uint64_t currTimeMilli) {
-  if (currentReplica_ != NO_REPLICA) {
-    preferredReplicas_.erase(currentReplica_);
-  }
+void SourceSelector::checkAndRefillPreferredReplicas() {
   if (preferredReplicas_.empty()) {
     preferredReplicas_ = allOtherReplicas_;
     if (currentPrimary_ != NO_REPLICA) {
       preferredReplicas_.erase(currentPrimary_);
     }
+    metrics_.preferred_replicas_.Get().Set(preferredReplicasToString());
   }
+}
+
+// Replace the source.
+void SourceSelector::updateSource(uint64_t currTimeMilli) {
+  if (currentReplica_ != NO_REPLICA) {
+    preferredReplicas_.erase(currentReplica_);
+  }
+  checkAndRefillPreferredReplicas();
   selectSource(currTimeMilli);
 }
 

--- a/bftengine/src/bcstatetransfer/SourceSelector.hpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.hpp
@@ -72,7 +72,6 @@ class SourceSelector {
 
   bool hasSource() const;
   void removeCurrentReplica();
-  void setAllReplicasAsPreferred();
   void reset();
   bool isReset() const;
   bool retransmissionTimeoutExpired(uint64_t currTimeMilli) const;
@@ -106,7 +105,7 @@ class SourceSelector {
 
   uint16_t currentPrimary() { return currentPrimary_; }
 
-  void removePreferredReplica(uint16_t replicaId) { preferredReplicas_.erase(replicaId); }
+  void removePreferredReplica(uint16_t replicaId);
 
   uint16_t numberOfPreferredReplicas() const { return static_cast<uint16_t>(preferredReplicas_.size()); }
 
@@ -123,6 +122,8 @@ class SourceSelector {
   void updateCurrentPrimary(uint16_t newPrimaryReplicaId);
 
   uint16_t minPrePrepareMsgsForPrimaryAwareness() { return minPrePrepareMsgsForPrimaryAwareness_; }
+
+  void checkAndRefillPreferredReplicas();
 
   // Metric
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -38,6 +38,7 @@
 #include "storage/direct_kv_key_manipulator.h"
 #include "ReservedPagesMock.hpp"
 #include "EpochManager.hpp"
+#include "Messages.hpp"
 #include "messages/PrePrepareMsg.hpp"
 #include "hex_tools.h"  //leave for debug
 #include "RVBManager.hpp"
@@ -1035,8 +1036,8 @@ void FakeSources::replyFetchBlocksMsg() {
   size_t numOfSentChunks = 0;
 
   // very basic validity check, no simulate corruption
-  if ((fetchBlocksMsg->msgSeqNum == 0) || (fetchBlocksMsg->minBlockId == 0) || (fetchBlocksMsg->maxBlockId == 0)) {
-    RejectFetchingMsg outMsg;
+  if ((fetchBlocksMsg->minBlockId == 0) || (fetchBlocksMsg->maxBlockId == 0)) {
+    RejectFetchingMsg outMsg(RejectFetchingMsg::Reason::BLOCK_NOT_FOUND_IN_STORAGE);
     outMsg.requestMsgSeqNum = fetchBlocksMsg->msgSeqNum;
     stDelegator_->onMessage(&outMsg, sizeof(RejectFetchingMsg), msg.to_);
     testedReplicaIf_.sent_messages_.pop_front();
@@ -1507,7 +1508,7 @@ void BcStTest::getReservedPagesStage(bool skipReply, bool reject, size_t sleepDu
     const auto& msg = testedReplicaIf_.sent_messages_.front();
     ASSERT_NFF(assertMsgType(msg, MsgType::FetchResPages));
     auto fetchResPagesMsg = reinterpret_cast<FetchResPagesMsg*>(msg.data_.get());
-    RejectFetchingMsg outMsg;
+    RejectFetchingMsg outMsg(RejectFetchingMsg::Reason::RES_PAGE_NOT_FOUND);
     outMsg.requestMsgSeqNum = fetchResPagesMsg->msgSeqNum;
     stDelegator_->onMessage(&outMsg, sizeof(RejectFetchingMsg), msg.to_);
     testedReplicaIf_.sent_messages_.pop_front();

--- a/bftengine/tests/bcstatetransfer/source_selector_test.cpp
+++ b/bftengine/tests/bcstatetransfer/source_selector_test.cpp
@@ -117,7 +117,7 @@ TEST_F(SourceSelectorTestFixture, on_construction_is_reset_reports_true) { ASSER
 
 TEST_F(SourceSelectorTestFixture, leave_initial_state_when_there_are_any_preferred_replicas) {
   ASSERT_TRUE(source_selector.isReset());
-  source_selector.setAllReplicasAsPreferred();
+  source_selector.checkAndRefillPreferredReplicas();
   ASSERT_FALSE(source_selector.isReset());
 }
 
@@ -135,7 +135,7 @@ TEST_F(SourceSelectorTestFixture, leave_initial_state_when_the_fetching_timestam
 
 TEST_F(SourceSelectorTestFixture, reset_removes_preferred_replicas) {
   ASSERT_EQ(source_selector.numberOfPreferredReplicas(), 0);
-  source_selector.setAllReplicasAsPreferred();
+  source_selector.checkAndRefillPreferredReplicas();
   ASSERT_EQ(source_selector.numberOfPreferredReplicas(), replicas.size());
   source_selector.reset();
   ASSERT_EQ(source_selector.numberOfPreferredReplicas(), 0);
@@ -174,7 +174,7 @@ TEST_F(SourceSelectorTestFixture, reset_sets_the_fetching_timestamp_to_zero) {
 // Others
 TEST_F(SourceSelectorTestFixture, set_all_replicas_as_preferred) {
   ASSERT_FALSE(source_selector.hasPreferredReplicas());
-  source_selector.setAllReplicasAsPreferred();
+  source_selector.checkAndRefillPreferredReplicas();
   ASSERT_TRUE(source_selector.hasPreferredReplicas());
 
   for (const auto& replica : replicas) {


### PR DESCRIPTION
* **Problem Overview**  

-  Asserts throughout code had assumption that source selector will always have some replica in preferred list. Race between the only replica becoming primary and getting response from it proved such assumptions wrong. From now on, whenever last source is removed, preferred list of sources will be populated.
- Fix for above issue un-earthed new issue where rejections while fetching (V)blocks were not handled gracefully and destination replica was infinitely looping through preferred list of source instead of entering new internal cycle.

* **Testing Done**  

- Added GTest to produce crash observed on ticket.
- Added Gtest to validate rejections while getting (V)Blocks.
- Ran all apollo tests