### PR TITLE
Stop adaptive pruning manager on wedge and start it on unwedge (witho…

### DIFF
--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -619,6 +619,8 @@ bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& comma
   auto blockId = persistReconfigurationBlock(
       serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key}, ts, false);
   LOG_INFO(getLogger(), "WedgeCommand block is " << blockId);
+  LOG_INFO(getLogger(), "Stoppint adaptive pruning resource manager");
+  apm_.stop();
   return true;
 }
 
@@ -710,7 +712,8 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
                           std::string(serialized_cmd_data.begin(), serialized_cmd_data.end()));
   }
   auto blockId = persistReconfigurationBlock(ver_updates, sequence_number, ts, true);
-
+  LOG_INFO(getLogger(), "Stoppint adaptive pruning resource manager");
+  apm_.stop();
   // update reserved pages for RO replica
   auto epochNum = bftEngine::EpochManager::instance().getSelfEpochNumber();
   auto wedgePoint = (sequence_number + 2 * checkpointWindowSize);
@@ -739,6 +742,8 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
   auto blockId = persistReconfigurationBlock(
       serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_restart_key}, ts, true);
   LOG_INFO(getLogger(), "RestartCommand block is " << blockId);
+  LOG_INFO(getLogger(), "Stoppint adaptive pruning resource manager");
+  apm_.stop();
   return true;
 }
 
@@ -1007,6 +1012,8 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
       bftEngine::ControlStateManager::instance().setStopAtNextCheckpoint(0);
       bftEngine::ControlStateManager::instance().unwedge();
       bftEngine::IControlHandler::instance()->resetState();
+      LOG_INFO(getLogger(), "Starting adaptive pruning resource manager");
+      apm_.start();
       LOG_INFO(getLogger(), "Unwedge command completed successfully");
     } else {
       bftEngine::EpochManager::instance().setNewEpochFlag(true);

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -619,7 +619,7 @@ bool ReconfigurationHandler::handle(const concord::messages::WedgeCommand& comma
   auto blockId = persistReconfigurationBlock(
       serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_wedge_key}, ts, false);
   LOG_INFO(getLogger(), "WedgeCommand block is " << blockId);
-  LOG_INFO(getLogger(), "Stoppint adaptive pruning resource manager");
+  LOG_INFO(getLogger(), "Stopping adaptive pruning resource manager");
   apm_.stop();
   return true;
 }
@@ -712,7 +712,7 @@ bool ReconfigurationHandler::handle(const concord::messages::AddRemoveWithWedgeC
                           std::string(serialized_cmd_data.begin(), serialized_cmd_data.end()));
   }
   auto blockId = persistReconfigurationBlock(ver_updates, sequence_number, ts, true);
-  LOG_INFO(getLogger(), "Stoppint adaptive pruning resource manager");
+  LOG_INFO(getLogger(), "Stopping adaptive pruning resource manager");
   apm_.stop();
   // update reserved pages for RO replica
   auto epochNum = bftEngine::EpochManager::instance().getSelfEpochNumber();
@@ -742,7 +742,7 @@ bool ReconfigurationHandler::handle(const concord::messages::RestartCommand& com
   auto blockId = persistReconfigurationBlock(
       serialized_command, bft_seq_num, std::string{kvbc::keyTypes::reconfiguration_restart_key}, ts, true);
   LOG_INFO(getLogger(), "RestartCommand block is " << blockId);
-  LOG_INFO(getLogger(), "Stoppint adaptive pruning resource manager");
+  LOG_INFO(getLogger(), "Stopping adaptive pruning resource manager");
   apm_.stop();
   return true;
 }


### PR DESCRIPTION
…ut restart)

* **Problem Overview**  
 Adaptive pruning is a component that runs in an async thread and continuously sends bft requests. 
It makes sense to stop it on the wedge because we block all consensuses in any case.
We want to start it on unwedge (but not with restart) because if we do activate it with restart as well, we may end up restarting the system while adding blocks which is not recommended and may lead to an unstable situation.
* **Testing Done**  
  CI + fixing specific test that was arbitrarily failing due to this error (test_remove_nodes_with_unwedge)
