### PR TITLE
state transfer apollo internal cycle validation test

### DIFF
--- a/tests/apollo/util/bft_network_partitioning.py
+++ b/tests/apollo/util/bft_network_partitioning.py
@@ -305,10 +305,10 @@ class ReplicaSubsetTwoWayIsolatingAdversary(NetworkPartitioningAdversary):
         self.replicas_to_isolate = replicas_to_isolate
         super(ReplicaSubsetTwoWayIsolatingAdversary, self).__init__(bft_network)
 
-    def interfere(self):
+    def interfere(self, drop_rate_percentage=100):
         for ir in self.replicas_to_isolate:
             for r in self.bft_network.all_replicas():
                 if ir != r:
-                    self._drop_packets_between(ir, r)
-                    self._drop_packets_between(r, ir)
+                    self._drop_packets_between(ir, r, drop_rate_percentage)
+                    self._drop_packets_between(r, ir, drop_rate_percentage)
 

--- a/tests/apollo/util/bft_network_traffic_control.py
+++ b/tests/apollo/util/bft_network_traffic_control.py
@@ -28,7 +28,7 @@ class NetworkTrafficControl():
         assert 0 == os.system('tc qdisc del dev lo root') == 0,\
                  "tc delte command failed, need to be removed orelse it will affect the replica"
     
-    def put_loop_back_interface_delay(self,delay_factor):
+    def put_loop_back_interface_delay(self, delay_factor):
         assert 0 == os.system('tc qdisc add dev lo root netem delay '+\
                          str(delay_factor) + 'ms'),\
                          "Make sure tc is installed in the replica"


### PR DESCRIPTION
Internal cycle validation would be done using newly added metric

* **Problem Overview**  
This apollo test was failing intermittently. Fixed it to validate internal cycle with metric counter.
* **Testing Done**  
Ran 50 times locally with configuration as same as CI.