### PR TITLE
Reserved Pages divergence after State Transfer fix

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -55,8 +55,7 @@ class KeyExchangeManager {
   const std::string kInitialClientsKeysCid = "CLIENTS-PUB-KEYS-";
   ///////// Clients public keys interface///////////////
   // whether clients keys were published
-  bool clientKeysPublished() const { return clientsPublicKeys_.published_; }
-  void setClientKeysAsPublished() { clientsPublicKeys_.published_ = true; }
+  bool clientKeysPublished() const { return clientsPublicKeys_.published(); }
   void saveClientsPublicKeys(const std::string& keys) {
     metrics_->clients_keys_published_status.Get().Set("True");
     clientsPublicKeys_.save(keys);

--- a/bftengine/include/bftengine/ReservedPagesClient.hpp
+++ b/bftengine/include/bftengine/ReservedPagesClient.hpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <map>
 #include <iostream>
+#include "Logger.hpp"
 
 namespace bftEngine {
 
@@ -102,6 +103,9 @@ class ResPagesClient : public ReservedPagesClientBase, public IReservedPages {
     return res_pages_->loadReservedPage(my_offset() + reservedPageId, copyLength, outReservedPage);
   }
   void saveReservedPage(uint32_t reservedPageId, uint32_t copyLength, const char* inReservedPage) override {
+    LOG_TRACE(logging::getLogger("bftengine.res_page"),
+              typeid(T).name() << " page: " << reservedPageId << " offset: " << my_offset()
+                               << " abs page: " << my_offset() + reservedPageId);
     res_pages_->saveReservedPage(my_offset() + reservedPageId, copyLength, inReservedPage);
   }
   void zeroReservedPage(uint32_t reservedPageId) override {

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -5127,6 +5127,11 @@ void ReplicaImp::finishExecutePrePrepareMsg(PrePrepareMsg *ppMsg,
   LOG_INFO(CNSUS, "Finished execution of request seqNum:" << ppMsg->seqNumber());
   uint64_t checkpointNum{};
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {
+    // Save the epoch to the reserved pages
+    auto epochMgr = bftEngine::EpochManager::instance();
+    auto epochNum = epochMgr.getSelfEpochNumber();
+    epochMgr.setSelfEpochNumber(epochNum);
+    epochMgr.setGlobalEpochNumber(epochNum);
     checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;
     stateTransfer->createCheckpointOfCurrentState(
         checkpointNum);  // TODO(GG): should make sure that this operation is idempotent, even if it was partially
@@ -5196,10 +5201,6 @@ void ReplicaImp::finalizeExecution() {
   }
 
   if (lastExecutedSeqNum % checkpointWindowSize == 0) {
-    // Load the epoch to the reserved pages
-    auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
-    bftEngine::EpochManager::instance().setSelfEpochNumber(epoch);
-    bftEngine::EpochManager::instance().setGlobalEpochNumber(epoch);
     Digest stateDigest, reservedPagesDigest, rvbDataDigest;
     CheckpointMsg::State checkState;
     const uint64_t checkpointNum = lastExecutedSeqNum / checkpointWindowSize;
@@ -5478,6 +5479,11 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
   }
   uint64_t checkpointNum{};
   if ((lastExecutedSeqNum + 1) % checkpointWindowSize == 0) {
+    // Save the epoch to the reserved pages
+    auto epochMgr = bftEngine::EpochManager::instance();
+    auto epochNum = epochMgr.getSelfEpochNumber();
+    epochMgr.setSelfEpochNumber(epochNum);
+    epochMgr.setGlobalEpochNumber(epochNum);
     checkpointNum = (lastExecutedSeqNum + 1) / checkpointWindowSize;
     stateTransfer->createCheckpointOfCurrentState(checkpointNum);
     checkpoint_times_.start(lastExecutedSeqNum);
@@ -5520,10 +5526,6 @@ void ReplicaImp::executeRequestsInPrePrepareMsg(concordUtils::SpanWrapper &paren
   }
 
   if (lastExecutedSeqNum % checkpointWindowSize == 0) {
-    // Load the epoch to the reserved pages
-    auto epoch = bftEngine::EpochManager::instance().getSelfEpochNumber();
-    bftEngine::EpochManager::instance().setSelfEpochNumber(epoch);
-    bftEngine::EpochManager::instance().setGlobalEpochNumber(epoch);
     Digest stateDigest, reservedPagesDigest, rvbDataDigest;
     CheckpointMsg::State state;
     const uint64_t checkpointNum = lastExecutedSeqNum / checkpointWindowSize;

--- a/bftengine/tests/KeyStore/KeyStore_test.cpp
+++ b/bftengine/tests/KeyStore/KeyStore_test.cpp
@@ -36,8 +36,8 @@ struct ReservedPagesMock : public IReservedPages {
 
 TEST(checkAndSetState_empty, ClientKeyStore) {
   ReservedPagesMock rpm{5, true};
-  ClientKeyStore cks;
-  ASSERT_FALSE(cks.published_);
+  ClientKeyStore cks(true);
+  ASSERT_FALSE(cks.published());
 }
 
 TEST(checkAndSetState_set_true, ClientKeyStore) {
@@ -48,9 +48,9 @@ TEST(checkAndSetState_set_true, ClientKeyStore) {
   std::vector<uint8_t> ser_keys;
   concord::messages::keys_and_signatures::serialize(ser_keys, cpk);
   std::string str_ser(ser_keys.begin(), ser_keys.end());
-  ClientKeyStore cks;
+  ClientKeyStore cks(false);
   cks.save(str_ser);
-  ASSERT_TRUE(cks.published_);
+  ASSERT_TRUE(cks.published());
   auto loaded_keys = cks.load();
   auto hashed_keys = concord::util::SHA3_256().digest(str_ser.c_str(), str_ser.size());
   auto strHashed_keys = std::string(hashed_keys.begin(), hashed_keys.end());
@@ -66,13 +66,13 @@ TEST(checkAndSetState_start_true, ClientKeyStore) {
   concord::messages::keys_and_signatures::serialize(ser_keys, cpk);
   std::string str_ser(ser_keys.begin(), ser_keys.end());
   {
-    ClientKeyStore cks;
-    ASSERT_FALSE(cks.published_);
+    ClientKeyStore cks(true);
+    ASSERT_FALSE(cks.published());
     cks.save(str_ser);
-    ASSERT_TRUE(cks.published_);
+    ASSERT_TRUE(cks.published());
   }
   {
-    ClientKeyStore cks;
-    ASSERT_TRUE(cks.published_);
+    ClientKeyStore cks(false);
+    ASSERT_TRUE(cks.published());
   }
 }

--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -232,7 +232,6 @@ class SkvbcStateTransferTest(ApolloTest):
         await bft_network.wait_for_state_transfer_to_stop(0, stale_node)
         await bft_network.wait_for_replicas_rvt_root_values_to_be_in_sync(bft_network.all_replicas())
 
-    @unittest.skip("Unstable test - disabled until fixed BC-19123")
     @with_trio
     @with_bft_network(start_replica_cmd)
     async def test_state_transfer_rvt_validity_after_pruning(self, bft_network):

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -800,17 +800,22 @@ class BftTestNetwork:
 
         with log.start_action(action_type="start_replica_process", replica=replica_id, is_external=is_external,
                               binary_path=replica_binary_path, binary_digest=digest):
+            my_env = os.environ.copy()
+            my_env["RID"] = str(replica_id)
             if is_external:
                 self.procs[replica_id] = subprocess.run(
                     start_cmd,
-                    check=True
+                    check=True,
+                    env=my_env
                 )
             else:
                 self.procs[replica_id] = subprocess.Popen(
                     start_cmd,
                     stdout=stdout_file,
                     stderr=stderr_file,
-                    close_fds=True)
+                    close_fds=True,
+                    env=my_env
+                    )
 
                 if keep_logs:
                     self.verify_matching_replica_client_communication(replica_test_log_path)

--- a/tests/simpleKVBC/scripts/logging.properties
+++ b/tests/simpleKVBC/scripts/logging.properties
@@ -11,7 +11,7 @@ log4cplus.appender.STDOUT.layout=log4cplus::PatternLayout
 log4cplus.appender.STDOUT.layout.ConversionPattern=%X{rid}|%d{%d-%m-%Y %H:%M:%S.%q}|%-5p|%c|%X{thread}|%X{pri}|%X{cid}|%X{sn}|%X{path}|%M|L:%L|%m%n
 
 log4cplus.appender.R=log4cplus::RollingFileAppender
-log4cplus.appender.R.File=concord.log
+log4cplus.appender.R.File=concord-${RID}.log
 log4cplus.appender.R.MaxFileSize=10MB
 log4cplus.appender.R.MaxBackupIndex=10
 log4cplus.appender.R.layout=log4cplus::PatternLayout


### PR DESCRIPTION
1. test_state_transfer_rvt_validity_after_pruning in test_skvbc_state_transfer was disabled because it revealed the Reserved Pages divergence bug.
Two Reserved Pages clients contributed to this bug:
- EpochManager, which was setting the epoch on every checkpoint AFTER the checkpointing the state with reserved pages.
   It caused its reserved page to enter the next checkpoint.
   If the current checkpoint was trasferred to another replica, since this replica wouldn't execute requests for the received checkpoint,
   it wouldn't add an epoch to the next state as well and the pages will diverge.
   The solution is to set epoch BEFORE checkpoinntinng.
- ClientKeyStore:
   when loading from its reserved page, if the page is empty would ALWAYS publish its client keys, even if the publishig is disabled and other replicas were not publishig their client keys.
   The solution is to check whether publishing is enabled when loading from the reserved pages.

2. Re-enable test_state_transfer_rvt_validity_after_pruning.
3. Add replica ID to the concord.log files in simpleKVBC tests (Apollo): concord-<RID>.log, so they will be split per replica.
   This allows for easier debugging without a need to visit apollo/logs.

* **Problem Overview**  
  < a few sentences about what problem we want to solve with our change(e.g. description of the bug we are fixing) >
* **Testing Done**  
all the related unit tests + apollo tests including re-enabling the test_state_transfer_rvt_validity_after_pruning