### PR TITLE
RangeValidationTree: modify printToLog

### DIFF
--- a/bftengine/src/bcstatetransfer/RVBManager.cpp
+++ b/bftengine/src/bcstatetransfer/RVBManager.cpp
@@ -116,7 +116,7 @@ void RVBManager::init(bool fetching) {
 
   LOG_INFO(logger_, std::boolalpha << KVLOG(pruned_blocks_digests_.size(), desc.checkpointNum, loaded_from_data_store));
   if (print_rvt && (debug_prints_log_level.find(getLogLevel()) != debug_prints_log_level.end())) {
-    in_mem_rvt_->printToLog(LogPrintVerbosity::DETAILED, "init");
+    in_mem_rvt_->printToLog(LogPrintVerbosity::SUMMARY, "init");
   }
 }
 
@@ -258,7 +258,7 @@ void RVBManager::updateRvbDataDuringCheckpoint(CheckpointDesc& new_checkpoint_de
     }
     std::string label{"updateRvbDataDuringCheckpoint"};
     label += std::to_string(new_checkpoint_desc.checkpointNum);
-    in_mem_rvt_->printToLog(LogPrintVerbosity::DETAILED, label.c_str());
+    in_mem_rvt_->printToLog(LogPrintVerbosity::SUMMARY, label.c_str());
   }
   last_checkpoint_desc_ = new_checkpoint_desc;
 }
@@ -309,7 +309,7 @@ bool RVBManager::setRvbData(char* data, size_t data_size, BlockId min_block_id_s
   }
 
   LOG_INFO(logger_, "Success setting new RVB data from network!");
-  in_mem_rvt_->printToLog(LogPrintVerbosity::DETAILED, "setRvbData");
+  in_mem_rvt_->printToLog(LogPrintVerbosity::SUMMARY, "setRvbData");
   rvb_data_source_ = RvbDataInitialSource::FROM_NETWORK;
   if (!data) {
     LOG_WARN(logger_, "Empty RVB data in checkpoint!");

--- a/bftengine/src/bcstatetransfer/RangeValidationTree.hpp
+++ b/bftengine/src/bcstatetransfer/RangeValidationTree.hpp
@@ -130,9 +130,10 @@ class RangeValidationTree {
 
   enum class LogPrintVerbosity { DETAILED, SUMMARY };
 
-  // Log tree only if total elements are less than 10K. In case of failure can assert.
-  // SUMMARY - prints basic structure and node ids only
-  void printToLog(LogPrintVerbosity verbosity, std::string&& user_label = "") const noexcept;  // change to 3 levels
+  // Prints current tree information to log. Basic information is always printed. If verbosity is DETAILED and there
+  // less than kMaxNodesToPrintStructure+1 nodes in the tree, structure is printed as well.
+  // The label is an optional string, to mark the caller.
+  void printToLog(LogPrintVerbosity verbosity, std::string&& user_label = "") const noexcept;
 
   // Validate structure and values inside tree. In case of failure can assert.
   bool validate() const noexcept;
@@ -371,7 +372,7 @@ class RangeValidationTree {
   static uint32_t RVT_K;
   const uint32_t fetch_range_size_{};
   const size_t value_size_{};
-  static constexpr size_t kMaxNodesToPrint{10000};
+  static constexpr size_t kMaxNodesToPrintStructure{100};
   static constexpr uint8_t CHECKPOINT_PERSISTENCY_VERSION{1};
   static constexpr uint8_t version_num_{CHECKPOINT_PERSISTENCY_VERSION};
   static constexpr uint64_t magic_num_{0x1122334455667788};


### PR DESCRIPTION
* **Problem Overview**  
RVT may be huge in production and can reach tens of thousands of nodes.
We always need the basic summary to be printed, but at this level,
it doesn't make sense to print the tree structure at all.

1) Always print the tree header (basic info).
2) If verbosity is DETAILED, print structure as well.
3) If verbosity is SUMMARY, or if there are more than 100 nodes -
print only basic header. This overrides section 2.
4) Change all calls to print SUMMARY level only.

* **Testing Done**  
NA
