### PR TITLE
BCStateTran: Disable primary awareness during GettingCheckpointSummaries

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -3952,7 +3952,10 @@ void BCStateTran::handleIncomingConsensusMessageImpl(ConsensusMsg msg) {
 
   switch (msg.type_) {
     case MsgCode::PrePrepare:
-      if (config_.enableSourceSelectorPrimaryAwareness) {
+      // As of now, during GettingCheckpointSummaries we expect preferred replicas to keep empty. For simplicity, avoid
+      // primary awareness during this short perio
+      if ((getFetchingState() != FetchingState::GettingCheckpointSummaries) &&
+          (config_.enableSourceSelectorPrimaryAwareness)) {
         sourceSelector_.updateCurrentPrimary(msg.sender_id_);
       }
       break;

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -221,7 +221,9 @@ void SourceSelector::selectSource(uint64_t currTimeMilli) {
 }
 
 void SourceSelector::updateCurrentPrimary(uint16_t newPrimary) {
-  if (currentPrimary_ == newPrimary) return;
+  if (currentPrimary_ == newPrimary) {
+    return;
+  }
   auto resetNominatedPrimary = [&]() {
     nominatedPrimary_ = NO_REPLICA;
     nominatedPrimaryCounter_ = 0;


### PR DESCRIPTION
* **Problem Overview**  
  GettingCheckpointSummaries requires empty preferred replicas.
Primary awareness might, under some conditions, add replicas to preferred
replicas.
For simplicity, here we disable primary awareness during this stage
(usually 1-2 seconds or less).

I've also added a test that reproduce the crash (assertion failure)
we had before disabling primary awareness during
GettingCheckpointSummaries. After the fix crash won't happen.

* **Testing Done**  
  Added a GTest which reproduce the issue. The after fix, test won't fail anymore.
