### PR TITLE
State Transfer : Destination replica to resume from last-stored-checkpoint instead of last-stored-checkpoint+1

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1215,7 +1215,7 @@ bool BCStateTran::checkStructureOfVirtualBlock(char *virtualBlock,
     char *p = virtualBlock + sizeof(HeaderOfVirtualBlock) + (i * elementSize);
     ElementOfVirtualBlock *e = reinterpret_cast<ElementOfVirtualBlock *>(p);
 
-    if (e->checkpointNumber <= h->lastCheckpointKnownToRequester) {
+    if (e->checkpointNumber < h->lastCheckpointKnownToRequester) {
       LOG_ERROR(logger, KVLOG(e->checkpointNumber, h->lastCheckpointKnownToRequester, i, e->pageId));
       return false;
     }
@@ -1489,7 +1489,10 @@ void BCStateTran::sendAskForCheckpointSummariesMsg() {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(config_.myReplicaId, lastMsgSeqNum_));
 
   msg.msgSeqNum = lastMsgSeqNum_;
-  msg.minRelevantCheckpointNum = psd_->getLastStoredCheckpoint() + 1;
+  // Abruptly restarted fetcher replica might have last-stored-checkpoint same as what *stopped* network would have.
+  // In case fetcher asks for last-stored-checkpoint + 1, consensus network may reject such request thinking it doesn't
+  // have requested checkpoint.
+  msg.minRelevantCheckpointNum = psd_->getLastStoredCheckpoint() ? psd_->getLastStoredCheckpoint() : 1;
 
   LOG_INFO(logger_, KVLOG(lastMsgSeqNum_, msg.minRelevantCheckpointNum));
 
@@ -1664,7 +1667,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
   }
 
   // if msg is not relevant
-  if (m->requestMsgSeqNum != lastMsgSeqNum_ || m->checkpointNum <= psd_->getLastStoredCheckpoint()) {
+  if (m->requestMsgSeqNum != lastMsgSeqNum_ || m->checkpointNum < psd_->getLastStoredCheckpoint()) {
     LOG_WARN(logger_,
              "Msg is irrelevant: " << KVLOG(
                  replicaId, m->requestMsgSeqNum, lastMsgSeqNum_, m->checkpointNum, psd_->getLastStoredCheckpoint()));
@@ -3511,14 +3514,16 @@ void BCStateTran::processData(bool lastInBatch, uint32_t rvbDigestsSize) {
         {
           DataStoreTransaction::Guard g(psd_->beginTransaction());
           sourceSelector_.onReceivedValidBlockFromSource();
-
+          // In case replica has received and stored same checkpoint in last unsuccessful cycle,
+          // corresponding checkpoint descriptor and reserved pages might be already present.
+          bool checkIfAlreadyExists = !(targetCheckpointDesc_.checkpointNum == g.txn()->getLastStoredCheckpoint());
           if (config_.enableReservedPages) {
             // set the updated pages
             uint32_t numOfUpdates = getNumberOfElements(buffer_.get());
             LOG_DEBUG(logger_, "numOfUpdates in vblock: " << numOfUpdates);
             for (uint32_t i = 0; i < numOfUpdates; i++) {
               ElementOfVirtualBlock *e = getVirtualElement(i, config_.sizeOfReservedPage, buffer_.get());
-              g.txn()->setResPage(e->pageId, e->checkpointNumber, e->pageDigest, e->page);
+              g.txn()->setResPage(e->pageId, e->checkpointNumber, e->pageDigest, e->page, checkIfAlreadyExists);
               LOG_DEBUG(logger_, "Update page " << e->pageId);
             }
           }
@@ -3526,12 +3531,12 @@ void BCStateTran::processData(bool lastInBatch, uint32_t rvbDigestsSize) {
           // Mark completion of GettingMissingResPages stage
           ConcordAssert(g.txn()->hasCheckpointBeingFetched());
           DataStore::CheckpointDesc cp = g.txn()->getCheckpointBeingFetched();
-          ConcordAssertGT(targetCheckpointDesc_.checkpointNum, g.txn()->getLastStoredCheckpoint());
+          ConcordAssertGE(targetCheckpointDesc_.checkpointNum, g.txn()->getLastStoredCheckpoint());
           ConcordAssertEQ(targetCheckpointDesc_.checkpointNum, cp.checkpointNum);
           ConcordAssertEQ(g.txn()->getFirstRequiredBlock(), 0);
           ConcordAssertEQ(g.txn()->getLastRequiredBlock(), 0);
           ConcordAssert(ioContexts_.empty());
-          g.txn()->setCheckpointDesc(targetCheckpointDesc_.checkpointNum, targetCheckpointDesc_);
+          g.txn()->setCheckpointDesc(targetCheckpointDesc_.checkpointNum, targetCheckpointDesc_, checkIfAlreadyExists);
           g.txn()->deleteCheckpointBeingFetched();
           deleteOldCheckpoints(targetCheckpointDesc_.checkpointNum, g.txn());
           metrics_.checkpoint_being_fetched_.Get().Set(0);

--- a/bftengine/src/bcstatetransfer/DBDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.hpp
@@ -74,9 +74,9 @@ class DBDataStore : public DataStore {
   void deleteDescOfSmallerCheckpoints(uint64_t) override;
   void deleteCoveredResPageInSmallerCheckpoints(uint64_t) override;
   void setCheckpointBeingFetched(const CheckpointDesc&) override;
-  void setResPage(uint32_t, uint64_t, const Digest&, const char*) override;
+  void setResPage(uint32_t, uint64_t, const Digest&, const char*, const bool) override;
   void setPendingResPage(uint32_t, const char*, uint32_t) override;
-  void setCheckpointDesc(uint64_t, const CheckpointDesc&) override;
+  void setCheckpointDesc(uint64_t, const CheckpointDesc&, const bool checkIfAlreadyExists) override;
   void associatePendingResPageWithCheckpoint(uint32_t, uint64_t, const Digest&) override;
 
   void free(ResPagesDescriptor* desc) override { inmem_->free(desc); }

--- a/bftengine/src/bcstatetransfer/DataStore.hpp
+++ b/bftengine/src/bcstatetransfer/DataStore.hpp
@@ -93,7 +93,9 @@ class DataStore : public std::enable_shared_from_this<DataStore> {
     std::vector<char> rvbData{};
   };
 
-  virtual void setCheckpointDesc(uint64_t checkpoint, const CheckpointDesc& desc) = 0;
+  virtual void setCheckpointDesc(uint64_t checkpoint,
+                                 const CheckpointDesc& desc,
+                                 const bool checkIfAlreadyExists = true) = 0;
   virtual CheckpointDesc getCheckpointDesc(uint64_t checkpoint) = 0;
   virtual bool hasCheckpointDesc(uint64_t checkpoint) = 0;
   virtual void deleteDescOfSmallerCheckpoints(uint64_t checkpoint) = 0;
@@ -113,7 +115,11 @@ class DataStore : public std::enable_shared_from_this<DataStore> {
                                                      uint64_t inCheckpoint,
                                                      const Digest& inPageDigest) = 0;
 
-  virtual void setResPage(uint32_t inPageId, uint64_t inCheckpoint, const Digest& inPageDigest, const char* inPage) = 0;
+  virtual void setResPage(uint32_t inPageId,
+                          uint64_t inCheckpoint,
+                          const Digest& inPageDigest,
+                          const char* inPage,
+                          const bool checkIfAlreadyExists = true) = 0;
   virtual bool getResPage(uint32_t inPageId, uint64_t inCheckpoint, uint64_t* outActualCheckpoint) {
     return getResPage(inPageId, inCheckpoint, outActualCheckpoint, nullptr, nullptr, 0);
   }
@@ -227,15 +233,21 @@ class DataStoreTransaction : public DataStore, public ITransaction {
                                              const Digest& inPageDigest) override {
     ds_->associatePendingResPageWithCheckpoint(inPageId, inCheckpoint, inPageDigest);
   }
-  void setCheckpointDesc(uint64_t checkpoint, const CheckpointDesc& desc) override {
-    ds_->setCheckpointDesc(checkpoint, desc);
+  void setCheckpointDesc(uint64_t checkpoint,
+                         const CheckpointDesc& desc,
+                         const bool checkIfAlreadyExists = true) override {
+    ds_->setCheckpointDesc(checkpoint, desc, checkIfAlreadyExists);
   }
   void setFirstStoredCheckpoint(uint64_t c) override { ds_->setFirstStoredCheckpoint(c); }
   void setPendingResPage(uint32_t inPageId, const char* inPage, uint32_t pageLen) override {
     ds_->setPendingResPage(inPageId, inPage, pageLen);
   }
-  void setResPage(uint32_t inPageId, uint64_t inCheckpoint, const Digest& inPageDigest, const char* inPage) override {
-    ds_->setResPage(inPageId, inCheckpoint, inPageDigest, inPage);
+  void setResPage(uint32_t inPageId,
+                  uint64_t inCheckpoint,
+                  const Digest& inPageDigest,
+                  const char* inPage,
+                  const bool checkIfAlreadyExists = true) override {
+    ds_->setResPage(inPageId, inCheckpoint, inPageDigest, inPage, checkIfAlreadyExists);
   }
   bool initialized() override { return ds_->initialized(); }
   bool getIsFetchingState() override { return ds_->getIsFetchingState(); }

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -79,7 +79,9 @@ class InMemoryDataStore : public DataStore {
   // Checkpoints
   //////////////////////////////////////////////////////////////////////////
 
-  void setCheckpointDesc(uint64_t checkpoint, const CheckpointDesc& desc) override;
+  void setCheckpointDesc(uint64_t checkpoint,
+                         const CheckpointDesc& desc,
+                         const bool checkIfAlreadyExists = true) override;
   CheckpointDesc getCheckpointDesc(uint64_t checkpoint) override;
   bool hasCheckpointDesc(uint64_t checkpoint) override;
   void deleteDescOfSmallerCheckpoints(uint64_t checkpoint) override;
@@ -117,7 +119,11 @@ class InMemoryDataStore : public DataStore {
                                              uint64_t inCheckpoint,
                                              const Digest& inPageDigest) override;
 
-  void setResPage(uint32_t inPageId, uint64_t inCheckpoint, const Digest& inPageDigest, const char* inPage) override;
+  void setResPage(uint32_t inPageId,
+                  uint64_t inCheckpoint,
+                  const Digest& inPageDigest,
+                  const char* inPage,
+                  const bool checkIfAlreadyExists = true) override;
 
   bool getResPage(uint32_t inPageId,
                   uint64_t inCheckpoint,

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -275,7 +275,6 @@ class SkvbcPersistenceTest(ApolloTest):
                log.log_message(message_type=f'Stopping replica {stale_node}')
                bft_network.stop_replica(stale_node)
 
-    @unittest.skip("Unstable test - BC-19210")
     @with_trio
     @with_bft_network(start_replica_cmd,
                       selected_configs=lambda n, f, c: f >= 2)
@@ -303,15 +302,15 @@ class SkvbcPersistenceTest(ApolloTest):
 
         client, known_key, known_val = \
             await skvbc.prime_for_state_transfer(stale_nodes={stale_node},
-                                                           checkpoints_num=4)
+                                                           checkpoints_num=random.randint(5, 7))
 
         # exclude the primary and the stale node
-        unstable_replicas = bft_network.all_replicas(without={0, stale_node})
+        non_primary_replicas = bft_network.all_replicas(without={0, stale_node})
 
         await self._run_state_transfer_while_crashing_non_primary(
             bft_network=bft_network,
             primary=0, stale=stale_node,
-            unstable_replicas=unstable_replicas
+            non_primary_replicas=non_primary_replicas
         )
 
         await bft_network.force_quorum_including_replica(stale_node)
@@ -324,20 +323,14 @@ class SkvbcPersistenceTest(ApolloTest):
     async def _run_state_transfer_while_crashing_non_primary(
             self, bft_network,
             primary, stale,
-            unstable_replicas):
+            non_primary_replicas):
 
         source_replica_id = \
-            await self._restart_stale_until_fetches_from_unstable(
-                bft_network, stale, unstable_replicas
+            await self._restart_stale_until_non_primary_chosen_as_source(
+                bft_network, primary, stale, non_primary_replicas
             )
 
-        self.assertTrue(
-            expr=source_replica_id != primary,
-            msg="The source must NOT be the primary "
-                "(to avoid triggering a view change)"
-        )
-
-        if source_replica_id in unstable_replicas:
+        if source_replica_id in non_primary_replicas:
             log.log_message(message_type=f'Stopping source replica {source_replica_id}')
             bft_network.stop_replica(source_replica_id)
 
@@ -554,13 +547,13 @@ class SkvbcPersistenceTest(ApolloTest):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(skvbc.send_indefinite_write_requests)
 
-    async def _restart_stale_until_fetches_from_unstable(
-            self, bft_network, stale, unstable_replicas):
+    async def _restart_stale_until_non_primary_chosen_as_source(
+            self, bft_network, primary, stale, non_primary_replicas):
 
         source_replica_id = inf
 
         log.log_message(message_type=f'Restarting stale replica until '
-              f'it fetches from {unstable_replicas}...')
+              f'it fetches from {non_primary_replicas}...')
         with trio.move_on_after(10):  # seconds
             while True:
                 bft_network.start_replica(stale)
@@ -568,13 +561,14 @@ class SkvbcPersistenceTest(ApolloTest):
                     replica_id=stale
                 )
                 bft_network.stop_replica(stale)
-                if source_replica_id in unstable_replicas:
-                    # Nice! The source is a replica we can crash
+                if source_replica_id in non_primary_replicas:
+                    self.assertTrue(
+                        expr=source_replica_id != primary,
+                        msg="The source must NOT be the primary "
+                        "(to avoid triggering a view change)"
+                    )
+                    log.log_message(message_type=f'Stale replica fetching from {source_replica_id}')
                     break
-
-        if source_replica_id < inf:
-            log.log_message(message_type=f'Stale replica now fetching from {source_replica_id}')
-        else:
-            log.log_message(message_type=f'Stale replica is not fetching right now.')
-
+        
+        self.assertTrue(source_replica_id != inf, msg="Stale replica is not fetching right now.")
         return source_replica_id


### PR DESCRIPTION
Abruptly restarted destination replica to ask for state from network with last-stored-checkpoint as minimum required instead of earlier last-stored-checkpoint+1.
* **Problem Overview**  
Apollo test validating state transfer by abruptly restarting fetcher and sender nodes was failing intermittently in CI runs. After simplifying apollo test code, it also exposed a bug in fetcher replica where it was asking for last-stored-checkpoint + 1 from stopped consensus network having same last-stored-checkpoint.
* **Testing Done**  
Ran test locally 25 times with config matching with CI runs.
Reproduced issue and validated fix by writing Gtest.