### PR TITLE
Fixed a memory leak reported by ASAN

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -5670,6 +5670,7 @@ void ReplicaImp::sendResponses(PrePrepareMsg *ppMsg, IRequestsHandler::Execution
     // Internal clients don't expect to be answered
     if (repsInfo->isIdOfInternalClient(req.clientId)) {
       clientsManager->removePendingForExecutionRequest(req.clientId, req.requestSequenceNum);
+      free(req.outReply);
       continue;
     }
     if (executionResult != 0) {


### PR DESCRIPTION
* **Problem Overview**  
memory leak was found while running internal test with ASAN enabled.
* **Testing Done**  
enabled ASAN and tested the changes, the ASAN report looks clean.
