### PR TITLE
Fix getBlockStaleKeys method

### DIFF
--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -69,6 +69,7 @@ class BlockMerkleCategory {
                              std::vector<std::optional<TaggedVersion>>& versions) const;
 
   std::vector<std::string> getBlockStaleKeys(BlockId, const BlockMerkleOutput&) const;
+  std::set<std::string> getStaleActiveKeys(BlockId, const BlockMerkleOutput&) const;
   // Delete the given block ID as a genesis one.
   // Precondition: The given block ID must be the genesis one.
   std::size_t deleteGenesisBlock(BlockId, const BlockMerkleOutput&, detail::LocalWriteBatch&);

--- a/kvbc/include/categorization/immutable_kv_category.h
+++ b/kvbc/include/categorization/immutable_kv_category.h
@@ -50,6 +50,7 @@ class ImmutableKeyValueCategory {
   ImmutableOutput add(BlockId, ImmutableInput &&, storage::rocksdb::NativeWriteBatch &);
 
   std::vector<std::string> getBlockStaleKeys(BlockId, const ImmutableOutput &) const;
+  std::set<std::string> getStaleActiveKeys(BlockId, const ImmutableOutput &) const { return {}; }
 
   // Delete the genesis block. Implemented by directly calling deleteBlock().
   std::size_t deleteGenesisBlock(BlockId, const ImmutableOutput &, detail::LocalWriteBatch &);

--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -95,6 +95,18 @@ class KeyValueBlockchain {
                                         const std::string& category_id,
                                         const BlockMerkleOutput& updates_info) const;
 
+  std::set<std::string> getStaleActiveKeys(BlockId block_id,
+                                           const std::string& category_id,
+                                           const ImmutableOutput& updates_info) const;
+
+  std::set<std::string> getStaleActiveKeys(BlockId block_id,
+                                           const std::string& category_id,
+                                           const VersionedOutput& updates_info) const;
+
+  std::set<std::string> getStaleActiveKeys(BlockId block_id,
+                                           const std::string& category_id,
+                                           const BlockMerkleOutput& updates_info) const;
+
   /////////////////////// Read interface ///////////////////////
 
   // Gets the value of a key by the exact blockVersion.
@@ -123,6 +135,7 @@ class KeyValueBlockchain {
 
   // Get a map of category_id and stale keys for `block_id`
   std::map<std::string, std::vector<std::string>> getBlockStaleKeys(BlockId block_id) const;
+  std::map<std::string, std::set<std::string>> getStaleActiveKeys(BlockId block_id) const;
 
   // Get a map from category ID -> type for all known categories in the blockchain.
   const std::map<std::string, CATEGORY_TYPE>& blockchainCategories() const { return category_types_; }

--- a/kvbc/include/categorization/versioned_kv_category.h
+++ b/kvbc/include/categorization/versioned_kv_category.h
@@ -91,6 +91,8 @@ class VersionedKeyValueCategory {
 
   // Get all stale keys as of `block_id`.
   std::vector<std::string> getBlockStaleKeys(BlockId block_id, const VersionedOutput &) const;
+  // Get all stale keys from active keys as of `block_id`.
+  std::set<std::string> getStaleActiveKeys(BlockId block_id, const VersionedOutput &) const;
 
  private:
   void addDeletes(BlockId, std::vector<std::string> &&keys, VersionedOutput &, storage::rocksdb::NativeWriteBatch &);

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -561,13 +561,6 @@ std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id
   std::vector<Hash> hash_stale_keys;
   auto [hashed_keys, _, latest_versions] = getLatestVersions(out);
   (void)_;
-  auto overwritten_active_keys_from_pruned_blocks = findActiveKeysFromPrunedBlocks(hashed_keys);
-  for (auto& kv : overwritten_active_keys_from_pruned_blocks) {
-    for (const auto& hashed_key : kv.second) {
-      hash_stale_keys.push_back(Hash(hashed_key.value));
-    }
-  }
-
   for (auto i = 0u; i < hashed_keys.size(); i++) {
     auto& tagged_version = latest_versions[i];
     auto& hashed_key = hashed_keys[i];

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -561,6 +561,7 @@ std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id
   std::vector<Hash> hash_stale_keys;
   auto [hashed_keys, _, latest_versions] = getLatestVersions(out);
   (void)_;
+  (void)latest_versions;
   for (auto i = 0u; i < hashed_keys.size(); i++) {
     auto& tagged_version = latest_versions[i];
     auto& hashed_key = hashed_keys[i];

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -541,13 +541,13 @@ std::pair<SetOfKeyValuePairs, KeysVector> BlockMerkleCategory::rewriteAlreadyPru
 }
 
 std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id, const BlockMerkleOutput& out) const {
-  std::vector<Hash> hash_stale_keys;
+  std::set<Hash> hash_stale_keys;
   auto [hashed_keys, _, latest_versions] = getLatestVersions(out);
   (void)_;
   auto overwritten_active_keys_from_pruned_blocks = findActiveKeysFromPrunedBlocks(hashed_keys);
   for (auto& kv : overwritten_active_keys_from_pruned_blocks) {
     for (const auto& hashed_key : kv.second) {
-      hash_stale_keys.push_back(Hash(hashed_key.value));
+      hash_stale_keys.emplace(Hash(hashed_key.value));
     }
   }
 
@@ -560,12 +560,12 @@ std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id
     if (block_id == tagged_version->version) {
       if (tagged_version->deleted) {
         // The latest version is a tombstone.
-        hash_stale_keys.push_back(hashed_key);
+        hash_stale_keys.emplace(hashed_key);
       }
     } else {
       // block_id < tagged_version->version
       // The key has been overwritten.
-      hash_stale_keys.push_back(hashed_key);
+      hash_stale_keys.emplace(hashed_key);
     }
   }
   std::vector<std::string> stale_keys;

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -539,8 +539,7 @@ std::pair<SetOfKeyValuePairs, KeysVector> BlockMerkleCategory::rewriteAlreadyPru
   }
   return std::make_pair(merkle_blocks_to_rewrite, merkle_blocks_to_delete);
 }
-
-std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id, const BlockMerkleOutput& out) const {
+std::set<std::string> BlockMerkleCategory::getStaleActiveKeys(BlockId block_id, const BlockMerkleOutput& out) const {
   std::set<Hash> hash_stale_keys;
   auto [hashed_keys, _, latest_versions] = getLatestVersions(out);
   (void)_;
@@ -548,6 +547,24 @@ std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id
   for (auto& kv : overwritten_active_keys_from_pruned_blocks) {
     for (const auto& hashed_key : kv.second) {
       hash_stale_keys.emplace(Hash(hashed_key.value));
+    }
+  }
+  std::set<std::string> stale_keys;
+  for (auto& key : out.keys) {
+    if (std::find(hash_stale_keys.begin(), hash_stale_keys.end(), hash(key.first)) != hash_stale_keys.end()) {
+      stale_keys.emplace(key.first);
+    }
+  }
+  return stale_keys;
+}
+std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id, const BlockMerkleOutput& out) const {
+  std::vector<Hash> hash_stale_keys;
+  auto [hashed_keys, _, latest_versions] = getLatestVersions(out);
+  (void)_;
+  auto overwritten_active_keys_from_pruned_blocks = findActiveKeysFromPrunedBlocks(hashed_keys);
+  for (auto& kv : overwritten_active_keys_from_pruned_blocks) {
+    for (const auto& hashed_key : kv.second) {
+      hash_stale_keys.push_back(Hash(hashed_key.value));
     }
   }
 
@@ -560,12 +577,12 @@ std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id
     if (block_id == tagged_version->version) {
       if (tagged_version->deleted) {
         // The latest version is a tombstone.
-        hash_stale_keys.emplace(hashed_key);
+        hash_stale_keys.push_back(hashed_key);
       }
     } else {
       // block_id < tagged_version->version
       // The key has been overwritten.
-      hash_stale_keys.emplace(hashed_key);
+      hash_stale_keys.push_back(hashed_key);
     }
   }
   std::vector<std::string> stale_keys;

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -542,6 +542,7 @@ std::pair<SetOfKeyValuePairs, KeysVector> BlockMerkleCategory::rewriteAlreadyPru
 std::set<std::string> BlockMerkleCategory::getStaleActiveKeys(BlockId block_id, const BlockMerkleOutput& out) const {
   std::set<Hash> hash_stale_keys;
   auto [hashed_keys, _, latest_versions] = getLatestVersions(out);
+  (void)latest_versions;
   (void)_;
   auto overwritten_active_keys_from_pruned_blocks = findActiveKeysFromPrunedBlocks(hashed_keys);
   for (auto& kv : overwritten_active_keys_from_pruned_blocks) {
@@ -561,7 +562,6 @@ std::vector<std::string> BlockMerkleCategory::getBlockStaleKeys(BlockId block_id
   std::vector<Hash> hash_stale_keys;
   auto [hashed_keys, _, latest_versions] = getLatestVersions(out);
   (void)_;
-  (void)latest_versions;
   for (auto i = 0u; i < hashed_keys.size(); i++) {
     auto& tagged_version = latest_versions[i];
     auto& hashed_key = hashed_keys[i];

--- a/kvbc/src/categorization/versioned_kv_category.cpp
+++ b/kvbc/src/categorization/versioned_kv_category.cpp
@@ -172,11 +172,11 @@ std::unordered_map<BlockId, std::vector<std::string>> VersionedKeyValueCategory:
 
 std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId block_id,
                                                                       const VersionedOutput &out) const {
-  std::vector<std::string> stale_keys_;
+  std::set<std::string> stale_keys_;
   for (const auto &[_, keys] : activeKeysFromPrunedBlocks(out.keys)) {
     (void)_;
     for (const auto &key : keys) {
-      stale_keys_.push_back(key);
+      stale_keys_.emplace(key);
     }
   }
   for (const auto &[key, flags] : out.keys) {
@@ -186,10 +186,10 @@ std::vector<std::string> VersionedKeyValueCategory::getBlockStaleKeys(BlockId bl
 
     // Note: Deleted keys cannot be marked as stale on update.
     if (flags.stale_on_update || flags.deleted || latest->version > block_id) {
-      stale_keys_.push_back(key);
+      stale_keys_.emplace(key);
     }
   }
-  return stale_keys_;
+  return std::vector<std::string>(stale_keys_.begin(), stale_keys_.end());
 }
 
 std::size_t VersionedKeyValueCategory::deleteGenesisBlock(BlockId block_id,

--- a/kvbc/test/sparse_merkle_storage/db_editor_tests_base.h
+++ b/kvbc/test/sparse_merkle_storage/db_editor_tests_base.h
@@ -24,11 +24,13 @@
 #include "sliver.hpp"
 #include "storage/db_types.h"
 #include "storage/merkle_tree_key_manipulator.h"
+#include "categorization/updates.h"
 
 namespace {
 
 using namespace concord::kvbc::v2MerkleTree;
 using concord::kvbc::BlockId;
+using concord::kvbc::categorization::Updates;
 using concord::kvbc::INITIAL_GENESIS_BLOCK_ID;
 using concord::kvbc::SetOfKeyValuePairs;
 using concordUtils::toBigEndianStringBuffer;
@@ -61,10 +63,11 @@ class DbEditorTestsBase : public Test {
 
   virtual void CreateBlockchain(std::size_t db_id,
                                 BlockId blocks,
-                                std::optional<BlockId> mismatch_at = std::nullopt) = 0;
+                                std::optional<BlockId> mismatch_at = std::nullopt,
+                                bool override_keys = false) = 0;
 
   virtual void DeleteBlocksUntil(std::size_t db_id, BlockId until_block_id) = 0;
-
+  virtual BlockId AddBlock(std::size_t db_id, Updates&& updates) = 0;
   Sliver getSliver(unsigned value) { return toBigEndianStringBuffer(value); }
 
   SetOfKeyValuePairs generateMetadata() {

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -530,7 +530,8 @@ struct GetCategoryEarliestStale {
            "  Returns the first blockID and a list of stale keys for this blockID a given category has in \n"
            "  the [genesisBlockID, BLOCK-VERSION-TO] range.\n"
            "  If BLOCK-VERSION-TO is not set, the search range is [genesisBlockID, lastReachableBlockID].\n"
-           "  Note that this method performs linear search which may take time on big blockchains.";
+           "  Note that this method performs linear search which may take time on big blockchains."
+           "  Note that this method does not take into account stale active keys";
   }
 
   std::string execute(KeyValueBlockchain &adapter, const CommandArguments &args) const {
@@ -606,16 +607,24 @@ struct GetStaleKeysSummary {
     }
     const auto &categories = adapter.blockchainCategories();
     std::map<CATEGORY_TYPE, uint64_t> stale_keys_per_category_type_;
+    std::map<CATEGORY_TYPE, std::set<std::string>> stale__active_keys_per_category_type_;
     for (const auto &[cat_id, cat_type] : categories) {
       (void)cat_id;
       stale_keys_per_category_type_.emplace(cat_type, 0);
     }
     for (auto block = firstBlockID; block <= latestBlockID; block++) {
       auto stale_keys = adapter.getBlockStaleKeys(block);
+      auto stale_active_keys = adapter.getStaleActiveKeys(block);
       for (const auto &[cat_id, cat_type] : categories) {
         stale_keys_per_category_type_[cat_type] += stale_keys[cat_id].size();
+        stale__active_keys_per_category_type_[cat_type].insert(stale_active_keys[cat_id].begin(),
+                                                               stale_active_keys[cat_id].end());
       }
     }
+    for (const auto &[cat_id, cat_type] : categories) {
+      stale_keys_per_category_type_[cat_type] += stale__active_keys_per_category_type_[cat_type].size();
+    }
+
     std::map<std::string, std::string> out;
     for (auto const &[cat_type, num_of_stale] : stale_keys_per_category_type_) {
       out[cat_type_str.at(cat_type)] = std::to_string(num_of_stale);

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -607,7 +607,7 @@ struct GetStaleKeysSummary {
     }
     const auto &categories = adapter.blockchainCategories();
     std::map<CATEGORY_TYPE, uint64_t> stale_keys_per_category_type_;
-    std::map<CATEGORY_TYPE, std::set<std::string>> stale__active_keys_per_category_type_;
+    std::map<CATEGORY_TYPE, std::set<std::string>> stale_active_keys_per_category_type_;
     for (const auto &[cat_id, cat_type] : categories) {
       (void)cat_id;
       stale_keys_per_category_type_.emplace(cat_type, 0);
@@ -617,18 +617,21 @@ struct GetStaleKeysSummary {
       auto stale_active_keys = adapter.getStaleActiveKeys(block);
       for (const auto &[cat_id, cat_type] : categories) {
         stale_keys_per_category_type_[cat_type] += stale_keys[cat_id].size();
-        stale__active_keys_per_category_type_[cat_type].insert(stale_active_keys[cat_id].begin(),
-                                                               stale_active_keys[cat_id].end());
+        stale_active_keys_per_category_type_[cat_type].insert(stale_active_keys[cat_id].begin(),
+                                                              stale_active_keys[cat_id].end());
       }
     }
-    for (const auto &[cat_id, cat_type] : categories) {
-      stale_keys_per_category_type_[cat_type] += stale__active_keys_per_category_type_[cat_type].size();
-    }
-
+    stale_keys_per_category_type_[CATEGORY_TYPE::block_merkle] +=
+        stale_active_keys_per_category_type_[CATEGORY_TYPE::block_merkle].size();
+    stale_keys_per_category_type_[CATEGORY_TYPE::versioned_kv] +=
+        stale_active_keys_per_category_type_[CATEGORY_TYPE::versioned_kv].size();
     std::map<std::string, std::string> out;
-    for (auto const &[cat_type, num_of_stale] : stale_keys_per_category_type_) {
-      out[cat_type_str.at(cat_type)] = std::to_string(num_of_stale);
-    }
+    out[cat_type_str.at(CATEGORY_TYPE::block_merkle)] =
+        std::to_string(stale_keys_per_category_type_[CATEGORY_TYPE::block_merkle]);
+    out[cat_type_str.at(CATEGORY_TYPE::versioned_kv)] =
+        std::to_string(stale_keys_per_category_type_[CATEGORY_TYPE::versioned_kv]);
+    out[cat_type_str.at(CATEGORY_TYPE::immutable)] =
+        std::to_string(stale_keys_per_category_type_[CATEGORY_TYPE::immutable]);
     return toJson(out);
   }
 };


### PR DESCRIPTION
* **Problem Overview**  
Consider the following BC state:
activeKeys = [key1], Block(x) = [key1], Block(x+1) = [key1], Block(x+2)=[key1]
On an actual pruning, we prune 3 keys:
1. In block(x), key1 is pruned from **active keys** and from **block(x)**.
2. In block (x+1) key1 is pruned from **block(x+1)**
3. In block(x+2) key1 is not stale and hence won't be pruned.

However, when calculating the stale keys, because we don't do the actual pruning, we calculate 5 stale keys:
1. In block(x), key1 is counted as stale from **active keys** and from **block(x)**. 
2. In block(x + 1), key1 is counted as stale from **active keys** and from **block(x + 1)**. 
3. In block(x + 1), key1 is counted as stale from **active keys**.

The solution is to separate the two kinds of keys. 
First, we will calculate only the keys that are staled due to a newer version.
Then, we rotate over the blocks again and count (without duplications) the stale active keys --> each active key may be counted only once.
**Why it is ok and we don't need to actually simulate pruning?**
If during pruning, a key is added to active keys, it means that it doesn't have a newer version. Hence no new version will make it counted as stale in the future.

In addition, I've fixed some minor issues and refactored in kv_blockchain_editor tool
* **Testing Done**  
  CI + new unittest to test this fix
