### PR TITLE
bcstatetransfer: fix alloc-dealloc-mismatch

### DIFF
--- a/bftengine/tests/bcstatetransfer/test_app_state.hpp
+++ b/bftengine/tests/bcstatetransfer/test_app_state.hpp
@@ -54,7 +54,10 @@ class Block {
     return std::shared_ptr<Block>(reinterpret_cast<Block*>(buff));
   }
 
-  static void free(Block* i) { std::free(static_cast<void*>(i)); }
+  static void free(Block* blk) {
+    char* blockBytes = reinterpret_cast<char*>(blk);
+    delete[] blockBytes;
+  }
 
   StateTransferDigest digestPrev;  // For block ID N, this is the digest calculated on block ID N-1
   uint32_t actualDataSize;


### PR DESCRIPTION
* **Problem Overview**  
An _alloc-dealloc-mismatch_ was reported from the ASAN run, which was supposed to check State transfer's latest changes.
* **Testing Done**
The gtest `bcstatetransfer_tests` suite was run with ASAN enabled.